### PR TITLE
Implement OPAL v2 token optimization syntax

### DIFF
--- a/samples/Contracts/contracts.opal
+++ b/samples/Contracts/contracts.opal
@@ -1,63 +1,57 @@
-§MODULE[id=m001][name=Contracts]
+§M[m001:Contracts]
 
-§FUNC[id=f001][name=Main][visibility=public]
-  §OUT[type=VOID]
-  §EFFECTS[io=console_write]
-  §BODY
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"=== OPAL Contracts Demo ==="
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:""
-    §END_CALL
+§F[f001:Main:pub]
+  §O[void]
+  §E[cw]
+  §C[Console.WriteLine]
+    §A "=== OPAL Contracts Demo ==="
+  §/C
+  §C[Console.WriteLine]
+    §A ""
+  §/C
 
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"Testing Square(5) - has REQUIRES x >= 0 and ENSURES result >= 0"
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"  If precondition fails, throws ArgumentException"
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"  If postcondition fails, throws InvalidOperationException"
-    §END_CALL
+  §C[Console.WriteLine]
+    §A "Testing Square(5) - has REQUIRES x >= 0 and ENSURES result >= 0"
+  §/C
+  §C[Console.WriteLine]
+    §A "  If precondition fails, throws ArgumentException"
+  §/C
+  §C[Console.WriteLine]
+    §A "  If postcondition fails, throws InvalidOperationException"
+  §/C
 
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:""
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"Testing Divide(10, 2) - has REQUIRES b != 0 with custom message"
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"  Custom message: divisor must not be zero"
-    §END_CALL
+  §C[Console.WriteLine]
+    §A ""
+  §/C
+  §C[Console.WriteLine]
+    §A "Testing Divide(10, 2) - has REQUIRES b != 0 with custom message"
+  §/C
+  §C[Console.WriteLine]
+    §A "  Custom message: divisor must not be zero"
+  §/C
 
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:""
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"Contracts are enforced at runtime with clear error messages."
-    §END_CALL
-  §END_BODY
-§END_FUNC[id=f001]
+  §C[Console.WriteLine]
+    §A ""
+  §/C
+  §C[Console.WriteLine]
+    §A "Contracts are enforced at runtime with clear error messages."
+  §/C
+§/F[f001]
 
-§FUNC[id=f002][name=Square][visibility=public]
-  §IN[name=x][type=INT]
-  §OUT[type=INT]
-  §REQUIRES §OP[kind=gte] §REF[name=x] INT:0
-  §ENSURES §OP[kind=gte] §REF[name=result] INT:0
-  §BODY
-    §RETURN §OP[kind=mul] §REF[name=x] §REF[name=x]
-  §END_BODY
-§END_FUNC[id=f002]
+§F[f002:Square:pub]
+  §I[i32:x]
+  §O[i32]
+  §Q §OP[kind=gte] §REF[name=x] 0
+  §S §OP[kind=gte] §REF[name=result] 0
+  §R §OP[kind=mul] §REF[name=x] §REF[name=x]
+§/F[f002]
 
-§FUNC[id=f003][name=Divide][visibility=public]
-  §IN[name=a][type=INT]
-  §IN[name=b][type=INT]
-  §OUT[type=INT]
-  §REQUIRES[message="divisor must not be zero"] §OP[kind=neq] §REF[name=b] INT:0
-  §BODY
-    §RETURN §OP[kind=div] §REF[name=a] §REF[name=b]
-  §END_BODY
-§END_FUNC[id=f003]
+§F[f003:Divide:pub]
+  §I[i32:a]
+  §I[i32:b]
+  §O[i32]
+  §Q[message="divisor must not be zero"] §OP[kind=neq] §REF[name=b] 0
+  §R §OP[kind=div] §REF[name=a] §REF[name=b]
+§/F[f003]
 
-§END_MODULE[id=m001]
+§/M[m001]

--- a/samples/FizzBuzz/FizzBuzz.csproj
+++ b/samples/FizzBuzz/FizzBuzz.csproj
@@ -8,4 +8,8 @@
     <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="../../src/Opal.Runtime/Opal.Runtime.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/samples/FizzBuzz/fizzbuzz.g.cs
+++ b/samples/FizzBuzz/fizzbuzz.g.cs
@@ -4,6 +4,7 @@
 // </auto-generated>
 
 using System;
+using Opal.Runtime;
 
 namespace FizzBuzz
 {

--- a/samples/FizzBuzz/fizzbuzz.opal
+++ b/samples/FizzBuzz/fizzbuzz.opal
@@ -1,27 +1,25 @@
-§MODULE[id=m001][name=FizzBuzz]
-§FUNC[id=f001][name=Main][visibility=public]
-  §OUT[type=VOID]
-  §EFFECTS[io=console_write]
-  §BODY
-    §FOR[id=for1][var=i][from=1][to=100][step=1]
-      §IF[id=if1] §OP[kind=EQ] §OP[kind=MOD] §REF[name=i] INT:15 INT:0
-        §CALL[target=Console.WriteLine][fallible=false]
-          §ARG STR:"FizzBuzz"
-        §END_CALL
-      §ELSEIF §OP[kind=EQ] §OP[kind=MOD] §REF[name=i] INT:3 INT:0
-        §CALL[target=Console.WriteLine][fallible=false]
-          §ARG STR:"Fizz"
-        §END_CALL
-      §ELSEIF §OP[kind=EQ] §OP[kind=MOD] §REF[name=i] INT:5 INT:0
-        §CALL[target=Console.WriteLine][fallible=false]
-          §ARG STR:"Buzz"
-        §END_CALL
-      §ELSE
-        §CALL[target=Console.WriteLine][fallible=false]
-          §ARG §REF[name=i]
-        §END_CALL
-      §END_IF[id=if1]
-    §END_FOR[id=for1]
-  §END_BODY
-§END_FUNC[id=f001]
-§END_MODULE[id=m001]
+§M[m001:FizzBuzz]
+§F[f001:Main:pub]
+  §O[void]
+  §E[cw]
+  §L[for1:i:1:100:1]
+    §IF[if1] §OP[kind=EQ] §OP[kind=MOD] §REF[name=i] 15 0
+      §C[Console.WriteLine]
+        §A "FizzBuzz"
+      §/C
+    §ELSEIF §OP[kind=EQ] §OP[kind=MOD] §REF[name=i] 3 0
+      §C[Console.WriteLine]
+        §A "Fizz"
+      §/C
+    §ELSEIF §OP[kind=EQ] §OP[kind=MOD] §REF[name=i] 5 0
+      §C[Console.WriteLine]
+        §A "Buzz"
+      §/C
+    §ELSE
+      §C[Console.WriteLine]
+        §A §REF[name=i]
+      §/C
+    §/I[if1]
+  §/L[for1]
+§/F[f001]
+§/M[m001]

--- a/samples/HelloWorld/HelloWorld.csproj
+++ b/samples/HelloWorld/HelloWorld.csproj
@@ -8,4 +8,8 @@
     <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="../../src/Opal.Runtime/Opal.Runtime.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/samples/HelloWorld/hello.g.cs
+++ b/samples/HelloWorld/hello.g.cs
@@ -4,6 +4,7 @@
 // </auto-generated>
 
 using System;
+using Opal.Runtime;
 
 namespace Hello
 {

--- a/samples/HelloWorld/hello.opal
+++ b/samples/HelloWorld/hello.opal
@@ -1,11 +1,9 @@
-§MODULE[id=m001][name=Hello]
-§FUNC[id=f001][name=Main][visibility=public]
-  §OUT[type=VOID]
-  §EFFECTS[io=console_write]
-  §BODY
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"Hello from OPAL!"
-    §END_CALL
-  §END_BODY
-§END_FUNC[id=f001]
-§END_MODULE[id=m001]
+§M[m001:Hello]
+§F[f001:Main:pub]
+  §O[void]
+  §E[cw]
+  §C[Console.WriteLine]
+    §A "Hello from OPAL!"
+  §/C
+§/F[f001]
+§/M[m001]

--- a/samples/SdkSample/program.opal
+++ b/samples/SdkSample/program.opal
@@ -1,28 +1,26 @@
-§MODULE[id=m001][name=SdkSample]
+§M[m001:SdkSample]
 
-§FUNC[id=f001][name=Main][visibility=public]
-  §OUT[type=VOID]
-  §EFFECTS[io=console_write]
-  §BODY
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"=== OPAL SDK Sample ==="
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:""
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"This project was built using the OPAL MSBuild SDK!"
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"The .opal files are automatically compiled to C# during build."
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:""
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"Build command: dotnet build SdkSample.csproj"
-    §END_CALL
-  §END_BODY
-§END_FUNC[id=f001]
+§F[f001:Main:pub]
+  §O[void]
+  §E[cw]
+  §C[Console.WriteLine]
+    §A "=== OPAL SDK Sample ==="
+  §/C
+  §C[Console.WriteLine]
+    §A ""
+  §/C
+  §C[Console.WriteLine]
+    §A "This project was built using the OPAL MSBuild SDK!"
+  §/C
+  §C[Console.WriteLine]
+    §A "The .opal files are automatically compiled to C# during build."
+  §/C
+  §C[Console.WriteLine]
+    §A ""
+  §/C
+  §C[Console.WriteLine]
+    §A "Build command: dotnet build SdkSample.csproj"
+  §/C
+§/F[f001]
 
-§END_MODULE[id=m001]
+§/M[m001]

--- a/samples/TypeSystem/typesystem.opal
+++ b/samples/TypeSystem/typesystem.opal
@@ -1,89 +1,79 @@
-§MODULE[id=m001][name=TypeSystem]
+§M[m001:TypeSystem]
 
-§FUNC[id=f001][name=Main][visibility=public]
-  §OUT[type=VOID]
-  §EFFECTS[io=console_write]
-  §BODY
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"=== OPAL Type System Demo ==="
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:""
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"Testing Option.Some(42)..."
-    §END_CALL
-    §CALL[target=TestSome][fallible=false]
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:""
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"Testing Option.None()..."
-    §END_CALL
-    §CALL[target=TestNone][fallible=false]
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:""
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"Testing Result.Ok(100)..."
-    §END_CALL
-    §CALL[target=TestOk][fallible=false]
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:""
-    §END_CALL
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"Testing Result.Err(error)..."
-    §END_CALL
-    §CALL[target=TestErr][fallible=false]
-    §END_CALL
-  §END_BODY
-§END_FUNC[id=f001]
+§F[f001:Main:pub]
+  §O[void]
+  §E[cw]
+  §C[Console.WriteLine]
+    §A "=== OPAL Type System Demo ==="
+  §/C
+  §C[Console.WriteLine]
+    §A ""
+  §/C
+  §C[Console.WriteLine]
+    §A "Testing Option.Some(42)..."
+  §/C
+  §C[TestSome]
+  §/C
+  §C[Console.WriteLine]
+    §A ""
+  §/C
+  §C[Console.WriteLine]
+    §A "Testing Option.None()..."
+  §/C
+  §C[TestNone]
+  §/C
+  §C[Console.WriteLine]
+    §A ""
+  §/C
+  §C[Console.WriteLine]
+    §A "Testing Result.Ok(100)..."
+  §/C
+  §C[TestOk]
+  §/C
+  §C[Console.WriteLine]
+    §A ""
+  §/C
+  §C[Console.WriteLine]
+    §A "Testing Result.Err(error)..."
+  §/C
+  §C[TestErr]
+  §/C
+§/F[f001]
 
-§FUNC[id=f002][name=TestSome][visibility=private]
-  §OUT[type=VOID]
-  §EFFECTS[io=console_write]
-  §BODY
-    §BIND[name=opt] §SOME INT:42
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"  Created Some(42)"
-    §END_CALL
-  §END_BODY
-§END_FUNC[id=f002]
+§F[f002:TestSome:pri]
+  §O[void]
+  §E[cw]
+  §B[opt] §SOME 42
+  §C[Console.WriteLine]
+    §A "  Created Some(42)"
+  §/C
+§/F[f002]
 
-§FUNC[id=f003][name=TestNone][visibility=private]
-  §OUT[type=VOID]
-  §EFFECTS[io=console_write]
-  §BODY
-    §BIND[name=opt] §NONE[type=INT]
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"  Created None"
-    §END_CALL
-  §END_BODY
-§END_FUNC[id=f003]
+§F[f003:TestNone:pri]
+  §O[void]
+  §E[cw]
+  §B[opt] §NONE[type=INT]
+  §C[Console.WriteLine]
+    §A "  Created None"
+  §/C
+§/F[f003]
 
-§FUNC[id=f004][name=TestOk][visibility=private]
-  §OUT[type=VOID]
-  §EFFECTS[io=console_write]
-  §BODY
-    §BIND[name=result] §OK INT:100
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"  Created Ok(100)"
-    §END_CALL
-  §END_BODY
-§END_FUNC[id=f004]
+§F[f004:TestOk:pri]
+  §O[void]
+  §E[cw]
+  §B[result] §OK 100
+  §C[Console.WriteLine]
+    §A "  Created Ok(100)"
+  §/C
+§/F[f004]
 
-§FUNC[id=f005][name=TestErr][visibility=private]
-  §OUT[type=VOID]
-  §EFFECTS[io=console_write]
-  §BODY
-    §BIND[name=result] §ERR STR:"Something went wrong"
-    §CALL[target=Console.WriteLine][fallible=false]
-      §ARG STR:"  Created Err(Something went wrong)"
-    §END_CALL
-  §END_BODY
-§END_FUNC[id=f005]
+§F[f005:TestErr:pri]
+  §O[void]
+  §E[cw]
+  §B[result] §ERR "Something went wrong"
+  §C[Console.WriteLine]
+    §A "  Created Err(Something went wrong)"
+  §/C
+§/F[f005]
 
-§END_MODULE[id=m001]
+§/M[m001]

--- a/src/Opal.Compiler/Parsing/Token.cs
+++ b/src/Opal.Compiler/Parsing/Token.cs
@@ -11,6 +11,13 @@ public enum TokenKind
     CloseBracket,       // ]
     Equals,             // =
 
+    // v2 syntax tokens
+    Colon,              // :
+    Exclamation,        // !
+    Tilde,              // ~
+    Hash,               // #
+    Question,           // ?
+
     // Keywords (recognized after §)
     Module,
     EndModule,

--- a/src/Opal.Compiler/Parsing/V2AttributeHelper.cs
+++ b/src/Opal.Compiler/Parsing/V2AttributeHelper.cs
@@ -1,0 +1,391 @@
+using Opal.Compiler.Ast;
+
+namespace Opal.Compiler.Parsing;
+
+/// <summary>
+/// Helper for interpreting v2 positional attributes in context.
+/// Maps positional attributes to their v1 named equivalents.
+/// </summary>
+public static class V2AttributeHelper
+{
+    /// <summary>
+    /// Interprets attributes for MODULE/§M: [id:name]
+    /// </summary>
+    public static (string Id, string Name) InterpretModuleAttributes(AttributeCollection attrs)
+    {
+        // Check for v1 format first
+        var v1Id = attrs["id"];
+        if (!string.IsNullOrEmpty(v1Id))
+        {
+            return (v1Id, attrs["name"] ?? "");
+        }
+
+        // v2 positional format: [id:name]
+        return (attrs["_pos0"] ?? "", attrs["_pos1"] ?? "");
+    }
+
+    /// <summary>
+    /// Interprets attributes for END_MODULE/§/M: [id]
+    /// </summary>
+    public static string InterpretEndModuleAttributes(AttributeCollection attrs)
+    {
+        // Check for v1 format first
+        var v1Id = attrs["id"];
+        if (!string.IsNullOrEmpty(v1Id))
+        {
+            return v1Id;
+        }
+
+        // v2 positional format: [id]
+        return attrs["_pos0"] ?? "";
+    }
+
+    /// <summary>
+    /// Interprets attributes for FUNC/§F: [id:name:visibility]
+    /// </summary>
+    public static (string Id, string Name, string Visibility) InterpretFuncAttributes(AttributeCollection attrs)
+    {
+        // Check for v1 format first
+        var v1Id = attrs["id"];
+        if (!string.IsNullOrEmpty(v1Id))
+        {
+            return (v1Id, attrs["name"] ?? "", attrs["visibility"] ?? "private");
+        }
+
+        // v2 positional format: [id:name:visibility] or [id:name] (private default)
+        var visibility = attrs["_pos2"] ?? "";
+        if (string.IsNullOrEmpty(visibility))
+        {
+            visibility = "private";
+        }
+        else if (visibility == "pub")
+        {
+            visibility = "public";
+        }
+        else if (visibility == "pri")
+        {
+            visibility = "private";
+        }
+        else if (visibility == "int")
+        {
+            visibility = "internal";
+        }
+
+        return (attrs["_pos0"] ?? "", attrs["_pos1"] ?? "", visibility);
+    }
+
+    /// <summary>
+    /// Interprets attributes for END_FUNC/§/F: [id]
+    /// </summary>
+    public static string InterpretEndFuncAttributes(AttributeCollection attrs)
+    {
+        // Check for v1 format first
+        var v1Id = attrs["id"];
+        if (!string.IsNullOrEmpty(v1Id))
+        {
+            return v1Id;
+        }
+
+        // v2 positional format: [id]
+        return attrs["_pos0"] ?? "";
+    }
+
+    /// <summary>
+    /// Interprets attributes for IN/§I: [type:name:semantic]
+    /// </summary>
+    public static (string Type, string Name, string? Semantic) InterpretInputAttributes(AttributeCollection attrs)
+    {
+        // Check for v1 format first
+        var v1Type = attrs["type"];
+        if (!string.IsNullOrEmpty(v1Type))
+        {
+            return (v1Type, attrs["name"] ?? "", attrs["semantic"]);
+        }
+
+        // v2 positional format: [type:name:semantic] or [type:name]
+        var semantic = attrs["_pos2"];
+        if (!string.IsNullOrEmpty(semantic) && semantic.StartsWith('#'))
+        {
+            semantic = ExpandSemanticShortcode(semantic);
+        }
+
+        var compactType = attrs["_pos0"] ?? "";
+        return (ExpandType(compactType), attrs["_pos1"] ?? "", semantic);
+    }
+
+    /// <summary>
+    /// Interprets attributes for OUT/§O: [type]
+    /// </summary>
+    public static string InterpretOutputAttributes(AttributeCollection attrs)
+    {
+        // Check for v1 format first
+        var v1Type = attrs["type"];
+        if (!string.IsNullOrEmpty(v1Type))
+        {
+            return v1Type;
+        }
+
+        // v2 positional format: [type]
+        var compactType = attrs["_pos0"] ?? "";
+        return ExpandType(compactType);
+    }
+
+    /// <summary>
+    /// Interprets attributes for CALL/§C: [target] or [target!]
+    /// </summary>
+    public static (string Target, bool Fallible) InterpretCallAttributes(AttributeCollection attrs)
+    {
+        // Check for v1 format first
+        var v1Target = attrs["target"];
+        if (!string.IsNullOrEmpty(v1Target))
+        {
+            var fallible = attrs["fallible"]?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
+            return (v1Target, fallible);
+        }
+
+        // v2 positional format: [target] or [target!]
+        var target = attrs["_pos0"] ?? "";
+        var isFallible = target.EndsWith('!');
+        if (isFallible)
+        {
+            target = target[..^1]; // Remove the ! suffix
+        }
+
+        return (target, isFallible);
+    }
+
+    /// <summary>
+    /// Interprets attributes for BIND/§B: [name] or [~name]
+    /// </summary>
+    public static (string Name, bool Mutable) InterpretBindAttributes(AttributeCollection attrs)
+    {
+        // Check for v1 format first
+        var v1Name = attrs["name"];
+        if (!string.IsNullOrEmpty(v1Name))
+        {
+            var mutable = attrs["mutable"]?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
+            return (v1Name, mutable);
+        }
+
+        // v2 positional format: [name] or [~name]
+        var name = attrs["_pos0"] ?? "";
+        var isMutable = name.StartsWith('~');
+        if (isMutable)
+        {
+            name = name[1..]; // Remove the ~ prefix
+        }
+
+        return (name, isMutable);
+    }
+
+    /// <summary>
+    /// Interprets attributes for FOR/§L (loop): [id:var:from:to:step]
+    /// </summary>
+    public static (string Id, string Var, string From, string To, string Step) InterpretForAttributes(AttributeCollection attrs)
+    {
+        // Check for v1 format first
+        var v1Id = attrs["id"];
+        if (!string.IsNullOrEmpty(v1Id))
+        {
+            return (v1Id, attrs["var"] ?? "", attrs["from"] ?? "", attrs["to"] ?? "", attrs["step"] ?? "1");
+        }
+
+        // v2 positional format: [id:var:from:to:step] or [id:var:from:to]
+        var step = attrs["_pos4"] ?? "";
+        if (string.IsNullOrEmpty(step))
+        {
+            step = "1";
+        }
+
+        return (attrs["_pos0"] ?? "", attrs["_pos1"] ?? "", attrs["_pos2"] ?? "", attrs["_pos3"] ?? "", step);
+    }
+
+    /// <summary>
+    /// Interprets attributes for IF/§I: [id]
+    /// </summary>
+    public static string InterpretIfAttributes(AttributeCollection attrs)
+    {
+        // Check for v1 format first
+        var v1Id = attrs["id"];
+        if (!string.IsNullOrEmpty(v1Id))
+        {
+            return v1Id;
+        }
+
+        // v2 positional format: [id]
+        return attrs["_pos0"] ?? "";
+    }
+
+    /// <summary>
+    /// Interprets attributes for REQUIRES/§Q: [message]
+    /// </summary>
+    public static string? InterpretRequiresAttributes(AttributeCollection attrs)
+    {
+        // Check for v1 format first
+        var v1Msg = attrs["message"];
+        if (!string.IsNullOrEmpty(v1Msg))
+        {
+            return v1Msg;
+        }
+
+        // v2 doesn't have positional attributes for requires, just the expression
+        return null;
+    }
+
+    /// <summary>
+    /// Interprets attributes for EFFECTS/§E: effect codes
+    /// </summary>
+    public static Dictionary<string, string> InterpretEffectsAttributes(AttributeCollection attrs)
+    {
+        var effects = new Dictionary<string, string>();
+
+        // Check for v1 format first
+        var v1Io = attrs["io"];
+        if (!string.IsNullOrEmpty(v1Io))
+        {
+            effects["io"] = v1Io;
+            return effects;
+        }
+
+        // v2 format: effect codes like cw, cr, fw, fr
+        for (int i = 0; ; i++)
+        {
+            var code = attrs[$"_pos{i}"];
+            if (string.IsNullOrEmpty(code)) break;
+
+            var (category, value) = ExpandEffectCode(code);
+            if (effects.ContainsKey(category))
+            {
+                // Combine multiple effects in same category
+                effects[category] = effects[category] + "," + value;
+            }
+            else
+            {
+                effects[category] = value;
+            }
+        }
+
+        return effects;
+    }
+
+    /// <summary>
+    /// Expands v2 compact type to v1 full type name.
+    /// </summary>
+    public static string ExpandType(string compactType)
+    {
+        if (string.IsNullOrEmpty(compactType))
+            return compactType;
+
+        // Handle Option type: ?T -> OPTION[inner=T]
+        if (compactType.StartsWith('?'))
+        {
+            var inner = ExpandType(compactType[1..]);
+            return $"OPTION[inner={inner}]";
+        }
+
+        // Handle Result type: T!E -> RESULT[ok=T][err=E]
+        if (compactType.Contains('!'))
+        {
+            var parts = compactType.Split('!', 2);
+            var ok = ExpandType(parts[0]);
+            var err = parts.Length > 1 ? ExpandType(parts[1]) : "STRING";
+            return $"RESULT[ok={ok}][err={err}]";
+        }
+
+        // Primitive type mappings
+        return compactType.ToLowerInvariant() switch
+        {
+            "i8" => "INT[bits=8][signed=true]",
+            "i16" => "INT[bits=16][signed=true]",
+            "i32" or "int" => "INT",
+            "i64" => "INT[bits=64][signed=true]",
+            "u8" => "INT[bits=8][signed=false]",
+            "u16" => "INT[bits=16][signed=false]",
+            "u32" => "INT[bits=32][signed=false]",
+            "u64" => "INT[bits=64][signed=false]",
+            "f32" => "FLOAT[bits=32]",
+            "f64" or "float" => "FLOAT",
+            "str" or "string" => "STRING",
+            "bool" => "BOOL",
+            "void" => "VOID",
+            "never" => "NEVER",
+            "char" => "CHAR",
+            _ => compactType.ToUpperInvariant() // Pass through unknown types
+        };
+    }
+
+    /// <summary>
+    /// Expands v2 effect shortcode to category and value.
+    /// </summary>
+    public static (string Category, string Value) ExpandEffectCode(string code)
+    {
+        return code.ToLowerInvariant() switch
+        {
+            // Console I/O
+            "cw" => ("io", "console_write"),
+            "cr" => ("io", "console_read"),
+
+            // File I/O
+            "fw" => ("io", "file_write"),
+            "fr" => ("io", "file_read"),
+            "fd" => ("io", "file_delete"),
+
+            // Network
+            "net" => ("io", "network"),
+            "http" => ("io", "http"),
+
+            // Database
+            "db" => ("io", "database"),
+            "dbr" => ("io", "database_read"),
+            "dbw" => ("io", "database_write"),
+
+            // System
+            "env" => ("io", "environment"),
+            "proc" => ("io", "process"),
+
+            // Memory/Resources
+            "alloc" => ("memory", "allocation"),
+
+            // Non-determinism
+            "time" => ("nondeterminism", "time"),
+            "rand" => ("nondeterminism", "random"),
+
+            // Default: treat as io with the code as value
+            _ => ("io", code)
+        };
+    }
+
+    /// <summary>
+    /// Expands v2 semantic shortcode to full description.
+    /// </summary>
+    public static string? ExpandSemanticShortcode(string? shortcode)
+    {
+        if (string.IsNullOrEmpty(shortcode))
+            return null;
+
+        if (!shortcode.StartsWith('#'))
+            return shortcode;
+
+        // Handle quoted custom semantics: #"custom description"
+        if (shortcode.StartsWith("#\"") && shortcode.EndsWith("\""))
+        {
+            return shortcode[2..^1];
+        }
+
+        // Predefined shortcodes
+        return shortcode.ToLowerInvariant() switch
+        {
+            "#input" => "user input",
+            "#dbid" => "database identifier",
+            "#errmsg" => "error message",
+            "#counter" => "loop counter",
+            "#retval" => "return value",
+            "#index" => "array index",
+            "#count" => "count value",
+            "#name" => "name identifier",
+            "#path" => "file path",
+            "#url" => "URL",
+            _ => shortcode[1..] // Remove # and use as-is
+        };
+    }
+}

--- a/tests/Opal.Compiler.Tests/V2SyntaxTests.cs
+++ b/tests/Opal.Compiler.Tests/V2SyntaxTests.cs
@@ -1,0 +1,697 @@
+using Opal.Compiler.Ast;
+using Opal.Compiler.Diagnostics;
+using Opal.Compiler.Parsing;
+using Xunit;
+
+namespace Opal.Compiler.Tests;
+
+public class V2SyntaxTests
+{
+    private static List<Token> Tokenize(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, diagnostics);
+        return lexer.TokenizeAll();
+    }
+
+    #region Single-Letter Keywords
+
+    [Fact]
+    public void Lexer_RecognizesSingleLetterModule()
+    {
+        var tokens = Tokenize("§M");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Module, tokens[0].Kind);
+        Assert.Equal(TokenKind.Eof, tokens[1].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesSingleLetterFunc()
+    {
+        var tokens = Tokenize("§F");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Func, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesSingleLetterCall()
+    {
+        var tokens = Tokenize("§C");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Call, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesSingleLetterBind()
+    {
+        var tokens = Tokenize("§B");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Bind, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesSingleLetterReturn()
+    {
+        var tokens = Tokenize("§R");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Return, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesSingleLetterInput()
+    {
+        var tokens = Tokenize("§I");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.In, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesSingleLetterOutput()
+    {
+        var tokens = Tokenize("§O");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Out, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesSingleLetterArg()
+    {
+        var tokens = Tokenize("§A");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Arg, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesSingleLetterEffects()
+    {
+        var tokens = Tokenize("§E");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Effects, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesSingleLetterLoop()
+    {
+        var tokens = Tokenize("§L");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.For, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesSingleLetterMatch()
+    {
+        var tokens = Tokenize("§W");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Match, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesSingleLetterCase()
+    {
+        var tokens = Tokenize("§K");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Case, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesSingleLetterRequires()
+    {
+        var tokens = Tokenize("§Q");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Requires, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesSingleLetterEnsures()
+    {
+        var tokens = Tokenize("§S");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Ensures, tokens[0].Kind);
+    }
+
+    #endregion
+
+    #region Closing Tags
+
+    [Fact]
+    public void Lexer_RecognizesClosingModule()
+    {
+        var tokens = Tokenize("§/M");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.EndModule, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesClosingFunc()
+    {
+        var tokens = Tokenize("§/F");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.EndFunc, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesClosingCall()
+    {
+        var tokens = Tokenize("§/C");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.EndCall, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesClosingIf()
+    {
+        var tokens = Tokenize("§/I");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.EndIf, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesClosingLoop()
+    {
+        var tokens = Tokenize("§/L");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.EndFor, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesClosingMatch()
+    {
+        var tokens = Tokenize("§/W");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.EndMatch, tokens[0].Kind);
+    }
+
+    #endregion
+
+    #region Mixed V1 and V2
+
+    [Fact]
+    public void Lexer_HandlesMixedV1AndV2Keywords()
+    {
+        var tokens = Tokenize("§M §MODULE §F §FUNC");
+
+        Assert.Equal(5, tokens.Count);
+        Assert.Equal(TokenKind.Module, tokens[0].Kind);
+        Assert.Equal(TokenKind.Module, tokens[1].Kind);
+        Assert.Equal(TokenKind.Func, tokens[2].Kind);
+        Assert.Equal(TokenKind.Func, tokens[3].Kind);
+    }
+
+    [Fact]
+    public void Lexer_HandlesMixedClosingTags()
+    {
+        var tokens = Tokenize("§/F §END_FUNC");
+
+        Assert.Equal(3, tokens.Count);
+        Assert.Equal(TokenKind.EndFunc, tokens[0].Kind);
+        Assert.Equal(TokenKind.EndFunc, tokens[1].Kind);
+    }
+
+    #endregion
+
+    #region V2 Full Program
+
+    [Fact]
+    public void Lexer_TokenizesV2Program()
+    {
+        var source = @"
+§M[m001:Hello]
+§F[f001:Main:pub]
+  §O[void]
+  §E[cw]
+  §C[Console.WriteLine]
+    §A ""Hello from OPAL v2!""
+  §/C
+§/F[f001]
+§/M[m001]
+";
+        var tokens = Tokenize(source);
+
+        // Verify key tokens are present
+        Assert.Contains(tokens, t => t.Kind == TokenKind.Module);
+        Assert.Contains(tokens, t => t.Kind == TokenKind.Func);
+        Assert.Contains(tokens, t => t.Kind == TokenKind.Out);
+        Assert.Contains(tokens, t => t.Kind == TokenKind.Effects);
+        Assert.Contains(tokens, t => t.Kind == TokenKind.Call);
+        Assert.Contains(tokens, t => t.Kind == TokenKind.Arg);
+        Assert.Contains(tokens, t => t.Kind == TokenKind.EndCall);
+        Assert.Contains(tokens, t => t.Kind == TokenKind.EndFunc);
+        Assert.Contains(tokens, t => t.Kind == TokenKind.EndModule);
+    }
+
+    #endregion
+
+    #region V2 Tokens
+
+    [Fact]
+    public void Lexer_RecognizesColon()
+    {
+        var tokens = Tokenize(":");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Colon, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesExclamation()
+    {
+        var tokens = Tokenize("!");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Exclamation, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesTilde()
+    {
+        var tokens = Tokenize("~");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Tilde, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesHash()
+    {
+        var tokens = Tokenize("#");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Hash, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesQuestion()
+    {
+        var tokens = Tokenize("?");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Question, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_TokenizesPositionalAttribute()
+    {
+        var tokens = Tokenize("[f001:Main:pub]");
+
+        // Should be: [ f001 : Main : pub ]
+        Assert.Equal(TokenKind.OpenBracket, tokens[0].Kind);
+        Assert.Equal(TokenKind.Identifier, tokens[1].Kind);
+        Assert.Equal("f001", tokens[1].Text);
+        Assert.Equal(TokenKind.Colon, tokens[2].Kind);
+        Assert.Equal(TokenKind.Identifier, tokens[3].Kind);
+        Assert.Equal("Main", tokens[3].Text);
+        Assert.Equal(TokenKind.Colon, tokens[4].Kind);
+        Assert.Equal(TokenKind.Identifier, tokens[5].Kind);
+        Assert.Equal("pub", tokens[5].Text);
+        Assert.Equal(TokenKind.CloseBracket, tokens[6].Kind);
+    }
+
+    [Fact]
+    public void Lexer_TokenizesFallibleCall()
+    {
+        var tokens = Tokenize("[RiskyOp!]");
+
+        Assert.Equal(TokenKind.OpenBracket, tokens[0].Kind);
+        Assert.Equal(TokenKind.Identifier, tokens[1].Kind);
+        Assert.Equal("RiskyOp", tokens[1].Text);
+        Assert.Equal(TokenKind.Exclamation, tokens[2].Kind);
+        Assert.Equal(TokenKind.CloseBracket, tokens[3].Kind);
+    }
+
+    [Fact]
+    public void Lexer_TokenizesMutableBind()
+    {
+        var tokens = Tokenize("[~myVar]");
+
+        Assert.Equal(TokenKind.OpenBracket, tokens[0].Kind);
+        Assert.Equal(TokenKind.Tilde, tokens[1].Kind);
+        Assert.Equal(TokenKind.Identifier, tokens[2].Kind);
+        Assert.Equal("myVar", tokens[2].Text);
+        Assert.Equal(TokenKind.CloseBracket, tokens[3].Kind);
+    }
+
+    [Fact]
+    public void Lexer_TokenizesOptionType()
+    {
+        var tokens = Tokenize("[?i32]");
+
+        Assert.Equal(TokenKind.OpenBracket, tokens[0].Kind);
+        Assert.Equal(TokenKind.Question, tokens[1].Kind);
+        Assert.Equal(TokenKind.Identifier, tokens[2].Kind);
+        Assert.Equal("i32", tokens[2].Text);
+        Assert.Equal(TokenKind.CloseBracket, tokens[3].Kind);
+    }
+
+    [Fact]
+    public void Lexer_TokenizesResultType()
+    {
+        var tokens = Tokenize("[i32!str]");
+
+        Assert.Equal(TokenKind.OpenBracket, tokens[0].Kind);
+        Assert.Equal(TokenKind.Identifier, tokens[1].Kind);
+        Assert.Equal("i32", tokens[1].Text);
+        Assert.Equal(TokenKind.Exclamation, tokens[2].Kind);
+        Assert.Equal(TokenKind.Identifier, tokens[3].Kind);
+        Assert.Equal("str", tokens[3].Text);
+        Assert.Equal(TokenKind.CloseBracket, tokens[4].Kind);
+    }
+
+    #endregion
+
+    #region V2 Parser Integration
+
+    [Fact]
+    public void Parser_ParsesV2ModuleWithPositionalAttributes()
+    {
+        var diagnostics = new DiagnosticBag();
+        var source = "§M[m001:Hello] §/M[m001]";
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        Assert.Equal("m001", module.Id);
+        Assert.Equal("Hello", module.Name);
+    }
+
+    [Fact]
+    public void Parser_ParsesV2FunctionWithVisibility()
+    {
+        var diagnostics = new DiagnosticBag();
+        var source = @"
+§M[m001:Test]
+§F[f001:MyFunc:pub]
+  §O[void]
+  §BODY
+  §END_BODY
+§/F[f001]
+§/M[m001]";
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        Assert.Single(module.Functions);
+        Assert.Equal("MyFunc", module.Functions[0].Name);
+        Assert.Equal(Ast.Visibility.Public, module.Functions[0].Visibility);
+    }
+
+    [Fact]
+    public void Parser_ParsesV2OutputType()
+    {
+        var diagnostics = new DiagnosticBag();
+        var source = @"
+§M[m001:Test]
+§F[f001:Add:pub]
+  §O[i32]
+  §BODY
+    §RETURN INT:0
+  §END_BODY
+§/F[f001]
+§/M[m001]";
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        Assert.Equal("INT", module.Functions[0].Output?.TypeName);
+    }
+
+    [Fact]
+    public void Parser_ParsesV2InputParameters()
+    {
+        var diagnostics = new DiagnosticBag();
+        var source = @"
+§M[m001:Test]
+§F[f001:Add:pub]
+  §I[i32:a]
+  §I[i32:b]
+  §O[i32]
+  §BODY
+    §RETURN INT:0
+  §END_BODY
+§/F[f001]
+§/M[m001]";
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        Assert.Equal(2, module.Functions[0].Parameters.Count);
+        Assert.Equal("a", module.Functions[0].Parameters[0].Name);
+        Assert.Equal("INT", module.Functions[0].Parameters[0].TypeName);
+    }
+
+    [Fact]
+    public void Parser_ParsesV2EffectShortcodes()
+    {
+        var diagnostics = new DiagnosticBag();
+        var source = @"
+§M[m001:Test]
+§F[f001:Print:pub]
+  §O[void]
+  §E[cw]
+  §BODY
+  §END_BODY
+§/F[f001]
+§/M[m001]";
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        Assert.NotNull(module.Functions[0].Effects);
+        Assert.Equal("console_write", module.Functions[0].Effects?.Effects["io"]);
+    }
+
+    [Fact]
+    public void Parser_ParsesV2ImplicitBody()
+    {
+        var diagnostics = new DiagnosticBag();
+        // No §BODY/§END_BODY markers - implicit body
+        var source = @"
+§M[m001:Test]
+§F[f001:Print:pub]
+  §O[void]
+  §E[cw]
+  §C[Console.WriteLine]
+    §A ""Hello v2!""
+  §/C
+§/F[f001]
+§/M[m001]";
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        Assert.Single(module.Functions);
+        Assert.Single(module.Functions[0].Body);
+    }
+
+    [Fact]
+    public void Parser_ParsesV2ImplicitBodyWithMultipleStatements()
+    {
+        var diagnostics = new DiagnosticBag();
+        var source = @"
+§M[m001:Test]
+§F[f001:Print:pub]
+  §O[void]
+  §E[cw]
+  §C[Console.WriteLine]
+    §A ""Line 1""
+  §/C
+  §C[Console.WriteLine]
+    §A ""Line 2""
+  §/C
+§/F[f001]
+§/M[m001]";
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        Assert.Equal(2, module.Functions[0].Body.Count);
+    }
+
+    #endregion
+
+    #region V2 Compact Types
+
+    [Fact]
+    public void V2AttributeHelper_ExpandsI32ToInt()
+    {
+        var result = V2AttributeHelper.ExpandType("i32");
+        Assert.Equal("INT", result);
+    }
+
+    [Fact]
+    public void V2AttributeHelper_ExpandsStrToString()
+    {
+        var result = V2AttributeHelper.ExpandType("str");
+        Assert.Equal("STRING", result);
+    }
+
+    [Fact]
+    public void V2AttributeHelper_ExpandsOptionType()
+    {
+        var result = V2AttributeHelper.ExpandType("?i32");
+        Assert.Equal("OPTION[inner=INT]", result);
+    }
+
+    [Fact]
+    public void V2AttributeHelper_ExpandsResultType()
+    {
+        var result = V2AttributeHelper.ExpandType("i32!str");
+        Assert.Equal("RESULT[ok=INT][err=STRING]", result);
+    }
+
+    [Fact]
+    public void V2AttributeHelper_ExpandsVoid()
+    {
+        var result = V2AttributeHelper.ExpandType("void");
+        Assert.Equal("VOID", result);
+    }
+
+    [Fact]
+    public void V2AttributeHelper_ExpandsBool()
+    {
+        var result = V2AttributeHelper.ExpandType("bool");
+        Assert.Equal("BOOL", result);
+    }
+
+    #endregion
+
+    #region V2 Bare Literals
+
+    [Fact]
+    public void Lexer_RecognizesBareInteger()
+    {
+        var tokens = Tokenize("42");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.IntLiteral, tokens[0].Kind);
+        Assert.Equal(42, tokens[0].Value);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesBareNegativeInteger()
+    {
+        var tokens = Tokenize("-42");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.IntLiteral, tokens[0].Kind);
+        Assert.Equal(-42, tokens[0].Value);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesBareFloat()
+    {
+        var tokens = Tokenize("3.14");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.FloatLiteral, tokens[0].Kind);
+        Assert.Equal(3.14, tokens[0].Value);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesBareString()
+    {
+        var tokens = Tokenize("\"hello\"");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.StrLiteral, tokens[0].Kind);
+        Assert.Equal("hello", tokens[0].Value);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesBareTrueLiteral()
+    {
+        var tokens = Tokenize("true");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.BoolLiteral, tokens[0].Kind);
+        Assert.Equal(true, tokens[0].Value);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesBareFalseLiteral()
+    {
+        var tokens = Tokenize("false");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.BoolLiteral, tokens[0].Kind);
+        Assert.Equal(false, tokens[0].Value);
+    }
+
+    #endregion
+
+    #region V2 Effect Shortcodes
+
+    [Fact]
+    public void V2AttributeHelper_ExpandsConsoleWriteEffect()
+    {
+        var (category, value) = V2AttributeHelper.ExpandEffectCode("cw");
+        Assert.Equal("io", category);
+        Assert.Equal("console_write", value);
+    }
+
+    [Fact]
+    public void V2AttributeHelper_ExpandsFileReadEffect()
+    {
+        var (category, value) = V2AttributeHelper.ExpandEffectCode("fr");
+        Assert.Equal("io", category);
+        Assert.Equal("file_read", value);
+    }
+
+    [Fact]
+    public void V2AttributeHelper_ExpandsNetworkEffect()
+    {
+        var (category, value) = V2AttributeHelper.ExpandEffectCode("net");
+        Assert.Equal("io", category);
+        Assert.Equal("network", value);
+    }
+
+    [Fact]
+    public void V2AttributeHelper_ExpandsRandomEffect()
+    {
+        var (category, value) = V2AttributeHelper.ExpandEffectCode("rand");
+        Assert.Equal("nondeterminism", category);
+        Assert.Equal("random", value);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Add compact v2 syntax to reduce token consumption by ~50%
- Single-letter keywords (§M, §F, §C, §B, §R, §I, §O, §A, §E, §L, §W, §K, §Q, §S)
- Compact closing tags (§/M, §/F, §/C, §/I, §/L, §/W)
- Positional attributes: `[id:name:visibility]` instead of `[id=x][name=y]`
- Implicit body: no `§BODY`/`§END_BODY` required
- Compact types: `i32`, `str`, `bool`, `?T` (Option), `T!E` (Result)
- Effect shortcodes: `cw`, `cr`, `fw`, `fr`, `net`, `db`, `rand`, `time`
- Bare literals: `42`, `"hello"`, `true` instead of `INT:42`, `STR:"hello"`
- Upgrade all sample files to v2 syntax
- Full backward compatibility with v1 syntax maintained

## Test plan

- [x] All 174 tests pass
- [x] HelloWorld sample compiles and runs
- [x] FizzBuzz sample compiles and runs
- [x] Contracts sample compiles and runs
- [x] TypeSystem sample compiles and runs
- [x] SdkSample builds with MSBuild SDK and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)