### PR TITLE
Remove LSP/IDE integration from roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,5 +198,4 @@ dotnet run --project samples/HelloWorld
 - [x] Type system (Option, Result)
 - [x] Contracts (requires, ensures)
 - [x] MSBuild SDK integration
-- [ ] LSP/IDE integration
 - [ ] Direct IL emission


### PR DESCRIPTION
## Summary

- Remove LSP/IDE integration task from README status section
- Not needed for an agent-first language where humans aren't the target audience

🤖 Generated with [Claude Code](https://claude.com/claude-code)