### PR TITLE
Add full C# language support across 10 phases

### DIFF
--- a/src/Opal.Compiler/Ast/ArrayNodes.cs
+++ b/src/Opal.Compiler/Ast/ArrayNodes.cs
@@ -1,0 +1,164 @@
+using Opal.Compiler.Parsing;
+
+namespace Opal.Compiler.Ast;
+
+/// <summary>
+/// Represents array creation.
+/// §ARR[arr1:i32:10]                         // int[] arr1 = new int[10];
+/// §ARR[arr2:i32] §A 1 §A 2 §A 3 §/ARR[arr2] // int[] arr2 = { 1, 2, 3 };
+/// </summary>
+public sealed class ArrayCreationNode : ExpressionNode
+{
+    /// <summary>
+    /// The unique ID for this array declaration.
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// The variable name for this array.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// The element type of the array.
+    /// </summary>
+    public string ElementType { get; }
+
+    /// <summary>
+    /// The size of the array (for sized arrays). Null if using initializer.
+    /// </summary>
+    public ExpressionNode? Size { get; }
+
+    /// <summary>
+    /// The initial elements (for initialized arrays). Empty if using size.
+    /// </summary>
+    public IReadOnlyList<ExpressionNode> Initializer { get; }
+
+    public AttributeCollection Attributes { get; }
+
+    public ArrayCreationNode(
+        TextSpan span,
+        string id,
+        string name,
+        string elementType,
+        ExpressionNode? size,
+        IReadOnlyList<ExpressionNode> initializer,
+        AttributeCollection attributes)
+        : base(span)
+    {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        ElementType = elementType ?? throw new ArgumentNullException(nameof(elementType));
+        Size = size;
+        Initializer = initializer ?? throw new ArgumentNullException(nameof(initializer));
+        Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents array element access.
+/// §IDX §REF[name=arr] 0                     // arr[0]
+/// </summary>
+public sealed class ArrayAccessNode : ExpressionNode
+{
+    /// <summary>
+    /// The array being accessed.
+    /// </summary>
+    public ExpressionNode Array { get; }
+
+    /// <summary>
+    /// The index expression.
+    /// </summary>
+    public ExpressionNode Index { get; }
+
+    public ArrayAccessNode(TextSpan span, ExpressionNode array, ExpressionNode index)
+        : base(span)
+    {
+        Array = array ?? throw new ArgumentNullException(nameof(array));
+        Index = index ?? throw new ArgumentNullException(nameof(index));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents array length access.
+/// §LEN §REF[name=arr]                       // arr.Length
+/// </summary>
+public sealed class ArrayLengthNode : ExpressionNode
+{
+    /// <summary>
+    /// The array whose length is being accessed.
+    /// </summary>
+    public ExpressionNode Array { get; }
+
+    public ArrayLengthNode(TextSpan span, ExpressionNode array)
+        : base(span)
+    {
+        Array = array ?? throw new ArgumentNullException(nameof(array));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a foreach loop.
+/// §EACH[each1:item:i32] §REF[name=arr]      // foreach (int item in arr)
+///   ...
+/// §/EACH[each1]
+/// </summary>
+public sealed class ForeachStatementNode : StatementNode
+{
+    /// <summary>
+    /// The unique ID for this foreach statement.
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// The loop variable name.
+    /// </summary>
+    public string VariableName { get; }
+
+    /// <summary>
+    /// The type of the loop variable.
+    /// </summary>
+    public string VariableType { get; }
+
+    /// <summary>
+    /// The collection being iterated.
+    /// </summary>
+    public ExpressionNode Collection { get; }
+
+    /// <summary>
+    /// The loop body statements.
+    /// </summary>
+    public IReadOnlyList<StatementNode> Body { get; }
+
+    public AttributeCollection Attributes { get; }
+
+    public ForeachStatementNode(
+        TextSpan span,
+        string id,
+        string variableName,
+        string variableType,
+        ExpressionNode collection,
+        IReadOnlyList<StatementNode> body,
+        AttributeCollection attributes)
+        : base(span)
+    {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        VariableName = variableName ?? throw new ArgumentNullException(nameof(variableName));
+        VariableType = variableType ?? throw new ArgumentNullException(nameof(variableType));
+        Collection = collection ?? throw new ArgumentNullException(nameof(collection));
+        Body = body ?? throw new ArgumentNullException(nameof(body));
+        Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}

--- a/src/Opal.Compiler/Ast/AstNode.cs
+++ b/src/Opal.Compiler/Ast/AstNode.cs
@@ -50,10 +50,76 @@ public interface IAstVisitor
     void Visit(ErrExpressionNode node);
     void Visit(MatchExpressionNode node);
     void Visit(MatchStatementNode node);
+    void Visit(MatchCaseNode node);
+    void Visit(WildcardPatternNode node);
+    void Visit(VariablePatternNode node);
+    void Visit(LiteralPatternNode node);
+    void Visit(SomePatternNode node);
+    void Visit(NonePatternNode node);
+    void Visit(OkPatternNode node);
+    void Visit(ErrPatternNode node);
     // Phase 4: Contracts
     void Visit(RequiresNode node);
     void Visit(EnsuresNode node);
     void Visit(InvariantNode node);
+    // Phase 5: Using Statements
+    void Visit(UsingDirectiveNode node);
+    // Phase 6: Arrays and Collections
+    void Visit(ArrayCreationNode node);
+    void Visit(ArrayAccessNode node);
+    void Visit(ArrayLengthNode node);
+    void Visit(ForeachStatementNode node);
+    // Phase 7: Generics
+    void Visit(TypeParameterNode node);
+    void Visit(TypeConstraintNode node);
+    void Visit(GenericTypeNode node);
+    // Phase 8: Classes, Interfaces, Inheritance
+    void Visit(InterfaceDefinitionNode node);
+    void Visit(MethodSignatureNode node);
+    void Visit(ClassDefinitionNode node);
+    void Visit(ClassFieldNode node);
+    void Visit(MethodNode node);
+    void Visit(NewExpressionNode node);
+    void Visit(ThisExpressionNode node);
+    void Visit(BaseExpressionNode node);
+    // Phase 9: Properties and Constructors
+    void Visit(PropertyNode node);
+    void Visit(PropertyAccessorNode node);
+    void Visit(ConstructorNode node);
+    void Visit(ConstructorInitializerNode node);
+    void Visit(AssignmentStatementNode node);
+    // Phase 10: Try/Catch/Finally
+    void Visit(TryStatementNode node);
+    void Visit(CatchClauseNode node);
+    void Visit(ThrowStatementNode node);
+    void Visit(RethrowStatementNode node);
+    // Phase 11: Lambdas, Delegates, Events
+    void Visit(LambdaParameterNode node);
+    void Visit(LambdaExpressionNode node);
+    void Visit(DelegateDefinitionNode node);
+    void Visit(EventDefinitionNode node);
+    void Visit(EventSubscribeNode node);
+    void Visit(EventUnsubscribeNode node);
+    // Phase 12: Async/Await
+    void Visit(AwaitExpressionNode node);
+    // Phase 9: String Interpolation and Modern Operators
+    void Visit(InterpolatedStringNode node);
+    void Visit(InterpolatedStringTextNode node);
+    void Visit(InterpolatedStringExpressionNode node);
+    void Visit(NullCoalesceNode node);
+    void Visit(NullConditionalNode node);
+    void Visit(RangeExpressionNode node);
+    void Visit(IndexFromEndNode node);
+    // Phase 10: Advanced Patterns
+    void Visit(WithExpressionNode node);
+    void Visit(WithPropertyAssignmentNode node);
+    void Visit(PositionalPatternNode node);
+    void Visit(PropertyPatternNode node);
+    void Visit(PropertyMatchNode node);
+    void Visit(RelationalPatternNode node);
+    void Visit(ListPatternNode node);
+    void Visit(VarPatternNode node);
+    void Visit(ConstantPatternNode node);
 }
 
 /// <summary>
@@ -88,10 +154,76 @@ public interface IAstVisitor<T>
     T Visit(ErrExpressionNode node);
     T Visit(MatchExpressionNode node);
     T Visit(MatchStatementNode node);
+    T Visit(MatchCaseNode node);
+    T Visit(WildcardPatternNode node);
+    T Visit(VariablePatternNode node);
+    T Visit(LiteralPatternNode node);
+    T Visit(SomePatternNode node);
+    T Visit(NonePatternNode node);
+    T Visit(OkPatternNode node);
+    T Visit(ErrPatternNode node);
     // Phase 4: Contracts
     T Visit(RequiresNode node);
     T Visit(EnsuresNode node);
     T Visit(InvariantNode node);
+    // Phase 5: Using Statements
+    T Visit(UsingDirectiveNode node);
+    // Phase 6: Arrays and Collections
+    T Visit(ArrayCreationNode node);
+    T Visit(ArrayAccessNode node);
+    T Visit(ArrayLengthNode node);
+    T Visit(ForeachStatementNode node);
+    // Phase 7: Generics
+    T Visit(TypeParameterNode node);
+    T Visit(TypeConstraintNode node);
+    T Visit(GenericTypeNode node);
+    // Phase 8: Classes, Interfaces, Inheritance
+    T Visit(InterfaceDefinitionNode node);
+    T Visit(MethodSignatureNode node);
+    T Visit(ClassDefinitionNode node);
+    T Visit(ClassFieldNode node);
+    T Visit(MethodNode node);
+    T Visit(NewExpressionNode node);
+    T Visit(ThisExpressionNode node);
+    T Visit(BaseExpressionNode node);
+    // Phase 9: Properties and Constructors
+    T Visit(PropertyNode node);
+    T Visit(PropertyAccessorNode node);
+    T Visit(ConstructorNode node);
+    T Visit(ConstructorInitializerNode node);
+    T Visit(AssignmentStatementNode node);
+    // Phase 10: Try/Catch/Finally
+    T Visit(TryStatementNode node);
+    T Visit(CatchClauseNode node);
+    T Visit(ThrowStatementNode node);
+    T Visit(RethrowStatementNode node);
+    // Phase 11: Lambdas, Delegates, Events
+    T Visit(LambdaParameterNode node);
+    T Visit(LambdaExpressionNode node);
+    T Visit(DelegateDefinitionNode node);
+    T Visit(EventDefinitionNode node);
+    T Visit(EventSubscribeNode node);
+    T Visit(EventUnsubscribeNode node);
+    // Phase 12: Async/Await
+    T Visit(AwaitExpressionNode node);
+    // Phase 9: String Interpolation and Modern Operators
+    T Visit(InterpolatedStringNode node);
+    T Visit(InterpolatedStringTextNode node);
+    T Visit(InterpolatedStringExpressionNode node);
+    T Visit(NullCoalesceNode node);
+    T Visit(NullConditionalNode node);
+    T Visit(RangeExpressionNode node);
+    T Visit(IndexFromEndNode node);
+    // Phase 10: Advanced Patterns
+    T Visit(WithExpressionNode node);
+    T Visit(WithPropertyAssignmentNode node);
+    T Visit(PositionalPatternNode node);
+    T Visit(PropertyPatternNode node);
+    T Visit(PropertyMatchNode node);
+    T Visit(RelationalPatternNode node);
+    T Visit(ListPatternNode node);
+    T Visit(VarPatternNode node);
+    T Visit(ConstantPatternNode node);
 }
 
 /// <summary>

--- a/src/Opal.Compiler/Ast/AsyncNodes.cs
+++ b/src/Opal.Compiler/Ast/AsyncNodes.cs
@@ -1,0 +1,31 @@
+using Opal.Compiler.Parsing;
+
+namespace Opal.Compiler.Ast;
+
+/// <summary>
+/// Represents an await expression.
+/// §AWAIT §C[client.GetStringAsync] §A §REF[name=url] §/C
+/// §AWAIT[false] §C[reader.ReadAsync] §/C   // ConfigureAwait(false)
+/// </summary>
+public sealed class AwaitExpressionNode : ExpressionNode
+{
+    /// <summary>
+    /// The expression being awaited.
+    /// </summary>
+    public ExpressionNode Awaited { get; }
+
+    /// <summary>
+    /// Whether to ConfigureAwait(true/false). Null means no explicit configuration.
+    /// </summary>
+    public bool? ConfigureAwait { get; }
+
+    public AwaitExpressionNode(TextSpan span, ExpressionNode awaited, bool? configureAwait = null)
+        : base(span)
+    {
+        Awaited = awaited ?? throw new ArgumentNullException(nameof(awaited));
+        ConfigureAwait = configureAwait;
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}

--- a/src/Opal.Compiler/Ast/ClassNodes.cs
+++ b/src/Opal.Compiler/Ast/ClassNodes.cs
@@ -1,0 +1,338 @@
+using Opal.Compiler.Parsing;
+
+namespace Opal.Compiler.Ast;
+
+/// <summary>
+/// Method modifiers for OOP.
+/// </summary>
+[Flags]
+public enum MethodModifiers
+{
+    None = 0,
+    Virtual = 1,
+    Override = 2,
+    Abstract = 4,
+    Sealed = 8,
+    Static = 16
+}
+
+/// <summary>
+/// Represents an interface definition.
+/// §IFACE[i001:IShape]
+///   §METHOD[m001:Area] §O[f64] §E[] §/METHOD[m001]
+/// §/IFACE[i001]
+/// </summary>
+public sealed class InterfaceDefinitionNode : TypeDefinitionNode
+{
+    /// <summary>
+    /// Interface methods (signatures only).
+    /// </summary>
+    public IReadOnlyList<MethodSignatureNode> Methods { get; }
+
+    /// <summary>
+    /// Interfaces this interface extends.
+    /// </summary>
+    public IReadOnlyList<string> BaseInterfaces { get; }
+
+    public InterfaceDefinitionNode(
+        TextSpan span,
+        string id,
+        string name,
+        IReadOnlyList<string> baseInterfaces,
+        IReadOnlyList<MethodSignatureNode> methods,
+        AttributeCollection attributes)
+        : base(span, id, name, attributes)
+    {
+        BaseInterfaces = baseInterfaces ?? throw new ArgumentNullException(nameof(baseInterfaces));
+        Methods = methods ?? throw new ArgumentNullException(nameof(methods));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a method signature (for interfaces).
+/// §METHOD[m001:Area] §O[f64] §E[] §/METHOD[m001]
+/// </summary>
+public sealed class MethodSignatureNode : AstNode
+{
+    public string Id { get; }
+    public string Name { get; }
+    public IReadOnlyList<TypeParameterNode> TypeParameters { get; }
+    public IReadOnlyList<ParameterNode> Parameters { get; }
+    public OutputNode? Output { get; }
+    public EffectsNode? Effects { get; }
+    public AttributeCollection Attributes { get; }
+
+    public MethodSignatureNode(
+        TextSpan span,
+        string id,
+        string name,
+        IReadOnlyList<TypeParameterNode> typeParameters,
+        IReadOnlyList<ParameterNode> parameters,
+        OutputNode? output,
+        EffectsNode? effects,
+        AttributeCollection attributes)
+        : base(span)
+    {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        TypeParameters = typeParameters ?? throw new ArgumentNullException(nameof(typeParameters));
+        Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+        Output = output;
+        Effects = effects;
+        Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a class definition.
+/// §CLASS[c001:Shape:abs]
+///   §IMPL[IShape]
+///   §FIELD[string:Name:pri]
+///   §METHOD[m001:Area:pub:abs] §O[f64] §E[] §/METHOD[m001]
+/// §/CLASS[c001]
+/// </summary>
+public sealed class ClassDefinitionNode : TypeDefinitionNode
+{
+    /// <summary>
+    /// True if this is an abstract class.
+    /// </summary>
+    public bool IsAbstract { get; }
+
+    /// <summary>
+    /// True if this is a sealed class.
+    /// </summary>
+    public bool IsSealed { get; }
+
+    /// <summary>
+    /// The base class (if any).
+    /// </summary>
+    public string? BaseClass { get; }
+
+    /// <summary>
+    /// Interfaces implemented by this class.
+    /// </summary>
+    public IReadOnlyList<string> ImplementedInterfaces { get; }
+
+    /// <summary>
+    /// Type parameters if this is a generic class.
+    /// </summary>
+    public IReadOnlyList<TypeParameterNode> TypeParameters { get; }
+
+    /// <summary>
+    /// Fields defined in this class.
+    /// </summary>
+    public IReadOnlyList<ClassFieldNode> Fields { get; }
+
+    /// <summary>
+    /// Properties defined in this class.
+    /// </summary>
+    public IReadOnlyList<PropertyNode> Properties { get; }
+
+    /// <summary>
+    /// Constructors defined in this class.
+    /// </summary>
+    public IReadOnlyList<ConstructorNode> Constructors { get; }
+
+    /// <summary>
+    /// Methods defined in this class.
+    /// </summary>
+    public IReadOnlyList<MethodNode> Methods { get; }
+
+    public ClassDefinitionNode(
+        TextSpan span,
+        string id,
+        string name,
+        bool isAbstract,
+        bool isSealed,
+        string? baseClass,
+        IReadOnlyList<string> implementedInterfaces,
+        IReadOnlyList<TypeParameterNode> typeParameters,
+        IReadOnlyList<ClassFieldNode> fields,
+        IReadOnlyList<MethodNode> methods,
+        AttributeCollection attributes)
+        : this(span, id, name, isAbstract, isSealed, baseClass, implementedInterfaces,
+               typeParameters, fields, Array.Empty<PropertyNode>(), Array.Empty<ConstructorNode>(), methods, attributes)
+    {
+    }
+
+    public ClassDefinitionNode(
+        TextSpan span,
+        string id,
+        string name,
+        bool isAbstract,
+        bool isSealed,
+        string? baseClass,
+        IReadOnlyList<string> implementedInterfaces,
+        IReadOnlyList<TypeParameterNode> typeParameters,
+        IReadOnlyList<ClassFieldNode> fields,
+        IReadOnlyList<PropertyNode> properties,
+        IReadOnlyList<ConstructorNode> constructors,
+        IReadOnlyList<MethodNode> methods,
+        AttributeCollection attributes)
+        : base(span, id, name, attributes)
+    {
+        IsAbstract = isAbstract;
+        IsSealed = isSealed;
+        BaseClass = baseClass;
+        ImplementedInterfaces = implementedInterfaces ?? throw new ArgumentNullException(nameof(implementedInterfaces));
+        TypeParameters = typeParameters ?? throw new ArgumentNullException(nameof(typeParameters));
+        Fields = fields ?? throw new ArgumentNullException(nameof(fields));
+        Properties = properties ?? throw new ArgumentNullException(nameof(properties));
+        Constructors = constructors ?? throw new ArgumentNullException(nameof(constructors));
+        Methods = methods ?? throw new ArgumentNullException(nameof(methods));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a field in a class.
+/// §FLD[string:Name:pri]
+/// </summary>
+public sealed class ClassFieldNode : AstNode
+{
+    public string Name { get; }
+    public string TypeName { get; }
+    public Visibility Visibility { get; }
+    public ExpressionNode? DefaultValue { get; }
+    public AttributeCollection Attributes { get; }
+
+    public ClassFieldNode(
+        TextSpan span,
+        string name,
+        string typeName,
+        Visibility visibility,
+        ExpressionNode? defaultValue,
+        AttributeCollection attributes)
+        : base(span)
+    {
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
+        Visibility = visibility;
+        DefaultValue = defaultValue;
+        Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a method in a class (like FunctionNode but with OOP modifiers).
+/// §METHOD[m001:Area:pub:over]
+///   §O[f64] §E[]
+///   §R §OP[kind=mul] 3.14159 §OP[kind=mul] §REF[name=Radius] §REF[name=Radius]
+/// §/METHOD[m001]
+/// </summary>
+public sealed class MethodNode : AstNode
+{
+    public string Id { get; }
+    public string Name { get; }
+    public Visibility Visibility { get; }
+    public MethodModifiers Modifiers { get; }
+    public IReadOnlyList<TypeParameterNode> TypeParameters { get; }
+    public IReadOnlyList<ParameterNode> Parameters { get; }
+    public OutputNode? Output { get; }
+    public EffectsNode? Effects { get; }
+    public IReadOnlyList<RequiresNode> Preconditions { get; }
+    public IReadOnlyList<EnsuresNode> Postconditions { get; }
+    public IReadOnlyList<StatementNode> Body { get; }
+    public AttributeCollection Attributes { get; }
+
+    public MethodNode(
+        TextSpan span,
+        string id,
+        string name,
+        Visibility visibility,
+        MethodModifiers modifiers,
+        IReadOnlyList<TypeParameterNode> typeParameters,
+        IReadOnlyList<ParameterNode> parameters,
+        OutputNode? output,
+        EffectsNode? effects,
+        IReadOnlyList<RequiresNode> preconditions,
+        IReadOnlyList<EnsuresNode> postconditions,
+        IReadOnlyList<StatementNode> body,
+        AttributeCollection attributes)
+        : base(span)
+    {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        Visibility = visibility;
+        Modifiers = modifiers;
+        TypeParameters = typeParameters ?? throw new ArgumentNullException(nameof(typeParameters));
+        Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+        Output = output;
+        Effects = effects;
+        Preconditions = preconditions ?? throw new ArgumentNullException(nameof(preconditions));
+        Postconditions = postconditions ?? throw new ArgumentNullException(nameof(postconditions));
+        Body = body ?? throw new ArgumentNullException(nameof(body));
+        Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+    }
+
+    public bool IsVirtual => (Modifiers & MethodModifiers.Virtual) != 0;
+    public bool IsOverride => (Modifiers & MethodModifiers.Override) != 0;
+    public bool IsAbstract => (Modifiers & MethodModifiers.Abstract) != 0;
+    public bool IsSealed => (Modifiers & MethodModifiers.Sealed) != 0;
+    public bool IsStatic => (Modifiers & MethodModifiers.Static) != 0;
+    public bool HasContracts => Preconditions.Count > 0 || Postconditions.Count > 0;
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a 'new' expression.
+/// §NEW[Circle] §A "MyCircle" §A 5.0 §/NEW
+/// </summary>
+public sealed class NewExpressionNode : ExpressionNode
+{
+    public string TypeName { get; }
+    public IReadOnlyList<string> TypeArguments { get; }
+    public IReadOnlyList<ExpressionNode> Arguments { get; }
+
+    public NewExpressionNode(
+        TextSpan span,
+        string typeName,
+        IReadOnlyList<string> typeArguments,
+        IReadOnlyList<ExpressionNode> arguments)
+        : base(span)
+    {
+        TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
+        TypeArguments = typeArguments ?? throw new ArgumentNullException(nameof(typeArguments));
+        Arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a 'this' expression.
+/// §THIS
+/// </summary>
+public sealed class ThisExpressionNode : ExpressionNode
+{
+    public ThisExpressionNode(TextSpan span) : base(span) { }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a 'base' expression for calling base class members.
+/// §BASE
+/// </summary>
+public sealed class BaseExpressionNode : ExpressionNode
+{
+    public BaseExpressionNode(TextSpan span) : base(span) { }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}

--- a/src/Opal.Compiler/Ast/ExceptionNodes.cs
+++ b/src/Opal.Compiler/Ast/ExceptionNodes.cs
@@ -1,0 +1,125 @@
+using Opal.Compiler.Parsing;
+
+namespace Opal.Compiler.Ast;
+
+/// <summary>
+/// Represents a try/catch/finally statement.
+/// §TRY[try1]
+///   ...
+/// §CATCH[IOException:ex]
+///   ...
+/// §CATCH
+///   §RETHROW
+/// §FINALLY
+///   ...
+/// §/TRY[try1]
+/// </summary>
+public sealed class TryStatementNode : StatementNode
+{
+    public string Id { get; }
+    public IReadOnlyList<StatementNode> TryBody { get; }
+    public IReadOnlyList<CatchClauseNode> CatchClauses { get; }
+    public IReadOnlyList<StatementNode>? FinallyBody { get; }
+    public AttributeCollection Attributes { get; }
+
+    public TryStatementNode(
+        TextSpan span,
+        string id,
+        IReadOnlyList<StatementNode> tryBody,
+        IReadOnlyList<CatchClauseNode> catchClauses,
+        IReadOnlyList<StatementNode>? finallyBody,
+        AttributeCollection attributes)
+        : base(span)
+    {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        TryBody = tryBody ?? throw new ArgumentNullException(nameof(tryBody));
+        CatchClauses = catchClauses ?? throw new ArgumentNullException(nameof(catchClauses));
+        FinallyBody = finallyBody;
+        Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a catch clause.
+/// §CATCH[IOException:ex]
+/// §CATCH
+/// </summary>
+public sealed class CatchClauseNode : AstNode
+{
+    /// <summary>
+    /// The exception type to catch. Null for catch-all.
+    /// </summary>
+    public string? ExceptionType { get; }
+
+    /// <summary>
+    /// The variable name for the exception. Null if not capturing.
+    /// </summary>
+    public string? VariableName { get; }
+
+    /// <summary>
+    /// Optional filter expression (when clause).
+    /// </summary>
+    public ExpressionNode? Filter { get; }
+
+    /// <summary>
+    /// The catch body statements.
+    /// </summary>
+    public IReadOnlyList<StatementNode> Body { get; }
+
+    public AttributeCollection Attributes { get; }
+
+    public CatchClauseNode(
+        TextSpan span,
+        string? exceptionType,
+        string? variableName,
+        ExpressionNode? filter,
+        IReadOnlyList<StatementNode> body,
+        AttributeCollection attributes)
+        : base(span)
+    {
+        ExceptionType = exceptionType;
+        VariableName = variableName;
+        Filter = filter;
+        Body = body ?? throw new ArgumentNullException(nameof(body));
+        Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a throw statement.
+/// §THROW §NEW[ArgumentException] §A "Invalid" §/NEW
+/// </summary>
+public sealed class ThrowStatementNode : StatementNode
+{
+    /// <summary>
+    /// The exception to throw. Null for rethrow.
+    /// </summary>
+    public ExpressionNode? Exception { get; }
+
+    public ThrowStatementNode(TextSpan span, ExpressionNode? exception)
+        : base(span)
+    {
+        Exception = exception;
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a rethrow statement.
+/// §RETHROW
+/// </summary>
+public sealed class RethrowStatementNode : StatementNode
+{
+    public RethrowStatementNode(TextSpan span) : base(span) { }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}

--- a/src/Opal.Compiler/Ast/FunctionNode.cs
+++ b/src/Opal.Compiler/Ast/FunctionNode.cs
@@ -8,6 +8,7 @@ namespace Opal.Compiler.Ast;
 public enum Visibility
 {
     Private,
+    Protected,
     Internal,
     Public
 }
@@ -53,6 +54,7 @@ public sealed class FunctionNode : AstNode
     public string Id { get; }
     public string Name { get; }
     public Visibility Visibility { get; }
+    public IReadOnlyList<TypeParameterNode> TypeParameters { get; }
     public IReadOnlyList<ParameterNode> Parameters { get; }
     public OutputNode? Output { get; }
     public EffectsNode? Effects { get; }
@@ -71,7 +73,7 @@ public sealed class FunctionNode : AstNode
         EffectsNode? effects,
         IReadOnlyList<StatementNode> body,
         AttributeCollection attributes)
-        : this(span, id, name, visibility, parameters, output, effects,
+        : this(span, id, name, visibility, Array.Empty<TypeParameterNode>(), parameters, output, effects,
                Array.Empty<RequiresNode>(), Array.Empty<EnsuresNode>(), body, attributes)
     {
     }
@@ -88,11 +90,30 @@ public sealed class FunctionNode : AstNode
         IReadOnlyList<EnsuresNode> postconditions,
         IReadOnlyList<StatementNode> body,
         AttributeCollection attributes)
+        : this(span, id, name, visibility, Array.Empty<TypeParameterNode>(), parameters, output, effects,
+               preconditions, postconditions, body, attributes)
+    {
+    }
+
+    public FunctionNode(
+        TextSpan span,
+        string id,
+        string name,
+        Visibility visibility,
+        IReadOnlyList<TypeParameterNode> typeParameters,
+        IReadOnlyList<ParameterNode> parameters,
+        OutputNode? output,
+        EffectsNode? effects,
+        IReadOnlyList<RequiresNode> preconditions,
+        IReadOnlyList<EnsuresNode> postconditions,
+        IReadOnlyList<StatementNode> body,
+        AttributeCollection attributes)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
         Name = name ?? throw new ArgumentNullException(nameof(name));
         Visibility = visibility;
+        TypeParameters = typeParameters ?? throw new ArgumentNullException(nameof(typeParameters));
         Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
         Output = output;
         Effects = effects;
@@ -106,6 +127,11 @@ public sealed class FunctionNode : AstNode
     /// Returns true if this function has any contracts (preconditions or postconditions).
     /// </summary>
     public bool HasContracts => Preconditions.Count > 0 || Postconditions.Count > 0;
+
+    /// <summary>
+    /// Returns true if this function is generic (has type parameters).
+    /// </summary>
+    public bool IsGeneric => TypeParameters.Count > 0;
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
     public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);

--- a/src/Opal.Compiler/Ast/GenericNodes.cs
+++ b/src/Opal.Compiler/Ast/GenericNodes.cs
@@ -1,0 +1,107 @@
+using Opal.Compiler.Parsing;
+
+namespace Opal.Compiler.Ast;
+
+/// <summary>
+/// Represents a type parameter declaration.
+/// §TP[T]                                    // type parameter T
+/// </summary>
+public sealed class TypeParameterNode : AstNode
+{
+    /// <summary>
+    /// The name of the type parameter.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// The constraints on this type parameter (from WHERE clauses).
+    /// </summary>
+    public IReadOnlyList<TypeConstraintNode> Constraints { get; }
+
+    public TypeParameterNode(TextSpan span, string name, IReadOnlyList<TypeConstraintNode> constraints)
+        : base(span)
+    {
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        Constraints = constraints ?? throw new ArgumentNullException(nameof(constraints));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// The kind of type constraint.
+/// </summary>
+public enum TypeConstraintKind
+{
+    /// <summary>Type must be a reference type (class)</summary>
+    Class,
+    /// <summary>Type must be a value type (struct)</summary>
+    Struct,
+    /// <summary>Type must have a parameterless constructor (new())</summary>
+    New,
+    /// <summary>Type must implement an interface</summary>
+    Interface,
+    /// <summary>Type must derive from a base class</summary>
+    BaseClass,
+    /// <summary>Type must be or derive from the specified type</summary>
+    TypeName
+}
+
+/// <summary>
+/// Represents a constraint on a type parameter.
+/// §WHERE[T:IComparable]                     // where T : IComparable
+/// §WHERE[T:class]                           // where T : class
+/// §WHERE[T:struct]                          // where T : struct
+/// §WHERE[T:new]                             // where T : new()
+/// </summary>
+public sealed class TypeConstraintNode : AstNode
+{
+    /// <summary>
+    /// The kind of constraint.
+    /// </summary>
+    public TypeConstraintKind Kind { get; }
+
+    /// <summary>
+    /// For Interface, BaseClass, or TypeName constraints, the type name.
+    /// </summary>
+    public string? TypeName { get; }
+
+    public TypeConstraintNode(TextSpan span, TypeConstraintKind kind, string? typeName = null)
+        : base(span)
+    {
+        Kind = kind;
+        TypeName = typeName;
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a generic type instantiation.
+/// §G[List:i32]                              // List&lt;int&gt;
+/// §G[Dictionary:string:i32]                 // Dictionary&lt;string, int&gt;
+/// </summary>
+public sealed class GenericTypeNode : ExpressionNode
+{
+    /// <summary>
+    /// The name of the generic type (e.g., "List", "Dictionary").
+    /// </summary>
+    public string TypeName { get; }
+
+    /// <summary>
+    /// The type arguments.
+    /// </summary>
+    public IReadOnlyList<string> TypeArguments { get; }
+
+    public GenericTypeNode(TextSpan span, string typeName, IReadOnlyList<string> typeArguments)
+        : base(span)
+    {
+        TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
+        TypeArguments = typeArguments ?? throw new ArgumentNullException(nameof(typeArguments));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}

--- a/src/Opal.Compiler/Ast/LambdaNodes.cs
+++ b/src/Opal.Compiler/Ast/LambdaNodes.cs
@@ -1,0 +1,172 @@
+using Opal.Compiler.Parsing;
+
+namespace Opal.Compiler.Ast;
+
+/// <summary>
+/// Represents a lambda parameter.
+/// </summary>
+public sealed class LambdaParameterNode : AstNode
+{
+    public string Name { get; }
+    public string? TypeName { get; }
+
+    public LambdaParameterNode(TextSpan span, string name, string? typeName)
+        : base(span)
+    {
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        TypeName = typeName;
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a lambda expression.
+/// §LAM[lam1:x:i32] §OP[kind=mul] §REF[name=x] 2 §/LAM[lam1]
+/// // (int x) => x * 2
+/// </summary>
+public sealed class LambdaExpressionNode : ExpressionNode
+{
+    public string Id { get; }
+    public IReadOnlyList<LambdaParameterNode> Parameters { get; }
+    public EffectsNode? Effects { get; }
+    public bool IsAsync { get; }
+
+    /// <summary>
+    /// The body can be either an expression (for expression lambdas)
+    /// or statements (for statement lambdas).
+    /// </summary>
+    public ExpressionNode? ExpressionBody { get; }
+    public IReadOnlyList<StatementNode>? StatementBody { get; }
+
+    public AttributeCollection Attributes { get; }
+
+    public LambdaExpressionNode(
+        TextSpan span,
+        string id,
+        IReadOnlyList<LambdaParameterNode> parameters,
+        EffectsNode? effects,
+        bool isAsync,
+        ExpressionNode? expressionBody,
+        IReadOnlyList<StatementNode>? statementBody,
+        AttributeCollection attributes)
+        : base(span)
+    {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+        Effects = effects;
+        IsAsync = isAsync;
+        ExpressionBody = expressionBody;
+        StatementBody = statementBody;
+        Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+    }
+
+    public bool IsExpressionLambda => ExpressionBody != null;
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a delegate definition.
+/// §DEL[d001:Processor]
+///   §I[string:input] §O[bool] §E[fr,fw]
+/// §/DEL[d001]
+/// </summary>
+public sealed class DelegateDefinitionNode : TypeDefinitionNode
+{
+    public IReadOnlyList<ParameterNode> Parameters { get; }
+    public OutputNode? Output { get; }
+    public EffectsNode? Effects { get; }
+
+    public DelegateDefinitionNode(
+        TextSpan span,
+        string id,
+        string name,
+        IReadOnlyList<ParameterNode> parameters,
+        OutputNode? output,
+        EffectsNode? effects,
+        AttributeCollection attributes)
+        : base(span, id, name, attributes)
+    {
+        Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+        Output = output;
+        Effects = effects;
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents an event definition.
+/// §EVT[e001:Click:pub:EventHandler]
+/// </summary>
+public sealed class EventDefinitionNode : AstNode
+{
+    public string Id { get; }
+    public string Name { get; }
+    public Visibility Visibility { get; }
+    public string DelegateType { get; }
+    public AttributeCollection Attributes { get; }
+
+    public EventDefinitionNode(
+        TextSpan span,
+        string id,
+        string name,
+        Visibility visibility,
+        string delegateType,
+        AttributeCollection attributes)
+        : base(span)
+    {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        Visibility = visibility;
+        DelegateType = delegateType ?? throw new ArgumentNullException(nameof(delegateType));
+        Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents event subscription.
+/// §SUB §REF[name=button.Click] §REF[name=handler]
+/// </summary>
+public sealed class EventSubscribeNode : StatementNode
+{
+    public ExpressionNode Event { get; }
+    public ExpressionNode Handler { get; }
+
+    public EventSubscribeNode(TextSpan span, ExpressionNode @event, ExpressionNode handler)
+        : base(span)
+    {
+        Event = @event ?? throw new ArgumentNullException(nameof(@event));
+        Handler = handler ?? throw new ArgumentNullException(nameof(handler));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents event unsubscription.
+/// §UNSUB §REF[name=button.Click] §REF[name=handler]
+/// </summary>
+public sealed class EventUnsubscribeNode : StatementNode
+{
+    public ExpressionNode Event { get; }
+    public ExpressionNode Handler { get; }
+
+    public EventUnsubscribeNode(TextSpan span, ExpressionNode @event, ExpressionNode handler)
+        : base(span)
+    {
+        Event = @event ?? throw new ArgumentNullException(nameof(@event));
+        Handler = handler ?? throw new ArgumentNullException(nameof(handler));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}

--- a/src/Opal.Compiler/Ast/ModernOperatorNodes.cs
+++ b/src/Opal.Compiler/Ast/ModernOperatorNodes.cs
@@ -1,0 +1,173 @@
+using Opal.Compiler.Parsing;
+
+namespace Opal.Compiler.Ast;
+
+/// <summary>
+/// Represents an interpolated string expression.
+/// §INTERP["Hello, " §EXP §REF[name=name] "!"]
+/// generates: $"Hello, {name}!"
+/// </summary>
+public sealed class InterpolatedStringNode : ExpressionNode
+{
+    /// <summary>
+    /// The parts of the interpolated string (literals or expressions).
+    /// </summary>
+    public IReadOnlyList<InterpolatedStringPartNode> Parts { get; }
+
+    public InterpolatedStringNode(TextSpan span, IReadOnlyList<InterpolatedStringPartNode> parts)
+        : base(span)
+    {
+        Parts = parts ?? throw new ArgumentNullException(nameof(parts));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Base class for parts of an interpolated string.
+/// </summary>
+public abstract class InterpolatedStringPartNode : AstNode
+{
+    protected InterpolatedStringPartNode(TextSpan span) : base(span) { }
+}
+
+/// <summary>
+/// A literal text part of an interpolated string.
+/// </summary>
+public sealed class InterpolatedStringTextNode : InterpolatedStringPartNode
+{
+    public string Text { get; }
+
+    public InterpolatedStringTextNode(TextSpan span, string text)
+        : base(span)
+    {
+        Text = text ?? "";
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// An expression part of an interpolated string.
+/// </summary>
+public sealed class InterpolatedStringExpressionNode : InterpolatedStringPartNode
+{
+    public ExpressionNode Expression { get; }
+
+    public InterpolatedStringExpressionNode(TextSpan span, ExpressionNode expression)
+        : base(span)
+    {
+        Expression = expression ?? throw new ArgumentNullException(nameof(expression));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a null-coalescing expression.
+/// §?? §REF[name=value] "default"
+/// generates: value ?? "default"
+/// </summary>
+public sealed class NullCoalesceNode : ExpressionNode
+{
+    /// <summary>
+    /// The left operand (value to check for null).
+    /// </summary>
+    public ExpressionNode Left { get; }
+
+    /// <summary>
+    /// The right operand (fallback value).
+    /// </summary>
+    public ExpressionNode Right { get; }
+
+    public NullCoalesceNode(TextSpan span, ExpressionNode left, ExpressionNode right)
+        : base(span)
+    {
+        Left = left ?? throw new ArgumentNullException(nameof(left));
+        Right = right ?? throw new ArgumentNullException(nameof(right));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a null-conditional access expression.
+/// §?. §REF[name=person] Name
+/// generates: person?.Name
+/// </summary>
+public sealed class NullConditionalNode : ExpressionNode
+{
+    /// <summary>
+    /// The expression being accessed (may be null).
+    /// </summary>
+    public ExpressionNode Target { get; }
+
+    /// <summary>
+    /// The member or index being accessed.
+    /// </summary>
+    public string MemberName { get; }
+
+    public NullConditionalNode(TextSpan span, ExpressionNode target, string memberName)
+        : base(span)
+    {
+        Target = target ?? throw new ArgumentNullException(nameof(target));
+        MemberName = memberName ?? "";
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a range expression.
+/// §RANGE 1 5
+/// generates: 1..5
+/// </summary>
+public sealed class RangeExpressionNode : ExpressionNode
+{
+    /// <summary>
+    /// The start of the range (null for open-ended).
+    /// </summary>
+    public ExpressionNode? Start { get; }
+
+    /// <summary>
+    /// The end of the range (null for open-ended).
+    /// </summary>
+    public ExpressionNode? End { get; }
+
+    public RangeExpressionNode(TextSpan span, ExpressionNode? start, ExpressionNode? end)
+        : base(span)
+    {
+        Start = start;
+        End = end;
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents an index-from-end expression.
+/// §^ 1
+/// generates: ^1 (index from end)
+/// </summary>
+public sealed class IndexFromEndNode : ExpressionNode
+{
+    /// <summary>
+    /// The offset from the end.
+    /// </summary>
+    public ExpressionNode Offset { get; }
+
+    public IndexFromEndNode(TextSpan span, ExpressionNode offset)
+        : base(span)
+    {
+        Offset = offset ?? throw new ArgumentNullException(nameof(offset));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}

--- a/src/Opal.Compiler/Ast/ModuleNode.cs
+++ b/src/Opal.Compiler/Ast/ModuleNode.cs
@@ -10,6 +10,9 @@ public sealed class ModuleNode : AstNode
 {
     public string Id { get; }
     public string Name { get; }
+    public IReadOnlyList<UsingDirectiveNode> Usings { get; }
+    public IReadOnlyList<InterfaceDefinitionNode> Interfaces { get; }
+    public IReadOnlyList<ClassDefinitionNode> Classes { get; }
     public IReadOnlyList<FunctionNode> Functions { get; }
     public AttributeCollection Attributes { get; }
 
@@ -17,12 +20,30 @@ public sealed class ModuleNode : AstNode
         TextSpan span,
         string id,
         string name,
+        IReadOnlyList<UsingDirectiveNode> usings,
+        IReadOnlyList<FunctionNode> functions,
+        AttributeCollection attributes)
+        : this(span, id, name, usings, Array.Empty<InterfaceDefinitionNode>(),
+               Array.Empty<ClassDefinitionNode>(), functions, attributes)
+    {
+    }
+
+    public ModuleNode(
+        TextSpan span,
+        string id,
+        string name,
+        IReadOnlyList<UsingDirectiveNode> usings,
+        IReadOnlyList<InterfaceDefinitionNode> interfaces,
+        IReadOnlyList<ClassDefinitionNode> classes,
         IReadOnlyList<FunctionNode> functions,
         AttributeCollection attributes)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
         Name = name ?? throw new ArgumentNullException(nameof(name));
+        Usings = usings ?? throw new ArgumentNullException(nameof(usings));
+        Interfaces = interfaces ?? throw new ArgumentNullException(nameof(interfaces));
+        Classes = classes ?? throw new ArgumentNullException(nameof(classes));
         Functions = functions ?? throw new ArgumentNullException(nameof(functions));
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
     }

--- a/src/Opal.Compiler/Ast/PatternNodes.cs
+++ b/src/Opal.Compiler/Ast/PatternNodes.cs
@@ -2,12 +2,13 @@ using Opal.Compiler.Parsing;
 
 namespace Opal.Compiler.Ast;
 
+// Match expression and statement nodes (Phase 3: Type System)
+
 /// <summary>
-/// Represents a pattern match expression.
-/// §MATCH[id=xxx] expression
-///   §CASE pattern body
-///   §CASE pattern body
-/// §END_MATCH[id=xxx]
+/// Represents a match expression that returns a value.
+/// §MATCH[id] §REF[name=value]
+///   §CASE ... §BODY ... §/CASE
+/// §/MATCH[id]
 /// </summary>
 public sealed class MatchExpressionNode : ExpressionNode
 {
@@ -16,15 +17,10 @@ public sealed class MatchExpressionNode : ExpressionNode
     public IReadOnlyList<MatchCaseNode> Cases { get; }
     public AttributeCollection Attributes { get; }
 
-    public MatchExpressionNode(
-        TextSpan span,
-        string id,
-        ExpressionNode target,
-        IReadOnlyList<MatchCaseNode> cases,
-        AttributeCollection attributes)
+    public MatchExpressionNode(TextSpan span, string id, ExpressionNode target, IReadOnlyList<MatchCaseNode> cases, AttributeCollection attributes)
         : base(span)
     {
-        Id = id ?? throw new ArgumentNullException(nameof(id));
+        Id = id ?? "";
         Target = target ?? throw new ArgumentNullException(nameof(target));
         Cases = cases ?? throw new ArgumentNullException(nameof(cases));
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
@@ -35,7 +31,7 @@ public sealed class MatchExpressionNode : ExpressionNode
 }
 
 /// <summary>
-/// Represents a pattern match statement (for side effects).
+/// Represents a match statement (no return value).
 /// </summary>
 public sealed class MatchStatementNode : StatementNode
 {
@@ -44,15 +40,10 @@ public sealed class MatchStatementNode : StatementNode
     public IReadOnlyList<MatchCaseNode> Cases { get; }
     public AttributeCollection Attributes { get; }
 
-    public MatchStatementNode(
-        TextSpan span,
-        string id,
-        ExpressionNode target,
-        IReadOnlyList<MatchCaseNode> cases,
-        AttributeCollection attributes)
+    public MatchStatementNode(TextSpan span, string id, ExpressionNode target, IReadOnlyList<MatchCaseNode> cases, AttributeCollection attributes)
         : base(span)
     {
-        Id = id ?? throw new ArgumentNullException(nameof(id));
+        Id = id ?? "";
         Target = target ?? throw new ArgumentNullException(nameof(target));
         Cases = cases ?? throw new ArgumentNullException(nameof(cases));
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
@@ -63,8 +54,7 @@ public sealed class MatchStatementNode : StatementNode
 }
 
 /// <summary>
-/// Represents a case in a match expression/statement.
-/// §CASE pattern body
+/// Represents a case in a match expression or statement.
 /// </summary>
 public sealed class MatchCaseNode : AstNode
 {
@@ -72,11 +62,7 @@ public sealed class MatchCaseNode : AstNode
     public ExpressionNode? Guard { get; }
     public IReadOnlyList<StatementNode> Body { get; }
 
-    public MatchCaseNode(
-        TextSpan span,
-        PatternNode pattern,
-        ExpressionNode? guard,
-        IReadOnlyList<StatementNode> body)
+    public MatchCaseNode(TextSpan span, PatternNode pattern, ExpressionNode? guard, IReadOnlyList<StatementNode> body)
         : base(span)
     {
         Pattern = pattern ?? throw new ArgumentNullException(nameof(pattern));
@@ -84,33 +70,85 @@ public sealed class MatchCaseNode : AstNode
         Body = body ?? throw new ArgumentNullException(nameof(body));
     }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+// Phase 10: With expressions
+
+/// <summary>
+/// Represents a with-expression for non-destructive mutation.
+/// §WITH §REF[name=person]
+///   §SET[Name] "New Name"
+/// §/WITH
+/// generates: person with { Name = "New Name" }
+/// </summary>
+public sealed class WithExpressionNode : ExpressionNode
+{
+    /// <summary>
+    /// The target expression to copy and modify.
+    /// </summary>
+    public ExpressionNode Target { get; }
+
+    /// <summary>
+    /// The property assignments in the with expression.
+    /// </summary>
+    public IReadOnlyList<WithPropertyAssignmentNode> Assignments { get; }
+
+    public WithExpressionNode(TextSpan span, ExpressionNode target, IReadOnlyList<WithPropertyAssignmentNode> assignments)
+        : base(span)
+    {
+        Target = target ?? throw new ArgumentNullException(nameof(target));
+        Assignments = assignments ?? throw new ArgumentNullException(nameof(assignments));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
 
 /// <summary>
-/// Base class for pattern nodes.
+/// Represents a property assignment within a with-expression.
+/// §SET[Name] "New Name"
+/// </summary>
+public sealed class WithPropertyAssignmentNode : AstNode
+{
+    public string PropertyName { get; }
+    public ExpressionNode Value { get; }
+
+    public WithPropertyAssignmentNode(TextSpan span, string propertyName, ExpressionNode value)
+        : base(span)
+    {
+        PropertyName = propertyName ?? throw new ArgumentNullException(nameof(propertyName));
+        Value = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Base class for pattern nodes used in match expressions.
 /// </summary>
 public abstract class PatternNode : AstNode
 {
     protected PatternNode(TextSpan span) : base(span) { }
 }
 
+// Existing pattern nodes (used by match expressions)
+
 /// <summary>
 /// Represents a wildcard pattern that matches anything.
-/// _
 /// </summary>
 public sealed class WildcardPatternNode : PatternNode
 {
     public WildcardPatternNode(TextSpan span) : base(span) { }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
 
 /// <summary>
-/// Represents a variable binding pattern.
-/// x (binds the matched value to x)
+/// Represents a variable pattern that captures a value.
 /// </summary>
 public sealed class VariablePatternNode : PatternNode
 {
@@ -121,13 +159,12 @@ public sealed class VariablePatternNode : PatternNode
         Name = name ?? throw new ArgumentNullException(nameof(name));
     }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
 
 /// <summary>
-/// Represents a literal pattern.
-/// INT:42, STR:"hello", BOOL:true
+/// Represents a literal pattern that matches a specific value.
 /// </summary>
 public sealed class LiteralPatternNode : PatternNode
 {
@@ -138,13 +175,12 @@ public sealed class LiteralPatternNode : PatternNode
         Literal = literal ?? throw new ArgumentNullException(nameof(literal));
     }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
 
 /// <summary>
-/// Represents a Some(x) pattern for Option types.
-/// §SOME pattern
+/// Represents a Some pattern for Option types.
 /// </summary>
 public sealed class SomePatternNode : PatternNode
 {
@@ -155,25 +191,23 @@ public sealed class SomePatternNode : PatternNode
         InnerPattern = innerPattern ?? throw new ArgumentNullException(nameof(innerPattern));
     }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
 
 /// <summary>
 /// Represents a None pattern for Option types.
-/// §NONE
 /// </summary>
 public sealed class NonePatternNode : PatternNode
 {
     public NonePatternNode(TextSpan span) : base(span) { }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
 
 /// <summary>
-/// Represents an Ok(x) pattern for Result types.
-/// §OK pattern
+/// Represents an Ok pattern for Result types.
 /// </summary>
 public sealed class OkPatternNode : PatternNode
 {
@@ -184,13 +218,12 @@ public sealed class OkPatternNode : PatternNode
         InnerPattern = innerPattern ?? throw new ArgumentNullException(nameof(innerPattern));
     }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
 
 /// <summary>
-/// Represents an Err(x) pattern for Result types.
-/// §ERR pattern
+/// Represents an Err pattern for Result types.
 /// </summary>
 public sealed class ErrPatternNode : PatternNode
 {
@@ -201,65 +234,179 @@ public sealed class ErrPatternNode : PatternNode
         InnerPattern = innerPattern ?? throw new ArgumentNullException(nameof(innerPattern));
     }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
 
-/// <summary>
-/// Represents a constructor/variant pattern for discriminated unions.
-/// §VARIANT[name=Circle] pattern...
-/// </summary>
-public sealed class ConstructorPatternNode : PatternNode
-{
-    public string TypeName { get; }
-    public IReadOnlyList<FieldPatternNode> Fields { get; }
+// Phase 10: Advanced Patterns
 
-    public ConstructorPatternNode(TextSpan span, string typeName, IReadOnlyList<FieldPatternNode> fields)
+/// <summary>
+/// Represents a positional pattern for deconstructing types.
+/// §PPOS[Point] §VAR[x] §VAR[y]
+/// generates: Point(var x, var y)
+/// </summary>
+public sealed class PositionalPatternNode : PatternNode
+{
+    /// <summary>
+    /// The type being matched.
+    /// </summary>
+    public string TypeName { get; }
+
+    /// <summary>
+    /// The patterns for each position.
+    /// </summary>
+    public IReadOnlyList<PatternNode> Patterns { get; }
+
+    public PositionalPatternNode(TextSpan span, string typeName, IReadOnlyList<PatternNode> patterns)
         : base(span)
     {
-        TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
-        Fields = fields ?? throw new ArgumentNullException(nameof(fields));
+        TypeName = typeName ?? "";
+        Patterns = patterns ?? throw new ArgumentNullException(nameof(patterns));
     }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
 
 /// <summary>
-/// Represents a field pattern within a constructor pattern.
+/// Represents a property pattern for matching object properties.
+/// §PPROP[Person] §PMATCH[Age] §PREL[gte] 18
+/// generates: Person { Age: >= 18 }
 /// </summary>
-public sealed class FieldPatternNode : AstNode
+public sealed class PropertyPatternNode : PatternNode
 {
-    public string FieldName { get; }
-    public PatternNode Pattern { get; }
+    /// <summary>
+    /// The type being matched (optional).
+    /// </summary>
+    public string? TypeName { get; }
 
-    public FieldPatternNode(TextSpan span, string fieldName, PatternNode pattern)
+    /// <summary>
+    /// The property matches.
+    /// </summary>
+    public IReadOnlyList<PropertyMatchNode> Matches { get; }
+
+    public PropertyPatternNode(TextSpan span, string? typeName, IReadOnlyList<PropertyMatchNode> matches)
         : base(span)
     {
-        FieldName = fieldName ?? throw new ArgumentNullException(nameof(fieldName));
+        TypeName = typeName;
+        Matches = matches ?? throw new ArgumentNullException(nameof(matches));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a property match within a property pattern.
+/// §PMATCH[Age] §PREL[gte] 18
+/// </summary>
+public sealed class PropertyMatchNode : AstNode
+{
+    public string PropertyName { get; }
+    public PatternNode Pattern { get; }
+
+    public PropertyMatchNode(TextSpan span, string propertyName, PatternNode pattern)
+        : base(span)
+    {
+        PropertyName = propertyName ?? throw new ArgumentNullException(nameof(propertyName));
         Pattern = pattern ?? throw new ArgumentNullException(nameof(pattern));
     }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
 
 /// <summary>
-/// Represents a record pattern for destructuring records.
-/// §RECORD[type=Person] §FIELD[name=Name] namePattern §FIELD[name=Age] agePattern
+/// Represents a relational pattern.
+/// §PREL[gte] 18
+/// generates: >= 18
 /// </summary>
-public sealed class RecordPatternNode : PatternNode
+public sealed class RelationalPatternNode : PatternNode
 {
-    public string TypeName { get; }
-    public IReadOnlyList<FieldPatternNode> Fields { get; }
+    /// <summary>
+    /// The operator: lt, lte, gt, gte
+    /// </summary>
+    public string Operator { get; }
 
-    public RecordPatternNode(TextSpan span, string typeName, IReadOnlyList<FieldPatternNode> fields)
+    /// <summary>
+    /// The value being compared to.
+    /// </summary>
+    public ExpressionNode Value { get; }
+
+    public RelationalPatternNode(TextSpan span, string @operator, ExpressionNode value)
         : base(span)
     {
-        TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
-        Fields = fields ?? throw new ArgumentNullException(nameof(fields));
+        Operator = @operator ?? throw new ArgumentNullException(nameof(@operator));
+        Value = value ?? throw new ArgumentNullException(nameof(value));
     }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a list pattern for matching collections.
+/// §PLIST §VAR[first] §REST[rest]
+/// generates: [var first, ..var rest]
+/// </summary>
+public sealed class ListPatternNode : PatternNode
+{
+    /// <summary>
+    /// The patterns for each element.
+    /// </summary>
+    public IReadOnlyList<PatternNode> Patterns { get; }
+
+    /// <summary>
+    /// The slice pattern if present (..rest).
+    /// </summary>
+    public VarPatternNode? SlicePattern { get; }
+
+    public ListPatternNode(TextSpan span, IReadOnlyList<PatternNode> patterns, VarPatternNode? slicePattern)
+        : base(span)
+    {
+        Patterns = patterns ?? throw new ArgumentNullException(nameof(patterns));
+        SlicePattern = slicePattern;
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a var pattern that captures a value.
+/// §VAR[x]
+/// generates: var x
+/// </summary>
+public sealed class VarPatternNode : PatternNode
+{
+    /// <summary>
+    /// The variable name to bind.
+    /// </summary>
+    public string Name { get; }
+
+    public VarPatternNode(TextSpan span, string name)
+        : base(span)
+    {
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a constant pattern that matches a literal value.
+/// </summary>
+public sealed class ConstantPatternNode : PatternNode
+{
+    public ExpressionNode Value { get; }
+
+    public ConstantPatternNode(TextSpan span, ExpressionNode value)
+        : base(span)
+    {
+        Value = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }

--- a/src/Opal.Compiler/Ast/PropertyNodes.cs
+++ b/src/Opal.Compiler/Ast/PropertyNodes.cs
@@ -1,0 +1,176 @@
+using Opal.Compiler.Parsing;
+
+namespace Opal.Compiler.Ast;
+
+/// <summary>
+/// Represents a property in a class.
+/// §PROP[p001:Name:string:pub]
+///   §GET
+///   §SET[pri]
+///     §Q §OP[kind=gte] §REF[name=value] 0   // setter precondition
+/// §/PROP[p001]
+/// </summary>
+public sealed class PropertyNode : AstNode
+{
+    public string Id { get; }
+    public string Name { get; }
+    public string TypeName { get; }
+    public Visibility Visibility { get; }
+    public PropertyAccessorNode? Getter { get; }
+    public PropertyAccessorNode? Setter { get; }
+    public PropertyAccessorNode? Initer { get; }
+    public ExpressionNode? DefaultValue { get; }
+    public AttributeCollection Attributes { get; }
+
+    public PropertyNode(
+        TextSpan span,
+        string id,
+        string name,
+        string typeName,
+        Visibility visibility,
+        PropertyAccessorNode? getter,
+        PropertyAccessorNode? setter,
+        PropertyAccessorNode? initer,
+        ExpressionNode? defaultValue,
+        AttributeCollection attributes)
+        : base(span)
+    {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
+        Visibility = visibility;
+        Getter = getter;
+        Setter = setter;
+        Initer = initer;
+        DefaultValue = defaultValue;
+        Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+    }
+
+    public bool IsAutoProperty => Getter == null && Setter == null && Initer == null;
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a property accessor (get, set, or init).
+/// §GET
+/// §SET[pri]
+/// </summary>
+public sealed class PropertyAccessorNode : AstNode
+{
+    public enum AccessorKind { Get, Set, Init }
+
+    public AccessorKind Kind { get; }
+    public Visibility? Visibility { get; }
+    public IReadOnlyList<RequiresNode> Preconditions { get; }
+    public IReadOnlyList<StatementNode> Body { get; }
+    public AttributeCollection Attributes { get; }
+
+    public PropertyAccessorNode(
+        TextSpan span,
+        AccessorKind kind,
+        Visibility? visibility,
+        IReadOnlyList<RequiresNode> preconditions,
+        IReadOnlyList<StatementNode> body,
+        AttributeCollection attributes)
+        : base(span)
+    {
+        Kind = kind;
+        Visibility = visibility;
+        Preconditions = preconditions ?? throw new ArgumentNullException(nameof(preconditions));
+        Body = body ?? throw new ArgumentNullException(nameof(body));
+        Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+    }
+
+    public bool IsAutoImplemented => Body.Count == 0;
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a constructor.
+/// §CTOR[ctor1:pub]
+///   §I[string:name] §I[f64:radius]
+///   §Q §OP[kind=gt] §REF[name=radius] 0
+///   §BASE §A §REF[name=name] §/BASE
+///   §ASSIGN §REF[name=Radius] §REF[name=radius]
+/// §/CTOR[ctor1]
+/// </summary>
+public sealed class ConstructorNode : AstNode
+{
+    public string Id { get; }
+    public Visibility Visibility { get; }
+    public IReadOnlyList<ParameterNode> Parameters { get; }
+    public IReadOnlyList<RequiresNode> Preconditions { get; }
+    public ConstructorInitializerNode? Initializer { get; }
+    public IReadOnlyList<StatementNode> Body { get; }
+    public AttributeCollection Attributes { get; }
+
+    public ConstructorNode(
+        TextSpan span,
+        string id,
+        Visibility visibility,
+        IReadOnlyList<ParameterNode> parameters,
+        IReadOnlyList<RequiresNode> preconditions,
+        ConstructorInitializerNode? initializer,
+        IReadOnlyList<StatementNode> body,
+        AttributeCollection attributes)
+        : base(span)
+    {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        Visibility = visibility;
+        Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+        Preconditions = preconditions ?? throw new ArgumentNullException(nameof(preconditions));
+        Initializer = initializer;
+        Body = body ?? throw new ArgumentNullException(nameof(body));
+        Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a constructor initializer (: base(...) or : this(...)).
+/// §BASE §A §REF[name=name] §/BASE
+/// </summary>
+public sealed class ConstructorInitializerNode : AstNode
+{
+    public bool IsBaseCall { get; }
+    public IReadOnlyList<ExpressionNode> Arguments { get; }
+
+    public ConstructorInitializerNode(
+        TextSpan span,
+        bool isBaseCall,
+        IReadOnlyList<ExpressionNode> arguments)
+        : base(span)
+    {
+        IsBaseCall = isBaseCall;
+        Arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents an assignment statement.
+/// §ASSIGN §REF[name=Radius] §REF[name=radius]
+/// </summary>
+public sealed class AssignmentStatementNode : StatementNode
+{
+    public ExpressionNode Target { get; }
+    public ExpressionNode Value { get; }
+
+    public AssignmentStatementNode(TextSpan span, ExpressionNode target, ExpressionNode value)
+        : base(span)
+    {
+        Target = target ?? throw new ArgumentNullException(nameof(target));
+        Value = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}

--- a/src/Opal.Compiler/Ast/UsingDirectiveNode.cs
+++ b/src/Opal.Compiler/Ast/UsingDirectiveNode.cs
@@ -1,0 +1,38 @@
+using Opal.Compiler.Parsing;
+
+namespace Opal.Compiler.Ast;
+
+/// <summary>
+/// Represents a using directive for .NET namespace imports.
+/// §U[System.Collections.Generic]            // using System.Collections.Generic;
+/// §U[Gen:System.Collections.Generic]        // using Gen = System.Collections.Generic;
+/// §U[static:System.Math]                    // using static System.Math;
+/// </summary>
+public sealed class UsingDirectiveNode : AstNode
+{
+    /// <summary>
+    /// The namespace being imported.
+    /// </summary>
+    public string Namespace { get; }
+
+    /// <summary>
+    /// Optional alias for the namespace (e.g., "Gen" in "using Gen = System.Collections.Generic").
+    /// </summary>
+    public string? Alias { get; }
+
+    /// <summary>
+    /// Whether this is a "using static" directive.
+    /// </summary>
+    public bool IsStatic { get; }
+
+    public UsingDirectiveNode(TextSpan span, string @namespace, string? alias = null, bool isStatic = false)
+        : base(span)
+    {
+        Namespace = @namespace ?? throw new ArgumentNullException(nameof(@namespace));
+        Alias = alias;
+        IsStatic = isStatic;
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}

--- a/src/Opal.Compiler/Parsing/Lexer.cs
+++ b/src/Opal.Compiler/Parsing/Lexer.cs
@@ -63,6 +63,82 @@ public sealed class Lexer
         ["REQUIRES"] = TokenKind.Requires,
         ["ENSURES"] = TokenKind.Ensures,
         ["INVARIANT"] = TokenKind.Invariant,
+        // Phase 5: Using Statements
+        ["USING"] = TokenKind.Using,
+        // Phase 6: Arrays and Collections
+        ["ARR"] = TokenKind.Array,
+        ["END_ARR"] = TokenKind.EndArray,
+        ["IDX"] = TokenKind.Index,
+        ["LEN"] = TokenKind.Length,
+        ["EACH"] = TokenKind.Foreach,
+        ["END_EACH"] = TokenKind.EndForeach,
+        // Phase 7: Generics
+        ["TP"] = TokenKind.TypeParam,
+        ["WHERE"] = TokenKind.Where,
+        ["G"] = TokenKind.Generic,
+        // Phase 8: Classes, Interfaces, Inheritance
+        ["CLASS"] = TokenKind.Class,
+        ["END_CLASS"] = TokenKind.EndClass,
+        ["IFACE"] = TokenKind.Interface,
+        ["END_IFACE"] = TokenKind.EndInterface,
+        ["IMPL"] = TokenKind.Implements,
+        ["EXT"] = TokenKind.Extends,
+        ["METHOD"] = TokenKind.Method,
+        ["END_METHOD"] = TokenKind.EndMethod,
+        ["VIRTUAL"] = TokenKind.Virtual,
+        ["OVERRIDE"] = TokenKind.Override,
+        ["ABSTRACT"] = TokenKind.Abstract,
+        ["SEALED"] = TokenKind.Sealed,
+        ["THIS"] = TokenKind.This,
+        ["BASE"] = TokenKind.Base,
+        ["NEW"] = TokenKind.New,
+        ["FLD"] = TokenKind.FieldDef,
+        // Phase 9: Properties and Constructors
+        ["PROP"] = TokenKind.Property,
+        ["END_PROP"] = TokenKind.EndProperty,
+        ["GET"] = TokenKind.Get,
+        ["SET"] = TokenKind.Set,
+        ["INIT"] = TokenKind.Init,
+        ["CTOR"] = TokenKind.Constructor,
+        ["END_CTOR"] = TokenKind.EndConstructor,
+        ["ASSIGN"] = TokenKind.Assign,
+        // Phase 10: Try/Catch/Finally
+        ["TRY"] = TokenKind.Try,
+        ["END_TRY"] = TokenKind.EndTry,
+        ["CATCH"] = TokenKind.Catch,
+        ["FINALLY"] = TokenKind.Finally,
+        ["THROW"] = TokenKind.Throw,
+        ["RETHROW"] = TokenKind.Rethrow,
+        ["WHEN"] = TokenKind.When,
+        // Phase 11: Lambdas, Delegates, Events
+        ["LAM"] = TokenKind.Lambda,
+        ["END_LAM"] = TokenKind.EndLambda,
+        ["DEL"] = TokenKind.Delegate,
+        ["END_DEL"] = TokenKind.EndDelegate,
+        ["EVT"] = TokenKind.Event,
+        ["SUB"] = TokenKind.Subscribe,
+        ["UNSUB"] = TokenKind.Unsubscribe,
+        // Phase 12: Async/Await
+        ["ASYNC"] = TokenKind.Async,
+        ["AWAIT"] = TokenKind.Await,
+        // Phase 9: String Interpolation and Modern Operators
+        ["INTERP"] = TokenKind.Interpolate,
+        ["/INTERP"] = TokenKind.EndInterpolate,
+        ["??"] = TokenKind.NullCoalesce,
+        ["?."] = TokenKind.NullConditional,
+        ["RANGE"] = TokenKind.RangeOp,
+        ["^"] = TokenKind.IndexEnd,
+        ["EXP"] = TokenKind.Expression,
+        // Phase 10: Advanced Patterns
+        ["WITH"] = TokenKind.With,
+        ["/WITH"] = TokenKind.EndWith,
+        ["PPOS"] = TokenKind.PositionalPattern,
+        ["PPROP"] = TokenKind.PropertyPattern,
+        ["PMATCH"] = TokenKind.PropertyMatch,
+        ["PREL"] = TokenKind.RelationalPattern,
+        ["PLIST"] = TokenKind.ListPattern,
+        ["VAR"] = TokenKind.Var,
+        ["REST"] = TokenKind.Rest,
 
         // v2 single-letter keywords (compact syntax)
         ["M"] = TokenKind.Module,           // §M = §MODULE
@@ -82,6 +158,22 @@ public sealed class Lexer
         ["T"] = TokenKind.Type,             // §T = §TYPE
         ["D"] = TokenKind.Record,           // §D = §RECORD (Data)
         ["V"] = TokenKind.Variant,          // §V = §VARIANT
+        ["U"] = TokenKind.Using,            // §U = §USING
+        // Phase 6: v2 closing tags for arrays
+        ["/ARR"] = TokenKind.EndArray,      // §/ARR = §END_ARR
+        ["/EACH"] = TokenKind.EndForeach,   // §/EACH = §END_EACH
+        // Phase 8: v2 closing tags for classes
+        ["/CLASS"] = TokenKind.EndClass,    // §/CLASS = §END_CLASS
+        ["/IFACE"] = TokenKind.EndInterface, // §/IFACE = §END_IFACE
+        ["/METHOD"] = TokenKind.EndMethod,  // §/METHOD = §END_METHOD
+        // Phase 9: v2 closing tags for properties/constructors
+        ["/PROP"] = TokenKind.EndProperty,  // §/PROP = §END_PROP
+        ["/CTOR"] = TokenKind.EndConstructor, // §/CTOR = §END_CTOR
+        // Phase 10: v2 closing tags for try/catch
+        ["/TRY"] = TokenKind.EndTry,        // §/TRY = §END_TRY
+        // Phase 11: v2 closing tags for lambdas/delegates
+        ["/LAM"] = TokenKind.EndLambda,     // §/LAM = §END_LAM
+        ["/DEL"] = TokenKind.EndDelegate,   // §/DEL = §END_DEL
 
         // v2 closing tags (§/X pattern)
         ["/M"] = TokenKind.EndModule,       // §/M = §END_MODULE

--- a/src/Opal.Compiler/Parsing/Token.cs
+++ b/src/Opal.Compiler/Parsing/Token.cs
@@ -66,6 +66,94 @@ public enum TokenKind
     Ensures,
     Invariant,
 
+    // Phase 5: Using Statements (.NET Interop)
+    Using,
+
+    // Phase 6: Arrays and Collections
+    Array,
+    EndArray,
+    Index,
+    Length,
+    Foreach,
+    EndForeach,
+
+    // Phase 7: Generics
+    TypeParam,
+    Where,
+    Generic,
+
+    // Phase 8: Classes, Interfaces, Inheritance
+    Class,
+    EndClass,
+    Interface,
+    EndInterface,
+    Implements,
+    Extends,
+    Method,
+    EndMethod,
+    Virtual,
+    Override,
+    Abstract,
+    Sealed,
+    This,
+    Base,
+    New,
+    FieldDef,
+
+    // Phase 9: Properties and Constructors
+    Property,
+    EndProperty,
+    Get,
+    Set,
+    Init,
+    Constructor,
+    EndConstructor,
+    BaseCall,
+    EndBaseCall,
+    Assign,
+
+    // Phase 10: Try/Catch/Finally
+    Try,
+    EndTry,
+    Catch,
+    Finally,
+    Throw,
+    Rethrow,
+    When,
+
+    // Phase 11: Lambdas, Delegates, Events
+    Lambda,
+    EndLambda,
+    Delegate,
+    EndDelegate,
+    Event,
+    Subscribe,
+    Unsubscribe,
+
+    // Phase 12: Async/Await
+    Async,
+    Await,
+
+    // Phase 9: String Interpolation and Modern Operators
+    Interpolate,
+    EndInterpolate,
+    NullCoalesce,
+    NullConditional,
+    RangeOp,
+    IndexEnd,
+    Expression,
+
+    // Phase 10: Advanced Patterns
+    With,
+    EndWith,
+    PositionalPattern,
+    PropertyPattern,
+    PropertyMatch,
+    RelationalPattern,
+    ListPattern,
+    Var,
+    Rest,
+
     // Typed Literals
     IntLiteral,         // INT:42
     StrLiteral,         // STR:"hello"
@@ -100,7 +188,7 @@ public readonly struct Token : IEquatable<Token>
         Value = value;
     }
 
-    public bool IsKeyword => Kind is >= TokenKind.Module and <= TokenKind.Invariant;
+    public bool IsKeyword => Kind is >= TokenKind.Module and <= TokenKind.Rest;
 
     public bool IsLiteral => Kind is TokenKind.IntLiteral or TokenKind.StrLiteral
         or TokenKind.BoolLiteral or TokenKind.FloatLiteral;


### PR DESCRIPTION
## Summary

- Implement comprehensive C# language features in OPAL to enable conversion of any C# file and full .NET framework interop
- Add support across 10 phases covering all major C# constructs
- Create new AST node files for each feature set
- All 174 existing tests pass

### Phases Implemented:

1. **Using Statements** - `§U` directive for .NET namespace imports
2. **Arrays and Collections** - `§ARR`, `§IDX`, `§LEN`, `§EACH`
3. **User-Defined Generics** - `§TP`, `§WHERE`, `§G` for generic types
4. **Classes, Interfaces, Inheritance** - `§CLASS`, `§IFACE`, `§METHOD`, `§NEW`
5. **Properties and Constructors** - `§PROP`, `§CTOR`, `§ASSIGN`
6. **Try/Catch/Finally** - `§TRY`, `§CATCH`, `§FINALLY`, `§THROW`, `§RETHROW`
7. **Lambdas, Delegates, Events** - `§LAM`, `§DEL`, `§EVT`, `§SUB`, `§UNSUB`
8. **Async/Await** - `§ASYNC`, `§AWAIT` with ConfigureAwait support
9. **String Interpolation and Modern Operators** - `§INTERP`, `§??`, `§?.`, `§RANGE`, `§^`
10. **Advanced Patterns** - `§WITH`, `§PPOS`, `§PPROP`, `§PMATCH`, `§PREL`, `§PLIST`

## Test plan

- [x] All 174 existing tests pass
- [x] Build succeeds without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)