### PR TITLE
Add v2 expression syntax enhancements for token efficiency

### DIFF
--- a/samples/FizzBuzz/fizzbuzz_v2.opal
+++ b/samples/FizzBuzz/fizzbuzz_v2.opal
@@ -1,0 +1,13 @@
+§M[m001:FizzBuzz]
+§F[f001:Main:pub]
+  §O[void]
+  §E[cw]
+  §L[for1:i:1:100:1]
+    §IF[if1] (== (% i 15) 0) → §P "FizzBuzz"
+    §EI (== (% i 3) 0) → §P "Fizz"
+    §EI (== (% i 5) 0) → §P "Buzz"
+    §EL → §P i
+    §/I[if1]
+  §/L[for1]
+§/F[f001]
+§/M[m001]

--- a/src/Opal.Compiler/Ast/AstNode.cs
+++ b/src/Opal.Compiler/Ast/AstNode.cs
@@ -39,6 +39,9 @@ public interface IAstVisitor
     void Visit(IfStatementNode node);
     void Visit(BindStatementNode node);
     void Visit(BinaryOperationNode node);
+    void Visit(UnaryOperationNode node);
+    // v2 built-in operations
+    void Visit(PrintStatementNode node);
     // Phase 3: Type System
     void Visit(RecordDefinitionNode node);
     void Visit(UnionTypeDefinitionNode node);
@@ -143,6 +146,9 @@ public interface IAstVisitor<T>
     T Visit(IfStatementNode node);
     T Visit(BindStatementNode node);
     T Visit(BinaryOperationNode node);
+    T Visit(UnaryOperationNode node);
+    // v2 built-in operations
+    T Visit(PrintStatementNode node);
     // Phase 3: Type System
     T Visit(RecordDefinitionNode node);
     T Visit(UnionTypeDefinitionNode node);

--- a/src/Opal.Compiler/Ast/ControlFlowNodes.cs
+++ b/src/Opal.Compiler/Ast/ControlFlowNodes.cs
@@ -196,6 +196,7 @@ public enum BinaryOperator
     Multiply,   // *
     Divide,     // /
     Modulo,     // %
+    Power,      // **
 
     // Comparison
     Equal,          // ==
@@ -208,6 +209,13 @@ public enum BinaryOperator
     // Logical
     And,    // &&
     Or,     // ||
+
+    // Bitwise
+    BitwiseAnd,     // &
+    BitwiseOr,      // |
+    BitwiseXor,     // ^
+    LeftShift,      // <<
+    RightShift,     // >>
 }
 
 /// <summary>
@@ -224,6 +232,7 @@ public static class BinaryOperatorExtensions
             "MUL" or "MULTIPLY" or "*" => BinaryOperator.Multiply,
             "DIV" or "DIVIDE" or "/" => BinaryOperator.Divide,
             "MOD" or "MODULO" or "%" => BinaryOperator.Modulo,
+            "POW" or "POWER" or "**" => BinaryOperator.Power,
             "EQ" or "EQUAL" or "==" => BinaryOperator.Equal,
             "NEQ" or "NOTEQUAL" or "NE" or "!=" => BinaryOperator.NotEqual,
             "LT" or "LESSTHAN" or "<" => BinaryOperator.LessThan,
@@ -232,6 +241,11 @@ public static class BinaryOperatorExtensions
             "GTE" or "GE" or "GREATEROREQUAL" or ">=" => BinaryOperator.GreaterOrEqual,
             "AND" or "&&" => BinaryOperator.And,
             "OR" or "||" => BinaryOperator.Or,
+            "BAND" or "BITWISEAND" or "&" => BinaryOperator.BitwiseAnd,
+            "BOR" or "BITWISEOR" or "|" => BinaryOperator.BitwiseOr,
+            "BXOR" or "BITWISEXOR" or "^" => BinaryOperator.BitwiseXor,
+            "SHL" or "LEFTSHIFT" or "<<" => BinaryOperator.LeftShift,
+            "SHR" or "RIGHTSHIFT" or ">>" => BinaryOperator.RightShift,
             _ => null
         };
     }
@@ -245,6 +259,7 @@ public static class BinaryOperatorExtensions
             BinaryOperator.Multiply => "*",
             BinaryOperator.Divide => "/",
             BinaryOperator.Modulo => "%",
+            BinaryOperator.Power => "**", // Will need Math.Pow in emitter
             BinaryOperator.Equal => "==",
             BinaryOperator.NotEqual => "!=",
             BinaryOperator.LessThan => "<",
@@ -253,6 +268,11 @@ public static class BinaryOperatorExtensions
             BinaryOperator.GreaterOrEqual => ">=",
             BinaryOperator.And => "&&",
             BinaryOperator.Or => "||",
+            BinaryOperator.BitwiseAnd => "&",
+            BinaryOperator.BitwiseOr => "|",
+            BinaryOperator.BitwiseXor => "^",
+            BinaryOperator.LeftShift => "<<",
+            BinaryOperator.RightShift => ">>",
             _ => throw new ArgumentOutOfRangeException(nameof(op))
         };
     }

--- a/src/Opal.Compiler/Ast/ExpressionNodes.cs
+++ b/src/Opal.Compiler/Ast/ExpressionNodes.cs
@@ -93,3 +93,60 @@ public sealed class ReferenceNode : ExpressionNode
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
     public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
+
+/// <summary>
+/// Represents a unary operation (prefix operators like !, ~, -).
+/// </summary>
+public sealed class UnaryOperationNode : ExpressionNode
+{
+    public UnaryOperator Operator { get; }
+    public ExpressionNode Operand { get; }
+
+    public UnaryOperationNode(TextSpan span, UnaryOperator op, ExpressionNode operand)
+        : base(span)
+    {
+        Operator = op;
+        Operand = operand ?? throw new ArgumentNullException(nameof(operand));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Unary operators supported by OPAL.
+/// </summary>
+public enum UnaryOperator
+{
+    Negate,         // - (unary minus)
+    Not,            // ! (logical not)
+    BitwiseNot,     // ~ (bitwise not)
+}
+
+/// <summary>
+/// Helper methods for UnaryOperator.
+/// </summary>
+public static class UnaryOperatorExtensions
+{
+    public static UnaryOperator? FromString(string? value)
+    {
+        return value?.ToUpperInvariant() switch
+        {
+            "NEG" or "NEGATE" or "-" => UnaryOperator.Negate,
+            "NOT" or "!" => UnaryOperator.Not,
+            "BNOT" or "BITWISENOT" or "~" => UnaryOperator.BitwiseNot,
+            _ => null
+        };
+    }
+
+    public static string ToCSharpOperator(this UnaryOperator op)
+    {
+        return op switch
+        {
+            UnaryOperator.Negate => "-",
+            UnaryOperator.Not => "!",
+            UnaryOperator.BitwiseNot => "~",
+            _ => throw new ArgumentOutOfRangeException(nameof(op))
+        };
+    }
+}

--- a/src/Opal.Compiler/Ast/StatementNodes.cs
+++ b/src/Opal.Compiler/Ast/StatementNodes.cs
@@ -56,3 +56,23 @@ public sealed class ReturnStatementNode : StatementNode
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
     public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
+
+/// <summary>
+/// Represents a print statement (§P shorthand for Console.WriteLine).
+/// §P expression
+/// </summary>
+public sealed class PrintStatementNode : StatementNode
+{
+    public ExpressionNode Expression { get; }
+    public bool IsWriteLine { get; }  // true for §P (WriteLine), false for §Pf (Write)
+
+    public PrintStatementNode(TextSpan span, ExpressionNode expression, bool isWriteLine = true)
+        : base(span)
+    {
+        Expression = expression ?? throw new ArgumentNullException(nameof(expression));
+        IsWriteLine = isWriteLine;
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}

--- a/src/Opal.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Opal.Compiler/CodeGen/CSharpEmitter.cs
@@ -421,9 +421,29 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     {
         var left = node.Left.Accept(this);
         var right = node.Right.Accept(this);
-        var op = node.Operator.ToCSharpOperator();
 
+        // Special handling for Power operator (use Math.Pow)
+        if (node.Operator == BinaryOperator.Power)
+        {
+            return $"Math.Pow({left}, {right})";
+        }
+
+        var op = node.Operator.ToCSharpOperator();
         return $"({left} {op} {right})";
+    }
+
+    public string Visit(UnaryOperationNode node)
+    {
+        var operand = node.Operand.Accept(this);
+        var op = node.Operator.ToCSharpOperator();
+        return $"({op}{operand})";
+    }
+
+    public string Visit(PrintStatementNode node)
+    {
+        var expr = node.Expression.Accept(this);
+        var method = node.IsWriteLine ? "Console.WriteLine" : "Console.Write";
+        return $"{method}({expr});";
     }
 
     // Phase 3: Type System

--- a/src/Opal.Compiler/Parsing/Token.cs
+++ b/src/Opal.Compiler/Parsing/Token.cs
@@ -17,6 +17,36 @@ public enum TokenKind
     Tilde,              // ~
     Hash,               // #
     Question,           // ?
+    OpenParen,          // (
+    CloseParen,         // )
+    Arrow,              // → or ->
+
+    // v2 operator symbols (for Lisp-style expressions)
+    Plus,               // +
+    Minus,              // -
+    Star,               // *
+    Slash,              // /
+    Percent,            // %
+    EqualEqual,         // ==
+    BangEqual,          // !=
+    Less,               // <
+    LessEqual,          // <=
+    Greater,            // >
+    GreaterEqual,       // >=
+    AmpAmp,             // &&
+    PipePipe,           // ||
+    Amp,                // &
+    Pipe,               // |
+    Caret,              // ^
+    LessLess,           // <<
+    GreaterGreater,     // >>
+    StarStar,           // **
+
+    // v2 built-in aliases
+    Print,              // §P = Console.WriteLine
+    PrintF,             // §Pf = Console.Write
+    ReadLine,           // §G = Console.ReadLine (renamed from Get to avoid conflict)
+    DebugPrint,         // §D = Debug.WriteLine (renamed from Debug to avoid potential conflicts)
 
     // Keywords (recognized after §)
     Module,

--- a/tests/Opal.Compiler.Tests/V2SyntaxTests.cs
+++ b/tests/Opal.Compiler.Tests/V2SyntaxTests.cs
@@ -694,4 +694,542 @@ public class V2SyntaxTests
     }
 
     #endregion
+
+    #region v2 Lisp-Style Expressions
+
+    [Fact]
+    public void Lexer_RecognizesOpenParen()
+    {
+        var tokens = Tokenize("(");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.OpenParen, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesCloseParen()
+    {
+        var tokens = Tokenize(")");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.CloseParen, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesArrow()
+    {
+        var tokens = Tokenize("->");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Arrow, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesUnicodeArrow()
+    {
+        var tokens = Tokenize("→");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Arrow, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesPlusOperator()
+    {
+        var tokens = Tokenize("+");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Plus, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesMinusOperator()
+    {
+        var tokens = Tokenize("- ");  // space to avoid arrow or number
+
+        Assert.Contains(tokens, t => t.Kind == TokenKind.Minus);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesStarOperator()
+    {
+        var tokens = Tokenize("*");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Star, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesDoubleStarOperator()
+    {
+        var tokens = Tokenize("**");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.StarStar, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesSlashOperator()
+    {
+        var tokens = Tokenize("/");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Slash, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesPercentOperator()
+    {
+        var tokens = Tokenize("%");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Percent, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesEqualEqualOperator()
+    {
+        var tokens = Tokenize("==");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.EqualEqual, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesBangEqualOperator()
+    {
+        var tokens = Tokenize("!=");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.BangEqual, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesLessOperator()
+    {
+        var tokens = Tokenize("<");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Less, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesLessEqualOperator()
+    {
+        var tokens = Tokenize("<=");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.LessEqual, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesGreaterOperator()
+    {
+        var tokens = Tokenize(">");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Greater, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesGreaterEqualOperator()
+    {
+        var tokens = Tokenize(">=");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.GreaterEqual, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesAmpAmpOperator()
+    {
+        var tokens = Tokenize("&&");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.AmpAmp, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesPipePipeOperator()
+    {
+        var tokens = Tokenize("||");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.PipePipe, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesLeftShiftOperator()
+    {
+        var tokens = Tokenize("<<");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.LessLess, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesRightShiftOperator()
+    {
+        var tokens = Tokenize(">>");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.GreaterGreater, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_TokenizesLispExpression()
+    {
+        var tokens = Tokenize("(== (% i 15) 0)");
+
+        // ( == ( % i 15 ) 0 )
+        Assert.Equal(TokenKind.OpenParen, tokens[0].Kind);
+        Assert.Equal(TokenKind.EqualEqual, tokens[1].Kind);
+        Assert.Equal(TokenKind.OpenParen, tokens[2].Kind);
+        Assert.Equal(TokenKind.Percent, tokens[3].Kind);
+        Assert.Equal(TokenKind.Identifier, tokens[4].Kind);
+        Assert.Equal("i", tokens[4].Text);
+        Assert.Equal(TokenKind.IntLiteral, tokens[5].Kind);
+        Assert.Equal(TokenKind.CloseParen, tokens[6].Kind);
+        Assert.Equal(TokenKind.IntLiteral, tokens[7].Kind);
+        Assert.Equal(TokenKind.CloseParen, tokens[8].Kind);
+    }
+
+    [Fact]
+    public void Parser_ParsesSimpleLispAddition()
+    {
+        var diagnostics = new DiagnosticBag();
+        var source = @"
+§M[m001:Test]
+§F[f001:Add:pub]
+  §O[i32]
+  §BODY
+    §RETURN (+ 1 2)
+  §END_BODY
+§/F[f001]
+§/M[m001]";
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        Assert.Single(module.Functions);
+        var returnStmt = module.Functions[0].Body[0] as ReturnStatementNode;
+        Assert.NotNull(returnStmt);
+        Assert.IsType<BinaryOperationNode>(returnStmt!.Expression);
+        var binOp = (BinaryOperationNode)returnStmt.Expression!;
+        Assert.Equal(BinaryOperator.Add, binOp.Operator);
+    }
+
+    [Fact]
+    public void Parser_ParsesNestedLispExpression()
+    {
+        var diagnostics = new DiagnosticBag();
+        var source = @"
+§M[m001:Test]
+§F[f001:Calc:pub]
+  §O[bool]
+  §BODY
+    §RETURN (== (% i 15) 0)
+  §END_BODY
+§/F[f001]
+§/M[m001]";
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        var returnStmt = module.Functions[0].Body[0] as ReturnStatementNode;
+        Assert.NotNull(returnStmt);
+        Assert.IsType<BinaryOperationNode>(returnStmt!.Expression);
+        var binOp = (BinaryOperationNode)returnStmt.Expression!;
+        Assert.Equal(BinaryOperator.Equal, binOp.Operator);
+        // Left should be a modulo operation
+        Assert.IsType<BinaryOperationNode>(binOp.Left);
+        var modOp = (BinaryOperationNode)binOp.Left;
+        Assert.Equal(BinaryOperator.Modulo, modOp.Operator);
+    }
+
+    [Fact]
+    public void Parser_ParsesBareVariableInLispExpression()
+    {
+        var diagnostics = new DiagnosticBag();
+        var source = @"
+§M[m001:Test]
+§F[f001:Test:pub]
+  §I[i32:x]
+  §O[i32]
+  §BODY
+    §RETURN (+ x 1)
+  §END_BODY
+§/F[f001]
+§/M[m001]";
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        var returnStmt = module.Functions[0].Body[0] as ReturnStatementNode;
+        var binOp = (BinaryOperationNode)returnStmt!.Expression!;
+        Assert.IsType<ReferenceNode>(binOp.Left);
+        var refNode = (ReferenceNode)binOp.Left;
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void Parser_ParsesUnaryNot()
+    {
+        var diagnostics = new DiagnosticBag();
+        var source = @"
+§M[m001:Test]
+§F[f001:Test:pub]
+  §I[BOOL:flag]
+  §O[BOOL]
+  §BODY
+    §RETURN (! flag)
+  §END_BODY
+§/F[f001]
+§/M[m001]";
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        var returnStmt = module.Functions[0].Body[0] as ReturnStatementNode;
+        Assert.IsType<UnaryOperationNode>(returnStmt!.Expression);
+        var unaryOp = (UnaryOperationNode)returnStmt.Expression!;
+        Assert.Equal(UnaryOperator.Not, unaryOp.Operator);
+    }
+
+    #endregion
+
+    #region v2 Print Alias
+
+    [Fact]
+    public void Lexer_RecognizesPrintAlias()
+    {
+        var tokens = Tokenize("§P");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Print, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesPrintFAlias()
+    {
+        var tokens = Tokenize("§Pf");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.PrintF, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Parser_ParsesPrintStatement()
+    {
+        var diagnostics = new DiagnosticBag();
+        var source = @"
+§M[m001:Test]
+§F[f001:Main:pub]
+  §O[void]
+  §BODY
+    §P ""Hello World""
+  §END_BODY
+§/F[f001]
+§/M[m001]";
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        Assert.Single(module.Functions[0].Body);
+        Assert.IsType<PrintStatementNode>(module.Functions[0].Body[0]);
+        var printStmt = (PrintStatementNode)module.Functions[0].Body[0];
+        Assert.True(printStmt.IsWriteLine);
+    }
+
+    [Fact]
+    public void Parser_ParsesPrintWithLispExpression()
+    {
+        var diagnostics = new DiagnosticBag();
+        var source = @"
+§M[m001:Test]
+§F[f001:Main:pub]
+  §I[i32:x]
+  §O[void]
+  §BODY
+    §P (+ x 1)
+  §END_BODY
+§/F[f001]
+§/M[m001]";
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        var printStmt = (PrintStatementNode)module.Functions[0].Body[0];
+        Assert.IsType<BinaryOperationNode>(printStmt.Expression);
+    }
+
+    #endregion
+
+    #region v2 Arrow Syntax
+
+    [Fact]
+    public void Parser_ParsesIfWithArrowSyntax()
+    {
+        var diagnostics = new DiagnosticBag();
+        var source = @"
+§M[m001:Test]
+§F[f001:Main:pub]
+  §I[BOOL:flag]
+  §O[void]
+  §BODY
+    §IF[i1] flag → §P ""Yes""
+    §/I[i1]
+  §END_BODY
+§/F[f001]
+§/M[m001]";
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        Assert.Single(module.Functions[0].Body);
+        var ifStmt = module.Functions[0].Body[0] as IfStatementNode;
+        Assert.NotNull(ifStmt);
+        Assert.Single(ifStmt!.ThenBody);
+        Assert.IsType<PrintStatementNode>(ifStmt.ThenBody[0]);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesElseIfShortcut()
+    {
+        var tokens = Tokenize("§EI");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.ElseIf, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesElseShortcut()
+    {
+        var tokens = Tokenize("§EL");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Else, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesWhileShortcut()
+    {
+        var tokens = Tokenize("§WH");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.While, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesEndWhileShortcut()
+    {
+        var tokens = Tokenize("§/WH");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.EndWhile, tokens[0].Kind);
+    }
+
+    #endregion
+
+    #region v2 Implicit Closing
+
+    [Fact]
+    public void Parser_ParsesCallWithImplicitClosing()
+    {
+        var diagnostics = new DiagnosticBag();
+        var source = @"
+§M[m001:Test]
+§F[f001:Main:pub]
+  §O[void]
+  §BODY
+    §C[Console.WriteLine] ""Hello""
+  §END_BODY
+§/F[f001]
+§/M[m001]";
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        Assert.Single(module.Functions[0].Body);
+        var callStmt = module.Functions[0].Body[0] as CallStatementNode;
+        Assert.NotNull(callStmt);
+        Assert.Single(callStmt!.Arguments);
+    }
+
+    [Fact]
+    public void Parser_ParsesCallWithImplicitClosingAndLispExpression()
+    {
+        var diagnostics = new DiagnosticBag();
+        var source = @"
+§M[m001:Test]
+§F[f001:Main:pub]
+  §I[i32:x]
+  §O[void]
+  §BODY
+    §C[Console.WriteLine] (+ x 1)
+  §END_BODY
+§/F[f001]
+§/M[m001]";
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        var callStmt = module.Functions[0].Body[0] as CallStatementNode;
+        Assert.NotNull(callStmt);
+        Assert.Single(callStmt!.Arguments);
+        Assert.IsType<BinaryOperationNode>(callStmt.Arguments[0]);
+    }
+
+    #endregion
+
+    #region v2 Backtick Identifiers
+
+    [Fact]
+    public void Lexer_RecognizesBacktickIdentifier()
+    {
+        var tokens = Tokenize("`true`");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Identifier, tokens[0].Kind);
+        Assert.Equal("true", tokens[0].Text);
+    }
+
+    [Fact]
+    public void Lexer_RecognizesBacktickIdentifierWithSpaces()
+    {
+        var tokens = Tokenize("`my var`");
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenKind.Identifier, tokens[0].Kind);
+        Assert.Equal("my var", tokens[0].Text);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- Implement Lisp-style prefix expressions: `(== (% i 15) 0)` instead of `§OP[kind=EQ] §OP[kind=MOD] §REF[name=i] 15 0`
- Add bare variable references in expressions: `i` instead of `§REF[name=i]`
- Add arrow syntax for single-expression if/else: `§IF[id] cond → stmt`
- Add print alias: `§P "text"` expands to `Console.WriteLine`
- Add implicit closing for single-arg calls: `§C[target] expr` (no `§A` or `§/C` needed)
- Add short control flow keywords: `§EI` (else-if), `§EL` (else), `§WH` (while)

## Test plan

- [x] All 218 tests pass (174 original + 44 new)
- [x] Full backward compatibility with v1 syntax
- [x] FizzBuzz v2 compiles to valid C#
- [x] 51% reduction in FizzBuzz source size (571 → 277 chars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)