### PR TITLE
Add C# test suite for OPAL converter validation

### DIFF
--- a/tests/Opal.Compiler.Tests/CSharpImportBulkTests.cs
+++ b/tests/Opal.Compiler.Tests/CSharpImportBulkTests.cs
@@ -1,0 +1,473 @@
+using Opal.Compiler.CSharpImport;
+using Opal.Compiler.Parsing;
+using Opal.Compiler.CodeGen;
+using Opal.Compiler.Diagnostics;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Opal.Compiler.Tests;
+
+/// <summary>
+/// Bulk tests for the C# to OPAL converter using the test data files.
+/// </summary>
+public class CSharpImportBulkTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public CSharpImportBulkTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    #region Level 1 - Basic Tests
+
+    [Theory]
+    [MemberData(nameof(GetLevel1TestFiles))]
+    public void Level1_Basic_FilesConvertSuccessfully(TestFileInfo file)
+    {
+        AssertConversionSucceeds(file);
+    }
+
+    public static IEnumerable<object[]> GetLevel1TestFiles()
+    {
+        return TestDataLoader.GetTestFilesByLevel(1)
+            .Select(f => new object[] { f });
+    }
+
+    #endregion
+
+    #region Level 2 - Control Flow Tests
+
+    [Theory]
+    [MemberData(nameof(GetLevel2TestFiles))]
+    public void Level2_ControlFlow_FilesConvertSuccessfully(TestFileInfo file)
+    {
+        AssertConversionSucceeds(file);
+    }
+
+    public static IEnumerable<object[]> GetLevel2TestFiles()
+    {
+        return TestDataLoader.GetTestFilesByLevel(2)
+            .Select(f => new object[] { f });
+    }
+
+    #endregion
+
+    #region Level 3 - Types & Data Tests
+
+    [Theory]
+    [MemberData(nameof(GetLevel3TestFiles))]
+    public void Level3_Types_FilesConvertSuccessfully(TestFileInfo file)
+    {
+        AssertConversionSucceeds(file);
+    }
+
+    public static IEnumerable<object[]> GetLevel3TestFiles()
+    {
+        return TestDataLoader.GetTestFilesByLevel(3)
+            .Select(f => new object[] { f });
+    }
+
+    #endregion
+
+    #region Level 4 - Methods Tests
+
+    [Theory]
+    [MemberData(nameof(GetLevel4TestFiles))]
+    public void Level4_Methods_FilesConvertSuccessfully(TestFileInfo file)
+    {
+        AssertConversionSucceeds(file);
+    }
+
+    public static IEnumerable<object[]> GetLevel4TestFiles()
+    {
+        return TestDataLoader.GetTestFilesByLevel(4)
+            .Select(f => new object[] { f });
+    }
+
+    #endregion
+
+    #region Level 5 - Advanced Tests
+
+    [Theory]
+    [MemberData(nameof(GetLevel5TestFiles))]
+    public void Level5_Advanced_FilesConvertSuccessfully(TestFileInfo file)
+    {
+        AssertConversionSucceeds(file);
+    }
+
+    public static IEnumerable<object[]> GetLevel5TestFiles()
+    {
+        return TestDataLoader.GetTestFilesByLevel(5)
+            .Select(f => new object[] { f });
+    }
+
+    #endregion
+
+    #region All Files Tests
+
+    [Theory]
+    [MemberData(nameof(GetAllTestFiles))]
+    public void AllFiles_ProduceValidOpal(TestFileInfo file)
+    {
+        // Load and convert the C# file
+        var csharpCode = TestDataLoader.LoadTestFile(file);
+        var converter = new CSharpToOpalConverter();
+        var result = converter.Convert(csharpCode);
+
+        _output.WriteLine($"File: {file.DisplayName}");
+        _output.WriteLine($"Expected: {file.ExpectedResult}");
+        _output.WriteLine($"Features: {string.Join(", ", file.Features)}");
+        _output.WriteLine("---");
+
+        if (!result.Success)
+        {
+            _output.WriteLine($"Conversion errors:");
+            foreach (var error in result.Errors)
+            {
+                _output.WriteLine($"  {error}");
+            }
+
+            if (file.ExpectedResult == "success")
+            {
+                Assert.Fail($"Conversion failed for {file.DisplayName}: {result.Errors.FirstOrDefault()}");
+            }
+            return;
+        }
+
+        var opalCode = result.OpalCode!;
+        _output.WriteLine($"OPAL Output ({opalCode.Length} chars):");
+        _output.WriteLine(opalCode);
+
+        // Basic validation - output should not be empty
+        Assert.False(string.IsNullOrWhiteSpace(opalCode),
+            $"Converter produced empty output for {file.DisplayName}");
+
+        // Try to parse the generated OPAL to validate syntax
+        var opalParseResult = TryParseOpal(opalCode);
+        if (!opalParseResult.Success)
+        {
+            _output.WriteLine($"OPAL Parse Warning: {opalParseResult.Error}");
+
+            // For files expected to succeed, this is a failure
+            if (file.ExpectedResult == "success")
+            {
+                Assert.Fail($"Generated OPAL failed to parse: {opalParseResult.Error}");
+            }
+        }
+    }
+
+    public static IEnumerable<object[]> GetAllTestFiles()
+    {
+        return TestDataLoader.GetAllTestFiles()
+            .Select(f => new object[] { f });
+    }
+
+    #endregion
+
+    #region Round Trip Tests
+
+    [Theory]
+    [MemberData(nameof(GetRoundTripTestFiles))]
+    public void RoundTrip_OpalCompilesToCSharp(TestFileInfo file)
+    {
+        // Load and convert the C# file to OPAL
+        var originalCSharp = TestDataLoader.LoadTestFile(file);
+        var converter = new CSharpToOpalConverter();
+        var conversionResult = converter.Convert(originalCSharp);
+
+        _output.WriteLine($"File: {file.DisplayName}");
+        _output.WriteLine("--- Original C# ---");
+        _output.WriteLine(originalCSharp);
+
+        if (!conversionResult.Success)
+        {
+            _output.WriteLine($"Conversion failed: {conversionResult.Errors.FirstOrDefault()}");
+            if (file.ExpectedResult == "success")
+            {
+                Assert.Fail($"Conversion failed: {conversionResult.Errors.FirstOrDefault()}");
+            }
+            return;
+        }
+
+        var opalCode = conversionResult.OpalCode!;
+        _output.WriteLine("--- OPAL ---");
+        _output.WriteLine(opalCode);
+
+        // Try to compile the OPAL back to C#
+        var roundTripResult = TryCompileOpalToCSharp(opalCode);
+
+        _output.WriteLine("--- Round-trip C# ---");
+        _output.WriteLine(roundTripResult.CSharpCode ?? "(failed)");
+
+        if (!roundTripResult.Success)
+        {
+            _output.WriteLine($"Round-trip Warning: {roundTripResult.Error}");
+
+            // Only fail for files expected to fully succeed
+            if (file.ExpectedResult == "success")
+            {
+                Assert.Fail($"Round-trip compilation failed: {roundTripResult.Error}");
+            }
+        }
+        else
+        {
+            Assert.False(string.IsNullOrWhiteSpace(roundTripResult.CSharpCode),
+                "Round-trip produced empty C# code");
+        }
+    }
+
+    public static IEnumerable<object[]> GetRoundTripTestFiles()
+    {
+        // Only include files expected to succeed for round-trip tests
+        return TestDataLoader.GetTestFilesByExpectedResult("success")
+            .Select(f => new object[] { f });
+    }
+
+    #endregion
+
+    #region Feature-specific Tests
+
+    [Theory]
+    [MemberData(nameof(GetRecursionTestFiles))]
+    public void Feature_Recursion_ConvertsCorrectly(TestFileInfo file)
+    {
+        AssertConversionSucceeds(file);
+    }
+
+    public static IEnumerable<object[]> GetRecursionTestFiles()
+    {
+        return TestDataLoader.GetTestFilesByFeature("recursion")
+            .Select(f => new object[] { f });
+    }
+
+    [Theory]
+    [MemberData(nameof(GetLoopTestFiles))]
+    public void Feature_Loops_ConvertsCorrectly(TestFileInfo file)
+    {
+        AssertConversionSucceeds(file);
+    }
+
+    public static IEnumerable<object[]> GetLoopTestFiles()
+    {
+        return TestDataLoader.GetAllTestFiles()
+            .Where(f => f.Features.Any(feat =>
+                feat.Contains("loop") || feat == "for_loop" || feat == "while_loop"))
+            .Select(f => new object[] { f });
+    }
+
+    #endregion
+
+    #region Summary Tests
+
+    [Fact]
+    public void Summary_AllFilesLoaded()
+    {
+        var files = TestDataLoader.GetAllTestFiles().ToList();
+        _output.WriteLine($"Total test files: {files.Count}");
+
+        var byLevel = files.GroupBy(f => f.Level).OrderBy(g => g.Key);
+        foreach (var group in byLevel)
+        {
+            _output.WriteLine($"  Level {group.Key}: {group.Count()} files");
+        }
+
+        var byExpected = files.GroupBy(f => f.ExpectedResult);
+        foreach (var group in byExpected)
+        {
+            _output.WriteLine($"  Expected '{group.Key}': {group.Count()} files");
+        }
+
+        Assert.Equal(100, files.Count);
+    }
+
+    [Fact]
+    public void Summary_ConversionSuccessRates()
+    {
+        var files = TestDataLoader.GetAllTestFiles().ToList();
+        var results = new Dictionary<int, (int total, int success, int partial, int failed)>();
+
+        for (int level = 1; level <= 5; level++)
+        {
+            var levelFiles = files.Where(f => f.Level == level).ToList();
+            int success = 0, partial = 0, failed = 0;
+
+            foreach (var file in levelFiles)
+            {
+                try
+                {
+                    var csharpCode = TestDataLoader.LoadTestFile(file);
+                    var converter = new CSharpToOpalConverter();
+                    var conversionResult = converter.Convert(csharpCode);
+
+                    if (conversionResult.Success && !string.IsNullOrWhiteSpace(conversionResult.OpalCode))
+                    {
+                        var parseResult = TryParseOpal(conversionResult.OpalCode);
+                        if (parseResult.Success)
+                        {
+                            success++;
+                        }
+                        else
+                        {
+                            partial++;
+                        }
+                    }
+                    else
+                    {
+                        failed++;
+                    }
+                }
+                catch
+                {
+                    failed++;
+                }
+            }
+
+            results[level] = (levelFiles.Count, success, partial, failed);
+        }
+
+        _output.WriteLine("=== Conversion Success Rates ===");
+        foreach (var kvp in results.OrderBy(k => k.Key))
+        {
+            var (total, success, partial, failed) = kvp.Value;
+            var successRate = total > 0 ? (success * 100.0 / total) : 0;
+            _output.WriteLine($"Level {kvp.Key}: {success}/{total} ({successRate:F1}%) success, {partial} partial, {failed} failed");
+        }
+
+        var overall = results.Values.Aggregate(
+            (0, 0, 0, 0),
+            (acc, val) => (acc.Item1 + val.total, acc.Item2 + val.success, acc.Item3 + val.partial, acc.Item4 + val.failed));
+
+        var overallRate = overall.Item1 > 0 ? (overall.Item2 * 100.0 / overall.Item1) : 0;
+        _output.WriteLine($"Overall: {overall.Item2}/{overall.Item1} ({overallRate:F1}%) success");
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private void AssertConversionSucceeds(TestFileInfo file)
+    {
+        var csharpCode = TestDataLoader.LoadTestFile(file);
+
+        _output.WriteLine($"File: {file.DisplayName}");
+        _output.WriteLine($"Level: {file.Level}");
+        _output.WriteLine($"Expected: {file.ExpectedResult}");
+        _output.WriteLine($"Features: {string.Join(", ", file.Features)}");
+        _output.WriteLine("--- C# Input ---");
+        _output.WriteLine(csharpCode);
+
+        ConversionResult conversionResult;
+        try
+        {
+            var converter = new CSharpToOpalConverter();
+            conversionResult = converter.Convert(csharpCode);
+        }
+        catch (Exception ex)
+        {
+            _output.WriteLine($"Conversion failed with exception: {ex.Message}");
+
+            if (file.ExpectedResult == "unsupported")
+            {
+                // Expected to fail
+                return;
+            }
+
+            throw;
+        }
+
+        if (!conversionResult.Success)
+        {
+            _output.WriteLine($"Conversion errors:");
+            foreach (var error in conversionResult.Errors)
+            {
+                _output.WriteLine($"  {error}");
+            }
+
+            if (file.ExpectedResult == "unsupported")
+            {
+                return; // Expected to fail
+            }
+
+            Assert.Fail($"Conversion failed for {file.DisplayName}");
+            return;
+        }
+
+        var opalCode = conversionResult.OpalCode!;
+        _output.WriteLine("--- OPAL Output ---");
+        _output.WriteLine(opalCode);
+
+        Assert.False(string.IsNullOrWhiteSpace(opalCode),
+            $"Converter produced empty output for {file.DisplayName}");
+    }
+
+    private static (bool Success, string? Error) TryParseOpal(string opalCode)
+    {
+        try
+        {
+            // Use the OPAL lexer and parser to validate the generated code
+            var diagnostics = new DiagnosticBag();
+            var lexer = new Lexer(opalCode, diagnostics);
+            var tokens = lexer.Tokenize().ToList();
+
+            // Check for lexer errors
+            if (diagnostics.HasErrors)
+            {
+                return (false, $"Lexer errors: {string.Join(", ", diagnostics.Errors.Select(d => d.Message))}");
+            }
+
+            // Try to parse
+            var parser = new Parser(tokens, diagnostics);
+            var module = parser.Parse();
+
+            // Check for parse errors
+            if (diagnostics.HasErrors)
+            {
+                return (false, $"Parser errors: {string.Join(", ", diagnostics.Errors.Select(d => d.Message))}");
+            }
+
+            return (true, null);
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Parse exception: {ex.Message}");
+        }
+    }
+
+    private static (bool Success, string? CSharpCode, string? Error) TryCompileOpalToCSharp(string opalCode)
+    {
+        try
+        {
+            // Tokenize
+            var diagnostics = new DiagnosticBag();
+            var lexer = new Lexer(opalCode, diagnostics);
+            var tokens = lexer.Tokenize().ToList();
+
+            if (diagnostics.HasErrors)
+            {
+                return (false, null, $"Lexer errors: {string.Join(", ", diagnostics.Errors.Select(d => d.Message))}");
+            }
+
+            // Parse
+            var parser = new Parser(tokens, diagnostics);
+            var module = parser.Parse();
+
+            if (diagnostics.HasErrors)
+            {
+                return (false, null, $"Parse errors: {string.Join(", ", diagnostics.Errors.Select(d => d.Message))}");
+            }
+
+            // Generate C#
+            var emitter = new CSharpEmitter();
+            var csharpCode = emitter.Emit(module);
+
+            return (true, csharpCode, null);
+        }
+        catch (Exception ex)
+        {
+            return (false, null, $"Compilation exception: {ex.Message}");
+        }
+    }
+
+    #endregion
+}

--- a/tests/Opal.Compiler.Tests/Opal.Compiler.Tests.csproj
+++ b/tests/Opal.Compiler.Tests/Opal.Compiler.Tests.csproj
@@ -23,4 +23,12 @@
     <ProjectReference Include="..\..\src\Opal.Compiler\Opal.Compiler.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Include all test data files in the output directory -->
+    <None Include="..\TestData\CSharpImport\**\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>TestData\CSharpImport\%(RecursiveDir)%(FileName)%(Extension)</Link>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/tests/Opal.Compiler.Tests/TestDataLoader.cs
+++ b/tests/Opal.Compiler.Tests/TestDataLoader.cs
@@ -1,0 +1,179 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Opal.Compiler.Tests;
+
+/// <summary>
+/// Loads test data files and manifest for the C# Import tests.
+/// </summary>
+public static class TestDataLoader
+{
+    private static readonly string TestDataRoot = GetTestDataPath();
+    private static ManifestFile? _cachedManifest;
+
+    /// <summary>
+    /// Gets the path to the TestData/CSharpImport directory.
+    /// </summary>
+    public static string GetTestDataPath()
+    {
+        // Try to find the TestData directory relative to the test assembly
+        var assemblyLocation = AppDomain.CurrentDomain.BaseDirectory;
+        var testDataPath = Path.Combine(assemblyLocation, "TestData", "CSharpImport");
+
+        if (Directory.Exists(testDataPath))
+        {
+            return testDataPath;
+        }
+
+        // Fallback: walk up from the assembly location to find the tests directory
+        var current = new DirectoryInfo(assemblyLocation);
+        while (current != null)
+        {
+            var candidate = Path.Combine(current.FullName, "tests", "TestData", "CSharpImport");
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not find TestData/CSharpImport directory. Searched from: {assemblyLocation}");
+    }
+
+    /// <summary>
+    /// Loads the manifest.json file containing metadata for all test files.
+    /// </summary>
+    public static ManifestFile LoadManifest()
+    {
+        if (_cachedManifest != null)
+        {
+            return _cachedManifest;
+        }
+
+        var manifestPath = Path.Combine(TestDataRoot, "manifest.json");
+        if (!File.Exists(manifestPath))
+        {
+            throw new FileNotFoundException($"Manifest file not found: {manifestPath}");
+        }
+
+        var json = File.ReadAllText(manifestPath);
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        _cachedManifest = JsonSerializer.Deserialize<ManifestFile>(json, options)
+            ?? throw new InvalidOperationException("Failed to deserialize manifest.json");
+
+        return _cachedManifest;
+    }
+
+    /// <summary>
+    /// Gets all test file info from the manifest.
+    /// </summary>
+    public static IEnumerable<TestFileInfo> GetAllTestFiles()
+    {
+        var manifest = LoadManifest();
+        return manifest.Files;
+    }
+
+    /// <summary>
+    /// Gets test files filtered by level.
+    /// </summary>
+    public static IEnumerable<TestFileInfo> GetTestFilesByLevel(int level)
+    {
+        return GetAllTestFiles().Where(f => f.Level == level);
+    }
+
+    /// <summary>
+    /// Gets test files filtered by expected result.
+    /// </summary>
+    public static IEnumerable<TestFileInfo> GetTestFilesByExpectedResult(string expectedResult)
+    {
+        return GetAllTestFiles().Where(f => f.ExpectedResult == expectedResult);
+    }
+
+    /// <summary>
+    /// Gets test files that have a specific feature.
+    /// </summary>
+    public static IEnumerable<TestFileInfo> GetTestFilesByFeature(string feature)
+    {
+        return GetAllTestFiles().Where(f => f.Features.Contains(feature));
+    }
+
+    /// <summary>
+    /// Loads the content of a test file by its relative path.
+    /// </summary>
+    public static string LoadTestFile(string relativePath)
+    {
+        var fullPath = Path.Combine(TestDataRoot, relativePath);
+        if (!File.Exists(fullPath))
+        {
+            throw new FileNotFoundException($"Test file not found: {fullPath}");
+        }
+
+        return File.ReadAllText(fullPath);
+    }
+
+    /// <summary>
+    /// Loads the content of a test file by its TestFileInfo.
+    /// </summary>
+    public static string LoadTestFile(TestFileInfo fileInfo)
+    {
+        return LoadTestFile(fileInfo.File);
+    }
+
+    /// <summary>
+    /// Gets the full path to a test file.
+    /// </summary>
+    public static string GetFullPath(string relativePath)
+    {
+        return Path.Combine(TestDataRoot, relativePath);
+    }
+
+    /// <summary>
+    /// Gets the full path to a test file.
+    /// </summary>
+    public static string GetFullPath(TestFileInfo fileInfo)
+    {
+        return GetFullPath(fileInfo.File);
+    }
+}
+
+/// <summary>
+/// Represents the manifest.json file structure.
+/// </summary>
+public class ManifestFile
+{
+    public string Version { get; set; } = "";
+    public string Description { get; set; } = "";
+    public List<TestFileInfo> Files { get; set; } = new();
+}
+
+/// <summary>
+/// Represents a single test file entry in the manifest.
+/// </summary>
+public class TestFileInfo
+{
+    public string Id { get; set; } = "";
+    public string File { get; set; } = "";
+    public int Level { get; set; }
+    public List<string> Features { get; set; } = new();
+    public string ExpectedResult { get; set; } = "";
+    public string Notes { get; set; } = "";
+
+    /// <summary>
+    /// Gets the file name without path for display purposes.
+    /// </summary>
+    [JsonIgnore]
+    public string FileName => Path.GetFileName(File);
+
+    /// <summary>
+    /// Gets a display-friendly name for the test.
+    /// </summary>
+    [JsonIgnore]
+    public string DisplayName => $"[{Id}] {FileName}";
+
+    public override string ToString() => DisplayName;
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/001_HelloWorld.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/001_HelloWorld.cs
@@ -1,0 +1,10 @@
+namespace HelloWorld
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            Console.WriteLine("Hello, World!");
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/002_ReturnValue.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/002_ReturnValue.cs
@@ -1,0 +1,10 @@
+namespace ReturnValue
+{
+    public static class Math
+    {
+        public static int GetAnswer()
+        {
+            return 42;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/003_StringLiteral.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/003_StringLiteral.cs
@@ -1,0 +1,15 @@
+namespace StringLiteral
+{
+    public static class Strings
+    {
+        public static string GetGreeting()
+        {
+            return "Hello";
+        }
+
+        public static string GetName()
+        {
+            return "Alice";
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/004_IntLiteral.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/004_IntLiteral.cs
@@ -1,0 +1,20 @@
+namespace IntLiteral
+{
+    public static class Numbers
+    {
+        public static int GetZero()
+        {
+            return 0;
+        }
+
+        public static int GetPositive()
+        {
+            return 100;
+        }
+
+        public static int GetNegative()
+        {
+            return -50;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/005_BoolLiteral.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/005_BoolLiteral.cs
@@ -1,0 +1,15 @@
+namespace BoolLiteral
+{
+    public static class Booleans
+    {
+        public static bool GetTrue()
+        {
+            return true;
+        }
+
+        public static bool GetFalse()
+        {
+            return false;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/006_DoubleLiteral.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/006_DoubleLiteral.cs
@@ -1,0 +1,20 @@
+namespace DoubleLiteral
+{
+    public static class Doubles
+    {
+        public static double GetPi()
+        {
+            return 3.14159;
+        }
+
+        public static double GetNegative()
+        {
+            return -2.5;
+        }
+
+        public static double GetZero()
+        {
+            return 0.0;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/007_SimpleAddition.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/007_SimpleAddition.cs
@@ -1,0 +1,10 @@
+namespace SimpleAddition
+{
+    public static class Calculator
+    {
+        public static int Add(int a, int b)
+        {
+            return a + b;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/008_SimpleSubtraction.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/008_SimpleSubtraction.cs
@@ -1,0 +1,10 @@
+namespace SimpleSubtraction
+{
+    public static class Calculator
+    {
+        public static int Subtract(int a, int b)
+        {
+            return a - b;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/009_SimpleMultiplication.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/009_SimpleMultiplication.cs
@@ -1,0 +1,10 @@
+namespace SimpleMultiplication
+{
+    public static class Calculator
+    {
+        public static int Multiply(int a, int b)
+        {
+            return a * b;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/010_SimpleDivision.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/010_SimpleDivision.cs
@@ -1,0 +1,10 @@
+namespace SimpleDivision
+{
+    public static class Calculator
+    {
+        public static int Divide(int a, int b)
+        {
+            return a / b;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/011_Modulo.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/011_Modulo.cs
@@ -1,0 +1,10 @@
+namespace Modulo
+{
+    public static class Calculator
+    {
+        public static int Remainder(int a, int b)
+        {
+            return a % b;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/012_StringConcat.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/012_StringConcat.cs
@@ -1,0 +1,10 @@
+namespace StringConcat
+{
+    public static class Strings
+    {
+        public static string Combine(string a, string b)
+        {
+            return a + b;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/013_LocalVariable.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/013_LocalVariable.cs
@@ -1,0 +1,13 @@
+namespace LocalVariable
+{
+    public static class Variables
+    {
+        public static int Calculate()
+        {
+            int x = 10;
+            int y = 20;
+            int result = x + y;
+            return result;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/014_VarKeyword.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/014_VarKeyword.cs
@@ -1,0 +1,13 @@
+namespace VarKeyword
+{
+    public static class Variables
+    {
+        public static int Calculate()
+        {
+            var x = 10;
+            var y = 20;
+            var result = x + y;
+            return result;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/015_ComparisonOperators.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/015_ComparisonOperators.cs
@@ -1,0 +1,25 @@
+namespace ComparisonOperators
+{
+    public static class Comparisons
+    {
+        public static bool IsEqual(int a, int b)
+        {
+            return a == b;
+        }
+
+        public static bool IsNotEqual(int a, int b)
+        {
+            return a != b;
+        }
+
+        public static bool IsGreater(int a, int b)
+        {
+            return a > b;
+        }
+
+        public static bool IsLess(int a, int b)
+        {
+            return a < b;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/016_LogicalOperators.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/016_LogicalOperators.cs
@@ -1,0 +1,20 @@
+namespace LogicalOperators
+{
+    public static class Logic
+    {
+        public static bool And(bool a, bool b)
+        {
+            return a && b;
+        }
+
+        public static bool Or(bool a, bool b)
+        {
+            return a || b;
+        }
+
+        public static bool Not(bool a)
+        {
+            return !a;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/017_UnaryOperators.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/017_UnaryOperators.cs
@@ -1,0 +1,15 @@
+namespace UnaryOperators
+{
+    public static class Unary
+    {
+        public static int Negate(int x)
+        {
+            return -x;
+        }
+
+        public static int Positive(int x)
+        {
+            return +x;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/018_ParenthesizedExpr.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/018_ParenthesizedExpr.cs
@@ -1,0 +1,15 @@
+namespace ParenthesizedExpr
+{
+    public static class Math
+    {
+        public static int Calculate(int a, int b, int c)
+        {
+            return (a + b) * c;
+        }
+
+        public static int Complex(int x, int y)
+        {
+            return ((x + 1) * (y - 1)) + 5;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/019_MultipleStatements.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/019_MultipleStatements.cs
@@ -1,0 +1,14 @@
+namespace MultipleStatements
+{
+    public static class Program
+    {
+        public static void Run()
+        {
+            int a = 1;
+            int b = 2;
+            int c = 3;
+            int sum = a + b + c;
+            Console.WriteLine(sum);
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level1_Basic/020_BasicCalculator.cs
+++ b/tests/TestData/CSharpImport/Level1_Basic/020_BasicCalculator.cs
@@ -1,0 +1,25 @@
+namespace BasicCalculator
+{
+    public static class Calculator
+    {
+        public static int Add(int a, int b)
+        {
+            return a + b;
+        }
+
+        public static int Subtract(int a, int b)
+        {
+            return a - b;
+        }
+
+        public static int Multiply(int a, int b)
+        {
+            return a * b;
+        }
+
+        public static int Divide(int a, int b)
+        {
+            return a / b;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/021_SimpleIf.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/021_SimpleIf.cs
@@ -1,0 +1,14 @@
+namespace SimpleIf
+{
+    public static class Conditionals
+    {
+        public static string Check(int x)
+        {
+            if (x > 0)
+            {
+                return "positive";
+            }
+            return "not positive";
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/022_IfElse.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/022_IfElse.cs
@@ -1,0 +1,17 @@
+namespace IfElse
+{
+    public static class Conditionals
+    {
+        public static string Check(int x)
+        {
+            if (x > 0)
+            {
+                return "positive";
+            }
+            else
+            {
+                return "not positive";
+            }
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/023_IfElseIfElse.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/023_IfElseIfElse.cs
@@ -1,0 +1,21 @@
+namespace IfElseIfElse
+{
+    public static class Conditionals
+    {
+        public static string Check(int x)
+        {
+            if (x > 0)
+            {
+                return "positive";
+            }
+            else if (x < 0)
+            {
+                return "negative";
+            }
+            else
+            {
+                return "zero";
+            }
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/024_ForLoop.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/024_ForLoop.cs
@@ -1,0 +1,15 @@
+namespace ForLoop
+{
+    public static class Loops
+    {
+        public static int Sum(int n)
+        {
+            int result = 0;
+            for (int i = 1; i <= n; i++)
+            {
+                result = result + i;
+            }
+            return result;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/025_WhileLoop.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/025_WhileLoop.cs
@@ -1,0 +1,17 @@
+namespace WhileLoop
+{
+    public static class Loops
+    {
+        public static int Sum(int n)
+        {
+            int result = 0;
+            int i = 1;
+            while (i <= n)
+            {
+                result = result + i;
+                i = i + 1;
+            }
+            return result;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/026_DoWhileLoop.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/026_DoWhileLoop.cs
@@ -1,0 +1,16 @@
+namespace DoWhileLoop
+{
+    public static class Loops
+    {
+        public static int CountDown(int n)
+        {
+            int count = 0;
+            do
+            {
+                count = count + 1;
+                n = n - 1;
+            } while (n > 0);
+            return count;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/027_NestedLoops.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/027_NestedLoops.cs
@@ -1,0 +1,18 @@
+namespace NestedLoops
+{
+    public static class Loops
+    {
+        public static int MultiplicationTable(int size)
+        {
+            int sum = 0;
+            for (int i = 1; i <= size; i++)
+            {
+                for (int j = 1; j <= size; j++)
+                {
+                    sum = sum + (i * j);
+                }
+            }
+            return sum;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/028_FizzBuzz.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/028_FizzBuzz.cs
@@ -1,0 +1,25 @@
+namespace FizzBuzz
+{
+    public static class Game
+    {
+        public static string GetResult(int n)
+        {
+            if (n % 15 == 0)
+            {
+                return "FizzBuzz";
+            }
+            else if (n % 3 == 0)
+            {
+                return "Fizz";
+            }
+            else if (n % 5 == 0)
+            {
+                return "Buzz";
+            }
+            else
+            {
+                return n.ToString();
+            }
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/029_FactorialIterative.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/029_FactorialIterative.cs
@@ -1,0 +1,15 @@
+namespace FactorialIterative
+{
+    public static class Math
+    {
+        public static int Factorial(int n)
+        {
+            int result = 1;
+            for (int i = 2; i <= n; i++)
+            {
+                result = result * i;
+            }
+            return result;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/030_FactorialRecursive.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/030_FactorialRecursive.cs
@@ -1,0 +1,14 @@
+namespace FactorialRecursive
+{
+    public static class Math
+    {
+        public static int Factorial(int n)
+        {
+            if (n <= 1)
+            {
+                return 1;
+            }
+            return n * Factorial(n - 1);
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/031_FibonacciIterative.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/031_FibonacciIterative.cs
@@ -1,0 +1,22 @@
+namespace FibonacciIterative
+{
+    public static class Math
+    {
+        public static int Fibonacci(int n)
+        {
+            if (n <= 1)
+            {
+                return n;
+            }
+            int a = 0;
+            int b = 1;
+            for (int i = 2; i <= n; i++)
+            {
+                int temp = a + b;
+                a = b;
+                b = temp;
+            }
+            return b;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/032_FibonacciRecursive.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/032_FibonacciRecursive.cs
@@ -1,0 +1,14 @@
+namespace FibonacciRecursive
+{
+    public static class Math
+    {
+        public static int Fibonacci(int n)
+        {
+            if (n <= 1)
+            {
+                return n;
+            }
+            return Fibonacci(n - 1) + Fibonacci(n - 2);
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/033_SwitchStatement.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/033_SwitchStatement.cs
@@ -1,0 +1,28 @@
+namespace SwitchStatement
+{
+    public static class DayOfWeek
+    {
+        public static string GetDayName(int day)
+        {
+            switch (day)
+            {
+                case 1:
+                    return "Monday";
+                case 2:
+                    return "Tuesday";
+                case 3:
+                    return "Wednesday";
+                case 4:
+                    return "Thursday";
+                case 5:
+                    return "Friday";
+                case 6:
+                    return "Saturday";
+                case 7:
+                    return "Sunday";
+                default:
+                    return "Unknown";
+            }
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/034_SwitchExpression.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/034_SwitchExpression.cs
@@ -1,0 +1,20 @@
+namespace SwitchExpression
+{
+    public static class DayOfWeek
+    {
+        public static string GetDayName(int day)
+        {
+            return day switch
+            {
+                1 => "Monday",
+                2 => "Tuesday",
+                3 => "Wednesday",
+                4 => "Thursday",
+                5 => "Friday",
+                6 => "Saturday",
+                7 => "Sunday",
+                _ => "Unknown"
+            };
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/035_BreakStatement.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/035_BreakStatement.cs
@@ -1,0 +1,19 @@
+namespace BreakStatement
+{
+    public static class Search
+    {
+        public static int FindFirst(int target)
+        {
+            int result = -1;
+            for (int i = 0; i < 100; i++)
+            {
+                if (i == target)
+                {
+                    result = i;
+                    break;
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/036_ContinueStatement.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/036_ContinueStatement.cs
@@ -1,0 +1,19 @@
+namespace ContinueStatement
+{
+    public static class Filter
+    {
+        public static int SumEven(int n)
+        {
+            int sum = 0;
+            for (int i = 1; i <= n; i++)
+            {
+                if (i % 2 != 0)
+                {
+                    continue;
+                }
+                sum = sum + i;
+            }
+            return sum;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/037_TernaryOperator.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/037_TernaryOperator.cs
@@ -1,0 +1,20 @@
+namespace TernaryOperator
+{
+    public static class Conditionals
+    {
+        public static int Max(int a, int b)
+        {
+            return a > b ? a : b;
+        }
+
+        public static int Min(int a, int b)
+        {
+            return a < b ? a : b;
+        }
+
+        public static int Abs(int x)
+        {
+            return x >= 0 ? x : -x;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/038_NestedConditions.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/038_NestedConditions.cs
@@ -1,0 +1,24 @@
+namespace NestedConditions
+{
+    public static class Validator
+    {
+        public static string Validate(int age, bool hasLicense)
+        {
+            if (age >= 18)
+            {
+                if (hasLicense)
+                {
+                    return "can drive";
+                }
+                else
+                {
+                    return "needs license";
+                }
+            }
+            else
+            {
+                return "too young";
+            }
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/039_EarlyReturn.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/039_EarlyReturn.cs
@@ -1,0 +1,18 @@
+namespace EarlyReturn
+{
+    public static class Validator
+    {
+        public static bool IsValidAge(int age)
+        {
+            if (age < 0)
+            {
+                return false;
+            }
+            if (age > 150)
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level2_ControlFlow/040_ComplexConditions.cs
+++ b/tests/TestData/CSharpImport/Level2_ControlFlow/040_ComplexConditions.cs
@@ -1,0 +1,22 @@
+namespace ComplexConditions
+{
+    public static class Validator
+    {
+        public static bool IsValidInput(int x, int y, int z)
+        {
+            if (x > 0 && y > 0 && z > 0)
+            {
+                if ((x + y > z) && (x + z > y) && (y + z > x))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public static bool IsInRange(int value, int min, int max)
+        {
+            return value >= min && value <= max;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/041_SimpleClass.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/041_SimpleClass.cs
@@ -1,0 +1,19 @@
+namespace SimpleClass
+{
+    public class Person
+    {
+        public string Name;
+        public int Age;
+    }
+
+    public static class Factory
+    {
+        public static Person Create()
+        {
+            var p = new Person();
+            p.Name = "Alice";
+            p.Age = 30;
+            return p;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/042_ClassWithFields.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/042_ClassWithFields.cs
@@ -1,0 +1,18 @@
+namespace ClassWithFields
+{
+    public class Rectangle
+    {
+        public int Width;
+        public int Height;
+
+        public int GetArea()
+        {
+            return Width * Height;
+        }
+
+        public int GetPerimeter()
+        {
+            return 2 * (Width + Height);
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/043_ClassWithProperties.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/043_ClassWithProperties.cs
@@ -1,0 +1,17 @@
+namespace ClassWithProperties
+{
+    public class Circle
+    {
+        public double Radius { get; set; }
+
+        public double GetArea()
+        {
+            return 3.14159 * Radius * Radius;
+        }
+
+        public double GetCircumference()
+        {
+            return 2 * 3.14159 * Radius;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/044_Record.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/044_Record.cs
@@ -1,0 +1,17 @@
+namespace RecordType
+{
+    public record Point(int X, int Y);
+
+    public static class Geometry
+    {
+        public static Point Origin()
+        {
+            return new Point(0, 0);
+        }
+
+        public static Point Create(int x, int y)
+        {
+            return new Point(x, y);
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/045_Enum.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/045_Enum.cs
@@ -1,0 +1,22 @@
+namespace EnumType
+{
+    public enum Color
+    {
+        Red,
+        Green,
+        Blue
+    }
+
+    public static class Colors
+    {
+        public static Color GetDefault()
+        {
+            return Color.Red;
+        }
+
+        public static bool IsRed(Color c)
+        {
+            return c == Color.Red;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/046_EnumWithValues.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/046_EnumWithValues.cs
@@ -1,0 +1,22 @@
+namespace EnumWithValues
+{
+    public enum StatusCode
+    {
+        Ok = 200,
+        NotFound = 404,
+        ServerError = 500
+    }
+
+    public static class Status
+    {
+        public static int GetCode(StatusCode status)
+        {
+            return (int)status;
+        }
+
+        public static bool IsSuccess(StatusCode status)
+        {
+            return status == StatusCode.Ok;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/047_ArrayDeclaration.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/047_ArrayDeclaration.cs
@@ -1,0 +1,26 @@
+namespace ArrayDeclaration
+{
+    public static class Arrays
+    {
+        public static int[] CreateArray()
+        {
+            int[] numbers = new int[5];
+            numbers[0] = 1;
+            numbers[1] = 2;
+            numbers[2] = 3;
+            numbers[3] = 4;
+            numbers[4] = 5;
+            return numbers;
+        }
+
+        public static int GetFirst(int[] arr)
+        {
+            return arr[0];
+        }
+
+        public static int GetLength(int[] arr)
+        {
+            return arr.Length;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/048_ArrayInitializer.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/048_ArrayInitializer.cs
@@ -1,0 +1,25 @@
+namespace ArrayInitializer
+{
+    public static class Arrays
+    {
+        public static int[] CreateNumbers()
+        {
+            return new int[] { 1, 2, 3, 4, 5 };
+        }
+
+        public static string[] CreateNames()
+        {
+            return new string[] { "Alice", "Bob", "Charlie" };
+        }
+
+        public static int Sum(int[] numbers)
+        {
+            int total = 0;
+            for (int i = 0; i < numbers.Length; i++)
+            {
+                total = total + numbers[i];
+            }
+            return total;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/049_ListUsage.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/049_ListUsage.cs
@@ -1,0 +1,26 @@
+namespace ListUsage
+{
+    using System.Collections.Generic;
+
+    public static class Lists
+    {
+        public static List<int> CreateList()
+        {
+            var list = new List<int>();
+            list.Add(1);
+            list.Add(2);
+            list.Add(3);
+            return list;
+        }
+
+        public static int GetCount(List<int> list)
+        {
+            return list.Count;
+        }
+
+        public static int GetFirst(List<int> list)
+        {
+            return list[0];
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/050_DictionaryUsage.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/050_DictionaryUsage.cs
@@ -1,0 +1,26 @@
+namespace DictionaryUsage
+{
+    using System.Collections.Generic;
+
+    public static class Dictionaries
+    {
+        public static Dictionary<string, int> CreateScores()
+        {
+            var dict = new Dictionary<string, int>();
+            dict["Alice"] = 100;
+            dict["Bob"] = 85;
+            dict["Charlie"] = 92;
+            return dict;
+        }
+
+        public static int GetScore(Dictionary<string, int> scores, string name)
+        {
+            return scores[name];
+        }
+
+        public static bool HasKey(Dictionary<string, int> scores, string name)
+        {
+            return scores.ContainsKey(name);
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/051_Struct.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/051_Struct.cs
@@ -1,0 +1,24 @@
+namespace StructType
+{
+    public struct Vector2
+    {
+        public double X;
+        public double Y;
+
+        public double GetMagnitude()
+        {
+            return System.Math.Sqrt(X * X + Y * Y);
+        }
+    }
+
+    public static class Vectors
+    {
+        public static Vector2 Create(double x, double y)
+        {
+            var v = new Vector2();
+            v.X = x;
+            v.Y = y;
+            return v;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/052_NullableTypes.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/052_NullableTypes.cs
@@ -1,0 +1,28 @@
+namespace NullableTypes
+{
+    public static class Nullables
+    {
+        public static int? GetNullableInt(bool returnNull)
+        {
+            if (returnNull)
+            {
+                return null;
+            }
+            return 42;
+        }
+
+        public static bool HasValue(int? value)
+        {
+            return value.HasValue;
+        }
+
+        public static int GetValueOrDefault(int? value, int defaultValue)
+        {
+            if (value.HasValue)
+            {
+                return value.Value;
+            }
+            return defaultValue;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/053_ClassWithConstructor.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/053_ClassWithConstructor.cs
@@ -1,0 +1,29 @@
+namespace ClassWithConstructor
+{
+    public class BankAccount
+    {
+        public string Owner;
+        public decimal Balance;
+
+        public BankAccount(string owner, decimal initialBalance)
+        {
+            Owner = owner;
+            Balance = initialBalance;
+        }
+
+        public void Deposit(decimal amount)
+        {
+            Balance = Balance + amount;
+        }
+
+        public bool Withdraw(decimal amount)
+        {
+            if (amount <= Balance)
+            {
+                Balance = Balance - amount;
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/054_Inheritance.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/054_Inheritance.cs
@@ -1,0 +1,30 @@
+namespace Inheritance
+{
+    public class Animal
+    {
+        public string Name;
+
+        public string GetName()
+        {
+            return Name;
+        }
+    }
+
+    public class Dog : Animal
+    {
+        public string Breed;
+
+        public string Bark()
+        {
+            return "Woof!";
+        }
+    }
+
+    public class Cat : Animal
+    {
+        public string Meow()
+        {
+            return "Meow!";
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/055_Interface.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/055_Interface.cs
@@ -1,0 +1,23 @@
+namespace InterfaceType
+{
+    public interface IShape
+    {
+        double GetArea();
+        double GetPerimeter();
+    }
+
+    public class Square : IShape
+    {
+        public double Side;
+
+        public double GetArea()
+        {
+            return Side * Side;
+        }
+
+        public double GetPerimeter()
+        {
+            return 4 * Side;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/056_AbstractClass.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/056_AbstractClass.cs
@@ -1,0 +1,23 @@
+namespace AbstractClass
+{
+    public abstract class Shape
+    {
+        public abstract double GetArea();
+
+        public string Describe()
+        {
+            return "This is a shape";
+        }
+    }
+
+    public class Triangle : Shape
+    {
+        public double Base;
+        public double Height;
+
+        public override double GetArea()
+        {
+            return 0.5 * Base * Height;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/057_StaticClass.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/057_StaticClass.cs
@@ -1,0 +1,19 @@
+namespace StaticClass
+{
+    public static class Constants
+    {
+        public static readonly double Pi = 3.14159;
+        public static readonly double E = 2.71828;
+        public static readonly int MaxValue = 1000;
+
+        public static double GetPi()
+        {
+            return Pi;
+        }
+
+        public static double GetE()
+        {
+            return E;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/058_NestedClass.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/058_NestedClass.cs
@@ -1,0 +1,24 @@
+namespace NestedClass
+{
+    public class Outer
+    {
+        public int Value;
+
+        public class Inner
+        {
+            public int InnerValue;
+
+            public int GetValue()
+            {
+                return InnerValue;
+            }
+        }
+
+        public Inner CreateInner()
+        {
+            var inner = new Inner();
+            inner.InnerValue = Value * 2;
+            return inner;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/059_Tuple.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/059_Tuple.cs
@@ -1,0 +1,24 @@
+namespace TupleType
+{
+    public static class Tuples
+    {
+        public static (int, int) GetMinMax(int a, int b)
+        {
+            if (a < b)
+            {
+                return (a, b);
+            }
+            return (b, a);
+        }
+
+        public static (string Name, int Age) GetPerson()
+        {
+            return ("Alice", 30);
+        }
+
+        public static int GetFirst((int, int) tuple)
+        {
+            return tuple.Item1;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level3_Types/060_ObjectInitializer.cs
+++ b/tests/TestData/CSharpImport/Level3_Types/060_ObjectInitializer.cs
@@ -1,0 +1,27 @@
+namespace ObjectInitializer
+{
+    public class Product
+    {
+        public string Name { get; set; }
+        public decimal Price { get; set; }
+        public int Quantity { get; set; }
+    }
+
+    public static class Store
+    {
+        public static Product CreateProduct()
+        {
+            return new Product
+            {
+                Name = "Widget",
+                Price = 9.99m,
+                Quantity = 100
+            };
+        }
+
+        public static decimal GetTotal(Product p)
+        {
+            return p.Price * p.Quantity;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/061_MultipleParameters.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/061_MultipleParameters.cs
@@ -1,0 +1,20 @@
+namespace MultipleParameters
+{
+    public static class Calculator
+    {
+        public static int Add3(int a, int b, int c)
+        {
+            return a + b + c;
+        }
+
+        public static int Add4(int a, int b, int c, int d)
+        {
+            return a + b + c + d;
+        }
+
+        public static double Average(double a, double b, double c)
+        {
+            return (a + b + c) / 3.0;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/062_OptionalParameters.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/062_OptionalParameters.cs
@@ -1,0 +1,28 @@
+namespace OptionalParameters
+{
+    public static class Greeter
+    {
+        public static string Greet(string name, string greeting = "Hello")
+        {
+            return greeting + ", " + name + "!";
+        }
+
+        public static int Add(int a, int b = 0, int c = 0)
+        {
+            return a + b + c;
+        }
+
+        public static string Format(string text, bool uppercase = false, bool trim = true)
+        {
+            if (trim)
+            {
+                text = text.Trim();
+            }
+            if (uppercase)
+            {
+                text = text.ToUpper();
+            }
+            return text;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/063_RefParameters.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/063_RefParameters.cs
@@ -1,0 +1,22 @@
+namespace RefParameters
+{
+    public static class Swapper
+    {
+        public static void Swap(ref int a, ref int b)
+        {
+            int temp = a;
+            a = b;
+            b = temp;
+        }
+
+        public static void Increment(ref int value)
+        {
+            value = value + 1;
+        }
+
+        public static void Reset(ref int value)
+        {
+            value = 0;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/064_OutParameters.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/064_OutParameters.cs
@@ -1,0 +1,30 @@
+namespace OutParameters
+{
+    public static class Parser
+    {
+        public static bool TryParse(string text, out int result)
+        {
+            if (text == "42")
+            {
+                result = 42;
+                return true;
+            }
+            result = 0;
+            return false;
+        }
+
+        public static void GetMinMax(int a, int b, out int min, out int max)
+        {
+            if (a < b)
+            {
+                min = a;
+                max = b;
+            }
+            else
+            {
+                min = b;
+                max = a;
+            }
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/065_MethodOverloads.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/065_MethodOverloads.cs
@@ -1,0 +1,25 @@
+namespace MethodOverloads
+{
+    public static class Calculator
+    {
+        public static int Add(int a, int b)
+        {
+            return a + b;
+        }
+
+        public static double Add(double a, double b)
+        {
+            return a + b;
+        }
+
+        public static int Add(int a, int b, int c)
+        {
+            return a + b + c;
+        }
+
+        public static string Add(string a, string b)
+        {
+            return a + b;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/066_ExpressionBodied.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/066_ExpressionBodied.cs
@@ -1,0 +1,15 @@
+namespace ExpressionBodied
+{
+    public static class Math
+    {
+        public static int Square(int x) => x * x;
+
+        public static int Cube(int x) => x * x * x;
+
+        public static double Half(double x) => x / 2.0;
+
+        public static bool IsPositive(int x) => x > 0;
+
+        public static int Max(int a, int b) => a > b ? a : b;
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/067_PrivateMethods.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/067_PrivateMethods.cs
@@ -1,0 +1,28 @@
+namespace PrivateMethods
+{
+    public class Calculator
+    {
+        private int lastResult;
+
+        public int Add(int a, int b)
+        {
+            lastResult = AddInternal(a, b);
+            return lastResult;
+        }
+
+        private int AddInternal(int a, int b)
+        {
+            return a + b;
+        }
+
+        public int GetLastResult()
+        {
+            return lastResult;
+        }
+
+        private void Reset()
+        {
+            lastResult = 0;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/068_StaticVsInstance.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/068_StaticVsInstance.cs
@@ -1,0 +1,29 @@
+namespace StaticVsInstance
+{
+    public class Counter
+    {
+        private static int globalCount = 0;
+        private int instanceCount = 0;
+
+        public void Increment()
+        {
+            instanceCount = instanceCount + 1;
+            globalCount = globalCount + 1;
+        }
+
+        public int GetInstanceCount()
+        {
+            return instanceCount;
+        }
+
+        public static int GetGlobalCount()
+        {
+            return globalCount;
+        }
+
+        public static void ResetGlobal()
+        {
+            globalCount = 0;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/069_MethodChaining.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/069_MethodChaining.cs
@@ -1,0 +1,30 @@
+namespace MethodChaining
+{
+    public class StringBuilder
+    {
+        private string value = "";
+
+        public StringBuilder Append(string text)
+        {
+            value = value + text;
+            return this;
+        }
+
+        public StringBuilder AppendLine(string text)
+        {
+            value = value + text + "\n";
+            return this;
+        }
+
+        public StringBuilder Clear()
+        {
+            value = "";
+            return this;
+        }
+
+        public string Build()
+        {
+            return value;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/070_VoidMethods.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/070_VoidMethods.cs
@@ -1,0 +1,25 @@
+namespace VoidMethods
+{
+    public static class Logger
+    {
+        public static void Log(string message)
+        {
+            Console.WriteLine(message);
+        }
+
+        public static void LogError(string message)
+        {
+            Console.WriteLine("ERROR: " + message);
+        }
+
+        public static void LogWarning(string message)
+        {
+            Console.WriteLine("WARNING: " + message);
+        }
+
+        public static void LogInfo(string message)
+        {
+            Console.WriteLine("INFO: " + message);
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/071_ParamsArray.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/071_ParamsArray.cs
@@ -1,0 +1,29 @@
+namespace ParamsArray
+{
+    public static class Calculator
+    {
+        public static int Sum(params int[] numbers)
+        {
+            int total = 0;
+            for (int i = 0; i < numbers.Length; i++)
+            {
+                total = total + numbers[i];
+            }
+            return total;
+        }
+
+        public static string Join(string separator, params string[] items)
+        {
+            if (items.Length == 0)
+            {
+                return "";
+            }
+            string result = items[0];
+            for (int i = 1; i < items.Length; i++)
+            {
+                result = result + separator + items[i];
+            }
+            return result;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/072_NamedArguments.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/072_NamedArguments.cs
@@ -1,0 +1,33 @@
+namespace NamedArguments
+{
+    public static class Geometry
+    {
+        public static double CalculateArea(double width, double height)
+        {
+            return width * height;
+        }
+
+        public static double CalculateVolume(double width, double height, double depth)
+        {
+            return width * height * depth;
+        }
+
+        public static string FormatDimensions(int x, int y, int z)
+        {
+            return x.ToString() + "x" + y.ToString() + "x" + z.ToString();
+        }
+    }
+
+    public static class Demo
+    {
+        public static double GetArea()
+        {
+            return Geometry.CalculateArea(width: 10, height: 20);
+        }
+
+        public static double GetVolume()
+        {
+            return Geometry.CalculateVolume(height: 5, width: 3, depth: 2);
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/073_RecursiveMethods.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/073_RecursiveMethods.cs
@@ -1,0 +1,32 @@
+namespace RecursiveMethods
+{
+    public static class Math
+    {
+        public static int Factorial(int n)
+        {
+            if (n <= 1)
+            {
+                return 1;
+            }
+            return n * Factorial(n - 1);
+        }
+
+        public static int Gcd(int a, int b)
+        {
+            if (b == 0)
+            {
+                return a;
+            }
+            return Gcd(b, a % b);
+        }
+
+        public static int Power(int baseNum, int exp)
+        {
+            if (exp == 0)
+            {
+                return 1;
+            }
+            return baseNum * Power(baseNum, exp - 1);
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/074_LocalFunctions.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/074_LocalFunctions.cs
@@ -1,0 +1,36 @@
+namespace LocalFunctions
+{
+    public static class Calculator
+    {
+        public static int Calculate(int x, int y)
+        {
+            int Add(int a, int b)
+            {
+                return a + b;
+            }
+
+            int Multiply(int a, int b)
+            {
+                return a * b;
+            }
+
+            int sum = Add(x, y);
+            int product = Multiply(x, y);
+            return sum + product;
+        }
+
+        public static int Factorial(int n)
+        {
+            int FactorialInternal(int num)
+            {
+                if (num <= 1)
+                {
+                    return 1;
+                }
+                return num * FactorialInternal(num - 1);
+            }
+
+            return FactorialInternal(n);
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/075_ExtensionMethods.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/075_ExtensionMethods.cs
@@ -1,0 +1,39 @@
+namespace ExtensionMethods
+{
+    public static class StringExtensions
+    {
+        public static bool IsNullOrEmpty(this string s)
+        {
+            return s == null || s.Length == 0;
+        }
+
+        public static string Reverse(this string s)
+        {
+            char[] chars = s.ToCharArray();
+            System.Array.Reverse(chars);
+            return new string(chars);
+        }
+
+        public static int WordCount(this string s)
+        {
+            if (s.IsNullOrEmpty())
+            {
+                return 0;
+            }
+            return s.Split(' ').Length;
+        }
+    }
+
+    public static class IntExtensions
+    {
+        public static bool IsEven(this int n)
+        {
+            return n % 2 == 0;
+        }
+
+        public static bool IsOdd(this int n)
+        {
+            return n % 2 != 0;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/076_VirtualMethods.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/076_VirtualMethods.cs
@@ -1,0 +1,41 @@
+namespace VirtualMethods
+{
+    public class Animal
+    {
+        public virtual string Speak()
+        {
+            return "...";
+        }
+
+        public virtual string GetType()
+        {
+            return "Animal";
+        }
+    }
+
+    public class Dog : Animal
+    {
+        public override string Speak()
+        {
+            return "Woof!";
+        }
+
+        public override string GetType()
+        {
+            return "Dog";
+        }
+    }
+
+    public class Cat : Animal
+    {
+        public override string Speak()
+        {
+            return "Meow!";
+        }
+
+        public override string GetType()
+        {
+            return "Cat";
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/077_PropertyGetSet.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/077_PropertyGetSet.cs
@@ -1,0 +1,24 @@
+namespace PropertyGetSet
+{
+    public class Temperature
+    {
+        private double celsius;
+
+        public double Celsius
+        {
+            get { return celsius; }
+            set { celsius = value; }
+        }
+
+        public double Fahrenheit
+        {
+            get { return celsius * 9.0 / 5.0 + 32.0; }
+            set { celsius = (value - 32.0) * 5.0 / 9.0; }
+        }
+
+        public double Kelvin
+        {
+            get { return celsius + 273.15; }
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/078_IndexerProperty.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/078_IndexerProperty.cs
@@ -1,0 +1,31 @@
+namespace IndexerProperty
+{
+    public class IntArray
+    {
+        private int[] data;
+        private int size;
+
+        public IntArray(int capacity)
+        {
+            data = new int[capacity];
+            size = 0;
+        }
+
+        public int this[int index]
+        {
+            get { return data[index]; }
+            set { data[index] = value; }
+        }
+
+        public int Count
+        {
+            get { return size; }
+        }
+
+        public void Add(int value)
+        {
+            data[size] = value;
+            size = size + 1;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/079_OperatorOverload.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/079_OperatorOverload.cs
@@ -1,0 +1,39 @@
+namespace OperatorOverload
+{
+    public struct Vector2D
+    {
+        public double X;
+        public double Y;
+
+        public Vector2D(double x, double y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        public static Vector2D operator +(Vector2D a, Vector2D b)
+        {
+            return new Vector2D(a.X + b.X, a.Y + b.Y);
+        }
+
+        public static Vector2D operator -(Vector2D a, Vector2D b)
+        {
+            return new Vector2D(a.X - b.X, a.Y - b.Y);
+        }
+
+        public static Vector2D operator *(Vector2D v, double scalar)
+        {
+            return new Vector2D(v.X * scalar, v.Y * scalar);
+        }
+
+        public static bool operator ==(Vector2D a, Vector2D b)
+        {
+            return a.X == b.X && a.Y == b.Y;
+        }
+
+        public static bool operator !=(Vector2D a, Vector2D b)
+        {
+            return a.X != b.X || a.Y != b.Y;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level4_Methods/080_ImplicitExplicitConversion.cs
+++ b/tests/TestData/CSharpImport/Level4_Methods/080_ImplicitExplicitConversion.cs
@@ -1,0 +1,42 @@
+namespace ImplicitExplicitConversion
+{
+    public struct Celsius
+    {
+        public double Temperature;
+
+        public Celsius(double temp)
+        {
+            Temperature = temp;
+        }
+
+        public static implicit operator double(Celsius c)
+        {
+            return c.Temperature;
+        }
+
+        public static explicit operator Celsius(double d)
+        {
+            return new Celsius(d);
+        }
+    }
+
+    public struct Fahrenheit
+    {
+        public double Temperature;
+
+        public Fahrenheit(double temp)
+        {
+            Temperature = temp;
+        }
+
+        public static implicit operator Fahrenheit(Celsius c)
+        {
+            return new Fahrenheit(c.Temperature * 9.0 / 5.0 + 32.0);
+        }
+
+        public static explicit operator Celsius(Fahrenheit f)
+        {
+            return new Celsius((f.Temperature - 32.0) * 5.0 / 9.0);
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/081_AsyncMethod.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/081_AsyncMethod.cs
@@ -1,0 +1,25 @@
+namespace AsyncMethod
+{
+    using System.Threading.Tasks;
+
+    public static class AsyncOperations
+    {
+        public static async Task<int> GetValueAsync()
+        {
+            await Task.Delay(100);
+            return 42;
+        }
+
+        public static async Task<string> GetMessageAsync()
+        {
+            await Task.Delay(50);
+            return "Hello";
+        }
+
+        public static async Task DoWorkAsync()
+        {
+            await Task.Delay(100);
+            Console.WriteLine("Work done");
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/082_Lambda.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/082_Lambda.cs
@@ -1,0 +1,32 @@
+namespace Lambda
+{
+    using System;
+
+    public static class Lambdas
+    {
+        public static Func<int, int> GetDoubler()
+        {
+            return x => x * 2;
+        }
+
+        public static Func<int, int, int> GetAdder()
+        {
+            return (a, b) => a + b;
+        }
+
+        public static Func<int, bool> GetIsPositive()
+        {
+            return x => x > 0;
+        }
+
+        public static Action<string> GetPrinter()
+        {
+            return msg => Console.WriteLine(msg);
+        }
+
+        public static int Apply(Func<int, int> f, int x)
+        {
+            return f(x);
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/083_LinqSelect.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/083_LinqSelect.cs
@@ -1,0 +1,29 @@
+namespace LinqSelect
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public static class Queries
+    {
+        public static IEnumerable<int> DoubleAll(IEnumerable<int> numbers)
+        {
+            return numbers.Select(x => x * 2);
+        }
+
+        public static IEnumerable<string> GetNames(IEnumerable<Person> people)
+        {
+            return people.Select(p => p.Name);
+        }
+
+        public static IEnumerable<int> GetLengths(IEnumerable<string> strings)
+        {
+            return strings.Select(s => s.Length);
+        }
+    }
+
+    public class Person
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/084_LinqWhere.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/084_LinqWhere.cs
@@ -1,0 +1,34 @@
+namespace LinqWhere
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public static class Filters
+    {
+        public static IEnumerable<int> GetPositive(IEnumerable<int> numbers)
+        {
+            return numbers.Where(x => x > 0);
+        }
+
+        public static IEnumerable<int> GetEven(IEnumerable<int> numbers)
+        {
+            return numbers.Where(x => x % 2 == 0);
+        }
+
+        public static IEnumerable<string> GetLong(IEnumerable<string> strings, int minLength)
+        {
+            return strings.Where(s => s.Length >= minLength);
+        }
+
+        public static IEnumerable<Person> GetAdults(IEnumerable<Person> people)
+        {
+            return people.Where(p => p.Age >= 18);
+        }
+    }
+
+    public class Person
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/085_GenericClass.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/085_GenericClass.cs
@@ -1,0 +1,39 @@
+namespace GenericClass
+{
+    public class Box<T>
+    {
+        private T value;
+
+        public Box(T initial)
+        {
+            value = initial;
+        }
+
+        public T GetValue()
+        {
+            return value;
+        }
+
+        public void SetValue(T newValue)
+        {
+            value = newValue;
+        }
+
+        public bool HasValue()
+        {
+            return value != null;
+        }
+    }
+
+    public class Pair<T1, T2>
+    {
+        public T1 First { get; set; }
+        public T2 Second { get; set; }
+
+        public Pair(T1 first, T2 second)
+        {
+            First = first;
+            Second = second;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/086_GenericMethod.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/086_GenericMethod.cs
@@ -1,0 +1,34 @@
+namespace GenericMethod
+{
+    public static class Utilities
+    {
+        public static T Identity<T>(T value)
+        {
+            return value;
+        }
+
+        public static void Swap<T>(ref T a, ref T b)
+        {
+            T temp = a;
+            a = b;
+            b = temp;
+        }
+
+        public static T[] CreateArray<T>(T value, int count)
+        {
+            T[] result = new T[count];
+            for (int i = 0; i < count; i++)
+            {
+                result[i] = value;
+            }
+            return result;
+        }
+
+        public static bool AreEqual<T>(T a, T b) where T : class
+        {
+            if (a == null && b == null) return true;
+            if (a == null || b == null) return false;
+            return a.Equals(b);
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/087_TryCatch.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/087_TryCatch.cs
@@ -1,0 +1,57 @@
+namespace TryCatch
+{
+    using System;
+
+    public static class SafeOperations
+    {
+        public static int SafeDivide(int a, int b)
+        {
+            try
+            {
+                return a / b;
+            }
+            catch (DivideByZeroException)
+            {
+                return 0;
+            }
+        }
+
+        public static int SafeParse(string text)
+        {
+            try
+            {
+                return int.Parse(text);
+            }
+            catch (FormatException)
+            {
+                return -1;
+            }
+            catch (Exception)
+            {
+                return -2;
+            }
+        }
+
+        public static string ReadWithFinally(bool throwError)
+        {
+            string result = "";
+            try
+            {
+                if (throwError)
+                {
+                    throw new Exception("Error");
+                }
+                result = "success";
+            }
+            catch (Exception ex)
+            {
+                result = "error: " + ex.Message;
+            }
+            finally
+            {
+                result = result + " (cleaned up)";
+            }
+            return result;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/088_UsingStatement.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/088_UsingStatement.cs
@@ -1,0 +1,47 @@
+namespace UsingStatement
+{
+    using System;
+    using System.IO;
+
+    public static class FileOperations
+    {
+        public static string ReadFile(string path)
+        {
+            using (var reader = new StreamReader(path))
+            {
+                return reader.ReadToEnd();
+            }
+        }
+
+        public static void WriteFile(string path, string content)
+        {
+            using (var writer = new StreamWriter(path))
+            {
+                writer.Write(content);
+            }
+        }
+
+        public static int CountLines(string path)
+        {
+            int count = 0;
+            using (var reader = new StreamReader(path))
+            {
+                while (reader.ReadLine() != null)
+                {
+                    count = count + 1;
+                }
+            }
+            return count;
+        }
+    }
+
+    public class Resource : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose()
+        {
+            IsDisposed = true;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/089_LinqAggregate.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/089_LinqAggregate.cs
@@ -1,0 +1,43 @@
+namespace LinqAggregate
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public static class Aggregations
+    {
+        public static int GetSum(IEnumerable<int> numbers)
+        {
+            return numbers.Sum();
+        }
+
+        public static double GetAverage(IEnumerable<int> numbers)
+        {
+            return numbers.Average();
+        }
+
+        public static int GetMax(IEnumerable<int> numbers)
+        {
+            return numbers.Max();
+        }
+
+        public static int GetMin(IEnumerable<int> numbers)
+        {
+            return numbers.Min();
+        }
+
+        public static int GetCount(IEnumerable<int> numbers)
+        {
+            return numbers.Count();
+        }
+
+        public static int GetFirst(IEnumerable<int> numbers)
+        {
+            return numbers.First();
+        }
+
+        public static int GetFirstOrDefault(IEnumerable<int> numbers)
+        {
+            return numbers.FirstOrDefault();
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/090_LinqOrderBy.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/090_LinqOrderBy.cs
@@ -1,0 +1,34 @@
+namespace LinqOrderBy
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public static class Sorting
+    {
+        public static IEnumerable<int> SortAscending(IEnumerable<int> numbers)
+        {
+            return numbers.OrderBy(x => x);
+        }
+
+        public static IEnumerable<int> SortDescending(IEnumerable<int> numbers)
+        {
+            return numbers.OrderByDescending(x => x);
+        }
+
+        public static IEnumerable<Person> SortByName(IEnumerable<Person> people)
+        {
+            return people.OrderBy(p => p.Name);
+        }
+
+        public static IEnumerable<Person> SortByAgeThenName(IEnumerable<Person> people)
+        {
+            return people.OrderBy(p => p.Age).ThenBy(p => p.Name);
+        }
+    }
+
+    public class Person
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/091_LinqGroupBy.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/091_LinqGroupBy.cs
@@ -1,0 +1,29 @@
+namespace LinqGroupBy
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public static class Grouping
+    {
+        public static IEnumerable<IGrouping<int, int>> GroupByModulo(IEnumerable<int> numbers, int divisor)
+        {
+            return numbers.GroupBy(x => x % divisor);
+        }
+
+        public static IEnumerable<IGrouping<int, Person>> GroupByAge(IEnumerable<Person> people)
+        {
+            return people.GroupBy(p => p.Age);
+        }
+
+        public static IEnumerable<IGrouping<char, string>> GroupByFirstLetter(IEnumerable<string> strings)
+        {
+            return strings.GroupBy(s => s[0]);
+        }
+    }
+
+    public class Person
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/092_Events.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/092_Events.cs
@@ -1,0 +1,35 @@
+namespace Events
+{
+    using System;
+
+    public class Button
+    {
+        public event EventHandler Clicked;
+
+        public void Click()
+        {
+            if (Clicked != null)
+            {
+                Clicked(this, EventArgs.Empty);
+            }
+        }
+    }
+
+    public class CustomEventArgs : EventArgs
+    {
+        public string Message { get; set; }
+    }
+
+    public class Publisher
+    {
+        public event EventHandler<CustomEventArgs> MessageSent;
+
+        public void Send(string message)
+        {
+            if (MessageSent != null)
+            {
+                MessageSent(this, new CustomEventArgs { Message = message });
+            }
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/093_Delegates.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/093_Delegates.cs
@@ -1,0 +1,53 @@
+namespace Delegates
+{
+    public delegate int BinaryOperation(int a, int b);
+    public delegate bool Predicate(int value);
+    public delegate void Logger(string message);
+
+    public static class Operations
+    {
+        public static int Add(int a, int b)
+        {
+            return a + b;
+        }
+
+        public static int Multiply(int a, int b)
+        {
+            return a * b;
+        }
+
+        public static bool IsPositive(int x)
+        {
+            return x > 0;
+        }
+
+        public static int Apply(BinaryOperation op, int a, int b)
+        {
+            return op(a, b);
+        }
+
+        public static int[] Filter(int[] numbers, Predicate pred)
+        {
+            int count = 0;
+            for (int i = 0; i < numbers.Length; i++)
+            {
+                if (pred(numbers[i]))
+                {
+                    count = count + 1;
+                }
+            }
+
+            int[] result = new int[count];
+            int index = 0;
+            for (int i = 0; i < numbers.Length; i++)
+            {
+                if (pred(numbers[i]))
+                {
+                    result[index] = numbers[i];
+                    index = index + 1;
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/094_PatternMatching.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/094_PatternMatching.cs
@@ -1,0 +1,45 @@
+namespace PatternMatching
+{
+    public static class Patterns
+    {
+        public static string DescribeObject(object obj)
+        {
+            if (obj is int i)
+            {
+                return "Integer: " + i;
+            }
+            if (obj is string s)
+            {
+                return "String: " + s;
+            }
+            if (obj is bool b)
+            {
+                return "Boolean: " + b;
+            }
+            return "Unknown";
+        }
+
+        public static string DescribeNumber(int n)
+        {
+            return n switch
+            {
+                < 0 => "negative",
+                0 => "zero",
+                > 0 and < 10 => "small positive",
+                >= 10 and < 100 => "medium positive",
+                _ => "large positive"
+            };
+        }
+
+        public static int GetLength(object obj)
+        {
+            return obj switch
+            {
+                string s => s.Length,
+                int[] arr => arr.Length,
+                null => 0,
+                _ => -1
+            };
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/095_NullCoalescing.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/095_NullCoalescing.cs
@@ -1,0 +1,35 @@
+namespace NullCoalescing
+{
+    public static class NullHandling
+    {
+        public static string GetOrDefault(string value, string defaultValue)
+        {
+            return value ?? defaultValue;
+        }
+
+        public static int GetOrZero(int? value)
+        {
+            return value ?? 0;
+        }
+
+        public static string GetSafe(string value)
+        {
+            return value ?? "";
+        }
+
+        public static int? GetChained(int? a, int? b, int? c)
+        {
+            return a ?? b ?? c;
+        }
+
+        public static string GetLength(string value)
+        {
+            return value?.Length.ToString() ?? "null";
+        }
+
+        public static void SetIfNull(ref string value, string newValue)
+        {
+            value ??= newValue;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/096_StringInterpolation.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/096_StringInterpolation.cs
@@ -1,0 +1,31 @@
+namespace StringInterpolation
+{
+    public static class Formatting
+    {
+        public static string Greet(string name)
+        {
+            return $"Hello, {name}!";
+        }
+
+        public static string FormatPerson(string name, int age)
+        {
+            return $"{name} is {age} years old";
+        }
+
+        public static string FormatExpression(int a, int b)
+        {
+            return $"{a} + {b} = {a + b}";
+        }
+
+        public static string FormatNumber(double value)
+        {
+            return $"Value: {value:F2}";
+        }
+
+        public static string MultiLine(string title, string body)
+        {
+            return $@"Title: {title}
+Body: {body}";
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/097_AsyncAwaitChain.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/097_AsyncAwaitChain.cs
@@ -1,0 +1,44 @@
+namespace AsyncAwaitChain
+{
+    using System.Threading.Tasks;
+
+    public static class AsyncChain
+    {
+        public static async Task<int> Step1Async()
+        {
+            await Task.Delay(10);
+            return 1;
+        }
+
+        public static async Task<int> Step2Async(int input)
+        {
+            await Task.Delay(10);
+            return input + 10;
+        }
+
+        public static async Task<int> Step3Async(int input)
+        {
+            await Task.Delay(10);
+            return input * 2;
+        }
+
+        public static async Task<int> RunPipelineAsync()
+        {
+            int result1 = await Step1Async();
+            int result2 = await Step2Async(result1);
+            int result3 = await Step3Async(result2);
+            return result3;
+        }
+
+        public static async Task<int[]> RunParallelAsync()
+        {
+            var task1 = Step1Async();
+            var task2 = Step1Async();
+            var task3 = Step1Async();
+
+            await Task.WhenAll(task1, task2, task3);
+
+            return new int[] { task1.Result, task2.Result, task3.Result };
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/098_GenericConstraints.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/098_GenericConstraints.cs
@@ -1,0 +1,53 @@
+namespace GenericConstraints
+{
+    using System;
+
+    public interface IIdentifiable
+    {
+        int Id { get; }
+    }
+
+    public class Repository<T> where T : class, IIdentifiable, new()
+    {
+        private T[] items = new T[100];
+        private int count = 0;
+
+        public void Add(T item)
+        {
+            items[count] = item;
+            count = count + 1;
+        }
+
+        public T FindById(int id)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                if (items[i].Id == id)
+                {
+                    return items[i];
+                }
+            }
+            return null;
+        }
+
+        public T CreateNew()
+        {
+            return new T();
+        }
+    }
+
+    public class ComparableBox<T> where T : IComparable<T>
+    {
+        public T Value { get; set; }
+
+        public int CompareTo(ComparableBox<T> other)
+        {
+            return Value.CompareTo(other.Value);
+        }
+
+        public bool IsGreaterThan(ComparableBox<T> other)
+        {
+            return Value.CompareTo(other.Value) > 0;
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/099_Deconstruction.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/099_Deconstruction.cs
@@ -1,0 +1,47 @@
+namespace Deconstruction
+{
+    public class Point
+    {
+        public int X { get; set; }
+        public int Y { get; set; }
+
+        public Point(int x, int y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        public void Deconstruct(out int x, out int y)
+        {
+            x = X;
+            y = Y;
+        }
+    }
+
+    public static class Examples
+    {
+        public static (int, int) GetCoordinates()
+        {
+            return (10, 20);
+        }
+
+        public static int SumTuple()
+        {
+            var (x, y) = GetCoordinates();
+            return x + y;
+        }
+
+        public static int SumPoint(Point p)
+        {
+            var (x, y) = p;
+            return x + y;
+        }
+
+        public static void Swap()
+        {
+            int a = 1;
+            int b = 2;
+            (a, b) = (b, a);
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/Level5_Advanced/100_RecordWithMethods.cs
+++ b/tests/TestData/CSharpImport/Level5_Advanced/100_RecordWithMethods.cs
@@ -1,0 +1,36 @@
+namespace RecordWithMethods
+{
+    public record Person(string FirstName, string LastName, int Age)
+    {
+        public string FullName => FirstName + " " + LastName;
+
+        public bool IsAdult => Age >= 18;
+
+        public Person WithAge(int newAge)
+        {
+            return this with { Age = newAge };
+        }
+
+        public string Greet()
+        {
+            return "Hello, I am " + FullName;
+        }
+    }
+
+    public record Point3D(double X, double Y, double Z)
+    {
+        public double Magnitude => System.Math.Sqrt(X * X + Y * Y + Z * Z);
+
+        public static Point3D Origin => new Point3D(0, 0, 0);
+
+        public Point3D Add(Point3D other)
+        {
+            return new Point3D(X + other.X, Y + other.Y, Z + other.Z);
+        }
+
+        public Point3D Scale(double factor)
+        {
+            return new Point3D(X * factor, Y * factor, Z * factor);
+        }
+    }
+}

--- a/tests/TestData/CSharpImport/manifest.json
+++ b/tests/TestData/CSharpImport/manifest.json
@@ -1,0 +1,806 @@
+{
+  "version": "1.0",
+  "description": "C# test files for validating the C# to OPAL converter",
+  "files": [
+    {
+      "id": "001",
+      "file": "Level1_Basic/001_HelloWorld.cs",
+      "level": 1,
+      "features": ["namespace", "static_class", "main_method", "console_write"],
+      "expectedResult": "success",
+      "notes": "Simple hello world program"
+    },
+    {
+      "id": "002",
+      "file": "Level1_Basic/002_ReturnValue.cs",
+      "level": 1,
+      "features": ["namespace", "static_class", "return_statement", "int_literal"],
+      "expectedResult": "success",
+      "notes": "Method returning integer value"
+    },
+    {
+      "id": "003",
+      "file": "Level1_Basic/003_StringLiteral.cs",
+      "level": 1,
+      "features": ["string_literal", "multiple_methods"],
+      "expectedResult": "success",
+      "notes": "String literal return values"
+    },
+    {
+      "id": "004",
+      "file": "Level1_Basic/004_IntLiteral.cs",
+      "level": 1,
+      "features": ["int_literal", "negative_number", "zero"],
+      "expectedResult": "success",
+      "notes": "Integer literals including negative"
+    },
+    {
+      "id": "005",
+      "file": "Level1_Basic/005_BoolLiteral.cs",
+      "level": 1,
+      "features": ["bool_literal", "true", "false"],
+      "expectedResult": "success",
+      "notes": "Boolean literal values"
+    },
+    {
+      "id": "006",
+      "file": "Level1_Basic/006_DoubleLiteral.cs",
+      "level": 1,
+      "features": ["double_literal", "floating_point"],
+      "expectedResult": "success",
+      "notes": "Double/floating-point literals"
+    },
+    {
+      "id": "007",
+      "file": "Level1_Basic/007_SimpleAddition.cs",
+      "level": 1,
+      "features": ["binary_expression", "addition", "parameters"],
+      "expectedResult": "success",
+      "notes": "Simple addition of two parameters"
+    },
+    {
+      "id": "008",
+      "file": "Level1_Basic/008_SimpleSubtraction.cs",
+      "level": 1,
+      "features": ["binary_expression", "subtraction", "parameters"],
+      "expectedResult": "success",
+      "notes": "Simple subtraction operation"
+    },
+    {
+      "id": "009",
+      "file": "Level1_Basic/009_SimpleMultiplication.cs",
+      "level": 1,
+      "features": ["binary_expression", "multiplication", "parameters"],
+      "expectedResult": "success",
+      "notes": "Simple multiplication operation"
+    },
+    {
+      "id": "010",
+      "file": "Level1_Basic/010_SimpleDivision.cs",
+      "level": 1,
+      "features": ["binary_expression", "division", "parameters"],
+      "expectedResult": "success",
+      "notes": "Simple division operation"
+    },
+    {
+      "id": "011",
+      "file": "Level1_Basic/011_Modulo.cs",
+      "level": 1,
+      "features": ["binary_expression", "modulo"],
+      "expectedResult": "success",
+      "notes": "Modulo/remainder operation"
+    },
+    {
+      "id": "012",
+      "file": "Level1_Basic/012_StringConcat.cs",
+      "level": 1,
+      "features": ["string_concatenation", "binary_expression"],
+      "expectedResult": "success",
+      "notes": "String concatenation with + operator"
+    },
+    {
+      "id": "013",
+      "file": "Level1_Basic/013_LocalVariable.cs",
+      "level": 1,
+      "features": ["local_variable", "variable_declaration", "assignment"],
+      "expectedResult": "success",
+      "notes": "Local variable declarations with types"
+    },
+    {
+      "id": "014",
+      "file": "Level1_Basic/014_VarKeyword.cs",
+      "level": 1,
+      "features": ["var_keyword", "type_inference"],
+      "expectedResult": "success",
+      "notes": "Type inference with var keyword"
+    },
+    {
+      "id": "015",
+      "file": "Level1_Basic/015_ComparisonOperators.cs",
+      "level": 1,
+      "features": ["comparison", "equals", "not_equals", "greater_than", "less_than"],
+      "expectedResult": "success",
+      "notes": "Comparison operators"
+    },
+    {
+      "id": "016",
+      "file": "Level1_Basic/016_LogicalOperators.cs",
+      "level": 1,
+      "features": ["logical_and", "logical_or", "logical_not"],
+      "expectedResult": "success",
+      "notes": "Logical operators &&, ||, !"
+    },
+    {
+      "id": "017",
+      "file": "Level1_Basic/017_UnaryOperators.cs",
+      "level": 1,
+      "features": ["unary_minus", "unary_plus"],
+      "expectedResult": "partial",
+      "notes": "Unary operators +, - - OPAL parser may not support unary plus"
+    },
+    {
+      "id": "018",
+      "file": "Level1_Basic/018_ParenthesizedExpr.cs",
+      "level": 1,
+      "features": ["parenthesized_expression", "operator_precedence"],
+      "expectedResult": "success",
+      "notes": "Parenthesized expressions for precedence"
+    },
+    {
+      "id": "019",
+      "file": "Level1_Basic/019_MultipleStatements.cs",
+      "level": 1,
+      "features": ["multiple_statements", "statement_sequence"],
+      "expectedResult": "success",
+      "notes": "Multiple statements in method body"
+    },
+    {
+      "id": "020",
+      "file": "Level1_Basic/020_BasicCalculator.cs",
+      "level": 1,
+      "features": ["multiple_methods", "arithmetic"],
+      "expectedResult": "success",
+      "notes": "Calculator with multiple arithmetic methods"
+    },
+    {
+      "id": "021",
+      "file": "Level2_ControlFlow/021_SimpleIf.cs",
+      "level": 2,
+      "features": ["if_statement", "conditional"],
+      "expectedResult": "success",
+      "notes": "Simple if statement without else"
+    },
+    {
+      "id": "022",
+      "file": "Level2_ControlFlow/022_IfElse.cs",
+      "level": 2,
+      "features": ["if_else", "conditional"],
+      "expectedResult": "success",
+      "notes": "If-else statement"
+    },
+    {
+      "id": "023",
+      "file": "Level2_ControlFlow/023_IfElseIfElse.cs",
+      "level": 2,
+      "features": ["if_elseif_else", "chained_conditional"],
+      "expectedResult": "success",
+      "notes": "Chained if-else-if-else"
+    },
+    {
+      "id": "024",
+      "file": "Level2_ControlFlow/024_ForLoop.cs",
+      "level": 2,
+      "features": ["for_loop", "loop_variable", "increment"],
+      "expectedResult": "success",
+      "notes": "Basic for loop"
+    },
+    {
+      "id": "025",
+      "file": "Level2_ControlFlow/025_WhileLoop.cs",
+      "level": 2,
+      "features": ["while_loop"],
+      "expectedResult": "success",
+      "notes": "Basic while loop"
+    },
+    {
+      "id": "026",
+      "file": "Level2_ControlFlow/026_DoWhileLoop.cs",
+      "level": 2,
+      "features": ["do_while_loop"],
+      "expectedResult": "success",
+      "notes": "Do-while loop"
+    },
+    {
+      "id": "027",
+      "file": "Level2_ControlFlow/027_NestedLoops.cs",
+      "level": 2,
+      "features": ["nested_loops", "for_loop"],
+      "expectedResult": "success",
+      "notes": "Nested for loops"
+    },
+    {
+      "id": "028",
+      "file": "Level2_ControlFlow/028_FizzBuzz.cs",
+      "level": 2,
+      "features": ["if_else", "modulo", "to_string"],
+      "expectedResult": "success",
+      "notes": "FizzBuzz implementation"
+    },
+    {
+      "id": "029",
+      "file": "Level2_ControlFlow/029_FactorialIterative.cs",
+      "level": 2,
+      "features": ["for_loop", "accumulator"],
+      "expectedResult": "success",
+      "notes": "Iterative factorial"
+    },
+    {
+      "id": "030",
+      "file": "Level2_ControlFlow/030_FactorialRecursive.cs",
+      "level": 2,
+      "features": ["recursion", "if_statement"],
+      "expectedResult": "success",
+      "notes": "Recursive factorial"
+    },
+    {
+      "id": "031",
+      "file": "Level2_ControlFlow/031_FibonacciIterative.cs",
+      "level": 2,
+      "features": ["for_loop", "multiple_variables"],
+      "expectedResult": "success",
+      "notes": "Iterative Fibonacci"
+    },
+    {
+      "id": "032",
+      "file": "Level2_ControlFlow/032_FibonacciRecursive.cs",
+      "level": 2,
+      "features": ["recursion", "binary_recursion"],
+      "expectedResult": "success",
+      "notes": "Recursive Fibonacci"
+    },
+    {
+      "id": "033",
+      "file": "Level2_ControlFlow/033_SwitchStatement.cs",
+      "level": 2,
+      "features": ["switch_statement", "case", "default"],
+      "expectedResult": "success",
+      "notes": "Classic switch statement"
+    },
+    {
+      "id": "034",
+      "file": "Level2_ControlFlow/034_SwitchExpression.cs",
+      "level": 2,
+      "features": ["switch_expression", "pattern_matching"],
+      "expectedResult": "partial",
+      "notes": "C# 8.0 switch expression syntax"
+    },
+    {
+      "id": "035",
+      "file": "Level2_ControlFlow/035_BreakStatement.cs",
+      "level": 2,
+      "features": ["break", "for_loop"],
+      "expectedResult": "success",
+      "notes": "Break statement in loop"
+    },
+    {
+      "id": "036",
+      "file": "Level2_ControlFlow/036_ContinueStatement.cs",
+      "level": 2,
+      "features": ["continue", "for_loop"],
+      "expectedResult": "success",
+      "notes": "Continue statement in loop"
+    },
+    {
+      "id": "037",
+      "file": "Level2_ControlFlow/037_TernaryOperator.cs",
+      "level": 2,
+      "features": ["ternary_operator", "conditional_expression"],
+      "expectedResult": "success",
+      "notes": "Ternary conditional operator"
+    },
+    {
+      "id": "038",
+      "file": "Level2_ControlFlow/038_NestedConditions.cs",
+      "level": 2,
+      "features": ["nested_if", "multiple_conditions"],
+      "expectedResult": "success",
+      "notes": "Nested if statements"
+    },
+    {
+      "id": "039",
+      "file": "Level2_ControlFlow/039_EarlyReturn.cs",
+      "level": 2,
+      "features": ["early_return", "guard_clause"],
+      "expectedResult": "success",
+      "notes": "Early return pattern"
+    },
+    {
+      "id": "040",
+      "file": "Level2_ControlFlow/040_ComplexConditions.cs",
+      "level": 2,
+      "features": ["complex_conditions", "logical_operators"],
+      "expectedResult": "success",
+      "notes": "Complex boolean conditions"
+    },
+    {
+      "id": "041",
+      "file": "Level3_Types/041_SimpleClass.cs",
+      "level": 3,
+      "features": ["class", "fields", "new_expression"],
+      "expectedResult": "success",
+      "notes": "Simple non-static class"
+    },
+    {
+      "id": "042",
+      "file": "Level3_Types/042_ClassWithFields.cs",
+      "level": 3,
+      "features": ["class", "public_fields", "instance_methods"],
+      "expectedResult": "success",
+      "notes": "Class with fields and methods"
+    },
+    {
+      "id": "043",
+      "file": "Level3_Types/043_ClassWithProperties.cs",
+      "level": 3,
+      "features": ["auto_properties", "get_set"],
+      "expectedResult": "partial",
+      "notes": "Auto-implemented properties"
+    },
+    {
+      "id": "044",
+      "file": "Level3_Types/044_Record.cs",
+      "level": 3,
+      "features": ["record", "positional_record"],
+      "expectedResult": "partial",
+      "notes": "Record type (C# 9.0)"
+    },
+    {
+      "id": "045",
+      "file": "Level3_Types/045_Enum.cs",
+      "level": 3,
+      "features": ["enum", "enum_member"],
+      "expectedResult": "success",
+      "notes": "Basic enum definition"
+    },
+    {
+      "id": "046",
+      "file": "Level3_Types/046_EnumWithValues.cs",
+      "level": 3,
+      "features": ["enum", "explicit_values", "cast"],
+      "expectedResult": "success",
+      "notes": "Enum with explicit values"
+    },
+    {
+      "id": "047",
+      "file": "Level3_Types/047_ArrayDeclaration.cs",
+      "level": 3,
+      "features": ["array", "array_access", "array_length"],
+      "expectedResult": "success",
+      "notes": "Array declaration and access"
+    },
+    {
+      "id": "048",
+      "file": "Level3_Types/048_ArrayInitializer.cs",
+      "level": 3,
+      "features": ["array_initializer", "collection_initializer"],
+      "expectedResult": "success",
+      "notes": "Array with initializer syntax"
+    },
+    {
+      "id": "049",
+      "file": "Level3_Types/049_ListUsage.cs",
+      "level": 3,
+      "features": ["list", "generic_type", "add_method"],
+      "expectedResult": "partial",
+      "notes": "List<T> usage"
+    },
+    {
+      "id": "050",
+      "file": "Level3_Types/050_DictionaryUsage.cs",
+      "level": 3,
+      "features": ["dictionary", "generic_type", "indexer"],
+      "expectedResult": "partial",
+      "notes": "Dictionary<K,V> usage"
+    },
+    {
+      "id": "051",
+      "file": "Level3_Types/051_Struct.cs",
+      "level": 3,
+      "features": ["struct", "value_type"],
+      "expectedResult": "partial",
+      "notes": "Struct definition"
+    },
+    {
+      "id": "052",
+      "file": "Level3_Types/052_NullableTypes.cs",
+      "level": 3,
+      "features": ["nullable", "has_value", "value"],
+      "expectedResult": "partial",
+      "notes": "Nullable value types"
+    },
+    {
+      "id": "053",
+      "file": "Level3_Types/053_ClassWithConstructor.cs",
+      "level": 3,
+      "features": ["constructor", "this", "decimal"],
+      "expectedResult": "success",
+      "notes": "Class with constructor"
+    },
+    {
+      "id": "054",
+      "file": "Level3_Types/054_Inheritance.cs",
+      "level": 3,
+      "features": ["inheritance", "base_class", "derived_class"],
+      "expectedResult": "partial",
+      "notes": "Class inheritance"
+    },
+    {
+      "id": "055",
+      "file": "Level3_Types/055_Interface.cs",
+      "level": 3,
+      "features": ["interface", "implements"],
+      "expectedResult": "partial",
+      "notes": "Interface definition and implementation"
+    },
+    {
+      "id": "056",
+      "file": "Level3_Types/056_AbstractClass.cs",
+      "level": 3,
+      "features": ["abstract_class", "abstract_method", "override"],
+      "expectedResult": "partial",
+      "notes": "Abstract class and override"
+    },
+    {
+      "id": "057",
+      "file": "Level3_Types/057_StaticClass.cs",
+      "level": 3,
+      "features": ["static_class", "readonly_field"],
+      "expectedResult": "success",
+      "notes": "Static class with constants"
+    },
+    {
+      "id": "058",
+      "file": "Level3_Types/058_NestedClass.cs",
+      "level": 3,
+      "features": ["nested_class", "inner_class"],
+      "expectedResult": "partial",
+      "notes": "Nested class definition"
+    },
+    {
+      "id": "059",
+      "file": "Level3_Types/059_Tuple.cs",
+      "level": 3,
+      "features": ["tuple", "named_tuple", "tuple_access"],
+      "expectedResult": "partial",
+      "notes": "ValueTuple usage"
+    },
+    {
+      "id": "060",
+      "file": "Level3_Types/060_ObjectInitializer.cs",
+      "level": 3,
+      "features": ["object_initializer"],
+      "expectedResult": "partial",
+      "notes": "Object initializer syntax"
+    },
+    {
+      "id": "061",
+      "file": "Level4_Methods/061_MultipleParameters.cs",
+      "level": 4,
+      "features": ["multiple_parameters", "three_params"],
+      "expectedResult": "success",
+      "notes": "Methods with 3+ parameters"
+    },
+    {
+      "id": "062",
+      "file": "Level4_Methods/062_OptionalParameters.cs",
+      "level": 4,
+      "features": ["optional_parameters", "default_values"],
+      "expectedResult": "partial",
+      "notes": "Optional parameters with defaults"
+    },
+    {
+      "id": "063",
+      "file": "Level4_Methods/063_RefParameters.cs",
+      "level": 4,
+      "features": ["ref_parameter"],
+      "expectedResult": "partial",
+      "notes": "Ref parameters"
+    },
+    {
+      "id": "064",
+      "file": "Level4_Methods/064_OutParameters.cs",
+      "level": 4,
+      "features": ["out_parameter"],
+      "expectedResult": "partial",
+      "notes": "Out parameters"
+    },
+    {
+      "id": "065",
+      "file": "Level4_Methods/065_MethodOverloads.cs",
+      "level": 4,
+      "features": ["method_overloading"],
+      "expectedResult": "success",
+      "notes": "Method overloading"
+    },
+    {
+      "id": "066",
+      "file": "Level4_Methods/066_ExpressionBodied.cs",
+      "level": 4,
+      "features": ["expression_bodied_member"],
+      "expectedResult": "success",
+      "notes": "Expression-bodied methods"
+    },
+    {
+      "id": "067",
+      "file": "Level4_Methods/067_PrivateMethods.cs",
+      "level": 4,
+      "features": ["private_method", "accessibility"],
+      "expectedResult": "success",
+      "notes": "Private methods"
+    },
+    {
+      "id": "068",
+      "file": "Level4_Methods/068_StaticVsInstance.cs",
+      "level": 4,
+      "features": ["static_method", "instance_method", "static_field"],
+      "expectedResult": "success",
+      "notes": "Static vs instance members"
+    },
+    {
+      "id": "069",
+      "file": "Level4_Methods/069_MethodChaining.cs",
+      "level": 4,
+      "features": ["method_chaining", "fluent_interface", "return_this"],
+      "expectedResult": "partial",
+      "notes": "Method chaining pattern"
+    },
+    {
+      "id": "070",
+      "file": "Level4_Methods/070_VoidMethods.cs",
+      "level": 4,
+      "features": ["void_method", "console_write"],
+      "expectedResult": "success",
+      "notes": "Void return type methods"
+    },
+    {
+      "id": "071",
+      "file": "Level4_Methods/071_ParamsArray.cs",
+      "level": 4,
+      "features": ["params", "variable_arguments"],
+      "expectedResult": "partial",
+      "notes": "Params array parameter"
+    },
+    {
+      "id": "072",
+      "file": "Level4_Methods/072_NamedArguments.cs",
+      "level": 4,
+      "features": ["named_arguments"],
+      "expectedResult": "partial",
+      "notes": "Named arguments in calls"
+    },
+    {
+      "id": "073",
+      "file": "Level4_Methods/073_RecursiveMethods.cs",
+      "level": 4,
+      "features": ["recursion", "tail_recursion"],
+      "expectedResult": "success",
+      "notes": "Recursive methods"
+    },
+    {
+      "id": "074",
+      "file": "Level4_Methods/074_LocalFunctions.cs",
+      "level": 4,
+      "features": ["local_function"],
+      "expectedResult": "partial",
+      "notes": "Local functions (C# 7.0)"
+    },
+    {
+      "id": "075",
+      "file": "Level4_Methods/075_ExtensionMethods.cs",
+      "level": 4,
+      "features": ["extension_method", "this_parameter"],
+      "expectedResult": "partial",
+      "notes": "Extension methods"
+    },
+    {
+      "id": "076",
+      "file": "Level4_Methods/076_VirtualMethods.cs",
+      "level": 4,
+      "features": ["virtual_method", "override"],
+      "expectedResult": "partial",
+      "notes": "Virtual and override methods"
+    },
+    {
+      "id": "077",
+      "file": "Level4_Methods/077_PropertyGetSet.cs",
+      "level": 4,
+      "features": ["property_getter", "property_setter", "backing_field"],
+      "expectedResult": "partial",
+      "notes": "Property with custom get/set"
+    },
+    {
+      "id": "078",
+      "file": "Level4_Methods/078_IndexerProperty.cs",
+      "level": 4,
+      "features": ["indexer"],
+      "expectedResult": "partial",
+      "notes": "Indexer property"
+    },
+    {
+      "id": "079",
+      "file": "Level4_Methods/079_OperatorOverload.cs",
+      "level": 4,
+      "features": ["operator_overload"],
+      "expectedResult": "partial",
+      "notes": "Operator overloading"
+    },
+    {
+      "id": "080",
+      "file": "Level4_Methods/080_ImplicitExplicitConversion.cs",
+      "level": 4,
+      "features": ["implicit_conversion", "explicit_conversion"],
+      "expectedResult": "unsupported",
+      "notes": "Implicit/explicit conversion operators"
+    },
+    {
+      "id": "081",
+      "file": "Level5_Advanced/081_AsyncMethod.cs",
+      "level": 5,
+      "features": ["async", "await", "task"],
+      "expectedResult": "partial",
+      "notes": "Async/await methods"
+    },
+    {
+      "id": "082",
+      "file": "Level5_Advanced/082_Lambda.cs",
+      "level": 5,
+      "features": ["lambda", "func", "action"],
+      "expectedResult": "partial",
+      "notes": "Lambda expressions"
+    },
+    {
+      "id": "083",
+      "file": "Level5_Advanced/083_LinqSelect.cs",
+      "level": 5,
+      "features": ["linq", "select", "ienumerable"],
+      "expectedResult": "partial",
+      "notes": "LINQ Select method"
+    },
+    {
+      "id": "084",
+      "file": "Level5_Advanced/084_LinqWhere.cs",
+      "level": 5,
+      "features": ["linq", "where", "filter"],
+      "expectedResult": "partial",
+      "notes": "LINQ Where method"
+    },
+    {
+      "id": "085",
+      "file": "Level5_Advanced/085_GenericClass.cs",
+      "level": 5,
+      "features": ["generic_class", "type_parameter"],
+      "expectedResult": "partial",
+      "notes": "Generic class definition"
+    },
+    {
+      "id": "086",
+      "file": "Level5_Advanced/086_GenericMethod.cs",
+      "level": 5,
+      "features": ["generic_method", "type_constraint"],
+      "expectedResult": "partial",
+      "notes": "Generic methods with constraints"
+    },
+    {
+      "id": "087",
+      "file": "Level5_Advanced/087_TryCatch.cs",
+      "level": 5,
+      "features": ["try_catch", "exception", "finally"],
+      "expectedResult": "partial",
+      "notes": "Exception handling"
+    },
+    {
+      "id": "088",
+      "file": "Level5_Advanced/088_UsingStatement.cs",
+      "level": 5,
+      "features": ["using_statement", "idisposable"],
+      "expectedResult": "partial",
+      "notes": "Using statement for IDisposable"
+    },
+    {
+      "id": "089",
+      "file": "Level5_Advanced/089_LinqAggregate.cs",
+      "level": 5,
+      "features": ["linq", "sum", "average", "max", "min"],
+      "expectedResult": "partial",
+      "notes": "LINQ aggregation methods"
+    },
+    {
+      "id": "090",
+      "file": "Level5_Advanced/090_LinqOrderBy.cs",
+      "level": 5,
+      "features": ["linq", "orderby", "thenby"],
+      "expectedResult": "partial",
+      "notes": "LINQ sorting methods"
+    },
+    {
+      "id": "091",
+      "file": "Level5_Advanced/091_LinqGroupBy.cs",
+      "level": 5,
+      "features": ["linq", "groupby", "igrouping"],
+      "expectedResult": "partial",
+      "notes": "LINQ GroupBy method"
+    },
+    {
+      "id": "092",
+      "file": "Level5_Advanced/092_Events.cs",
+      "level": 5,
+      "features": ["event", "eventhandler", "event_args"],
+      "expectedResult": "unsupported",
+      "notes": "Events and event handlers"
+    },
+    {
+      "id": "093",
+      "file": "Level5_Advanced/093_Delegates.cs",
+      "level": 5,
+      "features": ["delegate", "multicast_delegate"],
+      "expectedResult": "unsupported",
+      "notes": "Delegate types"
+    },
+    {
+      "id": "094",
+      "file": "Level5_Advanced/094_PatternMatching.cs",
+      "level": 5,
+      "features": ["pattern_matching", "is_expression", "switch_expression"],
+      "expectedResult": "partial",
+      "notes": "Pattern matching (C# 7.0+)"
+    },
+    {
+      "id": "095",
+      "file": "Level5_Advanced/095_NullCoalescing.cs",
+      "level": 5,
+      "features": ["null_coalescing", "null_conditional", "null_assignment"],
+      "expectedResult": "partial",
+      "notes": "Null coalescing operators"
+    },
+    {
+      "id": "096",
+      "file": "Level5_Advanced/096_StringInterpolation.cs",
+      "level": 5,
+      "features": ["string_interpolation", "format_string"],
+      "expectedResult": "partial",
+      "notes": "String interpolation"
+    },
+    {
+      "id": "097",
+      "file": "Level5_Advanced/097_AsyncAwaitChain.cs",
+      "level": 5,
+      "features": ["async", "await", "task_whenall", "parallel"],
+      "expectedResult": "partial",
+      "notes": "Complex async patterns"
+    },
+    {
+      "id": "098",
+      "file": "Level5_Advanced/098_GenericConstraints.cs",
+      "level": 5,
+      "features": ["generic_constraint", "where_clause", "new_constraint"],
+      "expectedResult": "partial",
+      "notes": "Generic constraints"
+    },
+    {
+      "id": "099",
+      "file": "Level5_Advanced/099_Deconstruction.cs",
+      "level": 5,
+      "features": ["deconstruction", "tuple_deconstruct"],
+      "expectedResult": "partial",
+      "notes": "Deconstruction patterns"
+    },
+    {
+      "id": "100",
+      "file": "Level5_Advanced/100_RecordWithMethods.cs",
+      "level": 5,
+      "features": ["record", "with_expression", "computed_property"],
+      "expectedResult": "partial",
+      "notes": "Record with methods and with-expression"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add comprehensive test suite of 100 purpose-built C# files to validate the C# → OPAL converter
- Create test infrastructure with `TestDataLoader` and `CSharpImportBulkTests`
- Include manifest.json with metadata for all test files including expected results

## Test Data Organization (100 files)

| Level | Files | Description |
|-------|-------|-------------|
| Level 1 | 001-020 | Basic - literals, operators, expressions |
| Level 2 | 021-040 | Control flow - if/else, loops, switch, recursion |
| Level 3 | 041-060 | Types - classes, records, enums, collections |
| Level 4 | 061-080 | Methods - parameters, overloads, properties |
| Level 5 | 081-100 | Advanced - async, LINQ, generics, patterns |

## Baseline Results

| Level | Success Rate | Notes |
|-------|--------------|-------|
| Level 1 | 95% | Basic features fully supported |
| Level 2 | 35% | Some loop constructs unsupported |
| Level 3 | 15% | Complex type features |
| Level 4 | 40% | Method patterns vary |
| Level 5 | 5% | Documents converter limits |
| **Overall** | **38%** | |

## Test plan

- [x] All 100 test files created and loadable
- [x] Tests run and produce baseline metrics
- [x] Failing tests at higher levels are expected and document converter limitations

🤖 Generated with [Claude Code](https://claude.ai/code)