### PR TITLE
Add C# ↔ OPAL bidirectional migration tool

### DIFF
--- a/src/Opal.Compiler/Commands/BenchmarkCommand.cs
+++ b/src/Opal.Compiler/Commands/BenchmarkCommand.cs
@@ -1,0 +1,332 @@
+using System.CommandLine;
+using Opal.Compiler.Migration;
+
+namespace Opal.Compiler.Commands;
+
+/// <summary>
+/// CLI command for standalone benchmarking.
+/// </summary>
+public static class BenchmarkCommand
+{
+    public static Command Create()
+    {
+        var opalOption = new Option<FileInfo?>(
+            aliases: new[] { "--opal" },
+            description: "The OPAL file to benchmark");
+
+        var csharpOption = new Option<FileInfo?>(
+            aliases: new[] { "--csharp", "--cs" },
+            description: "The C# file to benchmark");
+
+        var projectArgument = new Argument<DirectoryInfo?>(
+            name: "project",
+            description: "The project directory to benchmark (optional)")
+        {
+            Arity = ArgumentArity.ZeroOrOne
+        };
+
+        var formatOption = new Option<string>(
+            aliases: new[] { "--format", "-f" },
+            description: "Output format (console, markdown, json)",
+            getDefaultValue: () => "console");
+
+        var outputOption = new Option<FileInfo?>(
+            aliases: new[] { "--output", "-o" },
+            description: "Save benchmark results to file");
+
+        var command = new Command("benchmark", "Compare token economics between C# and OPAL")
+        {
+            projectArgument,
+            opalOption,
+            csharpOption,
+            formatOption,
+            outputOption
+        };
+
+        command.SetHandler(ExecuteAsync, projectArgument, opalOption, csharpOption, formatOption, outputOption);
+
+        return command;
+    }
+
+    private static async Task ExecuteAsync(
+        DirectoryInfo? project,
+        FileInfo? opalFile,
+        FileInfo? csharpFile,
+        string format,
+        FileInfo? output)
+    {
+        try
+        {
+            if (opalFile != null && csharpFile != null)
+            {
+                // Single file comparison
+                await BenchmarkFilesAsync(opalFile, csharpFile, format, output);
+            }
+            else if (project != null)
+            {
+                // Project-level comparison
+                await BenchmarkProjectAsync(project, format, output);
+            }
+            else
+            {
+                Console.Error.WriteLine("Error: Provide either --opal and --csharp files, or a project directory.");
+                Console.Error.WriteLine();
+                Console.Error.WriteLine("Examples:");
+                Console.Error.WriteLine("  opalc benchmark --opal file.opal --csharp file.cs");
+                Console.Error.WriteLine("  opalc benchmark ./MyProject");
+                Environment.ExitCode = 1;
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            Environment.ExitCode = 1;
+        }
+    }
+
+    private static async Task BenchmarkFilesAsync(FileInfo opalFile, FileInfo csharpFile, string format, FileInfo? output)
+    {
+        if (!opalFile.Exists)
+        {
+            Console.Error.WriteLine($"Error: OPAL file not found: {opalFile.FullName}");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        if (!csharpFile.Exists)
+        {
+            Console.Error.WriteLine($"Error: C# file not found: {csharpFile.FullName}");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        var opalSource = await File.ReadAllTextAsync(opalFile.FullName);
+        var csharpSource = await File.ReadAllTextAsync(csharpFile.FullName);
+
+        var result = BenchmarkIntegration.RunQuickBenchmark(csharpSource, opalSource);
+
+        var outputContent = format.ToLowerInvariant() switch
+        {
+            "markdown" or "md" => FormatMarkdown(opalFile.Name, csharpFile.Name, result),
+            "json" => FormatJson(opalFile.Name, csharpFile.Name, result),
+            _ => FormatConsole(opalFile.Name, csharpFile.Name, result)
+        };
+
+        if (output != null)
+        {
+            await File.WriteAllTextAsync(output.FullName, outputContent);
+            Console.WriteLine($"Results saved to: {output.FullName}");
+        }
+        else
+        {
+            Console.WriteLine(outputContent);
+        }
+    }
+
+    private static async Task BenchmarkProjectAsync(DirectoryInfo project, string format, FileInfo? output)
+    {
+        if (!project.Exists)
+        {
+            Console.Error.WriteLine($"Error: Project directory not found: {project.FullName}");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        Console.WriteLine($"Scanning project: {project.FullName}");
+        Console.WriteLine();
+
+        // Find paired files
+        var opalFiles = Directory.GetFiles(project.FullName, "*.opal", SearchOption.AllDirectories);
+        var pairs = new List<(string opal, string cs, FileMetrics metrics)>();
+
+        foreach (var opalPath in opalFiles)
+        {
+            var baseName = Path.GetFileNameWithoutExtension(opalPath);
+            var directory = Path.GetDirectoryName(opalPath) ?? ".";
+
+            // Look for matching C# file
+            var csPath = Path.Combine(directory, baseName + ".cs");
+            var gcsPath = Path.Combine(directory, baseName + ".g.cs");
+
+            string? matchingCs = null;
+            if (File.Exists(csPath))
+                matchingCs = csPath;
+            else if (File.Exists(gcsPath))
+                matchingCs = gcsPath;
+
+            if (matchingCs != null)
+            {
+                var opalSource = await File.ReadAllTextAsync(opalPath);
+                var csSource = await File.ReadAllTextAsync(matchingCs);
+                var metrics = BenchmarkIntegration.CalculateMetrics(csSource, opalSource);
+
+                pairs.Add((opalPath, matchingCs, metrics));
+            }
+        }
+
+        if (pairs.Count == 0)
+        {
+            Console.WriteLine("No paired .opal and .cs files found.");
+            Console.WriteLine("Looking for files with the same base name (e.g., foo.opal and foo.cs)");
+            return;
+        }
+
+        // Calculate summary
+        var summary = BenchmarkIntegration.CreateSummary(pairs.Select(p => p.metrics));
+
+        // Output results
+        var outputContent = format.ToLowerInvariant() switch
+        {
+            "markdown" or "md" => FormatProjectMarkdown(project.Name, pairs, summary),
+            "json" => FormatProjectJson(project.Name, pairs, summary),
+            _ => FormatProjectConsole(project.Name, pairs, summary)
+        };
+
+        if (output != null)
+        {
+            await File.WriteAllTextAsync(output.FullName, outputContent);
+            Console.WriteLine($"Results saved to: {output.FullName}");
+        }
+        else
+        {
+            Console.WriteLine(outputContent);
+        }
+    }
+
+    private static string FormatConsole(string opalName, string csName, BenchmarkResult result)
+    {
+        return $"""
+            Benchmark: {csName} vs {opalName}
+
+            {result.Summary}
+            """;
+    }
+
+    private static string FormatMarkdown(string opalName, string csName, BenchmarkResult result)
+    {
+        var m = result.Metrics;
+        return $"""
+            # Benchmark Results
+
+            **Comparison:** `{csName}` vs `{opalName}`
+
+            | Metric | C# | OPAL | Savings |
+            |--------|-----|------|---------|
+            | Tokens | {m.OriginalTokens:N0} | {m.OutputTokens:N0} | {m.TokenReduction:F1}% |
+            | Lines | {m.OriginalLines:N0} | {m.OutputLines:N0} | {m.LineReduction:F1}% |
+            | Characters | {m.OriginalCharacters:N0} | {m.OutputCharacters:N0} | {m.CharReduction:F1}% |
+
+            **Overall OPAL Advantage:** {result.AdvantageRatio:F2}x
+            """;
+    }
+
+    private static string FormatJson(string opalName, string csName, BenchmarkResult result)
+    {
+        var m = result.Metrics;
+        return $$"""
+            {
+              "comparison": {
+                "csharpFile": "{{csName}}",
+                "opalFile": "{{opalName}}"
+              },
+              "metrics": {
+                "tokens": { "csharp": {{m.OriginalTokens}}, "opal": {{m.OutputTokens}}, "savings": {{m.TokenReduction:F1}} },
+                "lines": { "csharp": {{m.OriginalLines}}, "opal": {{m.OutputLines}}, "savings": {{m.LineReduction:F1}} },
+                "characters": { "csharp": {{m.OriginalCharacters}}, "opal": {{m.OutputCharacters}}, "savings": {{m.CharReduction:F1}} }
+              },
+              "advantageRatio": {{result.AdvantageRatio:F2}}
+            }
+            """;
+    }
+
+    private static string FormatProjectConsole(string projectName, List<(string opal, string cs, FileMetrics metrics)> pairs, BenchmarkSummary summary)
+    {
+        var sb = new System.Text.StringBuilder();
+
+        sb.AppendLine($"Project Benchmark: {projectName}");
+        sb.AppendLine($"Files compared: {pairs.Count}");
+        sb.AppendLine();
+        sb.AppendLine("Summary:");
+        sb.AppendLine($"  Total tokens: {summary.TotalOriginalTokens:N0} → {summary.TotalOutputTokens:N0} ({summary.TokenSavingsPercent:F1}% savings)");
+        sb.AppendLine($"  Total lines: {summary.TotalOriginalLines:N0} → {summary.TotalOutputLines:N0} ({summary.LineSavingsPercent:F1}% savings)");
+        sb.AppendLine($"  Overall OPAL advantage: {summary.OverallAdvantage:F2}x");
+        sb.AppendLine();
+        sb.AppendLine("By File:");
+
+        foreach (var (opal, cs, metrics) in pairs.OrderByDescending(p => BenchmarkIntegration.CalculateAdvantageRatio(p.metrics)))
+        {
+            var advantage = BenchmarkIntegration.CalculateAdvantageRatio(metrics);
+            var indicator = advantage > 1 ? "+" : "";
+            sb.AppendLine($"  {Path.GetFileName(opal)}: {indicator}{(advantage - 1) * 100:F0}% tokens ({metrics.OriginalTokens} → {metrics.OutputTokens})");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string FormatProjectMarkdown(string projectName, List<(string opal, string cs, FileMetrics metrics)> pairs, BenchmarkSummary summary)
+    {
+        var sb = new System.Text.StringBuilder();
+
+        sb.AppendLine($"# Benchmark Results: {projectName}");
+        sb.AppendLine();
+        sb.AppendLine($"**Files compared:** {pairs.Count}");
+        sb.AppendLine();
+        sb.AppendLine("## Summary");
+        sb.AppendLine();
+        sb.AppendLine("| Metric | C# | OPAL | Savings |");
+        sb.AppendLine("|--------|-----|------|---------|");
+        sb.AppendLine($"| Tokens | {summary.TotalOriginalTokens:N0} | {summary.TotalOutputTokens:N0} | {summary.TokenSavingsPercent:F1}% |");
+        sb.AppendLine($"| Lines | {summary.TotalOriginalLines:N0} | {summary.TotalOutputLines:N0} | {summary.LineSavingsPercent:F1}% |");
+        sb.AppendLine();
+        sb.AppendLine($"**Overall OPAL Advantage:** {summary.OverallAdvantage:F2}x");
+        sb.AppendLine();
+        sb.AppendLine("## By File");
+        sb.AppendLine();
+        sb.AppendLine("| File | C# Tokens | OPAL Tokens | Advantage |");
+        sb.AppendLine("|------|-----------|-------------|-----------|");
+
+        foreach (var (opal, cs, metrics) in pairs.OrderByDescending(p => BenchmarkIntegration.CalculateAdvantageRatio(p.metrics)))
+        {
+            var advantage = BenchmarkIntegration.CalculateAdvantageRatio(metrics);
+            sb.AppendLine($"| {Path.GetFileName(opal)} | {metrics.OriginalTokens} | {metrics.OutputTokens} | {advantage:F2}x |");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string FormatProjectJson(string projectName, List<(string opal, string cs, FileMetrics metrics)> pairs, BenchmarkSummary summary)
+    {
+        var filesJson = string.Join(",\n    ", pairs.Select(p =>
+        {
+            var advantage = BenchmarkIntegration.CalculateAdvantageRatio(p.metrics);
+            return $$"""
+                {
+                      "opal": "{{Path.GetFileName(p.opal)}}",
+                      "csharp": "{{Path.GetFileName(p.cs)}}",
+                      "csharpTokens": {{p.metrics.OriginalTokens}},
+                      "opalTokens": {{p.metrics.OutputTokens}},
+                      "advantage": {{advantage:F2}}
+                    }
+                """;
+        }));
+
+        return $$"""
+            {
+              "project": "{{projectName}}",
+              "fileCount": {{pairs.Count}},
+              "summary": {
+                "totalCSharpTokens": {{summary.TotalOriginalTokens}},
+                "totalOpalTokens": {{summary.TotalOutputTokens}},
+                "tokenSavings": {{summary.TokenSavingsPercent:F1}},
+                "totalCSharpLines": {{summary.TotalOriginalLines}},
+                "totalOpalLines": {{summary.TotalOutputLines}},
+                "lineSavings": {{summary.LineSavingsPercent:F1}},
+                "overallAdvantage": {{summary.OverallAdvantage:F2}}
+              },
+              "files": [
+                {{filesJson}}
+              ]
+            }
+            """;
+    }
+}

--- a/src/Opal.Compiler/Commands/ConvertCommand.cs
+++ b/src/Opal.Compiler/Commands/ConvertCommand.cs
@@ -1,0 +1,170 @@
+using System.CommandLine;
+using Opal.Compiler.Migration;
+
+namespace Opal.Compiler.Commands;
+
+/// <summary>
+/// CLI command for single-file conversion.
+/// </summary>
+public static class ConvertCommand
+{
+    public static Command Create()
+    {
+        var inputArgument = new Argument<FileInfo>(
+            name: "input",
+            description: "The source file to convert (.cs or .opal)");
+
+        var outputOption = new Option<FileInfo?>(
+            aliases: new[] { "--output", "-o" },
+            description: "The output file path (auto-detected if not specified)");
+
+        var benchmarkOption = new Option<bool>(
+            aliases: new[] { "--benchmark", "-b" },
+            description: "Include benchmark metrics comparison");
+
+        var verboseOption = new Option<bool>(
+            aliases: new[] { "--verbose", "-v" },
+            description: "Enable verbose output");
+
+        var command = new Command("convert", "Convert a single file between C# and OPAL")
+        {
+            inputArgument,
+            outputOption,
+            benchmarkOption,
+            verboseOption
+        };
+
+        command.SetHandler(ExecuteAsync, inputArgument, outputOption, benchmarkOption, verboseOption);
+
+        return command;
+    }
+
+    private static async Task ExecuteAsync(FileInfo input, FileInfo? output, bool benchmark, bool verbose)
+    {
+        if (!input.Exists)
+        {
+            Console.Error.WriteLine($"Error: Input file not found: {input.FullName}");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        var direction = CSharpToOpalConverter.DetectDirection(input.FullName);
+
+        if (direction == ConversionDirection.Unknown)
+        {
+            Console.Error.WriteLine($"Error: Unknown file type. Expected .cs or .opal extension.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        var outputPath = output?.FullName ?? GetDefaultOutputPath(input.FullName, direction);
+
+        if (verbose)
+        {
+            Console.WriteLine($"Converting: {input.Name}");
+            Console.WriteLine($"Direction: {(direction == ConversionDirection.CSharpToOpal ? "C# → OPAL" : "OPAL → C#")}");
+        }
+
+        try
+        {
+            if (direction == ConversionDirection.CSharpToOpal)
+            {
+                await ConvertCSharpToOpalAsync(input.FullName, outputPath, benchmark, verbose);
+            }
+            else
+            {
+                await ConvertOpalToCSharpAsync(input.FullName, outputPath, verbose);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            Environment.ExitCode = 1;
+        }
+    }
+
+    private static async Task ConvertCSharpToOpalAsync(string inputPath, string outputPath, bool benchmark, bool verbose)
+    {
+        var converter = new CSharpToOpalConverter(new ConversionOptions
+        {
+            Verbose = verbose,
+            IncludeBenchmark = benchmark
+        });
+
+        var result = await converter.ConvertFileAsync(inputPath);
+
+        if (!result.Success)
+        {
+            Console.Error.WriteLine("Conversion failed:");
+            foreach (var issue in result.Issues.Where(i => i.Severity == ConversionIssueSeverity.Error))
+            {
+                Console.Error.WriteLine($"  {issue}");
+            }
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        // Write output
+        await File.WriteAllTextAsync(outputPath, result.OpalSource);
+
+        Console.WriteLine($"✓ Conversion successful");
+
+        // Show warnings
+        var warnings = result.Issues.Where(i => i.Severity == ConversionIssueSeverity.Warning).ToList();
+        if (warnings.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"Warnings ({warnings.Count}):");
+            foreach (var warning in warnings.Take(5))
+            {
+                Console.WriteLine($"  ⚠ {warning.Message}");
+            }
+            if (warnings.Count > 5)
+            {
+                Console.WriteLine($"  ... and {warnings.Count - 5} more");
+            }
+        }
+
+        // Show benchmark if requested
+        if (benchmark && result.OpalSource != null)
+        {
+            var originalSource = await File.ReadAllTextAsync(inputPath);
+            var metrics = BenchmarkIntegration.CalculateMetrics(originalSource, result.OpalSource);
+
+            Console.WriteLine();
+            Console.WriteLine(BenchmarkIntegration.FormatComparison(metrics));
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"Output: {outputPath}");
+    }
+
+    private static async Task ConvertOpalToCSharpAsync(string inputPath, string outputPath, bool verbose)
+    {
+        var source = await File.ReadAllTextAsync(inputPath);
+        var result = Program.Compile(source, inputPath, verbose);
+
+        if (result.HasErrors)
+        {
+            Console.Error.WriteLine("Compilation failed:");
+            foreach (var diag in result.Diagnostics.Errors)
+            {
+                Console.Error.WriteLine($"  {diag}");
+            }
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        await File.WriteAllTextAsync(outputPath, result.GeneratedCode);
+
+        Console.WriteLine($"✓ Conversion successful");
+        Console.WriteLine($"Output: {outputPath}");
+    }
+
+    private static string GetDefaultOutputPath(string inputPath, ConversionDirection direction)
+    {
+        return direction == ConversionDirection.CSharpToOpal
+            ? Path.ChangeExtension(inputPath, ".opal")
+            : Path.ChangeExtension(inputPath, ".g.cs");
+    }
+}

--- a/src/Opal.Compiler/Commands/MigrateCommand.cs
+++ b/src/Opal.Compiler/Commands/MigrateCommand.cs
@@ -1,0 +1,264 @@
+using System.CommandLine;
+using Opal.Compiler.Migration;
+using Opal.Compiler.Migration.Project;
+
+namespace Opal.Compiler.Commands;
+
+/// <summary>
+/// CLI command for project-level migration.
+/// </summary>
+public static class MigrateCommand
+{
+    public static Command Create()
+    {
+        var pathArgument = new Argument<DirectoryInfo>(
+            name: "path",
+            description: "The project directory or .csproj file to migrate");
+
+        var dryRunOption = new Option<bool>(
+            aliases: new[] { "--dry-run", "-n" },
+            description: "Preview changes without writing files");
+
+        var benchmarkOption = new Option<bool>(
+            aliases: new[] { "--benchmark", "-b" },
+            description: "Include before/after metrics");
+
+        var directionOption = new Option<string>(
+            aliases: new[] { "--direction", "-d" },
+            description: "Migration direction (cs-to-opal or opal-to-cs)",
+            getDefaultValue: () => "cs-to-opal");
+
+        var parallelOption = new Option<bool>(
+            aliases: new[] { "--parallel", "-p" },
+            description: "Run conversions in parallel",
+            getDefaultValue: () => true);
+
+        var reportOption = new Option<FileInfo?>(
+            aliases: new[] { "--report", "-r" },
+            description: "Save migration report to file (supports .md or .json)");
+
+        var verboseOption = new Option<bool>(
+            aliases: new[] { "--verbose", "-v" },
+            description: "Enable verbose output");
+
+        var command = new Command("migrate", "Migrate an entire project between C# and OPAL")
+        {
+            pathArgument,
+            dryRunOption,
+            benchmarkOption,
+            directionOption,
+            parallelOption,
+            reportOption,
+            verboseOption
+        };
+
+        command.SetHandler(ExecuteAsync, pathArgument, dryRunOption, benchmarkOption, directionOption, parallelOption, reportOption, verboseOption);
+
+        return command;
+    }
+
+    private static async Task ExecuteAsync(
+        DirectoryInfo path,
+        bool dryRun,
+        bool benchmark,
+        string direction,
+        bool parallel,
+        FileInfo? reportPath,
+        bool verbose)
+    {
+        if (!path.Exists && !File.Exists(path.FullName))
+        {
+            Console.Error.WriteLine($"Error: Path not found: {path.FullName}");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        var migrationDirection = direction.ToLowerInvariant() switch
+        {
+            "cs-to-opal" or "csharp-to-opal" or "c#-to-opal" => MigrationDirection.CSharpToOpal,
+            "opal-to-cs" or "opal-to-csharp" or "opal-to-c#" => MigrationDirection.OpalToCSharp,
+            _ => MigrationDirection.CSharpToOpal
+        };
+
+        var options = new MigrationPlanOptions
+        {
+            Parallel = parallel,
+            IncludeBenchmark = benchmark
+        };
+
+        var migrator = new ProjectMigrator(options);
+
+        try
+        {
+            // Create migration plan
+            Console.WriteLine($"Analyzing project: {path.FullName}");
+            Console.WriteLine();
+
+            var plan = await migrator.CreatePlanAsync(path.FullName, migrationDirection);
+
+            // Show plan summary
+            Console.WriteLine("Migration Plan:");
+            Console.WriteLine($"  Files to convert: {plan.ConvertibleFiles}");
+            Console.WriteLine($"  Files needing review: {plan.PartialFiles}");
+            Console.WriteLine($"  Files to skip: {plan.SkippedFiles}");
+            Console.WriteLine($"  Estimated issues: {plan.EstimatedIssues}");
+            Console.WriteLine();
+
+            if (plan.ConvertibleFiles == 0)
+            {
+                Console.WriteLine("No files to migrate.");
+                return;
+            }
+
+            if (dryRun)
+            {
+                Console.WriteLine("Dry run - no files will be modified.");
+                Console.WriteLine();
+                ShowPlanDetails(plan, verbose);
+                return;
+            }
+
+            // Execute migration
+            Console.Write("Migrating... ");
+
+            var progress = new Progress<MigrationProgress>(p =>
+            {
+                if (verbose)
+                {
+                    Console.WriteLine($"  [{p.ProcessedFiles}/{p.TotalFiles}] {p.CurrentFile}: {p.Status}");
+                }
+                else
+                {
+                    // Show progress bar
+                    var percent = (int)p.PercentComplete;
+                    Console.Write($"\rMigrating... [{new string('█', percent / 5)}{new string('░', 20 - percent / 5)}] {percent}%");
+                }
+            });
+
+            var report = await migrator.ExecuteAsync(plan, dryRun: false, progress);
+
+            if (!verbose)
+            {
+                Console.WriteLine(); // New line after progress bar
+            }
+
+            // Show results
+            Console.WriteLine();
+            Console.WriteLine("Results:");
+            Console.WriteLine($"  Successful: {report.Summary.SuccessfulFiles}");
+            if (report.Summary.PartialFiles > 0)
+                Console.WriteLine($"  Partial: {report.Summary.PartialFiles} (need review)");
+            if (report.Summary.FailedFiles > 0)
+                Console.WriteLine($"  Failed: {report.Summary.FailedFiles}");
+
+            // Show benchmark if requested
+            if (benchmark && report.Benchmark != null)
+            {
+                Console.WriteLine();
+                Console.WriteLine("Benchmark Summary:");
+                Console.WriteLine($"  Total tokens: {report.Benchmark.TotalOriginalTokens:N0} → {report.Benchmark.TotalOutputTokens:N0} ({report.Benchmark.TokenSavingsPercent:F1}% savings)");
+                Console.WriteLine($"  Total lines: {report.Benchmark.TotalOriginalLines:N0} → {report.Benchmark.TotalOutputLines:N0} ({report.Benchmark.LineSavingsPercent:F1}% savings)");
+                Console.WriteLine($"  Overall OPAL advantage: {report.Benchmark.OverallAdvantage:F2}x");
+            }
+
+            // Save report if requested
+            if (reportPath != null)
+            {
+                var generator = new MigrationReportGenerator(report);
+                var format = reportPath.Extension.ToLowerInvariant() == ".json"
+                    ? ReportFormat.Json
+                    : ReportFormat.Markdown;
+
+                await generator.SaveAsync(reportPath.FullName, format);
+                Console.WriteLine();
+                Console.WriteLine($"Report saved: {reportPath.FullName}");
+            }
+
+            // Show errors/warnings summary
+            if (report.Summary.TotalErrors > 0 || report.Summary.TotalWarnings > 0)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"Issues: {report.Summary.TotalErrors} error(s), {report.Summary.TotalWarnings} warning(s)");
+
+                if (verbose && report.Summary.MostCommonIssues.Count > 0)
+                {
+                    Console.WriteLine();
+                    Console.WriteLine("Most common issues:");
+                    foreach (var issue in report.Summary.MostCommonIssues.Take(5))
+                    {
+                        Console.WriteLine($"  • {issue}");
+                    }
+                }
+            }
+
+            // Set exit code based on results
+            if (report.Summary.FailedFiles > 0)
+            {
+                Environment.ExitCode = 1;
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            if (verbose)
+            {
+                Console.Error.WriteLine(ex.StackTrace);
+            }
+            Environment.ExitCode = 1;
+        }
+    }
+
+    private static void ShowPlanDetails(MigrationPlan plan, bool verbose)
+    {
+        var fullConvert = plan.Entries.Where(e => e.Convertibility == FileConvertibility.Full).ToList();
+        var partial = plan.Entries.Where(e => e.Convertibility == FileConvertibility.Partial).ToList();
+        var skip = plan.Entries.Where(e => e.Convertibility == FileConvertibility.Skip).ToList();
+
+        if (fullConvert.Count > 0)
+        {
+            Console.WriteLine("Files to convert:");
+            foreach (var entry in fullConvert.Take(verbose ? 100 : 10))
+            {
+                Console.WriteLine($"  ✓ {Path.GetFileName(entry.SourcePath)}");
+            }
+            if (!verbose && fullConvert.Count > 10)
+            {
+                Console.WriteLine($"  ... and {fullConvert.Count - 10} more");
+            }
+            Console.WriteLine();
+        }
+
+        if (partial.Count > 0)
+        {
+            Console.WriteLine("Files needing review:");
+            foreach (var entry in partial.Take(verbose ? 100 : 5))
+            {
+                Console.WriteLine($"  ⚠ {Path.GetFileName(entry.SourcePath)}");
+                foreach (var issue in entry.PotentialIssues.Take(2))
+                {
+                    Console.WriteLine($"      {issue}");
+                }
+            }
+            if (!verbose && partial.Count > 5)
+            {
+                Console.WriteLine($"  ... and {partial.Count - 5} more");
+            }
+            Console.WriteLine();
+        }
+
+        if (skip.Count > 0 && verbose)
+        {
+            Console.WriteLine("Files to skip:");
+            foreach (var entry in skip.Take(10))
+            {
+                var reason = entry.SkipReason ?? "excluded by pattern";
+                Console.WriteLine($"  ⊘ {Path.GetFileName(entry.SourcePath)}: {reason}");
+            }
+            if (skip.Count > 10)
+            {
+                Console.WriteLine($"  ... and {skip.Count - 10} more");
+            }
+            Console.WriteLine();
+        }
+    }
+}

--- a/src/Opal.Compiler/Migration/BenchmarkIntegration.cs
+++ b/src/Opal.Compiler/Migration/BenchmarkIntegration.cs
@@ -1,0 +1,157 @@
+namespace Opal.Compiler.Migration;
+
+/// <summary>
+/// Integrates with the evaluation framework to provide benchmark metrics during migration.
+/// </summary>
+public sealed class BenchmarkIntegration
+{
+    /// <summary>
+    /// Calculates token and line metrics for source code comparison.
+    /// </summary>
+    public static FileMetrics CalculateMetrics(string originalSource, string convertedSource)
+    {
+        var originalTokens = TokenizeSource(originalSource);
+        var convertedTokens = TokenizeSource(convertedSource);
+
+        return new FileMetrics
+        {
+            OriginalLines = CountLines(originalSource),
+            OutputLines = CountLines(convertedSource),
+            OriginalTokens = originalTokens.Count,
+            OutputTokens = convertedTokens.Count,
+            OriginalCharacters = CountNonWhitespaceChars(originalSource),
+            OutputCharacters = CountNonWhitespaceChars(convertedSource)
+        };
+    }
+
+    /// <summary>
+    /// Simple tokenizer that approximates LLM tokenization.
+    /// </summary>
+    private static List<string> TokenizeSource(string source)
+    {
+        var tokens = new List<string>();
+        var currentToken = "";
+
+        foreach (var ch in source)
+        {
+            if (char.IsWhiteSpace(ch))
+            {
+                if (!string.IsNullOrEmpty(currentToken))
+                {
+                    tokens.Add(currentToken);
+                    currentToken = "";
+                }
+            }
+            else if (char.IsPunctuation(ch) || char.IsSymbol(ch))
+            {
+                if (!string.IsNullOrEmpty(currentToken))
+                {
+                    tokens.Add(currentToken);
+                    currentToken = "";
+                }
+                tokens.Add(ch.ToString());
+            }
+            else
+            {
+                currentToken += ch;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(currentToken))
+        {
+            tokens.Add(currentToken);
+        }
+
+        return tokens;
+    }
+
+    private static int CountLines(string source)
+    {
+        if (string.IsNullOrEmpty(source))
+            return 0;
+
+        var lines = source.Split('\n');
+        // Count non-empty lines
+        return lines.Count(line => !string.IsNullOrWhiteSpace(line));
+    }
+
+    private static int CountNonWhitespaceChars(string source)
+    {
+        return source.Count(c => !char.IsWhiteSpace(c));
+    }
+
+    /// <summary>
+    /// Calculates the advantage ratio (higher = more compact OPAL).
+    /// </summary>
+    public static double CalculateAdvantageRatio(FileMetrics metrics)
+    {
+        if (metrics.OutputTokens == 0)
+            return 1.0;
+
+        // Calculate geometric mean of ratios
+        var tokenRatio = (double)metrics.OriginalTokens / metrics.OutputTokens;
+        var lineRatio = metrics.OutputLines > 0 ? (double)metrics.OriginalLines / metrics.OutputLines : 1.0;
+        var charRatio = metrics.OutputCharacters > 0 ? (double)metrics.OriginalCharacters / metrics.OutputCharacters : 1.0;
+
+        return Math.Pow(tokenRatio * lineRatio * charRatio, 1.0 / 3.0);
+    }
+
+    /// <summary>
+    /// Formats a benchmark comparison for console output.
+    /// </summary>
+    public static string FormatComparison(FileMetrics metrics)
+    {
+        var advantage = CalculateAdvantageRatio(metrics);
+
+        return $"""
+            Token Economics:
+              Before: {metrics.OriginalTokens:N0} tokens, {metrics.OriginalLines:N0} lines
+              After:  {metrics.OutputTokens:N0} tokens, {metrics.OutputLines:N0} lines
+              Token Savings: {metrics.TokenReduction:F1}%
+              Line Savings: {metrics.LineReduction:F1}%
+              Overall Advantage: {advantage:F2}x
+            """;
+    }
+
+    /// <summary>
+    /// Creates a benchmark summary from multiple file metrics.
+    /// </summary>
+    public static BenchmarkSummary CreateSummary(IEnumerable<FileMetrics> metricsCollection)
+    {
+        var metricsList = metricsCollection.ToList();
+
+        return new BenchmarkSummary
+        {
+            TotalOriginalTokens = metricsList.Sum(m => m.OriginalTokens),
+            TotalOutputTokens = metricsList.Sum(m => m.OutputTokens),
+            TotalOriginalLines = metricsList.Sum(m => m.OriginalLines),
+            TotalOutputLines = metricsList.Sum(m => m.OutputLines)
+        };
+    }
+
+    /// <summary>
+    /// Runs a quick benchmark comparison between C# and OPAL source.
+    /// </summary>
+    public static BenchmarkResult RunQuickBenchmark(string csharpSource, string opalSource)
+    {
+        var metrics = CalculateMetrics(csharpSource, opalSource);
+        var advantage = CalculateAdvantageRatio(metrics);
+
+        return new BenchmarkResult
+        {
+            Metrics = metrics,
+            AdvantageRatio = advantage,
+            Summary = FormatComparison(metrics)
+        };
+    }
+}
+
+/// <summary>
+/// Result of a benchmark comparison.
+/// </summary>
+public sealed class BenchmarkResult
+{
+    public required FileMetrics Metrics { get; init; }
+    public required double AdvantageRatio { get; init; }
+    public required string Summary { get; init; }
+}

--- a/src/Opal.Compiler/Migration/CSharpToOpalConverter.cs
+++ b/src/Opal.Compiler/Migration/CSharpToOpalConverter.cs
@@ -1,0 +1,304 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Opal.Compiler.Ast;
+
+namespace Opal.Compiler.Migration;
+
+/// <summary>
+/// Result of a C# to OPAL conversion.
+/// </summary>
+public sealed class ConversionResult
+{
+    public bool Success { get; init; }
+    public string? OpalSource { get; init; }
+    public ModuleNode? Ast { get; init; }
+    public ConversionContext Context { get; init; } = new();
+    public TimeSpan Duration { get; init; }
+
+    public bool HasErrors => Context.HasErrors;
+    public bool HasWarnings => Context.HasWarnings;
+    public IReadOnlyList<ConversionIssue> Issues => Context.Issues;
+}
+
+/// <summary>
+/// Options for C# to OPAL conversion.
+/// </summary>
+public sealed class ConversionOptions
+{
+    /// <summary>
+    /// The module name to use in the generated OPAL code.
+    /// If not specified, derived from the source file name.
+    /// </summary>
+    public string? ModuleName { get; set; }
+
+    /// <summary>
+    /// Whether to preserve original comments in the output.
+    /// </summary>
+    public bool PreserveComments { get; set; } = true;
+
+    /// <summary>
+    /// Whether to include benchmark metrics comparison.
+    /// </summary>
+    public bool IncludeBenchmark { get; set; }
+
+    /// <summary>
+    /// Whether to enable verbose output.
+    /// </summary>
+    public bool Verbose { get; set; }
+
+    /// <summary>
+    /// Whether to auto-generate unique IDs for OPAL elements.
+    /// </summary>
+    public bool AutoGenerateIds { get; set; } = true;
+}
+
+/// <summary>
+/// Main converter that orchestrates the C# to OPAL conversion pipeline.
+///
+/// Pipeline: C# Source → Roslyn Parse → RoslynSyntaxVisitor → OPAL AST → OpalEmitter → OPAL Source
+/// </summary>
+public sealed class CSharpToOpalConverter
+{
+    private readonly ConversionOptions _options;
+
+    public CSharpToOpalConverter(ConversionOptions? options = null)
+    {
+        _options = options ?? new ConversionOptions();
+    }
+
+    /// <summary>
+    /// Converts C# source code to OPAL source code.
+    /// </summary>
+    public ConversionResult Convert(string csharpSource, string? sourceFile = null)
+    {
+        var startTime = DateTime.UtcNow;
+        var context = CreateContext(sourceFile);
+        context.OriginalSource = csharpSource;
+
+        try
+        {
+            // Step 1: Parse C# with Roslyn
+            var syntaxTree = CSharpSyntaxTree.ParseText(csharpSource);
+            var root = syntaxTree.GetCompilationUnitRoot();
+
+            // Check for parse errors
+            var diagnostics = root.GetDiagnostics()
+                .Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .ToList();
+
+            if (diagnostics.Count > 0)
+            {
+                foreach (var diag in diagnostics)
+                {
+                    var lineSpan = diag.Location.GetLineSpan();
+                    context.AddError(
+                        $"C# parse error: {diag.GetMessage()}",
+                        line: lineSpan.StartLinePosition.Line + 1,
+                        column: lineSpan.StartLinePosition.Character + 1);
+                }
+
+                return new ConversionResult
+                {
+                    Success = false,
+                    Context = context,
+                    Duration = DateTime.UtcNow - startTime
+                };
+            }
+
+            // Step 2: Visit C# AST and build OPAL AST
+            var moduleName = _options.ModuleName ?? DeriveModuleName(sourceFile, root);
+            var visitor = new RoslynSyntaxVisitor(context);
+            var opalAst = visitor.Convert(root, moduleName);
+
+            if (context.HasErrors)
+            {
+                return new ConversionResult
+                {
+                    Success = false,
+                    Ast = opalAst,
+                    Context = context,
+                    Duration = DateTime.UtcNow - startTime
+                };
+            }
+
+            // Step 3: Emit OPAL source code
+            var emitter = new OpalEmitter(context);
+            var opalSource = emitter.Emit(opalAst);
+
+            if (_options.Verbose)
+            {
+                Console.WriteLine($"Converted {context.Stats.ConvertedNodes} nodes");
+                Console.WriteLine($"  Classes: {context.Stats.ClassesConverted}");
+                Console.WriteLine($"  Interfaces: {context.Stats.InterfacesConverted}");
+                Console.WriteLine($"  Methods: {context.Stats.MethodsConverted}");
+                Console.WriteLine($"  Properties: {context.Stats.PropertiesConverted}");
+                Console.WriteLine($"  Fields: {context.Stats.FieldsConverted}");
+            }
+
+            return new ConversionResult
+            {
+                Success = true,
+                OpalSource = opalSource,
+                Ast = opalAst,
+                Context = context,
+                Duration = DateTime.UtcNow - startTime
+            };
+        }
+        catch (Exception ex)
+        {
+            context.AddError($"Conversion failed: {ex.Message}");
+
+            return new ConversionResult
+            {
+                Success = false,
+                Context = context,
+                Duration = DateTime.UtcNow - startTime
+            };
+        }
+    }
+
+    /// <summary>
+    /// Converts a C# file to OPAL.
+    /// </summary>
+    public async Task<ConversionResult> ConvertFileAsync(string csharpFilePath)
+    {
+        if (!File.Exists(csharpFilePath))
+        {
+            var context = new ConversionContext { SourceFile = csharpFilePath };
+            context.AddError($"Source file not found: {csharpFilePath}");
+            return new ConversionResult { Success = false, Context = context };
+        }
+
+        var source = await File.ReadAllTextAsync(csharpFilePath);
+        return Convert(source, csharpFilePath);
+    }
+
+    /// <summary>
+    /// Converts a C# file and writes the output to an OPAL file.
+    /// </summary>
+    public async Task<ConversionResult> ConvertFileAndSaveAsync(string csharpFilePath, string? outputPath = null)
+    {
+        var result = await ConvertFileAsync(csharpFilePath);
+
+        if (result.Success && result.OpalSource != null)
+        {
+            var opalPath = outputPath ?? Path.ChangeExtension(csharpFilePath, ".opal");
+            await File.WriteAllTextAsync(opalPath, result.OpalSource);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Detects the direction of conversion based on file extension.
+    /// </summary>
+    public static ConversionDirection DetectDirection(string filePath)
+    {
+        var ext = Path.GetExtension(filePath).ToLowerInvariant();
+        return ext switch
+        {
+            ".cs" => ConversionDirection.CSharpToOpal,
+            ".opal" => ConversionDirection.OpalToCSharp,
+            _ => ConversionDirection.Unknown
+        };
+    }
+
+    private ConversionContext CreateContext(string? sourceFile)
+    {
+        return new ConversionContext
+        {
+            SourceFile = sourceFile,
+            Verbose = _options.Verbose,
+            IncludeBenchmark = _options.IncludeBenchmark,
+            PreserveComments = _options.PreserveComments,
+            AutoGenerateIds = _options.AutoGenerateIds,
+            ModuleName = _options.ModuleName
+        };
+    }
+
+    private static string DeriveModuleName(string? sourceFile, CompilationUnitSyntax root)
+    {
+        // Try to get namespace from the source
+        var namespaceDecl = root.DescendantNodes()
+            .OfType<BaseNamespaceDeclarationSyntax>()
+            .FirstOrDefault();
+
+        if (namespaceDecl != null)
+        {
+            return namespaceDecl.Name.ToString();
+        }
+
+        // Fall back to file name
+        if (!string.IsNullOrEmpty(sourceFile))
+        {
+            return Path.GetFileNameWithoutExtension(sourceFile);
+        }
+
+        return "ConvertedModule";
+    }
+}
+
+/// <summary>
+/// Direction of conversion.
+/// </summary>
+public enum ConversionDirection
+{
+    Unknown,
+    CSharpToOpal,
+    OpalToCSharp
+}
+
+/// <summary>
+/// Provides a simple facade for bidirectional conversion.
+/// </summary>
+public static class Converter
+{
+    /// <summary>
+    /// Converts a file in the detected direction.
+    /// </summary>
+    public static async Task<object> ConvertFileAsync(string filePath, string? outputPath = null)
+    {
+        var direction = CSharpToOpalConverter.DetectDirection(filePath);
+
+        return direction switch
+        {
+            ConversionDirection.CSharpToOpal => await ConvertCSharpToOpalAsync(filePath, outputPath),
+            ConversionDirection.OpalToCSharp => await ConvertOpalToCSharpAsync(filePath, outputPath),
+            _ => throw new ArgumentException($"Unknown file type: {filePath}")
+        };
+    }
+
+    /// <summary>
+    /// Converts C# to OPAL.
+    /// </summary>
+    public static async Task<ConversionResult> ConvertCSharpToOpalAsync(string csharpPath, string? outputPath = null)
+    {
+        var converter = new CSharpToOpalConverter();
+        var result = await converter.ConvertFileAsync(csharpPath);
+
+        if (result.Success && result.OpalSource != null)
+        {
+            var opalPath = outputPath ?? Path.ChangeExtension(csharpPath, ".opal");
+            await File.WriteAllTextAsync(opalPath, result.OpalSource);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Converts OPAL to C# using the existing compiler.
+    /// </summary>
+    public static async Task<CompilationResult> ConvertOpalToCSharpAsync(string opalPath, string? outputPath = null)
+    {
+        var source = await File.ReadAllTextAsync(opalPath);
+        var result = Program.Compile(source, opalPath);
+
+        if (!result.HasErrors && !string.IsNullOrEmpty(result.GeneratedCode))
+        {
+            var csPath = outputPath ?? Path.ChangeExtension(opalPath, ".g.cs");
+            await File.WriteAllTextAsync(csPath, result.GeneratedCode);
+        }
+
+        return result;
+    }
+}

--- a/src/Opal.Compiler/Migration/ConversionContext.cs
+++ b/src/Opal.Compiler/Migration/ConversionContext.cs
@@ -1,0 +1,371 @@
+namespace Opal.Compiler.Migration;
+
+/// <summary>
+/// Severity level for conversion issues.
+/// </summary>
+public enum ConversionIssueSeverity
+{
+    Info,
+    Warning,
+    Error
+}
+
+/// <summary>
+/// Represents an issue encountered during conversion.
+/// </summary>
+public sealed class ConversionIssue
+{
+    public required ConversionIssueSeverity Severity { get; init; }
+    public required string Message { get; init; }
+    public string? Feature { get; init; }
+    public int? Line { get; init; }
+    public int? Column { get; init; }
+    public string? Suggestion { get; init; }
+
+    public override string ToString()
+    {
+        var location = Line.HasValue ? $" (line {Line}" + (Column.HasValue ? $", col {Column})" : ")") : "";
+        var feature = Feature != null ? $" [{Feature}]" : "";
+        return $"{Severity}{feature}{location}: {Message}";
+    }
+}
+
+/// <summary>
+/// Statistics about the conversion process.
+/// </summary>
+public sealed class ConversionStats
+{
+    public int TotalNodes { get; set; }
+    public int ConvertedNodes { get; set; }
+    public int SkippedNodes { get; set; }
+    public int ClassesConverted { get; set; }
+    public int InterfacesConverted { get; set; }
+    public int MethodsConverted { get; set; }
+    public int PropertiesConverted { get; set; }
+    public int FieldsConverted { get; set; }
+    public int StatementsConverted { get; set; }
+    public int ExpressionsConverted { get; set; }
+
+    public double ConversionRate => TotalNodes > 0 ? (double)ConvertedNodes / TotalNodes * 100 : 0;
+}
+
+/// <summary>
+/// Shared context for tracking state during C# to OPAL conversion.
+/// </summary>
+public sealed class ConversionContext
+{
+    private readonly List<ConversionIssue> _issues = new();
+    private readonly HashSet<string> _usedFeatures = new();
+    private readonly Stack<string> _scopeStack = new();
+    private int _idCounter = 0;
+
+    /// <summary>
+    /// The source file being converted.
+    /// </summary>
+    public string? SourceFile { get; set; }
+
+    /// <summary>
+    /// Whether to use verbose output.
+    /// </summary>
+    public bool Verbose { get; set; }
+
+    /// <summary>
+    /// Whether to include benchmark metrics.
+    /// </summary>
+    public bool IncludeBenchmark { get; set; }
+
+    /// <summary>
+    /// Whether to preserve original comments.
+    /// </summary>
+    public bool PreserveComments { get; set; } = true;
+
+    /// <summary>
+    /// Whether to generate module IDs automatically.
+    /// </summary>
+    public bool AutoGenerateIds { get; set; } = true;
+
+    /// <summary>
+    /// The module name to use (derived from file name if not set).
+    /// </summary>
+    public string? ModuleName { get; set; }
+
+    /// <summary>
+    /// Current namespace being processed.
+    /// </summary>
+    public string? CurrentNamespace { get; private set; }
+
+    /// <summary>
+    /// Current type being processed.
+    /// </summary>
+    public string? CurrentTypeName { get; private set; }
+
+    /// <summary>
+    /// Current method being processed.
+    /// </summary>
+    public string? CurrentMethodName { get; private set; }
+
+    /// <summary>
+    /// All issues encountered during conversion.
+    /// </summary>
+    public IReadOnlyList<ConversionIssue> Issues => _issues;
+
+    /// <summary>
+    /// All features used in the source code.
+    /// </summary>
+    public IReadOnlySet<string> UsedFeatures => _usedFeatures;
+
+    /// <summary>
+    /// Conversion statistics.
+    /// </summary>
+    public ConversionStats Stats { get; } = new();
+
+    /// <summary>
+    /// Original C# source code.
+    /// </summary>
+    public string? OriginalSource { get; set; }
+
+    /// <summary>
+    /// Checks if any errors were encountered.
+    /// </summary>
+    public bool HasErrors => _issues.Any(i => i.Severity == ConversionIssueSeverity.Error);
+
+    /// <summary>
+    /// Checks if any warnings were encountered.
+    /// </summary>
+    public bool HasWarnings => _issues.Any(i => i.Severity == ConversionIssueSeverity.Warning);
+
+    /// <summary>
+    /// Generates a unique ID for OPAL elements.
+    /// </summary>
+    public string GenerateId(string prefix = "")
+    {
+        _idCounter++;
+        return string.IsNullOrEmpty(prefix) ? $"id{_idCounter:D3}" : $"{prefix}{_idCounter:D3}";
+    }
+
+    /// <summary>
+    /// Records usage of a feature.
+    /// </summary>
+    public void RecordFeatureUsage(string feature)
+    {
+        _usedFeatures.Add(feature);
+
+        var info = FeatureSupport.GetFeatureInfo(feature);
+        if (info == null)
+            return;
+
+        switch (info.Support)
+        {
+            case SupportLevel.Partial:
+                AddWarning($"Feature '{feature}' is partially supported. {info.Workaround ?? ""}", feature);
+                break;
+            case SupportLevel.NotSupported:
+                AddError($"Feature '{feature}' is not supported. {info.Workaround ?? ""}", feature);
+                break;
+            case SupportLevel.ManualRequired:
+                AddWarning($"Feature '{feature}' requires manual intervention. {info.Workaround ?? ""}", feature);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Enters a new namespace scope.
+    /// </summary>
+    public void EnterNamespace(string namespaceName)
+    {
+        CurrentNamespace = namespaceName;
+        _scopeStack.Push($"namespace:{namespaceName}");
+    }
+
+    /// <summary>
+    /// Exits the current namespace scope.
+    /// </summary>
+    public void ExitNamespace()
+    {
+        if (_scopeStack.Count > 0 && _scopeStack.Peek().StartsWith("namespace:"))
+        {
+            _scopeStack.Pop();
+            CurrentNamespace = _scopeStack
+                .Where(s => s.StartsWith("namespace:"))
+                .Select(s => s["namespace:".Length..])
+                .FirstOrDefault();
+        }
+    }
+
+    /// <summary>
+    /// Enters a type scope.
+    /// </summary>
+    public void EnterType(string typeName)
+    {
+        CurrentTypeName = typeName;
+        _scopeStack.Push($"type:{typeName}");
+    }
+
+    /// <summary>
+    /// Exits the current type scope.
+    /// </summary>
+    public void ExitType()
+    {
+        if (_scopeStack.Count > 0 && _scopeStack.Peek().StartsWith("type:"))
+        {
+            _scopeStack.Pop();
+            CurrentTypeName = _scopeStack
+                .Where(s => s.StartsWith("type:"))
+                .Select(s => s["type:".Length..])
+                .FirstOrDefault();
+        }
+    }
+
+    /// <summary>
+    /// Enters a method scope.
+    /// </summary>
+    public void EnterMethod(string methodName)
+    {
+        CurrentMethodName = methodName;
+        _scopeStack.Push($"method:{methodName}");
+    }
+
+    /// <summary>
+    /// Exits the current method scope.
+    /// </summary>
+    public void ExitMethod()
+    {
+        if (_scopeStack.Count > 0 && _scopeStack.Peek().StartsWith("method:"))
+        {
+            _scopeStack.Pop();
+            CurrentMethodName = _scopeStack
+                .Where(s => s.StartsWith("method:"))
+                .Select(s => s["method:".Length..])
+                .FirstOrDefault();
+        }
+    }
+
+    /// <summary>
+    /// Gets the current scope path.
+    /// </summary>
+    public string GetCurrentScopePath()
+    {
+        var parts = new List<string>();
+        if (CurrentNamespace != null) parts.Add(CurrentNamespace);
+        if (CurrentTypeName != null) parts.Add(CurrentTypeName);
+        if (CurrentMethodName != null) parts.Add(CurrentMethodName);
+        return string.Join(".", parts);
+    }
+
+    /// <summary>
+    /// Adds an informational message.
+    /// </summary>
+    public void AddInfo(string message, string? feature = null, int? line = null, int? column = null)
+    {
+        _issues.Add(new ConversionIssue
+        {
+            Severity = ConversionIssueSeverity.Info,
+            Message = message,
+            Feature = feature,
+            Line = line,
+            Column = column
+        });
+    }
+
+    /// <summary>
+    /// Adds a warning.
+    /// </summary>
+    public void AddWarning(string message, string? feature = null, int? line = null, int? column = null, string? suggestion = null)
+    {
+        _issues.Add(new ConversionIssue
+        {
+            Severity = ConversionIssueSeverity.Warning,
+            Message = message,
+            Feature = feature,
+            Line = line,
+            Column = column,
+            Suggestion = suggestion
+        });
+    }
+
+    /// <summary>
+    /// Adds an error.
+    /// </summary>
+    public void AddError(string message, string? feature = null, int? line = null, int? column = null, string? suggestion = null)
+    {
+        _issues.Add(new ConversionIssue
+        {
+            Severity = ConversionIssueSeverity.Error,
+            Message = message,
+            Feature = feature,
+            Line = line,
+            Column = column,
+            Suggestion = suggestion
+        });
+    }
+
+    /// <summary>
+    /// Increments the converted nodes count.
+    /// </summary>
+    public void IncrementConverted()
+    {
+        Stats.TotalNodes++;
+        Stats.ConvertedNodes++;
+    }
+
+    /// <summary>
+    /// Increments the skipped nodes count.
+    /// </summary>
+    public void IncrementSkipped()
+    {
+        Stats.TotalNodes++;
+        Stats.SkippedNodes++;
+    }
+
+    /// <summary>
+    /// Gets a summary of all issues.
+    /// </summary>
+    public string GetIssuesSummary()
+    {
+        var errors = _issues.Count(i => i.Severity == ConversionIssueSeverity.Error);
+        var warnings = _issues.Count(i => i.Severity == ConversionIssueSeverity.Warning);
+        var infos = _issues.Count(i => i.Severity == ConversionIssueSeverity.Info);
+
+        return $"{errors} error(s), {warnings} warning(s), {infos} info(s)";
+    }
+
+    /// <summary>
+    /// Gets issues filtered by severity.
+    /// </summary>
+    public IEnumerable<ConversionIssue> GetIssuesBySeverity(ConversionIssueSeverity severity)
+    {
+        return _issues.Where(i => i.Severity == severity);
+    }
+
+    /// <summary>
+    /// Gets features that were used but are not fully supported.
+    /// </summary>
+    public IEnumerable<string> GetProblematicFeatures()
+    {
+        return _usedFeatures.Where(f => !FeatureSupport.IsFullySupported(f));
+    }
+
+    /// <summary>
+    /// Resets the context for a new conversion.
+    /// </summary>
+    public void Reset()
+    {
+        _issues.Clear();
+        _usedFeatures.Clear();
+        _scopeStack.Clear();
+        _idCounter = 0;
+        CurrentNamespace = null;
+        CurrentTypeName = null;
+        CurrentMethodName = null;
+        Stats.TotalNodes = 0;
+        Stats.ConvertedNodes = 0;
+        Stats.SkippedNodes = 0;
+        Stats.ClassesConverted = 0;
+        Stats.InterfacesConverted = 0;
+        Stats.MethodsConverted = 0;
+        Stats.PropertiesConverted = 0;
+        Stats.FieldsConverted = 0;
+        Stats.StatementsConverted = 0;
+        Stats.ExpressionsConverted = 0;
+    }
+}

--- a/src/Opal.Compiler/Migration/FeatureSupport.cs
+++ b/src/Opal.Compiler/Migration/FeatureSupport.cs
@@ -1,0 +1,359 @@
+namespace Opal.Compiler.Migration;
+
+/// <summary>
+/// Defines the support level for a C# feature during migration.
+/// </summary>
+public enum SupportLevel
+{
+    /// <summary>Feature is fully supported with direct mapping.</summary>
+    Full,
+
+    /// <summary>Feature is partially supported, may need manual review.</summary>
+    Partial,
+
+    /// <summary>Feature is not supported and will be skipped.</summary>
+    NotSupported,
+
+    /// <summary>Feature requires manual intervention.</summary>
+    ManualRequired
+}
+
+/// <summary>
+/// Describes a feature and its support status.
+/// </summary>
+public sealed class FeatureInfo
+{
+    public required string Name { get; init; }
+    public required SupportLevel Support { get; init; }
+    public string? Description { get; init; }
+    public string? Workaround { get; init; }
+}
+
+/// <summary>
+/// Registry of supported C# features for OPAL conversion.
+/// </summary>
+public static class FeatureSupport
+{
+    /// <summary>
+    /// All feature support information indexed by feature name.
+    /// </summary>
+    private static readonly Dictionary<string, FeatureInfo> Features = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Fully supported features
+        ["class"] = new FeatureInfo
+        {
+            Name = "class",
+            Support = SupportLevel.Full,
+            Description = "Classes are converted to OPAL class definitions"
+        },
+        ["interface"] = new FeatureInfo
+        {
+            Name = "interface",
+            Support = SupportLevel.Full,
+            Description = "Interfaces are converted to OPAL interface definitions"
+        },
+        ["record"] = new FeatureInfo
+        {
+            Name = "record",
+            Support = SupportLevel.Full,
+            Description = "Records are converted to OPAL record definitions"
+        },
+        ["struct"] = new FeatureInfo
+        {
+            Name = "struct",
+            Support = SupportLevel.Full,
+            Description = "Structs are converted to OPAL struct definitions"
+        },
+        ["method"] = new FeatureInfo
+        {
+            Name = "method",
+            Support = SupportLevel.Full,
+            Description = "Methods are converted to OPAL function definitions"
+        },
+        ["property"] = new FeatureInfo
+        {
+            Name = "property",
+            Support = SupportLevel.Full,
+            Description = "Properties are converted to OPAL property definitions"
+        },
+        ["field"] = new FeatureInfo
+        {
+            Name = "field",
+            Support = SupportLevel.Full,
+            Description = "Fields are converted to OPAL field definitions"
+        },
+        ["constructor"] = new FeatureInfo
+        {
+            Name = "constructor",
+            Support = SupportLevel.Full,
+            Description = "Constructors are converted to OPAL constructors"
+        },
+        ["if"] = new FeatureInfo
+        {
+            Name = "if",
+            Support = SupportLevel.Full,
+            Description = "If statements are converted to OPAL IF blocks"
+        },
+        ["for"] = new FeatureInfo
+        {
+            Name = "for",
+            Support = SupportLevel.Full,
+            Description = "For loops are converted to OPAL LOOP blocks"
+        },
+        ["foreach"] = new FeatureInfo
+        {
+            Name = "foreach",
+            Support = SupportLevel.Full,
+            Description = "Foreach loops are converted to OPAL FOREACH blocks"
+        },
+        ["while"] = new FeatureInfo
+        {
+            Name = "while",
+            Support = SupportLevel.Full,
+            Description = "While loops are converted to OPAL WHILE blocks"
+        },
+        ["switch"] = new FeatureInfo
+        {
+            Name = "switch",
+            Support = SupportLevel.Full,
+            Description = "Switch statements are converted to OPAL MATCH blocks"
+        },
+        ["try-catch"] = new FeatureInfo
+        {
+            Name = "try-catch",
+            Support = SupportLevel.Full,
+            Description = "Try/catch/finally blocks are converted to OPAL TRY blocks"
+        },
+        ["async-await"] = new FeatureInfo
+        {
+            Name = "async-await",
+            Support = SupportLevel.Full,
+            Description = "Async/await is converted to OPAL async functions"
+        },
+        ["lambda"] = new FeatureInfo
+        {
+            Name = "lambda",
+            Support = SupportLevel.Full,
+            Description = "Lambda expressions are converted to OPAL lambda syntax"
+        },
+        ["generics"] = new FeatureInfo
+        {
+            Name = "generics",
+            Support = SupportLevel.Full,
+            Description = "Generic types and methods are supported"
+        },
+        ["pattern-matching-basic"] = new FeatureInfo
+        {
+            Name = "pattern-matching-basic",
+            Support = SupportLevel.Full,
+            Description = "Basic pattern matching (type, constant, var) is supported"
+        },
+        ["string-interpolation"] = new FeatureInfo
+        {
+            Name = "string-interpolation",
+            Support = SupportLevel.Full,
+            Description = "String interpolation is converted to OPAL format"
+        },
+        ["null-coalescing"] = new FeatureInfo
+        {
+            Name = "null-coalescing",
+            Support = SupportLevel.Full,
+            Description = "Null coalescing operators are converted"
+        },
+        ["null-conditional"] = new FeatureInfo
+        {
+            Name = "null-conditional",
+            Support = SupportLevel.Full,
+            Description = "Null conditional operators are converted"
+        },
+
+        // Partially supported features
+        ["linq-method"] = new FeatureInfo
+        {
+            Name = "linq-method",
+            Support = SupportLevel.Partial,
+            Description = "LINQ method syntax is converted but may need review",
+            Workaround = "Consider using explicit loops for complex queries"
+        },
+        ["linq-query"] = new FeatureInfo
+        {
+            Name = "linq-query",
+            Support = SupportLevel.Partial,
+            Description = "LINQ query syntax is converted to method syntax",
+            Workaround = "Review converted queries for correctness"
+        },
+        ["ref-parameter"] = new FeatureInfo
+        {
+            Name = "ref-parameter",
+            Support = SupportLevel.Partial,
+            Description = "Ref parameters are kept as-is with warning",
+            Workaround = "Consider refactoring to return tuples"
+        },
+        ["out-parameter"] = new FeatureInfo
+        {
+            Name = "out-parameter",
+            Support = SupportLevel.Partial,
+            Description = "Out parameters are kept as-is with warning",
+            Workaround = "Consider refactoring to return tuples or Result<T, E>"
+        },
+        ["pattern-matching-advanced"] = new FeatureInfo
+        {
+            Name = "pattern-matching-advanced",
+            Support = SupportLevel.Partial,
+            Description = "Advanced patterns (list, property, relational) may be simplified",
+            Workaround = "Review converted patterns for semantic correctness"
+        },
+        ["attributes"] = new FeatureInfo
+        {
+            Name = "attributes",
+            Support = SupportLevel.Partial,
+            Description = "Attributes are converted to comments",
+            Workaround = "Add OPAL metadata annotations manually if needed"
+        },
+        ["dynamic"] = new FeatureInfo
+        {
+            Name = "dynamic",
+            Support = SupportLevel.Partial,
+            Description = "Dynamic type is converted to 'any' with warning",
+            Workaround = "Consider using generics or interfaces"
+        },
+
+        // Not supported features
+        ["goto"] = new FeatureInfo
+        {
+            Name = "goto",
+            Support = SupportLevel.NotSupported,
+            Description = "Goto statements are not supported",
+            Workaround = "Refactor to use structured control flow"
+        },
+        ["labeled-statement"] = new FeatureInfo
+        {
+            Name = "labeled-statement",
+            Support = SupportLevel.NotSupported,
+            Description = "Labeled statements are not supported",
+            Workaround = "Refactor to use structured control flow"
+        },
+        ["unsafe"] = new FeatureInfo
+        {
+            Name = "unsafe",
+            Support = SupportLevel.NotSupported,
+            Description = "Unsafe code blocks are not supported",
+            Workaround = "Use safe alternatives or keep as C# interop"
+        },
+        ["pointer"] = new FeatureInfo
+        {
+            Name = "pointer",
+            Support = SupportLevel.NotSupported,
+            Description = "Pointer types are not supported",
+            Workaround = "Use safe alternatives"
+        },
+        ["stackalloc"] = new FeatureInfo
+        {
+            Name = "stackalloc",
+            Support = SupportLevel.NotSupported,
+            Description = "Stackalloc is not supported",
+            Workaround = "Use regular array allocation"
+        },
+        ["fixed"] = new FeatureInfo
+        {
+            Name = "fixed",
+            Support = SupportLevel.NotSupported,
+            Description = "Fixed buffers are not supported",
+            Workaround = "Use regular arrays"
+        },
+        ["volatile"] = new FeatureInfo
+        {
+            Name = "volatile",
+            Support = SupportLevel.NotSupported,
+            Description = "Volatile keyword is not supported",
+            Workaround = "Use proper synchronization primitives"
+        },
+
+        // Manual required
+        ["extension-method"] = new FeatureInfo
+        {
+            Name = "extension-method",
+            Support = SupportLevel.ManualRequired,
+            Description = "Extension methods require manual conversion to regular methods or traits",
+            Workaround = "Convert to instance methods or OPAL traits"
+        },
+        ["operator-overload"] = new FeatureInfo
+        {
+            Name = "operator-overload",
+            Support = SupportLevel.ManualRequired,
+            Description = "Operator overloading requires manual conversion",
+            Workaround = "Define explicit methods instead"
+        },
+        ["implicit-conversion"] = new FeatureInfo
+        {
+            Name = "implicit-conversion",
+            Support = SupportLevel.ManualRequired,
+            Description = "Implicit conversions require manual handling",
+            Workaround = "Use explicit conversion methods"
+        },
+        ["explicit-conversion"] = new FeatureInfo
+        {
+            Name = "explicit-conversion",
+            Support = SupportLevel.ManualRequired,
+            Description = "Explicit conversions require manual handling",
+            Workaround = "Use explicit conversion methods"
+        },
+    };
+
+    /// <summary>
+    /// Gets the support info for a feature.
+    /// </summary>
+    public static FeatureInfo? GetFeatureInfo(string featureName)
+    {
+        return Features.TryGetValue(featureName, out var info) ? info : null;
+    }
+
+    /// <summary>
+    /// Gets the support level for a feature.
+    /// </summary>
+    public static SupportLevel GetSupportLevel(string featureName)
+    {
+        return Features.TryGetValue(featureName, out var info) ? info.Support : SupportLevel.Full;
+    }
+
+    /// <summary>
+    /// Checks if a feature is fully supported.
+    /// </summary>
+    public static bool IsFullySupported(string featureName)
+    {
+        return GetSupportLevel(featureName) == SupportLevel.Full;
+    }
+
+    /// <summary>
+    /// Checks if a feature is supported (full or partial).
+    /// </summary>
+    public static bool IsSupported(string featureName)
+    {
+        var level = GetSupportLevel(featureName);
+        return level == SupportLevel.Full || level == SupportLevel.Partial;
+    }
+
+    /// <summary>
+    /// Gets all features with a specific support level.
+    /// </summary>
+    public static IEnumerable<FeatureInfo> GetFeaturesBySupport(SupportLevel level)
+    {
+        return Features.Values.Where(f => f.Support == level);
+    }
+
+    /// <summary>
+    /// Gets all registered features.
+    /// </summary>
+    public static IEnumerable<FeatureInfo> GetAllFeatures()
+    {
+        return Features.Values;
+    }
+
+    /// <summary>
+    /// Gets the workaround text for an unsupported or partially supported feature.
+    /// </summary>
+    public static string? GetWorkaround(string featureName)
+    {
+        return Features.TryGetValue(featureName, out var info) ? info.Workaround : null;
+    }
+}

--- a/src/Opal.Compiler/Migration/MigrationReport.cs
+++ b/src/Opal.Compiler/Migration/MigrationReport.cs
@@ -1,0 +1,108 @@
+using System.Text.Json.Serialization;
+
+namespace Opal.Compiler.Migration;
+
+/// <summary>
+/// Complete migration report for a file or project.
+/// </summary>
+public sealed class MigrationReport
+{
+    public required string ReportId { get; init; }
+    public required DateTime GeneratedAt { get; init; }
+    public required MigrationDirection Direction { get; init; }
+    public required MigrationSummary Summary { get; init; }
+    public List<FileMigrationResult> FileResults { get; init; } = new();
+    public BenchmarkSummary? Benchmark { get; init; }
+    public List<string> Recommendations { get; init; } = new();
+}
+
+/// <summary>
+/// Direction of the migration.
+/// </summary>
+public enum MigrationDirection
+{
+    CSharpToOpal,
+    OpalToCSharp
+}
+
+/// <summary>
+/// Summary of migration results.
+/// </summary>
+public sealed class MigrationSummary
+{
+    public int TotalFiles { get; set; }
+    public int SuccessfulFiles { get; set; }
+    public int PartialFiles { get; set; }
+    public int FailedFiles { get; set; }
+    public int TotalErrors { get; set; }
+    public int TotalWarnings { get; set; }
+    public TimeSpan TotalDuration { get; set; }
+    public double SuccessRate => TotalFiles > 0 ? (double)SuccessfulFiles / TotalFiles * 100 : 0;
+
+    public List<string> MostCommonIssues { get; init; } = new();
+    public List<string> UnsupportedFeatures { get; init; } = new();
+}
+
+/// <summary>
+/// Result of migrating a single file.
+/// </summary>
+public sealed class FileMigrationResult
+{
+    public required string SourcePath { get; init; }
+    public required string? OutputPath { get; init; }
+    public required FileMigrationStatus Status { get; init; }
+    public TimeSpan Duration { get; init; }
+    public List<ConversionIssue> Issues { get; init; } = new();
+    public FileMetrics? Metrics { get; init; }
+}
+
+/// <summary>
+/// Status of a file migration.
+/// </summary>
+public enum FileMigrationStatus
+{
+    Success,
+    Partial,
+    Failed,
+    Skipped
+}
+
+/// <summary>
+/// Metrics for a migrated file.
+/// </summary>
+public sealed class FileMetrics
+{
+    public int OriginalLines { get; set; }
+    public int OutputLines { get; set; }
+    public int OriginalTokens { get; set; }
+    public int OutputTokens { get; set; }
+    public int OriginalCharacters { get; set; }
+    public int OutputCharacters { get; set; }
+
+    public double LineReduction => OriginalLines > 0
+        ? (1.0 - (double)OutputLines / OriginalLines) * 100 : 0;
+    public double TokenReduction => OriginalTokens > 0
+        ? (1.0 - (double)OutputTokens / OriginalTokens) * 100 : 0;
+    public double CharReduction => OriginalCharacters > 0
+        ? (1.0 - (double)OutputCharacters / OriginalCharacters) * 100 : 0;
+}
+
+/// <summary>
+/// Benchmark summary comparing original and converted code.
+/// </summary>
+public sealed class BenchmarkSummary
+{
+    public int TotalOriginalTokens { get; set; }
+    public int TotalOutputTokens { get; set; }
+    public int TotalOriginalLines { get; set; }
+    public int TotalOutputLines { get; set; }
+
+    public double TokenSavingsPercent => TotalOriginalTokens > 0
+        ? (1.0 - (double)TotalOutputTokens / TotalOriginalTokens) * 100 : 0;
+    public double LineSavingsPercent => TotalOriginalLines > 0
+        ? (1.0 - (double)TotalOutputLines / TotalOriginalLines) * 100 : 0;
+    public double OverallAdvantage => TotalOutputTokens > 0
+        ? (double)TotalOriginalTokens / TotalOutputTokens : 1.0;
+
+    public Dictionary<string, double> CategoryAdvantages { get; init; } = new();
+}

--- a/src/Opal.Compiler/Migration/MigrationReportGenerator.cs
+++ b/src/Opal.Compiler/Migration/MigrationReportGenerator.cs
@@ -1,0 +1,369 @@
+using System.Text;
+using System.Text.Json;
+
+namespace Opal.Compiler.Migration;
+
+/// <summary>
+/// Generates migration reports in various formats.
+/// </summary>
+public sealed class MigrationReportGenerator
+{
+    private readonly MigrationReport _report;
+
+    public MigrationReportGenerator(MigrationReport report)
+    {
+        _report = report;
+    }
+
+    /// <summary>
+    /// Generates a Markdown report.
+    /// </summary>
+    public string GenerateMarkdown()
+    {
+        var sb = new StringBuilder();
+
+        // Header
+        sb.AppendLine("# Migration Report");
+        sb.AppendLine();
+        sb.AppendLine($"**Generated:** {_report.GeneratedAt:yyyy-MM-dd HH:mm:ss UTC}");
+        sb.AppendLine($"**Direction:** {FormatDirection(_report.Direction)}");
+        sb.AppendLine($"**Report ID:** `{_report.ReportId}`");
+        sb.AppendLine();
+
+        // Summary
+        sb.AppendLine("## Summary");
+        sb.AppendLine();
+        sb.AppendLine("| Metric | Value |");
+        sb.AppendLine("|--------|-------|");
+        sb.AppendLine($"| Total Files | {_report.Summary.TotalFiles} |");
+        sb.AppendLine($"| Successful | {_report.Summary.SuccessfulFiles} |");
+        sb.AppendLine($"| Partial | {_report.Summary.PartialFiles} |");
+        sb.AppendLine($"| Failed | {_report.Summary.FailedFiles} |");
+        sb.AppendLine($"| Success Rate | {_report.Summary.SuccessRate:F1}% |");
+        sb.AppendLine($"| Total Errors | {_report.Summary.TotalErrors} |");
+        sb.AppendLine($"| Total Warnings | {_report.Summary.TotalWarnings} |");
+        sb.AppendLine($"| Duration | {FormatDuration(_report.Summary.TotalDuration)} |");
+        sb.AppendLine();
+
+        // Benchmark results
+        if (_report.Benchmark != null)
+        {
+            sb.AppendLine("## Benchmark Results");
+            sb.AppendLine();
+            sb.AppendLine("### Token Economics");
+            sb.AppendLine();
+            sb.AppendLine("| Metric | Before | After | Savings |");
+            sb.AppendLine("|--------|--------|-------|---------|");
+            sb.AppendLine($"| Tokens | {_report.Benchmark.TotalOriginalTokens:N0} | {_report.Benchmark.TotalOutputTokens:N0} | {_report.Benchmark.TokenSavingsPercent:F1}% |");
+            sb.AppendLine($"| Lines | {_report.Benchmark.TotalOriginalLines:N0} | {_report.Benchmark.TotalOutputLines:N0} | {_report.Benchmark.LineSavingsPercent:F1}% |");
+            sb.AppendLine();
+            sb.AppendLine($"**Overall OPAL Advantage:** {_report.Benchmark.OverallAdvantage:F2}x");
+            sb.AppendLine();
+
+            if (_report.Benchmark.CategoryAdvantages.Count > 0)
+            {
+                sb.AppendLine("### Category Advantages");
+                sb.AppendLine();
+                foreach (var (category, advantage) in _report.Benchmark.CategoryAdvantages.OrderByDescending(kv => kv.Value))
+                {
+                    var indicator = advantage > 1 ? "+" : "";
+                    sb.AppendLine($"- **{category}:** {indicator}{(advantage - 1) * 100:F1}%");
+                }
+                sb.AppendLine();
+            }
+        }
+
+        // File results
+        if (_report.FileResults.Count > 0)
+        {
+            sb.AppendLine("## File Results");
+            sb.AppendLine();
+
+            var successFiles = _report.FileResults.Where(f => f.Status == FileMigrationStatus.Success).ToList();
+            var partialFiles = _report.FileResults.Where(f => f.Status == FileMigrationStatus.Partial).ToList();
+            var failedFiles = _report.FileResults.Where(f => f.Status == FileMigrationStatus.Failed).ToList();
+
+            if (successFiles.Count > 0)
+            {
+                sb.AppendLine("### Successful");
+                sb.AppendLine();
+                foreach (var file in successFiles)
+                {
+                    sb.AppendLine($"- `{Path.GetFileName(file.SourcePath)}` → `{Path.GetFileName(file.OutputPath ?? "")}`");
+                    if (file.Metrics != null)
+                    {
+                        sb.AppendLine($"  - Lines: {file.Metrics.OriginalLines} → {file.Metrics.OutputLines} ({file.Metrics.LineReduction:F1}% reduction)");
+                    }
+                }
+                sb.AppendLine();
+            }
+
+            if (partialFiles.Count > 0)
+            {
+                sb.AppendLine("### Partial (Needs Review)");
+                sb.AppendLine();
+                foreach (var file in partialFiles)
+                {
+                    sb.AppendLine($"- `{Path.GetFileName(file.SourcePath)}`");
+                    foreach (var issue in file.Issues.Where(i => i.Severity == ConversionIssueSeverity.Warning))
+                    {
+                        sb.AppendLine($"  - ⚠️ {issue.Message}");
+                    }
+                }
+                sb.AppendLine();
+            }
+
+            if (failedFiles.Count > 0)
+            {
+                sb.AppendLine("### Failed");
+                sb.AppendLine();
+                foreach (var file in failedFiles)
+                {
+                    sb.AppendLine($"- `{Path.GetFileName(file.SourcePath)}`");
+                    foreach (var issue in file.Issues.Where(i => i.Severity == ConversionIssueSeverity.Error))
+                    {
+                        sb.AppendLine($"  - ❌ {issue.Message}");
+                    }
+                }
+                sb.AppendLine();
+            }
+        }
+
+        // Common issues
+        if (_report.Summary.MostCommonIssues.Count > 0)
+        {
+            sb.AppendLine("## Common Issues");
+            sb.AppendLine();
+            foreach (var issue in _report.Summary.MostCommonIssues.Take(10))
+            {
+                sb.AppendLine($"- {issue}");
+            }
+            sb.AppendLine();
+        }
+
+        // Unsupported features
+        if (_report.Summary.UnsupportedFeatures.Count > 0)
+        {
+            sb.AppendLine("## Unsupported Features");
+            sb.AppendLine();
+            sb.AppendLine("The following C# features were encountered but are not fully supported:");
+            sb.AppendLine();
+            foreach (var feature in _report.Summary.UnsupportedFeatures)
+            {
+                var info = FeatureSupport.GetFeatureInfo(feature);
+                var workaround = info?.Workaround ?? "Consider manual conversion";
+                sb.AppendLine($"- **{feature}**: {workaround}");
+            }
+            sb.AppendLine();
+        }
+
+        // Recommendations
+        if (_report.Recommendations.Count > 0)
+        {
+            sb.AppendLine("## Recommendations");
+            sb.AppendLine();
+            foreach (var rec in _report.Recommendations)
+            {
+                sb.AppendLine($"1. {rec}");
+            }
+            sb.AppendLine();
+        }
+
+        // Footer
+        sb.AppendLine("---");
+        sb.AppendLine("*Generated by OPAL Migration Tool*");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Generates a JSON report.
+    /// </summary>
+    public string GenerateJson()
+    {
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        return JsonSerializer.Serialize(_report, options);
+    }
+
+    /// <summary>
+    /// Generates a concise console summary.
+    /// </summary>
+    public string GenerateConsoleSummary()
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine();
+        sb.AppendLine($"Migration {(_report.Summary.SuccessRate >= 100 ? "✓ Complete" : _report.Summary.SuccessRate > 0 ? "⚠ Partial" : "✗ Failed")}");
+        sb.AppendLine();
+        sb.AppendLine($"  Files: {_report.Summary.SuccessfulFiles}/{_report.Summary.TotalFiles} successful");
+
+        if (_report.Summary.PartialFiles > 0)
+            sb.AppendLine($"         {_report.Summary.PartialFiles} need review");
+        if (_report.Summary.FailedFiles > 0)
+            sb.AppendLine($"         {_report.Summary.FailedFiles} failed");
+
+        if (_report.Benchmark != null)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Token Economics:");
+            sb.AppendLine($"  Before: {_report.Benchmark.TotalOriginalTokens:N0} tokens");
+            sb.AppendLine($"  After:  {_report.Benchmark.TotalOutputTokens:N0} tokens");
+            sb.AppendLine($"  Savings: {_report.Benchmark.TokenSavingsPercent:F1}%");
+        }
+
+        if (_report.Summary.TotalErrors > 0 || _report.Summary.TotalWarnings > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"Issues: {_report.Summary.TotalErrors} error(s), {_report.Summary.TotalWarnings} warning(s)");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"Duration: {FormatDuration(_report.Summary.TotalDuration)}");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Saves the report to a file.
+    /// </summary>
+    public async Task SaveAsync(string path, ReportFormat format = ReportFormat.Markdown)
+    {
+        var content = format switch
+        {
+            ReportFormat.Markdown => GenerateMarkdown(),
+            ReportFormat.Json => GenerateJson(),
+            _ => GenerateMarkdown()
+        };
+
+        await File.WriteAllTextAsync(path, content);
+    }
+
+    private static string FormatDirection(MigrationDirection direction)
+    {
+        return direction switch
+        {
+            MigrationDirection.CSharpToOpal => "C# → OPAL",
+            MigrationDirection.OpalToCSharp => "OPAL → C#",
+            _ => "Unknown"
+        };
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        if (duration.TotalSeconds < 1)
+            return $"{duration.TotalMilliseconds:F0}ms";
+        if (duration.TotalMinutes < 1)
+            return $"{duration.TotalSeconds:F1}s";
+        return $"{duration.TotalMinutes:F1}m";
+    }
+}
+
+/// <summary>
+/// Report output format.
+/// </summary>
+public enum ReportFormat
+{
+    Markdown,
+    Json
+}
+
+/// <summary>
+/// Builder for creating migration reports.
+/// </summary>
+public sealed class MigrationReportBuilder
+{
+    private readonly List<FileMigrationResult> _fileResults = new();
+    private readonly List<string> _recommendations = new();
+    private MigrationDirection _direction = MigrationDirection.CSharpToOpal;
+    private bool _includeBenchmark;
+
+    public MigrationReportBuilder SetDirection(MigrationDirection direction)
+    {
+        _direction = direction;
+        return this;
+    }
+
+    public MigrationReportBuilder IncludeBenchmark(bool include = true)
+    {
+        _includeBenchmark = include;
+        return this;
+    }
+
+    public MigrationReportBuilder AddFileResult(FileMigrationResult result)
+    {
+        _fileResults.Add(result);
+        return this;
+    }
+
+    public MigrationReportBuilder AddRecommendation(string recommendation)
+    {
+        _recommendations.Add(recommendation);
+        return this;
+    }
+
+    public MigrationReport Build()
+    {
+        var summary = BuildSummary();
+        var benchmark = _includeBenchmark ? BuildBenchmark() : null;
+
+        return new MigrationReport
+        {
+            ReportId = Guid.NewGuid().ToString("N")[..8],
+            GeneratedAt = DateTime.UtcNow,
+            Direction = _direction,
+            Summary = summary,
+            FileResults = _fileResults.ToList(),
+            Benchmark = benchmark,
+            Recommendations = _recommendations.ToList()
+        };
+    }
+
+    private MigrationSummary BuildSummary()
+    {
+        var allIssues = _fileResults.SelectMany(f => f.Issues).ToList();
+
+        var issueGroups = allIssues
+            .GroupBy(i => i.Message)
+            .OrderByDescending(g => g.Count())
+            .Take(10)
+            .Select(g => $"{g.Key} ({g.Count()}x)")
+            .ToList();
+
+        var unsupportedFeatures = allIssues
+            .Where(i => i.Feature != null && !FeatureSupport.IsFullySupported(i.Feature))
+            .Select(i => i.Feature!)
+            .Distinct()
+            .ToList();
+
+        return new MigrationSummary
+        {
+            TotalFiles = _fileResults.Count,
+            SuccessfulFiles = _fileResults.Count(f => f.Status == FileMigrationStatus.Success),
+            PartialFiles = _fileResults.Count(f => f.Status == FileMigrationStatus.Partial),
+            FailedFiles = _fileResults.Count(f => f.Status == FileMigrationStatus.Failed),
+            TotalErrors = allIssues.Count(i => i.Severity == ConversionIssueSeverity.Error),
+            TotalWarnings = allIssues.Count(i => i.Severity == ConversionIssueSeverity.Warning),
+            TotalDuration = TimeSpan.FromTicks(_fileResults.Sum(f => f.Duration.Ticks)),
+            MostCommonIssues = issueGroups,
+            UnsupportedFeatures = unsupportedFeatures
+        };
+    }
+
+    private BenchmarkSummary BuildBenchmark()
+    {
+        var filesWithMetrics = _fileResults.Where(f => f.Metrics != null).ToList();
+
+        return new BenchmarkSummary
+        {
+            TotalOriginalTokens = filesWithMetrics.Sum(f => f.Metrics!.OriginalTokens),
+            TotalOutputTokens = filesWithMetrics.Sum(f => f.Metrics!.OutputTokens),
+            TotalOriginalLines = filesWithMetrics.Sum(f => f.Metrics!.OriginalLines),
+            TotalOutputLines = filesWithMetrics.Sum(f => f.Metrics!.OutputLines)
+        };
+    }
+}

--- a/src/Opal.Compiler/Migration/OpalEmitter.cs
+++ b/src/Opal.Compiler/Migration/OpalEmitter.cs
@@ -1,0 +1,1312 @@
+using System.Text;
+using Opal.Compiler.Ast;
+
+namespace Opal.Compiler.Migration;
+
+/// <summary>
+/// Emits OPAL v2+ source code from an OPAL AST.
+/// Uses Lisp-style expressions and arrow syntax for control flow.
+/// </summary>
+public sealed class OpalEmitter : IAstVisitor<string>
+{
+    private readonly StringBuilder _builder = new();
+    private int _indentLevel;
+    private readonly ConversionContext? _context;
+
+    public OpalEmitter(ConversionContext? context = null)
+    {
+        _context = context;
+    }
+
+    public string Emit(ModuleNode module)
+    {
+        _builder.Clear();
+        _indentLevel = 0;
+        Visit(module);
+        return _builder.ToString();
+    }
+
+    private void AppendLine(string line = "")
+    {
+        if (string.IsNullOrEmpty(line))
+        {
+            _builder.AppendLine();
+        }
+        else
+        {
+            _builder.Append(new string(' ', _indentLevel * 2));
+            _builder.AppendLine(line);
+        }
+    }
+
+    private void Append(string text)
+    {
+        _builder.Append(text);
+    }
+
+    private void Indent() => _indentLevel++;
+    private void Dedent() => _indentLevel--;
+
+    public string Visit(ModuleNode node)
+    {
+        // Module header
+        AppendLine($"§M[{node.Id}:{node.Name}]");
+        Indent();
+
+        // Emit using directives
+        foreach (var usingDir in node.Usings)
+        {
+            Visit(usingDir);
+        }
+        if (node.Usings.Count > 0)
+            AppendLine();
+
+        // Emit interfaces
+        foreach (var iface in node.Interfaces)
+        {
+            Visit(iface);
+            AppendLine();
+        }
+
+        // Emit classes
+        foreach (var cls in node.Classes)
+        {
+            Visit(cls);
+            AppendLine();
+        }
+
+        // Emit module-level functions
+        foreach (var func in node.Functions)
+        {
+            Visit(func);
+            AppendLine();
+        }
+
+        Dedent();
+        AppendLine($"§/M[{node.Id}]");
+
+        return _builder.ToString();
+    }
+
+    public string Visit(UsingDirectiveNode node)
+    {
+        if (node.IsStatic)
+        {
+            AppendLine($"§USE[static:{node.Namespace}]");
+        }
+        else if (node.Alias != null)
+        {
+            AppendLine($"§USE[{node.Alias}={node.Namespace}]");
+        }
+        else
+        {
+            AppendLine($"§USE[{node.Namespace}]");
+        }
+        return "";
+    }
+
+    public string Visit(InterfaceDefinitionNode node)
+    {
+        var baseList = node.BaseInterfaces.Count > 0
+            ? $":{string.Join(",", node.BaseInterfaces)}"
+            : "";
+
+        AppendLine($"§IFACE[{node.Id}:{node.Name}{baseList}]");
+        Indent();
+
+        foreach (var method in node.Methods)
+        {
+            Visit(method);
+        }
+
+        Dedent();
+        AppendLine($"§/IFACE[{node.Id}]");
+
+        return "";
+    }
+
+    public string Visit(MethodSignatureNode node)
+    {
+        var typeParams = node.TypeParameters.Count > 0
+            ? $"<{string.Join(",", node.TypeParameters.Select(tp => tp.Name))}>"
+            : "";
+
+        var output = node.Output != null ? TypeMapper.CSharpToOpal(node.Output.TypeName) : "void";
+        var paramList = string.Join(",", node.Parameters.Select(p =>
+            $"{TypeMapper.CSharpToOpal(p.TypeName)}:{p.Name}"));
+
+        AppendLine($"§SIG[{node.Id}:{node.Name}{typeParams}] ({paramList}) → {output}");
+
+        return "";
+    }
+
+    public string Visit(ClassDefinitionNode node)
+    {
+        var modifiers = new List<string>();
+        if (node.IsAbstract) modifiers.Add("abs");
+        if (node.IsSealed) modifiers.Add("sealed");
+
+        var modStr = modifiers.Count > 0 ? $":{string.Join(",", modifiers)}" : "";
+        var baseStr = node.BaseClass != null ? $":{node.BaseClass}" : "";
+
+        var typeParams = node.TypeParameters.Count > 0
+            ? $"<{string.Join(",", node.TypeParameters.Select(tp => tp.Name))}>"
+            : "";
+
+        AppendLine($"§CLASS[{node.Id}:{node.Name}{typeParams}{baseStr}{modStr}]");
+        Indent();
+
+        // Emit implemented interfaces
+        foreach (var iface in node.ImplementedInterfaces)
+        {
+            AppendLine($"§IMPL[{iface}]");
+        }
+        if (node.ImplementedInterfaces.Count > 0)
+            AppendLine();
+
+        // Emit fields
+        foreach (var field in node.Fields)
+        {
+            Visit(field);
+        }
+        if (node.Fields.Count > 0)
+            AppendLine();
+
+        // Emit properties
+        foreach (var prop in node.Properties)
+        {
+            Visit(prop);
+        }
+        if (node.Properties.Count > 0)
+            AppendLine();
+
+        // Emit constructors
+        foreach (var ctor in node.Constructors)
+        {
+            Visit(ctor);
+            AppendLine();
+        }
+
+        // Emit methods
+        foreach (var method in node.Methods)
+        {
+            Visit(method);
+            AppendLine();
+        }
+
+        Dedent();
+        AppendLine($"§/CLASS[{node.Id}]");
+
+        return "";
+    }
+
+    public string Visit(ClassFieldNode node)
+    {
+        var visibility = GetVisibilityShorthand(node.Visibility);
+        var typeName = TypeMapper.CSharpToOpal(node.TypeName);
+        var defaultVal = node.DefaultValue != null ? $" = {node.DefaultValue.Accept(this)}" : "";
+
+        AppendLine($"§FLD[{typeName}:{node.Name}:{visibility}]{defaultVal}");
+
+        return "";
+    }
+
+    public string Visit(PropertyNode node)
+    {
+        var visibility = GetVisibilityShorthand(node.Visibility);
+        var typeName = TypeMapper.CSharpToOpal(node.TypeName);
+
+        if (node.IsAutoProperty)
+        {
+            var accessors = "";
+            if (node.Getter != null) accessors += "get";
+            if (node.Setter != null) accessors += accessors.Length > 0 ? ",set" : "set";
+            if (node.Initer != null) accessors += accessors.Length > 0 ? ",init" : "init";
+
+            var defaultVal = node.DefaultValue != null ? $" = {node.DefaultValue.Accept(this)}" : "";
+            AppendLine($"§PROP[{typeName}:{node.Name}:{visibility}:{accessors}]{defaultVal}");
+        }
+        else
+        {
+            AppendLine($"§PROP[{typeName}:{node.Name}:{visibility}]");
+            Indent();
+
+            if (node.Getter != null)
+            {
+                Visit(node.Getter);
+            }
+            if (node.Setter != null)
+            {
+                Visit(node.Setter);
+            }
+            if (node.Initer != null)
+            {
+                Visit(node.Initer);
+            }
+
+            Dedent();
+            AppendLine($"§/PROP");
+        }
+
+        return "";
+    }
+
+    public string Visit(PropertyAccessorNode node)
+    {
+        var keyword = node.Kind switch
+        {
+            PropertyAccessorNode.AccessorKind.Get => "GET",
+            PropertyAccessorNode.AccessorKind.Set => "SET",
+            PropertyAccessorNode.AccessorKind.Init => "INIT",
+            _ => "GET"
+        };
+
+        if (node.IsAutoImplemented)
+        {
+            AppendLine($"§{keyword}[]");
+        }
+        else
+        {
+            AppendLine($"§{keyword}");
+            Indent();
+            foreach (var stmt in node.Body)
+            {
+                stmt.Accept(this);
+            }
+            Dedent();
+            AppendLine($"§/{keyword}");
+        }
+
+        return "";
+    }
+
+    public string Visit(ConstructorNode node)
+    {
+        var visibility = GetVisibilityShorthand(node.Visibility);
+        var paramList = string.Join(",", node.Parameters.Select(p =>
+            $"{TypeMapper.CSharpToOpal(p.TypeName)}:{p.Name}"));
+
+        var initStr = "";
+        if (node.Initializer != null)
+        {
+            var initType = node.Initializer.IsBaseCall ? "base" : "this";
+            var initArgs = string.Join(",", node.Initializer.Arguments.Select(a => a.Accept(this)));
+            initStr = $" → {initType}({initArgs})";
+        }
+
+        AppendLine($"§CTOR[{visibility}] ({paramList}){initStr}");
+        Indent();
+
+        foreach (var pre in node.Preconditions)
+        {
+            Visit(pre);
+        }
+
+        foreach (var stmt in node.Body)
+        {
+            stmt.Accept(this);
+        }
+
+        Dedent();
+        AppendLine($"§/CTOR");
+
+        return "";
+    }
+
+    public string Visit(ConstructorInitializerNode node)
+    {
+        var keyword = node.IsBaseCall ? "base" : "this";
+        var args = string.Join(", ", node.Arguments.Select(a => a.Accept(this)));
+        return $"{keyword}({args})";
+    }
+
+    public string Visit(MethodNode node)
+    {
+        var visibility = GetVisibilityShorthand(node.Visibility);
+        var modifiers = new List<string>();
+
+        if (node.IsVirtual) modifiers.Add("virt");
+        if (node.IsOverride) modifiers.Add("over");
+        if (node.IsAbstract) modifiers.Add("abs");
+        if (node.IsSealed) modifiers.Add("sealed");
+        if (node.IsStatic) modifiers.Add("static");
+
+        var modStr = modifiers.Count > 0 ? $":{string.Join(",", modifiers)}" : "";
+
+        var typeParams = node.TypeParameters.Count > 0
+            ? $"<{string.Join(",", node.TypeParameters.Select(tp => tp.Name))}>"
+            : "";
+
+        var output = node.Output != null ? TypeMapper.CSharpToOpal(node.Output.TypeName) : "void";
+
+        AppendLine($"§METHOD[{node.Id}:{node.Name}{typeParams}:{visibility}{modStr}]");
+        Indent();
+
+        // Parameters
+        foreach (var param in node.Parameters)
+        {
+            var paramType = TypeMapper.CSharpToOpal(param.TypeName);
+            AppendLine($"§I[{paramType}:{param.Name}]");
+        }
+
+        // Output
+        if (node.Output != null)
+        {
+            AppendLine($"§O[{output}]");
+        }
+
+        // Preconditions
+        foreach (var pre in node.Preconditions)
+        {
+            Visit(pre);
+        }
+
+        // Postconditions
+        foreach (var post in node.Postconditions)
+        {
+            Visit(post);
+        }
+
+        // Body (only for non-abstract methods)
+        if (!node.IsAbstract)
+        {
+            foreach (var stmt in node.Body)
+            {
+                stmt.Accept(this);
+            }
+        }
+
+        Dedent();
+        AppendLine($"§/METHOD[{node.Id}]");
+
+        return "";
+    }
+
+    public string Visit(FunctionNode node)
+    {
+        var visibility = GetVisibilityShorthand(node.Visibility);
+        var typeParams = node.TypeParameters.Count > 0
+            ? $"<{string.Join(",", node.TypeParameters.Select(tp => tp.Name))}>"
+            : "";
+
+        var output = node.Output != null ? TypeMapper.CSharpToOpal(node.Output.TypeName) : "void";
+
+        AppendLine($"§F[{node.Id}:{node.Name}{typeParams}:{visibility}]");
+        Indent();
+
+        // Parameters
+        foreach (var param in node.Parameters)
+        {
+            var paramType = TypeMapper.CSharpToOpal(param.TypeName);
+            AppendLine($"§I[{paramType}:{param.Name}]");
+        }
+
+        // Output
+        if (node.Output != null)
+        {
+            AppendLine($"§O[{output}]");
+        }
+
+        // Preconditions
+        foreach (var pre in node.Preconditions)
+        {
+            Visit(pre);
+        }
+
+        // Postconditions
+        foreach (var post in node.Postconditions)
+        {
+            Visit(post);
+        }
+
+        // Body
+        foreach (var stmt in node.Body)
+        {
+            stmt.Accept(this);
+        }
+
+        Dedent();
+        AppendLine($"§/F[{node.Id}]");
+
+        return "";
+    }
+
+    public string Visit(ParameterNode node)
+    {
+        var typeName = TypeMapper.CSharpToOpal(node.TypeName);
+        return $"§I[{typeName}:{node.Name}]";
+    }
+
+    public string Visit(RequiresNode node)
+    {
+        var condition = node.Condition.Accept(this);
+        var message = node.Message != null ? $" \"{node.Message}\"" : "";
+        AppendLine($"§REQ {condition}{message}");
+        return "";
+    }
+
+    public string Visit(EnsuresNode node)
+    {
+        var condition = node.Condition.Accept(this);
+        var message = node.Message != null ? $" \"{node.Message}\"" : "";
+        AppendLine($"§ENS {condition}{message}");
+        return "";
+    }
+
+    public string Visit(InvariantNode node)
+    {
+        var condition = node.Condition.Accept(this);
+        var message = node.Message != null ? $" \"{node.Message}\"" : "";
+        AppendLine($"§INV {condition}{message}");
+        return "";
+    }
+
+    // Statements
+
+    public string Visit(ReturnStatementNode node)
+    {
+        if (node.Expression != null)
+        {
+            var expr = node.Expression.Accept(this);
+            AppendLine($"§R {expr}");
+        }
+        else
+        {
+            AppendLine("§R");
+        }
+        return "";
+    }
+
+    public string Visit(CallStatementNode node)
+    {
+        var args = string.Join(" ", node.Arguments.Select(a => a.Accept(this)));
+        var argsStr = args.Length > 0 ? $" {args}" : "";
+        AppendLine($"§C[{node.Target}]{argsStr}");
+        return "";
+    }
+
+    public string Visit(PrintStatementNode node)
+    {
+        var expr = node.Expression.Accept(this);
+        var tag = node.IsWriteLine ? "§P" : "§Pf";
+        AppendLine($"{tag} {expr}");
+        return "";
+    }
+
+    public string Visit(BindStatementNode node)
+    {
+        var typePart = node.TypeName != null ? $"{TypeMapper.CSharpToOpal(node.TypeName)}:" : "";
+        var mutPart = node.IsMutable ? "" : ":const";
+        var initPart = node.Initializer != null ? $" = {node.Initializer.Accept(this)}" : "";
+
+        AppendLine($"§B[{typePart}{node.Name}{mutPart}]{initPart}");
+        return "";
+    }
+
+    public string Visit(AssignmentStatementNode node)
+    {
+        var target = node.Target.Accept(this);
+        var value = node.Value.Accept(this);
+        AppendLine($"§SET {target} = {value}");
+        return "";
+    }
+
+    public string Visit(IfStatementNode node)
+    {
+        var condition = node.Condition.Accept(this);
+
+        AppendLine($"§IF[{node.Id}] {condition}");
+        Indent();
+
+        foreach (var stmt in node.ThenBody)
+        {
+            stmt.Accept(this);
+        }
+
+        Dedent();
+
+        // ElseIf clauses
+        foreach (var elseIf in node.ElseIfClauses)
+        {
+            var elseIfCondition = elseIf.Condition.Accept(this);
+            AppendLine($"§ELIF {elseIfCondition}");
+            Indent();
+
+            foreach (var stmt in elseIf.Body)
+            {
+                stmt.Accept(this);
+            }
+
+            Dedent();
+        }
+
+        // Else clause
+        if (node.ElseBody != null)
+        {
+            AppendLine("§ELSE");
+            Indent();
+
+            foreach (var stmt in node.ElseBody)
+            {
+                stmt.Accept(this);
+            }
+
+            Dedent();
+        }
+
+        AppendLine($"§/IF[{node.Id}]");
+        return "";
+    }
+
+    public string Visit(ForStatementNode node)
+    {
+        var from = node.From.Accept(this);
+        var to = node.To.Accept(this);
+        var step = node.Step?.Accept(this) ?? "1";
+
+        AppendLine($"§L[{node.Id}:{node.VariableName}:{from}:{to}:{step}]");
+        Indent();
+
+        foreach (var stmt in node.Body)
+        {
+            stmt.Accept(this);
+        }
+
+        Dedent();
+        AppendLine($"§/L[{node.Id}]");
+        return "";
+    }
+
+    public string Visit(WhileStatementNode node)
+    {
+        var condition = node.Condition.Accept(this);
+
+        AppendLine($"§WHILE[{node.Id}] {condition}");
+        Indent();
+
+        foreach (var stmt in node.Body)
+        {
+            stmt.Accept(this);
+        }
+
+        Dedent();
+        AppendLine($"§/WHILE[{node.Id}]");
+        return "";
+    }
+
+    public string Visit(ForeachStatementNode node)
+    {
+        var collection = node.Collection.Accept(this);
+        var varType = TypeMapper.CSharpToOpal(node.VariableType);
+
+        AppendLine($"§EACH[{varType}:{node.VariableName}] {collection}");
+        Indent();
+
+        foreach (var stmt in node.Body)
+        {
+            stmt.Accept(this);
+        }
+
+        Dedent();
+        AppendLine("§/EACH");
+        return "";
+    }
+
+    public string Visit(TryStatementNode node)
+    {
+        AppendLine("§TRY");
+        Indent();
+
+        foreach (var stmt in node.TryBody)
+        {
+            stmt.Accept(this);
+        }
+
+        Dedent();
+
+        foreach (var catchClause in node.CatchClauses)
+        {
+            Visit(catchClause);
+        }
+
+        if (node.FinallyBody != null)
+        {
+            AppendLine("§FINALLY");
+            Indent();
+
+            foreach (var stmt in node.FinallyBody)
+            {
+                stmt.Accept(this);
+            }
+
+            Dedent();
+        }
+
+        AppendLine("§/TRY");
+        return "";
+    }
+
+    public string Visit(CatchClauseNode node)
+    {
+        var exType = node.ExceptionType ?? "Exception";
+        var varPart = node.VariableName != null ? $":{node.VariableName}" : "";
+        var filterPart = node.Filter != null ? $" when {node.Filter.Accept(this)}" : "";
+
+        AppendLine($"§CATCH[{exType}{varPart}]{filterPart}");
+        Indent();
+
+        foreach (var stmt in node.Body)
+        {
+            stmt.Accept(this);
+        }
+
+        Dedent();
+        return "";
+    }
+
+    public string Visit(ThrowStatementNode node)
+    {
+        if (node.Exception != null)
+        {
+            var expr = node.Exception.Accept(this);
+            AppendLine($"§THROW {expr}");
+        }
+        else
+        {
+            AppendLine("§RETHROW");
+        }
+        return "";
+    }
+
+    public string Visit(RethrowStatementNode node)
+    {
+        AppendLine("§RETHROW");
+        return "";
+    }
+
+    public string Visit(MatchStatementNode node)
+    {
+        var target = node.Target.Accept(this);
+
+        AppendLine($"§MATCH {target}");
+        Indent();
+
+        foreach (var matchCase in node.Cases)
+        {
+            Visit(matchCase);
+        }
+
+        Dedent();
+        AppendLine("§/MATCH");
+        return "";
+    }
+
+    public string Visit(MatchCaseNode node)
+    {
+        var pattern = EmitPattern(node.Pattern);
+        AppendLine($"§CASE {pattern} →");
+        Indent();
+
+        foreach (var stmt in node.Body)
+        {
+            stmt.Accept(this);
+        }
+
+        Dedent();
+        return "";
+    }
+
+    // Expressions - return strings
+
+    public string Visit(IntLiteralNode node)
+    {
+        return node.Value.ToString();
+    }
+
+    public string Visit(FloatLiteralNode node)
+    {
+        return node.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    public string Visit(StringLiteralNode node)
+    {
+        var escaped = node.Value
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"")
+            .Replace("\n", "\\n")
+            .Replace("\r", "\\r")
+            .Replace("\t", "\\t");
+        return $"\"{escaped}\"";
+    }
+
+    public string Visit(BoolLiteralNode node)
+    {
+        return node.Value ? "true" : "false";
+    }
+
+    public string Visit(ReferenceNode node)
+    {
+        return $"§REF[name={node.Name}]";
+    }
+
+    public string Visit(BinaryOperationNode node)
+    {
+        var left = node.Left.Accept(this);
+        var right = node.Right.Accept(this);
+        var opKind = GetOpalOperatorKind(node.Operator);
+
+        // Use Lisp-style prefix notation: (op left right)
+        return $"§OP[kind={opKind}] {left} {right}";
+    }
+
+    public string Visit(UnaryOperationNode node)
+    {
+        var operand = node.Operand.Accept(this);
+        var opKind = node.Operator switch
+        {
+            UnaryOperator.Negate => "neg",
+            UnaryOperator.Not => "not",
+            UnaryOperator.BitwiseNot => "bnot",
+            _ => "neg"
+        };
+
+        return $"§UOP[kind={opKind}] {operand}";
+    }
+
+    public string Visit(FieldAccessNode node)
+    {
+        var target = node.Target.Accept(this);
+        return $"{target}.{node.FieldName}";
+    }
+
+    public string Visit(NewExpressionNode node)
+    {
+        var typeArgs = node.TypeArguments.Count > 0
+            ? $"<{string.Join(",", node.TypeArguments)}>"
+            : "";
+        var args = string.Join(" ", node.Arguments.Select(a => a.Accept(this)));
+        var argsStr = args.Length > 0 ? $" {args}" : "";
+
+        return $"§NEW[{node.TypeName}{typeArgs}]{argsStr}";
+    }
+
+    public string Visit(ThisExpressionNode node)
+    {
+        return "§THIS";
+    }
+
+    public string Visit(BaseExpressionNode node)
+    {
+        return "§BASE";
+    }
+
+    public string Visit(MatchExpressionNode node)
+    {
+        var target = node.Target.Accept(this);
+        var cases = string.Join(", ", node.Cases.Select(c =>
+        {
+            var pattern = EmitPattern(c.Pattern);
+            var body = c.Body.Count > 0 && c.Body[^1] is ReturnStatementNode ret && ret.Expression != null
+                ? ret.Expression.Accept(this)
+                : "default";
+            return $"{pattern} → {body}";
+        }));
+
+        return $"(match {target} {{ {cases} }})";
+    }
+
+    public string Visit(SomeExpressionNode node)
+    {
+        var value = node.Value.Accept(this);
+        return $"§SOME[{value}]";
+    }
+
+    public string Visit(NoneExpressionNode node)
+    {
+        var typePart = node.TypeName != null ? $"<{TypeMapper.CSharpToOpal(node.TypeName)}>" : "";
+        return $"§NONE{typePart}";
+    }
+
+    public string Visit(OkExpressionNode node)
+    {
+        var value = node.Value.Accept(this);
+        return $"§OK[{value}]";
+    }
+
+    public string Visit(ErrExpressionNode node)
+    {
+        var error = node.Error.Accept(this);
+        return $"§ERR[{error}]";
+    }
+
+    public string Visit(ArrayCreationNode node)
+    {
+        var elementType = TypeMapper.CSharpToOpal(node.ElementType);
+
+        if (node.Initializer.Count > 0)
+        {
+            var elements = string.Join(", ", node.Initializer.Select(e => e.Accept(this)));
+            return $"[{elements}]";
+        }
+        else if (node.Size != null)
+        {
+            var size = node.Size.Accept(this);
+            return $"§ARR[{elementType}:{node.Name}:{size}]";
+        }
+        else
+        {
+            return $"§ARR[{elementType}:{node.Name}]";
+        }
+    }
+
+    public string Visit(ArrayAccessNode node)
+    {
+        var array = node.Array.Accept(this);
+        var index = node.Index.Accept(this);
+        return $"{array}[{index}]";
+    }
+
+    public string Visit(ArrayLengthNode node)
+    {
+        var array = node.Array.Accept(this);
+        return $"{array}.len";
+    }
+
+    public string Visit(LambdaExpressionNode node)
+    {
+        var asyncPart = node.IsAsync ? "async " : "";
+        var paramList = string.Join(", ", node.Parameters.Select(p =>
+            p.TypeName != null ? $"{TypeMapper.CSharpToOpal(p.TypeName)}:{p.Name}" : p.Name));
+
+        if (node.IsExpressionLambda && node.ExpressionBody != null)
+        {
+            var body = node.ExpressionBody.Accept(this);
+            return $"{asyncPart}({paramList}) → {body}";
+        }
+        else
+        {
+            return $"{asyncPart}({paramList}) → {{ ... }}";
+        }
+    }
+
+    public string Visit(LambdaParameterNode node)
+    {
+        if (node.TypeName != null)
+        {
+            return $"{TypeMapper.CSharpToOpal(node.TypeName)}:{node.Name}";
+        }
+        return node.Name;
+    }
+
+    public string Visit(AwaitExpressionNode node)
+    {
+        var awaited = node.Awaited.Accept(this);
+        return $"§AWAIT {awaited}";
+    }
+
+    public string Visit(InterpolatedStringNode node)
+    {
+        var parts = new StringBuilder();
+        parts.Append("\"");
+
+        foreach (var part in node.Parts)
+        {
+            if (part is InterpolatedStringTextNode textPart)
+            {
+                parts.Append(textPart.Text);
+            }
+            else if (part is InterpolatedStringExpressionNode exprPart)
+            {
+                parts.Append("${");
+                parts.Append(exprPart.Expression.Accept(this));
+                parts.Append("}");
+            }
+        }
+
+        parts.Append("\"");
+        return parts.ToString();
+    }
+
+    public string Visit(InterpolatedStringTextNode node)
+    {
+        return node.Text;
+    }
+
+    public string Visit(InterpolatedStringExpressionNode node)
+    {
+        return $"${{{node.Expression.Accept(this)}}}";
+    }
+
+    public string Visit(NullCoalesceNode node)
+    {
+        var left = node.Left.Accept(this);
+        var right = node.Right.Accept(this);
+        return $"({left} ?? {right})";
+    }
+
+    public string Visit(NullConditionalNode node)
+    {
+        var target = node.Target.Accept(this);
+        return $"{target}?.{node.MemberName}";
+    }
+
+    // Pattern-related methods
+
+    private string EmitPattern(PatternNode pattern)
+    {
+        return pattern switch
+        {
+            WildcardPatternNode => "_",
+            VariablePatternNode vp => $"var {vp.Name}",
+            LiteralPatternNode lp => lp.Literal.Accept(this),
+            SomePatternNode sp => $"some({EmitPattern(sp.InnerPattern)})",
+            NonePatternNode => "none",
+            OkPatternNode op => $"ok({EmitPattern(op.InnerPattern)})",
+            ErrPatternNode ep => $"err({EmitPattern(ep.InnerPattern)})",
+            VarPatternNode varp => $"var {varp.Name}",
+            ConstantPatternNode cp => cp.Value.Accept(this),
+            _ => "_"
+        };
+    }
+
+    public string Visit(WildcardPatternNode node) => "_";
+    public string Visit(VariablePatternNode node) => $"var {node.Name}";
+    public string Visit(LiteralPatternNode node) => node.Literal.Accept(this);
+    public string Visit(SomePatternNode node) => $"some({EmitPattern(node.InnerPattern)})";
+    public string Visit(NonePatternNode node) => "none";
+    public string Visit(OkPatternNode node) => $"ok({EmitPattern(node.InnerPattern)})";
+    public string Visit(ErrPatternNode node) => $"err({EmitPattern(node.InnerPattern)})";
+    public string Visit(VarPatternNode node) => $"var {node.Name}";
+    public string Visit(ConstantPatternNode node) => node.Value.Accept(this);
+
+    // Additional pattern nodes
+    public string Visit(PositionalPatternNode node)
+    {
+        var patterns = string.Join(", ", node.Patterns.Select(EmitPattern));
+        return $"{node.TypeName}({patterns})";
+    }
+
+    public string Visit(PropertyPatternNode node)
+    {
+        var matches = string.Join(", ", node.Matches.Select(m => m.Accept(this)));
+        var typePart = string.IsNullOrEmpty(node.TypeName) ? "" : $"{node.TypeName} ";
+        return $"{typePart}{{ {matches} }}";
+    }
+
+    public string Visit(PropertyMatchNode node)
+    {
+        return $"{node.PropertyName}: {EmitPattern(node.Pattern)}";
+    }
+
+    public string Visit(RelationalPatternNode node)
+    {
+        var value = node.Value.Accept(this);
+        return $"{node.Operator} {value}";
+    }
+
+    public string Visit(ListPatternNode node)
+    {
+        var patterns = string.Join(", ", node.Patterns.Select(EmitPattern));
+        var slice = node.SlicePattern != null ? $", ..{EmitPattern(node.SlicePattern)}" : "";
+        return $"[{patterns}{slice}]";
+    }
+
+    // Type system nodes
+    public string Visit(RecordDefinitionNode node)
+    {
+        var fields = string.Join(", ", node.Fields.Select(f =>
+            $"{TypeMapper.CSharpToOpal(f.TypeName)}:{f.Name}"));
+        AppendLine($"§RECORD[{node.Name}] ({fields})");
+        return "";
+    }
+
+    public string Visit(UnionTypeDefinitionNode node)
+    {
+        AppendLine($"§UNION[{node.Name}]");
+        Indent();
+        foreach (var variant in node.Variants)
+        {
+            var fields = variant.Fields.Count > 0
+                ? $"({string.Join(", ", variant.Fields.Select(f => $"{TypeMapper.CSharpToOpal(f.TypeName)}:{f.Name}"))})"
+                : "";
+            AppendLine($"§V[{variant.Name}]{fields}");
+        }
+        Dedent();
+        AppendLine("§/UNION");
+        return "";
+    }
+
+    public string Visit(RecordCreationNode node)
+    {
+        var fields = string.Join(", ", node.Fields.Select(f => f.Value.Accept(this)));
+        return $"§NEW[{node.TypeName}] {fields}";
+    }
+
+    // Generic type nodes
+    public string Visit(TypeParameterNode node) => node.Name;
+    public string Visit(TypeConstraintNode node) => node.TypeName ?? "";
+    public string Visit(GenericTypeNode node)
+    {
+        if (node.TypeArguments.Count == 0)
+            return TypeMapper.CSharpToOpal(node.TypeName);
+        var args = string.Join(", ", node.TypeArguments.Select(TypeMapper.CSharpToOpal));
+        return $"{TypeMapper.CSharpToOpal(node.TypeName)}<{args}>";
+    }
+
+    // Delegate and event nodes
+    public string Visit(DelegateDefinitionNode node)
+    {
+        var output = node.Output != null ? TypeMapper.CSharpToOpal(node.Output.TypeName) : "void";
+        var paramList = string.Join(", ", node.Parameters.Select(p =>
+            $"{TypeMapper.CSharpToOpal(p.TypeName)}:{p.Name}"));
+        AppendLine($"§DELEGATE[{node.Name}] ({paramList}) → {output}");
+        return "";
+    }
+
+    public string Visit(EventDefinitionNode node)
+    {
+        var visibility = GetVisibilityShorthand(node.Visibility);
+        AppendLine($"§EVENT[{node.DelegateType}:{node.Name}:{visibility}]");
+        return "";
+    }
+
+    public string Visit(EventSubscribeNode node)
+    {
+        var evt = node.Event.Accept(this);
+        var handler = node.Handler.Accept(this);
+        return $"{evt} += {handler}";
+    }
+
+    public string Visit(EventUnsubscribeNode node)
+    {
+        var evt = node.Event.Accept(this);
+        var handler = node.Handler.Accept(this);
+        return $"{evt} -= {handler}";
+    }
+
+    // Modern operator nodes
+    public string Visit(RangeExpressionNode node)
+    {
+        var start = node.Start?.Accept(this) ?? "";
+        var end = node.End?.Accept(this) ?? "";
+        return $"{start}..{end}";
+    }
+
+    public string Visit(IndexFromEndNode node)
+    {
+        var offset = node.Offset.Accept(this);
+        return $"^{offset}";
+    }
+
+    public string Visit(WithExpressionNode node)
+    {
+        var target = node.Target.Accept(this);
+        var assignments = string.Join(", ", node.Assignments.Select(a => a.Accept(this)));
+        return $"{target} with {{ {assignments} }}";
+    }
+
+    public string Visit(WithPropertyAssignmentNode node)
+    {
+        var value = node.Value.Accept(this);
+        return $"{node.PropertyName} = {value}";
+    }
+
+    // Extended metadata nodes - emit as comments
+    public string Visit(ExampleNode node)
+    {
+        var expr = node.Expression.Accept(this);
+        var expected = node.Expected.Accept(this);
+        AppendLine($"§EX[{node.Id ?? ""}] {expr} == {expected}");
+        return "";
+    }
+
+    public string Visit(IssueNode node)
+    {
+        var id = node.Id != null ? $"{node.Id}:" : "";
+        AppendLine($"§{node.Kind.ToString().ToUpper()}[{id}{node.Category ?? ""}] {node.Description}");
+        return "";
+    }
+
+    public string Visit(DependencyNode node)
+    {
+        var version = node.Version != null ? $"@{node.Version}" : "";
+        var optional = node.IsOptional ? "?" : "";
+        return $"{node.Target}{version}{optional}";
+    }
+
+    public string Visit(UsesNode node)
+    {
+        var deps = string.Join(", ", node.Dependencies.Select(d => d.Accept(this)));
+        AppendLine($"§USES {deps}");
+        return "";
+    }
+
+    public string Visit(UsedByNode node)
+    {
+        var deps = string.Join(", ", node.Dependents.Select(d => d.Accept(this)));
+        var external = node.HasUnknownCallers ? ", [external]" : "";
+        AppendLine($"§USEDBY {deps}{external}");
+        return "";
+    }
+
+    public string Visit(AssumeNode node)
+    {
+        var category = node.Category.HasValue ? $"[{node.Category.Value.ToString().ToLower()}]" : "";
+        AppendLine($"§ASSUME{category} {node.Description}");
+        return "";
+    }
+
+    public string Visit(ComplexityNode node)
+    {
+        var parts = new List<string>();
+        if (node.TimeComplexity.HasValue) parts.Add($"time:{FormatComplexity(node.TimeComplexity.Value)}");
+        if (node.SpaceComplexity.HasValue) parts.Add($"space:{FormatComplexity(node.SpaceComplexity.Value)}");
+        if (node.CustomExpression != null) parts.Add(node.CustomExpression);
+        var worst = node.IsWorstCase ? "worst:" : "";
+        AppendLine($"§COMPLEXITY[{worst}{string.Join(",", parts)}]");
+        return "";
+    }
+
+    public string Visit(SinceNode node)
+    {
+        AppendLine($"§SINCE[{node.Version}]");
+        return "";
+    }
+
+    public string Visit(DeprecatedNode node)
+    {
+        var replacement = node.Replacement != null ? $":use={node.Replacement}" : "";
+        var removed = node.RemovedInVersion != null ? $":removed={node.RemovedInVersion}" : "";
+        AppendLine($"§DEPRECATED[{node.SinceVersion}{replacement}{removed}]");
+        return "";
+    }
+
+    public string Visit(BreakingChangeNode node)
+    {
+        AppendLine($"§BREAKING[{node.Version}] {node.Description}");
+        return "";
+    }
+
+    public string Visit(DecisionNode node)
+    {
+        AppendLine($"§DECISION[{node.Id}:{node.Title}]");
+        Indent();
+        AppendLine($"chosen: {node.ChosenOption}");
+        foreach (var reason in node.ChosenReasons)
+        {
+            AppendLine($"reason: {reason}");
+        }
+        Dedent();
+        AppendLine("§/DECISION");
+        return "";
+    }
+
+    public string Visit(RejectedOptionNode node)
+    {
+        AppendLine($"rejected: {node.Name}");
+        foreach (var reason in node.Reasons)
+        {
+            AppendLine($"  reason: {reason}");
+        }
+        return "";
+    }
+
+    public string Visit(ContextNode node)
+    {
+        var partial = node.IsPartial ? ":partial" : "";
+        AppendLine($"§CONTEXT{partial}");
+        return "";
+    }
+
+    public string Visit(FileRefNode node)
+    {
+        var desc = node.Description != null ? $" ({node.Description})" : "";
+        return $"§FILE[{node.FilePath}]{desc}";
+    }
+
+    public string Visit(PropertyTestNode node)
+    {
+        var quantifiers = node.Quantifiers.Count > 0 ? $"∀{string.Join(",", node.Quantifiers)}: " : "";
+        var predicate = node.Predicate.Accept(this);
+        AppendLine($"§PROP[{quantifiers}{predicate}]");
+        return "";
+    }
+
+    public string Visit(LockNode node)
+    {
+        var acquired = node.Acquired.HasValue ? $":acquired={node.Acquired.Value:O}" : "";
+        var expires = node.Expires.HasValue ? $":expires={node.Expires.Value:O}" : "";
+        AppendLine($"§LOCK[agent={node.AgentId}{acquired}{expires}]");
+        return "";
+    }
+
+    public string Visit(AuthorNode node)
+    {
+        var task = node.TaskId != null ? $":task={node.TaskId}" : "";
+        AppendLine($"§AUTHOR[agent={node.AgentId}:date={node.Date:yyyy-MM-dd}{task}]");
+        return "";
+    }
+
+    public string Visit(TaskRefNode node)
+    {
+        AppendLine($"§TASK[{node.TaskId}] {node.Description}");
+        return "";
+    }
+
+    // Helper methods
+
+    private static string GetVisibilityShorthand(Visibility visibility)
+    {
+        return visibility switch
+        {
+            Visibility.Public => "pub",
+            Visibility.Protected => "prot",
+            Visibility.Internal => "int",
+            Visibility.Private => "priv",
+            _ => "priv"
+        };
+    }
+
+    private static string GetOpalOperatorKind(BinaryOperator op)
+    {
+        return op switch
+        {
+            BinaryOperator.Add => "add",
+            BinaryOperator.Subtract => "sub",
+            BinaryOperator.Multiply => "mul",
+            BinaryOperator.Divide => "div",
+            BinaryOperator.Modulo => "mod",
+            BinaryOperator.Power => "pow",
+            BinaryOperator.Equal => "eq",
+            BinaryOperator.NotEqual => "neq",
+            BinaryOperator.LessThan => "lt",
+            BinaryOperator.LessOrEqual => "lte",
+            BinaryOperator.GreaterThan => "gt",
+            BinaryOperator.GreaterOrEqual => "gte",
+            BinaryOperator.And => "and",
+            BinaryOperator.Or => "or",
+            BinaryOperator.BitwiseAnd => "band",
+            BinaryOperator.BitwiseOr => "bor",
+            BinaryOperator.BitwiseXor => "xor",
+            BinaryOperator.LeftShift => "shl",
+            BinaryOperator.RightShift => "shr",
+            _ => "add"
+        };
+    }
+
+    private static string FormatComplexity(ComplexityClass c)
+    {
+        return c switch
+        {
+            ComplexityClass.O1 => "O(1)",
+            ComplexityClass.OLogN => "O(logn)",
+            ComplexityClass.ON => "O(n)",
+            ComplexityClass.ONLogN => "O(nlogn)",
+            ComplexityClass.ON2 => "O(n²)",
+            ComplexityClass.ON3 => "O(n³)",
+            ComplexityClass.O2N => "O(2ⁿ)",
+            ComplexityClass.ONFact => "O(n!)",
+            _ => c.ToString()
+        };
+    }
+}

--- a/src/Opal.Compiler/Migration/Project/CsprojUpdater.cs
+++ b/src/Opal.Compiler/Migration/Project/CsprojUpdater.cs
@@ -1,0 +1,222 @@
+using System.Xml.Linq;
+
+namespace Opal.Compiler.Migration.Project;
+
+/// <summary>
+/// Updates .csproj files for OPAL integration.
+/// </summary>
+public sealed class CsprojUpdater
+{
+    /// <summary>
+    /// Updates a .csproj file to include OPAL compilation support.
+    /// </summary>
+    public async Task<CsprojUpdateResult> UpdateForOpalAsync(string csprojPath)
+    {
+        if (!File.Exists(csprojPath))
+        {
+            return new CsprojUpdateResult
+            {
+                Success = false,
+                ErrorMessage = $"Project file not found: {csprojPath}"
+            };
+        }
+
+        try
+        {
+            var content = await File.ReadAllTextAsync(csprojPath);
+            var doc = XDocument.Parse(content);
+
+            var changes = new List<string>();
+
+            // Add Opal.Runtime reference if not present
+            if (!HasPackageReference(doc, "Opal.Runtime"))
+            {
+                AddPackageReference(doc, "Opal.Runtime", "*");
+                changes.Add("Added Opal.Runtime package reference");
+            }
+
+            // Add opalc tool reference if not present
+            if (!HasDotNetTool(doc, "opalc"))
+            {
+                changes.Add("Consider adding 'dotnet tool install -g opalc' to enable compilation");
+            }
+
+            // Add OPAL file compilation items if there are .opal files
+            var projectDir = Path.GetDirectoryName(csprojPath) ?? ".";
+            var opalFiles = Directory.GetFiles(projectDir, "*.opal", SearchOption.AllDirectories);
+
+            if (opalFiles.Length > 0 && !HasOpalCompileTarget(doc))
+            {
+                AddOpalCompileTarget(doc);
+                changes.Add("Added OPAL pre-build compilation target");
+            }
+
+            // Save changes
+            if (changes.Count > 0)
+            {
+                var backupPath = csprojPath + ".bak";
+                File.Copy(csprojPath, backupPath, overwrite: true);
+
+                await using var stream = File.Create(csprojPath);
+                await doc.SaveAsync(stream, SaveOptions.None, CancellationToken.None);
+
+                return new CsprojUpdateResult
+                {
+                    Success = true,
+                    Changes = changes,
+                    BackupPath = backupPath
+                };
+            }
+
+            return new CsprojUpdateResult
+            {
+                Success = true,
+                Changes = new List<string> { "No changes needed" }
+            };
+        }
+        catch (Exception ex)
+        {
+            return new CsprojUpdateResult
+            {
+                Success = false,
+                ErrorMessage = $"Failed to update project: {ex.Message}"
+            };
+        }
+    }
+
+    /// <summary>
+    /// Creates a new .csproj file with OPAL support.
+    /// </summary>
+    public async Task<CsprojUpdateResult> CreateOpalProjectAsync(string projectPath, string projectName)
+    {
+        var csprojPath = Path.Combine(projectPath, $"{projectName}.csproj");
+
+        if (File.Exists(csprojPath))
+        {
+            return new CsprojUpdateResult
+            {
+                Success = false,
+                ErrorMessage = $"Project file already exists: {csprojPath}"
+            };
+        }
+
+        try
+        {
+            Directory.CreateDirectory(projectPath);
+
+            var csprojContent = $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+
+                  <ItemGroup>
+                    <PackageReference Include="Opal.Runtime" Version="*" />
+                  </ItemGroup>
+
+                  <!-- Compile OPAL files before build -->
+                  <Target Name="CompileOpal" BeforeTargets="BeforeBuild">
+                    <Exec Command="opalc --input %(OpalFiles.Identity) --output %(OpalFiles.RootDir)%(OpalFiles.Directory)%(OpalFiles.Filename).g.cs"
+                          Condition="'@(OpalFiles)' != ''" />
+                  </Target>
+
+                  <ItemGroup>
+                    <OpalFiles Include="**/*.opal" />
+                    <Compile Include="**/*.g.cs" Condition="Exists('**/*.g.cs')" />
+                  </ItemGroup>
+
+                </Project>
+                """;
+
+            await File.WriteAllTextAsync(csprojPath, csprojContent);
+
+            return new CsprojUpdateResult
+            {
+                Success = true,
+                Changes = new List<string>
+                {
+                    $"Created project file: {csprojPath}",
+                    "Added Opal.Runtime reference",
+                    "Added OPAL pre-build compilation target"
+                }
+            };
+        }
+        catch (Exception ex)
+        {
+            return new CsprojUpdateResult
+            {
+                Success = false,
+                ErrorMessage = $"Failed to create project: {ex.Message}"
+            };
+        }
+    }
+
+    private static bool HasPackageReference(XDocument doc, string packageName)
+    {
+        return doc.Descendants("PackageReference")
+            .Any(e => e.Attribute("Include")?.Value.Equals(packageName, StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    private static bool HasDotNetTool(XDocument doc, string toolName)
+    {
+        return doc.Descendants("DotNetCliToolReference")
+            .Any(e => e.Attribute("Include")?.Value.Contains(toolName, StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    private static bool HasOpalCompileTarget(XDocument doc)
+    {
+        return doc.Descendants("Target")
+            .Any(e => e.Attribute("Name")?.Value.Equals("CompileOpal", StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    private static void AddPackageReference(XDocument doc, string packageName, string version)
+    {
+        var itemGroup = doc.Descendants("ItemGroup")
+            .FirstOrDefault(g => g.Elements("PackageReference").Any());
+
+        if (itemGroup == null)
+        {
+            itemGroup = new XElement("ItemGroup");
+            doc.Root?.Add(itemGroup);
+        }
+
+        itemGroup.Add(new XElement("PackageReference",
+            new XAttribute("Include", packageName),
+            new XAttribute("Version", version)));
+    }
+
+    private static void AddOpalCompileTarget(XDocument doc)
+    {
+        var target = new XElement("Target",
+            new XAttribute("Name", "CompileOpal"),
+            new XAttribute("BeforeTargets", "BeforeBuild"),
+            new XElement("Exec",
+                new XAttribute("Command", "opalc --input %(OpalFiles.Identity) --output %(OpalFiles.RootDir)%(OpalFiles.Directory)%(OpalFiles.Filename).g.cs"),
+                new XAttribute("Condition", "'@(OpalFiles)' != ''")));
+
+        var opalFilesItemGroup = new XElement("ItemGroup",
+            new XElement("OpalFiles",
+                new XAttribute("Include", "**/*.opal")),
+            new XElement("Compile",
+                new XAttribute("Include", "**/*.g.cs"),
+                new XAttribute("Condition", "Exists('**/*.g.cs')")));
+
+        doc.Root?.Add(target);
+        doc.Root?.Add(opalFilesItemGroup);
+    }
+}
+
+/// <summary>
+/// Result of updating a .csproj file.
+/// </summary>
+public sealed class CsprojUpdateResult
+{
+    public required bool Success { get; init; }
+    public string? ErrorMessage { get; init; }
+    public List<string> Changes { get; init; } = new();
+    public string? BackupPath { get; init; }
+}

--- a/src/Opal.Compiler/Migration/Project/MigrationPlan.cs
+++ b/src/Opal.Compiler/Migration/Project/MigrationPlan.cs
@@ -1,0 +1,84 @@
+namespace Opal.Compiler.Migration.Project;
+
+/// <summary>
+/// Represents a plan for migrating a project or set of files.
+/// </summary>
+public sealed class MigrationPlan
+{
+    public required string ProjectPath { get; init; }
+    public required MigrationDirection Direction { get; init; }
+    public required List<MigrationPlanEntry> Entries { get; init; }
+    public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
+    public MigrationPlanOptions Options { get; init; } = new();
+
+    public int TotalFiles => Entries.Count;
+    public int ConvertibleFiles => Entries.Count(e => e.Convertibility == FileConvertibility.Full);
+    public int PartialFiles => Entries.Count(e => e.Convertibility == FileConvertibility.Partial);
+    public int SkippedFiles => Entries.Count(e => e.Convertibility == FileConvertibility.Skip);
+
+    /// <summary>
+    /// Gets estimated issues based on feature analysis.
+    /// </summary>
+    public int EstimatedIssues => Entries.Sum(e => e.EstimatedIssues);
+}
+
+/// <summary>
+/// An entry in the migration plan representing a single file.
+/// </summary>
+public sealed class MigrationPlanEntry
+{
+    public required string SourcePath { get; init; }
+    public required string OutputPath { get; init; }
+    public required FileConvertibility Convertibility { get; init; }
+    public List<string> DetectedFeatures { get; init; } = new();
+    public List<string> PotentialIssues { get; init; } = new();
+    public int EstimatedIssues { get; init; }
+    public long FileSizeBytes { get; init; }
+    public string? SkipReason { get; init; }
+}
+
+/// <summary>
+/// Convertibility level for a file.
+/// </summary>
+public enum FileConvertibility
+{
+    /// <summary>File can be fully converted.</summary>
+    Full,
+    /// <summary>File can be partially converted, needs review.</summary>
+    Partial,
+    /// <summary>File should be skipped.</summary>
+    Skip
+}
+
+/// <summary>
+/// Options for migration plan creation.
+/// </summary>
+public sealed class MigrationPlanOptions
+{
+    /// <summary>Whether to include test files.</summary>
+    public bool IncludeTests { get; set; } = true;
+
+    /// <summary>Whether to include generated files (*.g.cs, *.Designer.cs).</summary>
+    public bool IncludeGenerated { get; set; } = false;
+
+    /// <summary>File patterns to exclude.</summary>
+    public List<string> ExcludePatterns { get; init; } = new()
+    {
+        "*.g.cs",
+        "*.Designer.cs",
+        "GlobalUsings.cs",
+        "AssemblyInfo.cs"
+    };
+
+    /// <summary>Maximum file size to process (bytes).</summary>
+    public long MaxFileSizeBytes { get; set; } = 1_000_000; // 1MB
+
+    /// <summary>Whether to run in parallel.</summary>
+    public bool Parallel { get; set; } = true;
+
+    /// <summary>Maximum degree of parallelism.</summary>
+    public int MaxParallelism { get; set; } = Environment.ProcessorCount;
+
+    /// <summary>Whether to include benchmark metrics.</summary>
+    public bool IncludeBenchmark { get; set; } = false;
+}

--- a/src/Opal.Compiler/Migration/Project/ProjectDiscovery.cs
+++ b/src/Opal.Compiler/Migration/Project/ProjectDiscovery.cs
@@ -1,0 +1,457 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxKind;
+using CSharpExtensions = Microsoft.CodeAnalysis.CSharpExtensions;
+
+namespace Opal.Compiler.Migration.Project;
+
+/// <summary>
+/// Discovers files to migrate in a project or directory.
+/// </summary>
+public sealed class ProjectDiscovery
+{
+    private readonly MigrationPlanOptions _options;
+
+    public ProjectDiscovery(MigrationPlanOptions? options = null)
+    {
+        _options = options ?? new MigrationPlanOptions();
+    }
+
+    /// <summary>
+    /// Discovers all C# files in a project directory.
+    /// </summary>
+    public async Task<MigrationPlan> DiscoverCSharpFilesAsync(string projectPath, MigrationDirection direction)
+    {
+        var entries = new List<MigrationPlanEntry>();
+
+        // Determine if projectPath is a .csproj file or directory
+        string searchPath;
+        if (File.Exists(projectPath) && projectPath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+        {
+            searchPath = Path.GetDirectoryName(projectPath) ?? projectPath;
+        }
+        else if (Directory.Exists(projectPath))
+        {
+            searchPath = projectPath;
+        }
+        else
+        {
+            throw new DirectoryNotFoundException($"Project path not found: {projectPath}");
+        }
+
+        // Find all C# files
+        var csFiles = Directory.EnumerateFiles(searchPath, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !ShouldExclude(f))
+            .ToList();
+
+        foreach (var csFile in csFiles)
+        {
+            var entry = await AnalyzeFileAsync(csFile, direction);
+            entries.Add(entry);
+        }
+
+        return new MigrationPlan
+        {
+            ProjectPath = projectPath,
+            Direction = direction,
+            Entries = entries,
+            Options = _options
+        };
+    }
+
+    /// <summary>
+    /// Discovers all OPAL files in a project directory.
+    /// </summary>
+    public async Task<MigrationPlan> DiscoverOpalFilesAsync(string projectPath)
+    {
+        var entries = new List<MigrationPlanEntry>();
+
+        string searchPath = Directory.Exists(projectPath) ? projectPath : Path.GetDirectoryName(projectPath) ?? projectPath;
+
+        var opalFiles = Directory.EnumerateFiles(searchPath, "*.opal", SearchOption.AllDirectories)
+            .ToList();
+
+        foreach (var opalFile in opalFiles)
+        {
+            var entry = await AnalyzeOpalFileAsync(opalFile);
+            entries.Add(entry);
+        }
+
+        return new MigrationPlan
+        {
+            ProjectPath = projectPath,
+            Direction = MigrationDirection.OpalToCSharp,
+            Entries = entries,
+            Options = _options
+        };
+    }
+
+    private bool ShouldExclude(string filePath)
+    {
+        var fileName = Path.GetFileName(filePath);
+        var relativePath = filePath.Replace('\\', '/');
+
+        // Check exclude patterns
+        foreach (var pattern in _options.ExcludePatterns)
+        {
+            if (MatchesPattern(fileName, pattern) || MatchesPattern(relativePath, pattern))
+            {
+                return true;
+            }
+        }
+
+        // Check if it's in a common exclude directory
+        var excludeDirs = new[] { "bin", "obj", "node_modules", ".git", ".vs" };
+        foreach (var dir in excludeDirs)
+        {
+            if (relativePath.Contains($"/{dir}/") || relativePath.Contains($"\\{dir}\\"))
+            {
+                return true;
+            }
+        }
+
+        // Check file size
+        try
+        {
+            var fileInfo = new FileInfo(filePath);
+            if (fileInfo.Length > _options.MaxFileSizeBytes)
+            {
+                return true;
+            }
+        }
+        catch
+        {
+            // If we can't check file size, include it
+        }
+
+        return false;
+    }
+
+    private static bool MatchesPattern(string fileName, string pattern)
+    {
+        // Simple wildcard matching
+        if (pattern.StartsWith("*"))
+        {
+            return fileName.EndsWith(pattern[1..], StringComparison.OrdinalIgnoreCase);
+        }
+        if (pattern.EndsWith("*"))
+        {
+            return fileName.StartsWith(pattern[..^1], StringComparison.OrdinalIgnoreCase);
+        }
+        return string.Equals(fileName, pattern, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task<MigrationPlanEntry> AnalyzeFileAsync(string filePath, MigrationDirection direction)
+    {
+        var source = await File.ReadAllTextAsync(filePath);
+        var fileInfo = new FileInfo(filePath);
+
+        var detectedFeatures = new List<string>();
+        var potentialIssues = new List<string>();
+        var estimatedIssues = 0;
+        var convertibility = FileConvertibility.Full;
+        string? skipReason = null;
+
+        try
+        {
+            // Parse the file to detect features
+            var syntaxTree = CSharpSyntaxTree.ParseText(source);
+            var root = syntaxTree.GetCompilationUnitRoot();
+
+            // Check for parse errors
+            var errors = root.GetDiagnostics()
+                .Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .ToList();
+
+            if (errors.Count > 0)
+            {
+                convertibility = FileConvertibility.Skip;
+                skipReason = $"Parse errors: {errors.Count}";
+                estimatedIssues = errors.Count;
+            }
+            else
+            {
+                // Detect features
+                var detector = new FeatureDetector();
+                detector.Visit(root);
+
+                detectedFeatures = detector.DetectedFeatures.ToList();
+
+                // Check for unsupported features
+                foreach (var feature in detectedFeatures)
+                {
+                    var info = FeatureSupport.GetFeatureInfo(feature);
+                    if (info != null)
+                    {
+                        switch (info.Support)
+                        {
+                            case SupportLevel.NotSupported:
+                                potentialIssues.Add($"Unsupported feature: {feature}");
+                                estimatedIssues++;
+                                convertibility = FileConvertibility.Partial;
+                                break;
+                            case SupportLevel.Partial:
+                            case SupportLevel.ManualRequired:
+                                potentialIssues.Add($"Partially supported: {feature}");
+                                if (convertibility == FileConvertibility.Full)
+                                    convertibility = FileConvertibility.Partial;
+                                break;
+                        }
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            convertibility = FileConvertibility.Skip;
+            skipReason = $"Analysis failed: {ex.Message}";
+            estimatedIssues = 1;
+        }
+
+        var outputPath = direction == MigrationDirection.CSharpToOpal
+            ? Path.ChangeExtension(filePath, ".opal")
+            : Path.ChangeExtension(filePath, ".g.cs");
+
+        return new MigrationPlanEntry
+        {
+            SourcePath = filePath,
+            OutputPath = outputPath,
+            Convertibility = convertibility,
+            DetectedFeatures = detectedFeatures,
+            PotentialIssues = potentialIssues,
+            EstimatedIssues = estimatedIssues,
+            FileSizeBytes = fileInfo.Length,
+            SkipReason = skipReason
+        };
+    }
+
+    private Task<MigrationPlanEntry> AnalyzeOpalFileAsync(string filePath)
+    {
+        var fileInfo = new FileInfo(filePath);
+
+        return Task.FromResult(new MigrationPlanEntry
+        {
+            SourcePath = filePath,
+            OutputPath = Path.ChangeExtension(filePath, ".g.cs"),
+            Convertibility = FileConvertibility.Full,
+            FileSizeBytes = fileInfo.Length
+        });
+    }
+}
+
+/// <summary>
+/// Detects C# features used in source code.
+/// </summary>
+internal sealed class FeatureDetector : Microsoft.CodeAnalysis.CSharp.CSharpSyntaxWalker
+{
+    public HashSet<string> DetectedFeatures { get; } = new();
+
+    public override void VisitClassDeclaration(Microsoft.CodeAnalysis.CSharp.Syntax.ClassDeclarationSyntax node)
+    {
+        DetectedFeatures.Add("class");
+        base.VisitClassDeclaration(node);
+    }
+
+    public override void VisitInterfaceDeclaration(Microsoft.CodeAnalysis.CSharp.Syntax.InterfaceDeclarationSyntax node)
+    {
+        DetectedFeatures.Add("interface");
+        base.VisitInterfaceDeclaration(node);
+    }
+
+    public override void VisitRecordDeclaration(Microsoft.CodeAnalysis.CSharp.Syntax.RecordDeclarationSyntax node)
+    {
+        DetectedFeatures.Add("record");
+        base.VisitRecordDeclaration(node);
+    }
+
+    public override void VisitStructDeclaration(Microsoft.CodeAnalysis.CSharp.Syntax.StructDeclarationSyntax node)
+    {
+        DetectedFeatures.Add("struct");
+        base.VisitStructDeclaration(node);
+    }
+
+    public override void VisitMethodDeclaration(Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax node)
+    {
+        DetectedFeatures.Add("method");
+
+        if (node.Modifiers.Any(m => CSharpExtensions.IsKind(m, AsyncKeyword)))
+        {
+            DetectedFeatures.Add("async-await");
+        }
+
+        base.VisitMethodDeclaration(node);
+    }
+
+    public override void VisitPropertyDeclaration(Microsoft.CodeAnalysis.CSharp.Syntax.PropertyDeclarationSyntax node)
+    {
+        DetectedFeatures.Add("property");
+        base.VisitPropertyDeclaration(node);
+    }
+
+    public override void VisitFieldDeclaration(Microsoft.CodeAnalysis.CSharp.Syntax.FieldDeclarationSyntax node)
+    {
+        DetectedFeatures.Add("field");
+        base.VisitFieldDeclaration(node);
+    }
+
+    public override void VisitConstructorDeclaration(Microsoft.CodeAnalysis.CSharp.Syntax.ConstructorDeclarationSyntax node)
+    {
+        DetectedFeatures.Add("constructor");
+        base.VisitConstructorDeclaration(node);
+    }
+
+    public override void VisitIfStatement(Microsoft.CodeAnalysis.CSharp.Syntax.IfStatementSyntax node)
+    {
+        DetectedFeatures.Add("if");
+        base.VisitIfStatement(node);
+    }
+
+    public override void VisitForStatement(Microsoft.CodeAnalysis.CSharp.Syntax.ForStatementSyntax node)
+    {
+        DetectedFeatures.Add("for");
+        base.VisitForStatement(node);
+    }
+
+    public override void VisitForEachStatement(Microsoft.CodeAnalysis.CSharp.Syntax.ForEachStatementSyntax node)
+    {
+        DetectedFeatures.Add("foreach");
+        base.VisitForEachStatement(node);
+    }
+
+    public override void VisitWhileStatement(Microsoft.CodeAnalysis.CSharp.Syntax.WhileStatementSyntax node)
+    {
+        DetectedFeatures.Add("while");
+        base.VisitWhileStatement(node);
+    }
+
+    public override void VisitSwitchStatement(Microsoft.CodeAnalysis.CSharp.Syntax.SwitchStatementSyntax node)
+    {
+        DetectedFeatures.Add("switch");
+        base.VisitSwitchStatement(node);
+    }
+
+    public override void VisitTryStatement(Microsoft.CodeAnalysis.CSharp.Syntax.TryStatementSyntax node)
+    {
+        DetectedFeatures.Add("try-catch");
+        base.VisitTryStatement(node);
+    }
+
+    public override void VisitSimpleLambdaExpression(Microsoft.CodeAnalysis.CSharp.Syntax.SimpleLambdaExpressionSyntax node)
+    {
+        DetectedFeatures.Add("lambda");
+        base.VisitSimpleLambdaExpression(node);
+    }
+
+    public override void VisitParenthesizedLambdaExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ParenthesizedLambdaExpressionSyntax node)
+    {
+        DetectedFeatures.Add("lambda");
+        base.VisitParenthesizedLambdaExpression(node);
+    }
+
+    public override void VisitAwaitExpression(Microsoft.CodeAnalysis.CSharp.Syntax.AwaitExpressionSyntax node)
+    {
+        DetectedFeatures.Add("async-await");
+        base.VisitAwaitExpression(node);
+    }
+
+    public override void VisitGenericName(Microsoft.CodeAnalysis.CSharp.Syntax.GenericNameSyntax node)
+    {
+        DetectedFeatures.Add("generics");
+        base.VisitGenericName(node);
+    }
+
+    public override void VisitInterpolatedStringExpression(Microsoft.CodeAnalysis.CSharp.Syntax.InterpolatedStringExpressionSyntax node)
+    {
+        DetectedFeatures.Add("string-interpolation");
+        base.VisitInterpolatedStringExpression(node);
+    }
+
+    public override void VisitBinaryExpression(Microsoft.CodeAnalysis.CSharp.Syntax.BinaryExpressionSyntax node)
+    {
+        if (CSharpExtensions.IsKind(node, CoalesceExpression))
+        {
+            DetectedFeatures.Add("null-coalescing");
+        }
+        base.VisitBinaryExpression(node);
+    }
+
+    public override void VisitConditionalAccessExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ConditionalAccessExpressionSyntax node)
+    {
+        DetectedFeatures.Add("null-conditional");
+        base.VisitConditionalAccessExpression(node);
+    }
+
+    public override void VisitQueryExpression(Microsoft.CodeAnalysis.CSharp.Syntax.QueryExpressionSyntax node)
+    {
+        DetectedFeatures.Add("linq-query");
+        base.VisitQueryExpression(node);
+    }
+
+    public override void VisitGotoStatement(Microsoft.CodeAnalysis.CSharp.Syntax.GotoStatementSyntax node)
+    {
+        DetectedFeatures.Add("goto");
+        base.VisitGotoStatement(node);
+    }
+
+    public override void VisitLabeledStatement(Microsoft.CodeAnalysis.CSharp.Syntax.LabeledStatementSyntax node)
+    {
+        DetectedFeatures.Add("labeled-statement");
+        base.VisitLabeledStatement(node);
+    }
+
+    public override void VisitUnsafeStatement(Microsoft.CodeAnalysis.CSharp.Syntax.UnsafeStatementSyntax node)
+    {
+        DetectedFeatures.Add("unsafe");
+        base.VisitUnsafeStatement(node);
+    }
+
+    public override void VisitPointerType(Microsoft.CodeAnalysis.CSharp.Syntax.PointerTypeSyntax node)
+    {
+        DetectedFeatures.Add("pointer");
+        base.VisitPointerType(node);
+    }
+
+    public override void VisitStackAllocArrayCreationExpression(Microsoft.CodeAnalysis.CSharp.Syntax.StackAllocArrayCreationExpressionSyntax node)
+    {
+        DetectedFeatures.Add("stackalloc");
+        base.VisitStackAllocArrayCreationExpression(node);
+    }
+
+    public override void VisitFixedStatement(Microsoft.CodeAnalysis.CSharp.Syntax.FixedStatementSyntax node)
+    {
+        DetectedFeatures.Add("fixed");
+        base.VisitFixedStatement(node);
+    }
+
+    public override void VisitParameter(Microsoft.CodeAnalysis.CSharp.Syntax.ParameterSyntax node)
+    {
+        if (node.Modifiers.Any(m => CSharpExtensions.IsKind(m, RefKeyword)))
+        {
+            DetectedFeatures.Add("ref-parameter");
+        }
+        if (node.Modifiers.Any(m => CSharpExtensions.IsKind(m, OutKeyword)))
+        {
+            DetectedFeatures.Add("out-parameter");
+        }
+        base.VisitParameter(node);
+    }
+
+    public override void VisitConversionOperatorDeclaration(Microsoft.CodeAnalysis.CSharp.Syntax.ConversionOperatorDeclarationSyntax node)
+    {
+        if (CSharpExtensions.IsKind(node.ImplicitOrExplicitKeyword, ImplicitKeyword))
+        {
+            DetectedFeatures.Add("implicit-conversion");
+        }
+        else
+        {
+            DetectedFeatures.Add("explicit-conversion");
+        }
+        base.VisitConversionOperatorDeclaration(node);
+    }
+
+    public override void VisitOperatorDeclaration(Microsoft.CodeAnalysis.CSharp.Syntax.OperatorDeclarationSyntax node)
+    {
+        DetectedFeatures.Add("operator-overload");
+        base.VisitOperatorDeclaration(node);
+    }
+}

--- a/src/Opal.Compiler/Migration/Project/ProjectMigrator.cs
+++ b/src/Opal.Compiler/Migration/Project/ProjectMigrator.cs
@@ -1,0 +1,276 @@
+namespace Opal.Compiler.Migration.Project;
+
+/// <summary>
+/// Orchestrates project-level migration.
+/// </summary>
+public sealed class ProjectMigrator
+{
+    private readonly MigrationPlanOptions _options;
+
+    public ProjectMigrator(MigrationPlanOptions? options = null)
+    {
+        _options = options ?? new MigrationPlanOptions();
+    }
+
+    /// <summary>
+    /// Creates a migration plan for a project.
+    /// </summary>
+    public async Task<MigrationPlan> CreatePlanAsync(string projectPath, MigrationDirection direction)
+    {
+        var discovery = new ProjectDiscovery(_options);
+
+        return direction == MigrationDirection.CSharpToOpal
+            ? await discovery.DiscoverCSharpFilesAsync(projectPath, direction)
+            : await discovery.DiscoverOpalFilesAsync(projectPath);
+    }
+
+    /// <summary>
+    /// Executes a migration plan.
+    /// </summary>
+    public async Task<MigrationReport> ExecuteAsync(MigrationPlan plan, bool dryRun = false, IProgress<MigrationProgress>? progress = null)
+    {
+        var reportBuilder = new MigrationReportBuilder()
+            .SetDirection(plan.Direction)
+            .IncludeBenchmark(_options.IncludeBenchmark);
+
+        var entriesToProcess = plan.Entries
+            .Where(e => e.Convertibility != FileConvertibility.Skip)
+            .ToList();
+
+        var processedCount = 0;
+        var totalCount = entriesToProcess.Count;
+
+        if (_options.Parallel && !dryRun)
+        {
+            var semaphore = new SemaphoreSlim(_options.MaxParallelism);
+            var tasks = entriesToProcess.Select(async entry =>
+            {
+                await semaphore.WaitAsync();
+                try
+                {
+                    var result = await ProcessEntryAsync(entry, plan.Direction, dryRun);
+                    reportBuilder.AddFileResult(result);
+
+                    Interlocked.Increment(ref processedCount);
+                    progress?.Report(new MigrationProgress
+                    {
+                        CurrentFile = Path.GetFileName(entry.SourcePath),
+                        ProcessedFiles = processedCount,
+                        TotalFiles = totalCount,
+                        Status = result.Status
+                    });
+
+                    return result;
+                }
+                finally
+                {
+                    semaphore.Release();
+                }
+            });
+
+            await Task.WhenAll(tasks);
+        }
+        else
+        {
+            foreach (var entry in entriesToProcess)
+            {
+                var result = await ProcessEntryAsync(entry, plan.Direction, dryRun);
+                reportBuilder.AddFileResult(result);
+
+                processedCount++;
+                progress?.Report(new MigrationProgress
+                {
+                    CurrentFile = Path.GetFileName(entry.SourcePath),
+                    ProcessedFiles = processedCount,
+                    TotalFiles = totalCount,
+                    Status = result.Status
+                });
+            }
+        }
+
+        // Add skipped files
+        foreach (var entry in plan.Entries.Where(e => e.Convertibility == FileConvertibility.Skip))
+        {
+            reportBuilder.AddFileResult(new FileMigrationResult
+            {
+                SourcePath = entry.SourcePath,
+                OutputPath = null,
+                Status = FileMigrationStatus.Skipped,
+                Issues = entry.SkipReason != null
+                    ? new List<ConversionIssue>
+                    {
+                        new() { Severity = ConversionIssueSeverity.Info, Message = entry.SkipReason }
+                    }
+                    : new List<ConversionIssue>()
+            });
+        }
+
+        // Add recommendations based on results
+        AddRecommendations(reportBuilder, plan);
+
+        return reportBuilder.Build();
+    }
+
+    /// <summary>
+    /// Performs a dry run showing what would be migrated.
+    /// </summary>
+    public async Task<MigrationReport> DryRunAsync(MigrationPlan plan)
+    {
+        return await ExecuteAsync(plan, dryRun: true);
+    }
+
+    private async Task<FileMigrationResult> ProcessEntryAsync(MigrationPlanEntry entry, MigrationDirection direction, bool dryRun)
+    {
+        var startTime = DateTime.UtcNow;
+
+        try
+        {
+            if (direction == MigrationDirection.CSharpToOpal)
+            {
+                return await ProcessCSharpToOpalAsync(entry, dryRun, startTime);
+            }
+            else
+            {
+                return await ProcessOpalToCSharpAsync(entry, dryRun, startTime);
+            }
+        }
+        catch (Exception ex)
+        {
+            return new FileMigrationResult
+            {
+                SourcePath = entry.SourcePath,
+                OutputPath = null,
+                Status = FileMigrationStatus.Failed,
+                Duration = DateTime.UtcNow - startTime,
+                Issues = new List<ConversionIssue>
+                {
+                    new() { Severity = ConversionIssueSeverity.Error, Message = ex.Message }
+                }
+            };
+        }
+    }
+
+    private async Task<FileMigrationResult> ProcessCSharpToOpalAsync(MigrationPlanEntry entry, bool dryRun, DateTime startTime)
+    {
+        var converter = new CSharpToOpalConverter(new ConversionOptions
+        {
+            IncludeBenchmark = _options.IncludeBenchmark
+        });
+
+        var result = await converter.ConvertFileAsync(entry.SourcePath);
+
+        FileMetrics? metrics = null;
+        if (result.Success && result.OpalSource != null && _options.IncludeBenchmark)
+        {
+            var originalSource = await File.ReadAllTextAsync(entry.SourcePath);
+            metrics = BenchmarkIntegration.CalculateMetrics(originalSource, result.OpalSource);
+        }
+
+        if (!dryRun && result.Success && result.OpalSource != null)
+        {
+            await File.WriteAllTextAsync(entry.OutputPath, result.OpalSource);
+        }
+
+        var status = result.Success
+            ? (result.Context.HasWarnings ? FileMigrationStatus.Partial : FileMigrationStatus.Success)
+            : FileMigrationStatus.Failed;
+
+        return new FileMigrationResult
+        {
+            SourcePath = entry.SourcePath,
+            OutputPath = result.Success ? entry.OutputPath : null,
+            Status = status,
+            Duration = DateTime.UtcNow - startTime,
+            Issues = result.Issues.ToList(),
+            Metrics = metrics
+        };
+    }
+
+    private async Task<FileMigrationResult> ProcessOpalToCSharpAsync(MigrationPlanEntry entry, bool dryRun, DateTime startTime)
+    {
+        var source = await File.ReadAllTextAsync(entry.SourcePath);
+        var result = Program.Compile(source, entry.SourcePath);
+
+        FileMetrics? metrics = null;
+        if (!result.HasErrors && _options.IncludeBenchmark)
+        {
+            metrics = BenchmarkIntegration.CalculateMetrics(source, result.GeneratedCode);
+        }
+
+        if (!dryRun && !result.HasErrors)
+        {
+            await File.WriteAllTextAsync(entry.OutputPath, result.GeneratedCode);
+        }
+
+        var status = result.HasErrors
+            ? FileMigrationStatus.Failed
+            : FileMigrationStatus.Success;
+
+        var issues = result.Diagnostics.Errors
+            .Select(d => new ConversionIssue
+            {
+                Severity = ConversionIssueSeverity.Error,
+                Message = d.Message,
+                Line = d.Span.Line,
+                Column = d.Span.Column
+            })
+            .ToList();
+
+        return new FileMigrationResult
+        {
+            SourcePath = entry.SourcePath,
+            OutputPath = result.HasErrors ? null : entry.OutputPath,
+            Status = status,
+            Duration = DateTime.UtcNow - startTime,
+            Issues = issues,
+            Metrics = metrics
+        };
+    }
+
+    private void AddRecommendations(MigrationReportBuilder builder, MigrationPlan plan)
+    {
+        var unsupportedFeatures = plan.Entries
+            .SelectMany(e => e.DetectedFeatures)
+            .Where(f => !FeatureSupport.IsFullySupported(f))
+            .Distinct()
+            .ToList();
+
+        if (unsupportedFeatures.Contains("goto") || unsupportedFeatures.Contains("labeled-statement"))
+        {
+            builder.AddRecommendation("Refactor goto statements to use structured control flow (if/while/for)");
+        }
+
+        if (unsupportedFeatures.Contains("unsafe") || unsupportedFeatures.Contains("pointer"))
+        {
+            builder.AddRecommendation("Move unsafe code to a separate C# interop module");
+        }
+
+        if (unsupportedFeatures.Contains("linq-query"))
+        {
+            builder.AddRecommendation("Review LINQ query syntax conversions for correctness");
+        }
+
+        if (unsupportedFeatures.Contains("ref-parameter") || unsupportedFeatures.Contains("out-parameter"))
+        {
+            builder.AddRecommendation("Consider refactoring ref/out parameters to return tuples or Result types");
+        }
+
+        if (plan.PartialFiles > plan.TotalFiles * 0.3)
+        {
+            builder.AddRecommendation("Many files have partial conversions - consider breaking into smaller migration phases");
+        }
+    }
+}
+
+/// <summary>
+/// Progress information for migration.
+/// </summary>
+public sealed class MigrationProgress
+{
+    public required string CurrentFile { get; init; }
+    public required int ProcessedFiles { get; init; }
+    public required int TotalFiles { get; init; }
+    public required FileMigrationStatus Status { get; init; }
+
+    public double PercentComplete => TotalFiles > 0 ? (double)ProcessedFiles / TotalFiles * 100 : 0;
+}

--- a/src/Opal.Compiler/Migration/RoslynSyntaxVisitor.cs
+++ b/src/Opal.Compiler/Migration/RoslynSyntaxVisitor.cs
@@ -1,0 +1,1332 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Opal.Compiler.Ast;
+using Opal.Compiler.Parsing;
+
+namespace Opal.Compiler.Migration;
+
+/// <summary>
+/// Roslyn syntax visitor that builds OPAL AST nodes from C# syntax.
+/// </summary>
+public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
+{
+    private readonly ConversionContext _context;
+    private readonly List<UsingDirectiveNode> _usings = new();
+    private readonly List<InterfaceDefinitionNode> _interfaces = new();
+    private readonly List<ClassDefinitionNode> _classes = new();
+    private readonly List<FunctionNode> _functions = new();
+
+    public RoslynSyntaxVisitor(ConversionContext context) : base(SyntaxWalkerDepth.Node)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    /// <summary>
+    /// Converts a C# compilation unit to an OPAL ModuleNode.
+    /// </summary>
+    public ModuleNode Convert(CompilationUnitSyntax root, string moduleName)
+    {
+        _usings.Clear();
+        _interfaces.Clear();
+        _classes.Clear();
+        _functions.Clear();
+
+        // Visit all nodes
+        Visit(root);
+
+        var moduleId = _context.GenerateId("m");
+
+        return new ModuleNode(
+            GetTextSpan(root),
+            moduleId,
+            moduleName,
+            _usings,
+            _interfaces,
+            _classes,
+            _functions,
+            new AttributeCollection());
+    }
+
+    public override void VisitUsingDirective(UsingDirectiveSyntax node)
+    {
+        if (node.Name != null)
+        {
+            var namespaceName = node.Name.ToString();
+            var isStatic = node.StaticKeyword.IsKind(SyntaxKind.StaticKeyword);
+            var alias = node.Alias?.Name.ToString();
+
+            _usings.Add(new UsingDirectiveNode(
+                GetTextSpan(node),
+                namespaceName,
+                alias,
+                isStatic));
+        }
+
+        base.VisitUsingDirective(node);
+    }
+
+    public override void VisitNamespaceDeclaration(NamespaceDeclarationSyntax node)
+    {
+        _context.EnterNamespace(node.Name.ToString());
+        base.VisitNamespaceDeclaration(node);
+        _context.ExitNamespace();
+    }
+
+    public override void VisitFileScopedNamespaceDeclaration(FileScopedNamespaceDeclarationSyntax node)
+    {
+        _context.EnterNamespace(node.Name.ToString());
+        base.VisitFileScopedNamespaceDeclaration(node);
+        _context.ExitNamespace();
+    }
+
+    public override void VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
+    {
+        _context.RecordFeatureUsage("interface");
+        _context.EnterType(node.Identifier.Text);
+
+        var id = _context.GenerateId("i");
+        var name = node.Identifier.Text;
+        var baseInterfaces = node.BaseList?.Types
+            .Select(t => t.Type.ToString())
+            .ToList() ?? new List<string>();
+
+        var methods = new List<MethodSignatureNode>();
+        foreach (var member in node.Members)
+        {
+            if (member is MethodDeclarationSyntax methodSyntax)
+            {
+                methods.Add(ConvertMethodSignature(methodSyntax));
+            }
+        }
+
+        var interfaceNode = new InterfaceDefinitionNode(
+            GetTextSpan(node),
+            id,
+            name,
+            baseInterfaces,
+            methods,
+            new AttributeCollection());
+
+        _interfaces.Add(interfaceNode);
+        _context.Stats.InterfacesConverted++;
+        _context.IncrementConverted();
+        _context.ExitType();
+    }
+
+    public override void VisitClassDeclaration(ClassDeclarationSyntax node)
+    {
+        _context.RecordFeatureUsage("class");
+        _context.EnterType(node.Identifier.Text);
+
+        var classNode = ConvertClass(node);
+        _classes.Add(classNode);
+        _context.Stats.ClassesConverted++;
+        _context.IncrementConverted();
+        _context.ExitType();
+    }
+
+    public override void VisitRecordDeclaration(RecordDeclarationSyntax node)
+    {
+        _context.RecordFeatureUsage("record");
+        _context.EnterType(node.Identifier.Text);
+
+        // Treat records as classes for conversion
+        var classNode = ConvertRecord(node);
+        _classes.Add(classNode);
+        _context.Stats.ClassesConverted++;
+        _context.IncrementConverted();
+        _context.ExitType();
+    }
+
+    public override void VisitStructDeclaration(StructDeclarationSyntax node)
+    {
+        _context.RecordFeatureUsage("struct");
+        _context.EnterType(node.Identifier.Text);
+
+        // Treat structs as classes for conversion
+        var classNode = ConvertStruct(node);
+        _classes.Add(classNode);
+        _context.Stats.ClassesConverted++;
+        _context.IncrementConverted();
+        _context.ExitType();
+    }
+
+    private ClassDefinitionNode ConvertClass(ClassDeclarationSyntax node)
+    {
+        var id = _context.GenerateId("c");
+        var name = node.Identifier.Text;
+        var isAbstract = node.Modifiers.Any(SyntaxKind.AbstractKeyword);
+        var isSealed = node.Modifiers.Any(SyntaxKind.SealedKeyword);
+
+        string? baseClass = null;
+        var interfaces = new List<string>();
+
+        if (node.BaseList != null)
+        {
+            foreach (var baseType in node.BaseList.Types)
+            {
+                var typeName = baseType.Type.ToString();
+                // First non-interface base type is the base class
+                if (baseClass == null && !typeName.StartsWith("I") || !char.IsUpper(typeName.ElementAtOrDefault(1)))
+                {
+                    // Simple heuristic: interfaces typically start with 'I'
+                    if (typeName.StartsWith("I") && typeName.Length > 1 && char.IsUpper(typeName[1]))
+                    {
+                        interfaces.Add(typeName);
+                    }
+                    else
+                    {
+                        baseClass = typeName;
+                    }
+                }
+                else
+                {
+                    interfaces.Add(typeName);
+                }
+            }
+        }
+
+        var typeParameters = ConvertTypeParameters(node.TypeParameterList);
+        var fields = new List<ClassFieldNode>();
+        var properties = new List<PropertyNode>();
+        var constructors = new List<ConstructorNode>();
+        var methods = new List<MethodNode>();
+
+        foreach (var member in node.Members)
+        {
+            switch (member)
+            {
+                case FieldDeclarationSyntax fieldSyntax:
+                    fields.AddRange(ConvertFields(fieldSyntax));
+                    break;
+                case PropertyDeclarationSyntax propertySyntax:
+                    properties.Add(ConvertProperty(propertySyntax));
+                    break;
+                case ConstructorDeclarationSyntax ctorSyntax:
+                    constructors.Add(ConvertConstructor(ctorSyntax));
+                    break;
+                case MethodDeclarationSyntax methodSyntax:
+                    methods.Add(ConvertMethod(methodSyntax));
+                    break;
+            }
+        }
+
+        return new ClassDefinitionNode(
+            GetTextSpan(node),
+            id,
+            name,
+            isAbstract,
+            isSealed,
+            baseClass,
+            interfaces,
+            typeParameters,
+            fields,
+            properties,
+            constructors,
+            methods,
+            new AttributeCollection());
+    }
+
+    private ClassDefinitionNode ConvertRecord(RecordDeclarationSyntax node)
+    {
+        var id = _context.GenerateId("r");
+        var name = node.Identifier.Text;
+
+        var typeParameters = ConvertTypeParameters(node.TypeParameterList);
+        var fields = new List<ClassFieldNode>();
+        var properties = new List<PropertyNode>();
+        var constructors = new List<ConstructorNode>();
+        var methods = new List<MethodNode>();
+
+        // Convert primary constructor parameters to properties
+        if (node.ParameterList != null)
+        {
+            foreach (var param in node.ParameterList.Parameters)
+            {
+                var propId = _context.GenerateId("p");
+                var propName = param.Identifier.Text;
+                var typeName = TypeMapper.CSharpToOpal(param.Type?.ToString() ?? "any");
+
+                properties.Add(new PropertyNode(
+                    GetTextSpan(param),
+                    propId,
+                    propName,
+                    typeName,
+                    Visibility.Public,
+                    getter: null,
+                    setter: null,
+                    initer: null,
+                    defaultValue: param.Default != null ? ConvertExpression(param.Default.Value) : null,
+                    new AttributeCollection()));
+            }
+        }
+
+        foreach (var member in node.Members)
+        {
+            switch (member)
+            {
+                case FieldDeclarationSyntax fieldSyntax:
+                    fields.AddRange(ConvertFields(fieldSyntax));
+                    break;
+                case PropertyDeclarationSyntax propertySyntax:
+                    properties.Add(ConvertProperty(propertySyntax));
+                    break;
+                case ConstructorDeclarationSyntax ctorSyntax:
+                    constructors.Add(ConvertConstructor(ctorSyntax));
+                    break;
+                case MethodDeclarationSyntax methodSyntax:
+                    methods.Add(ConvertMethod(methodSyntax));
+                    break;
+            }
+        }
+
+        return new ClassDefinitionNode(
+            GetTextSpan(node),
+            id,
+            name,
+            isAbstract: false,
+            isSealed: true,
+            baseClass: null,
+            implementedInterfaces: new List<string>(),
+            typeParameters,
+            fields,
+            properties,
+            constructors,
+            methods,
+            new AttributeCollection());
+    }
+
+    private ClassDefinitionNode ConvertStruct(StructDeclarationSyntax node)
+    {
+        var id = _context.GenerateId("s");
+        var name = node.Identifier.Text;
+
+        var typeParameters = ConvertTypeParameters(node.TypeParameterList);
+        var fields = new List<ClassFieldNode>();
+        var properties = new List<PropertyNode>();
+        var constructors = new List<ConstructorNode>();
+        var methods = new List<MethodNode>();
+
+        foreach (var member in node.Members)
+        {
+            switch (member)
+            {
+                case FieldDeclarationSyntax fieldSyntax:
+                    fields.AddRange(ConvertFields(fieldSyntax));
+                    break;
+                case PropertyDeclarationSyntax propertySyntax:
+                    properties.Add(ConvertProperty(propertySyntax));
+                    break;
+                case ConstructorDeclarationSyntax ctorSyntax:
+                    constructors.Add(ConvertConstructor(ctorSyntax));
+                    break;
+                case MethodDeclarationSyntax methodSyntax:
+                    methods.Add(ConvertMethod(methodSyntax));
+                    break;
+            }
+        }
+
+        var interfaces = node.BaseList?.Types
+            .Select(t => t.Type.ToString())
+            .ToList() ?? new List<string>();
+
+        return new ClassDefinitionNode(
+            GetTextSpan(node),
+            id,
+            name,
+            isAbstract: false,
+            isSealed: true,
+            baseClass: null,
+            interfaces,
+            typeParameters,
+            fields,
+            properties,
+            constructors,
+            methods,
+            new AttributeCollection());
+    }
+
+    private MethodSignatureNode ConvertMethodSignature(MethodDeclarationSyntax node)
+    {
+        var id = _context.GenerateId("m");
+        var name = node.Identifier.Text;
+        var typeParameters = ConvertTypeParameters(node.TypeParameterList);
+        var parameters = ConvertParameters(node.ParameterList);
+        var returnType = TypeMapper.CSharpToOpal(node.ReturnType.ToString());
+        var output = returnType != "void" ? new OutputNode(GetTextSpan(node.ReturnType), returnType) : null;
+
+        return new MethodSignatureNode(
+            GetTextSpan(node),
+            id,
+            name,
+            typeParameters,
+            parameters,
+            output,
+            effects: null,
+            new AttributeCollection());
+    }
+
+    private MethodNode ConvertMethod(MethodDeclarationSyntax node)
+    {
+        _context.RecordFeatureUsage("method");
+        _context.EnterMethod(node.Identifier.Text);
+
+        var id = _context.GenerateId("m");
+        var name = node.Identifier.Text;
+        var visibility = GetVisibility(node.Modifiers);
+        var modifiers = GetMethodModifiers(node.Modifiers);
+        var typeParameters = ConvertTypeParameters(node.TypeParameterList);
+        var parameters = ConvertParameters(node.ParameterList);
+        var returnType = TypeMapper.CSharpToOpal(node.ReturnType.ToString());
+        var output = returnType != "void" ? new OutputNode(GetTextSpan(node.ReturnType), returnType) : null;
+        var body = ConvertMethodBody(node.Body, node.ExpressionBody);
+
+        _context.Stats.MethodsConverted++;
+        _context.IncrementConverted();
+        _context.ExitMethod();
+
+        return new MethodNode(
+            GetTextSpan(node),
+            id,
+            name,
+            visibility,
+            modifiers,
+            typeParameters,
+            parameters,
+            output,
+            effects: null,
+            preconditions: Array.Empty<RequiresNode>(),
+            postconditions: Array.Empty<EnsuresNode>(),
+            body,
+            new AttributeCollection());
+    }
+
+    private ConstructorNode ConvertConstructor(ConstructorDeclarationSyntax node)
+    {
+        _context.RecordFeatureUsage("constructor");
+
+        var id = _context.GenerateId("ctor");
+        var visibility = GetVisibility(node.Modifiers);
+        var parameters = ConvertParameters(node.ParameterList);
+        var body = node.Body != null ? ConvertBlock(node.Body) : new List<StatementNode>();
+
+        ConstructorInitializerNode? initializer = null;
+        if (node.Initializer != null)
+        {
+            var isBase = node.Initializer.ThisOrBaseKeyword.IsKind(SyntaxKind.BaseKeyword);
+            var args = node.Initializer.ArgumentList.Arguments
+                .Select(a => ConvertExpression(a.Expression))
+                .ToList();
+
+            initializer = new ConstructorInitializerNode(
+                GetTextSpan(node.Initializer),
+                isBase,
+                args);
+        }
+
+        _context.IncrementConverted();
+
+        return new ConstructorNode(
+            GetTextSpan(node),
+            id,
+            visibility,
+            parameters,
+            preconditions: Array.Empty<RequiresNode>(),
+            initializer,
+            body,
+            new AttributeCollection());
+    }
+
+    private IReadOnlyList<ClassFieldNode> ConvertFields(FieldDeclarationSyntax node)
+    {
+        _context.RecordFeatureUsage("field");
+
+        var fields = new List<ClassFieldNode>();
+        var visibility = GetVisibility(node.Modifiers);
+        var typeName = TypeMapper.CSharpToOpal(node.Declaration.Type.ToString());
+
+        foreach (var variable in node.Declaration.Variables)
+        {
+            var defaultValue = variable.Initializer != null
+                ? ConvertExpression(variable.Initializer.Value)
+                : null;
+
+            fields.Add(new ClassFieldNode(
+                GetTextSpan(variable),
+                variable.Identifier.Text,
+                typeName,
+                visibility,
+                defaultValue,
+                new AttributeCollection()));
+
+            _context.Stats.FieldsConverted++;
+            _context.IncrementConverted();
+        }
+
+        return fields;
+    }
+
+    private PropertyNode ConvertProperty(PropertyDeclarationSyntax node)
+    {
+        _context.RecordFeatureUsage("property");
+
+        var name = node.Identifier.Text;
+        var typeName = TypeMapper.CSharpToOpal(node.Type.ToString());
+        var visibility = GetVisibility(node.Modifiers);
+
+        PropertyAccessorNode? getter = null;
+        PropertyAccessorNode? setter = null;
+        PropertyAccessorNode? initer = null;
+
+        var isAutoProperty = node.AccessorList != null &&
+            node.AccessorList.Accessors.All(a => a.Body == null && a.ExpressionBody == null);
+
+        if (node.AccessorList != null)
+        {
+            foreach (var accessor in node.AccessorList.Accessors)
+            {
+                var accessorVisibility = accessor.Modifiers.Any()
+                    ? GetVisibility(accessor.Modifiers)
+                    : visibility;
+
+                if (accessor.Keyword.IsKind(SyntaxKind.GetKeyword))
+                {
+                    getter = new PropertyAccessorNode(
+                        GetTextSpan(accessor),
+                        PropertyAccessorNode.AccessorKind.Get,
+                        accessorVisibility,
+                        preconditions: Array.Empty<RequiresNode>(),
+                        body: ConvertAccessorBody(accessor),
+                        new AttributeCollection());
+                }
+                else if (accessor.Keyword.IsKind(SyntaxKind.SetKeyword))
+                {
+                    setter = new PropertyAccessorNode(
+                        GetTextSpan(accessor),
+                        PropertyAccessorNode.AccessorKind.Set,
+                        accessorVisibility,
+                        preconditions: Array.Empty<RequiresNode>(),
+                        body: ConvertAccessorBody(accessor),
+                        new AttributeCollection());
+                }
+                else if (accessor.Keyword.IsKind(SyntaxKind.InitKeyword))
+                {
+                    initer = new PropertyAccessorNode(
+                        GetTextSpan(accessor),
+                        PropertyAccessorNode.AccessorKind.Init,
+                        accessorVisibility,
+                        preconditions: Array.Empty<RequiresNode>(),
+                        body: ConvertAccessorBody(accessor),
+                        new AttributeCollection());
+                }
+            }
+        }
+        else if (node.ExpressionBody != null)
+        {
+            // Expression-bodied property (getter only)
+            getter = new PropertyAccessorNode(
+                GetTextSpan(node),
+                PropertyAccessorNode.AccessorKind.Get,
+                visibility,
+                preconditions: Array.Empty<RequiresNode>(),
+                body: new List<StatementNode>
+                {
+                    new ReturnStatementNode(
+                        GetTextSpan(node.ExpressionBody),
+                        ConvertExpression(node.ExpressionBody.Expression))
+                },
+                new AttributeCollection());
+        }
+
+        var defaultValue = node.Initializer != null
+            ? ConvertExpression(node.Initializer.Value)
+            : null;
+
+        _context.Stats.PropertiesConverted++;
+        _context.IncrementConverted();
+
+        var propId = _context.GenerateId("p");
+        return new PropertyNode(
+            GetTextSpan(node),
+            propId,
+            name,
+            typeName,
+            visibility,
+            getter,
+            setter,
+            initer,
+            defaultValue,
+            new AttributeCollection());
+    }
+
+    private IReadOnlyList<StatementNode> ConvertAccessorBody(AccessorDeclarationSyntax accessor)
+    {
+        if (accessor.Body != null)
+        {
+            return ConvertBlock(accessor.Body);
+        }
+        else if (accessor.ExpressionBody != null)
+        {
+            return new List<StatementNode>
+            {
+                new ReturnStatementNode(
+                    GetTextSpan(accessor.ExpressionBody),
+                    ConvertExpression(accessor.ExpressionBody.Expression))
+            };
+        }
+        return Array.Empty<StatementNode>();
+    }
+
+    private IReadOnlyList<StatementNode> ConvertMethodBody(BlockSyntax? body, ArrowExpressionClauseSyntax? expressionBody)
+    {
+        if (body != null)
+        {
+            return ConvertBlock(body);
+        }
+        else if (expressionBody != null)
+        {
+            return new List<StatementNode>
+            {
+                new ReturnStatementNode(
+                    GetTextSpan(expressionBody),
+                    ConvertExpression(expressionBody.Expression))
+            };
+        }
+        return Array.Empty<StatementNode>();
+    }
+
+    private IReadOnlyList<StatementNode> ConvertBlock(BlockSyntax block)
+    {
+        var statements = new List<StatementNode>();
+
+        foreach (var statement in block.Statements)
+        {
+            var converted = ConvertStatement(statement);
+            if (converted != null)
+            {
+                statements.Add(converted);
+            }
+        }
+
+        return statements;
+    }
+
+    private StatementNode? ConvertStatement(StatementSyntax statement)
+    {
+        _context.Stats.StatementsConverted++;
+
+        return statement switch
+        {
+            ReturnStatementSyntax returnStmt => ConvertReturnStatement(returnStmt),
+            ExpressionStatementSyntax exprStmt => ConvertExpressionStatement(exprStmt),
+            LocalDeclarationStatementSyntax localDecl => ConvertLocalDeclaration(localDecl),
+            IfStatementSyntax ifStmt => ConvertIfStatement(ifStmt),
+            ForStatementSyntax forStmt => ConvertForStatement(forStmt),
+            ForEachStatementSyntax forEachStmt => ConvertForEachStatement(forEachStmt),
+            WhileStatementSyntax whileStmt => ConvertWhileStatement(whileStmt),
+            TryStatementSyntax tryStmt => ConvertTryStatement(tryStmt),
+            ThrowStatementSyntax throwStmt => ConvertThrowStatement(throwStmt),
+            BlockSyntax blockStmt => ConvertBlockAsStatement(blockStmt),
+            SwitchStatementSyntax switchStmt => ConvertSwitchStatement(switchStmt),
+            BreakStatementSyntax => null, // Break is handled within loops
+            ContinueStatementSyntax => null, // Continue is handled within loops
+            _ => HandleUnsupportedStatement(statement)
+        };
+    }
+
+    private StatementNode? HandleUnsupportedStatement(StatementSyntax statement)
+    {
+        var lineSpan = statement.GetLocation().GetLineSpan();
+        _context.AddWarning(
+            $"Unsupported statement type: {statement.Kind()}",
+            line: lineSpan.StartLinePosition.Line + 1,
+            column: lineSpan.StartLinePosition.Character + 1);
+        _context.IncrementSkipped();
+        return null;
+    }
+
+    private ReturnStatementNode ConvertReturnStatement(ReturnStatementSyntax node)
+    {
+        var expr = node.Expression != null ? ConvertExpression(node.Expression) : null;
+        _context.IncrementConverted();
+        return new ReturnStatementNode(GetTextSpan(node), expr);
+    }
+
+    private StatementNode ConvertExpressionStatement(ExpressionStatementSyntax node)
+    {
+        var expr = node.Expression;
+        _context.IncrementConverted();
+
+        // Handle assignment expressions
+        if (expr is AssignmentExpressionSyntax assignment)
+        {
+            return new AssignmentStatementNode(
+                GetTextSpan(node),
+                ConvertExpression(assignment.Left),
+                ConvertExpression(assignment.Right));
+        }
+
+        // Handle invocation expressions (method calls)
+        if (expr is InvocationExpressionSyntax invocation)
+        {
+            var target = invocation.Expression.ToString();
+            var args = invocation.ArgumentList.Arguments
+                .Select(a => ConvertExpression(a.Expression))
+                .ToList();
+
+            // Check for Console.WriteLine as special case
+            if (target == "Console.WriteLine" || target == "System.Console.WriteLine")
+            {
+                if (args.Count == 1)
+                {
+                    return new PrintStatementNode(GetTextSpan(node), args[0], isWriteLine: true);
+                }
+            }
+            else if (target == "Console.Write" || target == "System.Console.Write")
+            {
+                if (args.Count == 1)
+                {
+                    return new PrintStatementNode(GetTextSpan(node), args[0], isWriteLine: false);
+                }
+            }
+
+            return new CallStatementNode(
+                GetTextSpan(node),
+                target,
+                fallible: false,
+                args,
+                new AttributeCollection());
+        }
+
+        // Default: wrap as call statement
+        return new CallStatementNode(
+            GetTextSpan(node),
+            expr.ToString(),
+            fallible: false,
+            Array.Empty<ExpressionNode>(),
+            new AttributeCollection());
+    }
+
+    private BindStatementNode ConvertLocalDeclaration(LocalDeclarationStatementSyntax node)
+    {
+        _context.IncrementConverted();
+
+        var variable = node.Declaration.Variables.First();
+        var name = variable.Identifier.Text;
+        var typeName = node.Declaration.Type.IsVar
+            ? null
+            : TypeMapper.CSharpToOpal(node.Declaration.Type.ToString());
+        var isMutable = !node.Modifiers.Any(SyntaxKind.ReadOnlyKeyword);
+        var initializer = variable.Initializer != null
+            ? ConvertExpression(variable.Initializer.Value)
+            : null;
+
+        return new BindStatementNode(
+            GetTextSpan(node),
+            name,
+            typeName,
+            isMutable,
+            initializer,
+            new AttributeCollection());
+    }
+
+    private IfStatementNode ConvertIfStatement(IfStatementSyntax node)
+    {
+        _context.RecordFeatureUsage("if");
+        _context.IncrementConverted();
+
+        var id = _context.GenerateId("if");
+        var condition = ConvertExpression(node.Condition);
+        var thenBody = node.Statement is BlockSyntax block
+            ? ConvertBlock(block)
+            : new List<StatementNode> { ConvertStatement(node.Statement)! };
+
+        var elseIfClauses = new List<ElseIfClauseNode>();
+        IReadOnlyList<StatementNode>? elseBody = null;
+
+        var currentElse = node.Else;
+        while (currentElse != null)
+        {
+            if (currentElse.Statement is IfStatementSyntax elseIfStmt)
+            {
+                var elseIfCondition = ConvertExpression(elseIfStmt.Condition);
+                var elseIfBody = elseIfStmt.Statement is BlockSyntax elseIfBlock
+                    ? ConvertBlock(elseIfBlock)
+                    : new List<StatementNode> { ConvertStatement(elseIfStmt.Statement)! };
+
+                elseIfClauses.Add(new ElseIfClauseNode(
+                    GetTextSpan(elseIfStmt),
+                    elseIfCondition,
+                    elseIfBody));
+
+                currentElse = elseIfStmt.Else;
+            }
+            else
+            {
+                elseBody = currentElse.Statement is BlockSyntax elseBlock
+                    ? ConvertBlock(elseBlock)
+                    : new List<StatementNode> { ConvertStatement(currentElse.Statement)! };
+                currentElse = null;
+            }
+        }
+
+        return new IfStatementNode(
+            GetTextSpan(node),
+            id,
+            condition,
+            thenBody,
+            elseIfClauses,
+            elseBody,
+            new AttributeCollection());
+    }
+
+    private ForStatementNode ConvertForStatement(ForStatementSyntax node)
+    {
+        _context.RecordFeatureUsage("for");
+        _context.IncrementConverted();
+
+        var id = _context.GenerateId("for");
+
+        // Try to extract standard for loop pattern: for (var i = from; i <= to; i += step)
+        var varName = "i";
+        ExpressionNode from = new IntLiteralNode(TextSpan.Empty, 0);
+        ExpressionNode to = new IntLiteralNode(TextSpan.Empty, 10);
+        ExpressionNode? step = null;
+
+        // Extract variable name and initial value from declaration
+        if (node.Declaration?.Variables.Count > 0)
+        {
+            var decl = node.Declaration.Variables[0];
+            varName = decl.Identifier.Text;
+            if (decl.Initializer != null)
+            {
+                from = ConvertExpression(decl.Initializer.Value);
+            }
+        }
+
+        // Extract upper bound from condition
+        if (node.Condition is BinaryExpressionSyntax binExpr)
+        {
+            to = ConvertExpression(binExpr.Right);
+        }
+
+        // Extract step from incrementors
+        if (node.Incrementors.Count > 0)
+        {
+            var incrementor = node.Incrementors[0];
+            if (incrementor is PostfixUnaryExpressionSyntax postfix)
+            {
+                step = postfix.OperatorToken.IsKind(SyntaxKind.PlusPlusToken)
+                    ? new IntLiteralNode(TextSpan.Empty, 1)
+                    : new IntLiteralNode(TextSpan.Empty, -1);
+            }
+            else if (incrementor is PrefixUnaryExpressionSyntax prefix)
+            {
+                step = prefix.OperatorToken.IsKind(SyntaxKind.PlusPlusToken)
+                    ? new IntLiteralNode(TextSpan.Empty, 1)
+                    : new IntLiteralNode(TextSpan.Empty, -1);
+            }
+            else if (incrementor is AssignmentExpressionSyntax assignment)
+            {
+                step = ConvertExpression(assignment.Right);
+            }
+        }
+
+        var body = node.Statement is BlockSyntax block
+            ? ConvertBlock(block)
+            : new List<StatementNode> { ConvertStatement(node.Statement)! };
+
+        return new ForStatementNode(
+            GetTextSpan(node),
+            id,
+            varName,
+            from,
+            to,
+            step,
+            body,
+            new AttributeCollection());
+    }
+
+    private ForeachStatementNode ConvertForEachStatement(ForEachStatementSyntax node)
+    {
+        _context.RecordFeatureUsage("foreach");
+        _context.IncrementConverted();
+
+        var id = _context.GenerateId("each");
+        var varType = TypeMapper.CSharpToOpal(node.Type.ToString());
+        var varName = node.Identifier.Text;
+        var collection = ConvertExpression(node.Expression);
+        var body = node.Statement is BlockSyntax block
+            ? ConvertBlock(block)
+            : new List<StatementNode> { ConvertStatement(node.Statement)! };
+
+        return new ForeachStatementNode(
+            GetTextSpan(node),
+            id,
+            varName,
+            varType,
+            collection,
+            body,
+            new AttributeCollection());
+    }
+
+    private WhileStatementNode ConvertWhileStatement(WhileStatementSyntax node)
+    {
+        _context.RecordFeatureUsage("while");
+        _context.IncrementConverted();
+
+        var id = _context.GenerateId("while");
+        var condition = ConvertExpression(node.Condition);
+        var body = node.Statement is BlockSyntax block
+            ? ConvertBlock(block)
+            : new List<StatementNode> { ConvertStatement(node.Statement)! };
+
+        return new WhileStatementNode(
+            GetTextSpan(node),
+            id,
+            condition,
+            body,
+            new AttributeCollection());
+    }
+
+    private TryStatementNode ConvertTryStatement(TryStatementSyntax node)
+    {
+        _context.RecordFeatureUsage("try-catch");
+        _context.IncrementConverted();
+
+        var id = _context.GenerateId("try");
+        var tryBody = ConvertBlock(node.Block);
+        var catches = node.Catches.Select(ConvertCatchClause).ToList();
+        var finallyBody = node.Finally != null ? ConvertBlock(node.Finally.Block) : null;
+
+        return new TryStatementNode(
+            GetTextSpan(node),
+            id,
+            tryBody,
+            catches,
+            finallyBody,
+            new AttributeCollection());
+    }
+
+    private CatchClauseNode ConvertCatchClause(CatchClauseSyntax node)
+    {
+        var exceptionType = node.Declaration?.Type.ToString();
+        var varName = node.Declaration?.Identifier.Text;
+        var filter = node.Filter?.FilterExpression != null
+            ? ConvertExpression(node.Filter.FilterExpression)
+            : null;
+        var body = ConvertBlock(node.Block);
+
+        return new CatchClauseNode(
+            GetTextSpan(node),
+            exceptionType,
+            varName,
+            filter,
+            body,
+            new AttributeCollection());
+    }
+
+    private ThrowStatementNode ConvertThrowStatement(ThrowStatementSyntax node)
+    {
+        _context.IncrementConverted();
+
+        var exception = node.Expression != null
+            ? ConvertExpression(node.Expression)
+            : null;
+
+        return new ThrowStatementNode(GetTextSpan(node), exception);
+    }
+
+    private StatementNode ConvertBlockAsStatement(BlockSyntax block)
+    {
+        var statements = ConvertBlock(block);
+        // Return the first statement or a placeholder
+        if (statements.Count > 0)
+        {
+            return statements[0];
+        }
+        return new CallStatementNode(
+            GetTextSpan(block),
+            "noop",
+            fallible: false,
+            Array.Empty<ExpressionNode>(),
+            new AttributeCollection());
+    }
+
+    private MatchStatementNode ConvertSwitchStatement(SwitchStatementSyntax node)
+    {
+        _context.RecordFeatureUsage("switch");
+        _context.IncrementConverted();
+
+        var id = _context.GenerateId("match");
+        var target = ConvertExpression(node.Expression);
+        var cases = new List<MatchCaseNode>();
+
+        foreach (var section in node.Sections)
+        {
+            foreach (var label in section.Labels)
+            {
+                PatternNode pattern = label switch
+                {
+                    CaseSwitchLabelSyntax caseLabel => new LiteralPatternNode(
+                        GetTextSpan(caseLabel),
+                        ConvertExpression(caseLabel.Value)),
+                    DefaultSwitchLabelSyntax => new WildcardPatternNode(GetTextSpan(label)),
+                    _ => new WildcardPatternNode(GetTextSpan(label))
+                };
+
+                var body = section.Statements
+                    .Where(s => !(s is BreakStatementSyntax))
+                    .Select(ConvertStatement)
+                    .Where(s => s != null)
+                    .Cast<StatementNode>()
+                    .ToList();
+
+                cases.Add(new MatchCaseNode(GetTextSpan(section), pattern, guard: null, body));
+            }
+        }
+
+        return new MatchStatementNode(GetTextSpan(node), id, target, cases, new AttributeCollection());
+    }
+
+    private ExpressionNode ConvertExpression(ExpressionSyntax expression)
+    {
+        _context.Stats.ExpressionsConverted++;
+
+        return expression switch
+        {
+            LiteralExpressionSyntax literal => ConvertLiteral(literal),
+            IdentifierNameSyntax identifier => new ReferenceNode(GetTextSpan(identifier), identifier.Identifier.Text),
+            BinaryExpressionSyntax binary => ConvertBinaryExpression(binary),
+            PrefixUnaryExpressionSyntax prefix => ConvertPrefixUnaryExpression(prefix),
+            ParenthesizedExpressionSyntax paren => ConvertExpression(paren.Expression),
+            InvocationExpressionSyntax invocation => ConvertInvocationExpression(invocation),
+            MemberAccessExpressionSyntax memberAccess => ConvertMemberAccessExpression(memberAccess),
+            ObjectCreationExpressionSyntax objCreation => ConvertObjectCreation(objCreation),
+            ThisExpressionSyntax => new ThisExpressionNode(GetTextSpan(expression)),
+            BaseExpressionSyntax => new BaseExpressionNode(GetTextSpan(expression)),
+            ConditionalExpressionSyntax conditional => ConvertConditionalExpression(conditional),
+            ArrayCreationExpressionSyntax arrayCreation => ConvertArrayCreation(arrayCreation),
+            ElementAccessExpressionSyntax elementAccess => ConvertElementAccess(elementAccess),
+            LambdaExpressionSyntax lambda => ConvertLambdaExpression(lambda),
+            AwaitExpressionSyntax awaitExpr => ConvertAwaitExpression(awaitExpr),
+            InterpolatedStringExpressionSyntax interpolated => ConvertInterpolatedString(interpolated),
+            ConditionalAccessExpressionSyntax condAccess => ConvertConditionalAccess(condAccess),
+            CastExpressionSyntax cast => ConvertExpression(cast.Expression), // Just use inner expression
+            _ => new ReferenceNode(GetTextSpan(expression), expression.ToString())
+        };
+    }
+
+    private ExpressionNode ConvertLiteral(LiteralExpressionSyntax literal)
+    {
+        return literal.Kind() switch
+        {
+            SyntaxKind.NumericLiteralExpression when literal.Token.Value is int intVal =>
+                new IntLiteralNode(GetTextSpan(literal), intVal),
+            SyntaxKind.NumericLiteralExpression when literal.Token.Value is double doubleVal =>
+                new FloatLiteralNode(GetTextSpan(literal), doubleVal),
+            SyntaxKind.NumericLiteralExpression when literal.Token.Value is float floatVal =>
+                new FloatLiteralNode(GetTextSpan(literal), floatVal),
+            SyntaxKind.NumericLiteralExpression when literal.Token.Value is long longVal =>
+                new IntLiteralNode(GetTextSpan(literal), (int)longVal),
+            SyntaxKind.StringLiteralExpression =>
+                new StringLiteralNode(GetTextSpan(literal), literal.Token.ValueText),
+            SyntaxKind.CharacterLiteralExpression =>
+                new StringLiteralNode(GetTextSpan(literal), literal.Token.ValueText),
+            SyntaxKind.TrueLiteralExpression =>
+                new BoolLiteralNode(GetTextSpan(literal), true),
+            SyntaxKind.FalseLiteralExpression =>
+                new BoolLiteralNode(GetTextSpan(literal), false),
+            SyntaxKind.NullLiteralExpression =>
+                new ReferenceNode(GetTextSpan(literal), "null"),
+            _ => new ReferenceNode(GetTextSpan(literal), literal.ToString())
+        };
+    }
+
+    private BinaryOperationNode ConvertBinaryExpression(BinaryExpressionSyntax binary)
+    {
+        var left = ConvertExpression(binary.Left);
+        var right = ConvertExpression(binary.Right);
+        var op = binary.OperatorToken.Text;
+        var binaryOp = BinaryOperatorExtensions.FromString(op) ?? BinaryOperator.Add;
+
+        return new BinaryOperationNode(GetTextSpan(binary), binaryOp, left, right);
+    }
+
+    private UnaryOperationNode ConvertPrefixUnaryExpression(PrefixUnaryExpressionSyntax prefix)
+    {
+        var operand = ConvertExpression(prefix.Operand);
+        var op = prefix.OperatorToken.Text;
+        var unaryOp = UnaryOperatorExtensions.FromString(op) ?? UnaryOperator.Negate;
+
+        return new UnaryOperationNode(GetTextSpan(prefix), unaryOp, operand);
+    }
+
+    private ExpressionNode ConvertInvocationExpression(InvocationExpressionSyntax invocation)
+    {
+        var target = invocation.Expression.ToString();
+        var args = invocation.ArgumentList.Arguments
+            .Select(a => ConvertExpression(a.Expression))
+            .ToList();
+
+        // Return as a field access with call semantics
+        return new FieldAccessNode(
+            GetTextSpan(invocation),
+            new ReferenceNode(TextSpan.Empty, target),
+            $"({string.Join(", ", args.Select(a => a.ToString()))})");
+    }
+
+    private ExpressionNode ConvertMemberAccessExpression(MemberAccessExpressionSyntax memberAccess)
+    {
+        var target = ConvertExpression(memberAccess.Expression);
+        var memberName = memberAccess.Name.Identifier.Text;
+
+        return new FieldAccessNode(GetTextSpan(memberAccess), target, memberName);
+    }
+
+    private NewExpressionNode ConvertObjectCreation(ObjectCreationExpressionSyntax objCreation)
+    {
+        var typeName = objCreation.Type.ToString();
+        var typeArgs = new List<string>();
+
+        if (objCreation.Type is GenericNameSyntax genericName)
+        {
+            typeName = genericName.Identifier.Text;
+            typeArgs = genericName.TypeArgumentList.Arguments
+                .Select(a => TypeMapper.CSharpToOpal(a.ToString()))
+                .ToList();
+        }
+
+        var args = objCreation.ArgumentList?.Arguments
+            .Select(a => ConvertExpression(a.Expression))
+            .ToList() ?? new List<ExpressionNode>();
+
+        return new NewExpressionNode(GetTextSpan(objCreation), typeName, typeArgs, args);
+    }
+
+    private ExpressionNode ConvertConditionalExpression(ConditionalExpressionSyntax conditional)
+    {
+        // Ternary is converted to if-then-else expression using Match
+        var condition = ConvertExpression(conditional.Condition);
+        var whenTrue = ConvertExpression(conditional.WhenTrue);
+        var whenFalse = ConvertExpression(conditional.WhenFalse);
+
+        var id = _context.GenerateId("cond");
+
+        // Create a match expression
+        var trueBranch = new MatchCaseNode(
+            GetTextSpan(conditional.WhenTrue),
+            new LiteralPatternNode(TextSpan.Empty, new BoolLiteralNode(TextSpan.Empty, true)),
+            guard: null,
+            new List<StatementNode> { new ReturnStatementNode(TextSpan.Empty, whenTrue) });
+
+        var falseBranch = new MatchCaseNode(
+            GetTextSpan(conditional.WhenFalse),
+            new WildcardPatternNode(TextSpan.Empty),
+            guard: null,
+            new List<StatementNode> { new ReturnStatementNode(TextSpan.Empty, whenFalse) });
+
+        return new MatchExpressionNode(
+            GetTextSpan(conditional),
+            id,
+            condition,
+            new List<MatchCaseNode> { trueBranch, falseBranch },
+            new AttributeCollection());
+    }
+
+    private ArrayCreationNode ConvertArrayCreation(ArrayCreationExpressionSyntax arrayCreation)
+    {
+        var id = _context.GenerateId("arr");
+        var name = _context.GenerateId("arr");
+        var elementType = TypeMapper.CSharpToOpal(arrayCreation.Type.ElementType.ToString());
+
+        ExpressionNode? size = null;
+        var initializer = new List<ExpressionNode>();
+
+        if (arrayCreation.Type.RankSpecifiers.Count > 0)
+        {
+            var rank = arrayCreation.Type.RankSpecifiers[0];
+            if (rank.Sizes.Count > 0 && rank.Sizes[0] is ExpressionSyntax sizeExpr)
+            {
+                size = ConvertExpression(sizeExpr);
+            }
+        }
+
+        if (arrayCreation.Initializer != null)
+        {
+            initializer = arrayCreation.Initializer.Expressions
+                .Select(ConvertExpression)
+                .ToList();
+        }
+
+        return new ArrayCreationNode(GetTextSpan(arrayCreation), id, name, elementType, size, initializer, new AttributeCollection());
+    }
+
+    private ArrayAccessNode ConvertElementAccess(ElementAccessExpressionSyntax elementAccess)
+    {
+        var array = ConvertExpression(elementAccess.Expression);
+        var index = ConvertExpression(elementAccess.ArgumentList.Arguments[0].Expression);
+
+        return new ArrayAccessNode(GetTextSpan(elementAccess), array, index);
+    }
+
+    private LambdaExpressionNode ConvertLambdaExpression(LambdaExpressionSyntax lambda)
+    {
+        _context.RecordFeatureUsage("lambda");
+
+        var id = _context.GenerateId("lam");
+        var parameters = new List<LambdaParameterNode>();
+        var isAsync = lambda.AsyncKeyword.IsKind(SyntaxKind.AsyncKeyword);
+
+        switch (lambda)
+        {
+            case SimpleLambdaExpressionSyntax simple:
+                parameters.Add(new LambdaParameterNode(
+                    GetTextSpan(simple.Parameter),
+                    simple.Parameter.Identifier.Text,
+                    null));
+                break;
+
+            case ParenthesizedLambdaExpressionSyntax paren:
+                foreach (var param in paren.ParameterList.Parameters)
+                {
+                    parameters.Add(new LambdaParameterNode(
+                        GetTextSpan(param),
+                        param.Identifier.Text,
+                        param.Type != null ? TypeMapper.CSharpToOpal(param.Type.ToString()) : null));
+                }
+                break;
+        }
+
+        ExpressionNode? exprBody = null;
+        List<StatementNode>? stmtBody = null;
+
+        if (lambda.ExpressionBody != null)
+        {
+            exprBody = ConvertExpression(lambda.ExpressionBody);
+        }
+        else if (lambda.Body is BlockSyntax block)
+        {
+            stmtBody = ConvertBlock(block).ToList();
+        }
+
+        return new LambdaExpressionNode(
+            GetTextSpan(lambda),
+            id,
+            parameters,
+            effects: null,
+            isAsync,
+            exprBody,
+            stmtBody,
+            new AttributeCollection());
+    }
+
+    private AwaitExpressionNode ConvertAwaitExpression(AwaitExpressionSyntax awaitExpr)
+    {
+        _context.RecordFeatureUsage("async-await");
+
+        var awaited = ConvertExpression(awaitExpr.Expression);
+        return new AwaitExpressionNode(GetTextSpan(awaitExpr), awaited, null);
+    }
+
+    private InterpolatedStringNode ConvertInterpolatedString(InterpolatedStringExpressionSyntax interpolated)
+    {
+        _context.RecordFeatureUsage("string-interpolation");
+
+        var parts = new List<InterpolatedStringPartNode>();
+
+        foreach (var content in interpolated.Contents)
+        {
+            switch (content)
+            {
+                case InterpolatedStringTextSyntax text:
+                    parts.Add(new InterpolatedStringTextNode(GetTextSpan(text), text.TextToken.Text));
+                    break;
+
+                case InterpolationSyntax interp:
+                    parts.Add(new InterpolatedStringExpressionNode(
+                        GetTextSpan(interp),
+                        ConvertExpression(interp.Expression)));
+                    break;
+            }
+        }
+
+        return new InterpolatedStringNode(GetTextSpan(interpolated), parts);
+    }
+
+    private NullConditionalNode ConvertConditionalAccess(ConditionalAccessExpressionSyntax condAccess)
+    {
+        _context.RecordFeatureUsage("null-conditional");
+
+        var target = ConvertExpression(condAccess.Expression);
+        var memberName = condAccess.WhenNotNull.ToString();
+
+        return new NullConditionalNode(GetTextSpan(condAccess), target, memberName);
+    }
+
+    private IReadOnlyList<TypeParameterNode> ConvertTypeParameters(TypeParameterListSyntax? typeParamList)
+    {
+        if (typeParamList == null)
+            return Array.Empty<TypeParameterNode>();
+
+        _context.RecordFeatureUsage("generics");
+
+        return typeParamList.Parameters
+            .Select(p => new TypeParameterNode(
+                GetTextSpan(p),
+                p.Identifier.Text,
+                Array.Empty<TypeConstraintNode>()))
+            .ToList();
+    }
+
+    private IReadOnlyList<ParameterNode> ConvertParameters(ParameterListSyntax paramList)
+    {
+        return paramList.Parameters
+            .Select(p => new ParameterNode(
+                GetTextSpan(p),
+                p.Identifier.Text,
+                TypeMapper.CSharpToOpal(p.Type?.ToString() ?? "any"),
+                new AttributeCollection()))
+            .ToList();
+    }
+
+    private static Visibility GetVisibility(SyntaxTokenList modifiers)
+    {
+        if (modifiers.Any(SyntaxKind.PublicKeyword))
+            return Visibility.Public;
+        if (modifiers.Any(SyntaxKind.InternalKeyword))
+            return Visibility.Internal;
+        if (modifiers.Any(SyntaxKind.ProtectedKeyword))
+            return Visibility.Protected;
+        return Visibility.Private;
+    }
+
+    private static MethodModifiers GetMethodModifiers(SyntaxTokenList modifiers)
+    {
+        var result = MethodModifiers.None;
+
+        if (modifiers.Any(SyntaxKind.VirtualKeyword))
+            result |= MethodModifiers.Virtual;
+        if (modifiers.Any(SyntaxKind.OverrideKeyword))
+            result |= MethodModifiers.Override;
+        if (modifiers.Any(SyntaxKind.AbstractKeyword))
+            result |= MethodModifiers.Abstract;
+        if (modifiers.Any(SyntaxKind.SealedKeyword))
+            result |= MethodModifiers.Sealed;
+        if (modifiers.Any(SyntaxKind.StaticKeyword))
+            result |= MethodModifiers.Static;
+
+        return result;
+    }
+
+    private static TextSpan GetTextSpan(SyntaxNode node)
+    {
+        var lineSpan = node.GetLocation().GetLineSpan();
+        return new TextSpan(
+            node.SpanStart,
+            node.Span.Length,
+            lineSpan.StartLinePosition.Line + 1,
+            lineSpan.StartLinePosition.Character + 1);
+    }
+}

--- a/src/Opal.Compiler/Migration/TypeMapper.cs
+++ b/src/Opal.Compiler/Migration/TypeMapper.cs
@@ -1,0 +1,373 @@
+namespace Opal.Compiler.Migration;
+
+/// <summary>
+/// Provides bidirectional type mapping between C# and OPAL types.
+/// </summary>
+public static class TypeMapper
+{
+    /// <summary>
+    /// Maps C# type names to OPAL type names.
+    /// </summary>
+    private static readonly Dictionary<string, string> CSharpToOpalMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Numeric types
+        ["int"] = "i32",
+        ["Int32"] = "i32",
+        ["System.Int32"] = "i32",
+        ["long"] = "i64",
+        ["Int64"] = "i64",
+        ["System.Int64"] = "i64",
+        ["short"] = "i16",
+        ["Int16"] = "i16",
+        ["System.Int16"] = "i16",
+        ["byte"] = "u8",
+        ["Byte"] = "u8",
+        ["System.Byte"] = "u8",
+        ["sbyte"] = "i8",
+        ["SByte"] = "i8",
+        ["System.SByte"] = "i8",
+        ["uint"] = "u32",
+        ["UInt32"] = "u32",
+        ["System.UInt32"] = "u32",
+        ["ulong"] = "u64",
+        ["UInt64"] = "u64",
+        ["System.UInt64"] = "u64",
+        ["ushort"] = "u16",
+        ["UInt16"] = "u16",
+        ["System.UInt16"] = "u16",
+
+        // Floating point
+        ["float"] = "f32",
+        ["Single"] = "f32",
+        ["System.Single"] = "f32",
+        ["double"] = "f64",
+        ["Double"] = "f64",
+        ["System.Double"] = "f64",
+        ["decimal"] = "decimal",
+        ["Decimal"] = "decimal",
+        ["System.Decimal"] = "decimal",
+
+        // Boolean
+        ["bool"] = "bool",
+        ["Boolean"] = "bool",
+        ["System.Boolean"] = "bool",
+
+        // String and char
+        ["string"] = "str",
+        ["String"] = "str",
+        ["System.String"] = "str",
+        ["char"] = "char",
+        ["Char"] = "char",
+        ["System.Char"] = "char",
+
+        // Void
+        ["void"] = "void",
+        ["Void"] = "void",
+        ["System.Void"] = "void",
+
+        // Object
+        ["object"] = "any",
+        ["Object"] = "any",
+        ["System.Object"] = "any",
+
+        // Common collections
+        ["List"] = "List",
+        ["Dictionary"] = "Dict",
+        ["HashSet"] = "Set",
+        ["IEnumerable"] = "Seq",
+        ["IList"] = "List",
+        ["IDictionary"] = "Dict",
+        ["ICollection"] = "Collection",
+
+        // Async types
+        ["Task"] = "Task",
+        ["ValueTask"] = "Task",
+    };
+
+    /// <summary>
+    /// Maps OPAL type names to C# type names.
+    /// </summary>
+    private static readonly Dictionary<string, string> OpalToCSharpMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Numeric types
+        ["i32"] = "int",
+        ["i64"] = "long",
+        ["i16"] = "short",
+        ["i8"] = "sbyte",
+        ["u32"] = "uint",
+        ["u64"] = "ulong",
+        ["u16"] = "ushort",
+        ["u8"] = "byte",
+
+        // Floating point
+        ["f32"] = "float",
+        ["f64"] = "double",
+        ["decimal"] = "decimal",
+
+        // Boolean
+        ["bool"] = "bool",
+
+        // String and char
+        ["str"] = "string",
+        ["char"] = "char",
+
+        // Void
+        ["void"] = "void",
+
+        // Object
+        ["any"] = "object",
+
+        // Collections
+        ["List"] = "List",
+        ["Dict"] = "Dictionary",
+        ["Set"] = "HashSet",
+        ["Seq"] = "IEnumerable",
+        ["Collection"] = "ICollection",
+
+        // Async
+        ["Task"] = "Task",
+    };
+
+    /// <summary>
+    /// Maps C# binary operators to OPAL operator kinds.
+    /// </summary>
+    private static readonly Dictionary<string, string> CSharpOperatorToOpal = new()
+    {
+        ["+"] = "add",
+        ["-"] = "sub",
+        ["*"] = "mul",
+        ["/"] = "div",
+        ["%"] = "mod",
+        ["=="] = "eq",
+        ["!="] = "neq",
+        ["<"] = "lt",
+        ["<="] = "lte",
+        [">"] = "gt",
+        [">="] = "gte",
+        ["&&"] = "and",
+        ["||"] = "or",
+        ["&"] = "band",
+        ["|"] = "bor",
+        ["^"] = "xor",
+        ["<<"] = "shl",
+        [">>"] = "shr",
+        ["??"] = "coalesce",
+    };
+
+    /// <summary>
+    /// Maps OPAL operator kinds to C# operators.
+    /// </summary>
+    private static readonly Dictionary<string, string> OpalOperatorToCSharp = new()
+    {
+        ["add"] = "+",
+        ["sub"] = "-",
+        ["mul"] = "*",
+        ["div"] = "/",
+        ["mod"] = "%",
+        ["eq"] = "==",
+        ["neq"] = "!=",
+        ["lt"] = "<",
+        ["lte"] = "<=",
+        ["gt"] = ">",
+        ["gte"] = ">=",
+        ["and"] = "&&",
+        ["or"] = "||",
+        ["band"] = "&",
+        ["bor"] = "|",
+        ["xor"] = "^",
+        ["shl"] = "<<",
+        ["shr"] = ">>",
+        ["coalesce"] = "??",
+    };
+
+    /// <summary>
+    /// Converts a C# type name to an OPAL type name.
+    /// </summary>
+    public static string CSharpToOpal(string csharpType)
+    {
+        if (string.IsNullOrEmpty(csharpType))
+            return csharpType;
+
+        // Handle nullable types T? -> ?T
+        if (csharpType.EndsWith("?"))
+        {
+            var innerType = csharpType[..^1];
+            var mappedInner = CSharpToOpal(innerType);
+            return $"?{mappedInner}";
+        }
+
+        // Handle Nullable<T> -> ?T
+        if (csharpType.StartsWith("Nullable<") && csharpType.EndsWith(">"))
+        {
+            var innerType = csharpType["Nullable<".Length..^1];
+            var mappedInner = CSharpToOpal(innerType);
+            return $"?{mappedInner}";
+        }
+
+        // Handle arrays T[] -> [T]
+        if (csharpType.EndsWith("[]"))
+        {
+            var elementType = csharpType[..^2];
+            var mappedElement = CSharpToOpal(elementType);
+            return $"[{mappedElement}]";
+        }
+
+        // Handle generic types
+        var genericIndex = csharpType.IndexOf('<');
+        if (genericIndex > 0)
+        {
+            var baseName = csharpType[..genericIndex];
+            var typeArgs = csharpType[(genericIndex + 1)..^1];
+            var mappedBase = CSharpToOpalMap.TryGetValue(baseName, out var opalBase) ? opalBase : baseName;
+            var mappedArgs = MapGenericArguments(typeArgs, CSharpToOpal);
+            return $"{mappedBase}<{mappedArgs}>";
+        }
+
+        // Direct mapping
+        return CSharpToOpalMap.TryGetValue(csharpType, out var result) ? result : csharpType;
+    }
+
+    /// <summary>
+    /// Converts an OPAL type name to a C# type name.
+    /// </summary>
+    public static string OpalToCSharp(string opalType)
+    {
+        if (string.IsNullOrEmpty(opalType))
+            return opalType;
+
+        // Handle Option types ?T -> T?
+        if (opalType.StartsWith("?"))
+        {
+            var innerType = opalType[1..];
+            var mappedInner = OpalToCSharp(innerType);
+            return $"{mappedInner}?";
+        }
+
+        // Handle array types [T] -> T[]
+        if (opalType.StartsWith("[") && opalType.EndsWith("]"))
+        {
+            var elementType = opalType[1..^1];
+            var mappedElement = OpalToCSharp(elementType);
+            return $"{mappedElement}[]";
+        }
+
+        // Handle generic types
+        var genericIndex = opalType.IndexOf('<');
+        if (genericIndex > 0)
+        {
+            var baseName = opalType[..genericIndex];
+            var typeArgs = opalType[(genericIndex + 1)..^1];
+            var mappedBase = OpalToCSharpMap.TryGetValue(baseName, out var csharpBase) ? csharpBase : baseName;
+            var mappedArgs = MapGenericArguments(typeArgs, OpalToCSharp);
+            return $"{mappedBase}<{mappedArgs}>";
+        }
+
+        // Direct mapping
+        return OpalToCSharpMap.TryGetValue(opalType, out var result) ? result : opalType;
+    }
+
+    /// <summary>
+    /// Converts a C# operator to an OPAL operator kind.
+    /// </summary>
+    public static string CSharpOperatorToOpalKind(string csharpOp)
+    {
+        return CSharpOperatorToOpal.TryGetValue(csharpOp, out var result) ? result : csharpOp;
+    }
+
+    /// <summary>
+    /// Converts an OPAL operator kind to a C# operator.
+    /// </summary>
+    public static string OpalOperatorToCSharpOp(string opalKind)
+    {
+        return OpalOperatorToCSharp.TryGetValue(opalKind, out var result) ? result : opalKind;
+    }
+
+    /// <summary>
+    /// Maps generic type arguments using the provided mapper function.
+    /// </summary>
+    private static string MapGenericArguments(string typeArgs, Func<string, string> mapper)
+    {
+        var depth = 0;
+        var current = "";
+        var result = new List<string>();
+
+        foreach (var c in typeArgs)
+        {
+            if (c == '<')
+            {
+                depth++;
+                current += c;
+            }
+            else if (c == '>')
+            {
+                depth--;
+                current += c;
+            }
+            else if (c == ',' && depth == 0)
+            {
+                result.Add(mapper(current.Trim()));
+                current = "";
+            }
+            else
+            {
+                current += c;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(current))
+        {
+            result.Add(mapper(current.Trim()));
+        }
+
+        return string.Join(", ", result);
+    }
+
+    /// <summary>
+    /// Checks if a type is a primitive type.
+    /// </summary>
+    public static bool IsPrimitiveType(string typeName)
+    {
+        var normalizedLower = typeName.ToLowerInvariant();
+        return normalizedLower switch
+        {
+            "int" or "i32" or "long" or "i64" or "short" or "i16" or "byte" or "u8" or
+            "sbyte" or "i8" or "uint" or "u32" or "ulong" or "u64" or "ushort" or "u16" or
+            "float" or "f32" or "double" or "f64" or "decimal" or
+            "bool" or "string" or "str" or "char" or "void" => true,
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Checks if a type is a numeric type.
+    /// </summary>
+    public static bool IsNumericType(string typeName)
+    {
+        var normalizedLower = typeName.ToLowerInvariant();
+        return normalizedLower switch
+        {
+            "int" or "i32" or "long" or "i64" or "short" or "i16" or "byte" or "u8" or
+            "sbyte" or "i8" or "uint" or "u32" or "ulong" or "u64" or "ushort" or "u16" or
+            "float" or "f32" or "double" or "f64" or "decimal" => true,
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Gets the default value literal for a type.
+    /// </summary>
+    public static string GetDefaultValueLiteral(string opalType)
+    {
+        return opalType.ToLowerInvariant() switch
+        {
+            "i32" or "i64" or "i16" or "i8" or "u32" or "u64" or "u16" or "u8" => "0",
+            "f32" or "f64" => "0.0",
+            "decimal" => "0m",
+            "bool" => "false",
+            "str" => "\"\"",
+            "char" => "'\\0'",
+            _ when opalType.StartsWith("?") => "none",
+            _ => "default"
+        };
+    }
+}

--- a/src/Opal.Compiler/Opal.Compiler.csproj
+++ b/src/Opal.Compiler/Opal.Compiler.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Adds complete C# to OPAL migration infrastructure using Roslyn for C# parsing
- Implements three new CLI commands: `convert`, `migrate`, and `benchmark`
- Supports project-level migration with dry-run, progress reporting, and report generation

## New CLI Commands

```bash
# Convert single file
opalc convert MyClass.cs                    # Auto-detect direction
opalc convert MyClass.cs --benchmark        # Include metrics

# Migrate entire project  
opalc migrate ./MyProject --dry-run         # Preview changes
opalc migrate ./MyProject --benchmark       # Include before/after metrics
opalc migrate ./MyProject --report out.md   # Generate report

# Benchmark comparison
opalc benchmark --opal file.opal --csharp file.cs
opalc benchmark ./MyProject --format markdown
```

## Files Added

**Core Migration:**
- `Migration/TypeMapper.cs` - Bidirectional type mapping
- `Migration/RoslynSyntaxVisitor.cs` - C# AST to OPAL AST conversion
- `Migration/OpalEmitter.cs` - OPAL source code generation
- `Migration/CSharpToOpalConverter.cs` - Pipeline orchestrator
- `Migration/FeatureSupport.cs` - C# feature support registry
- `Migration/BenchmarkIntegration.cs` - Token economics

**Project Migration:**
- `Migration/Project/ProjectDiscovery.cs` - File discovery and analysis
- `Migration/Project/ProjectMigrator.cs` - Migration orchestration
- `Migration/Project/MigrationPlan.cs` - Migration manifest
- `Migration/Project/CsprojUpdater.cs` - .csproj modification

**CLI Commands:**
- `Commands/ConvertCommand.cs` - Single-file conversion
- `Commands/MigrateCommand.cs` - Project migration
- `Commands/BenchmarkCommand.cs` - Benchmarking

## Test plan

- [x] All 256 existing tests pass
- [x] `opalc convert` works for C# → OPAL
- [x] `opalc migrate --dry-run` shows migration plan
- [x] `opalc benchmark` compares token economics
- [x] Build succeeds with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)