### PR TITLE
Add NuGet publishing workflow and update installation docs

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,47 @@
+name: Publish to NuGet
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version override (leave empty to use project version)'
+        required: false
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore src/Opal.Compiler/Opal.Compiler.csproj
+
+      - name: Build
+        run: dotnet build src/Opal.Compiler/Opal.Compiler.csproj -c Release --no-restore
+
+      - name: Pack
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            dotnet pack src/Opal.Compiler/Opal.Compiler.csproj -c Release --no-build -o ./nupkg /p:Version=${{ github.event.inputs.version }}
+          else
+            dotnet pack src/Opal.Compiler/Opal.Compiler.csproj -c Release --no-build -o ./nupkg
+          fi
+
+      - name: Push to NuGet
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-package
+          path: ./nupkg/*.nupkg

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,7 +7,73 @@ nav_order: 1
 
 # Installation
 
-This guide covers installing and building the OPAL compiler.
+This guide covers installing the OPAL compiler and setting up your development environment.
+
+---
+
+## Quick Install
+
+The fastest way to get started with OPAL is using our initialization scripts, which install the compiler globally and set up Claude Code integration.
+
+**macOS/Linux:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/juanmicrosoft/opal/main/scripts/init-opal.sh | bash
+```
+
+**Windows (PowerShell):**
+```powershell
+irm https://raw.githubusercontent.com/juanmicrosoft/opal/main/scripts/init-opal.ps1 | iex
+```
+
+The init script will:
+- Install `opalc` as a global dotnet tool
+- Set up Claude Code skills for `/opal` and `/opal-convert` commands
+- Create a sample OPAL project
+
+---
+
+## Global Tool Install
+
+If you prefer to install just the compiler without the full setup:
+
+```bash
+dotnet tool install -g opalc
+```
+
+After installation, you can compile OPAL files from anywhere:
+
+```bash
+opalc --input program.opal --output program.g.cs
+```
+
+To update to the latest version:
+
+```bash
+dotnet tool update -g opalc
+```
+
+---
+
+## Claude Code Integration
+
+OPAL includes skills for Claude Code that help you write and convert OPAL code.
+
+### Installing Skills
+
+The init scripts automatically install these skills to `.claude/skills/`. To install them manually:
+
+```bash
+mkdir -p .claude/skills
+curl -fsSL https://raw.githubusercontent.com/juanmicrosoft/opal/main/.claude/skills/opal.md -o .claude/skills/opal.md
+curl -fsSL https://raw.githubusercontent.com/juanmicrosoft/opal/main/.claude/skills/opal-convert.md -o .claude/skills/opal-convert.md
+```
+
+### Available Commands
+
+| Command | Description |
+|:--------|:------------|
+| `/opal` | Write new OPAL code with Claude's assistance |
+| `/opal-convert` | Convert existing C# code to OPAL syntax |
 
 ---
 
@@ -38,7 +104,9 @@ sudo apt-get install -y dotnet-sdk-8.0
 
 ---
 
-## Clone and Build
+## Clone and Build (For Contributors)
+
+If you want to contribute to OPAL or build from source:
 
 ```bash
 # Clone the repository

--- a/scripts/init-opal.ps1
+++ b/scripts/init-opal.ps1
@@ -1,11 +1,11 @@
 # OPAL Initialization Script for Windows
-# Usage: irm https://raw.githubusercontent.com/juanmicrosoft/opal-2/main/scripts/init-opal.ps1 | iex
+# Usage: irm https://raw.githubusercontent.com/juanmicrosoft/opal/main/scripts/init-opal.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 
 $Version = "0.1.0"
-$RepoUrl = "https://github.com/juanmicrosoft/opal-2"
-$RawUrl = "https://raw.githubusercontent.com/juanmicrosoft/opal-2/main"
+$RepoUrl = "https://github.com/juanmicrosoft/opal"
+$RawUrl = "https://raw.githubusercontent.com/juanmicrosoft/opal/main"
 
 function Write-Banner {
     Write-Host @"
@@ -114,7 +114,7 @@ function Install-FromSource {
             Write-Warn "Could not clone from GitHub. This is expected if the repo is not public yet."
             Write-Warn "You can manually install opalc by running:"
             Write-Host "  git clone $RepoUrl"
-            Write-Host "  cd opal-2"
+            Write-Host "  cd opal"
             Write-Host "  dotnet pack src\Opal.Compiler\Opal.Compiler.csproj -c Release -o .\nupkg"
             Write-Host "  dotnet tool install -g --add-source .\nupkg opalc"
             return

--- a/scripts/init-opal.sh
+++ b/scripts/init-opal.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 # OPAL Initialization Script
-# Usage: curl -fsSL https://raw.githubusercontent.com/juanmicrosoft/opal-2/main/scripts/init-opal.sh | bash
+# Usage: curl -fsSL https://raw.githubusercontent.com/juanmicrosoft/opal/main/scripts/init-opal.sh | bash
 
 VERSION="0.1.0"
-REPO_URL="https://github.com/juanmicrosoft/opal-2"
-RAW_URL="https://raw.githubusercontent.com/juanmicrosoft/opal-2/main"
+REPO_URL="https://github.com/juanmicrosoft/opal"
+RAW_URL="https://raw.githubusercontent.com/juanmicrosoft/opal/main"
 
 # Colors (with fallback for non-interactive terminals)
 if [[ -t 1 ]]; then
@@ -135,7 +135,7 @@ install_from_source() {
         warn "Could not clone from GitHub. This is expected if the repo is not public yet."
         warn "You can manually install opalc by running:"
         echo "  git clone $REPO_URL"
-        echo "  cd opal-2"
+        echo "  cd opal"
         echo "  dotnet pack src/Opal.Compiler/Opal.Compiler.csproj -c Release -o ./nupkg"
         echo "  dotnet tool install -g --add-source ./nupkg opalc"
         rm -rf "$temp_dir"


### PR DESCRIPTION
## Summary
- Create GitHub Action to publish `opalc` to NuGet on release creation or manual dispatch
- Fix repo URLs in init scripts (`opal-2` → `opal`)
- Update installation docs with quick install, global tool, and Claude Code integration sections

## Changes
| File | Description |
|------|-------------|
| `.github/workflows/publish-nuget.yml` | New workflow for NuGet publishing |
| `scripts/init-opal.sh` | Fix repo URLs |
| `scripts/init-opal.ps1` | Fix repo URLs |
| `docs/getting-started/installation.md` | Add quick install, global tool, Claude Code sections |

## Test plan
- [ ] Verify no `opal-2` references remain: `grep -r "opal-2" scripts/`
- [ ] Create a release to trigger NuGet publish workflow
- [ ] After publish, verify: `dotnet tool install -g opalc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)