### PR TITLE
Integrate full 7-metric benchmark into CLI

### DIFF
--- a/src/Opal.Compiler/Commands/BenchmarkCommand.cs
+++ b/src/Opal.Compiler/Commands/BenchmarkCommand.cs
@@ -4,7 +4,7 @@ using Opal.Compiler.Migration;
 namespace Opal.Compiler.Commands;
 
 /// <summary>
-/// CLI command for standalone benchmarking.
+/// CLI command for standalone benchmarking with full 7-metric evaluation.
 /// </summary>
 public static class BenchmarkCommand
 {
@@ -25,6 +25,10 @@ public static class BenchmarkCommand
             Arity = ArgumentArity.ZeroOrOne
         };
 
+        var categoryOption = new Option<string?>(
+            aliases: new[] { "--category", "-c" },
+            description: "Filter by category (TokenEconomics, GenerationAccuracy, Comprehension, EditPrecision, ErrorDetection, InformationDensity, TaskCompletion)");
+
         var formatOption = new Option<string>(
             aliases: new[] { "--format", "-f" },
             description: "Output format (console, markdown, json)",
@@ -34,16 +38,27 @@ public static class BenchmarkCommand
             aliases: new[] { "--output", "-o" },
             description: "Save benchmark results to file");
 
-        var command = new Command("benchmark", "Compare token economics between C# and OPAL")
+        var verboseOption = new Option<bool>(
+            aliases: new[] { "--verbose", "-v" },
+            description: "Show detailed per-metric breakdown");
+
+        var quickOption = new Option<bool>(
+            aliases: new[] { "--quick", "-q" },
+            description: "Use quick token-only benchmark (skip full 7-metric evaluation)");
+
+        var command = new Command("benchmark", "Compare OPAL vs C# across 7 evaluation categories")
         {
             projectArgument,
             opalOption,
             csharpOption,
+            categoryOption,
             formatOption,
-            outputOption
+            outputOption,
+            verboseOption,
+            quickOption
         };
 
-        command.SetHandler(ExecuteAsync, projectArgument, opalOption, csharpOption, formatOption, outputOption);
+        command.SetHandler(ExecuteAsync, projectArgument, opalOption, csharpOption, categoryOption, formatOption, outputOption, verboseOption, quickOption);
 
         return command;
     }
@@ -52,20 +67,53 @@ public static class BenchmarkCommand
         DirectoryInfo? project,
         FileInfo? opalFile,
         FileInfo? csharpFile,
+        string? category,
         string format,
-        FileInfo? output)
+        FileInfo? output,
+        bool verbose,
+        bool quick)
     {
         try
         {
+            // Validate category if provided
+            if (category != null && !BenchmarkIntegration.AllCategories.Contains(category, StringComparer.OrdinalIgnoreCase))
+            {
+                Console.Error.WriteLine($"Error: Invalid category '{category}'");
+                Console.Error.WriteLine();
+                Console.Error.WriteLine("Valid categories:");
+                foreach (var cat in BenchmarkIntegration.AllCategories)
+                {
+                    Console.Error.WriteLine($"  - {cat}");
+                }
+                Environment.ExitCode = 1;
+                return;
+            }
+
             if (opalFile != null && csharpFile != null)
             {
-                // Single file comparison
-                await BenchmarkFilesAsync(opalFile, csharpFile, format, output);
+                if (quick)
+                {
+                    // Legacy quick benchmark
+                    await QuickBenchmarkFilesAsync(opalFile, csharpFile, format, output);
+                }
+                else
+                {
+                    // Full 7-metric benchmark
+                    await FullBenchmarkFilesAsync(opalFile, csharpFile, category, format, output, verbose);
+                }
             }
             else if (project != null)
             {
-                // Project-level comparison
-                await BenchmarkProjectAsync(project, format, output);
+                if (quick)
+                {
+                    // Legacy quick project benchmark
+                    await QuickBenchmarkProjectAsync(project, format, output);
+                }
+                else
+                {
+                    // Full 7-metric project benchmark
+                    await FullBenchmarkProjectAsync(project, category, format, output, verbose);
+                }
             }
             else
             {
@@ -73,18 +121,131 @@ public static class BenchmarkCommand
                 Console.Error.WriteLine();
                 Console.Error.WriteLine("Examples:");
                 Console.Error.WriteLine("  opalc benchmark --opal file.opal --csharp file.cs");
+                Console.Error.WriteLine("  opalc benchmark --opal file.opal --csharp file.cs --verbose");
+                Console.Error.WriteLine("  opalc benchmark --opal file.opal --csharp file.cs --category TokenEconomics");
                 Console.Error.WriteLine("  opalc benchmark ./MyProject");
+                Console.Error.WriteLine("  opalc benchmark ./MyProject --format markdown -o report.md");
+                Console.Error.WriteLine("  opalc benchmark --opal file.opal --csharp file.cs --quick  # Token-only");
                 Environment.ExitCode = 1;
             }
         }
         catch (Exception ex)
         {
             Console.Error.WriteLine($"Error: {ex.Message}");
+            if (verbose)
+            {
+                Console.Error.WriteLine(ex.StackTrace);
+            }
             Environment.ExitCode = 1;
         }
     }
 
-    private static async Task BenchmarkFilesAsync(FileInfo opalFile, FileInfo csharpFile, string format, FileInfo? output)
+    private static async Task FullBenchmarkFilesAsync(
+        FileInfo opalFile,
+        FileInfo csharpFile,
+        string? category,
+        string format,
+        FileInfo? output,
+        bool verbose)
+    {
+        if (!opalFile.Exists)
+        {
+            Console.Error.WriteLine($"Error: OPAL file not found: {opalFile.FullName}");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        if (!csharpFile.Exists)
+        {
+            Console.Error.WriteLine($"Error: C# file not found: {csharpFile.FullName}");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        var opalSource = await File.ReadAllTextAsync(opalFile.FullName);
+        var csharpSource = await File.ReadAllTextAsync(csharpFile.FullName);
+
+        if (verbose)
+        {
+            Console.WriteLine($"Running full benchmark: {csharpFile.Name} vs {opalFile.Name}");
+            if (category != null)
+            {
+                Console.WriteLine($"Filtering by category: {category}");
+            }
+            Console.WriteLine();
+        }
+
+        var result = await BenchmarkIntegration.RunFullBenchmarkAsync(csharpSource, opalSource, category, verbose);
+
+        var outputContent = format.ToLowerInvariant() switch
+        {
+            "markdown" or "md" => BenchmarkIntegration.GenerateMarkdownReport(result, opalFile.Name, csharpFile.Name),
+            "json" => BenchmarkIntegration.GenerateJsonReport(result),
+            _ => BenchmarkIntegration.FormatConsoleOutput(result, opalFile.Name, csharpFile.Name, verbose)
+        };
+
+        if (output != null)
+        {
+            await File.WriteAllTextAsync(output.FullName, outputContent);
+            Console.WriteLine($"Results saved to: {output.FullName}");
+        }
+        else
+        {
+            Console.WriteLine(outputContent);
+        }
+    }
+
+    private static async Task FullBenchmarkProjectAsync(
+        DirectoryInfo project,
+        string? category,
+        string format,
+        FileInfo? output,
+        bool verbose)
+    {
+        if (!project.Exists)
+        {
+            Console.Error.WriteLine($"Error: Project directory not found: {project.FullName}");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        Console.WriteLine($"Scanning project: {project.FullName}");
+        if (category != null)
+        {
+            Console.WriteLine($"Filtering by category: {category}");
+        }
+        Console.WriteLine();
+
+        var result = await BenchmarkIntegration.RunProjectBenchmarkAsync(project.FullName, category, verbose);
+
+        if (result.ProjectResults == null || result.ProjectResults.Count == 0)
+        {
+            Console.WriteLine("No paired .opal and .cs files found.");
+            Console.WriteLine("Looking for files with the same base name (e.g., foo.opal and foo.cs)");
+            return;
+        }
+
+        var outputContent = format.ToLowerInvariant() switch
+        {
+            "markdown" or "md" => BenchmarkIntegration.GenerateMarkdownReport(result, project.Name, project.Name),
+            "json" => BenchmarkIntegration.GenerateJsonReport(result),
+            _ => BenchmarkIntegration.FormatProjectConsoleOutput(result, project.Name, verbose)
+        };
+
+        if (output != null)
+        {
+            await File.WriteAllTextAsync(output.FullName, outputContent);
+            Console.WriteLine($"Results saved to: {output.FullName}");
+        }
+        else
+        {
+            Console.WriteLine(outputContent);
+        }
+    }
+
+    // ========== Legacy quick benchmark methods ==========
+
+    private static async Task QuickBenchmarkFilesAsync(FileInfo opalFile, FileInfo csharpFile, string format, FileInfo? output)
     {
         if (!opalFile.Exists)
         {
@@ -107,9 +268,9 @@ public static class BenchmarkCommand
 
         var outputContent = format.ToLowerInvariant() switch
         {
-            "markdown" or "md" => FormatMarkdown(opalFile.Name, csharpFile.Name, result),
-            "json" => FormatJson(opalFile.Name, csharpFile.Name, result),
-            _ => FormatConsole(opalFile.Name, csharpFile.Name, result)
+            "markdown" or "md" => FormatQuickMarkdown(opalFile.Name, csharpFile.Name, result),
+            "json" => FormatQuickJson(opalFile.Name, csharpFile.Name, result),
+            _ => FormatQuickConsole(opalFile.Name, csharpFile.Name, result)
         };
 
         if (output != null)
@@ -123,7 +284,7 @@ public static class BenchmarkCommand
         }
     }
 
-    private static async Task BenchmarkProjectAsync(DirectoryInfo project, string format, FileInfo? output)
+    private static async Task QuickBenchmarkProjectAsync(DirectoryInfo project, string format, FileInfo? output)
     {
         if (!project.Exists)
         {
@@ -132,7 +293,7 @@ public static class BenchmarkCommand
             return;
         }
 
-        Console.WriteLine($"Scanning project: {project.FullName}");
+        Console.WriteLine($"Scanning project (quick mode): {project.FullName}");
         Console.WriteLine();
 
         // Find paired files
@@ -177,9 +338,9 @@ public static class BenchmarkCommand
         // Output results
         var outputContent = format.ToLowerInvariant() switch
         {
-            "markdown" or "md" => FormatProjectMarkdown(project.Name, pairs, summary),
-            "json" => FormatProjectJson(project.Name, pairs, summary),
-            _ => FormatProjectConsole(project.Name, pairs, summary)
+            "markdown" or "md" => FormatQuickProjectMarkdown(project.Name, pairs, summary),
+            "json" => FormatQuickProjectJson(project.Name, pairs, summary),
+            _ => FormatQuickProjectConsole(project.Name, pairs, summary)
         };
 
         if (output != null)
@@ -193,20 +354,20 @@ public static class BenchmarkCommand
         }
     }
 
-    private static string FormatConsole(string opalName, string csName, BenchmarkResult result)
+    private static string FormatQuickConsole(string opalName, string csName, BenchmarkResult result)
     {
         return $"""
-            Benchmark: {csName} vs {opalName}
+            Benchmark (Quick Mode): {csName} vs {opalName}
 
             {result.Summary}
             """;
     }
 
-    private static string FormatMarkdown(string opalName, string csName, BenchmarkResult result)
+    private static string FormatQuickMarkdown(string opalName, string csName, BenchmarkResult result)
     {
         var m = result.Metrics;
         return $"""
-            # Benchmark Results
+            # Benchmark Results (Quick Mode)
 
             **Comparison:** `{csName}` vs `{opalName}`
 
@@ -220,11 +381,12 @@ public static class BenchmarkCommand
             """;
     }
 
-    private static string FormatJson(string opalName, string csName, BenchmarkResult result)
+    private static string FormatQuickJson(string opalName, string csName, BenchmarkResult result)
     {
         var m = result.Metrics;
         return $$"""
             {
+              "mode": "quick",
               "comparison": {
                 "csharpFile": "{{csName}}",
                 "opalFile": "{{opalName}}"
@@ -239,16 +401,16 @@ public static class BenchmarkCommand
             """;
     }
 
-    private static string FormatProjectConsole(string projectName, List<(string opal, string cs, FileMetrics metrics)> pairs, BenchmarkSummary summary)
+    private static string FormatQuickProjectConsole(string projectName, List<(string opal, string cs, FileMetrics metrics)> pairs, BenchmarkSummary summary)
     {
         var sb = new System.Text.StringBuilder();
 
-        sb.AppendLine($"Project Benchmark: {projectName}");
+        sb.AppendLine($"Project Benchmark (Quick Mode): {projectName}");
         sb.AppendLine($"Files compared: {pairs.Count}");
         sb.AppendLine();
         sb.AppendLine("Summary:");
-        sb.AppendLine($"  Total tokens: {summary.TotalOriginalTokens:N0} → {summary.TotalOutputTokens:N0} ({summary.TokenSavingsPercent:F1}% savings)");
-        sb.AppendLine($"  Total lines: {summary.TotalOriginalLines:N0} → {summary.TotalOutputLines:N0} ({summary.LineSavingsPercent:F1}% savings)");
+        sb.AppendLine($"  Total tokens: {summary.TotalOriginalTokens:N0} -> {summary.TotalOutputTokens:N0} ({summary.TokenSavingsPercent:F1}% savings)");
+        sb.AppendLine($"  Total lines: {summary.TotalOriginalLines:N0} -> {summary.TotalOutputLines:N0} ({summary.LineSavingsPercent:F1}% savings)");
         sb.AppendLine($"  Overall OPAL advantage: {summary.OverallAdvantage:F2}x");
         sb.AppendLine();
         sb.AppendLine("By File:");
@@ -257,17 +419,17 @@ public static class BenchmarkCommand
         {
             var advantage = BenchmarkIntegration.CalculateAdvantageRatio(metrics);
             var indicator = advantage > 1 ? "+" : "";
-            sb.AppendLine($"  {Path.GetFileName(opal)}: {indicator}{(advantage - 1) * 100:F0}% tokens ({metrics.OriginalTokens} → {metrics.OutputTokens})");
+            sb.AppendLine($"  {Path.GetFileName(opal)}: {indicator}{(advantage - 1) * 100:F0}% tokens ({metrics.OriginalTokens} -> {metrics.OutputTokens})");
         }
 
         return sb.ToString();
     }
 
-    private static string FormatProjectMarkdown(string projectName, List<(string opal, string cs, FileMetrics metrics)> pairs, BenchmarkSummary summary)
+    private static string FormatQuickProjectMarkdown(string projectName, List<(string opal, string cs, FileMetrics metrics)> pairs, BenchmarkSummary summary)
     {
         var sb = new System.Text.StringBuilder();
 
-        sb.AppendLine($"# Benchmark Results: {projectName}");
+        sb.AppendLine($"# Benchmark Results (Quick Mode): {projectName}");
         sb.AppendLine();
         sb.AppendLine($"**Files compared:** {pairs.Count}");
         sb.AppendLine();
@@ -294,7 +456,7 @@ public static class BenchmarkCommand
         return sb.ToString();
     }
 
-    private static string FormatProjectJson(string projectName, List<(string opal, string cs, FileMetrics metrics)> pairs, BenchmarkSummary summary)
+    private static string FormatQuickProjectJson(string projectName, List<(string opal, string cs, FileMetrics metrics)> pairs, BenchmarkSummary summary)
     {
         var filesJson = string.Join(",\n    ", pairs.Select(p =>
         {
@@ -312,6 +474,7 @@ public static class BenchmarkCommand
 
         return $$"""
             {
+              "mode": "quick",
               "project": "{{projectName}}",
               "fileCount": {{pairs.Count}},
               "summary": {

--- a/src/Opal.Compiler/Evaluation/Benchmarks/BenchmarkRunner.cs
+++ b/src/Opal.Compiler/Evaluation/Benchmarks/BenchmarkRunner.cs
@@ -1,0 +1,172 @@
+using Opal.Compiler.Evaluation.Core;
+using Opal.Compiler.Evaluation.Metrics;
+
+namespace Opal.Compiler.Evaluation.Benchmarks;
+
+/// <summary>
+/// Orchestrates benchmark execution across all 7 evaluation categories.
+/// </summary>
+public class BenchmarkRunner
+{
+    private readonly List<IMetricCalculator> _calculators;
+    private readonly BenchmarkRunnerOptions _options;
+
+    public BenchmarkRunner(BenchmarkRunnerOptions? options = null)
+    {
+        _options = options ?? new BenchmarkRunnerOptions();
+
+        // Initialize all 7 calculators
+        _calculators = new List<IMetricCalculator>
+        {
+            new TokenEconomicsCalculator(),
+            new GenerationAccuracyCalculator(),
+            new ComprehensionCalculator(),
+            new EditPrecisionCalculator(),
+            new ErrorDetectionCalculator(),
+            new InformationDensityCalculator(),
+            new TaskCompletionCalculator()
+        };
+    }
+
+    /// <summary>
+    /// Runs benchmarks from source code strings.
+    /// </summary>
+    public async Task<BenchmarkCaseResult> RunFromSourceAsync(
+        string opalSource,
+        string csharpSource,
+        string name = "inline")
+    {
+        var context = new EvaluationContext
+        {
+            OpalSource = opalSource,
+            CSharpSource = csharpSource,
+            FileName = name,
+            Level = 1,
+            Features = new List<string>()
+        };
+
+        return await RunSingleBenchmarkAsync(context, name);
+    }
+
+    /// <summary>
+    /// Runs a single benchmark case.
+    /// </summary>
+    public async Task<BenchmarkCaseResult> RunSingleBenchmarkAsync(
+        EvaluationContext context,
+        string caseId)
+    {
+        var caseResult = new BenchmarkCaseResult
+        {
+            CaseId = caseId,
+            FileName = context.FileName,
+            Level = context.Level,
+            Features = context.Features,
+            OpalSuccess = context.OpalCompilation.Success,
+            CSharpSuccess = context.CSharpCompilation.Success
+        };
+
+        // Run each calculator
+        foreach (var calculator in _calculators)
+        {
+            // Skip calculators if filtering is enabled
+            if (_options.Categories.Count > 0 &&
+                !_options.Categories.Contains(calculator.Category, StringComparer.OrdinalIgnoreCase))
+                continue;
+
+            try
+            {
+                var metric = await calculator.CalculateAsync(context);
+                caseResult.Metrics.Add(metric);
+            }
+            catch (Exception ex)
+            {
+                if (_options.Verbose)
+                    Console.Error.WriteLine($"Warning: Calculator {calculator.Category} failed: {ex.Message}");
+
+                // Add a failed metric result
+                caseResult.Metrics.Add(new MetricResult(
+                    calculator.Category,
+                    "Error",
+                    0, 0, 1.0,
+                    new Dictionary<string, object> { ["error"] = ex.Message }));
+            }
+        }
+
+        return caseResult;
+    }
+
+    /// <summary>
+    /// Runs benchmarks for paired files.
+    /// </summary>
+    public async Task<BenchmarkCaseResult> RunFromFilesAsync(
+        string opalPath,
+        string csharpPath,
+        string? name = null)
+    {
+        var opalSource = await File.ReadAllTextAsync(opalPath);
+        var csharpSource = await File.ReadAllTextAsync(csharpPath);
+
+        var caseName = name ?? Path.GetFileNameWithoutExtension(opalPath);
+
+        return await RunFromSourceAsync(opalSource, csharpSource, caseName);
+    }
+
+    /// <summary>
+    /// Gets a specific calculator by category.
+    /// </summary>
+    public IMetricCalculator? GetCalculator(string category)
+    {
+        return _calculators.FirstOrDefault(c =>
+            string.Equals(c.Category, category, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Gets all registered calculators.
+    /// </summary>
+    public IReadOnlyList<IMetricCalculator> GetCalculators() => _calculators.AsReadOnly();
+
+    /// <summary>
+    /// Gets all available category names.
+    /// </summary>
+    public static IReadOnlyList<string> GetAvailableCategories() => new[]
+    {
+        "TokenEconomics",
+        "GenerationAccuracy",
+        "Comprehension",
+        "EditPrecision",
+        "ErrorDetection",
+        "InformationDensity",
+        "TaskCompletion"
+    };
+}
+
+/// <summary>
+/// Options for configuring the benchmark runner.
+/// </summary>
+public class BenchmarkRunnerOptions
+{
+    /// <summary>
+    /// Enable verbose logging.
+    /// </summary>
+    public bool Verbose { get; set; }
+
+    /// <summary>
+    /// Categories to run (empty = all).
+    /// </summary>
+    public List<string> Categories { get; set; } = new();
+
+    /// <summary>
+    /// Maximum level to include.
+    /// </summary>
+    public int MaxLevel { get; set; } = 5;
+
+    /// <summary>
+    /// Timeout per benchmark in milliseconds.
+    /// </summary>
+    public int TimeoutMs { get; set; } = 30000;
+
+    /// <summary>
+    /// Enable parallel execution.
+    /// </summary>
+    public bool Parallel { get; set; } = true;
+}

--- a/src/Opal.Compiler/Evaluation/Core/EvaluationContext.cs
+++ b/src/Opal.Compiler/Evaluation/Core/EvaluationContext.cs
@@ -1,0 +1,176 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Opal.Compiler.Ast;
+using Opal.Compiler.Diagnostics;
+using Opal.Compiler.Parsing;
+using RoslynDiagnosticSeverity = Microsoft.CodeAnalysis.DiagnosticSeverity;
+
+namespace Opal.Compiler.Evaluation.Core;
+
+/// <summary>
+/// Shared context for evaluation containing both OPAL and C# source code,
+/// along with lazy-loaded compilation results for each.
+/// </summary>
+public class EvaluationContext
+{
+    /// <summary>
+    /// The OPAL source code being evaluated.
+    /// </summary>
+    public required string OpalSource { get; init; }
+
+    /// <summary>
+    /// The equivalent C# source code being compared.
+    /// </summary>
+    public required string CSharpSource { get; init; }
+
+    /// <summary>
+    /// The file name or identifier for this benchmark case.
+    /// </summary>
+    public required string FileName { get; init; }
+
+    /// <summary>
+    /// Complexity level (1-5) of this benchmark case.
+    /// </summary>
+    public int Level { get; init; } = 1;
+
+    /// <summary>
+    /// Feature tags describing what this benchmark tests.
+    /// </summary>
+    public List<string> Features { get; init; } = new();
+
+    /// <summary>
+    /// Optional metadata for this evaluation case.
+    /// </summary>
+    public Dictionary<string, object> Metadata { get; init; } = new();
+
+    private OpalCompilationResult? _opalCompilation;
+    private CSharpCompilationResult? _csharpCompilation;
+
+    /// <summary>
+    /// Gets the lazy-loaded OPAL compilation result.
+    /// </summary>
+    public OpalCompilationResult OpalCompilation
+    {
+        get
+        {
+            _opalCompilation ??= CompileOpal();
+            return _opalCompilation;
+        }
+    }
+
+    /// <summary>
+    /// Gets the lazy-loaded C# compilation result.
+    /// </summary>
+    public CSharpCompilationResult CSharpCompilation
+    {
+        get
+        {
+            _csharpCompilation ??= CompileCSharp();
+            return _csharpCompilation;
+        }
+    }
+
+    private OpalCompilationResult CompileOpal()
+    {
+        var diagnostics = new DiagnosticBag();
+
+        try
+        {
+            var lexer = new Lexer(OpalSource, diagnostics);
+            var tokens = lexer.TokenizeAll();
+
+            if (diagnostics.HasErrors)
+            {
+                return new OpalCompilationResult(
+                    Success: false,
+                    Module: null,
+                    Tokens: tokens,
+                    Errors: diagnostics.Errors.Select(d => d.Message).ToList());
+            }
+
+            var parser = new Parser(tokens, diagnostics);
+            var module = parser.Parse();
+
+            return new OpalCompilationResult(
+                Success: !diagnostics.HasErrors,
+                Module: module,
+                Tokens: tokens,
+                Errors: diagnostics.Errors.Select(d => d.Message).ToList());
+        }
+        catch (Exception ex)
+        {
+            return new OpalCompilationResult(
+                Success: false,
+                Module: null,
+                Tokens: new List<Token>(),
+                Errors: new List<string> { ex.Message });
+        }
+    }
+
+    private CSharpCompilationResult CompileCSharp()
+    {
+        try
+        {
+            var syntaxTree = CSharpSyntaxTree.ParseText(CSharpSource);
+            var root = syntaxTree.GetCompilationUnitRoot();
+            var diagnostics = root.GetDiagnostics().ToList();
+
+            return new CSharpCompilationResult(
+                Success: !diagnostics.Any(d => d.Severity == RoslynDiagnosticSeverity.Error),
+                SyntaxTree: syntaxTree,
+                Root: root,
+                Errors: diagnostics
+                    .Where(d => d.Severity == RoslynDiagnosticSeverity.Error)
+                    .Select(d => d.GetMessage())
+                    .ToList());
+        }
+        catch (Exception ex)
+        {
+            return new CSharpCompilationResult(
+                Success: false,
+                SyntaxTree: null,
+                Root: null,
+                Errors: new List<string> { ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Creates an evaluation context from paired OPAL and C# files.
+    /// </summary>
+    public static async Task<EvaluationContext> FromFilesAsync(
+        string opalPath,
+        string csharpPath,
+        int level = 1,
+        List<string>? features = null)
+    {
+        var opalSource = await File.ReadAllTextAsync(opalPath);
+        var csharpSource = await File.ReadAllTextAsync(csharpPath);
+
+        return new EvaluationContext
+        {
+            OpalSource = opalSource,
+            CSharpSource = csharpSource,
+            FileName = Path.GetFileNameWithoutExtension(opalPath),
+            Level = level,
+            Features = features ?? new List<string>()
+        };
+    }
+}
+
+/// <summary>
+/// Result of compiling OPAL source code.
+/// </summary>
+public record OpalCompilationResult(
+    bool Success,
+    ModuleNode? Module,
+    List<Token> Tokens,
+    List<string> Errors);
+
+/// <summary>
+/// Result of compiling C# source code.
+/// </summary>
+public record CSharpCompilationResult(
+    bool Success,
+    SyntaxTree? SyntaxTree,
+    Microsoft.CodeAnalysis.CSharp.Syntax.CompilationUnitSyntax? Root,
+    List<string> Errors);

--- a/src/Opal.Compiler/Evaluation/Core/EvaluationResult.cs
+++ b/src/Opal.Compiler/Evaluation/Core/EvaluationResult.cs
@@ -1,0 +1,139 @@
+using System.Text.Json.Serialization;
+
+namespace Opal.Compiler.Evaluation.Core;
+
+/// <summary>
+/// Unified result structure containing all evaluation metrics across categories.
+/// </summary>
+public class EvaluationResult
+{
+    /// <summary>
+    /// Timestamp when the evaluation was run.
+    /// </summary>
+    public DateTime Timestamp { get; init; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Version of the evaluation framework.
+    /// </summary>
+    public string Version { get; init; } = "1.0.0";
+
+    /// <summary>
+    /// Number of benchmark cases evaluated.
+    /// </summary>
+    public int BenchmarkCount { get; init; }
+
+    /// <summary>
+    /// Individual metric results from all calculators.
+    /// </summary>
+    public List<MetricResult> Metrics { get; init; } = new();
+
+    /// <summary>
+    /// Summary statistics aggregated by category.
+    /// </summary>
+    public EvaluationSummary Summary { get; set; } = new();
+
+    /// <summary>
+    /// Detailed results per benchmark case.
+    /// </summary>
+    public List<BenchmarkCaseResult> CaseResults { get; init; } = new();
+
+    /// <summary>
+    /// Calculates and returns the overall OPAL advantage ratio (geometric mean of all category ratios).
+    /// </summary>
+    public double CalculateOverallAdvantage()
+    {
+        if (Summary.CategoryAdvantages.Count == 0)
+            return 1.0;
+
+        var product = Summary.CategoryAdvantages.Values
+            .Where(v => v > 0)
+            .Aggregate(1.0, (acc, v) => acc * v);
+
+        return Math.Pow(product, 1.0 / Summary.CategoryAdvantages.Count);
+    }
+}
+
+/// <summary>
+/// Summary statistics for the evaluation.
+/// </summary>
+public class EvaluationSummary
+{
+    /// <summary>
+    /// Overall OPAL advantage ratio across all categories.
+    /// </summary>
+    public double OverallOpalAdvantage { get; set; }
+
+    /// <summary>
+    /// Advantage ratios by category.
+    /// </summary>
+    public Dictionary<string, double> CategoryAdvantages { get; set; } = new();
+
+    /// <summary>
+    /// Total benchmarks that passed for OPAL.
+    /// </summary>
+    public int OpalPassCount { get; set; }
+
+    /// <summary>
+    /// Total benchmarks that passed for C#.
+    /// </summary>
+    public int CSharpPassCount { get; set; }
+
+    /// <summary>
+    /// Categories where OPAL has the largest advantage.
+    /// </summary>
+    public List<string> TopOpalCategories { get; set; } = new();
+
+    /// <summary>
+    /// Categories where C# has an advantage (if any).
+    /// </summary>
+    public List<string> CSharpAdvantageCategories { get; set; } = new();
+}
+
+/// <summary>
+/// Detailed results for a single benchmark case.
+/// </summary>
+public class BenchmarkCaseResult
+{
+    /// <summary>
+    /// Identifier for this benchmark case.
+    /// </summary>
+    public required string CaseId { get; init; }
+
+    /// <summary>
+    /// File name or description.
+    /// </summary>
+    public required string FileName { get; init; }
+
+    /// <summary>
+    /// Complexity level.
+    /// </summary>
+    public int Level { get; init; }
+
+    /// <summary>
+    /// Features tested by this case.
+    /// </summary>
+    public List<string> Features { get; init; } = new();
+
+    /// <summary>
+    /// All metric results for this case.
+    /// </summary>
+    public List<MetricResult> Metrics { get; init; } = new();
+
+    /// <summary>
+    /// Whether OPAL compilation succeeded.
+    /// </summary>
+    public bool OpalSuccess { get; init; }
+
+    /// <summary>
+    /// Whether C# compilation succeeded.
+    /// </summary>
+    public bool CSharpSuccess { get; init; }
+
+    /// <summary>
+    /// Average OPAL advantage ratio for this case.
+    /// </summary>
+    [JsonIgnore]
+    public double AverageAdvantage => Metrics.Count > 0
+        ? Metrics.Average(m => m.AdvantageRatio)
+        : 1.0;
+}

--- a/src/Opal.Compiler/Evaluation/Core/IMetricCalculator.cs
+++ b/src/Opal.Compiler/Evaluation/Core/IMetricCalculator.cs
@@ -1,0 +1,23 @@
+namespace Opal.Compiler.Evaluation.Core;
+
+/// <summary>
+/// Base interface for all metric calculators in the evaluation framework.
+/// Each calculator measures a specific aspect of OPAL vs C# code effectiveness.
+/// </summary>
+public interface IMetricCalculator
+{
+    /// <summary>
+    /// The evaluation category this calculator measures.
+    /// </summary>
+    string Category { get; }
+
+    /// <summary>
+    /// Human-readable description of what this calculator measures.
+    /// </summary>
+    string Description { get; }
+
+    /// <summary>
+    /// Calculates metrics for the given evaluation context.
+    /// </summary>
+    Task<MetricResult> CalculateAsync(EvaluationContext context);
+}

--- a/src/Opal.Compiler/Evaluation/Core/MetricResult.cs
+++ b/src/Opal.Compiler/Evaluation/Core/MetricResult.cs
@@ -1,0 +1,59 @@
+namespace Opal.Compiler.Evaluation.Core;
+
+/// <summary>
+/// Represents the result of a single metric calculation comparing OPAL to C#.
+/// </summary>
+/// <param name="Category">The evaluation category (e.g., "TokenEconomics", "GenerationAccuracy").</param>
+/// <param name="MetricName">Specific metric name within the category (e.g., "TokenCount", "CharacterCount").</param>
+/// <param name="OpalScore">The raw score for OPAL (interpretation depends on metric).</param>
+/// <param name="CSharpScore">The raw score for C# (interpretation depends on metric).</param>
+/// <param name="AdvantageRatio">Ratio indicating OPAL advantage. >1 means OPAL is better, &lt;1 means C# is better.</param>
+/// <param name="Details">Additional metric-specific details for debugging and analysis.</param>
+public record MetricResult(
+    string Category,
+    string MetricName,
+    double OpalScore,
+    double CSharpScore,
+    double AdvantageRatio,
+    Dictionary<string, object> Details)
+{
+    /// <summary>
+    /// Creates a metric result where lower values are better (e.g., token count).
+    /// Advantage ratio is calculated as CSharpScore / OpalScore.
+    /// </summary>
+    public static MetricResult CreateLowerIsBetter(
+        string category,
+        string metricName,
+        double opalScore,
+        double csharpScore,
+        Dictionary<string, object>? details = null)
+    {
+        var ratio = opalScore > 0 ? csharpScore / opalScore : 1.0;
+        return new MetricResult(category, metricName, opalScore, csharpScore, ratio, details ?? new());
+    }
+
+    /// <summary>
+    /// Creates a metric result where higher values are better (e.g., accuracy).
+    /// Advantage ratio is calculated as OpalScore / CSharpScore.
+    /// </summary>
+    public static MetricResult CreateHigherIsBetter(
+        string category,
+        string metricName,
+        double opalScore,
+        double csharpScore,
+        Dictionary<string, object>? details = null)
+    {
+        var ratio = csharpScore > 0 ? opalScore / csharpScore : 1.0;
+        return new MetricResult(category, metricName, opalScore, csharpScore, ratio, details ?? new());
+    }
+
+    /// <summary>
+    /// Returns true if OPAL has an advantage (ratio > 1).
+    /// </summary>
+    public bool OpalHasAdvantage => AdvantageRatio > 1.0;
+
+    /// <summary>
+    /// Returns the percentage advantage for OPAL (positive) or C# (negative).
+    /// </summary>
+    public double AdvantagePercentage => (AdvantageRatio - 1.0) * 100;
+}

--- a/src/Opal.Compiler/Evaluation/Metrics/ComprehensionCalculator.cs
+++ b/src/Opal.Compiler/Evaluation/Metrics/ComprehensionCalculator.cs
@@ -1,0 +1,172 @@
+using Opal.Compiler.Evaluation.Core;
+
+namespace Opal.Compiler.Evaluation.Metrics;
+
+/// <summary>
+/// Category 3: Comprehension Calculator
+/// Measures structural clarity and explicit markers visibility.
+/// OPAL's explicit structure markers (§M, §F, §REQ) should aid comprehension.
+/// </summary>
+public class ComprehensionCalculator : IMetricCalculator
+{
+    public string Category => "Comprehension";
+
+    public string Description => "Measures structural clarity and explicit markers for code understanding";
+
+    public Task<MetricResult> CalculateAsync(EvaluationContext context)
+    {
+        var opalScore = CalculateOpalComprehensionScore(context);
+        var csharpScore = CalculateCSharpComprehensionScore(context);
+
+        var details = new Dictionary<string, object>
+        {
+            ["opalExplicitMarkers"] = CountExplicitMarkers(context.OpalSource),
+            ["csharpCommentDensity"] = CalculateCommentDensity(context.CSharpSource),
+            ["opalStructureDepth"] = CalculateStructureDepth(context.OpalSource),
+            ["csharpStructureDepth"] = CalculateStructureDepth(context.CSharpSource)
+        };
+
+        return Task.FromResult(MetricResult.CreateHigherIsBetter(
+            Category,
+            "StructuralClarity",
+            opalScore,
+            csharpScore,
+            details));
+    }
+
+    private static double CalculateOpalComprehensionScore(EvaluationContext context)
+    {
+        var source = context.OpalSource;
+        var score = 0.0;
+
+        // Explicit structure markers contribute to clarity
+        var markers = new[]
+        {
+            ("§M[", 1.0),   // Module marker
+            ("§F[", 1.0),   // Function marker
+            ("§V[", 0.5),   // Variable marker
+            ("§I[", 0.5),   // Input parameter
+            ("§O[", 0.5),   // Output/return type
+            ("§REQ", 1.0),  // Requires (precondition)
+            ("§ENS", 1.0),  // Ensures (postcondition)
+            ("§INV", 1.0),  // Invariant
+            ("§E[", 0.8),   // Effects
+            ("id:", 0.5)    // Explicit IDs for targeting
+        };
+
+        foreach (var (marker, weight) in markers)
+        {
+            if (source.Contains(marker))
+            {
+                score += weight;
+            }
+        }
+
+        // Normalize to 0-1 range
+        var maxPossible = markers.Sum(m => m.Item2);
+        return Math.Min(1.0, score / maxPossible);
+    }
+
+    private static double CalculateCSharpComprehensionScore(EvaluationContext context)
+    {
+        var source = context.CSharpSource;
+        var score = 0.0;
+
+        // Comments contribute to comprehension
+        var commentDensity = CalculateCommentDensity(source);
+        score += commentDensity * 0.3;
+
+        // XML documentation
+        if (source.Contains("///") || source.Contains("/** "))
+        {
+            score += 0.2;
+        }
+
+        // Meaningful type annotations
+        if (source.Contains("public") || source.Contains("private"))
+        {
+            score += 0.1;
+        }
+
+        // Named parameters usage
+        if (source.Contains(": ") && (source.Contains("string ") || source.Contains("int ")))
+        {
+            score += 0.1;
+        }
+
+        // Attributes (metadata)
+        if (source.Contains("[") && source.Contains("]"))
+        {
+            score += 0.1;
+        }
+
+        // Clear method signatures
+        if (context.CSharpCompilation.Success && context.CSharpCompilation.Root != null)
+        {
+            score += 0.2;
+        }
+
+        return Math.Min(1.0, score);
+    }
+
+    private static Dictionary<string, int> CountExplicitMarkers(string source)
+    {
+        var markers = new Dictionary<string, int>
+        {
+            ["module"] = CountOccurrences(source, "§M["),
+            ["function"] = CountOccurrences(source, "§F["),
+            ["variable"] = CountOccurrences(source, "§V["),
+            ["requires"] = CountOccurrences(source, "§REQ"),
+            ["ensures"] = CountOccurrences(source, "§ENS"),
+            ["invariant"] = CountOccurrences(source, "§INV"),
+            ["effects"] = CountOccurrences(source, "§E["),
+            ["ids"] = CountOccurrences(source, "id:")
+        };
+        return markers;
+    }
+
+    private static double CalculateCommentDensity(string source)
+    {
+        var lines = source.Split('\n');
+        var commentLines = lines.Count(l =>
+            l.Trim().StartsWith("//") ||
+            l.Trim().StartsWith("/*") ||
+            l.Trim().StartsWith("*") ||
+            l.Trim().StartsWith("///"));
+
+        return lines.Length > 0 ? (double)commentLines / lines.Length : 0;
+    }
+
+    private static int CalculateStructureDepth(string source)
+    {
+        var maxDepth = 0;
+        var currentDepth = 0;
+
+        foreach (var ch in source)
+        {
+            if (ch == '{')
+            {
+                currentDepth++;
+                maxDepth = Math.Max(maxDepth, currentDepth);
+            }
+            else if (ch == '}')
+            {
+                currentDepth--;
+            }
+        }
+
+        return maxDepth;
+    }
+
+    private static int CountOccurrences(string source, string pattern)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = source.IndexOf(pattern, index, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += pattern.Length;
+        }
+        return count;
+    }
+}

--- a/src/Opal.Compiler/Evaluation/Metrics/EditPrecisionCalculator.cs
+++ b/src/Opal.Compiler/Evaluation/Metrics/EditPrecisionCalculator.cs
@@ -1,0 +1,220 @@
+using Opal.Compiler.Evaluation.Core;
+
+namespace Opal.Compiler.Evaluation.Metrics;
+
+/// <summary>
+/// Category 4: Edit Precision Calculator
+/// Measures the ability to make targeted edits via unique IDs.
+/// OPAL's §F[id:name] enables precise edits without context ambiguity.
+/// </summary>
+public class EditPrecisionCalculator : IMetricCalculator
+{
+    public string Category => "EditPrecision";
+
+    public string Description => "Measures targeting precision via unique IDs and structural markers";
+
+    public Task<MetricResult> CalculateAsync(EvaluationContext context)
+    {
+        var opalScore = CalculateOpalEditPrecision(context);
+        var csharpScore = CalculateCSharpEditPrecision(context);
+
+        var details = new Dictionary<string, object>
+        {
+            ["opalUniqueIds"] = CountUniqueIds(context.OpalSource),
+            ["opalAddressableElements"] = CountAddressableElements(context.OpalSource),
+            ["csharpNamedElements"] = CountNamedElements(context.CSharpSource),
+            ["opalTargetingScore"] = opalScore,
+            ["csharpTargetingScore"] = csharpScore
+        };
+
+        return Task.FromResult(MetricResult.CreateHigherIsBetter(
+            Category,
+            "TargetingPrecision",
+            opalScore,
+            csharpScore,
+            details));
+    }
+
+    private static double CalculateOpalEditPrecision(EvaluationContext context)
+    {
+        var source = context.OpalSource;
+        var score = 0.0;
+
+        // Count explicit IDs that enable precise targeting
+        var idCount = CountUniqueIds(source);
+        score += Math.Min(1.0, idCount * 0.15);
+
+        // Function markers with IDs
+        var functionIds = CountOccurrences(source, "§F[id:");
+        score += Math.Min(0.3, functionIds * 0.1);
+
+        // Variable markers
+        var varMarkers = CountOccurrences(source, "§V[");
+        score += Math.Min(0.2, varMarkers * 0.05);
+
+        // Module markers
+        var moduleMarkers = CountOccurrences(source, "§M[");
+        score += Math.Min(0.2, moduleMarkers * 0.1);
+
+        // Return markers (enable precise return targeting)
+        var returnMarkers = CountOccurrences(source, "§RET");
+        score += Math.Min(0.1, returnMarkers * 0.05);
+
+        // Call markers (enable precise call site targeting)
+        var callMarkers = CountOccurrences(source, "§C[");
+        score += Math.Min(0.2, callMarkers * 0.05);
+
+        return Math.Min(1.0, score);
+    }
+
+    private static double CalculateCSharpEditPrecision(EvaluationContext context)
+    {
+        var source = context.CSharpSource;
+        var score = 0.0;
+
+        // Named elements in C# require context to target
+        var namedElements = CountNamedElements(source);
+
+        // Base score from having named elements
+        score += Math.Min(0.3, namedElements * 0.02);
+
+        // Attributes can help with targeting
+        var attributeCount = CountOccurrences(source, "[");
+        score += Math.Min(0.1, attributeCount * 0.02);
+
+        // XML comments with references can help
+        var xmlRefs = CountOccurrences(source, "<see cref=");
+        score += Math.Min(0.1, xmlRefs * 0.05);
+
+        // Regions help organize for targeting
+        var regions = CountOccurrences(source, "#region");
+        score += Math.Min(0.1, regions * 0.05);
+
+        // Partial classes enable splitting
+        if (source.Contains("partial class") || source.Contains("partial struct"))
+        {
+            score += 0.1;
+        }
+
+        // Method overloads require more context to target correctly (penalty)
+        var methodMatches = CountMethodDeclarations(source);
+        var duplicateNames = FindDuplicateMethodNames(source);
+        if (duplicateNames > 0)
+        {
+            score -= duplicateNames * 0.05;
+        }
+
+        return Math.Max(0, Math.Min(1.0, score));
+    }
+
+    private static int CountUniqueIds(string source)
+    {
+        var count = 0;
+        var index = 0;
+        var pattern = "id:";
+
+        while ((index = source.IndexOf(pattern, index, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += pattern.Length;
+        }
+
+        return count;
+    }
+
+    private static int CountAddressableElements(string source)
+    {
+        var count = 0;
+
+        // Count all major addressable markers
+        count += CountOccurrences(source, "§M[");
+        count += CountOccurrences(source, "§F[");
+        count += CountOccurrences(source, "§V[");
+        count += CountOccurrences(source, "§C[");
+
+        return count;
+    }
+
+    private static int CountNamedElements(string source)
+    {
+        var count = 0;
+
+        // Count class/struct/interface declarations
+        count += CountOccurrences(source, "class ");
+        count += CountOccurrences(source, "struct ");
+        count += CountOccurrences(source, "interface ");
+        count += CountOccurrences(source, "enum ");
+
+        // Count method declarations (simplified)
+        count += CountMethodDeclarations(source);
+
+        // Count property declarations
+        count += CountOccurrences(source, " get;");
+        count += CountOccurrences(source, " set;");
+
+        return count;
+    }
+
+    private static int CountMethodDeclarations(string source)
+    {
+        // Simplified method counting - look for common patterns
+        var count = 0;
+
+        var lines = source.Split('\n');
+        foreach (var line in lines)
+        {
+            var trimmed = line.Trim();
+            if ((trimmed.Contains("public ") || trimmed.Contains("private ") ||
+                 trimmed.Contains("protected ") || trimmed.Contains("internal ")) &&
+                trimmed.Contains("(") && trimmed.Contains(")") &&
+                !trimmed.Contains("=") && !trimmed.StartsWith("//"))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static int FindDuplicateMethodNames(string source)
+    {
+        var methodNames = new List<string>();
+        var lines = source.Split('\n');
+
+        foreach (var line in lines)
+        {
+            var trimmed = line.Trim();
+            if ((trimmed.Contains("public ") || trimmed.Contains("private ") ||
+                 trimmed.Contains("protected ") || trimmed.Contains("internal ")) &&
+                trimmed.Contains("("))
+            {
+                // Extract method name (simplified)
+                var parenIndex = trimmed.IndexOf('(');
+                if (parenIndex > 0)
+                {
+                    var beforeParen = trimmed.Substring(0, parenIndex);
+                    var parts = beforeParen.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length > 0)
+                    {
+                        var methodName = parts[^1];
+                        methodNames.Add(methodName);
+                    }
+                }
+            }
+        }
+
+        return methodNames.Count - methodNames.Distinct().Count();
+    }
+
+    private static int CountOccurrences(string source, string pattern)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = source.IndexOf(pattern, index, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += pattern.Length;
+        }
+        return count;
+    }
+}

--- a/src/Opal.Compiler/Evaluation/Metrics/ErrorDetectionCalculator.cs
+++ b/src/Opal.Compiler/Evaluation/Metrics/ErrorDetectionCalculator.cs
@@ -1,0 +1,161 @@
+using Opal.Compiler.Evaluation.Core;
+
+namespace Opal.Compiler.Evaluation.Metrics;
+
+/// <summary>
+/// Category 5: Error Detection Calculator
+/// Measures the presence of contracts, assertions, and error detection mechanisms.
+/// OPAL's built-in §REQ/§ENS/§INV provides explicit error detection.
+/// </summary>
+public class ErrorDetectionCalculator : IMetricCalculator
+{
+    public string Category => "ErrorDetection";
+
+    public string Description => "Measures contracts, assertions, and error detection mechanisms";
+
+    public Task<MetricResult> CalculateAsync(EvaluationContext context)
+    {
+        var opalScore = CalculateOpalErrorDetection(context);
+        var csharpScore = CalculateCSharpErrorDetection(context);
+
+        var details = new Dictionary<string, object>
+        {
+            ["opalContracts"] = CountOpalContracts(context.OpalSource),
+            ["csharpGuards"] = CountCSharpGuards(context.CSharpSource),
+            ["opalPreconditions"] = CountOccurrences(context.OpalSource, "§REQ"),
+            ["opalPostconditions"] = CountOccurrences(context.OpalSource, "§ENS"),
+            ["opalInvariants"] = CountOccurrences(context.OpalSource, "§INV"),
+            ["csharpExceptions"] = CountOccurrences(context.CSharpSource, "throw ")
+        };
+
+        return Task.FromResult(MetricResult.CreateHigherIsBetter(
+            Category,
+            "ContractCoverage",
+            opalScore,
+            csharpScore,
+            details));
+    }
+
+    private static double CalculateOpalErrorDetection(EvaluationContext context)
+    {
+        var source = context.OpalSource;
+        var score = 0.0;
+
+        // Preconditions (§REQ)
+        var reqCount = CountOccurrences(source, "§REQ");
+        score += Math.Min(0.3, reqCount * 0.1);
+
+        // Postconditions (§ENS)
+        var ensCount = CountOccurrences(source, "§ENS");
+        score += Math.Min(0.3, ensCount * 0.1);
+
+        // Invariants (§INV)
+        var invCount = CountOccurrences(source, "§INV");
+        score += Math.Min(0.2, invCount * 0.1);
+
+        // Effect declarations (explicit side effect documentation)
+        var effectCount = CountOccurrences(source, "§E[");
+        score += Math.Min(0.1, effectCount * 0.05);
+
+        // Assert statements
+        var assertCount = CountOccurrences(source, "§ASSERT");
+        score += Math.Min(0.1, assertCount * 0.05);
+
+        // Null checks in contracts
+        if (source.Contains("!= null") || source.Contains("!= §NULL"))
+        {
+            score += 0.05;
+        }
+
+        return Math.Min(1.0, score);
+    }
+
+    private static double CalculateCSharpErrorDetection(EvaluationContext context)
+    {
+        var source = context.CSharpSource;
+        var score = 0.0;
+
+        // Null checks
+        var nullChecks = CountOccurrences(source, "!= null") + CountOccurrences(source, "is not null");
+        score += Math.Min(0.15, nullChecks * 0.03);
+
+        // ArgumentNullException
+        var argNullEx = CountOccurrences(source, "ArgumentNullException");
+        score += Math.Min(0.1, argNullEx * 0.05);
+
+        // ArgumentException variations
+        var argEx = CountOccurrences(source, "ArgumentException") +
+                    CountOccurrences(source, "ArgumentOutOfRangeException");
+        score += Math.Min(0.1, argEx * 0.05);
+
+        // InvalidOperationException
+        var invalidOp = CountOccurrences(source, "InvalidOperationException");
+        score += Math.Min(0.1, invalidOp * 0.05);
+
+        // Debug.Assert
+        var debugAssert = CountOccurrences(source, "Debug.Assert");
+        score += Math.Min(0.1, debugAssert * 0.05);
+
+        // Contract.Requires (Code Contracts)
+        var contractReq = CountOccurrences(source, "Contract.Requires");
+        score += Math.Min(0.15, contractReq * 0.05);
+
+        // Contract.Ensures
+        var contractEns = CountOccurrences(source, "Contract.Ensures");
+        score += Math.Min(0.15, contractEns * 0.05);
+
+        // Nullable reference type annotations
+        if (source.Contains("?") && (source.Contains("string?") || source.Contains("int?")))
+        {
+            score += 0.05;
+        }
+
+        // Guard clauses (if throwing)
+        var guardPatterns = CountOccurrences(source, "if (") + CountOccurrences(source, "if(");
+        var throwCount = CountOccurrences(source, "throw ");
+        if (throwCount > 0 && guardPatterns > 0)
+        {
+            score += Math.Min(0.1, (throwCount / (double)guardPatterns) * 0.1);
+        }
+
+        return Math.Min(1.0, score);
+    }
+
+    private static Dictionary<string, int> CountOpalContracts(string source)
+    {
+        return new Dictionary<string, int>
+        {
+            ["requires"] = CountOccurrences(source, "§REQ"),
+            ["ensures"] = CountOccurrences(source, "§ENS"),
+            ["invariants"] = CountOccurrences(source, "§INV"),
+            ["effects"] = CountOccurrences(source, "§E["),
+            ["asserts"] = CountOccurrences(source, "§ASSERT")
+        };
+    }
+
+    private static Dictionary<string, int> CountCSharpGuards(string source)
+    {
+        return new Dictionary<string, int>
+        {
+            ["nullChecks"] = CountOccurrences(source, "!= null") + CountOccurrences(source, "is not null"),
+            ["argumentExceptions"] = CountOccurrences(source, "ArgumentException") +
+                                     CountOccurrences(source, "ArgumentNullException"),
+            ["throws"] = CountOccurrences(source, "throw "),
+            ["debugAsserts"] = CountOccurrences(source, "Debug.Assert"),
+            ["contracts"] = CountOccurrences(source, "Contract.Requires") +
+                           CountOccurrences(source, "Contract.Ensures")
+        };
+    }
+
+    private static int CountOccurrences(string source, string pattern)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = source.IndexOf(pattern, index, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += pattern.Length;
+        }
+        return count;
+    }
+}

--- a/src/Opal.Compiler/Evaluation/Metrics/GenerationAccuracyCalculator.cs
+++ b/src/Opal.Compiler/Evaluation/Metrics/GenerationAccuracyCalculator.cs
@@ -1,0 +1,139 @@
+using Opal.Compiler.Evaluation.Core;
+
+namespace Opal.Compiler.Evaluation.Metrics;
+
+/// <summary>
+/// Category 2: Generation Accuracy Calculator
+/// Measures compilation success and AST structure validity.
+/// OPAL's explicit structure markers should improve accuracy.
+/// </summary>
+public class GenerationAccuracyCalculator : IMetricCalculator
+{
+    public string Category => "GenerationAccuracy";
+
+    public string Description => "Measures compilation success and structural validity";
+
+    public Task<MetricResult> CalculateAsync(EvaluationContext context)
+    {
+        var opalSuccess = context.OpalCompilation.Success;
+        var csharpSuccess = context.CSharpCompilation.Success;
+
+        // Calculate scores based on compilation success and error count
+        var opalErrorCount = context.OpalCompilation.Errors.Count;
+        var csharpErrorCount = context.CSharpCompilation.Errors.Count;
+
+        // Score: 1.0 for success, reduced by error count
+        var opalScore = opalSuccess ? 1.0 : Math.Max(0, 1.0 - (opalErrorCount * 0.1));
+        var csharpScore = csharpSuccess ? 1.0 : Math.Max(0, 1.0 - (csharpErrorCount * 0.1));
+
+        // Additional structural metrics for OPAL
+        var opalStructuralScore = CalculateOpalStructuralScore(context);
+        var csharpStructuralScore = CalculateCSharpStructuralScore(context);
+
+        // Combine compilation and structural scores
+        var opalCombined = (opalScore + opalStructuralScore) / 2.0;
+        var csharpCombined = (csharpScore + csharpStructuralScore) / 2.0;
+
+        var details = new Dictionary<string, object>
+        {
+            ["opalSuccess"] = opalSuccess,
+            ["csharpSuccess"] = csharpSuccess,
+            ["opalErrorCount"] = opalErrorCount,
+            ["csharpErrorCount"] = csharpErrorCount,
+            ["opalStructuralScore"] = opalStructuralScore,
+            ["csharpStructuralScore"] = csharpStructuralScore,
+            ["opalErrors"] = context.OpalCompilation.Errors.Take(5).ToList(),
+            ["csharpErrors"] = context.CSharpCompilation.Errors.Take(5).ToList()
+        };
+
+        return Task.FromResult(MetricResult.CreateHigherIsBetter(
+            Category,
+            "CompilationAccuracy",
+            opalCombined,
+            csharpCombined,
+            details));
+    }
+
+    private static double CalculateOpalStructuralScore(EvaluationContext context)
+    {
+        var source = context.OpalSource;
+        var score = 0.0;
+        var checks = 0;
+
+        // Check for proper module structure
+        if (source.Contains("§M["))
+        {
+            score += 1.0;
+            checks++;
+        }
+
+        // Check for function definitions
+        if (source.Contains("§F["))
+        {
+            score += 1.0;
+            checks++;
+        }
+
+        // Check for proper block structure
+        var openBraces = source.Count(c => c == '{');
+        var closeBraces = source.Count(c => c == '}');
+        if (openBraces == closeBraces)
+        {
+            score += 1.0;
+            checks++;
+        }
+
+        // Check for proper parameter definitions
+        if (source.Contains("§I[") || source.Contains("§O["))
+        {
+            score += 1.0;
+            checks++;
+        }
+
+        return checks > 0 ? score / checks : 0.5;
+    }
+
+    private static double CalculateCSharpStructuralScore(EvaluationContext context)
+    {
+        if (!context.CSharpCompilation.Success || context.CSharpCompilation.Root == null)
+            return 0.0;
+
+        var root = context.CSharpCompilation.Root;
+        var score = 0.0;
+        var checks = 0;
+
+        // Check for namespace or type declarations
+        if (root.Members.Any())
+        {
+            score += 1.0;
+            checks++;
+        }
+
+        // Check for using directives
+        if (root.Usings.Any())
+        {
+            score += 1.0;
+            checks++;
+        }
+
+        // Check for proper semicolons (basic structural validity)
+        var source = context.CSharpSource;
+        var semicolons = source.Count(c => c == ';');
+        if (semicolons > 0)
+        {
+            score += 1.0;
+            checks++;
+        }
+
+        // Check balanced braces
+        var openBraces = source.Count(c => c == '{');
+        var closeBraces = source.Count(c => c == '}');
+        if (openBraces == closeBraces && openBraces > 0)
+        {
+            score += 1.0;
+            checks++;
+        }
+
+        return checks > 0 ? score / checks : 0.5;
+    }
+}

--- a/src/Opal.Compiler/Evaluation/Metrics/InformationDensityCalculator.cs
+++ b/src/Opal.Compiler/Evaluation/Metrics/InformationDensityCalculator.cs
@@ -1,0 +1,235 @@
+using Opal.Compiler.Evaluation.Core;
+
+namespace Opal.Compiler.Evaluation.Metrics;
+
+/// <summary>
+/// Category 6: Information Density Calculator
+/// Measures semantic elements per token ratio.
+/// OPAL carries more semantic information inline (effects, contracts).
+/// </summary>
+public class InformationDensityCalculator : IMetricCalculator
+{
+    public string Category => "InformationDensity";
+
+    public string Description => "Measures semantic information per token ratio";
+
+    public Task<MetricResult> CalculateAsync(EvaluationContext context)
+    {
+        var opalDensity = CalculateOpalDensity(context);
+        var csharpDensity = CalculateCSharpDensity(context);
+
+        var opalTokens = TokenizeSource(context.OpalSource).Count;
+        var csharpTokens = TokenizeSource(context.CSharpSource).Count;
+
+        var details = new Dictionary<string, object>
+        {
+            ["opalSemanticElements"] = CountOpalSemanticElements(context.OpalSource),
+            ["csharpSemanticElements"] = CountCSharpSemanticElements(context.CSharpSource),
+            ["opalTokenCount"] = opalTokens,
+            ["csharpTokenCount"] = csharpTokens,
+            ["opalDensity"] = opalDensity,
+            ["csharpDensity"] = csharpDensity
+        };
+
+        return Task.FromResult(MetricResult.CreateHigherIsBetter(
+            Category,
+            "SemanticDensity",
+            opalDensity,
+            csharpDensity,
+            details));
+    }
+
+    private static double CalculateOpalDensity(EvaluationContext context)
+    {
+        var source = context.OpalSource;
+        var tokenCount = TokenizeSource(source).Count;
+
+        if (tokenCount == 0)
+            return 0;
+
+        var semanticElements = CountOpalSemanticElements(source);
+        var totalElements = semanticElements.Values.Sum();
+
+        // Semantic elements per token, normalized
+        return totalElements / (double)tokenCount * 10.0; // Scale factor
+    }
+
+    private static double CalculateCSharpDensity(EvaluationContext context)
+    {
+        var source = context.CSharpSource;
+        var tokenCount = TokenizeSource(source).Count;
+
+        if (tokenCount == 0)
+            return 0;
+
+        var semanticElements = CountCSharpSemanticElements(source);
+        var totalElements = semanticElements.Values.Sum();
+
+        // Semantic elements per token, normalized
+        return totalElements / (double)tokenCount * 10.0; // Scale factor
+    }
+
+    private static Dictionary<string, int> CountOpalSemanticElements(string source)
+    {
+        var elements = new Dictionary<string, int>
+        {
+            // Structural elements
+            ["modules"] = CountOccurrences(source, "§M["),
+            ["functions"] = CountOccurrences(source, "§F["),
+            ["variables"] = CountOccurrences(source, "§V["),
+            ["parameters"] = CountOccurrences(source, "§I[") + CountOccurrences(source, "§O["),
+
+            // Contract elements (high semantic value)
+            ["requires"] = CountOccurrences(source, "§REQ") * 2, // Weight contracts higher
+            ["ensures"] = CountOccurrences(source, "§ENS") * 2,
+            ["invariants"] = CountOccurrences(source, "§INV") * 2,
+
+            // Effect declarations (high semantic value)
+            ["effects"] = CountOccurrences(source, "§E[") * 2,
+
+            // Control flow
+            ["conditionals"] = CountOccurrences(source, "§IF") + CountOccurrences(source, "§ELSE"),
+            ["loops"] = CountOccurrences(source, "§LOOP") + CountOccurrences(source, "§FOR") +
+                       CountOccurrences(source, "§WHILE"),
+            ["matches"] = CountOccurrences(source, "§MATCH") * 2, // Pattern matching is semantic-rich
+
+            // Calls and returns
+            ["calls"] = CountOccurrences(source, "§C["),
+            ["returns"] = CountOccurrences(source, "§RET"),
+
+            // Type annotations
+            ["types"] = CountOccurrences(source, ":") // Approximate type annotations
+        };
+
+        return elements;
+    }
+
+    private static Dictionary<string, int> CountCSharpSemanticElements(string source)
+    {
+        var elements = new Dictionary<string, int>
+        {
+            // Structural elements
+            ["classes"] = CountOccurrences(source, "class "),
+            ["structs"] = CountOccurrences(source, "struct "),
+            ["interfaces"] = CountOccurrences(source, "interface "),
+            ["methods"] = CountMethodCount(source),
+            ["properties"] = CountOccurrences(source, " get;") + CountOccurrences(source, " set;"),
+
+            // Control flow
+            ["conditionals"] = CountOccurrences(source, "if (") + CountOccurrences(source, "if(") +
+                              CountOccurrences(source, "else"),
+            ["loops"] = CountOccurrences(source, "for (") + CountOccurrences(source, "for(") +
+                       CountOccurrences(source, "while (") + CountOccurrences(source, "while(") +
+                       CountOccurrences(source, "foreach (") + CountOccurrences(source, "foreach("),
+            ["switches"] = CountOccurrences(source, "switch (") + CountOccurrences(source, "switch("),
+
+            // Error handling
+            ["exceptions"] = CountOccurrences(source, "throw ") + CountOccurrences(source, "try") +
+                            CountOccurrences(source, "catch"),
+
+            // LINQ (semantic-rich)
+            ["linq"] = CountOccurrences(source, ".Select(") + CountOccurrences(source, ".Where(") +
+                      CountOccurrences(source, ".OrderBy(") + CountOccurrences(source, ".GroupBy("),
+
+            // Async
+            ["async"] = CountOccurrences(source, "async ") + CountOccurrences(source, "await "),
+
+            // Attributes
+            ["attributes"] = CountAttributeCount(source)
+        };
+
+        return elements;
+    }
+
+    private static int CountMethodCount(string source)
+    {
+        var count = 0;
+        var lines = source.Split('\n');
+
+        foreach (var line in lines)
+        {
+            var trimmed = line.Trim();
+            if ((trimmed.Contains("public ") || trimmed.Contains("private ") ||
+                 trimmed.Contains("protected ") || trimmed.Contains("internal ") ||
+                 trimmed.Contains("static ")) &&
+                trimmed.Contains("(") && !trimmed.StartsWith("//") &&
+                !trimmed.Contains("="))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static int CountAttributeCount(string source)
+    {
+        var count = 0;
+        var inAttribute = false;
+
+        foreach (var ch in source)
+        {
+            if (ch == '[' && !inAttribute)
+            {
+                inAttribute = true;
+            }
+            else if (ch == ']' && inAttribute)
+            {
+                count++;
+                inAttribute = false;
+            }
+        }
+
+        return count;
+    }
+
+    private static List<string> TokenizeSource(string source)
+    {
+        var tokens = new List<string>();
+        var currentToken = "";
+
+        foreach (var ch in source)
+        {
+            if (char.IsWhiteSpace(ch))
+            {
+                if (!string.IsNullOrEmpty(currentToken))
+                {
+                    tokens.Add(currentToken);
+                    currentToken = "";
+                }
+            }
+            else if (char.IsPunctuation(ch) || char.IsSymbol(ch))
+            {
+                if (!string.IsNullOrEmpty(currentToken))
+                {
+                    tokens.Add(currentToken);
+                    currentToken = "";
+                }
+                tokens.Add(ch.ToString());
+            }
+            else
+            {
+                currentToken += ch;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(currentToken))
+        {
+            tokens.Add(currentToken);
+        }
+
+        return tokens;
+    }
+
+    private static int CountOccurrences(string source, string pattern)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = source.IndexOf(pattern, index, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += pattern.Length;
+        }
+        return count;
+    }
+}

--- a/src/Opal.Compiler/Evaluation/Metrics/TaskCompletionCalculator.cs
+++ b/src/Opal.Compiler/Evaluation/Metrics/TaskCompletionCalculator.cs
@@ -1,0 +1,195 @@
+using Opal.Compiler.Evaluation.Core;
+
+namespace Opal.Compiler.Evaluation.Metrics;
+
+/// <summary>
+/// Category 7: Task Completion Calculator
+/// Measures end-to-end success rate considering context efficiency.
+/// OPAL's compactness should enable better task completion within context limits.
+/// </summary>
+public class TaskCompletionCalculator : IMetricCalculator
+{
+    public string Category => "TaskCompletion";
+
+    public string Description => "Measures end-to-end completeness and context efficiency";
+
+    public Task<MetricResult> CalculateAsync(EvaluationContext context)
+    {
+        var opalScore = CalculateOpalTaskCompletion(context);
+        var csharpScore = CalculateCSharpTaskCompletion(context);
+
+        var details = new Dictionary<string, object>
+        {
+            ["opalCompleteness"] = CalculateCompleteness(context.OpalSource, context.OpalCompilation.Success),
+            ["csharpCompleteness"] = CalculateCompleteness(context.CSharpSource, context.CSharpCompilation.Success),
+            ["opalContextEfficiency"] = CalculateContextEfficiency(context.OpalSource),
+            ["csharpContextEfficiency"] = CalculateContextEfficiency(context.CSharpSource),
+            ["opalCompilationSuccess"] = context.OpalCompilation.Success,
+            ["csharpCompilationSuccess"] = context.CSharpCompilation.Success
+        };
+
+        return Task.FromResult(MetricResult.CreateHigherIsBetter(
+            Category,
+            "OverallCompletion",
+            opalScore,
+            csharpScore,
+            details));
+    }
+
+    private static double CalculateOpalTaskCompletion(EvaluationContext context)
+    {
+        var score = 0.0;
+
+        // Compilation success is primary indicator
+        if (context.OpalCompilation.Success)
+        {
+            score += 0.4;
+        }
+        else
+        {
+            // Partial credit for partial success
+            var errorCount = context.OpalCompilation.Errors.Count;
+            score += Math.Max(0, 0.2 - (errorCount * 0.02));
+        }
+
+        // Completeness score
+        var completeness = CalculateCompleteness(context.OpalSource, context.OpalCompilation.Success);
+        score += completeness * 0.3;
+
+        // Context efficiency (compact code can fit more in context)
+        var efficiency = CalculateContextEfficiency(context.OpalSource);
+        score += efficiency * 0.3;
+
+        return Math.Min(1.0, score);
+    }
+
+    private static double CalculateCSharpTaskCompletion(EvaluationContext context)
+    {
+        var score = 0.0;
+
+        // Compilation success is primary indicator
+        if (context.CSharpCompilation.Success)
+        {
+            score += 0.4;
+        }
+        else
+        {
+            // Partial credit for partial success
+            var errorCount = context.CSharpCompilation.Errors.Count;
+            score += Math.Max(0, 0.2 - (errorCount * 0.02));
+        }
+
+        // Completeness score
+        var completeness = CalculateCompleteness(context.CSharpSource, context.CSharpCompilation.Success);
+        score += completeness * 0.3;
+
+        // Context efficiency
+        var efficiency = CalculateContextEfficiency(context.CSharpSource);
+        score += efficiency * 0.3;
+
+        return Math.Min(1.0, score);
+    }
+
+    private static double CalculateCompleteness(string source, bool compilationSuccess)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+            return 0;
+
+        var score = 0.0;
+
+        // Has content
+        if (source.Length > 10)
+            score += 0.2;
+
+        // Balanced braces indicate structural completeness
+        var openBraces = source.Count(c => c == '{');
+        var closeBraces = source.Count(c => c == '}');
+        if (openBraces == closeBraces && openBraces > 0)
+            score += 0.2;
+
+        // Balanced parentheses
+        var openParens = source.Count(c => c == '(');
+        var closeParens = source.Count(c => c == ')');
+        if (openParens == closeParens && openParens > 0)
+            score += 0.2;
+
+        // Has at least one complete statement
+        if (source.Contains(";") || source.Contains("}"))
+            score += 0.2;
+
+        // Compilation success indicates full completeness
+        if (compilationSuccess)
+            score += 0.2;
+
+        return Math.Min(1.0, score);
+    }
+
+    private static double CalculateContextEfficiency(string source)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+            return 0;
+
+        // Calculate information density relative to size
+        var tokens = TokenizeSource(source).Count;
+        var lines = source.Split('\n', StringSplitOptions.RemoveEmptyEntries).Length;
+
+        if (tokens == 0 || lines == 0)
+            return 0;
+
+        // Tokens per line (higher is more efficient)
+        var tokensPerLine = (double)tokens / lines;
+
+        // Normalize to 0-1 (assuming 5-20 tokens per line is normal range)
+        var efficiency = Math.Min(1.0, tokensPerLine / 15.0);
+
+        // Penalty for excessive whitespace/comments ratio
+        var whitespaceCount = source.Count(char.IsWhiteSpace);
+        var whitespaceRatio = (double)whitespaceCount / source.Length;
+
+        // Good code has 20-40% whitespace
+        if (whitespaceRatio > 0.5)
+        {
+            efficiency *= (1.0 - (whitespaceRatio - 0.5));
+        }
+
+        return efficiency;
+    }
+
+    private static List<string> TokenizeSource(string source)
+    {
+        var tokens = new List<string>();
+        var currentToken = "";
+
+        foreach (var ch in source)
+        {
+            if (char.IsWhiteSpace(ch))
+            {
+                if (!string.IsNullOrEmpty(currentToken))
+                {
+                    tokens.Add(currentToken);
+                    currentToken = "";
+                }
+            }
+            else if (char.IsPunctuation(ch) || char.IsSymbol(ch))
+            {
+                if (!string.IsNullOrEmpty(currentToken))
+                {
+                    tokens.Add(currentToken);
+                    currentToken = "";
+                }
+                tokens.Add(ch.ToString());
+            }
+            else
+            {
+                currentToken += ch;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(currentToken))
+        {
+            tokens.Add(currentToken);
+        }
+
+        return tokens;
+    }
+}

--- a/src/Opal.Compiler/Evaluation/Metrics/TokenEconomicsCalculator.cs
+++ b/src/Opal.Compiler/Evaluation/Metrics/TokenEconomicsCalculator.cs
@@ -1,0 +1,105 @@
+using Opal.Compiler.Evaluation.Core;
+
+namespace Opal.Compiler.Evaluation.Metrics;
+
+/// <summary>
+/// Category 1: Token Economics Calculator
+/// Measures the token count and character count comparison between OPAL and C#.
+/// OPAL is hypothesized to be ~40-60% more compact.
+/// </summary>
+public class TokenEconomicsCalculator : IMetricCalculator
+{
+    public string Category => "TokenEconomics";
+
+    public string Description => "Measures token and character counts to compare code compactness";
+
+    public Task<MetricResult> CalculateAsync(EvaluationContext context)
+    {
+        // Calculate token counts using simple tokenization
+        var opalTokens = TokenizeSource(context.OpalSource);
+        var csharpTokens = TokenizeSource(context.CSharpSource);
+
+        var opalTokenCount = opalTokens.Count;
+        var csharpTokenCount = csharpTokens.Count;
+
+        // Character counts (excluding whitespace for fair comparison)
+        var opalCharCount = context.OpalSource.Replace(" ", "").Replace("\n", "").Replace("\r", "").Replace("\t", "").Length;
+        var csharpCharCount = context.CSharpSource.Replace(" ", "").Replace("\n", "").Replace("\r", "").Replace("\t", "").Length;
+
+        // Line counts
+        var opalLineCount = context.OpalSource.Split('\n').Length;
+        var csharpLineCount = context.CSharpSource.Split('\n').Length;
+
+        // Calculate ratios (lower is better for OPAL, so C#/OPAL gives advantage ratio)
+        var tokenRatio = opalTokenCount > 0 ? (double)csharpTokenCount / opalTokenCount : 1.0;
+        var charRatio = opalCharCount > 0 ? (double)csharpCharCount / opalCharCount : 1.0;
+        var lineRatio = opalLineCount > 0 ? (double)csharpLineCount / opalLineCount : 1.0;
+
+        // Composite advantage (geometric mean of ratios)
+        var compositeAdvantage = Math.Pow(tokenRatio * charRatio * lineRatio, 1.0 / 3.0);
+
+        var details = new Dictionary<string, object>
+        {
+            ["opalTokenCount"] = opalTokenCount,
+            ["csharpTokenCount"] = csharpTokenCount,
+            ["tokenRatio"] = tokenRatio,
+            ["opalCharCount"] = opalCharCount,
+            ["csharpCharCount"] = csharpCharCount,
+            ["charRatio"] = charRatio,
+            ["opalLineCount"] = opalLineCount,
+            ["csharpLineCount"] = csharpLineCount,
+            ["lineRatio"] = lineRatio,
+            ["opalTokens"] = opalTokens.Take(50).ToList(),
+            ["csharpTokens"] = csharpTokens.Take(50).ToList()
+        };
+
+        return Task.FromResult(MetricResult.CreateLowerIsBetter(
+            Category,
+            "CompositeTokenEconomics",
+            opalTokenCount,
+            csharpTokenCount,
+            details));
+    }
+
+    /// <summary>
+    /// Simple tokenizer that splits source code into tokens.
+    /// Approximates LLM tokenization by splitting on whitespace and punctuation.
+    /// </summary>
+    private static List<string> TokenizeSource(string source)
+    {
+        var tokens = new List<string>();
+        var currentToken = "";
+
+        foreach (var ch in source)
+        {
+            if (char.IsWhiteSpace(ch))
+            {
+                if (!string.IsNullOrEmpty(currentToken))
+                {
+                    tokens.Add(currentToken);
+                    currentToken = "";
+                }
+            }
+            else if (char.IsPunctuation(ch) || char.IsSymbol(ch))
+            {
+                if (!string.IsNullOrEmpty(currentToken))
+                {
+                    tokens.Add(currentToken);
+                    currentToken = "";
+                }
+                tokens.Add(ch.ToString());
+            }
+            else
+            {
+                currentToken += ch;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(currentToken))
+        {
+            tokens.Add(currentToken);
+        }
+
+        return tokens;
+    }
+}

--- a/src/Opal.Compiler/Evaluation/Reports/JsonReportGenerator.cs
+++ b/src/Opal.Compiler/Evaluation/Reports/JsonReportGenerator.cs
@@ -1,0 +1,175 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Opal.Compiler.Evaluation.Core;
+
+namespace Opal.Compiler.Evaluation.Reports;
+
+/// <summary>
+/// Generates JSON reports from evaluation results.
+/// </summary>
+public class JsonReportGenerator
+{
+    private static readonly JsonSerializerOptions DefaultOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    /// <summary>
+    /// Generates a complete JSON report.
+    /// </summary>
+    public string Generate(EvaluationResult result)
+    {
+        var report = new JsonReport
+        {
+            Metadata = new ReportMetadata
+            {
+                GeneratedAt = result.Timestamp,
+                Version = result.Version,
+                BenchmarkCount = result.BenchmarkCount
+            },
+            Summary = MapSummary(result.Summary),
+            CategoryResults = GroupByCategory(result),
+            DetailedResults = MapDetailedResults(result)
+        };
+
+        return JsonSerializer.Serialize(report, DefaultOptions);
+    }
+
+    /// <summary>
+    /// Generates a summary-only JSON report (smaller output).
+    /// </summary>
+    public string GenerateSummary(EvaluationResult result)
+    {
+        var report = new
+        {
+            summary = new
+            {
+                overallOpalAdvantage = result.Summary.OverallOpalAdvantage,
+                categoryAdvantages = result.Summary.CategoryAdvantages
+            }
+        };
+
+        return JsonSerializer.Serialize(report, DefaultOptions);
+    }
+
+    /// <summary>
+    /// Saves the report to a file.
+    /// </summary>
+    public async Task SaveAsync(EvaluationResult result, string path)
+    {
+        var json = Generate(result);
+        await File.WriteAllTextAsync(path, json);
+    }
+
+    private static JsonSummary MapSummary(EvaluationSummary summary)
+    {
+        return new JsonSummary
+        {
+            OverallOpalAdvantage = summary.OverallOpalAdvantage,
+            CategoryAdvantages = summary.CategoryAdvantages,
+            OpalPassCount = summary.OpalPassCount,
+            CSharpPassCount = summary.CSharpPassCount,
+            TopOpalCategories = summary.TopOpalCategories,
+            CSharpAdvantageCategories = summary.CSharpAdvantageCategories
+        };
+    }
+
+    private static Dictionary<string, JsonCategoryResult> GroupByCategory(EvaluationResult result)
+    {
+        return result.Metrics
+            .GroupBy(m => m.Category)
+            .ToDictionary(
+                g => g.Key,
+                g => new JsonCategoryResult
+                {
+                    MetricCount = g.Count(),
+                    AverageAdvantage = Math.Round(g.Average(m => m.AdvantageRatio), 2),
+                    OpalWins = g.Count(m => m.AdvantageRatio > 1.0),
+                    CSharpWins = g.Count(m => m.AdvantageRatio < 1.0),
+                    Ties = g.Count(m => Math.Abs(m.AdvantageRatio - 1.0) < 0.01),
+                    Metrics = g.Select(m => new JsonMetric
+                    {
+                        Name = m.MetricName,
+                        OpalScore = Math.Round(m.OpalScore, 2),
+                        CSharpScore = Math.Round(m.CSharpScore, 2),
+                        AdvantageRatio = Math.Round(m.AdvantageRatio, 2),
+                        AdvantagePercent = Math.Round(m.AdvantagePercentage, 1)
+                    }).ToList()
+                });
+    }
+
+    private static List<JsonCaseResult> MapDetailedResults(EvaluationResult result)
+    {
+        return result.CaseResults.Select(c => new JsonCaseResult
+        {
+            CaseId = c.CaseId,
+            FileName = c.FileName,
+            Level = c.Level,
+            Features = c.Features,
+            OpalSuccess = c.OpalSuccess,
+            CSharpSuccess = c.CSharpSuccess,
+            AverageAdvantage = Math.Round(c.AverageAdvantage, 2),
+            MetricCount = c.Metrics.Count
+        }).ToList();
+    }
+}
+
+// JSON structure classes
+
+internal class JsonReport
+{
+    public required ReportMetadata Metadata { get; set; }
+    public required JsonSummary Summary { get; set; }
+    public required Dictionary<string, JsonCategoryResult> CategoryResults { get; set; }
+    public required List<JsonCaseResult> DetailedResults { get; set; }
+}
+
+internal class ReportMetadata
+{
+    public DateTime GeneratedAt { get; set; }
+    public string Version { get; set; } = "";
+    public int BenchmarkCount { get; set; }
+}
+
+internal class JsonSummary
+{
+    public double OverallOpalAdvantage { get; set; }
+    public Dictionary<string, double> CategoryAdvantages { get; set; } = new();
+    public int OpalPassCount { get; set; }
+    public int CSharpPassCount { get; set; }
+    public List<string> TopOpalCategories { get; set; } = new();
+    public List<string> CSharpAdvantageCategories { get; set; } = new();
+}
+
+internal class JsonCategoryResult
+{
+    public int MetricCount { get; set; }
+    public double AverageAdvantage { get; set; }
+    public int OpalWins { get; set; }
+    public int CSharpWins { get; set; }
+    public int Ties { get; set; }
+    public List<JsonMetric> Metrics { get; set; } = new();
+}
+
+internal class JsonMetric
+{
+    public string Name { get; set; } = "";
+    public double OpalScore { get; set; }
+    public double CSharpScore { get; set; }
+    public double AdvantageRatio { get; set; }
+    public double AdvantagePercent { get; set; }
+}
+
+internal class JsonCaseResult
+{
+    public string CaseId { get; set; } = "";
+    public string FileName { get; set; } = "";
+    public int Level { get; set; }
+    public List<string> Features { get; set; } = new();
+    public bool OpalSuccess { get; set; }
+    public bool CSharpSuccess { get; set; }
+    public double AverageAdvantage { get; set; }
+    public int MetricCount { get; set; }
+}

--- a/src/Opal.Compiler/Evaluation/Reports/MarkdownReportGenerator.cs
+++ b/src/Opal.Compiler/Evaluation/Reports/MarkdownReportGenerator.cs
@@ -1,0 +1,237 @@
+using System.Text;
+using Opal.Compiler.Evaluation.Core;
+
+namespace Opal.Compiler.Evaluation.Reports;
+
+/// <summary>
+/// Generates human-readable Markdown reports from evaluation results.
+/// </summary>
+public class MarkdownReportGenerator
+{
+    /// <summary>
+    /// Generates a complete Markdown report.
+    /// </summary>
+    public string Generate(EvaluationResult result)
+    {
+        var sb = new StringBuilder();
+
+        WriteHeader(sb, result);
+        WriteSummary(sb, result.Summary);
+        WriteCategoryBreakdown(sb, result);
+        WriteDetailedResults(sb, result);
+        WriteConclusions(sb, result);
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Generates a summary-only Markdown report.
+    /// </summary>
+    public string GenerateSummary(EvaluationResult result)
+    {
+        var sb = new StringBuilder();
+
+        WriteHeader(sb, result);
+        WriteSummary(sb, result.Summary);
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Saves the report to a file.
+    /// </summary>
+    public async Task SaveAsync(EvaluationResult result, string path)
+    {
+        var markdown = Generate(result);
+        await File.WriteAllTextAsync(path, markdown);
+    }
+
+    private static void WriteHeader(StringBuilder sb, EvaluationResult result)
+    {
+        sb.AppendLine("# OPAL vs C# Evaluation Report");
+        sb.AppendLine();
+        sb.AppendLine($"**Generated:** {result.Timestamp:yyyy-MM-dd HH:mm:ss} UTC");
+        sb.AppendLine($"**Framework Version:** {result.Version}");
+        sb.AppendLine($"**Benchmarks Evaluated:** {result.BenchmarkCount}");
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+    }
+
+    private static void WriteSummary(StringBuilder sb, EvaluationSummary summary)
+    {
+        sb.AppendLine("## Executive Summary");
+        sb.AppendLine();
+
+        // Overall result
+        var overallAdvantage = summary.OverallOpalAdvantage;
+        var advantagePercent = (overallAdvantage - 1.0) * 100;
+        var winner = overallAdvantage > 1.0 ? "OPAL" : (overallAdvantage < 1.0 ? "C#" : "Neither");
+
+        sb.AppendLine($"**Overall Winner:** {winner}");
+        sb.AppendLine($"**Overall Advantage Ratio:** {overallAdvantage:F2}x");
+
+        if (overallAdvantage != 1.0)
+        {
+            sb.AppendLine($"**Advantage Percentage:** {Math.Abs(advantagePercent):F1}% in favor of {winner}");
+        }
+
+        sb.AppendLine();
+
+        // Category breakdown table
+        sb.AppendLine("### Category Advantages");
+        sb.AppendLine();
+        sb.AppendLine("| Category | Advantage Ratio | Winner |");
+        sb.AppendLine("|----------|-----------------|--------|");
+
+        foreach (var (category, ratio) in summary.CategoryAdvantages.OrderByDescending(kv => kv.Value))
+        {
+            var catWinner = ratio > 1.0 ? "OPAL" : (ratio < 1.0 ? "C#" : "Tie");
+            var indicator = ratio > 1.2 ? "+" : (ratio < 0.8 ? "-" : "=");
+            sb.AppendLine($"| {category} | {ratio:F2}x | {indicator} {catWinner} |");
+        }
+
+        sb.AppendLine();
+
+        // Pass counts
+        sb.AppendLine("### Compilation Success");
+        sb.AppendLine();
+        sb.AppendLine($"- OPAL passed: {summary.OpalPassCount}");
+        sb.AppendLine($"- C# passed: {summary.CSharpPassCount}");
+        sb.AppendLine();
+    }
+
+    private static void WriteCategoryBreakdown(StringBuilder sb, EvaluationResult result)
+    {
+        sb.AppendLine("## Category Breakdown");
+        sb.AppendLine();
+
+        var byCategory = result.Metrics
+            .GroupBy(m => m.Category)
+            .OrderByDescending(g => g.Average(m => m.AdvantageRatio));
+
+        foreach (var category in byCategory)
+        {
+            var avgAdvantage = category.Average(m => m.AdvantageRatio);
+            var opalWins = category.Count(m => m.AdvantageRatio > 1.0);
+            var csharpWins = category.Count(m => m.AdvantageRatio < 1.0);
+
+            sb.AppendLine($"### {category.Key}");
+            sb.AppendLine();
+            sb.AppendLine($"**Average Advantage:** {avgAdvantage:F2}x");
+            sb.AppendLine($"**OPAL wins:** {opalWins} | **C# wins:** {csharpWins}");
+            sb.AppendLine();
+
+            // Top metrics
+            var topMetrics = category.OrderByDescending(m => m.AdvantageRatio).Take(5);
+            sb.AppendLine("| Metric | OPAL | C# | Ratio |");
+            sb.AppendLine("|--------|------|-----|-------|");
+
+            foreach (var metric in topMetrics)
+            {
+                sb.AppendLine($"| {metric.MetricName} | {metric.OpalScore:F2} | {metric.CSharpScore:F2} | {metric.AdvantageRatio:F2}x |");
+            }
+
+            sb.AppendLine();
+        }
+    }
+
+    private static void WriteDetailedResults(StringBuilder sb, EvaluationResult result)
+    {
+        if (result.CaseResults.Count == 0)
+            return;
+
+        sb.AppendLine("## Detailed Results by Benchmark");
+        sb.AppendLine();
+
+        // Group by level
+        var byLevel = result.CaseResults.GroupBy(c => c.Level).OrderBy(g => g.Key);
+
+        foreach (var level in byLevel)
+        {
+            sb.AppendLine($"### Level {level.Key}");
+            sb.AppendLine();
+            sb.AppendLine("| Benchmark | OPAL OK | C# OK | Avg Advantage |");
+            sb.AppendLine("|-----------|---------|-------|---------------|");
+
+            foreach (var caseResult in level.OrderByDescending(c => c.AverageAdvantage))
+            {
+                var opalOk = caseResult.OpalSuccess ? "Yes" : "No";
+                var csharpOk = caseResult.CSharpSuccess ? "Yes" : "No";
+                sb.AppendLine($"| {caseResult.FileName} | {opalOk} | {csharpOk} | {caseResult.AverageAdvantage:F2}x |");
+            }
+
+            sb.AppendLine();
+        }
+    }
+
+    private static void WriteConclusions(StringBuilder sb, EvaluationResult result)
+    {
+        sb.AppendLine("## Conclusions");
+        sb.AppendLine();
+
+        var summary = result.Summary;
+
+        // Key findings
+        sb.AppendLine("### Key Findings");
+        sb.AppendLine();
+
+        if (summary.TopOpalCategories.Count > 0)
+        {
+            sb.AppendLine($"1. **OPAL excels in:** {string.Join(", ", summary.TopOpalCategories)}");
+        }
+
+        if (summary.CSharpAdvantageCategories.Count > 0)
+        {
+            sb.AppendLine($"2. **C# advantages:** {string.Join(", ", summary.CSharpAdvantageCategories)}");
+        }
+
+        // Token economics highlight
+        if (summary.CategoryAdvantages.TryGetValue("TokenEconomics", out var tokenAdvantage))
+        {
+            var savings = (1 - 1.0 / tokenAdvantage) * 100;
+            if (savings > 0)
+            {
+                sb.AppendLine($"3. **Token savings:** OPAL uses approximately {savings:F0}% fewer tokens than equivalent C# code");
+            }
+        }
+
+        // Information density highlight
+        if (summary.CategoryAdvantages.TryGetValue("InformationDensity", out var densityAdvantage))
+        {
+            if (densityAdvantage > 1.0)
+            {
+                sb.AppendLine($"4. **Information density:** OPAL carries {densityAdvantage:F1}x more semantic information per token");
+            }
+        }
+
+        sb.AppendLine();
+
+        // Recommendations
+        sb.AppendLine("### Recommendations");
+        sb.AppendLine();
+        sb.AppendLine("Based on the evaluation results:");
+        sb.AppendLine();
+
+        if (summary.OverallOpalAdvantage > 1.2)
+        {
+            sb.AppendLine("- Consider using OPAL for AI agent interactions to reduce token costs");
+            sb.AppendLine("- OPAL's explicit structure may improve AI code generation accuracy");
+        }
+        else if (summary.OverallOpalAdvantage < 0.8)
+        {
+            sb.AppendLine("- C# may be more suitable for the evaluated use cases");
+            sb.AppendLine("- Consider the specific task requirements when choosing");
+        }
+        else
+        {
+            sb.AppendLine("- Results are similar; choose based on team familiarity and tooling");
+            sb.AppendLine("- Consider category-specific advantages for specialized tasks");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("*Report generated by OPAL Evaluation Framework*");
+    }
+}

--- a/src/Opal.Compiler/Migration/BenchmarkIntegration.cs
+++ b/src/Opal.Compiler/Migration/BenchmarkIntegration.cs
@@ -1,12 +1,342 @@
+using Opal.Compiler.Evaluation.Benchmarks;
+using Opal.Compiler.Evaluation.Core;
+using Opal.Compiler.Evaluation.Reports;
+
 namespace Opal.Compiler.Migration;
 
 /// <summary>
-/// Integrates with the evaluation framework to provide benchmark metrics during migration.
+/// Integrates with the full evaluation framework to provide comprehensive benchmark metrics.
+/// Wraps the BenchmarkRunner to provide all 7 metric categories.
 /// </summary>
 public sealed class BenchmarkIntegration
 {
     /// <summary>
+    /// All available benchmark categories.
+    /// </summary>
+    public static readonly string[] AllCategories = new[]
+    {
+        "TokenEconomics",
+        "GenerationAccuracy",
+        "Comprehension",
+        "EditPrecision",
+        "ErrorDetection",
+        "InformationDensity",
+        "TaskCompletion"
+    };
+
+    /// <summary>
+    /// Runs the full 7-metric benchmark on the provided source code.
+    /// </summary>
+    public static async Task<FullBenchmarkResult> RunFullBenchmarkAsync(
+        string csharpSource,
+        string opalSource,
+        string? category = null,
+        bool verbose = false)
+    {
+        var options = new BenchmarkRunnerOptions
+        {
+            Verbose = verbose,
+            Categories = category != null ? new List<string> { category } : new List<string>()
+        };
+
+        var runner = new BenchmarkRunner(options);
+        var caseResult = await runner.RunFromSourceAsync(opalSource, csharpSource, "inline");
+
+        // Build the full result
+        var result = new FullBenchmarkResult
+        {
+            CaseResult = caseResult,
+            Summary = CalculateSummaryFromCase(caseResult)
+        };
+
+        return result;
+    }
+
+    /// <summary>
+    /// Runs benchmarks for all paired files in a directory.
+    /// </summary>
+    public static async Task<FullBenchmarkResult> RunProjectBenchmarkAsync(
+        string directory,
+        string? category = null,
+        bool verbose = false)
+    {
+        var options = new BenchmarkRunnerOptions
+        {
+            Verbose = verbose,
+            Categories = category != null ? new List<string> { category } : new List<string>()
+        };
+
+        var runner = new BenchmarkRunner(options);
+
+        // Discover paired files
+        var opalFiles = Directory.GetFiles(directory, "*.opal", SearchOption.AllDirectories);
+        var projectResults = new List<BenchmarkCaseResult>();
+
+        foreach (var opalPath in opalFiles)
+        {
+            var baseName = Path.GetFileNameWithoutExtension(opalPath);
+            var dir = Path.GetDirectoryName(opalPath)!;
+
+            // Look for matching C# file
+            var csharpPath = Path.Combine(dir, baseName + ".cs");
+            if (!File.Exists(csharpPath))
+            {
+                csharpPath = Path.Combine(dir, baseName + ".g.cs");
+                if (!File.Exists(csharpPath))
+                    continue;
+            }
+
+            try
+            {
+                var caseResult = await runner.RunFromFilesAsync(opalPath, csharpPath, baseName);
+                projectResults.Add(caseResult);
+
+                if (verbose)
+                {
+                    Console.WriteLine($"  Benchmarked: {baseName}");
+                }
+            }
+            catch (Exception ex)
+            {
+                if (verbose)
+                {
+                    Console.Error.WriteLine($"  Warning: Failed to benchmark {baseName}: {ex.Message}");
+                }
+            }
+        }
+
+        if (projectResults.Count == 0)
+        {
+            return new FullBenchmarkResult
+            {
+                CaseResult = null,
+                Summary = new EvaluationSummary(),
+                ProjectResults = new List<BenchmarkCaseResult>()
+            };
+        }
+
+        var summary = CalculateSummaryFromCases(projectResults);
+
+        return new FullBenchmarkResult
+        {
+            CaseResult = projectResults.FirstOrDefault(),
+            Summary = summary,
+            ProjectResults = projectResults
+        };
+    }
+
+    /// <summary>
+    /// Generates a markdown report from the benchmark result.
+    /// </summary>
+    public static string GenerateMarkdownReport(FullBenchmarkResult result, string? opalName = null, string? csharpName = null)
+    {
+        var generator = new MarkdownReportGenerator();
+
+        // Build an EvaluationResult from the FullBenchmarkResult
+        var evalResult = new EvaluationResult
+        {
+            BenchmarkCount = result.ProjectResults?.Count ?? (result.CaseResult != null ? 1 : 0),
+            Summary = result.Summary
+        };
+
+        if (result.ProjectResults != null && result.ProjectResults.Count > 0)
+        {
+            foreach (var caseResult in result.ProjectResults)
+            {
+                evalResult.CaseResults.Add(caseResult);
+                evalResult.Metrics.AddRange(caseResult.Metrics);
+            }
+        }
+        else if (result.CaseResult != null)
+        {
+            evalResult.CaseResults.Add(result.CaseResult);
+            evalResult.Metrics.AddRange(result.CaseResult.Metrics);
+        }
+
+        return generator.Generate(evalResult);
+    }
+
+    /// <summary>
+    /// Generates a JSON report from the benchmark result.
+    /// </summary>
+    public static string GenerateJsonReport(FullBenchmarkResult result)
+    {
+        var generator = new JsonReportGenerator();
+
+        // Build an EvaluationResult from the FullBenchmarkResult
+        var evalResult = new EvaluationResult
+        {
+            BenchmarkCount = result.ProjectResults?.Count ?? (result.CaseResult != null ? 1 : 0),
+            Summary = result.Summary
+        };
+
+        if (result.ProjectResults != null && result.ProjectResults.Count > 0)
+        {
+            foreach (var caseResult in result.ProjectResults)
+            {
+                evalResult.CaseResults.Add(caseResult);
+                evalResult.Metrics.AddRange(caseResult.Metrics);
+            }
+        }
+        else if (result.CaseResult != null)
+        {
+            evalResult.CaseResults.Add(result.CaseResult);
+            evalResult.Metrics.AddRange(result.CaseResult.Metrics);
+        }
+
+        return generator.Generate(evalResult);
+    }
+
+    /// <summary>
+    /// Formats a console output with the full 7-metric table.
+    /// </summary>
+    public static string FormatConsoleOutput(FullBenchmarkResult result, string opalName, string csharpName, bool verbose = false)
+    {
+        var sb = new System.Text.StringBuilder();
+
+        sb.AppendLine($"Benchmark: {csharpName} vs {opalName}");
+        sb.AppendLine();
+
+        if (result.CaseResult == null || result.CaseResult.Metrics.Count == 0)
+        {
+            sb.AppendLine("No metrics calculated.");
+            return sb.ToString();
+        }
+
+        // Build category table
+        sb.AppendLine("+-------------------------+--------+--------+-----------+");
+        sb.AppendLine("| Category                | C#     | OPAL   | Advantage |");
+        sb.AppendLine("+-------------------------+--------+--------+-----------+");
+
+        // Group metrics by category and calculate averages
+        var byCategory = result.CaseResult.Metrics
+            .GroupBy(m => m.Category)
+            .OrderByDescending(g => g.Average(m => m.AdvantageRatio));
+
+        foreach (var category in byCategory)
+        {
+            var avgOpal = category.Average(m => m.OpalScore);
+            var avgCSharp = category.Average(m => m.CSharpScore);
+            var avgAdvantage = category.Average(m => m.AdvantageRatio);
+
+            // Normalize scores to 0-1 range for display
+            var opalNorm = NormalizeScore(avgOpal, avgCSharp, category.Key);
+            var csharpNorm = NormalizeScore(avgCSharp, avgOpal, category.Key);
+
+            sb.AppendLine($"| {category.Key,-23} | {csharpNorm,6:F2} | {opalNorm,6:F2} | {avgAdvantage,7:F2}x |");
+        }
+
+        sb.AppendLine("+-------------------------+--------+--------+-----------+");
+        sb.AppendLine();
+
+        // Overall advantage
+        var overallAdvantage = result.Summary.OverallOpalAdvantage > 0
+            ? result.Summary.OverallOpalAdvantage
+            : CalculateGeometricMean(byCategory.Select(g => g.Average(m => m.AdvantageRatio)));
+
+        sb.AppendLine($"Overall OPAL Advantage: {overallAdvantage:F2}x (geometric mean)");
+
+        // Verbose mode: show per-metric breakdown
+        if (verbose)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Detailed Metrics:");
+            sb.AppendLine();
+
+            foreach (var category in byCategory)
+            {
+                sb.AppendLine($"  {category.Key}:");
+                foreach (var metric in category)
+                {
+                    var indicator = metric.AdvantageRatio > 1 ? "+" : "";
+                    sb.AppendLine($"    {metric.MetricName}: OPAL={metric.OpalScore:F0}, C#={metric.CSharpScore:F0} ({indicator}{(metric.AdvantageRatio - 1) * 100:F0}%)");
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Formats project-level console output.
+    /// </summary>
+    public static string FormatProjectConsoleOutput(FullBenchmarkResult result, string projectName, bool verbose = false)
+    {
+        var sb = new System.Text.StringBuilder();
+
+        sb.AppendLine($"Project Benchmark: {projectName}");
+        sb.AppendLine($"Files compared: {result.ProjectResults?.Count ?? 0}");
+        sb.AppendLine();
+
+        if (result.ProjectResults == null || result.ProjectResults.Count == 0)
+        {
+            sb.AppendLine("No paired .opal and .cs files found.");
+            return sb.ToString();
+        }
+
+        // Summary table by category
+        sb.AppendLine("Category Summary:");
+        sb.AppendLine("+-------------------------+-----------+-----------+-----------+");
+        sb.AppendLine("| Category                | Avg OPAL  | Avg C#    | Advantage |");
+        sb.AppendLine("+-------------------------+-----------+-----------+-----------+");
+
+        // Aggregate all metrics from all cases
+        var allMetrics = result.ProjectResults.SelectMany(c => c.Metrics).ToList();
+        var byCategory = allMetrics
+            .GroupBy(m => m.Category)
+            .OrderByDescending(g => g.Average(m => m.AdvantageRatio));
+
+        foreach (var category in byCategory)
+        {
+            var avgOpal = category.Average(m => m.OpalScore);
+            var avgCSharp = category.Average(m => m.CSharpScore);
+            var avgAdvantage = category.Average(m => m.AdvantageRatio);
+
+            sb.AppendLine($"| {category.Key,-23} | {avgOpal,9:F1} | {avgCSharp,9:F1} | {avgAdvantage,7:F2}x |");
+        }
+
+        sb.AppendLine("+-------------------------+-----------+-----------+-----------+");
+        sb.AppendLine();
+
+        sb.AppendLine($"Overall OPAL Advantage: {result.Summary.OverallOpalAdvantage:F2}x");
+        sb.AppendLine();
+
+        // Per-file breakdown
+        sb.AppendLine("By File:");
+        foreach (var caseResult in result.ProjectResults.OrderByDescending(c => c.AverageAdvantage))
+        {
+            var indicator = caseResult.AverageAdvantage > 1 ? "+" : "";
+            sb.AppendLine($"  {caseResult.FileName}: {indicator}{(caseResult.AverageAdvantage - 1) * 100:F0}% advantage ({caseResult.Metrics.Count} metrics)");
+        }
+
+        if (verbose)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Top OPAL Advantages:");
+            foreach (var cat in result.Summary.TopOpalCategories.Take(3))
+            {
+                sb.AppendLine($"  - {cat}");
+            }
+
+            if (result.Summary.CSharpAdvantageCategories.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("C# Advantages:");
+                foreach (var cat in result.Summary.CSharpAdvantageCategories)
+                {
+                    sb.AppendLine($"  - {cat}");
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    // ========== Legacy methods for backward compatibility ==========
+
+    /// <summary>
     /// Calculates token and line metrics for source code comparison.
+    /// Kept for backward compatibility with the migration tool.
     /// </summary>
     public static FileMetrics CalculateMetrics(string originalSource, string convertedSource)
     {
@@ -25,8 +355,72 @@ public sealed class BenchmarkIntegration
     }
 
     /// <summary>
-    /// Simple tokenizer that approximates LLM tokenization.
+    /// Calculates the advantage ratio (higher = more compact OPAL).
     /// </summary>
+    public static double CalculateAdvantageRatio(FileMetrics metrics)
+    {
+        if (metrics.OutputTokens == 0)
+            return 1.0;
+
+        // Calculate geometric mean of ratios
+        var tokenRatio = (double)metrics.OriginalTokens / metrics.OutputTokens;
+        var lineRatio = metrics.OutputLines > 0 ? (double)metrics.OriginalLines / metrics.OutputLines : 1.0;
+        var charRatio = metrics.OutputCharacters > 0 ? (double)metrics.OriginalCharacters / metrics.OutputCharacters : 1.0;
+
+        return Math.Pow(tokenRatio * lineRatio * charRatio, 1.0 / 3.0);
+    }
+
+    /// <summary>
+    /// Formats a benchmark comparison for console output (legacy format).
+    /// </summary>
+    public static string FormatComparison(FileMetrics metrics)
+    {
+        var advantage = CalculateAdvantageRatio(metrics);
+
+        return $"""
+            Token Economics:
+              Before: {metrics.OriginalTokens:N0} tokens, {metrics.OriginalLines:N0} lines
+              After:  {metrics.OutputTokens:N0} tokens, {metrics.OutputLines:N0} lines
+              Token Savings: {metrics.TokenReduction:F1}%
+              Line Savings: {metrics.LineReduction:F1}%
+              Overall Advantage: {advantage:F2}x
+            """;
+    }
+
+    /// <summary>
+    /// Creates a benchmark summary from multiple file metrics.
+    /// </summary>
+    public static BenchmarkSummary CreateSummary(IEnumerable<FileMetrics> metricsCollection)
+    {
+        var metricsList = metricsCollection.ToList();
+
+        return new BenchmarkSummary
+        {
+            TotalOriginalTokens = metricsList.Sum(m => m.OriginalTokens),
+            TotalOutputTokens = metricsList.Sum(m => m.OutputTokens),
+            TotalOriginalLines = metricsList.Sum(m => m.OriginalLines),
+            TotalOutputLines = metricsList.Sum(m => m.OutputLines)
+        };
+    }
+
+    /// <summary>
+    /// Runs a quick benchmark comparison between C# and OPAL source.
+    /// </summary>
+    public static BenchmarkResult RunQuickBenchmark(string csharpSource, string opalSource)
+    {
+        var metrics = CalculateMetrics(csharpSource, opalSource);
+        var advantage = CalculateAdvantageRatio(metrics);
+
+        return new BenchmarkResult
+        {
+            Metrics = metrics,
+            AdvantageRatio = advantage,
+            Summary = FormatComparison(metrics)
+        };
+    }
+
+    // ========== Private helper methods ==========
+
     private static List<string> TokenizeSource(string source)
     {
         var tokens = new List<string>();
@@ -80,74 +474,156 @@ public sealed class BenchmarkIntegration
         return source.Count(c => !char.IsWhiteSpace(c));
     }
 
-    /// <summary>
-    /// Calculates the advantage ratio (higher = more compact OPAL).
-    /// </summary>
-    public static double CalculateAdvantageRatio(FileMetrics metrics)
+    private static EvaluationSummary CalculateSummaryFromCase(BenchmarkCaseResult caseResult)
     {
-        if (metrics.OutputTokens == 0)
+        var summary = new EvaluationSummary();
+
+        // Group metrics by category
+        var byCategory = caseResult.Metrics
+            .GroupBy(m => m.Category)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        // Calculate average advantage per category
+        foreach (var (category, metrics) in byCategory)
+        {
+            var validMetrics = metrics.Where(m => m.AdvantageRatio > 0).ToList();
+            if (validMetrics.Count > 0)
+            {
+                var product = validMetrics.Aggregate(1.0, (acc, m) => acc * m.AdvantageRatio);
+                var geoMean = Math.Pow(product, 1.0 / validMetrics.Count);
+                summary.CategoryAdvantages[category] = Math.Round(geoMean, 2);
+            }
+        }
+
+        // Calculate overall advantage
+        if (summary.CategoryAdvantages.Count > 0)
+        {
+            var product = summary.CategoryAdvantages.Values.Aggregate(1.0, (acc, v) => acc * v);
+            summary.OverallOpalAdvantage = Math.Round(
+                Math.Pow(product, 1.0 / summary.CategoryAdvantages.Count), 2);
+        }
+
+        summary.OpalPassCount = caseResult.OpalSuccess ? 1 : 0;
+        summary.CSharpPassCount = caseResult.CSharpSuccess ? 1 : 0;
+
+        summary.TopOpalCategories = summary.CategoryAdvantages
+            .Where(kv => kv.Value > 1.0)
+            .OrderByDescending(kv => kv.Value)
+            .Take(3)
+            .Select(kv => kv.Key)
+            .ToList();
+
+        summary.CSharpAdvantageCategories = summary.CategoryAdvantages
+            .Where(kv => kv.Value < 1.0)
+            .OrderBy(kv => kv.Value)
+            .Select(kv => kv.Key)
+            .ToList();
+
+        return summary;
+    }
+
+    private static EvaluationSummary CalculateSummaryFromCases(List<BenchmarkCaseResult> caseResults)
+    {
+        var summary = new EvaluationSummary();
+
+        if (caseResults.Count == 0)
+            return summary;
+
+        // Aggregate all metrics
+        var allMetrics = caseResults.SelectMany(c => c.Metrics).ToList();
+
+        // Group metrics by category
+        var byCategory = allMetrics
+            .GroupBy(m => m.Category)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        // Calculate average advantage per category
+        foreach (var (category, metrics) in byCategory)
+        {
+            var validMetrics = metrics.Where(m => m.AdvantageRatio > 0).ToList();
+            if (validMetrics.Count > 0)
+            {
+                var product = validMetrics.Aggregate(1.0, (acc, m) => acc * m.AdvantageRatio);
+                var geoMean = Math.Pow(product, 1.0 / validMetrics.Count);
+                summary.CategoryAdvantages[category] = Math.Round(geoMean, 2);
+            }
+        }
+
+        // Calculate overall advantage
+        if (summary.CategoryAdvantages.Count > 0)
+        {
+            var product = summary.CategoryAdvantages.Values.Aggregate(1.0, (acc, v) => acc * v);
+            summary.OverallOpalAdvantage = Math.Round(
+                Math.Pow(product, 1.0 / summary.CategoryAdvantages.Count), 2);
+        }
+
+        summary.OpalPassCount = caseResults.Count(c => c.OpalSuccess);
+        summary.CSharpPassCount = caseResults.Count(c => c.CSharpSuccess);
+
+        summary.TopOpalCategories = summary.CategoryAdvantages
+            .Where(kv => kv.Value > 1.0)
+            .OrderByDescending(kv => kv.Value)
+            .Take(3)
+            .Select(kv => kv.Key)
+            .ToList();
+
+        summary.CSharpAdvantageCategories = summary.CategoryAdvantages
+            .Where(kv => kv.Value < 1.0)
+            .OrderBy(kv => kv.Value)
+            .Select(kv => kv.Key)
+            .ToList();
+
+        return summary;
+    }
+
+    private static double NormalizeScore(double score, double otherScore, string category)
+    {
+        // For token economics, lower is better, so invert
+        if (category == "TokenEconomics" || category == "EditPrecision")
+        {
+            var maxScore = Math.Max(score, otherScore);
+            return maxScore > 0 ? 1.0 - (score / maxScore) : 0.5;
+        }
+
+        // For other categories, higher is better
+        var max = Math.Max(score, otherScore);
+        return max > 0 ? score / max : 0.5;
+    }
+
+    private static double CalculateGeometricMean(IEnumerable<double> values)
+    {
+        var list = values.Where(v => v > 0).ToList();
+        if (list.Count == 0)
             return 1.0;
 
-        // Calculate geometric mean of ratios
-        var tokenRatio = (double)metrics.OriginalTokens / metrics.OutputTokens;
-        var lineRatio = metrics.OutputLines > 0 ? (double)metrics.OriginalLines / metrics.OutputLines : 1.0;
-        var charRatio = metrics.OutputCharacters > 0 ? (double)metrics.OriginalCharacters / metrics.OutputCharacters : 1.0;
-
-        return Math.Pow(tokenRatio * lineRatio * charRatio, 1.0 / 3.0);
-    }
-
-    /// <summary>
-    /// Formats a benchmark comparison for console output.
-    /// </summary>
-    public static string FormatComparison(FileMetrics metrics)
-    {
-        var advantage = CalculateAdvantageRatio(metrics);
-
-        return $"""
-            Token Economics:
-              Before: {metrics.OriginalTokens:N0} tokens, {metrics.OriginalLines:N0} lines
-              After:  {metrics.OutputTokens:N0} tokens, {metrics.OutputLines:N0} lines
-              Token Savings: {metrics.TokenReduction:F1}%
-              Line Savings: {metrics.LineReduction:F1}%
-              Overall Advantage: {advantage:F2}x
-            """;
-    }
-
-    /// <summary>
-    /// Creates a benchmark summary from multiple file metrics.
-    /// </summary>
-    public static BenchmarkSummary CreateSummary(IEnumerable<FileMetrics> metricsCollection)
-    {
-        var metricsList = metricsCollection.ToList();
-
-        return new BenchmarkSummary
-        {
-            TotalOriginalTokens = metricsList.Sum(m => m.OriginalTokens),
-            TotalOutputTokens = metricsList.Sum(m => m.OutputTokens),
-            TotalOriginalLines = metricsList.Sum(m => m.OriginalLines),
-            TotalOutputLines = metricsList.Sum(m => m.OutputLines)
-        };
-    }
-
-    /// <summary>
-    /// Runs a quick benchmark comparison between C# and OPAL source.
-    /// </summary>
-    public static BenchmarkResult RunQuickBenchmark(string csharpSource, string opalSource)
-    {
-        var metrics = CalculateMetrics(csharpSource, opalSource);
-        var advantage = CalculateAdvantageRatio(metrics);
-
-        return new BenchmarkResult
-        {
-            Metrics = metrics,
-            AdvantageRatio = advantage,
-            Summary = FormatComparison(metrics)
-        };
+        var product = list.Aggregate(1.0, (acc, v) => acc * v);
+        return Math.Pow(product, 1.0 / list.Count);
     }
 }
 
 /// <summary>
-/// Result of a benchmark comparison.
+/// Result of running the full 7-metric benchmark.
+/// </summary>
+public sealed class FullBenchmarkResult
+{
+    /// <summary>
+    /// Result for a single benchmark case.
+    /// </summary>
+    public BenchmarkCaseResult? CaseResult { get; init; }
+
+    /// <summary>
+    /// Summary statistics.
+    /// </summary>
+    public EvaluationSummary Summary { get; init; } = new();
+
+    /// <summary>
+    /// Results for all files in a project benchmark.
+    /// </summary>
+    public List<BenchmarkCaseResult>? ProjectResults { get; init; }
+}
+
+/// <summary>
+/// Result of a benchmark comparison (legacy).
 /// </summary>
 public sealed class BenchmarkResult
 {

--- a/src/Opal.Compiler/Opal.Compiler.csproj
+++ b/src/Opal.Compiler/Opal.Compiler.csproj
@@ -29,4 +29,8 @@
     <ProjectReference Include="..\Opal.Runtime\Opal.Runtime.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="DiffPlex" Version="1.7.2" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

- Enhances `opalc benchmark` CLI command to use the full 7-metric evaluation framework
- Adds comprehensive metric calculators for all evaluation categories
- Supports filtering by category, verbose output, and multiple output formats

## Changes

### New CLI Options
- `--category` / `-c`: Filter by specific metric category
- `--verbose` / `-v`: Show detailed per-metric breakdown  
- `--quick` / `-q`: Use legacy token-only benchmark (skip full evaluation)

### 7 Metric Categories
| Category | Measures |
|----------|----------|
| TokenEconomics | Token/line/char compactness |
| GenerationAccuracy | Compilation success, AST structure |
| Comprehension | Structural clarity, explicit markers |
| EditPrecision | Targeting via unique IDs |
| ErrorDetection | Contracts, assertions |
| InformationDensity | Semantic elements per token |
| TaskCompletion | End-to-end success rate |

### Output Formats
- Console table with category breakdown
- Markdown report with full analysis
- JSON report for programmatic access

## Test plan

- [x] All 284 existing tests pass
- [x] Manual testing of single file benchmark
- [x] Manual testing of project-level benchmark
- [x] Manual testing of category filtering
- [x] Manual testing of verbose output
- [x] Manual testing of markdown/JSON output formats

## Usage Examples

```bash
# Full benchmark with all 7 metrics
opalc benchmark --opal file.opal --csharp file.cs

# Filter by category
opalc benchmark --opal file.opal --csharp file.cs --category TokenEconomics

# Verbose output
opalc benchmark --opal file.opal --csharp file.cs --verbose

# Project-level benchmark
opalc benchmark ./tests/TestData/Benchmarks/TokenEconomics

# Generate reports
opalc benchmark ./project --format markdown -o report.md
opalc benchmark ./project --format json -o report.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)