### PR TITLE
Add C# attribute support to OPAL language

### DIFF
--- a/src/Opal.Compiler/Ast/AstNode.cs
+++ b/src/Opal.Compiler/Ast/AstNode.cs
@@ -145,6 +145,8 @@ public interface IAstVisitor
     void Visit(LockNode node);
     void Visit(AuthorNode node);
     void Visit(TaskRefNode node);
+    // C# Attribute Support
+    void Visit(OpalAttributeNode node);
 }
 
 /// <summary>
@@ -274,6 +276,8 @@ public interface IAstVisitor<T>
     T Visit(LockNode node);
     T Visit(AuthorNode node);
     T Visit(TaskRefNode node);
+    // C# Attribute Support
+    T Visit(OpalAttributeNode node);
 }
 
 /// <summary>

--- a/src/Opal.Compiler/Ast/AttributeNodes.cs
+++ b/src/Opal.Compiler/Ast/AttributeNodes.cs
@@ -1,0 +1,131 @@
+using Opal.Compiler.Parsing;
+
+namespace Opal.Compiler.Ast;
+
+/// <summary>
+/// Represents a C#-style attribute in OPAL (e.g., [@HttpPost], [@Route("api/[controller]")]).
+/// </summary>
+public sealed class OpalAttributeNode : AstNode
+{
+    /// <summary>
+    /// The attribute name (e.g., "HttpPost", "Route", "ApiController").
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// The attribute arguments (positional and named).
+    /// </summary>
+    public IReadOnlyList<OpalAttributeArgument> Arguments { get; }
+
+    public OpalAttributeNode(TextSpan span, string name, IReadOnlyList<OpalAttributeArgument>? arguments = null)
+        : base(span)
+    {
+        Name = name;
+        Arguments = arguments ?? Array.Empty<OpalAttributeArgument>();
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+
+    /// <summary>
+    /// Returns true if this attribute has no arguments.
+    /// </summary>
+    public bool HasNoArguments => Arguments.Count == 0;
+
+    /// <summary>
+    /// Returns true if this attribute has only positional arguments (no named arguments).
+    /// </summary>
+    public bool HasOnlyPositionalArguments => Arguments.All(a => a.Name == null);
+}
+
+/// <summary>
+/// Represents an argument to a C#-style attribute.
+/// </summary>
+public sealed class OpalAttributeArgument
+{
+    /// <summary>
+    /// The argument name for named arguments (e.g., "PropertyName" in [JsonProperty(PropertyName="foo")]).
+    /// Null for positional arguments.
+    /// </summary>
+    public string? Name { get; }
+
+    /// <summary>
+    /// The argument value. Can be string, int, bool, double, or a type reference.
+    /// </summary>
+    public object Value { get; }
+
+    /// <summary>
+    /// Creates a positional argument.
+    /// </summary>
+    public OpalAttributeArgument(object value)
+    {
+        Name = null;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Creates a named argument.
+    /// </summary>
+    public OpalAttributeArgument(string? name, object value)
+    {
+        Name = name;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Returns true if this is a positional argument.
+    /// </summary>
+    public bool IsPositional => Name == null;
+
+    /// <summary>
+    /// Returns true if this is a named argument.
+    /// </summary>
+    public bool IsNamed => Name != null;
+
+    /// <summary>
+    /// Gets the value formatted as a string for OPAL/C# emission.
+    /// </summary>
+    public string GetFormattedValue()
+    {
+        return Value switch
+        {
+            string s => $"\"{EscapeString(s)}\"",
+            bool b => b ? "true" : "false",
+            int i => i.ToString(),
+            long l => l.ToString(),
+            double d => d.ToString(),
+            float f => f.ToString(),
+            // Type reference (typeof)
+            Type t => $"typeof({t.Name})",
+            // For type name strings that represent typeof expressions
+            TypeOfReference tr => $"typeof({tr.TypeName})",
+            // Default: treat as identifier/enum value
+            _ => Value?.ToString() ?? "null"
+        };
+    }
+
+    private static string EscapeString(string s)
+    {
+        return s
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"")
+            .Replace("\n", "\\n")
+            .Replace("\r", "\\r")
+            .Replace("\t", "\\t");
+    }
+}
+
+/// <summary>
+/// Represents a typeof() reference in an attribute argument.
+/// </summary>
+public sealed class TypeOfReference
+{
+    public string TypeName { get; }
+
+    public TypeOfReference(string typeName)
+    {
+        TypeName = typeName;
+    }
+
+    public override string ToString() => $"typeof({TypeName})";
+}

--- a/src/Opal.Compiler/Ast/ClassNodes.cs
+++ b/src/Opal.Compiler/Ast/ClassNodes.cs
@@ -34,6 +34,11 @@ public sealed class InterfaceDefinitionNode : TypeDefinitionNode
     /// </summary>
     public IReadOnlyList<string> BaseInterfaces { get; }
 
+    /// <summary>
+    /// C#-style attributes (e.g., [@Obsolete], [@ComVisible]).
+    /// </summary>
+    public IReadOnlyList<OpalAttributeNode> CSharpAttributes { get; }
+
     public InterfaceDefinitionNode(
         TextSpan span,
         string id,
@@ -41,10 +46,23 @@ public sealed class InterfaceDefinitionNode : TypeDefinitionNode
         IReadOnlyList<string> baseInterfaces,
         IReadOnlyList<MethodSignatureNode> methods,
         AttributeCollection attributes)
+        : this(span, id, name, baseInterfaces, methods, attributes, Array.Empty<OpalAttributeNode>())
+    {
+    }
+
+    public InterfaceDefinitionNode(
+        TextSpan span,
+        string id,
+        string name,
+        IReadOnlyList<string> baseInterfaces,
+        IReadOnlyList<MethodSignatureNode> methods,
+        AttributeCollection attributes,
+        IReadOnlyList<OpalAttributeNode> csharpAttributes)
         : base(span, id, name, attributes)
     {
         BaseInterfaces = baseInterfaces ?? throw new ArgumentNullException(nameof(baseInterfaces));
         Methods = methods ?? throw new ArgumentNullException(nameof(methods));
+        CSharpAttributes = csharpAttributes ?? Array.Empty<OpalAttributeNode>();
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
@@ -65,6 +83,11 @@ public sealed class MethodSignatureNode : AstNode
     public EffectsNode? Effects { get; }
     public AttributeCollection Attributes { get; }
 
+    /// <summary>
+    /// C#-style attributes (e.g., [@Obsolete]).
+    /// </summary>
+    public IReadOnlyList<OpalAttributeNode> CSharpAttributes { get; }
+
     public MethodSignatureNode(
         TextSpan span,
         string id,
@@ -74,6 +97,20 @@ public sealed class MethodSignatureNode : AstNode
         OutputNode? output,
         EffectsNode? effects,
         AttributeCollection attributes)
+        : this(span, id, name, typeParameters, parameters, output, effects, attributes, Array.Empty<OpalAttributeNode>())
+    {
+    }
+
+    public MethodSignatureNode(
+        TextSpan span,
+        string id,
+        string name,
+        IReadOnlyList<TypeParameterNode> typeParameters,
+        IReadOnlyList<ParameterNode> parameters,
+        OutputNode? output,
+        EffectsNode? effects,
+        AttributeCollection attributes,
+        IReadOnlyList<OpalAttributeNode> csharpAttributes)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
@@ -83,6 +120,7 @@ public sealed class MethodSignatureNode : AstNode
         Output = output;
         Effects = effects;
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+        CSharpAttributes = csharpAttributes ?? Array.Empty<OpalAttributeNode>();
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
@@ -144,6 +182,11 @@ public sealed class ClassDefinitionNode : TypeDefinitionNode
     /// </summary>
     public IReadOnlyList<MethodNode> Methods { get; }
 
+    /// <summary>
+    /// C#-style attributes (e.g., [@Route("api/[controller]")], [@ApiController]).
+    /// </summary>
+    public IReadOnlyList<OpalAttributeNode> CSharpAttributes { get; }
+
     public ClassDefinitionNode(
         TextSpan span,
         string id,
@@ -157,7 +200,7 @@ public sealed class ClassDefinitionNode : TypeDefinitionNode
         IReadOnlyList<MethodNode> methods,
         AttributeCollection attributes)
         : this(span, id, name, isAbstract, isSealed, baseClass, implementedInterfaces,
-               typeParameters, fields, Array.Empty<PropertyNode>(), Array.Empty<ConstructorNode>(), methods, attributes)
+               typeParameters, fields, Array.Empty<PropertyNode>(), Array.Empty<ConstructorNode>(), methods, attributes, Array.Empty<OpalAttributeNode>())
     {
     }
 
@@ -175,6 +218,26 @@ public sealed class ClassDefinitionNode : TypeDefinitionNode
         IReadOnlyList<ConstructorNode> constructors,
         IReadOnlyList<MethodNode> methods,
         AttributeCollection attributes)
+        : this(span, id, name, isAbstract, isSealed, baseClass, implementedInterfaces,
+               typeParameters, fields, properties, constructors, methods, attributes, Array.Empty<OpalAttributeNode>())
+    {
+    }
+
+    public ClassDefinitionNode(
+        TextSpan span,
+        string id,
+        string name,
+        bool isAbstract,
+        bool isSealed,
+        string? baseClass,
+        IReadOnlyList<string> implementedInterfaces,
+        IReadOnlyList<TypeParameterNode> typeParameters,
+        IReadOnlyList<ClassFieldNode> fields,
+        IReadOnlyList<PropertyNode> properties,
+        IReadOnlyList<ConstructorNode> constructors,
+        IReadOnlyList<MethodNode> methods,
+        AttributeCollection attributes,
+        IReadOnlyList<OpalAttributeNode> csharpAttributes)
         : base(span, id, name, attributes)
     {
         IsAbstract = isAbstract;
@@ -186,6 +249,7 @@ public sealed class ClassDefinitionNode : TypeDefinitionNode
         Properties = properties ?? throw new ArgumentNullException(nameof(properties));
         Constructors = constructors ?? throw new ArgumentNullException(nameof(constructors));
         Methods = methods ?? throw new ArgumentNullException(nameof(methods));
+        CSharpAttributes = csharpAttributes ?? Array.Empty<OpalAttributeNode>();
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
@@ -204,6 +268,11 @@ public sealed class ClassFieldNode : AstNode
     public ExpressionNode? DefaultValue { get; }
     public AttributeCollection Attributes { get; }
 
+    /// <summary>
+    /// C#-style attributes (e.g., [@JsonIgnore], [@NonSerialized]).
+    /// </summary>
+    public IReadOnlyList<OpalAttributeNode> CSharpAttributes { get; }
+
     public ClassFieldNode(
         TextSpan span,
         string name,
@@ -211,6 +280,18 @@ public sealed class ClassFieldNode : AstNode
         Visibility visibility,
         ExpressionNode? defaultValue,
         AttributeCollection attributes)
+        : this(span, name, typeName, visibility, defaultValue, attributes, Array.Empty<OpalAttributeNode>())
+    {
+    }
+
+    public ClassFieldNode(
+        TextSpan span,
+        string name,
+        string typeName,
+        Visibility visibility,
+        ExpressionNode? defaultValue,
+        AttributeCollection attributes,
+        IReadOnlyList<OpalAttributeNode> csharpAttributes)
         : base(span)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
@@ -218,6 +299,7 @@ public sealed class ClassFieldNode : AstNode
         Visibility = visibility;
         DefaultValue = defaultValue;
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+        CSharpAttributes = csharpAttributes ?? Array.Empty<OpalAttributeNode>();
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
@@ -246,6 +328,11 @@ public sealed class MethodNode : AstNode
     public IReadOnlyList<StatementNode> Body { get; }
     public AttributeCollection Attributes { get; }
 
+    /// <summary>
+    /// C#-style attributes (e.g., [@HttpPost], [@Authorize], [@Route("api/users")]).
+    /// </summary>
+    public IReadOnlyList<OpalAttributeNode> CSharpAttributes { get; }
+
     public MethodNode(
         TextSpan span,
         string id,
@@ -260,6 +347,26 @@ public sealed class MethodNode : AstNode
         IReadOnlyList<EnsuresNode> postconditions,
         IReadOnlyList<StatementNode> body,
         AttributeCollection attributes)
+        : this(span, id, name, visibility, modifiers, typeParameters, parameters, output, effects,
+               preconditions, postconditions, body, attributes, Array.Empty<OpalAttributeNode>())
+    {
+    }
+
+    public MethodNode(
+        TextSpan span,
+        string id,
+        string name,
+        Visibility visibility,
+        MethodModifiers modifiers,
+        IReadOnlyList<TypeParameterNode> typeParameters,
+        IReadOnlyList<ParameterNode> parameters,
+        OutputNode? output,
+        EffectsNode? effects,
+        IReadOnlyList<RequiresNode> preconditions,
+        IReadOnlyList<EnsuresNode> postconditions,
+        IReadOnlyList<StatementNode> body,
+        AttributeCollection attributes,
+        IReadOnlyList<OpalAttributeNode> csharpAttributes)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
@@ -274,6 +381,7 @@ public sealed class MethodNode : AstNode
         Postconditions = postconditions ?? throw new ArgumentNullException(nameof(postconditions));
         Body = body ?? throw new ArgumentNullException(nameof(body));
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+        CSharpAttributes = csharpAttributes ?? Array.Empty<OpalAttributeNode>();
     }
 
     public bool IsVirtual => (Modifiers & MethodModifiers.Virtual) != 0;

--- a/src/Opal.Compiler/Ast/FunctionNode.cs
+++ b/src/Opal.Compiler/Ast/FunctionNode.cs
@@ -230,16 +230,32 @@ public sealed class ParameterNode : AstNode
     public string TypeName { get; }
     public AttributeCollection Attributes { get; }
 
+    /// <summary>
+    /// C#-style attributes (e.g., [@FromBody], [@Required]).
+    /// </summary>
+    public IReadOnlyList<OpalAttributeNode> CSharpAttributes { get; }
+
     public ParameterNode(
         TextSpan span,
         string name,
         string typeName,
         AttributeCollection attributes)
+        : this(span, name, typeName, attributes, Array.Empty<OpalAttributeNode>())
+    {
+    }
+
+    public ParameterNode(
+        TextSpan span,
+        string name,
+        string typeName,
+        AttributeCollection attributes,
+        IReadOnlyList<OpalAttributeNode> csharpAttributes)
         : base(span)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
         TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+        CSharpAttributes = csharpAttributes ?? Array.Empty<OpalAttributeNode>();
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);

--- a/src/Opal.Compiler/Ast/PropertyNodes.cs
+++ b/src/Opal.Compiler/Ast/PropertyNodes.cs
@@ -22,6 +22,11 @@ public sealed class PropertyNode : AstNode
     public ExpressionNode? DefaultValue { get; }
     public AttributeCollection Attributes { get; }
 
+    /// <summary>
+    /// C#-style attributes (e.g., [@JsonProperty("name")], [@Required]).
+    /// </summary>
+    public IReadOnlyList<OpalAttributeNode> CSharpAttributes { get; }
+
     public PropertyNode(
         TextSpan span,
         string id,
@@ -33,6 +38,22 @@ public sealed class PropertyNode : AstNode
         PropertyAccessorNode? initer,
         ExpressionNode? defaultValue,
         AttributeCollection attributes)
+        : this(span, id, name, typeName, visibility, getter, setter, initer, defaultValue, attributes, Array.Empty<OpalAttributeNode>())
+    {
+    }
+
+    public PropertyNode(
+        TextSpan span,
+        string id,
+        string name,
+        string typeName,
+        Visibility visibility,
+        PropertyAccessorNode? getter,
+        PropertyAccessorNode? setter,
+        PropertyAccessorNode? initer,
+        ExpressionNode? defaultValue,
+        AttributeCollection attributes,
+        IReadOnlyList<OpalAttributeNode> csharpAttributes)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
@@ -44,6 +65,7 @@ public sealed class PropertyNode : AstNode
         Initer = initer;
         DefaultValue = defaultValue;
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+        CSharpAttributes = csharpAttributes ?? Array.Empty<OpalAttributeNode>();
     }
 
     public bool IsAutoProperty => Getter == null && Setter == null && Initer == null;
@@ -67,6 +89,11 @@ public sealed class PropertyAccessorNode : AstNode
     public IReadOnlyList<StatementNode> Body { get; }
     public AttributeCollection Attributes { get; }
 
+    /// <summary>
+    /// C#-style attributes (e.g., [@MethodImpl(MethodImplOptions.AggressiveInlining)]).
+    /// </summary>
+    public IReadOnlyList<OpalAttributeNode> CSharpAttributes { get; }
+
     public PropertyAccessorNode(
         TextSpan span,
         AccessorKind kind,
@@ -74,6 +101,18 @@ public sealed class PropertyAccessorNode : AstNode
         IReadOnlyList<RequiresNode> preconditions,
         IReadOnlyList<StatementNode> body,
         AttributeCollection attributes)
+        : this(span, kind, visibility, preconditions, body, attributes, Array.Empty<OpalAttributeNode>())
+    {
+    }
+
+    public PropertyAccessorNode(
+        TextSpan span,
+        AccessorKind kind,
+        Visibility? visibility,
+        IReadOnlyList<RequiresNode> preconditions,
+        IReadOnlyList<StatementNode> body,
+        AttributeCollection attributes,
+        IReadOnlyList<OpalAttributeNode> csharpAttributes)
         : base(span)
     {
         Kind = kind;
@@ -81,6 +120,7 @@ public sealed class PropertyAccessorNode : AstNode
         Preconditions = preconditions ?? throw new ArgumentNullException(nameof(preconditions));
         Body = body ?? throw new ArgumentNullException(nameof(body));
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+        CSharpAttributes = csharpAttributes ?? Array.Empty<OpalAttributeNode>();
     }
 
     public bool IsAutoImplemented => Body.Count == 0;
@@ -108,6 +148,11 @@ public sealed class ConstructorNode : AstNode
     public IReadOnlyList<StatementNode> Body { get; }
     public AttributeCollection Attributes { get; }
 
+    /// <summary>
+    /// C#-style attributes (e.g., [@Obsolete], [@JsonConstructor]).
+    /// </summary>
+    public IReadOnlyList<OpalAttributeNode> CSharpAttributes { get; }
+
     public ConstructorNode(
         TextSpan span,
         string id,
@@ -117,6 +162,20 @@ public sealed class ConstructorNode : AstNode
         ConstructorInitializerNode? initializer,
         IReadOnlyList<StatementNode> body,
         AttributeCollection attributes)
+        : this(span, id, visibility, parameters, preconditions, initializer, body, attributes, Array.Empty<OpalAttributeNode>())
+    {
+    }
+
+    public ConstructorNode(
+        TextSpan span,
+        string id,
+        Visibility visibility,
+        IReadOnlyList<ParameterNode> parameters,
+        IReadOnlyList<RequiresNode> preconditions,
+        ConstructorInitializerNode? initializer,
+        IReadOnlyList<StatementNode> body,
+        AttributeCollection attributes,
+        IReadOnlyList<OpalAttributeNode> csharpAttributes)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
@@ -126,6 +185,7 @@ public sealed class ConstructorNode : AstNode
         Initializer = initializer;
         Body = body ?? throw new ArgumentNullException(nameof(body));
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+        CSharpAttributes = csharpAttributes ?? Array.Empty<OpalAttributeNode>();
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);

--- a/src/Opal.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Opal.Compiler/CodeGen/CSharpEmitter.cs
@@ -873,6 +873,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(InterfaceDefinitionNode node)
     {
+        EmitCSharpAttributes(node.CSharpAttributes);
+
         var name = SanitizeIdentifier(node.Name);
         var baseList = node.BaseInterfaces.Count > 0
             ? " : " + string.Join(", ", node.BaseInterfaces.Select(SanitizeIdentifier))
@@ -895,6 +897,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(MethodSignatureNode node)
     {
+        EmitCSharpAttributes(node.CSharpAttributes);
+
         var returnType = node.Output?.TypeName ?? "void";
         var mappedReturnType = MapTypeName(returnType);
         var methodName = SanitizeIdentifier(node.Name);
@@ -915,6 +919,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(ClassDefinitionNode node)
     {
+        EmitCSharpAttributes(node.CSharpAttributes);
+
         var name = SanitizeIdentifier(node.Name);
 
         var modifiers = "public";
@@ -996,6 +1002,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(ClassFieldNode node)
     {
+        EmitCSharpAttributes(node.CSharpAttributes);
+
         var visibility = node.Visibility switch
         {
             Visibility.Public => "public",
@@ -1022,6 +1030,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(MethodNode node)
     {
+        EmitCSharpAttributes(node.CSharpAttributes);
+
         var visibility = node.Visibility switch
         {
             Visibility.Public => "public",
@@ -1161,6 +1171,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(PropertyNode node)
     {
+        EmitCSharpAttributes(node.CSharpAttributes);
+
         var visibility = node.Visibility switch
         {
             Visibility.Public => "public",
@@ -1260,6 +1272,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(ConstructorNode node)
     {
+        EmitCSharpAttributes(node.CSharpAttributes);
+
         var visibility = node.Visibility switch
         {
             Visibility.Public => "public",
@@ -1989,5 +2003,38 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             => "@" + result,
             _ => result
         };
+    }
+
+    /// <summary>
+    /// Emits C#-style attributes.
+    /// </summary>
+    private void EmitCSharpAttributes(IReadOnlyList<OpalAttributeNode> attributes)
+    {
+        foreach (var attr in attributes)
+        {
+            AppendLine(Visit(attr));
+        }
+    }
+
+    public string Visit(OpalAttributeNode node)
+    {
+        if (node.Arguments.Count == 0)
+        {
+            return $"[{node.Name}]";
+        }
+
+        var args = string.Join(", ", node.Arguments.Select(FormatCSharpAttributeArgument));
+        return $"[{node.Name}({args})]";
+    }
+
+    private static string FormatCSharpAttributeArgument(OpalAttributeArgument arg)
+    {
+        var value = arg.GetFormattedValue();
+
+        if (arg.IsNamed)
+        {
+            return $"{arg.Name} = {value}";
+        }
+        return value;
     }
 }

--- a/src/Opal.Compiler/Parsing/Lexer.cs
+++ b/src/Opal.Compiler/Parsing/Lexer.cs
@@ -324,6 +324,8 @@ public sealed class Lexer
             '~' => ScanSingle(TokenKind.Tilde),
             '#' => ScanSingle(TokenKind.Hash),
             '?' => ScanSingle(TokenKind.Question),
+            '@' => ScanSingle(TokenKind.At),
+            ',' => ScanSingle(TokenKind.Comma),
             '"' => ScanStringLiteral(),
             '\r' or '\n' => ScanNewline(),
             ' ' or '\t' => ScanWhitespace(),

--- a/src/Opal.Compiler/Parsing/Token.cs
+++ b/src/Opal.Compiler/Parsing/Token.cs
@@ -20,6 +20,8 @@ public enum TokenKind
     OpenParen,          // (
     CloseParen,         // )
     Arrow,              // → or ->
+    At,                 // @ (for C#-style attributes)
+    Comma,              // , (for attribute arguments)
 
     // v2 operator symbols (for Lisp-style expressions)
     Plus,               // +

--- a/tests/Opal.Compiler.Tests/AttributeConversionTests.cs
+++ b/tests/Opal.Compiler.Tests/AttributeConversionTests.cs
@@ -1,0 +1,520 @@
+using Opal.Compiler.Ast;
+using Opal.Compiler.CodeGen;
+using Opal.Compiler.Diagnostics;
+using Opal.Compiler.Migration;
+using Opal.Compiler.Parsing;
+using Xunit;
+
+namespace Opal.Compiler.Tests;
+
+/// <summary>
+/// Tests for C# attribute preservation during C# → OPAL → C# conversion.
+/// </summary>
+public class AttributeConversionTests
+{
+    private readonly CSharpToOpalConverter _converter = new();
+
+    #region C# to OPAL Attribute Conversion Tests
+
+    [Fact]
+    public void Convert_ClassWithRouteAttribute_PreservesAttribute()
+    {
+        var csharpSource = """
+            using Microsoft.AspNetCore.Mvc;
+
+            [Route("api/[controller]")]
+            [ApiController]
+            public class TestController : ControllerBase
+            {
+            }
+            """;
+
+        var result = _converter.Convert(csharpSource);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        Assert.NotNull(result.Ast);
+        Assert.Single(result.Ast.Classes);
+
+        var cls = result.Ast.Classes[0];
+        Assert.Equal("TestController", cls.Name);
+        Assert.Equal(2, cls.CSharpAttributes.Count);
+
+        var routeAttr = cls.CSharpAttributes.FirstOrDefault(a => a.Name == "Route");
+        Assert.NotNull(routeAttr);
+        Assert.Single(routeAttr.Arguments);
+        Assert.Equal("api/[controller]", routeAttr.Arguments[0].Value);
+
+        var apiControllerAttr = cls.CSharpAttributes.FirstOrDefault(a => a.Name == "ApiController");
+        Assert.NotNull(apiControllerAttr);
+        Assert.Empty(apiControllerAttr.Arguments);
+    }
+
+    [Fact]
+    public void Convert_MethodWithHttpPostAttribute_PreservesAttribute()
+    {
+        var csharpSource = """
+            using Microsoft.AspNetCore.Mvc;
+
+            public class TestController : ControllerBase
+            {
+                [HttpPost]
+                public void Post()
+                {
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharpSource);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        Assert.NotNull(result.Ast);
+        Assert.Single(result.Ast.Classes);
+
+        var cls = result.Ast.Classes[0];
+        Assert.Single(cls.Methods);
+
+        var method = cls.Methods[0];
+        Assert.Equal("Post", method.Name);
+        Assert.Single(method.CSharpAttributes);
+
+        var httpPostAttr = method.CSharpAttributes[0];
+        Assert.Equal("HttpPost", httpPostAttr.Name);
+        Assert.Empty(httpPostAttr.Arguments);
+    }
+
+    [Fact]
+    public void Convert_AttributeWithPositionalArgs_PreservesArgs()
+    {
+        var csharpSource = """
+            using System.ComponentModel.DataAnnotations;
+
+            public class TestModel
+            {
+                [StringLength(100, MinimumLength = 10)]
+                public string Name { get; set; }
+            }
+            """;
+
+        var result = _converter.Convert(csharpSource);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        Assert.NotNull(result.Ast);
+        Assert.Single(result.Ast.Classes);
+
+        var cls = result.Ast.Classes[0];
+        Assert.Single(cls.Properties);
+
+        var prop = cls.Properties[0];
+        Assert.Equal("Name", prop.Name);
+        Assert.Single(prop.CSharpAttributes);
+
+        var attr = prop.CSharpAttributes[0];
+        Assert.Equal("StringLength", attr.Name);
+        Assert.Equal(2, attr.Arguments.Count);
+
+        // First arg is positional (100)
+        Assert.Null(attr.Arguments[0].Name);
+        Assert.Equal(100, attr.Arguments[0].Value);
+
+        // Second arg is named (MinimumLength = 10)
+        Assert.Equal("MinimumLength", attr.Arguments[1].Name);
+        Assert.Equal(10, attr.Arguments[1].Value);
+    }
+
+    [Fact]
+    public void Convert_MultipleAttributes_PreservesAll()
+    {
+        var csharpSource = """
+            using Microsoft.AspNetCore.Mvc;
+            using Microsoft.AspNetCore.Authorization;
+
+            public class TestController : ControllerBase
+            {
+                [HttpGet("status")]
+                [Authorize]
+                [ProducesResponseType(200)]
+                public string Get()
+                {
+                    return "ok";
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharpSource);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        Assert.NotNull(result.Ast);
+        Assert.Single(result.Ast.Classes);
+
+        var cls = result.Ast.Classes[0];
+        Assert.Single(cls.Methods);
+
+        var method = cls.Methods[0];
+        Assert.Equal(3, method.CSharpAttributes.Count);
+
+        Assert.Contains(method.CSharpAttributes, a => a.Name == "HttpGet");
+        Assert.Contains(method.CSharpAttributes, a => a.Name == "Authorize");
+        Assert.Contains(method.CSharpAttributes, a => a.Name == "ProducesResponseType");
+    }
+
+    [Fact]
+    public void Convert_FieldWithAttribute_PreservesAttribute()
+    {
+        var csharpSource = """
+            using System.Text.Json.Serialization;
+
+            public class TestModel
+            {
+                [JsonIgnore]
+                private string _internalData;
+            }
+            """;
+
+        var result = _converter.Convert(csharpSource);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        Assert.NotNull(result.Ast);
+        Assert.Single(result.Ast.Classes);
+
+        var cls = result.Ast.Classes[0];
+        Assert.Single(cls.Fields);
+
+        var field = cls.Fields[0];
+        Assert.Equal("_internalData", field.Name);
+        Assert.Single(field.CSharpAttributes);
+
+        var attr = field.CSharpAttributes[0];
+        Assert.Equal("JsonIgnore", attr.Name);
+    }
+
+    [Fact]
+    public void Convert_InterfaceWithAttribute_PreservesAttribute()
+    {
+        var csharpSource = """
+            using System;
+
+            [Obsolete("Use INewService instead")]
+            public interface IOldService
+            {
+                void DoWork();
+            }
+            """;
+
+        var result = _converter.Convert(csharpSource);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        Assert.NotNull(result.Ast);
+        Assert.Single(result.Ast.Interfaces);
+
+        var iface = result.Ast.Interfaces[0];
+        Assert.Equal("IOldService", iface.Name);
+        Assert.Single(iface.CSharpAttributes);
+
+        var attr = iface.CSharpAttributes[0];
+        Assert.Equal("Obsolete", attr.Name);
+        Assert.Single(attr.Arguments);
+        Assert.Equal("Use INewService instead", attr.Arguments[0].Value);
+    }
+
+    #endregion
+
+    #region OPAL Emitter Tests
+
+    [Fact]
+    public void OpalEmitter_EmitsClassAttributes()
+    {
+        var csharpSource = """
+            using Microsoft.AspNetCore.Mvc;
+
+            [Route("api/test")]
+            [ApiController]
+            public class TestController : ControllerBase
+            {
+            }
+            """;
+
+        var result = _converter.Convert(csharpSource);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        var emitter = new OpalEmitter();
+        var opalCode = emitter.Emit(result.Ast!);
+
+        Assert.Contains("[@Route(\"api/test\")]", opalCode);
+        Assert.Contains("[@ApiController]", opalCode);
+    }
+
+    [Fact]
+    public void OpalEmitter_EmitsMethodAttributes()
+    {
+        var csharpSource = """
+            using Microsoft.AspNetCore.Mvc;
+
+            public class TestController : ControllerBase
+            {
+                [HttpPost]
+                public void Post() { }
+            }
+            """;
+
+        var result = _converter.Convert(csharpSource);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        var emitter = new OpalEmitter();
+        var opalCode = emitter.Emit(result.Ast!);
+
+        Assert.Contains("[@HttpPost]", opalCode);
+    }
+
+    [Fact]
+    public void OpalEmitter_EmitsAttributeWithNamedArgs()
+    {
+        var csharpSource = """
+            using System.ComponentModel.DataAnnotations;
+
+            public class TestModel
+            {
+                [Range(1, 100, ErrorMessage = "Value out of range")]
+                public int Value { get; set; }
+            }
+            """;
+
+        var result = _converter.Convert(csharpSource);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        var emitter = new OpalEmitter();
+        var opalCode = emitter.Emit(result.Ast!);
+
+        Assert.Contains("[@Range(1, 100, ErrorMessage=\"Value out of range\")]", opalCode);
+    }
+
+    #endregion
+
+    #region C# Emitter Tests
+
+    [Fact]
+    public void CSharpEmitter_EmitsClassAttributes()
+    {
+        var csharpSource = """
+            using Microsoft.AspNetCore.Mvc;
+
+            [Route("api/test")]
+            [ApiController]
+            public class TestController : ControllerBase
+            {
+            }
+            """;
+
+        var result = _converter.Convert(csharpSource);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        var emitter = new CSharpEmitter();
+        var outputCode = emitter.Emit(result.Ast!);
+
+        Assert.Contains("[Route(\"api/test\")]", outputCode);
+        Assert.Contains("[ApiController]", outputCode);
+    }
+
+    [Fact]
+    public void CSharpEmitter_EmitsMethodAttributes()
+    {
+        var csharpSource = """
+            using Microsoft.AspNetCore.Mvc;
+
+            public class TestController : ControllerBase
+            {
+                [HttpPost]
+                public void Post() { }
+            }
+            """;
+
+        var result = _converter.Convert(csharpSource);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        var emitter = new CSharpEmitter();
+        var outputCode = emitter.Emit(result.Ast!);
+
+        Assert.Contains("[HttpPost]", outputCode);
+    }
+
+    [Fact]
+    public void CSharpEmitter_EmitsAttributeWithNamedArgs()
+    {
+        var csharpSource = """
+            using System.ComponentModel.DataAnnotations;
+
+            public class TestModel
+            {
+                [Range(1, 100, ErrorMessage = "Value out of range")]
+                public int Value { get; set; }
+            }
+            """;
+
+        var result = _converter.Convert(csharpSource);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        var emitter = new CSharpEmitter();
+        var outputCode = emitter.Emit(result.Ast!);
+
+        Assert.Contains("[Range(1, 100, ErrorMessage = \"Value out of range\")]", outputCode);
+    }
+
+    #endregion
+
+    #region OPAL Parser Tests
+
+    [Fact]
+    public void Parser_ParsesClassWithAttributes()
+    {
+        var opalSource = """
+            §M[m001:TestModule]
+              §CLASS[c001:TestController:ControllerBase][@Route("api/test")][@ApiController]
+              §/CLASS[c001]
+            §/M[m001]
+            """;
+
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(opalSource, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        Assert.Single(module.Classes);
+
+        var cls = module.Classes[0];
+        Assert.Equal("TestController", cls.Name);
+        Assert.Equal(2, cls.CSharpAttributes.Count);
+
+        Assert.Contains(cls.CSharpAttributes, a => a.Name == "Route");
+        Assert.Contains(cls.CSharpAttributes, a => a.Name == "ApiController");
+    }
+
+    [Fact]
+    public void Parser_ParsesMethodWithAttributes()
+    {
+        var opalSource = """
+            §M[m001:TestModule]
+              §CLASS[c001:TestController:ControllerBase]
+                §METHOD[m001:Post:pub][@HttpPost]
+                  §O[void]
+                §/METHOD[m001]
+              §/CLASS[c001]
+            §/M[m001]
+            """;
+
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(opalSource, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        Assert.Single(module.Classes);
+
+        var cls = module.Classes[0];
+        Assert.Single(cls.Methods);
+
+        var method = cls.Methods[0];
+        Assert.Equal("Post", method.Name);
+        Assert.Single(method.CSharpAttributes);
+        Assert.Equal("HttpPost", method.CSharpAttributes[0].Name);
+    }
+
+    [Fact]
+    public void Parser_ParsesAttributeWithArgs()
+    {
+        var opalSource = """
+            §M[m001:TestModule]
+              §CLASS[c001:TestModel]
+                §PROP[p001:Value:int:pub][@Range(1, 100, ErrorMessage="Invalid")]
+                  §GET
+                  §SET
+                §/PROP[p001]
+              §/CLASS[c001]
+            §/M[m001]
+            """;
+
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(opalSource, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        Assert.Single(module.Classes);
+
+        var cls = module.Classes[0];
+        Assert.Single(cls.Properties);
+
+        var prop = cls.Properties[0];
+        Assert.Single(prop.CSharpAttributes);
+
+        var attr = prop.CSharpAttributes[0];
+        Assert.Equal("Range", attr.Name);
+        Assert.Equal(3, attr.Arguments.Count);
+
+        // First two are positional
+        Assert.Equal(1, attr.Arguments[0].Value);
+        Assert.Equal(100, attr.Arguments[1].Value);
+
+        // Third is named
+        Assert.Equal("ErrorMessage", attr.Arguments[2].Name);
+        Assert.Equal("Invalid", attr.Arguments[2].Value);
+    }
+
+    #endregion
+
+    #region Round-Trip Tests
+
+    [Fact]
+    public void RoundTrip_CSharpToOpalToCSharp_AttributesPreserved()
+    {
+        var csharpSource = """
+            using Microsoft.AspNetCore.Mvc;
+
+            [Route("api/[controller]")]
+            [ApiController]
+            public class JoinController : ControllerBase
+            {
+                [HttpPost]
+                public void Post()
+                {
+                }
+            }
+            """;
+
+        // C# → OPAL
+        var result = _converter.Convert(csharpSource);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        // OPAL → OPAL text
+        var opalEmitter = new OpalEmitter();
+        var opalCode = opalEmitter.Emit(result.Ast!);
+
+        // Parse the OPAL text
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(opalCode, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+        var parsedModule = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+
+        // OPAL → C#
+        var csharpEmitter = new CSharpEmitter();
+        var outputCode = csharpEmitter.Emit(parsedModule);
+
+        // Verify attributes are preserved
+        Assert.Contains("[Route(\"api/[controller]\")]", outputCode);
+        Assert.Contains("[ApiController]", outputCode);
+        Assert.Contains("[HttpPost]", outputCode);
+    }
+
+    #endregion
+
+    private static string GetErrorMessage(ConversionResult result)
+    {
+        if (result.Success) return "";
+        return string.Join("\n", result.Issues.Select(i => $"{i.Severity}: {i.Message}"));
+    }
+}


### PR DESCRIPTION
## Summary
- Preserves C# attributes (like `[HttpPost]`, `[Route]`, `[ApiController]`) during C# → OPAL → C# conversion
- Uses inline bracket syntax `[@Attribute(args)]` for OPAL representation
- Supports positional arguments, named arguments, and mixed argument styles

## Changes
- **New AST nodes**: `OpalAttributeNode`, `OpalAttributeArgument`, `TypeOfReference` in `AttributeNodes.cs`
- **Updated AST nodes**: Added `CSharpAttributes` property to `ClassDefinitionNode`, `MethodNode`, `PropertyNode`, `ClassFieldNode`, `ParameterNode`, `InterfaceDefinitionNode`, `MethodSignatureNode`, `PropertyAccessorNode`, `ConstructorNode`
- **Lexer**: Added `@` and `,` token support
- **Parser**: Added `[@Attribute(args)]` parsing after structural brackets
- **RoslynSyntaxVisitor**: Converts C# attributes to `OpalAttributeNode`
- **OpalEmitter**: Emits `[@attr]` inline syntax
- **CSharpEmitter**: Emits `[Attribute]` C# syntax
- **Tests**: 16 new attribute conversion tests

## Example
```csharp
// C# Input
[Route("api/[controller]")]
[ApiController]
public class JoinController : ControllerBase
{
    [HttpPost]
    public void Post() { }
}
```

```opal
// OPAL Output
§CLASS[c001:JoinController:ControllerBase][@Route("api/[controller]")][@ApiController]
  §METHOD[m003:Post:pub][@HttpPost]
  §/METHOD[m003]
§/CLASS[c001]
```

## Test plan
- [x] All 290 existing tests pass
- [x] 16 new attribute conversion tests pass
- [x] C# → OPAL conversion preserves attributes
- [x] OPAL → C# emission generates correct attribute syntax
- [x] Round-trip (C# → OPAL → C#) preserves attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)