### PR TITLE
Document C# attribute syntax in OPAL language

### DIFF
--- a/.claude/skills/opal-convert.md
+++ b/.claude/skills/opal-convert.md
@@ -137,6 +137,40 @@ Debug.Assert(result >= 0);
 §S (>= result 0)
 ```
 
+## C# Attribute Conversion
+
+Attributes are preserved using inline bracket syntax `[@Attribute]`:
+
+### Class Attributes
+```csharp
+[Route("api/[controller]")]
+[ApiController]
+public class TestController : ControllerBase { }
+```
+```opal
+§CLASS[c001:TestController:ControllerBase][@Route("api/[controller]")][@ApiController]
+§/CLASS[c001]
+```
+
+### Method Attributes
+```csharp
+[HttpPost]
+[Authorize]
+public void Post() { }
+```
+```opal
+§METHOD[m001:Post:pub][@HttpPost][@Authorize]
+§/METHOD[m001]
+```
+
+### Attribute Arguments
+| C# | OPAL |
+|---|---|
+| `[Required]` | `[@Required]` |
+| `[Route("api")]` | `[@Route("api")]` |
+| `[JsonProperty(PropertyName="id")]` | `[@JsonProperty(PropertyName="id")]` |
+| `[Range(1, 100)]` | `[@Range(1, 100)]` |
+
 ## Supported Features
 
 - Static methods
@@ -145,16 +179,15 @@ Debug.Assert(result >= 0);
 - Console I/O
 - Arithmetic/comparison operators
 - Simple contracts
+- C# attributes (on classes, methods, properties, fields, parameters)
 
 ## Not Yet Supported
 
-- Classes/objects
 - Async/await
 - LINQ
 - Generics
 - Events/delegates
 - Exception handling (try/catch)
-- Properties
 - Collections (List, Dictionary)
 
 ## Conversion Example

--- a/.claude/skills/opal.md
+++ b/.claude/skills/opal.md
@@ -106,6 +106,24 @@ Multi-line form:
 §/C
 ```
 
+## C# Attributes
+
+Attributes attach inline after structural brackets:
+
+```
+[@AttributeName]              No arguments
+[@Route("api/test")]          Positional argument
+[@JsonProperty(Name="id")]    Named argument
+```
+
+Example with class and method:
+```
+§CLASS[c001:TestController:ControllerBase][@Route("api/[controller]")][@ApiController]
+  §METHOD[m001:Get:pub][@HttpGet]
+  §/METHOD[m001]
+§/CLASS[c001]
+```
+
 ## Template: FizzBuzz
 
 ```opal

--- a/docs/syntax-reference/index.md
+++ b/docs/syntax-reference/index.md
@@ -26,6 +26,7 @@ Complete reference for OPAL syntax. Always use V2+ syntax (Lisp-style expression
 | Loop | `§L[id:var:from:to:step]` | `§L[l1:i:1:100:1]` |
 | If/ElseIf/Else | `§IF...§EI...§EL` | `§IF (> x 0) → §R x §EL → §R 0` |
 | Call | `§C[target]...§/C` | `§C[Math.Max] §A 1 §A 2 §/C` |
+| C# Attribute | `[@Name]` or `[@Name(args)]` | `[@HttpPost]`, `[@Route("api")]` |
 | Print | `§P expr` | `§P "Hello"` |
 | Return | `§R expr` | `§R (+ a b)` |
 | Binding | `§B[name] expr` | `§B[x] (+ 1 2)` |

--- a/docs/syntax-reference/structure-tags.md
+++ b/docs/syntax-reference/structure-tags.md
@@ -202,6 +202,57 @@ Every structural element must be closed with a matching tag.
 
 ---
 
+## C# Attributes
+
+C# attributes are preserved during conversion using inline bracket syntax `[@Attribute]`.
+
+### Syntax
+
+```
+§CLASS[id:name][@AttributeName]
+§CLASS[id:name][@AttributeName(args)]
+§METHOD[id:name:vis][@Attr1][@Attr2]
+```
+
+### Examples
+
+**Class with routing attributes (ASP.NET Core):**
+```
+§CLASS[c001:JoinController:ControllerBase][@Route("api/[controller]")][@ApiController]
+  §METHOD[m001:Post:pub][@HttpPost]
+  §/METHOD[m001]
+§/CLASS[c001]
+```
+
+**Property with validation:**
+```
+§PROP[p001:Email:str:pub][@Required][@EmailAddress]
+  §GET
+  §SET
+§/PROP[p001]
+```
+
+### Attribute Arguments
+
+| Style | Syntax | Example |
+|:------|:-------|:--------|
+| No args | `[@Name]` | `[@ApiController]` |
+| Positional | `[@Name(value)]` | `[@Route("api/test")]` |
+| Named | `[@Name(Key="value")]` | `[@JsonProperty(PropertyName="id")]` |
+| Mixed | `[@Name(pos, Key=val)]` | `[@Range(1, 100, ErrorMessage="Invalid")]` |
+
+### Supported Elements
+
+Attributes can be attached to:
+- Classes: `§CLASS[...][@attr]`
+- Interfaces: `§IFACE[...][@attr]`
+- Methods: `§METHOD[...][@attr]`
+- Properties: `§PROP[...][@attr]`
+- Fields: `§FLD[...][@attr]`
+- Parameters: `§I[type:name][@attr]`
+
+---
+
 ## Why Explicit Closing Tags?
 
 1. **Unambiguous parsing** - No brace-counting needed


### PR DESCRIPTION
## Summary
- Documents the new `[@Attribute]` syntax for C# attributes in OPAL
- Updates syntax reference documentation
- Updates Claude skills for OPAL code generation and conversion

## Changes
- **docs/syntax-reference/index.md**: Add C# Attribute row to quick reference table
- **docs/syntax-reference/structure-tags.md**: Add comprehensive C# Attributes section with syntax, examples, and supported elements
- **.claude/skills/opal.md**: Add C# Attributes section with inline syntax examples
- **.claude/skills/opal-convert.md**: Add C# Attribute Conversion section showing C# → OPAL mapping

## Test plan
- [x] Documentation renders correctly
- [x] Examples are accurate and match implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)