### PR TITLE
Fix C# → OPAL converter bugs for proper v2 syntax emission

### DIFF
--- a/src/Opal.Compiler/Ast/AstNode.cs
+++ b/src/Opal.Compiler/Ast/AstNode.cs
@@ -83,6 +83,7 @@ public interface IAstVisitor
     void Visit(ClassFieldNode node);
     void Visit(MethodNode node);
     void Visit(NewExpressionNode node);
+    void Visit(CallExpressionNode node);
     void Visit(ThisExpressionNode node);
     void Visit(BaseExpressionNode node);
     // Phase 9: Properties and Constructors
@@ -214,6 +215,7 @@ public interface IAstVisitor<T>
     T Visit(ClassFieldNode node);
     T Visit(MethodNode node);
     T Visit(NewExpressionNode node);
+    T Visit(CallExpressionNode node);
     T Visit(ThisExpressionNode node);
     T Visit(BaseExpressionNode node);
     // Phase 9: Properties and Constructors

--- a/src/Opal.Compiler/Ast/ClassNodes.cs
+++ b/src/Opal.Compiler/Ast/ClassNodes.cs
@@ -422,6 +422,26 @@ public sealed class NewExpressionNode : ExpressionNode
 }
 
 /// <summary>
+/// Represents a method/function call expression.
+/// §C[target] §A arg1 §A arg2 §/C
+/// </summary>
+public sealed class CallExpressionNode : ExpressionNode
+{
+    public string Target { get; }
+    public IReadOnlyList<ExpressionNode> Arguments { get; }
+
+    public CallExpressionNode(TextSpan span, string target, IReadOnlyList<ExpressionNode> arguments)
+        : base(span)
+    {
+        Target = target ?? throw new ArgumentNullException(nameof(target));
+        Arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
 /// Represents a 'this' expression.
 /// §THIS
 /// </summary>

--- a/src/Opal.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Opal.Compiler/CodeGen/CSharpEmitter.cs
@@ -1157,6 +1157,12 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         return $"new {typeName}({args})";
     }
 
+    public string Visit(CallExpressionNode node)
+    {
+        var args = string.Join(", ", node.Arguments.Select(a => a.Accept(this)));
+        return $"{node.Target}({args})";
+    }
+
     public string Visit(ThisExpressionNode node)
     {
         return "this";


### PR DESCRIPTION
## Summary
- Fix ReferenceNode to emit variable name directly instead of `§REF[name=x]`
- Fix BinaryOperationNode to emit Lisp-style `(== a b)` instead of `§OP[kind=eq]`
- Fix UnaryOperationNode to emit `(! x)` instead of `§UOP[kind=not]`
- Add CallExpressionNode for proper method call handling with arguments
- Fix property emission to include ID in `§PROP` tag
- Add warning for unsupported continue statements instead of silent drop

## Test plan
- [x] All 290 existing tests pass
- [x] Build succeeds with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)