### PR TITLE
Add local install scripts and bump version to 0.1.2

### DIFF
--- a/scripts/install-local.ps1
+++ b/scripts/install-local.ps1
@@ -1,0 +1,23 @@
+# Local Install Script for opalc (Windows)
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+Write-Host "Building opalc..."
+dotnet build src/Opal.Compiler/Opal.Compiler.csproj -c Release
+
+Write-Host "Packing..."
+dotnet pack src/Opal.Compiler/Opal.Compiler.csproj -c Release -o ./nupkg
+
+Write-Host "Installing globally..."
+try {
+    dotnet tool install -g --add-source ./nupkg opalc
+} catch {
+    dotnet tool update -g --add-source ./nupkg opalc
+}
+
+Write-Host "Verifying..."
+opalc --help
+
+Write-Host "Done! opalc installed globally."

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Local Install Script for opalc
+# Run from repo root: ./scripts/install-local.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$REPO_ROOT"
+
+echo "Building opalc..."
+dotnet build src/Opal.Compiler/Opal.Compiler.csproj -c Release
+
+echo "Packing..."
+dotnet pack src/Opal.Compiler/Opal.Compiler.csproj -c Release -o ./nupkg
+
+echo "Installing globally..."
+dotnet tool install -g --add-source ./nupkg opalc 2>/dev/null \
+  || dotnet tool update -g --add-source ./nupkg opalc
+
+echo "Verifying..."
+opalc --help
+
+echo "Done! opalc installed globally."

--- a/src/Opal.Compiler/Opal.Compiler.csproj
+++ b/src/Opal.Compiler/Opal.Compiler.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>opalc</ToolCommandName>
     <PackageId>opalc</PackageId>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
     <Description>OPAL compiler - Optimized Programming for Agent Logic</Description>
     <PackageProjectUrl>https://github.com/juanmicrosoft/opal-2</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Add `scripts/install-local.sh` (bash) and `scripts/install-local.ps1` (PowerShell) for building and installing opalc globally from local source
- Bump version to 0.1.2

## Test plan
- [x] Run `./scripts/install-local.sh` and verify opalc installs successfully
- [x] Verify `opalc --help` works after installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)