### PR TITLE
Fix OPAL acronym: Logic → Language

### DIFF
--- a/.claude/skills/opal.md
+++ b/.claude/skills/opal.md
@@ -1,6 +1,6 @@
 # /opal - Write OPAL Code
 
-OPAL (Optimized Programming for Agent Logic) compiles to C# via .NET.
+OPAL (Optimized Programming for Agent Language) compiles to C# via .NET.
 
 **IMPORTANT: Always use v2+ syntax when writing OPAL code:**
 - Use Lisp-style expressions: `(+ a b)`, `(== x 0)`, `(% i 15)`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OPAL — Optimized Programming for Agent Logic
+# OPAL — Optimized Programming for Agent Language
 
 A programming language designed specifically for AI coding agents, compiling to .NET via C# emission.
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: OPAL Documentation
-description: Optimized Programming for Agent Logic - A language designed for AI coding agents
+description: Optimized Programming for Agent Language - A language designed for AI coding agents
 baseurl: "/opal"
 url: "https://juanmicrosoft.github.io"
 remote_theme: just-the-docs/just-the-docs

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -102,7 +102,7 @@ dotnet run --project src/Opal.Compiler -- --help
 
 Expected output:
 ```
-OPAL Compiler - Optimized Programming for Agent Logic
+OPAL Compiler - Optimized Programming for Agent Language
 
 Usage:
   opalc --input <file.opal> --output <file.cs>

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,14 @@
 layout: default
 title: Home
 nav_order: 1
-description: "OPAL - Optimized Programming for Agent Logic"
+description: "OPAL - Optimized Programming for Agent Language"
 permalink: /
 ---
 
 # OPAL
 {: .fs-9 }
 
-Optimized Programming for Agent Logic
+Optimized Programming for Agent Language
 {: .fs-6 .fw-300 }
 
 A programming language designed specifically for AI coding agents, compiling to .NET via C# emission.

--- a/src/Opal.Compiler/Opal.Compiler.csproj
+++ b/src/Opal.Compiler/Opal.Compiler.csproj
@@ -10,7 +10,7 @@
     <ToolCommandName>opalc</ToolCommandName>
     <PackageId>opalc</PackageId>
     <Version>0.1.2</Version>
-    <Description>OPAL compiler - Optimized Programming for Agent Logic</Description>
+    <Description>OPAL compiler - Optimized Programming for Agent Language</Description>
     <PackageProjectUrl>https://github.com/juanmicrosoft/opal-2</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Opal.Compiler/Resources/Skills/opal.md
+++ b/src/Opal.Compiler/Resources/Skills/opal.md
@@ -1,6 +1,6 @@
 # /opal - Write OPAL Code
 
-OPAL (Optimized Programming for Agent Logic) compiles to C# via .NET.
+OPAL (Optimized Programming for Agent Language) compiles to C# via .NET.
 
 **IMPORTANT: Always use v2+ syntax when writing OPAL code:**
 - Use Lisp-style expressions: `(+ a b)`, `(== x 0)`, `(% i 15)`

--- a/src/Opal.Compiler/Resources/Templates/CLAUDE.md.template
+++ b/src/Opal.Compiler/Resources/Templates/CLAUDE.md.template
@@ -1,7 +1,7 @@
 <!-- BEGIN OPALC SECTION - DO NOT EDIT -->
 ## OPAL Project
 
-This project uses OPAL (Optimized Programming for Agent Logic), a domain-specific language that compiles to C#.
+This project uses OPAL (Optimized Programming for Agent Language), a domain-specific language that compiles to C#.
 
 ### Quick Reference
 


### PR DESCRIPTION
## Summary

- Fix OPAL acronym from "Optimized Programming for Agent Logic" to "Optimized Programming for Agent Language"

## Files Updated (9)

- README.md
- src/Opal.Compiler/Opal.Compiler.csproj
- docs/getting-started/installation.md
- docs/index.md (2 occurrences)
- docs/_config.yml
- .claude/skills/opal.md
- src/Opal.Compiler/Resources/Skills/opal.md
- src/Opal.Compiler/Resources/Templates/CLAUDE.md.template

🤖 Generated with [Claude Code](https://claude.com/claude-code)