### PR TITLE
Add CLI Reference documentation for opalc analyze command

### DIFF
--- a/docs/cli/analyze.md
+++ b/docs/cli/analyze.md
@@ -1,0 +1,286 @@
+---
+layout: default
+title: analyze
+parent: CLI Reference
+nav_order: 1
+permalink: /cli/analyze/
+---
+
+# opalc analyze
+
+Score C# files for OPAL migration potential.
+
+```bash
+opalc analyze <path> [options]
+```
+
+---
+
+## Overview
+
+The `analyze` command scans a C# codebase and scores each file based on how much it would benefit from OPAL's features. It detects patterns like argument validation, null handling, error handling, and side effects that map directly to OPAL language constructs.
+
+Use this command to:
+
+- **Prioritize migration efforts** - Focus on files that benefit most from OPAL's contracts and effects
+- **Understand your codebase** - See which patterns are most common across your project
+- **Generate reports** - Export analysis in JSON or SARIF format for tooling integration
+
+---
+
+## Quick Start
+
+```bash
+# Analyze current directory
+opalc analyze .
+
+# Analyze with detailed breakdown
+opalc analyze ./src --verbose
+
+# Export as JSON for processing
+opalc analyze ./src --format json --output analysis.json
+```
+
+---
+
+## Scoring Dimensions
+
+Each file is scored across six dimensions that correspond to OPAL language features:
+
+| Dimension | Weight | What It Detects | OPAL Feature |
+|:----------|:------:|:----------------|:-------------|
+| **ContractPotential** | 20% | Argument validation, `ArgumentException` throws, range checks | `§Q`/`§S` contracts |
+| **NullSafetyPotential** | 20% | Nullable types, `?.`, `??`, null checks | `Option<T>` |
+| **ErrorHandlingPotential** | 20% | Try/catch blocks, throw statements | `Result<T,E>` |
+| **EffectPotential** | 15% | File I/O, network calls, database access, console | `§E` effect declarations |
+| **ApiComplexityPotential** | 15% | Undocumented public APIs | OPAL metadata requirements |
+| **PatternMatchPotential** | 10% | Switch statements/expressions | Exhaustiveness checking |
+
+The total score (0-100) is the weighted sum of individual dimension scores.
+
+---
+
+## Priority Bands
+
+Files are categorized into priority bands based on their total score:
+
+| Priority | Score Range | Meaning |
+|:---------|:------------|:--------|
+| **Critical** | 76-100 | Excellent migration candidate - high density of patterns that OPAL improves |
+| **High** | 51-75 | Good migration candidate - significant benefit from OPAL features |
+| **Medium** | 26-50 | Some benefit from migration - moderate pattern density |
+| **Low** | 0-25 | Minimal benefit - few patterns that OPAL addresses |
+
+---
+
+## Command Options
+
+| Option | Short | Default | Description |
+|:-------|:------|:--------|:------------|
+| `--format` | `-f` | `text` | Output format: `text`, `json`, or `sarif` |
+| `--output` | `-o` | stdout | Write output to file instead of stdout |
+| `--threshold` | `-t` | `0` | Minimum score to include (0-100) |
+| `--top` | `-n` | `20` | Number of top files to show |
+| `--verbose` | `-v` | `false` | Show detailed per-file breakdown |
+
+---
+
+## Output Formats
+
+### Text (Default)
+
+Human-readable summary with ASCII bar charts:
+
+```
+=== OPAL Migration Analysis ===
+
+Analyzed: 42 files
+Skipped: 8 files (generated/errors)
+Average Score: 34.2/100
+
+Priority Breakdown:
+  Critical (76-100): 2 files
+  High (51-75):      8 files
+  Medium (26-50):    18 files
+  Low (0-25):        14 files
+
+Average Scores by Dimension:
+  ErrorHandlingPotential   45.2 |#########
+  ContractPotential        38.1 |#######
+  NullSafetyPotential      35.6 |#######
+  EffectPotential          28.4 |#####
+  ApiComplexityPotential   22.1 |####
+  PatternMatchPotential    12.3 |##
+
+Top 20 Files for Migration:
+--------------------------------------------------------------------------------
+ 82/100 [Critical]  src/Services/PaymentProcessor.cs
+ 78/100 [Critical]  src/Services/OrderService.cs
+ 65/100 [High]      src/Repositories/UserRepository.cs
+...
+```
+
+With `--verbose`, each file shows dimension breakdown:
+
+```
+ 82/100 [Critical]  src/Services/PaymentProcessor.cs
+         ErrorHandlingPotential: 95 (12 patterns)
+         ContractPotential: 88 (8 patterns)
+         EffectPotential: 75 (6 patterns)
+         NullSafetyPotential: 62 (15 patterns)
+```
+
+### JSON
+
+Machine-readable format for processing:
+
+```bash
+opalc analyze ./src --format json --output analysis.json
+```
+
+```json
+{
+  "version": "1.0",
+  "analyzedAt": "2025-01-15T10:30:00Z",
+  "rootPath": "/path/to/src",
+  "durationMs": 1234,
+  "summary": {
+    "totalFiles": 42,
+    "skippedFiles": 8,
+    "averageScore": 34.2,
+    "priorityBreakdown": {
+      "critical": 2,
+      "high": 8,
+      "medium": 18,
+      "low": 14
+    },
+    "averagesByDimension": {
+      "ContractPotential": 38.1,
+      "EffectPotential": 28.4,
+      "NullSafetyPotential": 35.6,
+      "ErrorHandlingPotential": 45.2,
+      "PatternMatchPotential": 12.3,
+      "ApiComplexityPotential": 22.1
+    }
+  },
+  "files": [
+    {
+      "path": "Services/PaymentProcessor.cs",
+      "score": 82.3,
+      "priority": "critical",
+      "lineCount": 245,
+      "methodCount": 12,
+      "typeCount": 1,
+      "dimensions": {
+        "ContractPotential": {
+          "score": 88.0,
+          "weight": 0.20,
+          "patternCount": 8,
+          "examples": ["throw new ArgumentNullException(...)", "if (...) throw validation"]
+        }
+      }
+    }
+  ]
+}
+```
+
+### SARIF
+
+[SARIF](https://sarifweb.azurewebsites.net/) (Static Analysis Results Interchange Format) for IDE and CI/CD integration:
+
+```bash
+opalc analyze ./src --format sarif --output analysis.sarif
+```
+
+SARIF output integrates with:
+- **VS Code** - SARIF Viewer extension
+- **GitHub** - Code scanning alerts
+- **Azure DevOps** - Build results
+- **Other tools** - Any SARIF-compatible viewer
+
+Each scoring dimension becomes a SARIF rule (e.g., `OPAL-ContractPotential`), and findings appear as diagnostics in your IDE.
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|:-----|:--------|
+| `0` | Success - no high-priority files found |
+| `1` | Success - high or critical priority files found |
+| `2` | Error - invalid arguments, directory not found, etc. |
+
+Use exit code `1` in CI/CD to flag codebases with high migration potential:
+
+```bash
+# Fail CI if high-priority migration candidates exist
+opalc analyze ./src --threshold 51
+if [ $? -eq 1 ]; then
+  echo "High-priority OPAL migration candidates found"
+fi
+```
+
+---
+
+## Practical Examples
+
+### Find Top Migration Candidates
+
+```bash
+# Show top 10 files scoring above 50
+opalc analyze ./src --threshold 50 --top 10
+```
+
+### CI/CD Integration
+
+```yaml
+# GitHub Actions example
+- name: Analyze OPAL migration potential
+  run: |
+    opalc analyze ./src --format sarif --output opal-analysis.sarif
+
+- name: Upload SARIF
+  uses: github/codeql-action/upload-sarif@v2
+  with:
+    sarif_file: opal-analysis.sarif
+```
+
+### Generate Migration Report
+
+```bash
+# Full JSON report for documentation
+opalc analyze . --format json --output migration-report.json
+
+# Parse with jq to find critical files
+cat migration-report.json | jq '.files[] | select(.priority == "critical") | .path'
+```
+
+### Verbose Analysis of Specific Area
+
+```bash
+# Deep dive into a specific directory
+opalc analyze ./src/Services --verbose --top 50
+```
+
+---
+
+## Skipped Files
+
+The analyzer automatically skips:
+
+- **Generated files**: `*.g.cs`, `*.generated.cs`, `*.Designer.cs`
+- **Build directories**: `obj/`, `bin/`
+- **Version control**: `.git/`
+- **Dependencies**: `node_modules/`
+- **Files with parse errors**
+
+Skipped files are reported in the summary but don't affect scoring.
+
+---
+
+## See Also
+
+- [Getting Started](/opal/getting-started/) - Install OPAL and write your first program
+- [Syntax Reference](/opal/syntax-reference/) - Complete language reference
+- [Contracts](/opal/syntax-reference/contracts/) - Learn about `§Q`/`§S` contracts
+- [Effects](/opal/syntax-reference/effects/) - Learn about `§E` effect declarations

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,0 +1,71 @@
+---
+layout: default
+title: CLI Reference
+nav_order: 6
+has_children: true
+permalink: /cli/
+---
+
+# CLI Reference
+
+The `opalc` command-line tool provides commands for working with OPAL code and analyzing C# codebases for migration.
+
+---
+
+## Installation
+
+Install `opalc` as a global .NET tool:
+
+```bash
+dotnet tool install --global Opal.Compiler
+```
+
+Or run the quick-start script which installs everything:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/juanmicrosoft/opal/main/scripts/init-opal.sh | bash
+```
+
+---
+
+## Available Commands
+
+| Command | Description |
+|:--------|:------------|
+| `opalc` (default) | Compile OPAL source files to C# |
+| [`opalc analyze`](/opal/cli/analyze/) | Score C# files for OPAL migration potential |
+
+---
+
+## Compilation (Default Command)
+
+Compile OPAL source files to C#:
+
+```bash
+opalc --input file.opal --output file.g.cs
+```
+
+### Options
+
+| Option | Description |
+|:-------|:------------|
+| `--input`, `-i` | Input OPAL file path (required) |
+| `--output`, `-o` | Output C# file path (required) |
+| `--verbose`, `-v` | Show detailed compilation output |
+
+### Example
+
+```bash
+# Compile a single file
+opalc --input src/MyModule.opal --output src/MyModule.g.cs
+
+# Compile with verbose output
+opalc -v -i src/MyModule.opal -o src/MyModule.g.cs
+```
+
+---
+
+## See Also
+
+- [Getting Started](/opal/getting-started/) - Installation and first program
+- [Syntax Reference](/opal/syntax-reference/) - Complete language reference

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -76,3 +76,4 @@ For alternative installation methods (global tool only, manual Claude skills set
 - [Installation](/opal/getting-started/installation/) - Detailed setup instructions
 - [Hello World](/opal/getting-started/hello-world/) - Understand the hello world program
 - [Syntax Reference](/opal/syntax-reference/) - Complete language reference
+- [CLI Reference](/opal/cli/) - All `opalc` commands including migration analysis

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,6 +111,31 @@ dotnet run --project samples/HelloWorld
 
 ---
 
+## Migration Analysis
+
+Have an existing C# codebase? Use `opalc analyze` to find files that would benefit most from OPAL:
+
+```bash
+# Score C# files for migration potential
+opalc analyze ./src
+
+# Output:
+# === OPAL Migration Analysis ===
+# Analyzed: 42 files
+# Average Score: 34.2/100
+#
+# Priority Breakdown:
+#   Critical (76-100): 2 files
+#   High (51-75):      8 files
+#   ...
+```
+
+The analyzer scores files based on patterns like null handling, error handling, and argument validation that map to OPAL features.
+
+[Learn more about analyze](/opal/cli/analyze/){: .btn .btn-outline }
+
+---
+
 ## Project Status
 
 - [x] Core compiler (lexer, parser, C# code generation)


### PR DESCRIPTION
## Summary

- Create new `docs/cli/` section for CLI command documentation
- Add detailed documentation for `opalc analyze` command including scoring dimensions, priority bands, output formats, and usage examples
- Update `docs/index.md` with Migration Analysis section
- Update `docs/getting-started/index.md` with CLI Reference link

🤖 Generated with [Claude Code](https://claude.com/claude-code)