### PR TITLE
Update quickstart flow and CLAUDE.md AI guidelines

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -57,21 +57,28 @@ irm https://raw.githubusercontent.com/juanmicrosoft/opal/main/scripts/init-opal.
 
 ### Existing C# Project
 
-Add OPAL to your existing codebase:
+Add OPAL to your existing codebase in two steps:
 
 ```bash
-# 1. Find best migration candidates
+# 1. Enable OPAL in your project (adds MSBuild integration)
+opalc init
+
+# 2. Analyze your codebase to find migration candidates
 opalc analyze ./src --top 10
-
-# 2. Set up tooling and MSBuild integration
-opalc init --ai claude
-
-# 3. Start migrating files
-opalc convert HighScoreFile.cs
-
-# 4. Build - OPAL compiles automatically
-dotnet build
 ```
+
+After init, you can:
+- Write new `.opal` files that compile automatically during `dotnet build`
+- Use `opalc convert` to migrate high-scoring C# files to OPAL
+
+**Optional: Enable Claude Code integration**
+
+```bash
+# Add Claude skills for AI-assisted OPAL development
+opalc init --ai claude
+```
+
+This adds `/opal` and `/opal-convert` skills, plus CLAUDE.md with guidelines that instruct Claude to write new code in OPAL and analyze C# files before modifying them.
 
 See the [Adding OPAL to Existing Projects](/opal/guides/adding-opal-to-existing-projects/) guide for the complete walkthrough.
 
@@ -79,14 +86,19 @@ See the [Adding OPAL to Existing Projects](/opal/guides/adding-opal-to-existing-
 
 ## What You Get
 
-The init script (new projects) or `opalc init` (existing projects) sets up:
+### Basic Init (`opalc init`)
 
 | Component | Description |
 |:----------|:------------|
-| `opalc` global tool | Compile OPAL to C# from anywhere: `opalc --input file.opal --output file.g.cs` |
-| Claude Code skills | Use `/opal` to write OPAL code and `/opal-convert` to convert C# to OPAL |
 | MSBuild integration | `.opal` files compile automatically during `dotnet build` |
-| Sample project | A ready-to-run OPAL project to explore (new projects only) |
+| Generated output | C# files go to `obj/` directory, keeping source tree clean |
+
+### With Claude (`opalc init --ai claude`)
+
+| Component | Description |
+|:----------|:------------|
+| Claude Code skills | `/opal` to write OPAL code, `/opal-convert` to convert C# |
+| CLAUDE.md | Project guidelines instructing Claude to prefer OPAL for new code |
 
 ---
 

--- a/src/Opal.Compiler/Resources/Templates/CLAUDE.md.template
+++ b/src/Opal.Compiler/Resources/Templates/CLAUDE.md.template
@@ -3,11 +3,29 @@
 
 This project uses OPAL (Optimized Programming for Agent Language), a domain-specific language that compiles to C#.
 
+### Coding Guidelines for AI Agents
+
+**When creating new files:**
+- Write new code in OPAL (`.opal`), not C# (`.cs`)
+- OPAL files compile automatically during `dotnet build`
+- Use the `/opal` skill for OPAL syntax assistance
+
+**When modifying existing C# files:**
+- Before making changes to a `.cs` file, run `opalc analyze <file.cs>` to check its migration score
+- If the file scores **High** (51+) or **Critical** (76+), convert it to OPAL first using `/opal-convert`, then make your changes in the OPAL version
+- If the file scores **Medium** or **Low**, you may modify the C# directly
+
+**When asked to add features or fix bugs:**
+1. Check if the target file is `.opal` or `.cs`
+2. For `.cs` files, run analyze first to determine if conversion is worthwhile
+3. Prefer OPAL for files with validation logic, error handling, or side effects
+
 ### Quick Reference
 
 #### File Types
-- `.opal` - OPAL source files
-- `.g.cs` - Generated C# files (do not edit)
+- `.opal` - OPAL source files (preferred for new code)
+- `.g.cs` - Generated C# files (do not edit manually)
+- `.cs` - Legacy C# files (consider converting high-scoring files)
 
 #### Available Skills
 - `/opal` - Write OPAL code with v2+ syntax
@@ -15,16 +33,17 @@ This project uses OPAL (Optimized Programming for Agent Language), a domain-spec
 
 #### Key Commands
 ```bash
-opalc --input file.opal              # Compile OPAL to C#
+opalc analyze <path>                 # Score files for OPAL migration potential
+opalc --input file.opal -o file.g.cs # Compile OPAL to C#
 opalc convert file.cs                # Convert C# to OPAL
 opalc convert file.opal              # Convert OPAL to C#
-opalc migrate <project>              # Migrate entire project
-opalc benchmark [options]            # Compare token economics
 ```
 
 #### OPAL v2+ Syntax Highlights
 - Lisp-style expressions: `(+ a b)`, `(== x 0)`, `(% i 15)`
 - Arrow conditionals: `§IF[id] condition → action`
+- Contracts: `§Q (> x 0)` (precondition), `§S (>= result 0)` (postcondition)
+- Effects: `§E[db,net,cw]` (database, network, console write)
 - Print shorthand: `§P "message"`
 - Variable binding: `§B[name] expr`
 - Return: `§R expr`

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -56,21 +56,28 @@ irm https://raw.githubusercontent.com/juanmicrosoft/opal/main/scripts/init-opal.
 
 ### Existing C# Project
 
-Add OPAL to your existing codebase:
+Add OPAL to your existing codebase in two steps:
 
 ```bash
-# 1. Find best migration candidates
+# 1. Enable OPAL in your project (adds MSBuild integration)
+opalc init
+
+# 2. Analyze your codebase to find migration candidates
 opalc analyze ./src --top 10
-
-# 2. Set up tooling and MSBuild integration
-opalc init --ai claude
-
-# 3. Start migrating files
-opalc convert HighScoreFile.cs
-
-# 4. Build - OPAL compiles automatically
-dotnet build
 ```
+
+After init, you can:
+- Write new `.opal` files that compile automatically during `dotnet build`
+- Use `opalc convert` to migrate high-scoring C# files to OPAL
+
+**Optional: Enable Claude Code integration**
+
+```bash
+# Add Claude skills for AI-assisted OPAL development
+opalc init --ai claude
+```
+
+This adds `/opal` and `/opal-convert` skills, plus CLAUDE.md with guidelines that instruct Claude to write new code in OPAL and analyze C# files before modifying them.
 
 See the [Adding OPAL to Existing Projects](/guides/adding-opal-to-existing-projects/) guide for the complete walkthrough.
 
@@ -78,14 +85,19 @@ See the [Adding OPAL to Existing Projects](/guides/adding-opal-to-existing-proje
 
 ## What You Get
 
-The init script (new projects) or `opalc init` (existing projects) sets up:
+### Basic Init (`opalc init`)
 
 | Component | Description |
 |:----------|:------------|
-| `opalc` global tool | Compile OPAL to C# from anywhere: `opalc --input file.opal --output file.g.cs` |
-| Claude Code skills | Use `/opal` to write OPAL code and `/opal-convert` to convert C# to OPAL |
 | MSBuild integration | `.opal` files compile automatically during `dotnet build` |
-| Sample project | A ready-to-run OPAL project to explore (new projects only) |
+| Generated output | C# files go to `obj/` directory, keeping source tree clean |
+
+### With Claude (`opalc init --ai claude`)
+
+| Component | Description |
+|:----------|:------------|
+| Claude Code skills | `/opal` to write OPAL code, `/opal-convert` to convert C# |
+| CLAUDE.md | Project guidelines instructing Claude to prefer OPAL for new code |
 
 ---
 

--- a/website/content/guides/adding-opal-to-existing-projects.mdx
+++ b/website/content/guides/adding-opal-to-existing-projects.mdx
@@ -6,7 +6,7 @@ order: 1
 
 # Adding OPAL to an Existing C# Project
 
-This guide walks you through adding OPAL to an existing C# project, from identifying migration candidates to building with mixed OPAL/C# code.
+This guide walks you through adding OPAL to an existing C# project, from enabling OPAL to building with mixed OPAL/C# code.
 
 ---
 
@@ -14,18 +14,34 @@ This guide walks you through adding OPAL to an existing C# project, from identif
 
 Adding OPAL to an existing project is a gradual process:
 
-1. **Analyze** - Find files that benefit most from OPAL's features
-2. **Initialize** - Set up tooling and MSBuild integration
-3. **Convert** - Migrate files one at a time
+1. **Initialize** - Enable OPAL with MSBuild integration
+2. **Analyze** - Find files that benefit most from OPAL's features
+3. **Write/Convert** - Create new files in OPAL, convert high-scoring C# files
 4. **Build** - OPAL compiles automatically with your project
 
 You don't need to convert everything at once. OPAL and C# coexist seamlessly.
 
 ---
 
-## Step 1: Find Migration Candidates
+## Step 1: Enable OPAL in Your Project
 
-Use `opalc analyze` to score your C# files for OPAL migration potential:
+Enable OPAL with MSBuild integration:
+
+```bash
+# Initialize OPAL in your project
+opalc init
+
+# Or specify a specific project file
+opalc init --project MyApp.csproj
+```
+
+Your `.csproj` is updated with MSBuild targets that compile `.opal` files automatically during `dotnet build`.
+
+---
+
+## Step 2: Analyze Your Codebase
+
+Use `opalc analyze` to find C# files that would benefit most from OPAL:
 
 ```bash
 # Analyze your source directory
@@ -50,37 +66,12 @@ Top 10 Files for Migration:
  65/100 [High]      src/Repositories/UserRepository.cs
 ```
 
-Files are scored based on patterns that map to OPAL features:
-
-| Pattern | OPAL Feature |
-|:--------|:-------------|
-| Argument validation, `ArgumentException` | `§Q` precondition contracts |
-| Null checks, `?.`, `??` | `Option<T>` types |
-| Try/catch blocks | `Result<T,E>` error handling |
-| File I/O, network, database calls | `§E` effect declarations |
-
----
-
-## Step 2: Initialize Your Project
-
-Set up OPAL tooling and MSBuild integration:
-
-```bash
-# Initialize with Claude Code support
-opalc init --ai claude
-
-# Or specify a specific project file
-opalc init --ai claude --project MyApp.csproj
-```
-
-### What Gets Created
-
-| File | Purpose |
-|:-----|:--------|
-| `.claude/skills/opal.md` | Claude skill for writing OPAL code |
-| `.claude/skills/opal-convert.md` | Claude skill for C# to OPAL conversion |
-| `CLAUDE.md` | Project documentation with OPAL reference |
-| `MyApp.csproj` (updated) | MSBuild targets for automatic OPAL compilation |
+| Priority | Score | Recommendation |
+|:---------|:------|:---------------|
+| **Critical** | 76-100 | Convert to OPAL - high benefit |
+| **High** | 51-75 | Good conversion candidate |
+| **Medium** | 26-50 | Optional - some benefit |
+| **Low** | 0-25 | Keep in C# - minimal benefit |
 
 ---
 
@@ -118,21 +109,19 @@ The build process:
 
 ---
 
-## Step 5: Gradual Migration
+## Step 5: Convert High-Scoring C# Files
 
-### Option A: Use Claude Code (Recommended)
-
-```
-/opal-convert src/Services/PaymentProcessor.cs
-```
-
-### Option B: Use the CLI
+Based on your analysis results, convert files that score High or Critical:
 
 ```bash
+# Convert a single file
 opalc convert src/Services/PaymentProcessor.cs
+
+# With benchmark comparison
+opalc convert src/Services/PaymentProcessor.cs --benchmark
 ```
 
-### Option C: Convert Entire Project
+For bulk conversion:
 
 ```bash
 opalc migrate ./src --dry-run  # Preview first
@@ -141,12 +130,21 @@ opalc migrate ./src            # Execute
 
 ---
 
-## Using Claude Code
+## Optional: Enable Claude Code Integration
 
-After initialization, Claude Code provides powerful assistance:
+For AI-assisted OPAL development:
 
-### Writing New OPAL Code
+```bash
+opalc init --ai claude
+```
 
+This adds:
+- `/opal` and `/opal-convert` skills
+- `CLAUDE.md` with guidelines instructing Claude to write new code in OPAL and analyze C# files before modifying them
+
+### Using Claude Code
+
+**Write new OPAL code:**
 ```
 /opal
 
@@ -155,13 +153,9 @@ Write a function that validates email addresses with:
 - Postcondition: returns true only for valid emails
 ```
 
-### Converting Existing Code
-
+**Convert existing C# to OPAL:**
 ```
-/opal-convert
-
-Convert this C# class to OPAL:
-[paste your C# code]
+/opal-convert src/Services/PaymentProcessor.cs
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Refocus quickstart on enabling OPAL (`opalc init`) then analyzing codebase with `opalc analyze`
- Make Claude Code integration an optional additional step rather than the primary path
- Update CLAUDE.md template with AI coding guidelines that instruct Claude to:
  - Write new files in OPAL instead of C#
  - Run `opalc analyze` on C# files before modifying them to determine if they should be converted to OPAL first
  - Prefer OPAL for files with validation logic, error handling, or side effects

## Changes

### CLAUDE.md Template (`src/Opal.Compiler/Resources/Templates/CLAUDE.md.template`)
Added "Coding Guidelines for AI Agents" section with specific instructions for:
- Creating new files in OPAL
- Analyzing C# files before modification
- Converting high-scoring files to OPAL before making changes

### Documentation Flow
Updated quickstart and migration guide to follow:
1. `opalc init` - Enable OPAL with MSBuild integration
2. `opalc analyze` - Find migration candidates  
3. Write new code in OPAL / Convert high-scoring C# files
4. (Optional) `opalc init --ai claude` for Claude skills

## Note

The current `opalc init` command requires `--ai` flag. To fully support the documented flow where `opalc init` (without `--ai`) adds only MSBuild integration, a code change would be needed to make `--ai` optional.

## Test plan

- [ ] Verify CLAUDE.md template renders correctly with `opalc init --ai claude`
- [ ] Review documentation flow makes sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)