### PR TITLE
Update installation instructions to use dotnet tool

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -17,13 +17,13 @@ The `opalc` command-line tool provides commands for working with OPAL code and a
 Install `opalc` as a global .NET tool:
 
 ```bash
-dotnet tool install --global Opal.Compiler
+dotnet tool install -g opalc --version 0.1.2
 ```
 
-Or run the quick-start script which installs everything:
+Or update an existing installation:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/juanmicrosoft/opal/main/scripts/init-opal.sh | bash
+dotnet tool update -g opalc
 ```
 
 ---

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -37,22 +37,34 @@ your_code.opal → OPAL Compiler → your_code.g.cs → .NET Build → executabl
 
 ---
 
+## Installation
+
+Install the OPAL compiler as a global .NET tool:
+
+```bash
+dotnet tool install -g opalc --version 0.1.2
+```
+
+Or update an existing installation:
+
+```bash
+dotnet tool update -g opalc
+```
+
+---
+
 ## Two Paths to OPAL
 
 Choose your starting point based on your situation:
 
 ### New Project
 
-Get up and running with OPAL in one command:
+Create a new .NET project and initialize OPAL:
 
-**macOS/Linux:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/juanmicrosoft/opal/main/scripts/init-opal.sh | bash
-```
-
-**Windows (PowerShell):**
-```powershell
-irm https://raw.githubusercontent.com/juanmicrosoft/opal/main/scripts/init-opal.ps1 | iex
+dotnet new console -o MyOpalApp
+cd MyOpalApp
+opalc init
 ```
 
 ### Existing C# Project

--- a/website/content/cli/index.mdx
+++ b/website/content/cli/index.mdx
@@ -16,13 +16,13 @@ The `opalc` command-line tool provides commands for working with OPAL code and a
 Install `opalc` as a global .NET tool:
 
 ```bash
-dotnet tool install --global Opal.Compiler
+dotnet tool install -g opalc --version 0.1.2
 ```
 
-Or run the quick-start script which installs everything:
+Or update an existing installation:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/juanmicrosoft/opal/main/scripts/init-opal.sh | bash
+dotnet tool update -g opalc
 ```
 
 ---

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -36,22 +36,34 @@ your_code.opal → OPAL Compiler → your_code.g.cs → .NET Build → executabl
 
 ---
 
+## Installation
+
+Install the OPAL compiler as a global .NET tool:
+
+```bash
+dotnet tool install -g opalc --version 0.1.2
+```
+
+Or update an existing installation:
+
+```bash
+dotnet tool update -g opalc
+```
+
+---
+
 ## Two Paths to OPAL
 
 Choose your starting point based on your situation:
 
 ### New Project
 
-Get up and running with OPAL in one command:
+Create a new .NET project and initialize OPAL:
 
-**macOS/Linux:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/juanmicrosoft/opal/main/scripts/init-opal.sh | bash
-```
-
-**Windows (PowerShell):**
-```powershell
-irm https://raw.githubusercontent.com/juanmicrosoft/opal/main/scripts/init-opal.ps1 | iex
+dotnet new console -o MyOpalApp
+cd MyOpalApp
+opalc init
 ```
 
 ### Existing C# Project


### PR DESCRIPTION
## Summary
- Replace old shell script installation instructions with dotnet tool commands
- Use `dotnet tool install -g opalc --version 0.1.2` for new installations
- Use `dotnet tool update -g opalc` for updates

## Test plan
- [ ] Verify documentation site shows updated installation commands
- [ ] Test `dotnet tool install -g opalc --version 0.1.2` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)