### PR TITLE
Fix OPAL syntax example in quickstart

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -85,15 +85,25 @@ This adds `/opal` and `/opal-convert` skills, plus CLAUDE.md with guidelines tha
 
 ### Step 4: Write OPAL Code
 
-After init, create `.opal` files and they compile automatically:
+After init, create `.opal` files and they compile automatically. Create `Program.opal`:
+
+```
+§M{m001:MyApp}
+§F{f001:Main:pub}
+  §O{void}
+  §E{cw}
+  §P "Hello from OPAL!"
+§/F{f001}
+§/M{m001}
+```
+
+Then build:
 
 ```bash
-# Create your first OPAL file
-echo 'namespace MyApp { §M Main() { Console.WriteLine("Hello from OPAL!") } }' > Program.opal
-
-# Build runs OPAL compilation automatically
 dotnet build
 ```
+
+See [Hello World](/opal/getting-started/hello-world/) for a detailed explanation of the syntax.
 
 ### Step 5: (Optional) Migrate Existing C# Files
 

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -84,15 +84,25 @@ This adds `/opal` and `/opal-convert` skills, plus CLAUDE.md with guidelines tha
 
 ### Step 4: Write OPAL Code
 
-After init, create `.opal` files and they compile automatically:
+After init, create `.opal` files and they compile automatically. Create `Program.opal`:
+
+```
+§M{m001:MyApp}
+§F{f001:Main:pub}
+  §O{void}
+  §E{cw}
+  §P "Hello from OPAL!"
+§/F{f001}
+§/M{m001}
+```
+
+Then build:
 
 ```bash
-# Create your first OPAL file
-echo 'namespace MyApp { §M Main() { Console.WriteLine("Hello from OPAL!") } }' > Program.opal
-
-# Build runs OPAL compilation automatically
 dotnet build
 ```
+
+See [Hello World](/getting-started/hello-world/) for a detailed explanation of the syntax.
 
 ### Step 5: (Optional) Migrate Existing C# Files
 


### PR DESCRIPTION
## Summary
- Replace incorrect pseudo-syntax with proper OPAL tag-based syntax in Step 4
- Show the actual §M, §F, §O, §E, §P tags that OPAL uses
- Add link to Hello World page for detailed syntax explanation

## Test plan
- [ ] Verify documentation renders correctly
- [ ] Confirm example matches actual OPAL syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)