### PR TITLE
Make CLAUDE.md enforce OPAL-first development

### DIFF
--- a/src/Opal.Compiler/Resources/Templates/CLAUDE.md.template
+++ b/src/Opal.Compiler/Resources/Templates/CLAUDE.md.template
@@ -1,31 +1,35 @@
 <!-- BEGIN OPALC SECTION - DO NOT EDIT -->
-## OPAL Project
+## OPAL-First Project
 
-This project uses OPAL (Optimized Programming for Agent Language), a domain-specific language that compiles to C#.
+This is an **OPAL-first project**. All new code MUST be written in OPAL. Existing C# files should be converted to OPAL before modification.
 
-### Coding Guidelines for AI Agents
+### MANDATORY Rules for AI Agents
 
-**When creating new files:**
-- Write new code in OPAL (`.opal`), not C# (`.cs`)
+**Rule 1: Never create new `.cs` files**
+- All new code MUST be written in OPAL (`.opal` files)
 - OPAL files compile automatically during `dotnet build`
-- Use the `/opal` skill for OPAL syntax assistance
+- Use the `/opal` skill for syntax assistance
 
-**When modifying existing C# files:**
-- Before making changes to a `.cs` file, run `opalc analyze <file.cs>` to check its migration score
-- If the file scores **High** (51+) or **Critical** (76+), convert it to OPAL first using `/opal-convert`, then make your changes in the OPAL version
-- If the file scores **Medium** or **Low**, you may modify the C# directly
+**Rule 2: Convert C# to OPAL before modifying**
+- Before modifying ANY `.cs` file, convert it to OPAL first using `/opal-convert`
+- Make your changes in the new `.opal` file, not the original `.cs` file
+- Delete the original `.cs` file after successful conversion
+- Run `opalc analyze <file.cs>` to understand the file's complexity before conversion
 
-**When asked to add features or fix bugs:**
-1. Check if the target file is `.opal` or `.cs`
-2. For `.cs` files, run analyze first to determine if conversion is worthwhile
-3. Prefer OPAL for files with validation logic, error handling, or side effects
+**Rule 3: Never edit generated files**
+- Files ending in `.g.cs` are auto-generated from OPAL - do not edit them
+- If you need to change generated output, edit the source `.opal` file instead
 
-### Quick Reference
+### Workflow for Any Code Change
 
-#### File Types
-- `.opal` - OPAL source files (preferred for new code)
-- `.g.cs` - Generated C# files (do not edit manually)
-- `.cs` - Legacy C# files (consider converting high-scoring files)
+1. **New feature/file?** → Create `.opal` file using `/opal` skill
+2. **Modify existing `.opal` file?** → Edit the `.opal` file directly
+3. **Modify existing `.cs` file?** → Convert to `.opal` first, then make changes
+
+### File Types
+- `.opal` - OPAL source files (**use this for all code**)
+- `.g.cs` - Generated C# files (never edit)
+- `.cs` - Legacy C# files (**convert to OPAL before modifying**)
 
 #### Available Skills
 - `/opal` - Write OPAL code with v2+ syntax

--- a/tests/Opal.Compiler.Tests/InitCommandIntegrationTests.cs
+++ b/tests/Opal.Compiler.Tests/InitCommandIntegrationTests.cs
@@ -154,8 +154,8 @@ public class InitCommandIntegrationTests : IDisposable
 
         // OPAL section should be appended
         Assert.Contains("<!-- BEGIN OPALC SECTION - DO NOT EDIT -->", content);
-        Assert.Contains("## OPAL Project", content);
-        Assert.Contains("Coding Guidelines for AI Agents", content);
+        Assert.Contains("## OPAL-First Project", content);
+        Assert.Contains("MANDATORY Rules for AI Agents", content);
         Assert.Contains("<!-- END OPALC SECTION -->", content);
     }
 
@@ -203,8 +203,8 @@ public class InitCommandIntegrationTests : IDisposable
         Assert.DoesNotContain("Old version info here", content);
 
         // New OPAL content should be present
-        Assert.Contains("## OPAL Project", content);
-        Assert.Contains("Coding Guidelines for AI Agents", content);
+        Assert.Contains("## OPAL-First Project", content);
+        Assert.Contains("MANDATORY Rules for AI Agents", content);
         Assert.Matches(@"opalc v\d+\.\d+\.\d+", content);
     }
 

--- a/tests/Opal.Compiler.Tests/InitCommandTests.cs
+++ b/tests/Opal.Compiler.Tests/InitCommandTests.cs
@@ -47,7 +47,7 @@ public class InitCommandTests : IDisposable
         var content = EmbeddedResourceHelper.ReadTemplate("CLAUDE.md.template");
 
         Assert.NotEmpty(content);
-        Assert.Contains("OPAL Project", content);
+        Assert.Contains("OPAL-First Project", content);
         Assert.Contains("{{VERSION}}", content);
         Assert.Contains("<!-- BEGIN OPALC SECTION - DO NOT EDIT -->", content);
         Assert.Contains("<!-- END OPALC SECTION -->", content);
@@ -166,7 +166,7 @@ public class InitCommandTests : IDisposable
         Assert.Contains(claudeMdPath, result.CreatedFiles);
 
         var content = await File.ReadAllTextAsync(claudeMdPath);
-        Assert.Contains("OPAL Project", content);
+        Assert.Contains("OPAL-First Project", content);
         Assert.DoesNotContain("{{VERSION}}", content); // Version should be replaced
         Assert.Matches(@"opalc v\d+\.\d+\.\d+", content);
         Assert.Contains("<!-- BEGIN OPALC SECTION - DO NOT EDIT -->", content);
@@ -261,7 +261,7 @@ This should be preserved.
         Assert.DoesNotContain("This is old content that should be replaced.", content);
 
         // New OPAL content should be present
-        Assert.Contains("## OPAL Project", content);
+        Assert.Contains("## OPAL-First Project", content);
         Assert.Matches(@"opalc v\d+\.\d+\.\d+", content);
     }
 
@@ -297,7 +297,7 @@ Run `dotnet build` to compile.
         // OPAL section should be appended
         Assert.Contains("<!-- BEGIN OPALC SECTION - DO NOT EDIT -->", content);
         Assert.Contains("<!-- END OPALC SECTION -->", content);
-        Assert.Contains("## OPAL Project", content);
+        Assert.Contains("## OPAL-First Project", content);
 
         // OPAL section should come after original content
         var userContentIndex = content.IndexOf("## Build Instructions");
@@ -335,7 +335,7 @@ Run `dotnet build` to compile.
         // OPAL section should still be present and valid
         Assert.Contains("<!-- BEGIN OPALC SECTION - DO NOT EDIT -->", finalContent);
         Assert.Contains("<!-- END OPALC SECTION -->", finalContent);
-        Assert.Contains("## OPAL Project", finalContent);
+        Assert.Contains("## OPAL-First Project", finalContent);
     }
 
     [Fact]
@@ -402,14 +402,14 @@ Run `dotnet build` to compile.
     {
         var template = EmbeddedResourceHelper.ReadTemplate("CLAUDE.md.template");
 
-        // Verify the new AI coding guidelines section exists
-        Assert.Contains("Coding Guidelines for AI Agents", template);
-        Assert.Contains("When creating new files:", template);
-        Assert.Contains("Write new code in OPAL", template);
-        Assert.Contains("When modifying existing C# files:", template);
+        // Verify the OPAL-first mandatory rules section exists
+        Assert.Contains("OPAL-First Project", template);
+        Assert.Contains("MANDATORY Rules for AI Agents", template);
+        Assert.Contains("Rule 1: Never create new `.cs` files", template);
+        Assert.Contains("All new code MUST be written in OPAL", template);
+        Assert.Contains("Rule 2: Convert C# to OPAL before modifying", template);
+        Assert.Contains("Rule 3: Never edit generated files", template);
         Assert.Contains("opalc analyze", template);
-        Assert.Contains("High", template);
-        Assert.Contains("Critical", template);
     }
 
     [Fact]
@@ -422,11 +422,11 @@ Run `dotnet build` to compile.
         var claudeMdPath = Path.Combine(_testDirectory, "CLAUDE.md");
         var content = await File.ReadAllTextAsync(claudeMdPath);
 
-        // Verify AI guidelines are in the generated file
-        Assert.Contains("Coding Guidelines for AI Agents", content);
-        Assert.Contains("When creating new files:", content);
-        Assert.Contains("Write new code in OPAL", content);
-        Assert.Contains("When modifying existing C# files:", content);
+        // Verify OPAL-first mandatory rules are in the generated file
+        Assert.Contains("OPAL-First Project", content);
+        Assert.Contains("MANDATORY Rules for AI Agents", content);
+        Assert.Contains("Rule 1: Never create new `.cs` files", content);
+        Assert.Contains("Rule 2: Convert C# to OPAL before modifying", content);
         Assert.Contains("opalc analyze", content);
     }
 }


### PR DESCRIPTION
## Summary

Update the CLAUDE.md template to use stronger, mandatory language that ensures AI agents (like Claude) write code in OPAL rather than C#.

## Key Changes

### Before (soft guidelines)
- "When creating new files: Write new code in OPAL"
- "When modifying C# files: If score is High/Critical, convert first; otherwise modify C# directly"

### After (mandatory rules)
- **Rule 1**: Never create new `.cs` files - all new code MUST be `.opal`
- **Rule 2**: Convert C# to OPAL before modifying ANY `.cs` file
- **Rule 3**: Never edit generated `.g.cs` files

### Removed Loopholes
- Removed the score threshold that allowed modifying C# directly for Medium/Low scores
- Now ALL C# files must be converted to OPAL before modification

## Rationale

The goal is to make Claude program primarily in OPAL. The previous guidelines were too soft and gave Claude escape routes to continue writing C#. The new mandatory rules ensure:
1. New features are always written in OPAL
2. Existing C# gets progressively converted as it's touched
3. The codebase naturally migrates toward OPAL over time

## Test plan
- [x] All InitCommand tests pass (33/33)
- [ ] Run `opalc init --ai claude` and verify CLAUDE.md content

🤖 Generated with [Claude Code](https://claude.com/claude-code)