### PR TITLE
Add Claude Code hooks to enforce OPAL-first development

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "opalc hook validate-write $TOOL_INPUT"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/Opal.Compiler/Commands/HookCommand.cs
+++ b/src/Opal.Compiler/Commands/HookCommand.cs
@@ -1,0 +1,129 @@
+using System.CommandLine;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Opal.Compiler.Commands;
+
+/// <summary>
+/// CLI command for Claude Code hook integration.
+/// Validates tool inputs to enforce OPAL-first development.
+/// </summary>
+public static class HookCommand
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public static Command Create()
+    {
+        var command = new Command("hook", "Claude Code hook commands for OPAL-first enforcement");
+
+        command.AddCommand(CreateValidateWriteCommand());
+
+        return command;
+    }
+
+    private static Command CreateValidateWriteCommand()
+    {
+        var inputArgument = new Argument<string>(
+            name: "tool-input",
+            description: "The JSON tool input from Claude Code");
+
+        var command = new Command("validate-write", "Validate a Write tool call to enforce OPAL-first development")
+        {
+            inputArgument
+        };
+
+        command.SetHandler((System.CommandLine.Invocation.InvocationContext context) =>
+        {
+            var toolInputJson = context.ParseResult.GetValueForArgument(inputArgument);
+            var exitCode = ValidateWrite(toolInputJson);
+            context.ExitCode = exitCode;
+        });
+
+        return command;
+    }
+
+    /// <summary>
+    /// Validates a Write tool input and returns exit code.
+    /// Returns 0 to allow the operation, 1 to block it.
+    /// </summary>
+    public static int ValidateWrite(string toolInputJson)
+    {
+        try
+        {
+            var input = JsonSerializer.Deserialize<WriteToolInput>(toolInputJson, JsonOptions);
+
+            if (input == null)
+            {
+                // Can't parse input, allow the operation
+                return 0;
+            }
+
+            // Check both snake_case (file_path) and camelCase (filePath)
+            var path = input.FilePathSnake ?? input.FilePathCamel;
+
+            if (string.IsNullOrEmpty(path))
+            {
+                // No file path found, allow the operation
+                return 0;
+            }
+
+            // Allow .opal files
+            if (path.EndsWith(".opal", StringComparison.OrdinalIgnoreCase))
+            {
+                return 0;
+            }
+
+            // Allow generated files (.g.cs) anywhere
+            if (path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase))
+            {
+                return 0;
+            }
+
+            // Allow files in obj/ directory (build artifacts)
+            if (path.Contains("/obj/") || path.Contains("\\obj\\") ||
+                path.StartsWith("obj/", StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWith("obj\\", StringComparison.OrdinalIgnoreCase))
+            {
+                return 0;
+            }
+
+            // Block new .cs files
+            if (path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+            {
+                var suggestedPath = Path.ChangeExtension(path, ".opal");
+
+                Console.Error.WriteLine($"BLOCKED: Cannot create C# file '{path}'");
+                Console.Error.WriteLine();
+                Console.Error.WriteLine("This is an OPAL-first project. Create an .opal file instead:");
+                Console.Error.WriteLine($"  {suggestedPath}");
+                Console.Error.WriteLine();
+                Console.Error.WriteLine("Use /opal skill for OPAL syntax help.");
+
+                return 1;
+            }
+
+            // Allow all other file types
+            return 0;
+        }
+        catch (JsonException)
+        {
+            // If we can't parse the JSON, allow the operation
+            return 0;
+        }
+    }
+
+    private sealed class WriteToolInput
+    {
+        [JsonPropertyName("file_path")]
+        public string? FilePathSnake { get; set; }
+
+        [JsonPropertyName("filePath")]
+        public string? FilePathCamel { get; set; }
+
+        [JsonPropertyName("content")]
+        public string? Content { get; set; }
+    }
+}

--- a/src/Opal.Compiler/Init/ClaudeInitializer.cs
+++ b/src/Opal.Compiler/Init/ClaudeInitializer.cs
@@ -1,11 +1,21 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 namespace Opal.Compiler.Init;
 
 /// <summary>
 /// Initializer for Claude Code AI agent.
-/// Creates .claude/skills/ directory with OPAL skills and CLAUDE.md project file.
+/// Creates .claude/skills/ directory with OPAL skills, CLAUDE.md project file,
+/// and configures hooks to enforce OPAL-first development.
 /// </summary>
 public class ClaudeInitializer : IAiInitializer
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        // Note: No PropertyNamingPolicy - Claude Code expects PascalCase (e.g., PreToolUse, not pre_tool_use)
+    };
     private const string SectionStart = "<!-- BEGIN OPALC SECTION - DO NOT EDIT -->";
     private const string SectionEnd = "<!-- END OPALC SECTION -->";
 
@@ -59,6 +69,18 @@ public class ClaudeInitializer : IAiInitializer
             else if (claudeMdResult == ClaudeMdUpdateResult.Updated)
             {
                 updatedFiles.Add(claudeMdPath);
+            }
+
+            // Configure Claude Code hooks for OPAL-first enforcement
+            var settingsPath = Path.Combine(targetDirectory, ".claude", "settings.json");
+            var settingsResult = await ConfigureHooksAsync(settingsPath, force);
+            if (settingsResult == HookSettingsResult.Created)
+            {
+                createdFiles.Add(settingsPath);
+            }
+            else if (settingsResult == HookSettingsResult.Updated)
+            {
+                updatedFiles.Add(settingsPath);
             }
 
             var allModifiedFiles = createdFiles.Concat(updatedFiles).ToList();
@@ -142,4 +164,130 @@ public class ClaudeInitializer : IAiInitializer
         await File.WriteAllTextAsync(path, newContent);
         return ClaudeMdUpdateResult.Updated;
     }
+
+    private enum HookSettingsResult
+    {
+        Created,
+        Updated,
+        Unchanged
+    }
+
+    private static async Task<HookSettingsResult> ConfigureHooksAsync(string settingsPath, bool force)
+    {
+        var opalHookConfig = new ClaudeHookMatcher
+        {
+            Matcher = "Write",
+            Hooks = new[]
+            {
+                new ClaudeHook
+                {
+                    Type = "command",
+                    Command = "opalc hook validate-write $TOOL_INPUT"
+                }
+            }
+        };
+
+        if (!File.Exists(settingsPath))
+        {
+            // Create new settings file with hook configuration
+            var settings = new ClaudeSettings
+            {
+                Hooks = new ClaudeHooksConfig
+                {
+                    PreToolUse = new[] { opalHookConfig }
+                }
+            };
+
+            await File.WriteAllTextAsync(settingsPath, JsonSerializer.Serialize(settings, JsonOptions));
+            return HookSettingsResult.Created;
+        }
+
+        // Read existing settings
+        var existingJson = await File.ReadAllTextAsync(settingsPath);
+        ClaudeSettings? existingSettings;
+
+        try
+        {
+            existingSettings = JsonSerializer.Deserialize<ClaudeSettings>(existingJson, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            // If we can't parse existing settings and force is set, overwrite
+            if (force)
+            {
+                var settings = new ClaudeSettings
+                {
+                    Hooks = new ClaudeHooksConfig
+                    {
+                        PreToolUse = new[] { opalHookConfig }
+                    }
+                };
+                await File.WriteAllTextAsync(settingsPath, JsonSerializer.Serialize(settings, JsonOptions));
+                return HookSettingsResult.Updated;
+            }
+            // Otherwise, leave the file unchanged
+            return HookSettingsResult.Unchanged;
+        }
+
+        existingSettings ??= new ClaudeSettings();
+        existingSettings.Hooks ??= new ClaudeHooksConfig();
+
+        // Check if our hook already exists
+        var existingHooks = existingSettings.Hooks.PreToolUse?.ToList() ?? new List<ClaudeHookMatcher>();
+        var hasOpalHook = existingHooks.Any(h =>
+            h.Matcher == "Write" &&
+            h.Hooks?.Any(hook => hook.Command?.Contains("opalc hook validate-write") == true) == true);
+
+        if (hasOpalHook)
+        {
+            return HookSettingsResult.Unchanged;
+        }
+
+        // Add our hook
+        existingHooks.Add(opalHookConfig);
+        existingSettings.Hooks.PreToolUse = existingHooks.ToArray();
+
+        var newJson = JsonSerializer.Serialize(existingSettings, JsonOptions);
+
+        // Check if content actually changed
+        if (newJson.TrimEnd() == existingJson.TrimEnd())
+        {
+            return HookSettingsResult.Unchanged;
+        }
+
+        await File.WriteAllTextAsync(settingsPath, newJson);
+        return HookSettingsResult.Updated;
+    }
+}
+
+// JSON structure classes for Claude Code settings
+// Note: Claude Code expects "hooks" and "PreToolUse" in specific casing
+internal class ClaudeSettings
+{
+    [JsonPropertyName("hooks")]
+    public ClaudeHooksConfig? Hooks { get; set; }
+}
+
+internal class ClaudeHooksConfig
+{
+    // PreToolUse must be PascalCase - this is a Claude Code requirement
+    public ClaudeHookMatcher[]? PreToolUse { get; set; }
+}
+
+internal class ClaudeHookMatcher
+{
+    [JsonPropertyName("matcher")]
+    public string? Matcher { get; set; }
+
+    [JsonPropertyName("hooks")]
+    public ClaudeHook[]? Hooks { get; set; }
+}
+
+internal class ClaudeHook
+{
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("command")]
+    public string? Command { get; set; }
 }

--- a/src/Opal.Compiler/Opal.Compiler.csproj
+++ b/src/Opal.Compiler/Opal.Compiler.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>opalc</ToolCommandName>
     <PackageId>opalc</PackageId>
-    <Version>0.1.2</Version>
+    <Version>0.1.3</Version>
     <Description>OPAL compiler - Optimized Programming for Agent Language</Description>
     <PackageProjectUrl>https://github.com/juanmicrosoft/opal-2</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Opal.Compiler/Program.cs
+++ b/src/Opal.Compiler/Program.cs
@@ -52,6 +52,7 @@ public class Program
         rootCommand.AddCommand(FormatCommand.Create());
         rootCommand.AddCommand(DiagnoseCommand.Create());
         rootCommand.AddCommand(AnalyzeCommand.Create());
+        rootCommand.AddCommand(HookCommand.Create());
 
         return await rootCommand.InvokeAsync(args);
     }

--- a/tests/Opal.Compiler.Tests/HookCommandTests.cs
+++ b/tests/Opal.Compiler.Tests/HookCommandTests.cs
@@ -1,0 +1,253 @@
+using Opal.Compiler.Commands;
+using Opal.Compiler.Init;
+using Xunit;
+
+namespace Opal.Compiler.Tests;
+
+public class HookCommandTests : IDisposable
+{
+    private readonly string _testDirectory;
+
+    public HookCommandTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), $"opal-hook-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            Directory.Delete(_testDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ValidateWrite_AllowsOpalFiles()
+    {
+        var result = HookCommand.ValidateWrite("{\"file_path\": \"MyClass.opal\"}");
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_AllowsOpalFilesWithPath()
+    {
+        var result = HookCommand.ValidateWrite("{\"file_path\": \"src/Services/MyService.opal\"}");
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_AllowsOpalFilesCaseInsensitive()
+    {
+        var result = HookCommand.ValidateWrite("{\"file_path\": \"Test.OPAL\"}");
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_BlocksCsFiles()
+    {
+        var result = HookCommand.ValidateWrite("{\"file_path\": \"MyClass.cs\"}");
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_BlocksCsFilesWithPath()
+    {
+        var result = HookCommand.ValidateWrite("{\"file_path\": \"src/Services/MyService.cs\"}");
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_BlocksCsFilesCaseInsensitive()
+    {
+        var result = HookCommand.ValidateWrite("{\"file_path\": \"Test.CS\"}");
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_AllowsGeneratedCsFiles()
+    {
+        var result = HookCommand.ValidateWrite("{\"file_path\": \"MyClass.g.cs\"}");
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_AllowsGeneratedCsFilesInObjDirectory()
+    {
+        var result = HookCommand.ValidateWrite("{\"file_path\": \"obj/Debug/net8.0/opal/Test.g.cs\"}");
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_AllowsFilesInObjDirectory()
+    {
+        var result = HookCommand.ValidateWrite("{\"file_path\": \"obj/Debug/net8.0/SomeFile.cs\"}");
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_AllowsFilesInObjDirectoryWindowsPath()
+    {
+        var result = HookCommand.ValidateWrite("{\"file_path\": \"obj\\\\Debug\\\\net8.0\\\\SomeFile.cs\"}");
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_AllowsNonCsFiles()
+    {
+        var result = HookCommand.ValidateWrite("{\"file_path\": \"README.md\"}");
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_AllowsJsonFiles()
+    {
+        var result = HookCommand.ValidateWrite("{\"file_path\": \"config.json\"}");
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_AllowsCsprojFiles()
+    {
+        var result = HookCommand.ValidateWrite("{\"file_path\": \"MyProject.csproj\"}");
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_AllowsOnInvalidJson()
+    {
+        var result = HookCommand.ValidateWrite("not valid json");
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_AllowsOnEmptyJson()
+    {
+        var result = HookCommand.ValidateWrite("{}");
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_AllowsOnMissingFilePath()
+    {
+        var result = HookCommand.ValidateWrite("{\"content\": \"some content\"}");
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_HandlesSnakeCaseFilePath()
+    {
+        var result = HookCommand.ValidateWrite("{\"file_path\": \"Test.cs\"}");
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public void ValidateWrite_HandlesCamelCaseFilePath()
+    {
+        var result = HookCommand.ValidateWrite("{\"filePath\": \"Test.cs\"}");
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task ClaudeInitializer_ConfiguresHooks()
+    {
+        var initializer = new ClaudeInitializer();
+
+        await initializer.InitializeAsync(_testDirectory, force: false);
+
+        var settingsPath = Path.Combine(_testDirectory, ".claude", "settings.json");
+        Assert.True(File.Exists(settingsPath));
+
+        var content = await File.ReadAllTextAsync(settingsPath);
+        Assert.Contains("\"hooks\"", content);
+        Assert.Contains("PreToolUse", content);
+        Assert.Contains("\"matcher\"", content);
+        Assert.Contains("Write", content);
+        Assert.Contains("opalc hook validate-write", content);
+    }
+
+    [Fact]
+    public async Task ClaudeInitializer_PreservesExistingSettings()
+    {
+        // Create an existing settings file with custom content
+        var claudeDir = Path.Combine(_testDirectory, ".claude");
+        Directory.CreateDirectory(claudeDir);
+        var settingsPath = Path.Combine(claudeDir, "settings.json");
+
+        var existingSettings = """
+            {
+              "some_other_setting": "value"
+            }
+            """;
+        await File.WriteAllTextAsync(settingsPath, existingSettings);
+
+        var initializer = new ClaudeInitializer();
+        await initializer.InitializeAsync(_testDirectory, force: false);
+
+        var content = await File.ReadAllTextAsync(settingsPath);
+
+        // Our hooks should be added
+        Assert.Contains("opalc hook validate-write", content);
+    }
+
+    [Fact]
+    public async Task ClaudeInitializer_DoesNotDuplicateHooks()
+    {
+        var initializer = new ClaudeInitializer();
+
+        // Run init twice
+        await initializer.InitializeAsync(_testDirectory, force: false);
+        await initializer.InitializeAsync(_testDirectory, force: false);
+
+        var settingsPath = Path.Combine(_testDirectory, ".claude", "settings.json");
+        var content = await File.ReadAllTextAsync(settingsPath);
+
+        // Should only have one instance of our hook command
+        var count = content.Split("opalc hook validate-write").Length - 1;
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task ClaudeInitializer_ReportsSettingsFileAsCreated()
+    {
+        var initializer = new ClaudeInitializer();
+
+        var result = await initializer.InitializeAsync(_testDirectory, force: false);
+
+        var settingsPath = Path.Combine(_testDirectory, ".claude", "settings.json");
+        Assert.Contains(settingsPath, result.CreatedFiles);
+    }
+
+    [Fact]
+    public async Task ClaudeInitializer_ReportsSettingsFileAsUpdatedWhenModified()
+    {
+        // Create an existing settings file without hooks
+        var claudeDir = Path.Combine(_testDirectory, ".claude");
+        Directory.CreateDirectory(claudeDir);
+        var settingsPath = Path.Combine(claudeDir, "settings.json");
+        await File.WriteAllTextAsync(settingsPath, "{}");
+
+        var initializer = new ClaudeInitializer();
+        var result = await initializer.InitializeAsync(_testDirectory, force: false);
+
+        Assert.Contains(settingsPath, result.UpdatedFiles);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Claude Code PreToolUse hooks that **block creation of .cs files**, forcing Claude to write .opal files instead.

- New `opalc hook validate-write` command for hook validation
- `opalc init --ai claude` now creates `.claude/settings.json` with hooks configured
- Allows: `.opal` files, `.g.cs` generated files, `obj/` directory files
- Blocks: all other `.cs` file creation with helpful error message

## How It Works

When Claude tries to write a `.cs` file, the hook returns exit code 1 with:

```
BLOCKED: Cannot create C# file 'MyClass.cs'

This is an OPAL-first project. Create an .opal file instead:
  MyClass.opal

Use /opal skill for OPAL syntax help.
```

## Files Changed

| File | Change |
|------|--------|
| `src/Opal.Compiler/Commands/HookCommand.cs` | New - hook validation command |
| `src/Opal.Compiler/Init/ClaudeInitializer.cs` | Add hook configuration |
| `src/Opal.Compiler/Program.cs` | Register hook command |
| `tests/Opal.Compiler.Tests/HookCommandTests.cs` | New - 23 tests |
| `.claude/settings.json` | Enable hooks for this repo |
| `Opal.Compiler.csproj` | Version bump to 0.1.3 |

## Test plan

- [x] All 564 tests pass
- [x] `opalc hook validate-write '{"file_path": "Test.cs"}'` returns exit 1
- [x] `opalc hook validate-write '{"file_path": "Test.opal"}'` returns exit 0
- [x] `opalc init --ai claude` creates correct settings.json
- [ ] Manual: New Claude session blocks .cs file creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)