### PR TITLE
Add Codex integration guide to documentation

### DIFF
--- a/docs/getting-started/codex-integration.md
+++ b/docs/getting-started/codex-integration.md
@@ -1,0 +1,269 @@
+---
+layout: default
+title: Codex Integration
+parent: Getting Started
+nav_order: 4
+---
+
+# Using OPAL with OpenAI Codex CLI
+
+This guide explains how to use OPAL with OpenAI Codex CLI. For Claude Code integration, see [Claude Integration](/opal/getting-started/claude-integration/).
+
+---
+
+## Quick Setup
+
+Initialize your project for Codex CLI with a single command:
+
+```bash
+opalc init --ai codex
+```
+
+This creates:
+
+| File | Purpose |
+|:-----|:--------|
+| `.codex/skills/opal/SKILL.md` | Teaches Codex OPAL v2+ syntax for writing new code |
+| `.codex/skills/opal-convert/SKILL.md` | Teaches Codex how to convert C# to OPAL |
+| `AGENTS.md` | Project documentation with OPAL-first guidelines |
+
+You can run this command again anytime to update the OPAL documentation section in AGENTS.md without losing your custom content.
+
+---
+
+## Important: Guidance-Based Enforcement
+
+Unlike Claude Code which uses hooks to enforce OPAL-first development, **Codex CLI does not support hooks**. This means:
+
+- OPAL-first development is **guidance-based only**
+- Codex *should* follow the instructions in AGENTS.md and create `.opal` files
+- However, enforcement is not automatic - Codex may occasionally create `.cs` files
+- Always review file extensions after code generation
+- Use `opalc analyze` to find any unconverted `.cs` files
+
+---
+
+## Available Skills
+
+### The `$opal` Skill
+
+When working with Codex CLI in an OPAL-initialized project, use the `$opal` command to activate OPAL-aware code generation.
+
+**Example prompts:**
+
+```
+$opal
+
+Write a function that calculates compound interest with:
+- Preconditions: principal > 0, rate >= 0, years > 0
+- Postcondition: result >= principal
+- Effects: pure (no side effects)
+```
+
+```
+$opal
+
+Create a UserService class with methods for:
+- GetUserById (returns Option<User>)
+- CreateUser (returns Result<User, ValidationError>)
+- DeleteUser (effects: database write)
+```
+
+### The `$opal-convert` Skill
+
+Use `$opal-convert` to convert existing C# code to OPAL:
+
+```
+$opal-convert
+
+Convert this C# class to OPAL:
+
+public class Calculator
+{
+    public int Add(int a, int b) => a + b;
+
+    public int Divide(int a, int b)
+    {
+        if (b == 0) throw new ArgumentException("Cannot divide by zero");
+        return a / b;
+    }
+}
+```
+
+Codex will:
+1. Convert the class structure to OPAL syntax
+2. Add appropriate contracts (e.g., `§Q (!= b 0)` for the divide precondition)
+3. Generate unique IDs for all structural elements
+4. Declare effects based on detected side effects
+
+---
+
+## Skill Capabilities
+
+The OPAL skills teach Codex:
+
+### Syntax Knowledge
+
+- All OPAL v2+ structure tags (`§M`, `§F`, `§C`, etc.)
+- Lisp-style expressions: `(+ a b)`, `(== x 0)`, `(% i 15)`
+- Arrow syntax conditionals: `§IF{id} condition → action`
+- Type system: `i32`, `f64`, `str`, `bool`, `Option<T>`, `Result<T,E>`, arrays
+
+### Best Practices
+
+- Unique ID generation (`m001`, `f001`, `c001`, etc.)
+- Contract placement (`§Q` preconditions, `§S` postconditions)
+- Effect declarations (`§E[db,net,cw]`)
+- Proper structure nesting and closing tags
+
+### Code Patterns
+
+- Error handling with `Result<T,E>`
+- Null safety with `Option<T>`
+- Iteration patterns (for, while, do-while)
+- Class definitions with fields, properties, methods
+
+---
+
+## Codex vs Claude Code Comparison
+
+| Feature | Claude Code | Codex CLI |
+|:--------|:------------|:----------|
+| Skills directory | `.claude/skills/` | `.codex/skills/<name>/` |
+| Skill file format | `opal.md` | `SKILL.md` with YAML frontmatter |
+| Project instructions | `CLAUDE.md` | `AGENTS.md` |
+| Skill invocation | `/opal` | `$opal` |
+| OPAL-first enforcement | **Hooks (enforced)** | **Guidance only** |
+| Blocks `.cs` creation | Yes | No |
+
+---
+
+## Example Prompts
+
+### Generate a Function
+
+**Prompt:**
+```
+$opal
+
+Write an OPAL function that calculates factorial with a precondition
+that n >= 0 and postcondition that result >= 1
+```
+
+**Expected Response:**
+```
+§M[m001:Math]
+§F[f001:Factorial:pub]
+  §I[i32:n]
+  §O[i32]
+  §Q (>= n 0)
+  §S (>= result 1)
+  §IF[if1] (<= n 1) → §R 1
+  §EL → §R (* n §C[Factorial] §A (- n 1) §/C)
+  §/I[if1]
+§/F[f001]
+§/M[m001]
+```
+
+### Find Bugs
+
+**Prompt:**
+```
+Is there a bug in this OPAL code?
+
+§F[f001:Divide:pub]
+  §I[i32:a]
+  §I[i32:b]
+  §O[i32]
+  §R (/ a b)
+§/F[f001]
+```
+
+**Expected Response:**
+```
+Yes - missing precondition. Add:
+
+§Q (!= b 0)
+
+Otherwise division by zero is possible.
+```
+
+---
+
+## Workflow Tips
+
+### Starting a New Feature
+
+```
+$opal
+
+I need to implement [feature description].
+
+The requirements are:
+- [requirement 1]
+- [requirement 2]
+
+Please create the OPAL code with appropriate contracts and effects.
+```
+
+### Converting Existing Code
+
+```
+$opal-convert
+
+Convert src/Services/PaymentService.cs to OPAL, adding:
+- Contracts based on the validation logic
+- Effect declarations for database and network calls
+```
+
+### Verifying OPAL-First Compliance
+
+Since Codex doesn't enforce OPAL-first automatically, periodically check for unconverted files:
+
+```bash
+# Find C# files that might need conversion
+opalc analyze ./src --top 10
+
+# Check for any new .cs files that should be .opal
+find . -name "*.cs" -not -name "*.g.cs" -not -path "./obj/*"
+```
+
+---
+
+## Best Practices
+
+1. **Review generated files** - Always check that Codex created `.opal` files, not `.cs`
+2. **Use explicit instructions** - Be specific about wanting OPAL output
+3. **Include skill reference** - Start prompts with `$opal` or `$opal-convert`
+4. **Run analysis regularly** - Use `opalc analyze` to find migration candidates
+5. **Convert promptly** - If Codex creates a `.cs` file, convert it immediately
+
+---
+
+## Troubleshooting
+
+### Codex Creates `.cs` Files Instead of `.opal`
+
+This can happen since enforcement is guidance-based. Solutions:
+
+1. Be more explicit: "Create this as an OPAL file (`.opal`), not C#"
+2. Start your prompt with `$opal` to activate the skill
+3. Convert the file: `opalc convert filename.cs`
+
+### Skills Not Recognized
+
+Ensure you've run `opalc init --ai codex` and the skill files exist:
+
+```bash
+ls -la .codex/skills/opal/SKILL.md
+ls -la .codex/skills/opal-convert/SKILL.md
+```
+
+---
+
+## Next Steps
+
+- [Syntax Reference](/opal/syntax-reference/) - Complete language reference
+- [Adding OPAL to Existing Projects](/opal/guides/adding-opal-to-existing-projects/) - Migration guide
+- [opalc init](/opal/cli/init/) - Full init command documentation
+- [Claude Integration](/opal/getting-started/claude-integration/) - Alternative with enforced OPAL-first

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -26,7 +26,8 @@ your_code.opal → OPAL Compiler → your_code.g.cs → .NET Build → executabl
 
 1. **[Installation](/opal/getting-started/installation/)** - Set up the OPAL compiler
 2. **[Hello World](/opal/getting-started/hello-world/)** - Write and run your first OPAL program
-3. **[Claude Integration](/opal/getting-started/claude-integration/)** - Use OPAL with AI coding agents
+3. **[Claude Integration](/opal/getting-started/claude-integration/)** - Use OPAL with Claude Code (enforced OPAL-first)
+4. **[Codex Integration](/opal/getting-started/codex-integration/)** - Use OPAL with OpenAI Codex CLI
 
 ---
 
@@ -75,13 +76,21 @@ This adds MSBuild integration so `.opal` files compile automatically during `dot
 
 ### Step 3: (Optional) Enable AI Agent Integration
 
+For Claude Code (with enforced OPAL-first via hooks):
 ```bash
 opalc init --ai claude
 ```
 
-This adds `/opal` and `/opal-convert` skills, plus CLAUDE.md with guidelines that instruct Claude to:
+For OpenAI Codex CLI (guidance-based):
+```bash
+opalc init --ai codex
+```
+
+This adds OPAL skills and project documentation that instruct the AI to:
 - Write all new code in OPAL (not C#)
 - Analyze existing C# files before modifying them to determine if they should be converted to OPAL first
+
+**Note:** Claude Code enforces OPAL-first via hooks (blocks `.cs` creation). Codex CLI is guidance-based only.
 
 ### Step 4: Write OPAL Code
 
@@ -137,7 +146,17 @@ See the [Adding OPAL to Existing Projects](/opal/guides/adding-opal-to-existing-
 | Component | Description |
 |:----------|:------------|
 | Claude Code skills | `/opal` to write OPAL code, `/opal-convert` to convert C# |
+| Hook configuration | **Enforces OPAL-first** - blocks `.cs` file creation |
 | CLAUDE.md | Project guidelines instructing Claude to prefer OPAL for new code |
+
+### With Codex (`opalc init --ai codex`)
+
+| Component | Description |
+|:----------|:------------|
+| Codex skills | `$opal` to write OPAL code, `$opal-convert` to convert C# |
+| AGENTS.md | Project guidelines (guidance-based, not enforced) |
+
+**Note:** Codex CLI does not support hooks, so OPAL-first is guidance-based only. Review file extensions after generation.
 
 ---
 

--- a/website/content/getting-started/codex-integration.mdx
+++ b/website/content/getting-started/codex-integration.mdx
@@ -1,0 +1,97 @@
+---
+title: "Codex Integration"
+section: "getting-started"
+order: 4
+---
+
+# Using OPAL with OpenAI Codex CLI
+
+This guide explains how to use OPAL with OpenAI Codex CLI. For Claude Code integration, see [Claude Integration](/getting-started/claude-integration/).
+
+---
+
+## Quick Setup
+
+Initialize your project for Codex CLI with a single command:
+
+```bash
+opalc init --ai codex
+```
+
+This creates:
+
+| File | Purpose |
+|:-----|:--------|
+| `.codex/skills/opal/SKILL.md` | Teaches Codex OPAL v2+ syntax |
+| `.codex/skills/opal-convert/SKILL.md` | Teaches Codex C# to OPAL conversion |
+| `AGENTS.md` | Project documentation with OPAL-first guidelines |
+
+---
+
+## Important: Guidance-Based Enforcement
+
+Unlike Claude Code which uses hooks to enforce OPAL-first development, **Codex CLI does not support hooks**. This means:
+
+- OPAL-first development is **guidance-based only**
+- Codex *should* follow the instructions and create `.opal` files
+- Enforcement is not automatic - review file extensions after generation
+- Use `opalc analyze` to find any unconverted `.cs` files
+
+---
+
+## Available Skills
+
+### The `$opal` Skill
+
+Use `$opal` to activate OPAL-aware code generation:
+
+```
+$opal
+
+Write a function that calculates factorial with:
+- Precondition: n >= 0
+- Postcondition: result >= 1
+```
+
+### The `$opal-convert` Skill
+
+Use `$opal-convert` to convert existing C# code to OPAL:
+
+```
+$opal-convert
+
+Convert this C# class to OPAL:
+
+public class Calculator
+{
+    public int Add(int a, int b) => a + b;
+}
+```
+
+---
+
+## Codex vs Claude Code
+
+| Feature | Claude Code | Codex CLI |
+|:--------|:------------|:----------|
+| Skills directory | `.claude/skills/` | `.codex/skills/<name>/` |
+| Project instructions | `CLAUDE.md` | `AGENTS.md` |
+| Skill invocation | `/opal` | `$opal` |
+| Enforcement | **Hooks (enforced)** | **Guidance only** |
+
+---
+
+## Best Practices
+
+1. **Review generated files** - Check that Codex created `.opal` files, not `.cs`
+2. **Use explicit instructions** - Be specific about wanting OPAL output
+3. **Start with skill reference** - Begin prompts with `$opal` or `$opal-convert`
+4. **Run analysis regularly** - Use `opalc analyze` to find migration candidates
+
+---
+
+## See Also
+
+- [Syntax Reference](/syntax-reference/) - Complete language reference
+- [opalc init](/cli/init/) - Full init command documentation
+- [Claude Integration](/getting-started/claude-integration/) - Alternative with enforced OPAL-first

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -25,7 +25,8 @@ your_code.opal → OPAL Compiler → your_code.g.cs → .NET Build → executabl
 
 1. **[Installation](/getting-started/installation/)** - Set up the OPAL compiler
 2. **[Hello World](/getting-started/hello-world/)** - Write and run your first OPAL program
-3. **[Claude Integration](/getting-started/claude-integration/)** - Use OPAL with AI coding agents
+3. **[Claude Integration](/getting-started/claude-integration/)** - Use OPAL with Claude Code (enforced OPAL-first)
+4. **[Codex Integration](/getting-started/codex-integration/)** - Use OPAL with OpenAI Codex CLI
 
 ---
 
@@ -74,13 +75,21 @@ This adds MSBuild integration so `.opal` files compile automatically during `dot
 
 ### Step 3: (Optional) Enable AI Agent Integration
 
+For Claude Code (with enforced OPAL-first via hooks):
 ```bash
 opalc init --ai claude
 ```
 
-This adds `/opal` and `/opal-convert` skills, plus CLAUDE.md with guidelines that instruct Claude to:
+For OpenAI Codex CLI (guidance-based):
+```bash
+opalc init --ai codex
+```
+
+This adds OPAL skills and project documentation that instruct the AI to:
 - Write all new code in OPAL (not C#)
-- Analyze existing C# files before modifying them to determine if they should be converted to OPAL first
+- Analyze existing C# files before modifying them
+
+**Note:** Claude Code enforces OPAL-first via hooks (blocks `.cs` creation). Codex CLI is guidance-based only.
 
 ### Step 4: Write OPAL Code
 
@@ -136,7 +145,17 @@ See the [Adding OPAL to Existing Projects](/guides/adding-opal-to-existing-proje
 | Component | Description |
 |:----------|:------------|
 | Claude Code skills | `/opal` to write OPAL code, `/opal-convert` to convert C# |
+| Hook configuration | **Enforces OPAL-first** - blocks `.cs` file creation |
 | CLAUDE.md | Project guidelines instructing Claude to prefer OPAL for new code |
+
+### With Codex (`opalc init --ai codex`)
+
+| Component | Description |
+|:----------|:------------|
+| Codex skills | `$opal` to write OPAL code, `$opal-convert` to convert C# |
+| AGENTS.md | Project guidelines (guidance-based, not enforced) |
+
+**Note:** Codex CLI does not support hooks, so OPAL-first is guidance-based only.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add comprehensive Codex integration guide for both docs and website
- Update getting-started index pages to list both Claude and Codex options
- Document the key differences between Claude Code (enforced) and Codex CLI (guidance-based)

## Changes

- `docs/getting-started/codex-integration.md` - Full Codex integration guide
- `website/content/getting-started/codex-integration.mdx` - Website version
- `docs/getting-started/index.md` - Updated to list Codex option
- `website/content/getting-started/index.mdx` - Updated to list Codex option

## Key Documentation Points

- Explains guidance-based vs enforced OPAL-first
- Shows `$opal` and `$opal-convert` skill usage
- Provides comparison table between Claude and Codex
- Includes troubleshooting section for common issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)