### PR TITLE
Fix Claude skills directory structure to match Codex/Gemini

### DIFF
--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -65,8 +65,8 @@ Creates the following files:
 
 | File | Purpose |
 |:-----|:--------|
-| `.claude/skills/opal.md` | OPAL code writing skill - teaches Claude OPAL v2+ syntax |
-| `.claude/skills/opal-convert.md` | C# to OPAL conversion skill |
+| `.claude/skills/opal/SKILL.md` | OPAL code writing skill with YAML frontmatter |
+| `.claude/skills/opal-convert/SKILL.md` | C# to OPAL conversion skill |
 | `.claude/settings.json` | **Hook configuration** - enforces OPAL-first development |
 | `CLAUDE.md` | Project documentation (creates new or updates OPAL section) |
 

--- a/docs/getting-started/claude-integration.md
+++ b/docs/getting-started/claude-integration.md
@@ -23,8 +23,8 @@ This creates:
 
 | File | Purpose |
 |:-----|:--------|
-| `.claude/skills/opal.md` | Teaches Claude OPAL v2+ syntax for writing new code |
-| `.claude/skills/opal-convert.md` | Teaches Claude how to convert C# to OPAL |
+| `.claude/skills/opal/SKILL.md` | Teaches Claude OPAL v2+ syntax for writing new code |
+| `.claude/skills/opal-convert/SKILL.md` | Teaches Claude how to convert C# to OPAL |
 | `.claude/settings.json` | **Enforces OPAL-first** - blocks `.cs` file creation |
 | `CLAUDE.md` | Project documentation with OPAL reference and conventions |
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -58,8 +58,8 @@ This creates:
 
 | File | Purpose |
 |:-----|:--------|
-| `.claude/skills/opal.md` | OPAL code writing skill - teaches Claude OPAL v2+ syntax |
-| `.claude/skills/opal-convert.md` | C# to OPAL conversion skill |
+| `.claude/skills/opal/SKILL.md` | OPAL code writing skill with YAML frontmatter |
+| `.claude/skills/opal-convert/SKILL.md` | C# to OPAL conversion skill |
 | `CLAUDE.md` | Project documentation (creates new or updates OPAL section) |
 
 ### Claude Code Commands

--- a/docs/guides/adding-opal-to-existing-projects.md
+++ b/docs/guides/adding-opal-to-existing-projects.md
@@ -217,8 +217,8 @@ opalc init --ai claude
 
 | File | Purpose |
 |:-----|:--------|
-| `.claude/skills/opal.md` | Skill for writing OPAL code |
-| `.claude/skills/opal-convert.md` | Skill for C# to OPAL conversion |
+| `.claude/skills/opal/SKILL.md` | Skill for writing OPAL code |
+| `.claude/skills/opal-convert/SKILL.md` | Skill for C# to OPAL conversion |
 | `CLAUDE.md` | Project guidelines for Claude |
 
 ### CLAUDE.md Guidelines
@@ -272,8 +272,10 @@ MyProject/
 ├── CLAUDE.md                  # Project docs for Claude
 ├── .claude/
 │   └── skills/
-│       ├── opal.md           # OPAL writing skill
-│       └── opal-convert.md   # Conversion skill
+│       ├── opal/
+│       │   └── SKILL.md      # OPAL writing skill
+│       └── opal-convert/
+│           └── SKILL.md      # Conversion skill
 ├── src/
 │   ├── Program.cs            # C# entry point
 │   ├── Models/

--- a/src/Opal.Compiler/Init/ClaudeInitializer.cs
+++ b/src/Opal.Compiler/Init/ClaudeInitializer.cs
@@ -29,15 +29,19 @@ public class ClaudeInitializer : IAiInitializer
 
         try
         {
-            // Create .claude/skills/ directory
-            var skillsDir = Path.Combine(targetDirectory, ".claude", "skills");
-            Directory.CreateDirectory(skillsDir);
+            // Create .claude/skills/opal/ directory
+            var opalSkillDir = Path.Combine(targetDirectory, ".claude", "skills", "opal");
+            Directory.CreateDirectory(opalSkillDir);
 
-            // Write skill files
-            var opalSkillPath = Path.Combine(skillsDir, "opal.md");
-            var convertSkillPath = Path.Combine(skillsDir, "opal-convert.md");
+            // Create .claude/skills/opal-convert/ directory
+            var convertSkillDir = Path.Combine(targetDirectory, ".claude", "skills", "opal-convert");
+            Directory.CreateDirectory(convertSkillDir);
 
-            if (await WriteFileIfNeeded(opalSkillPath, EmbeddedResourceHelper.ReadSkill("opal.md"), force))
+            // Write skill files (Claude uses SKILL.md format with YAML frontmatter)
+            var opalSkillPath = Path.Combine(opalSkillDir, "SKILL.md");
+            var convertSkillPath = Path.Combine(convertSkillDir, "SKILL.md");
+
+            if (await WriteFileIfNeeded(opalSkillPath, EmbeddedResourceHelper.ReadSkill("claude-opal-SKILL.md"), force))
             {
                 createdFiles.Add(opalSkillPath);
             }
@@ -46,7 +50,7 @@ public class ClaudeInitializer : IAiInitializer
                 warnings.Add($"Skipped existing file: {opalSkillPath}");
             }
 
-            if (await WriteFileIfNeeded(convertSkillPath, EmbeddedResourceHelper.ReadSkill("opal-convert.md"), force))
+            if (await WriteFileIfNeeded(convertSkillPath, EmbeddedResourceHelper.ReadSkill("claude-opal-convert-SKILL.md"), force))
             {
                 createdFiles.Add(convertSkillPath);
             }

--- a/src/Opal.Compiler/Resources/Skills/claude-opal-SKILL.md
+++ b/src/Opal.Compiler/Resources/Skills/claude-opal-SKILL.md
@@ -1,0 +1,235 @@
+---
+name: opal
+description: Write OPAL v2+ code with Lisp-style expressions, contracts, and effects. Use for all new code in OPAL-first projects.
+---
+
+# /opal - Write OPAL Code
+
+OPAL (Optimized Programming for Agent Language) compiles to C# via .NET.
+
+**IMPORTANT: Always use v2+ syntax when writing OPAL code:**
+- Use Lisp-style expressions: `(+ a b)`, `(== x 0)`, `(% i 15)`
+- Use arrow syntax for conditionals: `§IF{id} condition → action`
+- Use `§P` for print, `§B` for bindings, `§R` for return
+- Do NOT use the legacy v1 syntax with `§OP[kind=...]` or `§REF[name=...]`
+
+## Structure Tags
+
+```
+§M{id:Name}           Module (namespace)
+§F{id:Name:vis}       Function (pub|pri)
+§I{type:name}         Input parameter
+§O{type}              Output/return type
+§E{effects}           Side effects: cw,cr,fw,fr,net,db
+§/M{id} §/F{id}       Close tags (ID must match)
+```
+
+## Types
+
+```
+i32, i64, f32, f64    Numbers
+u8, u16, u32, u64     Unsigned integers
+str, bool, void       String, boolean, unit
+?T                    Option<T> (nullable)
+T!E                   Result<T,E> (fallible)
+[T]                   Array of T (e.g., [u8], [i32], [str])
+[[T]]                 Nested array (e.g., [[i32]] for int[][])
+```
+
+### Array Type Examples
+
+```
+[u8]                  byte[]
+[i32]                 int[]
+[str]                 string[]
+[[i32]]               int[][] (jagged array)
+```
+
+## Lisp-Style Expressions (v2+)
+
+```
+(+ a b)               Add
+(- a b)               Subtract
+(* a b)               Multiply
+(/ a b)               Divide
+(% a b)               Modulo
+(== a b)              Equal
+(!= a b)              Not equal
+(< a b) (> a b)       Less/greater
+(<= a b) (>= a b)     Less-equal/greater-equal
+(&& a b) (|| a b)     Logical and/or
+(! a)                 Logical not
+```
+
+## Statements
+
+```
+§B{name} expr         Bind variable
+§R expr               Return value
+§P expr               Print (shorthand for Console.WriteLine)
+```
+
+## Control Flow
+
+### For Loop
+```
+§L{id:var:from:to:step}
+  ...body...
+§/L{id}
+```
+
+### While Loop
+```
+§WH{id} condition
+  ...body...
+§/WH{id}
+```
+
+### Do-While Loop
+```
+§DO{id}
+  ...body (executes at least once)...
+§/DO{id} condition
+```
+
+### Conditionals (v2 arrow syntax)
+```
+§IF{id} condition → action
+§EI condition → action        ElseIf
+§EL → action                  Else
+§/I{id}
+```
+
+Multi-line form:
+```
+§IF{id} condition
+  ...body...
+§EI condition
+  ...body...
+§EL
+  ...body...
+§/I{id}
+```
+
+## Contracts
+
+```
+§Q condition                  Requires (precondition)
+§Q{message="err"} condition   With custom error
+§S condition                  Ensures (postcondition)
+```
+
+## Option/Result
+
+```
+§SOME value           Some(value)
+§NONE{type=T}         None of type T
+§OK value             Ok(value)
+§ERR "message"        Err(message)
+```
+
+## Calls
+
+```
+§C{Target}
+  §A arg1
+  §A arg2
+§/C
+```
+
+## C# Attributes
+
+Attributes attach inline after structural braces using `[@...]` syntax:
+
+```
+[@AttributeName]              No arguments
+[@Route("api/test")]          Positional argument
+[@JsonProperty(Name="id")]    Named argument
+```
+
+Example with class and method:
+```
+§CLASS{c001:TestController:ControllerBase}[@Route("api/[controller]")][@ApiController]
+  §METHOD{m001:Get:pub}[@HttpGet]
+  §/METHOD{m001}
+§/CLASS{c001}
+```
+
+## Fields and Properties
+
+```
+§FLD{[u8]:_buffer:priv}       Private byte[] field
+§FLD{i32:_count:priv}         Private int field
+
+§PROP{p001:Buffer:[u8]:pub}   Public byte[] property
+  §GET{pub}
+    §R _buffer
+  §/GET
+§/PROP{p001}
+```
+
+## Template: FizzBuzz
+
+```opal
+§M{m001:FizzBuzz}
+§F{f001:Main:pub}
+  §O{void}
+  §E{cw}
+  §L{for1:i:1:100:1}
+    §IF{if1} (== (% i 15) 0) → §P "FizzBuzz"
+    §EI (== (% i 3) 0) → §P "Fizz"
+    §EI (== (% i 5) 0) → §P "Buzz"
+    §EL → §P i
+    §/I{if1}
+  §/L{for1}
+§/F{f001}
+§/M{m001}
+```
+
+## Template: Function with Contracts
+
+```opal
+§M{m001:Math}
+§F{f001:SafeDivide:pub}
+  §I{i32:a}
+  §I{i32:b}
+  §O{i32}
+  §Q (!= b 0)
+  §S (>= result 0)
+  §R (/ a b)
+§/F{f001}
+§/M{m001}
+```
+
+## Template: Class with Array Fields
+
+```opal
+§M{m001:DataProcessor}
+§CLASS{c001:DataProcessor}
+  §FLD{[u8]:_buffer:priv}
+  §FLD{[i32]:_indices:priv}
+
+  §PROP{p001:Buffer:[u8]:pub}
+    §GET{pub}
+      §R _buffer
+    §/GET
+  §/PROP{p001}
+
+  §METHOD{m001:ProcessData:pub}
+    §I{[str]:args}
+    §O{i32}
+    §R args.Length
+  §/METHOD{m001}
+§/CLASS{c001}
+§/M{m001}
+```
+
+## ID Conventions
+
+- Modules: `m001`, `m002`
+- Functions: `f001`, `f002`
+- Classes: `c001`, `c002`
+- Properties: `p001`, `p002`
+- Methods: `m001`, `m002`
+- Loops: `for1`, `while1`, `do1`
+- Conditionals: `if1`, `if2`

--- a/src/Opal.Compiler/Resources/Skills/claude-opal-convert-SKILL.md
+++ b/src/Opal.Compiler/Resources/Skills/claude-opal-convert-SKILL.md
@@ -1,0 +1,236 @@
+---
+name: opal-convert
+description: Convert C# code to OPAL syntax with type mappings, operator conversions, and effect detection.
+---
+
+# /opal-convert - Convert C# to OPAL
+
+**IMPORTANT: Always generate OPAL v2+ syntax:**
+- Use Lisp-style expressions: `(+ a b)` not `§OP[kind=add] §REF[name=a] §REF[name=b]`
+- Use arrow syntax for conditionals: `§IF[id] condition → action`
+- Use `§P` for Console.WriteLine, `§B` for variable bindings
+
+## Type Mappings
+
+| C# | OPAL |
+|---|---|
+| `int` | `i32` |
+| `long` | `i64` |
+| `float` | `f32` |
+| `double` | `f64` |
+| `string` | `str` |
+| `bool` | `bool` |
+| `void` | `void` |
+| `T?` | `?T` |
+| `Result<T,E>` | `T!E` |
+
+## Operator Mappings
+
+| C# | OPAL |
+|---|---|
+| `a + b` | `(+ a b)` |
+| `a - b` | `(- a b)` |
+| `a * b` | `(* a b)` |
+| `a / b` | `(/ a b)` |
+| `a % b` | `(% a b)` |
+| `a == b` | `(== a b)` |
+| `a != b` | `(!= a b)` |
+| `a < b` | `(< a b)` |
+| `a > b` | `(> a b)` |
+| `a <= b` | `(<= a b)` |
+| `a >= b` | `(>= a b)` |
+| `a && b` | `(&& a b)` |
+| `a \|\| b` | `(\|\| a b)` |
+| `!a` | `(! a)` |
+
+## Structure Conversion
+
+### Namespace → Module
+```csharp
+namespace MyApp { ... }
+```
+```opal
+§M[m001:MyApp]
+...
+§/M[m001]
+```
+
+### Method → Function
+```csharp
+public static int Add(int a, int b) {
+    return a + b;
+}
+```
+```opal
+§F[f001:Add:pub]
+  §I[i32:a]
+  §I[i32:b]
+  §O[i32]
+  §R (+ a b)
+§/F[f001]
+```
+
+### For Loop
+```csharp
+for (int i = 1; i <= 100; i++) { ... }
+```
+```opal
+§L[for1:i:1:100:1]
+  ...
+§/L[for1]
+```
+
+### If/Else
+```csharp
+if (x > 0) { DoA(); }
+else if (x < 0) { DoB(); }
+else { DoC(); }
+```
+```opal
+§IF[if1] (> x 0) → §C[DoA] §/C
+§EI (< x 0) → §C[DoB] §/C
+§EL → §C[DoC] §/C
+§/I[if1]
+```
+
+### Console.WriteLine
+```csharp
+Console.WriteLine("Hello");
+Console.WriteLine(x);
+```
+```opal
+§P "Hello"
+§P x
+```
+
+### Variable Declaration
+```csharp
+var result = a + b;
+```
+```opal
+§B[result] (+ a b)
+```
+
+## Effect Detection
+
+Add `§E[...]` based on C# calls:
+
+| C# Usage | Effect |
+|---|---|
+| `Console.Write*` | `cw` |
+| `Console.Read*` | `cr` |
+| `File.Write*`, `StreamWriter` | `fw` |
+| `File.Read*`, `StreamReader` | `fr` |
+| `HttpClient`, `WebRequest` | `net` |
+| `SqlConnection`, `DbContext` | `db` |
+
+## Contract Conversion
+
+```csharp
+// Precondition comment or ArgumentException
+if (x < 0) throw new ArgumentException();
+```
+```opal
+§Q (>= x 0)
+```
+
+```csharp
+// Postcondition - Debug.Assert at end
+Debug.Assert(result >= 0);
+```
+```opal
+§S (>= result 0)
+```
+
+## C# Attribute Conversion
+
+Attributes are preserved using inline bracket syntax `[@Attribute]`:
+
+### Class Attributes
+```csharp
+[Route("api/[controller]")]
+[ApiController]
+public class TestController : ControllerBase { }
+```
+```opal
+§CLASS[c001:TestController:ControllerBase][@Route("api/[controller]")][@ApiController]
+§/CLASS[c001]
+```
+
+### Method Attributes
+```csharp
+[HttpPost]
+[Authorize]
+public void Post() { }
+```
+```opal
+§METHOD[m001:Post:pub][@HttpPost][@Authorize]
+§/METHOD[m001]
+```
+
+### Attribute Arguments
+| C# | OPAL |
+|---|---|
+| `[Required]` | `[@Required]` |
+| `[Route("api")]` | `[@Route("api")]` |
+| `[JsonProperty(PropertyName="id")]` | `[@JsonProperty(PropertyName="id")]` |
+| `[Range(1, 100)]` | `[@Range(1, 100)]` |
+
+## Supported Features
+
+- Static methods
+- Primitive types
+- Basic control flow (for, if/else)
+- Console I/O
+- Arithmetic/comparison operators
+- Simple contracts
+- C# attributes (on classes, methods, properties, fields, parameters)
+
+## Not Yet Supported
+
+- Async/await
+- LINQ
+- Generics
+- Events/delegates
+- Exception handling (try/catch)
+- Collections (List, Dictionary)
+
+## Conversion Example
+
+### C# Input
+```csharp
+namespace Calculator {
+    public static class Program {
+        public static void Main() {
+            Console.WriteLine(Add(5, 3));
+        }
+
+        public static int Add(int a, int b) {
+            if (a < 0 || b < 0)
+                throw new ArgumentException("negative");
+            return a + b;
+        }
+    }
+}
+```
+
+### OPAL Output
+```opal
+§M[m001:Calculator]
+§F[f001:Main:pub]
+  §O[void]
+  §E[cw]
+  §C[Console.WriteLine]
+    §A §C[Add] §A 5 §A 3 §/C
+  §/C
+§/F[f001]
+
+§F[f002:Add:pub]
+  §I[i32:a]
+  §I[i32:b]
+  §O[i32]
+  §Q (&& (>= a 0) (>= b 0))
+  §R (+ a b)
+§/F[f002]
+§/M[m001]
+```

--- a/tests/Opal.Compiler.Tests/InitCommandIntegrationTests.cs
+++ b/tests/Opal.Compiler.Tests/InitCommandIntegrationTests.cs
@@ -85,9 +85,10 @@ public class InitCommandIntegrationTests : IDisposable
 
         // Assert - Claude files should exist
         Assert.True(claudeResult.Success);
-        Assert.True(Directory.Exists(Path.Combine(_testDirectory, ".claude", "skills")));
-        Assert.True(File.Exists(Path.Combine(_testDirectory, ".claude", "skills", "opal.md")));
-        Assert.True(File.Exists(Path.Combine(_testDirectory, ".claude", "skills", "opal-convert.md")));
+        Assert.True(Directory.Exists(Path.Combine(_testDirectory, ".claude", "skills", "opal")));
+        Assert.True(Directory.Exists(Path.Combine(_testDirectory, ".claude", "skills", "opal-convert")));
+        Assert.True(File.Exists(Path.Combine(_testDirectory, ".claude", "skills", "opal", "SKILL.md")));
+        Assert.True(File.Exists(Path.Combine(_testDirectory, ".claude", "skills", "opal-convert", "SKILL.md")));
         Assert.True(File.Exists(Path.Combine(_testDirectory, "CLAUDE.md")));
     }
 
@@ -113,7 +114,7 @@ public class InitCommandIntegrationTests : IDisposable
         // Assert - Claude files should now exist
         Assert.True(claudeResult.Success);
         Assert.True(File.Exists(Path.Combine(_testDirectory, "CLAUDE.md")));
-        Assert.True(File.Exists(Path.Combine(_testDirectory, ".claude", "skills", "opal.md")));
+        Assert.True(File.Exists(Path.Combine(_testDirectory, ".claude", "skills", "opal", "SKILL.md")));
 
         // Assert - MSBuild targets should still be present (not removed)
         var csprojContent = await File.ReadAllTextAsync(csprojPath);

--- a/tests/Opal.Compiler.Tests/InitCommandTests.cs
+++ b/tests/Opal.Compiler.Tests/InitCommandTests.cs
@@ -117,14 +117,15 @@ public class InitCommandTests : IDisposable
     }
 
     [Fact]
-    public async Task ClaudeInitializer_Initialize_CreatesSkillsDirectory()
+    public async Task ClaudeInitializer_Initialize_CreatesSkillsDirectories()
     {
         var initializer = new ClaudeInitializer();
 
         var result = await initializer.InitializeAsync(_testDirectory, force: false);
 
         Assert.True(result.Success);
-        Assert.True(Directory.Exists(Path.Combine(_testDirectory, ".claude", "skills")));
+        Assert.True(Directory.Exists(Path.Combine(_testDirectory, ".claude", "skills", "opal")));
+        Assert.True(Directory.Exists(Path.Combine(_testDirectory, ".claude", "skills", "opal-convert")));
     }
 
     [Fact]
@@ -134,12 +135,13 @@ public class InitCommandTests : IDisposable
 
         var result = await initializer.InitializeAsync(_testDirectory, force: false);
 
-        var skillPath = Path.Combine(_testDirectory, ".claude", "skills", "opal.md");
+        var skillPath = Path.Combine(_testDirectory, ".claude", "skills", "opal", "SKILL.md");
         Assert.True(File.Exists(skillPath));
         Assert.Contains(skillPath, result.CreatedFiles);
 
         var content = await File.ReadAllTextAsync(skillPath);
         Assert.Contains("OPAL", content);
+        Assert.Contains("name: opal", content); // YAML frontmatter
     }
 
     [Fact]
@@ -149,7 +151,7 @@ public class InitCommandTests : IDisposable
 
         var result = await initializer.InitializeAsync(_testDirectory, force: false);
 
-        var skillPath = Path.Combine(_testDirectory, ".claude", "skills", "opal-convert.md");
+        var skillPath = Path.Combine(_testDirectory, ".claude", "skills", "opal-convert", "SKILL.md");
         Assert.True(File.Exists(skillPath));
         Assert.Contains(skillPath, result.CreatedFiles);
     }
@@ -182,7 +184,7 @@ public class InitCommandTests : IDisposable
         await initializer.InitializeAsync(_testDirectory, force: false);
 
         // Modify a skill file
-        var skillPath = Path.Combine(_testDirectory, ".claude", "skills", "opal.md");
+        var skillPath = Path.Combine(_testDirectory, ".claude", "skills", "opal", "SKILL.md");
         await File.WriteAllTextAsync(skillPath, "Custom skill content");
 
         // Second initialization without force
@@ -206,7 +208,7 @@ public class InitCommandTests : IDisposable
         await initializer.InitializeAsync(_testDirectory, force: false);
 
         // Modify a skill file
-        var skillPath = Path.Combine(_testDirectory, ".claude", "skills", "opal.md");
+        var skillPath = Path.Combine(_testDirectory, ".claude", "skills", "opal", "SKILL.md");
         await File.WriteAllTextAsync(skillPath, "Custom skill content");
 
         // Second initialization with force

--- a/website/content/cli/init.mdx
+++ b/website/content/cli/init.mdx
@@ -60,8 +60,8 @@ Creates the following files:
 
 | File | Purpose |
 |:-----|:--------|
-| `.claude/skills/opal.md` | OPAL code writing skill - teaches Claude OPAL v2+ syntax |
-| `.claude/skills/opal-convert.md` | C# to OPAL conversion skill |
+| `.claude/skills/opal/SKILL.md` | OPAL code writing skill with YAML frontmatter |
+| `.claude/skills/opal-convert/SKILL.md` | C# to OPAL conversion skill |
 | `.claude/settings.json` | **Hook configuration** - enforces OPAL-first development |
 | `CLAUDE.md` | Project guidelines instructing Claude to prefer OPAL for new code |
 

--- a/website/content/getting-started/claude-integration.mdx
+++ b/website/content/getting-started/claude-integration.mdx
@@ -22,8 +22,8 @@ This creates:
 
 | File | Purpose |
 |:-----|:--------|
-| `.claude/skills/opal.md` | Teaches Claude OPAL v2+ syntax for writing new code |
-| `.claude/skills/opal-convert.md` | Teaches Claude how to convert C# to OPAL |
+| `.claude/skills/opal/SKILL.md` | Teaches Claude OPAL v2+ syntax for writing new code |
+| `.claude/skills/opal-convert/SKILL.md` | Teaches Claude how to convert C# to OPAL |
 | `.claude/settings.json` | **Enforces OPAL-first** - blocks `.cs` file creation |
 | `CLAUDE.md` | Project documentation with OPAL reference and conventions |
 

--- a/website/content/getting-started/installation.mdx
+++ b/website/content/getting-started/installation.mdx
@@ -57,8 +57,8 @@ This creates:
 
 | File | Purpose |
 |:-----|:--------|
-| `.claude/skills/opal.md` | OPAL code writing skill - teaches Claude OPAL v2+ syntax |
-| `.claude/skills/opal-convert.md` | C# to OPAL conversion skill |
+| `.claude/skills/opal/SKILL.md` | OPAL code writing skill with YAML frontmatter |
+| `.claude/skills/opal-convert/SKILL.md` | C# to OPAL conversion skill |
 | `CLAUDE.md` | Project documentation (creates new or updates OPAL section) |
 
 ### Claude Code Commands


### PR DESCRIPTION
## Summary

Fix the Claude skills directory structure to use subdirectories with `SKILL.md` files, matching the pattern used by Codex and Gemini.

## Problem

Claude skills were using flat files:
```
.claude/skills/
├── opal.md
└── opal-convert.md
```

## Solution

Now uses the correct subdirectory structure:
```
.claude/skills/
├── opal/
│   └── SKILL.md
└── opal-convert/
    └── SKILL.md
```

## Changes

- Create `claude-opal-SKILL.md` and `claude-opal-convert-SKILL.md` with YAML frontmatter
- Update `ClaudeInitializer.cs` to create subdirectory structure
- Update all tests to expect new paths
- Update all documentation (docs/ and website/content/)

## Test plan

- [x] All 606 tests pass
- [x] Manual test: `opalc init --ai claude` creates correct structure

🤖 Generated with [Claude Code](https://claude.ai/code)