### PR TITLE
Add solution-level initialization support to opalc init

### DIFF
--- a/src/Opal.Compiler/Commands/InitCommand.cs
+++ b/src/Opal.Compiler/Commands/InitCommand.cs
@@ -5,6 +5,7 @@ namespace Opal.Compiler.Commands;
 
 /// <summary>
 /// CLI command for initializing OPAL projects with AI agent support and .csproj integration.
+/// Supports both single projects and solutions.
 /// </summary>
 public static class InitCommand
 {
@@ -18,6 +19,10 @@ public static class InitCommand
             aliases: new[] { "--project", "-p" },
             description: "The .csproj file to configure (auto-detects if single .csproj exists)");
 
+        var solutionOption = new Option<string?>(
+            aliases: new[] { "--solution", "-s" },
+            description: "The .sln or .slnx file to configure (initializes all projects in solution)");
+
         var forceOption = new Option<bool>(
             aliases: new[] { "--force", "-f" },
             description: "Overwrite existing files without prompting");
@@ -26,25 +31,31 @@ public static class InitCommand
         {
             aiOption,
             projectOption,
+            solutionOption,
             forceOption
         };
 
-        command.SetHandler(ExecuteAsync, aiOption, projectOption, forceOption);
+        command.SetHandler(ExecuteAsync, aiOption, projectOption, solutionOption, forceOption);
 
         return command;
     }
 
-    private static async Task ExecuteAsync(string? ai, string? project, bool force)
+    private static async Task ExecuteAsync(string? ai, string? project, string? solution, bool force)
     {
         try
         {
             var targetDirectory = Directory.GetCurrentDirectory();
-            var createdFiles = new List<string>();
-            var updatedFiles = new List<string>();
-            var warnings = new List<string>();
-            string? agentName = null;
+
+            // Validate mutual exclusivity of --project and --solution
+            if (!string.IsNullOrEmpty(project) && !string.IsNullOrEmpty(solution))
+            {
+                Console.Error.WriteLine("Error: Cannot specify both --project and --solution. Use one or the other.");
+                Environment.ExitCode = 1;
+                return;
+            }
 
             // Validate AI agent type if provided
+            IAiInitializer? aiInitializer = null;
             if (!string.IsNullOrEmpty(ai))
             {
                 if (!AiInitializerFactory.IsSupported(ai))
@@ -54,141 +65,308 @@ public static class InitCommand
                     Environment.ExitCode = 1;
                     return;
                 }
+                aiInitializer = AiInitializerFactory.Create(ai);
             }
 
-            // Step 1: Detect and validate .csproj file
-            var detector = new ProjectDetector();
-            var detection = detector.Detect(targetDirectory, project);
-
-            if (!detection.IsSuccess)
+            // Determine mode: solution, explicit project, or auto-detect
+            if (!string.IsNullOrEmpty(solution))
             {
-                Console.Error.WriteLine($"Error: {detection.ErrorMessage}");
+                // Explicit solution mode
+                await ExecuteSolutionModeAsync(targetDirectory, solution, force, aiInitializer);
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(project))
+            {
+                // Explicit project mode
+                await ExecuteProjectModeAsync(targetDirectory, project, force, aiInitializer);
+                return;
+            }
+
+            // Auto-detection mode: try solution first, then project
+            var solutionDetector = new SolutionDetector();
+            var solutionDetection = solutionDetector.Detect(targetDirectory);
+
+            if (solutionDetection.IsSuccess)
+            {
+                // Found a solution - use solution mode
+                await ExecuteSolutionModeAsync(targetDirectory, solutionDetection.SolutionPath!, force, aiInitializer);
+                return;
+            }
+
+            if (solutionDetection.HasMultipleSolutions)
+            {
+                // Multiple solutions found - require explicit selection
+                Console.Error.WriteLine($"Error: {solutionDetection.ErrorMessage}");
                 Environment.ExitCode = 1;
                 return;
             }
 
-            var projectPath = detection.ProjectPath!;
-
-            // Step 2: Initialize AI agent configuration (if --ai specified)
-            if (!string.IsNullOrEmpty(ai))
-            {
-                var aiInitializer = AiInitializerFactory.Create(ai);
-                agentName = aiInitializer.AgentName;
-                var aiResult = await aiInitializer.InitializeAsync(targetDirectory, force);
-
-                if (!aiResult.Success)
-                {
-                    foreach (var message in aiResult.Messages)
-                    {
-                        Console.Error.WriteLine($"Error: {message}");
-                    }
-                    Environment.ExitCode = 1;
-                    return;
-                }
-
-                createdFiles.AddRange(aiResult.CreatedFiles);
-                updatedFiles.AddRange(aiResult.UpdatedFiles);
-                warnings.AddRange(aiResult.Warnings);
-            }
-
-            // Step 3: Initialize .csproj with OPAL targets
-            var csprojInitializer = new CsprojInitializer(detector);
-            var csprojResult = await csprojInitializer.InitializeAsync(projectPath, force);
-
-            if (!csprojResult.IsSuccess)
-            {
-                Console.Error.WriteLine($"Error: {csprojResult.ErrorMessage}");
-                Environment.ExitCode = 1;
-                return;
-            }
-
-            if (csprojResult.WasAlreadyInitialized)
-            {
-                warnings.Add($"Project already has OPAL targets: {Path.GetFileName(projectPath)}");
-            }
-            else
-            {
-                updatedFiles.Add(projectPath);
-            }
-
-            // Check if opalc is available in PATH
-            if (!IsOpalcInPath())
-            {
-                warnings.Add("'opalc' not found in PATH. Ensure opalc is installed and accessible.");
-            }
-
-            // Show success message
-            var version = EmbeddedResourceHelper.GetVersion();
-            if (agentName != null)
-            {
-                Console.WriteLine($"Initialized OPAL project for {agentName} (opalc v{version})");
-            }
-            else
-            {
-                Console.WriteLine($"Initialized OPAL project with MSBuild integration (opalc v{version})");
-            }
-
-            // Show created files
-            if (createdFiles.Count > 0)
-            {
-                Console.WriteLine();
-                Console.WriteLine("Created files:");
-                foreach (var file in createdFiles)
-                {
-                    var relativePath = Path.GetRelativePath(targetDirectory, file);
-                    Console.WriteLine($"  {relativePath}");
-                }
-            }
-
-            // Show updated files
-            if (updatedFiles.Count > 0)
-            {
-                Console.WriteLine();
-                Console.WriteLine("Updated files:");
-                foreach (var file in updatedFiles)
-                {
-                    var relativePath = Path.GetRelativePath(targetDirectory, file);
-                    Console.WriteLine($"  {relativePath}");
-                }
-            }
-
-            // Show .csproj changes
-            if (!csprojResult.WasAlreadyInitialized && csprojResult.Changes.Count > 0)
-            {
-                Console.WriteLine();
-                Console.WriteLine("MSBuild configuration:");
-                foreach (var change in csprojResult.Changes)
-                {
-                    Console.WriteLine($"  - {change}");
-                }
-            }
-
-            // Show warnings
-            if (warnings.Count > 0)
-            {
-                Console.WriteLine();
-                foreach (var warning in warnings)
-                {
-                    Console.WriteLine($"Warning: {warning}");
-                }
-            }
-
-            // Show next steps
-            Console.WriteLine();
-            Console.WriteLine("Next steps:");
-            Console.WriteLine("  1. Run 'opalc analyze ./src' to find migration candidates");
-            Console.WriteLine("  2. Create .opal files in your project");
-            Console.WriteLine("  3. Run 'dotnet build' to compile OPAL to C#");
-            if (agentName == null)
-            {
-                Console.WriteLine();
-                Console.WriteLine("Optional: Run 'opalc init --ai claude' to add Claude Code skills");
-            }
+            // No solution found - fall back to project mode
+            await ExecuteProjectModeAsync(targetDirectory, null, force, aiInitializer);
         }
         catch (Exception ex)
         {
             Console.Error.WriteLine($"Error: {ex.Message}");
             Environment.ExitCode = 1;
+        }
+    }
+
+    private static async Task ExecuteSolutionModeAsync(
+        string targetDirectory,
+        string solutionPathOrName,
+        bool force,
+        IAiInitializer? aiInitializer)
+    {
+        var solutionDetector = new SolutionDetector();
+
+        // Resolve solution path
+        var solutionPath = Path.IsPathRooted(solutionPathOrName)
+            ? solutionPathOrName
+            : Path.Combine(targetDirectory, solutionPathOrName);
+
+        if (!File.Exists(solutionPath))
+        {
+            Console.Error.WriteLine($"Error: Solution file not found: {solutionPath}");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        var solutionDirectory = Path.GetDirectoryName(solutionPath)!;
+        var solutionInitializer = new SolutionInitializer();
+        var result = await solutionInitializer.InitializeAsync(solutionPath, force, aiInitializer);
+
+        if (!result.IsSuccess)
+        {
+            Console.Error.WriteLine($"Error: {result.ErrorMessage}");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        // Check if opalc is available in PATH
+        var warnings = new List<string>(result.Warnings);
+        if (!IsOpalcInPath())
+        {
+            warnings.Add("'opalc' not found in PATH. Ensure opalc is installed and accessible.");
+        }
+
+        // Show success message
+        var version = EmbeddedResourceHelper.GetVersion();
+        if (result.AgentName != null)
+        {
+            Console.WriteLine($"Initialized OPAL solution for {result.AgentName} (opalc v{version})");
+        }
+        else
+        {
+            Console.WriteLine($"Initialized OPAL solution with MSBuild integration (opalc v{version})");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"Solution: {result.SolutionName} ({result.TotalProjects} projects)");
+
+        // Show created files
+        if (result.CreatedFiles.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Created files:");
+            foreach (var file in result.CreatedFiles)
+            {
+                var relativePath = Path.GetRelativePath(solutionDirectory, file);
+                Console.WriteLine($"  {relativePath}");
+            }
+        }
+
+        // Show updated projects
+        var updatedProjects = result.ProjectResults
+            .Where(r => r.Status == InitStatus.Initialized)
+            .ToList();
+
+        if (updatedProjects.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Updated projects:");
+            foreach (var proj in updatedProjects)
+            {
+                var relativePath = Path.GetRelativePath(solutionDirectory, proj.ProjectPath);
+                Console.WriteLine($"  {relativePath}");
+            }
+        }
+
+        // Show MSBuild configuration summary
+        if (result.InitializedCount > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("MSBuild configuration:");
+            Console.WriteLine($"  - Added OPAL compilation targets to {result.InitializedCount} projects");
+        }
+
+        // Show skipped/already initialized info
+        if (result.AlreadyInitializedCount > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"Skipped {result.AlreadyInitializedCount} projects (already initialized). Use --force to reinitialize.");
+        }
+
+        // Show warnings
+        if (warnings.Count > 0)
+        {
+            Console.WriteLine();
+            foreach (var warning in warnings)
+            {
+                Console.WriteLine($"Warning: {warning}");
+            }
+        }
+
+        // Show next steps
+        Console.WriteLine();
+        Console.WriteLine("Next steps:");
+        Console.WriteLine("  1. Run 'opalc analyze ./src' to find migration candidates");
+        Console.WriteLine("  2. Create .opal files in your projects");
+        Console.WriteLine("  3. Run 'dotnet build' to compile OPAL to C#");
+        if (result.AgentName == null)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Optional: Run 'opalc init --ai claude' to add Claude Code skills");
+        }
+    }
+
+    private static async Task ExecuteProjectModeAsync(
+        string targetDirectory,
+        string? specificProject,
+        bool force,
+        IAiInitializer? aiInitializer)
+    {
+        var createdFiles = new List<string>();
+        var updatedFiles = new List<string>();
+        var warnings = new List<string>();
+        string? agentName = null;
+
+        // Step 1: Detect and validate .csproj file
+        var detector = new ProjectDetector();
+        var detection = detector.Detect(targetDirectory, specificProject);
+
+        if (!detection.IsSuccess)
+        {
+            Console.Error.WriteLine($"Error: {detection.ErrorMessage}");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        var projectPath = detection.ProjectPath!;
+
+        // Step 2: Initialize AI agent configuration (if --ai specified)
+        if (aiInitializer != null)
+        {
+            agentName = aiInitializer.AgentName;
+            var aiResult = await aiInitializer.InitializeAsync(targetDirectory, force);
+
+            if (!aiResult.Success)
+            {
+                foreach (var message in aiResult.Messages)
+                {
+                    Console.Error.WriteLine($"Error: {message}");
+                }
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            createdFiles.AddRange(aiResult.CreatedFiles);
+            updatedFiles.AddRange(aiResult.UpdatedFiles);
+            warnings.AddRange(aiResult.Warnings);
+        }
+
+        // Step 3: Initialize .csproj with OPAL targets
+        var csprojInitializer = new CsprojInitializer(detector);
+        var csprojResult = await csprojInitializer.InitializeAsync(projectPath, force);
+
+        if (!csprojResult.IsSuccess)
+        {
+            Console.Error.WriteLine($"Error: {csprojResult.ErrorMessage}");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        if (csprojResult.WasAlreadyInitialized)
+        {
+            warnings.Add($"Project already has OPAL targets: {Path.GetFileName(projectPath)}");
+        }
+        else
+        {
+            updatedFiles.Add(projectPath);
+        }
+
+        // Check if opalc is available in PATH
+        if (!IsOpalcInPath())
+        {
+            warnings.Add("'opalc' not found in PATH. Ensure opalc is installed and accessible.");
+        }
+
+        // Show success message
+        var version = EmbeddedResourceHelper.GetVersion();
+        if (agentName != null)
+        {
+            Console.WriteLine($"Initialized OPAL project for {agentName} (opalc v{version})");
+        }
+        else
+        {
+            Console.WriteLine($"Initialized OPAL project with MSBuild integration (opalc v{version})");
+        }
+
+        // Show created files
+        if (createdFiles.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Created files:");
+            foreach (var file in createdFiles)
+            {
+                var relativePath = Path.GetRelativePath(targetDirectory, file);
+                Console.WriteLine($"  {relativePath}");
+            }
+        }
+
+        // Show updated files
+        if (updatedFiles.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Updated files:");
+            foreach (var file in updatedFiles)
+            {
+                var relativePath = Path.GetRelativePath(targetDirectory, file);
+                Console.WriteLine($"  {relativePath}");
+            }
+        }
+
+        // Show .csproj changes
+        if (!csprojResult.WasAlreadyInitialized && csprojResult.Changes.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("MSBuild configuration:");
+            foreach (var change in csprojResult.Changes)
+            {
+                Console.WriteLine($"  - {change}");
+            }
+        }
+
+        // Show warnings
+        if (warnings.Count > 0)
+        {
+            Console.WriteLine();
+            foreach (var warning in warnings)
+            {
+                Console.WriteLine($"Warning: {warning}");
+            }
+        }
+
+        // Show next steps
+        Console.WriteLine();
+        Console.WriteLine("Next steps:");
+        Console.WriteLine("  1. Run 'opalc analyze ./src' to find migration candidates");
+        Console.WriteLine("  2. Create .opal files in your project");
+        Console.WriteLine("  3. Run 'dotnet build' to compile OPAL to C#");
+        if (agentName == null)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Optional: Run 'opalc init --ai claude' to add Claude Code skills");
         }
     }
 

--- a/src/Opal.Compiler/Init/SolutionDetector.cs
+++ b/src/Opal.Compiler/Init/SolutionDetector.cs
@@ -1,0 +1,164 @@
+namespace Opal.Compiler.Init;
+
+/// <summary>
+/// Detects and validates solution files (.sln and .slnx) in a directory.
+/// </summary>
+public sealed class SolutionDetector
+{
+    /// <summary>
+    /// Detects solution files in the specified directory.
+    /// Priority: .slnx files first (newer XML format), then .sln files.
+    /// </summary>
+    /// <param name="directory">The directory to search.</param>
+    /// <param name="specificSolution">Optional specific solution file path.</param>
+    /// <returns>Detection result with the solution path or an error.</returns>
+    public SolutionDetectionResult Detect(string directory, string? specificSolution = null)
+    {
+        if (!Directory.Exists(directory))
+        {
+            return SolutionDetectionResult.Error($"Directory not found: {directory}");
+        }
+
+        // If a specific solution is specified, use it
+        if (!string.IsNullOrEmpty(specificSolution))
+        {
+            var solutionPath = Path.IsPathRooted(specificSolution)
+                ? specificSolution
+                : Path.Combine(directory, specificSolution);
+
+            if (!File.Exists(solutionPath))
+            {
+                return SolutionDetectionResult.Error($"Solution file not found: {solutionPath}");
+            }
+
+            return SolutionDetectionResult.Success(solutionPath);
+        }
+
+        // Auto-detect solution files - prefer .slnx over .sln
+        var slnxFiles = Directory.GetFiles(directory, "*.slnx", SearchOption.TopDirectoryOnly);
+        var slnFiles = Directory.GetFiles(directory, "*.sln", SearchOption.TopDirectoryOnly);
+
+        var allSolutions = slnxFiles.Concat(slnFiles).ToArray();
+
+        if (allSolutions.Length == 0)
+        {
+            return SolutionDetectionResult.NotFound();
+        }
+
+        if (allSolutions.Length == 1)
+        {
+            return SolutionDetectionResult.Success(allSolutions[0]);
+        }
+
+        // Multiple solutions found - require explicit specification
+        var solutionNames = allSolutions.Select(s => Path.GetFileName(s)).ToList();
+        return SolutionDetectionResult.MultipleSolutions(allSolutions,
+            $"Multiple solution files found. Please specify one with --solution:\n  " +
+            string.Join("\n  ", solutionNames));
+    }
+
+    /// <summary>
+    /// Parses a solution file and returns information about all its projects.
+    /// </summary>
+    public SolutionParseResult ParseSolution(string solutionPath)
+    {
+        if (!File.Exists(solutionPath))
+        {
+            return SolutionParseResult.Error($"Solution file not found: {solutionPath}");
+        }
+
+        try
+        {
+            var projects = SolutionParser.Parse(solutionPath).ToList();
+            return SolutionParseResult.Success(solutionPath, projects);
+        }
+        catch (Exception ex)
+        {
+            return SolutionParseResult.Error($"Failed to parse solution: {ex.Message}");
+        }
+    }
+}
+
+/// <summary>
+/// Result of solution detection.
+/// </summary>
+public sealed class SolutionDetectionResult
+{
+    public bool IsSuccess { get; private init; }
+    public bool WasNotFound { get; private init; }
+    public string? SolutionPath { get; private init; }
+    public string? ErrorMessage { get; private init; }
+    public IReadOnlyList<string>? AvailableSolutions { get; private init; }
+    public bool HasMultipleSolutions => AvailableSolutions?.Count > 1;
+
+    private SolutionDetectionResult() { }
+
+    public static SolutionDetectionResult Success(string solutionPath)
+    {
+        return new SolutionDetectionResult
+        {
+            IsSuccess = true,
+            SolutionPath = solutionPath
+        };
+    }
+
+    public static SolutionDetectionResult NotFound()
+    {
+        return new SolutionDetectionResult
+        {
+            IsSuccess = false,
+            WasNotFound = true
+        };
+    }
+
+    public static SolutionDetectionResult Error(string message)
+    {
+        return new SolutionDetectionResult
+        {
+            IsSuccess = false,
+            ErrorMessage = message
+        };
+    }
+
+    public static SolutionDetectionResult MultipleSolutions(string[] solutions, string message)
+    {
+        return new SolutionDetectionResult
+        {
+            IsSuccess = false,
+            ErrorMessage = message,
+            AvailableSolutions = solutions
+        };
+    }
+}
+
+/// <summary>
+/// Result of parsing a solution file.
+/// </summary>
+public sealed class SolutionParseResult
+{
+    public bool IsSuccess { get; private init; }
+    public string? SolutionPath { get; private init; }
+    public string? ErrorMessage { get; private init; }
+    public IReadOnlyList<SolutionProject> Projects { get; private init; } = Array.Empty<SolutionProject>();
+
+    private SolutionParseResult() { }
+
+    public static SolutionParseResult Success(string solutionPath, IReadOnlyList<SolutionProject> projects)
+    {
+        return new SolutionParseResult
+        {
+            IsSuccess = true,
+            SolutionPath = solutionPath,
+            Projects = projects
+        };
+    }
+
+    public static SolutionParseResult Error(string message)
+    {
+        return new SolutionParseResult
+        {
+            IsSuccess = false,
+            ErrorMessage = message
+        };
+    }
+}

--- a/src/Opal.Compiler/Init/SolutionInitializer.cs
+++ b/src/Opal.Compiler/Init/SolutionInitializer.cs
@@ -1,0 +1,244 @@
+namespace Opal.Compiler.Init;
+
+/// <summary>
+/// Initializes all projects in a solution with OPAL compilation targets.
+/// </summary>
+public sealed class SolutionInitializer
+{
+    private readonly SolutionDetector _solutionDetector;
+    private readonly ProjectDetector _projectDetector;
+    private readonly CsprojInitializer _csprojInitializer;
+
+    public SolutionInitializer()
+    {
+        _solutionDetector = new SolutionDetector();
+        _projectDetector = new ProjectDetector();
+        _csprojInitializer = new CsprojInitializer(_projectDetector);
+    }
+
+    public SolutionInitializer(
+        SolutionDetector solutionDetector,
+        ProjectDetector projectDetector,
+        CsprojInitializer csprojInitializer)
+    {
+        _solutionDetector = solutionDetector;
+        _projectDetector = projectDetector;
+        _csprojInitializer = csprojInitializer;
+    }
+
+    /// <summary>
+    /// Initializes all projects in a solution with OPAL compilation support.
+    /// AI agent files are placed in the solution directory.
+    /// </summary>
+    /// <param name="solutionPath">Path to the solution file.</param>
+    /// <param name="force">If true, overwrite existing configurations.</param>
+    /// <param name="aiInitializer">Optional AI agent initializer.</param>
+    /// <returns>Result of the initialization.</returns>
+    public async Task<SolutionInitResult> InitializeAsync(
+        string solutionPath,
+        bool force,
+        IAiInitializer? aiInitializer = null)
+    {
+        // Parse the solution to get all projects
+        var parseResult = _solutionDetector.ParseSolution(solutionPath);
+        if (!parseResult.IsSuccess)
+        {
+            return SolutionInitResult.Error(parseResult.ErrorMessage!);
+        }
+
+        var solutionDirectory = Path.GetDirectoryName(solutionPath)!;
+        var solutionName = Path.GetFileName(solutionPath);
+        var createdFiles = new List<string>();
+        var updatedFiles = new List<string>();
+        var warnings = new List<string>();
+        var projectResults = new List<ProjectInitStatus>();
+        string? agentName = null;
+
+        // Initialize AI agent files in the solution directory
+        if (aiInitializer != null)
+        {
+            agentName = aiInitializer.AgentName;
+            var aiResult = await aiInitializer.InitializeAsync(solutionDirectory, force);
+
+            if (!aiResult.Success)
+            {
+                return SolutionInitResult.Error(string.Join("; ", aiResult.Messages));
+            }
+
+            createdFiles.AddRange(aiResult.CreatedFiles);
+            updatedFiles.AddRange(aiResult.UpdatedFiles);
+            warnings.AddRange(aiResult.Warnings);
+        }
+
+        // Initialize each project in the solution
+        foreach (var project in parseResult.Projects)
+        {
+            var projectStatus = await InitializeProjectAsync(project, force);
+            projectResults.Add(projectStatus);
+
+            if (projectStatus.Status == InitStatus.Initialized)
+            {
+                updatedFiles.Add(project.FullPath);
+            }
+            else if (projectStatus.Status == InitStatus.Skipped)
+            {
+                warnings.Add(projectStatus.Message ?? $"Skipped: {project.Name}");
+            }
+            else if (projectStatus.Status == InitStatus.Failed)
+            {
+                warnings.Add(projectStatus.Message ?? $"Failed: {project.Name}");
+            }
+        }
+
+        var initializedCount = projectResults.Count(r => r.Status == InitStatus.Initialized);
+        var skippedCount = projectResults.Count(r => r.Status == InitStatus.Skipped);
+        var failedCount = projectResults.Count(r => r.Status == InitStatus.Failed);
+        var alreadyInitializedCount = projectResults.Count(r => r.Status == InitStatus.AlreadyInitialized);
+
+        // Determine overall success - succeed if at least one project was initialized or all were already done
+        var anySuccess = initializedCount > 0 || alreadyInitializedCount > 0;
+        if (!anySuccess && projectResults.Count > 0)
+        {
+            return SolutionInitResult.Error($"No projects could be initialized. {failedCount} failed, {skippedCount} skipped.");
+        }
+
+        return SolutionInitResult.Success(
+            solutionPath,
+            solutionName,
+            parseResult.Projects.Count,
+            projectResults,
+            createdFiles,
+            updatedFiles,
+            warnings,
+            agentName);
+    }
+
+    private async Task<ProjectInitStatus> InitializeProjectAsync(SolutionProject project, bool force)
+    {
+        // Check if project file exists
+        if (!project.Exists)
+        {
+            return new ProjectInitStatus(
+                project.Name,
+                project.FullPath,
+                InitStatus.Skipped,
+                $"Project file not found: {project.RelativePath}");
+        }
+
+        // Validate SDK-style project
+        var validation = _projectDetector.ValidateProject(project.FullPath);
+        if (!validation.IsValid)
+        {
+            return new ProjectInitStatus(
+                project.Name,
+                project.FullPath,
+                InitStatus.Skipped,
+                $"Non-SDK-style project skipped: {project.Name}");
+        }
+
+        // Check if already initialized
+        if (_projectDetector.HasOpalTargets(project.FullPath) && !force)
+        {
+            return new ProjectInitStatus(
+                project.Name,
+                project.FullPath,
+                InitStatus.AlreadyInitialized,
+                null);
+        }
+
+        // Initialize the project
+        var result = await _csprojInitializer.InitializeAsync(project.FullPath, force);
+
+        if (!result.IsSuccess)
+        {
+            return new ProjectInitStatus(
+                project.Name,
+                project.FullPath,
+                InitStatus.Failed,
+                result.ErrorMessage);
+        }
+
+        return new ProjectInitStatus(
+            project.Name,
+            project.FullPath,
+            result.WasAlreadyInitialized ? InitStatus.AlreadyInitialized : InitStatus.Initialized,
+            null);
+    }
+}
+
+/// <summary>
+/// Status of a single project initialization.
+/// </summary>
+public enum InitStatus
+{
+    Initialized,
+    AlreadyInitialized,
+    Skipped,
+    Failed
+}
+
+/// <summary>
+/// Result of initializing a single project.
+/// </summary>
+public sealed record ProjectInitStatus(
+    string ProjectName,
+    string ProjectPath,
+    InitStatus Status,
+    string? Message);
+
+/// <summary>
+/// Result of solution initialization.
+/// </summary>
+public sealed class SolutionInitResult
+{
+    public bool IsSuccess { get; private init; }
+    public string? SolutionPath { get; private init; }
+    public string? SolutionName { get; private init; }
+    public int TotalProjects { get; private init; }
+    public string? ErrorMessage { get; private init; }
+    public string? AgentName { get; private init; }
+    public IReadOnlyList<ProjectInitStatus> ProjectResults { get; private init; } = Array.Empty<ProjectInitStatus>();
+    public IReadOnlyList<string> CreatedFiles { get; private init; } = Array.Empty<string>();
+    public IReadOnlyList<string> UpdatedFiles { get; private init; } = Array.Empty<string>();
+    public IReadOnlyList<string> Warnings { get; private init; } = Array.Empty<string>();
+
+    public int InitializedCount => ProjectResults.Count(r => r.Status == InitStatus.Initialized);
+    public int AlreadyInitializedCount => ProjectResults.Count(r => r.Status == InitStatus.AlreadyInitialized);
+    public int SkippedCount => ProjectResults.Count(r => r.Status == InitStatus.Skipped);
+    public int FailedCount => ProjectResults.Count(r => r.Status == InitStatus.Failed);
+
+    private SolutionInitResult() { }
+
+    public static SolutionInitResult Success(
+        string solutionPath,
+        string solutionName,
+        int totalProjects,
+        IReadOnlyList<ProjectInitStatus> projectResults,
+        IReadOnlyList<string> createdFiles,
+        IReadOnlyList<string> updatedFiles,
+        IReadOnlyList<string> warnings,
+        string? agentName)
+    {
+        return new SolutionInitResult
+        {
+            IsSuccess = true,
+            SolutionPath = solutionPath,
+            SolutionName = solutionName,
+            TotalProjects = totalProjects,
+            ProjectResults = projectResults,
+            CreatedFiles = createdFiles,
+            UpdatedFiles = updatedFiles,
+            Warnings = warnings,
+            AgentName = agentName
+        };
+    }
+
+    public static SolutionInitResult Error(string message)
+    {
+        return new SolutionInitResult
+        {
+            IsSuccess = false,
+            ErrorMessage = message
+        };
+    }
+}

--- a/src/Opal.Compiler/Init/SolutionParser.cs
+++ b/src/Opal.Compiler/Init/SolutionParser.cs
@@ -1,0 +1,160 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace Opal.Compiler.Init;
+
+/// <summary>
+/// Parses .sln (text format) and .slnx (XML format) solution files.
+/// </summary>
+internal static class SolutionParser
+{
+    // C# Project type GUID
+    private const string CSharpProjectTypeGuid = "FAE04EC0-301F-11D3-BF4B-00C04F79EFBC";
+
+    // Solution folder type GUID (to skip)
+    private const string SolutionFolderTypeGuid = "2150E333-8FDC-42A3-9474-1A3956D46DE8";
+
+    // Regex pattern for .sln project lines:
+    // Project("{TypeGuid}") = "Name", "Path\Project.csproj", "{ProjectGuid}"
+    private static readonly Regex SlnProjectPattern = new(
+        @"Project\(\""(?<typeGuid>[^""]+)\""\)\s*=\s*\""(?<name>[^""]+)\""\s*,\s*\""(?<path>[^""]+)\""\s*,\s*\""(?<projectGuid>[^""]+)\""",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Parses a .sln file and returns all C# projects.
+    /// </summary>
+    public static IEnumerable<SolutionProject> ParseSln(string path)
+    {
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException($"Solution file not found: {path}");
+        }
+
+        var solutionDirectory = Path.GetDirectoryName(path)!;
+        var lines = File.ReadAllLines(path);
+        var projects = new List<SolutionProject>();
+
+        foreach (var line in lines)
+        {
+            var match = SlnProjectPattern.Match(line);
+            if (!match.Success) continue;
+
+            var typeGuid = match.Groups["typeGuid"].Value.Trim('{', '}');
+            var name = match.Groups["name"].Value;
+            var relativePath = match.Groups["path"].Value;
+            var projectGuid = match.Groups["projectGuid"].Value.Trim('{', '}');
+
+            // Skip solution folders
+            if (typeGuid.Equals(SolutionFolderTypeGuid, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            // Only include C# projects (.csproj)
+            if (!relativePath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            // Normalize path separators
+            relativePath = relativePath.Replace('\\', Path.DirectorySeparatorChar);
+            var fullPath = Path.GetFullPath(Path.Combine(solutionDirectory, relativePath));
+
+            projects.Add(new SolutionProject(name, fullPath, relativePath, typeGuid, projectGuid));
+        }
+
+        return projects;
+    }
+
+    /// <summary>
+    /// Parses a .slnx file (XML format) and returns all C# projects.
+    /// </summary>
+    public static IEnumerable<SolutionProject> ParseSlnx(string path)
+    {
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException($"Solution file not found: {path}");
+        }
+
+        var solutionDirectory = Path.GetDirectoryName(path)!;
+        var projects = new List<SolutionProject>();
+
+        try
+        {
+            var doc = XDocument.Load(path);
+            var root = doc.Root;
+
+            if (root == null)
+            {
+                return projects;
+            }
+
+            // .slnx format uses <Project> elements with Path attribute
+            // Example: <Project Path="src/MyProject/MyProject.csproj" />
+            var projectElements = root.Descendants()
+                .Where(e => e.Name.LocalName == "Project");
+
+            foreach (var element in projectElements)
+            {
+                var relativePath = element.Attribute("Path")?.Value;
+                if (string.IsNullOrEmpty(relativePath))
+                {
+                    continue;
+                }
+
+                // Only include C# projects
+                if (!relativePath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                // Normalize path separators
+                relativePath = relativePath.Replace('\\', Path.DirectorySeparatorChar);
+                var fullPath = Path.GetFullPath(Path.Combine(solutionDirectory, relativePath));
+                var name = Path.GetFileNameWithoutExtension(relativePath);
+
+                // Get optional type and GUID attributes
+                var typeGuid = element.Attribute("Type")?.Value ?? CSharpProjectTypeGuid;
+                var projectGuid = element.Attribute("Id")?.Value ?? Guid.NewGuid().ToString();
+
+                projects.Add(new SolutionProject(name, fullPath, relativePath, typeGuid, projectGuid));
+            }
+        }
+        catch (Exception ex) when (ex is not FileNotFoundException)
+        {
+            throw new InvalidOperationException($"Failed to parse solution file: {ex.Message}", ex);
+        }
+
+        return projects;
+    }
+
+    /// <summary>
+    /// Parses a solution file (auto-detects format based on extension).
+    /// </summary>
+    public static IEnumerable<SolutionProject> Parse(string path)
+    {
+        var extension = Path.GetExtension(path).ToLowerInvariant();
+        return extension switch
+        {
+            ".slnx" => ParseSlnx(path),
+            ".sln" => ParseSln(path),
+            _ => throw new ArgumentException($"Unknown solution file format: {extension}")
+        };
+    }
+}
+
+/// <summary>
+/// Represents a project referenced in a solution file.
+/// </summary>
+public sealed record SolutionProject(
+    string Name,
+    string FullPath,
+    string RelativePath,
+    string TypeGuid,
+    string ProjectGuid)
+{
+    /// <summary>
+    /// Whether this project file exists on disk.
+    /// </summary>
+    public bool Exists => File.Exists(FullPath);
+}

--- a/tests/Opal.Compiler.Tests/Helpers/GitHubTestRepo.cs
+++ b/tests/Opal.Compiler.Tests/Helpers/GitHubTestRepo.cs
@@ -1,0 +1,115 @@
+using System.Diagnostics;
+
+namespace Opal.Compiler.Tests.Helpers;
+
+/// <summary>
+/// Represents a GitHub repository for integration testing.
+/// </summary>
+public record GitHubTestRepo(string Owner, string Repo, string Tag, int MinProjects)
+{
+    /// <summary>
+    /// Gets the clone URL for this repository.
+    /// </summary>
+    public string CloneUrl => $"https://github.com/{Owner}/{Repo}.git";
+
+    /// <summary>
+    /// Gets a display name for test output.
+    /// </summary>
+    public string DisplayName => $"{Owner}/{Repo}@{Tag}";
+
+    /// <summary>
+    /// Clones the repository to a temporary directory.
+    /// Uses shallow clone with specific tag for efficiency.
+    /// </summary>
+    /// <returns>Path to the cloned repository.</returns>
+    public async Task<string> CloneAsync(CancellationToken cancellationToken = default)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"opal-test-{Repo}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = $"clone --depth 1 --branch {Tag} {CloneUrl} .",
+                WorkingDirectory = tempDir,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        process.Start();
+        await process.WaitForExitAsync(cancellationToken);
+
+        if (process.ExitCode != 0)
+        {
+            var error = await process.StandardError.ReadToEndAsync(cancellationToken);
+            Directory.Delete(tempDir, recursive: true);
+            throw new InvalidOperationException($"Failed to clone {DisplayName}: {error}");
+        }
+
+        return tempDir;
+    }
+
+    /// <summary>
+    /// Clones the repository synchronously.
+    /// </summary>
+    public string CloneSync()
+    {
+        return CloneAsync().GetAwaiter().GetResult();
+    }
+}
+
+/// <summary>
+/// Manages test repository lifecycle.
+/// </summary>
+public sealed class TestRepoManager : IDisposable
+{
+    private readonly List<string> _tempDirectories = new();
+
+    /// <summary>
+    /// Clones a repository and registers it for cleanup.
+    /// </summary>
+    public async Task<string> CloneAsync(GitHubTestRepo repo, CancellationToken cancellationToken = default)
+    {
+        var path = await repo.CloneAsync(cancellationToken);
+        _tempDirectories.Add(path);
+        return path;
+    }
+
+    /// <summary>
+    /// Cleans up all cloned repositories.
+    /// </summary>
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirectories)
+        {
+            try
+            {
+                if (Directory.Exists(dir))
+                {
+                    // On Windows, git files can be locked, so retry with delay
+                    for (int i = 0; i < 3; i++)
+                    {
+                        try
+                        {
+                            Directory.Delete(dir, recursive: true);
+                            break;
+                        }
+                        catch (IOException) when (i < 2)
+                        {
+                            Thread.Sleep(100);
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Ignore cleanup errors in tests
+            }
+        }
+    }
+}

--- a/tests/Opal.Compiler.Tests/Helpers/SolutionInitAudit.cs
+++ b/tests/Opal.Compiler.Tests/Helpers/SolutionInitAudit.cs
@@ -1,0 +1,177 @@
+using System.Xml.Linq;
+
+namespace Opal.Compiler.Tests.Helpers;
+
+/// <summary>
+/// Audits OPAL initialization results for a solution directory.
+/// </summary>
+public static class SolutionInitAudit
+{
+    /// <summary>
+    /// Performs a comprehensive audit of OPAL initialization in a solution directory.
+    /// </summary>
+    /// <param name="solutionDir">The solution directory to audit.</param>
+    /// <returns>Detailed audit results.</returns>
+    public static AuditResult Audit(string solutionDir)
+    {
+        var result = new AuditResult();
+
+        // Find all .csproj files
+        var allCsprojFiles = Directory.GetFiles(solutionDir, "*.csproj", SearchOption.AllDirectories)
+            .Where(f => !f.Contains("obj") && !f.Contains("bin")) // Exclude build outputs
+            .ToList();
+
+        result.TotalProjects = allCsprojFiles.Count;
+
+        // Check each project for OPAL targets
+        foreach (var csproj in allCsprojFiles)
+        {
+            if (HasOpalTargets(csproj))
+            {
+                result.InitializedProjects++;
+            }
+            else
+            {
+                result.MissingTargets.Add(Path.GetRelativePath(solutionDir, csproj));
+            }
+        }
+
+        // Check for AI files in solution root
+        result.HasClaudeMd = File.Exists(Path.Combine(solutionDir, "CLAUDE.md"));
+        result.HasSkills = Directory.Exists(Path.Combine(solutionDir, ".claude", "skills", "opal")) &&
+                          File.Exists(Path.Combine(solutionDir, ".claude", "skills", "opal", "SKILL.md"));
+        result.HasHooks = File.Exists(Path.Combine(solutionDir, ".claude", "settings.json"));
+
+        // Check for CODEX files
+        result.HasCodexMd = File.Exists(Path.Combine(solutionDir, "AGENTS.md"));
+
+        // Check for Gemini files
+        result.HasGeminiMd = File.Exists(Path.Combine(solutionDir, "GEMINI.md"));
+
+        return result;
+    }
+
+    /// <summary>
+    /// Checks if a .csproj file has OPAL compilation targets.
+    /// </summary>
+    public static bool HasOpalTargets(string csprojPath)
+    {
+        if (!File.Exists(csprojPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var content = File.ReadAllText(csprojPath);
+            var doc = XDocument.Parse(content);
+
+            return doc.Descendants()
+                .Any(e => e.Name.LocalName == "Target" &&
+                         e.Attribute("Name")?.Value == "CompileOpalFiles");
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Checks if a .csproj is SDK-style.
+    /// </summary>
+    public static bool IsSdkStyleProject(string csprojPath)
+    {
+        if (!File.Exists(csprojPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var content = File.ReadAllText(csprojPath);
+            var doc = XDocument.Parse(content);
+
+            if (doc.Root == null) return false;
+
+            // Check for Sdk attribute on root
+            if (doc.Root.Attribute("Sdk") != null)
+            {
+                return true;
+            }
+
+            // Check for <Import Sdk="..."> pattern
+            return doc.Root.Elements()
+                .Any(e => e.Name.LocalName == "Import" && e.Attribute("Sdk") != null);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}
+
+/// <summary>
+/// Results of auditing OPAL initialization.
+/// </summary>
+public class AuditResult
+{
+    /// <summary>
+    /// Total number of .csproj files found.
+    /// </summary>
+    public int TotalProjects { get; set; }
+
+    /// <summary>
+    /// Number of projects with OPAL targets.
+    /// </summary>
+    public int InitializedProjects { get; set; }
+
+    /// <summary>
+    /// Relative paths to projects missing OPAL targets.
+    /// </summary>
+    public List<string> MissingTargets { get; set; } = new();
+
+    /// <summary>
+    /// Whether CLAUDE.md exists in the solution root.
+    /// </summary>
+    public bool HasClaudeMd { get; set; }
+
+    /// <summary>
+    /// Whether OPAL skills exist in .claude/skills/opal/.
+    /// </summary>
+    public bool HasSkills { get; set; }
+
+    /// <summary>
+    /// Whether hooks are configured in .claude/settings.json.
+    /// </summary>
+    public bool HasHooks { get; set; }
+
+    /// <summary>
+    /// Whether AGENTS.md (Codex) exists in the solution root.
+    /// </summary>
+    public bool HasCodexMd { get; set; }
+
+    /// <summary>
+    /// Whether GEMINI.md exists in the solution root.
+    /// </summary>
+    public bool HasGeminiMd { get; set; }
+
+    /// <summary>
+    /// Percentage of projects initialized.
+    /// </summary>
+    public double InitializationRate =>
+        TotalProjects > 0 ? (double)InitializedProjects / TotalProjects * 100 : 0;
+
+    /// <summary>
+    /// Whether all SDK-style projects are initialized (ignoring legacy projects).
+    /// </summary>
+    public bool IsFullyInitialized => MissingTargets.Count == 0 && InitializedProjects > 0;
+
+    /// <summary>
+    /// Returns a summary string for test output.
+    /// </summary>
+    public override string ToString()
+    {
+        return $"Audit: {InitializedProjects}/{TotalProjects} projects initialized ({InitializationRate:F1}%), " +
+               $"CLAUDE.md={HasClaudeMd}, Skills={HasSkills}, Hooks={HasHooks}";
+    }
+}

--- a/tests/Opal.Compiler.Tests/SolutionDetectorTests.cs
+++ b/tests/Opal.Compiler.Tests/SolutionDetectorTests.cs
@@ -1,0 +1,390 @@
+using Opal.Compiler.Init;
+using Xunit;
+
+namespace Opal.Compiler.Tests;
+
+public class SolutionDetectorTests : IDisposable
+{
+    private readonly string _testDir;
+    private readonly SolutionDetector _detector;
+
+    public SolutionDetectorTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), $"opal-sln-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDir);
+        _detector = new SolutionDetector();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir))
+        {
+            Directory.Delete(_testDir, recursive: true);
+        }
+    }
+
+    #region Detection Tests
+
+    [Fact]
+    public void Detect_SingleSln_ReturnsSolution()
+    {
+        // Arrange
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+        File.WriteAllText(slnPath, SimpleSln);
+
+        // Act
+        var result = _detector.Detect(_testDir);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(slnPath, result.SolutionPath);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Detect_SingleSlnx_ReturnsSolution()
+    {
+        // Arrange
+        var slnxPath = Path.Combine(_testDir, "Test.slnx");
+        File.WriteAllText(slnxPath, SimpleSlnx);
+
+        // Act
+        var result = _detector.Detect(_testDir);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(slnxPath, result.SolutionPath);
+    }
+
+    [Fact]
+    public void Detect_SlnxAndSln_PrefersSlnx()
+    {
+        // Arrange - both types present, only one of each
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+        var slnxPath = Path.Combine(_testDir, "Test.slnx");
+        File.WriteAllText(slnPath, SimpleSln);
+        File.WriteAllText(slnxPath, SimpleSlnx);
+
+        // Act
+        var result = _detector.Detect(_testDir);
+
+        // Assert - multiple solutions, require explicit selection
+        Assert.False(result.IsSuccess);
+        Assert.True(result.HasMultipleSolutions);
+    }
+
+    [Fact]
+    public void Detect_MultipleSln_ReturnsErrorWithList()
+    {
+        // Arrange
+        File.WriteAllText(Path.Combine(_testDir, "Project1.sln"), SimpleSln);
+        File.WriteAllText(Path.Combine(_testDir, "Project2.sln"), SimpleSln);
+
+        // Act
+        var result = _detector.Detect(_testDir);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.True(result.HasMultipleSolutions);
+        Assert.NotNull(result.AvailableSolutions);
+        Assert.Equal(2, result.AvailableSolutions.Count);
+        Assert.Contains("Multiple solution files found", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Detect_NoSolution_ReturnsNotFound()
+    {
+        // Act
+        var result = _detector.Detect(_testDir);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.True(result.WasNotFound);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Detect_SpecificSolution_ReturnsSpecifiedSolution()
+    {
+        // Arrange
+        File.WriteAllText(Path.Combine(_testDir, "Project1.sln"), SimpleSln);
+        File.WriteAllText(Path.Combine(_testDir, "Project2.sln"), SimpleSln);
+
+        // Act
+        var result = _detector.Detect(_testDir, "Project2.sln");
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(Path.Combine(_testDir, "Project2.sln"), result.SolutionPath);
+    }
+
+    [Fact]
+    public void Detect_SpecificSolutionAbsolutePath_ReturnsSpecifiedSolution()
+    {
+        // Arrange
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+        File.WriteAllText(slnPath, SimpleSln);
+
+        // Act
+        var result = _detector.Detect(_testDir, slnPath);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(slnPath, result.SolutionPath);
+    }
+
+    [Fact]
+    public void Detect_SpecificSolutionNotFound_ReturnsError()
+    {
+        // Act
+        var result = _detector.Detect(_testDir, "NonExistent.sln");
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Solution file not found", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Detect_DirectoryNotFound_ReturnsError()
+    {
+        // Act
+        var result = _detector.Detect("/non/existent/path");
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Directory not found", result.ErrorMessage);
+    }
+
+    #endregion
+
+    #region Parsing Tests - .sln Format
+
+    [Fact]
+    public void ParseSolution_SlnWithProjects_ReturnsProjects()
+    {
+        // Arrange
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+        File.WriteAllText(slnPath, SlnWithProjects);
+
+        // Act
+        var result = _detector.ParseSolution(slnPath);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.Projects.Count);
+        Assert.Contains(result.Projects, p => p.Name == "Project1");
+        Assert.Contains(result.Projects, p => p.Name == "Project2");
+    }
+
+    [Fact]
+    public void ParseSolution_SlnWithSolutionFolders_SkipsFolders()
+    {
+        // Arrange
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+        File.WriteAllText(slnPath, SlnWithSolutionFolders);
+
+        // Act
+        var result = _detector.ParseSolution(slnPath);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Projects);
+        Assert.Equal("Project1", result.Projects[0].Name);
+    }
+
+    [Fact]
+    public void ParseSolution_SlnWithMixedProjects_OnlyReturnsCsproj()
+    {
+        // Arrange
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+        File.WriteAllText(slnPath, SlnWithMixedProjects);
+
+        // Act
+        var result = _detector.ParseSolution(slnPath);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Projects);
+        Assert.Equal("CSharpProject", result.Projects[0].Name);
+    }
+
+    [Fact]
+    public void ParseSolution_SlnNotFound_ReturnsError()
+    {
+        // Act
+        var result = _detector.ParseSolution(Path.Combine(_testDir, "NonExistent.sln"));
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Solution file not found", result.ErrorMessage);
+    }
+
+    #endregion
+
+    #region Parsing Tests - .slnx Format
+
+    [Fact]
+    public void ParseSolution_SlnxWithProjects_ReturnsProjects()
+    {
+        // Arrange
+        var slnxPath = Path.Combine(_testDir, "Test.slnx");
+        File.WriteAllText(slnxPath, SlnxWithProjects);
+
+        // Act
+        var result = _detector.ParseSolution(slnxPath);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.Projects.Count);
+        Assert.Contains(result.Projects, p => p.Name == "Project1");
+        Assert.Contains(result.Projects, p => p.Name == "Project2");
+    }
+
+    [Fact]
+    public void ParseSolution_SlnxWithFolders_SkipsFolders()
+    {
+        // Arrange
+        var slnxPath = Path.Combine(_testDir, "Test.slnx");
+        File.WriteAllText(slnxPath, SlnxWithFolders);
+
+        // Act
+        var result = _detector.ParseSolution(slnxPath);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Projects);
+    }
+
+    [Fact]
+    public void ParseSolution_SlnxInvalidXml_ReturnsError()
+    {
+        // Arrange
+        var slnxPath = Path.Combine(_testDir, "Test.slnx");
+        File.WriteAllText(slnxPath, "invalid xml <>");
+
+        // Act
+        var result = _detector.ParseSolution(slnxPath);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Failed to parse", result.ErrorMessage);
+    }
+
+    #endregion
+
+    #region Project Path Tests
+
+    [Fact]
+    public void ParseSolution_RelativePaths_ResolvedCorrectly()
+    {
+        // Arrange
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+        File.WriteAllText(slnPath, SlnWithProjects);
+
+        // Act
+        var result = _detector.ParseSolution(slnPath);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        var project1 = result.Projects.First(p => p.Name == "Project1");
+        var expectedPath = Path.GetFullPath(Path.Combine(_testDir, "src", "Project1", "Project1.csproj"));
+        Assert.Equal(expectedPath, project1.FullPath);
+    }
+
+    [Fact]
+    public void ParseSolution_ProjectExists_ReportsCorrectly()
+    {
+        // Arrange
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+        File.WriteAllText(slnPath, SlnWithProjects);
+
+        // Create one of the project directories/files
+        var projectDir = Path.Combine(_testDir, "src", "Project1");
+        Directory.CreateDirectory(projectDir);
+        File.WriteAllText(Path.Combine(projectDir, "Project1.csproj"), SdkStyleCsproj);
+
+        // Act
+        var result = _detector.ParseSolution(slnPath);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        var project1 = result.Projects.First(p => p.Name == "Project1");
+        var project2 = result.Projects.First(p => p.Name == "Project2");
+        Assert.True(project1.Exists);
+        Assert.False(project2.Exists);
+    }
+
+    #endregion
+
+    #region Test Data
+
+    private const string SimpleSln = """
+        Microsoft Visual Studio Solution File, Format Version 12.00
+        # Visual Studio Version 17
+        VisualStudioVersion = 17.0.31903.59
+        MinimumVisualStudioVersion = 10.0.40219.1
+        Global
+        EndGlobal
+        """;
+
+    private const string SimpleSlnx = """
+        <Solution>
+        </Solution>
+        """;
+
+    private const string SlnWithProjects = """
+        Microsoft Visual Studio Solution File, Format Version 12.00
+        # Visual Studio Version 17
+        Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project1", "src\Project1\Project1.csproj", "{12345678-1234-1234-1234-123456789012}"
+        EndProject
+        Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project2", "src\Project2\Project2.csproj", "{12345678-1234-1234-1234-123456789013}"
+        EndProject
+        Global
+        EndGlobal
+        """;
+
+    private const string SlnWithSolutionFolders = """
+        Microsoft Visual Studio Solution File, Format Version 12.00
+        Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FOLDER-GUID}"
+        EndProject
+        Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project1", "src\Project1\Project1.csproj", "{12345678-1234-1234-1234-123456789012}"
+        EndProject
+        Global
+        EndGlobal
+        """;
+
+    private const string SlnWithMixedProjects = """
+        Microsoft Visual Studio Solution File, Format Version 12.00
+        Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpProject", "src\CSharpProject\CSharpProject.csproj", "{12345678-1234-1234-1234-123456789012}"
+        EndProject
+        Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpProject", "src\FSharpProject\FSharpProject.fsproj", "{12345678-1234-1234-1234-123456789013}"
+        EndProject
+        Global
+        EndGlobal
+        """;
+
+    private const string SlnxWithProjects = """
+        <Solution>
+          <Project Path="src/Project1/Project1.csproj" />
+          <Project Path="src/Project2/Project2.csproj" />
+        </Solution>
+        """;
+
+    private const string SlnxWithFolders = """
+        <Solution>
+          <Folder Name="src">
+            <Project Path="src/Project1/Project1.csproj" />
+          </Folder>
+        </Solution>
+        """;
+
+    private const string SdkStyleCsproj = """
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>net8.0</TargetFramework>
+          </PropertyGroup>
+        </Project>
+        """;
+
+    #endregion
+}

--- a/tests/Opal.Compiler.Tests/SolutionInitializationIntegrationTests.cs
+++ b/tests/Opal.Compiler.Tests/SolutionInitializationIntegrationTests.cs
@@ -1,0 +1,302 @@
+using Opal.Compiler.Init;
+using Opal.Compiler.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Opal.Compiler.Tests;
+
+/// <summary>
+/// Integration tests that verify OPAL initialization works on real-world GitHub projects.
+/// These tests clone actual repositories and verify initialization behavior.
+///
+/// Note: These tests require network access and may be slow.
+/// They are marked with a [Trait] to allow filtering in CI.
+/// </summary>
+[Trait("Category", "Integration")]
+public class SolutionInitializationIntegrationTests : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly TestRepoManager _repoManager;
+    private readonly SolutionInitializer _initializer;
+
+    // Test repositories - easily extensible for future projects
+    // Using smaller, well-maintained projects for faster tests
+    public static IEnumerable<object[]> TestRepos => new List<object[]>
+    {
+        // Small well-known project with solution file
+        new object[] { new GitHubTestRepo("dotnet", "try-convert", "v0.9.232202", 5) },
+    };
+
+    public SolutionInitializationIntegrationTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _repoManager = new TestRepoManager();
+        _initializer = new SolutionInitializer();
+    }
+
+    public void Dispose()
+    {
+        _repoManager.Dispose();
+    }
+
+    [Theory(Skip = "Integration test - requires network access")]
+    [MemberData(nameof(TestRepos))]
+    public async Task Init_RealGitHubProject_InitializesProjects(GitHubTestRepo repo)
+    {
+        // Arrange
+        _output.WriteLine($"Testing: {repo.DisplayName}");
+        var repoPath = await _repoManager.CloneAsync(repo);
+        _output.WriteLine($"Cloned to: {repoPath}");
+
+        // Find solution file
+        var solutionDetector = new SolutionDetector();
+        var detection = solutionDetector.Detect(repoPath);
+
+        if (!detection.IsSuccess)
+        {
+            _output.WriteLine($"No solution found, skipping: {detection.ErrorMessage}");
+            return;
+        }
+
+        _output.WriteLine($"Found solution: {detection.SolutionPath}");
+
+        // Act
+        var result = await _initializer.InitializeAsync(detection.SolutionPath!, force: false);
+
+        // Assert
+        _output.WriteLine($"Result: Success={result.IsSuccess}, " +
+                         $"Total={result.TotalProjects}, " +
+                         $"Initialized={result.InitializedCount}, " +
+                         $"Skipped={result.SkippedCount}");
+
+        Assert.True(result.IsSuccess, result.ErrorMessage);
+        Assert.True(result.TotalProjects >= 1, $"Expected at least 1 project, found {result.TotalProjects}");
+        Assert.True(result.InitializedCount > 0, "Expected at least one project to be initialized");
+
+        // Verify via audit
+        var solutionDir = Path.GetDirectoryName(detection.SolutionPath!)!;
+        var audit = SolutionInitAudit.Audit(solutionDir);
+        _output.WriteLine(audit.ToString());
+
+        Assert.True(audit.InitializedProjects > 0, "Audit found no initialized projects");
+    }
+
+    [Theory(Skip = "Integration test - requires network access")]
+    [MemberData(nameof(TestRepos))]
+    public async Task Init_RealGitHubProject_CreatesAiFilesInSolutionRoot(GitHubTestRepo repo)
+    {
+        // Arrange
+        _output.WriteLine($"Testing: {repo.DisplayName}");
+        var repoPath = await _repoManager.CloneAsync(repo);
+
+        var solutionDetector = new SolutionDetector();
+        var detection = solutionDetector.Detect(repoPath);
+
+        if (!detection.IsSuccess)
+        {
+            _output.WriteLine($"No solution found, skipping");
+            return;
+        }
+
+        var aiInitializer = new ClaudeInitializer();
+
+        // Act
+        var result = await _initializer.InitializeAsync(
+            detection.SolutionPath!, force: false, aiInitializer);
+
+        // Assert
+        Assert.True(result.IsSuccess, result.ErrorMessage);
+        Assert.Equal("Claude Code", result.AgentName);
+
+        var solutionDir = Path.GetDirectoryName(detection.SolutionPath!)!;
+        var audit = SolutionInitAudit.Audit(solutionDir);
+        _output.WriteLine(audit.ToString());
+
+        Assert.True(audit.HasClaudeMd, "CLAUDE.md should exist in solution root");
+        Assert.True(audit.HasSkills, "OPAL skills should exist");
+        Assert.True(audit.HasHooks, "Hooks should be configured");
+    }
+
+    [Fact]
+    public async Task Init_LocalMockSolution_InitializesAllProjects()
+    {
+        // This test doesn't require network access - uses local mock
+        var testDir = Path.Combine(Path.GetTempPath(), $"opal-int-test-{Guid.NewGuid():N}");
+
+        try
+        {
+            // Setup mock solution with multiple projects
+            Directory.CreateDirectory(testDir);
+            SetupMockSolution(testDir, projectCount: 5);
+
+            var slnPath = Path.Combine(testDir, "MockSolution.sln");
+
+            // Act
+            var result = await _initializer.InitializeAsync(slnPath, force: false);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal(5, result.TotalProjects);
+            Assert.Equal(5, result.InitializedCount);
+
+            var audit = SolutionInitAudit.Audit(testDir);
+            Assert.Equal(5, audit.TotalProjects);
+            Assert.Equal(5, audit.InitializedProjects);
+            Assert.Empty(audit.MissingTargets);
+        }
+        finally
+        {
+            if (Directory.Exists(testDir))
+            {
+                Directory.Delete(testDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Init_LocalMockSolution_WithAi_CreatesFilesCorrectly()
+    {
+        var testDir = Path.Combine(Path.GetTempPath(), $"opal-int-test-{Guid.NewGuid():N}");
+
+        try
+        {
+            Directory.CreateDirectory(testDir);
+            SetupMockSolution(testDir, projectCount: 3);
+
+            var slnPath = Path.Combine(testDir, "MockSolution.sln");
+            var aiInitializer = new ClaudeInitializer();
+
+            // Act
+            var result = await _initializer.InitializeAsync(slnPath, force: false, aiInitializer);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal("Claude Code", result.AgentName);
+
+            var audit = SolutionInitAudit.Audit(testDir);
+            Assert.True(audit.HasClaudeMd, "CLAUDE.md should exist");
+            Assert.True(audit.HasSkills, "Skills should exist");
+            Assert.True(audit.HasHooks, "Hooks should be configured");
+            Assert.Equal(3, audit.InitializedProjects);
+        }
+        finally
+        {
+            if (Directory.Exists(testDir))
+            {
+                Directory.Delete(testDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Init_MixedSdkAndLegacyProjects_InitializesOnlySdkProjects()
+    {
+        var testDir = Path.Combine(Path.GetTempPath(), $"opal-int-test-{Guid.NewGuid():N}");
+
+        try
+        {
+            Directory.CreateDirectory(testDir);
+            SetupMockSolutionWithMixedProjects(testDir);
+
+            var slnPath = Path.Combine(testDir, "Mixed.sln");
+
+            // Act
+            var result = await _initializer.InitializeAsync(slnPath, force: false);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal(4, result.TotalProjects); // 2 SDK + 2 legacy
+            Assert.Equal(2, result.InitializedCount); // Only SDK projects
+            Assert.Equal(2, result.SkippedCount); // Legacy projects skipped
+
+            // Warnings should mention non-SDK projects
+            Assert.Contains(result.Warnings, w => w.Contains("Non-SDK-style") || w.Contains("skipped"));
+        }
+        finally
+        {
+            if (Directory.Exists(testDir))
+            {
+                Directory.Delete(testDir, recursive: true);
+            }
+        }
+    }
+
+    #region Mock Solution Setup Helpers
+
+    private void SetupMockSolution(string baseDir, int projectCount)
+    {
+        var slnBuilder = new System.Text.StringBuilder();
+        slnBuilder.AppendLine("Microsoft Visual Studio Solution File, Format Version 12.00");
+
+        for (int i = 1; i <= projectCount; i++)
+        {
+            var projectName = $"Project{i}";
+            var projectDir = Path.Combine(baseDir, "src", projectName);
+            Directory.CreateDirectory(projectDir);
+
+            var csprojPath = Path.Combine(projectDir, $"{projectName}.csproj");
+            File.WriteAllText(csprojPath, SdkStyleCsproj);
+
+            var guid = Guid.NewGuid().ToString().ToUpper();
+            slnBuilder.AppendLine($"Project(\"{{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}}\") = \"{projectName}\", \"src\\{projectName}\\{projectName}.csproj\", \"{{{guid}}}\"");
+            slnBuilder.AppendLine("EndProject");
+        }
+
+        slnBuilder.AppendLine("Global");
+        slnBuilder.AppendLine("EndGlobal");
+
+        File.WriteAllText(Path.Combine(baseDir, "MockSolution.sln"), slnBuilder.ToString());
+    }
+
+    private void SetupMockSolutionWithMixedProjects(string baseDir)
+    {
+        var slnBuilder = new System.Text.StringBuilder();
+        slnBuilder.AppendLine("Microsoft Visual Studio Solution File, Format Version 12.00");
+
+        // SDK-style projects
+        CreateProjectInSolution(baseDir, slnBuilder, "SdkProject1", SdkStyleCsproj);
+        CreateProjectInSolution(baseDir, slnBuilder, "SdkProject2", SdkStyleCsproj);
+
+        // Legacy projects
+        CreateProjectInSolution(baseDir, slnBuilder, "LegacyProject1", LegacyStyleCsproj);
+        CreateProjectInSolution(baseDir, slnBuilder, "LegacyProject2", LegacyStyleCsproj);
+
+        slnBuilder.AppendLine("Global");
+        slnBuilder.AppendLine("EndGlobal");
+
+        File.WriteAllText(Path.Combine(baseDir, "Mixed.sln"), slnBuilder.ToString());
+    }
+
+    private void CreateProjectInSolution(string baseDir, System.Text.StringBuilder slnBuilder, string projectName, string csprojContent)
+    {
+        var projectDir = Path.Combine(baseDir, "src", projectName);
+        Directory.CreateDirectory(projectDir);
+
+        var csprojPath = Path.Combine(projectDir, $"{projectName}.csproj");
+        File.WriteAllText(csprojPath, csprojContent);
+
+        var guid = Guid.NewGuid().ToString().ToUpper();
+        slnBuilder.AppendLine($"Project(\"{{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}}\") = \"{projectName}\", \"src\\{projectName}\\{projectName}.csproj\", \"{{{guid}}}\"");
+        slnBuilder.AppendLine("EndProject");
+    }
+
+    private const string SdkStyleCsproj = """
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>net8.0</TargetFramework>
+          </PropertyGroup>
+        </Project>
+        """;
+
+    private const string LegacyStyleCsproj = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+          <PropertyGroup>
+            <OutputType>Library</OutputType>
+            <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+          </PropertyGroup>
+        </Project>
+        """;
+
+    #endregion
+}

--- a/tests/Opal.Compiler.Tests/SolutionInitializerTests.cs
+++ b/tests/Opal.Compiler.Tests/SolutionInitializerTests.cs
@@ -1,0 +1,394 @@
+using Opal.Compiler.Init;
+using Xunit;
+
+namespace Opal.Compiler.Tests;
+
+public class SolutionInitializerTests : IDisposable
+{
+    private readonly string _testDir;
+    private readonly SolutionInitializer _initializer;
+
+    public SolutionInitializerTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), $"opal-sln-init-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDir);
+        _initializer = new SolutionInitializer();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir))
+        {
+            Directory.Delete(_testDir, recursive: true);
+        }
+    }
+
+    #region Basic Initialization Tests
+
+    [Fact]
+    public async Task InitializeAsync_SolutionWithProjects_InitializesAllProjects()
+    {
+        // Arrange
+        SetupSolutionWithProjects();
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+
+        // Act
+        var result = await _initializer.InitializeAsync(slnPath, force: false);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.TotalProjects);
+        Assert.Equal(2, result.InitializedCount);
+        Assert.Equal(0, result.SkippedCount);
+        Assert.Equal(0, result.FailedCount);
+
+        // Verify projects have OPAL targets
+        var project1Path = Path.Combine(_testDir, "src", "Project1", "Project1.csproj");
+        var project2Path = Path.Combine(_testDir, "src", "Project2", "Project2.csproj");
+        Assert.Contains("CompileOpalFiles", File.ReadAllText(project1Path));
+        Assert.Contains("CompileOpalFiles", File.ReadAllText(project2Path));
+    }
+
+    [Fact]
+    public async Task InitializeAsync_SlnxSolution_InitializesAllProjects()
+    {
+        // Arrange
+        SetupSlnxSolutionWithProjects();
+        var slnxPath = Path.Combine(_testDir, "Test.slnx");
+
+        // Act
+        var result = await _initializer.InitializeAsync(slnxPath, force: false);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.TotalProjects);
+        Assert.Equal(2, result.InitializedCount);
+
+        // Verify projects have OPAL targets
+        var project1Path = Path.Combine(_testDir, "src", "Project1", "Project1.csproj");
+        Assert.Contains("CompileOpalFiles", File.ReadAllText(project1Path));
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithAiInitializer_CreatesAiFilesInSolutionDir()
+    {
+        // Arrange
+        SetupSolutionWithProjects();
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+        var aiInitializer = new ClaudeInitializer();
+
+        // Act
+        var result = await _initializer.InitializeAsync(slnPath, force: false, aiInitializer);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Claude Code", result.AgentName);
+
+        // AI files should be in solution directory, not project directories
+        Assert.True(File.Exists(Path.Combine(_testDir, "CLAUDE.md")));
+        Assert.True(Directory.Exists(Path.Combine(_testDir, ".claude", "skills", "opal")));
+        Assert.True(File.Exists(Path.Combine(_testDir, ".claude", "settings.json")));
+
+        // AI files should NOT be in project directories
+        Assert.False(File.Exists(Path.Combine(_testDir, "src", "Project1", "CLAUDE.md")));
+    }
+
+    #endregion
+
+    #region Error Handling Tests
+
+    [Fact]
+    public async Task InitializeAsync_MissingProjectFile_SkipsWithWarning()
+    {
+        // Arrange - Create solution but only one project
+        SetupSolutionWithMissingProject();
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+
+        // Act
+        var result = await _initializer.InitializeAsync(slnPath, force: false);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.InitializedCount);
+        Assert.Equal(1, result.SkippedCount);
+        Assert.Contains(result.Warnings, w => w.Contains("not found"));
+    }
+
+    [Fact]
+    public async Task InitializeAsync_NonSdkProject_SkipsWithWarning()
+    {
+        // Arrange
+        SetupSolutionWithLegacyProject();
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+
+        // Act
+        var result = await _initializer.InitializeAsync(slnPath, force: false);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.InitializedCount);
+        Assert.Equal(1, result.SkippedCount);
+        Assert.Contains(result.Warnings, w => w.Contains("Non-SDK-style"));
+    }
+
+    [Fact]
+    public async Task InitializeAsync_SolutionNotFound_ReturnsError()
+    {
+        // Act
+        var result = await _initializer.InitializeAsync(
+            Path.Combine(_testDir, "NonExistent.sln"), force: false);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Solution file not found", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_AllProjectsFail_ReturnsError()
+    {
+        // Arrange - Solution with only legacy projects
+        SetupSolutionWithOnlyLegacyProjects();
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+
+        // Act
+        var result = await _initializer.InitializeAsync(slnPath, force: false);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("No projects could be initialized", result.ErrorMessage);
+    }
+
+    #endregion
+
+    #region Force Option Tests
+
+    [Fact]
+    public async Task InitializeAsync_AlreadyInitialized_SkipsWithoutForce()
+    {
+        // Arrange
+        SetupSolutionWithProjects();
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+
+        // First initialization
+        await _initializer.InitializeAsync(slnPath, force: false);
+
+        // Act - Second initialization without force
+        var result = await _initializer.InitializeAsync(slnPath, force: false);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, result.InitializedCount);
+        Assert.Equal(2, result.AlreadyInitializedCount);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_AlreadyInitialized_ReinitializesWithForce()
+    {
+        // Arrange
+        SetupSolutionWithProjects();
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+
+        // First initialization
+        await _initializer.InitializeAsync(slnPath, force: false);
+
+        // Act - Second initialization with force
+        var result = await _initializer.InitializeAsync(slnPath, force: true);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.InitializedCount);
+        Assert.Equal(0, result.AlreadyInitializedCount);
+    }
+
+    #endregion
+
+    #region Output Verification Tests
+
+    [Fact]
+    public async Task InitializeAsync_ReturnsCorrectSolutionInfo()
+    {
+        // Arrange
+        SetupSolutionWithProjects();
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+
+        // Act
+        var result = await _initializer.InitializeAsync(slnPath, force: false);
+
+        // Assert
+        Assert.Equal(slnPath, result.SolutionPath);
+        Assert.Equal("Test.sln", result.SolutionName);
+        Assert.Equal(2, result.TotalProjects);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_ReturnsProjectResults()
+    {
+        // Arrange
+        SetupSolutionWithProjects();
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+
+        // Act
+        var result = await _initializer.InitializeAsync(slnPath, force: false);
+
+        // Assert
+        Assert.Equal(2, result.ProjectResults.Count);
+        Assert.All(result.ProjectResults, pr =>
+        {
+            Assert.Equal(InitStatus.Initialized, pr.Status);
+            Assert.NotNull(pr.ProjectName);
+            Assert.NotNull(pr.ProjectPath);
+        });
+    }
+
+    [Fact]
+    public async Task InitializeAsync_ReturnsUpdatedFilesList()
+    {
+        // Arrange
+        SetupSolutionWithProjects();
+        var slnPath = Path.Combine(_testDir, "Test.sln");
+
+        // Act
+        var result = await _initializer.InitializeAsync(slnPath, force: false);
+
+        // Assert
+        Assert.Equal(2, result.UpdatedFiles.Count);
+        Assert.All(result.UpdatedFiles, f => Assert.EndsWith(".csproj", f));
+    }
+
+    #endregion
+
+    #region Setup Helpers
+
+    private void SetupSolutionWithProjects()
+    {
+        // Create solution file
+        var slnContent = """
+            Microsoft Visual Studio Solution File, Format Version 12.00
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project1", "src\Project1\Project1.csproj", "{12345678-1234-1234-1234-123456789012}"
+            EndProject
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project2", "src\Project2\Project2.csproj", "{12345678-1234-1234-1234-123456789013}"
+            EndProject
+            Global
+            EndGlobal
+            """;
+        File.WriteAllText(Path.Combine(_testDir, "Test.sln"), slnContent);
+
+        // Create project directories and files
+        var project1Dir = Path.Combine(_testDir, "src", "Project1");
+        var project2Dir = Path.Combine(_testDir, "src", "Project2");
+        Directory.CreateDirectory(project1Dir);
+        Directory.CreateDirectory(project2Dir);
+
+        File.WriteAllText(Path.Combine(project1Dir, "Project1.csproj"), SdkStyleCsproj);
+        File.WriteAllText(Path.Combine(project2Dir, "Project2.csproj"), SdkStyleCsproj);
+    }
+
+    private void SetupSlnxSolutionWithProjects()
+    {
+        // Create solution file
+        var slnxContent = """
+            <Solution>
+              <Project Path="src/Project1/Project1.csproj" />
+              <Project Path="src/Project2/Project2.csproj" />
+            </Solution>
+            """;
+        File.WriteAllText(Path.Combine(_testDir, "Test.slnx"), slnxContent);
+
+        // Create project directories and files
+        var project1Dir = Path.Combine(_testDir, "src", "Project1");
+        var project2Dir = Path.Combine(_testDir, "src", "Project2");
+        Directory.CreateDirectory(project1Dir);
+        Directory.CreateDirectory(project2Dir);
+
+        File.WriteAllText(Path.Combine(project1Dir, "Project1.csproj"), SdkStyleCsproj);
+        File.WriteAllText(Path.Combine(project2Dir, "Project2.csproj"), SdkStyleCsproj);
+    }
+
+    private void SetupSolutionWithMissingProject()
+    {
+        // Create solution referencing two projects, but only create one
+        var slnContent = """
+            Microsoft Visual Studio Solution File, Format Version 12.00
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project1", "src\Project1\Project1.csproj", "{12345678-1234-1234-1234-123456789012}"
+            EndProject
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project2", "src\Project2\Project2.csproj", "{12345678-1234-1234-1234-123456789013}"
+            EndProject
+            Global
+            EndGlobal
+            """;
+        File.WriteAllText(Path.Combine(_testDir, "Test.sln"), slnContent);
+
+        // Only create Project1
+        var project1Dir = Path.Combine(_testDir, "src", "Project1");
+        Directory.CreateDirectory(project1Dir);
+        File.WriteAllText(Path.Combine(project1Dir, "Project1.csproj"), SdkStyleCsproj);
+    }
+
+    private void SetupSolutionWithLegacyProject()
+    {
+        var slnContent = """
+            Microsoft Visual Studio Solution File, Format Version 12.00
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModernProject", "src\ModernProject\ModernProject.csproj", "{12345678-1234-1234-1234-123456789012}"
+            EndProject
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LegacyProject", "src\LegacyProject\LegacyProject.csproj", "{12345678-1234-1234-1234-123456789013}"
+            EndProject
+            Global
+            EndGlobal
+            """;
+        File.WriteAllText(Path.Combine(_testDir, "Test.sln"), slnContent);
+
+        var modernDir = Path.Combine(_testDir, "src", "ModernProject");
+        var legacyDir = Path.Combine(_testDir, "src", "LegacyProject");
+        Directory.CreateDirectory(modernDir);
+        Directory.CreateDirectory(legacyDir);
+
+        File.WriteAllText(Path.Combine(modernDir, "ModernProject.csproj"), SdkStyleCsproj);
+        File.WriteAllText(Path.Combine(legacyDir, "LegacyProject.csproj"), LegacyStyleCsproj);
+    }
+
+    private void SetupSolutionWithOnlyLegacyProjects()
+    {
+        var slnContent = """
+            Microsoft Visual Studio Solution File, Format Version 12.00
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LegacyProject1", "src\LegacyProject1\LegacyProject1.csproj", "{12345678-1234-1234-1234-123456789012}"
+            EndProject
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LegacyProject2", "src\LegacyProject2\LegacyProject2.csproj", "{12345678-1234-1234-1234-123456789013}"
+            EndProject
+            Global
+            EndGlobal
+            """;
+        File.WriteAllText(Path.Combine(_testDir, "Test.sln"), slnContent);
+
+        var legacy1Dir = Path.Combine(_testDir, "src", "LegacyProject1");
+        var legacy2Dir = Path.Combine(_testDir, "src", "LegacyProject2");
+        Directory.CreateDirectory(legacy1Dir);
+        Directory.CreateDirectory(legacy2Dir);
+
+        File.WriteAllText(Path.Combine(legacy1Dir, "LegacyProject1.csproj"), LegacyStyleCsproj);
+        File.WriteAllText(Path.Combine(legacy2Dir, "LegacyProject2.csproj"), LegacyStyleCsproj);
+    }
+
+    #endregion
+
+    #region Test Data
+
+    private const string SdkStyleCsproj = """
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>net8.0</TargetFramework>
+          </PropertyGroup>
+        </Project>
+        """;
+
+    private const string LegacyStyleCsproj = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+          <PropertyGroup>
+            <OutputType>Library</OutputType>
+            <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+          </PropertyGroup>
+        </Project>
+        """;
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Expand `opalc init` to work with .NET solutions (.sln and .slnx files)
- When a solution is detected, AI agent files are created in the **solution directory** and OPAL MSBuild targets are added to **each project**
- Auto-detection priority: `.slnx` → `.sln` → `.csproj` fallback

## Changes

### New Files
- `SolutionParser.cs` - Parses .sln (text regex) and .slnx (XML) formats
- `SolutionDetector.cs` - Detects and validates solution files
- `SolutionInitializer.cs` - Orchestrates multi-project initialization

### Modified
- `InitCommand.cs` - Added `--solution/-s` option, auto-detection logic

### Tests
- 30 unit tests for SolutionDetector and SolutionInitializer
- 5 integration tests (3 local mock, 2 real GitHub repo tests)
- Test helpers: GitHubTestRepo.cs, SolutionInitAudit.cs

## Test Results

Tested against real GitHub projects:

| Project | Projects | Initialized | Skipped | Result |
|---------|----------|-------------|---------|--------|
| dotnet/try-convert | 10 | 10 | 0 | ✅ |
| NuGet/NuGet.Client | 93 | 92 | 1 (legacy) | ✅ |

## Example Output

```
Initialized OPAL solution for Claude Code (opalc v0.1.3)

Solution: NuGet.sln (93 projects)

Created files:
  .claude/skills/opal/SKILL.md
  .claude/skills/opal-convert/SKILL.md
  CLAUDE.md
  .claude/settings.json

Updated projects:
  src/NuGet.Core/NuGet.Versioning/NuGet.Versioning.csproj
  ... (92 projects)

MSBuild configuration:
  - Added OPAL compilation targets to 92 projects

Warning: Non-SDK-style project skipped: TestableVSCredentialProvider
```

🤖 Generated with [Claude Code](https://claude.ai/code)