### PR TITLE
Add comprehensive NuGet package metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.4] - 2025-02-02
+
+### Added
+- Enum support for C# to OPAL conversion
+- Support for explicit enum values and underlying types
+- OPAL syntax: `§ENUM{id:Name}` and `§ENUM{id:Name:underlyingType}`
+
+### Changed
+- Updated documentation to reflect current feature support status
+
+### Fixed
+- Type mappings documentation for DateTime, Guid, ReadList, ReadDict
+
+## [0.1.3] - Previous Release
+- Type mappings for DateTime, Guid, and read-only collections
+
+## [0.1.0] - Initial Release
+- Initial public release of OPAL compiler

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,4 +21,13 @@
     <Product>OPAL Compiler</Product>
     <Copyright>Copyright © 2024</Copyright>
   </PropertyGroup>
+
+  <PropertyGroup Label="NuGet Package Metadata">
+    <Authors>Juan Rivera</Authors>
+    <PackageProjectUrl>https://github.com/juanmicrosoft/opal</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/juanmicrosoft/opal</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>opal;compiler;dsl;code-generation;dotnet;csharp</PackageTags>
+  </PropertyGroup>
 </Project>

--- a/src/Opal.Compiler/Opal.Compiler.csproj
+++ b/src/Opal.Compiler/Opal.Compiler.csproj
@@ -10,10 +10,9 @@
     <ToolCommandName>opalc</ToolCommandName>
     <PackageId>opalc</PackageId>
     <Version>0.1.4</Version>
-    <Description>OPAL compiler - Optimized Programming for Agent Language</Description>
-    <PackageProjectUrl>https://github.com/juanmicrosoft/opal-2</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Description>OPAL compiler CLI - Convert C# to OPAL and compile OPAL to C#</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>See https://github.com/juanmicrosoft/opal/blob/main/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Opal.Sdk/Opal.Sdk.csproj
+++ b/src/Opal.Sdk/Opal.Sdk.csproj
@@ -8,7 +8,10 @@
     <IsPackable>true</IsPackable>
     <PackageId>Opal.Sdk</PackageId>
     <PackageType>MSBuildSdk</PackageType>
-    <Description>MSBuild SDK for building OPAL projects</Description>
+    <Version>0.1.4</Version>
+    <Description>MSBuild SDK for building OPAL projects. Use with Sdk="Opal.Sdk/0.1.4"</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>See https://github.com/juanmicrosoft/opal/blob/main/CHANGELOG.md</PackageReleaseNotes>
 
     <!-- Suppress NU5128 warning about dependency groups -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
@@ -33,6 +36,7 @@
   <ItemGroup>
     <None Include="Sdk\Sdk.props" Pack="true" PackagePath="Sdk" />
     <None Include="Sdk\Sdk.targets" Pack="true" PackagePath="Sdk" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <!-- Include task assemblies in the package -->

--- a/src/Opal.Tasks/Opal.Tasks.csproj
+++ b/src/Opal.Tasks/Opal.Tasks.csproj
@@ -5,8 +5,15 @@
     <RootNamespace>Opal.Tasks</RootNamespace>
     <IsPackable>true</IsPackable>
     <PackageId>Opal.Tasks</PackageId>
-    <Description>MSBuild tasks for compiling OPAL source files</Description>
+    <Version>0.1.4</Version>
+    <Description>MSBuild tasks for compiling OPAL source files to C#</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>See https://github.com/juanmicrosoft/opal/blob/main/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.0.2" />


### PR DESCRIPTION
## Summary
- Create CHANGELOG.md documenting version history (0.1.0, 0.1.3, 0.1.4)
- Add centralized NuGet metadata in Directory.Build.props (Authors, PackageTags, RepositoryUrl, License)
- Update all three distributable packages (opalc, Opal.Sdk, Opal.Tasks) with PackageReleaseNotes and PackageReadmeFile

## Test plan
- [x] Verified `dotnet pack` succeeds for all three packages
- [x] Verified nuspec files contain all expected metadata fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)