### PR TITLE
Complete Opal to Calor rebrand in docs and website

### DIFF
--- a/docs/cli/analyze.md
+++ b/docs/cli/analyze.md
@@ -6,12 +6,12 @@ nav_order: 1
 permalink: /cli/analyze/
 ---
 
-# calorc analyze
+# calor analyze
 
 Score C# files for Calor migration potential.
 
 ```bash
-calorc analyze <path> [options]
+calor analyze <path> [options]
 ```
 
 ---
@@ -32,13 +32,13 @@ Use this command to:
 
 ```bash
 # Analyze current directory
-calorc analyze .
+calor analyze .
 
 # Analyze with detailed breakdown
-calorc analyze ./src --verbose
+calor analyze ./src --verbose
 
 # Export as JSON for processing
-calorc analyze ./src --format json --output analysis.json
+calor analyze ./src --format json --output analysis.json
 ```
 
 ---
@@ -135,7 +135,7 @@ With `--verbose`, each file shows dimension breakdown:
 Machine-readable format for processing:
 
 ```bash
-calorc analyze ./src --format json --output analysis.json
+calor analyze ./src --format json --output analysis.json
 ```
 
 ```json
@@ -189,7 +189,7 @@ calorc analyze ./src --format json --output analysis.json
 [SARIF](https://sarifweb.azurewebsites.net/) (Static Analysis Results Interchange Format) for IDE and CI/CD integration:
 
 ```bash
-calorc analyze ./src --format sarif --output analysis.sarif
+calor analyze ./src --format sarif --output analysis.sarif
 ```
 
 SARIF output integrates with:
@@ -214,7 +214,7 @@ Use exit code `1` in CI/CD to flag codebases with high migration potential:
 
 ```bash
 # Fail CI if high-priority migration candidates exist
-calorc analyze ./src --threshold 51
+calor analyze ./src --threshold 51
 if [ $? -eq 1 ]; then
   echo "High-priority Calor migration candidates found"
 fi
@@ -228,7 +228,7 @@ fi
 
 ```bash
 # Show top 10 files scoring above 50
-calorc analyze ./src --threshold 50 --top 10
+calor analyze ./src --threshold 50 --top 10
 ```
 
 ### CI/CD Integration
@@ -237,7 +237,7 @@ calorc analyze ./src --threshold 50 --top 10
 # GitHub Actions example
 - name: Analyze Calor migration potential
   run: |
-    calorc analyze ./src --format sarif --output calor-analysis.sarif
+    calor analyze ./src --format sarif --output calor-analysis.sarif
 
 - name: Upload SARIF
   uses: github/codeql-action/upload-sarif@v2
@@ -249,7 +249,7 @@ calorc analyze ./src --threshold 50 --top 10
 
 ```bash
 # Full JSON report for documentation
-calorc analyze . --format json --output migration-report.json
+calor analyze . --format json --output migration-report.json
 
 # Parse with jq to find critical files
 cat migration-report.json | jq '.files[] | select(.priority == "critical") | .path'
@@ -259,7 +259,7 @@ cat migration-report.json | jq '.files[] | select(.priority == "critical") | .pa
 
 ```bash
 # Deep dive into a specific directory
-calorc analyze ./src/Services --verbose --top 50
+calor analyze ./src/Services --verbose --top 50
 ```
 
 ---

--- a/docs/cli/benchmark.md
+++ b/docs/cli/benchmark.md
@@ -6,12 +6,12 @@ nav_order: 5
 permalink: /cli/benchmark/
 ---
 
-# calorc benchmark
+# calor benchmark
 
 Compare Calor vs C# across evaluation metrics.
 
 ```bash
-calorc benchmark [project] [options]
+calor benchmark [project] [options]
 ```
 
 ---
@@ -36,16 +36,16 @@ Use this to quantify Calor's advantages for AI-assisted development.
 
 ```bash
 # Compare two files
-calorc benchmark --calor Calculator.calor --csharp Calculator.cs
+calor benchmark --calor Calculator.calr --csharp Calculator.cs
 
 # Benchmark entire project
-calorc benchmark ./src
+calor benchmark ./src
 
 # Quick token-only comparison
-calorc benchmark --calor file.calor --csharp file.cs --quick
+calor benchmark --calor file.calr --csharp file.cs --quick
 
 # Generate markdown report
-calorc benchmark ./src --format markdown --output report.md
+calor benchmark ./src --format markdown --output report.md
 ```
 
 ---
@@ -87,7 +87,7 @@ calorc benchmark ./src --format markdown --output report.md
 Compare a specific Calor file against its C# equivalent:
 
 ```bash
-calorc benchmark --calor PaymentService.calor --csharp PaymentService.cs
+calor benchmark --calor PaymentService.calr --csharp PaymentService.cs
 ```
 
 Output:
@@ -95,7 +95,7 @@ Output:
 === Calor vs C# Benchmark ===
 
 Files:
-  Calor: PaymentService.calor
+  Calor: PaymentService.calr
   C#:   PaymentService.cs
 
 Results:
@@ -123,10 +123,10 @@ Calor shows 1.27x overall advantage for AI agent tasks.
 Benchmark all paired files in a project:
 
 ```bash
-calorc benchmark ./src
+calor benchmark ./src
 ```
 
-The command finds files with matching base names (e.g., `UserService.calor` and `UserService.cs`) and benchmarks each pair.
+The command finds files with matching base names (e.g., `UserService.calr` and `UserService.cs`) and benchmarks each pair.
 
 Output:
 ```
@@ -157,7 +157,7 @@ Per-File Breakdown:
 For fast token/line comparison without the full 7-metric evaluation:
 
 ```bash
-calorc benchmark --calor file.calor --csharp file.cs --quick
+calor benchmark --calor file.calr --csharp file.cs --quick
 ```
 
 Output:
@@ -180,7 +180,7 @@ Output:
 Use `--verbose` for detailed metric breakdown:
 
 ```bash
-calorc benchmark --calor file.calor --csharp file.cs --verbose
+calor benchmark --calor file.calr --csharp file.cs --verbose
 ```
 
 Shows individual metrics within each category:
@@ -210,7 +210,7 @@ Human-readable tables and summaries in the terminal.
 ### Markdown
 
 ```bash
-calorc benchmark ./src --format markdown --output benchmark.md
+calor benchmark ./src --format markdown --output benchmark.md
 ```
 
 Creates a markdown report suitable for documentation or GitHub.
@@ -218,7 +218,7 @@ Creates a markdown report suitable for documentation or GitHub.
 ### JSON
 
 ```bash
-calorc benchmark ./src --format json --output benchmark.json
+calor benchmark ./src --format json --output benchmark.json
 ```
 
 Creates machine-readable output:
@@ -246,7 +246,7 @@ Creates machine-readable output:
     "files": [
       {
         "name": "PaymentService",
-        "calorPath": "src/PaymentService.calor",
+        "calorPath": "src/PaymentService.calr",
         "csharpPath": "src/PaymentService.cs",
         "advantage": 1.42
       }
@@ -262,7 +262,7 @@ Creates machine-readable output:
 Focus on a specific evaluation category:
 
 ```bash
-calorc benchmark --calor file.calor --csharp file.cs --category TokenEconomics
+calor benchmark --calor file.calr --csharp file.cs --category TokenEconomics
 ```
 
 ---
@@ -332,7 +332,7 @@ Measures end-to-end success:
 
 ## See Also
 
-- [calorc analyze](/calor/cli/analyze/) - Score files for migration potential
-- [calorc convert](/calor/cli/convert/) - Convert files with benchmark option
+- [calor analyze](/calor/cli/analyze/) - Score files for migration potential
+- [calor convert](/calor/cli/convert/) - Convert files with benchmark option
 - [Benchmarking](/calor/benchmarking/) - Detailed methodology documentation
 - [Results](/calor/benchmarking/results/) - Published benchmark results

--- a/docs/cli/compile.md
+++ b/docs/cli/compile.md
@@ -6,19 +6,19 @@ nav_order: 0
 permalink: /cli/compile/
 ---
 
-# calorc (compile)
+# calor (compile)
 
 Compile Calor source files to C#.
 
 ```bash
-calorc --input <file.calor> --output <file.cs>
+calor --input <file.calr> --output <file.cs>
 ```
 
 ---
 
 ## Overview
 
-The default `calorc` command (when no subcommand is specified) compiles Calor source files to C#. This is the core functionality of the Calor compiler.
+The default `calor` command (when no subcommand is specified) compiles Calor source files to C#. This is the core functionality of the Calor compiler.
 
 ---
 
@@ -26,13 +26,13 @@ The default `calorc` command (when no subcommand is specified) compiles Calor so
 
 ```bash
 # Compile a single file
-calorc --input MyModule.calor --output MyModule.g.cs
+calor --input MyModule.calr --output MyModule.g.cs
 
 # Short form
-calorc -i MyModule.calor -o MyModule.g.cs
+calor -i MyModule.calr -o MyModule.g.cs
 
 # With verbose output
-calorc -v -i MyModule.calor -o MyModule.g.cs
+calor -v -i MyModule.calr -o MyModule.g.cs
 ```
 
 ---
@@ -52,7 +52,7 @@ calorc -v -i MyModule.calor -o MyModule.g.cs
 The recommended convention for generated C# files is the `.g.cs` extension:
 
 ```
-MyModule.calor → MyModule.g.cs
+MyModule.calr → MyModule.g.cs
 ```
 
 This indicates "generated C#" and helps distinguish Calor-generated code from hand-written C#.
@@ -76,12 +76,12 @@ The compiler performs these steps:
 Use `--verbose` to see compilation details:
 
 ```bash
-calorc -v -i Calculator.calor -o Calculator.g.cs
+calor -v -i Calculator.calr -o Calculator.g.cs
 ```
 
 Output:
 ```
-Compiling Calculator.calor...
+Compiling Calculator.calr...
   Parsing: OK
   Validating: OK
   Modules: 1
@@ -100,7 +100,7 @@ Compilation successful
 When compilation fails, errors are reported with file location:
 
 ```
-Error in Calculator.calor:12:5
+Error in Calculator.calr:12:5
   Undefined variable 'x' in expression
 
   §R (+ x 1)
@@ -109,13 +109,13 @@ Error in Calculator.calor:12:5
 Compilation failed with 1 error
 ```
 
-For machine-readable error output, use [`calorc diagnose`](/calor/cli/diagnose/).
+For machine-readable error output, use [`calor diagnose`](/calor/cli/diagnose/).
 
 ---
 
 ## Integration with MSBuild
 
-For automatic compilation during `dotnet build`, use [`calorc init`](/calor/cli/init/) to set up MSBuild integration. This eliminates the need to run `calorc` manually.
+For automatic compilation during `dotnet build`, use [`calor init`](/calor/cli/init/) to set up MSBuild integration. This eliminates the need to run `calor` manually.
 
 After initialization:
 
@@ -131,9 +131,9 @@ dotnet build
 To compile multiple files, use shell scripting:
 
 ```bash
-# Compile all .calor files in a directory
-for f in src/*.calor; do
-  calorc -i "$f" -o "${f%.calor}.g.cs"
+# Compile all .calr files in a directory
+for f in src/*.calr; do
+  calor -i "$f" -o "${f%.calr}.g.cs"
 done
 ```
 
@@ -157,7 +157,7 @@ Or use the MSBuild integration which handles this automatically.
 
 ```bash
 # Compile Calor to C#
-calorc -i Program.calor -o Program.g.cs
+calor -i Program.calr -o Program.g.cs
 
 # Build and run with .NET
 dotnet run
@@ -167,18 +167,18 @@ dotnet run
 
 ```bash
 # Output to build directory
-calorc -i src/MyModule.calor -o build/generated/MyModule.g.cs
+calor -i src/MyModule.calr -o build/generated/MyModule.g.cs
 ```
 
 ### Watch Mode (using external tools)
 
 ```bash
 # Using fswatch (macOS)
-fswatch -o src/*.calor | xargs -n1 -I{} calorc -i src/MyModule.calor -o src/MyModule.g.cs
+fswatch -o src/*.calr | xargs -n1 -I{} calor -i src/MyModule.calr -o src/MyModule.g.cs
 
 # Using inotifywait (Linux)
-while inotifywait -e modify src/*.calor; do
-  calorc -i src/MyModule.calor -o src/MyModule.g.cs
+while inotifywait -e modify src/*.calr; do
+  calor -i src/MyModule.calr -o src/MyModule.g.cs
 done
 ```
 
@@ -186,7 +186,7 @@ done
 
 ## See Also
 
-- [calorc init](/calor/cli/init/) - Set up automatic compilation with MSBuild
-- [calorc diagnose](/calor/cli/diagnose/) - Machine-readable diagnostics
-- [calorc format](/calor/cli/format/) - Format Calor source files
+- [calor init](/calor/cli/init/) - Set up automatic compilation with MSBuild
+- [calor diagnose](/calor/cli/diagnose/) - Machine-readable diagnostics
+- [calor format](/calor/cli/format/) - Format Calor source files
 - [Getting Started](/calor/getting-started/) - Installation and first program

--- a/docs/cli/convert.md
+++ b/docs/cli/convert.md
@@ -6,12 +6,12 @@ nav_order: 3
 permalink: /cli/convert/
 ---
 
-# calorc convert
+# calor convert
 
 Convert a single file between C# and Calor.
 
 ```bash
-calorc convert <input> [options]
+calor convert <input> [options]
 ```
 
 ---
@@ -21,7 +21,7 @@ calorc convert <input> [options]
 The `convert` command performs bidirectional conversion between C# and Calor:
 
 - **C# → Calor**: Convert `.cs` files to Calor syntax
-- **Calor → C#**: Convert `.calor` files to generated C#
+- **Calor → C#**: Convert `.calr` files to generated C#
 
 The conversion direction is automatically detected from the input file extension.
 
@@ -31,16 +31,16 @@ The conversion direction is automatically detected from the input file extension
 
 ```bash
 # Convert C# to Calor
-calorc convert MyService.cs
+calor convert MyService.cs
 
 # Convert Calor to C#
-calorc convert MyService.calor
+calor convert MyService.calr
 
 # Specify output path
-calorc convert MyService.cs --output src/MyService.calor
+calor convert MyService.cs --output src/MyService.calr
 
 # Include benchmark comparison
-calorc convert MyService.cs --benchmark
+calor convert MyService.cs --benchmark
 ```
 
 ---
@@ -49,7 +49,7 @@ calorc convert MyService.cs --benchmark
 
 | Argument | Required | Description |
 |:---------|:---------|:------------|
-| `input` | Yes | The source file to convert (`.cs` or `.calor`) |
+| `input` | Yes | The source file to convert (`.cs` or `.calr`) |
 
 ---
 
@@ -69,8 +69,8 @@ If `--output` is not specified:
 
 | Input | Output |
 |:------|:-------|
-| `MyFile.cs` | `MyFile.calor` |
-| `MyFile.calor` | `MyFile.g.cs` |
+| `MyFile.cs` | `MyFile.calr` |
+| `MyFile.calr` | `MyFile.g.cs` |
 
 ---
 
@@ -105,7 +105,7 @@ When converting C# to Calor, the converter:
 The converter reports patterns it can't perfectly translate:
 
 ```
-Converting MyService.cs → MyService.calor
+Converting MyService.cs → MyService.calr
   Warning: Complex LINQ query at line 42 - manual review recommended
   Warning: Async method at line 78 - converted to sync equivalent
 
@@ -119,7 +119,7 @@ Conversion complete with 2 warnings
 When converting Calor to C#, the converter generates idiomatic C# code:
 
 ```bash
-calorc convert Calculator.calor
+calor convert Calculator.calr
 ```
 
 Output includes:
@@ -135,12 +135,12 @@ Output includes:
 Use `--benchmark` to see how the Calor version compares to C#:
 
 ```bash
-calorc convert PaymentService.cs --benchmark
+calor convert PaymentService.cs --benchmark
 ```
 
 Output:
 ```
-Converting PaymentService.cs → PaymentService.calor
+Converting PaymentService.cs → PaymentService.calr
 
 Benchmark Comparison:
 ┌─────────────────┬────────┬────────┬──────────┐
@@ -151,7 +151,7 @@ Benchmark Comparison:
 │ Characters      │ 4,521  │ 2,891  │ 36.1%    │
 └─────────────────┴────────┴────────┴──────────┘
 
-Conversion complete: PaymentService.calor
+Conversion complete: PaymentService.calr
 ```
 
 ---
@@ -161,12 +161,12 @@ Conversion complete: PaymentService.calor
 Use `--verbose` to see detailed conversion progress:
 
 ```bash
-calorc convert MyService.cs --verbose
+calor convert MyService.cs --verbose
 ```
 
 Output:
 ```
-Converting MyService.cs → MyService.calor
+Converting MyService.cs → MyService.calr
 
 Parsing C# source...
   Found: 1 namespace, 2 classes, 8 methods, 3 properties
@@ -187,7 +187,7 @@ Detecting effects:
 Generating contracts:
   f002: Added §Q (!= input null) from null check at line 24
 
-Writing output: MyService.calor
+Writing output: MyService.calr
 Conversion complete with 1 warning
 ```
 
@@ -199,10 +199,10 @@ Conversion complete with 1 warning
 
 ```bash
 # Convert a service class
-calorc convert src/Services/UserService.cs
+calor convert src/Services/UserService.cs
 
 # Convert back to C#
-calorc convert src/Services/UserService.calor
+calor convert src/Services/UserService.calr
 ```
 
 ### Batch Conversion with Shell
@@ -210,11 +210,11 @@ calorc convert src/Services/UserService.calor
 ```bash
 # Convert all C# files in a directory
 for f in src/Services/*.cs; do
-  calorc convert "$f"
+  calor convert "$f"
 done
 ```
 
-For project-wide conversion, use [`calorc migrate`](/calor/cli/migrate/) instead.
+For project-wide conversion, use [`calor migrate`](/calor/cli/migrate/) instead.
 
 ### Integration with Claude Code
 
@@ -223,7 +223,7 @@ After conversion, use Claude to refine the Calor:
 ```
 /calor
 
-Review the converted file src/Services/UserService.calor and:
+Review the converted file src/Services/UserService.calr and:
 1. Add appropriate contracts based on the business logic
 2. Verify effect declarations are complete
 3. Improve naming of generated IDs if needed
@@ -257,7 +257,7 @@ Review the warnings and manually adjust as needed.
 
 ## See Also
 
-- [calorc migrate](/calor/cli/migrate/) - Convert entire projects
-- [calorc analyze](/calor/cli/analyze/) - Find best conversion candidates
-- [calorc benchmark](/calor/cli/benchmark/) - Detailed metrics comparison
+- [calor migrate](/calor/cli/migrate/) - Convert entire projects
+- [calor analyze](/calor/cli/analyze/) - Find best conversion candidates
+- [calor benchmark](/calor/cli/benchmark/) - Detailed metrics comparison
 - [Adding Calor to Existing Projects](/calor/guides/adding-calor-to-existing-projects/) - Complete migration guide

--- a/docs/cli/diagnose.md
+++ b/docs/cli/diagnose.md
@@ -6,12 +6,12 @@ nav_order: 7
 permalink: /cli/diagnose/
 ---
 
-# calorc diagnose
+# calor diagnose
 
 Output machine-readable diagnostics for Calor files.
 
 ```bash
-calorc diagnose <files...> [options]
+calor diagnose <files...> [options]
 ```
 
 ---
@@ -32,16 +32,16 @@ Use this for automated fix workflows, CI/CD pipelines, and editor integrations.
 
 ```bash
 # Diagnose a single file (text output)
-calorc diagnose MyModule.calor
+calor diagnose MyModule.calr
 
 # JSON output for processing
-calorc diagnose MyModule.calor --format json
+calor diagnose MyModule.calr --format json
 
 # SARIF output for IDE integration
-calorc diagnose src/*.calor --format sarif --output diagnostics.sarif
+calor diagnose src/*.calr --format sarif --output diagnostics.sarif
 
 # Enable strict checking
-calorc diagnose MyModule.calor --strict-api --require-docs
+calor diagnose MyModule.calr --strict-api --require-docs
 ```
 
 ---
@@ -72,19 +72,19 @@ calorc diagnose MyModule.calor --strict-api --require-docs
 Human-readable diagnostics:
 
 ```bash
-calorc diagnose Calculator.calor
+calor diagnose Calculator.calr
 ```
 
 Output:
 ```
-Calculator.calor:12:5: error: Undefined variable 'x'
+Calculator.calr:12:5: error: Undefined variable 'x'
   §R (+ x 1)
        ^
 
-Calculator.calor:8:3: warning: Function 'Calculate' has no effect declaration
+Calculator.calr:8:3: warning: Function 'Calculate' has no effect declaration
   Consider adding §E[] for pure functions
 
-Calculator.calor:15:3: info: Unused variable 'temp'
+Calculator.calr:15:3: info: Unused variable 'temp'
   §B[temp] 42
 
 Summary: 1 error, 1 warning, 1 info
@@ -95,7 +95,7 @@ Summary: 1 error, 1 warning, 1 info
 Machine-readable format for automated processing:
 
 ```bash
-calorc diagnose Calculator.calor --format json
+calor diagnose Calculator.calr --format json
 ```
 
 Output:
@@ -104,7 +104,7 @@ Output:
   "version": "1.0",
   "files": [
     {
-      "path": "Calculator.calor",
+      "path": "Calculator.calr",
       "diagnostics": [
         {
           "severity": "error",
@@ -155,7 +155,7 @@ Output:
 [SARIF](https://sarifweb.azurewebsites.net/) format for IDE and CI/CD integration:
 
 ```bash
-calorc diagnose src/*.calor --format sarif --output diagnostics.sarif
+calor diagnose src/*.calr --format sarif --output diagnostics.sarif
 ```
 
 SARIF output integrates with:
@@ -194,7 +194,7 @@ Enforces stricter API rules:
 - No implicit any types
 
 ```bash
-calorc diagnose MyModule.calor --strict-api
+calor diagnose MyModule.calr --strict-api
 ```
 
 ### Require Docs (`--require-docs`)
@@ -202,12 +202,12 @@ calorc diagnose MyModule.calor --strict-api
 Requires documentation on public APIs:
 
 ```bash
-calorc diagnose MyModule.calor --require-docs
+calor diagnose MyModule.calr --require-docs
 ```
 
 Error:
 ```
-MyModule.calor:5:1: error: Public function 'ProcessOrder' missing documentation
+MyModule.calr:5:1: error: Public function 'ProcessOrder' missing documentation
   Add documentation comment before function declaration
 ```
 
@@ -218,7 +218,7 @@ MyModule.calor:5:1: error: Public function 'ProcessOrder' missing documentation
 Diagnostics from all files are aggregated:
 
 ```bash
-calorc diagnose src/*.calor --format json
+calor diagnose src/*.calr --format json
 ```
 
 The output includes diagnostics from all files in a single report.
@@ -243,12 +243,12 @@ The `diagnose` command is designed for AI agent workflows:
 
 ```bash
 # 1. Get diagnostics in JSON
-calorc diagnose MyModule.calor --format json > diagnostics.json
+calor diagnose MyModule.calr --format json > diagnostics.json
 
 # 2. AI agent reads diagnostics and applies fixes
 
 # 3. Re-run diagnostics to verify
-calorc diagnose MyModule.calor --format json
+calor diagnose MyModule.calr --format json
 ```
 
 ### Claude Code Integration
@@ -256,7 +256,7 @@ calorc diagnose MyModule.calor --format json
 In Claude Code, use the diagnostics to guide fixes:
 
 ```
-Run calorc diagnose on MyModule.calor and fix any errors
+Run calor diagnose on MyModule.calr and fix any errors
 ```
 
 Claude will:
@@ -274,7 +274,7 @@ Claude will:
 ```yaml
 - name: Check Calor diagnostics
   run: |
-    calorc diagnose src/**/*.calor --format sarif --output calor.sarif
+    calor diagnose src/**/*.calr --format sarif --output calor.sarif
 
 - name: Upload SARIF
   uses: github/codeql-action/upload-sarif@v2
@@ -286,7 +286,7 @@ Claude will:
 
 ```yaml
 - script: |
-    calorc diagnose src/**/*.calor --format sarif --output $(Build.ArtifactStagingDirectory)/calor.sarif
+    calor diagnose src/**/*.calr --format sarif --output $(Build.ArtifactStagingDirectory)/calor.sarif
   displayName: 'Run Calor diagnostics'
 
 - task: PublishBuildArtifacts@1
@@ -303,7 +303,7 @@ Claude will:
 
 ```bash
 # Check for errors only
-calorc diagnose MyModule.calor
+calor diagnose MyModule.calr
 if [ $? -ne 0 ]; then
   echo "Errors found, fix before committing"
   exit 1
@@ -314,7 +314,7 @@ fi
 
 ```bash
 # Generate comprehensive report
-calorc diagnose src/*.calor \
+calor diagnose src/*.calr \
   --strict-api \
   --require-docs \
   --format json \
@@ -327,10 +327,10 @@ calorc diagnose src/*.calor \
 #!/bin/bash
 # .git/hooks/pre-commit
 
-Calor_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.calor$')
+Calor_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.calr$')
 
 if [ -n "$Calor_FILES" ]; then
-  echo "$Calor_FILES" | xargs calorc diagnose
+  echo "$Calor_FILES" | xargs calor diagnose
   if [ $? -ne 0 ]; then
     echo "Calor diagnostics found errors. Fix before committing."
     exit 1
@@ -342,6 +342,6 @@ fi
 
 ## See Also
 
-- [calorc format](/calor/cli/format/) - Format Calor source files
-- [calorc compile](/calor/cli/compile/) - Compile with error reporting
-- [calorc analyze](/calor/cli/analyze/) - Analyze C# for migration potential
+- [calor format](/calor/cli/format/) - Format Calor source files
+- [calor compile](/calor/cli/compile/) - Compile with error reporting
+- [calor analyze](/calor/cli/analyze/) - Analyze C# for migration potential

--- a/docs/cli/format.md
+++ b/docs/cli/format.md
@@ -6,12 +6,12 @@ nav_order: 6
 permalink: /cli/format/
 ---
 
-# calorc format
+# calor format
 
 Format Calor source files to canonical style.
 
 ```bash
-calorc format <files...> [options]
+calor format <files...> [options]
 ```
 
 ---
@@ -26,16 +26,16 @@ The `format` command formats Calor source files according to the canonical Calor
 
 ```bash
 # Format a single file (output to stdout)
-calorc format MyModule.calor
+calor format MyModule.calr
 
 # Format and overwrite the file
-calorc format MyModule.calor --write
+calor format MyModule.calr --write
 
 # Check if files are formatted (for CI)
-calorc format src/*.calor --check
+calor format src/*.calr --check
 
 # Show diff of changes
-calorc format MyModule.calor --diff
+calor format MyModule.calr --diff
 ```
 
 ---
@@ -64,7 +64,7 @@ calorc format MyModule.calor --diff
 By default (no flags), the formatted output is written to stdout:
 
 ```bash
-calorc format MyModule.calor
+calor format MyModule.calr
 ```
 
 This allows you to preview changes before applying them.
@@ -77,10 +77,10 @@ Use `--write` to format files in place:
 
 ```bash
 # Format single file
-calorc format MyModule.calor --write
+calor format MyModule.calr --write
 
 # Format multiple files
-calorc format src/*.calor --write
+calor format src/*.calr --write
 ```
 
 ---
@@ -90,7 +90,7 @@ calorc format src/*.calor --write
 Use `--check` in CI/CD to verify formatting:
 
 ```bash
-calorc format src/*.calor --check
+calor format src/*.calr --check
 ```
 
 Exit codes:
@@ -102,7 +102,7 @@ Example CI configuration:
 ```yaml
 # GitHub Actions
 - name: Check Calor formatting
-  run: calorc format src/**/*.calor --check
+  run: calor format src/**/*.calr --check
 ```
 
 ---
@@ -112,12 +112,12 @@ Example CI configuration:
 Use `--diff` to see what would change:
 
 ```bash
-calorc format MyModule.calor --diff
+calor format MyModule.calr --diff
 ```
 
 Output:
 ```
-MyModule.calor
+MyModule.calr
 --- original
 +++ formatted
 @@ -5,7 +5,7 @@
@@ -199,17 +199,17 @@ The Calor formatter applies these rules:
 When formatting multiple files, errors in one file don't stop processing of others:
 
 ```bash
-calorc format src/*.calor --write --verbose
+calor format src/*.calr --write --verbose
 ```
 
 Output:
 ```
 Formatting 5 files...
-  [OK] src/Calculator.calor
-  [OK] src/UserService.calor
-  [ERR] src/Broken.calor: Parse error at line 12
-  [OK] src/OrderService.calor
-  [OK] src/PaymentService.calor
+  [OK] src/Calculator.calr
+  [OK] src/UserService.calr
+  [ERR] src/Broken.calr: Parse error at line 12
+  [OK] src/OrderService.calr
+  [OK] src/PaymentService.calr
 
 Summary: 4 formatted, 1 error
 ```
@@ -221,12 +221,12 @@ Summary: 4 formatted, 1 error
 Use `--verbose` to see detailed processing information:
 
 ```bash
-calorc format MyModule.calor --write --verbose
+calor format MyModule.calr --write --verbose
 ```
 
 Output:
 ```
-Formatting MyModule.calor...
+Formatting MyModule.calr...
   Parsing: OK
   Changes: 3 lines modified
   Writing: OK
@@ -249,11 +249,11 @@ Formatting MyModule.calor...
 ### Format All Calor Files
 
 ```bash
-# Find and format all .calor files
-find . -name "*.calor" -exec calorc format {} --write \;
+# Find and format all .calr files
+find . -name "*.calr" -exec calor format {} --write \;
 
 # Or use shell globbing
-calorc format **/*.calor --write
+calor format **/*.calr --write
 ```
 
 ### Pre-Commit Hook
@@ -263,13 +263,13 @@ calorc format **/*.calor --write
 # .git/hooks/pre-commit
 
 # Check if any Calor files are staged
-Calor_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.calor$')
+Calor_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.calr$')
 
 if [ -n "$Calor_FILES" ]; then
   # Format staged files
-  echo "$Calor_FILES" | xargs calorc format --check
+  echo "$Calor_FILES" | xargs calor format --check
   if [ $? -ne 0 ]; then
-    echo "Calor files are not formatted. Run 'calorc format --write' to fix."
+    echo "Calor files are not formatted. Run 'calor format --write' to fix."
     exit 1
   fi
 fi
@@ -285,7 +285,7 @@ Most editors can be configured to run formatters on save:
   "[calor]": {
     "editor.formatOnSave": true
   },
-  "calor.formatCommand": "calorc format --write"
+  "calor.formatCommand": "calor format --write"
 }
 ```
 
@@ -293,6 +293,6 @@ Most editors can be configured to run formatters on save:
 
 ## See Also
 
-- [calorc diagnose](/calor/cli/diagnose/) - Check for errors and warnings
-- [calorc compile](/calor/cli/compile/) - Compile Calor to C#
+- [calor diagnose](/calor/cli/diagnose/) - Check for errors and warnings
+- [calor compile](/calor/cli/compile/) - Compile Calor to C#
 - [Syntax Reference](/calor/syntax-reference/) - Calor language reference

--- a/docs/cli/hook.md
+++ b/docs/cli/hook.md
@@ -6,19 +6,19 @@ nav_order: 9
 permalink: /cli/hook/
 ---
 
-# calorc hook
+# calor hook
 
 Internal commands for Claude Code hook integration. These commands are called automatically by Claude Code hooks and are not typically invoked directly.
 
 ```bash
-calorc hook <subcommand> [args]
+calor hook <subcommand> [args]
 ```
 
 ---
 
 ## Overview
 
-The `hook` command provides subcommands that integrate with Claude Code's hook system to enforce Calor-first development. When you run `calorc init --ai claude`, it configures these hooks automatically.
+The `hook` command provides subcommands that integrate with Claude Code's hook system to enforce Calor-first development. When you run `calor init --ai claude`, it configures these hooks automatically.
 
 ---
 
@@ -29,14 +29,14 @@ The `hook` command provides subcommands that integrate with Claude Code's hook s
 Validates Write tool calls to enforce Calor-first development.
 
 ```bash
-calorc hook validate-write <tool-input-json>
+calor hook validate-write <tool-input-json>
 ```
 
 **Behavior:**
 
 | File Type | Action |
 |:----------|:-------|
-| `.calor` files | Allowed (exit 0) |
+| `.calr` files | Allowed (exit 0) |
 | `.g.cs` generated files | Allowed (exit 0) |
 | Files in `obj/` directory | Allowed (exit 0) |
 | Other `.cs` files | **Blocked** (exit 1) |
@@ -45,25 +45,25 @@ calorc hook validate-write <tool-input-json>
 
 ```bash
 # This will be blocked (exit 1)
-calorc hook validate-write '{"file_path": "MyClass.cs"}'
+calor hook validate-write '{"file_path": "MyClass.cs"}'
 
 # Output:
 # BLOCKED: Cannot create C# file 'MyClass.cs'
 #
-# This is an Calor-first project. Create an .calor file instead:
-#   MyClass.calor
+# This is an Calor-first project. Create an .calr file instead:
+#   MyClass.calr
 #
 # Use /calor skill for Calor syntax help.
 
 # This will be allowed (exit 0)
-calorc hook validate-write '{"file_path": "MyClass.calor"}'
+calor hook validate-write '{"file_path": "MyClass.calr"}'
 ```
 
 ---
 
 ## How Hooks Work
 
-When you initialize a project with `calorc init --ai claude`, it creates `.claude/settings.json` with hook configuration:
+When you initialize a project with `calor init --ai claude`, it creates `.claude/settings.json` with hook configuration:
 
 ```json
 {
@@ -74,7 +74,7 @@ When you initialize a project with `calorc init --ai claude`, it creates `.claud
         "hooks": [
           {
             "type": "command",
-            "command": "calorc hook validate-write $TOOL_INPUT"
+            "command": "calor hook validate-write $TOOL_INPUT"
           }
         ]
       }
@@ -83,7 +83,7 @@ When you initialize a project with `calorc init --ai claude`, it creates `.claud
 }
 ```
 
-This hook runs **before** every Write tool call. If the hook returns exit code 1, Claude Code blocks the operation and shows the error message to Claude, who will then retry with an `.calor` file.
+This hook runs **before** every Write tool call. If the hook returns exit code 1, Claude Code blocks the operation and shows the error message to Claude, who will then retry with an `.calr` file.
 
 ---
 
@@ -95,7 +95,7 @@ When Claude tries to create a `.cs` file in an Calor-initialized project:
 2. The hook intercepts the call and validates the path
 3. Hook returns exit 1 with guidance message
 4. Claude Code blocks the write operation
-5. Claude sees the error and creates an `.calor` file instead
+5. Claude sees the error and creates an `.calr` file instead
 
 This enforcement happens automatically - no user intervention required.
 
@@ -111,10 +111,10 @@ This enforcement happens automatically - no user intervention required.
    ```
    Should contain `PreToolUse` hook for `Write`
 
-2. **Verify calorc is in PATH:**
+2. **Verify calor is in PATH:**
    ```bash
-   which calorc
-   calorc hook validate-write '{"file_path": "test.cs"}'
+   which calor
+   calor hook validate-write '{"file_path": "test.cs"}'
    echo $?  # Should be 1
    ```
 
@@ -123,12 +123,12 @@ This enforcement happens automatically - no user intervention required.
 ### Re-enable Hooks After Manual Removal
 
 ```bash
-calorc init --ai claude --force
+calor init --ai claude --force
 ```
 
 ---
 
 ## See Also
 
-- [calorc init](/calor/cli/init/) - Initialize Calor with hook configuration
+- [calor init](/calor/cli/init/) - Initialize Calor with hook configuration
 - [Claude Integration](/calor/getting-started/claude-integration/) - Using Calor with Claude

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -8,22 +8,22 @@ permalink: /cli/
 
 # CLI Reference
 
-The `calorc` command-line tool provides commands for working with Calor code and analyzing C# codebases for migration.
+The `calor` command-line tool provides commands for working with Calor code and analyzing C# codebases for migration.
 
 ---
 
 ## Installation
 
-Install `calorc` as a global .NET tool:
+Install `calor` as a global .NET tool:
 
 ```bash
-dotnet tool install -g calorc --version 0.1.3
+dotnet tool install -g calor --version 0.1.3
 ```
 
 Or update an existing installation:
 
 ```bash
-dotnet tool update -g calorc
+dotnet tool update -g calor
 ```
 
 ---
@@ -32,15 +32,15 @@ dotnet tool update -g calorc
 
 | Command | Description |
 |:--------|:------------|
-| `calorc` (default) | Compile Calor source files to C# |
-| [`calorc analyze`](/calor/cli/analyze/) | Score C# files for Calor migration potential |
-| [`calorc init`](/calor/cli/init/) | Initialize Calor with AI agent support and .csproj integration |
-| [`calorc convert`](/calor/cli/convert/) | Convert single files between C# and Calor |
-| [`calorc migrate`](/calor/cli/migrate/) | Migrate entire projects between C# and Calor |
-| [`calorc benchmark`](/calor/cli/benchmark/) | Compare Calor vs C# across evaluation metrics |
-| [`calorc format`](/calor/cli/format/) | Format Calor source files to canonical style |
-| [`calorc diagnose`](/calor/cli/diagnose/) | Output machine-readable diagnostics for tooling |
-| [`calorc hook`](/calor/cli/hook/) | Claude Code hook commands (internal) |
+| `calor` (default) | Compile Calor source files to C# |
+| [`calor analyze`](/calor/cli/analyze/) | Score C# files for Calor migration potential |
+| [`calor init`](/calor/cli/init/) | Initialize Calor with AI agent support and .csproj integration |
+| [`calor convert`](/calor/cli/convert/) | Convert single files between C# and Calor |
+| [`calor migrate`](/calor/cli/migrate/) | Migrate entire projects between C# and Calor |
+| [`calor benchmark`](/calor/cli/benchmark/) | Compare Calor vs C# across evaluation metrics |
+| [`calor format`](/calor/cli/format/) | Format Calor source files to canonical style |
+| [`calor diagnose`](/calor/cli/diagnose/) | Output machine-readable diagnostics for tooling |
+| [`calor hook`](/calor/cli/hook/) | Claude Code hook commands (internal) |
 
 ---
 
@@ -49,7 +49,7 @@ dotnet tool update -g calorc
 Compile Calor source files to C#:
 
 ```bash
-calorc --input file.calor --output file.g.cs
+calor --input file.calr --output file.g.cs
 ```
 
 ### Options
@@ -64,10 +64,10 @@ calorc --input file.calor --output file.g.cs
 
 ```bash
 # Compile a single file
-calorc --input src/MyModule.calor --output src/MyModule.g.cs
+calor --input src/MyModule.calr --output src/MyModule.g.cs
 
 # Compile with verbose output
-calorc -v -i src/MyModule.calor -o src/MyModule.g.cs
+calor -v -i src/MyModule.calr -o src/MyModule.g.cs
 ```
 
 ---

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -6,12 +6,12 @@ nav_order: 2
 permalink: /cli/init/
 ---
 
-# calorc init
+# calor init
 
 Initialize Calor development environment with MSBuild integration and optional AI agent support.
 
 ```bash
-calorc init [options]
+calor init [options]
 ```
 
 ---
@@ -23,7 +23,7 @@ The `init` command sets up your project for Calor development by:
 1. **Adding MSBuild targets** - Integrates Calor compilation into your .NET build process
 2. **Configuring AI agent integration** (optional) - Creates skills/prompts for your preferred AI coding assistant
 
-After running `init`, you can write `.calor` files alongside your `.cs` files and they'll compile automatically during `dotnet build`.
+After running `init`, you can write `.calr` files alongside your `.cs` files and they'll compile automatically during `dotnet build`.
 
 ---
 
@@ -81,22 +81,22 @@ MyProject/
 
 ```bash
 # Basic initialization (MSBuild integration only)
-calorc init
+calor init
 
 # Initialize with Claude Code support
-calorc init --ai claude
+calor init --ai claude
 
 # Initialize a solution (auto-detected or explicit)
-calorc init --ai claude
+calor init --ai claude
 
 # Initialize with explicit solution file
-calorc init --solution MySolution.sln --ai claude
+calor init --solution MySolution.sln --ai claude
 
 # Initialize with a specific .csproj
-calorc init --project MyApp.csproj
+calor init --project MyApp.csproj
 
 # Initialize with both Claude and specific project
-calorc init --ai claude --project MyApp.csproj
+calor init --ai claude --project MyApp.csproj
 ```
 
 ---
@@ -134,16 +134,16 @@ The `.claude/settings.json` file configures a `PreToolUse` hook that **blocks Cl
 ```
 BLOCKED: Cannot create C# file 'MyClass.cs'
 
-This is an Calor-first project. Create an .calor file instead:
-  MyClass.calor
+This is an Calor-first project. Create an .calr file instead:
+  MyClass.calr
 
 Use /calor skill for Calor syntax help.
 ```
 
-Claude will then automatically retry with an `.calor` file. This enforcement ensures all new code is written in Calor.
+Claude will then automatically retry with an `.calr` file. This enforcement ensures all new code is written in Calor.
 
 **Allowed file types:**
-- `.calor` files (always allowed)
+- `.calr` files (always allowed)
 - `.g.cs` generated files (build output)
 - Files in `obj/` directory (build artifacts)
 
@@ -169,10 +169,10 @@ Creates the following files:
 **Important:** Codex CLI does not support hooks like Claude Code. Calor-first development is **guidance-based only**, relying on instructions in `AGENTS.md` and the skill files.
 
 This means:
-- Codex *should* create `.calor` files based on the instructions
+- Codex *should* create `.calr` files based on the instructions
 - However, enforcement is not automatic - Codex may occasionally create `.cs` files
 - Review file extensions after code generation
-- Use `calorc analyze` to find any unconverted `.cs` files
+- Use `calor analyze` to find any unconverted `.cs` files
 
 After initialization, use these Codex commands:
 
@@ -216,14 +216,14 @@ When Gemini tries to write a C# file, the hook returns a JSON response that bloc
 {
   "decision": "deny",
   "reason": "BLOCKED: Cannot create C# file 'MyClass.cs'",
-  "systemMessage": "This is an Calor-first project. Create an .calor file instead: MyClass.calor\n\nUse @calor skill for Calor syntax help."
+  "systemMessage": "This is an Calor-first project. Create an .calr file instead: MyClass.calr\n\nUse @calor skill for Calor syntax help."
 }
 ```
 
-Gemini will then automatically retry with an `.calor` file. This enforcement ensures all new code is written in Calor.
+Gemini will then automatically retry with an `.calr` file. This enforcement ensures all new code is written in Calor.
 
 **Allowed file types:**
-- `.calor` files (always allowed)
+- `.calr` files (always allowed)
 - `.g.cs` generated files (build output)
 - Files in `obj/` directory (build artifacts)
 
@@ -264,10 +264,10 @@ Creates the following files:
 **Important:** GitHub Copilot does not support hooks like Claude Code. Calor-first development is **guidance-based only**, relying on instructions in `copilot-instructions.md` and the skill files.
 
 This means:
-- Copilot *should* create `.calor` files based on the instructions
+- Copilot *should* create `.calr` files based on the instructions
 - However, enforcement is not automatic - Copilot may occasionally create `.cs` files
 - Review file extensions after code generation
-- Use `calorc analyze` to find any unconverted `.cs` files
+- Use `calor analyze` to find any unconverted `.cs` files
 
 After initialization, reference the Calor skills when asking Copilot about Calor syntax or converting C# code.
 
@@ -294,11 +294,11 @@ The `init` command adds three MSBuild targets to your `.csproj` file:
 
 ### CompileCalorFiles
 
-Compiles all `.calor` files before C# compilation:
+Compiles all `.calr` files before C# compilation:
 
 ```xml
 <Target Name="CompileCalorFiles" BeforeTargets="BeforeBuild">
-  <Exec Command="calorc --input %(CalorFiles.Identity) --output $(CalorOutputPath)%(CalorFiles.Filename).g.cs" />
+  <Exec Command="calor --input %(CalorFiles.Identity) --output $(CalorOutputPath)%(CalorFiles.Filename).g.cs" />
 </Target>
 ```
 
@@ -340,7 +340,7 @@ This keeps generated files out of your source tree while still making them part 
 
 ## Calor/C# Coexistence
 
-After initialization, `.calor` and `.cs` files coexist seamlessly in your project:
+After initialization, `.calr` and `.cs` files coexist seamlessly in your project:
 
 ```
 MyProject/
@@ -348,7 +348,7 @@ MyProject/
 ├── Program.cs              # Existing C# code
 ├── Services/
 │   ├── UserService.cs      # Existing C# service
-│   └── PaymentService.calor # New Calor service
+│   └── PaymentService.calr # New Calor service
 └── obj/
     └── Debug/net8.0/calor/
         └── PaymentService.g.cs  # Generated C#
@@ -358,13 +358,13 @@ MyProject/
 
 1. Run `dotnet build`
 2. MSBuild triggers `CompileCalorFiles` target
-3. Each `.calor` file is compiled to `.g.cs` in `obj/calor/`
+3. Each `.calr` file is compiled to `.g.cs` in `obj/calor/`
 4. Generated files are included in C# compilation
 5. Normal .NET build continues
 
 ### No Manual Steps
 
-- No need to run `calorc` manually
+- No need to run `calor` manually
 - No need to manage generated file paths
 - `dotnet clean` removes generated files automatically
 
@@ -387,10 +387,10 @@ If multiple solution files are found in the current directory, you must specify 
 
 ```bash
 # Error: Multiple solutions found
-calorc init --ai claude
+calor init --ai claude
 
 # Specify the solution explicitly
-calorc init --solution MyApp.sln --ai claude
+calor init --solution MyApp.sln --ai claude
 ```
 
 ### Solution Parsing
@@ -418,7 +418,7 @@ This allows you to restore the original if needed.
 
 ## Re-running Init
 
-You can safely run `calorc init` multiple times:
+You can safely run `calor init` multiple times:
 
 - **CLAUDE.md**: Updates only the Calor section, preserving your custom content
 - **Skills files**: Overwrites with latest version (use `--force` or confirm)
@@ -435,17 +435,17 @@ You can safely run `calorc init` multiple times:
 cd ~/projects/MyApp
 
 # Initialize Calor (MSBuild integration only)
-calorc init
+calor init
 
 # Analyze codebase for migration candidates
-calorc analyze ./src --top 10
+calor analyze ./src --top 10
 ```
 
 ### Initialize with Claude Code
 
 ```bash
 # Initialize with Claude Code support
-calorc init --ai claude
+calor init --ai claude
 ```
 
 This adds `/calor` and `/calor-convert` skills plus CLAUDE.md with guidelines that instruct Claude to:
@@ -458,24 +458,24 @@ This adds `/calor` and `/calor-convert` skills plus CLAUDE.md with guidelines th
 # Create a new console app and initialize Calor
 dotnet new console -o MyCalorApp
 cd MyCalorApp
-calorc init
-calorc init --ai claude  # Optional: add Claude support
+calor init
+calor init --ai claude  # Optional: add Claude support
 ```
 
 ### Initialize a Solution
 
 ```bash
 # Initialize all projects in a solution (auto-detected)
-calorc init --ai claude
+calor init --ai claude
 
 # Or specify the solution explicitly
-calorc init --solution MySolution.sln --ai claude
+calor init --solution MySolution.sln --ai claude
 ```
 
 This creates AI files in the solution root and adds MSBuild targets to all projects:
 
 ```
-Initialized Calor solution for Claude Code (calorc v0.1.5)
+Initialized Calor solution for Claude Code (calor v0.1.5)
 
 Solution: MySolution.sln (3 projects)
 
@@ -499,20 +499,20 @@ MSBuild configuration:
 If you need to initialize projects independently (different AI configs per project):
 
 ```bash
-calorc init --ai claude --project src/Core/Core.csproj
-calorc init --ai claude --project src/Web/Web.csproj
+calor init --ai claude --project src/Core/Core.csproj
+calor init --ai claude --project src/Web/Web.csproj
 ```
 
 ---
 
 ## Troubleshooting
 
-### "calorc not found"
+### "calor not found"
 
 Ensure the Calor compiler is installed globally:
 
 ```bash
-dotnet tool install -g calorc
+dotnet tool install -g calor
 ```
 
 And that your PATH includes the .NET tools directory:
@@ -526,7 +526,7 @@ export PATH="$PATH:$HOME/.dotnet/tools"
 Specify the exact project:
 
 ```bash
-calorc init --ai claude --project ./src/MyApp/MyApp.csproj
+calor init --ai claude --project ./src/MyApp/MyApp.csproj
 ```
 
 ### "Multiple solution files found"
@@ -534,22 +534,22 @@ calorc init --ai claude --project ./src/MyApp/MyApp.csproj
 Specify which solution to use:
 
 ```bash
-calorc init --solution MyApp.sln --ai claude
+calor init --solution MyApp.sln --ai claude
 ```
 
 ### Build Fails After Init
 
-1. Verify `calorc` is in PATH: `which calorc`
+1. Verify `calor` is in PATH: `which calor`
 2. Check the `.csproj` has the Calor targets
-3. Try running `calorc` manually on a test file
+3. Try running `calor` manually on a test file
 
 ---
 
 ## See Also
 
 - [Adding Calor to Existing Projects](/calor/guides/adding-calor-to-existing-projects/) - Complete migration guide
-- [calorc convert](/calor/cli/convert/) - Convert individual files
-- [calorc analyze](/calor/cli/analyze/) - Find migration candidates
+- [calor convert](/calor/cli/convert/) - Convert individual files
+- [calor analyze](/calor/cli/analyze/) - Find migration candidates
 - [Claude Integration](/calor/getting-started/claude-integration/) - Using Calor with Claude Code
 - [Codex Integration](/calor/getting-started/codex-integration/) - Using Calor with OpenAI Codex CLI
 - [Gemini Integration](/calor/getting-started/gemini-integration/) - Using Calor with Google Gemini CLI

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -6,12 +6,12 @@ nav_order: 4
 permalink: /cli/migrate/
 ---
 
-# calorc migrate
+# calor migrate
 
 Migrate an entire project between C# and Calor.
 
 ```bash
-calorc migrate <path> [options]
+calor migrate <path> [options]
 ```
 
 ---
@@ -34,16 +34,16 @@ Use this for bulk conversion of entire codebases.
 
 ```bash
 # Preview migration (dry run)
-calorc migrate ./src --dry-run
+calor migrate ./src --dry-run
 
 # Migrate C# to Calor
-calorc migrate ./src
+calor migrate ./src
 
 # Migrate with report
-calorc migrate ./src --report migration-report.md
+calor migrate ./src --report migration-report.md
 
 # Migrate Calor back to C#
-calorc migrate ./src --direction calor-to-cs
+calor migrate ./src --direction calor-to-cs
 ```
 
 ---
@@ -81,7 +81,7 @@ calorc migrate ./src --direction calor-to-cs
 Before converting, the command analyzes your codebase and creates a plan:
 
 ```bash
-calorc migrate ./src --dry-run
+calor migrate ./src --dry-run
 ```
 
 Output:
@@ -144,7 +144,7 @@ With `--verbose`, each file is logged individually:
 Use `--benchmark` to see aggregate metrics:
 
 ```bash
-calorc migrate ./src --benchmark
+calor migrate ./src --benchmark
 ```
 
 Output includes:
@@ -172,7 +172,7 @@ Generate detailed reports for documentation:
 ### Markdown Report
 
 ```bash
-calorc migrate ./src --report migration-report.md
+calor migrate ./src --report migration-report.md
 ```
 
 Creates a human-readable report with:
@@ -184,7 +184,7 @@ Creates a human-readable report with:
 ### JSON Report
 
 ```bash
-calorc migrate ./src --report migration-report.json
+calor migrate ./src --report migration-report.json
 ```
 
 Creates a machine-readable report for processing:
@@ -205,7 +205,7 @@ Creates a machine-readable report for processing:
   "files": [
     {
       "source": "src/Services/UserService.cs",
-      "output": "src/Services/UserService.calor",
+      "output": "src/Services/UserService.calr",
       "status": "success",
       "warnings": [],
       "benchmark": {
@@ -233,7 +233,7 @@ By default, files are converted in parallel for speed. Disable for debugging:
 
 ```bash
 # Sequential processing
-calorc migrate ./src --parallel false --verbose
+calor migrate ./src --parallel false --verbose
 ```
 
 ---
@@ -244,7 +244,7 @@ The migrate command automatically skips:
 
 - **Generated files**: `*.g.cs`, `*.generated.cs`, `*.Designer.cs`
 - **Build artifacts**: `obj/`, `bin/`
-- **Already converted**: Files that already have a corresponding `.calor` or `.g.cs`
+- **Already converted**: Files that already have a corresponding `.calr` or `.g.cs`
 
 ---
 
@@ -264,38 +264,38 @@ The migrate command automatically skips:
 
 ```bash
 # See what would be converted
-calorc migrate ./src --dry-run
+calor migrate ./src --dry-run
 
 # See detailed plan
-calorc migrate ./src --dry-run --verbose
+calor migrate ./src --dry-run --verbose
 ```
 
 ### Migrate with Full Reporting
 
 ```bash
 # Complete migration with benchmark and report
-calorc migrate ./src --benchmark --report migration.md --verbose
+calor migrate ./src --benchmark --report migration.md --verbose
 ```
 
 ### Migrate Specific Project
 
 ```bash
 # Migrate a specific .csproj
-calorc migrate ./src/MyProject/MyProject.csproj
+calor migrate ./src/MyProject/MyProject.csproj
 ```
 
 ### Reverse Migration
 
 ```bash
 # Convert Calor back to C# (e.g., for debugging)
-calorc migrate ./src --direction calor-to-cs
+calor migrate ./src --direction calor-to-cs
 ```
 
 ### CI/CD Integration
 
 ```bash
 # In CI: verify all files can be converted
-calorc migrate ./src --dry-run
+calor migrate ./src --dry-run
 if [ $? -ne 0 ]; then
   echo "Migration issues detected"
   exit 1
@@ -316,7 +316,7 @@ fi
 
 ## See Also
 
-- [calorc convert](/calor/cli/convert/) - Convert single files
-- [calorc analyze](/calor/cli/analyze/) - Find migration candidates
-- [calorc benchmark](/calor/cli/benchmark/) - Detailed metrics comparison
+- [calor convert](/calor/cli/convert/) - Convert single files
+- [calor analyze](/calor/cli/analyze/) - Find migration candidates
+- [calor benchmark](/calor/cli/benchmark/) - Detailed metrics comparison
 - [Adding Calor to Existing Projects](/calor/guides/adding-calor-to-existing-projects/) - Complete migration guide

--- a/docs/contributing/adding-benchmarks.md
+++ b/docs/contributing/adding-benchmarks.md
@@ -27,15 +27,15 @@ Each benchmark needs:
 ```
 tests/Calor.Evaluation/Benchmarks/
 ├── HelloWorld/
-│   ├── hello.calor
+│   ├── hello.calr
 │   ├── hello.cs
 │   └── metadata.json
 ├── FizzBuzz/
-│   ├── fizzbuzz.calor
+│   ├── fizzbuzz.calr
 │   ├── fizzbuzz.cs
 │   └── metadata.json
 └── YourNewBenchmark/
-    ├── program.calor
+    ├── program.calr
     ├── program.cs
     └── metadata.json
 ```
@@ -53,7 +53,7 @@ cd tests/Calor.Evaluation/Benchmarks/YourBenchmark
 
 ### Step 2: Write Calor Code
 
-Create `program.calor`:
+Create `program.calr`:
 
 ```
 §M[m001:YourModule]
@@ -115,7 +115,7 @@ Create `metadata.json`:
 ```bash
 # Compile Calor
 dotnet run --project src/Calor.Compiler -- \
-  --input tests/Calor.Evaluation/Benchmarks/YourBenchmark/program.calor \
+  --input tests/Calor.Evaluation/Benchmarks/YourBenchmark/program.calr \
   --output /tmp/test.g.cs
 
 # Verify C# compiles
@@ -143,7 +143,7 @@ dotnet run --project tests/Calor.Evaluation -- --output report.json
 
 ## Example: Factorial Benchmark
 
-### Calor (`factorial.calor`)
+### Calor (`factorial.calr`)
 
 ```
 §M[m001:Math]
@@ -253,13 +253,13 @@ For simpler test cases, you can add to the E2E test suite instead:
 ```
 tests/E2E/scenarios/
 ├── 01_hello_world/
-│   ├── input.calor
+│   ├── input.calr
 │   └── verify.sh
 ├── 02_fizzbuzz/
-│   ├── input.calor
+│   ├── input.calr
 │   └── verify.sh
 └── XX_your_test/
-    ├── input.calor
+    ├── input.calr
     └── verify.sh
 ```
 

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -72,12 +72,12 @@ calor/
 ```bash
 # Compile an Calor file
 dotnet run --project src/Calor.Compiler -- \
-  --input path/to/file.calor \
+  --input path/to/file.calr \
   --output path/to/output.g.cs
 
 # With verbose output
 dotnet run --project src/Calor.Compiler -- \
-  --input file.calor \
+  --input file.calr \
   --output file.g.cs \
   --verbose
 ```
@@ -201,7 +201,7 @@ Add to `.vscode/launch.json`:
       "type": "coreclr",
       "request": "launch",
       "program": "${workspaceFolder}/src/Calor.Compiler/bin/Debug/net8.0/Calor.Compiler.dll",
-      "args": ["--input", "test.calor", "--output", "test.g.cs"],
+      "args": ["--input", "test.calr", "--output", "test.g.cs"],
       "cwd": "${workspaceFolder}",
       "console": "internalConsole"
     }
@@ -213,7 +213,7 @@ Add to `.vscode/launch.json`:
 
 Set `Calor.Compiler` as startup project with command line arguments:
 ```
---input samples/HelloWorld/hello.calor --output output.g.cs
+--input samples/HelloWorld/hello.calr --output output.g.cs
 ```
 
 ---

--- a/docs/getting-started/claude-integration.md
+++ b/docs/getting-started/claude-integration.md
@@ -16,7 +16,7 @@ Calor is designed specifically for AI coding agents. This guide explains how to 
 Initialize your project for Claude Code with a single command:
 
 ```bash
-calorc init --ai claude
+calor init --ai claude
 ```
 
 This creates:
@@ -43,24 +43,24 @@ When Claude tries to create a C# file:
 ```
 BLOCKED: Cannot create C# file 'UserService.cs'
 
-This is an Calor-first project. Create an .calor file instead:
-  UserService.calor
+This is an Calor-first project. Create an .calr file instead:
+  UserService.calr
 
 Use /calor skill for Calor syntax help.
 ```
 
-Claude will automatically retry with an `.calor` file - no user intervention required.
+Claude will automatically retry with an `.calr` file - no user intervention required.
 
 ### Allowed Files
 
 The hook allows:
-- **`.calor` files** - All Calor source files
+- **`.calr` files** - All Calor source files
 - **`.g.cs` files** - Generated C# output from Calor compilation
 - **`obj/` directory** - Build artifacts
 
 ### Disabling Enforcement
 
-If you need to temporarily allow `.cs` file creation, remove or rename `.claude/settings.json`. Re-run `calorc init --ai claude` to restore enforcement.
+If you need to temporarily allow `.cs` file creation, remove or rename `.claude/settings.json`. Re-run `calor init --ai claude` to restore enforcement.
 
 ---
 
@@ -394,7 +394,7 @@ Convert src/Services/PaymentService.cs to Calor, adding:
 Reference specific elements by their IDs:
 
 ```
-In PaymentService.calor:
+In PaymentService.calr:
 - Extract the validation logic from f002 into a new private function
 - Add a postcondition to f001 ensuring the result is positive
 - Rename loop l001 to something more descriptive
@@ -403,7 +403,7 @@ In PaymentService.calor:
 ### Debugging with Claude
 
 ```
-Review OrderService.calor and identify:
+Review OrderService.calr and identify:
 1. Any missing preconditions that could cause runtime errors
 2. Functions that should be marked pure but have undeclared effects
 3. Opportunities to use Result<T,E> instead of exceptions
@@ -438,5 +438,5 @@ Then use the skills as normal.
 
 - [Syntax Reference](/calor/syntax-reference/) - Complete language reference
 - [Adding Calor to Existing Projects](/calor/guides/adding-calor-to-existing-projects/) - Migration guide
-- [calorc init](/calor/cli/init/) - Full init command documentation
+- [calor init](/calor/cli/init/) - Full init command documentation
 - [Benchmarking](/calor/benchmarking/) - See how Calor compares to C#

--- a/docs/getting-started/codex-integration.md
+++ b/docs/getting-started/codex-integration.md
@@ -16,7 +16,7 @@ This guide explains how to use Calor with OpenAI Codex CLI. For Claude Code inte
 Initialize your project for Codex CLI with a single command:
 
 ```bash
-calorc init --ai codex
+calor init --ai codex
 ```
 
 This creates:
@@ -36,10 +36,10 @@ You can run this command again anytime to update the Calor documentation section
 Unlike Claude Code which uses hooks to enforce Calor-first development, **Codex CLI does not support hooks**. This means:
 
 - Calor-first development is **guidance-based only**
-- Codex *should* follow the instructions in AGENTS.md and create `.calor` files
+- Codex *should* follow the instructions in AGENTS.md and create `.calr` files
 - However, enforcement is not automatic - Codex may occasionally create `.cs` files
 - Always review file extensions after code generation
-- Use `calorc analyze` to find any unconverted `.cs` files
+- Use `calor analyze` to find any unconverted `.cs` files
 
 ---
 
@@ -222,9 +222,9 @@ Since Codex doesn't enforce Calor-first automatically, periodically check for un
 
 ```bash
 # Find C# files that might need conversion
-calorc analyze ./src --top 10
+calor analyze ./src --top 10
 
-# Check for any new .cs files that should be .calor
+# Check for any new .cs files that should be .calr
 find . -name "*.cs" -not -name "*.g.cs" -not -path "./obj/*"
 ```
 
@@ -232,27 +232,27 @@ find . -name "*.cs" -not -name "*.g.cs" -not -path "./obj/*"
 
 ## Best Practices
 
-1. **Review generated files** - Always check that Codex created `.calor` files, not `.cs`
+1. **Review generated files** - Always check that Codex created `.calr` files, not `.cs`
 2. **Use explicit instructions** - Be specific about wanting Calor output
 3. **Include skill reference** - Start prompts with `$calor` or `$calor-convert`
-4. **Run analysis regularly** - Use `calorc analyze` to find migration candidates
+4. **Run analysis regularly** - Use `calor analyze` to find migration candidates
 5. **Convert promptly** - If Codex creates a `.cs` file, convert it immediately
 
 ---
 
 ## Troubleshooting
 
-### Codex Creates `.cs` Files Instead of `.calor`
+### Codex Creates `.cs` Files Instead of `.calr`
 
 This can happen since enforcement is guidance-based. Solutions:
 
-1. Be more explicit: "Create this as an Calor file (`.calor`), not C#"
+1. Be more explicit: "Create this as an Calor file (`.calr`), not C#"
 2. Start your prompt with `$calor` to activate the skill
-3. Convert the file: `calorc convert filename.cs`
+3. Convert the file: `calor convert filename.cs`
 
 ### Skills Not Recognized
 
-Ensure you've run `calorc init --ai codex` and the skill files exist:
+Ensure you've run `calor init --ai codex` and the skill files exist:
 
 ```bash
 ls -la .codex/skills/calor/SKILL.md
@@ -265,5 +265,5 @@ ls -la .codex/skills/calor-convert/SKILL.md
 
 - [Syntax Reference](/calor/syntax-reference/) - Complete language reference
 - [Adding Calor to Existing Projects](/calor/guides/adding-calor-to-existing-projects/) - Migration guide
-- [calorc init](/calor/cli/init/) - Full init command documentation
+- [calor init](/calor/cli/init/) - Full init command documentation
 - [Claude Integration](/calor/getting-started/claude-integration/) - Alternative with enforced Calor-first

--- a/docs/getting-started/gemini-integration.md
+++ b/docs/getting-started/gemini-integration.md
@@ -16,7 +16,7 @@ This guide explains how to use Calor with Google Gemini CLI. For other AI integr
 Initialize your project for Gemini CLI with a single command:
 
 ```bash
-calorc init --ai gemini
+calor init --ai gemini
 ```
 
 This creates:
@@ -42,14 +42,14 @@ When Gemini tries to create a `.cs` file, the hook blocks the operation:
 {
   "decision": "deny",
   "reason": "BLOCKED: Cannot create C# file 'MyClass.cs'",
-  "systemMessage": "This is an Calor-first project. Create an .calor file instead: MyClass.calor\n\nUse @calor skill for Calor syntax help."
+  "systemMessage": "This is an Calor-first project. Create an .calr file instead: MyClass.calr\n\nUse @calor skill for Calor syntax help."
 }
 ```
 
-Gemini will then automatically retry with an `.calor` file.
+Gemini will then automatically retry with an `.calr` file.
 
 **Allowed file types:**
-- `.calor` files (Calor source code)
+- `.calr` files (Calor source code)
 - `.g.cs` files (generated C# from Calor)
 - Files in `obj/` directory (build artifacts)
 
@@ -249,7 +249,7 @@ Test that the hook blocks `.cs` creation:
 # Ask Gemini to create a C# file
 gemini "Create a new utility class called StringHelper in StringHelper.cs"
 
-# The hook should block and suggest StringHelper.calor instead
+# The hook should block and suggest StringHelper.calr instead
 ```
 
 ---
@@ -285,7 +285,7 @@ Expected content includes:
           {
             "name": "calor-validate-write",
             "type": "command",
-            "command": "calorc hook validate-write --format gemini $TOOL_INPUT"
+            "command": "calor hook validate-write --format gemini $TOOL_INPUT"
           }
         ]
       }
@@ -294,18 +294,18 @@ Expected content includes:
 }
 ```
 
-### "calorc: command not found"
+### "calor: command not found"
 
 Ensure the Calor compiler is installed and in your PATH:
 
 ```bash
-dotnet tool install -g calorc
+dotnet tool install -g calor
 export PATH="$PATH:$HOME/.dotnet/tools"
 ```
 
 ### Skills Not Recognized
 
-Ensure you've run `calorc init --ai gemini` and the skill files exist:
+Ensure you've run `calor init --ai gemini` and the skill files exist:
 
 ```bash
 ls -la .gemini/skills/calor/SKILL.md
@@ -318,6 +318,6 @@ ls -la .gemini/skills/calor-convert/SKILL.md
 
 - [Syntax Reference](/calor/syntax-reference/) - Complete language reference
 - [Adding Calor to Existing Projects](/calor/guides/adding-calor-to-existing-projects/) - Migration guide
-- [calorc init](/calor/cli/init/) - Full init command documentation
+- [calor init](/calor/cli/init/) - Full init command documentation
 - [Claude Integration](/calor/getting-started/claude-integration/) - Alternative with Claude Code
 - [Codex Integration](/calor/getting-started/codex-integration/) - Alternative with OpenAI Codex CLI

--- a/docs/getting-started/hello-world.md
+++ b/docs/getting-started/hello-world.md
@@ -105,7 +105,7 @@ Every `§F` must have a matching `§/F` with the same ID. Same for modules.
 ```bash
 # Compile
 dotnet run --project src/Calor.Compiler -- \
-  --input samples/HelloWorld/hello.calor \
+  --input samples/HelloWorld/hello.calr \
   --output samples/HelloWorld/hello.g.cs
 
 # Run

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -17,7 +17,7 @@ This guide will help you install Calor, write your first program, and understand
 Calor is a programming language that compiles to C# via source-to-source transformation. The workflow is:
 
 ```
-your_code.calor → Calor Compiler → your_code.g.cs → .NET Build → executable
+your_code.calr → Calor Compiler → your_code.g.cs → .NET Build → executable
 ```
 
 ---
@@ -43,13 +43,13 @@ your_code.calor → Calor Compiler → your_code.g.cs → .NET Build → executa
 Install the Calor compiler as a global .NET tool:
 
 ```bash
-dotnet tool install -g calorc --version 0.1.2
+dotnet tool install -g calor --version 0.1.2
 ```
 
 Or update an existing installation:
 
 ```bash
-dotnet tool update -g calorc
+dotnet tool update -g calor
 ```
 
 ---
@@ -69,21 +69,21 @@ cd MyApp
 ### Step 2: Enable Calor
 
 ```bash
-calorc init
+calor init
 ```
 
-This adds MSBuild integration so `.calor` files compile automatically during `dotnet build`.
+This adds MSBuild integration so `.calr` files compile automatically during `dotnet build`.
 
 ### Step 3: (Optional) Enable AI Agent Integration
 
 For Claude Code (with enforced Calor-first via hooks):
 ```bash
-calorc init --ai claude
+calor init --ai claude
 ```
 
 For OpenAI Codex CLI (guidance-based):
 ```bash
-calorc init --ai codex
+calor init --ai codex
 ```
 
 This adds Calor skills and project documentation that instruct the AI to:
@@ -94,7 +94,7 @@ This adds Calor skills and project documentation that instruct the AI to:
 
 ### Step 4: Write Calor Code
 
-After init, create `.calor` files and they compile automatically. Create `Program.calor`:
+After init, create `.calr` files and they compile automatically. Create `Program.calr`:
 
 ```
 §M{m001:MyApp}
@@ -119,13 +119,13 @@ See [Hello World](/calor/getting-started/hello-world/) for a detailed explanatio
 For existing C# codebases, analyze which files are good candidates for migration:
 
 ```bash
-calorc analyze ./src --top 10
+calor analyze ./src --top 10
 ```
 
 Then convert high-scoring files:
 
 ```bash
-calorc convert HighScoreFile.cs
+calor convert HighScoreFile.cs
 ```
 
 See the [Adding Calor to Existing Projects](/calor/guides/adding-calor-to-existing-projects/) guide for the complete walkthrough.
@@ -134,14 +134,14 @@ See the [Adding Calor to Existing Projects](/calor/guides/adding-calor-to-existi
 
 ## What You Get
 
-### Basic Init (`calorc init`)
+### Basic Init (`calor init`)
 
 | Component | Description |
 |:----------|:------------|
-| MSBuild integration | `.calor` files compile automatically during `dotnet build` |
+| MSBuild integration | `.calr` files compile automatically during `dotnet build` |
 | Generated output | C# files go to `obj/` directory, keeping source tree clean |
 
-### With Claude (`calorc init --ai claude`)
+### With Claude (`calor init --ai claude`)
 
 | Component | Description |
 |:----------|:------------|
@@ -149,7 +149,7 @@ See the [Adding Calor to Existing Projects](/calor/guides/adding-calor-to-existi
 | Hook configuration | **Enforces Calor-first** - blocks `.cs` file creation |
 | CLAUDE.md | Project guidelines instructing Claude to prefer Calor for new code |
 
-### With Codex (`calorc init --ai codex`)
+### With Codex (`calor init --ai codex`)
 
 | Component | Description |
 |:----------|:------------|
@@ -172,4 +172,4 @@ For alternative installation methods (global tool only, manual Claude skills set
 - [Hello World](/calor/getting-started/hello-world/) - Understand the hello world program
 - [Adding Calor to Existing Projects](/calor/guides/adding-calor-to-existing-projects/) - Complete migration guide
 - [Syntax Reference](/calor/syntax-reference/) - Complete language reference
-- [CLI Reference](/calor/cli/) - All `calorc` commands including migration analysis
+- [CLI Reference](/calor/cli/) - All `calor` commands including migration analysis

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -16,26 +16,26 @@ This guide covers installing the Calor compiler and setting up your development 
 Install the Calor compiler as a global .NET tool:
 
 ```bash
-dotnet tool install -g calorc
+dotnet tool install -g calor
 ```
 
 After installation, you can compile Calor files from anywhere:
 
 ```bash
-calorc --input program.calor --output program.g.cs
+calor --input program.calr --output program.g.cs
 ```
 
 To update to the latest version:
 
 ```bash
-dotnet tool update -g calorc
+dotnet tool update -g calor
 ```
 
 ---
 
 ## AI Agent Integration
 
-Calor provides first-class support for AI coding agents. The `calorc init` command sets up your project for AI-assisted development.
+Calor provides first-class support for AI coding agents. The `calor init` command sets up your project for AI-assisted development.
 
 ### Supported AI Agents
 
@@ -51,7 +51,7 @@ Calor provides first-class support for AI coding agents. The `calorc init` comma
 Initialize your project for Claude Code:
 
 ```bash
-calorc init --ai claude
+calor init --ai claude
 ```
 
 This creates:
@@ -73,7 +73,7 @@ After initialization, use these commands in Claude Code:
 
 ### Re-running Init
 
-You can run `calorc init --ai claude` multiple times safely:
+You can run `calor init --ai claude` multiple times safely:
 
 - **CLAUDE.md** - Updates only the Calor section, preserving your custom content
 - **Skills files** - Updates to latest version (prompts to confirm or use `--force`)
@@ -85,21 +85,21 @@ The `init` command also adds MSBuild targets to your `.csproj` file for automati
 
 ```bash
 # Specify project explicitly
-calorc init --ai claude --project MyApp.csproj
+calor init --ai claude --project MyApp.csproj
 
 # Auto-detect single .csproj
-calorc init --ai claude
+calor init --ai claude
 ```
 
 After initialization, Calor files compile automatically during `dotnet build`:
 
 ```
 dotnet build
-# → Compiles all .calor files to obj/<config>/<tfm>/calor/*.g.cs
+# → Compiles all .calr files to obj/<config>/<tfm>/calor/*.g.cs
 # → Includes generated C# in compilation
 ```
 
-See [`calorc init`](/calor/cli/init/) for complete documentation.
+See [`calor init`](/calor/cli/init/) for complete documentation.
 
 ---
 
@@ -151,7 +151,7 @@ Expected output:
 Calor Compiler - Coding Agent Language for Optimized Reasoning
 
 Usage:
-  calorc --input <file.calor> --output <file.cs>
+  calor --input <file.calr> --output <file.cs>
 
 Options:
   --input, -i    Input Calor source file
@@ -183,7 +183,7 @@ Basic usage:
 
 ```bash
 dotnet run --project src/Calor.Compiler -- \
-  --input path/to/your/program.calor \
+  --input path/to/your/program.calr \
   --output path/to/output/program.g.cs
 ```
 
@@ -200,7 +200,7 @@ After compilation, you need a C# project to run the generated code:
 ```bash
 # Compile your Calor file
 dotnet run --project src/Calor.Compiler -- \
-  --input your-program.calor \
+  --input your-program.calr \
   --output samples/HelloWorld/your-program.g.cs
 
 # Run it (requires modifying HelloWorld.csproj or including the file)
@@ -216,7 +216,7 @@ cd MyCalorProgram
 
 # Compile Calor to the project directory
 dotnet run --project ../src/Calor.Compiler -- \
-  --input ../my-code.calor \
+  --input ../my-code.calr \
   --output my-code.g.cs
 
 # Run the program

--- a/docs/guides/adding-calor-to-existing-projects.md
+++ b/docs/guides/adding-calor-to-existing-projects.md
@@ -27,7 +27,7 @@ You don't need to convert everything at once. Calor and C# coexist seamlessly.
 ## Prerequisites
 
 - .NET 8.0 SDK or later
-- `calorc` global tool installed: `dotnet tool install -g calorc`
+- `calor` global tool installed: `dotnet tool install -g calor`
 - An existing C# project
 
 ---
@@ -38,36 +38,36 @@ Enable Calor with MSBuild integration:
 
 ```bash
 # Initialize Calor in your project
-calorc init
+calor init
 
 # Or specify a specific project file
-calorc init --project MyApp.csproj
+calor init --project MyApp.csproj
 ```
 
 ### What Happens
 
 Your `.csproj` is updated with MSBuild targets that:
 
-- Compile `.calor` files automatically before C# compilation
+- Compile `.calr` files automatically before C# compilation
 - Include generated `.g.cs` files in the build
 - Clean generated files on `dotnet clean`
 
 Generated files go to `obj/<Configuration>/<TargetFramework>/calor/`, keeping your source tree clean.
 
-After this step, you can immediately start writing `.calor` files and they'll compile during `dotnet build`.
+After this step, you can immediately start writing `.calr` files and they'll compile during `dotnet build`.
 
 ---
 
 ## Step 2: Analyze Your Codebase
 
-Use `calorc analyze` to find C# files that would benefit most from Calor:
+Use `calor analyze` to find C# files that would benefit most from Calor:
 
 ```bash
 # Analyze your source directory
-calorc analyze ./src
+calor analyze ./src
 
 # Show top 10 candidates with detailed scores
-calorc analyze ./src --top 10 --verbose
+calor analyze ./src --top 10 --verbose
 ```
 
 ### Understanding the Output
@@ -109,11 +109,11 @@ Files are scored based on patterns that map to Calor features:
 
 ## Step 3: Add Your First Calor File
 
-Create a new `.calor` file alongside your existing code:
+Create a new `.calr` file alongside your existing code:
 
 ```bash
 # Create a simple Calor module
-cat > src/Services/Calculator.calor << 'EOF'
+cat > src/Services/Calculator.calr << 'EOF'
 §M[m001:Calculator]
 
 §F[f001:Add:pub]
@@ -146,7 +146,7 @@ dotnet build
 
 The build process:
 
-1. Finds all `.calor` files in your project
+1. Finds all `.calr` files in your project
 2. Compiles each to `.g.cs` in the `obj/calor/` directory
 3. Includes generated C# in the normal compilation
 4. Produces your final assembly
@@ -167,25 +167,25 @@ Based on your analysis results, convert files that score High or Critical:
 
 ```bash
 # Convert a single file
-calorc convert src/Services/PaymentProcessor.cs
+calor convert src/Services/PaymentProcessor.cs
 
-# Output: src/Services/PaymentProcessor.calor
+# Output: src/Services/PaymentProcessor.calr
 
 # With benchmark comparison to see token savings
-calorc convert src/Services/PaymentProcessor.cs --benchmark
+calor convert src/Services/PaymentProcessor.cs --benchmark
 ```
 
 For bulk conversion:
 
 ```bash
 # Preview what would be converted
-calorc migrate ./src --dry-run
+calor migrate ./src --dry-run
 
 # Convert all files
-calorc migrate ./src --direction cs-to-calor
+calor migrate ./src --direction cs-to-calor
 
 # Generate a migration report
-calorc migrate ./src --report migration-report.md
+calor migrate ./src --report migration-report.md
 ```
 
 ---
@@ -210,7 +210,7 @@ Or keep both if you want to compare them during a transition period.
 For AI-assisted Calor development, add Claude Code support:
 
 ```bash
-calorc init --ai claude
+calor init --ai claude
 ```
 
 ### What Gets Added
@@ -282,8 +282,8 @@ MyProject/
 │   │   └── User.cs           # Keep simple DTOs in C#
 │   └── Services/
 │       ├── AuthService.cs    # Legacy C# (not yet converted)
-│       ├── PaymentService.calor    # Converted to Calor
-│       └── OrderService.calor      # Converted to Calor
+│       ├── PaymentService.calr    # Converted to Calor
+│       └── OrderService.calr      # Converted to Calor
 └── obj/
     └── Debug/net8.0/calor/
         ├── PaymentService.g.cs    # Generated C#
@@ -296,7 +296,7 @@ MyProject/
 
 ### What to Convert First
 
-1. **High-scoring files** from `calorc analyze`
+1. **High-scoring files** from `calor analyze`
 2. **Files with complex validation** - benefit from contracts
 3. **Files with error handling** - benefit from `Result<T,E>`
 4. **Files with side effects** - benefit from effect declarations
@@ -319,7 +319,7 @@ MyProject/
 
 ## Troubleshooting
 
-### Build Fails: "calorc not found"
+### Build Fails: "calor not found"
 
 Add the .NET tools directory to your PATH:
 
@@ -360,5 +360,5 @@ Review these manually and adjust the Calor code as needed.
 - [Syntax Reference](/calor/syntax-reference/) - Complete Calor language reference
 - [Contracts](/calor/syntax-reference/contracts/) - Writing preconditions and postconditions
 - [Effects](/calor/syntax-reference/effects/) - Declaring side effects
-- [calorc analyze](/calor/cli/analyze/) - Understanding migration scores
-- [calorc benchmark](/calor/cli/benchmark/) - Comparing Calor vs C# metrics
+- [calor analyze](/calor/cli/analyze/) - Understanding migration scores
+- [calor benchmark](/calor/cli/benchmark/) - Comparing Calor vs C# metrics

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,7 +100,7 @@ cd calor && dotnet build
 
 # Compile Calor to C#
 dotnet run --project src/Calor.Compiler -- \
-  --input samples/HelloWorld/hello.calor \
+  --input samples/HelloWorld/hello.calr \
   --output samples/HelloWorld/hello.g.cs
 
 # Run the generated program
@@ -113,11 +113,11 @@ dotnet run --project samples/HelloWorld
 
 ## Migration Analysis
 
-Have an existing C# codebase? Use `calorc analyze` to find files that would benefit most from Calor:
+Have an existing C# codebase? Use `calor analyze` to find files that would benefit most from Calor:
 
 ```bash
 # Score C# files for migration potential
-calorc analyze ./src
+calor analyze ./src
 
 # Output:
 # === Calor Migration Analysis ===

--- a/website/content/cli/analyze.mdx
+++ b/website/content/cli/analyze.mdx
@@ -4,12 +4,12 @@ section: "cli"
 order: 1
 ---
 
-# calorc analyze
+# calor analyze
 
 Score C# files for Calor migration potential.
 
 ```bash
-calorc analyze <path> [options]
+calor analyze <path> [options]
 ```
 
 ---
@@ -30,13 +30,13 @@ Use this command to:
 
 ```bash
 # Analyze current directory
-calorc analyze .
+calor analyze .
 
 # Analyze with detailed breakdown
-calorc analyze ./src --verbose
+calor analyze ./src --verbose
 
 # Export as JSON for processing
-calorc analyze ./src --format json --output analysis.json
+calor analyze ./src --format json --output analysis.json
 ```
 
 ---
@@ -133,7 +133,7 @@ With `--verbose`, each file shows dimension breakdown:
 Machine-readable format for processing:
 
 ```bash
-calorc analyze ./src --format json --output analysis.json
+calor analyze ./src --format json --output analysis.json
 ```
 
 ```json
@@ -187,7 +187,7 @@ calorc analyze ./src --format json --output analysis.json
 [SARIF](https://sarifweb.azurewebsites.net/) (Static Analysis Results Interchange Format) for IDE and CI/CD integration:
 
 ```bash
-calorc analyze ./src --format sarif --output analysis.sarif
+calor analyze ./src --format sarif --output analysis.sarif
 ```
 
 SARIF output integrates with:
@@ -212,7 +212,7 @@ Use exit code `1` in CI/CD to flag codebases with high migration potential:
 
 ```bash
 # Fail CI if high-priority migration candidates exist
-calorc analyze ./src --threshold 51
+calor analyze ./src --threshold 51
 if [ $? -eq 1 ]; then
   echo "High-priority Calor migration candidates found"
 fi
@@ -226,7 +226,7 @@ fi
 
 ```bash
 # Show top 10 files scoring above 50
-calorc analyze ./src --threshold 50 --top 10
+calor analyze ./src --threshold 50 --top 10
 ```
 
 ### CI/CD Integration
@@ -235,7 +235,7 @@ calorc analyze ./src --threshold 50 --top 10
 # GitHub Actions example
 - name: Analyze Calor migration potential
   run: |
-    calorc analyze ./src --format sarif --output calor-analysis.sarif
+    calor analyze ./src --format sarif --output calor-analysis.sarif
 
 - name: Upload SARIF
   uses: github/codeql-action/upload-sarif@v2
@@ -247,7 +247,7 @@ calorc analyze ./src --threshold 50 --top 10
 
 ```bash
 # Full JSON report for documentation
-calorc analyze . --format json --output migration-report.json
+calor analyze . --format json --output migration-report.json
 
 # Parse with jq to find critical files
 cat migration-report.json | jq '.files[] | select(.priority == "critical") | .path'
@@ -257,7 +257,7 @@ cat migration-report.json | jq '.files[] | select(.priority == "critical") | .pa
 
 ```bash
 # Deep dive into a specific directory
-calorc analyze ./src/Services --verbose --top 50
+calor analyze ./src/Services --verbose --top 50
 ```
 
 ---

--- a/website/content/cli/benchmark.mdx
+++ b/website/content/cli/benchmark.mdx
@@ -4,12 +4,12 @@ section: "cli"
 order: 5
 ---
 
-# calorc benchmark
+# calor benchmark
 
 Compare Calor vs C# across evaluation metrics.
 
 ```bash
-calorc benchmark [project] [options]
+calor benchmark [project] [options]
 ```
 
 ---
@@ -32,16 +32,16 @@ The `benchmark` command measures and compares Calor against C# across seven eval
 
 ```bash
 # Compare two files
-calorc benchmark --calor Calculator.calor --csharp Calculator.cs
+calor benchmark --calor Calculator.calr --csharp Calculator.cs
 
 # Benchmark entire project
-calorc benchmark ./src
+calor benchmark ./src
 
 # Quick token-only comparison
-calorc benchmark --calor file.calor --csharp file.cs --quick
+calor benchmark --calor file.calr --csharp file.cs --quick
 
 # Generate markdown report
-calorc benchmark ./src --format markdown --output report.md
+calor benchmark ./src --format markdown --output report.md
 ```
 
 ---
@@ -65,7 +65,7 @@ calorc benchmark ./src --format markdown --output report.md
 Compare a specific Calor file against its C# equivalent:
 
 ```bash
-calorc benchmark --calor PaymentService.calor --csharp PaymentService.cs
+calor benchmark --calor PaymentService.calr --csharp PaymentService.cs
 ```
 
 Output:
@@ -90,7 +90,7 @@ Calor shows 1.27x overall advantage for AI agent tasks.
 For fast token/line comparison without the full 7-metric evaluation:
 
 ```bash
-calorc benchmark --calor file.calor --csharp file.cs --quick
+calor benchmark --calor file.calr --csharp file.cs --quick
 ```
 
 Output:
@@ -117,6 +117,6 @@ Output:
 
 ## See Also
 
-- [calorc analyze](/cli/analyze/) - Score files for migration potential
+- [calor analyze](/cli/analyze/) - Score files for migration potential
 - [Benchmarking Methodology](/benchmarking/methodology/) - Detailed methodology
 - [Benchmark Results](/benchmarking/results/) - Published results

--- a/website/content/cli/compile.mdx
+++ b/website/content/cli/compile.mdx
@@ -4,19 +4,19 @@ section: "cli"
 order: 0
 ---
 
-# calorc (compile)
+# calor (compile)
 
 Compile Calor source files to C#.
 
 ```bash
-calorc --input <file.calor> --output <file.cs>
+calor --input <file.calr> --output <file.cs>
 ```
 
 ---
 
 ## Overview
 
-The default `calorc` command (when no subcommand is specified) compiles Calor source files to C#. This is the core functionality of the Calor compiler.
+The default `calor` command (when no subcommand is specified) compiles Calor source files to C#. This is the core functionality of the Calor compiler.
 
 ---
 
@@ -24,13 +24,13 @@ The default `calorc` command (when no subcommand is specified) compiles Calor so
 
 ```bash
 # Compile a single file
-calorc --input MyModule.calor --output MyModule.g.cs
+calor --input MyModule.calr --output MyModule.g.cs
 
 # Short form
-calorc -i MyModule.calor -o MyModule.g.cs
+calor -i MyModule.calr -o MyModule.g.cs
 
 # With verbose output
-calorc -v -i MyModule.calor -o MyModule.g.cs
+calor -v -i MyModule.calr -o MyModule.g.cs
 ```
 
 ---
@@ -50,7 +50,7 @@ calorc -v -i MyModule.calor -o MyModule.g.cs
 The recommended convention for generated C# files is the `.g.cs` extension:
 
 ```
-MyModule.calor → MyModule.g.cs
+MyModule.calr → MyModule.g.cs
 ```
 
 This indicates "generated C#" and helps distinguish Calor-generated code from hand-written C#.
@@ -62,7 +62,7 @@ This indicates "generated C#" and helps distinguish Calor-generated code from ha
 When compilation fails, errors are reported with file location:
 
 ```
-Error in Calculator.calor:12:5
+Error in Calculator.calr:12:5
   Undefined variable 'x' in expression
 
   §R (+ x 1)
@@ -71,13 +71,13 @@ Error in Calculator.calor:12:5
 Compilation failed with 1 error
 ```
 
-For machine-readable error output, use [`calorc diagnose`](/cli/diagnose/).
+For machine-readable error output, use [`calor diagnose`](/cli/diagnose/).
 
 ---
 
 ## Integration with MSBuild
 
-For automatic compilation during `dotnet build`, use [`calorc init`](/cli/init/) to set up MSBuild integration.
+For automatic compilation during `dotnet build`, use [`calor init`](/cli/init/) to set up MSBuild integration.
 
 ---
 
@@ -93,6 +93,6 @@ For automatic compilation during `dotnet build`, use [`calorc init`](/cli/init/)
 
 ## See Also
 
-- [calorc init](/cli/init/) - Set up automatic compilation with MSBuild
-- [calorc diagnose](/cli/diagnose/) - Machine-readable diagnostics
-- [calorc format](/cli/format/) - Format Calor source files
+- [calor init](/cli/init/) - Set up automatic compilation with MSBuild
+- [calor diagnose](/cli/diagnose/) - Machine-readable diagnostics
+- [calor format](/cli/format/) - Format Calor source files

--- a/website/content/cli/convert.mdx
+++ b/website/content/cli/convert.mdx
@@ -4,12 +4,12 @@ section: "cli"
 order: 3
 ---
 
-# calorc convert
+# calor convert
 
 Convert a single file between C# and Calor.
 
 ```bash
-calorc convert <input> [options]
+calor convert <input> [options]
 ```
 
 ---
@@ -19,7 +19,7 @@ calorc convert <input> [options]
 The `convert` command performs bidirectional conversion between C# and Calor:
 
 - **C# → Calor**: Convert `.cs` files to Calor syntax
-- **Calor → C#**: Convert `.calor` files to generated C#
+- **Calor → C#**: Convert `.calr` files to generated C#
 
 The conversion direction is automatically detected from the input file extension.
 
@@ -29,16 +29,16 @@ The conversion direction is automatically detected from the input file extension
 
 ```bash
 # Convert C# to Calor
-calorc convert MyService.cs
+calor convert MyService.cs
 
 # Convert Calor to C#
-calorc convert MyService.calor
+calor convert MyService.calr
 
 # Specify output path
-calorc convert MyService.cs --output src/MyService.calor
+calor convert MyService.cs --output src/MyService.calr
 
 # Include benchmark comparison
-calorc convert MyService.cs --benchmark
+calor convert MyService.cs --benchmark
 ```
 
 ---
@@ -59,8 +59,8 @@ If `--output` is not specified:
 
 | Input | Output |
 |:------|:-------|
-| `MyFile.cs` | `MyFile.calor` |
-| `MyFile.calor` | `MyFile.g.cs` |
+| `MyFile.cs` | `MyFile.calr` |
+| `MyFile.calr` | `MyFile.g.cs` |
 
 ---
 
@@ -84,7 +84,7 @@ If `--output` is not specified:
 Use `--benchmark` to see how the Calor version compares to C#:
 
 ```bash
-calorc convert PaymentService.cs --benchmark
+calor convert PaymentService.cs --benchmark
 ```
 
 Output:
@@ -113,6 +113,6 @@ Benchmark Comparison:
 
 ## See Also
 
-- [calorc migrate](/cli/migrate/) - Convert entire projects
-- [calorc analyze](/cli/analyze/) - Find best conversion candidates
-- [calorc benchmark](/cli/benchmark/) - Detailed metrics comparison
+- [calor migrate](/cli/migrate/) - Convert entire projects
+- [calor analyze](/cli/analyze/) - Find best conversion candidates
+- [calor benchmark](/cli/benchmark/) - Detailed metrics comparison

--- a/website/content/cli/diagnose.mdx
+++ b/website/content/cli/diagnose.mdx
@@ -4,12 +4,12 @@ section: "cli"
 order: 7
 ---
 
-# calorc diagnose
+# calor diagnose
 
 Output machine-readable diagnostics for Calor files.
 
 ```bash
-calorc diagnose <files...> [options]
+calor diagnose <files...> [options]
 ```
 
 ---
@@ -28,16 +28,16 @@ The `diagnose` command analyzes Calor files and outputs diagnostics in formats s
 
 ```bash
 # Diagnose a single file (text output)
-calorc diagnose MyModule.calor
+calor diagnose MyModule.calr
 
 # JSON output for processing
-calorc diagnose MyModule.calor --format json
+calor diagnose MyModule.calr --format json
 
 # SARIF output for IDE integration
-calorc diagnose src/*.calor --format sarif --output diagnostics.sarif
+calor diagnose src/*.calr --format sarif --output diagnostics.sarif
 
 # Enable strict checking
-calorc diagnose MyModule.calor --strict-api --require-docs
+calor diagnose MyModule.calr --strict-api --require-docs
 ```
 
 ---
@@ -58,7 +58,7 @@ calorc diagnose MyModule.calor --strict-api --require-docs
 ### Text (Default)
 
 ```
-Calculator.calor:12:5: error: Undefined variable 'x'
+Calculator.calr:12:5: error: Undefined variable 'x'
   §R (+ x 1)
        ^
 
@@ -90,7 +90,7 @@ Integrates with VS Code, GitHub Code Scanning, Azure DevOps, and other SARIF-com
 ```yaml
 # GitHub Actions
 - name: Check Calor diagnostics
-  run: calorc diagnose src/**/*.calor --format sarif --output calor.sarif
+  run: calor diagnose src/**/*.calr --format sarif --output calor.sarif
 
 - name: Upload SARIF
   uses: github/codeql-action/upload-sarif@v2
@@ -102,5 +102,5 @@ Integrates with VS Code, GitHub Code Scanning, Azure DevOps, and other SARIF-com
 
 ## See Also
 
-- [calorc format](/cli/format/) - Format Calor source files
-- [calorc compile](/cli/compile/) - Compile with error reporting
+- [calor format](/cli/format/) - Format Calor source files
+- [calor compile](/cli/compile/) - Compile with error reporting

--- a/website/content/cli/format.mdx
+++ b/website/content/cli/format.mdx
@@ -4,12 +4,12 @@ section: "cli"
 order: 6
 ---
 
-# calorc format
+# calor format
 
 Format Calor source files to canonical style.
 
 ```bash
-calorc format <files...> [options]
+calor format <files...> [options]
 ```
 
 ---
@@ -24,16 +24,16 @@ The `format` command formats Calor source files according to the canonical Calor
 
 ```bash
 # Format a single file (output to stdout)
-calorc format MyModule.calor
+calor format MyModule.calr
 
 # Format and overwrite the file
-calorc format MyModule.calor --write
+calor format MyModule.calr --write
 
 # Check if files are formatted (for CI)
-calorc format src/*.calor --check
+calor format src/*.calr --check
 
 # Show diff of changes
-calorc format MyModule.calor --diff
+calor format MyModule.calr --diff
 ```
 
 ---
@@ -67,7 +67,7 @@ The Calor formatter applies these rules:
 Use `--check` in CI/CD to verify formatting:
 
 ```bash
-calorc format src/*.calor --check
+calor format src/*.calr --check
 ```
 
 Exit codes:
@@ -88,5 +88,5 @@ Exit codes:
 
 ## See Also
 
-- [calorc diagnose](/cli/diagnose/) - Check for errors and warnings
-- [calorc compile](/cli/compile/) - Compile Calor to C#
+- [calor diagnose](/cli/diagnose/) - Check for errors and warnings
+- [calor compile](/cli/compile/) - Compile Calor to C#

--- a/website/content/cli/hook.mdx
+++ b/website/content/cli/hook.mdx
@@ -3,19 +3,19 @@ title: hook
 description: Claude Code hook commands for Calor-first enforcement
 ---
 
-# calorc hook
+# calor hook
 
 Internal commands for Claude Code hook integration. These commands are called automatically by Claude Code hooks and are not typically invoked directly.
 
 ```bash
-calorc hook <subcommand> [args]
+calor hook <subcommand> [args]
 ```
 
 ---
 
 ## Overview
 
-The `hook` command provides subcommands that integrate with Claude Code's hook system to enforce Calor-first development. When you run `calorc init --ai claude`, it configures these hooks automatically.
+The `hook` command provides subcommands that integrate with Claude Code's hook system to enforce Calor-first development. When you run `calor init --ai claude`, it configures these hooks automatically.
 
 ---
 
@@ -26,14 +26,14 @@ The `hook` command provides subcommands that integrate with Claude Code's hook s
 Validates Write tool calls to enforce Calor-first development.
 
 ```bash
-calorc hook validate-write <tool-input-json>
+calor hook validate-write <tool-input-json>
 ```
 
 **Behavior:**
 
 | File Type | Action |
 |:----------|:-------|
-| `.calor` files | Allowed (exit 0) |
+| `.calr` files | Allowed (exit 0) |
 | `.g.cs` generated files | Allowed (exit 0) |
 | Files in `obj/` directory | Allowed (exit 0) |
 | Other `.cs` files | **Blocked** (exit 1) |
@@ -42,25 +42,25 @@ calorc hook validate-write <tool-input-json>
 
 ```bash
 # This will be blocked (exit 1)
-calorc hook validate-write '{"file_path": "MyClass.cs"}'
+calor hook validate-write '{"file_path": "MyClass.cs"}'
 
 # Output:
 # BLOCKED: Cannot create C# file 'MyClass.cs'
 #
-# This is an Calor-first project. Create an .calor file instead:
-#   MyClass.calor
+# This is an Calor-first project. Create an .calr file instead:
+#   MyClass.calr
 #
 # Use /calor skill for Calor syntax help.
 
 # This will be allowed (exit 0)
-calorc hook validate-write '{"file_path": "MyClass.calor"}'
+calor hook validate-write '{"file_path": "MyClass.calr"}'
 ```
 
 ---
 
 ## How Hooks Work
 
-When you initialize a project with `calorc init --ai claude`, it creates `.claude/settings.json` with hook configuration:
+When you initialize a project with `calor init --ai claude`, it creates `.claude/settings.json` with hook configuration:
 
 ```json
 {
@@ -71,7 +71,7 @@ When you initialize a project with `calorc init --ai claude`, it creates `.claud
         "hooks": [
           {
             "type": "command",
-            "command": "calorc hook validate-write $TOOL_INPUT"
+            "command": "calor hook validate-write $TOOL_INPUT"
           }
         ]
       }
@@ -80,7 +80,7 @@ When you initialize a project with `calorc init --ai claude`, it creates `.claud
 }
 ```
 
-This hook runs **before** every Write tool call. If the hook returns exit code 1, Claude Code blocks the operation and shows the error message to Claude, who will then retry with an `.calor` file.
+This hook runs **before** every Write tool call. If the hook returns exit code 1, Claude Code blocks the operation and shows the error message to Claude, who will then retry with an `.calr` file.
 
 ---
 
@@ -92,7 +92,7 @@ When Claude tries to create a `.cs` file in an Calor-initialized project:
 2. The hook intercepts the call and validates the path
 3. Hook returns exit 1 with guidance message
 4. Claude Code blocks the write operation
-5. Claude sees the error and creates an `.calor` file instead
+5. Claude sees the error and creates an `.calr` file instead
 
 This enforcement happens automatically - no user intervention required.
 
@@ -108,10 +108,10 @@ This enforcement happens automatically - no user intervention required.
    ```
    Should contain `PreToolUse` hook for `Write`
 
-2. **Verify calorc is in PATH:**
+2. **Verify calor is in PATH:**
    ```bash
-   which calorc
-   calorc hook validate-write '{"file_path": "test.cs"}'
+   which calor
+   calor hook validate-write '{"file_path": "test.cs"}'
    echo $?  # Should be 1
    ```
 
@@ -120,12 +120,12 @@ This enforcement happens automatically - no user intervention required.
 ### Re-enable Hooks After Manual Removal
 
 ```bash
-calorc init --ai claude --force
+calor init --ai claude --force
 ```
 
 ---
 
 ## See Also
 
-- [calorc init](/cli/init/) - Initialize Calor with hook configuration
+- [calor init](/cli/init/) - Initialize Calor with hook configuration
 - [Claude Integration](/getting-started/claude-integration/) - Using Calor with Claude

--- a/website/content/cli/index.mdx
+++ b/website/content/cli/index.mdx
@@ -7,22 +7,22 @@ hasChildren: true
 
 # CLI Reference
 
-The `calorc` command-line tool provides commands for working with Calor code and analyzing C# codebases for migration.
+The `calor` command-line tool provides commands for working with Calor code and analyzing C# codebases for migration.
 
 ---
 
 ## Installation
 
-Install `calorc` as a global .NET tool:
+Install `calor` as a global .NET tool:
 
 ```bash
-dotnet tool install -g calorc --version 0.1.3
+dotnet tool install -g calor --version 0.1.3
 ```
 
 Or update an existing installation:
 
 ```bash
-dotnet tool update -g calorc
+dotnet tool update -g calor
 ```
 
 ---
@@ -31,15 +31,15 @@ dotnet tool update -g calorc
 
 | Command | Description |
 |:--------|:------------|
-| `calorc` (default) | Compile Calor source files to C# |
-| [`calorc analyze`](/cli/analyze/) | Score C# files for Calor migration potential |
-| [`calorc init`](/cli/init/) | Initialize Calor with AI agent support and .csproj integration |
-| [`calorc convert`](/cli/convert/) | Convert single files between C# and Calor |
-| [`calorc migrate`](/cli/migrate/) | Migrate entire projects between C# and Calor |
-| [`calorc benchmark`](/cli/benchmark/) | Compare Calor vs C# across evaluation metrics |
-| [`calorc format`](/cli/format/) | Format Calor source files to canonical style |
-| [`calorc diagnose`](/cli/diagnose/) | Output machine-readable diagnostics for tooling |
-| [`calorc hook`](/cli/hook/) | Claude Code hook commands (internal) |
+| `calor` (default) | Compile Calor source files to C# |
+| [`calor analyze`](/cli/analyze/) | Score C# files for Calor migration potential |
+| [`calor init`](/cli/init/) | Initialize Calor with AI agent support and .csproj integration |
+| [`calor convert`](/cli/convert/) | Convert single files between C# and Calor |
+| [`calor migrate`](/cli/migrate/) | Migrate entire projects between C# and Calor |
+| [`calor benchmark`](/cli/benchmark/) | Compare Calor vs C# across evaluation metrics |
+| [`calor format`](/cli/format/) | Format Calor source files to canonical style |
+| [`calor diagnose`](/cli/diagnose/) | Output machine-readable diagnostics for tooling |
+| [`calor hook`](/cli/hook/) | Claude Code hook commands (internal) |
 
 ---
 
@@ -48,7 +48,7 @@ dotnet tool update -g calorc
 Compile Calor source files to C#:
 
 ```bash
-calorc --input file.calor --output file.g.cs
+calor --input file.calr --output file.g.cs
 ```
 
 ### Options
@@ -63,10 +63,10 @@ calorc --input file.calor --output file.g.cs
 
 ```bash
 # Compile a single file
-calorc --input src/MyModule.calor --output src/MyModule.g.cs
+calor --input src/MyModule.calr --output src/MyModule.g.cs
 
 # Compile with verbose output
-calorc -v -i src/MyModule.calor -o src/MyModule.g.cs
+calor -v -i src/MyModule.calr -o src/MyModule.g.cs
 ```
 
 ---

--- a/website/content/cli/init.mdx
+++ b/website/content/cli/init.mdx
@@ -4,12 +4,12 @@ section: "cli"
 order: 2
 ---
 
-# calorc init
+# calor init
 
 Initialize Calor development environment with MSBuild integration and optional AI agent support.
 
 ```bash
-calorc init [options]
+calor init [options]
 ```
 
 ---
@@ -21,7 +21,7 @@ The `init` command sets up your project for Calor development by:
 1. **Adding MSBuild targets** - Integrates Calor compilation into your .NET build process
 2. **Configuring AI agent integration** (optional) - Creates skills/prompts for your preferred AI coding assistant
 
-After running `init`, you can write `.calor` files alongside your `.cs` files and they'll compile automatically during `dotnet build`.
+After running `init`, you can write `.calr` files alongside your `.cs` files and they'll compile automatically during `dotnet build`.
 
 ---
 
@@ -29,13 +29,13 @@ After running `init`, you can write `.calor` files alongside your `.cs` files an
 
 ```bash
 # Basic initialization (MSBuild integration only)
-calorc init
+calor init
 
 # Initialize with Claude Code support
-calorc init --ai claude
+calor init --ai claude
 
 # Initialize with a specific .csproj
-calorc init --project MyApp.csproj
+calor init --project MyApp.csproj
 ```
 
 ---
@@ -72,16 +72,16 @@ The `.claude/settings.json` file configures a `PreToolUse` hook that **blocks Cl
 ```
 BLOCKED: Cannot create C# file 'MyClass.cs'
 
-This is an Calor-first project. Create an .calor file instead:
-  MyClass.calor
+This is an Calor-first project. Create an .calr file instead:
+  MyClass.calr
 
 Use /calor skill for Calor syntax help.
 ```
 
-Claude will then automatically retry with an `.calor` file. This enforcement ensures all new code is written in Calor.
+Claude will then automatically retry with an `.calr` file. This enforcement ensures all new code is written in Calor.
 
 **Allowed file types:**
-- `.calor` files (always allowed)
+- `.calr` files (always allowed)
 - `.g.cs` generated files (build output)
 - Files in `obj/` directory (build artifacts)
 
@@ -107,9 +107,9 @@ Creates the following files:
 **Important:** Codex CLI does not support hooks like Claude Code. Calor-first development is **guidance-based only**.
 
 This means:
-- Codex *should* create `.calor` files based on the instructions
+- Codex *should* create `.calr` files based on the instructions
 - Enforcement is not automatic - review file extensions after generation
-- Use `calorc analyze` to find any unconverted `.cs` files
+- Use `calor analyze` to find any unconverted `.cs` files
 
 After initialization, use these Codex commands:
 
@@ -133,10 +133,10 @@ Creates the following files:
 
 Like Claude Code, **Gemini CLI supports hooks** (as of v0.26.0+). The `.gemini/settings.json` file configures a `BeforeTool` hook that **blocks Gemini from creating `.cs` files**.
 
-Gemini will receive a JSON response blocking the operation and suggesting an `.calor` file instead. This enforcement ensures all new code is written in Calor.
+Gemini will receive a JSON response blocking the operation and suggesting an `.calr` file instead. This enforcement ensures all new code is written in Calor.
 
 **Allowed file types:**
-- `.calor` files (always allowed)
+- `.calr` files (always allowed)
 - `.g.cs` generated files (build output)
 - Files in `obj/` directory (build artifacts)
 
@@ -153,7 +153,7 @@ After initialization, use these Gemini CLI commands:
 
 The `init` command adds MSBuild targets to your `.csproj` file that:
 
-- Compile `.calor` files before C# compilation
+- Compile `.calr` files before C# compilation
 - Include generated `.g.cs` files in the build
 - Clean generated files on `dotnet clean`
 
@@ -175,17 +175,17 @@ This keeps generated files out of your source tree.
 
 ```bash
 # Initialize Calor (MSBuild only)
-calorc init
+calor init
 
 # Analyze codebase for migration candidates
-calorc analyze ./src --top 10
+calor analyze ./src --top 10
 ```
 
 ### With Claude Code
 
 ```bash
 # Add Claude Code support
-calorc init --ai claude
+calor init --ai claude
 ```
 
 ### Initialize New Project
@@ -193,8 +193,8 @@ calorc init --ai claude
 ```bash
 dotnet new console -o MyCalorApp
 cd MyCalorApp
-calorc init
-calorc init --ai claude  # Optional
+calor init
+calor init --ai claude  # Optional
 ```
 
 ---
@@ -202,8 +202,8 @@ calorc init --ai claude  # Optional
 ## See Also
 
 - [Adding Calor to Existing Projects](/guides/adding-calor-to-existing-projects/) - Complete migration guide
-- [calorc convert](/cli/convert/) - Convert individual files
-- [calorc analyze](/cli/analyze/) - Find migration candidates
+- [calor convert](/cli/convert/) - Convert individual files
+- [calor analyze](/cli/analyze/) - Find migration candidates
 - [Claude Integration](/getting-started/claude-integration/) - Using Calor with Claude Code
 - [Codex Integration](/getting-started/codex-integration/) - Using Calor with OpenAI Codex CLI
 - [Gemini Integration](/getting-started/gemini-integration/) - Using Calor with Google Gemini CLI

--- a/website/content/cli/migrate.mdx
+++ b/website/content/cli/migrate.mdx
@@ -4,12 +4,12 @@ section: "cli"
 order: 4
 ---
 
-# calorc migrate
+# calor migrate
 
 Migrate an entire project between C# and Calor.
 
 ```bash
-calorc migrate <path> [options]
+calor migrate <path> [options]
 ```
 
 ---
@@ -30,16 +30,16 @@ The `migrate` command converts all applicable files in a project or directory. I
 
 ```bash
 # Preview migration (dry run)
-calorc migrate ./src --dry-run
+calor migrate ./src --dry-run
 
 # Migrate C# to Calor
-calorc migrate ./src
+calor migrate ./src
 
 # Migrate with report
-calorc migrate ./src --report migration-report.md
+calor migrate ./src --report migration-report.md
 
 # Migrate Calor back to C#
-calorc migrate ./src --direction calor-to-cs
+calor migrate ./src --direction calor-to-cs
 ```
 
 ---
@@ -62,7 +62,7 @@ calorc migrate ./src --direction calor-to-cs
 Before converting, the command analyzes your codebase and creates a plan:
 
 ```bash
-calorc migrate ./src --dry-run
+calor migrate ./src --dry-run
 ```
 
 Output:
@@ -85,7 +85,7 @@ Files to Convert:
 Use `--benchmark` to see aggregate metrics:
 
 ```bash
-calorc migrate ./src --benchmark
+calor migrate ./src --benchmark
 ```
 
 Output includes:
@@ -103,10 +103,10 @@ Generate detailed reports for documentation:
 
 ```bash
 # Markdown report
-calorc migrate ./src --report migration-report.md
+calor migrate ./src --report migration-report.md
 
 # JSON report
-calorc migrate ./src --report migration-report.json
+calor migrate ./src --report migration-report.json
 ```
 
 ---
@@ -123,6 +123,6 @@ calorc migrate ./src --report migration-report.json
 
 ## See Also
 
-- [calorc convert](/cli/convert/) - Convert single files
-- [calorc analyze](/cli/analyze/) - Find migration candidates
+- [calor convert](/cli/convert/) - Convert single files
+- [calor analyze](/cli/analyze/) - Find migration candidates
 - [Adding Calor to Existing Projects](/guides/adding-calor-to-existing-projects/) - Complete migration guide

--- a/website/content/contributing/adding-benchmarks.mdx
+++ b/website/content/contributing/adding-benchmarks.mdx
@@ -26,15 +26,15 @@ Each benchmark needs:
 ```
 tests/Calor.Evaluation/Benchmarks/
 ├── HelloWorld/
-│   ├── hello.calor
+│   ├── hello.calr
 │   ├── hello.cs
 │   └── metadata.json
 ├── FizzBuzz/
-│   ├── fizzbuzz.calor
+│   ├── fizzbuzz.calr
 │   ├── fizzbuzz.cs
 │   └── metadata.json
 └── YourNewBenchmark/
-    ├── program.calor
+    ├── program.calr
     ├── program.cs
     └── metadata.json
 ```
@@ -52,7 +52,7 @@ cd tests/Calor.Evaluation/Benchmarks/YourBenchmark
 
 ### Step 2: Write Calor Code
 
-Create `program.calor`:
+Create `program.calr`:
 
 ```
 §M[m001:YourModule]
@@ -114,7 +114,7 @@ Create `metadata.json`:
 ```bash
 # Compile Calor
 dotnet run --project src/Calor.Compiler -- \
-  --input tests/Calor.Evaluation/Benchmarks/YourBenchmark/program.calor \
+  --input tests/Calor.Evaluation/Benchmarks/YourBenchmark/program.calr \
   --output /tmp/test.g.cs
 
 # Verify C# compiles
@@ -142,7 +142,7 @@ dotnet run --project tests/Calor.Evaluation -- --output report.json
 
 ## Example: Factorial Benchmark
 
-### Calor (`factorial.calor`)
+### Calor (`factorial.calr`)
 
 ```
 §M[m001:Math]
@@ -252,13 +252,13 @@ For simpler test cases, you can add to the E2E test suite instead:
 ```
 tests/E2E/scenarios/
 ├── 01_hello_world/
-│   ├── input.calor
+│   ├── input.calr
 │   └── verify.sh
 ├── 02_fizzbuzz/
-│   ├── input.calor
+│   ├── input.calr
 │   └── verify.sh
 └── XX_your_test/
-    ├── input.calor
+    ├── input.calr
     └── verify.sh
 ```
 

--- a/website/content/contributing/development-setup.mdx
+++ b/website/content/contributing/development-setup.mdx
@@ -71,12 +71,12 @@ calor/
 ```bash
 # Compile an Calor file
 dotnet run --project src/Calor.Compiler -- \
-  --input path/to/file.calor \
+  --input path/to/file.calr \
   --output path/to/output.g.cs
 
 # With verbose output
 dotnet run --project src/Calor.Compiler -- \
-  --input file.calor \
+  --input file.calr \
   --output file.g.cs \
   --verbose
 ```
@@ -200,7 +200,7 @@ Add to `.vscode/launch.json`:
       "type": "coreclr",
       "request": "launch",
       "program": "${workspaceFolder}/src/Calor.Compiler/bin/Debug/net8.0/Calor.Compiler.dll",
-      "args": ["--input", "test.calor", "--output", "test.g.cs"],
+      "args": ["--input", "test.calr", "--output", "test.g.cs"],
       "cwd": "${workspaceFolder}",
       "console": "internalConsole"
     }
@@ -212,7 +212,7 @@ Add to `.vscode/launch.json`:
 
 Set `Calor.Compiler` as startup project with command line arguments:
 ```
---input samples/HelloWorld/hello.calor --output output.g.cs
+--input samples/HelloWorld/hello.calr --output output.g.cs
 ```
 
 ---

--- a/website/content/getting-started/claude-integration.mdx
+++ b/website/content/getting-started/claude-integration.mdx
@@ -15,7 +15,7 @@ Calor is designed specifically for AI coding agents. This guide explains how to 
 Initialize your project for Claude Code with a single command:
 
 ```bash
-calorc init --ai claude
+calor init --ai claude
 ```
 
 This creates:
@@ -42,24 +42,24 @@ When Claude tries to create a C# file:
 ```
 BLOCKED: Cannot create C# file 'UserService.cs'
 
-This is an Calor-first project. Create an .calor file instead:
-  UserService.calor
+This is an Calor-first project. Create an .calr file instead:
+  UserService.calr
 
 Use /calor skill for Calor syntax help.
 ```
 
-Claude will automatically retry with an `.calor` file - no user intervention required.
+Claude will automatically retry with an `.calr` file - no user intervention required.
 
 ### Allowed Files
 
 The hook allows:
-- **`.calor` files** - All Calor source files
+- **`.calr` files** - All Calor source files
 - **`.g.cs` files** - Generated C# output from Calor compilation
 - **`obj/` directory** - Build artifacts
 
 ### Disabling Enforcement
 
-If you need to temporarily allow `.cs` file creation, remove or rename `.claude/settings.json`. Re-run `calorc init --ai claude` to restore enforcement.
+If you need to temporarily allow `.cs` file creation, remove or rename `.claude/settings.json`. Re-run `calor init --ai claude` to restore enforcement.
 
 ---
 
@@ -338,7 +338,7 @@ Convert src/Services/PaymentService.cs to Calor
 Reference specific elements by their IDs:
 
 ```
-In PaymentService.calor:
+In PaymentService.calr:
 - Extract the validation logic from f002 into a new private function
 - Add a postcondition to f001 ensuring the result is positive
 ```
@@ -349,5 +349,5 @@ In PaymentService.calor:
 
 - [Syntax Reference](/syntax-reference/) - Complete language reference
 - [Adding Calor to Existing Projects](/guides/adding-calor-to-existing-projects/) - Migration guide
-- [calorc init](/cli/init/) - Full init command documentation
+- [calor init](/cli/init/) - Full init command documentation
 - [Benchmarking](/benchmarking/) - See how Calor compares to C#

--- a/website/content/getting-started/codex-integration.mdx
+++ b/website/content/getting-started/codex-integration.mdx
@@ -15,7 +15,7 @@ This guide explains how to use Calor with OpenAI Codex CLI. For Claude Code inte
 Initialize your project for Codex CLI with a single command:
 
 ```bash
-calorc init --ai codex
+calor init --ai codex
 ```
 
 This creates:
@@ -33,9 +33,9 @@ This creates:
 Unlike Claude Code which uses hooks to enforce Calor-first development, **Codex CLI does not support hooks**. This means:
 
 - Calor-first development is **guidance-based only**
-- Codex *should* follow the instructions and create `.calor` files
+- Codex *should* follow the instructions and create `.calr` files
 - Enforcement is not automatic - review file extensions after generation
-- Use `calorc analyze` to find any unconverted `.cs` files
+- Use `calor analyze` to find any unconverted `.cs` files
 
 ---
 
@@ -83,15 +83,15 @@ public class Calculator
 
 ## Best Practices
 
-1. **Review generated files** - Check that Codex created `.calor` files, not `.cs`
+1. **Review generated files** - Check that Codex created `.calr` files, not `.cs`
 2. **Use explicit instructions** - Be specific about wanting Calor output
 3. **Start with skill reference** - Begin prompts with `$calor` or `$calor-convert`
-4. **Run analysis regularly** - Use `calorc analyze` to find migration candidates
+4. **Run analysis regularly** - Use `calor analyze` to find migration candidates
 
 ---
 
 ## See Also
 
 - [Syntax Reference](/syntax-reference/) - Complete language reference
-- [calorc init](/cli/init/) - Full init command documentation
+- [calor init](/cli/init/) - Full init command documentation
 - [Claude Integration](/getting-started/claude-integration/) - Alternative with enforced Calor-first

--- a/website/content/getting-started/gemini-integration.mdx
+++ b/website/content/getting-started/gemini-integration.mdx
@@ -15,7 +15,7 @@ This guide explains how to use Calor with Google Gemini CLI. For other AI integr
 Initialize your project for Gemini CLI with a single command:
 
 ```bash
-calorc init --ai gemini
+calor init --ai gemini
 ```
 
 This creates:
@@ -39,11 +39,11 @@ When Gemini tries to create a `.cs` file, the hook blocks the operation and retu
 {
   "decision": "deny",
   "reason": "BLOCKED: Cannot create C# file 'MyClass.cs'",
-  "systemMessage": "This is an Calor-first project. Create an .calor file instead..."
+  "systemMessage": "This is an Calor-first project. Create an .calr file instead..."
 }
 ```
 
-Gemini will then automatically retry with an `.calor` file.
+Gemini will then automatically retry with an `.calr` file.
 
 ---
 
@@ -109,14 +109,14 @@ Verify the settings file exists:
 cat .gemini/settings.json
 ```
 
-It should contain the `BeforeTool` hook configuration with `calorc hook validate-write --format gemini`.
+It should contain the `BeforeTool` hook configuration with `calor hook validate-write --format gemini`.
 
-### calorc Not Found
+### calor Not Found
 
 Ensure the Calor compiler is installed:
 
 ```bash
-dotnet tool install -g calorc
+dotnet tool install -g calor
 export PATH="$PATH:$HOME/.dotnet/tools"
 ```
 
@@ -125,6 +125,6 @@ export PATH="$PATH:$HOME/.dotnet/tools"
 ## See Also
 
 - [Syntax Reference](/syntax-reference/) - Complete language reference
-- [calorc init](/cli/init/) - Full init command documentation
+- [calor init](/cli/init/) - Full init command documentation
 - [Claude Integration](/getting-started/claude-integration/) - Alternative with Claude Code
 - [Codex Integration](/getting-started/codex-integration/) - Alternative with OpenAI Codex CLI

--- a/website/content/getting-started/hello-world.mdx
+++ b/website/content/getting-started/hello-world.mdx
@@ -104,7 +104,7 @@ Every `§F` must have a matching `§/F` with the same ID. Same for modules.
 ```bash
 # Compile
 dotnet run --project src/Calor.Compiler -- \
-  --input samples/HelloWorld/hello.calor \
+  --input samples/HelloWorld/hello.calr \
   --output samples/HelloWorld/hello.g.cs
 
 # Run

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -16,7 +16,7 @@ This guide will help you install Calor, write your first program, and understand
 Calor is a programming language that compiles to C# via source-to-source transformation. The workflow is:
 
 ```
-your_code.calor → Calor Compiler → your_code.g.cs → .NET Build → executable
+your_code.calr → Calor Compiler → your_code.g.cs → .NET Build → executable
 ```
 
 ---
@@ -42,13 +42,13 @@ your_code.calor → Calor Compiler → your_code.g.cs → .NET Build → executa
 Install the Calor compiler as a global .NET tool:
 
 ```bash
-dotnet tool install -g calorc --version 0.1.2
+dotnet tool install -g calor --version 0.1.2
 ```
 
 Or update an existing installation:
 
 ```bash
-dotnet tool update -g calorc
+dotnet tool update -g calor
 ```
 
 ---
@@ -68,21 +68,21 @@ cd MyApp
 ### Step 2: Enable Calor
 
 ```bash
-calorc init
+calor init
 ```
 
-This adds MSBuild integration so `.calor` files compile automatically during `dotnet build`.
+This adds MSBuild integration so `.calr` files compile automatically during `dotnet build`.
 
 ### Step 3: (Optional) Enable AI Agent Integration
 
 For Claude Code (with enforced Calor-first via hooks):
 ```bash
-calorc init --ai claude
+calor init --ai claude
 ```
 
 For OpenAI Codex CLI (guidance-based):
 ```bash
-calorc init --ai codex
+calor init --ai codex
 ```
 
 This adds Calor skills and project documentation that instruct the AI to:
@@ -93,7 +93,7 @@ This adds Calor skills and project documentation that instruct the AI to:
 
 ### Step 4: Write Calor Code
 
-After init, create `.calor` files and they compile automatically. Create `Program.calor`:
+After init, create `.calr` files and they compile automatically. Create `Program.calr`:
 
 ```
 §M{m001:MyApp}
@@ -118,13 +118,13 @@ See [Hello World](/getting-started/hello-world/) for a detailed explanation of t
 For existing C# codebases, analyze which files are good candidates for migration:
 
 ```bash
-calorc analyze ./src --top 10
+calor analyze ./src --top 10
 ```
 
 Then convert high-scoring files:
 
 ```bash
-calorc convert HighScoreFile.cs
+calor convert HighScoreFile.cs
 ```
 
 See the [Adding Calor to Existing Projects](/guides/adding-calor-to-existing-projects/) guide for the complete walkthrough.
@@ -133,14 +133,14 @@ See the [Adding Calor to Existing Projects](/guides/adding-calor-to-existing-pro
 
 ## What You Get
 
-### Basic Init (`calorc init`)
+### Basic Init (`calor init`)
 
 | Component | Description |
 |:----------|:------------|
-| MSBuild integration | `.calor` files compile automatically during `dotnet build` |
+| MSBuild integration | `.calr` files compile automatically during `dotnet build` |
 | Generated output | C# files go to `obj/` directory, keeping source tree clean |
 
-### With Claude (`calorc init --ai claude`)
+### With Claude (`calor init --ai claude`)
 
 | Component | Description |
 |:----------|:------------|
@@ -148,7 +148,7 @@ See the [Adding Calor to Existing Projects](/guides/adding-calor-to-existing-pro
 | Hook configuration | **Enforces Calor-first** - blocks `.cs` file creation |
 | CLAUDE.md | Project guidelines instructing Claude to prefer Calor for new code |
 
-### With Codex (`calorc init --ai codex`)
+### With Codex (`calor init --ai codex`)
 
 | Component | Description |
 |:----------|:------------|
@@ -171,4 +171,4 @@ For alternative installation methods (global tool only, manual Claude skills set
 - [Hello World](/getting-started/hello-world/) - Understand the hello world program
 - [Adding Calor to Existing Projects](/guides/adding-calor-to-existing-projects/) - Complete migration guide
 - [Syntax Reference](/syntax-reference/) - Complete language reference
-- [CLI Reference](/cli/) - All `calorc` commands including migration analysis
+- [CLI Reference](/cli/) - All `calor` commands including migration analysis

--- a/website/content/getting-started/installation.mdx
+++ b/website/content/getting-started/installation.mdx
@@ -15,26 +15,26 @@ This guide covers installing the Calor compiler and setting up your development 
 Install the Calor compiler as a global .NET tool:
 
 ```bash
-dotnet tool install -g calorc
+dotnet tool install -g calor
 ```
 
 After installation, you can compile Calor files from anywhere:
 
 ```bash
-calorc --input program.calor --output program.g.cs
+calor --input program.calr --output program.g.cs
 ```
 
 To update to the latest version:
 
 ```bash
-dotnet tool update -g calorc
+dotnet tool update -g calor
 ```
 
 ---
 
 ## AI Agent Integration
 
-Calor provides first-class support for AI coding agents. The `calorc init` command sets up your project for AI-assisted development.
+Calor provides first-class support for AI coding agents. The `calor init` command sets up your project for AI-assisted development.
 
 ### Supported AI Agents
 
@@ -50,7 +50,7 @@ Calor provides first-class support for AI coding agents. The `calorc init` comma
 Initialize your project for Claude Code:
 
 ```bash
-calorc init --ai claude
+calor init --ai claude
 ```
 
 This creates:
@@ -76,15 +76,15 @@ The `init` command also adds MSBuild targets to your `.csproj` file for automati
 
 ```bash
 # Specify project explicitly
-calorc init --ai claude --project MyApp.csproj
+calor init --ai claude --project MyApp.csproj
 
 # Auto-detect single .csproj
-calorc init --ai claude
+calor init --ai claude
 ```
 
 After initialization, Calor files compile automatically during `dotnet build`.
 
-See [`calorc init`](/cli/init/) for complete documentation.
+See [`calor init`](/cli/init/) for complete documentation.
 
 ---
 
@@ -136,7 +136,7 @@ Expected output:
 Calor Compiler - Coding Agent Language for Optimized Reasoning
 
 Usage:
-  calorc --input <file.calor> --output <file.cs>
+  calor --input <file.calr> --output <file.cs>
 
 Options:
   --input, -i    Input Calor source file
@@ -168,7 +168,7 @@ Basic usage:
 
 ```bash
 dotnet run --project src/Calor.Compiler -- \
-  --input path/to/your/program.calor \
+  --input path/to/your/program.calr \
   --output path/to/output/program.g.cs
 ```
 
@@ -185,7 +185,7 @@ After compilation, you need a C# project to run the generated code:
 ```bash
 # Compile your Calor file
 dotnet run --project src/Calor.Compiler -- \
-  --input your-program.calor \
+  --input your-program.calr \
   --output samples/HelloWorld/your-program.g.cs
 
 # Run it (requires modifying HelloWorld.csproj or including the file)
@@ -201,7 +201,7 @@ cd MyCalorProgram
 
 # Compile Calor to the project directory
 dotnet run --project ../src/Calor.Compiler -- \
-  --input ../my-code.calor \
+  --input ../my-code.calr \
   --output my-code.g.cs
 
 # Run the program

--- a/website/content/guides/adding-calor-to-existing-projects.mdx
+++ b/website/content/guides/adding-calor-to-existing-projects.mdx
@@ -29,26 +29,26 @@ Enable Calor with MSBuild integration:
 
 ```bash
 # Initialize Calor in your project
-calorc init
+calor init
 
 # Or specify a specific project file
-calorc init --project MyApp.csproj
+calor init --project MyApp.csproj
 ```
 
-Your `.csproj` is updated with MSBuild targets that compile `.calor` files automatically during `dotnet build`.
+Your `.csproj` is updated with MSBuild targets that compile `.calr` files automatically during `dotnet build`.
 
 ---
 
 ## Step 2: Analyze Your Codebase
 
-Use `calorc analyze` to find C# files that would benefit most from Calor:
+Use `calor analyze` to find C# files that would benefit most from Calor:
 
 ```bash
 # Analyze your source directory
-calorc analyze ./src
+calor analyze ./src
 
 # Show top 10 candidates with detailed scores
-calorc analyze ./src --top 10 --verbose
+calor analyze ./src --top 10 --verbose
 ```
 
 ### Understanding the Output
@@ -77,7 +77,7 @@ Top 10 Files for Migration:
 
 ## Step 3: Add Your First Calor File
 
-Create a new `.calor` file alongside your existing code:
+Create a new `.calr` file alongside your existing code:
 
 ```calor
 §M[m001:Calculator]
@@ -103,7 +103,7 @@ dotnet build
 
 The build process:
 
-1. Finds all `.calor` files in your project
+1. Finds all `.calr` files in your project
 2. Compiles each to `.g.cs` in the `obj/calor/` directory
 3. Includes generated C# in the normal compilation
 
@@ -115,17 +115,17 @@ Based on your analysis results, convert files that score High or Critical:
 
 ```bash
 # Convert a single file
-calorc convert src/Services/PaymentProcessor.cs
+calor convert src/Services/PaymentProcessor.cs
 
 # With benchmark comparison
-calorc convert src/Services/PaymentProcessor.cs --benchmark
+calor convert src/Services/PaymentProcessor.cs --benchmark
 ```
 
 For bulk conversion:
 
 ```bash
-calorc migrate ./src --dry-run  # Preview first
-calorc migrate ./src            # Execute
+calor migrate ./src --dry-run  # Preview first
+calor migrate ./src            # Execute
 ```
 
 ---
@@ -135,7 +135,7 @@ calorc migrate ./src            # Execute
 For AI-assisted Calor development:
 
 ```bash
-calorc init --ai claude
+calor init --ai claude
 ```
 
 This adds:
@@ -164,7 +164,7 @@ Write a function that validates email addresses with:
 
 ### What to Convert First
 
-1. **High-scoring files** from `calorc analyze`
+1. **High-scoring files** from `calor analyze`
 2. **Files with complex validation** - benefit from contracts
 3. **Files with error handling** - benefit from `Result<T,E>`
 4. **Files with side effects** - benefit from effect declarations
@@ -182,4 +182,4 @@ Write a function that validates email addresses with:
 - [Syntax Reference](/syntax-reference/) - Complete Calor language reference
 - [Contracts](/syntax-reference/contracts/) - Writing preconditions and postconditions
 - [Effects](/syntax-reference/effects/) - Declaring side effects
-- [calorc analyze](/cli/analyze/) - Understanding migration scores
+- [calor analyze](/cli/analyze/) - Understanding migration scores

--- a/website/content/index.mdx
+++ b/website/content/index.mdx
@@ -35,8 +35,8 @@ Complete language reference:
 
 Command-line tools:
 
-- [calorc](/calor/cli/) - Compile Calor to C#
-- [calorc analyze](/calor/cli/analyze/) - Score C# files for migration potential
+- [calor](/calor/cli/) - Compile Calor to C#
+- [calor analyze](/calor/cli/analyze/) - Score C# files for migration potential
 
 ### Benchmarking
 

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
-  basePath: process.env.NEXT_PUBLIC_BASE_PATH || '/opal',
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || '/calor',
   images: {
     unoptimized: true,
   },

--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -5,48 +5,55 @@
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --foreground: 216 100% 17%;
 
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 216 100% 17%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
+    --popover-foreground: 216 100% 17%;
 
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
+    --primary: 216 100% 17%;
+    --primary-foreground: 0 0% 100%;
 
     --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+    --secondary-foreground: 216 100% 17%;
 
     --muted: 210 40% 96.1%;
     --muted-foreground: 215.4 16.3% 46.9%;
 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 186 100% 56%;
+    --accent-foreground: 216 100% 17%;
 
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
 
     --border: 214.3 31.8% 91.4%;
     --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --ring: 216 100% 17%;
 
     --radius: 0.5rem;
+
+    /* Calor Brand Colors */
+    --calor-navy: 216 100% 17%;
+    --calor-pink: 346 95% 61%;
+    --calor-salmon: 12 100% 73%;
+    --calor-cerulean: 193 100% 26%;
+    --calor-cyan: 183 78% 56%;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
+    --background: 216 100% 17%;
     --foreground: 210 40% 98%;
 
-    --card: 222.2 84% 4.9%;
+    --card: 216 100% 17%;
     --card-foreground: 210 40% 98%;
 
-    --popover: 222.2 84% 4.9%;
+    --popover: 216 100% 17%;
     --popover-foreground: 210 40% 98%;
 
     --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary-foreground: 216 100% 17%;
 
     --secondary: 217.2 32.6% 17.5%;
     --secondary-foreground: 210 40% 98%;
@@ -54,15 +61,22 @@
     --muted: 217.2 32.6% 17.5%;
     --muted-foreground: 215 20.2% 65.1%;
 
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --accent: 186 100% 56%;
+    --accent-foreground: 216 100% 17%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
 
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --ring: 186 100% 56%;
+
+    /* Calor Brand Colors (same in dark mode) */
+    --calor-navy: 216 100% 17%;
+    --calor-pink: 346 95% 61%;
+    --calor-salmon: 12 100% 73%;
+    --calor-cerulean: 193 100% 26%;
+    --calor-cyan: 183 78% 56%;
   }
 }
 

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -22,25 +22,25 @@ const vt323 = VT323({
 
 export const metadata: Metadata = {
   title: {
-    default: 'OPAL - Coding Agent Language for Optimized Reasoning',
-    template: '%s | OPAL',
+    default: 'Calor - Coding Agent Language for Optimized Reasoning',
+    template: '%s | Calor',
   },
   description:
     'A programming language designed specifically for AI coding agents, compiling to .NET via C# emission.',
-  keywords: ['OPAL', 'programming language', 'AI', 'coding agents', 'compiler', '.NET', 'C#'],
-  authors: [{ name: 'OPAL Team' }],
+  keywords: ['Calor', 'programming language', 'AI', 'coding agents', 'compiler', '.NET', 'C#'],
+  authors: [{ name: 'Calor Team' }],
   openGraph: {
     type: 'website',
     locale: 'en_US',
-    url: 'https://juanmicrosoft.github.io/opal',
-    siteName: 'OPAL',
-    title: 'OPAL - Coding Agent Language for Optimized Reasoning',
+    url: 'https://juanmicrosoft.github.io/calor',
+    siteName: 'Calor',
+    title: 'Calor - Coding Agent Language for Optimized Reasoning',
     description:
       'A programming language designed specifically for AI coding agents, compiling to .NET via C# emission.',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'OPAL - Coding Agent Language for Optimized Reasoning',
+    title: 'Calor - Coding Agent Language for Optimized Reasoning',
     description:
       'A programming language designed specifically for AI coding agents, compiling to .NET via C# emission.',
   },

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -12,8 +12,8 @@ const footerLinks = {
     { name: 'Contributing', href: '/docs/contributing/' },
   ],
   community: [
-    { name: 'GitHub', href: 'https://github.com/juanmicrosoft/opal', external: true },
-    { name: 'Issues', href: 'https://github.com/juanmicrosoft/opal/issues', external: true },
+    { name: 'GitHub', href: 'https://github.com/juanmicrosoft/calor', external: true },
+    { name: 'Issues', href: 'https://github.com/juanmicrosoft/calor/issues', external: true },
   ],
 };
 
@@ -24,7 +24,7 @@ export function Footer() {
         <div className="grid grid-cols-2 gap-8 md:grid-cols-4">
           <div className="col-span-2 md:col-span-1">
             <Link href="/" className="text-xl font-bold">
-              OPAL
+              Calor
             </Link>
             <p className="mt-4 text-sm text-muted-foreground">
               Coding Agent Language for Optimized Reasoning. A language designed for AI coding agents.
@@ -84,7 +84,7 @@ export function Footer() {
 
         <div className="mt-12 border-t pt-8">
           <p className="text-center text-sm text-muted-foreground">
-            OPAL is open source. Licensed under MIT.
+            Calor is open source. Licensed under MIT.
           </p>
         </div>
       </div>

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -31,7 +31,7 @@ export function Header() {
       <nav className="mx-auto flex max-w-7xl items-center justify-between p-4 lg:px-8">
         <div className="flex lg:flex-1">
           <Link href="/" className="-m-1.5 p-1.5">
-            <span className="text-xl font-bold">OPAL</span>
+            <span className="text-xl font-bold">Calor</span>
           </Link>
         </div>
 
@@ -74,7 +74,7 @@ export function Header() {
           </Button>
           <Button variant="ghost" size="icon" asChild>
             <a
-              href="https://github.com/juanmicrosoft/opal"
+              href="https://github.com/juanmicrosoft/calor"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -92,7 +92,7 @@ export function Header() {
           <div className="fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-background px-6 py-6 sm:max-w-sm sm:ring-1 sm:ring-border">
             <div className="flex items-center justify-between">
               <Link href="/" className="-m-1.5 p-1.5">
-                <span className="text-xl font-bold">OPAL</span>
+                <span className="text-xl font-bold">Calor</span>
               </Link>
               <button
                 type="button"
@@ -127,7 +127,7 @@ export function Header() {
                   </Button>
                   <Button variant="ghost" size="icon" asChild>
                     <a
-                      href="https://github.com/juanmicrosoft/opal"
+                      href="https://github.com/juanmicrosoft/calor"
                       target="_blank"
                       rel="noopener noreferrer"
                     >

--- a/website/src/components/docs/Sidebar.tsx
+++ b/website/src/components/docs/Sidebar.tsx
@@ -18,7 +18,7 @@ export function Sidebar({ sections }: SidebarProps) {
   const pathname = usePathname();
   const [expandedSections, setExpandedSections] = useState<Set<string>>(() => {
     // Expand the current section by default
-    const currentSection = pathname?.split('/')[3]; // /opal/docs/{section}/...
+    const currentSection = pathname?.split('/')[3]; // /calor/docs/{section}/...
     return new Set(currentSection ? [currentSection] : sections.map((s) => s.slug));
   });
 

--- a/website/src/components/landing/BenchmarkChart.tsx
+++ b/website/src/components/landing/BenchmarkChart.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils';
 interface BenchmarkResult {
   category: string;
   ratio: number;
-  winner: 'opal' | 'csharp';
+  winner: 'calor' | 'csharp';
   interpretation: string;
 }
 
@@ -13,19 +13,19 @@ const results: BenchmarkResult[] = [
   {
     category: 'Comprehension',
     ratio: 1.33,
-    winner: 'opal',
+    winner: 'calor',
     interpretation: 'Explicit structure aids understanding',
   },
   {
     category: 'Error Detection',
     ratio: 1.19,
-    winner: 'opal',
+    winner: 'calor',
     interpretation: 'Contracts surface invariant violations',
   },
   {
     category: 'Edit Precision',
     ratio: 1.15,
-    winner: 'opal',
+    winner: 'calor',
     interpretation: 'Unique IDs enable targeted changes',
   },
   {
@@ -44,7 +44,7 @@ const results: BenchmarkResult[] = [
     category: 'Token Economics',
     ratio: 0.67,
     winner: 'csharp',
-    interpretation: "OPAL's explicit syntax uses more tokens",
+    interpretation: "Calor's explicit syntax uses more tokens",
   },
 ];
 
@@ -72,7 +72,7 @@ export function BenchmarkChart() {
             Benchmark Results
           </h2>
           <p className="mt-4 text-lg text-muted-foreground">
-            Evaluated across 20 paired OPAL/C# programs using V2 compact syntax
+            Evaluated across 20 paired Calor/C# programs using V2 compact syntax
           </p>
         </div>
 
@@ -86,12 +86,12 @@ export function BenchmarkChart() {
                     <span
                       className={cn(
                         'text-xs px-2 py-0.5 rounded-full',
-                        result.winner === 'opal'
-                          ? 'bg-green-500/10 text-green-600'
-                          : 'bg-blue-500/10 text-blue-600'
+                        result.winner === 'calor'
+                          ? 'bg-calor-cyan/20 text-calor-cerulean'
+                          : 'bg-calor-salmon/20 text-calor-salmon'
                       )}
                     >
-                      {result.winner === 'opal' ? 'OPAL' : 'C#'} wins
+                      {result.winner === 'calor' ? 'Calor' : 'C#'} wins
                     </span>
                   </div>
                   <span className="font-mono font-bold">
@@ -103,9 +103,9 @@ export function BenchmarkChart() {
                   <div
                     className={cn(
                       'absolute inset-y-0 left-0 rounded-full transition-all duration-500',
-                      result.winner === 'opal'
-                        ? 'bg-gradient-to-r from-green-500 to-green-400'
-                        : 'bg-gradient-to-r from-blue-500 to-blue-400'
+                      result.winner === 'calor'
+                        ? 'bg-gradient-to-r from-calor-cyan to-calor-cyan/80'
+                        : 'bg-gradient-to-r from-calor-salmon to-calor-salmon/80'
                     )}
                     style={{ width: `${getBarWidth(result.ratio)}%` }}
                   />
@@ -123,11 +123,11 @@ export function BenchmarkChart() {
           {/* Legend */}
           <div className="mt-8 flex items-center justify-center gap-8 text-sm text-muted-foreground">
             <div className="flex items-center gap-2">
-              <div className="w-3 h-3 rounded-full bg-green-500" />
-              <span>OPAL better</span>
+              <div className="w-3 h-3 rounded-full bg-calor-cyan" />
+              <span>Calor better</span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="w-3 h-3 rounded-full bg-blue-500" />
+              <div className="w-3 h-3 rounded-full bg-calor-salmon" />
               <span>C# better</span>
             </div>
             <span className="text-xs">|</span>
@@ -138,7 +138,7 @@ export function BenchmarkChart() {
           <div className="mt-12 p-6 rounded-lg border bg-muted/50">
             <h3 className="font-semibold mb-2">Key Finding</h3>
             <p className="text-muted-foreground">
-              OPAL excels where explicitness matters - comprehension, error detection,
+              Calor excels where explicitness matters - comprehension, error detection,
               and edit precision. C# wins on token efficiency, reflecting a fundamental
               tradeoff: explicit semantics require more tokens but enable better agent reasoning.
             </p>

--- a/website/src/components/landing/CodeComparison.tsx
+++ b/website/src/components/landing/CodeComparison.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { cn } from '@/lib/utils';
 
-const opalCode = `§F[f002:Square:pub]
+const calorCode = `§F[f002:Square:pub]
   §I[i32:x]
   §O[i32]
   §Q (>= x 0)
@@ -21,7 +21,7 @@ const csharpCode = `public static int Square(int x)
     return result;
 }`;
 
-const opalAnnotations = [
+const calorAnnotations = [
   { line: 0, text: 'Function ID: f002 - can reference precisely' },
   { line: 3, text: 'Precondition (§Q): x >= 0' },
   { line: 4, text: 'Postcondition (§S): result >= 0' },
@@ -35,7 +35,7 @@ const csharpAnnotations = [
 ];
 
 export function CodeComparison() {
-  const [activeTab, setActiveTab] = useState<'opal' | 'csharp'>('opal');
+  const [activeTab, setActiveTab] = useState<'calor' | 'csharp'>('calor');
 
   return (
     <section className="py-24 bg-muted/30">
@@ -45,7 +45,7 @@ export function CodeComparison() {
             What Agents See
           </h2>
           <p className="mt-4 text-lg text-muted-foreground">
-            OPAL makes semantics explicit. C# requires inference.
+            Calor makes semantics explicit. C# requires inference.
           </p>
         </div>
 
@@ -54,15 +54,15 @@ export function CodeComparison() {
           <div className="flex justify-center mb-6">
             <div className="inline-flex rounded-lg border p-1 bg-background">
               <button
-                onClick={() => setActiveTab('opal')}
+                onClick={() => setActiveTab('calor')}
                 className={cn(
                   'px-4 py-2 rounded-md text-sm font-medium transition-colors',
-                  activeTab === 'opal'
+                  activeTab === 'calor'
                     ? 'bg-primary text-primary-foreground'
                     : 'hover:bg-muted'
                 )}
               >
-                OPAL - Everything Explicit
+                Calor - Everything Explicit
               </button>
               <button
                 onClick={() => setActiveTab('csharp')}
@@ -84,12 +84,12 @@ export function CodeComparison() {
             <div className="rounded-lg border bg-zinc-950 overflow-hidden">
               <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-2">
                 <span className="text-sm text-zinc-400">
-                  {activeTab === 'opal' ? 'program.opal' : 'Program.cs'}
+                  {activeTab === 'calor' ? 'program.calr' : 'Program.cs'}
                 </span>
               </div>
               <pre className="p-4 text-sm leading-6 overflow-x-auto">
                 <code className="text-zinc-100">
-                  {activeTab === 'opal' ? opalCode : csharpCode}
+                  {activeTab === 'calor' ? calorCode : csharpCode}
                 </code>
               </pre>
             </div>
@@ -97,18 +97,18 @@ export function CodeComparison() {
             {/* Annotations */}
             <div className="space-y-4">
               <h3 className="font-semibold text-lg">
-                {activeTab === 'opal'
-                  ? 'What OPAL tells the agent directly:'
+                {activeTab === 'calor'
+                  ? 'What Calor tells the agent directly:'
                   : 'What C# requires the agent to infer:'}
               </h3>
               <ul className="space-y-3">
-                {(activeTab === 'opal' ? opalAnnotations : csharpAnnotations).map(
+                {(activeTab === 'calor' ? calorAnnotations : csharpAnnotations).map(
                   (annotation, i) => (
                     <li
                       key={i}
                       className={cn(
                         'flex items-start gap-3 p-3 rounded-lg',
-                        activeTab === 'opal'
+                        activeTab === 'calor'
                           ? 'bg-green-500/10 border border-green-500/20'
                           : 'bg-yellow-500/10 border border-yellow-500/20'
                       )}
@@ -116,7 +116,7 @@ export function CodeComparison() {
                       <span
                         className={cn(
                           'shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-medium',
-                          activeTab === 'opal'
+                          activeTab === 'calor'
                             ? 'bg-green-500/20 text-green-600'
                             : 'bg-yellow-500/20 text-yellow-600'
                         )}

--- a/website/src/components/landing/CompetitivePositioning.tsx
+++ b/website/src/components/landing/CompetitivePositioning.tsx
@@ -5,27 +5,27 @@ const comparisons = [
     rows: [
       {
         feature: 'Contracts',
-        opal: 'First-class syntax (§Q, §S)',
+        calor: 'First-class syntax (§Q, §S)',
         others: 'Deprecated / Comments / None',
       },
       {
         feature: 'Side Effects',
-        opal: 'Declared explicitly (§E)',
+        calor: 'Declared explicitly (§E)',
         others: 'Implicit, inferred from I/O',
       },
       {
         feature: 'References',
-        opal: 'Unique IDs (f001, m001)',
+        calor: 'Unique IDs (f001, m001)',
         others: 'Line numbers, fragile paths',
       },
       {
         feature: 'Scope Boundaries',
-        opal: 'Matched open/close tags',
+        calor: 'Matched open/close tags',
         others: 'Braces, indentation rules',
       },
       {
         feature: 'Agent Optimization',
-        opal: 'Primary design goal',
+        calor: 'Primary design goal',
         others: 'Not considered',
       },
     ],
@@ -36,22 +36,22 @@ const comparisons = [
     rows: [
       {
         feature: 'Primary Focus',
-        opal: 'AI agent collaboration',
+        calor: 'AI agent collaboration',
         others: 'Memory safety, zero-cost abstractions',
       },
       {
         feature: 'Learning Curve',
-        opal: '.NET ecosystem, familiar concepts',
+        calor: '.NET ecosystem, familiar concepts',
         others: 'Ownership model, lifetimes, borrowing',
       },
       {
         feature: 'Contracts',
-        opal: 'Native preconditions/postconditions',
+        calor: 'Native preconditions/postconditions',
         others: 'Via debug_assert! or external crates',
       },
       {
         feature: 'Target Use Case',
-        opal: 'AI-generated business logic',
+        calor: 'AI-generated business logic',
         others: 'Systems programming, performance-critical',
       },
     ],
@@ -62,22 +62,22 @@ const comparisons = [
     rows: [
       {
         feature: 'Modern Ecosystem',
-        opal: '.NET, NuGet, full interop',
+        calor: '.NET, NuGet, full interop',
         others: 'Limited package ecosystem',
       },
       {
         feature: 'Adoption Path',
-        opal: 'Interop with existing C# code',
+        calor: 'Interop with existing C# code',
         others: 'Full rewrite typically required',
       },
       {
         feature: 'AI Optimization',
-        opal: 'Unique IDs, explicit structure',
+        calor: 'Unique IDs, explicit structure',
         others: 'Human-readable syntax only',
       },
       {
         feature: 'Industry Adoption',
-        opal: 'Emerging, .NET compatible',
+        calor: 'Emerging, .NET compatible',
         others: 'Niche, specialized domains',
       },
     ],
@@ -90,10 +90,10 @@ export function CompetitivePositioning() {
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center mb-16">
           <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
-            How OPAL Compares
+            How Calor Compares
           </h2>
           <p className="mt-4 text-lg text-muted-foreground">
-            See how OPAL stacks up against existing solutions
+            See how Calor stacks up against existing solutions
           </p>
         </div>
 
@@ -122,7 +122,7 @@ export function CompetitivePositioning() {
                         Feature
                       </th>
                       <th className="px-6 py-3 text-left text-sm font-medium text-primary">
-                        OPAL
+                        Calor
                       </th>
                       <th className="px-6 py-3 text-left text-sm font-medium text-muted-foreground">
                         Others
@@ -136,7 +136,7 @@ export function CompetitivePositioning() {
                           {row.feature}
                         </td>
                         <td className="px-6 py-3 text-sm text-foreground">
-                          {row.opal}
+                          {row.calor}
                         </td>
                         <td className="px-6 py-3 text-sm text-muted-foreground">
                           {row.others}

--- a/website/src/components/landing/FeatureGrid.tsx
+++ b/website/src/components/landing/FeatureGrid.tsx
@@ -50,17 +50,17 @@ export function FeatureGrid() {
             return (
               <div
                 key={feature.name}
-                className="relative rounded-lg border bg-background p-6 hover:shadow-md transition-shadow"
+                className="relative rounded-lg border bg-background p-6 hover:border-calor-pink hover:shadow-md transition-all"
               >
-                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-                  <Icon className="h-5 w-5 text-primary" />
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-br from-calor-navy/10 to-calor-cyan/10">
+                  <Icon className="h-5 w-5 text-calor-navy" />
                 </div>
                 <h3 className="mt-4 font-semibold">{feature.name}</h3>
                 <p className="mt-2 text-sm text-muted-foreground">
                   {feature.description}
                 </p>
-                <div className="mt-4 rounded bg-zinc-950 p-3">
-                  <code className="text-xs text-zinc-300 whitespace-pre">
+                <div className="mt-4 rounded bg-calor-navy p-3">
+                  <code className="text-xs text-calor-cyan whitespace-pre">
                     {feature.code}
                   </code>
                 </div>

--- a/website/src/components/landing/Hero.tsx
+++ b/website/src/components/landing/Hero.tsx
@@ -4,14 +4,14 @@ import { Github, ArrowRight } from 'lucide-react';
 
 export function Hero() {
   return (
-    <section className="relative overflow-hidden bg-gradient-to-b from-background to-muted/50 py-24 sm:py-32">
+    <section className="relative overflow-hidden bg-gradient-to-b from-white to-slate-50 py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-3xl text-center">
-          <h1 className="text-4xl font-bold tracking-tight sm:text-6xl">
-            OPAL
+          <h1 className="text-4xl font-bold tracking-tight text-calor-navy sm:text-6xl">
+            Calor
           </h1>
-          <p className="mt-4 text-xl font-medium text-primary sm:text-2xl">
-            The AI-Native Language
+          <p className="mt-4 text-xl font-medium text-calor-navy sm:text-2xl">
+            Coding Agent Language for Optimized Reasoning
           </p>
           <p className="mt-6 text-lg leading-8 text-muted-foreground">
             A programming language designed specifically for AI coding agents,
@@ -19,15 +19,15 @@ export function Hero() {
           </p>
 
           <div className="mt-10 flex items-center justify-center gap-x-4">
-            <Button asChild size="lg">
+            <Button asChild size="lg" className="bg-calor-pink hover:bg-calor-pink/90 text-white">
               <Link href="/docs/getting-started/">
                 Get Started
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Link>
             </Button>
-            <Button variant="outline" size="lg" asChild>
+            <Button variant="outline" size="lg" asChild className="border-calor-navy text-calor-navy hover:bg-calor-navy/5">
               <a
-                href="https://github.com/juanmicrosoft/opal"
+                href="https://github.com/juanmicrosoft/calor"
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -42,7 +42,7 @@ export function Hero() {
       {/* Background decoration */}
       <div className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80">
         <div
-          className="relative left-[calc(50%-11rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 rotate-[30deg] bg-gradient-to-tr from-primary to-primary/50 opacity-20 sm:left-[calc(50%-30rem)] sm:w-[72.1875rem]"
+          className="relative left-[calc(50%-11rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 rotate-[30deg] bg-gradient-to-tr from-calor-navy to-calor-cyan opacity-20 sm:left-[calc(50%-30rem)] sm:w-[72.1875rem]"
           style={{
             clipPath:
               'polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)',

--- a/website/src/components/landing/ProjectStatus.tsx
+++ b/website/src/components/landing/ProjectStatus.tsx
@@ -41,13 +41,13 @@ export function ProjectStatus() {
                 className={cn(
                   'flex items-center gap-3 rounded-lg border p-4 transition-colors',
                   item.completed
-                    ? 'bg-green-500/5 border-green-500/20'
+                    ? 'bg-calor-cyan/5 border-calor-cyan/20'
                     : 'bg-background'
                 )}
               >
                 {item.completed ? (
-                  <div className="flex h-6 w-6 items-center justify-center rounded-full bg-green-500">
-                    <Check className="h-4 w-4 text-white" />
+                  <div className="flex h-6 w-6 items-center justify-center rounded-full bg-calor-cyan">
+                    <Check className="h-4 w-4 text-calor-navy" />
                   </div>
                 ) : (
                   <div className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-muted-foreground/30">
@@ -76,7 +76,7 @@ export function ProjectStatus() {
             </div>
             <div className="h-2 bg-muted rounded-full overflow-hidden">
               <div
-                className="h-full bg-green-500 rounded-full transition-all duration-500"
+                className="h-full bg-calor-cyan rounded-full transition-all duration-500"
                 style={{ width: `${(completedCount / statusItems.length) * 100}%` }}
               />
             </div>

--- a/website/src/components/landing/QuickStart.tsx
+++ b/website/src/components/landing/QuickStart.tsx
@@ -5,8 +5,8 @@ import { Check, Copy, Terminal } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const commands = [
-  { label: 'Install the compiler', command: 'dotnet tool install -g opalc' },
-  { label: 'Compile OPAL to C#', command: 'opalc --input program.opal --output program.g.cs' },
+  { label: 'Install the compiler', command: 'dotnet tool install -g calor' },
+  { label: 'Compile Calor to C#', command: 'calor --input program.calr --output program.g.cs' },
   { label: 'Run with .NET', command: 'dotnet run' },
 ];
 

--- a/website/src/components/landing/Story.tsx
+++ b/website/src/components/landing/Story.tsx
@@ -17,7 +17,7 @@ const chapters = [
     number: 3,
     title: 'The Solution',
     message:
-      'OPAL: the first programming language built from the ground up for AI agent workflows. Contracts are syntax, not comments. Effects are declared, not guessed. Every element has a unique ID. And it compiles to standard .NET—no runtime penalty, full ecosystem access.',
+      'Calor: the first programming language built from the ground up for AI agent workflows. Contracts are syntax, not comments. Effects are declared, not guessed. Every element has a unique ID. And it compiles to standard .NET—no runtime penalty, full ecosystem access.',
     highlights: ['first-class contracts', 'declared effects', 'unique identifiers'],
   },
   {

--- a/website/src/components/mdx/CodeBlock.tsx
+++ b/website/src/components/mdx/CodeBlock.tsx
@@ -36,7 +36,7 @@ export function CodeBlock({
     ps1: 'powershell',
     javascript: 'js',
     typescript: 'ts',
-    opal: 'text', // OPAL doesn't have built-in highlighting yet
+    calor: 'text', // Calor doesn't have built-in highlighting yet
   };
 
   const normalizedLanguage = languageMap[language.toLowerCase()] || language;
@@ -52,7 +52,7 @@ export function CodeBlock({
     json: 'JSON',
     yaml: 'YAML',
     text: 'Plain Text',
-    opal: 'OPAL',
+    calor: 'Calor',
   };
 
   const displayLanguage = languageLabels[normalizedLanguage] || language;

--- a/website/src/components/mdx/index.tsx
+++ b/website/src/components/mdx/index.tsx
@@ -8,10 +8,10 @@ import Link from 'next/link';
 function transformHref(href: string): string {
   if (!href) return href;
 
-  // Handle relative /opal/ links (legacy Jekyll format)
-  if (href.startsWith('/opal/')) {
-    // Convert /opal/getting-started/ to /docs/getting-started/
-    const path = href.replace('/opal/', '');
+  // Handle relative /calor/ links (legacy Jekyll format)
+  if (href.startsWith('/calor/')) {
+    // Convert /calor/getting-started/ to /docs/getting-started/
+    const path = href.replace('/calor/', '');
     // Don't double-add docs/ prefix
     if (!path.startsWith('docs/')) {
       return `/docs/${path}`;

--- a/website/src/lib/utils.ts
+++ b/website/src/lib/utils.ts
@@ -6,5 +6,5 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function getBasePath() {
-  return process.env.NEXT_PUBLIC_BASE_PATH || '/opal';
+  return process.env.NEXT_PUBLIC_BASE_PATH || '/calor';
 }

--- a/website/tailwind.config.ts
+++ b/website/tailwind.config.ts
@@ -50,6 +50,13 @@ const config: Config = {
           black: '#0a0a0a',
           dark: '#121212',
         },
+        calor: {
+          navy: '#002257',
+          pink: '#FA3D6F',
+          salmon: '#FF8E77',
+          cerulean: '#006D87',
+          cyan: '#3DDFE7',
+        },
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
## Summary
- Replace OPAL/Opal with Calor in all website components
- Change file extension from `.calor` to `.calr` in all documentation
- Update CLI tool name from `calorc` to `calor`
- Modernize landing page with new brand color palette matching the logo
- Update basePath from `/opal` to `/calor`
- Rename guide files from `adding-opal-*` to `adding-calor-*`

## Color Palette Applied
| Color | Hex | Usage |
|-------|-----|-------|
| Deep Navy | `#002257` | Primary, headings, dark text |
| Bubblegum Pink | `#FA3D6F` | Primary CTA buttons, highlights |
| Salmon | `#FF8E77` | Warm accents, secondary highlights |
| Cerulean | `#006D87` | Informational elements |
| Strong Cyan | `#3DDFE7` | Secondary accents, hover states |

## Files Changed
- **58 files** across docs/ and website/
- 2 files renamed (adding-opal-* → adding-calor-*)
- Website builds successfully

## Test plan
- [x] Website builds successfully (`npm run build`)
- [x] No remaining "opal" references found
- [x] No remaining ".calor" file extension references
- [x] No remaining "calorc" CLI name references

🤖 Generated with [Claude Code](https://claude.ai/code)