### PR TITLE
Add Calor logo to website header and hero section

### DIFF
--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import { useState } from 'react';
 import { Menu, X, Github, Moon, Sun } from 'lucide-react';
@@ -30,7 +31,14 @@ export function Header() {
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <nav className="mx-auto flex max-w-7xl items-center justify-between p-4 lg:px-8">
         <div className="flex lg:flex-1">
-          <Link href="/" className="-m-1.5 p-1.5">
+          <Link href="/" className="-m-1.5 p-1.5 flex items-center gap-2">
+            <Image
+              src={`${basePath}/calor-logo.png`}
+              alt="Calor logo"
+              width={32}
+              height={32}
+              className="h-8 w-8"
+            />
             <span className="text-xl font-bold">Calor</span>
           </Link>
         </div>
@@ -91,7 +99,14 @@ export function Header() {
           <div className="fixed inset-0 z-50" />
           <div className="fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-background px-6 py-6 sm:max-w-sm sm:ring-1 sm:ring-border">
             <div className="flex items-center justify-between">
-              <Link href="/" className="-m-1.5 p-1.5">
+              <Link href="/" className="-m-1.5 p-1.5 flex items-center gap-2">
+                <Image
+                  src={`${basePath}/calor-logo.png`}
+                  alt="Calor logo"
+                  width={32}
+                  height={32}
+                  className="h-8 w-8"
+                />
                 <span className="text-xl font-bold">Calor</span>
               </Link>
               <button

--- a/website/src/components/landing/Hero.tsx
+++ b/website/src/components/landing/Hero.tsx
@@ -1,12 +1,26 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { Github, ArrowRight } from 'lucide-react';
+import { getBasePath } from '@/lib/utils';
+
+const basePath = getBasePath();
 
 export function Hero() {
   return (
     <section className="relative overflow-hidden bg-gradient-to-b from-white to-slate-50 py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-3xl text-center">
+          <div className="flex justify-center mb-6">
+            <Image
+              src={`${basePath}/calor-logo.png`}
+              alt="Calor logo"
+              width={120}
+              height={120}
+              className="h-24 w-24 sm:h-32 sm:w-32 drop-shadow-lg"
+              priority
+            />
+          </div>
           <h1 className="text-4xl font-bold tracking-tight text-calor-navy sm:text-6xl">
             Calor
           </h1>


### PR DESCRIPTION
## Summary
- Add logo (32x32px) next to "Calor" text in header navigation
- Add logo to mobile menu header for consistency
- Add larger logo (120-128px) above title in hero section with drop shadow
- Use Next.js Image component for optimized loading with priority flag on hero

## Changes
- `Header.tsx` - Added logo image next to brand name in both desktop and mobile views
- `Hero.tsx` - Added centered logo above the "Calor" title

## Test plan
- [x] Logo displays correctly in header
- [x] Logo displays correctly in mobile menu
- [x] Logo displays correctly in hero section
- [x] Dev server compiles without errors

🤖 Generated with [Claude Code](https://claude.ai/code)