### PR TITLE
Fix documentation links to use relative paths

### DIFF
--- a/website/content/index.mdx
+++ b/website/content/index.mdx
@@ -16,46 +16,46 @@ Welcome to the Calor documentation. Calor is a programming language designed spe
 
 New to Calor? Start here to learn the basics:
 
-- [Installation](/calor/getting-started/installation/) - Set up the Calor compiler
-- [Hello World](/calor/getting-started/hello-world/) - Write your first Calor program
-- [Claude Integration](/calor/getting-started/claude-integration/) - Use Calor with AI agents
+- [Installation](/docs/getting-started/installation/) - Set up the Calor compiler
+- [Hello World](/docs/getting-started/hello-world/) - Write your first Calor program
+- [Claude Integration](/docs/getting-started/claude-integration/) - Use Calor with AI agents
 
 ### Syntax Reference
 
 Complete language reference:
 
-- [Structure Tags](/calor/syntax-reference/structure-tags/) - Modules, functions, closing tags
-- [Types](/calor/syntax-reference/types/) - Type system, Option, Result
-- [Expressions](/calor/syntax-reference/expressions/) - Lisp-style operators
-- [Control Flow](/calor/syntax-reference/control-flow/) - Loops, conditionals
-- [Contracts](/calor/syntax-reference/contracts/) - Requires, ensures
-- [Effects](/calor/syntax-reference/effects/) - Effect declarations
+- [Structure Tags](/docs/syntax-reference/structure-tags/) - Modules, functions, closing tags
+- [Types](/docs/syntax-reference/types/) - Type system, Option, Result
+- [Expressions](/docs/syntax-reference/expressions/) - Lisp-style operators
+- [Control Flow](/docs/syntax-reference/control-flow/) - Loops, conditionals
+- [Contracts](/docs/syntax-reference/contracts/) - Requires, ensures
+- [Effects](/docs/syntax-reference/effects/) - Effect declarations
 
 ### CLI Reference
 
 Command-line tools:
 
-- [calor](/calor/cli/) - Compile Calor to C#
-- [calor analyze](/calor/cli/analyze/) - Score C# files for migration potential
+- [calor](/docs/cli/) - Compile Calor to C#
+- [calor analyze](/docs/cli/analyze/) - Score C# files for migration potential
 
 ### Benchmarking
 
 Evaluation framework and results:
 
-- [Results](/calor/benchmarking/results/) - Benchmark comparison with C#
-- [Methodology](/calor/benchmarking/methodology/) - How benchmarks are measured
+- [Results](/docs/benchmarking/results/) - Benchmark comparison with C#
+- [Methodology](/docs/benchmarking/methodology/) - How benchmarks are measured
 
 ### Philosophy
 
 Design decisions and rationale:
 
-- [Why Calor Exists](/calor/philosophy/) - The motivation behind Calor
-- [Design Principles](/calor/philosophy/design-principles/) - Core design principles
-- [Tradeoffs](/calor/philosophy/tradeoffs/) - What Calor gives up for explicitness
+- [Why Calor Exists](/docs/philosophy/) - The motivation behind Calor
+- [Design Principles](/docs/philosophy/design-principles/) - Core design principles
+- [Tradeoffs](/docs/philosophy/tradeoffs/) - What Calor gives up for explicitness
 
 ### Contributing
 
 Get involved:
 
-- [Development Setup](/calor/contributing/development-setup/) - Set up your dev environment
-- [Adding Benchmarks](/calor/contributing/adding-benchmarks/) - Contribute evaluation programs
+- [Development Setup](/docs/contributing/development-setup/) - Set up your dev environment
+- [Adding Benchmarks](/docs/contributing/adding-benchmarks/) - Contribute evaluation programs

--- a/website/src/components/mdx/index.tsx
+++ b/website/src/components/mdx/index.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link';
 function transformHref(href: string): string {
   if (!href) return href;
 
-  // Handle relative /calor/ links (legacy Jekyll format)
+  // Handle relative /calor/ links (legacy format, for backwards compatibility)
   if (href.startsWith('/calor/')) {
     // Convert /calor/getting-started/ to /docs/getting-started/
     const path = href.replace('/calor/', '');


### PR DESCRIPTION
## Summary
- Update links in `website/content/index.mdx` to use `/docs/` prefix instead of hardcoded `/calor/` prefix
- Update comment in `website/src/components/mdx/index.tsx` for clarity

This ensures documentation links work correctly regardless of the basePath configuration:
- Dev environment: basePath = `/calor` → links render as `/calor/docs/...`
- Production: basePath = `/` → links render as `/docs/...`

## Test plan
- [x] Website builds successfully (46 pages)
- [x] Dev server starts correctly
- [x] Links render with correct basePath prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)