### PR TITLE
Fix basePath to default to root for calor.dev

### DIFF
--- a/website/next.config.js
+++ b/website/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
-  basePath: process.env.NEXT_PUBLIC_BASE_PATH || '/calor',
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || '',
   images: {
     unoptimized: true,
   },

--- a/website/src/lib/utils.ts
+++ b/website/src/lib/utils.ts
@@ -6,5 +6,5 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function getBasePath() {
-  return process.env.NEXT_PUBLIC_BASE_PATH || '/calor';
+  return process.env.NEXT_PUBLIC_BASE_PATH || '';
 }


### PR DESCRIPTION
## Summary
- Change default basePath from `/calor` to empty string (`''`)
- Update both `next.config.js` and `src/lib/utils.ts`

## Problem
The site is deployed at `calor.dev` (root path), but the default basePath was `/calor` (which was for GitHub Pages at `juanmicrosoft.github.io/calor/`). This caused all links to have an incorrect `/calor/` prefix, resulting in broken navigation.

## Solution
Default to empty basePath for root domain deployment. For GitHub Pages deployment, set `NEXT_PUBLIC_BASE_PATH=/calor` environment variable.

## Test plan
- [x] Website builds successfully
- [x] Dev server shows links without `/calor/` prefix: `/docs/getting-started/` instead of `/calor/docs/getting-started/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)