### PR TITLE
Remove hardcoded NEXT_PUBLIC_BASE_PATH from GitHub Actions

### DIFF
--- a/.github/workflows/nextjs-gh-pages.yml
+++ b/.github/workflows/nextjs-gh-pages.yml
@@ -46,8 +46,6 @@ jobs:
       - name: Build
         working-directory: website
         run: npm run build
-        env:
-          NEXT_PUBLIC_BASE_PATH: /calor
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- Removes the hardcoded `NEXT_PUBLIC_BASE_PATH=/calor` environment variable from the GitHub Actions build step
- This fixes broken links on calor.dev that incorrectly had `/calor/` prefix (e.g., `/calor/docs/getting-started/`)
- The build will now use the default empty string from `next.config.js`

## Test plan
- [ ] After merge, wait for GitHub Actions to rebuild and deploy
- [ ] Visit https://calor.dev/
- [ ] Verify links no longer have `/calor/` prefix
- [ ] Test navigation to ensure all pages load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)