### PR TITLE
Fix Calor syntax in BenchmarkRunnerTests

### DIFF
--- a/tests/Calor.Evaluation/Tests/BenchmarkRunnerTests.cs
+++ b/tests/Calor.Evaluation/Tests/BenchmarkRunnerTests.cs
@@ -17,11 +17,11 @@ public class BenchmarkRunnerTests
     {
         // Arrange
         var runner = new BenchmarkRunner();
-        var calor = @"§M[m001:Test]
-§F[f001:Hello:pub]
-  §O[void]
-§/F[f001]
-§/M[m001]";
+        var calor = @"§M{m001:Test}
+§F{f001:Hello:pub}
+  §O{void}
+§/F{f001}
+§/M{m001}";
         var csharp = @"namespace Test { public class TestModule { public void Hello() { } } }";
 
         // Act


### PR DESCRIPTION
## Summary
- Fix incorrect Calor syntax in `BenchmarkRunner_RunFromSource_ReturnsValidResult` test
- Test used square brackets `[...]` but Calor syntax requires curly braces `{...}`

## Test plan
- [x] `dotnet test` passes (669 passed, 2 skipped, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)