### PR TITLE
Add PackageProjectUrl to NuGet package

### DIFF
--- a/src/Calor.Compiler/Calor.Compiler.csproj
+++ b/src/Calor.Compiler/Calor.Compiler.csproj
@@ -11,6 +11,7 @@
     <PackageId>calor</PackageId>
     <Version>0.1.5</Version>
     <Description>Calor compiler CLI - Convert C# to Calor and compile Calor to C#</Description>
+    <PackageProjectUrl>https://calor.dev</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReleaseNotes>See https://github.com/juanmicrosoft/calor/blob/main/CHANGELOG.md</PackageReleaseNotes>


### PR DESCRIPTION
## Summary
Set the NuGet package project URL to https://calor.dev

This will show as the "Project Site" link on the NuGet package page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)