### PR TITLE
Release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-02-05
+
+### Added
+- `calor lint` command for formatting and linting Calor files
+- Comprehensive linter regression test suite
+
 ### Changed
 - **Project renamed from OPAL to Calor**
   - Language name: Calor (was OPAL)
@@ -12,6 +18,10 @@ All notable changes to this project will be documented in this file.
   - NuGet packages: `calor`, `Calor.Tasks`, `Calor.Sdk`
 - New tagline: "Coding Agent Language for Optimized Reasoning"
 - Added project logo
+- Enhanced warning messages for non-Claude AI agents (Codex, GitHub Copilot) to clearly indicate they cannot enforce Calor-first development
+
+### Fixed
+- Claude skills directory structure now uses correct `SKILL.md` format
 
 ## [0.1.4] - 2025-02-03
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.6</Version>
+    <Version>0.1.7</Version>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "calor",
   "displayName": "Calor Language",
   "description": "Syntax highlighting for the Calor programming language",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "publisher": "calor-dev",
   "license": "Apache-2.0",
   "icon": "icons/calor-icon.png",

--- a/src/Calor.Compiler/Init/CodexInitializer.cs
+++ b/src/Calor.Compiler/Init/CodexInitializer.cs
@@ -73,8 +73,9 @@ public class CodexInitializer : IAiInitializer
             {
                 messages.Add($"Initialized Calor project for OpenAI Codex (calor v{version})");
                 messages.Add("");
-                messages.Add("Note: Codex CLI does not support hooks. Calor-first enforcement is");
-                messages.Add("guidance-based only. Review file extensions after generation.");
+                messages.Add("WARNING: OpenAI Codex cannot enforce Calor-first development.");
+                messages.Add("This agent lacks hooks to prevent writing .cs files directly.");
+                messages.Add("For best results, use Claude Code: calor init --ai claude");
             }
             else
             {

--- a/src/Calor.Compiler/Init/GitHubCopilotInitializer.cs
+++ b/src/Calor.Compiler/Init/GitHubCopilotInitializer.cs
@@ -73,8 +73,9 @@ public class GitHubCopilotInitializer : IAiInitializer
             {
                 messages.Add($"Initialized Calor project for GitHub Copilot (calor v{version})");
                 messages.Add("");
-                messages.Add("Note: GitHub Copilot does not support hooks. Calor-first enforcement is");
-                messages.Add("guidance-based only. Review file extensions after generation.");
+                messages.Add("WARNING: GitHub Copilot cannot enforce Calor-first development.");
+                messages.Add("This agent lacks hooks to prevent writing .cs files directly.");
+                messages.Add("For best results, use Claude Code: calor init --ai claude");
             }
             else
             {

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calor-website",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.7
- Update CHANGELOG.md with release date

## Changes in this release
- `calor lint` command for formatting and linting Calor files
- Comprehensive linter regression test suite
- Project renamed from OPAL to Calor
- Enhanced warning messages for non-Claude AI agents
- Fixed Claude skills directory structure

## Checklist
- [x] Version updated in Directory.Build.props
- [x] Version updated in editors/vscode/package.json
- [x] Version updated in website/package.json
- [x] CHANGELOG.md updated with version and date

🤖 Generated with [Claude Code](https://claude.com/claude-code)