### PR TITLE
fix: correct VS Code extension repository URL

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -8,7 +8,7 @@
   "icon": "icons/calor-icon.png",
   "repository": {
     "type": "git",
-    "url": "https://github.com/juanmicrosoft/calor-2"
+    "url": "https://github.com/juanmicrosoft/calor"
   },
   "engines": {
     "vscode": "^1.75.0"


### PR DESCRIPTION
## Summary
- Fixes incorrect repository URL in VS Code extension's package.json
- Changed from `calor-2` to `calor`

## Test plan
- [x] Verified change in package.json
- [x] Build succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)