### PR TITLE
fix: update E2E tests for .calr file extension

### DIFF
--- a/tests/E2E/project-init/run-tests.sh
+++ b/tests/E2E/project-init/run-tests.sh
@@ -142,7 +142,7 @@ count_analyzed_files() {
 # Convert a single C# file to Calor
 convert_file() {
     local cs_file="$1"
-    local opal_file="${cs_file%.cs}.opal"
+    local opal_file="${cs_file%.cs}.calr"
 
     if "$COMPILER" convert "$cs_file" > /dev/null 2>&1; then
         if [[ -f "$opal_file" ]]; then
@@ -316,9 +316,9 @@ test_github_project() {
     # Step 8: Verify generated files exist
     step "Verifying generated .g.cs files..."
     local gen_count
-    gen_count=$(find . -path "*/opal/*.g.cs" 2>/dev/null | wc -l | tr -d ' ')
+    gen_count=$(find . -path "*/calor/*.g.cs" 2>/dev/null | wc -l | tr -d ' ')
     if [[ "$gen_count" -eq 0 ]]; then
-        fail "$test_name - no generated files found in obj/*/opal/"
+        fail "$test_name - no generated files found in obj/*/calor/"
         return 0
     fi
     detail "Found $gen_count generated files"
@@ -386,13 +386,13 @@ test_basic_console_app() {
     use_local_compiler "TestApp.csproj"
 
     step "Verifying .csproj changes..."
-    if ! grep -q "CompileOpalFiles" TestApp.csproj; then
-        fail "$test_name - CompileOpalFiles target not found"
+    if ! grep -q "CompileCalorFiles" TestApp.csproj; then
+        fail "$test_name - CompileCalorFiles target not found"
         return 0
     fi
 
-    step "Creating test.opal file..."
-    cat > test.opal << 'CALOR_EOF'
+    step "Creating test.calr file..."
+    cat > test.calr << 'CALOR_EOF'
 §M{m001:TestModule}
 §F{f001:Add:pub}
   §I{i32:a}
@@ -480,11 +480,11 @@ EOF
         return 0
     fi
 
-    if ! grep -q "CompileOpalFiles" Project1.csproj; then
+    if ! grep -q "CompileCalorFiles" Project1.csproj; then
         fail "$test_name - Project1 not modified"
         return 0
     fi
-    if grep -q "CompileOpalFiles" Project2.csproj; then
+    if grep -q "CompileCalorFiles" Project2.csproj; then
         fail "$test_name - Project2 incorrectly modified"
         return 0
     fi
@@ -571,7 +571,7 @@ CSEOF
         fail "$test_name - conversion failed"
         return 0
     fi
-    if [[ ! -f "Calculator.opal" ]]; then
+    if [[ ! -f "Calculator.calr" ]]; then
         fail "$test_name - Calor file not created"
         return 0
     fi
@@ -614,8 +614,8 @@ CSEOF
     detail "Application ran correctly"
 
     # Step 6: Verify generated file location
-    step "Verifying generated file in obj/opal/..."
-    if ! find obj -path "*/opal/Calculator.g.cs" 2>/dev/null | grep -q .; then
+    step "Verifying generated file in obj/calor/..."
+    if ! find obj -path "*/calor/Calculator.g.cs" 2>/dev/null | grep -q .; then
         fail "$test_name - generated file not in expected location"
         return 0
     fi

--- a/tests/E2E/run-tests.sh
+++ b/tests/E2E/run-tests.sh
@@ -44,13 +44,13 @@ run_scenario() {
     local scenario_name
     scenario_name=$(basename "$scenario_dir")
 
-    local input_file="$scenario_dir/input.opal"
+    local input_file="$scenario_dir/input.calr"
     local verify_script="$scenario_dir/verify.sh"
     local output_file="$scenario_dir/output.g.cs"
 
     # Check for required files
     if [[ ! -f "$input_file" ]]; then
-        skip "$scenario_name - no input.opal"
+        skip "$scenario_name - no input.calr"
         return 0
     fi
 

--- a/tests/E2E/scenarios/03_contracts/verify.sh
+++ b/tests/E2E/scenarios/03_contracts/verify.sh
@@ -12,8 +12,8 @@ grep -q "namespace Contracts" "$OUTPUT_FILE" || { echo "Missing namespace"; exit
 grep -q "Square" "$OUTPUT_FILE" || { echo "Missing Square function"; exit 1; }
 grep -q "Divide" "$OUTPUT_FILE" || { echo "Missing Divide function"; exit 1; }
 
-# Check for precondition enforcement (ArgumentException)
-grep -q "ArgumentException" "$OUTPUT_FILE" || { echo "Missing precondition check"; exit 1; }
+# Check for precondition enforcement (ContractViolationException)
+grep -q "ContractViolationException" "$OUTPUT_FILE" || { echo "Missing precondition check"; exit 1; }
 
 # Check for custom error message
 grep -q "divisor must not be zero" "$OUTPUT_FILE" || { echo "Missing custom error message"; exit 1; }


### PR DESCRIPTION
## Summary
- Update E2E test scripts to use `.calr` file extension instead of `.opal`
- Update MSBuild target name from `CompileOpalFiles` to `CompileCalorFiles`
- Update generated file output directory from `obj/*/opal/` to `obj/*/calor/`
- Update contract verification to check for `ContractViolationException` instead of `ArgumentException`

## Test plan
- [x] Run `tests/E2E/run-tests.sh` - all 5 scenarios pass
- [x] Run `tests/E2E/project-init/run-tests.sh --quick` - all 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)