### PR TITLE
fix: remove remaining opal references in E2E test scripts

### DIFF
--- a/tests/E2E/project-init/run-tests.sh
+++ b/tests/E2E/project-init/run-tests.sh
@@ -142,10 +142,10 @@ count_analyzed_files() {
 # Convert a single C# file to Calor
 convert_file() {
     local cs_file="$1"
-    local opal_file="${cs_file%.cs}.calr"
+    local calor_file="${cs_file%.cs}.calr"
 
     if "$COMPILER" convert "$cs_file" > /dev/null 2>&1; then
-        if [[ -f "$opal_file" ]]; then
+        if [[ -f "$calor_file" ]]; then
             return 0
         fi
     fi

--- a/tests/E2E/run-tests.ps1
+++ b/tests/E2E/run-tests.ps1
@@ -35,13 +35,13 @@ function Invoke-Scenario {
     param($ScenarioDir)
 
     $scenarioName = Split-Path -Leaf $ScenarioDir
-    $inputFile = Join-Path $ScenarioDir "input.opal"
+    $inputFile = Join-Path $ScenarioDir "input.calr"
     $verifyScript = Join-Path $ScenarioDir "verify.ps1"
     $outputFile = Join-Path $ScenarioDir "output.g.cs"
 
     # Check for required files
     if (-not (Test-Path $inputFile)) {
-        Write-Skip "$scenarioName - no input.opal"
+        Write-Skip "$scenarioName - no input.calr"
         return
     }
 


### PR DESCRIPTION
## Summary
- Update `tests/E2E/run-tests.ps1`: change `input.opal` → `input.calr` references
- Update `tests/E2E/project-init/run-tests.sh`: rename `opal_file` variable → `calor_file`

## Test plan
- [x] E2E scenario tests pass (5/5)
- [x] Project-init tests pass (4/4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)