### PR TITLE
docs: Remove v1/v2 references and fix invalid tokens

### DIFF
--- a/docs/benchmarking/methodology.md
+++ b/docs/benchmarking/methodology.md
@@ -76,7 +76,7 @@ Both implementations must:
 **Calor factors:**
 - Preconditions (`§Q`)
 - Postconditions (`§S`)
-- Invariants (`§INV`)
+- Invariants (`§IV`)
 - Effect declarations
 - Typed inputs/outputs
 

--- a/docs/benchmarking/metrics/error-detection.md
+++ b/docs/benchmarking/metrics/error-detection.md
@@ -40,7 +40,7 @@ Explicit contracts make these violations visible without deep analysis.
 |:-------|:-------|:----------|
 | Has `§Q` (requires) | 0.25 | Preconditions catch caller errors |
 | Has `§S` (ensures) | 0.20 | Postconditions catch implementation errors |
-| Has `§INV` (invariant) | 0.15 | Invariants catch state errors |
+| Has `§IV` (invariant) | 0.15 | Invariants catch state errors |
 | Has `§E[...]` (effects) | 0.10 | Effect tracking catches side-effect bugs |
 | Has typed inputs | 0.05 | Type errors caught at compile time |
 | Has typed output | 0.05 | Return type errors caught |

--- a/docs/benchmarking/metrics/token-economics.md
+++ b/docs/benchmarking/metrics/token-economics.md
@@ -237,29 +237,6 @@ Contract.Ensures(Contract.Result<int>() >= 0);
 
 ---
 
-## V2 Improvement
-
-V1 syntax was extremely verbose:
-
-```
-// V1 (legacy)
-§OP[kind=add]
-  §REF[name=a]
-  §REF[name=b]
-§/OP
-```
-- Tokens: ~15 for addition
-
-```
-// V2 (current)
-(+ a b)
-```
-- Tokens: ~4 for addition
-
-**Improvement:** ~40% token reduction.
-
----
-
 ## Context Window Impact
 
 | Context Size | Calor Programs | C# Programs |
@@ -291,7 +268,7 @@ This is the price of:
 - Effect declarations
 - Closing tags
 
-The V2 syntax improved this from ~0.4x (V1 was ~2.5x more tokens).
+Lisp-style expressions help keep this ratio manageable.
 
 ---
 

--- a/docs/benchmarking/results.md
+++ b/docs/benchmarking/results.md
@@ -7,7 +7,7 @@ nav_order: 2
 
 # Benchmark Results
 
-Evaluated across 20 paired Calor/C# programs (100% compilation success for both) using V2 compact syntax.
+Evaluated across 20 paired Calor/C# programs (100% compilation success for both).
 
 ---
 
@@ -109,19 +109,6 @@ Task Completion   ░░░░░░░█████████  0.93x
 Token Economics   ░░░░░░░░░░██████  0.67x
 Info Density      ░░░░░░░░░░░░░░██  0.22x
 ```
-
----
-
-## V2 Syntax Improvement
-
-The V2 syntax (Lisp-style expressions) improved token economics by ~40% compared to V1:
-
-| Syntax | Example | Relative Tokens |
-|:-------|:--------|:----------------|
-| V1 (legacy) | `§OP[kind=add] §REF[name=a] §REF[name=b]` | 1.0x |
-| V2 (current) | `(+ a b)` | 0.6x |
-
-V2 is now the standard and recommended syntax.
 
 ---
 

--- a/docs/cli/convert.md
+++ b/docs/cli/convert.md
@@ -90,13 +90,13 @@ When converting C# to Calor, the converter:
 | C# Construct | Calor Equivalent |
 |:-------------|:----------------|
 | `namespace` | `§M[id:Name]` module |
-| `class` | `§C[id:Name:vis]` class |
+| `class` | `§CL[id:Name:vis]` class |
 | `method` | `§F[id:Name:vis]` function |
-| `property` | `§Y[id:Name:vis:type]` property |
-| `field` | `§D[id:type:name]` field |
+| `property` | `§PROP[id:Name:vis:type]` property |
+| `field` | `§FLD[id:type:name]` field |
 | `if/else if/else` | `§IF[id]...§EI...§EL...§/I[id]` |
 | `for` loop | `§L[id:var:from:to:step]` |
-| `while` loop | `§W[id]` |
+| `while` loop | `§WH[id]` |
 | `try/catch` | Converted to `Result<T,E>` pattern |
 | `?.`, `??` | Converted to `Option<T>` pattern |
 

--- a/docs/contributing/adding-benchmarks.md
+++ b/docs/contributing/adding-benchmarks.md
@@ -66,7 +66,7 @@ Create `program.calr`:
 ```
 
 **Guidelines:**
-- Use V2 syntax (Lisp-style expressions)
+- Use Lisp-style expressions for operations
 - Include all required IDs
 - Declare effects explicitly
 - Add contracts where meaningful
@@ -237,7 +237,7 @@ Before submitting:
 - [ ] Calor compiles without errors
 - [ ] C# compiles without errors
 - [ ] Both produce identical output (if applicable)
-- [ ] Uses V2 Calor syntax
+- [ ] Uses Lisp-style expressions
 - [ ] IDs are unique and meaningful
 - [ ] Effects are declared
 - [ ] Contracts are equivalent

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -229,7 +229,7 @@ Set `Calor.Compiler` as startup project with command line arguments:
 
 ### Calor Conventions
 
-- Use V2 syntax (Lisp-style expressions)
+- Use Lisp-style expressions for operations
 - Include IDs on all structures
 - Declare effects explicitly
 - Add contracts where meaningful

--- a/docs/effects-and-contracts-enforcement.md
+++ b/docs/effects-and-contracts-enforcement.md
@@ -51,7 +51,7 @@ For the motivation behind this design, see [The Verification Opportunity](/calor
 **Contract checks do NOT require a `throw` effect declaration.**
 - Contracts are a verification mechanism, not a business effect
 - A function with `§Q` and `§S` but no `§E` is valid and compiles
-- The `throw` effect applies only to intentional `§THROW` statements
+- The `throw` effect applies only to intentional `§TH` statements
 
 **Missing §E means: no operational effects allowed**
 - Contract-generated exceptions are not "operational effects"
@@ -92,7 +92,7 @@ The effect enforcement pass uses Strongly Connected Component (SCC) analysis:
 ### Effect Inference Coverage
 
 Effect inference covers:
-- Statements: §P (print), §C (call), §THROW
+- Statements: §P (print), §C (call), §TH
 - Expressions: CallExpressionNode
 - **Property getters/setters**: Treat as calls, need stubs
 - **Constructors**: `Type::.ctor()` in catalog

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,7 +104,7 @@ The compiler catches effect violations with full call chains. The runtime catche
 
 ## Benchmark Results
 
-Evaluated across 20 paired Calor/C# programs using V2 compact syntax:
+Evaluated across 20 paired Calor/C# programs:
 
 | Category | Calor vs C# | Winner | Interpretation |
 |:---------|:-----------|:-------|:---------------|

--- a/docs/philosophy/tradeoffs.md
+++ b/docs/philosophy/tradeoffs.md
@@ -43,7 +43,7 @@ This is a fundamental design choice, not a flaw to be fixed.
 
 | Quality | Impact | Mitigation |
 |:--------|:-------|:-----------|
-| **Token Efficiency** | 0.67x vs C# | V2 syntax improved 40% over V1 |
+| **Token Efficiency** | 0.67x vs C# | Lisp-style expressions minimize overhead |
 | **Information Density** | 0.22x vs C# | Acceptable for agent workflows |
 | **Human Readability** | Unfamiliar syntax | Not the target audience |
 | **Ecosystem** | No libraries | Compiles to C#, interop possible |
@@ -159,29 +159,6 @@ if (x > 0) return x;
 ### 3. You Need Library Ecosystem
 
 Calor compiles to C#, so interop is possible, but native library support doesn't exist.
-
----
-
-## The V2 Syntax Improvement
-
-V1 syntax was extremely verbose:
-
-```
-// V1 (legacy - do not use)
-§OP[kind=add]
-  §REF[name=a]
-  §REF[name=b]
-§/OP
-```
-
-V2 uses Lisp-style expressions:
-
-```
-// V2 (current)
-(+ a b)
-```
-
-This improved token economics by ~40% while maintaining parseability.
 
 ---
 

--- a/docs/syntax-reference/contracts.md
+++ b/docs/syntax-reference/contracts.md
@@ -310,7 +310,7 @@ A common question: Do contracts count as effects?
 §/F{f001}
 ```
 
-This function is pure (no `§E` declaration) even though the precondition might throw. The `throw` effect in `§E` is only for intentional `§THROW` statements in business logic, not contract violations.
+This function is pure (no `§E` declaration) even though the precondition might throw. The `throw` effect in `§E` is only for intentional `§TH` statements in business logic, not contract violations.
 
 ---
 

--- a/docs/syntax-reference/index.md
+++ b/docs/syntax-reference/index.md
@@ -8,7 +8,7 @@ permalink: /syntax-reference/
 
 # Syntax Reference
 
-Complete reference for Calor syntax. Always use V2+ syntax (Lisp-style expressions).
+Complete reference for Calor syntax. Calor uses Lisp-style expressions for all operations.
 
 ---
 

--- a/docs/syntax-reference/structure-tags.md
+++ b/docs/syntax-reference/structure-tags.md
@@ -182,16 +182,16 @@ Calor uses bracket notation `[T]` for array types, which aligns with common prog
 ### Usage in Fields and Methods
 
 ```
-§CLASS{c001:DataProcessor}
+§CL{c001:DataProcessor}
   §FLD{[u8]:_buffer:priv}       // private byte[] _buffer
   §FLD{[i32]:_indices:priv}     // private int[] _indices
 
-  §METHOD{m001:ProcessData:pub}
+  §MT{m001:ProcessData:pub}
     §I{[str]:args}              // string[] args parameter
     §O{i32}
     §R args.Length
-  §/METHOD{m001}
-§/CLASS{c001}
+  §/MT{m001}
+§/CL{c001}
 ```
 
 ---
@@ -253,19 +253,19 @@ C# attributes are preserved during conversion using inline bracket syntax `[@Att
 ### Syntax
 
 ```
-§CLASS{id:name}[@AttributeName]
-§CLASS{id:name}[@AttributeName(args)]
-§METHOD{id:name:vis}[@Attr1][@Attr2]
+§CL{id:name}[@AttributeName]
+§CL{id:name}[@AttributeName(args)]
+§MT{id:name:vis}[@Attr1][@Attr2]
 ```
 
 ### Examples
 
 **Class with routing attributes (ASP.NET Core):**
 ```
-§CLASS{c001:JoinController:ControllerBase}[@Route("api/[controller]")][@ApiController]
-  §METHOD{m001:Post:pub}[@HttpPost]
-  §/METHOD{m001}
-§/CLASS{c001}
+§CL{c001:JoinController:ControllerBase}[@Route("api/[controller]")][@ApiController]
+  §MT{m001:Post:pub}[@HttpPost]
+  §/MT{m001}
+§/CL{c001}
 ```
 
 **Property with validation:**
@@ -288,9 +288,9 @@ C# attributes are preserved during conversion using inline bracket syntax `[@Att
 ### Supported Elements
 
 Attributes can be attached to:
-- Classes: `§CLASS{...}[@attr]`
+- Classes: `§CL{...}[@attr]`
 - Interfaces: `§IFACE{...}[@attr]`
-- Methods: `§METHOD{...}[@attr]`
+- Methods: `§MT{...}[@attr]`
 - Properties: `§PROP{...}[@attr]`
 - Fields: `§FLD{...}[@attr]`
 - Parameters: `§I{type:name}[@attr]`

--- a/docs/syntax-reference/types.md
+++ b/docs/syntax-reference/types.md
@@ -113,8 +113,8 @@ Options represent values that may be absent.
 ### Creating Option Values
 
 ```
-§SOME value         // Some(value) - has a value
-§NONE{type=T}       // None of type T - no value
+§SM value           // Some(value) - has a value
+§NN                 // None - no value
 ```
 
 ### Example
@@ -124,9 +124,9 @@ Options represent values that may be absent.
   §I{i32:id}
   §O{?User}
   §IF{if1} (== id 0)
-    §R §NONE{type=User}
+    §R §NN
   §EL
-    §R §SOME user
+    §R §SM user
   §/I{if1}
 §/F{f001}
 ```

--- a/website/content/benchmarking/methodology.mdx
+++ b/website/content/benchmarking/methodology.mdx
@@ -75,7 +75,7 @@ Both implementations must:
 **Calor factors:**
 - Preconditions (`§Q`)
 - Postconditions (`§S`)
-- Invariants (`§INV`)
+- Invariants (`§IV`)
 - Effect declarations
 - Typed inputs/outputs
 

--- a/website/content/benchmarking/metrics/error-detection.mdx
+++ b/website/content/benchmarking/metrics/error-detection.mdx
@@ -39,7 +39,7 @@ Explicit contracts make these violations visible without deep analysis.
 |:-------|:-------|:----------|
 | Has `§Q` (requires) | 0.25 | Preconditions catch caller errors |
 | Has `§S` (ensures) | 0.20 | Postconditions catch implementation errors |
-| Has `§INV` (invariant) | 0.15 | Invariants catch state errors |
+| Has `§IV` (invariant) | 0.15 | Invariants catch state errors |
 | Has `§E[...]` (effects) | 0.10 | Effect tracking catches side-effect bugs |
 | Has typed inputs | 0.05 | Type errors caught at compile time |
 | Has typed output | 0.05 | Return type errors caught |

--- a/website/content/benchmarking/metrics/token-economics.mdx
+++ b/website/content/benchmarking/metrics/token-economics.mdx
@@ -236,29 +236,6 @@ Contract.Ensures(Contract.Result<int>() >= 0);
 
 ---
 
-## V2 Improvement
-
-V1 syntax was extremely verbose:
-
-```
-// V1 (legacy)
-§OP[kind=add]
-  §REF[name=a]
-  §REF[name=b]
-§/OP
-```
-- Tokens: ~15 for addition
-
-```
-// V2 (current)
-(+ a b)
-```
-- Tokens: ~4 for addition
-
-**Improvement:** ~40% token reduction.
-
----
-
 ## Context Window Impact
 
 | Context Size | Calor Programs | C# Programs |
@@ -290,7 +267,7 @@ This is the price of:
 - Effect declarations
 - Closing tags
 
-The V2 syntax improved this from ~0.4x (V1 was ~2.5x more tokens).
+Lisp-style expressions help keep this ratio manageable.
 
 ---
 

--- a/website/content/benchmarking/results.mdx
+++ b/website/content/benchmarking/results.mdx
@@ -6,7 +6,7 @@ order: 2
 
 # Benchmark Results
 
-Evaluated across 20 paired Calor/C# programs (100% compilation success for both) using V2 compact syntax.
+Evaluated across 20 paired Calor/C# programs (100% compilation success for both).
 
 ---
 
@@ -108,19 +108,6 @@ Task Completion   ░░░░░░░█████████  0.93x
 Token Economics   ░░░░░░░░░░██████  0.67x
 Info Density      ░░░░░░░░░░░░░░██  0.22x
 ```
-
----
-
-## V2 Syntax Improvement
-
-The V2 syntax (Lisp-style expressions) improved token economics by ~40% compared to V1:
-
-| Syntax | Example | Relative Tokens |
-|:-------|:--------|:----------------|
-| V1 (legacy) | `§OP[kind=add] §REF[name=a] §REF[name=b]` | 1.0x |
-| V2 (current) | `(+ a b)` | 0.6x |
-
-V2 is now the standard and recommended syntax.
 
 ---
 

--- a/website/content/cli/convert.mdx
+++ b/website/content/cli/convert.mdx
@@ -69,13 +69,13 @@ If `--output` is not specified:
 | C# Construct | Calor Equivalent |
 |:-------------|:----------------|
 | `namespace` | `§M[id:Name]` module |
-| `class` | `§C[id:Name:vis]` class |
+| `class` | `§CL[id:Name:vis]` class |
 | `method` | `§F[id:Name:vis]` function |
-| `property` | `§Y[id:Name:vis:type]` property |
-| `field` | `§D[id:type:name]` field |
+| `property` | `§PROP[id:Name:vis:type]` property |
+| `field` | `§FLD[id:type:name]` field |
 | `if/else if/else` | `§IF[id]...§EI...§EL...§/I[id]` |
 | `for` loop | `§L[id:var:from:to:step]` |
-| `while` loop | `§W[id]` |
+| `while` loop | `§WH[id]` |
 
 ---
 

--- a/website/content/cli/lint.mdx
+++ b/website/content/cli/lint.mdx
@@ -89,10 +89,9 @@ Calor uses explicit tags with IDs:
 §F{f1:Main:pub}
 §O{void}
 §L{l1:i:0:10:1}
-§IF{i1}
-§?(== (% i 2) 0)
+§IF{i1} (== (% i 2) 0)
 §P i
-§/IF{i1}
+§/I{i1}
 §/L{l1}
 §/F{f1}
 ```
@@ -131,10 +130,6 @@ Tags should use the canonical format.
 
 | Issue | Input | Fixed |
 |-------|-------|-------|
-| Verbose return | `§RET` | `§R` |
-| Verbose call | `§CALL` | `§C` |
-| Verbose while | `§WHILE{...}` | `§WH{...}` |
-| Verbose for | `§FOR{...}` | `§L{...}` |
 | External visibility | `§F{f1:Main} pub` | `§F{f1:Main:pub}` |
 
 ### Expression Format

--- a/website/content/contributing/adding-benchmarks.mdx
+++ b/website/content/contributing/adding-benchmarks.mdx
@@ -65,7 +65,7 @@ Create `program.calr`:
 ```
 
 **Guidelines:**
-- Use V2 syntax (Lisp-style expressions)
+- Use Lisp-style expressions for operations
 - Include all required IDs
 - Declare effects explicitly
 - Add contracts where meaningful
@@ -236,7 +236,7 @@ Before submitting:
 - [ ] Calor compiles without errors
 - [ ] C# compiles without errors
 - [ ] Both produce identical output (if applicable)
-- [ ] Uses V2 Calor syntax
+- [ ] Uses Lisp-style expressions
 - [ ] IDs are unique and meaningful
 - [ ] Effects are declared
 - [ ] Contracts are equivalent

--- a/website/content/contributing/development-setup.mdx
+++ b/website/content/contributing/development-setup.mdx
@@ -228,7 +228,7 @@ Set `Calor.Compiler` as startup project with command line arguments:
 
 ### Calor Conventions
 
-- Use V2 syntax (Lisp-style expressions)
+- Use Lisp-style expressions for operations
 - Include IDs on all structures
 - Declare effects explicitly
 - Add contracts where meaningful

--- a/website/content/philosophy/index.mdx
+++ b/website/content/philosophy/index.mdx
@@ -108,7 +108,7 @@ Even if you're writing Calor by hand (rather than generating it with AI), you be
 
 ### "This seems verbose compared to C#"
 
-Yes, Calor uses more tokens than equivalent C#. But that verbosity carries meaning—every extra character serves a purpose for AI comprehension. Interestingly, in benchmarks, Calor V2 code is often *more* compact than V1 because the Lisp-style expressions eliminate redundant syntax.
+Yes, Calor uses more tokens than equivalent C#. But that verbosity carries meaning—every extra character serves a purpose for AI comprehension. The Lisp-style expressions keep the syntax compact while maintaining clarity.
 
 ### "My team will never adopt this"
 

--- a/website/content/philosophy/tradeoffs.mdx
+++ b/website/content/philosophy/tradeoffs.mdx
@@ -42,7 +42,7 @@ This is a fundamental design choice, not a flaw to be fixed.
 
 | Quality | Impact | Mitigation |
 |:--------|:-------|:-----------|
-| **Token Efficiency** | 0.67x vs C# | V2 syntax improved 40% over V1 |
+| **Token Efficiency** | 0.67x vs C# | Lisp-style expressions minimize overhead |
 | **Information Density** | 0.22x vs C# | Acceptable for agent workflows |
 | **Human Readability** | Unfamiliar syntax | Not the target audience |
 | **Ecosystem** | No libraries | Compiles to C#, interop possible |
@@ -143,29 +143,6 @@ if (x > 0) return x;
 ### 3. You Need Library Ecosystem
 
 Calor compiles to C#, so interop is possible, but native library support doesn't exist.
-
----
-
-## The V2 Syntax Improvement
-
-V1 syntax was extremely verbose:
-
-```
-// V1 (legacy - do not use)
-§OP[kind=add]
-  §REF[name=a]
-  §REF[name=b]
-§/OP
-```
-
-V2 uses Lisp-style expressions:
-
-```
-// V2 (current)
-(+ a b)
-```
-
-This improved token economics by ~40% while maintaining parseability.
 
 ---
 

--- a/website/content/syntax-reference/index.mdx
+++ b/website/content/syntax-reference/index.mdx
@@ -7,7 +7,7 @@ hasChildren: true
 
 # Syntax Reference
 
-Complete reference for Calor syntax. Always use V2+ syntax (Lisp-style expressions).
+Complete reference for Calor syntax. Calor uses Lisp-style expressions for all operations.
 
 > **Note for Human Readers:** Calor's syntax is intentionally optimized for AI agent comprehension, not human aesthetics. The notation may look unusual at first, but each design choice serves a specific purpose: unique IDs enable precise references, matched tags eliminate scope ambiguity, and Lisp-style expressions allow direct AST manipulation.
 

--- a/website/content/syntax-reference/structure-tags.mdx
+++ b/website/content/syntax-reference/structure-tags.mdx
@@ -210,19 +210,19 @@ C# attributes are preserved during conversion using inline bracket syntax `[@Att
 ### Syntax
 
 ```
-§CLASS[id:name][@AttributeName]
-§CLASS[id:name][@AttributeName(args)]
-§METHOD[id:name:vis][@Attr1][@Attr2]
+§CL[id:name][@AttributeName]
+§CL[id:name][@AttributeName(args)]
+§MT[id:name:vis][@Attr1][@Attr2]
 ```
 
 ### Examples
 
 **Class with routing attributes (ASP.NET Core):**
 ```
-§CLASS[c001:JoinController:ControllerBase][@Route("api/[controller]")][@ApiController]
-  §METHOD[m001:Post:pub][@HttpPost]
-  §/METHOD[m001]
-§/CLASS[c001]
+§CL[c001:JoinController:ControllerBase][@Route("api/[controller]")][@ApiController]
+  §MT[m001:Post:pub][@HttpPost]
+  §/MT[m001]
+§/CL[c001]
 ```
 
 **Property with validation:**
@@ -245,9 +245,9 @@ C# attributes are preserved during conversion using inline bracket syntax `[@Att
 ### Supported Elements
 
 Attributes can be attached to:
-- Classes: `§CLASS[...][@attr]`
+- Classes: `§CL[...][@attr]`
 - Interfaces: `§IFACE[...][@attr]`
-- Methods: `§METHOD[...][@attr]`
+- Methods: `§MT[...][@attr]`
 - Properties: `§PROP[...][@attr]`
 - Fields: `§FLD[...][@attr]`
 - Parameters: `§I[type:name][@attr]`

--- a/website/content/syntax-reference/types.mdx
+++ b/website/content/syntax-reference/types.mdx
@@ -74,8 +74,8 @@ Options represent values that may be absent.
 ### Creating Option Values
 
 ```
-§SOME value         // Some(value) - has a value
-§NONE[type=T]       // None of type T - no value
+§SM value           // Some(value) - has a value
+§NN                 // None - no value
 ```
 
 ### Example
@@ -85,9 +85,9 @@ Options represent values that may be absent.
   §I[i32:id]
   §O[?User]
   §IF[if1] (== id 0)
-    §R §NONE[type=User]
+    §R §NN
   §EL
-    §R §SOME user
+    §R §SM user
   §/I[if1]
 §/F[f001]
 ```


### PR DESCRIPTION
## Summary

- Remove all v1/v2 terminology from documentation - present current syntax as THE syntax without version history
- Fix invalid token references to match current lexer
- Update 27 documentation files across docs/ and website/content/

## Changes

### V1/V2 References Removed
- Removed "V2 Syntax Improvement" sections from tradeoffs and results docs
- Changed "Use V2 syntax" → "Use Lisp-style expressions" in contributing guides
- Removed "using V2 compact syntax" from benchmark descriptions

### Invalid Tokens Fixed

| Old (Invalid) | New (Valid) | Reason |
|--------------|-------------|--------|
| `§SOME` | `§SM` | Short form token |
| `§NONE` | `§NN` | Short form token |
| `§CLASS` | `§CL` | Short form token |
| `§METHOD` | `§MT` | Short form token |
| `§INV` | `§IV` | Invariant token |
| `§THROW` | `§TH` | Throw token |
| `§Y` | `§PROP` | Property token |
| `§D` | `§FLD` | Field definition token |
| `§W` | `§WH` | While loop token |

## Test plan

- [x] Build passes with no errors
- [x] All § tokens in docs match valid lexer tokens
- [x] No remaining v1/v2 references (excluding legitimate uses like `--verbose` flag)

🤖 Generated with [Claude Code](https://claude.ai/code)