### PR TITLE
fix: Escape angle brackets in MDX to prevent JSX parsing errors

### DIFF
--- a/website/content/cli/analyze.mdx
+++ b/website/content/cli/analyze.mdx
@@ -48,8 +48,8 @@ Each file is scored across six dimensions that correspond to Calor language feat
 | Dimension | Weight | What It Detects | Calor Feature |
 |:----------|:------:|:----------------|:-------------|
 | **ContractPotential** | 20% | Argument validation, `ArgumentException` throws, range checks | `§Q`/`§S` contracts |
-| **NullSafetyPotential** | 20% | Nullable types, `?.`, `??`, null checks | `Option<T>` |
-| **ErrorHandlingPotential** | 20% | Try/catch blocks, throw statements | `Result<T,E>` |
+| **NullSafetyPotential** | 20% | Nullable types, `?.`, `??`, null checks | `Option\<T\>` |
+| **ErrorHandlingPotential** | 20% | Try/catch blocks, throw statements | `Result\<T,E\>` |
 | **EffectPotential** | 15% | File I/O, network calls, database access, console | `§E` effect declarations |
 | **ApiComplexityPotential** | 15% | Undocumented public APIs | Calor metadata requirements |
 | **PatternMatchPotential** | 10% | Switch statements/expressions | Exhaustiveness checking |

--- a/website/content/guides/adding-calor-to-existing-projects.mdx
+++ b/website/content/guides/adding-calor-to-existing-projects.mdx
@@ -166,7 +166,7 @@ Write a function that validates email addresses with:
 
 1. **High-scoring files** from `calor analyze`
 2. **Files with complex validation** - benefit from contracts
-3. **Files with error handling** - benefit from `Result<T,E>`
+3. **Files with error handling** - benefit from `Result\<T,E\>`
 4. **Files with side effects** - benefit from effect declarations
 
 ### What to Keep in C#

--- a/website/content/semantics/core.mdx
+++ b/website/content/semantics/core.mdx
@@ -249,7 +249,7 @@ Contracts are semantic constructs that specify behavioral requirements.
 
 ## 6. Option and Result Types
 
-### 6.1 Option<T>
+### 6.1 Option\<T\>
 
 Represents an optional value: either `Some(value)` or `None`.
 
@@ -260,7 +260,7 @@ Represents an optional value: either `Some(value)` or `None`.
 
 **Test:** `S9: OptionNone_BehavesCorrectly`
 
-### 6.2 Result<T,E>
+### 6.2 Result\<T,E\>
 
 Represents a computation that may fail: either `Ok(value)` or `Err(error)`.
 

--- a/website/content/semantics/index.mdx
+++ b/website/content/semantics/index.mdx
@@ -48,7 +48,7 @@ Calor defines its semantics **independently of any backend**. The C# emitter mus
 | **Scoping** | Lexical with explicit shadowing | No surprises from dynamic lookup |
 | **Integer Overflow** | TRAP by default | Safety-first; silent bugs are unacceptable |
 | **Type Conversions** | Explicit for narrowing | Prevents accidental data loss |
-| **Nullability** | `Option<T>` for optional values | No null pointer exceptions |
+| **Nullability** | `Option\<T\>` for optional values | No null pointer exceptions |
 | **Exceptions** | Typed, with semantic meaning | `ContractViolationException` carries context |
 
 ### Why This Matters for Agents
@@ -125,7 +125,7 @@ Every semantic decision is backed by tests:
 | S6 | `ReturnFromNestedScope` | Return unwinds to function boundary |
 | S7 | `IntegerOverflow_Traps` | Overflow throws `OverflowException` |
 | S8 | `NumericConversion_IntToFloat` | Implicit widening works |
-| S9 | `OptionNone_BehavesCorrectly` | `Option<T>` semantics correct |
+| S9 | `OptionNone_BehavesCorrectly` | `Option\<T\>` semantics correct |
 | S10 | `RequiresFails_ThrowsContractViolation` | Contracts throw with function ID |
 | S11 | `SemanticsVersionMismatch_EmitsDiagnostic` | Version checking works |
 

--- a/website/content/syntax-reference/index.mdx
+++ b/website/content/syntax-reference/index.mdx
@@ -50,7 +50,7 @@ Complete reference for Calor syntax. Calor uses Lisp-style expressions for all o
 | `bool` | Boolean | `bool` |
 | `void` | No return value | `void` |
 | `?T` | Optional T | `T?` (nullable) |
-| `T!E` | Result (T or error E) | `Result<T, E>` |
+| `T!E` | Result (T or error E) | `Result\<T, E\>` |
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes the Next.js deploy workflow failure caused by MDX interpreting generic type syntax as JSX tags.

## Problem

MDX interprets `<T>` and `<T,E>` as JSX tags. When the tag name contains a comma (e.g., `Result<T,E>`), MDX throws a parse error:

```
Unexpected character `,` (U+002C) in name, expected a name character such as letters, digits, `$`, or `_`
```

## Solution

Escaped angle brackets in all affected MDX files:
- `Option<T>` → `Option\<T\>`
- `Result<T,E>` → `Result\<T,E\>`

## Files Changed

- `website/content/semantics/core.mdx`
- `website/content/semantics/index.mdx`
- `website/content/cli/analyze.mdx`
- `website/content/guides/adding-calor-to-existing-projects.mdx`
- `website/content/syntax-reference/index.mdx`

## Test plan

- [ ] Next.js deploy workflow passes

🤖 Generated with [Claude Code](https://claude.ai/code)