### PR TITLE
fix: Remove Take(3) limit from TopCalorCategories calculation

### DIFF
--- a/tests/Calor.Evaluation/Benchmarks/BenchmarkRunner.cs
+++ b/tests/Calor.Evaluation/Benchmarks/BenchmarkRunner.cs
@@ -345,11 +345,10 @@ public class BenchmarkRunner
         summary.CalorPassCount = result.CaseResults.Count(c => c.CalorSuccess);
         summary.CSharpPassCount = result.CaseResults.Count(c => c.CSharpSuccess);
 
-        // Identify top categories
+        // Identify top categories (all categories where Calor wins)
         summary.TopCalorCategories = summary.CategoryAdvantages
             .Where(kv => kv.Value > 1.0)
             .OrderByDescending(kv => kv.Value)
-            .Take(3)
             .Select(kv => kv.Key)
             .ToList();
 


### PR DESCRIPTION
## Summary

The `.Take(3)` in `BenchmarkRunner.cs` was incorrectly limiting the count of Calor wins to 3, even when Calor wins in 4 categories.

## Problem

- Website showed "Calor Wins: 3" when it should be 4
- EditPrecision (1.36x) was being excluded from the count

## Fix

Removed the `.Take(3)` from TopCalorCategories calculation so all winning categories are counted.

## Test plan

- [x] All 28 tests pass
- [x] Verified JSON output now shows `calorWins: 4, cSharpWins: 4`

🤖 Generated with [Claude Code](https://claude.ai/code)