### PR TITLE
feat(website): restructure homepage from 9 to 7 sections

### DIFF
--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -1,10 +1,8 @@
 import { Hero } from '@/components/landing/Hero';
-import { Story } from '@/components/landing/Story';
 import { CodeComparison } from '@/components/landing/CodeComparison';
-import { BenchmarkChart } from '@/components/landing/BenchmarkChart';
-import { CompetitivePositioning } from '@/components/landing/CompetitivePositioning';
+import { CatchBugs } from '@/components/landing/CatchBugs';
 import { FeatureGrid } from '@/components/landing/FeatureGrid';
-import { VSCodeExtension } from '@/components/landing/VSCodeExtension';
+import { BenchmarkChart } from '@/components/landing/BenchmarkChart';
 import { QuickStart } from '@/components/landing/QuickStart';
 import { ProjectStatus } from '@/components/landing/ProjectStatus';
 
@@ -12,12 +10,10 @@ export default function HomePage() {
   return (
     <div className="flex flex-col">
       <Hero />
-      <Story />
       <CodeComparison />
-      <BenchmarkChart />
-      <CompetitivePositioning />
+      <CatchBugs />
       <FeatureGrid />
-      <VSCodeExtension />
+      <BenchmarkChart />
       <QuickStart />
       <ProjectStatus />
     </div>

--- a/website/src/components/landing/BenchmarkChart.tsx
+++ b/website/src/components/landing/BenchmarkChart.tsx
@@ -180,10 +180,10 @@ export function BenchmarkChart() {
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
-            Benchmark Results
+            Where Explicit Semantics Pay Off
           </h2>
           <p className="mt-4 text-lg text-muted-foreground">
-            Evaluated across {programCount} paired Calor/C# programs
+            Calor trades token efficiency for semantic explicitness. Here's where that pays off.
           </p>
           {lastUpdated && (
             <div className="mt-2 flex items-center justify-center gap-2 text-sm text-muted-foreground">
@@ -258,11 +258,11 @@ export function BenchmarkChart() {
 
           {/* Key finding */}
           <div className="mt-12 p-6 rounded-lg border bg-muted/50">
-            <h3 className="font-semibold mb-2">Key Finding</h3>
+            <h3 className="font-semibold mb-2">The Tradeoff</h3>
             <p className="text-muted-foreground">
-              Calor excels in error detection through explicit contracts. C# currently leads
-              in most other metrics, reflecting ecosystem maturity and LLM training data bias.
-              The tradeoff: explicit semantics require more tokens but enable better invariant checking.
+              Calor wins where correctness matters: comprehension, error detection, and refactoring stability.
+              C# wins where familiarity matters: generation accuracy and task completion. As LLMs train on
+              more Calor code, the familiarity gap closes. The correctness advantage is structural.
             </p>
           </div>
 

--- a/website/src/components/landing/CatchBugs.tsx
+++ b/website/src/components/landing/CatchBugs.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+export function CatchBugs() {
+  const calorCode = `§F[f_01A8X:ProcessOrder:pub]
+  §I[Order:order]
+  §O[bool]
+  §E[db]
+
+  §C[SaveOrder] order
+  §C[NotifyCustomer] order
+§/F[f_01A8X]`;
+
+  const errorOutput = `error CALOR0410: Function 'ProcessOrder' uses effect 'net'
+                   but does not declare it
+
+  Call chain: ProcessOrder → NotifyCustomer → SendEmail
+              → HttpClient.PostAsync
+
+  Declared effects: §E[db]
+  Required effects: §E[db,net]
+
+  Fix: Add 'net' to the effect declaration:
+       §E[db,net]`;
+
+  return (
+    <section className="py-24">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
+            Catch Bugs C# Can't
+          </h2>
+          <p className="mt-4 text-lg text-muted-foreground">
+            The compiler traces effects through your entire call graph.
+          </p>
+        </div>
+
+        <div className="mt-16 mx-auto max-w-5xl">
+          <div className="grid lg:grid-cols-2 gap-6">
+            {/* Code block */}
+            <div className="rounded-lg border bg-zinc-950 overflow-hidden">
+              <div className="border-b border-zinc-800 px-4 py-2">
+                <span className="text-sm text-zinc-400">order-service.calr</span>
+              </div>
+              <pre className="p-4 text-sm leading-6 overflow-x-auto">
+                <code className="text-zinc-100">{calorCode}</code>
+              </pre>
+            </div>
+
+            {/* Error output */}
+            <div className="rounded-lg border border-destructive/50 bg-destructive/5 overflow-hidden">
+              <div className="border-b border-destructive/30 px-4 py-2">
+                <span className="text-sm text-destructive">Compiler Output</span>
+              </div>
+              <pre className="p-4 text-sm leading-6 overflow-x-auto">
+                <code className="text-destructive/90 font-mono">{errorOutput}</code>
+              </pre>
+            </div>
+          </div>
+
+          {/* Explanation */}
+          <div className="mt-8 p-6 rounded-lg border bg-muted/50">
+            <p className="text-muted-foreground">
+              The compiler traced through 3 layers of function calls and found a network effect
+              hiding behind a helper function. In C#, this bug ships to production.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/landing/CodeComparison.tsx
+++ b/website/src/components/landing/CodeComparison.tsx
@@ -3,13 +3,13 @@
 import { useState } from 'react';
 import { cn } from '@/lib/utils';
 
-const calorCode = `§F[f002:Square:pub]
+const calorCode = `§F[f_01J5X7K9M2:Square:pub]
   §I[i32:x]
   §O[i32]
   §Q (>= x 0)
   §S (>= result 0)
   §R (* x x)
-§/F[f002]`;
+§/F[f_01J5X7K9M2]`;
 
 const csharpCode = `public static int Square(int x)
 {
@@ -22,7 +22,7 @@ const csharpCode = `public static int Square(int x)
 }`;
 
 const calorAnnotations = [
-  { line: 0, text: 'Function ID: f002 - can reference precisely' },
+  { line: 0, text: 'Stable ID f_01J5X7K9M2 - survives renames and refactors' },
   { line: 3, text: 'Precondition (§Q): x >= 0' },
   { line: 4, text: 'Postcondition (§S): result >= 0' },
   { line: 5, text: 'No side effects (no §E declaration)' },

--- a/website/src/components/landing/FeatureGrid.tsx
+++ b/website/src/components/landing/FeatureGrid.tsx
@@ -5,7 +5,7 @@ const features = [
   {
     name: 'First-Class Contracts',
     description:
-      'Preconditions and postconditions are syntax, not comments. Agents see requirements and guarantees directly.',
+      'Preconditions and postconditions are syntax, not comments. Catch contract violations at compile time, not in production logs.',
     icon: Shield,
     code: '§Q (>= x 0)\n§S (>= result 0)',
     href: '/docs/philosophy/effects-contracts-enforcement/',
@@ -13,24 +13,26 @@ const features = [
   {
     name: 'Explicit Effects',
     description:
-      'Declare side effects upfront. No guessing whether a function touches the file system or network.',
+      'Effects trace through the entire call graph. Hide a database call in a helper? The compiler finds it.',
     icon: FileCode,
-    code: '§E[cw,fr,net]',
+    code: '§E[db:rw,net:rw]',
     href: '/docs/philosophy/effects-contracts-enforcement/',
   },
   {
-    name: 'Unique Identifiers',
+    name: 'Stable Identifiers',
     description:
-      'Every element has a stable ID. Refactoring changes names, not references.',
+      'ULID-based IDs survive renaming, file moves, and refactoring. Agents reference code precisely.',
     icon: Fingerprint,
-    code: '§F[f001:Process:pub]',
+    code: '§F[f_01J5X7K9M2:Process:pub]',
+    href: '/docs/philosophy/stable-identifiers/',
   },
   {
     name: 'Explicit Structure',
     description:
-      'Matched opening and closing tags. No ambiguous scope boundaries for agents to parse.',
+      'Matched open/close tags eliminate bugs where agents miscalculate indentation or brace depth.',
     icon: Layers,
-    code: '§M[m001:App]\n  ...\n§/M[m001]',
+    code: '§M[m_01J5X7K9M2:App]\n  ...\n§/M[m_01J5X7K9M2]',
+    href: '/docs/syntax-reference/',
   },
 ];
 

--- a/website/src/components/landing/Hero.tsx
+++ b/website/src/components/landing/Hero.tsx
@@ -38,11 +38,10 @@ export function Hero() {
             Calor
           </h1>
           <p className="mt-4 text-xl font-medium text-white sm:text-2xl">
-            Coding Agent Language for Optimized Reasoning
+            When AI writes your code, the language should catch the bugs.
           </p>
           <p className="mt-6 text-lg leading-8 text-white/80">
-            A programming language designed specifically for AI coding agents,
-            compiling to .NET via C# emission.
+            Contracts, effects, and stable IDs—the guarantees agents need to write correct .NET code.
           </p>
 
           <div className="mt-10 flex items-center justify-center gap-x-4">

--- a/website/src/components/landing/ProjectStatus.tsx
+++ b/website/src/components/landing/ProjectStatus.tsx
@@ -1,86 +1,49 @@
-import { Check, Circle } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { Check } from 'lucide-react';
 
-interface StatusItem {
-  label: string;
-  completed: boolean;
-}
-
-const statusItems: StatusItem[] = [
-  { label: 'Core compiler (lexer, parser, C# code generation)', completed: true },
-  { label: 'Control flow (for, if/else, while)', completed: true },
-  { label: 'Type system (Option, Result)', completed: true },
-  { label: 'Contracts (requires, ensures)', completed: true },
-  { label: 'Effects declarations', completed: true },
-  { label: 'MSBuild SDK integration', completed: true },
-  { label: 'Evaluation framework (7 metrics, 20 benchmarks)', completed: true },
-  { label: 'Direct IL emission', completed: false },
-  { label: 'VS Code Extension', completed: true },
+const completedMilestones = [
+  'Core compiler',
+  'Control flow',
+  'Type system',
+  'Contracts',
+  'Effects',
+  'MSBuild SDK',
+  'Benchmarks',
+  'VS Code Extension',
 ];
 
+const currentFocus = 'Direct IL emission';
+
 export function ProjectStatus() {
-  const completedCount = statusItems.filter((item) => item.completed).length;
-
   return (
-    <section className="py-24 bg-muted/30">
+    <section className="py-16 bg-muted/30">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
-            Project Status
-          </h2>
-          <p className="mt-4 text-lg text-muted-foreground">
-            {completedCount} of {statusItems.length} milestones completed
-          </p>
-        </div>
-
-        <div className="mt-12 mx-auto max-w-2xl">
-          <div className="space-y-3">
-            {statusItems.map((item, index) => (
-              <div
-                key={index}
-                className={cn(
-                  'flex items-center gap-3 rounded-lg border p-4 transition-colors',
-                  item.completed
-                    ? 'bg-calor-cyan/5 border-calor-cyan/20'
-                    : 'bg-background'
-                )}
-              >
-                {item.completed ? (
-                  <div className="flex h-6 w-6 items-center justify-center rounded-full bg-calor-cyan">
-                    <Check className="h-4 w-4 text-calor-navy" />
-                  </div>
-                ) : (
-                  <div className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-muted-foreground/30">
-                    <Circle className="h-3 w-3 text-muted-foreground/30" />
-                  </div>
-                )}
-                <span
-                  className={cn(
-                    'text-sm',
-                    item.completed
-                      ? 'text-foreground'
-                      : 'text-muted-foreground'
-                  )}
-                >
-                  {item.label}
-                </span>
+        <div className="mx-auto max-w-3xl">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 p-6 rounded-lg border bg-background">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-calor-cyan">
+                <Check className="h-5 w-5 text-calor-navy" />
               </div>
-            ))}
-          </div>
-
-          {/* Progress bar */}
-          <div className="mt-8">
-            <div className="flex items-center justify-between text-sm text-muted-foreground mb-2">
-              <span>Progress</span>
-              <span>{Math.round((completedCount / statusItems.length) * 100)}%</span>
+              <div>
+                <h3 className="font-semibold">Project Status</h3>
+                <p className="text-sm text-muted-foreground">
+                  {completedMilestones.length} milestones completed
+                </p>
+              </div>
             </div>
-            <div className="h-2 bg-muted rounded-full overflow-hidden">
-              <div
-                className="h-full bg-calor-cyan rounded-full transition-all duration-500"
-                style={{ width: `${(completedCount / statusItems.length) * 100}%` }}
-              />
+            <div className="flex flex-wrap gap-2">
+              {completedMilestones.map((milestone) => (
+                <span
+                  key={milestone}
+                  className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs bg-calor-cyan/10 text-calor-cerulean"
+                >
+                  {milestone}
+                </span>
+              ))}
             </div>
           </div>
+          <p className="mt-4 text-center text-sm text-muted-foreground">
+            Currently working on: <span className="font-medium text-foreground">{currentFocus}</span>
+          </p>
         </div>
       </div>
     </section>

--- a/website/src/components/landing/QuickStart.tsx
+++ b/website/src/components/landing/QuickStart.tsx
@@ -5,9 +5,21 @@ import { Check, Copy, Terminal } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const commands = [
-  { label: 'Install the compiler', command: 'dotnet tool install -g calor' },
-  { label: 'Initialize with Claude Code', command: 'calor init --ai claude' },
-  { label: 'Build your project', command: 'dotnet build' },
+  {
+    label: 'Install the compiler',
+    command: 'dotnet tool install -g calor',
+    description: 'Adds calor to your PATH. Requires .NET 8+ SDK.',
+  },
+  {
+    label: 'Initialize with Claude Code',
+    command: 'calor init --ai claude',
+    description: 'Generates CLAUDE.md with Calor syntax reference.',
+  },
+  {
+    label: 'Build your project',
+    command: 'dotnet build',
+    description: 'Compiles .calr files to C# and builds the assembly.',
+  },
 ];
 
 export function QuickStart() {
@@ -58,6 +70,7 @@ export function QuickStart() {
                       <pre className="text-sm text-zinc-100 font-mono whitespace-pre-wrap">
                         <span className="text-green-400">$</span> {cmd.command}
                       </pre>
+                      <p className="text-xs text-zinc-500">{cmd.description}</p>
                     </div>
                     <button
                       onClick={() => copyToClipboard(cmd.command, index)}


### PR DESCRIPTION
## Summary
- Remove Story, CompetitivePositioning, and VSCodeExtension sections
- Update Hero with value-oriented messaging ("When AI writes your code, the language should catch the bugs")
- Update CodeComparison with ULID-based stable identifiers
- Add new CatchBugs component showing interprocedural effect analysis with compiler error demo
- Update FeatureGrid with impact statements and "Learn more" links for all cards
- Reframe BenchmarkChart as "Where Explicit Semantics Pay Off"
- Add descriptions to QuickStart commands
- Make ProjectStatus compact with chip-based milestones

## Test plan
- [ ] Verify Hero text updated, visual design preserved
- [ ] Verify Story section removed
- [ ] Verify CodeComparison appears after Hero with ULID
- [ ] Verify CatchBugs section renders with code + error output
- [ ] Verify Feature cards have ULIDs and "Learn more" links work
- [ ] Verify BenchmarkChart title is "Where Explicit Semantics Pay Off"
- [ ] Verify QuickStart has descriptions under commands
- [ ] Verify ProjectStatus is compact with milestone chips
- [ ] Verify dark mode works on all sections
- [ ] Verify mobile responsive layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)