### PR TITLE
docs: Remove hardcoded version from install commands

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -17,7 +17,7 @@ The `calor` command-line tool provides commands for working with Calor code and 
 Install `calor` as a global .NET tool:
 
 ```bash
-dotnet tool install -g calor --version 0.1.3
+dotnet tool install -g calor
 ```
 
 Or update an existing installation:

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -43,7 +43,7 @@ your_code.calr → Calor Compiler → your_code.g.cs → .NET Build → executab
 Install the Calor compiler as a global .NET tool:
 
 ```bash
-dotnet tool install -g calor --version 0.1.2
+dotnet tool install -g calor
 ```
 
 Or update an existing installation:

--- a/website/content/cli/index.mdx
+++ b/website/content/cli/index.mdx
@@ -15,7 +15,7 @@ The `calor` command-line tool provides commands for working with Calor code and 
 Install `calor` as a global .NET tool:
 
 ```bash
-dotnet tool install -g calor --version 0.1.3
+dotnet tool install -g calor
 ```
 
 Or update an existing installation:

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -44,7 +44,7 @@ your_code.calr → Calor Compiler → your_code.g.cs → .NET Build → executab
 Install the Calor compiler as a global .NET tool:
 
 ```bash
-dotnet tool install -g calor --version 0.1.2
+dotnet tool install -g calor
 ```
 
 Or update an existing installation:


### PR DESCRIPTION
## Summary
- Remove `--version` flag from `dotnet tool install` commands
- Documentation now shows how to install latest version
- Prevents docs from becoming stale as new versions are released

## Files changed
- `docs/getting-started/index.md`
- `docs/cli/index.md`
- `website/content/getting-started/index.mdx`
- `website/content/cli/index.mdx`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)