### PR TITLE
docs: update documentation for generics support

### DIFF
--- a/TODO-converter-gaps.md
+++ b/TODO-converter-gaps.md
@@ -110,15 +110,17 @@ if (expression is UnaryExpression unary)
 
 **Implementation Notes:** Need to generate proper Calor pattern matching with variable binding.
 
-#### Nested Generic Types
+#### ~~Nested Generic Types~~ ✅ DONE
 ```csharp
-// Not supported:
+// NOW SUPPORTED:
 Expression<Func<T, TProp>> expression;
 Action<Dictionary<string, List<int>>> handler;
 ```
-**Workaround:** Simplify generic nesting or use intermediate types.
-
-**Implementation Notes:** Type parameter parsing needs to handle recursive generic arguments.
+**Status:** Implemented in v0.3.0. Nested generic types are now parsed correctly using inline angle bracket syntax:
+```calor
+§I{Dictionary<str, List<i32>>:data}
+§O{Expression<Func<T, TProp>>}
+```
 
 #### Lambda Expressions
 ```csharp
@@ -139,14 +141,24 @@ Name = value ?? throw new ArgumentNullException(nameof(value));
 
 **Implementation Notes:** Throw expressions need proper Calor representation in S-expression context.
 
-#### Generic Type Constraints
+#### ~~Generic Type Constraints~~ ✅ DONE
 ```csharp
-// Not supported:
+// NOW SUPPORTED:
 public class UnitDefinition<TUnit> where TUnit : struct, Enum { }
+public T Identity<T>(T value) where T : class, IComparable<T> { ... }
 ```
-**Workaround:** Remove constraints or use simpler patterns.
+**Status:** Implemented in v0.3.0. Use the new `§WHERE` syntax:
+```calor
+§CL{c001:UnitDefinition}<TUnit>
+  §WHERE TUnit : struct
 
-**Implementation Notes:** Constraint syntax needs Calor §WHERE tag enhancement.
+§F{f001:Identity:pub}<T>
+  §WHERE T : class, IComparable<T>
+  §I{T:value}
+  §O{T}
+§/F{f001}
+```
+Supported constraints: `class`, `struct`, `new()`, interface types, and base class types.
 
 ### Medium Priority
 

--- a/docs/syntax-reference/structure-tags.md
+++ b/docs/syntax-reference/structure-tags.md
@@ -246,6 +246,95 @@ Every structural element must be closed with a matching tag.
 
 ---
 
+## Generics
+
+Calor supports generic functions, classes, interfaces, and methods using angle bracket syntax.
+
+### Type Parameters
+
+Type parameters are declared using `<T>` suffix syntax after the tag attributes.
+
+```
+§F{id:name:vis}<T>         // Generic function with one type parameter
+§F{id:name:vis}<T, U>      // Generic function with two type parameters
+§CL{id:name}<T>            // Generic class
+§IFACE{id:name}<T>         // Generic interface
+§MT{id:name:vis}<T>        // Generic method
+```
+
+### Constraints
+
+Type parameter constraints are declared using `§WHERE` clauses.
+
+**New syntax (recommended):**
+```
+§WHERE T : class                    // T must be a reference type
+§WHERE T : struct                   // T must be a value type
+§WHERE T : new()                    // T must have parameterless constructor
+§WHERE T : IComparable<T>           // T must implement interface
+§WHERE T : class, IComparable<T>    // Multiple constraints
+```
+
+**Legacy syntax (still supported):**
+```
+§WR{T:class}                        // T must be a reference type
+§WR{T:IComparable}                  // T must implement interface
+```
+
+### Generic Type References
+
+Generic types are written inline using angle bracket syntax.
+
+```
+§I{List<T>:items}                   // Parameter of type List<T>
+§I{Dictionary<str, T>:lookup}       // Nested generic types
+§O{IEnumerable<T>}                  // Generic return type
+§FLD{List<T>:_items:pri}            // Generic field type
+```
+
+### Examples
+
+**Generic identity function:**
+```
+§F{f001:Identity:pub}<T>
+  §I{T:value}
+  §O{T}
+  §R value
+§/F{f001}
+```
+
+**Generic class with constraint:**
+```
+§CL{c001:Repository:pub}<T>
+  §WHERE T : class
+  §FLD{List<T>:_items:pri}
+
+  §MT{m001:Add:pub}
+    §I{T:item}
+    §O{void}
+    §C{_items.Add} §A item §/C
+  §/MT{m001}
+
+  §MT{m002:GetAll:pub}
+    §O{IReadOnlyList<T>}
+    §R _items
+  §/MT{m002}
+§/CL{c001}
+```
+
+**Generic interface:**
+```
+§IFACE{i001:IRepository}<T>
+  §WHERE T : class
+  §MT{m001:Get}
+    §I{i32:id}
+    §O{T}
+  §/MT{m001}
+§/IFACE{i001}
+```
+
+---
+
 ## C# Attributes
 
 C# attributes are preserved during conversion using inline bracket syntax `[@Attribute]`.

--- a/docs/syntax-reference/types.md
+++ b/docs/syntax-reference/types.md
@@ -188,6 +188,53 @@ T!E                 // Result: either T (success) or E (error)
 
 ---
 
+## Generic Types
+
+Generic types use angle bracket syntax inline.
+
+### Syntax
+
+```
+List<T>                 // List of T
+Dictionary<K, V>        // Dictionary with key K and value V
+IEnumerable<T>          // Enumerable of T
+Func<T, U>              // Function from T to U
+```
+
+### Examples
+
+```
+§I{List<i32>:numbers}           // List<int> parameter
+§I{Dictionary<str, i32>:scores} // Dictionary<string, int>
+§O{IEnumerable<str>}            // Returns IEnumerable<string>
+§FLD{HashSet<T>:_items:pri}     // Generic field with type parameter T
+```
+
+### Nested Generic Types
+
+Generic types can be nested.
+
+```
+§I{Dictionary<str, List<i32>>:data}     // Dictionary<string, List<int>>
+§O{List<Tuple<str, i32>>}               // List<(string, int)>
+```
+
+### Type Parameters
+
+When defining generic functions or classes, type parameters (like `T`, `U`) can be used as types.
+
+```
+§F{f001:First:pub}<T>
+  §I{List<T>:items}
+  §O{T}
+  §R items[0]
+§/F{f001}
+```
+
+See [Structure Tags - Generics](/calor/syntax-reference/structure-tags/#generics) for more on defining generic functions and classes.
+
+---
+
 ## Type Annotations in Contracts
 
 Types matter in contracts for proper comparisons:

--- a/src/Calor.Compiler/Resources/Skills/claude-calor-SKILL.md
+++ b/src/Calor.Compiler/Resources/Skills/claude-calor-SKILL.md
@@ -169,6 +169,65 @@ Multi-line form:
 §/C
 ```
 
+## Generics
+
+### Generic Functions and Classes
+
+Type parameters use `<T>` suffix syntax after tag attributes:
+
+```
+§F{id:Name:pub}<T>            Generic function with one type param
+§F{id:Name:pub}<T, U>         Generic function with two type params
+§CL{id:Name}<T>               Generic class
+§IFACE{id:Name}<T>            Generic interface
+§MT{id:Name:vis}<T>           Generic method
+```
+
+### Generic Type References
+
+Use angle brackets inline for generic types:
+
+```
+§I{List<T>:items}             List<T> parameter
+§I{Dictionary<str, T>:lookup} Dictionary parameter
+§O{IEnumerable<T>}            Generic return type
+§FLD{List<T>:_items:pri}      Generic field
+```
+
+### Type Constraints (§WHERE)
+
+```
+§WHERE T : class              Reference type constraint
+§WHERE T : struct             Value type constraint
+§WHERE T : new()              Parameterless constructor
+§WHERE T : IComparable<T>     Interface constraint
+§WHERE T : class, IDisposable Multiple constraints
+```
+
+### Template: Generic Repository
+
+```calor
+§CL{c001:Repository:pub}<T>
+  §WHERE T : class
+  §FLD{List<T>:_items:pri}
+
+  §CTOR{ct001:pub}
+    §ASSIGN _items §NEW{List:T}
+  §/CTOR{ct001}
+
+  §MT{m001:Add:pub}
+    §I{T:item}
+    §O{void}
+    §C{_items.Add} §A item §/C
+  §/MT{m001}
+
+  §MT{m002:GetAll:pub}
+    §O{IReadOnlyList<T>}
+    §R _items
+  §/MT{m002}
+§/CL{c001}
+```
+
 ## C# Attributes
 
 Attributes attach inline after structural braces using `[@...]` syntax:

--- a/src/Calor.Compiler/Resources/Skills/codex-calor-SKILL.md
+++ b/src/Calor.Compiler/Resources/Skills/codex-calor-SKILL.md
@@ -169,6 +169,65 @@ Multi-line form:
 §/C
 ```
 
+## Generics
+
+### Generic Functions and Classes
+
+Type parameters use `<T>` suffix syntax after tag attributes:
+
+```
+§F{id:Name:pub}<T>            Generic function with one type param
+§F{id:Name:pub}<T, U>         Generic function with two type params
+§CL{id:Name}<T>               Generic class
+§IFACE{id:Name}<T>            Generic interface
+§MT{id:Name:vis}<T>           Generic method
+```
+
+### Generic Type References
+
+Use angle brackets inline for generic types:
+
+```
+§I{List<T>:items}             List<T> parameter
+§I{Dictionary<str, T>:lookup} Dictionary parameter
+§O{IEnumerable<T>}            Generic return type
+§FLD{List<T>:_items:pri}      Generic field
+```
+
+### Type Constraints (§WHERE)
+
+```
+§WHERE T : class              Reference type constraint
+§WHERE T : struct             Value type constraint
+§WHERE T : new()              Parameterless constructor
+§WHERE T : IComparable<T>     Interface constraint
+§WHERE T : class, IDisposable Multiple constraints
+```
+
+### Template: Generic Repository
+
+```calor
+§CL{c001:Repository:pub}<T>
+  §WHERE T : class
+  §FLD{List<T>:_items:pri}
+
+  §CTOR{ct001:pub}
+    §ASSIGN _items §NEW{List:T}
+  §/CTOR{ct001}
+
+  §MT{m001:Add:pub}
+    §I{T:item}
+    §O{void}
+    §C{_items.Add} §A item §/C
+  §/MT{m001}
+
+  §MT{m002:GetAll:pub}
+    §O{IReadOnlyList<T>}
+    §R _items
+  §/MT{m002}
+§/CL{c001}
+```
+
 ## C# Attributes
 
 Attributes attach inline after structural braces using `[@...]` syntax:

--- a/src/Calor.Compiler/Resources/Skills/gemini-calor-SKILL.md
+++ b/src/Calor.Compiler/Resources/Skills/gemini-calor-SKILL.md
@@ -169,6 +169,65 @@ Multi-line form:
 §/C
 ```
 
+## Generics
+
+### Generic Functions and Classes
+
+Type parameters use `<T>` suffix syntax after tag attributes:
+
+```
+§F{id:Name:pub}<T>            Generic function with one type param
+§F{id:Name:pub}<T, U>         Generic function with two type params
+§CL{id:Name}<T>               Generic class
+§IFACE{id:Name}<T>            Generic interface
+§MT{id:Name:vis}<T>           Generic method
+```
+
+### Generic Type References
+
+Use angle brackets inline for generic types:
+
+```
+§I{List<T>:items}             List<T> parameter
+§I{Dictionary<str, T>:lookup} Dictionary parameter
+§O{IEnumerable<T>}            Generic return type
+§FLD{List<T>:_items:pri}      Generic field
+```
+
+### Type Constraints (§WHERE)
+
+```
+§WHERE T : class              Reference type constraint
+§WHERE T : struct             Value type constraint
+§WHERE T : new()              Parameterless constructor
+§WHERE T : IComparable<T>     Interface constraint
+§WHERE T : class, IDisposable Multiple constraints
+```
+
+### Template: Generic Repository
+
+```calor
+§CL{c001:Repository:pub}<T>
+  §WHERE T : class
+  §FLD{List<T>:_items:pri}
+
+  §CTOR{ct001:pub}
+    §ASSIGN _items §NEW{List:T}
+  §/CTOR{ct001}
+
+  §MT{m001:Add:pub}
+    §I{T:item}
+    §O{void}
+    §C{_items.Add} §A item §/C
+  §/MT{m001}
+
+  §MT{m002:GetAll:pub}
+    §O{IReadOnlyList<T>}
+    §R _items
+  §/MT{m002}
+§/CL{c001}
+```
+
 ## C# Attributes
 
 Attributes attach inline after structural braces using `[@...]` syntax:

--- a/src/Calor.Compiler/Resources/Skills/github-calor-SKILL.md
+++ b/src/Calor.Compiler/Resources/Skills/github-calor-SKILL.md
@@ -169,6 +169,65 @@ Multi-line form:
 §/C
 ```
 
+## Generics
+
+### Generic Functions and Classes
+
+Type parameters use `<T>` suffix syntax after tag attributes:
+
+```
+§F{id:Name:pub}<T>            Generic function with one type param
+§F{id:Name:pub}<T, U>         Generic function with two type params
+§CL{id:Name}<T>               Generic class
+§IFACE{id:Name}<T>            Generic interface
+§MT{id:Name:vis}<T>           Generic method
+```
+
+### Generic Type References
+
+Use angle brackets inline for generic types:
+
+```
+§I{List<T>:items}             List<T> parameter
+§I{Dictionary<str, T>:lookup} Dictionary parameter
+§O{IEnumerable<T>}            Generic return type
+§FLD{List<T>:_items:pri}      Generic field
+```
+
+### Type Constraints (§WHERE)
+
+```
+§WHERE T : class              Reference type constraint
+§WHERE T : struct             Value type constraint
+§WHERE T : new()              Parameterless constructor
+§WHERE T : IComparable<T>     Interface constraint
+§WHERE T : class, IDisposable Multiple constraints
+```
+
+### Template: Generic Repository
+
+```calor
+§CL{c001:Repository:pub}<T>
+  §WHERE T : class
+  §FLD{List<T>:_items:pri}
+
+  §CTOR{ct001:pub}
+    §ASSIGN _items §NEW{List:T}
+  §/CTOR{ct001}
+
+  §MT{m001:Add:pub}
+    §I{T:item}
+    §O{void}
+    §C{_items.Add} §A item §/C
+  §/MT{m001}
+
+  §MT{m002:GetAll:pub}
+    §O{IReadOnlyList<T>}
+    §R _items
+  §/MT{m002}
+§/CL{c001}
+```
+
 ## C# Attributes
 
 Attributes attach inline after structural braces using `[@...]` syntax:

--- a/website/content/syntax-reference/structure-tags.mdx
+++ b/website/content/syntax-reference/structure-tags.mdx
@@ -253,6 +253,88 @@ Attributes can be attached to:
 
 ---
 
+## Generics
+
+Calor supports generic functions, classes, interfaces, and methods using angle bracket syntax.
+
+### Type Parameters
+
+Type parameters are declared using `<T>` suffix syntax after the tag attributes.
+
+```
+§F{id:name:vis}<T>         // Generic function with one type parameter
+§F{id:name:vis}<T, U>      // Generic function with two type parameters
+§CL{id:name}<T>            // Generic class
+§IFACE{id:name}<T>         // Generic interface
+§MT{id:name:vis}<T>        // Generic method
+```
+
+### Constraints
+
+Type parameter constraints are declared using `§WHERE` clauses.
+
+```
+§WHERE T : class                    // T must be a reference type
+§WHERE T : struct                   // T must be a value type
+§WHERE T : new()                    // T must have parameterless constructor
+§WHERE T : IComparable<T>           // T must implement interface
+§WHERE T : class, IComparable<T>    // Multiple constraints
+```
+
+### Generic Type References
+
+Generic types are written inline using angle bracket syntax.
+
+```
+§I{List<T>:items}                   // Parameter of type List<T>
+§I{Dictionary<str, T>:lookup}       // Nested generic types
+§O{IEnumerable<T>}                  // Generic return type
+§FLD{List<T>:_items:pri}            // Generic field type
+```
+
+### Examples
+
+**Generic identity function:**
+```
+§F{f001:Identity:pub}<T>
+  §I{T:value}
+  §O{T}
+  §R value
+§/F{f001}
+```
+
+**Generic class with constraint:**
+```
+§CL{c001:Repository:pub}<T>
+  §WHERE T : class
+  §FLD{List<T>:_items:pri}
+
+  §MT{m001:Add:pub}
+    §I{T:item}
+    §O{void}
+    §C{_items.Add} §A item §/C
+  §/MT{m001}
+
+  §MT{m002:GetAll:pub}
+    §O{IReadOnlyList<T>}
+    §R _items
+  §/MT{m002}
+§/CL{c001}
+```
+
+**Generic interface:**
+```
+§IFACE{i001:IRepository}<T>
+  §WHERE T : class
+  §MT{m001:Get}
+    §I{i32:id}
+    §O{T}
+  §/MT{m001}
+§/IFACE{i001}
+```
+
+---
+
 ## Why Explicit Closing Tags?
 
 1. **Unambiguous parsing** - No brace-counting needed

--- a/website/content/syntax-reference/types.mdx
+++ b/website/content/syntax-reference/types.mdx
@@ -148,6 +148,53 @@ T!E                 // Result: either T (success) or E (error)
 
 ---
 
+## Generic Types
+
+Generic types use angle bracket syntax inline.
+
+### Syntax
+
+```
+List<T>                 // List of T
+Dictionary<K, V>        // Dictionary with key K and value V
+IEnumerable<T>          // Enumerable of T
+Func<T, U>              // Function from T to U
+```
+
+### Examples
+
+```
+§I{List<i32>:numbers}           // List<int> parameter
+§I{Dictionary<str, i32>:scores} // Dictionary<string, int>
+§O{IEnumerable<str>}            // Returns IEnumerable<string>
+§FLD{HashSet<T>:_items:pri}     // Generic field with type parameter T
+```
+
+### Nested Generic Types
+
+Generic types can be nested.
+
+```
+§I{Dictionary<str, List<i32>>:data}     // Dictionary<string, List<int>>
+§O{List<Tuple<str, i32>>}               // List<(string, int)>
+```
+
+### Type Parameters
+
+When defining generic functions or classes, type parameters (like `T`, `U`) can be used as types.
+
+```
+§F{f001:First:pub}<T>
+  §I{List<T>:items}
+  §O{T}
+  §R items[0]
+§/F{f001}
+```
+
+See [Structure Tags - Generics](/syntax-reference/structure-tags/#generics) for more on defining generic functions and classes.
+
+---
+
 ## Type Annotations in Contracts
 
 Types matter in contracts for proper comparisons:


### PR DESCRIPTION
## Summary
Follow-up to #115 - adds documentation for the generics implementation.

- Update `TODO-converter-gaps.md` to mark generics as complete
- Add generic syntax documentation to `structure-tags.md`
- Add generic types documentation to `types.md`  
- Update AI skill files with generics information
- Update website documentation with generics syntax

## Test plan
- [x] Documentation only - no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)