### PR TITLE
fix: Type checker support for angle bracket generics

### DIFF
--- a/src/Calor.Compiler/TypeChecking/CalorType.cs
+++ b/src/Calor.Compiler/TypeChecking/CalorType.cs
@@ -290,3 +290,44 @@ public sealed class TypeParameterType : CalorType
 
     public override int GetHashCode() => Name.GetHashCode();
 }
+
+/// <summary>
+/// Represents an instantiated generic type (e.g., List&lt;int&gt;, Dictionary&lt;string, T&gt;).
+/// Used during type checking to track generic type instantiations.
+/// </summary>
+public sealed class GenericInstanceType : CalorType
+{
+    public string BaseName { get; }
+    public IReadOnlyList<CalorType> TypeArguments { get; }
+    public override string Name
+    {
+        get
+        {
+            var argsStr = string.Join(", ", TypeArguments.Select(a => a.Name));
+            return $"{BaseName}<{argsStr}>";
+        }
+    }
+
+    public GenericInstanceType(string baseName, IReadOnlyList<CalorType> typeArguments)
+    {
+        BaseName = baseName ?? throw new ArgumentNullException(nameof(baseName));
+        TypeArguments = typeArguments ?? throw new ArgumentNullException(nameof(typeArguments));
+    }
+
+    public override bool Equals(CalorType? other)
+    {
+        if (other is not GenericInstanceType git) return false;
+        if (BaseName != git.BaseName) return false;
+        if (TypeArguments.Count != git.TypeArguments.Count) return false;
+        return TypeArguments.Zip(git.TypeArguments).All(pair => pair.First.Equals(pair.Second));
+    }
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(BaseName);
+        foreach (var arg in TypeArguments)
+            hash.Add(arg);
+        return hash.ToHashCode();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `GenericInstanceType` class to represent instantiated generic types like `List<T>`, `Dictionary<K, V>`
- Update `ResolveTypeName()` to handle generic types with angle bracket syntax (`<>`) in addition to existing bracket syntax (`[]`)
- Add `SplitGenericArgs()` helper to properly split nested generic type arguments
- Fix type parameter registration order: register type params in `RegisterFunction()` before resolving parameter types
- Add 9 new tests covering type checker support for generics

## Fixes from PR #115 review
This PR addresses bugs and test coverage gaps identified during the review of PR #115:

| Issue | Fix |
|-------|-----|
| Generic types like `List<T>` not resolved | Added angle bracket parsing in `ResolveTypeName()` |
| Type params not in scope during function registration | Register type params before resolving parameter types |
| Missing type checker tests | Added 9 new tests covering type parameter scoping |

## Test plan
- [x] All existing tests pass (772 tests)
- [x] New tests pass (9 added, 38 total in GenericSyntaxTests)
- [x] `TypeChecker_TypeParamInScope_Resolves` - verifies T resolves in function body
- [x] `TypeChecker_GenericListType_Resolves` - verifies `List<T>` resolves
- [x] `TypeChecker_NestedGenericType_Resolves` - verifies `Dictionary<str, List<T>>` resolves
- [x] `Parse_MultipleWhereClauses_DifferentTypeParams` - verifies multiple WHERE clauses
- [x] `Parse_Where_InvalidTypeParam_ReportsError` - verifies error on invalid type param

🤖 Generated with [Claude Code](https://claude.com/claude-code)