### PR TITLE
fix(ci): Use correct ARM64 Linux runner name

### DIFF
--- a/.github/workflows/build-z3.yml
+++ b/.github/workflows/build-z3.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-24.04-arm64
+          - os: ubuntu-24.04-arm
             rid: linux-arm64
             lib: libz3.so
           - os: macos-latest


### PR DESCRIPTION
## Summary

Fixes the Linux ARM64 runner name in the build-z3.yml workflow.

- **Was:** `ubuntu-24.04-arm64` (invalid)
- **Now:** `ubuntu-24.04-arm` (correct per [GitHub docs](https://github.com/orgs/community/discussions/148648))

The previous workflow run was stuck in queue because the runner name didn't exist.

## Test plan
- [ ] Re-run build-z3 workflow after merge

🤖 Generated with [Claude Code](https://claude.ai/code)