### PR TITLE
feat(ci): change website deployment to trigger on releases only

### DIFF
--- a/.github/workflows/nextjs-gh-pages.yml
+++ b/.github/workflows/nextjs-gh-pages.yml
@@ -2,9 +2,9 @@
 name: Deploy Next.js to GitHub Pages
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["main"]
+  # Runs when a release is created
+  release:
+    types: [created]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Update GitHub Pages deployment workflow to trigger only on releases instead of every push to main
- Retain manual workflow dispatch for on-demand deployments
- Matches the pattern used by `publish-nuget.yml`

## Test plan

- [ ] Verify push to main does NOT trigger website deployment
- [ ] Verify creating a GitHub release DOES trigger website deployment
- [ ] Verify manual trigger via Actions tab still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)