### PR TITLE
style: update benchmark colors - Calor pink, C# cerulean

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "opal-website",
-  "version": "1.0.0",
+  "name": "calor-website",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "opal-website",
-      "version": "1.0.0",
+      "name": "calor-website",
+      "version": "0.2.1",
       "dependencies": {
         "@radix-ui/react-slot": "^1.0.2",
         "class-variance-authority": "^0.7.0",

--- a/website/src/components/benchmarks/BenchmarkDashboard.tsx
+++ b/website/src/components/benchmarks/BenchmarkDashboard.tsx
@@ -65,8 +65,8 @@ function SummaryCard({ icon, label, value, subtext, highlight = 'neutral' }: Sum
     <div
       className={cn(
         'p-4 rounded-lg border',
-        highlight === 'calor' && 'border-calor-cyan/50 bg-calor-cyan/5',
-        highlight === 'csharp' && 'border-calor-salmon/50 bg-calor-salmon/5',
+        highlight === 'calor' && 'border-calor-pink/50 bg-calor-pink/5',
+        highlight === 'csharp' && 'border-calor-cerulean/50 bg-calor-cerulean/5',
         highlight === 'neutral' && 'border-border bg-muted/30'
       )}
     >
@@ -159,11 +159,11 @@ export function BenchmarkDashboard() {
         {/* Legend */}
         <div className="mt-6 flex items-center justify-center gap-8 text-sm text-muted-foreground">
           <div className="flex items-center gap-2">
-            <div className="w-3 h-3 rounded-full bg-calor-cyan" />
+            <div className="w-3 h-3 rounded-full bg-calor-pink" />
             <span>Calor better</span>
           </div>
           <div className="flex items-center gap-2">
-            <div className="w-3 h-3 rounded-full bg-calor-salmon" />
+            <div className="w-3 h-3 rounded-full bg-calor-cerulean" />
             <span>C# better</span>
           </div>
           <span className="text-xs">|</span>

--- a/website/src/components/benchmarks/BenchmarkSummaryTable.tsx
+++ b/website/src/components/benchmarks/BenchmarkSummaryTable.tsx
@@ -88,10 +88,10 @@ export function BenchmarkSummaryTable() {
                 <span
                   className={
                     metric.isCalorOnly
-                      ? 'text-calor-cerulean font-medium'
+                      ? 'text-calor-pink font-medium'
                       : metric.winner === 'calor'
-                        ? 'text-calor-cerulean font-medium'
-                        : 'text-calor-salmon'
+                        ? 'text-calor-pink font-medium'
+                        : 'text-calor-cerulean'
                   }
                 >
                   {metric.isCalorOnly ? 'Calor only' : metric.winner === 'calor' ? 'Calor' : 'C#'}

--- a/website/src/components/benchmarks/MetricCard.tsx
+++ b/website/src/components/benchmarks/MetricCard.tsx
@@ -101,8 +101,8 @@ export function MetricCard({ name, ratio, winner, description }: MetricCardProps
             className={cn(
               'text-xs px-2 py-0.5 rounded-full',
               winner === 'calor'
-                ? 'bg-calor-cyan/20 text-calor-cerulean'
-                : 'bg-calor-salmon/20 text-calor-salmon'
+                ? 'bg-calor-pink/20 text-calor-pink'
+                : 'bg-calor-cerulean/20 text-calor-cerulean'
             )}
           >
             {winner === 'calor' ? 'Calor' : 'C#'} wins
@@ -116,8 +116,8 @@ export function MetricCard({ name, ratio, winner, description }: MetricCardProps
           className={cn(
             'absolute inset-y-0 left-0 rounded-full transition-all duration-500',
             winner === 'calor'
-              ? 'bg-gradient-to-r from-calor-cyan to-calor-cyan/80'
-              : 'bg-gradient-to-r from-calor-salmon to-calor-salmon/80'
+              ? 'bg-gradient-to-r from-calor-pink to-calor-pink/80'
+              : 'bg-gradient-to-r from-calor-cerulean to-calor-cerulean/80'
           )}
           style={{ width: `${getBarWidth(ratio)}%` }}
         />

--- a/website/src/components/benchmarks/ProgramTable.tsx
+++ b/website/src/components/benchmarks/ProgramTable.tsx
@@ -43,9 +43,9 @@ function formatValue(value: number): string {
 }
 
 function getValueColor(value: number): string {
-  if (value >= 1.0) return 'text-calor-cerulean font-medium';
+  if (value >= 1.0) return 'text-calor-pink font-medium';
   if (value >= 0.8) return 'text-muted-foreground';
-  return 'text-calor-salmon';
+  return 'text-calor-cerulean';
 }
 
 export function ProgramTable({ programs, metricNames }: ProgramTableProps) {
@@ -197,8 +197,8 @@ export function ProgramTable({ programs, metricNames }: ProgramTableProps) {
                       className={cn(
                         'flex items-center justify-center w-5 h-5 rounded-full text-xs',
                         program.calorSuccess
-                          ? 'bg-calor-cyan/20 text-calor-cerulean'
-                          : 'bg-calor-salmon/20 text-calor-salmon'
+                          ? 'bg-calor-pink/20 text-calor-pink'
+                          : 'bg-calor-cerulean/20 text-calor-cerulean'
                       )}
                     >
                       {program.calorSuccess ? (
@@ -246,7 +246,7 @@ export function ProgramTable({ programs, metricNames }: ProgramTableProps) {
 
       <p className="text-xs text-muted-foreground">
         Showing {sortedPrograms.length} of {programs.length} programs.
-        Values above 1.0 favor Calor (highlighted in blue), values below 1.0 favor C# (highlighted in red).
+        Values above 1.0 favor Calor (highlighted in pink), values below 1.0 favor C# (highlighted in teal).
       </p>
     </div>
   );

--- a/website/src/components/landing/BenchmarkChart.tsx
+++ b/website/src/components/landing/BenchmarkChart.tsx
@@ -166,10 +166,10 @@ export function BenchmarkChart() {
                       className={cn(
                         'text-xs px-2 py-0.5 rounded-full',
                         result.isCalorOnly
-                          ? 'bg-calor-cyan/20 text-calor-cerulean'
+                          ? 'bg-calor-pink/20 text-calor-pink'
                           : result.winner === 'calor'
-                            ? 'bg-calor-cyan/20 text-calor-cerulean'
-                            : 'bg-calor-salmon/20 text-calor-salmon'
+                            ? 'bg-calor-pink/20 text-calor-pink'
+                            : 'bg-calor-cerulean/20 text-calor-cerulean'
                       )}
                     >
                       {result.isCalorOnly ? 'Calor only' : result.winner === 'calor' ? 'Calor wins' : 'C# wins'}
@@ -185,10 +185,10 @@ export function BenchmarkChart() {
                     className={cn(
                       'absolute inset-y-0 left-0 rounded-full transition-all duration-500',
                       result.isCalorOnly
-                        ? 'bg-gradient-to-r from-calor-cyan to-calor-cerulean'
+                        ? 'bg-gradient-to-r from-calor-pink to-calor-pink/60'
                         : result.winner === 'calor'
-                          ? 'bg-gradient-to-r from-calor-cyan to-calor-cyan/80'
-                          : 'bg-gradient-to-r from-calor-salmon to-calor-salmon/80'
+                          ? 'bg-gradient-to-r from-calor-pink to-calor-pink/80'
+                          : 'bg-gradient-to-r from-calor-cerulean to-calor-cerulean/80'
                     )}
                     style={{ width: result.isCalorOnly ? '100%' : `${getBarWidth(result.ratio)}%` }}
                   />
@@ -208,11 +208,11 @@ export function BenchmarkChart() {
           {/* Legend */}
           <div className="mt-8 flex items-center justify-center gap-8 text-sm text-muted-foreground">
             <div className="flex items-center gap-2">
-              <div className="w-3 h-3 rounded-full bg-calor-cyan" />
+              <div className="w-3 h-3 rounded-full bg-calor-pink" />
               <span>Calor better</span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="w-3 h-3 rounded-full bg-calor-salmon" />
+              <div className="w-3 h-3 rounded-full bg-calor-cerulean" />
               <span>C# better</span>
             </div>
             <span className="text-xs">|</span>


### PR DESCRIPTION
Updates benchmark chart colors across homepage and results page:
- **Calor**: now uses `#FA3D6F` (pink)
- **C#**: now uses `#006D87` (cerulean)

Files changed:
- `BenchmarkChart.tsx` (homepage graph)
- `BenchmarkDashboard.tsx` (results page summary cards & legend)
- `MetricCard.tsx` (results page metric bars)
- `BenchmarkSummaryTable.tsx` (results page summary table)
- `ProgramTable.tsx` (results page per-program table)