### PR TITLE
feat: add Z3 SMT solver for contract inheritance verification

### DIFF
--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -135,6 +135,23 @@ public static class DiagnosticCode
     /// Info: Contract inheritance is valid.
     /// </summary>
     public const string ContractInheritanceValid = "Calor0814";
+
+    // Contract inheritance Z3 proving (Calor0815-0817)
+
+    /// <summary>
+    /// Info: Contract implication proven by Z3 SMT solver.
+    /// </summary>
+    public const string ImplicationProvenByZ3 = "Calor0815";
+
+    /// <summary>
+    /// Warning: Contract implication could not be determined (Z3 timeout or complexity).
+    /// </summary>
+    public const string ImplicationUnknown = "Calor0816";
+
+    /// <summary>
+    /// Info: Z3 SMT solver is unavailable, using heuristic checking only.
+    /// </summary>
+    public const string Z3UnavailableForInheritance = "Calor0817";
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -288,7 +288,7 @@ public class Program
         }
 
         // Contract inheritance checking
-        var contractInheritanceChecker = new ContractInheritanceChecker(diagnostics);
+        using var contractInheritanceChecker = new ContractInheritanceChecker(diagnostics);
         var inheritanceResult = contractInheritanceChecker.Check(ast);
 
         if (options.Verbose)

--- a/src/Calor.Compiler/Verification/Z3/Z3ImplicationProver.cs
+++ b/src/Calor.Compiler/Verification/Z3/Z3ImplicationProver.cs
@@ -1,0 +1,302 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Calor.Compiler.Ast;
+using Microsoft.Z3;
+
+namespace Calor.Compiler.Verification.Z3;
+
+/// <summary>
+/// Status of an implication proof attempt.
+/// </summary>
+public enum ImplicationStatus
+{
+    /// <summary>
+    /// Implication is valid (UNSAT - no counterexample exists).
+    /// </summary>
+    Proven,
+
+    /// <summary>
+    /// Implication is invalid (SAT - counterexample found).
+    /// </summary>
+    Disproven,
+
+    /// <summary>
+    /// Could not determine validity (timeout or complexity).
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// Expression contains unsupported constructs (strings, floats, function calls).
+    /// </summary>
+    Unsupported
+}
+
+/// <summary>
+/// Result of an implication proof attempt.
+/// </summary>
+/// <param name="Status">The status of the proof attempt.</param>
+/// <param name="CounterexampleDescription">Description of a counterexample if Status is Disproven.</param>
+/// <param name="Duration">Time taken to perform the proof.</param>
+public record ImplicationResult(
+    ImplicationStatus Status,
+    string? CounterexampleDescription = null,
+    TimeSpan? Duration = null);
+
+/// <summary>
+/// Proves contract implications using Z3 SMT solving.
+/// Used for LSP enforcement during contract inheritance checking.
+/// </summary>
+/// <remarks>
+/// This prover checks if one contract implies another using the formula:
+///   (A AND NOT(C)) is UNSAT
+///
+/// If UNSAT: A implies C (implication is proven)
+/// If SAT: A does not imply C (counterexample found)
+/// If UNKNOWN: Cannot determine (timeout or complexity)
+///
+/// For LSP checking:
+/// - Preconditions: P_interface → P_implementer (implementer must accept at least what interface accepts)
+/// - Postconditions: Q_implementer → Q_interface (implementer must guarantee at least what interface guarantees)
+/// </remarks>
+public sealed class Z3ImplicationProver : IDisposable
+{
+    private readonly Context _ctx;
+    private readonly uint _timeoutMs;
+    private bool _disposed;
+
+    /// <summary>
+    /// Creates a new implication prover with the given Z3 context.
+    /// </summary>
+    /// <param name="ctx">The Z3 context to use for proving.</param>
+    /// <param name="timeoutMs">Timeout in milliseconds (default: 5000ms).</param>
+    public Z3ImplicationProver(Context ctx, uint timeoutMs = VerificationOptions.DefaultTimeoutMs)
+    {
+        _ctx = ctx ?? throw new ArgumentNullException(nameof(ctx));
+        _timeoutMs = timeoutMs;
+    }
+
+    /// <summary>
+    /// Proves whether the antecedent implies the consequent.
+    /// Uses the formula: (A AND NOT(C)) is UNSAT means A → C.
+    /// </summary>
+    /// <param name="parameters">The parameters with their names and types.</param>
+    /// <param name="antecedent">The antecedent expression (A in A → C).</param>
+    /// <param name="consequent">The consequent expression (C in A → C).</param>
+    /// <returns>The result of the proof attempt.</returns>
+    public ImplicationResult ProveImplication(
+        IReadOnlyList<(string Name, string Type)> parameters,
+        ExpressionNode antecedent,
+        ExpressionNode consequent)
+    {
+        var sw = Stopwatch.StartNew();
+
+        var translator = new ContractTranslator(_ctx);
+
+        // Declare all parameters
+        foreach (var (name, type) in parameters)
+        {
+            if (!translator.DeclareVariable(name, type))
+            {
+                // Unsupported parameter type (strings, floats, etc.)
+                return new ImplicationResult(
+                    ImplicationStatus.Unsupported,
+                    Duration: sw.Elapsed);
+            }
+        }
+
+        // Also declare 'result' variable in case contracts reference it
+        // Use i32 as the default type for result
+        translator.DeclareVariable("result", "i32");
+
+        // Translate antecedent → Z3 BoolExpr A
+        var antecedentExpr = translator.TranslateBoolExpr(antecedent);
+        if (antecedentExpr == null)
+        {
+            return new ImplicationResult(
+                ImplicationStatus.Unsupported,
+                Duration: sw.Elapsed);
+        }
+
+        // Translate consequent → Z3 BoolExpr C
+        var consequentExpr = translator.TranslateBoolExpr(consequent);
+        if (consequentExpr == null)
+        {
+            return new ImplicationResult(
+                ImplicationStatus.Unsupported,
+                Duration: sw.Elapsed);
+        }
+
+        // Create solver and add constraint: A AND NOT(C)
+        var solver = _ctx.MkSolver();
+        solver.Set("timeout", _timeoutMs);
+        solver.Assert(antecedentExpr);
+        solver.Assert(_ctx.MkNot(consequentExpr));
+
+        // Check satisfiability
+        var status = solver.Check();
+
+        return status switch
+        {
+            // UNSAT means no counterexample exists → A always implies C
+            Status.UNSATISFIABLE => new ImplicationResult(
+                ImplicationStatus.Proven,
+                Duration: sw.Elapsed),
+
+            // SAT means counterexample found → A does not imply C
+            Status.SATISFIABLE => new ImplicationResult(
+                ImplicationStatus.Disproven,
+                CounterexampleDescription: ExtractCounterexample(solver.Model, translator.Variables),
+                Duration: sw.Elapsed),
+
+            // UNKNOWN → timeout or too complex
+            _ => new ImplicationResult(
+                ImplicationStatus.Unknown,
+                Duration: sw.Elapsed)
+        };
+    }
+
+    /// <summary>
+    /// Checks if a precondition weakening is valid for LSP.
+    /// The implementer's precondition must be weaker or equal to the interface's precondition.
+    /// This means: P_interface → P_implementer (interface precondition implies implementer precondition).
+    /// </summary>
+    /// <param name="parameters">The method parameters.</param>
+    /// <param name="interfacePrecondition">The interface's precondition (must be implied by).</param>
+    /// <param name="implementerPrecondition">The implementer's precondition (must be implied).</param>
+    /// <returns>The result of the LSP check.</returns>
+    public ImplicationResult CheckPreconditionWeakening(
+        IReadOnlyList<(string Name, string Type)> parameters,
+        ExpressionNode interfacePrecondition,
+        ExpressionNode implementerPrecondition)
+    {
+        // For LSP: interface precondition must imply implementer precondition
+        // i.e., anything that satisfies the interface precondition should also satisfy the implementer's
+        // This means the implementer can only accept MORE inputs (weaker precondition)
+        return ProveImplication(parameters, interfacePrecondition, implementerPrecondition);
+    }
+
+    /// <summary>
+    /// Checks if a postcondition strengthening is valid for LSP.
+    /// The implementer's postcondition must be stronger or equal to the interface's postcondition.
+    /// This means: Q_implementer → Q_interface (implementer postcondition implies interface postcondition).
+    /// </summary>
+    /// <param name="parameters">The method parameters.</param>
+    /// <param name="outputType">The return type of the method.</param>
+    /// <param name="interfacePostcondition">The interface's postcondition (must be implied).</param>
+    /// <param name="implementerPostcondition">The implementer's postcondition (must imply).</param>
+    /// <returns>The result of the LSP check.</returns>
+    public ImplicationResult CheckPostconditionStrengthening(
+        IReadOnlyList<(string Name, string Type)> parameters,
+        string? outputType,
+        ExpressionNode interfacePostcondition,
+        ExpressionNode implementerPostcondition)
+    {
+        var sw = Stopwatch.StartNew();
+
+        var translator = new ContractTranslator(_ctx);
+
+        // Declare all parameters
+        foreach (var (name, type) in parameters)
+        {
+            if (!translator.DeclareVariable(name, type))
+            {
+                return new ImplicationResult(
+                    ImplicationStatus.Unsupported,
+                    Duration: sw.Elapsed);
+            }
+        }
+
+        // Declare 'result' variable for postconditions
+        if (!string.IsNullOrEmpty(outputType))
+        {
+            if (!translator.DeclareVariable("result", outputType))
+            {
+                return new ImplicationResult(
+                    ImplicationStatus.Unsupported,
+                    Duration: sw.Elapsed);
+            }
+        }
+        else
+        {
+            // Default to i32 if no output type specified
+            translator.DeclareVariable("result", "i32");
+        }
+
+        // Translate implementer postcondition → Z3 BoolExpr (the antecedent)
+        var implementerExpr = translator.TranslateBoolExpr(implementerPostcondition);
+        if (implementerExpr == null)
+        {
+            return new ImplicationResult(
+                ImplicationStatus.Unsupported,
+                Duration: sw.Elapsed);
+        }
+
+        // Translate interface postcondition → Z3 BoolExpr (the consequent)
+        var interfaceExpr = translator.TranslateBoolExpr(interfacePostcondition);
+        if (interfaceExpr == null)
+        {
+            return new ImplicationResult(
+                ImplicationStatus.Unsupported,
+                Duration: sw.Elapsed);
+        }
+
+        // For LSP: implementer postcondition must imply interface postcondition
+        // i.e., anything the implementer guarantees should also satisfy what the interface guarantees
+        // This means the implementer can only guarantee MORE (stronger postcondition)
+        var solver = _ctx.MkSolver();
+        solver.Set("timeout", _timeoutMs);
+        solver.Assert(implementerExpr);
+        solver.Assert(_ctx.MkNot(interfaceExpr));
+
+        var status = solver.Check();
+
+        return status switch
+        {
+            Status.UNSATISFIABLE => new ImplicationResult(
+                ImplicationStatus.Proven,
+                Duration: sw.Elapsed),
+            Status.SATISFIABLE => new ImplicationResult(
+                ImplicationStatus.Disproven,
+                CounterexampleDescription: ExtractCounterexample(solver.Model, translator.Variables),
+                Duration: sw.Elapsed),
+            _ => new ImplicationResult(
+                ImplicationStatus.Unknown,
+                Duration: sw.Elapsed)
+        };
+    }
+
+    private static string ExtractCounterexample(Model model, IReadOnlyDictionary<string, (Expr Expr, string Type)> variables)
+    {
+        var sb = new StringBuilder("Counterexample: ");
+        var values = new List<string>();
+
+        foreach (var (name, (expr, _)) in variables)
+        {
+            try
+            {
+                var value = model.Evaluate(expr, true);
+                values.Add($"{name}={value}");
+            }
+            catch (Exception ex)
+            {
+                values.Add($"{name}=<eval failed: {ex.GetType().Name}>");
+            }
+        }
+
+        if (values.Count == 0)
+            return "Counterexample found (values unavailable)";
+
+        sb.Append(string.Join(", ", values));
+        return sb.ToString();
+    }
+
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            // Context is managed externally, don't dispose it here
+            _disposed = true;
+        }
+    }
+}

--- a/tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj
+++ b/tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj
@@ -17,6 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Calor.Compiler.Tests/ContractInheritanceTests.cs
+++ b/tests/Calor.Compiler.Tests/ContractInheritanceTests.cs
@@ -136,7 +136,7 @@ public class ContractInheritanceTests
         Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
 
         var checkDiags = new DiagnosticBag();
-        var checker = new ContractInheritanceChecker(checkDiags);
+        using var checker = new ContractInheritanceChecker(checkDiags);
         var result = checker.Check(module);
 
         // Should have inherited contracts
@@ -178,7 +178,7 @@ public class ContractInheritanceTests
         Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
 
         var checkDiags = new DiagnosticBag();
-        var checker = new ContractInheritanceChecker(checkDiags);
+        using var checker = new ContractInheritanceChecker(checkDiags);
         var result = checker.Check(module);
 
         Assert.False(result.HasViolations);
@@ -214,7 +214,7 @@ public class ContractInheritanceTests
         Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
 
         var checkDiags = new DiagnosticBag();
-        var checker = new ContractInheritanceChecker(checkDiags);
+        using var checker = new ContractInheritanceChecker(checkDiags);
         var result = checker.Check(module);
 
         // Should be valid (weaker precondition is OK per LSP)
@@ -250,7 +250,7 @@ public class ContractInheritanceTests
         Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
 
         var checkDiags = new DiagnosticBag();
-        var checker = new ContractInheritanceChecker(checkDiags);
+        using var checker = new ContractInheritanceChecker(checkDiags);
         var result = checker.Check(module);
 
         // Should have an LSP violation
@@ -285,7 +285,7 @@ public class ContractInheritanceTests
         Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
 
         var checkDiags = new DiagnosticBag();
-        var checker = new ContractInheritanceChecker(checkDiags);
+        using var checker = new ContractInheritanceChecker(checkDiags);
         var result = checker.Check(module);
 
         // Should have an LSP violation
@@ -319,7 +319,7 @@ public class ContractInheritanceTests
         Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
 
         var checkDiags = new DiagnosticBag();
-        var checker = new ContractInheritanceChecker(checkDiags);
+        using var checker = new ContractInheritanceChecker(checkDiags);
         var result = checker.Check(module);
 
         // Should have no issues
@@ -358,7 +358,7 @@ public class ContractInheritanceTests
         Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
 
         var checkDiags = new DiagnosticBag();
-        var checker = new ContractInheritanceChecker(checkDiags);
+        using var checker = new ContractInheritanceChecker(checkDiags);
         var inheritanceResult = checker.Check(module);
 
         var emitter = new CSharpEmitter(ContractMode.Debug, null, inheritanceResult);
@@ -398,7 +398,7 @@ public class ContractInheritanceTests
         Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
 
         var checkDiags = new DiagnosticBag();
-        var checker = new ContractInheritanceChecker(checkDiags);
+        using var checker = new ContractInheritanceChecker(checkDiags);
         var inheritanceResult = checker.Check(module);
 
         var emitter = new CSharpEmitter(ContractMode.Debug, null, inheritanceResult);
@@ -465,7 +465,7 @@ public class ContractInheritanceTests
         Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
 
         var checkDiags = new DiagnosticBag();
-        var checker = new ContractInheritanceChecker(checkDiags);
+        using var checker = new ContractInheritanceChecker(checkDiags);
         var inheritanceResult = checker.Check(module);
 
         var emitter = new CSharpEmitter(ContractMode.Debug, null, inheritanceResult);
@@ -516,7 +516,7 @@ public class ContractInheritanceTests
         Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
 
         var checkDiags = new DiagnosticBag();
-        var checker = new ContractInheritanceChecker(checkDiags);
+        using var checker = new ContractInheritanceChecker(checkDiags);
         var result = checker.Check(module);
 
         // Should inherit from both interfaces
@@ -548,7 +548,7 @@ public class ContractInheritanceTests
         Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
 
         var checkDiags = new DiagnosticBag();
-        var checker = new ContractInheritanceChecker(checkDiags);
+        using var checker = new ContractInheritanceChecker(checkDiags);
         var result = checker.Check(module);
 
         // No violations for external interface
@@ -583,7 +583,7 @@ public class ContractInheritanceTests
         Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
 
         var checkDiags = new DiagnosticBag();
-        var checker = new ContractInheritanceChecker(checkDiags);
+        using var checker = new ContractInheritanceChecker(checkDiags);
         var inheritanceResult = checker.Check(module);
 
         // Use ContractMode.Off
@@ -592,6 +592,479 @@ public class ContractInheritanceTests
 
         // Should not contain contract checks
         Assert.DoesNotContain("ContractViolationException", code);
+    }
+
+    #endregion
+
+    #region Z3 Integration Tests
+
+    [SkippableFact]
+    public void Z3_ValidWithMultiplePreconditions_AtLeastOneMatches()
+    {
+        Skip.IfNot(Calor.Compiler.Verification.Z3.Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        // Interface has one precondition, implementer has two.
+        // The first implementer precondition (>= x -10) is weaker than interface (>= x 0).
+        // The second implementer precondition (< x 1000) does NOT match the interface precondition.
+        // With correct "at least one matching" semantics, this should be VALID.
+        // With incorrect "all pairs" semantics, this would report a false positive violation.
+        var source = @"
+§M{m001:Test}
+§IFACE{i001:IService}
+  §MT{m001:Process}
+    §I{i32:x}
+    §O{i32}
+    §Q (>= x INT:0)
+  §/MT{m001}
+§/IFACE{i001}
+§CL{c001:Service:pub}
+  §IMPL{IService}
+  §MT{mt001:Process:pub}
+    §I{i32:x}
+    §O{i32}
+    §Q (>= x INT:-10)
+    §Q (< x INT:1000)
+    §R x
+  §/MT{mt001}
+§/CL{c001}
+§/M{m001}
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
+
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags, useZ3: true);
+        var result = checker.Check(module);
+
+        // Should be valid - the first precondition (>= x -10) is weaker than interface (>= x 0)
+        // The second precondition (< x 1000) should NOT cause a false positive
+        Assert.False(result.HasViolations,
+            "Expected no violations: at least one precondition matches. " +
+            $"Diagnostics: {string.Join("; ", checkDiags.Select(d => d.Message))}");
+
+        // Should have Z3 proven diagnostic for the matching precondition
+        Assert.Contains(checkDiags, d => d.Code == DiagnosticCode.ImplicationProvenByZ3);
+    }
+
+    [SkippableFact]
+    public void Z3_ValidWithMultiplePostconditions_AtLeastOneMatches()
+    {
+        Skip.IfNot(Calor.Compiler.Verification.Z3.Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        // Interface has one postcondition, implementer has two.
+        // The first implementer postcondition (>= result 10) is stronger than interface (> result 0).
+        // The second implementer postcondition (!= result 999) does NOT imply the interface postcondition.
+        // With correct "at least one matching" semantics, this should be VALID.
+        var source = @"
+§M{m001:Test}
+§IFACE{i001:IService}
+  §MT{m001:Process}
+    §I{i32:x}
+    §O{i32}
+    §S (> result INT:0)
+  §/MT{m001}
+§/IFACE{i001}
+§CL{c001:Service:pub}
+  §IMPL{IService}
+  §MT{mt001:Process:pub}
+    §I{i32:x}
+    §O{i32}
+    §S (>= result INT:10)
+    §S (!= result INT:999)
+    §R (+ x INT:10)
+  §/MT{mt001}
+§/CL{c001}
+§/M{m001}
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
+
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags, useZ3: true);
+        var result = checker.Check(module);
+
+        // Should be valid - the first postcondition (>= result 10) implies interface (> result 0)
+        // The second postcondition (!= result 999) should NOT cause a false positive
+        Assert.False(result.HasViolations,
+            "Expected no violations: at least one postcondition matches. " +
+            $"Diagnostics: {string.Join("; ", checkDiags.Select(d => d.Message))}");
+
+        // Should have Z3 proven diagnostic for the matching postcondition
+        Assert.Contains(checkDiags, d => d.Code == DiagnosticCode.ImplicationProvenByZ3);
+    }
+
+    [SkippableFact]
+    public void Z3_ViolationWithMultiplePreconditions_NoneMatch()
+    {
+        Skip.IfNot(Calor.Compiler.Verification.Z3.Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        // Interface requires (>= x 0)
+        // Implementer has two preconditions, but NEITHER satisfies the interface:
+        // - (>= x 10) is STRONGER than interface (rejects values 0-9)
+        // - (< x 1000) doesn't relate to the lower bound at all
+        // This should report a violation because no implementer precondition is weaker-or-equal.
+        var source = @"
+§M{m001:Test}
+§IFACE{i001:IService}
+  §MT{m001:Process}
+    §I{i32:x}
+    §O{i32}
+    §Q (>= x INT:0)
+  §/MT{m001}
+§/IFACE{i001}
+§CL{c001:Service:pub}
+  §IMPL{IService}
+  §MT{mt001:Process:pub}
+    §I{i32:x}
+    §O{i32}
+    §Q (>= x INT:10)
+    §Q (< x INT:1000)
+    §R x
+  §/MT{mt001}
+§/CL{c001}
+§/M{m001}
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
+
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags, useZ3: true);
+        var result = checker.Check(module);
+
+        // Should have LSP violation - neither precondition satisfies interface requirement
+        Assert.True(result.HasViolations,
+            "Expected violation: no precondition is weaker than interface. " +
+            $"Diagnostics: {string.Join("; ", checkDiags.Select(d => d.Message))}");
+        Assert.Contains(checkDiags, d => d.Code == DiagnosticCode.StrongerPrecondition);
+    }
+
+    [SkippableFact]
+    public void Z3_ViolationWithMultiplePostconditions_NoneMatch()
+    {
+        Skip.IfNot(Calor.Compiler.Verification.Z3.Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        // Interface requires (>= result 100)
+        // Implementer has two postconditions, but NEITHER satisfies the interface:
+        // - (> result 0) is WEAKER than interface (doesn't guarantee >= 100)
+        // - (!= result 0) doesn't guarantee >= 100 either
+        // This should report a violation because no implementer postcondition implies the interface.
+        var source = @"
+§M{m001:Test}
+§IFACE{i001:IService}
+  §MT{m001:Process}
+    §I{i32:x}
+    §O{i32}
+    §S (>= result INT:100)
+  §/MT{m001}
+§/IFACE{i001}
+§CL{c001:Service:pub}
+  §IMPL{IService}
+  §MT{mt001:Process:pub}
+    §I{i32:x}
+    §O{i32}
+    §S (> result INT:0)
+    §S (!= result INT:0)
+    §R x
+  §/MT{mt001}
+§/CL{c001}
+§/M{m001}
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
+
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags, useZ3: true);
+        var result = checker.Check(module);
+
+        // Should have LSP violation - neither postcondition implies interface requirement
+        Assert.True(result.HasViolations,
+            "Expected violation: no postcondition implies interface guarantee. " +
+            $"Diagnostics: {string.Join("; ", checkDiags.Select(d => d.Message))}");
+        Assert.Contains(checkDiags, d => d.Code == DiagnosticCode.WeakerPostcondition);
+    }
+
+    [SkippableFact]
+    public void Z3_ValidatesWeakerPrecondition_DifferentConstants()
+    {
+        Skip.IfNot(Calor.Compiler.Verification.Z3.Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        // Interface: §Q (>= id 1)
+        // Implementer: §Q (>= id 0)  // weaker - accepts more values - VALID
+        var source = @"
+§M{m001:Test}
+§IFACE{i001:IService}
+  §MT{m001:Process}
+    §I{i32:id}
+    §O{i32}
+    §Q (>= id INT:1)
+  §/MT{m001}
+§/IFACE{i001}
+§CL{c001:ValidService:pub}
+  §IMPL{IService}
+  §MT{mt001:Process:pub}
+    §I{i32:id}
+    §O{i32}
+    §Q (>= id INT:0)
+    §R id
+  §/MT{mt001}
+§/CL{c001}
+§/M{m001}
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
+
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags, useZ3: true);
+        var result = checker.Check(module);
+
+        // Should be valid - weaker precondition is OK
+        Assert.False(result.HasViolations);
+        // Check for Z3 proven diagnostic
+        Assert.Contains(checkDiags, d => d.Code == DiagnosticCode.ImplicationProvenByZ3);
+    }
+
+    [SkippableFact]
+    public void Z3_DetectsStrongerPrecondition_DifferentConstants()
+    {
+        Skip.IfNot(Calor.Compiler.Verification.Z3.Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        // Interface: §Q (>= id 0)
+        // Implementer: §Q (>= id 10)  // stronger - rejects valid inputs - VIOLATION
+        var source = @"
+§M{m001:Test}
+§IFACE{i001:IService}
+  §MT{m001:Process}
+    §I{i32:id}
+    §O{i32}
+    §Q (>= id INT:0)
+  §/MT{m001}
+§/IFACE{i001}
+§CL{c001:InvalidService:pub}
+  §IMPL{IService}
+  §MT{mt001:Process:pub}
+    §I{i32:id}
+    §O{i32}
+    §Q (>= id INT:10)
+    §R id
+  §/MT{mt001}
+§/CL{c001}
+§/M{m001}
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
+
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags, useZ3: true);
+        var result = checker.Check(module);
+
+        // Should have LSP violation
+        Assert.True(result.HasViolations);
+        Assert.Contains(checkDiags, d => d.Code == DiagnosticCode.StrongerPrecondition);
+    }
+
+    [SkippableFact]
+    public void Z3_DetectsStrongerPrecondition_Conjunction()
+    {
+        Skip.IfNot(Calor.Compiler.Verification.Z3.Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        // Interface: §Q (> x 0)
+        // Implementer: §Q (&& (> x 0) (< x 100))  // stronger - adds restriction - VIOLATION
+        var source = @"
+§M{m001:Test}
+§IFACE{i001:IService}
+  §MT{m001:Process}
+    §I{i32:x}
+    §O{i32}
+    §Q (> x INT:0)
+  §/MT{m001}
+§/IFACE{i001}
+§CL{c001:InvalidService:pub}
+  §IMPL{IService}
+  §MT{mt001:Process:pub}
+    §I{i32:x}
+    §O{i32}
+    §Q (&& (> x INT:0) (< x INT:100))
+    §R x
+  §/MT{mt001}
+§/CL{c001}
+§/M{m001}
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
+
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags, useZ3: true);
+        var result = checker.Check(module);
+
+        // Should have LSP violation - conjunction is stronger than single condition
+        Assert.True(result.HasViolations);
+        Assert.Contains(checkDiags, d => d.Code == DiagnosticCode.StrongerPrecondition);
+    }
+
+    [SkippableFact]
+    public void Z3_ValidatesPostconditionStrengthening()
+    {
+        Skip.IfNot(Calor.Compiler.Verification.Z3.Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        // Interface: §S (> result 0)
+        // Implementer: §S (>= result 10)  // stronger - guarantees more - VALID
+        var source = @"
+§M{m001:Test}
+§IFACE{i001:IService}
+  §MT{m001:Process}
+    §I{i32:value}
+    §O{i32}
+    §S (> result INT:0)
+  §/MT{m001}
+§/IFACE{i001}
+§CL{c001:ValidService:pub}
+  §IMPL{IService}
+  §MT{mt001:Process:pub}
+    §I{i32:value}
+    §O{i32}
+    §S (>= result INT:10)
+    §R (+ value INT:10)
+  §/MT{mt001}
+§/CL{c001}
+§/M{m001}
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
+
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags, useZ3: true);
+        var result = checker.Check(module);
+
+        // Should be valid - stronger postcondition is OK
+        Assert.False(result.HasViolations);
+        Assert.Contains(checkDiags, d => d.Code == DiagnosticCode.ImplicationProvenByZ3);
+    }
+
+    [SkippableFact]
+    public void Z3_DetectsWeakerPostcondition()
+    {
+        Skip.IfNot(Calor.Compiler.Verification.Z3.Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        // Interface: §S (>= result 10)
+        // Implementer: §S (> result 0)  // weaker - guarantees less - VIOLATION
+        var source = @"
+§M{m001:Test}
+§IFACE{i001:IService}
+  §MT{m001:Process}
+    §I{i32:value}
+    §O{i32}
+    §S (>= result INT:10)
+  §/MT{m001}
+§/IFACE{i001}
+§CL{c001:InvalidService:pub}
+  §IMPL{IService}
+  §MT{mt001:Process:pub}
+    §I{i32:value}
+    §O{i32}
+    §S (> result INT:0)
+    §R (+ value INT:1)
+  §/MT{mt001}
+§/CL{c001}
+§/M{m001}
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
+
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags, useZ3: true);
+        var result = checker.Check(module);
+
+        // Should have LSP violation
+        Assert.True(result.HasViolations);
+        Assert.Contains(checkDiags, d => d.Code == DiagnosticCode.WeakerPostcondition);
+    }
+
+    [SkippableFact]
+    public void Z3_ProvesArithmeticImplication()
+    {
+        Skip.IfNot(Calor.Compiler.Verification.Z3.Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        // Interface: §Q (> x 0)
+        // Implementer: §Q (>= x 1)  // equivalent for integers - VALID
+        // Z3 should prove that x >= 1 implies x > 0 for integers
+        var source = @"
+§M{m001:Test}
+§IFACE{i001:IService}
+  §MT{m001:Process}
+    §I{i32:x}
+    §O{i32}
+    §Q (> x INT:0)
+  §/MT{m001}
+§/IFACE{i001}
+§CL{c001:ValidService:pub}
+  §IMPL{IService}
+  §MT{mt001:Process:pub}
+    §I{i32:x}
+    §O{i32}
+    §Q (>= x INT:1)
+    §R x
+  §/MT{mt001}
+§/CL{c001}
+§/M{m001}
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
+
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags, useZ3: true);
+        var result = checker.Check(module);
+
+        // Should be valid - (x >= 1) is equivalent to (x > 0) for integers
+        // Z3 can prove this arithmetic relationship
+        Assert.False(result.HasViolations);
+    }
+
+    [Fact]
+    public void FallsBack_WhenZ3Disabled()
+    {
+        // When Z3 is explicitly disabled, should fall back to heuristics
+        var source = @"
+§M{m001:Test}
+§IFACE{i001:IService}
+  §MT{m001:Process}
+    §I{i32:id}
+    §O{i32}
+    §Q (> id INT:0)
+  §/MT{m001}
+§/IFACE{i001}
+§CL{c001:Service:pub}
+  §IMPL{IService}
+  §MT{mt001:Process:pub}
+    §I{i32:id}
+    §O{i32}
+    §Q (> id INT:0)
+    §R id
+  §/MT{mt001}
+§/CL{c001}
+§/M{m001}
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors, string.Join("\n", parseDiags.Select(d => d.Message)));
+
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags, useZ3: false);
+        var result = checker.Check(module);
+
+        // Should work without Z3
+        Assert.False(result.HasViolations);
+        // Should report Z3 unavailable
+        Assert.Contains(checkDiags, d => d.Code == DiagnosticCode.Z3UnavailableForInheritance);
     }
 
     #endregion

--- a/tests/Calor.Verification.Tests/ImplicationProverTests.cs
+++ b/tests/Calor.Verification.Tests/ImplicationProverTests.cs
@@ -1,0 +1,548 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Parsing;
+using Calor.Compiler.Verification.Z3;
+using Xunit;
+using System.Runtime.CompilerServices;
+
+namespace Calor.Verification.Tests;
+
+/// <summary>
+/// Tests for the Z3ImplicationProver that proves contract implications for LSP enforcement.
+/// All tests skip if Z3 is not available on the system.
+/// </summary>
+public class ImplicationProverTests
+{
+    #region Arithmetic Implication Tests
+
+    [SkippableFact]
+    public void Proves_ArithmeticImplication_GreaterOrEqual_Implies_GreaterThan()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        Proves_ArithmeticImplication_GreaterOrEqual_Implies_GreaterThan_Core();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void Proves_ArithmeticImplication_GreaterOrEqual_Implies_GreaterThan_Core()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var prover = new Z3ImplicationProver(ctx);
+
+        // (>= x 1) → (> x 0) should be PROVEN
+        // Because if x >= 1, then x is at least 1, which is > 0
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        var antecedent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterOrEqual,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, 1));
+
+        var consequent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterThan,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, 0));
+
+        var result = prover.ProveImplication(parameters, antecedent, consequent);
+
+        Assert.Equal(ImplicationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void Proves_ConjunctionImpliesConjunct()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        Proves_ConjunctionImpliesConjunct_Core();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void Proves_ConjunctionImpliesConjunct_Core()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var prover = new Z3ImplicationProver(ctx);
+
+        // (&& (> x 0) (< x 100)) → (> x 0) should be PROVEN
+        // Because if (x > 0 AND x < 100), then x > 0 is true
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        var antecedent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.And,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterThan,
+                new ReferenceNode(TextSpan.Empty, "x"),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.LessThan,
+                new ReferenceNode(TextSpan.Empty, "x"),
+                new IntLiteralNode(TextSpan.Empty, 100)));
+
+        var consequent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterThan,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, 0));
+
+        var result = prover.ProveImplication(parameters, antecedent, consequent);
+
+        Assert.Equal(ImplicationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void Proves_EqualityImplication()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        Proves_EqualityImplication_Core();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void Proves_EqualityImplication_Core()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var prover = new Z3ImplicationProver(ctx);
+
+        // (== x 5) → (> x 0) should be PROVEN
+        // Because if x == 5, then x > 0 is true
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        var antecedent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.Equal,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, 5));
+
+        var consequent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterThan,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, 0));
+
+        var result = prover.ProveImplication(parameters, antecedent, consequent);
+
+        Assert.Equal(ImplicationStatus.Proven, result.Status);
+    }
+
+    #endregion
+
+    #region Disproven Implication Tests
+
+    [SkippableFact]
+    public void Disproves_WeakerDoesNotImplyStronger()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        Disproves_WeakerDoesNotImplyStronger_Core();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void Disproves_WeakerDoesNotImplyStronger_Core()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var prover = new Z3ImplicationProver(ctx);
+
+        // (> x 0) → (> x 10) should be DISPROVEN
+        // Because x=5 satisfies x > 0 but not x > 10
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        var antecedent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterThan,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, 0));
+
+        var consequent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterThan,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, 10));
+
+        var result = prover.ProveImplication(parameters, antecedent, consequent);
+
+        Assert.Equal(ImplicationStatus.Disproven, result.Status);
+        Assert.NotNull(result.CounterexampleDescription);
+    }
+
+    [SkippableFact]
+    public void Disproves_StrongerPrecondition()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        Disproves_StrongerPrecondition_Core();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void Disproves_StrongerPrecondition_Core()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var prover = new Z3ImplicationProver(ctx);
+
+        // (>= x 0) → (> x 5) should be DISPROVEN
+        // Because x=0 satisfies x >= 0 but not x > 5
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        var antecedent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterOrEqual,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, 0));
+
+        var consequent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterThan,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, 5));
+
+        var result = prover.ProveImplication(parameters, antecedent, consequent);
+
+        Assert.Equal(ImplicationStatus.Disproven, result.Status);
+        Assert.NotNull(result.CounterexampleDescription);
+    }
+
+    [SkippableFact]
+    public void Disproves_DisjunctDoesNotImplyConjunction()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        Disproves_DisjunctDoesNotImplyConjunction_Core();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void Disproves_DisjunctDoesNotImplyConjunction_Core()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var prover = new Z3ImplicationProver(ctx);
+
+        // (> x 0) → (&& (> x 0) (< x 100)) should be DISPROVEN
+        // Because x=1000 satisfies x > 0 but not (x > 0 AND x < 100)
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        var antecedent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterThan,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, 0));
+
+        var consequent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.And,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterThan,
+                new ReferenceNode(TextSpan.Empty, "x"),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.LessThan,
+                new ReferenceNode(TextSpan.Empty, "x"),
+                new IntLiteralNode(TextSpan.Empty, 100)));
+
+        var result = prover.ProveImplication(parameters, antecedent, consequent);
+
+        Assert.Equal(ImplicationStatus.Disproven, result.Status);
+    }
+
+    #endregion
+
+    #region LSP Checking Tests
+
+    [SkippableFact]
+    public void CheckPreconditionWeakening_ValidWeakening()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        CheckPreconditionWeakening_ValidWeakening_Core();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void CheckPreconditionWeakening_ValidWeakening_Core()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var prover = new Z3ImplicationProver(ctx);
+
+        // Interface: (>= x 0)
+        // Implementer: (>= x -10) - weaker (accepts more) - VALID
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        var interfacePrecondition = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterOrEqual,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, 0));
+
+        var implementerPrecondition = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterOrEqual,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, -10));
+
+        var result = prover.CheckPreconditionWeakening(parameters, interfacePrecondition, implementerPrecondition);
+
+        Assert.Equal(ImplicationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void CheckPreconditionWeakening_InvalidStrengthening()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        CheckPreconditionWeakening_InvalidStrengthening_Core();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void CheckPreconditionWeakening_InvalidStrengthening_Core()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var prover = new Z3ImplicationProver(ctx);
+
+        // Interface: (>= x 0)
+        // Implementer: (>= x 10) - stronger (rejects valid inputs) - INVALID
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        var interfacePrecondition = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterOrEqual,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, 0));
+
+        var implementerPrecondition = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterOrEqual,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, 10));
+
+        var result = prover.CheckPreconditionWeakening(parameters, interfacePrecondition, implementerPrecondition);
+
+        Assert.Equal(ImplicationStatus.Disproven, result.Status);
+        Assert.NotNull(result.CounterexampleDescription);
+    }
+
+    [SkippableFact]
+    public void CheckPostconditionStrengthening_ValidStrengthening()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        CheckPostconditionStrengthening_ValidStrengthening_Core();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void CheckPostconditionStrengthening_ValidStrengthening_Core()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var prover = new Z3ImplicationProver(ctx);
+
+        // Interface: (> result 0)
+        // Implementer: (>= result 10) - stronger (guarantees more) - VALID
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        var interfacePostcondition = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterThan,
+            new ReferenceNode(TextSpan.Empty, "result"),
+            new IntLiteralNode(TextSpan.Empty, 0));
+
+        var implementerPostcondition = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterOrEqual,
+            new ReferenceNode(TextSpan.Empty, "result"),
+            new IntLiteralNode(TextSpan.Empty, 10));
+
+        var result = prover.CheckPostconditionStrengthening(
+            parameters,
+            "i32",
+            interfacePostcondition,
+            implementerPostcondition);
+
+        Assert.Equal(ImplicationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void CheckPostconditionStrengthening_InvalidWeakening()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        CheckPostconditionStrengthening_InvalidWeakening_Core();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void CheckPostconditionStrengthening_InvalidWeakening_Core()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var prover = new Z3ImplicationProver(ctx);
+
+        // Interface: (> result 10)
+        // Implementer: (> result 0) - weaker (guarantees less) - INVALID
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        var interfacePostcondition = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterThan,
+            new ReferenceNode(TextSpan.Empty, "result"),
+            new IntLiteralNode(TextSpan.Empty, 10));
+
+        var implementerPostcondition = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterThan,
+            new ReferenceNode(TextSpan.Empty, "result"),
+            new IntLiteralNode(TextSpan.Empty, 0));
+
+        var result = prover.CheckPostconditionStrengthening(
+            parameters,
+            "i32",
+            interfacePostcondition,
+            implementerPostcondition);
+
+        Assert.Equal(ImplicationStatus.Disproven, result.Status);
+    }
+
+    #endregion
+
+    #region Unsupported Construct Tests
+
+    [SkippableFact]
+    public void Returns_Unsupported_ForStrings()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        Returns_Unsupported_ForStrings_Core();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void Returns_Unsupported_ForStrings_Core()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var prover = new Z3ImplicationProver(ctx);
+
+        // String contracts are unsupported
+        var parameters = new List<(string Name, string Type)> { ("s", "string") };
+
+        var antecedent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.NotEqual,
+            new ReferenceNode(TextSpan.Empty, "s"),
+            new StringLiteralNode(TextSpan.Empty, ""));
+
+        var consequent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.NotEqual,
+            new ReferenceNode(TextSpan.Empty, "s"),
+            new StringLiteralNode(TextSpan.Empty, ""));
+
+        var result = prover.ProveImplication(parameters, antecedent, consequent);
+
+        Assert.Equal(ImplicationStatus.Unsupported, result.Status);
+    }
+
+    [SkippableFact]
+    public void Returns_Unsupported_ForFloats()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        Returns_Unsupported_ForFloats_Core();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void Returns_Unsupported_ForFloats_Core()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var prover = new Z3ImplicationProver(ctx);
+
+        // Float contracts are unsupported
+        var parameters = new List<(string Name, string Type)> { ("f", "f32") };
+
+        var antecedent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterThan,
+            new ReferenceNode(TextSpan.Empty, "f"),
+            new FloatLiteralNode(TextSpan.Empty, 0.0));
+
+        var consequent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterThan,
+            new ReferenceNode(TextSpan.Empty, "f"),
+            new FloatLiteralNode(TextSpan.Empty, 0.0));
+
+        var result = prover.ProveImplication(parameters, antecedent, consequent);
+
+        Assert.Equal(ImplicationStatus.Unsupported, result.Status);
+    }
+
+    [SkippableFact]
+    public void Returns_Unsupported_ForFunctionCalls()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        Returns_Unsupported_ForFunctionCalls_Core();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void Returns_Unsupported_ForFunctionCalls_Core()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var prover = new Z3ImplicationProver(ctx);
+
+        // Function calls in contracts are unsupported
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        var antecedent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterThan,
+            new CallExpressionNode(
+                TextSpan.Empty,
+                "abs",
+                new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "x") }),
+            new IntLiteralNode(TextSpan.Empty, 0));
+
+        var consequent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterThan,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, 0));
+
+        var result = prover.ProveImplication(parameters, antecedent, consequent);
+
+        Assert.Equal(ImplicationStatus.Unsupported, result.Status);
+    }
+
+    #endregion
+
+    #region Multi-Parameter Tests
+
+    [SkippableFact]
+    public void Proves_MultiParameter_Implication()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        Proves_MultiParameter_Implication_Core();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void Proves_MultiParameter_Implication_Core()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var prover = new Z3ImplicationProver(ctx);
+
+        // (&& (> x 0) (> y 0)) → (> (+ x y) 0) should be PROVEN
+        var parameters = new List<(string Name, string Type)> { ("x", "i32"), ("y", "i32") };
+
+        var antecedent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.And,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterThan,
+                new ReferenceNode(TextSpan.Empty, "x"),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterThan,
+                new ReferenceNode(TextSpan.Empty, "y"),
+                new IntLiteralNode(TextSpan.Empty, 0)));
+
+        var consequent = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.GreaterThan,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.Add,
+                new ReferenceNode(TextSpan.Empty, "x"),
+                new ReferenceNode(TextSpan.Empty, "y")),
+            new IntLiteralNode(TextSpan.Empty, 0));
+
+        var result = prover.ProveImplication(parameters, antecedent, consequent);
+
+        Assert.Equal(ImplicationStatus.Proven, result.Status);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Integrate Z3 SMT solver to prove/disprove contract implications for LSP checking
- Fix multiple preconditions semantic regression: use "at least one matching" instead of "all pairs" checking to avoid false positives
- Add proper `IDisposable` implementation and disposal in all callers (Program.cs and 13 test methods)
- Add comprehensive test coverage for multiple contracts scenarios

## Changes

| File | Change |
|------|--------|
| `ContractInheritanceChecker.cs` | Z3 integration + fix "at least one matching" semantics |
| `Z3ImplicationProver.cs` | New - Z3-based implication prover |
| `Program.cs` | Add `using` for proper disposal |
| `ContractInheritanceTests.cs` | Add `using` to tests + 4 new Z3 tests |
| `ImplicationProverTests.cs` | New - comprehensive Z3 prover tests |
| `Diagnostic.cs` | New diagnostic codes for Z3 results |

## Test plan

- [x] All 27 contract inheritance tests pass
- [x] All 48 verification tests pass
- [x] Full test suite passes (908+ tests)
- [x] E2E tests pass (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)