### PR TITLE
docs: add collection operations documentation

### DIFF
--- a/docs/syntax-reference/control-flow.md
+++ b/docs/syntax-reference/control-flow.md
@@ -148,6 +148,67 @@ The condition is placed at the end to match the semantics: the body always execu
 
 ---
 
+## Dictionary Iteration
+
+Use `§EACHKV` to iterate over key-value pairs in a dictionary.
+
+### Syntax
+
+```
+§EACHKV{id:keyVar:valueVar} dictName
+  // body uses keyVar and valueVar
+§/EACHKV{id}
+```
+
+| Part | Description |
+|:-----|:------------|
+| `id` | Unique loop identifier |
+| `keyVar` | Variable name for the current key |
+| `valueVar` | Variable name for the current value |
+| `dictName` | Name of the dictionary to iterate |
+
+### Examples
+
+**Print all entries:**
+```
+§DICT{ages:str:i32}
+  §KV "alice" 30
+  §KV "bob" 25
+§/DICT{ages}
+
+§EACHKV{e1:name:age} ages
+  §P name
+  §P age
+§/EACHKV{e1}
+```
+
+**Sum all values:**
+```
+§B{total} 0
+§EACHKV{e1:k:v} scores
+  §ASSIGN total (+ total v)
+§/EACHKV{e1}
+```
+
+**Conditional processing:**
+```
+§EACHKV{e1:key:val} data
+  §IF{if1} (> val 100)
+    §P key
+  §/I{if1}
+§/EACHKV{e1}
+```
+
+### Comparison with §FOREACH
+
+| Loop Type | Use Case |
+|:----------|:---------|
+| `§L{id:var:from:to:step}` | Numeric ranges |
+| `§FOREACH{id:var} collection` | Lists, arrays, sets |
+| `§EACHKV{id:k:v} dict` | Dictionaries (key-value pairs) |
+
+---
+
 ## Conditionals
 
 ### Single Line (Arrow Syntax)

--- a/docs/syntax-reference/expressions.md
+++ b/docs/syntax-reference/expressions.md
@@ -163,6 +163,74 @@ Loop bounds can be expressions:
 
 ---
 
+## Collection Expressions
+
+Calor provides expressions for querying collections.
+
+### Contains Check (`§HAS`)
+
+Check if a collection contains an element.
+
+| Syntax | Description | C# Equivalent |
+|:-------|:------------|:--------------|
+| `§HAS{coll} value` | Element in list/set | `coll.Contains(value)` |
+| `§HAS{dict} §KEY key` | Key in dictionary | `dict.ContainsKey(key)` |
+| `§HAS{dict} §VAL value` | Value in dictionary | `dict.ContainsValue(value)` |
+
+**Examples:**
+```
+// Check if list contains element
+§IF{if1} §HAS{numbers} 5
+  §P "Found 5"
+§/I{if1}
+
+// Check if key exists in dictionary
+§IF{if2} §HAS{ages} §KEY "alice"
+  §P "Alice found"
+§/I{if2}
+
+// Use in binding
+§B{hasItem} §HAS{inventory} "sword"
+```
+
+### Collection Count (`§CNT`)
+
+Get the number of elements in a collection.
+
+| Syntax | Returns | C# Equivalent |
+|:-------|:--------|:--------------|
+| `§CNT{coll}` | `i32` | `coll.Count` |
+
+**Examples:**
+```
+// Get count
+§B{size} §CNT{items}
+
+// Use in condition
+§IF{if1} (> §CNT{queue} 0)
+  §P "Queue not empty"
+§/I{if1}
+
+// Use in loop bound
+§L{for1:i:0:(- §CNT{list} 1):1}
+  §P list[i]
+§/L{for1}
+```
+
+### Using Collection Expressions in Contracts
+
+```
+§F{f001:ProcessItems:pub}
+  §I{List<i32>:items}
+  §O{i32}
+  §Q (> §CNT{items} 0)           // Requires: items not empty
+  §S (>= result 0)
+  // ...
+§/F{f001}
+```
+
+---
+
 ## Why Prefix Notation?
 
 ### 1. No Precedence Ambiguity

--- a/docs/syntax-reference/index.md
+++ b/docs/syntax-reference/index.md
@@ -34,6 +34,16 @@ Complete reference for Calor syntax. Calor uses Lisp-style expressions for all o
 | Binding | `§B{name} expr` | `§B{x} (+ 1 2)` |
 | Operations | `(op args...)` | `(+ a b)`, `(== x 0)` |
 | Close tag | `§/X{id}` | `§/F{f001}` |
+| List | `§LIST{id:type}` | `§LIST{nums:i32}` |
+| Dictionary | `§DICT{id:kType:vType}` | `§DICT{ages:str:i32}` |
+| HashSet | `§HSET{id:type}` | `§HSET{tags:str}` |
+| Key-Value | `§KV key value` | `§KV "alice" 30` |
+| Push | `§PUSH{coll} value` | `§PUSH{nums} 5` |
+| Put | `§PUT{dict} key value` | `§PUT{ages} "bob" 25` |
+| Set Index | `§SETIDX{list} idx val` | `§SETIDX{nums} 0 10` |
+| Contains | `§HAS{coll} value` | `§HAS{nums} 5` |
+| Count | `§CNT{coll}` | `§CNT{nums}` |
+| Dict Foreach | `§EACHKV{id:k:v} dict` | `§EACHKV{e1:k:v} ages` |
 
 ---
 

--- a/docs/syntax-reference/types.md
+++ b/docs/syntax-reference/types.md
@@ -235,6 +235,111 @@ See [Structure Tags - Generics](/calor/syntax-reference/structure-tags/#generics
 
 ---
 
+## Collection Types
+
+Calor provides built-in syntax for creating and manipulating collections with type-safe operations.
+
+### List Creation
+
+```
+§LIST{name:elementType}
+  element1
+  element2
+§/LIST{name}
+```
+
+| Part | Description |
+|:-----|:------------|
+| `name` | Variable name for the list |
+| `elementType` | Type of elements (`i32`, `str`, etc.) |
+
+**Example:**
+```
+§LIST{numbers:i32}
+  1
+  2
+  3
+§/LIST{numbers}
+```
+
+### Dictionary Creation
+
+```
+§DICT{name:keyType:valueType}
+  §KV key1 value1
+  §KV key2 value2
+§/DICT{name}
+```
+
+| Part | Description |
+|:-----|:------------|
+| `name` | Variable name for the dictionary |
+| `keyType` | Type of keys |
+| `valueType` | Type of values |
+| `§KV` | Key-value pair entry |
+
+**Example:**
+```
+§DICT{ages:str:i32}
+  §KV "alice" 30
+  §KV "bob" 25
+§/DICT{ages}
+```
+
+### HashSet Creation
+
+```
+§HSET{name:elementType}
+  element1
+  element2
+§/HSET{name}
+```
+
+**Example:**
+```
+§HSET{tags:str}
+  "urgent"
+  "review"
+§/HSET{tags}
+```
+
+### Collection Operations
+
+| Operation | Syntax | Description |
+|:----------|:-------|:------------|
+| Add to list/set | `§PUSH{coll} value` | `collection.Add(value)` |
+| Set dictionary entry | `§PUT{dict} key value` | `dict[key] = value` |
+| Set list index | `§SETIDX{list} idx value` | `list[index] = value` |
+| Insert at index | `§C{list.Insert} §A idx §A val §/C` | `list.Insert(idx, val)` |
+| Remove element | `§C{coll.Remove} §A val §/C` | `collection.Remove(val)` |
+| Clear collection | `§C{coll.Clear} §/C` | `collection.Clear()` |
+
+**Example:**
+```
+§PUSH{numbers} 4              // numbers.Add(4)
+§PUT{ages} "charlie" 35       // ages["charlie"] = 35
+§SETIDX{numbers} 0 10         // numbers[0] = 10
+```
+
+### Collection Queries
+
+| Query | Syntax | Returns |
+|:------|:-------|:--------|
+| Contains element | `§HAS{coll} value` | `bool` |
+| Contains key | `§HAS{dict} §KEY key` | `bool` |
+| Contains value | `§HAS{dict} §VAL value` | `bool` |
+| Collection count | `§CNT{coll}` | `i32` |
+
+**Example:**
+```
+§IF{if1} §HAS{numbers} 5 → §P "Found 5"
+§/I{if1}
+
+§B{count} §CNT{ages}
+```
+
+---
+
 ## Type Annotations in Contracts
 
 Types matter in contracts for proper comparisons:

--- a/website/content/syntax-reference/control-flow.mdx
+++ b/website/content/syntax-reference/control-flow.mdx
@@ -146,6 +146,67 @@ The condition is placed at the end to match the semantics: the body always execu
 
 ---
 
+## Dictionary Iteration
+
+Use `§EACHKV` to iterate over key-value pairs in a dictionary.
+
+### Syntax
+
+```
+§EACHKV{id:keyVar:valueVar} dictName
+  // body uses keyVar and valueVar
+§/EACHKV{id}
+```
+
+| Part | Description |
+|:-----|:------------|
+| `id` | Unique loop identifier |
+| `keyVar` | Variable name for the current key |
+| `valueVar` | Variable name for the current value |
+| `dictName` | Name of the dictionary to iterate |
+
+### Examples
+
+**Print all entries:**
+```
+§DICT{ages:str:i32}
+  §KV "alice" 30
+  §KV "bob" 25
+§/DICT{ages}
+
+§EACHKV{e1:name:age} ages
+  §P name
+  §P age
+§/EACHKV{e1}
+```
+
+**Sum all values:**
+```
+§B{total} 0
+§EACHKV{e1:k:v} scores
+  §ASSIGN total (+ total v)
+§/EACHKV{e1}
+```
+
+**Conditional processing:**
+```
+§EACHKV{e1:key:val} data
+  §IF{if1} (> val 100)
+    §P key
+  §/I{if1}
+§/EACHKV{e1}
+```
+
+### Comparison with §FOREACH
+
+| Loop Type | Use Case |
+|:----------|:---------|
+| `§L{id:var:from:to:step}` | Numeric ranges |
+| `§FOREACH{id:var} collection` | Lists, arrays, sets |
+| `§EACHKV{id:k:v} dict` | Dictionaries (key-value pairs) |
+
+---
+
 ## Conditionals
 
 ### Single Line (Arrow Syntax)

--- a/website/content/syntax-reference/expressions.mdx
+++ b/website/content/syntax-reference/expressions.mdx
@@ -161,6 +161,74 @@ Loop bounds can be expressions:
 
 ---
 
+## Collection Expressions
+
+Calor provides expressions for querying collections.
+
+### Contains Check (`§HAS`)
+
+Check if a collection contains an element.
+
+| Syntax | Description | C# Equivalent |
+|:-------|:------------|:--------------|
+| `§HAS{coll} value` | Element in list/set | `coll.Contains(value)` |
+| `§HAS{dict} §KEY key` | Key in dictionary | `dict.ContainsKey(key)` |
+| `§HAS{dict} §VAL value` | Value in dictionary | `dict.ContainsValue(value)` |
+
+**Examples:**
+```
+// Check if list contains element
+§IF{if1} §HAS{numbers} 5
+  §P "Found 5"
+§/I{if1}
+
+// Check if key exists in dictionary
+§IF{if2} §HAS{ages} §KEY "alice"
+  §P "Alice found"
+§/I{if2}
+
+// Use in binding
+§B{hasItem} §HAS{inventory} "sword"
+```
+
+### Collection Count (`§CNT`)
+
+Get the number of elements in a collection.
+
+| Syntax | Returns | C# Equivalent |
+|:-------|:--------|:--------------|
+| `§CNT{coll}` | `i32` | `coll.Count` |
+
+**Examples:**
+```
+// Get count
+§B{size} §CNT{items}
+
+// Use in condition
+§IF{if1} (> §CNT{queue} 0)
+  §P "Queue not empty"
+§/I{if1}
+
+// Use in loop bound
+§L{for1:i:0:(- §CNT{list} 1):1}
+  §P list[i]
+§/L{for1}
+```
+
+### Using Collection Expressions in Contracts
+
+```
+§F{f001:ProcessItems:pub}
+  §I{List<i32>:items}
+  §O{i32}
+  §Q (> §CNT{items} 0)           // Requires: items not empty
+  §S (>= result 0)
+  // ...
+§/F{f001}
+```
+
+---
+
 ## Why Prefix Notation?
 
 ### 1. No Precedence Ambiguity

--- a/website/content/syntax-reference/index.mdx
+++ b/website/content/syntax-reference/index.mdx
@@ -34,6 +34,16 @@ Complete reference for Calor syntax. Calor uses Lisp-style expressions for all o
 | Binding | `§B{name} expr` | `§B{x} (+ 1 2)` |
 | Operations | `(op args...)` | `(+ a b)`, `(== x 0)` |
 | Close tag | `§/X{id}` | `§/F{f001}` |
+| List | `§LIST{id:type}` | `§LIST{nums:i32}` |
+| Dictionary | `§DICT{id:kType:vType}` | `§DICT{ages:str:i32}` |
+| HashSet | `§HSET{id:type}` | `§HSET{tags:str}` |
+| Key-Value | `§KV key value` | `§KV "alice" 30` |
+| Push | `§PUSH{coll} value` | `§PUSH{nums} 5` |
+| Put | `§PUT{dict} key value` | `§PUT{ages} "bob" 25` |
+| Set Index | `§SETIDX{list} idx val` | `§SETIDX{nums} 0 10` |
+| Contains | `§HAS{coll} value` | `§HAS{nums} 5` |
+| Count | `§CNT{coll}` | `§CNT{nums}` |
+| Dict Foreach | `§EACHKV{id:k:v} dict` | `§EACHKV{e1:k:v} ages` |
 
 ---
 

--- a/website/content/syntax-reference/types.mdx
+++ b/website/content/syntax-reference/types.mdx
@@ -195,6 +195,111 @@ See [Structure Tags - Generics](/syntax-reference/structure-tags/#generics) for 
 
 ---
 
+## Collection Types
+
+Calor provides built-in syntax for creating and manipulating collections with type-safe operations.
+
+### List Creation
+
+```
+§LIST{name:elementType}
+  element1
+  element2
+§/LIST{name}
+```
+
+| Part | Description |
+|:-----|:------------|
+| `name` | Variable name for the list |
+| `elementType` | Type of elements (`i32`, `str`, etc.) |
+
+**Example:**
+```
+§LIST{numbers:i32}
+  1
+  2
+  3
+§/LIST{numbers}
+```
+
+### Dictionary Creation
+
+```
+§DICT{name:keyType:valueType}
+  §KV key1 value1
+  §KV key2 value2
+§/DICT{name}
+```
+
+| Part | Description |
+|:-----|:------------|
+| `name` | Variable name for the dictionary |
+| `keyType` | Type of keys |
+| `valueType` | Type of values |
+| `§KV` | Key-value pair entry |
+
+**Example:**
+```
+§DICT{ages:str:i32}
+  §KV "alice" 30
+  §KV "bob" 25
+§/DICT{ages}
+```
+
+### HashSet Creation
+
+```
+§HSET{name:elementType}
+  element1
+  element2
+§/HSET{name}
+```
+
+**Example:**
+```
+§HSET{tags:str}
+  "urgent"
+  "review"
+§/HSET{tags}
+```
+
+### Collection Operations
+
+| Operation | Syntax | Description |
+|:----------|:-------|:------------|
+| Add to list/set | `§PUSH{coll} value` | `collection.Add(value)` |
+| Set dictionary entry | `§PUT{dict} key value` | `dict[key] = value` |
+| Set list index | `§SETIDX{list} idx value` | `list[index] = value` |
+| Insert at index | `§C{list.Insert} §A idx §A val §/C` | `list.Insert(idx, val)` |
+| Remove element | `§C{coll.Remove} §A val §/C` | `collection.Remove(val)` |
+| Clear collection | `§C{coll.Clear} §/C` | `collection.Clear()` |
+
+**Example:**
+```
+§PUSH{numbers} 4              // numbers.Add(4)
+§PUT{ages} "charlie" 35       // ages["charlie"] = 35
+§SETIDX{numbers} 0 10         // numbers[0] = 10
+```
+
+### Collection Queries
+
+| Query | Syntax | Returns |
+|:------|:-------|:--------|
+| Contains element | `§HAS{coll} value` | `bool` |
+| Contains key | `§HAS{dict} §KEY key` | `bool` |
+| Contains value | `§HAS{dict} §VAL value` | `bool` |
+| Collection count | `§CNT{coll}` | `i32` |
+
+**Example:**
+```
+§IF{if1} §HAS{numbers} 5 → §P "Found 5"
+§/I{if1}
+
+§B{count} §CNT{ages}
+```
+
+---
+
 ## Type Annotations in Contracts
 
 Types matter in contracts for proper comparisons:


### PR DESCRIPTION
## Summary

- Document the collections feature implemented in PR #130
- Add Collection Types section to types documentation (§LIST, §DICT, §HSET creation syntax)
- Add collection syntax rows to quick reference tables
- Add Dictionary Iteration section to control-flow docs (§EACHKV)
- Add Collection Expressions section to expressions docs (§HAS, §CNT)

## Files Changed

| File | Changes |
|------|---------|
| `docs/syntax-reference/types.md` | Added "Collection Types" section |
| `docs/syntax-reference/index.md` | Added 11 collection syntax rows to Quick Reference Table |
| `docs/syntax-reference/control-flow.md` | Added "Dictionary Iteration" section |
| `docs/syntax-reference/expressions.md` | Added "Collection Expressions" section |
| `website/content/syntax-reference/*.mdx` | Same updates for website |

## Test plan

- [x] Website builds successfully with `npm run build`
- [ ] Review documentation reads clearly
- [ ] Verify examples are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)