### PR TITLE
docs: add pattern matching arrow syntax documentation

### DIFF
--- a/docs/syntax-reference/control-flow.md
+++ b/docs/syntax-reference/control-flow.md
@@ -361,6 +361,142 @@ Use conditionals with return for early exit:
 
 ---
 
+## Pattern Matching
+
+Pattern matching provides concise multi-way branching with C# switch expression semantics.
+
+### Switch Expression Syntax
+
+```
+§W{id} expression
+  §K pattern1 → result1
+  §K pattern2 → result2
+  §K _ → default
+§/W{id}
+```
+
+| Part | Description |
+|:-----|:------------|
+| `§W{id}` | Switch expression with unique ID |
+| `expression` | Value to match against |
+| `§K` | Case keyword |
+| `pattern` | Pattern to match |
+| `→` | Arrow to result (single expression) |
+| `_` | Wildcard (matches anything) |
+| `§/W{id}` | Closing tag |
+
+### Literal Patterns
+
+Match exact values:
+
+```
+§B{day} §W{sw1} dayNum
+  §K 0 → "Sunday"
+  §K 1 → "Monday"
+  §K 2 → "Tuesday"
+  §K _ → "Other"
+§/W{sw1}
+```
+
+### Relational Patterns (`§PREL`)
+
+Match value ranges using relational operators:
+
+| Syntax | Meaning | C# Equivalent |
+|:-------|:--------|:--------------|
+| `§PREL{gte} value` | Greater than or equal | `>= value` |
+| `§PREL{gt} value` | Greater than | `> value` |
+| `§PREL{lte} value` | Less than or equal | `<= value` |
+| `§PREL{lt} value` | Less than | `< value` |
+
+**Example - Grade calculation:**
+```
+§B{grade} §W{sw1} score
+  §K §PREL{gte} 90 → "A"
+  §K §PREL{gte} 80 → "B"
+  §K §PREL{gte} 70 → "C"
+  §K §PREL{gte} 60 → "D"
+  §K _ → "F"
+§/W{sw1}
+```
+
+### Variable Patterns with Guards (`§VAR`, `§WHEN`)
+
+Capture the matched value and add conditions:
+
+```
+§B{desc} §W{sw1} value
+  §K §VAR{n} §WHEN (> n 100) → "large positive"
+  §K §VAR{n} §WHEN (> n 0) → "small positive"
+  §K 0 → "zero"
+  §K §VAR{n} §WHEN (> n -100) → "small negative"
+  §K _ → "large negative"
+§/W{sw1}
+```
+
+| Part | Description |
+|:-----|:------------|
+| `§VAR{name}` | Captures value into variable `name` |
+| `§WHEN condition` | Guard condition (pattern matches only if true) |
+
+### Option Patterns (`§SM`, `§NN`)
+
+Match Option types:
+
+```
+§R §W{sw1} maybeValue
+  §K §SM §VAR{v} → v        // Some(v) - extract value
+  §K §NN → 0                 // None - default
+§/W{sw1}
+```
+
+### Result Patterns (`§OK`, `§ERR`)
+
+Match Result types:
+
+```
+§R §W{sw1} result
+  §K §OK §VAR{v} → (+ "Success: " v)
+  §K §ERR §VAR{e} → (+ "Error: " e)
+§/W{sw1}
+```
+
+### Block Syntax (`§/K`)
+
+For cases with multiple statements, use block syntax:
+
+```
+§W{sw1} x
+  §K 1 → "one"              // Arrow syntax (single expression)
+  §K 2
+    §P "matched two"         // Block syntax (multiple statements)
+    §R "two"
+  §/K
+  §K _ → "other"
+§/W{sw1}
+```
+
+### Complete Example
+
+```
+§M{m001:HttpStatus}
+§F{f001:GetStatusMessage:pub}
+  §I{i32:code}
+  §O{str}
+  §R §W{sw1} code
+    §K 200 → "OK"
+    §K 201 → "Created"
+    §K 400 → "Bad Request"
+    §K 404 → "Not Found"
+    §K 500 → "Server Error"
+    §K _ → "Unknown Status"
+  §/W{sw1}
+§/F{f001}
+§/M{m001}
+```
+
+---
+
 ## Why Explicit Loop IDs?
 
 1. **Precise targeting** - "Modify loop for1" is unambiguous

--- a/docs/syntax-reference/index.md
+++ b/docs/syntax-reference/index.md
@@ -44,6 +44,12 @@ Complete reference for Calor syntax. Calor uses Lisp-style expressions for all o
 | Contains | `§HAS{coll} value` | `§HAS{nums} 5` |
 | Count | `§CNT{coll}` | `§CNT{nums}` |
 | Dict Foreach | `§EACHKV{id:k:v} dict` | `§EACHKV{e1:k:v} ages` |
+| Switch | `§W{id} expr` | `§W{sw1} score` |
+| Case | `§K pattern → result` | `§K 200 → "OK"` |
+| Wildcard | `§K _` | `§K _ → "default"` |
+| Relational | `§PREL{op} value` | `§PREL{gte} 90` |
+| Var Pattern | `§VAR{name}` | `§VAR{n}` |
+| Guard | `§WHEN condition` | `§WHEN (> n 0)` |
 
 ---
 

--- a/website/content/syntax-reference/control-flow.mdx
+++ b/website/content/syntax-reference/control-flow.mdx
@@ -359,6 +359,142 @@ Use conditionals with return for early exit:
 
 ---
 
+## Pattern Matching
+
+Pattern matching provides concise multi-way branching with C# switch expression semantics.
+
+### Switch Expression Syntax
+
+```
+§W{id} expression
+  §K pattern1 → result1
+  §K pattern2 → result2
+  §K _ → default
+§/W{id}
+```
+
+| Part | Description |
+|:-----|:------------|
+| `§W{id}` | Switch expression with unique ID |
+| `expression` | Value to match against |
+| `§K` | Case keyword |
+| `pattern` | Pattern to match |
+| `→` | Arrow to result (single expression) |
+| `_` | Wildcard (matches anything) |
+| `§/W{id}` | Closing tag |
+
+### Literal Patterns
+
+Match exact values:
+
+```
+§B{day} §W{sw1} dayNum
+  §K 0 → "Sunday"
+  §K 1 → "Monday"
+  §K 2 → "Tuesday"
+  §K _ → "Other"
+§/W{sw1}
+```
+
+### Relational Patterns (`§PREL`)
+
+Match value ranges using relational operators:
+
+| Syntax | Meaning | C# Equivalent |
+|:-------|:--------|:--------------|
+| `§PREL{gte} value` | Greater than or equal | `>= value` |
+| `§PREL{gt} value` | Greater than | `> value` |
+| `§PREL{lte} value` | Less than or equal | `<= value` |
+| `§PREL{lt} value` | Less than | `< value` |
+
+**Example - Grade calculation:**
+```
+§B{grade} §W{sw1} score
+  §K §PREL{gte} 90 → "A"
+  §K §PREL{gte} 80 → "B"
+  §K §PREL{gte} 70 → "C"
+  §K §PREL{gte} 60 → "D"
+  §K _ → "F"
+§/W{sw1}
+```
+
+### Variable Patterns with Guards (`§VAR`, `§WHEN`)
+
+Capture the matched value and add conditions:
+
+```
+§B{desc} §W{sw1} value
+  §K §VAR{n} §WHEN (> n 100) → "large positive"
+  §K §VAR{n} §WHEN (> n 0) → "small positive"
+  §K 0 → "zero"
+  §K §VAR{n} §WHEN (> n -100) → "small negative"
+  §K _ → "large negative"
+§/W{sw1}
+```
+
+| Part | Description |
+|:-----|:------------|
+| `§VAR{name}` | Captures value into variable `name` |
+| `§WHEN condition` | Guard condition (pattern matches only if true) |
+
+### Option Patterns (`§SM`, `§NN`)
+
+Match Option types:
+
+```
+§R §W{sw1} maybeValue
+  §K §SM §VAR{v} → v        // Some(v) - extract value
+  §K §NN → 0                 // None - default
+§/W{sw1}
+```
+
+### Result Patterns (`§OK`, `§ERR`)
+
+Match Result types:
+
+```
+§R §W{sw1} result
+  §K §OK §VAR{v} → (+ "Success: " v)
+  §K §ERR §VAR{e} → (+ "Error: " e)
+§/W{sw1}
+```
+
+### Block Syntax (`§/K`)
+
+For cases with multiple statements, use block syntax:
+
+```
+§W{sw1} x
+  §K 1 → "one"              // Arrow syntax (single expression)
+  §K 2
+    §P "matched two"         // Block syntax (multiple statements)
+    §R "two"
+  §/K
+  §K _ → "other"
+§/W{sw1}
+```
+
+### Complete Example
+
+```
+§M{m001:HttpStatus}
+§F{f001:GetStatusMessage:pub}
+  §I{i32:code}
+  §O{str}
+  §R §W{sw1} code
+    §K 200 → "OK"
+    §K 201 → "Created"
+    §K 400 → "Bad Request"
+    §K 404 → "Not Found"
+    §K 500 → "Server Error"
+    §K _ → "Unknown Status"
+  §/W{sw1}
+§/F{f001}
+§/M{m001}
+```
+
+---
+
 ## Why Explicit Loop IDs?
 
 1. **Precise targeting** - "Modify loop for1" is unambiguous

--- a/website/content/syntax-reference/index.mdx
+++ b/website/content/syntax-reference/index.mdx
@@ -44,6 +44,12 @@ Complete reference for Calor syntax. Calor uses Lisp-style expressions for all o
 | Contains | `§HAS{coll} value` | `§HAS{nums} 5` |
 | Count | `§CNT{coll}` | `§CNT{nums}` |
 | Dict Foreach | `§EACHKV{id:k:v} dict` | `§EACHKV{e1:k:v} ages` |
+| Switch | `§W{id} expr` | `§W{sw1} score` |
+| Case | `§K pattern → result` | `§K 200 → "OK"` |
+| Wildcard | `§K _` | `§K _ → "default"` |
+| Relational | `§PREL{op} value` | `§PREL{gte} 90` |
+| Var Pattern | `§VAR{name}` | `§VAR{n}` |
+| Guard | `§WHEN condition` | `§WHEN (> n 0)` |
 
 ---
 


### PR DESCRIPTION
## Summary

Document the pattern matching feature implemented in PR #127.

### Added to control-flow.md/mdx:
- **Pattern Matching** section with:
  - Switch expression syntax (`§W{id}`, `§K`)
  - Literal patterns (exact value matching)
  - Relational patterns (`§PREL{gte}`, `§PREL{gt}`, `§PREL{lte}`, `§PREL{lt}`)
  - Variable patterns with guards (`§VAR{name}`, `§WHEN condition`)
  - Option patterns (`§SM`, `§NN`)
  - Result patterns (`§OK`, `§ERR`)
  - Block syntax (`§/K`) for multi-statement cases
  - Complete HTTP status example

### Added to index.md/mdx quick reference:
| Element | Syntax | Example |
|---------|--------|---------|
| Switch | `§W{id} expr` | `§W{sw1} score` |
| Case | `§K pattern → result` | `§K 200 → "OK"` |
| Wildcard | `§K _` | `§K _ → "default"` |
| Relational | `§PREL{op} value` | `§PREL{gte} 90` |
| Var Pattern | `§VAR{name}` | `§VAR{n}` |
| Guard | `§WHEN condition` | `§WHEN (> n 0)` |

## Test plan

- [x] Website builds successfully with `npm run build`
- [ ] Review documentation reads clearly
- [ ] Verify examples are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)