### PR TITLE
docs: add async/await support documentation

### DIFF
--- a/docs/syntax-reference/index.md
+++ b/docs/syntax-reference/index.md
@@ -18,6 +18,10 @@ Complete reference for Calor syntax. Calor uses Lisp-style expressions for all o
 |:--------|:-------|:--------|
 | Module | `§M{id:name}` | `§M{m001:Calculator}` |
 | Function | `§F{id:name:visibility}` | `§F{f001:Add:pub}` |
+| Async Function | `§AF{id:name:visibility}` | `§AF{f001:FetchAsync:pub}` |
+| Method | `§MT{id:name:visibility}` | `§MT{mt001:Process:pub}` |
+| Async Method | `§AMT{id:name:visibility}` | `§AMT{mt001:ProcessAsync:pub}` |
+| Await | `§AWAIT expr` | `§AWAIT §C{GetAsync} §/C` |
 | Input | `§I{type:name}` | `§I{i32:x}` |
 | Output | `§O{type}` | `§O{i32}` |
 | Effects | `§E{codes}` | `§E{cw,fs:r,net:rw}` |

--- a/docs/syntax-reference/structure-tags.md
+++ b/docs/syntax-reference/structure-tags.md
@@ -99,6 +99,137 @@ Functions are the primary code containers.
 
 ---
 
+## Async Functions
+
+Async functions use `§AF` instead of `§F` and automatically wrap return types in `Task<T>`.
+
+### Syntax
+
+```
+§AF{id:name:visibility}
+  §I{type:param}       // inputs (0 or more)
+  §O{type}             // output (auto-wrapped to Task<T>)
+  // body with §AWAIT expressions
+§/AF{id}
+```
+
+### Examples
+
+**Simple async function:**
+```
+§AF{f001:FetchDataAsync:pub}
+  §I{str:url}
+  §O{str}
+  §B{result} §AWAIT §C{httpClient.GetStringAsync} §A url §/C
+  §R result
+§/AF{f001}
+```
+
+Emits C#:
+```csharp
+public static async Task<string> FetchDataAsync(string url)
+{
+    var result = await httpClient.GetStringAsync(url);
+    return result;
+}
+```
+
+**Async void function (returns Task):**
+```
+§AF{f001:ProcessAsync:pub}
+  §O{void}
+  §AWAIT §C{Task.Delay} §A 1000 §/C
+§/AF{f001}
+```
+
+### Automatic Task Wrapping
+
+| Declared Output | Emitted Return Type |
+|:----------------|:--------------------|
+| `§O{void}` | `Task` |
+| `§O{i32}` | `Task<int>` |
+| `§O{str}` | `Task<string>` |
+| `§O{Task<i32>}` | `Task<int>` (no double-wrap) |
+
+---
+
+## Async Methods
+
+Async methods in classes use `§AMT` instead of `§MT`.
+
+### Syntax
+
+```
+§AMT{id:name:visibility}
+  §I{type:param}
+  §O{type}
+  // body
+§/AMT{id}
+```
+
+### Example
+
+```
+§CL{c001:DataService:pub}
+  §AMT{mt001:GetUserAsync:pub}
+    §I{i32:id}
+    §O{User}
+    §B{user} §AWAIT §C{_repository.FindAsync} §A id §/C
+    §R user
+  §/AMT{mt001}
+§/CL{c001}
+```
+
+### Modifiers
+
+Async methods support the same modifiers as regular methods:
+
+```
+§AMT{mt001:ProcessAsync:pub:virt}    // public virtual async
+§AMT{mt002:HandleAsync:prot:ovr}     // protected override async
+§AMT{mt003:ComputeAsync:pub:stat}    // public static async
+```
+
+---
+
+## Await Expression
+
+Use `§AWAIT` to await async operations.
+
+### Syntax
+
+```
+§AWAIT expression                    // Simple await
+§AWAIT{false} expression             // await with ConfigureAwait(false)
+§AWAIT{true} expression              // await with ConfigureAwait(true)
+```
+
+### Examples
+
+**Simple await:**
+```
+§B{data} §AWAIT §C{client.GetAsync} §A url §/C
+```
+
+**With ConfigureAwait(false) for library code:**
+```
+§B{data} §AWAIT{false} §C{client.GetAsync} §A url §/C
+```
+
+Emits: `var data = await client.GetAsync(url).ConfigureAwait(false);`
+
+### Using Await in Conditions and Expressions
+
+```
+§IF{if1} §AWAIT §C{IsValidAsync} §A id §/C
+  §P "Valid"
+§/I{if1}
+
+§R §AWAIT §C{ComputeAsync} §A x §/C
+```
+
+---
+
 ## Input Parameters
 
 Input parameters define function arguments.
@@ -238,6 +369,9 @@ Every structural element must be closed with a matching tag.
 |:--------|:--------|:--------|
 | `§M{id:name}` | `§/M{id}` | Module |
 | `§F{id:name:vis}` | `§/F{id}` | Function |
+| `§AF{id:name:vis}` | `§/AF{id}` | Async function |
+| `§MT{id:name:vis}` | `§/MT{id}` | Method |
+| `§AMT{id:name:vis}` | `§/AMT{id}` | Async method |
 | `§L{id:var:from:to:step}` | `§/L{id}` | For loop |
 | `§WH{id} cond` | `§/WH{id}` | While loop |
 | `§DO{id}` | `§/DO{id} cond` | Do-while loop |

--- a/website/content/syntax-reference/index.mdx
+++ b/website/content/syntax-reference/index.mdx
@@ -18,6 +18,10 @@ Complete reference for Calor syntax. Calor uses Lisp-style expressions for all o
 |:--------|:-------|:--------|
 | Module | `§M{id:name}` | `§M{m001:Calculator}` |
 | Function | `§F{id:name:visibility}` | `§F{f001:Add:pub}` |
+| Async Function | `§AF{id:name:visibility}` | `§AF{f001:FetchAsync:pub}` |
+| Method | `§MT{id:name:visibility}` | `§MT{mt001:Process:pub}` |
+| Async Method | `§AMT{id:name:visibility}` | `§AMT{mt001:ProcessAsync:pub}` |
+| Await | `§AWAIT expr` | `§AWAIT §C{GetAsync} §/C` |
 | Input | `§I{type:name}` | `§I{i32:x}` |
 | Output | `§O{type}` | `§O{i32}` |
 | Effects | `§E{codes}` | `§E{cw,fs:r,net:rw}` |

--- a/website/content/syntax-reference/structure-tags.mdx
+++ b/website/content/syntax-reference/structure-tags.mdx
@@ -97,6 +97,137 @@ Functions are the primary code containers.
 
 ---
 
+## Async Functions
+
+Async functions use `§AF` instead of `§F` and automatically wrap return types in `Task<T>`.
+
+### Syntax
+
+```
+§AF{id:name:visibility]
+  §I{type:param]       // inputs (0 or more)
+  §O{type]             // output (auto-wrapped to Task<T>)
+  // body with §AWAIT expressions
+§/AF{id]
+```
+
+### Examples
+
+**Simple async function:**
+```
+§AF{f001:FetchDataAsync:pub]
+  §I{str:url]
+  §O{str]
+  §B{result] §AWAIT §C{httpClient.GetStringAsync] §A url §/C
+  §R result
+§/AF{f001]
+```
+
+Emits C#:
+```csharp
+public static async Task<string> FetchDataAsync(string url)
+{
+    var result = await httpClient.GetStringAsync(url);
+    return result;
+}
+```
+
+**Async void function (returns Task):**
+```
+§AF{f001:ProcessAsync:pub]
+  §O{void]
+  §AWAIT §C{Task.Delay] §A 1000 §/C
+§/AF{f001]
+```
+
+### Automatic Task Wrapping
+
+| Declared Output | Emitted Return Type |
+|:----------------|:--------------------|
+| `§O{void]` | `Task` |
+| `§O{i32]` | `Task<int>` |
+| `§O{str]` | `Task<string>` |
+| `§O{Task<i32>]` | `Task<int>` (no double-wrap) |
+
+---
+
+## Async Methods
+
+Async methods in classes use `§AMT` instead of `§MT`.
+
+### Syntax
+
+```
+§AMT{id:name:visibility]
+  §I{type:param]
+  §O{type]
+  // body
+§/AMT{id]
+```
+
+### Example
+
+```
+§CL{c001:DataService:pub]
+  §AMT{mt001:GetUserAsync:pub]
+    §I{i32:id]
+    §O{User]
+    §B{user] §AWAIT §C{_repository.FindAsync] §A id §/C
+    §R user
+  §/AMT{mt001]
+§/CL{c001]
+```
+
+### Modifiers
+
+Async methods support the same modifiers as regular methods:
+
+```
+§AMT{mt001:ProcessAsync:pub:virt]    // public virtual async
+§AMT{mt002:HandleAsync:prot:ovr]     // protected override async
+§AMT{mt003:ComputeAsync:pub:stat]    // public static async
+```
+
+---
+
+## Await Expression
+
+Use `§AWAIT` to await async operations.
+
+### Syntax
+
+```
+§AWAIT expression                    // Simple await
+§AWAIT{false] expression             // await with ConfigureAwait(false)
+§AWAIT{true] expression              // await with ConfigureAwait(true)
+```
+
+### Examples
+
+**Simple await:**
+```
+§B{data] §AWAIT §C{client.GetAsync] §A url §/C
+```
+
+**With ConfigureAwait(false) for library code:**
+```
+§B{data] §AWAIT{false] §C{client.GetAsync] §A url §/C
+```
+
+Emits: `var data = await client.GetAsync(url).ConfigureAwait(false);`
+
+### Using Await in Conditions and Expressions
+
+```
+§IF{if1] §AWAIT §C{IsValidAsync] §A id §/C
+  §P "Valid"
+§/I{if1]
+
+§R §AWAIT §C{ComputeAsync] §A x §/C
+```
+
+---
+
 ## Input Parameters
 
 Input parameters define function arguments.
@@ -194,6 +325,9 @@ Every structural element must be closed with a matching tag.
 |:--------|:--------|:--------|
 | `§M{id:name]` | `§/M{id]` | Module |
 | `§F{id:name:vis]` | `§/F{id]` | Function |
+| `§AF{id:name:vis]` | `§/AF{id]` | Async function |
+| `§MT{id:name:vis]` | `§/MT{id]` | Method |
+| `§AMT{id:name:vis]` | `§/AMT{id]` | Async method |
 | `§L{id:var:from:to:step]` | `§/L{id]` | For loop |
 | `§WH{id] cond` | `§/WH{id]` | While loop |
 | `§DO{id]` | `§/DO{id] cond` | Do-while loop |


### PR DESCRIPTION
## Summary

Document the async/await feature implemented in PR #122.

### Added to structure-tags.md/mdx:

**Async Functions (`§AF`)**
- Syntax for async functions with automatic `Task<T>` wrapping
- Examples showing await usage and C# emission

**Async Methods (`§AMT`)**
- Syntax for async methods in classes
- Modifier support (virtual, override, static)

**Await Expression (`§AWAIT`)**
- Simple await syntax
- `ConfigureAwait(false)` support via `§AWAIT{false}`
- Usage in conditions and expressions

**Tag Reference Table**
- Added `§AF`/`§/AF` for async functions
- Added `§MT`/`§/MT` for methods
- Added `§AMT`/`§/AMT` for async methods

### Added to index.md/mdx quick reference:

| Element | Syntax | Example |
|---------|--------|---------|
| Async Function | `§AF{id:name:visibility}` | `§AF{f001:FetchAsync:pub}` |
| Method | `§MT{id:name:visibility}` | `§MT{mt001:Process:pub}` |
| Async Method | `§AMT{id:name:visibility}` | `§AMT{mt001:ProcessAsync:pub}` |
| Await | `§AWAIT expr` | `§AWAIT §C{GetAsync} §/C` |

## Test plan

- [x] Website builds successfully with `npm run build`
- [ ] Review documentation reads clearly
- [ ] Verify examples are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)