### PR TITLE
docs: add lambda expressions, delegates, and events documentation

### DIFF
--- a/docs/syntax-reference/index.md
+++ b/docs/syntax-reference/index.md
@@ -22,6 +22,12 @@ Complete reference for Calor syntax. Calor uses Lisp-style expressions for all o
 | Method | `§MT{id:name:visibility}` | `§MT{mt001:Process:pub}` |
 | Async Method | `§AMT{id:name:visibility}` | `§AMT{mt001:ProcessAsync:pub}` |
 | Await | `§AWAIT expr` | `§AWAIT §C{GetAsync} §/C` |
+| Lambda (inline) | `(params) → expr` | `(x) → (* x 2)` |
+| Lambda (block) | `§LAM{id:params}...§/LAM{id}` | `§LAM{l1:x:i32}...§/LAM{l1}` |
+| Delegate | `§DEL{id:name}...§/DEL{id}` | `§DEL{d1:Handler}...§/DEL{d1}` |
+| Event | `§EVT{id:name:vis:type}` | `§EVT{e1:Click:pub:EventHandler}` |
+| Subscribe | `§SUB event handler` | `§SUB btn.Click OnClick` |
+| Unsubscribe | `§UNSUB event handler` | `§UNSUB btn.Click OnClick` |
 | Input | `§I{type:name}` | `§I{i32:x}` |
 | Output | `§O{type}` | `§O{i32}` |
 | Effects | `§E{codes}` | `§E{cw,fs:r,net:rw}` |

--- a/docs/syntax-reference/structure-tags.md
+++ b/docs/syntax-reference/structure-tags.md
@@ -230,6 +230,190 @@ Emits: `var data = await client.GetAsync(url).ConfigureAwait(false);`
 
 ---
 
+## Lambda Expressions
+
+Lambda expressions create anonymous functions.
+
+### Inline Lambda Syntax
+
+For simple expression-body lambdas:
+
+```
+(param) → expression
+(param1, param2) → expression
+() → expression
+```
+
+### Examples
+
+**Single parameter:**
+```
+§B{doubler} (x) → (* x 2)
+```
+
+Emits: `var doubler = x => x * 2;`
+
+**Multiple parameters:**
+```
+§B{add} (a, b) → (+ a b)
+```
+
+Emits: `var add = (a, b) => a + b;`
+
+**No parameters:**
+```
+§B{getTime} () → §C{DateTime.Now} §/C
+```
+
+### Block Lambda Syntax
+
+For statement-body lambdas, use `§LAM`/`§/LAM`:
+
+```
+§LAM{id:param1:type1:param2:type2}
+  // statements
+§/LAM{id}
+```
+
+**Example:**
+```
+§B{printer} §LAM{lam1:x:i32}
+  §P x
+  §P (* x 2)
+§/LAM{lam1}
+```
+
+### Async Lambdas
+
+Add `async` before parameters:
+
+```
+§LAM{lam1:async:x:i32}
+  §B{result} §AWAIT §C{ProcessAsync} §A x §/C
+  §R result
+§/LAM{lam1}
+```
+
+---
+
+## Delegate Definitions
+
+Delegates define function signatures that can be passed as values.
+
+### Syntax
+
+```
+§DEL{id:name}
+  §I{type:param}       // parameters (0 or more)
+  §O{type}             // return type (optional for void)
+  §E{effects}          // effects (optional)
+§/DEL{id}
+```
+
+### Examples
+
+**Calculator delegate:**
+```
+§DEL{d001:Calculator}
+  §I{i32:a}
+  §I{i32:b}
+  §O{i32}
+§/DEL{d001}
+```
+
+Emits: `public delegate int Calculator(int a, int b);`
+
+**Void delegate:**
+```
+§DEL{d001:Logger}
+  §I{str:message}
+§/DEL{d001}
+```
+
+Emits: `public delegate void Logger(string message);`
+
+**Delegate with effects:**
+```
+§DEL{d001:FileProcessor}
+  §I{str:path}
+  §O{bool}
+  §E{fs:rw}
+§/DEL{d001}
+```
+
+---
+
+## Event Definitions
+
+Events allow objects to notify subscribers of state changes.
+
+### Syntax
+
+```
+§EVT{id:name:visibility:delegateType}
+```
+
+| Part | Description |
+|:-----|:------------|
+| `id` | Unique identifier |
+| `name` | Event name |
+| `visibility` | `pub`, `pri`, `prot` |
+| `delegateType` | Delegate type for handlers |
+
+### Example
+
+```
+§CL{c001:Button:pub}
+  §EVT{e001:Click:pub:EventHandler}
+  §EVT{e002:ValueChanged:pub:EventHandler<ValueChangedEventArgs>}
+§/CL{c001}
+```
+
+Emits:
+```csharp
+public class Button
+{
+    public event EventHandler Click;
+    public event EventHandler<ValueChangedEventArgs> ValueChanged;
+}
+```
+
+---
+
+## Event Subscribe/Unsubscribe
+
+Use `§SUB` and `§UNSUB` to add or remove event handlers.
+
+### Syntax
+
+```
+§SUB eventRef handlerRef      // Subscribe
+§UNSUB eventRef handlerRef    // Unsubscribe
+```
+
+### Examples
+
+**Subscribe to event:**
+```
+§SUB button.Click OnButtonClick
+```
+
+Emits: `button.Click += OnButtonClick;`
+
+**Unsubscribe from event:**
+```
+§UNSUB button.Click OnButtonClick
+```
+
+Emits: `button.Click -= OnButtonClick;`
+
+**Subscribe with lambda:**
+```
+§SUB button.Click (sender, e) → §P "Clicked!"
+```
+
+---
+
 ## Input Parameters
 
 Input parameters define function arguments.
@@ -372,6 +556,9 @@ Every structural element must be closed with a matching tag.
 | `§AF{id:name:vis}` | `§/AF{id}` | Async function |
 | `§MT{id:name:vis}` | `§/MT{id}` | Method |
 | `§AMT{id:name:vis}` | `§/AMT{id}` | Async method |
+| `§DEL{id:name}` | `§/DEL{id}` | Delegate definition |
+| `§LAM{id:params}` | `§/LAM{id}` | Lambda (block body) |
+| `§EVT{id:name:vis:type}` | - | Event definition |
 | `§L{id:var:from:to:step}` | `§/L{id}` | For loop |
 | `§WH{id} cond` | `§/WH{id}` | While loop |
 | `§DO{id}` | `§/DO{id} cond` | Do-while loop |

--- a/website/content/syntax-reference/index.mdx
+++ b/website/content/syntax-reference/index.mdx
@@ -22,6 +22,12 @@ Complete reference for Calor syntax. Calor uses Lisp-style expressions for all o
 | Method | `§MT{id:name:visibility}` | `§MT{mt001:Process:pub}` |
 | Async Method | `§AMT{id:name:visibility}` | `§AMT{mt001:ProcessAsync:pub}` |
 | Await | `§AWAIT expr` | `§AWAIT §C{GetAsync} §/C` |
+| Lambda (inline) | `(params) → expr` | `(x) → (* x 2)` |
+| Lambda (block) | `§LAM{id:params}...§/LAM{id}` | `§LAM{l1:x:i32}...§/LAM{l1}` |
+| Delegate | `§DEL{id:name}...§/DEL{id}` | `§DEL{d1:Handler}...§/DEL{d1}` |
+| Event | `§EVT{id:name:vis:type}` | `§EVT{e1:Click:pub:EventHandler}` |
+| Subscribe | `§SUB event handler` | `§SUB btn.Click OnClick` |
+| Unsubscribe | `§UNSUB event handler` | `§UNSUB btn.Click OnClick` |
 | Input | `§I{type:name}` | `§I{i32:x}` |
 | Output | `§O{type}` | `§O{i32}` |
 | Effects | `§E{codes}` | `§E{cw,fs:r,net:rw}` |

--- a/website/content/syntax-reference/structure-tags.mdx
+++ b/website/content/syntax-reference/structure-tags.mdx
@@ -228,6 +228,190 @@ Emits: `var data = await client.GetAsync(url).ConfigureAwait(false);`
 
 ---
 
+## Lambda Expressions
+
+Lambda expressions create anonymous functions.
+
+### Inline Lambda Syntax
+
+For simple expression-body lambdas:
+
+```
+(param) → expression
+(param1, param2) → expression
+() → expression
+```
+
+### Examples
+
+**Single parameter:**
+```
+§B{doubler] (x) → (* x 2)
+```
+
+Emits: `var doubler = x => x * 2;`
+
+**Multiple parameters:**
+```
+§B{add] (a, b) → (+ a b)
+```
+
+Emits: `var add = (a, b) => a + b;`
+
+**No parameters:**
+```
+§B{getTime] () → §C{DateTime.Now] §/C
+```
+
+### Block Lambda Syntax
+
+For statement-body lambdas, use `§LAM`/`§/LAM`:
+
+```
+§LAM{id:param1:type1:param2:type2]
+  // statements
+§/LAM{id]
+```
+
+**Example:**
+```
+§B{printer] §LAM{lam1:x:i32]
+  §P x
+  §P (* x 2)
+§/LAM{lam1]
+```
+
+### Async Lambdas
+
+Add `async` before parameters:
+
+```
+§LAM{lam1:async:x:i32]
+  §B{result] §AWAIT §C{ProcessAsync] §A x §/C
+  §R result
+§/LAM{lam1]
+```
+
+---
+
+## Delegate Definitions
+
+Delegates define function signatures that can be passed as values.
+
+### Syntax
+
+```
+§DEL{id:name]
+  §I{type:param]       // parameters (0 or more)
+  §O{type]             // return type (optional for void)
+  §E{effects]          // effects (optional)
+§/DEL{id]
+```
+
+### Examples
+
+**Calculator delegate:**
+```
+§DEL{d001:Calculator]
+  §I{i32:a]
+  §I{i32:b]
+  §O{i32]
+§/DEL{d001]
+```
+
+Emits: `public delegate int Calculator(int a, int b);`
+
+**Void delegate:**
+```
+§DEL{d001:Logger]
+  §I{str:message]
+§/DEL{d001]
+```
+
+Emits: `public delegate void Logger(string message);`
+
+**Delegate with effects:**
+```
+§DEL{d001:FileProcessor]
+  §I{str:path]
+  §O{bool]
+  §E{fs:rw]
+§/DEL{d001]
+```
+
+---
+
+## Event Definitions
+
+Events allow objects to notify subscribers of state changes.
+
+### Syntax
+
+```
+§EVT{id:name:visibility:delegateType]
+```
+
+| Part | Description |
+|:-----|:------------|
+| `id` | Unique identifier |
+| `name` | Event name |
+| `visibility` | `pub`, `pri`, `prot` |
+| `delegateType` | Delegate type for handlers |
+
+### Example
+
+```
+§CL{c001:Button:pub]
+  §EVT{e001:Click:pub:EventHandler]
+  §EVT{e002:ValueChanged:pub:EventHandler<ValueChangedEventArgs>]
+§/CL{c001]
+```
+
+Emits:
+```csharp
+public class Button
+{
+    public event EventHandler Click;
+    public event EventHandler<ValueChangedEventArgs> ValueChanged;
+}
+```
+
+---
+
+## Event Subscribe/Unsubscribe
+
+Use `§SUB` and `§UNSUB` to add or remove event handlers.
+
+### Syntax
+
+```
+§SUB eventRef handlerRef      // Subscribe
+§UNSUB eventRef handlerRef    // Unsubscribe
+```
+
+### Examples
+
+**Subscribe to event:**
+```
+§SUB button.Click OnButtonClick
+```
+
+Emits: `button.Click += OnButtonClick;`
+
+**Unsubscribe from event:**
+```
+§UNSUB button.Click OnButtonClick
+```
+
+Emits: `button.Click -= OnButtonClick;`
+
+**Subscribe with lambda:**
+```
+§SUB button.Click (sender, e) → §P "Clicked!"
+```
+
+---
+
 ## Input Parameters
 
 Input parameters define function arguments.
@@ -328,6 +512,9 @@ Every structural element must be closed with a matching tag.
 | `§AF{id:name:vis]` | `§/AF{id]` | Async function |
 | `§MT{id:name:vis]` | `§/MT{id]` | Method |
 | `§AMT{id:name:vis]` | `§/AMT{id]` | Async method |
+| `§DEL{id:name]` | `§/DEL{id]` | Delegate definition |
+| `§LAM{id:params]` | `§/LAM{id]` | Lambda (block body) |
+| `§EVT{id:name:vis:type]` | - | Event definition |
 | `§L{id:var:from:to:step]` | `§/L{id]` | For loop |
 | `§WH{id] cond` | `§/WH{id]` | While loop |
 | `§DO{id]` | `§/DO{id] cond` | Do-while loop |


### PR DESCRIPTION
## Summary

Document the lambda/delegates/events feature implemented in PR #120.

### Added to structure-tags.md/mdx:

**Lambda Expressions**
- Inline lambda syntax: `(params) → expr`
- Block lambda syntax: `§LAM{id:params}...§/LAM{id}`
- Async lambdas with `async` modifier

**Delegate Definitions (`§DEL`)**
- Syntax for defining delegate types
- Parameters, return types, and effects support

**Event Definitions (`§EVT`)**
- Syntax for declaring events in classes
- Visibility and delegate type specification

**Event Subscribe/Unsubscribe (`§SUB`, `§UNSUB`)**
- Adding and removing event handlers
- Lambda handler support

**Tag Reference Table**
- Added `§DEL`/`§/DEL` for delegates
- Added `§LAM`/`§/LAM` for block lambdas
- Added `§EVT` for events

### Added to index.md/mdx quick reference:

| Element | Syntax | Example |
|---------|--------|---------|
| Lambda (inline) | `(params) → expr` | `(x) → (* x 2)` |
| Lambda (block) | `§LAM{id:params}...§/LAM{id}` | `§LAM{l1:x:i32}...§/LAM{l1}` |
| Delegate | `§DEL{id:name}...§/DEL{id}` | `§DEL{d1:Handler}...§/DEL{d1}` |
| Event | `§EVT{id:name:vis:type}` | `§EVT{e1:Click:pub:EventHandler}` |
| Subscribe | `§SUB event handler` | `§SUB btn.Click OnClick` |
| Unsubscribe | `§UNSUB event handler` | `§UNSUB btn.Click OnClick` |

## Test plan

- [x] Website builds successfully with `npm run build`
- [ ] Review documentation reads clearly
- [ ] Verify examples are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)