### PR TITLE
feat: add contract simplification pass for expression optimization

### DIFF
--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -183,6 +183,23 @@ public static class DiagnosticCode
     /// Info: Z3 SMT solver is unavailable, using heuristic checking only.
     /// </summary>
     public const string Z3UnavailableForInheritance = "Calor0817";
+
+    // Contract simplification (Calor0330-0339)
+
+    /// <summary>
+    /// Info: Contract expression is a tautology (always true).
+    /// </summary>
+    public const string ContractTautology = "Calor0330";
+
+    /// <summary>
+    /// Warning: Contract expression is a contradiction (always false).
+    /// </summary>
+    public const string ContractContradiction = "Calor0331";
+
+    /// <summary>
+    /// Info: Contract expression was simplified.
+    /// </summary>
+    public const string ContractSimplified = "Calor0332";
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -310,6 +310,15 @@ public class Program
             Console.WriteLine("Contract semantic verification completed");
         }
 
+        // Contract simplification pass
+        var simplificationPass = new ContractSimplificationPass(diagnostics);
+        ast = simplificationPass.Simplify(ast);
+
+        if (options.Verbose)
+        {
+            Console.WriteLine("Contract simplification completed");
+        }
+
         // Static contract verification with Z3 (optional)
         if (options.VerifyContracts)
         {

--- a/src/Calor.Compiler/Verification/ContractSimplificationPass.cs
+++ b/src/Calor.Compiler/Verification/ContractSimplificationPass.cs
@@ -1,0 +1,363 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+
+namespace Calor.Compiler.Verification;
+
+/// <summary>
+/// Compiler pass that simplifies contract expressions before Z3 verification and runtime code generation.
+/// Applies algebraic simplifications iteratively until a fixed point is reached.
+/// </summary>
+public sealed class ContractSimplificationPass
+{
+    private readonly DiagnosticBag _diagnostics;
+    private const int MaxIterations = 10;
+
+    public ContractSimplificationPass(DiagnosticBag diagnostics)
+    {
+        _diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
+    }
+
+    /// <summary>
+    /// Simplify all contracts in a module.
+    /// Applies simplification rules iteratively until no more changes occur or max iterations reached.
+    /// </summary>
+    public ModuleNode Simplify(ModuleNode module)
+    {
+        var simplifiedFunctions = new List<FunctionNode>();
+        var moduleChanged = false;
+
+        foreach (var function in module.Functions)
+        {
+            var simplified = SimplifyFunction(function);
+            simplifiedFunctions.Add(simplified);
+            if (!ReferenceEquals(simplified, function))
+            {
+                moduleChanged = true;
+            }
+        }
+
+        // Also simplify contracts in classes
+        var simplifiedClasses = new List<ClassDefinitionNode>();
+        foreach (var cls in module.Classes)
+        {
+            var simplified = SimplifyClass(cls);
+            simplifiedClasses.Add(simplified);
+            if (!ReferenceEquals(simplified, cls))
+            {
+                moduleChanged = true;
+            }
+        }
+
+        // Also simplify contracts in interfaces
+        var simplifiedInterfaces = new List<InterfaceDefinitionNode>();
+        foreach (var iface in module.Interfaces)
+        {
+            var simplified = SimplifyInterface(iface);
+            simplifiedInterfaces.Add(simplified);
+            if (!ReferenceEquals(simplified, iface))
+            {
+                moduleChanged = true;
+            }
+        }
+
+        // Also simplify module-level invariants
+        var simplifiedInvariants = SimplifyInvariants(module.Invariants);
+        if (!ReferenceEquals(simplifiedInvariants, module.Invariants))
+        {
+            moduleChanged = true;
+        }
+
+        if (!moduleChanged)
+        {
+            return module;
+        }
+
+        return new ModuleNode(
+            module.Span,
+            module.Id,
+            module.Name,
+            module.Usings,
+            simplifiedInterfaces,
+            simplifiedClasses,
+            module.Enums,
+            module.Delegates,
+            simplifiedFunctions,
+            module.Attributes,
+            module.Issues,
+            module.Assumptions,
+            simplifiedInvariants,
+            module.Decisions,
+            module.Context);
+    }
+
+    private FunctionNode SimplifyFunction(FunctionNode function)
+    {
+        if (!function.HasContracts)
+        {
+            return function;
+        }
+
+        var simplifiedPreconditions = SimplifyContracts(function.Preconditions, SimplifyRequires);
+        var simplifiedPostconditions = SimplifyContracts(function.Postconditions, SimplifyEnsures);
+
+        var preChanged = !ReferenceEquals(simplifiedPreconditions, function.Preconditions);
+        var postChanged = !ReferenceEquals(simplifiedPostconditions, function.Postconditions);
+
+        if (!preChanged && !postChanged)
+        {
+            return function;
+        }
+
+        return new FunctionNode(
+            function.Span,
+            function.Id,
+            function.Name,
+            function.Visibility,
+            function.TypeParameters,
+            function.Parameters,
+            function.Output,
+            function.Effects,
+            simplifiedPreconditions,
+            simplifiedPostconditions,
+            function.Body,
+            function.Attributes,
+            function.Examples,
+            function.Issues,
+            function.Uses,
+            function.UsedBy,
+            function.Assumptions,
+            function.Complexity,
+            function.Since,
+            function.Deprecated,
+            function.BreakingChanges,
+            function.Properties,
+            function.Lock,
+            function.Author,
+            function.TaskRef,
+            function.IsAsync);
+    }
+
+    private ClassDefinitionNode SimplifyClass(ClassDefinitionNode cls)
+    {
+        var simplifiedMethods = new List<MethodNode>();
+        var methodsChanged = false;
+
+        foreach (var method in cls.Methods)
+        {
+            var simplified = SimplifyMethod(method);
+            simplifiedMethods.Add(simplified);
+            if (!ReferenceEquals(simplified, method))
+            {
+                methodsChanged = true;
+            }
+        }
+
+        if (!methodsChanged)
+        {
+            return cls;
+        }
+
+        return new ClassDefinitionNode(
+            cls.Span,
+            cls.Id,
+            cls.Name,
+            cls.IsAbstract,
+            cls.IsSealed,
+            cls.IsPartial,
+            cls.IsStatic,
+            cls.BaseClass,
+            cls.ImplementedInterfaces,
+            cls.TypeParameters,
+            cls.Fields,
+            cls.Properties,
+            cls.Constructors,
+            simplifiedMethods,
+            cls.Events,
+            cls.Attributes,
+            cls.CSharpAttributes);
+    }
+
+    private InterfaceDefinitionNode SimplifyInterface(InterfaceDefinitionNode iface)
+    {
+        var simplifiedMethods = new List<MethodSignatureNode>();
+        var methodsChanged = false;
+
+        foreach (var method in iface.Methods)
+        {
+            var simplified = SimplifyMethodSignature(method);
+            simplifiedMethods.Add(simplified);
+            if (!ReferenceEquals(simplified, method))
+            {
+                methodsChanged = true;
+            }
+        }
+
+        if (!methodsChanged)
+        {
+            return iface;
+        }
+
+        return new InterfaceDefinitionNode(
+            iface.Span,
+            iface.Id,
+            iface.Name,
+            iface.BaseInterfaces,
+            iface.TypeParameters,
+            simplifiedMethods,
+            iface.Attributes,
+            iface.CSharpAttributes);
+    }
+
+    private MethodNode SimplifyMethod(MethodNode method)
+    {
+        if (method.Preconditions.Count == 0 && method.Postconditions.Count == 0)
+        {
+            return method;
+        }
+
+        var simplifiedPreconditions = SimplifyContracts(method.Preconditions, SimplifyRequires);
+        var simplifiedPostconditions = SimplifyContracts(method.Postconditions, SimplifyEnsures);
+
+        var preChanged = !ReferenceEquals(simplifiedPreconditions, method.Preconditions);
+        var postChanged = !ReferenceEquals(simplifiedPostconditions, method.Postconditions);
+
+        if (!preChanged && !postChanged)
+        {
+            return method;
+        }
+
+        return new MethodNode(
+            method.Span,
+            method.Id,
+            method.Name,
+            method.Visibility,
+            method.Modifiers,
+            method.TypeParameters,
+            method.Parameters,
+            method.Output,
+            method.Effects,
+            simplifiedPreconditions,
+            simplifiedPostconditions,
+            method.Body,
+            method.Attributes,
+            method.CSharpAttributes,
+            method.IsAsync);
+    }
+
+    private MethodSignatureNode SimplifyMethodSignature(MethodSignatureNode method)
+    {
+        if (method.Preconditions.Count == 0 && method.Postconditions.Count == 0)
+        {
+            return method;
+        }
+
+        var simplifiedPreconditions = SimplifyContracts(method.Preconditions, SimplifyRequires);
+        var simplifiedPostconditions = SimplifyContracts(method.Postconditions, SimplifyEnsures);
+
+        var preChanged = !ReferenceEquals(simplifiedPreconditions, method.Preconditions);
+        var postChanged = !ReferenceEquals(simplifiedPostconditions, method.Postconditions);
+
+        if (!preChanged && !postChanged)
+        {
+            return method;
+        }
+
+        return new MethodSignatureNode(
+            method.Span,
+            method.Id,
+            method.Name,
+            method.TypeParameters,
+            method.Parameters,
+            method.Output,
+            method.Effects,
+            simplifiedPreconditions,
+            simplifiedPostconditions,
+            method.Attributes,
+            method.CSharpAttributes);
+    }
+
+    private IReadOnlyList<T> SimplifyContracts<T>(IReadOnlyList<T> contracts, Func<T, T> simplifier)
+    {
+        var simplified = new List<T>();
+        var changed = false;
+
+        foreach (var contract in contracts)
+        {
+            var simplifiedContract = simplifier(contract);
+            simplified.Add(simplifiedContract);
+            if (!ReferenceEquals(simplifiedContract, contract))
+            {
+                changed = true;
+            }
+        }
+
+        return changed ? simplified : contracts;
+    }
+
+    private IReadOnlyList<InvariantNode> SimplifyInvariants(IReadOnlyList<InvariantNode> invariants)
+    {
+        return SimplifyContracts(invariants, SimplifyInvariant);
+    }
+
+    private RequiresNode SimplifyRequires(RequiresNode requires)
+    {
+        var simplifiedCondition = SimplifyExpression(requires.Condition);
+
+        if (ReferenceEquals(simplifiedCondition, requires.Condition))
+        {
+            return requires;
+        }
+
+        return new RequiresNode(requires.Span, simplifiedCondition, requires.Message, requires.Attributes);
+    }
+
+    private EnsuresNode SimplifyEnsures(EnsuresNode ensures)
+    {
+        var simplifiedCondition = SimplifyExpression(ensures.Condition);
+
+        if (ReferenceEquals(simplifiedCondition, ensures.Condition))
+        {
+            return ensures;
+        }
+
+        return new EnsuresNode(ensures.Span, simplifiedCondition, ensures.Message, ensures.Attributes);
+    }
+
+    private InvariantNode SimplifyInvariant(InvariantNode invariant)
+    {
+        var simplifiedCondition = SimplifyExpression(invariant.Condition);
+
+        if (ReferenceEquals(simplifiedCondition, invariant.Condition))
+        {
+            return invariant;
+        }
+
+        return new InvariantNode(invariant.Span, simplifiedCondition, invariant.Message, invariant.Attributes);
+    }
+
+    /// <summary>
+    /// Simplify an expression with fixed-point iteration.
+    /// </summary>
+    private ExpressionNode SimplifyExpression(ExpressionNode expression)
+    {
+        var current = expression;
+
+        for (int i = 0; i < MaxIterations; i++)
+        {
+            var simplifier = new ExpressionSimplifier(_diagnostics);
+            var simplified = simplifier.Simplify(current);
+
+            if (!simplifier.Changed)
+            {
+                // Fixed point reached
+                return simplified;
+            }
+
+            current = simplified;
+        }
+
+        // Max iterations reached, return current state
+        return current;
+    }
+}

--- a/src/Calor.Compiler/Verification/ExpressionSimplifier.cs
+++ b/src/Calor.Compiler/Verification/ExpressionSimplifier.cs
@@ -1,0 +1,1333 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+
+namespace Calor.Compiler.Verification;
+
+/// <summary>
+/// Visitor that simplifies contract expressions by applying algebraic transformations.
+/// Supports constant folding (int and float), boolean identity, double negation elimination,
+/// tautology/contradiction detection, quantifier simplification, De Morgan's laws,
+/// arithmetic identities, and commutativity-aware redundancy elimination.
+/// </summary>
+public sealed class ExpressionSimplifier : IAstVisitor<ExpressionNode>
+{
+    private readonly DiagnosticBag? _diagnostics;
+
+    /// <summary>
+    /// Gets whether any simplification was applied during the visit.
+    /// </summary>
+    public bool Changed { get; private set; }
+
+    public ExpressionSimplifier(DiagnosticBag? diagnostics = null)
+    {
+        _diagnostics = diagnostics;
+    }
+
+    /// <summary>
+    /// Simplify an expression node.
+    /// </summary>
+    public ExpressionNode Simplify(ExpressionNode expr)
+    {
+        return expr.Accept(this);
+    }
+
+    #region Literal Nodes (unchanged)
+
+    public ExpressionNode Visit(IntLiteralNode node) => node;
+    public ExpressionNode Visit(StringLiteralNode node) => node;
+    public ExpressionNode Visit(BoolLiteralNode node) => node;
+    public ExpressionNode Visit(FloatLiteralNode node) => node;
+    public ExpressionNode Visit(ReferenceNode node) => node;
+
+    #endregion
+
+    #region Binary Operations
+
+    public ExpressionNode Visit(BinaryOperationNode node)
+    {
+        var left = node.Left.Accept(this);
+        var right = node.Right.Accept(this);
+
+        // Constant folding for integers
+        if (left is IntLiteralNode li && right is IntLiteralNode ri)
+        {
+            var folded = TryFoldIntegerBinaryOp(node.Span, node.Operator, li.Value, ri.Value);
+            if (folded != null)
+            {
+                Changed = true;
+                ReportSimplified(node.Span, "integer constant folded");
+                return folded;
+            }
+        }
+
+        // Constant folding for floats
+        if (left is FloatLiteralNode lf && right is FloatLiteralNode rf)
+        {
+            var folded = TryFoldFloatBinaryOp(node.Span, node.Operator, lf.Value, rf.Value);
+            if (folded != null)
+            {
+                Changed = true;
+                ReportSimplified(node.Span, "float constant folded");
+                return folded;
+            }
+        }
+
+        // Mixed int/float constant folding (promote int to float)
+        if ((left is IntLiteralNode lmi && right is FloatLiteralNode rmf) ||
+            (left is FloatLiteralNode lmf && right is IntLiteralNode rmi))
+        {
+            double leftVal = left is IntLiteralNode li2 ? li2.Value : ((FloatLiteralNode)left).Value;
+            double rightVal = right is IntLiteralNode ri2 ? ri2.Value : ((FloatLiteralNode)right).Value;
+            var folded = TryFoldFloatBinaryOp(node.Span, node.Operator, leftVal, rightVal);
+            if (folded != null)
+            {
+                Changed = true;
+                ReportSimplified(node.Span, "mixed constant folded");
+                return folded;
+            }
+        }
+
+        // Algebraic identity simplifications
+        var algebraic = TrySimplifyAlgebraicIdentity(node.Span, node.Operator, left, right);
+        if (algebraic != null)
+        {
+            Changed = true;
+            return algebraic;
+        }
+
+        // Boolean simplification
+        return node.Operator switch
+        {
+            BinaryOperator.And => SimplifyAnd(node.Span, left, right),
+            BinaryOperator.Or => SimplifyOr(node.Span, left, right),
+            BinaryOperator.Equal => SimplifyEqual(node.Span, left, right),
+            BinaryOperator.NotEqual => SimplifyNotEqual(node.Span, left, right),
+            _ => MaybeNewNode(node, left, right)
+        };
+    }
+
+    private ExpressionNode? TryFoldIntegerBinaryOp(TextSpan span, BinaryOperator op, int left, int right)
+    {
+        return op switch
+        {
+            BinaryOperator.Add => new IntLiteralNode(span, left + right),
+            BinaryOperator.Subtract => new IntLiteralNode(span, left - right),
+            BinaryOperator.Multiply => new IntLiteralNode(span, left * right),
+            BinaryOperator.Divide when right != 0 => new IntLiteralNode(span, left / right),
+            BinaryOperator.Modulo when right != 0 => new IntLiteralNode(span, left % right),
+            BinaryOperator.LessThan => new BoolLiteralNode(span, left < right),
+            BinaryOperator.LessOrEqual => new BoolLiteralNode(span, left <= right),
+            BinaryOperator.GreaterThan => new BoolLiteralNode(span, left > right),
+            BinaryOperator.GreaterOrEqual => new BoolLiteralNode(span, left >= right),
+            BinaryOperator.Equal => new BoolLiteralNode(span, left == right),
+            BinaryOperator.NotEqual => new BoolLiteralNode(span, left != right),
+            BinaryOperator.BitwiseAnd => new IntLiteralNode(span, left & right),
+            BinaryOperator.BitwiseOr => new IntLiteralNode(span, left | right),
+            BinaryOperator.BitwiseXor => new IntLiteralNode(span, left ^ right),
+            BinaryOperator.LeftShift => new IntLiteralNode(span, left << right),
+            BinaryOperator.RightShift => new IntLiteralNode(span, left >> right),
+            _ => null
+        };
+    }
+
+    private ExpressionNode? TryFoldFloatBinaryOp(TextSpan span, BinaryOperator op, double left, double right)
+    {
+        return op switch
+        {
+            BinaryOperator.Add => new FloatLiteralNode(span, left + right),
+            BinaryOperator.Subtract => new FloatLiteralNode(span, left - right),
+            BinaryOperator.Multiply => new FloatLiteralNode(span, left * right),
+            BinaryOperator.Divide when Math.Abs(right) > double.Epsilon => new FloatLiteralNode(span, left / right),
+            BinaryOperator.Modulo when Math.Abs(right) > double.Epsilon => new FloatLiteralNode(span, left % right),
+            BinaryOperator.Power => new FloatLiteralNode(span, Math.Pow(left, right)),
+            BinaryOperator.LessThan => new BoolLiteralNode(span, left < right),
+            BinaryOperator.LessOrEqual => new BoolLiteralNode(span, left <= right),
+            BinaryOperator.GreaterThan => new BoolLiteralNode(span, left > right),
+            BinaryOperator.GreaterOrEqual => new BoolLiteralNode(span, left >= right),
+            BinaryOperator.Equal => new BoolLiteralNode(span, Math.Abs(left - right) < double.Epsilon),
+            BinaryOperator.NotEqual => new BoolLiteralNode(span, Math.Abs(left - right) >= double.Epsilon),
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Simplifies algebraic identities like x + 0 → x, x * 1 → x, x - x → 0, etc.
+    /// </summary>
+    private ExpressionNode? TrySimplifyAlgebraicIdentity(TextSpan span, BinaryOperator op, ExpressionNode left, ExpressionNode right)
+    {
+        // x + 0 → x, 0 + x → x
+        if (op == BinaryOperator.Add)
+        {
+            if (IsZero(right))
+            {
+                ReportSimplified(span, "x + 0 -> x");
+                return left;
+            }
+            if (IsZero(left))
+            {
+                ReportSimplified(span, "0 + x -> x");
+                return right;
+            }
+        }
+
+        // x - 0 → x
+        if (op == BinaryOperator.Subtract)
+        {
+            if (IsZero(right))
+            {
+                ReportSimplified(span, "x - 0 -> x");
+                return left;
+            }
+            // x - x → 0 (also handles commutative equality like (+ a b) - (+ b a))
+            if (AreStructurallyEqualOrCommutative(left, right))
+            {
+                ReportSimplified(span, "x - x -> 0");
+                return new IntLiteralNode(span, 0);
+            }
+        }
+
+        // x * 1 → x, 1 * x → x
+        if (op == BinaryOperator.Multiply)
+        {
+            if (IsOne(right))
+            {
+                ReportSimplified(span, "x * 1 -> x");
+                return left;
+            }
+            if (IsOne(left))
+            {
+                ReportSimplified(span, "1 * x -> x");
+                return right;
+            }
+            // x * 0 → 0, 0 * x → 0
+            if (IsZero(right))
+            {
+                ReportSimplified(span, "x * 0 -> 0");
+                return right;
+            }
+            if (IsZero(left))
+            {
+                ReportSimplified(span, "0 * x -> 0");
+                return left;
+            }
+        }
+
+        // x / 1 → x
+        if (op == BinaryOperator.Divide)
+        {
+            if (IsOne(right))
+            {
+                ReportSimplified(span, "x / 1 -> x");
+                return left;
+            }
+            // Note: x / x → 1 is NOT safe in general (x could be 0)
+            // We only do this for known non-zero constants
+            if (left is IntLiteralNode li && right is IntLiteralNode ri && li.Value == ri.Value && li.Value != 0)
+            {
+                ReportSimplified(span, "n / n -> 1");
+                return new IntLiteralNode(span, 1);
+            }
+        }
+
+        // x % 1 → 0 (for integers)
+        if (op == BinaryOperator.Modulo && IsOne(right) && left is IntLiteralNode or ReferenceNode)
+        {
+            ReportSimplified(span, "x % 1 -> 0");
+            return new IntLiteralNode(span, 0);
+        }
+
+        return null;
+    }
+
+    private bool IsZero(ExpressionNode node)
+    {
+        return node switch
+        {
+            IntLiteralNode i => i.Value == 0,
+            FloatLiteralNode f => Math.Abs(f.Value) < double.Epsilon,
+            _ => false
+        };
+    }
+
+    private bool IsOne(ExpressionNode node)
+    {
+        return node switch
+        {
+            IntLiteralNode i => i.Value == 1,
+            FloatLiteralNode f => Math.Abs(f.Value - 1.0) < double.Epsilon,
+            _ => false
+        };
+    }
+
+    private ExpressionNode SimplifyAnd(TextSpan span, ExpressionNode left, ExpressionNode right)
+    {
+        // (&& true x) → x
+        if (left is BoolLiteralNode { Value: true })
+        {
+            Changed = true;
+            ReportSimplified(span, "(&& true x) -> x");
+            return right;
+        }
+
+        // (&& x true) → x
+        if (right is BoolLiteralNode { Value: true })
+        {
+            Changed = true;
+            ReportSimplified(span, "(&& x true) -> x");
+            return left;
+        }
+
+        // (&& false x) → false
+        if (left is BoolLiteralNode { Value: false })
+        {
+            Changed = true;
+            ReportContradiction(span, "(&& false x) is always false");
+            return left;
+        }
+
+        // (&& x false) → false
+        if (right is BoolLiteralNode { Value: false })
+        {
+            Changed = true;
+            ReportContradiction(span, "(&& x false) is always false");
+            return right;
+        }
+
+        // (&& x x) → x (redundant) - also check commutative equality
+        if (AreStructurallyEqualOrCommutative(left, right))
+        {
+            Changed = true;
+            ReportSimplified(span, "(&& x x) -> x");
+            return left;
+        }
+
+        // (&& x (! x)) → false (contradiction)
+        if (IsNegationOf(left, right) || IsNegationOf(right, left))
+        {
+            Changed = true;
+            ReportContradiction(span, "(&& x (! x)) is a contradiction");
+            return new BoolLiteralNode(span, false);
+        }
+
+        return MaybeNewBinaryNode(span, BinaryOperator.And, left, right);
+    }
+
+    private ExpressionNode SimplifyOr(TextSpan span, ExpressionNode left, ExpressionNode right)
+    {
+        // (|| true x) → true
+        if (left is BoolLiteralNode { Value: true })
+        {
+            Changed = true;
+            ReportTautology(span, "(|| true x) is always true");
+            return left;
+        }
+
+        // (|| x true) → true
+        if (right is BoolLiteralNode { Value: true })
+        {
+            Changed = true;
+            ReportTautology(span, "(|| x true) is always true");
+            return right;
+        }
+
+        // (|| false x) → x
+        if (left is BoolLiteralNode { Value: false })
+        {
+            Changed = true;
+            ReportSimplified(span, "(|| false x) -> x");
+            return right;
+        }
+
+        // (|| x false) → x
+        if (right is BoolLiteralNode { Value: false })
+        {
+            Changed = true;
+            ReportSimplified(span, "(|| x false) -> x");
+            return left;
+        }
+
+        // (|| x x) → x (redundant) - also check commutative equality
+        if (AreStructurallyEqualOrCommutative(left, right))
+        {
+            Changed = true;
+            ReportSimplified(span, "(|| x x) -> x");
+            return left;
+        }
+
+        // (|| x (! x)) → true (tautology)
+        if (IsNegationOf(left, right) || IsNegationOf(right, left))
+        {
+            Changed = true;
+            ReportTautology(span, "(|| x (! x)) is a tautology");
+            return new BoolLiteralNode(span, true);
+        }
+
+        return MaybeNewBinaryNode(span, BinaryOperator.Or, left, right);
+    }
+
+    private ExpressionNode SimplifyEqual(TextSpan span, ExpressionNode left, ExpressionNode right)
+    {
+        // (== x x) → true - also check commutative equality
+        if (AreStructurallyEqualOrCommutative(left, right))
+        {
+            Changed = true;
+            ReportTautology(span, "(== x x) is always true");
+            return new BoolLiteralNode(span, true);
+        }
+
+        // (== true x) → x, (== x true) → x
+        if (left is BoolLiteralNode { Value: true })
+        {
+            Changed = true;
+            ReportSimplified(span, "(== true x) -> x");
+            return right;
+        }
+        if (right is BoolLiteralNode { Value: true })
+        {
+            Changed = true;
+            ReportSimplified(span, "(== x true) -> x");
+            return left;
+        }
+
+        // (== false x) → (! x), (== x false) → (! x)
+        if (left is BoolLiteralNode { Value: false })
+        {
+            Changed = true;
+            ReportSimplified(span, "(== false x) -> (! x)");
+            return new UnaryOperationNode(span, UnaryOperator.Not, right);
+        }
+        if (right is BoolLiteralNode { Value: false })
+        {
+            Changed = true;
+            ReportSimplified(span, "(== x false) -> (! x)");
+            return new UnaryOperationNode(span, UnaryOperator.Not, left);
+        }
+
+        return MaybeNewBinaryNode(span, BinaryOperator.Equal, left, right);
+    }
+
+    private ExpressionNode SimplifyNotEqual(TextSpan span, ExpressionNode left, ExpressionNode right)
+    {
+        // (!= x x) → false - also check commutative equality
+        if (AreStructurallyEqualOrCommutative(left, right))
+        {
+            Changed = true;
+            ReportContradiction(span, "(!= x x) is always false");
+            return new BoolLiteralNode(span, false);
+        }
+
+        return MaybeNewBinaryNode(span, BinaryOperator.NotEqual, left, right);
+    }
+
+    #endregion
+
+    #region Unary Operations
+
+    public ExpressionNode Visit(UnaryOperationNode node)
+    {
+        var operand = node.Operand.Accept(this);
+
+        if (node.Operator == UnaryOperator.Not)
+        {
+            // (! true) → false
+            if (operand is BoolLiteralNode { Value: true })
+            {
+                Changed = true;
+                ReportSimplified(node.Span, "(! true) -> false");
+                return new BoolLiteralNode(node.Span, false);
+            }
+
+            // (! false) → true
+            if (operand is BoolLiteralNode { Value: false })
+            {
+                Changed = true;
+                ReportSimplified(node.Span, "(! false) -> true");
+                return new BoolLiteralNode(node.Span, true);
+            }
+
+            // (! (! x)) → x (double negation)
+            if (operand is UnaryOperationNode { Operator: UnaryOperator.Not } inner)
+            {
+                Changed = true;
+                ReportSimplified(node.Span, "(! (! x)) -> x");
+                return inner.Operand;
+            }
+
+            // De Morgan's Laws
+            // (! (&& a b)) → (|| (! a) (! b))
+            if (operand is BinaryOperationNode { Operator: BinaryOperator.And } andOp)
+            {
+                Changed = true;
+                ReportSimplified(node.Span, "De Morgan: (! (&& a b)) -> (|| (! a) (! b))");
+                return new BinaryOperationNode(node.Span, BinaryOperator.Or,
+                    new UnaryOperationNode(node.Span, UnaryOperator.Not, andOp.Left),
+                    new UnaryOperationNode(node.Span, UnaryOperator.Not, andOp.Right));
+            }
+
+            // (! (|| a b)) → (&& (! a) (! b))
+            if (operand is BinaryOperationNode { Operator: BinaryOperator.Or } orOp)
+            {
+                Changed = true;
+                ReportSimplified(node.Span, "De Morgan: (! (|| a b)) -> (&& (! a) (! b))");
+                return new BinaryOperationNode(node.Span, BinaryOperator.And,
+                    new UnaryOperationNode(node.Span, UnaryOperator.Not, orOp.Left),
+                    new UnaryOperationNode(node.Span, UnaryOperator.Not, orOp.Right));
+            }
+        }
+
+        if (node.Operator == UnaryOperator.Negate)
+        {
+            // (- INT:n) → INT:(-n)
+            if (operand is IntLiteralNode intLit)
+            {
+                Changed = true;
+                ReportSimplified(node.Span, "integer negation folded");
+                return new IntLiteralNode(node.Span, -intLit.Value);
+            }
+
+            // (- FLOAT:n) → FLOAT:(-n)
+            if (operand is FloatLiteralNode floatLit)
+            {
+                Changed = true;
+                ReportSimplified(node.Span, "float negation folded");
+                return new FloatLiteralNode(node.Span, -floatLit.Value);
+            }
+
+            // (- (- x)) → x (double negation for arithmetic)
+            if (operand is UnaryOperationNode { Operator: UnaryOperator.Negate } innerNeg)
+            {
+                Changed = true;
+                ReportSimplified(node.Span, "(- (- x)) -> x");
+                return innerNeg.Operand;
+            }
+        }
+
+        if (node.Operator == UnaryOperator.BitwiseNot)
+        {
+            // (~ INT:n) → INT:(~n)
+            if (operand is IntLiteralNode intLit)
+            {
+                Changed = true;
+                ReportSimplified(node.Span, "bitwise not folded");
+                return new IntLiteralNode(node.Span, ~intLit.Value);
+            }
+
+            // (~ (~ x)) → x
+            if (operand is UnaryOperationNode { Operator: UnaryOperator.BitwiseNot } innerBnot)
+            {
+                Changed = true;
+                ReportSimplified(node.Span, "(~ (~ x)) -> x");
+                return innerBnot.Operand;
+            }
+        }
+
+        return operand == node.Operand ? node : new UnaryOperationNode(node.Span, node.Operator, operand);
+    }
+
+    #endregion
+
+    #region Implication
+
+    public ExpressionNode Visit(ImplicationExpressionNode node)
+    {
+        var ante = node.Antecedent.Accept(this);
+        var cons = node.Consequent.Accept(this);
+
+        // (-> false p) → true
+        if (ante is BoolLiteralNode { Value: false })
+        {
+            Changed = true;
+            ReportTautology(node.Span, "(-> false p) is always true");
+            return new BoolLiteralNode(node.Span, true);
+        }
+
+        // (-> true p) → p
+        if (ante is BoolLiteralNode { Value: true })
+        {
+            Changed = true;
+            ReportSimplified(node.Span, "(-> true p) -> p");
+            return cons;
+        }
+
+        // (-> p true) → true
+        if (cons is BoolLiteralNode { Value: true })
+        {
+            Changed = true;
+            ReportTautology(node.Span, "(-> p true) is always true");
+            return new BoolLiteralNode(node.Span, true);
+        }
+
+        // (-> p false) → (! p)
+        if (cons is BoolLiteralNode { Value: false })
+        {
+            Changed = true;
+            ReportSimplified(node.Span, "(-> p false) -> (! p)");
+            return new UnaryOperationNode(node.Span, UnaryOperator.Not, ante);
+        }
+
+        // (-> p p) → true (reflexive implication) - also check commutative equality
+        if (AreStructurallyEqualOrCommutative(ante, cons))
+        {
+            Changed = true;
+            ReportTautology(node.Span, "(-> p p) is always true");
+            return new BoolLiteralNode(node.Span, true);
+        }
+
+        // (-> (! p) p) → p (double negation introduction)
+        if (IsNegationOf(ante, cons))
+        {
+            Changed = true;
+            ReportSimplified(node.Span, "(-> (! p) p) -> p");
+            return cons;
+        }
+
+        return ante == node.Antecedent && cons == node.Consequent
+            ? node
+            : new ImplicationExpressionNode(node.Span, ante, cons);
+    }
+
+    #endregion
+
+    #region Quantifiers
+
+    public ExpressionNode Visit(ForallExpressionNode node)
+    {
+        var body = node.Body.Accept(this);
+
+        // (forall (...) true) → true
+        if (body is BoolLiteralNode { Value: true })
+        {
+            Changed = true;
+            ReportTautology(node.Span, "(forall (...) true) is always true");
+            return new BoolLiteralNode(node.Span, true);
+        }
+
+        // (forall (...) false) → false (only true if domain is empty, but we assume non-empty domains)
+        if (body is BoolLiteralNode { Value: false })
+        {
+            Changed = true;
+            ReportContradiction(node.Span, "(forall (...) false) is always false (assuming non-empty domain)");
+            return new BoolLiteralNode(node.Span, false);
+        }
+
+        return body == node.Body
+            ? node
+            : new ForallExpressionNode(node.Span, node.BoundVariables, body);
+    }
+
+    public ExpressionNode Visit(ExistsExpressionNode node)
+    {
+        var body = node.Body.Accept(this);
+
+        // (exists (...) true) → true (assuming non-empty domain)
+        if (body is BoolLiteralNode { Value: true })
+        {
+            Changed = true;
+            ReportTautology(node.Span, "(exists (...) true) is always true (assuming non-empty domain)");
+            return new BoolLiteralNode(node.Span, true);
+        }
+
+        // (exists (...) false) → false
+        if (body is BoolLiteralNode { Value: false })
+        {
+            Changed = true;
+            ReportContradiction(node.Span, "(exists (...) false) is always false");
+            return new BoolLiteralNode(node.Span, false);
+        }
+
+        return body == node.Body
+            ? node
+            : new ExistsExpressionNode(node.Span, node.BoundVariables, body);
+    }
+
+    public ExpressionNode Visit(QuantifierVariableNode node) => throw new InvalidOperationException("QuantifierVariableNode should not be visited directly");
+
+    #endregion
+
+    #region Conditional Expression
+
+    public ExpressionNode Visit(ConditionalExpressionNode node)
+    {
+        var cond = node.Condition.Accept(this);
+        var whenTrue = node.WhenTrue.Accept(this);
+        var whenFalse = node.WhenFalse.Accept(this);
+
+        // (? true t f) → t
+        if (cond is BoolLiteralNode { Value: true })
+        {
+            Changed = true;
+            ReportSimplified(node.Span, "(? true t f) -> t");
+            return whenTrue;
+        }
+
+        // (? false t f) → f
+        if (cond is BoolLiteralNode { Value: false })
+        {
+            Changed = true;
+            ReportSimplified(node.Span, "(? false t f) -> f");
+            return whenFalse;
+        }
+
+        // (? c x x) → x
+        if (AreStructurallyEqualOrCommutative(whenTrue, whenFalse))
+        {
+            Changed = true;
+            ReportSimplified(node.Span, "(? c x x) -> x");
+            return whenTrue;
+        }
+
+        // (? c true false) → c
+        if (whenTrue is BoolLiteralNode { Value: true } && whenFalse is BoolLiteralNode { Value: false })
+        {
+            Changed = true;
+            ReportSimplified(node.Span, "(? c true false) -> c");
+            return cond;
+        }
+
+        // (? c false true) → (! c)
+        if (whenTrue is BoolLiteralNode { Value: false } && whenFalse is BoolLiteralNode { Value: true })
+        {
+            Changed = true;
+            ReportSimplified(node.Span, "(? c false true) -> (! c)");
+            return new UnaryOperationNode(node.Span, UnaryOperator.Not, cond);
+        }
+
+        return cond == node.Condition && whenTrue == node.WhenTrue && whenFalse == node.WhenFalse
+            ? node
+            : new ConditionalExpressionNode(node.Span, cond, whenTrue, whenFalse);
+    }
+
+    #endregion
+
+    #region Expression nodes that recursively simplify children
+
+    public ExpressionNode Visit(ArrayAccessNode node)
+    {
+        var array = node.Array.Accept(this);
+        var index = node.Index.Accept(this);
+        return array == node.Array && index == node.Index
+            ? node
+            : new ArrayAccessNode(node.Span, array, index);
+    }
+
+    public ExpressionNode Visit(ArrayLengthNode node)
+    {
+        var array = node.Array.Accept(this);
+        return array == node.Array
+            ? node
+            : new ArrayLengthNode(node.Span, array);
+    }
+
+    public ExpressionNode Visit(FieldAccessNode node)
+    {
+        var target = node.Target.Accept(this);
+        return target == node.Target
+            ? node
+            : new FieldAccessNode(node.Span, target, node.FieldName);
+    }
+
+    public ExpressionNode Visit(SomeExpressionNode node)
+    {
+        var value = node.Value.Accept(this);
+        return value == node.Value
+            ? node
+            : new SomeExpressionNode(node.Span, value);
+    }
+
+    public ExpressionNode Visit(NoneExpressionNode node) => node;
+
+    public ExpressionNode Visit(OkExpressionNode node)
+    {
+        var value = node.Value.Accept(this);
+        return value == node.Value
+            ? node
+            : new OkExpressionNode(node.Span, value);
+    }
+
+    public ExpressionNode Visit(ErrExpressionNode node)
+    {
+        var error = node.Error.Accept(this);
+        return error == node.Error
+            ? node
+            : new ErrExpressionNode(node.Span, error);
+    }
+
+    public ExpressionNode Visit(CallExpressionNode node)
+    {
+        var argsChanged = false;
+        var newArgs = new List<ExpressionNode>();
+        foreach (var arg in node.Arguments)
+        {
+            var simplified = arg.Accept(this);
+            newArgs.Add(simplified);
+            if (!ReferenceEquals(simplified, arg))
+                argsChanged = true;
+        }
+        return argsChanged
+            ? new CallExpressionNode(node.Span, node.Target, newArgs)
+            : node;
+    }
+
+    public ExpressionNode Visit(NewExpressionNode node)
+    {
+        var argsChanged = false;
+        var newArgs = new List<ExpressionNode>();
+        foreach (var arg in node.Arguments)
+        {
+            var simplified = arg.Accept(this);
+            newArgs.Add(simplified);
+            if (!ReferenceEquals(simplified, arg))
+                argsChanged = true;
+        }
+
+        var initializersChanged = false;
+        var newInitializers = new List<ObjectInitializerAssignment>();
+        foreach (var init in node.Initializers)
+        {
+            var simplified = init.Value.Accept(this);
+            if (!ReferenceEquals(simplified, init.Value))
+            {
+                initializersChanged = true;
+                newInitializers.Add(new ObjectInitializerAssignment(init.PropertyName, simplified));
+            }
+            else
+            {
+                newInitializers.Add(init);
+            }
+        }
+
+        return argsChanged || initializersChanged
+            ? new NewExpressionNode(node.Span, node.TypeName, node.TypeArguments, newArgs, newInitializers)
+            : node;
+    }
+
+    public ExpressionNode Visit(ThisExpressionNode node) => node;
+    public ExpressionNode Visit(BaseExpressionNode node) => node;
+
+    public ExpressionNode Visit(CollectionContainsNode node)
+    {
+        // CollectionName is a string, not an expression, so only simplify KeyOrValue
+        var keyOrValue = node.KeyOrValue.Accept(this);
+        return keyOrValue == node.KeyOrValue
+            ? node
+            : new CollectionContainsNode(node.Span, node.CollectionName, keyOrValue, node.Mode);
+    }
+
+    public ExpressionNode Visit(CollectionCountNode node)
+    {
+        var collection = node.Collection.Accept(this);
+        return collection == node.Collection
+            ? node
+            : new CollectionCountNode(node.Span, collection);
+    }
+
+    public ExpressionNode Visit(MatchExpressionNode node)
+    {
+        var target = node.Target.Accept(this);
+        var casesChanged = false;
+        var newCases = new List<MatchCaseNode>();
+        foreach (var c in node.Cases)
+        {
+            ExpressionNode? guard = null;
+            var guardChanged = false;
+            if (c.Guard != null)
+            {
+                guard = c.Guard.Accept(this);
+                if (!ReferenceEquals(guard, c.Guard))
+                    guardChanged = true;
+            }
+            // Body is statements, not an expression - cannot simplify here
+            if (guardChanged)
+            {
+                casesChanged = true;
+                newCases.Add(new MatchCaseNode(c.Span, c.Pattern, guard, c.Body));
+            }
+            else
+            {
+                newCases.Add(c);
+            }
+        }
+        return !ReferenceEquals(target, node.Target) || casesChanged
+            ? new MatchExpressionNode(node.Span, node.Id, target, newCases, node.Attributes)
+            : node;
+    }
+
+    public ExpressionNode Visit(NullCoalesceNode node)
+    {
+        var left = node.Left.Accept(this);
+        var right = node.Right.Accept(this);
+        return left == node.Left && right == node.Right
+            ? node
+            : new NullCoalesceNode(node.Span, left, right);
+    }
+
+    public ExpressionNode Visit(NullConditionalNode node)
+    {
+        var target = node.Target.Accept(this);
+        return target == node.Target
+            ? node
+            : new NullConditionalNode(node.Span, target, node.MemberName);
+    }
+
+    public ExpressionNode Visit(RangeExpressionNode node)
+    {
+        var start = node.Start?.Accept(this);
+        var end = node.End?.Accept(this);
+        return start == node.Start && end == node.End
+            ? node
+            : new RangeExpressionNode(node.Span, start, end);
+    }
+
+    public ExpressionNode Visit(IndexFromEndNode node)
+    {
+        var offset = node.Offset.Accept(this);
+        return offset == node.Offset
+            ? node
+            : new IndexFromEndNode(node.Span, offset);
+    }
+
+    public ExpressionNode Visit(WithExpressionNode node)
+    {
+        var target = node.Target.Accept(this);
+        var assignmentsChanged = false;
+        var newAssignments = new List<WithPropertyAssignmentNode>();
+        foreach (var assignment in node.Assignments)
+        {
+            var value = assignment.Value.Accept(this);
+            if (!ReferenceEquals(value, assignment.Value))
+            {
+                assignmentsChanged = true;
+                newAssignments.Add(new WithPropertyAssignmentNode(assignment.Span, assignment.PropertyName, value));
+            }
+            else
+            {
+                newAssignments.Add(assignment);
+            }
+        }
+        return !ReferenceEquals(target, node.Target) || assignmentsChanged
+            ? new WithExpressionNode(node.Span, target, newAssignments)
+            : node;
+    }
+
+    public ExpressionNode Visit(LambdaExpressionNode node)
+    {
+        // Lambda bodies might contain expressions that can be simplified
+        if (node.ExpressionBody != null)
+        {
+            var body = node.ExpressionBody.Accept(this);
+            return body == node.ExpressionBody
+                ? node
+                : new LambdaExpressionNode(node.Span, node.Id, node.Parameters, node.Effects, node.IsAsync, body, node.StatementBody, node.Attributes);
+        }
+        // Statement bodies are not simplified (would require statement visitor)
+        return node;
+    }
+
+    public ExpressionNode Visit(AwaitExpressionNode node)
+    {
+        var awaited = node.Awaited.Accept(this);
+        return awaited == node.Awaited
+            ? node
+            : new AwaitExpressionNode(node.Span, awaited, node.ConfigureAwait);
+    }
+
+    public ExpressionNode Visit(RecordCreationNode node)
+    {
+        var fieldsChanged = false;
+        var newFields = new List<FieldAssignmentNode>();
+        foreach (var field in node.Fields)
+        {
+            var value = field.Value.Accept(this);
+            if (!ReferenceEquals(value, field.Value))
+            {
+                fieldsChanged = true;
+                newFields.Add(new FieldAssignmentNode(field.Span, field.FieldName, value));
+            }
+            else
+            {
+                newFields.Add(field);
+            }
+        }
+        return fieldsChanged
+            ? new RecordCreationNode(node.Span, node.TypeName, newFields)
+            : node;
+    }
+
+    public ExpressionNode Visit(InterpolatedStringNode node)
+    {
+        var partsChanged = false;
+        var newParts = new List<InterpolatedStringPartNode>();
+        foreach (var part in node.Parts)
+        {
+            if (part is InterpolatedStringExpressionNode exprPart)
+            {
+                var simplified = exprPart.Expression.Accept(this);
+                if (!ReferenceEquals(simplified, exprPart.Expression))
+                {
+                    partsChanged = true;
+                    newParts.Add(new InterpolatedStringExpressionNode(exprPart.Span, simplified));
+                }
+                else
+                {
+                    newParts.Add(part);
+                }
+            }
+            else
+            {
+                newParts.Add(part);
+            }
+        }
+        return partsChanged
+            ? new InterpolatedStringNode(node.Span, newParts)
+            : node;
+    }
+
+    public ExpressionNode Visit(ArrayCreationNode node)
+    {
+        var sizeChanged = false;
+        ExpressionNode? newSize = node.Size;
+        if (node.Size != null)
+        {
+            newSize = node.Size.Accept(this);
+            sizeChanged = !ReferenceEquals(newSize, node.Size);
+        }
+
+        var initializerChanged = false;
+        var newInitializer = new List<ExpressionNode>();
+        foreach (var init in node.Initializer)
+        {
+            var simplified = init.Accept(this);
+            newInitializer.Add(simplified);
+            if (!ReferenceEquals(simplified, init))
+                initializerChanged = true;
+        }
+
+        return sizeChanged || initializerChanged
+            ? new ArrayCreationNode(node.Span, node.Id, node.Name, node.ElementType, newSize, newInitializer, node.Attributes)
+            : node;
+    }
+
+    public ExpressionNode Visit(ListCreationNode node)
+    {
+        var elementsChanged = false;
+        var newElements = new List<ExpressionNode>();
+        foreach (var elem in node.Elements)
+        {
+            var simplified = elem.Accept(this);
+            newElements.Add(simplified);
+            if (!ReferenceEquals(simplified, elem))
+                elementsChanged = true;
+        }
+        return elementsChanged
+            ? new ListCreationNode(node.Span, node.Id, node.Name, node.ElementType, newElements, node.Attributes)
+            : node;
+    }
+
+    public ExpressionNode Visit(DictionaryCreationNode node)
+    {
+        var entriesChanged = false;
+        var newEntries = new List<KeyValuePairNode>();
+        foreach (var entry in node.Entries)
+        {
+            var key = entry.Key.Accept(this);
+            var value = entry.Value.Accept(this);
+            if (!ReferenceEquals(key, entry.Key) || !ReferenceEquals(value, entry.Value))
+            {
+                entriesChanged = true;
+                newEntries.Add(new KeyValuePairNode(entry.Span, key, value));
+            }
+            else
+            {
+                newEntries.Add(entry);
+            }
+        }
+        return entriesChanged
+            ? new DictionaryCreationNode(node.Span, node.Id, node.Name, node.KeyType, node.ValueType, newEntries, node.Attributes)
+            : node;
+    }
+
+    public ExpressionNode Visit(SetCreationNode node)
+    {
+        var elementsChanged = false;
+        var newElements = new List<ExpressionNode>();
+        foreach (var elem in node.Elements)
+        {
+            var simplified = elem.Accept(this);
+            newElements.Add(simplified);
+            if (!ReferenceEquals(simplified, elem))
+                elementsChanged = true;
+        }
+        return elementsChanged
+            ? new SetCreationNode(node.Span, node.Id, node.Name, node.ElementType, newElements, node.Attributes)
+            : node;
+    }
+
+    #endregion
+
+    #region Helper methods
+
+    private BinaryOperationNode MaybeNewBinaryNode(TextSpan span, BinaryOperator op, ExpressionNode left, ExpressionNode right)
+    {
+        return new BinaryOperationNode(span, op, left, right);
+    }
+
+    private ExpressionNode MaybeNewNode(BinaryOperationNode original, ExpressionNode left, ExpressionNode right)
+    {
+        return left == original.Left && right == original.Right
+            ? original
+            : new BinaryOperationNode(original.Span, original.Operator, left, right);
+    }
+
+    /// <summary>
+    /// Checks if two expressions are structurally equal (same shape and values).
+    /// </summary>
+    private bool AreStructurallyEqual(ExpressionNode a, ExpressionNode b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a == null || b == null) return false;
+        if (a.GetType() != b.GetType()) return false;
+
+        return (a, b) switch
+        {
+            (IntLiteralNode ia, IntLiteralNode ib) => ia.Value == ib.Value,
+            (BoolLiteralNode ba, BoolLiteralNode bb) => ba.Value == bb.Value,
+            (StringLiteralNode sa, StringLiteralNode sb) => sa.Value == sb.Value,
+            (FloatLiteralNode fa, FloatLiteralNode fb) => Math.Abs(fa.Value - fb.Value) < double.Epsilon,
+            (ReferenceNode ra, ReferenceNode rb) => ra.Name == rb.Name,
+            (UnaryOperationNode ua, UnaryOperationNode ub) =>
+                ua.Operator == ub.Operator && AreStructurallyEqual(ua.Operand, ub.Operand),
+            (BinaryOperationNode ba, BinaryOperationNode bb) =>
+                ba.Operator == bb.Operator &&
+                AreStructurallyEqual(ba.Left, bb.Left) &&
+                AreStructurallyEqual(ba.Right, bb.Right),
+            (ImplicationExpressionNode ia, ImplicationExpressionNode ib) =>
+                AreStructurallyEqual(ia.Antecedent, ib.Antecedent) &&
+                AreStructurallyEqual(ia.Consequent, ib.Consequent),
+            (ArrayAccessNode aa, ArrayAccessNode ab) =>
+                AreStructurallyEqual(aa.Array, ab.Array) &&
+                AreStructurallyEqual(aa.Index, ab.Index),
+            (ArrayLengthNode ala, ArrayLengthNode alb) =>
+                AreStructurallyEqual(ala.Array, alb.Array),
+            (FieldAccessNode fa, FieldAccessNode fb) =>
+                fa.FieldName == fb.FieldName && AreStructurallyEqual(fa.Target, fb.Target),
+            (ConditionalExpressionNode ca, ConditionalExpressionNode cb) =>
+                AreStructurallyEqual(ca.Condition, cb.Condition) &&
+                AreStructurallyEqual(ca.WhenTrue, cb.WhenTrue) &&
+                AreStructurallyEqual(ca.WhenFalse, cb.WhenFalse),
+            (ForallExpressionNode fa, ForallExpressionNode fb) =>
+                AreQuantifierVariablesEqual(fa.BoundVariables, fb.BoundVariables) &&
+                AreStructurallyEqual(fa.Body, fb.Body),
+            (ExistsExpressionNode ea, ExistsExpressionNode eb) =>
+                AreQuantifierVariablesEqual(ea.BoundVariables, eb.BoundVariables) &&
+                AreStructurallyEqual(ea.Body, eb.Body),
+            (SomeExpressionNode sa, SomeExpressionNode sb) =>
+                AreStructurallyEqual(sa.Value, sb.Value),
+            (NoneExpressionNode, NoneExpressionNode) => true,
+            (OkExpressionNode oa, OkExpressionNode ob) =>
+                AreStructurallyEqual(oa.Value, ob.Value),
+            (ErrExpressionNode ea, ErrExpressionNode eb) =>
+                AreStructurallyEqual(ea.Error, eb.Error),
+            (ThisExpressionNode, ThisExpressionNode) => true,
+            (BaseExpressionNode, BaseExpressionNode) => true,
+            (CallExpressionNode ca, CallExpressionNode cb) =>
+                ca.Target == cb.Target && AreArgumentsEqual(ca.Arguments, cb.Arguments),
+            (CollectionCountNode cca, CollectionCountNode ccb) =>
+                AreStructurallyEqual(cca.Collection, ccb.Collection),
+            (CollectionContainsNode cca, CollectionContainsNode ccb) =>
+                cca.CollectionName == ccb.CollectionName &&
+                cca.Mode == ccb.Mode &&
+                AreStructurallyEqual(cca.KeyOrValue, ccb.KeyOrValue),
+            (NullCoalesceNode na, NullCoalesceNode nb) =>
+                AreStructurallyEqual(na.Left, nb.Left) &&
+                AreStructurallyEqual(na.Right, nb.Right),
+            (NullConditionalNode na, NullConditionalNode nb) =>
+                na.MemberName == nb.MemberName && AreStructurallyEqual(na.Target, nb.Target),
+            (IndexFromEndNode ia, IndexFromEndNode ib) =>
+                AreStructurallyEqual(ia.Offset, ib.Offset),
+            _ => false
+        };
+    }
+
+    private bool AreQuantifierVariablesEqual(IReadOnlyList<QuantifierVariableNode> a, IReadOnlyList<QuantifierVariableNode> b)
+    {
+        if (a.Count != b.Count) return false;
+        for (int i = 0; i < a.Count; i++)
+        {
+            if (a[i].Name != b[i].Name || a[i].TypeName != b[i].TypeName)
+                return false;
+        }
+        return true;
+    }
+
+    private bool AreArgumentsEqual(IReadOnlyList<ExpressionNode> a, IReadOnlyList<ExpressionNode> b)
+    {
+        if (a.Count != b.Count) return false;
+        for (int i = 0; i < a.Count; i++)
+        {
+            if (!AreStructurallyEqual(a[i], b[i]))
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Checks if two expressions are structurally equal, considering commutativity
+    /// for operators like &&, ||, +, *, ==, !=.
+    /// </summary>
+    private bool AreStructurallyEqualOrCommutative(ExpressionNode a, ExpressionNode b)
+    {
+        if (AreStructurallyEqual(a, b)) return true;
+
+        // Check commutative binary operators
+        if (a is BinaryOperationNode ba && b is BinaryOperationNode bb &&
+            ba.Operator == bb.Operator && IsCommutative(ba.Operator))
+        {
+            // Check if left-right swapped
+            return AreStructurallyEqual(ba.Left, bb.Right) &&
+                   AreStructurallyEqual(ba.Right, bb.Left);
+        }
+
+        return false;
+    }
+
+    private static bool IsCommutative(BinaryOperator op)
+    {
+        return op switch
+        {
+            BinaryOperator.Add => true,
+            BinaryOperator.Multiply => true,
+            BinaryOperator.And => true,
+            BinaryOperator.Or => true,
+            BinaryOperator.Equal => true,
+            BinaryOperator.NotEqual => true,
+            BinaryOperator.BitwiseAnd => true,
+            BinaryOperator.BitwiseOr => true,
+            BinaryOperator.BitwiseXor => true,
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Checks if 'a' is the negation of 'b' (i.e., a = (! b)).
+    /// </summary>
+    private bool IsNegationOf(ExpressionNode a, ExpressionNode b)
+    {
+        return a is UnaryOperationNode { Operator: UnaryOperator.Not } neg &&
+               AreStructurallyEqualOrCommutative(neg.Operand, b);
+    }
+
+    private void ReportTautology(TextSpan span, string message)
+    {
+        _diagnostics?.ReportInfo(span, DiagnosticCode.ContractTautology, message);
+    }
+
+    private void ReportContradiction(TextSpan span, string message)
+    {
+        _diagnostics?.ReportWarning(span, DiagnosticCode.ContractContradiction, message);
+    }
+
+    private void ReportSimplified(TextSpan span, string message)
+    {
+        _diagnostics?.ReportInfo(span, DiagnosticCode.ContractSimplified, message);
+    }
+
+    #endregion
+
+    #region Non-expression node stubs (required by interface but not used for expression simplification)
+
+    public ExpressionNode Visit(ModuleNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(FunctionNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ParameterNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(CallStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ReturnStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ForStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(WhileStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(DoWhileStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(IfStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(BindStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ContinueStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(BreakStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(PrintStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(RecordDefinitionNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(UnionTypeDefinitionNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(EnumDefinitionNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(EnumMemberNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(MatchStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(MatchCaseNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(WildcardPatternNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(VariablePatternNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(LiteralPatternNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(SomePatternNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(NonePatternNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(OkPatternNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ErrPatternNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(RequiresNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(EnsuresNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(InvariantNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(UsingDirectiveNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ForeachStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(KeyValuePairNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(CollectionPushNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(DictionaryPutNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(CollectionRemoveNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(CollectionSetIndexNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(CollectionClearNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(CollectionInsertNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(DictionaryForeachNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(TypeParameterNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(TypeConstraintNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(GenericTypeNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(InterfaceDefinitionNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(MethodSignatureNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ClassDefinitionNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ClassFieldNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(MethodNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(PropertyNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(PropertyAccessorNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ConstructorNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ConstructorInitializerNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(AssignmentStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(CompoundAssignmentStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(UsingStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(TryStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(CatchClauseNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ThrowStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(RethrowStatementNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(LambdaParameterNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(DelegateDefinitionNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(EventDefinitionNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(EventSubscribeNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(EventUnsubscribeNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(InterpolatedStringTextNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(InterpolatedStringExpressionNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(WithPropertyAssignmentNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(PositionalPatternNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(PropertyPatternNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(PropertyMatchNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(RelationalPatternNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ListPatternNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(VarPatternNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ConstantPatternNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ExampleNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(IssueNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(DependencyNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(UsesNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(UsedByNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(AssumeNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ComplexityNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(SinceNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(DeprecatedNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(BreakingChangeNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(DecisionNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(RejectedOptionNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ContextNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(FileRefNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(PropertyTestNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(LockNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(AuthorNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(TaskRefNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(CalorAttributeNode node) => throw new InvalidOperationException();
+
+    #endregion
+}

--- a/tests/Calor.Compiler.Tests/SimplificationTests.cs
+++ b/tests/Calor.Compiler.Tests/SimplificationTests.cs
@@ -1,0 +1,2275 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Calor.Compiler.Verification;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for contract simplification pass.
+/// </summary>
+public class SimplificationTests
+{
+    private static TextSpan Span => new(0, 0, 1, 1);
+
+    #region Constant Folding Tests
+
+    [Fact]
+    public void ConstantFolding_Addition()
+    {
+        // (+ 1 2) → 3
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 1),
+            new IntLiteralNode(Span, 2));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(3, lit.Value);
+    }
+
+    [Fact]
+    public void ConstantFolding_Subtraction()
+    {
+        // (- 5 3) → 2
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Subtract,
+            new IntLiteralNode(Span, 5),
+            new IntLiteralNode(Span, 3));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(2, lit.Value);
+    }
+
+    [Fact]
+    public void ConstantFolding_Multiplication()
+    {
+        // (* 5 0) → 0
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Multiply,
+            new IntLiteralNode(Span, 5),
+            new IntLiteralNode(Span, 0));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(0, lit.Value);
+    }
+
+    [Fact]
+    public void ConstantFolding_Division()
+    {
+        // (/ 10 2) → 5
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Divide,
+            new IntLiteralNode(Span, 10),
+            new IntLiteralNode(Span, 2));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(5, lit.Value);
+    }
+
+    [Fact]
+    public void ConstantFolding_LessThan_True()
+    {
+        // (< 1 2) → true
+        var expr = new BinaryOperationNode(Span, BinaryOperator.LessThan,
+            new IntLiteralNode(Span, 1),
+            new IntLiteralNode(Span, 2));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    [Fact]
+    public void ConstantFolding_LessThan_False()
+    {
+        // (< 5 2) → false
+        var expr = new BinaryOperationNode(Span, BinaryOperator.LessThan,
+            new IntLiteralNode(Span, 5),
+            new IntLiteralNode(Span, 2));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.False(lit.Value);
+    }
+
+    [Fact]
+    public void ConstantFolding_Equal()
+    {
+        // (== 5 5) → true
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Equal,
+            new IntLiteralNode(Span, 5),
+            new IntLiteralNode(Span, 5));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    [Fact]
+    public void ConstantFolding_NotNegation()
+    {
+        // (- INT:5) → INT:-5
+        var expr = new UnaryOperationNode(Span, UnaryOperator.Negate,
+            new IntLiteralNode(Span, 5));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(-5, lit.Value);
+    }
+
+    #endregion
+
+    #region Boolean Identity Tests
+
+    [Fact]
+    public void BooleanIdentity_AndTrue_Left()
+    {
+        // (&& true x) → x
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.And,
+            new BoolLiteralNode(Span, true), x);
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void BooleanIdentity_AndTrue_Right()
+    {
+        // (&& x true) → x
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.And,
+            x, new BoolLiteralNode(Span, true));
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void BooleanIdentity_AndFalse_Left()
+    {
+        // (&& false x) → false
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.And,
+            new BoolLiteralNode(Span, false), x);
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.False(lit.Value);
+    }
+
+    [Fact]
+    public void BooleanIdentity_AndFalse_Right()
+    {
+        // (&& x false) → false
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.And,
+            x, new BoolLiteralNode(Span, false));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.False(lit.Value);
+    }
+
+    [Fact]
+    public void BooleanIdentity_OrTrue_Left()
+    {
+        // (|| true x) → true
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Or,
+            new BoolLiteralNode(Span, true), x);
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    [Fact]
+    public void BooleanIdentity_OrTrue_Right()
+    {
+        // (|| x true) → true
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Or,
+            x, new BoolLiteralNode(Span, true));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    [Fact]
+    public void BooleanIdentity_OrFalse_Left()
+    {
+        // (|| false x) → x
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Or,
+            new BoolLiteralNode(Span, false), x);
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void BooleanIdentity_OrFalse_Right()
+    {
+        // (|| x false) → x
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Or,
+            x, new BoolLiteralNode(Span, false));
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    #endregion
+
+    #region Double Negation Tests
+
+    [Fact]
+    public void DoubleNegation_Removed()
+    {
+        // (! (! x)) → x
+        var x = new ReferenceNode(Span, "x");
+        var expr = new UnaryOperationNode(Span, UnaryOperator.Not,
+            new UnaryOperationNode(Span, UnaryOperator.Not, x));
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void NotTrue_ToFalse()
+    {
+        // (! true) → false
+        var expr = new UnaryOperationNode(Span, UnaryOperator.Not,
+            new BoolLiteralNode(Span, true));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.False(lit.Value);
+    }
+
+    [Fact]
+    public void NotFalse_ToTrue()
+    {
+        // (! false) → true
+        var expr = new UnaryOperationNode(Span, UnaryOperator.Not,
+            new BoolLiteralNode(Span, false));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    #endregion
+
+    #region Tautology Detection Tests
+
+    [Fact]
+    public void Tautology_OrNotSelf()
+    {
+        // (|| x (! x)) → true
+        var x = new ReferenceNode(Span, "x");
+        var notX = new UnaryOperationNode(Span, UnaryOperator.Not, x);
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Or, x, notX);
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    [Fact]
+    public void Tautology_OrNotSelf_Reversed()
+    {
+        // (|| (! x) x) → true
+        var x = new ReferenceNode(Span, "x");
+        var notX = new UnaryOperationNode(Span, UnaryOperator.Not, x);
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Or, notX, x);
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    [Fact]
+    public void Tautology_ImplicationReflexive()
+    {
+        // (-> p p) → true
+        var p = new ReferenceNode(Span, "p");
+        var expr = new ImplicationExpressionNode(Span, p, p);
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    [Fact]
+    public void Tautology_ImplicationFalseAntecedent()
+    {
+        // (-> false p) → true
+        var p = new ReferenceNode(Span, "p");
+        var expr = new ImplicationExpressionNode(Span, new BoolLiteralNode(Span, false), p);
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    [Fact]
+    public void Tautology_ImplicationTrueConsequent()
+    {
+        // (-> p true) → true
+        var p = new ReferenceNode(Span, "p");
+        var expr = new ImplicationExpressionNode(Span, p, new BoolLiteralNode(Span, true));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    #endregion
+
+    #region Contradiction Detection Tests
+
+    [Fact]
+    public void Contradiction_AndNotSelf()
+    {
+        // (&& x (! x)) → false
+        var x = new ReferenceNode(Span, "x");
+        var notX = new UnaryOperationNode(Span, UnaryOperator.Not, x);
+        var expr = new BinaryOperationNode(Span, BinaryOperator.And, x, notX);
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.False(lit.Value);
+    }
+
+    [Fact]
+    public void Contradiction_AndNotSelf_Reversed()
+    {
+        // (&& (! x) x) → false
+        var x = new ReferenceNode(Span, "x");
+        var notX = new UnaryOperationNode(Span, UnaryOperator.Not, x);
+        var expr = new BinaryOperationNode(Span, BinaryOperator.And, notX, x);
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.False(lit.Value);
+    }
+
+    #endregion
+
+    #region Redundant Expression Elimination Tests
+
+    [Fact]
+    public void Redundant_AndSelf()
+    {
+        // (&& x x) → x
+        var x = new ReferenceNode(Span, "x");
+        var xCopy = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.And, x, xCopy);
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void Redundant_OrSelf()
+    {
+        // (|| x x) → x
+        var x = new ReferenceNode(Span, "x");
+        var xCopy = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Or, x, xCopy);
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void Redundant_EqualSelf()
+    {
+        // (== x x) → true
+        var x = new ReferenceNode(Span, "x");
+        var xCopy = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Equal, x, xCopy);
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    [Fact]
+    public void Redundant_NotEqualSelf()
+    {
+        // (!= x x) → false
+        var x = new ReferenceNode(Span, "x");
+        var xCopy = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.NotEqual, x, xCopy);
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.False(lit.Value);
+    }
+
+    #endregion
+
+    #region Implication Simplification Tests
+
+    [Fact]
+    public void Implication_TrueAntecedent()
+    {
+        // (-> true p) → p
+        var p = new ReferenceNode(Span, "p");
+        var expr = new ImplicationExpressionNode(Span, new BoolLiteralNode(Span, true), p);
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("p", refNode.Name);
+    }
+
+    [Fact]
+    public void Implication_FalseConsequent()
+    {
+        // (-> p false) → (! p)
+        var p = new ReferenceNode(Span, "p");
+        var expr = new ImplicationExpressionNode(Span, p, new BoolLiteralNode(Span, false));
+
+        var result = Simplify(expr);
+
+        var notExpr = Assert.IsType<UnaryOperationNode>(result);
+        Assert.Equal(UnaryOperator.Not, notExpr.Operator);
+        var refNode = Assert.IsType<ReferenceNode>(notExpr.Operand);
+        Assert.Equal("p", refNode.Name);
+    }
+
+    #endregion
+
+    #region Quantifier Simplification Tests
+
+    [Fact]
+    public void Forall_TrueBody()
+    {
+        // (forall (...) true) → true
+        var boundVar = new QuantifierVariableNode(Span, "i", "i32");
+        var expr = new ForallExpressionNode(Span, new[] { boundVar },
+            new BoolLiteralNode(Span, true));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    [Fact]
+    public void Forall_FalseBody()
+    {
+        // (forall (...) false) → false
+        var boundVar = new QuantifierVariableNode(Span, "i", "i32");
+        var expr = new ForallExpressionNode(Span, new[] { boundVar },
+            new BoolLiteralNode(Span, false));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.False(lit.Value);
+    }
+
+    [Fact]
+    public void Exists_TrueBody()
+    {
+        // (exists (...) true) → true
+        var boundVar = new QuantifierVariableNode(Span, "i", "i32");
+        var expr = new ExistsExpressionNode(Span, new[] { boundVar },
+            new BoolLiteralNode(Span, true));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    [Fact]
+    public void Exists_FalseBody()
+    {
+        // (exists (...) false) → false
+        var boundVar = new QuantifierVariableNode(Span, "i", "i32");
+        var expr = new ExistsExpressionNode(Span, new[] { boundVar },
+            new BoolLiteralNode(Span, false));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.False(lit.Value);
+    }
+
+    #endregion
+
+    #region Fixed-Point Iteration Tests
+
+    [Fact]
+    public void FixedPoint_NestedSimplification()
+    {
+        // (&& true (&& true x)) → x (2 iterations)
+        var x = new ReferenceNode(Span, "x");
+        var inner = new BinaryOperationNode(Span, BinaryOperator.And,
+            new BoolLiteralNode(Span, true), x);
+        var outer = new BinaryOperationNode(Span, BinaryOperator.And,
+            new BoolLiteralNode(Span, true), inner);
+
+        var result = Simplify(outer);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void FixedPoint_TripleNegation()
+    {
+        // (! (! (! x))) → (! x)
+        var x = new ReferenceNode(Span, "x");
+        var notX = new UnaryOperationNode(Span, UnaryOperator.Not, x);
+        var notNotX = new UnaryOperationNode(Span, UnaryOperator.Not, notX);
+        var notNotNotX = new UnaryOperationNode(Span, UnaryOperator.Not, notNotX);
+
+        var result = Simplify(notNotNotX);
+
+        var unary = Assert.IsType<UnaryOperationNode>(result);
+        Assert.Equal(UnaryOperator.Not, unary.Operator);
+        var refNode = Assert.IsType<ReferenceNode>(unary.Operand);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void FixedPoint_NestedConstantFolding()
+    {
+        // (+ (+ 1 2) (+ 3 4)) → 10
+        var add12 = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2));
+        var add34 = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 3), new IntLiteralNode(Span, 4));
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Add, add12, add34);
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(10, lit.Value);
+    }
+
+    #endregion
+
+    #region Conditional Expression Tests
+
+    [Fact]
+    public void Conditional_TrueCondition()
+    {
+        // (? true t f) → t
+        var t = new ReferenceNode(Span, "t");
+        var f = new ReferenceNode(Span, "f");
+        var expr = new ConditionalExpressionNode(Span,
+            new BoolLiteralNode(Span, true), t, f);
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("t", refNode.Name);
+    }
+
+    [Fact]
+    public void Conditional_FalseCondition()
+    {
+        // (? false t f) → f
+        var t = new ReferenceNode(Span, "t");
+        var f = new ReferenceNode(Span, "f");
+        var expr = new ConditionalExpressionNode(Span,
+            new BoolLiteralNode(Span, false), t, f);
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("f", refNode.Name);
+    }
+
+    [Fact]
+    public void Conditional_SameBranches()
+    {
+        // (? c x x) → x
+        var c = new ReferenceNode(Span, "c");
+        var x1 = new ReferenceNode(Span, "x");
+        var x2 = new ReferenceNode(Span, "x");
+        var expr = new ConditionalExpressionNode(Span, c, x1, x2);
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    #endregion
+
+    #region Diagnostic Tests
+
+    [Fact]
+    public void Diagnostics_TautologyReported()
+    {
+        var diagnostics = new DiagnosticBag();
+        var simplifier = new ExpressionSimplifier(diagnostics);
+
+        // (-> p p) → true (tautology)
+        var p = new ReferenceNode(Span, "p");
+        var expr = new ImplicationExpressionNode(Span, p, p);
+
+        _ = simplifier.Simplify(expr);
+
+        var infos = diagnostics.Where(d => d.Code == DiagnosticCode.ContractTautology).ToList();
+        Assert.Single(infos);
+    }
+
+    [Fact]
+    public void Diagnostics_ContradictionReported()
+    {
+        var diagnostics = new DiagnosticBag();
+        var simplifier = new ExpressionSimplifier(diagnostics);
+
+        // (&& x (! x)) → false (contradiction)
+        var x = new ReferenceNode(Span, "x");
+        var notX = new UnaryOperationNode(Span, UnaryOperator.Not, x);
+        var expr = new BinaryOperationNode(Span, BinaryOperator.And, x, notX);
+
+        _ = simplifier.Simplify(expr);
+
+        var warnings = diagnostics.Where(d => d.Code == DiagnosticCode.ContractContradiction).ToList();
+        Assert.Single(warnings);
+    }
+
+    [Fact]
+    public void Diagnostics_SimplificationReported()
+    {
+        var diagnostics = new DiagnosticBag();
+        var simplifier = new ExpressionSimplifier(diagnostics);
+
+        // (+ 1 2) → 3 (simplification)
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2));
+
+        _ = simplifier.Simplify(expr);
+
+        var infos = diagnostics.Where(d => d.Code == DiagnosticCode.ContractSimplified).ToList();
+        Assert.Single(infos);
+    }
+
+    #endregion
+
+    #region Integration Tests
+
+    [Fact]
+    public void Integration_ParseAndSimplify()
+    {
+        var source = @"
+§M{m001:Test}
+§F{f001:TestFunc:pub}
+  §I{i32:x}
+  §O{bool}
+  §Q (&& true (>= x INT:0))
+  §R true
+§/F{f001}
+§/M{m001}
+";
+
+        var module = Parse(source, out var diagnostics);
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+
+        var simplificationPass = new ContractSimplificationPass(diagnostics);
+        var simplified = simplificationPass.Simplify(module);
+
+        var func = simplified.Functions[0];
+        Assert.Single(func.Preconditions);
+
+        // The precondition (&& true (>= x 0)) should simplify to (>= x 0)
+        var condition = func.Preconditions[0].Condition;
+        Assert.IsType<BinaryOperationNode>(condition);
+        var binOp = (BinaryOperationNode)condition;
+        Assert.Equal(BinaryOperator.GreaterOrEqual, binOp.Operator);
+    }
+
+    [Fact]
+    public void Integration_SimplifyTautology()
+    {
+        var source = @"
+§M{m001:Test}
+§F{f001:TestFunc:pub}
+  §I{i32:x}
+  §O{bool}
+  §Q (-> (>= x INT:0) (>= x INT:0))
+  §R true
+§/F{f001}
+§/M{m001}
+";
+
+        var module = Parse(source, out var diagnostics);
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+
+        var simplificationPass = new ContractSimplificationPass(diagnostics);
+        var simplified = simplificationPass.Simplify(module);
+
+        var func = simplified.Functions[0];
+        Assert.Single(func.Preconditions);
+
+        // The precondition (-> p p) should simplify to true
+        var condition = func.Preconditions[0].Condition;
+        var lit = Assert.IsType<BoolLiteralNode>(condition);
+        Assert.True(lit.Value);
+    }
+
+    [Fact]
+    public void Integration_NoSimplificationNeeded()
+    {
+        var source = @"
+§M{m001:Test}
+§F{f001:TestFunc:pub}
+  §I{i32:x}
+  §O{bool}
+  §Q (>= x INT:0)
+  §R true
+§/F{f001}
+§/M{m001}
+";
+
+        var module = Parse(source, out var diagnostics);
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+
+        var simplificationPass = new ContractSimplificationPass(diagnostics);
+        var simplified = simplificationPass.Simplify(module);
+
+        // When no simplification is needed, should return the same module instance
+        Assert.Same(module, simplified);
+    }
+
+    [Fact]
+    public void Integration_QuantifierBodySimplification()
+    {
+        var source = @"
+§M{m001:Test}
+§F{f001:TestFunc:pub}
+  §I{i32:n}
+  §O{bool}
+  §Q (forall ((i i32)) true)
+  §R true
+§/F{f001}
+§/M{m001}
+";
+
+        var module = Parse(source, out var diagnostics);
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+
+        var simplificationPass = new ContractSimplificationPass(diagnostics);
+        var simplified = simplificationPass.Simplify(module);
+
+        var func = simplified.Functions[0];
+        Assert.Single(func.Preconditions);
+
+        // (forall (...) true) should simplify to true
+        var condition = func.Preconditions[0].Condition;
+        var lit = Assert.IsType<BoolLiteralNode>(condition);
+        Assert.True(lit.Value);
+    }
+
+    #endregion
+
+    #region Float Constant Folding Tests
+
+    [Fact]
+    public void FloatConstantFolding_Addition()
+    {
+        // (+ 1.5 2.5) → 4.0
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new FloatLiteralNode(Span, 1.5),
+            new FloatLiteralNode(Span, 2.5));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<FloatLiteralNode>(result);
+        Assert.Equal(4.0, lit.Value, precision: 10);
+    }
+
+    [Fact]
+    public void FloatConstantFolding_Subtraction()
+    {
+        // (- 5.5 2.5) → 3.0
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Subtract,
+            new FloatLiteralNode(Span, 5.5),
+            new FloatLiteralNode(Span, 2.5));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<FloatLiteralNode>(result);
+        Assert.Equal(3.0, lit.Value, precision: 10);
+    }
+
+    [Fact]
+    public void FloatConstantFolding_Multiplication()
+    {
+        // (* 2.5 4.0) → 10.0
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Multiply,
+            new FloatLiteralNode(Span, 2.5),
+            new FloatLiteralNode(Span, 4.0));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<FloatLiteralNode>(result);
+        Assert.Equal(10.0, lit.Value, precision: 10);
+    }
+
+    [Fact]
+    public void FloatConstantFolding_Division()
+    {
+        // (/ 10.0 4.0) → 2.5
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Divide,
+            new FloatLiteralNode(Span, 10.0),
+            new FloatLiteralNode(Span, 4.0));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<FloatLiteralNode>(result);
+        Assert.Equal(2.5, lit.Value, precision: 10);
+    }
+
+    [Fact]
+    public void FloatConstantFolding_LessThan()
+    {
+        // (< 1.5 2.5) → true
+        var expr = new BinaryOperationNode(Span, BinaryOperator.LessThan,
+            new FloatLiteralNode(Span, 1.5),
+            new FloatLiteralNode(Span, 2.5));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    [Fact]
+    public void FloatConstantFolding_Negation()
+    {
+        // (- 3.5) → -3.5
+        var expr = new UnaryOperationNode(Span, UnaryOperator.Negate,
+            new FloatLiteralNode(Span, 3.5));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<FloatLiteralNode>(result);
+        Assert.Equal(-3.5, lit.Value, precision: 10);
+    }
+
+    #endregion
+
+    #region Mixed Int/Float Constant Folding Tests
+
+    [Fact]
+    public void MixedConstantFolding_IntPlusFloat()
+    {
+        // (+ 1 2.5) → 3.5
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 1),
+            new FloatLiteralNode(Span, 2.5));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<FloatLiteralNode>(result);
+        Assert.Equal(3.5, lit.Value, precision: 10);
+    }
+
+    [Fact]
+    public void MixedConstantFolding_FloatPlusInt()
+    {
+        // (+ 2.5 1) → 3.5
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new FloatLiteralNode(Span, 2.5),
+            new IntLiteralNode(Span, 1));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<FloatLiteralNode>(result);
+        Assert.Equal(3.5, lit.Value, precision: 10);
+    }
+
+    [Fact]
+    public void MixedConstantFolding_IntTimesFloat()
+    {
+        // (* 2 3.5) → 7.0
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Multiply,
+            new IntLiteralNode(Span, 2),
+            new FloatLiteralNode(Span, 3.5));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<FloatLiteralNode>(result);
+        Assert.Equal(7.0, lit.Value, precision: 10);
+    }
+
+    #endregion
+
+    #region Algebraic Identity Tests
+
+    [Fact]
+    public void AlgebraicIdentity_AddZeroRight()
+    {
+        // (+ x 0) → x
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Add,
+            x, new IntLiteralNode(Span, 0));
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void AlgebraicIdentity_AddZeroLeft()
+    {
+        // (+ 0 x) → x
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 0), x);
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void AlgebraicIdentity_SubtractZero()
+    {
+        // (- x 0) → x
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Subtract,
+            x, new IntLiteralNode(Span, 0));
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void AlgebraicIdentity_SubtractSelf()
+    {
+        // (- x x) → 0
+        var x1 = new ReferenceNode(Span, "x");
+        var x2 = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Subtract, x1, x2);
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(0, lit.Value);
+    }
+
+    [Fact]
+    public void AlgebraicIdentity_MultiplyOneRight()
+    {
+        // (* x 1) → x
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Multiply,
+            x, new IntLiteralNode(Span, 1));
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void AlgebraicIdentity_MultiplyOneLeft()
+    {
+        // (* 1 x) → x
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Multiply,
+            new IntLiteralNode(Span, 1), x);
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void AlgebraicIdentity_MultiplyZeroRight()
+    {
+        // (* x 0) → 0
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Multiply,
+            x, new IntLiteralNode(Span, 0));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(0, lit.Value);
+    }
+
+    [Fact]
+    public void AlgebraicIdentity_MultiplyZeroLeft()
+    {
+        // (* 0 x) → 0
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Multiply,
+            new IntLiteralNode(Span, 0), x);
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(0, lit.Value);
+    }
+
+    [Fact]
+    public void AlgebraicIdentity_DivideByOne()
+    {
+        // (/ x 1) → x
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Divide,
+            x, new IntLiteralNode(Span, 1));
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void AlgebraicIdentity_ModuloByOne()
+    {
+        // (% x 1) → 0 (for integer x)
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Modulo,
+            x, new IntLiteralNode(Span, 1));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(0, lit.Value);
+    }
+
+    [Fact]
+    public void AlgebraicIdentity_DivideSameConstants()
+    {
+        // (/ 5 5) → 1
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Divide,
+            new IntLiteralNode(Span, 5),
+            new IntLiteralNode(Span, 5));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(1, lit.Value);
+    }
+
+    [Fact]
+    public void AlgebraicIdentity_AddZeroFloat()
+    {
+        // (+ x 0.0) → x
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Add,
+            x, new FloatLiteralNode(Span, 0.0));
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void AlgebraicIdentity_MultiplyOneFloat()
+    {
+        // (* x 1.0) → x
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Multiply,
+            x, new FloatLiteralNode(Span, 1.0));
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    #endregion
+
+    #region De Morgan's Law Tests
+
+    [Fact]
+    public void DeMorgan_NotAnd()
+    {
+        // (! (&& a b)) → (|| (! a) (! b))
+        var a = new ReferenceNode(Span, "a");
+        var b = new ReferenceNode(Span, "b");
+        var andExpr = new BinaryOperationNode(Span, BinaryOperator.And, a, b);
+        var expr = new UnaryOperationNode(Span, UnaryOperator.Not, andExpr);
+
+        var result = Simplify(expr);
+
+        var orExpr = Assert.IsType<BinaryOperationNode>(result);
+        Assert.Equal(BinaryOperator.Or, orExpr.Operator);
+
+        var notA = Assert.IsType<UnaryOperationNode>(orExpr.Left);
+        Assert.Equal(UnaryOperator.Not, notA.Operator);
+        var refA = Assert.IsType<ReferenceNode>(notA.Operand);
+        Assert.Equal("a", refA.Name);
+
+        var notB = Assert.IsType<UnaryOperationNode>(orExpr.Right);
+        Assert.Equal(UnaryOperator.Not, notB.Operator);
+        var refB = Assert.IsType<ReferenceNode>(notB.Operand);
+        Assert.Equal("b", refB.Name);
+    }
+
+    [Fact]
+    public void DeMorgan_NotOr()
+    {
+        // (! (|| a b)) → (&& (! a) (! b))
+        var a = new ReferenceNode(Span, "a");
+        var b = new ReferenceNode(Span, "b");
+        var orExpr = new BinaryOperationNode(Span, BinaryOperator.Or, a, b);
+        var expr = new UnaryOperationNode(Span, UnaryOperator.Not, orExpr);
+
+        var result = Simplify(expr);
+
+        var andExpr = Assert.IsType<BinaryOperationNode>(result);
+        Assert.Equal(BinaryOperator.And, andExpr.Operator);
+
+        var notA = Assert.IsType<UnaryOperationNode>(andExpr.Left);
+        Assert.Equal(UnaryOperator.Not, notA.Operator);
+        var refA = Assert.IsType<ReferenceNode>(notA.Operand);
+        Assert.Equal("a", refA.Name);
+
+        var notB = Assert.IsType<UnaryOperationNode>(andExpr.Right);
+        Assert.Equal(UnaryOperator.Not, notB.Operator);
+        var refB = Assert.IsType<ReferenceNode>(notB.Operand);
+        Assert.Equal("b", refB.Name);
+    }
+
+    [Fact]
+    public void DeMorgan_WithConstant_SimplifiesToTruth()
+    {
+        // (! (&& true false)) → (|| false true) → true
+        var andExpr = new BinaryOperationNode(Span, BinaryOperator.And,
+            new BoolLiteralNode(Span, true),
+            new BoolLiteralNode(Span, false));
+        var expr = new UnaryOperationNode(Span, UnaryOperator.Not, andExpr);
+
+        var result = Simplify(expr);
+
+        // After De Morgan and simplification: (|| (! true) (! false)) → (|| false true) → true
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    #endregion
+
+    #region Bitwise Operation Tests
+
+    [Fact]
+    public void Bitwise_NotConstant()
+    {
+        // (~ 5) → -6 (in two's complement)
+        var expr = new UnaryOperationNode(Span, UnaryOperator.BitwiseNot,
+            new IntLiteralNode(Span, 5));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(~5, lit.Value);
+    }
+
+    [Fact]
+    public void Bitwise_DoubleNot()
+    {
+        // (~ (~ x)) → x
+        var x = new ReferenceNode(Span, "x");
+        var inner = new UnaryOperationNode(Span, UnaryOperator.BitwiseNot, x);
+        var expr = new UnaryOperationNode(Span, UnaryOperator.BitwiseNot, inner);
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void Bitwise_AndConstants()
+    {
+        // (& 0b1010 0b1100) → 0b1000 (8)
+        var expr = new BinaryOperationNode(Span, BinaryOperator.BitwiseAnd,
+            new IntLiteralNode(Span, 0b1010),
+            new IntLiteralNode(Span, 0b1100));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(0b1000, lit.Value);
+    }
+
+    [Fact]
+    public void Bitwise_OrConstants()
+    {
+        // (| 0b1010 0b1100) → 0b1110 (14)
+        var expr = new BinaryOperationNode(Span, BinaryOperator.BitwiseOr,
+            new IntLiteralNode(Span, 0b1010),
+            new IntLiteralNode(Span, 0b1100));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(0b1110, lit.Value);
+    }
+
+    [Fact]
+    public void Bitwise_XorConstants()
+    {
+        // (^ 0b1010 0b1100) → 0b0110 (6)
+        var expr = new BinaryOperationNode(Span, BinaryOperator.BitwiseXor,
+            new IntLiteralNode(Span, 0b1010),
+            new IntLiteralNode(Span, 0b1100));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(0b0110, lit.Value);
+    }
+
+    [Fact]
+    public void Bitwise_LeftShift()
+    {
+        // (<< 1 4) → 16
+        var expr = new BinaryOperationNode(Span, BinaryOperator.LeftShift,
+            new IntLiteralNode(Span, 1),
+            new IntLiteralNode(Span, 4));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(16, lit.Value);
+    }
+
+    [Fact]
+    public void Bitwise_RightShift()
+    {
+        // (>> 16 2) → 4
+        var expr = new BinaryOperationNode(Span, BinaryOperator.RightShift,
+            new IntLiteralNode(Span, 16),
+            new IntLiteralNode(Span, 2));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(4, lit.Value);
+    }
+
+    [Fact]
+    public void ArithmeticDoubleNegation()
+    {
+        // (- (- x)) → x
+        var x = new ReferenceNode(Span, "x");
+        var inner = new UnaryOperationNode(Span, UnaryOperator.Negate, x);
+        var expr = new UnaryOperationNode(Span, UnaryOperator.Negate, inner);
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    #endregion
+
+    #region Commutativity Tests
+
+    [Fact]
+    public void Commutativity_AndSameOperandsSwapped()
+    {
+        // (&& a b) structurally equal to (&& b a) for redundancy detection
+        var a1 = new ReferenceNode(Span, "a");
+        var b1 = new ReferenceNode(Span, "b");
+        var a2 = new ReferenceNode(Span, "a");
+        var b2 = new ReferenceNode(Span, "b");
+
+        var expr1 = new BinaryOperationNode(Span, BinaryOperator.And, a1, b1);
+        var expr2 = new BinaryOperationNode(Span, BinaryOperator.And, b2, a2);
+
+        // (&& (&& a b) (&& b a)) should simplify to (&& a b) because they're commutatively equal
+        var combined = new BinaryOperationNode(Span, BinaryOperator.And, expr1, expr2);
+
+        var result = Simplify(combined);
+
+        // Should simplify to just (&& a b)
+        var andResult = Assert.IsType<BinaryOperationNode>(result);
+        Assert.Equal(BinaryOperator.And, andResult.Operator);
+    }
+
+    [Fact]
+    public void Commutativity_AdditionRecognized()
+    {
+        // (+ a b) and (+ b a) should be recognized as structurally equivalent
+        var a1 = new ReferenceNode(Span, "a");
+        var b1 = new ReferenceNode(Span, "b");
+        var a2 = new ReferenceNode(Span, "a");
+        var b2 = new ReferenceNode(Span, "b");
+
+        var expr1 = new BinaryOperationNode(Span, BinaryOperator.Add, a1, b1);
+        var expr2 = new BinaryOperationNode(Span, BinaryOperator.Add, b2, a2);
+
+        // (- (+ a b) (+ b a)) should simplify to 0
+        var sub = new BinaryOperationNode(Span, BinaryOperator.Subtract, expr1, expr2);
+
+        var result = Simplify(sub);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(0, lit.Value);
+    }
+
+    [Fact]
+    public void Commutativity_EqualityRecognized()
+    {
+        // (== a b) and (== b a) should be recognized as structurally equivalent
+        var a1 = new ReferenceNode(Span, "a");
+        var b1 = new ReferenceNode(Span, "b");
+        var a2 = new ReferenceNode(Span, "a");
+        var b2 = new ReferenceNode(Span, "b");
+
+        var expr1 = new BinaryOperationNode(Span, BinaryOperator.Equal, a1, b1);
+        var expr2 = new BinaryOperationNode(Span, BinaryOperator.Equal, b2, a2);
+
+        // (&& (== a b) (== b a)) should simplify to (== a b)
+        var combined = new BinaryOperationNode(Span, BinaryOperator.And, expr1, expr2);
+
+        var result = Simplify(combined);
+
+        var eqResult = Assert.IsType<BinaryOperationNode>(result);
+        Assert.Equal(BinaryOperator.Equal, eqResult.Operator);
+    }
+
+    #endregion
+
+    #region Edge Case Tests
+
+    [Fact]
+    public void EdgeCase_DivisionByZeroNotFolded()
+    {
+        // (/ 10 0) should NOT be folded (division by zero)
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Divide,
+            new IntLiteralNode(Span, 10),
+            new IntLiteralNode(Span, 0));
+
+        var result = Simplify(expr);
+
+        // Should remain as-is, not folded
+        var binOp = Assert.IsType<BinaryOperationNode>(result);
+        Assert.Equal(BinaryOperator.Divide, binOp.Operator);
+    }
+
+    [Fact]
+    public void EdgeCase_ModuloByZeroNotFolded()
+    {
+        // (% 10 0) should NOT be folded
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Modulo,
+            new IntLiteralNode(Span, 10),
+            new IntLiteralNode(Span, 0));
+
+        var result = Simplify(expr);
+
+        // Should remain as-is, not folded
+        var binOp = Assert.IsType<BinaryOperationNode>(result);
+        Assert.Equal(BinaryOperator.Modulo, binOp.Operator);
+    }
+
+    [Fact]
+    public void EdgeCase_FloatDivisionByZeroNotFolded()
+    {
+        // (/ 10.0 0.0) should NOT be folded
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Divide,
+            new FloatLiteralNode(Span, 10.0),
+            new FloatLiteralNode(Span, 0.0));
+
+        var result = Simplify(expr);
+
+        // Should remain as-is, not folded
+        var binOp = Assert.IsType<BinaryOperationNode>(result);
+        Assert.Equal(BinaryOperator.Divide, binOp.Operator);
+    }
+
+    [Fact]
+    public void EdgeCase_NegativeZero()
+    {
+        // (+ x -0) should still simplify to x (negative zero equals zero)
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Add,
+            x, new FloatLiteralNode(Span, -0.0));
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void EdgeCase_DeeplyNested()
+    {
+        // (+ (+ (+ 1 2) 3) 4) → 10
+        var add12 = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2));
+        var add123 = new BinaryOperationNode(Span, BinaryOperator.Add,
+            add12, new IntLiteralNode(Span, 3));
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Add,
+            add123, new IntLiteralNode(Span, 4));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(10, lit.Value);
+    }
+
+    [Fact]
+    public void EdgeCase_ConditionalWithTrueFalse()
+    {
+        // (? c true false) → c
+        var c = new ReferenceNode(Span, "c");
+        var expr = new ConditionalExpressionNode(Span, c,
+            new BoolLiteralNode(Span, true),
+            new BoolLiteralNode(Span, false));
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("c", refNode.Name);
+    }
+
+    [Fact]
+    public void EdgeCase_ConditionalWithFalseTrue()
+    {
+        // (? c false true) → (! c)
+        var c = new ReferenceNode(Span, "c");
+        var expr = new ConditionalExpressionNode(Span, c,
+            new BoolLiteralNode(Span, false),
+            new BoolLiteralNode(Span, true));
+
+        var result = Simplify(expr);
+
+        var notExpr = Assert.IsType<UnaryOperationNode>(result);
+        Assert.Equal(UnaryOperator.Not, notExpr.Operator);
+        var refNode = Assert.IsType<ReferenceNode>(notExpr.Operand);
+        Assert.Equal("c", refNode.Name);
+    }
+
+    [Fact]
+    public void EdgeCase_EqualTrueSimplifies()
+    {
+        // (== true x) → x
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Equal,
+            new BoolLiteralNode(Span, true), x);
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void EdgeCase_EqualFalseSimplifiesToNot()
+    {
+        // (== false x) → (! x)
+        var x = new ReferenceNode(Span, "x");
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Equal,
+            new BoolLiteralNode(Span, false), x);
+
+        var result = Simplify(expr);
+
+        var notExpr = Assert.IsType<UnaryOperationNode>(result);
+        Assert.Equal(UnaryOperator.Not, notExpr.Operator);
+        var refNode = Assert.IsType<ReferenceNode>(notExpr.Operand);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void EdgeCase_ImplicationNotPToP()
+    {
+        // (-> (! p) p) → p
+        var p = new ReferenceNode(Span, "p");
+        var notP = new UnaryOperationNode(Span, UnaryOperator.Not, p);
+        var expr = new ImplicationExpressionNode(Span, notP, p);
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("p", refNode.Name);
+    }
+
+    #endregion
+
+    #region Expression Node Visitor Tests (Passthrough with Child Simplification)
+
+    [Fact]
+    public void Visitor_ArrayAccess_SimplifiesChildren()
+    {
+        // array[(+ 1 2)] → array[3]
+        var array = new ReferenceNode(Span, "array");
+        var index = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2));
+        var expr = new ArrayAccessNode(Span, array, index);
+
+        var result = Simplify(expr);
+
+        var access = Assert.IsType<ArrayAccessNode>(result);
+        var indexLit = Assert.IsType<IntLiteralNode>(access.Index);
+        Assert.Equal(3, indexLit.Value);
+    }
+
+    [Fact]
+    public void Visitor_ArrayLength_SimplifiesChild()
+    {
+        // For array length, the array expression itself could be simplified
+        // (though typically it's just a reference)
+        var array = new ReferenceNode(Span, "arr");
+        var expr = new ArrayLengthNode(Span, array);
+
+        var result = Simplify(expr);
+
+        var length = Assert.IsType<ArrayLengthNode>(result);
+        Assert.IsType<ReferenceNode>(length.Array);
+    }
+
+    [Fact]
+    public void Visitor_FieldAccess_SimplifiesTarget()
+    {
+        // target.field where target could be simplified
+        var target = new ReferenceNode(Span, "obj");
+        var expr = new FieldAccessNode(Span, target, "field");
+
+        var result = Simplify(expr);
+
+        var access = Assert.IsType<FieldAccessNode>(result);
+        Assert.Equal("field", access.FieldName);
+    }
+
+    [Fact]
+    public void Visitor_SomeExpression_SimplifiesValue()
+    {
+        // Some((+ 1 2)) → Some(3)
+        var value = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2));
+        var expr = new SomeExpressionNode(Span, value);
+
+        var result = Simplify(expr);
+
+        var some = Assert.IsType<SomeExpressionNode>(result);
+        var lit = Assert.IsType<IntLiteralNode>(some.Value);
+        Assert.Equal(3, lit.Value);
+    }
+
+    [Fact]
+    public void Visitor_NoneExpression_Unchanged()
+    {
+        var expr = new NoneExpressionNode(Span, null);
+
+        var result = Simplify(expr);
+
+        Assert.IsType<NoneExpressionNode>(result);
+    }
+
+    [Fact]
+    public void Visitor_OkExpression_SimplifiesValue()
+    {
+        // Ok((+ 1 2)) → Ok(3)
+        var value = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2));
+        var expr = new OkExpressionNode(Span, value);
+
+        var result = Simplify(expr);
+
+        var ok = Assert.IsType<OkExpressionNode>(result);
+        var lit = Assert.IsType<IntLiteralNode>(ok.Value);
+        Assert.Equal(3, lit.Value);
+    }
+
+    [Fact]
+    public void Visitor_ErrExpression_SimplifiesError()
+    {
+        // Err((+ 1 2)) → Err(3)
+        var error = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2));
+        var expr = new ErrExpressionNode(Span, error);
+
+        var result = Simplify(expr);
+
+        var err = Assert.IsType<ErrExpressionNode>(result);
+        var lit = Assert.IsType<IntLiteralNode>(err.Error);
+        Assert.Equal(3, lit.Value);
+    }
+
+    [Fact]
+    public void Visitor_CallExpression_SimplifiesArguments()
+    {
+        // func((+ 1 2), (+ 3 4)) → func(3, 7)
+        var args = new List<ExpressionNode>
+        {
+            new BinaryOperationNode(Span, BinaryOperator.Add,
+                new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2)),
+            new BinaryOperationNode(Span, BinaryOperator.Add,
+                new IntLiteralNode(Span, 3), new IntLiteralNode(Span, 4))
+        };
+        var expr = new CallExpressionNode(Span, "func", args);
+
+        var result = Simplify(expr);
+
+        var call = Assert.IsType<CallExpressionNode>(result);
+        Assert.Equal("func", call.Target);
+        Assert.Equal(2, call.Arguments.Count);
+        Assert.Equal(3, Assert.IsType<IntLiteralNode>(call.Arguments[0]).Value);
+        Assert.Equal(7, Assert.IsType<IntLiteralNode>(call.Arguments[1]).Value);
+    }
+
+    [Fact]
+    public void Visitor_NewExpression_SimplifiesArguments()
+    {
+        // new MyClass((+ 1 2)) → new MyClass(3)
+        var args = new List<ExpressionNode>
+        {
+            new BinaryOperationNode(Span, BinaryOperator.Add,
+                new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2))
+        };
+        var expr = new NewExpressionNode(Span, "MyClass", Array.Empty<string>(), args);
+
+        var result = Simplify(expr);
+
+        var newExpr = Assert.IsType<NewExpressionNode>(result);
+        Assert.Equal("MyClass", newExpr.TypeName);
+        Assert.Single(newExpr.Arguments);
+        Assert.Equal(3, Assert.IsType<IntLiteralNode>(newExpr.Arguments[0]).Value);
+    }
+
+    [Fact]
+    public void Visitor_ThisExpression_Unchanged()
+    {
+        var expr = new ThisExpressionNode(Span);
+
+        var result = Simplify(expr);
+
+        Assert.IsType<ThisExpressionNode>(result);
+    }
+
+    [Fact]
+    public void Visitor_BaseExpression_Unchanged()
+    {
+        var expr = new BaseExpressionNode(Span);
+
+        var result = Simplify(expr);
+
+        Assert.IsType<BaseExpressionNode>(result);
+    }
+
+    [Fact]
+    public void Visitor_CollectionContains_SimplifiesKeyOrValue()
+    {
+        // coll.Contains((+ 1 2)) → coll.Contains(3)
+        var keyOrValue = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2));
+        var expr = new CollectionContainsNode(Span, "coll", keyOrValue, ContainsMode.Value);
+
+        var result = Simplify(expr);
+
+        var contains = Assert.IsType<CollectionContainsNode>(result);
+        Assert.Equal("coll", contains.CollectionName);
+        Assert.Equal(3, Assert.IsType<IntLiteralNode>(contains.KeyOrValue).Value);
+    }
+
+    [Fact]
+    public void Visitor_CollectionCount_SimplifiesCollection()
+    {
+        var collection = new ReferenceNode(Span, "list");
+        var expr = new CollectionCountNode(Span, collection);
+
+        var result = Simplify(expr);
+
+        var count = Assert.IsType<CollectionCountNode>(result);
+        Assert.IsType<ReferenceNode>(count.Collection);
+    }
+
+    [Fact]
+    public void Visitor_NullCoalesce_SimplifiesBothSides()
+    {
+        // ((+ 1 2) ?? (+ 3 4)) → (3 ?? 7)
+        var left = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2));
+        var right = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 3), new IntLiteralNode(Span, 4));
+        var expr = new NullCoalesceNode(Span, left, right);
+
+        var result = Simplify(expr);
+
+        var coalesce = Assert.IsType<NullCoalesceNode>(result);
+        Assert.Equal(3, Assert.IsType<IntLiteralNode>(coalesce.Left).Value);
+        Assert.Equal(7, Assert.IsType<IntLiteralNode>(coalesce.Right).Value);
+    }
+
+    [Fact]
+    public void Visitor_NullConditional_SimplifiesTarget()
+    {
+        var target = new ReferenceNode(Span, "obj");
+        var expr = new NullConditionalNode(Span, target, "Property");
+
+        var result = Simplify(expr);
+
+        var conditional = Assert.IsType<NullConditionalNode>(result);
+        Assert.Equal("Property", conditional.MemberName);
+    }
+
+    [Fact]
+    public void Visitor_RangeExpression_SimplifiesBounds()
+    {
+        // ((+ 1 2)...(+ 3 4)) → (3...7)
+        var start = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2));
+        var end = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 3), new IntLiteralNode(Span, 4));
+        var expr = new RangeExpressionNode(Span, start, end);
+
+        var result = Simplify(expr);
+
+        var range = Assert.IsType<RangeExpressionNode>(result);
+        Assert.Equal(3, Assert.IsType<IntLiteralNode>(range.Start).Value);
+        Assert.Equal(7, Assert.IsType<IntLiteralNode>(range.End).Value);
+    }
+
+    [Fact]
+    public void Visitor_IndexFromEnd_SimplifiesOffset()
+    {
+        // ^(+ 1 2) → ^3
+        var offset = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2));
+        var expr = new IndexFromEndNode(Span, offset);
+
+        var result = Simplify(expr);
+
+        var index = Assert.IsType<IndexFromEndNode>(result);
+        Assert.Equal(3, Assert.IsType<IntLiteralNode>(index.Offset).Value);
+    }
+
+    [Fact]
+    public void Visitor_AwaitExpression_SimplifiesAwaited()
+    {
+        // await (condition ? task1 : task1) where condition simplifies
+        var awaited = new ReferenceNode(Span, "task");
+        var expr = new AwaitExpressionNode(Span, awaited, null);
+
+        var result = Simplify(expr);
+
+        var awaitExpr = Assert.IsType<AwaitExpressionNode>(result);
+        Assert.IsType<ReferenceNode>(awaitExpr.Awaited);
+    }
+
+    [Fact]
+    public void Visitor_RecordCreation_SimplifiesFieldValues()
+    {
+        // new Record { Field = (+ 1 2) } → new Record { Field = 3 }
+        var fields = new List<FieldAssignmentNode>
+        {
+            new FieldAssignmentNode(Span, "Field",
+                new BinaryOperationNode(Span, BinaryOperator.Add,
+                    new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2)))
+        };
+        var expr = new RecordCreationNode(Span, "MyRecord", fields);
+
+        var result = Simplify(expr);
+
+        var record = Assert.IsType<RecordCreationNode>(result);
+        Assert.Single(record.Fields);
+        Assert.Equal(3, Assert.IsType<IntLiteralNode>(record.Fields[0].Value).Value);
+    }
+
+    [Fact]
+    public void Visitor_InterpolatedString_SimplifiesExpressions()
+    {
+        // $"Value: {(+ 1 2)}" → $"Value: {3}"
+        var parts = new List<InterpolatedStringPartNode>
+        {
+            new InterpolatedStringTextNode(Span, "Value: "),
+            new InterpolatedStringExpressionNode(Span,
+                new BinaryOperationNode(Span, BinaryOperator.Add,
+                    new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2)))
+        };
+        var expr = new InterpolatedStringNode(Span, parts);
+
+        var result = Simplify(expr);
+
+        var interp = Assert.IsType<InterpolatedStringNode>(result);
+        Assert.Equal(2, interp.Parts.Count);
+        var exprPart = Assert.IsType<InterpolatedStringExpressionNode>(interp.Parts[1]);
+        Assert.Equal(3, Assert.IsType<IntLiteralNode>(exprPart.Expression).Value);
+    }
+
+    [Fact]
+    public void Visitor_ArrayCreation_SimplifiesInitializer()
+    {
+        // new int[] { (+ 1 2), (+ 3 4) } → new int[] { 3, 7 }
+        var initializer = new List<ExpressionNode>
+        {
+            new BinaryOperationNode(Span, BinaryOperator.Add,
+                new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2)),
+            new BinaryOperationNode(Span, BinaryOperator.Add,
+                new IntLiteralNode(Span, 3), new IntLiteralNode(Span, 4))
+        };
+        var expr = new ArrayCreationNode(Span, "arr1", "arr", "i32", null, initializer, new AttributeCollection());
+
+        var result = Simplify(expr);
+
+        var array = Assert.IsType<ArrayCreationNode>(result);
+        Assert.Equal(2, array.Initializer.Count);
+        Assert.Equal(3, Assert.IsType<IntLiteralNode>(array.Initializer[0]).Value);
+        Assert.Equal(7, Assert.IsType<IntLiteralNode>(array.Initializer[1]).Value);
+    }
+
+    [Fact]
+    public void Visitor_ListCreation_SimplifiesElements()
+    {
+        // List { (+ 1 2), (+ 3 4) } → List { 3, 7 }
+        var elements = new List<ExpressionNode>
+        {
+            new BinaryOperationNode(Span, BinaryOperator.Add,
+                new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2)),
+            new BinaryOperationNode(Span, BinaryOperator.Add,
+                new IntLiteralNode(Span, 3), new IntLiteralNode(Span, 4))
+        };
+        var expr = new ListCreationNode(Span, "list1", "list", "i32", elements, new AttributeCollection());
+
+        var result = Simplify(expr);
+
+        var list = Assert.IsType<ListCreationNode>(result);
+        Assert.Equal(2, list.Elements.Count);
+        Assert.Equal(3, Assert.IsType<IntLiteralNode>(list.Elements[0]).Value);
+        Assert.Equal(7, Assert.IsType<IntLiteralNode>(list.Elements[1]).Value);
+    }
+
+    [Fact]
+    public void Visitor_DictionaryCreation_SimplifiesEntries()
+    {
+        // Dict { (+ 1 2): (+ 3 4) } → Dict { 3: 7 }
+        var entries = new List<KeyValuePairNode>
+        {
+            new KeyValuePairNode(Span,
+                new BinaryOperationNode(Span, BinaryOperator.Add,
+                    new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2)),
+                new BinaryOperationNode(Span, BinaryOperator.Add,
+                    new IntLiteralNode(Span, 3), new IntLiteralNode(Span, 4)))
+        };
+        var expr = new DictionaryCreationNode(Span, "dict1", "dict", "i32", "i32", entries, new AttributeCollection());
+
+        var result = Simplify(expr);
+
+        var dict = Assert.IsType<DictionaryCreationNode>(result);
+        Assert.Single(dict.Entries);
+        Assert.Equal(3, Assert.IsType<IntLiteralNode>(dict.Entries[0].Key).Value);
+        Assert.Equal(7, Assert.IsType<IntLiteralNode>(dict.Entries[0].Value).Value);
+    }
+
+    [Fact]
+    public void Visitor_SetCreation_SimplifiesElements()
+    {
+        // Set { (+ 1 2), (+ 3 4) } → Set { 3, 7 }
+        var elements = new List<ExpressionNode>
+        {
+            new BinaryOperationNode(Span, BinaryOperator.Add,
+                new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2)),
+            new BinaryOperationNode(Span, BinaryOperator.Add,
+                new IntLiteralNode(Span, 3), new IntLiteralNode(Span, 4))
+        };
+        var expr = new SetCreationNode(Span, "set1", "set", "i32", elements, new AttributeCollection());
+
+        var result = Simplify(expr);
+
+        var set = Assert.IsType<SetCreationNode>(result);
+        Assert.Equal(2, set.Elements.Count);
+        Assert.Equal(3, Assert.IsType<IntLiteralNode>(set.Elements[0]).Value);
+        Assert.Equal(7, Assert.IsType<IntLiteralNode>(set.Elements[1]).Value);
+    }
+
+    [Fact]
+    public void Visitor_WithExpression_SimplifiesAssignments()
+    {
+        // record with { Field = (+ 1 2) } → record with { Field = 3 }
+        var target = new ReferenceNode(Span, "record");
+        var assignments = new List<WithPropertyAssignmentNode>
+        {
+            new WithPropertyAssignmentNode(Span, "Field",
+                new BinaryOperationNode(Span, BinaryOperator.Add,
+                    new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2)))
+        };
+        var expr = new WithExpressionNode(Span, target, assignments);
+
+        var result = Simplify(expr);
+
+        var withExpr = Assert.IsType<WithExpressionNode>(result);
+        Assert.Single(withExpr.Assignments);
+        Assert.Equal(3, Assert.IsType<IntLiteralNode>(withExpr.Assignments[0].Value).Value);
+    }
+
+    [Fact]
+    public void Visitor_LambdaExpression_SimplifiesBody()
+    {
+        // (x) => (+ 1 2) → (x) => 3
+        var param = new LambdaParameterNode(Span, "x", "i32");
+        var body = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2));
+        var expr = new LambdaExpressionNode(Span, "lam1", new[] { param }, null, false, body, null, new AttributeCollection());
+
+        var result = Simplify(expr);
+
+        var lambda = Assert.IsType<LambdaExpressionNode>(result);
+        Assert.NotNull(lambda.ExpressionBody);
+        Assert.Equal(3, Assert.IsType<IntLiteralNode>(lambda.ExpressionBody).Value);
+    }
+
+    #endregion
+
+    #region Pathological Input Tests (Fuzz-like)
+
+    [Fact]
+    public void Pathological_VeryDeepNesting_DoesNotStackOverflow()
+    {
+        // Create a very deeply nested expression: (+ (+ (+ ... (+ 1 1) ...) 1) 1)
+        ExpressionNode expr = new IntLiteralNode(Span, 1);
+        const int depth = 100;
+
+        for (int i = 0; i < depth; i++)
+        {
+            expr = new BinaryOperationNode(Span, BinaryOperator.Add,
+                expr, new IntLiteralNode(Span, 1));
+        }
+
+        var result = Simplify(expr);
+
+        // Should fold to 101
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(depth + 1, lit.Value);
+    }
+
+    [Fact]
+    public void Pathological_ManyIterations_ConvergesToFixedPoint()
+    {
+        // Create expression that requires many simplification iterations
+        // (&& true (&& true (&& true (&& true x))))
+        var x = new ReferenceNode(Span, "x");
+        ExpressionNode expr = x;
+
+        for (int i = 0; i < 20; i++)
+        {
+            expr = new BinaryOperationNode(Span, BinaryOperator.And,
+                new BoolLiteralNode(Span, true), expr);
+        }
+
+        var result = Simplify(expr);
+
+        // Should simplify to just x
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void Pathological_AlternatingNegations()
+    {
+        // (! (! (! (! (! (! x)))))) with 50 negations → x (even) or (! x) (odd)
+        var x = new ReferenceNode(Span, "x");
+        ExpressionNode expr = x;
+        const int negations = 50;
+
+        for (int i = 0; i < negations; i++)
+        {
+            expr = new UnaryOperationNode(Span, UnaryOperator.Not, expr);
+        }
+
+        var result = Simplify(expr);
+
+        // 50 negations (even) → x
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void Pathological_AlternatingNegations_Odd()
+    {
+        // 51 negations (odd) → (! x)
+        var x = new ReferenceNode(Span, "x");
+        ExpressionNode expr = x;
+        const int negations = 51;
+
+        for (int i = 0; i < negations; i++)
+        {
+            expr = new UnaryOperationNode(Span, UnaryOperator.Not, expr);
+        }
+
+        var result = Simplify(expr);
+
+        var notExpr = Assert.IsType<UnaryOperationNode>(result);
+        Assert.Equal(UnaryOperator.Not, notExpr.Operator);
+        var refNode = Assert.IsType<ReferenceNode>(notExpr.Operand);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void Pathological_ComplexCombination()
+    {
+        // (&& (|| true false) (-> (! false) (== (+ 1 2) 3)))
+        // Should simplify to true
+        var orExpr = new BinaryOperationNode(Span, BinaryOperator.Or,
+            new BoolLiteralNode(Span, true),
+            new BoolLiteralNode(Span, false));
+
+        var notFalse = new UnaryOperationNode(Span, UnaryOperator.Not,
+            new BoolLiteralNode(Span, false));
+
+        var add12 = new BinaryOperationNode(Span, BinaryOperator.Add,
+            new IntLiteralNode(Span, 1), new IntLiteralNode(Span, 2));
+
+        var eq = new BinaryOperationNode(Span, BinaryOperator.Equal,
+            add12, new IntLiteralNode(Span, 3));
+
+        var impl = new ImplicationExpressionNode(Span, notFalse, eq);
+
+        var expr = new BinaryOperationNode(Span, BinaryOperator.And, orExpr, impl);
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    [Fact]
+    public void Pathological_DeeplyNestedConditionals()
+    {
+        // (? true (? true (? true x y) y) y) → x
+        var x = new ReferenceNode(Span, "x");
+        var y = new ReferenceNode(Span, "y");
+
+        ExpressionNode expr = x;
+        for (int i = 0; i < 10; i++)
+        {
+            expr = new ConditionalExpressionNode(Span,
+                new BoolLiteralNode(Span, true), expr, y);
+        }
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void Pathological_ChainedImplications()
+    {
+        // (-> true (-> true (-> true x))) → x
+        var x = new ReferenceNode(Span, "x");
+        ExpressionNode expr = x;
+
+        for (int i = 0; i < 10; i++)
+        {
+            expr = new ImplicationExpressionNode(Span,
+                new BoolLiteralNode(Span, true), expr);
+        }
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void Pathological_MixedArithmeticIdentities()
+    {
+        // (+ (* x 1) (- y 0)) → (+ x y)
+        var x = new ReferenceNode(Span, "x");
+        var y = new ReferenceNode(Span, "y");
+
+        var xTimes1 = new BinaryOperationNode(Span, BinaryOperator.Multiply,
+            x, new IntLiteralNode(Span, 1));
+        var yMinus0 = new BinaryOperationNode(Span, BinaryOperator.Subtract,
+            y, new IntLiteralNode(Span, 0));
+
+        var expr = new BinaryOperationNode(Span, BinaryOperator.Add, xTimes1, yMinus0);
+
+        var result = Simplify(expr);
+
+        var add = Assert.IsType<BinaryOperationNode>(result);
+        Assert.Equal(BinaryOperator.Add, add.Operator);
+        Assert.Equal("x", Assert.IsType<ReferenceNode>(add.Left).Name);
+        Assert.Equal("y", Assert.IsType<ReferenceNode>(add.Right).Name);
+    }
+
+    [Fact]
+    public void Pathological_RedundantTautologyChain()
+    {
+        // (&& (|| a (! a)) (&& (|| b (! b)) (&& (|| c (! c)) x)))
+        // Should simplify to x (all tautologies become true)
+        var a = new ReferenceNode(Span, "a");
+        var b = new ReferenceNode(Span, "b");
+        var c = new ReferenceNode(Span, "c");
+        var x = new ReferenceNode(Span, "x");
+
+        var tautA = new BinaryOperationNode(Span, BinaryOperator.Or,
+            a, new UnaryOperationNode(Span, UnaryOperator.Not, new ReferenceNode(Span, "a")));
+        var tautB = new BinaryOperationNode(Span, BinaryOperator.Or,
+            b, new UnaryOperationNode(Span, UnaryOperator.Not, new ReferenceNode(Span, "b")));
+        var tautC = new BinaryOperationNode(Span, BinaryOperator.Or,
+            c, new UnaryOperationNode(Span, UnaryOperator.Not, new ReferenceNode(Span, "c")));
+
+        var inner = new BinaryOperationNode(Span, BinaryOperator.And, tautC, x);
+        var middle = new BinaryOperationNode(Span, BinaryOperator.And, tautB, inner);
+        var expr = new BinaryOperationNode(Span, BinaryOperator.And, tautA, middle);
+
+        var result = Simplify(expr);
+
+        var refNode = Assert.IsType<ReferenceNode>(result);
+        Assert.Equal("x", refNode.Name);
+    }
+
+    [Fact]
+    public void Pathological_LargeConstantFolding()
+    {
+        // Sum of 1 to 100 via constant folding
+        ExpressionNode expr = new IntLiteralNode(Span, 0);
+        for (int i = 1; i <= 100; i++)
+        {
+            expr = new BinaryOperationNode(Span, BinaryOperator.Add,
+                expr, new IntLiteralNode(Span, i));
+        }
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<IntLiteralNode>(result);
+        Assert.Equal(5050, lit.Value); // Sum of 1 to 100
+    }
+
+    [Fact]
+    public void Pathological_DeMorganChain()
+    {
+        // (! (&& (! (|| a b)) (! (|| c d))))
+        // → (! (&& (&& (! a) (! b)) (&& (! c) (! d))))  [De Morgan on inner]
+        // This tests that De Morgan doesn't cause infinite expansion
+        var a = new ReferenceNode(Span, "a");
+        var b = new ReferenceNode(Span, "b");
+        var c = new ReferenceNode(Span, "c");
+        var d = new ReferenceNode(Span, "d");
+
+        var orAB = new BinaryOperationNode(Span, BinaryOperator.Or, a, b);
+        var orCD = new BinaryOperationNode(Span, BinaryOperator.Or, c, d);
+
+        var notOrAB = new UnaryOperationNode(Span, UnaryOperator.Not, orAB);
+        var notOrCD = new UnaryOperationNode(Span, UnaryOperator.Not, orCD);
+
+        var andInner = new BinaryOperationNode(Span, BinaryOperator.And, notOrAB, notOrCD);
+        var expr = new UnaryOperationNode(Span, UnaryOperator.Not, andInner);
+
+        // This should complete without stack overflow or timeout
+        var result = Simplify(expr);
+
+        // The result structure may vary, but it should terminate and produce a valid expression
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void Pathological_SingleBoundVariableQuantifier()
+    {
+        // Forall with one bound variable and true body → true
+        var boundVar = new QuantifierVariableNode(Span, "i", "i32");
+        var expr = new ForallExpressionNode(Span, new[] { boundVar },
+            new BoolLiteralNode(Span, true));
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    [Fact]
+    public void Pathological_NestedQuantifiers()
+    {
+        // (forall ((i i32)) (forall ((j i32)) true)) → true
+        var innerForall = new ForallExpressionNode(Span,
+            new[] { new QuantifierVariableNode(Span, "j", "i32") },
+            new BoolLiteralNode(Span, true));
+        var expr = new ForallExpressionNode(Span,
+            new[] { new QuantifierVariableNode(Span, "i", "i32") },
+            innerForall);
+
+        var result = Simplify(expr);
+
+        var lit = Assert.IsType<BoolLiteralNode>(result);
+        Assert.True(lit.Value);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static ExpressionNode Simplify(ExpressionNode expr)
+    {
+        var simplifier = new ExpressionSimplifier();
+
+        // Run until fixed point (up to 10 iterations)
+        var current = expr;
+        for (int i = 0; i < 10; i++)
+        {
+            var newSimplifier = new ExpressionSimplifier();
+            var result = newSimplifier.Simplify(current);
+            if (!newSimplifier.Changed)
+                return result;
+            current = result;
+        }
+        return current;
+    }
+
+    private static ModuleNode Parse(string source, out DiagnosticBag diagnostics)
+    {
+        diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+        return parser.Parse();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Add `ContractSimplificationPass` that optimizes contract expressions before Z3 verification and runtime code generation
- Implements comprehensive algebraic simplification rules for reduced solver complexity and leaner runtime checks
- Includes 134 tests covering all simplification rules, expression node visitors, and pathological inputs

## Simplification Rules

| Category | Rules |
|----------|-------|
| **Constant Folding** | Integer, float, and mixed arithmetic operations |
| **Boolean Identity** | `true && x → x`, `false \|\| x → x`, etc. |
| **Double Negation** | `!!x → x`, `--x → x`, `~~x → x` |
| **Tautology Detection** | `x \|\| !x → true`, `p → p → true` |
| **Contradiction Detection** | `x && !x → false` |
| **Algebraic Identities** | `x + 0`, `x * 1`, `x - x`, `x / 1`, `x % 1` |
| **De Morgan's Laws** | `!(a && b) → !a \|\| !b` |
| **Implication** | `true → p → p`, `p → true → true` |
| **Quantifiers** | `forall/exists` with constant bodies |
| **Conditionals** | `c ? true : false → c` |
| **Commutativity** | Redundancy elimination for commutative ops |

## New Diagnostic Codes

- `Calor0330`: Contract tautology (info)
- `Calor0331`: Contract contradiction (warning)
- `Calor0332`: Contract simplified (info)

## Test Plan

- [x] All 134 simplification unit tests pass
- [x] All 1197 existing tests pass (2 skipped as before)
- [x] Pathological input tests (deep nesting, stress tests) complete without stack overflow
- [x] Verbose output shows "Contract simplification completed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)