### PR TITLE
feat: add Z3 verification result caching

### DIFF
--- a/docs/cli/compile.md
+++ b/docs/cli/compile.md
@@ -45,6 +45,8 @@ calor -v -i MyModule.calr -o MyModule.g.cs
 | `--output` | `-o` | Yes | Output C# file path |
 | `--verbose` | `-v` | No | Show detailed compilation output |
 | `--verify` | | No | Enable static contract verification with Z3 |
+| `--no-cache` | | No | Disable verification result caching |
+| `--clear-cache` | | No | Clear verification cache before compiling |
 | `--contract-mode` | | No | Contract enforcement mode: off, debug, release (default: debug) |
 | `--strict-api` | | No | Require §BREAKING markers for public API changes |
 | `--require-docs` | | No | Require documentation on public functions |
@@ -216,6 +218,35 @@ For proven contracts, the generated C# includes:
 ```
 
 For more details, see [Static Verification](/calor/philosophy/static-verification/).
+
+---
+
+## Verification Caching
+
+When using `--verify`, the compiler caches Z3 verification results to avoid redundant SMT solver invocations on subsequent compilations. This can dramatically improve compile times for projects with stable contracts.
+
+### How It Works
+
+- **Cache key**: SHA256 hash of the contract expression and parameter types
+- **Cache location**: `~/.calor/cache/z3/` (user-level) or `.calor/verification-cache/` (project-level)
+- **Cache invalidation**: Automatic when contract expression changes
+
+### Cache Options
+
+```bash
+# Default: caching enabled
+calor -i MyModule.calr -o MyModule.g.cs --verify
+
+# Disable caching (useful for CI or debugging)
+calor -i MyModule.calr -o MyModule.g.cs --verify --no-cache
+
+# Clear cache before verification
+calor -i MyModule.calr -o MyModule.g.cs --verify --clear-cache
+```
+
+### Performance Impact
+
+First compilation runs Z3 for each contract (can take seconds per complex contract). Subsequent compilations with unchanged contracts return cached results in milliseconds.
 
 ---
 

--- a/docs/philosophy/static-verification.md
+++ b/docs/philosophy/static-verification.md
@@ -229,6 +229,20 @@ If Z3 native libraries are missing on your platform, the compiler will:
 
 ---
 
+## Verification Caching
+
+Z3 verification results are automatically cached to disk. When you recompile a file with unchanged contracts, the compiler retrieves cached results instead of re-running Z3. This provides:
+
+- **Faster incremental builds**: Unchanged contracts verify in milliseconds instead of seconds
+- **Reduced CI load**: Build servers benefit from cached results across runs
+- **Deterministic results**: Same contract always produces same verification outcome
+
+The cache is keyed by a SHA256 hash of the contract expression and parameter types. When you modify a contract, its hash changes, and the cache misses—ensuring correctness.
+
+To disable caching (e.g., for debugging), use `--no-cache`. To clear the cache, use `--clear-cache`.
+
+---
+
 ## See Also
 
 - [Contracts in Calor](/calor/language/contracts/)

--- a/src/Calor.Compiler/Verification/VerificationOptions.cs
+++ b/src/Calor.Compiler/Verification/VerificationOptions.cs
@@ -1,3 +1,5 @@
+using Calor.Compiler.Verification.Z3.Cache;
+
 namespace Calor.Compiler.Verification.Z3;
 
 /// <summary>
@@ -20,6 +22,12 @@ public sealed class VerificationOptions
     /// Whether to emit verbose diagnostic output during verification.
     /// </summary>
     public bool Verbose { get; init; }
+
+    /// <summary>
+    /// Cache options for verification results.
+    /// Default: caching enabled.
+    /// </summary>
+    public VerificationCacheOptions CacheOptions { get; init; } = VerificationCacheOptions.Default;
 
     /// <summary>
     /// Default verification options.

--- a/src/Calor.Compiler/Verification/Z3/Cache/ContractHasher.cs
+++ b/src/Calor.Compiler/Verification/Z3/Cache/ContractHasher.cs
@@ -1,0 +1,243 @@
+using System.Security.Cryptography;
+using System.Text;
+using Calor.Compiler.Ast;
+
+namespace Calor.Compiler.Verification.Z3.Cache;
+
+/// <summary>
+/// Generates deterministic hash keys from contract expressions for caching.
+/// </summary>
+public sealed class ContractHasher
+{
+    /// <summary>
+    /// Computes a hash key for a precondition.
+    /// Format: PRE:{params}::{expression_hash}
+    /// </summary>
+    public string HashPrecondition(
+        IReadOnlyList<(string Name, string TypeName)> parameters,
+        RequiresNode precondition)
+    {
+        var sb = new StringBuilder();
+        sb.Append("PRE:");
+        AppendParameters(sb, parameters);
+        sb.Append("::");
+        AppendExpression(sb, precondition.Condition);
+
+        return ComputeSha256Hash(sb.ToString());
+    }
+
+    /// <summary>
+    /// Computes a hash key for a postcondition.
+    /// Format: POST:{params}:{output}:PRECS:{prec_hashes}::POST:{post_hash}
+    /// </summary>
+    public string HashPostcondition(
+        IReadOnlyList<(string Name, string TypeName)> parameters,
+        string? outputType,
+        IReadOnlyList<RequiresNode> preconditions,
+        EnsuresNode postcondition)
+    {
+        var sb = new StringBuilder();
+        sb.Append("POST:");
+        AppendParameters(sb, parameters);
+        sb.Append(':');
+        sb.Append(outputType ?? "void");
+        sb.Append(":PRECS:");
+
+        // Include all preconditions in the hash since they affect postcondition verification
+        foreach (var pre in preconditions)
+        {
+            AppendExpression(sb, pre.Condition);
+            sb.Append(';');
+        }
+
+        sb.Append("::POST:");
+        AppendExpression(sb, postcondition.Condition);
+
+        return ComputeSha256Hash(sb.ToString());
+    }
+
+    /// <summary>
+    /// Gets the canonical string representation of an expression (for testing).
+    /// </summary>
+    public string GetCanonicalExpression(ExpressionNode expression)
+    {
+        var sb = new StringBuilder();
+        AppendExpression(sb, expression);
+        return sb.ToString();
+    }
+
+    private void AppendParameters(StringBuilder sb, IReadOnlyList<(string Name, string TypeName)> parameters)
+    {
+        for (int i = 0; i < parameters.Count; i++)
+        {
+            if (i > 0)
+                sb.Append(',');
+            sb.Append(parameters[i].Name);
+            sb.Append(':');
+            sb.Append(parameters[i].TypeName);
+        }
+    }
+
+    private void AppendExpression(StringBuilder sb, ExpressionNode expr)
+    {
+        switch (expr)
+        {
+            case IntLiteralNode intLit:
+                sb.Append("INT:");
+                sb.Append(intLit.Value);
+                break;
+
+            case BoolLiteralNode boolLit:
+                sb.Append("BOOL:");
+                sb.Append(boolLit.Value ? "true" : "false");
+                break;
+
+            case FloatLiteralNode floatLit:
+                sb.Append("FLOAT:");
+                sb.Append(floatLit.Value.ToString("G17"));
+                break;
+
+            case StringLiteralNode strLit:
+                sb.Append("STR:\"");
+                sb.Append(strLit.Value.Replace("\\", "\\\\").Replace("\"", "\\\""));
+                sb.Append('"');
+                break;
+
+            case ReferenceNode refNode:
+                sb.Append("REF:");
+                sb.Append(refNode.Name);
+                break;
+
+            case BinaryOperationNode binOp:
+                sb.Append('(');
+                sb.Append(GetOperatorSymbol(binOp.Operator));
+                sb.Append(' ');
+                AppendExpression(sb, binOp.Left);
+                sb.Append(' ');
+                AppendExpression(sb, binOp.Right);
+                sb.Append(')');
+                break;
+
+            case UnaryOperationNode unaryOp:
+                sb.Append('(');
+                sb.Append(GetUnaryOperatorSymbol(unaryOp.Operator));
+                sb.Append(' ');
+                AppendExpression(sb, unaryOp.Operand);
+                sb.Append(')');
+                break;
+
+            case ForallExpressionNode forall:
+                sb.Append("(FORALL (");
+                foreach (var bv in forall.BoundVariables)
+                {
+                    sb.Append('(');
+                    sb.Append(bv.Name);
+                    sb.Append(' ');
+                    sb.Append(bv.TypeName);
+                    sb.Append(')');
+                }
+                sb.Append(") ");
+                AppendExpression(sb, forall.Body);
+                sb.Append(')');
+                break;
+
+            case ExistsExpressionNode exists:
+                sb.Append("(EXISTS (");
+                foreach (var bv in exists.BoundVariables)
+                {
+                    sb.Append('(');
+                    sb.Append(bv.Name);
+                    sb.Append(' ');
+                    sb.Append(bv.TypeName);
+                    sb.Append(')');
+                }
+                sb.Append(") ");
+                AppendExpression(sb, exists.Body);
+                sb.Append(')');
+                break;
+
+            case ImplicationExpressionNode impl:
+                sb.Append("(-> ");
+                AppendExpression(sb, impl.Antecedent);
+                sb.Append(' ');
+                AppendExpression(sb, impl.Consequent);
+                sb.Append(')');
+                break;
+
+            case ConditionalExpressionNode cond:
+                sb.Append("(ITE ");
+                AppendExpression(sb, cond.Condition);
+                sb.Append(' ');
+                AppendExpression(sb, cond.WhenTrue);
+                sb.Append(' ');
+                AppendExpression(sb, cond.WhenFalse);
+                sb.Append(')');
+                break;
+
+            case ArrayAccessNode arrAccess:
+                sb.Append("(IDX ");
+                AppendExpression(sb, arrAccess.Array);
+                sb.Append(' ');
+                AppendExpression(sb, arrAccess.Index);
+                sb.Append(')');
+                break;
+
+            case ArrayLengthNode arrLen:
+                sb.Append("(LEN ");
+                AppendExpression(sb, arrLen.Array);
+                sb.Append(')');
+                break;
+
+            default:
+                // For unsupported expressions, use the type name as a fallback
+                sb.Append("UNSUPPORTED:");
+                sb.Append(expr.GetType().Name);
+                break;
+        }
+    }
+
+    private static string GetOperatorSymbol(BinaryOperator op)
+    {
+        return op switch
+        {
+            BinaryOperator.Add => "+",
+            BinaryOperator.Subtract => "-",
+            BinaryOperator.Multiply => "*",
+            BinaryOperator.Divide => "/",
+            BinaryOperator.Modulo => "%",
+            BinaryOperator.Power => "**",
+            BinaryOperator.Equal => "==",
+            BinaryOperator.NotEqual => "!=",
+            BinaryOperator.LessThan => "<",
+            BinaryOperator.LessOrEqual => "<=",
+            BinaryOperator.GreaterThan => ">",
+            BinaryOperator.GreaterOrEqual => ">=",
+            BinaryOperator.And => "&&",
+            BinaryOperator.Or => "||",
+            BinaryOperator.BitwiseAnd => "&",
+            BinaryOperator.BitwiseOr => "|",
+            BinaryOperator.BitwiseXor => "^",
+            BinaryOperator.LeftShift => "<<",
+            BinaryOperator.RightShift => ">>",
+            _ => op.ToString()
+        };
+    }
+
+    private static string GetUnaryOperatorSymbol(UnaryOperator op)
+    {
+        return op switch
+        {
+            UnaryOperator.Negate => "-",
+            UnaryOperator.Not => "!",
+            UnaryOperator.BitwiseNot => "~",
+            _ => op.ToString()
+        };
+    }
+
+    private static string ComputeSha256Hash(string input)
+    {
+        var bytes = Encoding.UTF8.GetBytes(input);
+        var hashBytes = SHA256.HashData(bytes);
+        return Convert.ToHexString(hashBytes).ToLowerInvariant();
+    }
+}

--- a/src/Calor.Compiler/Verification/Z3/Cache/VerificationCache.cs
+++ b/src/Calor.Compiler/Verification/Z3/Cache/VerificationCache.cs
@@ -1,0 +1,357 @@
+using System.Text.Json;
+using Calor.Compiler.Ast;
+
+namespace Calor.Compiler.Verification.Z3.Cache;
+
+/// <summary>
+/// Caches Z3 verification results to avoid redundant SMT solver invocations.
+/// Thread-safe for concurrent access within a process.
+/// </summary>
+public sealed class VerificationCache : IDisposable
+{
+    private readonly VerificationCacheOptions _options;
+    private readonly ContractHasher _hasher;
+    private readonly string _cacheDirectory;
+    private readonly string? _z3Version;
+    private readonly object _lock = new();
+    private bool _disposed;
+
+    // Statistics
+    private int _hits;
+    private int _misses;
+    private int _writes;
+    private int _errors;
+    private int _evictions;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public VerificationCache(VerificationCacheOptions options)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _hasher = new ContractHasher();
+        _cacheDirectory = options.GetCacheDirectory();
+        _z3Version = Z3ContextFactory.GetZ3Version();
+
+        if (options.ClearBeforeVerification)
+        {
+            Clear();
+        }
+    }
+
+    /// <summary>
+    /// Whether caching is enabled.
+    /// </summary>
+    public bool IsEnabled => _options.Enabled;
+
+    /// <summary>
+    /// Tries to get a cached precondition result.
+    /// </summary>
+    public bool TryGetPreconditionResult(
+        IReadOnlyList<(string Name, string TypeName)> parameters,
+        RequiresNode precondition,
+        out ContractVerificationResult? result)
+    {
+        result = null;
+
+        if (!_options.Enabled)
+            return false;
+
+        var hash = _hasher.HashPrecondition(parameters, precondition);
+        return TryGetCachedResult(hash, out result);
+    }
+
+    /// <summary>
+    /// Tries to get a cached postcondition result.
+    /// </summary>
+    public bool TryGetPostconditionResult(
+        IReadOnlyList<(string Name, string TypeName)> parameters,
+        string? outputType,
+        IReadOnlyList<RequiresNode> preconditions,
+        EnsuresNode postcondition,
+        out ContractVerificationResult? result)
+    {
+        result = null;
+
+        if (!_options.Enabled)
+            return false;
+
+        var hash = _hasher.HashPostcondition(parameters, outputType, preconditions, postcondition);
+        return TryGetCachedResult(hash, out result);
+    }
+
+    /// <summary>
+    /// Caches a precondition result.
+    /// </summary>
+    public void CachePreconditionResult(
+        IReadOnlyList<(string Name, string TypeName)> parameters,
+        RequiresNode precondition,
+        ContractVerificationResult result)
+    {
+        if (!_options.Enabled)
+            return;
+
+        // Don't cache Unsupported or Skipped results - they may change with library updates
+        if (result.Status == ContractVerificationStatus.Unsupported ||
+            result.Status == ContractVerificationStatus.Skipped)
+            return;
+
+        var hash = _hasher.HashPrecondition(parameters, precondition);
+        CacheResult(hash, result);
+    }
+
+    /// <summary>
+    /// Caches a postcondition result.
+    /// </summary>
+    public void CachePostconditionResult(
+        IReadOnlyList<(string Name, string TypeName)> parameters,
+        string? outputType,
+        IReadOnlyList<RequiresNode> preconditions,
+        EnsuresNode postcondition,
+        ContractVerificationResult result)
+    {
+        if (!_options.Enabled)
+            return;
+
+        // Don't cache Unsupported or Skipped results
+        if (result.Status == ContractVerificationStatus.Unsupported ||
+            result.Status == ContractVerificationStatus.Skipped)
+            return;
+
+        var hash = _hasher.HashPostcondition(parameters, outputType, preconditions, postcondition);
+        CacheResult(hash, result);
+    }
+
+    /// <summary>
+    /// Clears all cached verification results.
+    /// </summary>
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            try
+            {
+                if (Directory.Exists(_cacheDirectory))
+                {
+                    Directory.Delete(_cacheDirectory, recursive: true);
+                }
+            }
+            catch
+            {
+                // Ignore errors during cache clear
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets statistics about cache usage.
+    /// </summary>
+    public CacheStatistics GetStatistics()
+    {
+        return new CacheStatistics(
+            Interlocked.CompareExchange(ref _hits, 0, 0),
+            Interlocked.CompareExchange(ref _misses, 0, 0),
+            Interlocked.CompareExchange(ref _writes, 0, 0),
+            Interlocked.CompareExchange(ref _errors, 0, 0),
+            Interlocked.CompareExchange(ref _evictions, 0, 0));
+    }
+
+    private bool TryGetCachedResult(string hash, out ContractVerificationResult? result)
+    {
+        result = null;
+
+        try
+        {
+            var filePath = GetCacheFilePath(hash);
+
+            if (!File.Exists(filePath))
+            {
+                Interlocked.Increment(ref _misses);
+                return false;
+            }
+
+            string json;
+            lock (_lock)
+            {
+                if (!File.Exists(filePath))
+                {
+                    Interlocked.Increment(ref _misses);
+                    return false;
+                }
+                json = File.ReadAllText(filePath);
+            }
+
+            var entry = JsonSerializer.Deserialize<VerificationCacheEntry>(json, JsonOptions);
+
+            if (entry == null || entry.ContractHash != hash || !entry.IsValidFor(_z3Version))
+            {
+                // Cache entry is invalid, version mismatch, or Z3 version changed
+                Interlocked.Increment(ref _misses);
+                TryDeleteFile(filePath);
+                return false;
+            }
+
+            // Update file access time for LRU tracking
+            try
+            {
+                File.SetLastAccessTimeUtc(filePath, DateTime.UtcNow);
+            }
+            catch
+            {
+                // Ignore - not critical for functionality
+            }
+
+            result = entry.ToResult();
+            Interlocked.Increment(ref _hits);
+            return true;
+        }
+        catch
+        {
+            Interlocked.Increment(ref _errors);
+            return false;
+        }
+    }
+
+    private void CacheResult(string hash, ContractVerificationResult result)
+    {
+        try
+        {
+            var filePath = GetCacheFilePath(hash);
+            var directory = Path.GetDirectoryName(filePath)!;
+
+            lock (_lock)
+            {
+                if (!Directory.Exists(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                // Enforce cache size limit before writing
+                EnforceCacheSizeLimit();
+
+                var entry = VerificationCacheEntry.FromResult(result, hash, _z3Version);
+                var json = JsonSerializer.Serialize(entry, JsonOptions);
+
+                // Write to a temp file first, then move for atomicity
+                var tempPath = filePath + $".{Environment.ProcessId}.tmp";
+                try
+                {
+                    File.WriteAllText(tempPath, json);
+                    File.Move(tempPath, filePath, overwrite: true);
+                }
+                finally
+                {
+                    // Clean up temp file if it still exists
+                    TryDeleteFile(tempPath);
+                }
+            }
+
+            Interlocked.Increment(ref _writes);
+        }
+        catch
+        {
+            Interlocked.Increment(ref _errors);
+        }
+    }
+
+    /// <summary>
+    /// Enforces the maximum cache size by evicting oldest entries (LRU).
+    /// Must be called while holding the lock.
+    /// </summary>
+    private void EnforceCacheSizeLimit()
+    {
+        if (_options.MaxCacheSizeBytes <= 0)
+            return; // No limit
+
+        if (!Directory.Exists(_cacheDirectory))
+            return;
+
+        try
+        {
+            var files = Directory.GetFiles(_cacheDirectory, "*.json", SearchOption.AllDirectories)
+                .Select(f => new FileInfo(f))
+                .ToList();
+
+            var totalSize = files.Sum(f => f.Length);
+
+            if (totalSize <= _options.MaxCacheSizeBytes)
+                return; // Under limit
+
+            // Sort by last access time (oldest first) for LRU eviction
+            var sortedFiles = files
+                .OrderBy(f => f.LastAccessTimeUtc)
+                .ToList();
+
+            // Evict oldest files until we're under 80% of the limit (to avoid frequent evictions)
+            var targetSize = (long)(_options.MaxCacheSizeBytes * 0.8);
+            foreach (var file in sortedFiles)
+            {
+                if (totalSize <= targetSize)
+                    break;
+
+                try
+                {
+                    var fileSize = file.Length;
+                    file.Delete();
+                    totalSize -= fileSize;
+                    Interlocked.Increment(ref _evictions);
+                }
+                catch
+                {
+                    // Ignore individual file deletion errors
+                }
+            }
+        }
+        catch
+        {
+            // Ignore errors during eviction - cache will still work, just might grow larger
+        }
+    }
+
+    private string GetCacheFilePath(string hash)
+    {
+        // Use first 2 characters as subdirectory for better filesystem performance
+        var prefix = hash[..2];
+        return Path.Combine(_cacheDirectory, prefix, hash + ".json");
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch
+        {
+            // Ignore deletion errors
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+    }
+}
+
+/// <summary>
+/// Statistics about verification cache usage.
+/// </summary>
+public record CacheStatistics(int Hits, int Misses, int Writes, int Errors, int Evictions)
+{
+    /// <summary>
+    /// Total cache lookups.
+    /// </summary>
+    public int TotalLookups => Hits + Misses;
+
+    /// <summary>
+    /// Cache hit rate as a percentage.
+    /// </summary>
+    public double HitRate => TotalLookups > 0 ? (double)Hits / TotalLookups * 100 : 0;
+}

--- a/src/Calor.Compiler/Verification/Z3/Cache/VerificationCacheEntry.cs
+++ b/src/Calor.Compiler/Verification/Z3/Cache/VerificationCacheEntry.cs
@@ -1,0 +1,96 @@
+namespace Calor.Compiler.Verification.Z3.Cache;
+
+/// <summary>
+/// Represents a cached verification result entry.
+/// </summary>
+public sealed class VerificationCacheEntry
+{
+    /// <summary>
+    /// Current cache format version.
+    /// Increment this when the cache entry structure changes.
+    /// </summary>
+    public const string CurrentFormatVersion = "1.1";
+
+    /// <summary>
+    /// Cache format version for invalidation on format changes.
+    /// </summary>
+    public string Version { get; set; } = CurrentFormatVersion;
+
+    /// <summary>
+    /// Z3 library version that produced this result.
+    /// Results are invalidated when Z3 version changes.
+    /// </summary>
+    public string? Z3Version { get; set; }
+
+    /// <summary>
+    /// The verification status.
+    /// </summary>
+    public ContractVerificationStatus Status { get; set; }
+
+    /// <summary>
+    /// Description of counterexample if Disproven.
+    /// </summary>
+    public string? CounterexampleDescription { get; set; }
+
+    /// <summary>
+    /// Original verification duration in milliseconds.
+    /// </summary>
+    public double OriginalDurationMs { get; set; }
+
+    /// <summary>
+    /// When this cache entry was created.
+    /// </summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// SHA256 hash of the contract expression for integrity verification.
+    /// </summary>
+    public string ContractHash { get; set; } = "";
+
+    /// <summary>
+    /// Creates a ContractVerificationResult from this cache entry.
+    /// </summary>
+    public ContractVerificationResult ToResult()
+    {
+        return new ContractVerificationResult(
+            Status,
+            CounterexampleDescription,
+            TimeSpan.FromMilliseconds(OriginalDurationMs));
+    }
+
+    /// <summary>
+    /// Creates a cache entry from a verification result.
+    /// </summary>
+    public static VerificationCacheEntry FromResult(
+        ContractVerificationResult result,
+        string contractHash,
+        string? z3Version)
+    {
+        return new VerificationCacheEntry
+        {
+            Version = CurrentFormatVersion,
+            Z3Version = z3Version,
+            Status = result.Status,
+            CounterexampleDescription = result.CounterexampleDescription,
+            OriginalDurationMs = result.Duration?.TotalMilliseconds ?? 0,
+            CreatedAt = DateTime.UtcNow,
+            ContractHash = contractHash
+        };
+    }
+
+    /// <summary>
+    /// Checks if this cache entry is valid for the given Z3 version.
+    /// </summary>
+    public bool IsValidFor(string? currentZ3Version)
+    {
+        // Format version must match
+        if (Version != CurrentFormatVersion)
+            return false;
+
+        // Z3 version must match (both null is OK for tests)
+        if (Z3Version != currentZ3Version)
+            return false;
+
+        return true;
+    }
+}

--- a/src/Calor.Compiler/Verification/Z3/Cache/VerificationCacheOptions.cs
+++ b/src/Calor.Compiler/Verification/Z3/Cache/VerificationCacheOptions.cs
@@ -1,0 +1,71 @@
+namespace Calor.Compiler.Verification.Z3.Cache;
+
+/// <summary>
+/// Configuration options for the verification cache.
+/// </summary>
+public sealed class VerificationCacheOptions
+{
+    /// <summary>
+    /// Default maximum cache size in bytes (50 MB).
+    /// </summary>
+    public const long DefaultMaxCacheSizeBytes = 50 * 1024 * 1024;
+
+    /// <summary>
+    /// Whether caching is enabled. Default: true.
+    /// </summary>
+    public bool Enabled { get; init; } = true;
+
+    /// <summary>
+    /// Whether to clear the cache before verification. Default: false.
+    /// </summary>
+    public bool ClearBeforeVerification { get; init; }
+
+    /// <summary>
+    /// Project directory for project-level cache location.
+    /// If null, user-level cache is used.
+    /// </summary>
+    public string? ProjectDirectory { get; init; }
+
+    /// <summary>
+    /// Custom cache directory override.
+    /// If null, default locations are used.
+    /// </summary>
+    public string? CacheDirectory { get; init; }
+
+    /// <summary>
+    /// Maximum cache size in bytes. When exceeded, oldest entries are evicted.
+    /// Default: 50 MB. Set to 0 for unlimited.
+    /// </summary>
+    public long MaxCacheSizeBytes { get; init; } = DefaultMaxCacheSizeBytes;
+
+    /// <summary>
+    /// Default cache options with caching enabled.
+    /// </summary>
+    public static VerificationCacheOptions Default { get; } = new();
+
+    /// <summary>
+    /// Cache options with caching disabled.
+    /// </summary>
+    public static VerificationCacheOptions Disabled { get; } = new() { Enabled = false };
+
+    /// <summary>
+    /// Gets the effective cache directory based on options.
+    /// Priority: CacheDirectory override > Project-level > User-level
+    /// </summary>
+    public string GetCacheDirectory()
+    {
+        if (!string.IsNullOrEmpty(CacheDirectory))
+            return CacheDirectory;
+
+        // Try project-level cache first
+        if (!string.IsNullOrEmpty(ProjectDirectory))
+        {
+            var projectCache = Path.Combine(ProjectDirectory, ".calor", "verification-cache");
+            return projectCache;
+        }
+
+        // Fall back to user-level cache
+        var userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(userHome, ".calor", "cache", "z3", "v1");
+    }
+}

--- a/src/Calor.Compiler/Verification/Z3/Z3ContextFactory.cs
+++ b/src/Calor.Compiler/Verification/Z3/Z3ContextFactory.cs
@@ -199,4 +199,28 @@ public static class Z3ContextFactory
     {
         return new Microsoft.Z3.Context();
     }
+
+    /// <summary>
+    /// Gets the Z3 library version string, or null if Z3 is unavailable.
+    /// </summary>
+    public static string? GetZ3Version()
+    {
+        if (!IsAvailable)
+            return null;
+
+        return GetZ3VersionInternal();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static string? GetZ3VersionInternal()
+    {
+        try
+        {
+            return Microsoft.Z3.Version.FullVersion;
+        }
+        catch
+        {
+            return null;
+        }
+    }
 }

--- a/tests/Calor.Compiler.Tests/VerificationCacheTests.cs
+++ b/tests/Calor.Compiler.Tests/VerificationCacheTests.cs
@@ -1,0 +1,1120 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Calor.Compiler.Verification.Z3;
+using Calor.Compiler.Verification.Z3.Cache;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for Z3 verification result caching.
+/// </summary>
+public class VerificationCacheTests : IDisposable
+{
+    private readonly string _testCacheDir;
+
+    public VerificationCacheTests()
+    {
+        _testCacheDir = Path.Combine(Path.GetTempPath(), "calor-cache-tests", Guid.NewGuid().ToString());
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_testCacheDir))
+            {
+                Directory.Delete(_testCacheDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup errors in tests
+        }
+    }
+
+    private static TextSpan EmptySpan => new(0, 0, 1, 1);
+
+    private static ModuleNode Parse(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+        return parser.Parse();
+    }
+
+    #region ContractHasher Unit Tests
+
+    [Fact]
+    public void HashPrecondition_SameExpression_SameHash()
+    {
+        var hasher = new ContractHasher();
+        var parameters = new List<(string Name, string TypeName)> { ("x", "i32") };
+
+        var pre1 = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var pre2 = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var hash1 = hasher.HashPrecondition(parameters, pre1);
+        var hash2 = hasher.HashPrecondition(parameters, pre2);
+
+        Assert.Equal(hash1, hash2);
+        Assert.Equal(64, hash1.Length); // SHA256 hex string is 64 chars
+    }
+
+    [Fact]
+    public void HashPrecondition_DifferentExpression_DifferentHash()
+    {
+        var hasher = new ContractHasher();
+        var parameters = new List<(string Name, string TypeName)> { ("x", "i32") };
+
+        var pre1 = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var pre2 = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterThan,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var hash1 = hasher.HashPrecondition(parameters, pre1);
+        var hash2 = hasher.HashPrecondition(parameters, pre2);
+
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void HashPrecondition_DifferentParams_DifferentHash()
+    {
+        var hasher = new ContractHasher();
+        var condition = new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+            new ReferenceNode(EmptySpan, "x"),
+            new IntLiteralNode(EmptySpan, 0));
+
+        var pre = new RequiresNode(EmptySpan, condition, null, new AttributeCollection());
+
+        var params1 = new List<(string Name, string TypeName)> { ("x", "i32") };
+        var params2 = new List<(string Name, string TypeName)> { ("x", "i64") }; // Different type
+
+        var hash1 = hasher.HashPrecondition(params1, pre);
+        var hash2 = hasher.HashPrecondition(params2, pre);
+
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void HashPrecondition_DifferentParamNames_DifferentHash()
+    {
+        var hasher = new ContractHasher();
+        var condition = new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+            new ReferenceNode(EmptySpan, "x"),
+            new IntLiteralNode(EmptySpan, 0));
+
+        var pre = new RequiresNode(EmptySpan, condition, null, new AttributeCollection());
+
+        var params1 = new List<(string Name, string TypeName)> { ("x", "i32") };
+        var params2 = new List<(string Name, string TypeName)> { ("y", "i32") }; // Different name
+
+        var hash1 = hasher.HashPrecondition(params1, pre);
+        var hash2 = hasher.HashPrecondition(params2, pre);
+
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void HashPostcondition_IncludesPreconditions()
+    {
+        var hasher = new ContractHasher();
+        var parameters = new List<(string Name, string TypeName)> { ("x", "i32") };
+
+        var post = new EnsuresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "result"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var pre1 = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var pre2 = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterThan,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var hash1 = hasher.HashPostcondition(parameters, "i32", new[] { pre1 }, post);
+        var hash2 = hasher.HashPostcondition(parameters, "i32", new[] { pre2 }, post);
+
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void Hash_AllExpressionNodeTypes()
+    {
+        var hasher = new ContractHasher();
+
+        // Test all expression node types
+        var intLit = new IntLiteralNode(EmptySpan, 42);
+        var boolLit = new BoolLiteralNode(EmptySpan, true);
+        var floatLit = new FloatLiteralNode(EmptySpan, 3.14);
+        var strLit = new StringLiteralNode(EmptySpan, "test");
+        var refNode = new ReferenceNode(EmptySpan, "x");
+
+        var binOp = new BinaryOperationNode(EmptySpan, BinaryOperator.Add, intLit, intLit);
+        var unaryOp = new UnaryOperationNode(EmptySpan, UnaryOperator.Negate, intLit);
+
+        var forall = new ForallExpressionNode(EmptySpan,
+            new[] { new QuantifierVariableNode(EmptySpan, "i", "i32") },
+            boolLit);
+
+        var exists = new ExistsExpressionNode(EmptySpan,
+            new[] { new QuantifierVariableNode(EmptySpan, "j", "i32") },
+            boolLit);
+
+        var impl = new ImplicationExpressionNode(EmptySpan, boolLit, boolLit);
+        var cond = new ConditionalExpressionNode(EmptySpan, boolLit, intLit, intLit);
+        var arrAccess = new ArrayAccessNode(EmptySpan, refNode, intLit);
+        var arrLen = new ArrayLengthNode(EmptySpan, refNode);
+
+        // All should produce non-empty canonical strings
+        Assert.NotEmpty(hasher.GetCanonicalExpression(intLit));
+        Assert.NotEmpty(hasher.GetCanonicalExpression(boolLit));
+        Assert.NotEmpty(hasher.GetCanonicalExpression(floatLit));
+        Assert.NotEmpty(hasher.GetCanonicalExpression(strLit));
+        Assert.NotEmpty(hasher.GetCanonicalExpression(refNode));
+        Assert.NotEmpty(hasher.GetCanonicalExpression(binOp));
+        Assert.NotEmpty(hasher.GetCanonicalExpression(unaryOp));
+        Assert.NotEmpty(hasher.GetCanonicalExpression(forall));
+        Assert.NotEmpty(hasher.GetCanonicalExpression(exists));
+        Assert.NotEmpty(hasher.GetCanonicalExpression(impl));
+        Assert.NotEmpty(hasher.GetCanonicalExpression(cond));
+        Assert.NotEmpty(hasher.GetCanonicalExpression(arrAccess));
+        Assert.NotEmpty(hasher.GetCanonicalExpression(arrLen));
+    }
+
+    [Fact]
+    public void Hash_NestedExpressions()
+    {
+        var hasher = new ContractHasher();
+
+        // Build: ((x + y) * (a - b))
+        var x = new ReferenceNode(EmptySpan, "x");
+        var y = new ReferenceNode(EmptySpan, "y");
+        var a = new ReferenceNode(EmptySpan, "a");
+        var b = new ReferenceNode(EmptySpan, "b");
+
+        var add = new BinaryOperationNode(EmptySpan, BinaryOperator.Add, x, y);
+        var sub = new BinaryOperationNode(EmptySpan, BinaryOperator.Subtract, a, b);
+        var mul = new BinaryOperationNode(EmptySpan, BinaryOperator.Multiply, add, sub);
+
+        var canonical = hasher.GetCanonicalExpression(mul);
+
+        Assert.Contains("(* ", canonical);
+        Assert.Contains("(+ REF:x REF:y)", canonical);
+        Assert.Contains("(- REF:a REF:b)", canonical);
+    }
+
+    [Fact]
+    public void Hash_Quantifiers()
+    {
+        var hasher = new ContractHasher();
+
+        // Build: forall i. (i >= 0)
+        var iRef = new ReferenceNode(EmptySpan, "i");
+        var zero = new IntLiteralNode(EmptySpan, 0);
+        var body = new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual, iRef, zero);
+
+        var forall = new ForallExpressionNode(EmptySpan,
+            new[] { new QuantifierVariableNode(EmptySpan, "i", "i32") },
+            body);
+
+        var canonical = hasher.GetCanonicalExpression(forall);
+
+        Assert.Contains("(FORALL ((i i32))", canonical);
+        Assert.Contains("(>= REF:i INT:0)", canonical);
+    }
+
+    #endregion
+
+    #region VerificationCache Unit Tests
+
+    [Fact]
+    public void Cache_HitsOnSecondCall()
+    {
+        var options = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir
+        };
+
+        var parameters = new List<(string Name, string TypeName)> { ("x", "i32") };
+        var pre = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = new ContractVerificationResult(ContractVerificationStatus.Proven);
+
+        // First call - cache miss
+        using (var cache = new VerificationCache(options))
+        {
+            Assert.False(cache.TryGetPreconditionResult(parameters, pre, out _));
+            cache.CachePreconditionResult(parameters, pre, result);
+        }
+
+        // Second call - cache hit
+        using (var cache2 = new VerificationCache(options))
+        {
+            Assert.True(cache2.TryGetPreconditionResult(parameters, pre, out var cached));
+            Assert.NotNull(cached);
+            Assert.Equal(ContractVerificationStatus.Proven, cached!.Status);
+        }
+    }
+
+    [Fact]
+    public void Cache_MissOnDifferentContract()
+    {
+        var options = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir
+        };
+
+        var parameters = new List<(string Name, string TypeName)> { ("x", "i32") };
+
+        var pre1 = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var pre2 = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterThan,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = new ContractVerificationResult(ContractVerificationStatus.Proven);
+
+        using var cache = new VerificationCache(options);
+
+        cache.CachePreconditionResult(parameters, pre1, result);
+
+        // Different contract should miss
+        Assert.False(cache.TryGetPreconditionResult(parameters, pre2, out _));
+    }
+
+    [Fact]
+    public void Cache_MissAfterClear()
+    {
+        var options = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir
+        };
+
+        var parameters = new List<(string Name, string TypeName)> { ("x", "i32") };
+        var pre = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = new ContractVerificationResult(ContractVerificationStatus.Proven);
+
+        using (var cache = new VerificationCache(options))
+        {
+            cache.CachePreconditionResult(parameters, pre, result);
+            Assert.True(cache.TryGetPreconditionResult(parameters, pre, out _));
+            cache.Clear();
+        }
+
+        // After clear, should miss
+        using (var cache2 = new VerificationCache(options))
+        {
+            Assert.False(cache2.TryGetPreconditionResult(parameters, pre, out _));
+        }
+    }
+
+    [Fact]
+    public void Cache_PersistsAcrossInstances()
+    {
+        var options = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir
+        };
+
+        var parameters = new List<(string Name, string TypeName)> { ("x", "i32") };
+        var pre = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = new ContractVerificationResult(
+            ContractVerificationStatus.Disproven,
+            "x = -1",
+            TimeSpan.FromMilliseconds(100));
+
+        // Write with one instance
+        using (var cache = new VerificationCache(options))
+        {
+            cache.CachePreconditionResult(parameters, pre, result);
+        }
+
+        // Read with new instance
+        using (var cache2 = new VerificationCache(options))
+        {
+            Assert.True(cache2.TryGetPreconditionResult(parameters, pre, out var cached));
+            Assert.NotNull(cached);
+            Assert.Equal(ContractVerificationStatus.Disproven, cached!.Status);
+            Assert.Equal("x = -1", cached.CounterexampleDescription);
+        }
+    }
+
+    [Fact]
+    public void Cache_DisabledReturnsNoHits()
+    {
+        var options = new VerificationCacheOptions
+        {
+            Enabled = false,
+            CacheDirectory = _testCacheDir
+        };
+
+        var parameters = new List<(string Name, string TypeName)> { ("x", "i32") };
+        var pre = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = new ContractVerificationResult(ContractVerificationStatus.Proven);
+
+        using var cache = new VerificationCache(options);
+
+        // Cache is disabled - should not store or retrieve
+        cache.CachePreconditionResult(parameters, pre, result);
+        Assert.False(cache.TryGetPreconditionResult(parameters, pre, out _));
+    }
+
+    [Fact]
+    public void Cache_HandlesMissingDirectory()
+    {
+        var nonExistentDir = Path.Combine(_testCacheDir, "deep", "nested", "path");
+        var options = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = nonExistentDir
+        };
+
+        var parameters = new List<(string Name, string TypeName)> { ("x", "i32") };
+        var pre = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = new ContractVerificationResult(ContractVerificationStatus.Proven);
+
+        using var cache = new VerificationCache(options);
+
+        // Should create directory and write successfully
+        cache.CachePreconditionResult(parameters, pre, result);
+        Assert.True(cache.TryGetPreconditionResult(parameters, pre, out _));
+    }
+
+    [Fact]
+    public void Cache_DoesNotCacheUnsupported()
+    {
+        var options = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir
+        };
+
+        var parameters = new List<(string Name, string TypeName)> { ("x", "i32") };
+        var pre = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var unsupportedResult = new ContractVerificationResult(ContractVerificationStatus.Unsupported);
+
+        using var cache = new VerificationCache(options);
+
+        cache.CachePreconditionResult(parameters, pre, unsupportedResult);
+
+        // Unsupported should not be cached
+        Assert.False(cache.TryGetPreconditionResult(parameters, pre, out _));
+    }
+
+    [Fact]
+    public void Cache_DoesNotCacheSkipped()
+    {
+        var options = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir
+        };
+
+        var parameters = new List<(string Name, string TypeName)> { ("x", "i32") };
+        var pre = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var skippedResult = new ContractVerificationResult(ContractVerificationStatus.Skipped);
+
+        using var cache = new VerificationCache(options);
+
+        cache.CachePreconditionResult(parameters, pre, skippedResult);
+
+        // Skipped should not be cached
+        Assert.False(cache.TryGetPreconditionResult(parameters, pre, out _));
+    }
+
+    [Fact]
+    public void Cache_ClearBeforeVerification()
+    {
+        var options = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir,
+            ClearBeforeVerification = false
+        };
+
+        var parameters = new List<(string Name, string TypeName)> { ("x", "i32") };
+        var pre = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = new ContractVerificationResult(ContractVerificationStatus.Proven);
+
+        // First, populate cache
+        using (var cache = new VerificationCache(options))
+        {
+            cache.CachePreconditionResult(parameters, pre, result);
+        }
+
+        // Now create cache with ClearBeforeVerification = true
+        var clearOptions = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir,
+            ClearBeforeVerification = true
+        };
+
+        using (var cache2 = new VerificationCache(clearOptions))
+        {
+            // Cache should have been cleared
+            Assert.False(cache2.TryGetPreconditionResult(parameters, pre, out _));
+        }
+    }
+
+    [Fact]
+    public void Cache_Statistics()
+    {
+        var options = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir
+        };
+
+        var parameters = new List<(string Name, string TypeName)> { ("x", "i32") };
+        var pre = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = new ContractVerificationResult(ContractVerificationStatus.Proven);
+
+        using var cache = new VerificationCache(options);
+
+        // 1 miss
+        cache.TryGetPreconditionResult(parameters, pre, out _);
+
+        // 1 write
+        cache.CachePreconditionResult(parameters, pre, result);
+
+        // 1 hit
+        cache.TryGetPreconditionResult(parameters, pre, out _);
+
+        var stats = cache.GetStatistics();
+
+        Assert.Equal(1, stats.Hits);
+        Assert.Equal(1, stats.Misses);
+        Assert.Equal(1, stats.Writes);
+        Assert.Equal(2, stats.TotalLookups);
+        Assert.Equal(50.0, stats.HitRate, precision: 1);
+    }
+
+    #endregion
+
+    #region Integration Tests
+
+    [SkippableFact]
+    public void E2E_CachePopulatesOnFirstRun()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        var source = @"
+§M{m001:Test}
+§F{f001:Square:pub}
+  §I{i32:x}
+  §O{i32}
+  §Q (>= x INT:0)
+  §S (>= result INT:0)
+  §R (* x x)
+§/F{f001}
+§/M{m001}
+";
+
+        var cacheOptions = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir,
+            ClearBeforeVerification = true
+        };
+
+        var options = new CompilationOptions
+        {
+            VerifyContracts = true,
+            VerificationCacheOptions = cacheOptions
+        };
+
+        // First run - cache miss, populates cache
+        var result = Program.Compile(source, "test.calr", options);
+
+        Assert.False(result.HasErrors);
+
+        // Verify cache files were created
+        var cacheFiles = Directory.GetFiles(_testCacheDir, "*.json", SearchOption.AllDirectories);
+        Assert.NotEmpty(cacheFiles);
+    }
+
+    [SkippableFact]
+    public void E2E_CacheHitOnSecondRun()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        var source = @"
+§M{m001:Test}
+§F{f001:Square:pub}
+  §I{i32:x}
+  §O{i32}
+  §Q (>= x INT:0)
+  §S (>= result INT:0)
+  §R (* x x)
+§/F{f001}
+§/M{m001}
+";
+
+        var cacheOptions = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir,
+            ClearBeforeVerification = true
+        };
+
+        var options = new CompilationOptions
+        {
+            VerifyContracts = true,
+            VerificationCacheOptions = cacheOptions
+        };
+
+        // First run
+        var result1 = Program.Compile(source, "test.calr", options);
+        Assert.False(result1.HasErrors);
+
+        // Second run with same options (no clear)
+        var secondCacheOptions = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir,
+            ClearBeforeVerification = false
+        };
+
+        var secondOptions = new CompilationOptions
+        {
+            VerifyContracts = true,
+            VerificationCacheOptions = secondCacheOptions
+        };
+
+        var result2 = Program.Compile(source, "test.calr", secondOptions);
+        Assert.False(result2.HasErrors);
+
+        // Both should produce same verification results
+        Assert.NotNull(options.VerificationResults);
+        Assert.NotNull(secondOptions.VerificationResults);
+    }
+
+    [SkippableFact]
+    public void E2E_NoCacheFlagDisablesCache()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        var source = @"
+§M{m001:Test}
+§F{f001:Square:pub}
+  §I{i32:x}
+  §O{i32}
+  §Q (>= x INT:0)
+  §R (* x x)
+§/F{f001}
+§/M{m001}
+";
+
+        var cacheOptions = new VerificationCacheOptions
+        {
+            Enabled = false,
+            CacheDirectory = _testCacheDir
+        };
+
+        var options = new CompilationOptions
+        {
+            VerifyContracts = true,
+            VerificationCacheOptions = cacheOptions
+        };
+
+        var result = Program.Compile(source, "test.calr", options);
+
+        Assert.False(result.HasErrors);
+
+        // Cache directory should not have any files (or not exist)
+        var cacheFiles = Directory.Exists(_testCacheDir)
+            ? Directory.GetFiles(_testCacheDir, "*.json", SearchOption.AllDirectories)
+            : Array.Empty<string>();
+        Assert.Empty(cacheFiles);
+    }
+
+    [SkippableFact]
+    public void E2E_ClearCacheFlagWorks()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        var source = @"
+§M{m001:Test}
+§F{f001:Square:pub}
+  §I{i32:x}
+  §O{i32}
+  §Q (>= x INT:0)
+  §R (* x x)
+§/F{f001}
+§/M{m001}
+";
+
+        // First, populate cache
+        var cacheOptions = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir,
+            ClearBeforeVerification = false
+        };
+
+        var options = new CompilationOptions
+        {
+            VerifyContracts = true,
+            VerificationCacheOptions = cacheOptions
+        };
+
+        Program.Compile(source, "test.calr", options);
+
+        // Verify cache has files
+        var cacheFilesBefore = Directory.GetFiles(_testCacheDir, "*.json", SearchOption.AllDirectories);
+        Assert.NotEmpty(cacheFilesBefore);
+
+        // Now clear with new compilation
+        var clearCacheOptions = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir,
+            ClearBeforeVerification = true
+        };
+
+        var clearOptions = new CompilationOptions
+        {
+            VerifyContracts = true,
+            VerificationCacheOptions = clearCacheOptions
+        };
+
+        // Clear should remove old files before verification
+        Program.Compile(source, "test.calr", clearOptions);
+
+        // Files should still exist (re-populated after clear)
+        var cacheFilesAfter = Directory.GetFiles(_testCacheDir, "*.json", SearchOption.AllDirectories);
+        Assert.NotEmpty(cacheFilesAfter);
+    }
+
+    [SkippableFact]
+    public void E2E_CachedResultsMatchFreshResults()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        var source = @"
+§M{m001:Test}
+§F{f001:Square:pub}
+  §I{i32:x}
+  §O{i32}
+  §Q (>= x INT:0)
+  §S (>= result INT:0)
+  §R (* x x)
+§/F{f001}
+§F{f002:BadDecrement:pub}
+  §I{i32:x}
+  §O{i32}
+  §S (>= result INT:0)
+  §R (- x INT:1)
+§/F{f002}
+§/M{m001}
+";
+
+        // Run with cache disabled to get fresh results
+        var freshOptions = new CompilationOptions
+        {
+            VerifyContracts = true,
+            VerificationCacheOptions = VerificationCacheOptions.Disabled
+        };
+
+        var freshResult = Program.Compile(source, "test.calr", freshOptions);
+        Assert.False(freshResult.HasErrors);
+
+        var freshSummary = freshOptions.VerificationResults!.GetSummary();
+
+        // Run with cache enabled (first time, will populate)
+        var cacheOptions = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir,
+            ClearBeforeVerification = true
+        };
+
+        var cachedOptions = new CompilationOptions
+        {
+            VerifyContracts = true,
+            VerificationCacheOptions = cacheOptions
+        };
+
+        Program.Compile(source, "test.calr", cachedOptions);
+
+        // Run again to use cache
+        var secondCachedOptions = new CompilationOptions
+        {
+            VerifyContracts = true,
+            VerificationCacheOptions = new VerificationCacheOptions
+            {
+                Enabled = true,
+                CacheDirectory = _testCacheDir
+            }
+        };
+
+        Program.Compile(source, "test.calr", secondCachedOptions);
+        var cachedSummary = secondCachedOptions.VerificationResults!.GetSummary();
+
+        // Results should match
+        Assert.Equal(freshSummary.Proven, cachedSummary.Proven);
+        Assert.Equal(freshSummary.Unproven, cachedSummary.Unproven);
+        Assert.Equal(freshSummary.Disproven, cachedSummary.Disproven);
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Fact]
+    public void Cache_VeryLongContractExpression()
+    {
+        var hasher = new ContractHasher();
+
+        // Build a deeply nested expression
+        ExpressionNode expr = new IntLiteralNode(EmptySpan, 0);
+        for (int i = 0; i < 100; i++)
+        {
+            expr = new BinaryOperationNode(EmptySpan, BinaryOperator.Add, expr, new IntLiteralNode(EmptySpan, i));
+        }
+
+        var parameters = new List<(string Name, string TypeName)> { ("x", "i32") };
+        var pre = new RequiresNode(EmptySpan, expr, null, new AttributeCollection());
+
+        var hash = hasher.HashPrecondition(parameters, pre);
+
+        // Should still produce a valid 64-char hash
+        Assert.Equal(64, hash.Length);
+        Assert.True(hash.All(c => char.IsAsciiHexDigitLower(c)));
+    }
+
+    [Fact]
+    public void Cache_UnicodeInIdentifiers()
+    {
+        var hasher = new ContractHasher();
+        var parameters = new List<(string Name, string TypeName)> { ("变量", "i32") };
+
+        var pre = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "变量"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var hash = hasher.HashPrecondition(parameters, pre);
+
+        Assert.Equal(64, hash.Length);
+    }
+
+    [Fact]
+    public void Cache_HandleCorruptedFile()
+    {
+        var options = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir
+        };
+
+        var parameters = new List<(string Name, string TypeName)> { ("x", "i32") };
+        var pre = new RequiresNode(
+            EmptySpan,
+            new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(EmptySpan, "x"),
+                new IntLiteralNode(EmptySpan, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = new ContractVerificationResult(ContractVerificationStatus.Proven);
+
+        using (var cache = new VerificationCache(options))
+        {
+            cache.CachePreconditionResult(parameters, pre, result);
+        }
+
+        // Corrupt all cache files
+        foreach (var file in Directory.GetFiles(_testCacheDir, "*.json", SearchOption.AllDirectories))
+        {
+            File.WriteAllText(file, "not valid json {{{");
+        }
+
+        // Should handle gracefully - cache miss
+        using (var cache2 = new VerificationCache(options))
+        {
+            var hit = cache2.TryGetPreconditionResult(parameters, pre, out _);
+            Assert.False(hit);
+
+            // Should not throw
+            var stats = cache2.GetStatistics();
+            Assert.True(stats.Errors > 0 || stats.Misses > 0);
+        }
+    }
+
+    [Fact]
+    public void CacheEntry_InvalidatesOnZ3VersionChange()
+    {
+        var entry = new VerificationCacheEntry
+        {
+            Version = VerificationCacheEntry.CurrentFormatVersion,
+            Z3Version = "4.12.0",
+            Status = ContractVerificationStatus.Proven,
+            ContractHash = "abc123"
+        };
+
+        // Same version should be valid
+        Assert.True(entry.IsValidFor("4.12.0"));
+
+        // Different version should be invalid
+        Assert.False(entry.IsValidFor("4.13.0"));
+
+        // Null vs non-null should be invalid
+        Assert.False(entry.IsValidFor(null));
+    }
+
+    [Fact]
+    public void CacheEntry_InvalidatesOnFormatVersionChange()
+    {
+        var entry = new VerificationCacheEntry
+        {
+            Version = "0.9", // Old format version
+            Z3Version = "4.12.0",
+            Status = ContractVerificationStatus.Proven,
+            ContractHash = "abc123"
+        };
+
+        // Should be invalid due to format version mismatch
+        Assert.False(entry.IsValidFor("4.12.0"));
+    }
+
+    [Fact]
+    public void Cache_EvictsOldEntriesWhenSizeLimitExceeded()
+    {
+        // Use a small cache limit (2 KB) - allows ~10 entries before eviction
+        var options = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir,
+            MaxCacheSizeBytes = 2048
+        };
+
+        var result = new ContractVerificationResult(ContractVerificationStatus.Proven);
+
+        using var cache = new VerificationCache(options);
+
+        // Write many entries to exceed the cache limit
+        for (int i = 0; i < 30; i++)
+        {
+            var parameters = new List<(string Name, string TypeName)> { ($"x{i}", "i32") };
+            var pre = new RequiresNode(
+                EmptySpan,
+                new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                    new ReferenceNode(EmptySpan, $"x{i}"),
+                    new IntLiteralNode(EmptySpan, i)),
+                null,
+                new AttributeCollection());
+
+            cache.CachePreconditionResult(parameters, pre, result);
+        }
+
+        var stats = cache.GetStatistics();
+
+        // Some entries should have been evicted
+        Assert.True(stats.Evictions > 0, $"Expected evictions > 0, got {stats.Evictions}");
+
+        // Cache size should be reasonable (under limit + one entry's worth of headroom)
+        // The eviction targets 80% of limit, so after eviction + 1 new write, we should be close to limit
+        var cacheFiles = Directory.GetFiles(_testCacheDir, "*.json", SearchOption.AllDirectories);
+        var totalSize = cacheFiles.Sum(f => new FileInfo(f).Length);
+        var maxAllowedSize = options.MaxCacheSizeBytes + 300; // Allow for one entry overhead
+        Assert.True(totalSize <= maxAllowedSize,
+            $"Cache size {totalSize} significantly exceeds limit {options.MaxCacheSizeBytes}");
+    }
+
+    [Fact]
+    public void Cache_NoEvictionWhenUnlimited()
+    {
+        // Set max to 0 for unlimited
+        var options = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir,
+            MaxCacheSizeBytes = 0 // Unlimited
+        };
+
+        var result = new ContractVerificationResult(ContractVerificationStatus.Proven);
+
+        using var cache = new VerificationCache(options);
+
+        // Write several entries
+        for (int i = 0; i < 10; i++)
+        {
+            var parameters = new List<(string Name, string TypeName)> { ($"x{i}", "i32") };
+            var pre = new RequiresNode(
+                EmptySpan,
+                new BinaryOperationNode(EmptySpan, BinaryOperator.GreaterOrEqual,
+                    new ReferenceNode(EmptySpan, $"x{i}"),
+                    new IntLiteralNode(EmptySpan, i)),
+                null,
+                new AttributeCollection());
+
+            cache.CachePreconditionResult(parameters, pre, result);
+        }
+
+        var stats = cache.GetStatistics();
+
+        // No evictions should occur
+        Assert.Equal(0, stats.Evictions);
+        Assert.Equal(10, stats.Writes);
+    }
+
+    [Fact]
+    public void Cache_StatisticsIncludesEvictions()
+    {
+        var options = new VerificationCacheOptions
+        {
+            Enabled = true,
+            CacheDirectory = _testCacheDir,
+            MaxCacheSizeBytes = 500 // Very small limit
+        };
+
+        var result = new ContractVerificationResult(ContractVerificationStatus.Proven);
+
+        using var cache = new VerificationCache(options);
+
+        // Write entries to trigger eviction
+        for (int i = 0; i < 10; i++)
+        {
+            var parameters = new List<(string Name, string TypeName)> { ($"var{i}", "i32") };
+            var pre = new RequiresNode(
+                EmptySpan,
+                new BinaryOperationNode(EmptySpan, BinaryOperator.Equal,
+                    new ReferenceNode(EmptySpan, $"var{i}"),
+                    new IntLiteralNode(EmptySpan, i * 100)),
+                null,
+                new AttributeCollection());
+
+            cache.CachePreconditionResult(parameters, pre, result);
+        }
+
+        var stats = cache.GetStatistics();
+
+        // Verify statistics include eviction count
+        Assert.True(stats.Evictions >= 0);
+        Assert.True(stats.Writes > 0);
+    }
+
+    #endregion
+}

--- a/website/content/cli/compile.mdx
+++ b/website/content/cli/compile.mdx
@@ -42,6 +42,8 @@ calor -v -i MyModule.calr -o MyModule.g.cs
 | `--output` | `-o` | Yes | Output C# file path |
 | `--verbose` | `-v` | No | Show detailed compilation output |
 | `--verify` | | No | Enable Z3 static contract verification |
+| `--no-cache` | | No | Disable verification result caching |
+| `--clear-cache` | | No | Clear verification cache before compiling |
 | `--contract-mode` | | No | Contract enforcement mode: `full`, `preconditions`, or `none` |
 
 ---
@@ -112,6 +114,25 @@ Generated MyModule.g.cs
 ```
 
 For details on verification categories (Proven, Unproven, Disproven, Unsupported), see [Static Contract Verification](/philosophy/static-verification/).
+
+---
+
+## Verification Caching
+
+When using `--verify`, the compiler caches Z3 verification results to avoid redundant SMT solver invocations on subsequent compilations. This can dramatically improve compile times for projects with stable contracts.
+
+### Cache Options
+
+```bash
+# Default: caching enabled
+calor -i MyModule.calr -o MyModule.g.cs --verify
+
+# Disable caching (useful for CI or debugging)
+calor -i MyModule.calr -o MyModule.g.cs --verify --no-cache
+
+# Clear cache before verification
+calor -i MyModule.calr -o MyModule.g.cs --verify --clear-cache
+```
 
 ---
 

--- a/website/content/philosophy/static-verification.mdx
+++ b/website/content/philosophy/static-verification.mdx
@@ -195,6 +195,20 @@ If Z3 native libraries are missing on your platform, the compiler will:
 
 ---
 
+## Verification Caching
+
+Z3 verification results are automatically cached to disk. When you recompile a file with unchanged contracts, the compiler retrieves cached results instead of re-running Z3. This provides:
+
+- **Faster incremental builds**: Unchanged contracts verify in milliseconds instead of seconds
+- **Reduced CI load**: Build servers benefit from cached results across runs
+- **Deterministic results**: Same contract always produces same verification outcome
+
+The cache is keyed by a SHA256 hash of the contract expression and parameter types. When you modify a contract, its hash changes, and the cache misses—ensuring correctness.
+
+To disable caching (e.g., for debugging), use `--no-cache`. To clear the cache, use `--clear-cache`.
+
+---
+
 ## See Also
 
 - [Contracts in Calor](/language/contracts/)


### PR DESCRIPTION
## Summary

- Add caching mechanism for Z3 verification results to avoid redundant SMT solver invocations
- Cache entries are keyed by SHA256 hash of contract expressions and parameter types
- Automatic invalidation when contracts change or Z3 version is upgraded
- LRU eviction with configurable max cache size (default 50MB)
- Thread-safe for concurrent access within a process

## New Files

| File | Purpose |
|------|---------|
| `VerificationCacheEntry.cs` | Cache entry data structure |
| `VerificationCacheOptions.cs` | Configuration options |
| `ContractHasher.cs` | AST visitor for deterministic hash generation |
| `VerificationCache.cs` | Main cache implementation |
| `VerificationCacheTests.cs` | 31 comprehensive tests |

## CLI Options

```bash
calor -i file.calr --verify              # Cache enabled (default)
calor -i file.calr --verify --no-cache   # Cache disabled
calor -i file.calr --verify --clear-cache # Clear cache before verify
```

## Test plan

- [x] All 31 new cache tests pass
- [x] All 1439 existing tests pass (no regressions)
- [x] Build succeeds with 0 warnings

🤖 Generated with [Claude Code](https://claude.ai/code)