### PR TITLE
feat: add comprehensive Google Analytics event tracking

### DIFF
--- a/website/src/app/docs/[[...slug]]/page.tsx
+++ b/website/src/app/docs/[[...slug]]/page.tsx
@@ -12,6 +12,7 @@ import { Sidebar } from '@/components/docs/Sidebar';
 import { TableOfContents } from '@/components/docs/TableOfContents';
 import { Pagination } from '@/components/docs/Pagination';
 import { MobileSidebar } from '@/components/docs/MobileSidebar';
+import { DocsPageTracker } from '@/components/docs/DocsPageTracker';
 import { mdxComponents } from '@/components/mdx';
 
 interface DocPageProps {
@@ -61,6 +62,7 @@ export default async function DocPage({ params }: DocPageProps) {
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8 lg:px-8">
+      <DocsPageTracker slug={slugPath} />
       <div className="flex gap-8">
         {/* Desktop Sidebar */}
         <div className="hidden lg:block">

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -5,10 +5,12 @@ import { FeatureGrid } from '@/components/landing/FeatureGrid';
 import { BenchmarkChart } from '@/components/landing/BenchmarkChart';
 import { QuickStart } from '@/components/landing/QuickStart';
 import { ProjectStatus } from '@/components/landing/ProjectStatus';
+import { ScrollDepthTracker } from '@/components/landing/ScrollDepthTracker';
 
 export default function HomePage() {
   return (
     <div className="flex flex-col">
+      <ScrollDepthTracker />
       <Hero />
       <CodeComparison />
       <CatchBugs />

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import { Menu, X, Github, Moon, Sun } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn, getBasePath } from '@/lib/utils';
+import { trackDarkModeToggle, trackOutboundLink } from '@/lib/analytics';
 
 // basePath needed for pathname comparison since usePathname returns full path
 const basePath = getBasePath();
@@ -23,8 +24,10 @@ export function Header() {
   const [isDark, setIsDark] = useState(false);
 
   const toggleDarkMode = () => {
+    const newMode = isDark ? 'light' : 'dark';
     setIsDark(!isDark);
     document.documentElement.classList.toggle('dark');
+    trackDarkModeToggle(newMode);
   };
 
   return (
@@ -86,6 +89,7 @@ export function Header() {
                 href="https://github.com/juanmicrosoft/calor"
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={() => trackOutboundLink('https://github.com/juanmicrosoft/calor')}
               >
                 <Github className="h-5 w-5" />
                 <span className="sr-only">GitHub</span>
@@ -150,6 +154,7 @@ export function Header() {
                       href="https://github.com/juanmicrosoft/calor"
                       target="_blank"
                       rel="noopener noreferrer"
+                      onClick={() => trackOutboundLink('https://github.com/juanmicrosoft/calor')}
                     >
                       <Github className="h-5 w-5" />
                     </a>

--- a/website/src/components/benchmarks/BenchmarkDashboard.tsx
+++ b/website/src/components/benchmarks/BenchmarkDashboard.tsx
@@ -4,6 +4,8 @@ import { MetricCard } from './MetricCard';
 import { ProgramTable } from './ProgramTable';
 import { cn } from '@/lib/utils';
 import { BarChart3, FileCode, Trophy, Clock } from 'lucide-react';
+import { trackBenchmarkResultsView } from '@/lib/analytics';
+import { useEffect } from 'react';
 
 // Build-time import of benchmark data
 import benchmarkData from '../../../public/data/benchmark-results.json';
@@ -81,6 +83,10 @@ function SummaryCard({ icon, label, value, subtext, highlight = 'neutral' }: Sum
 }
 
 export function BenchmarkDashboard() {
+  useEffect(() => {
+    trackBenchmarkResultsView();
+  }, []);
+
   // Sort metrics: Calor wins first, then by ratio descending
   const sortedMetrics = Object.entries(data.metrics).sort(([, a], [, b]) => {
     // Sort Calor-only metrics to the end, then Calor wins first, then by ratio descending

--- a/website/src/components/benchmarks/ProgramTable.tsx
+++ b/website/src/components/benchmarks/ProgramTable.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from 'react';
 import { cn } from '@/lib/utils';
 import { ChevronUp, ChevronDown, Check, X } from 'lucide-react';
+import { trackProgramTableSort, trackProgramTableFilter } from '@/lib/analytics';
 
 interface ProgramData {
   id: string;
@@ -54,6 +55,7 @@ export function ProgramTable({ programs, metricNames }: ProgramTableProps) {
   const [levelFilter, setLevelFilter] = useState<number | null>(null);
 
   const handleSort = (field: SortField) => {
+    trackProgramTableSort(field);
     if (sortField === field) {
       setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
     } else {
@@ -143,7 +145,7 @@ export function ProgramTable({ programs, metricNames }: ProgramTableProps) {
               ? 'bg-primary text-primary-foreground'
               : 'bg-muted hover:bg-muted/80'
           )}
-          onClick={() => setLevelFilter(null)}
+          onClick={() => { trackProgramTableFilter('all'); setLevelFilter(null); }}
         >
           All
         </button>
@@ -156,7 +158,7 @@ export function ProgramTable({ programs, metricNames }: ProgramTableProps) {
                 ? 'bg-primary text-primary-foreground'
                 : 'bg-muted hover:bg-muted/80'
             )}
-            onClick={() => setLevelFilter(level)}
+            onClick={() => { trackProgramTableFilter(`L${level}`); setLevelFilter(level); }}
           >
             L{level}
           </button>

--- a/website/src/components/docs/DocsPageTracker.tsx
+++ b/website/src/components/docs/DocsPageTracker.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { useEffect } from 'react';
+import { trackDocsPageView } from '@/lib/analytics';
+
+export function DocsPageTracker({ slug }: { slug: string }) {
+  useEffect(() => {
+    trackDocsPageView(slug);
+  }, [slug]);
+
+  return null;
+}

--- a/website/src/components/docs/Sidebar.tsx
+++ b/website/src/components/docs/Sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { useState } from 'react';
 import { cn, getBasePath } from '@/lib/utils';
+import { trackSidebarSectionExpand } from '@/lib/analytics';
 import type { DocSection } from '@/lib/docs';
 
 // basePath is needed for pathname comparison since usePathname returns full path
@@ -29,6 +30,7 @@ export function Sidebar({ sections }: SidebarProps) {
         next.delete(slug);
       } else {
         next.add(slug);
+        trackSidebarSectionExpand(slug);
       }
       return next;
     });

--- a/website/src/components/docs/TableOfContents.tsx
+++ b/website/src/components/docs/TableOfContents.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
+import { trackTocAnchorClick } from '@/lib/analytics';
 
 interface Heading {
   id: string;
@@ -71,6 +72,7 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
                 )}
                 onClick={(e) => {
                   e.preventDefault();
+                  trackTocAnchorClick(heading.text);
                   const element = document.getElementById(heading.id);
                   if (element) {
                     element.scrollIntoView({ behavior: 'smooth' });

--- a/website/src/components/landing/BenchmarkChart.tsx
+++ b/website/src/components/landing/BenchmarkChart.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { Clock } from 'lucide-react';
+import { trackBenchmarkDetailClick } from '@/lib/analytics';
 
 // Build-time import of benchmark data
 import benchmarkData from '../../../public/data/benchmark-results.json';
@@ -231,7 +232,7 @@ export function BenchmarkChart() {
 
           <div className="mt-8 text-center">
             <Button variant="outline" asChild>
-              <Link href="/docs/benchmarking/results/">
+              <Link href="/docs/benchmarking/results/" onClick={() => trackBenchmarkDetailClick()}>
                 View detailed benchmarks
               </Link>
             </Button>

--- a/website/src/components/landing/CodeComparison.tsx
+++ b/website/src/components/landing/CodeComparison.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { cn } from '@/lib/utils';
+import { trackCodeComparisonTab } from '@/lib/analytics';
 
 const calorCode = `§F{f_01J5X7K9M2:Square:pub}
   §I{i32:x}
@@ -54,7 +55,7 @@ export function CodeComparison() {
           <div className="flex justify-center mb-6">
             <div className="inline-flex rounded-lg border p-1 bg-background">
               <button
-                onClick={() => setActiveTab('calor')}
+                onClick={() => { setActiveTab('calor'); trackCodeComparisonTab('calor'); }}
                 className={cn(
                   'px-4 py-2 rounded-md text-sm font-medium transition-colors',
                   activeTab === 'calor'
@@ -65,7 +66,7 @@ export function CodeComparison() {
                 Calor - Everything Explicit
               </button>
               <button
-                onClick={() => setActiveTab('csharp')}
+                onClick={() => { setActiveTab('csharp'); trackCodeComparisonTab('csharp'); }}
                 className={cn(
                   'px-4 py-2 rounded-md text-sm font-medium transition-colors',
                   activeTab === 'csharp'

--- a/website/src/components/landing/FeatureGrid.tsx
+++ b/website/src/components/landing/FeatureGrid.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import { FileCode, Shield, Fingerprint, Layers, ChevronRight } from 'lucide-react';
 import Link from 'next/link';
+import { trackFeatureLearnMore } from '@/lib/analytics';
 
 const features = [
   {
@@ -73,6 +76,7 @@ export function FeatureGrid() {
                   <Link
                     href={feature.href}
                     className="mt-4 inline-flex items-center text-sm text-calor-cyan hover:underline"
+                    onClick={() => trackFeatureLearnMore(feature.name)}
                   >
                     Learn more
                     <ChevronRight className="ml-1 h-4 w-4" />

--- a/website/src/components/landing/Hero.tsx
+++ b/website/src/components/landing/Hero.tsx
@@ -1,8 +1,11 @@
+'use client';
+
 import Link from 'next/link';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { Github, ArrowRight } from 'lucide-react';
 import { getBasePath } from '@/lib/utils';
+import { trackCtaClick, trackOutboundLink } from '@/lib/analytics';
 
 const basePath = getBasePath();
 
@@ -46,7 +49,7 @@ export function Hero() {
 
           <div className="mt-10 flex items-center justify-center gap-x-4">
             <Button asChild size="lg" className="bg-calor-pink hover:bg-calor-pink/90 text-white">
-              <Link href="/docs/getting-started/">
+              <Link href="/docs/getting-started/" onClick={() => trackCtaClick('get_started')}>
                 Get Started
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Link>
@@ -56,6 +59,7 @@ export function Hero() {
                 href="https://github.com/juanmicrosoft/calor"
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={() => { trackCtaClick('github'); trackOutboundLink('https://github.com/juanmicrosoft/calor'); }}
               >
                 <Github className="mr-2 h-4 w-4" />
                 GitHub

--- a/website/src/components/landing/QuickStart.tsx
+++ b/website/src/components/landing/QuickStart.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Check, Copy, Terminal } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { trackInstallCommandCopy } from '@/lib/analytics';
 
 const commands = [
   {
@@ -27,6 +28,7 @@ export function QuickStart() {
 
   const copyToClipboard = async (text: string, index: number) => {
     await navigator.clipboard.writeText(text.replace(/\\\n/g, ''));
+    trackInstallCommandCopy(commands[index].label);
     setCopiedIndex(index);
     setTimeout(() => setCopiedIndex(null), 2000);
   };

--- a/website/src/components/landing/ScrollDepthTracker.tsx
+++ b/website/src/components/landing/ScrollDepthTracker.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { trackScrollDepth } from '@/lib/analytics';
+
+const THRESHOLDS = [25, 50, 75, 100];
+
+export function ScrollDepthTracker() {
+  const firedRef = useRef(new Set<number>());
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollTop = window.scrollY;
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      if (docHeight <= 0) return;
+
+      const percent = Math.round((scrollTop / docHeight) * 100);
+
+      for (const threshold of THRESHOLDS) {
+        if (percent >= threshold && !firedRef.current.has(threshold)) {
+          firedRef.current.add(threshold);
+          trackScrollDepth(threshold);
+        }
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return null;
+}

--- a/website/src/components/landing/VSCodeExtension.tsx
+++ b/website/src/components/landing/VSCodeExtension.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Check, Copy, FileCode, Palette, Settings, ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { trackVSCodeExtensionClick, trackOutboundLink } from '@/lib/analytics';
 
 const features = [
   {
@@ -30,6 +31,7 @@ export function VSCodeExtension() {
 
   const copyToClipboard = async () => {
     await navigator.clipboard.writeText(INSTALL_COMMAND);
+    trackVSCodeExtensionClick('copy_command');
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
@@ -82,6 +84,7 @@ export function VSCodeExtension() {
               href={MARKETPLACE_URL}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() => { trackVSCodeExtensionClick('marketplace'); trackOutboundLink(MARKETPLACE_URL); }}
               className="mt-6 flex items-center justify-center gap-2 rounded-lg bg-calor-navy px-6 py-3 font-medium text-white hover:bg-calor-navy/90 transition-colors"
             >
               <ExternalLink className="h-4 w-4" />

--- a/website/src/components/mdx/CodeBlock.tsx
+++ b/website/src/components/mdx/CodeBlock.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Check, Copy } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { trackCodeCopy } from '@/lib/analytics';
 
 interface CodeBlockProps {
   code: string;
@@ -21,6 +22,7 @@ export function CodeBlock({
 
   const copyToClipboard = async () => {
     await navigator.clipboard.writeText(code);
+    trackCodeCopy(language);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/website/src/lib/analytics.ts
+++ b/website/src/lib/analytics.ts
@@ -1,0 +1,86 @@
+type GTagEvent = {
+  action: string;
+  category: string;
+  label?: string;
+  value?: number;
+};
+
+function sendEvent({ action, category, label, value }: GTagEvent) {
+  if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+    window.gtag('event', action, {
+      event_category: category,
+      event_label: label,
+      value,
+    });
+  }
+}
+
+// --- High Priority ---
+
+export function trackCtaClick(button: 'get_started' | 'github') {
+  sendEvent({ action: 'cta_click', category: 'engagement', label: button });
+}
+
+export function trackInstallCommandCopy(step: string) {
+  sendEvent({ action: 'install_command_copy', category: 'conversion', label: step });
+}
+
+export function trackCodeCopy(language: string) {
+  sendEvent({ action: 'code_copy', category: 'engagement', label: language });
+}
+
+export function trackDocsPageView(slug: string) {
+  sendEvent({ action: 'docs_page_view', category: 'navigation', label: slug });
+}
+
+export function trackBenchmarkResultsView() {
+  sendEvent({ action: 'benchmark_results_view', category: 'engagement' });
+}
+
+// --- Medium Priority ---
+
+export function trackCodeComparisonTab(tab: 'calor' | 'csharp') {
+  sendEvent({ action: 'code_comparison_tab', category: 'engagement', label: tab });
+}
+
+export function trackFeatureLearnMore(feature: string) {
+  sendEvent({ action: 'feature_learn_more', category: 'engagement', label: feature });
+}
+
+export function trackVSCodeExtensionClick(action: 'marketplace' | 'copy_command') {
+  sendEvent({ action: 'vscode_extension_click', category: 'conversion', label: action });
+}
+
+export function trackBenchmarkDetailClick() {
+  sendEvent({ action: 'benchmark_detail_click', category: 'engagement' });
+}
+
+export function trackProgramTableSort(field: string) {
+  sendEvent({ action: 'program_table_sort', category: 'engagement', label: field });
+}
+
+export function trackProgramTableFilter(level: string) {
+  sendEvent({ action: 'program_table_filter', category: 'engagement', label: level });
+}
+
+export function trackDarkModeToggle(mode: 'dark' | 'light') {
+  sendEvent({ action: 'dark_mode_toggle', category: 'preferences', label: mode });
+}
+
+// --- Low Priority ---
+
+export function trackScrollDepth(depth: number) {
+  sendEvent({ action: 'scroll_depth', category: 'engagement', value: depth, label: `${depth}%` });
+}
+
+export function trackSidebarSectionExpand(section: string) {
+  sendEvent({ action: 'sidebar_section_expand', category: 'navigation', label: section });
+}
+
+export function trackTocAnchorClick(heading: string) {
+  sendEvent({ action: 'toc_anchor_click', category: 'navigation', label: heading });
+}
+
+export function trackOutboundLink(url: string) {
+  sendEvent({ action: 'outbound_link', category: 'navigation', label: url });
+}

--- a/website/src/types/global.d.ts
+++ b/website/src/types/global.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+  gtag?: (...args: unknown[]) => void;
+}


### PR DESCRIPTION
Adds 16 custom GA4 events across 14 website components via a typed analytics utility module.

### Events

| Priority | Event | Component | Trigger |
|----------|-------|-----------|---------|
| High | `cta_click` | Hero | Get Started / GitHub buttons |
| High | `install_command_copy` | QuickStart | Copy terminal commands |
| High | `code_copy` | CodeBlock | Copy code in docs |
| High | `docs_page_view` | DocsPageTracker | Each docs route |
| High | `benchmark_results_view` | BenchmarkDashboard | Results page load |
| Medium | `code_comparison_tab` | CodeComparison | Calor/C# tab switch |
| Medium | `feature_learn_more` | FeatureGrid | Learn more links |
| Medium | `vscode_extension_click` | VSCodeExtension | Marketplace/copy |
| Medium | `benchmark_detail_click` | BenchmarkChart | View benchmarks link |
| Medium | `program_table_sort` | ProgramTable | Column sort |
| Medium | `program_table_filter` | ProgramTable | Level filter |
| Medium | `dark_mode_toggle` | Header | Theme switch |
| Low | `scroll_depth` | ScrollDepthTracker | 25/50/75/100% scroll |
| Low | `sidebar_section_expand` | Sidebar | Expand docs section |
| Low | `toc_anchor_click` | TableOfContents | Click heading |
| Low | `outbound_link` | Hero, Header, VSCode | External links |

### Architecture
- `src/lib/analytics.ts` — typed utility with `sendEvent()` wrapper around `window.gtag`
- `src/types/global.d.ts` — TypeScript declaration for `window.gtag`
- `src/components/landing/ScrollDepthTracker.tsx` — scroll observer (passive listener)
- `src/components/docs/DocsPageTracker.tsx` — client wrapper for server-rendered docs page

### Verified
- Build passes with zero errors
- All 16 exported functions imported in components
- gtag present in 3 JS chunks
- GA ID (G-GR98MMDPX3) confirmed in HTML output