### PR TITLE
feat: add extended string operations (regex, char, StringBuilder, comparison modes)

### DIFF
--- a/docs/syntax-reference/index.md
+++ b/docs/syntax-reference/index.md
@@ -86,8 +86,12 @@ Complete reference for Calor syntax. Calor uses Lisp-style expressions for all o
 | Arithmetic | `+`, `-`, `*`, `/`, `%` |
 | Comparison | `==`, `!=`, `<`, `<=`, `>`, `>=` |
 | Logical | `&&`, `\|\|`, `!` |
+| String | `len`, `upper`, `lower`, `trim`, `contains`, `starts`, `ends`, `indexof`, `substr`, `replace`, `concat`, `equals` |
+| Char | `char-at`, `char-code`, `char-from-code`, `is-letter`, `is-digit`, `is-whitespace`, `is-upper`, `is-lower`, `char-upper`, `char-lower` |
+| Regex | `regex-test`, `regex-match`, `regex-replace`, `regex-split` |
+| StringBuilder | `sb-new`, `sb-append`, `sb-appendline`, `sb-insert`, `sb-remove`, `sb-clear`, `sb-tostring`, `sb-length` |
 
-All operators use Lisp-style prefix notation: `(+ a b)`, `(&& x y)`
+All operators use Lisp-style prefix notation: `(+ a b)`, `(&& x y)`, `(upper s)`
 
 ---
 
@@ -143,3 +147,4 @@ All operators use Lisp-style prefix notation: `(+ a b)`, `(&& x y)`
 - [Control Flow](/calor/syntax-reference/control-flow/) - Loops, conditionals
 - [Contracts](/calor/syntax-reference/contracts/) - Requires, ensures
 - [Effects](/calor/syntax-reference/effects/) - Effect declarations
+- [String Operations](/calor/syntax-reference/string-operations/) - String, char, regex, StringBuilder operations

--- a/docs/syntax-reference/string-operations.md
+++ b/docs/syntax-reference/string-operations.md
@@ -1,0 +1,360 @@
+---
+layout: default
+title: String Operations
+parent: Syntax Reference
+nav_order: 7
+---
+
+# String Operations
+
+Calor provides native string manipulation operations that compile directly to efficient C# code. These operations follow the same prefix notation as other expressions.
+
+---
+
+## Basic String Operations
+
+| Operation | Syntax | C# Equivalent | Description |
+|:----------|:-------|:--------------|:------------|
+| Length | `(len s)` | `s.Length` | Get string length |
+| Upper | `(upper s)` | `s.ToUpper()` | Convert to uppercase |
+| Lower | `(lower s)` | `s.ToLower()` | Convert to lowercase |
+| Trim | `(trim s)` | `s.Trim()` | Remove leading/trailing whitespace |
+| Contains | `(contains s sub)` | `s.Contains(sub)` | Check if string contains substring |
+| Starts | `(starts s prefix)` | `s.StartsWith(prefix)` | Check if string starts with prefix |
+| Ends | `(ends s suffix)` | `s.EndsWith(suffix)` | Check if string ends with suffix |
+| IndexOf | `(indexof s sub)` | `s.IndexOf(sub)` | Find index of substring (-1 if not found) |
+| Substring | `(substr s start len)` | `s.Substring(start, len)` | Extract substring |
+| Replace | `(replace s old new)` | `s.Replace(old, new)` | Replace all occurrences |
+| Concat | `(concat a b)` | `a + b` | Concatenate strings |
+| Equals | `(equals a b)` | `a.Equals(b)` | String equality check |
+
+### Examples
+
+```
+// Get string length
+§B{length} (len "hello")        // 5
+
+// Convert case
+§B{upper} (upper "hello")       // "HELLO"
+§B{lower} (lower "WORLD")       // "world"
+
+// Trim whitespace
+§B{trimmed} (trim "  hello  ")  // "hello"
+
+// Check contents
+§B{hasWorld} (contains "hello world" "world")  // true
+§B{startsH} (starts "hello" "he")              // true
+§B{endsO} (ends "hello" "lo")                  // true
+
+// Find and extract
+§B{idx} (indexof "hello" "ll")  // 2
+§B{sub} (substr "hello" 1 3)    // "ell"
+
+// Transform
+§B{replaced} (replace "hello" "l" "L")  // "heLLo"
+§B{full} (concat "hello" " world")      // "hello world"
+```
+
+---
+
+## String Comparison Modes
+
+String operations that compare text support optional comparison modes via keyword arguments:
+
+| Mode | Keyword | C# Equivalent |
+|:-----|:--------|:--------------|
+| Ordinal | `:ordinal` | `StringComparison.Ordinal` |
+| Ignore Case | `:ignore-case` | `StringComparison.OrdinalIgnoreCase` |
+| Invariant | `:invariant` | `StringComparison.InvariantCulture` |
+| Invariant Ignore Case | `:invariant-ignore-case` | `StringComparison.InvariantCultureIgnoreCase` |
+
+### Supported Operations
+
+- `contains`, `starts`, `ends`, `indexof`, `equals`
+
+### Examples
+
+```
+// Case-insensitive contains
+§B{found} (contains "Hello World" "HELLO" :ignore-case)  // true
+
+// Case-insensitive equals
+§B{same} (equals "YES" "yes" :ignore-case)  // true
+
+// Ordinal comparison (exact match)
+§B{exact} (contains "Hello" "hello" :ordinal)  // false
+
+// Case-insensitive startsWith
+§B{starts} (starts "Hello World" "HELLO" :ignore-case)  // true
+
+// Find index ignoring case
+§B{idx} (indexof "Hello World" "WORLD" :ignore-case)  // 6
+```
+
+---
+
+## Regex Operations
+
+Calor provides native regular expression support via the `regex-*` operations.
+
+| Operation | Syntax | C# Equivalent | Description |
+|:----------|:-------|:--------------|:------------|
+| Test | `(regex-test s pattern)` | `Regex.IsMatch(s, pattern)` | Test if pattern matches |
+| Match | `(regex-match s pattern)` | `Regex.Match(s, pattern)` | Get first match |
+| Replace | `(regex-replace s pattern replacement)` | `Regex.Replace(s, pattern, replacement)` | Replace matches |
+| Split | `(regex-split s pattern)` | `Regex.Split(s, pattern)` | Split by pattern |
+
+### Pattern Escaping
+
+In Calor strings, backslashes must be escaped. For regex patterns:
+- `\d` (digit) becomes `"\\d"` in Calor
+- `\s` (whitespace) becomes `"\\s"` in Calor
+- `\w` (word char) becomes `"\\w"` in Calor
+
+### Examples
+
+```
+// Test if string contains digits
+§B{hasDigits} (regex-test "hello123" "\\d+")  // true
+
+// Test email format (simplified)
+§B{isEmail} (regex-test email "^[^@]+@[^@]+$")
+
+// Replace whitespace with dashes
+§B{slugified} (regex-replace "hello world" "\\s+" "-")  // "hello-world"
+
+// Replace all digits with X
+§B{masked} (regex-replace "abc123xyz" "\\d" "X")  // "abcXXXxyz"
+
+// Split by comma
+§B{parts} (regex-split "a,b,c" ",")  // ["a", "b", "c"]
+
+// Split by any whitespace
+§B{words} (regex-split "hello   world\ttab" "\\s+")
+```
+
+---
+
+## Character Operations
+
+Calor provides operations for working with individual characters.
+
+| Operation | Syntax | C# Equivalent | Description |
+|:----------|:-------|:--------------|:------------|
+| Char At | `(char-at s index)` | `s[index]` | Get character at index |
+| Char Code | `(char-code c)` | `(int)c` | Get Unicode code point |
+| Char From Code | `(char-from-code n)` | `(char)n` | Create char from code point |
+| Is Letter | `(is-letter c)` | `char.IsLetter(c)` | Check if letter |
+| Is Digit | `(is-digit c)` | `char.IsDigit(c)` | Check if digit |
+| Is Whitespace | `(is-whitespace c)` | `char.IsWhiteSpace(c)` | Check if whitespace |
+| Is Upper | `(is-upper c)` | `char.IsUpper(c)` | Check if uppercase |
+| Is Lower | `(is-lower c)` | `char.IsLower(c)` | Check if lowercase |
+| Char Upper | `(char-upper c)` | `char.ToUpper(c)` | Convert to uppercase |
+| Char Lower | `(char-lower c)` | `char.ToLower(c)` | Convert to lowercase |
+
+### Examples
+
+```
+// Get first character
+§B{first} (char-at "hello" 0)  // 'h'
+
+// Check character properties
+§B{isLetter} (is-letter 'A')      // true
+§B{isDigit} (is-digit '5')        // true
+§B{isSpace} (is-whitespace ' ')   // true
+§B{isUpper} (is-upper 'A')        // true
+§B{isLower} (is-lower 'a')        // true
+
+// Convert character case
+§B{upper} (char-upper 'a')  // 'A'
+§B{lower} (char-lower 'Z')  // 'z'
+
+// Character code conversions
+§B{code} (char-code 'A')       // 65
+§B{char} (char-from-code 65)   // 'A'
+
+// Check if first char is uppercase letter
+§B{startsWithUpper} (&& (is-letter (char-at s 0)) (is-upper (char-at s 0)))
+```
+
+---
+
+## StringBuilder Operations
+
+For building strings efficiently, Calor provides StringBuilder operations that compile to `System.Text.StringBuilder`.
+
+| Operation | Syntax | C# Equivalent | Description |
+|:----------|:-------|:--------------|:------------|
+| New | `(sb-new)` | `new StringBuilder()` | Create empty builder |
+| New with init | `(sb-new "text")` | `new StringBuilder("text")` | Create with initial value |
+| Append | `(sb-append sb text)` | `sb.Append(text)` | Append text |
+| Append Line | `(sb-appendline sb text)` | `sb.AppendLine(text)` | Append text with newline |
+| Insert | `(sb-insert sb index text)` | `sb.Insert(index, text)` | Insert at position |
+| Remove | `(sb-remove sb start length)` | `sb.Remove(start, length)` | Remove characters |
+| Clear | `(sb-clear sb)` | `sb.Clear()` | Clear all content |
+| To String | `(sb-tostring sb)` | `sb.ToString()` | Get final string |
+| Length | `(sb-length sb)` | `sb.Length` | Get current length |
+
+### Functional Chaining Pattern
+
+StringBuilder operations return the builder, enabling functional chaining:
+
+```
+// Build a string with multiple appends
+§B{result} (sb-tostring
+             (sb-append
+               (sb-append
+                 (sb-new)
+                 "Hello")
+               " World"))
+// Result: "Hello World"
+```
+
+### Examples
+
+```
+// Simple string building
+§B{sb1} (sb-new)
+§B{sb2} (sb-append sb1 "Hello")
+§B{sb3} (sb-append sb2 " World")
+§B{result} (sb-tostring sb3)  // "Hello World"
+
+// Initialize with value
+§B{sb} (sb-new "Start: ")
+§B{sb} (sb-append sb "End")
+§B{result} (sb-tostring sb)  // "Start: End"
+
+// Build with newlines
+§B{sb1} (sb-new)
+§B{sb2} (sb-appendline sb1 "Line 1")
+§B{sb3} (sb-appendline sb2 "Line 2")
+§B{multiline} (sb-tostring sb3)
+
+// Insert and remove
+§B{sb} (sb-append (sb-new) "HelloWorld")
+§B{sb} (sb-insert sb 5 " ")          // "Hello World"
+§B{sb} (sb-remove sb 5 1)            // "HelloWorld"
+
+// Get length
+§B{len} (sb-length (sb-append (sb-new) "test"))  // 4
+
+// Clear and reuse
+§B{sb} (sb-append (sb-new) "temporary")
+§B{sb} (sb-clear sb)
+§B{len} (sb-length sb)  // 0
+```
+
+---
+
+## Composing Operations
+
+String operations can be freely composed with each other and with other Calor expressions.
+
+### String + Char Operations
+
+```
+// Check if first character is a letter
+§B{firstIsLetter} (is-letter (char-at name 0))
+
+// Get uppercase first character
+§B{firstUpper} (char-upper (char-at name 0))
+
+// Capitalize: uppercase first char + lowercase rest
+§B{sb1} (sb-new)
+§B{sb2} (sb-append sb1 (str (char-upper (char-at s 0))))
+§B{sb3} (sb-append sb2 (lower (substr s 1)))
+§B{capitalized} (sb-tostring sb3)
+```
+
+### String + Regex Operations
+
+```
+// Check if trimmed input has digits
+§B{hasDigits} (regex-test (trim input) "\\d")
+
+// Normalize whitespace then check pattern
+§B{normalized} (regex-replace (trim s) "\\s+" " ")
+§B{isValid} (regex-test normalized "^[a-z ]+$")
+```
+
+### In Conditions
+
+```
+// Validate input
+§IF{v1} (== (len input) 0)
+  §R "Input required"
+§EI (! (regex-test input "^[a-zA-Z]+$"))
+  §R "Letters only"
+§EL
+  §R (concat "Valid: " input)
+§/I{v1}
+```
+
+### In Contracts
+
+```
+§F{f001:ProcessName:pub}
+  §I{string:name}
+  §O{string}
+  §Q (> (len name) 0)                    // Requires: non-empty
+  §Q (is-letter (char-at name 0))        // Requires: starts with letter
+  §S (== (len result) (len name))        // Ensures: same length
+  §R (upper name)
+§/F{f001}
+```
+
+---
+
+## Error Handling
+
+String operations can throw exceptions at runtime:
+
+| Error | Cause | Example |
+|:------|:------|:--------|
+| `IndexOutOfRangeException` | Invalid index in `char-at` | `(char-at "hi" 10)` |
+| `ArgumentOutOfRangeException` | Invalid range in `substr`, `sb-remove` | `(substr "hi" 10 5)` |
+| `RegexParseException` | Invalid regex pattern | `(regex-test s "[invalid")` |
+
+### Safe Patterns
+
+```
+// Check length before accessing
+§IF{safe} (> (len s) 0)
+  §B{first} (char-at s 0)
+§/I{safe}
+
+// Check index before substring
+§IF{valid} (&& (>= start 0) (<= (+ start len) (len s)))
+  §B{sub} (substr s start len)
+§/I{valid}
+```
+
+---
+
+## C# Migration
+
+When converting C# code to Calor, string operations are automatically recognized:
+
+| C# | Calor |
+|:---|:------|
+| `s.ToUpper()` | `(upper s)` |
+| `s.ToLower()` | `(lower s)` |
+| `s.Trim()` | `(trim s)` |
+| `s.Contains("x")` | `(contains s "x")` |
+| `s.Contains("x", StringComparison.OrdinalIgnoreCase)` | `(contains s "x" :ignore-case)` |
+| `s[i]` | `(char-at s i)` |
+| `char.IsLetter(c)` | `(is-letter c)` |
+| `(int)c` | `(char-code c)` |
+| `(char)n` | `(char-from-code n)` |
+| `Regex.IsMatch(s, p)` | `(regex-test s p)` |
+| `Regex.Replace(s, p, r)` | `(regex-replace s p r)` |
+| `new StringBuilder()` | `(sb-new)` |
+| `sb.Append(x)` | `(sb-append sb x)` |
+| `sb.ToString()` | `(sb-tostring sb)` |
+
+---
+
+## Next
+
+- [Control Flow](/calor/syntax-reference/control-flow/) - Loops and conditionals
+- [Contracts](/calor/syntax-reference/contracts/) - Pre/post conditions

--- a/src/Calor.Compiler/Ast/AstNode.cs
+++ b/src/Calor.Compiler/Ast/AstNode.cs
@@ -177,6 +177,10 @@ public interface IAstVisitor
     void Visit(ImplicationExpressionNode node);
     // Native String Operations
     void Visit(StringOperationNode node);
+    // Native Char Operations
+    void Visit(CharOperationNode node);
+    // Native StringBuilder Operations
+    void Visit(StringBuilderOperationNode node);
 }
 
 /// <summary>
@@ -338,6 +342,10 @@ public interface IAstVisitor<T>
     T Visit(ImplicationExpressionNode node);
     // Native String Operations
     T Visit(StringOperationNode node);
+    // Native Char Operations
+    T Visit(CharOperationNode node);
+    // Native StringBuilder Operations
+    T Visit(StringBuilderOperationNode node);
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Ast/CharOperationNode.cs
+++ b/src/Calor.Compiler/Ast/CharOperationNode.cs
@@ -1,0 +1,159 @@
+using Calor.Compiler.Parsing;
+
+namespace Calor.Compiler.Ast;
+
+/// <summary>
+/// Char operations supported by Calor native char expressions.
+/// </summary>
+public enum CharOp
+{
+    // Extraction
+    CharAt,             // (char-at s i)         → s[i]
+    CharCode,           // (char-code c)         → (int)c
+    CharFromCode,       // (char-from-code n)    → (char)n
+
+    // Classification (return bool)
+    IsLetter,           // (is-letter c)         → char.IsLetter(c)
+    IsDigit,            // (is-digit c)          → char.IsDigit(c)
+    IsWhiteSpace,       // (is-whitespace c)     → char.IsWhiteSpace(c)
+    IsUpper,            // (is-upper c)          → char.IsUpper(c)
+    IsLower,            // (is-lower c)          → char.IsLower(c)
+
+    // Transformation (return char)
+    ToUpperChar,        // (char-upper c)        → char.ToUpper(c)
+    ToLowerChar,        // (char-lower c)        → char.ToLower(c)
+}
+
+/// <summary>
+/// Represents a native char operation.
+/// Examples: (char-at s 0), (is-letter c), (char-upper c)
+/// </summary>
+public sealed class CharOperationNode : ExpressionNode
+{
+    public CharOp Operation { get; }
+    public IReadOnlyList<ExpressionNode> Arguments { get; }
+
+    public CharOperationNode(
+        TextSpan span,
+        CharOp operation,
+        IReadOnlyList<ExpressionNode> arguments)
+        : base(span)
+    {
+        Operation = operation;
+        Arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Helper methods for CharOp enum.
+/// </summary>
+public static class CharOpExtensions
+{
+    /// <summary>
+    /// Parses a char operation name to its enum value.
+    /// Returns null if the name is not a recognized char operation.
+    /// </summary>
+    public static CharOp? FromString(string? name)
+    {
+        return name?.ToLowerInvariant() switch
+        {
+            // Extraction
+            "char-at" => CharOp.CharAt,
+            "char-code" => CharOp.CharCode,
+            "char-from-code" => CharOp.CharFromCode,
+
+            // Classification
+            "is-letter" => CharOp.IsLetter,
+            "is-digit" => CharOp.IsDigit,
+            "is-whitespace" => CharOp.IsWhiteSpace,
+            "is-upper" => CharOp.IsUpper,
+            "is-lower" => CharOp.IsLower,
+
+            // Transformation
+            "char-upper" => CharOp.ToUpperChar,
+            "char-lower" => CharOp.ToLowerChar,
+
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Converts a CharOp enum value back to its Calor syntax name.
+    /// </summary>
+    public static string ToCalorName(this CharOp op)
+    {
+        return op switch
+        {
+            // Extraction
+            CharOp.CharAt => "char-at",
+            CharOp.CharCode => "char-code",
+            CharOp.CharFromCode => "char-from-code",
+
+            // Classification
+            CharOp.IsLetter => "is-letter",
+            CharOp.IsDigit => "is-digit",
+            CharOp.IsWhiteSpace => "is-whitespace",
+            CharOp.IsUpper => "is-upper",
+            CharOp.IsLower => "is-lower",
+
+            // Transformation
+            CharOp.ToUpperChar => "char-upper",
+            CharOp.ToLowerChar => "char-lower",
+
+            _ => throw new ArgumentOutOfRangeException(nameof(op), op, "Unknown char operation")
+        };
+    }
+
+    /// <summary>
+    /// Gets the minimum number of arguments required for the operation.
+    /// </summary>
+    public static int GetMinArgCount(this CharOp op)
+    {
+        return op switch
+        {
+            // Single argument operations
+            CharOp.CharCode or
+            CharOp.CharFromCode or
+            CharOp.IsLetter or
+            CharOp.IsDigit or
+            CharOp.IsWhiteSpace or
+            CharOp.IsUpper or
+            CharOp.IsLower or
+            CharOp.ToUpperChar or
+            CharOp.ToLowerChar => 1,
+
+            // Two argument operations
+            CharOp.CharAt => 2,
+
+            _ => 1
+        };
+    }
+
+    /// <summary>
+    /// Gets the maximum number of arguments allowed for the operation.
+    /// </summary>
+    public static int GetMaxArgCount(this CharOp op)
+    {
+        return op switch
+        {
+            // Single argument operations
+            CharOp.CharCode or
+            CharOp.CharFromCode or
+            CharOp.IsLetter or
+            CharOp.IsDigit or
+            CharOp.IsWhiteSpace or
+            CharOp.IsUpper or
+            CharOp.IsLower or
+            CharOp.ToUpperChar or
+            CharOp.ToLowerChar => 1,
+
+            // Two argument operations
+            CharOp.CharAt => 2,
+
+            _ => 1
+        };
+    }
+}

--- a/src/Calor.Compiler/Ast/StringBuilderOperationNode.cs
+++ b/src/Calor.Compiler/Ast/StringBuilderOperationNode.cs
@@ -1,0 +1,148 @@
+using Calor.Compiler.Parsing;
+
+namespace Calor.Compiler.Ast;
+
+/// <summary>
+/// StringBuilder operations supported by Calor native expressions.
+/// </summary>
+public enum StringBuilderOp
+{
+    // Creation
+    New,                // (sb-new)              → new StringBuilder()
+                        // (sb-new "init")       → new StringBuilder("init")
+
+    // Modification (return StringBuilder for chaining)
+    Append,             // (sb-append b "text")  → b.Append("text")
+    AppendLine,         // (sb-appendline b "t") → b.AppendLine("t")
+    Insert,             // (sb-insert b i "t")   → b.Insert(i, "t")
+    Remove,             // (sb-remove b i len)   → b.Remove(i, len)
+    Clear,              // (sb-clear b)          → b.Clear()
+
+    // Query operations
+    ToString,           // (sb-tostring b)       → b.ToString()
+    Length,             // (sb-length b)         → b.Length
+}
+
+/// <summary>
+/// Represents a native StringBuilder operation.
+/// Examples: (sb-new), (sb-append builder "text"), (sb-tostring builder)
+/// </summary>
+public sealed class StringBuilderOperationNode : ExpressionNode
+{
+    public StringBuilderOp Operation { get; }
+    public IReadOnlyList<ExpressionNode> Arguments { get; }
+
+    public StringBuilderOperationNode(
+        TextSpan span,
+        StringBuilderOp operation,
+        IReadOnlyList<ExpressionNode> arguments)
+        : base(span)
+    {
+        Operation = operation;
+        Arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Helper methods for StringBuilderOp enum.
+/// </summary>
+public static class StringBuilderOpExtensions
+{
+    /// <summary>
+    /// Parses a StringBuilder operation name to its enum value.
+    /// Returns null if the name is not a recognized StringBuilder operation.
+    /// </summary>
+    public static StringBuilderOp? FromString(string? name)
+    {
+        return name?.ToLowerInvariant() switch
+        {
+            "sb-new" => StringBuilderOp.New,
+            "sb-append" => StringBuilderOp.Append,
+            "sb-appendline" => StringBuilderOp.AppendLine,
+            "sb-insert" => StringBuilderOp.Insert,
+            "sb-remove" => StringBuilderOp.Remove,
+            "sb-clear" => StringBuilderOp.Clear,
+            "sb-tostring" => StringBuilderOp.ToString,
+            "sb-length" => StringBuilderOp.Length,
+
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Converts a StringBuilderOp enum value back to its Calor syntax name.
+    /// </summary>
+    public static string ToCalorName(this StringBuilderOp op)
+    {
+        return op switch
+        {
+            StringBuilderOp.New => "sb-new",
+            StringBuilderOp.Append => "sb-append",
+            StringBuilderOp.AppendLine => "sb-appendline",
+            StringBuilderOp.Insert => "sb-insert",
+            StringBuilderOp.Remove => "sb-remove",
+            StringBuilderOp.Clear => "sb-clear",
+            StringBuilderOp.ToString => "sb-tostring",
+            StringBuilderOp.Length => "sb-length",
+
+            _ => throw new ArgumentOutOfRangeException(nameof(op), op, "Unknown StringBuilder operation")
+        };
+    }
+
+    /// <summary>
+    /// Gets the minimum number of arguments required for the operation.
+    /// </summary>
+    public static int GetMinArgCount(this StringBuilderOp op)
+    {
+        return op switch
+        {
+            // Zero argument operations
+            StringBuilderOp.New => 0,
+
+            // Single argument operations
+            StringBuilderOp.Clear or
+            StringBuilderOp.ToString or
+            StringBuilderOp.Length => 1,
+
+            // Two argument operations
+            StringBuilderOp.Append or
+            StringBuilderOp.AppendLine => 2,
+
+            // Three argument operations
+            StringBuilderOp.Insert or
+            StringBuilderOp.Remove => 3,
+
+            _ => 0
+        };
+    }
+
+    /// <summary>
+    /// Gets the maximum number of arguments allowed for the operation.
+    /// </summary>
+    public static int GetMaxArgCount(this StringBuilderOp op)
+    {
+        return op switch
+        {
+            // Zero or one argument (optional initial string)
+            StringBuilderOp.New => 1,
+
+            // Single argument operations
+            StringBuilderOp.Clear or
+            StringBuilderOp.ToString or
+            StringBuilderOp.Length => 1,
+
+            // Two argument operations
+            StringBuilderOp.Append or
+            StringBuilderOp.AppendLine => 2,
+
+            // Three argument operations
+            StringBuilderOp.Insert or
+            StringBuilderOp.Remove => 3,
+
+            _ => 1
+        };
+    }
+}

--- a/src/Calor.Compiler/Ids/IdScanner.cs
+++ b/src/Calor.Compiler/Ids/IdScanner.cs
@@ -248,4 +248,6 @@ public sealed class IdScanner : IAstVisitor
     public void Visit(ExistsExpressionNode node) { }
     public void Visit(ImplicationExpressionNode node) { }
     public void Visit(StringOperationNode node) { }
+    public void Visit(CharOperationNode node) { }
+    public void Visit(StringBuilderOperationNode node) { }
 }

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -2013,6 +2013,30 @@ public sealed class CalorEmitter : IAstVisitor<string>
     {
         var opName = node.Operation.ToCalorName();
         var args = node.Arguments.Select(a => a.Accept(this));
+        var argsStr = string.Join(" ", args);
+
+        // Append comparison mode keyword if present
+        if (node.ComparisonMode.HasValue)
+        {
+            var keyword = node.ComparisonMode.Value.ToKeyword();
+            return $"({opName} {argsStr} :{keyword})";
+        }
+
+        return $"({opName} {argsStr})";
+    }
+
+    public string Visit(CharOperationNode node)
+    {
+        var opName = node.Operation.ToCalorName();
+        var args = node.Arguments.Select(a => a.Accept(this));
         return $"({opName} {string.Join(" ", args)})";
+    }
+
+    public string Visit(StringBuilderOperationNode node)
+    {
+        var opName = node.Operation.ToCalorName();
+        var args = node.Arguments.Select(a => a.Accept(this));
+        var argsStr = string.Join(" ", args);
+        return args.Any() ? $"({opName} {argsStr})" : $"({opName})";
     }
 }

--- a/src/Calor.Compiler/Verification/ExpressionSimplifier.cs
+++ b/src/Calor.Compiler/Verification/ExpressionSimplifier.cs
@@ -1330,9 +1330,23 @@ public sealed class ExpressionSimplifier : IAstVisitor<ExpressionNode>
     public ExpressionNode Visit(CalorAttributeNode node) => throw new InvalidOperationException();
     public ExpressionNode Visit(StringOperationNode node)
     {
-        // Simplify arguments but preserve the string operation
+        // Simplify arguments but preserve the string operation and comparison mode
         var simplifiedArgs = node.Arguments.Select(a => a.Accept(this)).ToList();
-        return new StringOperationNode(node.Span, node.Operation, simplifiedArgs);
+        return new StringOperationNode(node.Span, node.Operation, simplifiedArgs, node.ComparisonMode);
+    }
+
+    public ExpressionNode Visit(CharOperationNode node)
+    {
+        // Simplify arguments but preserve the char operation
+        var simplifiedArgs = node.Arguments.Select(a => a.Accept(this)).ToList();
+        return new CharOperationNode(node.Span, node.Operation, simplifiedArgs);
+    }
+
+    public ExpressionNode Visit(StringBuilderOperationNode node)
+    {
+        // Simplify arguments but preserve the StringBuilder operation
+        var simplifiedArgs = node.Arguments.Select(a => a.Accept(this)).ToList();
+        return new StringBuilderOperationNode(node.Span, node.Operation, simplifiedArgs);
     }
 
     #endregion

--- a/tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj
+++ b/tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Calor.Compiler\Calor.Compiler.csproj" />
+    <ProjectReference Include="..\Calor.Enforcement.Tests\Calor.Enforcement.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Calor.Compiler.Tests/CharOperationTests.cs
+++ b/tests/Calor.Compiler.Tests/CharOperationTests.cs
@@ -1,0 +1,690 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Migration;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+public class CharOperationTests
+{
+    private static ModuleNode Parse(string source, out DiagnosticBag diagnostics)
+    {
+        diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+        return parser.Parse();
+    }
+
+    private static string WrapInFunction(string body, string inputType = "string", string outputType = "object")
+    {
+        return $$"""
+            §M{m001:Test}
+            §F{f001:Main:pub}
+              §I{{{inputType}}:s}
+              §O{{{outputType}}}
+              {{body}}
+            §/F{f001}
+            §/M{m001}
+            """;
+    }
+
+    private static string WrapCharFunction(string body)
+    {
+        return $$"""
+            §M{m001:Test}
+            §F{f001:Main:pub}
+              §I{char:c}
+              §O{object}
+              {{body}}
+            §/F{f001}
+            §/M{m001}
+            """;
+    }
+
+    private static CharOperationNode GetReturnCharExpression(ModuleNode module)
+    {
+        var func = module.Functions[0];
+        var returnStmt = func.Body[0] as ReturnStatementNode;
+        Assert.NotNull(returnStmt);
+        var charOp = returnStmt!.Expression as CharOperationNode;
+        Assert.NotNull(charOp);
+        return charOp!;
+    }
+
+    #region AST Tests
+
+    [Fact]
+    public void Parse_CharAt_ReturnsCharOperationNode()
+    {
+        var source = WrapInFunction("§R (char-at s 0)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var charOp = GetReturnCharExpression(module);
+        Assert.Equal(CharOp.CharAt, charOp.Operation);
+        Assert.Equal(2, charOp.Arguments.Count);
+    }
+
+    [Fact]
+    public void Parse_CharCode_ReturnsCharOperationNode()
+    {
+        var source = WrapCharFunction("§R (char-code c)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var charOp = GetReturnCharExpression(module);
+        Assert.Equal(CharOp.CharCode, charOp.Operation);
+        Assert.Single(charOp.Arguments);
+    }
+
+    [Fact]
+    public void Parse_CharFromCode_ReturnsCharOperationNode()
+    {
+        var source = WrapInFunction("§R (char-from-code 65)", "i32", "char");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var charOp = GetReturnCharExpression(module);
+        Assert.Equal(CharOp.CharFromCode, charOp.Operation);
+        Assert.Single(charOp.Arguments);
+    }
+
+    [Fact]
+    public void Parse_IsLetter_ReturnsCharOperationNode()
+    {
+        var source = WrapCharFunction("§R (is-letter c)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var charOp = GetReturnCharExpression(module);
+        Assert.Equal(CharOp.IsLetter, charOp.Operation);
+        Assert.Single(charOp.Arguments);
+    }
+
+    [Fact]
+    public void Parse_IsDigit_ReturnsCharOperationNode()
+    {
+        var source = WrapCharFunction("§R (is-digit c)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var charOp = GetReturnCharExpression(module);
+        Assert.Equal(CharOp.IsDigit, charOp.Operation);
+        Assert.Single(charOp.Arguments);
+    }
+
+    [Fact]
+    public void Parse_IsWhitespace_ReturnsCharOperationNode()
+    {
+        var source = WrapCharFunction("§R (is-whitespace c)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var charOp = GetReturnCharExpression(module);
+        Assert.Equal(CharOp.IsWhiteSpace, charOp.Operation);
+        Assert.Single(charOp.Arguments);
+    }
+
+    [Fact]
+    public void Parse_IsUpper_ReturnsCharOperationNode()
+    {
+        var source = WrapCharFunction("§R (is-upper c)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var charOp = GetReturnCharExpression(module);
+        Assert.Equal(CharOp.IsUpper, charOp.Operation);
+        Assert.Single(charOp.Arguments);
+    }
+
+    [Fact]
+    public void Parse_IsLower_ReturnsCharOperationNode()
+    {
+        var source = WrapCharFunction("§R (is-lower c)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var charOp = GetReturnCharExpression(module);
+        Assert.Equal(CharOp.IsLower, charOp.Operation);
+        Assert.Single(charOp.Arguments);
+    }
+
+    [Fact]
+    public void Parse_CharUpper_ReturnsCharOperationNode()
+    {
+        var source = WrapCharFunction("§R (char-upper c)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var charOp = GetReturnCharExpression(module);
+        Assert.Equal(CharOp.ToUpperChar, charOp.Operation);
+        Assert.Single(charOp.Arguments);
+    }
+
+    [Fact]
+    public void Parse_CharLower_ReturnsCharOperationNode()
+    {
+        var source = WrapCharFunction("§R (char-lower c)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var charOp = GetReturnCharExpression(module);
+        Assert.Equal(CharOp.ToLowerChar, charOp.Operation);
+        Assert.Single(charOp.Arguments);
+    }
+
+    #endregion
+
+    #region C# Emission Tests
+
+    [Theory]
+    [InlineData("(char-at s 0)", "s[0]")]
+    [InlineData("(char-code c)", "(int)c")]
+    [InlineData("(char-from-code 65)", "(char)65")]
+    [InlineData("(is-letter c)", "char.IsLetter(c)")]
+    [InlineData("(is-digit c)", "char.IsDigit(c)")]
+    [InlineData("(is-whitespace c)", "char.IsWhiteSpace(c)")]
+    [InlineData("(is-upper c)", "char.IsUpper(c)")]
+    [InlineData("(is-lower c)", "char.IsLower(c)")]
+    [InlineData("(char-upper c)", "char.ToUpper(c)")]
+    [InlineData("(char-lower c)", "char.ToLower(c)")]
+    public void Emit_CharOperation_ProducesCorrectCSharp(string calor, string expectedCSharp)
+    {
+        var source = $$"""
+            §M{m001:Test}
+            §F{f001:Main:pub}
+              §I{string:s}
+              §I{char:c}
+              §O{object}
+              §R {{calor}}
+            §/F{f001}
+            §/M{m001}
+            """;
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(module);
+
+        Assert.Contains(expectedCSharp, code);
+    }
+
+    #endregion
+
+    #region Round-Trip Tests
+
+    [Theory]
+    [InlineData("(char-at s 0)")]
+    [InlineData("(char-code c)")]
+    [InlineData("(char-from-code 65)")]
+    [InlineData("(is-letter c)")]
+    [InlineData("(is-digit c)")]
+    [InlineData("(is-whitespace c)")]
+    [InlineData("(is-upper c)")]
+    [InlineData("(is-lower c)")]
+    [InlineData("(char-upper c)")]
+    [InlineData("(char-lower c)")]
+    public void RoundTrip_CharOp_ProducesValidCalor(string op)
+    {
+        var source = $$"""
+            §M{m001:Test}
+            §F{f001:Main:pub}
+              §I{string:s}
+              §I{char:c}
+              §O{object}
+              §R {{op}}
+            §/F{f001}
+            §/M{m001}
+            """;
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var calorEmitter = new CalorEmitter();
+        var roundTripped = calorEmitter.Emit(module);
+
+        Assert.Contains(op, roundTripped);
+    }
+
+    #endregion
+
+    #region Error Tests
+
+    [Fact]
+    public void Parse_CharAt_NoArgs_ReportsError()
+    {
+        var source = WrapInFunction("§R (char-at)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("requires at least 2 argument"));
+    }
+
+    [Fact]
+    public void Parse_CharAt_OneArg_ReportsError()
+    {
+        var source = WrapInFunction("§R (char-at s)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("requires at least 2 argument"));
+    }
+
+    [Fact]
+    public void Parse_IsLetter_NoArgs_ReportsError()
+    {
+        var source = WrapCharFunction("§R (is-letter)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("requires at least 1 argument"));
+    }
+
+    [Fact]
+    public void Parse_IsLetter_TooManyArgs_ReportsError()
+    {
+        var source = WrapCharFunction("§R (is-letter c c)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("accepts at most 1 argument"));
+    }
+
+    #endregion
+
+    #region Extensions Tests
+
+    [Theory]
+    [InlineData("char-at", CharOp.CharAt)]
+    [InlineData("char-code", CharOp.CharCode)]
+    [InlineData("char-from-code", CharOp.CharFromCode)]
+    [InlineData("is-letter", CharOp.IsLetter)]
+    [InlineData("is-digit", CharOp.IsDigit)]
+    [InlineData("is-whitespace", CharOp.IsWhiteSpace)]
+    [InlineData("is-upper", CharOp.IsUpper)]
+    [InlineData("is-lower", CharOp.IsLower)]
+    [InlineData("char-upper", CharOp.ToUpperChar)]
+    [InlineData("char-lower", CharOp.ToLowerChar)]
+    public void FromString_ValidOperator_ReturnsCorrectEnum(string name, CharOp expected)
+    {
+        var result = CharOpExtensions.FromString(name);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void FromString_InvalidOperator_ReturnsNull()
+    {
+        var result = CharOpExtensions.FromString("invalid");
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData(CharOp.CharAt, "char-at")]
+    [InlineData(CharOp.CharCode, "char-code")]
+    [InlineData(CharOp.CharFromCode, "char-from-code")]
+    [InlineData(CharOp.IsLetter, "is-letter")]
+    [InlineData(CharOp.IsDigit, "is-digit")]
+    [InlineData(CharOp.IsWhiteSpace, "is-whitespace")]
+    [InlineData(CharOp.IsUpper, "is-upper")]
+    [InlineData(CharOp.IsLower, "is-lower")]
+    [InlineData(CharOp.ToUpperChar, "char-upper")]
+    [InlineData(CharOp.ToLowerChar, "char-lower")]
+    public void ToCalorName_ReturnsCorrectName(CharOp op, string expected)
+    {
+        var result = op.ToCalorName();
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(CharOp.CharAt, 2, 2)]
+    [InlineData(CharOp.CharCode, 1, 1)]
+    [InlineData(CharOp.CharFromCode, 1, 1)]
+    [InlineData(CharOp.IsLetter, 1, 1)]
+    [InlineData(CharOp.IsDigit, 1, 1)]
+    [InlineData(CharOp.IsWhiteSpace, 1, 1)]
+    [InlineData(CharOp.IsUpper, 1, 1)]
+    [InlineData(CharOp.IsLower, 1, 1)]
+    [InlineData(CharOp.ToUpperChar, 1, 1)]
+    [InlineData(CharOp.ToLowerChar, 1, 1)]
+    public void ArgCount_AllOperations_HaveCorrectBounds(CharOp op, int expectedMin, int expectedMax)
+    {
+        Assert.Equal(expectedMin, op.GetMinArgCount());
+        Assert.Equal(expectedMax, op.GetMaxArgCount());
+    }
+
+    #endregion
+
+    #region Composition Tests
+
+    [Fact]
+    public void Parse_CharAtWithStringOp_Works()
+    {
+        // Check first char of uppercased string
+        var source = WrapInFunction("§R (char-at (upper s) 0)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var charOp = GetReturnCharExpression(module);
+        Assert.Equal(CharOp.CharAt, charOp.Operation);
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(module);
+        Assert.Contains("s.ToUpper()[0]", code);
+    }
+
+    [Fact]
+    public void Parse_IsLetterWithCharAt_Works()
+    {
+        // Check if first char is a letter
+        var source = WrapInFunction("§R (is-letter (char-at s 0))");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var charOp = GetReturnCharExpression(module);
+        Assert.Equal(CharOp.IsLetter, charOp.Operation);
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(module);
+        Assert.Contains("char.IsLetter(s[0])", code);
+    }
+
+    [Fact]
+    public void Parse_CharUpperWithCharAt_Works()
+    {
+        // Convert first char to uppercase
+        var source = WrapInFunction("§R (char-upper (char-at s 0))");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var charOp = GetReturnCharExpression(module);
+        Assert.Equal(CharOp.ToUpperChar, charOp.Operation);
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(module);
+        Assert.Contains("char.ToUpper(s[0])", code);
+    }
+
+    #endregion
+
+    #region C# Migration Tests
+
+    private static CharOperationNode? FindCharOperationInResult(ConversionResult result)
+    {
+        if (!result.Success || result.Ast == null) return null;
+
+        // Search in top-level functions
+        foreach (var func in result.Ast.Functions)
+        {
+            var found = FindCharOperationInFunction(func);
+            if (found != null) return found;
+        }
+
+        // Search in class methods
+        foreach (var cls in result.Ast.Classes)
+        {
+            foreach (var method in cls.Methods)
+            {
+                var found = FindCharOperationInBody(method.Body);
+                if (found != null) return found;
+            }
+        }
+
+        return null;
+    }
+
+    private static CharOperationNode? FindCharOperationInFunction(FunctionNode func)
+    {
+        return FindCharOperationInBody(func.Body);
+    }
+
+    private static CharOperationNode? FindCharOperationInBody(IReadOnlyList<StatementNode> body)
+    {
+        foreach (var stmt in body)
+        {
+            var found = FindCharOperationInStatement(stmt);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    private static CharOperationNode? FindCharOperationInStatement(StatementNode stmt)
+    {
+        if (stmt is ReturnStatementNode ret)
+        {
+            return FindCharOperationInExpression(ret.Expression);
+        }
+        if (stmt is BindStatementNode bind)
+        {
+            return FindCharOperationInExpression(bind.Initializer);
+        }
+        return null;
+    }
+
+    private static CharOperationNode? FindCharOperationInExpression(ExpressionNode? expr)
+    {
+        if (expr == null) return null;
+        if (expr is CharOperationNode charOp) return charOp;
+
+        // Search recursively in common expression types
+        return expr switch
+        {
+            CallExpressionNode call => call.Arguments.Select(FindCharOperationInExpression).FirstOrDefault(x => x != null),
+            _ => null
+        };
+    }
+
+    [Theory]
+    [InlineData("char.IsLetter(c)", "is-letter")]
+    [InlineData("char.IsDigit(c)", "is-digit")]
+    [InlineData("char.IsWhiteSpace(c)", "is-whitespace")]
+    [InlineData("char.IsUpper(c)", "is-upper")]
+    [InlineData("char.IsLower(c)", "is-lower")]
+    [InlineData("char.ToUpper(c)", "char-upper")]
+    [InlineData("char.ToLower(c)", "char-lower")]
+    public void Migration_CharStaticMethod_ConvertsToCharOp(string csharpExpr, string expectedCalorOp)
+    {
+        // The C# to Calor converter converts char static methods to char operations
+        var csharp = $"public class Test {{ public object M(char c) {{ return {csharpExpr}; }} }}";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        // Check via round-trip
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+        Assert.Contains(expectedCalorOp, calor);
+    }
+
+    [Fact]
+    public void Migration_CharCastToInt_ConvertsToCharCode()
+    {
+        // The C# to Calor converter converts (int)c to char-code
+        // Verify the CalorEmitter produces the expected output
+        var csharp = "public class Test { public int M(char c) { return (int)c; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        // Check via round-trip - the emitted Calor should contain char-code
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+        Assert.Contains("char-code", calor);
+    }
+
+    [Fact]
+    public void Migration_IntCastToChar_ConvertsToCharFromCode()
+    {
+        // The C# to Calor converter converts (char)n to char-from-code
+        var csharp = "public class Test { public char M(int n) { return (char)n; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        // Check via round-trip - the emitted Calor should contain char-from-code
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+        Assert.Contains("char-from-code", calor);
+    }
+
+    [Fact]
+    public void Migration_StringIndexer_ConvertsToCharAt()
+    {
+        // The C# to Calor converter converts s[0] to char-at
+        var csharp = "public class Test { public char M(string s) { return s[0]; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        // Check via round-trip - the emitted Calor should contain char-at
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+        Assert.Contains("char-at", calor);
+    }
+
+    [Fact]
+    public void Migration_StringIndexerVariable_ConvertsToCharAt()
+    {
+        // The C# to Calor converter converts s[i] to char-at
+        var csharp = "public class Test { public char M(string s, int i) { return s[i]; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        // Check via round-trip - the emitted Calor should contain char-at
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+        Assert.Contains("char-at", calor);
+    }
+
+    [Theory]
+    [InlineData("char.IsLetter(c)", "is-letter")]
+    [InlineData("char.IsDigit(c)", "is-digit")]
+    [InlineData("char.IsWhiteSpace(c)", "is-whitespace")]
+    [InlineData("char.IsUpper(c)", "is-upper")]
+    [InlineData("char.IsLower(c)", "is-lower")]
+    [InlineData("char.ToUpper(c)", "char-upper")]
+    [InlineData("char.ToLower(c)", "char-lower")]
+    public void Migration_CharOperation_RoundTripsToCalor(string csharpExpr, string expectedCalorOp)
+    {
+        var csharp = $"public class Test {{ public object M(char c) => {csharpExpr}; }}";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+
+        Assert.Contains(expectedCalorOp, calor);
+    }
+
+    [Fact]
+    public void Migration_CharAt_RoundTripsToCalor()
+    {
+        var csharp = "public class Test { public char M(string s) { return s[0]; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+
+        Assert.Contains("char-at", calor);
+    }
+
+    [Fact]
+    public void Migration_CharCode_RoundTripsToCalor()
+    {
+        var csharp = "public class Test { public int M(char c) { return (int)c; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+
+        Assert.Contains("char-code", calor);
+    }
+
+    [Fact]
+    public void Migration_CharFromCode_RoundTripsToCalor()
+    {
+        var csharp = "public class Test { public char M(int n) { return (char)n; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+
+        Assert.Contains("char-from-code", calor);
+    }
+
+    [Fact]
+    public void Migration_CrossCategory_CharWithStringOp()
+    {
+        // Test cross-category: char.IsLetter(s.ToUpper()[0])
+        var csharp = "public class Test { public bool M(string s) { return char.IsLetter(s.ToUpper()[0]); } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+
+        // Should contain both char and string operations
+        Assert.Contains("is-letter", calor);
+        Assert.Contains("upper", calor);
+        Assert.Contains("char-at", calor);
+    }
+
+    [Fact]
+    public void Migration_IntCastFromDouble_DoesNotConvertToCharCode()
+    {
+        // (int)someDouble should NOT become char-code - it's a numeric conversion
+        var csharp = "public class Test { public int M(double d) { return (int)d; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+
+        // Should NOT contain char-code since source is double, not char
+        Assert.DoesNotContain("char-code", calor);
+    }
+
+    [Fact]
+    public void Migration_CharCastFromObject_DoesNotConvertToCharFromCode()
+    {
+        // (char)someObject should NOT become char-from-code without more context
+        var csharp = "public class Test { public char M(object obj) { return (char)obj; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+
+        // May or may not contain char-from-code depending on heuristics
+        // The important thing is it doesn't crash and produces valid output
+        Assert.NotNull(calor);
+    }
+
+    #endregion
+}

--- a/tests/Calor.Compiler.Tests/RegexOperationTests.cs
+++ b/tests/Calor.Compiler.Tests/RegexOperationTests.cs
@@ -1,0 +1,373 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Migration;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+public class RegexOperationTests
+{
+    private static ModuleNode Parse(string source, out DiagnosticBag diagnostics)
+    {
+        diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+        return parser.Parse();
+    }
+
+    private static string WrapInFunction(string body)
+    {
+        return $$"""
+            §M{m001:Test}
+            §F{f001:Main:pub}
+              §I{string:s}
+              §O{object}
+              {{body}}
+            §/F{f001}
+            §/M{m001}
+            """;
+    }
+
+    private static StringOperationNode GetReturnExpression(ModuleNode module)
+    {
+        var func = module.Functions[0];
+        var returnStmt = func.Body[0] as ReturnStatementNode;
+        Assert.NotNull(returnStmt);
+        var strOp = returnStmt!.Expression as StringOperationNode;
+        Assert.NotNull(strOp);
+        return strOp!;
+    }
+
+    #region AST Tests
+
+    [Fact]
+    public void Parse_RegexTest_ReturnsStringOperationNode()
+    {
+        var source = WrapInFunction("§R (regex-test s \"\\\\d+\")");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var strOp = GetReturnExpression(module);
+        Assert.Equal(StringOp.RegexTest, strOp.Operation);
+        Assert.Equal(2, strOp.Arguments.Count);
+    }
+
+    [Fact]
+    public void Parse_RegexMatch_ReturnsStringOperationNode()
+    {
+        var source = WrapInFunction("§R (regex-match s \"\\\\d+\")");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var strOp = GetReturnExpression(module);
+        Assert.Equal(StringOp.RegexMatch, strOp.Operation);
+        Assert.Equal(2, strOp.Arguments.Count);
+    }
+
+    [Fact]
+    public void Parse_RegexReplace_ReturnsStringOperationNode()
+    {
+        var source = WrapInFunction("§R (regex-replace s \"\\\\s+\" \"-\")");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var strOp = GetReturnExpression(module);
+        Assert.Equal(StringOp.RegexReplace, strOp.Operation);
+        Assert.Equal(3, strOp.Arguments.Count);
+    }
+
+    [Fact]
+    public void Parse_RegexSplit_ReturnsStringOperationNode()
+    {
+        var source = WrapInFunction("§R (regex-split s \",\")");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var strOp = GetReturnExpression(module);
+        Assert.Equal(StringOp.RegexSplit, strOp.Operation);
+        Assert.Equal(2, strOp.Arguments.Count);
+    }
+
+    #endregion
+
+    #region C# Emission Tests
+
+    [Fact]
+    public void Emit_RegexTest_ProducesCorrectCSharp()
+    {
+        var source = WrapInFunction("§R (regex-test s \"\\\\d+\")");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(module);
+
+        // The emitted C# will have \\d+ because Calor source has \\d+ (which is \d+ in the parsed string)
+        Assert.Contains("System.Text.RegularExpressions.Regex.IsMatch(s, \"\\\\d+\")", code);
+    }
+
+    [Fact]
+    public void Emit_RegexMatch_ProducesCorrectCSharp()
+    {
+        var source = WrapInFunction("§R (regex-match s \"\\\\d+\")");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(module);
+
+        Assert.Contains("System.Text.RegularExpressions.Regex.Match(s, \"\\\\d+\")", code);
+    }
+
+    [Fact]
+    public void Emit_RegexReplace_ProducesCorrectCSharp()
+    {
+        var source = WrapInFunction("§R (regex-replace s \"\\\\s+\" \"-\")");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(module);
+
+        Assert.Contains("System.Text.RegularExpressions.Regex.Replace(s, \"\\\\s+\", \"-\")", code);
+    }
+
+    [Fact]
+    public void Emit_RegexSplit_ProducesCorrectCSharp()
+    {
+        var source = WrapInFunction("§R (regex-split s \",\")");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(module);
+
+        Assert.Contains("System.Text.RegularExpressions.Regex.Split(s, \",\")", code);
+    }
+
+    #endregion
+
+    #region Round-Trip Tests
+
+    [Theory]
+    [InlineData("(regex-test s \"\\\\d+\")")]
+    [InlineData("(regex-match s \"\\\\d+\")")]
+    [InlineData("(regex-replace s \"\\\\s+\" \"-\")")]
+    [InlineData("(regex-split s \",\")")]
+    public void RoundTrip_RegexOp_ProducesValidCalor(string op)
+    {
+        var source = WrapInFunction($"§R {op}");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var calorEmitter = new CalorEmitter();
+        var roundTripped = calorEmitter.Emit(module);
+
+        // Extract the expected op name from the expression
+        var opName = op.Split(' ')[0].TrimStart('(');
+        Assert.Contains(opName, roundTripped);
+    }
+
+    #endregion
+
+    #region Error Tests
+
+    [Fact]
+    public void Parse_RegexTest_NoArgs_ReportsError()
+    {
+        var source = WrapInFunction("§R (regex-test)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("requires at least 2 argument"));
+    }
+
+    [Fact]
+    public void Parse_RegexTest_OneArg_ReportsError()
+    {
+        var source = WrapInFunction("§R (regex-test s)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("requires at least 2 argument"));
+    }
+
+    [Fact]
+    public void Parse_RegexReplace_TwoArgs_ReportsError()
+    {
+        var source = WrapInFunction("§R (regex-replace s \"pattern\")");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("requires at least 3 argument"));
+    }
+
+    #endregion
+
+    #region Extensions Tests
+
+    [Theory]
+    [InlineData("regex-test", StringOp.RegexTest)]
+    [InlineData("regex-match", StringOp.RegexMatch)]
+    [InlineData("regex-replace", StringOp.RegexReplace)]
+    [InlineData("regex-split", StringOp.RegexSplit)]
+    public void FromString_ValidOperator_ReturnsCorrectEnum(string name, StringOp expected)
+    {
+        var result = StringOpExtensions.FromString(name);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(StringOp.RegexTest, "regex-test")]
+    [InlineData(StringOp.RegexMatch, "regex-match")]
+    [InlineData(StringOp.RegexReplace, "regex-replace")]
+    [InlineData(StringOp.RegexSplit, "regex-split")]
+    public void ToCalorName_ReturnsCorrectName(StringOp op, string expected)
+    {
+        var result = op.ToCalorName();
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(StringOp.RegexTest, 2, 2)]
+    [InlineData(StringOp.RegexMatch, 2, 2)]
+    [InlineData(StringOp.RegexReplace, 3, 3)]
+    [InlineData(StringOp.RegexSplit, 2, 2)]
+    public void ArgCount_ReturnsCorrectBounds(StringOp op, int expectedMin, int expectedMax)
+    {
+        Assert.Equal(expectedMin, op.GetMinArgCount());
+        Assert.Equal(expectedMax, op.GetMaxArgCount());
+    }
+
+    #endregion
+
+    #region C# Migration Tests
+
+    private static StringOperationNode? FindStringOperationInResult(ConversionResult result)
+    {
+        if (!result.Success || result.Ast == null) return null;
+
+        // Search in top-level functions
+        foreach (var func in result.Ast.Functions)
+        {
+            var found = FindStringOperationInFunction(func);
+            if (found != null) return found;
+        }
+
+        // Search in class methods
+        foreach (var cls in result.Ast.Classes)
+        {
+            foreach (var method in cls.Methods)
+            {
+                var found = FindStringOperationInBody(method.Body);
+                if (found != null) return found;
+            }
+        }
+
+        return null;
+    }
+
+    private static StringOperationNode? FindStringOperationInFunction(FunctionNode func)
+    {
+        return FindStringOperationInBody(func.Body);
+    }
+
+    private static StringOperationNode? FindStringOperationInBody(IReadOnlyList<StatementNode> body)
+    {
+        foreach (var stmt in body)
+        {
+            if (stmt is ReturnStatementNode ret && ret.Expression is StringOperationNode strOp)
+                return strOp;
+            if (stmt is BindStatementNode bind && bind.Initializer is StringOperationNode bindStrOp)
+                return bindStrOp;
+        }
+        return null;
+    }
+
+    [Theory]
+    [InlineData("Regex.IsMatch(s, \"\\\\d+\")", "regex-test")]
+    [InlineData("Regex.Match(s, \"\\\\d+\")", "regex-match")]
+    [InlineData("Regex.Split(s, \",\")", "regex-split")]
+    public void Migration_RegexStaticMethod_ConvertsToStringOp(string csharpExpr, string expectedCalorOp)
+    {
+        // The C# to Calor converter converts Regex static methods
+        var csharp = $@"
+using System.Text.RegularExpressions;
+public class Test {{ public object M(string s) {{ return {csharpExpr}; }} }}";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        // Check via round-trip
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+        Assert.Contains(expectedCalorOp, calor);
+    }
+
+    [Fact]
+    public void Migration_RegexReplace_ConvertsToStringOp()
+    {
+        // The C# to Calor converter converts Regex.Replace
+        var csharp = @"
+using System.Text.RegularExpressions;
+public class Test { public string M(string s) { return Regex.Replace(s, ""\\s+"", ""-""); } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        // Check via round-trip
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+        Assert.Contains("regex-replace", calor);
+    }
+
+    [Fact]
+    public void Migration_RegexIsMatch_FullyQualified_ConvertsToStringOp()
+    {
+        // The C# to Calor converter converts fully qualified Regex.IsMatch
+        var csharp = @"
+public class Test { public bool M(string s) { return System.Text.RegularExpressions.Regex.IsMatch(s, ""\\d+""); } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        // Check via round-trip
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+        Assert.Contains("regex-test", calor);
+    }
+
+    [Theory]
+    [InlineData("Regex.IsMatch(s, \"\\\\d+\")", "regex-test")]
+    [InlineData("Regex.Match(s, \"\\\\d+\")", "regex-match")]
+    [InlineData("Regex.Replace(s, \"\\\\s+\", \"-\")", "regex-replace")]
+    [InlineData("Regex.Split(s, \",\")", "regex-split")]
+    public void Migration_RegexOperation_RoundTripsToCalor(string csharpExpr, string expectedCalorOp)
+    {
+        var csharp = $@"
+using System.Text.RegularExpressions;
+public class Test {{ public object M(string s) => {csharpExpr}; }}";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+
+        Assert.Contains(expectedCalorOp, calor);
+    }
+
+    #endregion
+}

--- a/tests/Calor.Compiler.Tests/StringBuilderOperationTests.cs
+++ b/tests/Calor.Compiler.Tests/StringBuilderOperationTests.cs
@@ -1,0 +1,595 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Migration;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+public class StringBuilderOperationTests
+{
+    private static ModuleNode Parse(string source, out DiagnosticBag diagnostics)
+    {
+        diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+        return parser.Parse();
+    }
+
+    private static string WrapInFunction(string body)
+    {
+        return $$"""
+            §M{m001:Test}
+            §F{f001:Main:pub}
+              §I{object:sb}
+              §O{object}
+              {{body}}
+            §/F{f001}
+            §/M{m001}
+            """;
+    }
+
+    private static StringBuilderOperationNode GetReturnExpression(ModuleNode module)
+    {
+        var func = module.Functions[0];
+        var returnStmt = func.Body[0] as ReturnStatementNode;
+        Assert.NotNull(returnStmt);
+        var sbOp = returnStmt!.Expression as StringBuilderOperationNode;
+        Assert.NotNull(sbOp);
+        return sbOp!;
+    }
+
+    #region AST Tests
+
+    [Fact]
+    public void Parse_SbNew_ReturnsStringBuilderOperationNode()
+    {
+        var source = WrapInFunction("§R (sb-new)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var sbOp = GetReturnExpression(module);
+        Assert.Equal(StringBuilderOp.New, sbOp.Operation);
+        Assert.Empty(sbOp.Arguments);
+    }
+
+    [Fact]
+    public void Parse_SbNewWithInit_ReturnsStringBuilderOperationNode()
+    {
+        var source = WrapInFunction("§R (sb-new \"init\")");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var sbOp = GetReturnExpression(module);
+        Assert.Equal(StringBuilderOp.New, sbOp.Operation);
+        Assert.Single(sbOp.Arguments);
+    }
+
+    [Fact]
+    public void Parse_SbAppend_ReturnsStringBuilderOperationNode()
+    {
+        var source = WrapInFunction("§R (sb-append sb \"text\")");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var sbOp = GetReturnExpression(module);
+        Assert.Equal(StringBuilderOp.Append, sbOp.Operation);
+        Assert.Equal(2, sbOp.Arguments.Count);
+    }
+
+    [Fact]
+    public void Parse_SbAppendLine_ReturnsStringBuilderOperationNode()
+    {
+        var source = WrapInFunction("§R (sb-appendline sb \"text\")");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var sbOp = GetReturnExpression(module);
+        Assert.Equal(StringBuilderOp.AppendLine, sbOp.Operation);
+        Assert.Equal(2, sbOp.Arguments.Count);
+    }
+
+    [Fact]
+    public void Parse_SbInsert_ReturnsStringBuilderOperationNode()
+    {
+        var source = WrapInFunction("§R (sb-insert sb 0 \"text\")");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var sbOp = GetReturnExpression(module);
+        Assert.Equal(StringBuilderOp.Insert, sbOp.Operation);
+        Assert.Equal(3, sbOp.Arguments.Count);
+    }
+
+    [Fact]
+    public void Parse_SbRemove_ReturnsStringBuilderOperationNode()
+    {
+        var source = WrapInFunction("§R (sb-remove sb 0 5)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var sbOp = GetReturnExpression(module);
+        Assert.Equal(StringBuilderOp.Remove, sbOp.Operation);
+        Assert.Equal(3, sbOp.Arguments.Count);
+    }
+
+    [Fact]
+    public void Parse_SbClear_ReturnsStringBuilderOperationNode()
+    {
+        var source = WrapInFunction("§R (sb-clear sb)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var sbOp = GetReturnExpression(module);
+        Assert.Equal(StringBuilderOp.Clear, sbOp.Operation);
+        Assert.Single(sbOp.Arguments);
+    }
+
+    [Fact]
+    public void Parse_SbToString_ReturnsStringBuilderOperationNode()
+    {
+        var source = WrapInFunction("§R (sb-tostring sb)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var sbOp = GetReturnExpression(module);
+        Assert.Equal(StringBuilderOp.ToString, sbOp.Operation);
+        Assert.Single(sbOp.Arguments);
+    }
+
+    [Fact]
+    public void Parse_SbLength_ReturnsStringBuilderOperationNode()
+    {
+        var source = WrapInFunction("§R (sb-length sb)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var sbOp = GetReturnExpression(module);
+        Assert.Equal(StringBuilderOp.Length, sbOp.Operation);
+        Assert.Single(sbOp.Arguments);
+    }
+
+    #endregion
+
+    #region C# Emission Tests
+
+    [Theory]
+    [InlineData("(sb-new)", "new System.Text.StringBuilder()")]
+    [InlineData("(sb-new \"init\")", "new System.Text.StringBuilder(\"init\")")]
+    [InlineData("(sb-append sb \"text\")", "sb.Append(\"text\")")]
+    [InlineData("(sb-appendline sb \"text\")", "sb.AppendLine(\"text\")")]
+    [InlineData("(sb-insert sb 0 \"text\")", "sb.Insert(0, \"text\")")]
+    [InlineData("(sb-remove sb 0 5)", "sb.Remove(0, 5)")]
+    [InlineData("(sb-clear sb)", "sb.Clear()")]
+    [InlineData("(sb-tostring sb)", "sb.ToString()")]
+    [InlineData("(sb-length sb)", "sb.Length")]
+    public void Emit_StringBuilderOperation_ProducesCorrectCSharp(string calor, string expectedCSharp)
+    {
+        var source = WrapInFunction($"§R {calor}");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(module);
+
+        Assert.Contains(expectedCSharp, code);
+    }
+
+    #endregion
+
+    #region Round-Trip Tests
+
+    [Theory]
+    [InlineData("(sb-new)")]
+    [InlineData("(sb-new \"init\")")]
+    [InlineData("(sb-append sb \"text\")")]
+    [InlineData("(sb-appendline sb \"text\")")]
+    [InlineData("(sb-insert sb 0 \"text\")")]
+    [InlineData("(sb-remove sb 0 5)")]
+    [InlineData("(sb-clear sb)")]
+    [InlineData("(sb-tostring sb)")]
+    [InlineData("(sb-length sb)")]
+    public void RoundTrip_StringBuilderOp_ProducesValidCalor(string op)
+    {
+        var source = WrapInFunction($"§R {op}");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var calorEmitter = new CalorEmitter();
+        var roundTripped = calorEmitter.Emit(module);
+
+        // Extract the expected op name from the expression
+        var opName = op.Split(' ')[0].TrimStart('(').TrimEnd(')');
+        Assert.Contains(opName, roundTripped);
+    }
+
+    #endregion
+
+    #region Error Tests
+
+    [Fact]
+    public void Parse_SbAppend_NoArgs_ReportsError()
+    {
+        var source = WrapInFunction("§R (sb-append)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("requires at least 2 argument"));
+    }
+
+    [Fact]
+    public void Parse_SbAppend_OneArg_ReportsError()
+    {
+        var source = WrapInFunction("§R (sb-append sb)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("requires at least 2 argument"));
+    }
+
+    [Fact]
+    public void Parse_SbInsert_TwoArgs_ReportsError()
+    {
+        var source = WrapInFunction("§R (sb-insert sb 0)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("requires at least 3 argument"));
+    }
+
+    [Fact]
+    public void Parse_SbClear_NoArgs_ReportsError()
+    {
+        var source = WrapInFunction("§R (sb-clear)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("requires at least 1 argument"));
+    }
+
+    [Fact]
+    public void Parse_SbNew_TooManyArgs_ReportsError()
+    {
+        var source = WrapInFunction("§R (sb-new \"a\" \"b\")");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("accepts at most 1 argument"));
+    }
+
+    #endregion
+
+    #region Extensions Tests
+
+    [Theory]
+    [InlineData("sb-new", StringBuilderOp.New)]
+    [InlineData("sb-append", StringBuilderOp.Append)]
+    [InlineData("sb-appendline", StringBuilderOp.AppendLine)]
+    [InlineData("sb-insert", StringBuilderOp.Insert)]
+    [InlineData("sb-remove", StringBuilderOp.Remove)]
+    [InlineData("sb-clear", StringBuilderOp.Clear)]
+    [InlineData("sb-tostring", StringBuilderOp.ToString)]
+    [InlineData("sb-length", StringBuilderOp.Length)]
+    public void FromString_ValidOperator_ReturnsCorrectEnum(string name, StringBuilderOp expected)
+    {
+        var result = StringBuilderOpExtensions.FromString(name);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void FromString_InvalidOperator_ReturnsNull()
+    {
+        var result = StringBuilderOpExtensions.FromString("invalid");
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData(StringBuilderOp.New, "sb-new")]
+    [InlineData(StringBuilderOp.Append, "sb-append")]
+    [InlineData(StringBuilderOp.AppendLine, "sb-appendline")]
+    [InlineData(StringBuilderOp.Insert, "sb-insert")]
+    [InlineData(StringBuilderOp.Remove, "sb-remove")]
+    [InlineData(StringBuilderOp.Clear, "sb-clear")]
+    [InlineData(StringBuilderOp.ToString, "sb-tostring")]
+    [InlineData(StringBuilderOp.Length, "sb-length")]
+    public void ToCalorName_ReturnsCorrectName(StringBuilderOp op, string expected)
+    {
+        var result = op.ToCalorName();
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(StringBuilderOp.New, 0, 1)]
+    [InlineData(StringBuilderOp.Append, 2, 2)]
+    [InlineData(StringBuilderOp.AppendLine, 2, 2)]
+    [InlineData(StringBuilderOp.Insert, 3, 3)]
+    [InlineData(StringBuilderOp.Remove, 3, 3)]
+    [InlineData(StringBuilderOp.Clear, 1, 1)]
+    [InlineData(StringBuilderOp.ToString, 1, 1)]
+    [InlineData(StringBuilderOp.Length, 1, 1)]
+    public void ArgCount_AllOperations_HaveCorrectBounds(StringBuilderOp op, int expectedMin, int expectedMax)
+    {
+        Assert.Equal(expectedMin, op.GetMinArgCount());
+        Assert.Equal(expectedMax, op.GetMaxArgCount());
+    }
+
+    #endregion
+
+    #region Composition Tests
+
+    [Fact]
+    public void Parse_NestedAppends_Works()
+    {
+        // (sb-tostring (sb-append (sb-append (sb-new) "a") "b"))
+        var source = WrapInFunction("§R (sb-tostring (sb-append (sb-append (sb-new) \"a\") \"b\"))");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var sbOp = GetReturnExpression(module);
+        Assert.Equal(StringBuilderOp.ToString, sbOp.Operation);
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(module);
+        Assert.Contains("new System.Text.StringBuilder().Append(\"a\").Append(\"b\").ToString()", code);
+    }
+
+    [Fact]
+    public void Parse_LengthAfterClear_Works()
+    {
+        // (sb-length (sb-clear (sb-append (sb-new "init") "more")))
+        var source = WrapInFunction("§R (sb-length (sb-clear (sb-append (sb-new \"init\") \"more\")))");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var sbOp = GetReturnExpression(module);
+        Assert.Equal(StringBuilderOp.Length, sbOp.Operation);
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(module);
+        Assert.Contains("new System.Text.StringBuilder(\"init\").Append(\"more\").Clear().Length", code);
+    }
+
+    #endregion
+
+    #region C# Migration Tests
+
+    private static StringBuilderOperationNode? FindStringBuilderOperationInResult(ConversionResult result)
+    {
+        if (!result.Success || result.Ast == null) return null;
+
+        // Search in top-level functions
+        foreach (var func in result.Ast.Functions)
+        {
+            var found = FindStringBuilderOperationInFunction(func);
+            if (found != null) return found;
+        }
+
+        // Search in class methods
+        foreach (var cls in result.Ast.Classes)
+        {
+            foreach (var method in cls.Methods)
+            {
+                var found = FindStringBuilderOperationInBody(method.Body);
+                if (found != null) return found;
+            }
+        }
+
+        return null;
+    }
+
+    private static StringBuilderOperationNode? FindStringBuilderOperationInFunction(FunctionNode func)
+    {
+        return FindStringBuilderOperationInBody(func.Body);
+    }
+
+    private static StringBuilderOperationNode? FindStringBuilderOperationInBody(IReadOnlyList<StatementNode> body)
+    {
+        foreach (var stmt in body)
+        {
+            if (stmt is ReturnStatementNode ret && ret.Expression is StringBuilderOperationNode sbOp)
+                return sbOp;
+            if (stmt is BindStatementNode bind && bind.Initializer is StringBuilderOperationNode bindSbOp)
+                return bindSbOp;
+        }
+        return null;
+    }
+
+    [Fact]
+    public void Migration_NewStringBuilder_ConvertsToSbNew()
+    {
+        // The C# to Calor converter converts new StringBuilder() to sb-new
+        var csharp = @"
+using System.Text;
+public class Test { public StringBuilder M() { return new StringBuilder(); } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        // Check via round-trip
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+        Assert.Contains("sb-new", calor);
+    }
+
+    [Fact]
+    public void Migration_NewStringBuilderWithInit_ConvertsToSbNew()
+    {
+        // The C# to Calor converter converts new StringBuilder("init") to sb-new
+        var csharp = @"
+using System.Text;
+public class Test { public StringBuilder M() { return new StringBuilder(""init""); } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        // Check via round-trip - the emitted Calor should contain sb-new
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+        Assert.Contains("sb-new", calor);
+    }
+
+    [Theory]
+    [InlineData("sb.Append(\"text\")", "sb-append")]
+    [InlineData("sb.AppendLine(\"text\")", "sb-appendline")]
+    [InlineData("sb.Clear()", "sb-clear")]
+    [InlineData("sb.ToString()", "sb-tostring")]
+    public void Migration_StringBuilderInstanceMethod_ConvertsToSbOp(string csharpExpr, string expectedCalorOp)
+    {
+        var csharp = $@"
+using System.Text;
+public class Test {{ public object M(StringBuilder sb) {{ return {csharpExpr}; }} }}";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        // Check via round-trip
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+        Assert.Contains(expectedCalorOp, calor);
+    }
+
+    [Fact]
+    public void Migration_StringBuilderInsert_ConvertsToSbInsert()
+    {
+        // The C# to Calor converter converts sb.Insert(0, "text") to sb-insert
+        var csharp = @"
+using System.Text;
+public class Test { public StringBuilder M(StringBuilder sb) { return sb.Insert(0, ""text""); } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        // Check via round-trip
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+        Assert.Contains("sb-insert", calor);
+    }
+
+    [Fact]
+    public void Migration_StringBuilderRemove_ConvertsToSbRemove()
+    {
+        // The C# to Calor converter converts sb.Remove(0, 5) to sb-remove
+        var csharp = @"
+using System.Text;
+public class Test { public StringBuilder M(StringBuilder sb) { return sb.Remove(0, 5); } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        // Check via round-trip
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+        Assert.Contains("sb-remove", calor);
+    }
+
+    [Fact]
+    public void Migration_StringBuilderLength_ConvertsToSbLength()
+    {
+        // The C# to Calor converter converts sb.Length to sb-length
+        var csharp = @"
+using System.Text;
+public class Test { public int M(StringBuilder sb) { return sb.Length; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        // Check via round-trip - the emitted Calor should contain sb-length
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+        Assert.Contains("sb-length", calor);
+    }
+
+    [Theory]
+    [InlineData("new StringBuilder()", "sb-new")]
+    [InlineData("new StringBuilder(\"init\")", "sb-new")]
+    public void Migration_NewStringBuilder_RoundTripsToCalor(string csharpExpr, string expectedCalorOp)
+    {
+        var csharp = $@"
+using System.Text;
+public class Test {{ public StringBuilder M() => {csharpExpr}; }}";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+
+        Assert.Contains(expectedCalorOp, calor);
+    }
+
+    [Theory]
+    [InlineData("sb.Append(\"text\")", "sb-append")]
+    [InlineData("sb.AppendLine(\"text\")", "sb-appendline")]
+    [InlineData("sb.Insert(0, \"text\")", "sb-insert")]
+    [InlineData("sb.Remove(0, 5)", "sb-remove")]
+    [InlineData("sb.Clear()", "sb-clear")]
+    [InlineData("sb.ToString()", "sb-tostring")]
+    public void Migration_StringBuilderMethod_RoundTripsToCalor(string csharpExpr, string expectedCalorOp)
+    {
+        var csharp = $@"
+using System.Text;
+public class Test {{ public object M(StringBuilder sb) => {csharpExpr}; }}";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+
+        Assert.Contains(expectedCalorOp, calor);
+    }
+
+    [Fact]
+    public void Migration_ChainedStringBuilder_ProducesNestedOperations()
+    {
+        // Test C# chained calls: new StringBuilder().Append("a").Append("b").ToString()
+        var csharp = @"
+using System.Text;
+public class Test { public string M() { return new StringBuilder().Append(""a"").Append(""b"").ToString(); } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+
+        // Should contain all the operations
+        Assert.Contains("sb-new", calor);
+        Assert.Contains("sb-append", calor);
+        Assert.Contains("sb-tostring", calor);
+    }
+
+    [Fact]
+    public void Migration_StringBuilderWithNonSbName_FallsBackToInterop()
+    {
+        // Variable named 'builder' instead of 'sb' - should still work due to method signature
+        var csharp = @"
+using System.Text;
+public class Test { public string M(StringBuilder builder) { return builder.ToString(); } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        // This may or may not be converted depending on heuristics
+        // The important thing is it doesn't crash
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+        Assert.NotNull(calor);
+    }
+
+    #endregion
+}

--- a/tests/Calor.Compiler.Tests/StringOperationsE2ETests.cs
+++ b/tests/Calor.Compiler.Tests/StringOperationsE2ETests.cs
@@ -1,0 +1,1098 @@
+using Calor.Compiler;
+using Calor.Enforcement.Tests;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// End-to-end tests that compile Calor code with string operations to C#,
+/// then compile and execute the C# to verify correct behavior.
+/// </summary>
+public class StringOperationsE2ETests
+{
+    private static RuntimeResult Execute(string calorSource, string methodName, object?[]? args = null)
+    {
+        var options = new CompilationOptions
+        {
+            EnforceEffects = false,
+            ContractMode = ContractMode.Debug
+        };
+        return TestHarness.Execute(calorSource, methodName, args, options);
+    }
+
+    #region Basic String Operations E2E
+
+    [Theory]
+    [InlineData("hello", "HELLO")]
+    [InlineData("World", "WORLD")]
+    [InlineData("", "")]
+    public void E2E_StringUpper_ReturnsUppercased(string input, string expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:ToUpperCase:pub}
+              §I{string:s}
+              §O{string}
+              §R (upper s)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "ToUpperCase", new object[] { input });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData("HELLO", "hello")]
+    [InlineData("World", "world")]
+    public void E2E_StringLower_ReturnsLowercased(string input, string expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:ToLowerCase:pub}
+              §I{string:s}
+              §O{string}
+              §R (lower s)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "ToLowerCase", new object[] { input });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData("  hello  ", "hello")]
+    [InlineData("no spaces", "no spaces")]
+    public void E2E_StringTrim_ReturnsTrimmed(string input, string expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:TrimString:pub}
+              §I{string:s}
+              §O{string}
+              §R (trim s)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "TrimString", new object[] { input });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData("hello world", "world", true)]
+    [InlineData("hello world", "WORLD", false)]
+    [InlineData("hello world", "xyz", false)]
+    public void E2E_StringContains_ReturnsCorrectResult(string input, string search, bool expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:ContainsString:pub}
+              §I{string:s}
+              §I{string:search}
+              §O{bool}
+              §R (contains s search)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "ContainsString", new object[] { input, search });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData("hello world", 0, 5, "hello")]
+    [InlineData("hello world", 6, 5, "world")]
+    public void E2E_StringSubstring_ReturnsSubstring(string input, int start, int length, string expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:GetSubstring:pub}
+              §I{string:s}
+              §I{i32:start}
+              §I{i32:len}
+              §O{string}
+              §R (substr s start len)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "GetSubstring", new object[] { input, start, length });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    #endregion
+
+    #region StringComparison Mode E2E
+
+    [Theory]
+    [InlineData("Hello", "HELLO", true)]
+    [InlineData("Hello", "hello", true)]
+    [InlineData("Hello", "World", false)]
+    public void E2E_StringContainsIgnoreCase_ReturnsCorrectResult(string input, string search, bool expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:ContainsIgnoreCase:pub}
+              §I{string:s}
+              §I{string:search}
+              §O{bool}
+              §R (contains s search :ignore-case)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "ContainsIgnoreCase", new object[] { input, search });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData("YES", "yes", true)]
+    [InlineData("YES", "YES", true)]
+    [InlineData("YES", "no", false)]
+    public void E2E_StringEqualsIgnoreCase_ReturnsCorrectResult(string a, string b, bool expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:EqualsIgnoreCase:pub}
+              §I{string:a}
+              §I{string:b}
+              §O{bool}
+              §R (equals a b :ignore-case)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "EqualsIgnoreCase", new object[] { a, b });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData("Hello", "Hello", true)]
+    [InlineData("Hello", "hello", false)]
+    public void E2E_StringEqualsOrdinal_ReturnsCorrectResult(string a, string b, bool expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:EqualsOrdinal:pub}
+              §I{string:a}
+              §I{string:b}
+              §O{bool}
+              §R (equals a b :ordinal)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "EqualsOrdinal", new object[] { a, b });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData("Hello World", "HELLO", true)]
+    [InlineData("Hello World", "hello", true)]
+    [InlineData("Hello World", "xyz", false)]
+    public void E2E_StringContainsInvariantIgnoreCase_ReturnsCorrectResult(string input, string search, bool expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:ContainsInvariant:pub}
+              §I{string:s}
+              §I{string:search}
+              §O{bool}
+              §R (contains s search :invariant-ignore-case)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "ContainsInvariant", new object[] { input, search });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData("Hello World", "Hello", true)]
+    [InlineData("Hello World", "hello", false)]
+    public void E2E_StringStartsWithOrdinal_ReturnsCorrectResult(string input, string prefix, bool expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:StartsOrdinal:pub}
+              §I{string:s}
+              §I{string:prefix}
+              §O{bool}
+              §R (starts s prefix :ordinal)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "StartsOrdinal", new object[] { input, prefix });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData("Hello World", "WORLD", true)]
+    [InlineData("Hello World", "world", true)]
+    public void E2E_StringEndsWithIgnoreCase_ReturnsCorrectResult(string input, string suffix, bool expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:EndsIgnoreCase:pub}
+              §I{string:s}
+              §I{string:suffix}
+              §O{bool}
+              §R (ends s suffix :ignore-case)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "EndsIgnoreCase", new object[] { input, suffix });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData("Hello World", "WORLD", 6)]
+    [InlineData("Hello World", "xyz", -1)]
+    public void E2E_StringIndexOfIgnoreCase_ReturnsCorrectResult(string input, string search, int expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:IndexOfIgnoreCase:pub}
+              §I{string:s}
+              §I{string:search}
+              §O{i32}
+              §R (indexof s search :ignore-case)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "IndexOfIgnoreCase", new object[] { input, search });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    #endregion
+
+    #region Regex Operations E2E
+
+    [Theory]
+    [InlineData("hello123", "\\d+", true)]
+    [InlineData("hello", "\\d+", false)]
+    [InlineData("abc123xyz", "[0-9]+", true)]
+    public void E2E_RegexTest_ReturnsCorrectResult(string input, string pattern, bool expected)
+    {
+        // Escape backslashes for Calor string literal (Calor needs \\ for a literal \)
+        var escapedPattern = pattern.Replace("\\", "\\\\");
+        var source = """
+            §M{m001:Test}
+            §F{f001:TestRegex:pub}
+              §I{string:s}
+              §O{bool}
+              §R (regex-test s "PATTERN")
+            §/F{f001}
+            §/M{m001}
+            """.Replace("PATTERN", escapedPattern);
+
+        var result = Execute(source, "TestRegex", new object[] { input });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData("hello world", "\\s+", "-", "hello-world")]
+    [InlineData("a1b2c3", "\\d", "X", "aXbXcX")]
+    public void E2E_RegexReplace_ReturnsCorrectResult(string input, string pattern, string replacement, string expected)
+    {
+        // Escape backslashes for Calor string literal (Calor needs \\ for a literal \)
+        var escapedPattern = pattern.Replace("\\", "\\\\");
+        var source = """
+            §M{m001:Test}
+            §F{f001:ReplaceRegex:pub}
+              §I{string:s}
+              §O{string}
+              §R (regex-replace s "PATTERN" "REPLACEMENT")
+            §/F{f001}
+            §/M{m001}
+            """.Replace("PATTERN", escapedPattern).Replace("REPLACEMENT", replacement);
+
+        var result = Execute(source, "ReplaceRegex", new object[] { input });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData("hello123world", "\\d+", true)]
+    [InlineData("abc", "\\d+", false)]
+    public void E2E_RegexMatch_ReturnsMatchObject(string input, string pattern, bool expectedSuccess)
+    {
+        // regex-match returns a Match object; test via Match.Success property
+        var escapedPattern = pattern.Replace("\\", "\\\\");
+        var source = """
+            §M{m001:Test}
+            §F{f001:MatchRegex:pub}
+              §I{string:s}
+              §O{object}
+              §R (regex-match s "PATTERN")
+            §/F{f001}
+            §/M{m001}
+            """.Replace("PATTERN", escapedPattern);
+
+        var result = Execute(source, "MatchRegex", new object[] { input });
+
+        Assert.Null(result.Exception);
+        var match = result.ReturnValue as System.Text.RegularExpressions.Match;
+        Assert.NotNull(match);
+        Assert.Equal(expectedSuccess, match!.Success);
+    }
+
+    [Fact]
+    public void E2E_RegexSplit_ReturnsSplitArray()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:SplitRegex:pub}
+              §I{string:s}
+              §O{i32}
+              §R (len (regex-split s ","))
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "SplitRegex", new object[] { "a,b,c,d" });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(4, result.ReturnValue);
+    }
+
+    #endregion
+
+    #region Char Operations E2E
+
+    [Theory]
+    [InlineData("hello", 0, 'h')]
+    [InlineData("hello", 4, 'o')]
+    [InlineData("ABC", 1, 'B')]
+    public void E2E_CharAt_ReturnsCorrectChar(string input, int index, char expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:GetCharAt:pub}
+              §I{string:s}
+              §I{i32:idx}
+              §O{char}
+              §R (char-at s idx)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "GetCharAt", new object[] { input, index });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData('A', true)]
+    [InlineData('z', true)]
+    [InlineData('5', false)]
+    [InlineData(' ', false)]
+    public void E2E_IsLetter_ReturnsCorrectResult(char input, bool expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:CheckIsLetter:pub}
+              §I{char:c}
+              §O{bool}
+              §R (is-letter c)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "CheckIsLetter", new object[] { input });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData('0', true)]
+    [InlineData('9', true)]
+    [InlineData('A', false)]
+    [InlineData(' ', false)]
+    public void E2E_IsDigit_ReturnsCorrectResult(char input, bool expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:CheckIsDigit:pub}
+              §I{char:c}
+              §O{bool}
+              §R (is-digit c)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "CheckIsDigit", new object[] { input });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData('a', 'A')]
+    [InlineData('Z', 'Z')]
+    [InlineData('5', '5')]
+    public void E2E_CharUpper_ReturnsUppercased(char input, char expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:ToUpperChar:pub}
+              §I{char:c}
+              §O{char}
+              §R (char-upper c)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "ToUpperChar", new object[] { input });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData('A', 65)]
+    [InlineData('a', 97)]
+    [InlineData('0', 48)]
+    public void E2E_CharCode_ReturnsAsciiCode(char input, int expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:GetCharCode:pub}
+              §I{char:c}
+              §O{i32}
+              §R (char-code c)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "GetCharCode", new object[] { input });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData(65, 'A')]
+    [InlineData(97, 'a')]
+    [InlineData(48, '0')]
+    public void E2E_CharFromCode_ReturnsChar(int input, char expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:CharFromCode:pub}
+              §I{i32:code}
+              §O{char}
+              §R (char-from-code code)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "CharFromCode", new object[] { input });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData(' ', true)]
+    [InlineData('\t', true)]
+    [InlineData('\n', true)]
+    [InlineData('A', false)]
+    [InlineData('5', false)]
+    public void E2E_IsWhiteSpace_ReturnsCorrectResult(char input, bool expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:CheckIsWhiteSpace:pub}
+              §I{char:c}
+              §O{bool}
+              §R (is-whitespace c)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "CheckIsWhiteSpace", new object[] { input });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData('A', true)]
+    [InlineData('Z', true)]
+    [InlineData('a', false)]
+    [InlineData('5', false)]
+    public void E2E_IsUpper_ReturnsCorrectResult(char input, bool expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:CheckIsUpper:pub}
+              §I{char:c}
+              §O{bool}
+              §R (is-upper c)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "CheckIsUpper", new object[] { input });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData('a', true)]
+    [InlineData('z', true)]
+    [InlineData('A', false)]
+    [InlineData('5', false)]
+    public void E2E_IsLower_ReturnsCorrectResult(char input, bool expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:CheckIsLower:pub}
+              §I{char:c}
+              §O{bool}
+              §R (is-lower c)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "CheckIsLower", new object[] { input });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Theory]
+    [InlineData('A', 'a')]
+    [InlineData('z', 'z')]
+    [InlineData('5', '5')]
+    public void E2E_CharLower_ReturnsLowercased(char input, char expected)
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:ToLowerChar:pub}
+              §I{char:c}
+              §O{char}
+              §R (char-lower c)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "ToLowerChar", new object[] { input });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    #endregion
+
+    #region StringBuilder Operations E2E
+
+    [Fact]
+    public void E2E_StringBuilderNew_CreatesEmptyBuilder()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:CreateBuilder:pub}
+              §O{string}
+              §R (sb-tostring (sb-new))
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "CreateBuilder");
+
+        Assert.Null(result.Exception);
+        Assert.Equal("", result.ReturnValue);
+    }
+
+    [Fact]
+    public void E2E_StringBuilderAppend_AppendsText()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:BuildString:pub}
+              §O{string}
+              §R (sb-tostring (sb-append (sb-append (sb-new) "Hello") " World"))
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "BuildString");
+
+        Assert.Null(result.Exception);
+        Assert.Equal("Hello World", result.ReturnValue);
+    }
+
+    [Fact]
+    public void E2E_StringBuilderWithInit_InitializesWithValue()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:BuildWithInit:pub}
+              §O{string}
+              §R (sb-tostring (sb-append (sb-new "Start: ") "End"))
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "BuildWithInit");
+
+        Assert.Null(result.Exception);
+        Assert.Equal("Start: End", result.ReturnValue);
+    }
+
+    [Fact]
+    public void E2E_StringBuilderLength_ReturnsLength()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:GetLength:pub}
+              §O{i32}
+              §R (sb-length (sb-append (sb-new) "Hello"))
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "GetLength");
+
+        Assert.Null(result.Exception);
+        Assert.Equal(5, result.ReturnValue);
+    }
+
+    [Fact]
+    public void E2E_StringBuilderClear_ClearsContent()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:ClearBuilder:pub}
+              §O{i32}
+              §R (sb-length (sb-clear (sb-append (sb-new) "Hello")))
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "ClearBuilder");
+
+        Assert.Null(result.Exception);
+        Assert.Equal(0, result.ReturnValue);
+    }
+
+    [Fact]
+    public void E2E_StringBuilderAppendLine_AppendsWithNewline()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:BuildWithLines:pub}
+              §O{string}
+              §R (sb-tostring (sb-appendline (sb-appendline (sb-new) "Line1") "Line2"))
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "BuildWithLines");
+
+        Assert.Null(result.Exception);
+        // AppendLine adds Environment.NewLine after each line
+        var expected = "Line1" + System.Environment.NewLine + "Line2" + System.Environment.NewLine;
+        Assert.Equal(expected, result.ReturnValue);
+    }
+
+    [Fact]
+    public void E2E_StringBuilderInsert_InsertsAtPosition()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:InsertText:pub}
+              §O{string}
+              §R (sb-tostring (sb-insert (sb-append (sb-new) "HelloWorld") 5 " "))
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "InsertText");
+
+        Assert.Null(result.Exception);
+        Assert.Equal("Hello World", result.ReturnValue);
+    }
+
+    [Fact]
+    public void E2E_StringBuilderRemove_RemovesCharacters()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:RemoveText:pub}
+              §O{string}
+              §R (sb-tostring (sb-remove (sb-append (sb-new) "Hello World") 5 6))
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "RemoveText");
+
+        Assert.Null(result.Exception);
+        Assert.Equal("Hello", result.ReturnValue);
+    }
+
+    #endregion
+
+    #region Cross-Category Composition E2E
+
+    [Fact]
+    public void E2E_CharWithStringOp_ComposesCorrectly()
+    {
+        // Test: is first char of uppercased string a letter?
+        var source = """
+            §M{m001:Test}
+            §F{f001:IsFirstCharLetter:pub}
+              §I{string:s}
+              §O{bool}
+              §R (is-letter (char-at (upper s) 0))
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "IsFirstCharLetter", new object[] { "hello" });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(true, result.ReturnValue);
+    }
+
+    [Fact]
+    public void E2E_RegexWithStringOp_ComposesCorrectly()
+    {
+        // Test: does trimmed string contain digits?
+        // Raw string \\d becomes Calor source "\\d", Calor parses as \d regex
+        var source = """
+            §M{m001:Test}
+            §F{f001:TrimmedHasDigits:pub}
+              §I{string:s}
+              §O{bool}
+              §R (regex-test (trim s) "\\d")
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "TrimmedHasDigits", new object[] { "  abc123  " });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(true, result.ReturnValue);
+    }
+
+    [Fact]
+    public void E2E_ComplexComposition_WorksCorrectly()
+    {
+        // Test: convert first char to uppercase, rest to lowercase
+        // This tests multiple operations working together
+        // Use unique names for each binding since Calor generates new 'var' for each
+        var source = """
+            §M{m001:Test}
+            §F{f001:Capitalize:pub}
+              §I{string:s}
+              §O{string}
+              §B{sb1} (sb-new)
+              §B{sb2} (sb-append sb1 (str (char-upper (char-at s 0))))
+              §B{sb3} (sb-append sb2 (lower (substr s 1)))
+              §R (sb-tostring sb3)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "Capitalize", new object[] { "hELLO" });
+
+        Assert.Null(result.Exception);
+        Assert.Equal("Hello", result.ReturnValue);
+    }
+
+    #endregion
+
+    #region Negative Tests - Runtime Errors
+
+    [Fact]
+    public void E2E_CharAt_IndexOutOfBounds_ThrowsException()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:GetCharAt:pub}
+              §I{string:s}
+              §O{char}
+              §R (char-at s 100)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "GetCharAt", new object[] { "hello" });
+
+        Assert.NotNull(result.Exception);
+        Assert.IsType<IndexOutOfRangeException>(result.Exception);
+    }
+
+    [Fact]
+    public void E2E_CharAt_NegativeIndex_ThrowsException()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:GetCharAt:pub}
+              §I{string:s}
+              §O{char}
+              §R (char-at s (- 0 1))
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "GetCharAt", new object[] { "hello" });
+
+        Assert.NotNull(result.Exception);
+        Assert.IsType<IndexOutOfRangeException>(result.Exception);
+    }
+
+    [Fact]
+    public void E2E_Substring_IndexOutOfBounds_ThrowsException()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:GetSubstr:pub}
+              §I{string:s}
+              §O{string}
+              §R (substr s 10 5)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "GetSubstr", new object[] { "hello" });
+
+        Assert.NotNull(result.Exception);
+        Assert.IsType<ArgumentOutOfRangeException>(result.Exception);
+    }
+
+    [Fact]
+    public void E2E_StringBuilderRemove_InvalidRange_ThrowsException()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:RemoveText:pub}
+              §O{string}
+              §R (sb-tostring (sb-remove (sb-append (sb-new) "Hi") 0 100))
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "RemoveText");
+
+        Assert.NotNull(result.Exception);
+        Assert.IsType<ArgumentOutOfRangeException>(result.Exception);
+    }
+
+    [Fact]
+    public void E2E_StringBuilderInsert_NegativeIndex_ThrowsException()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:InsertText:pub}
+              §O{string}
+              §R (sb-tostring (sb-insert (sb-new) (- 0 1) "x"))
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "InsertText");
+
+        Assert.NotNull(result.Exception);
+        Assert.IsType<ArgumentOutOfRangeException>(result.Exception);
+    }
+
+    [Fact]
+    public void E2E_RegexTest_InvalidPattern_ThrowsException()
+    {
+        // Invalid regex pattern: unclosed bracket
+        var source = """
+            §M{m001:Test}
+            §F{f001:TestRegex:pub}
+              §I{string:s}
+              §O{bool}
+              §R (regex-test s "[invalid")
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "TestRegex", new object[] { "test" });
+
+        Assert.NotNull(result.Exception);
+        Assert.IsType<System.Text.RegularExpressions.RegexParseException>(result.Exception);
+    }
+
+    [Fact]
+    public void E2E_CharFromCode_NegativeCode_ReturnsChar()
+    {
+        // Negative values wrap around in char conversion (implementation-defined behavior)
+        var source = """
+            §M{m001:Test}
+            §F{f001:CharFromCode:pub}
+              §I{i32:code}
+              §O{char}
+              §R (char-from-code code)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        // -1 wraps to 65535 (0xFFFF) in unchecked char conversion
+        var result = Execute(source, "CharFromCode", new object[] { -1 });
+
+        Assert.Null(result.Exception);
+        Assert.Equal((char)65535, result.ReturnValue);
+    }
+
+    #endregion
+
+    #region Negative Tests - Edge Cases
+
+    [Fact]
+    public void E2E_StringUpper_EmptyString_ReturnsEmpty()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:ToUpper:pub}
+              §I{string:s}
+              §O{string}
+              §R (upper s)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "ToUpper", new object[] { "" });
+
+        Assert.Null(result.Exception);
+        Assert.Equal("", result.ReturnValue);
+    }
+
+    [Fact]
+    public void E2E_StringLen_EmptyString_ReturnsZero()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:GetLen:pub}
+              §I{string:s}
+              §O{i32}
+              §R (len s)
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "GetLen", new object[] { "" });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(0, result.ReturnValue);
+    }
+
+    [Fact]
+    public void E2E_StringContains_EmptySearch_ReturnsTrue()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:ContainsEmpty:pub}
+              §I{string:s}
+              §O{bool}
+              §R (contains s "")
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "ContainsEmpty", new object[] { "hello" });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(true, result.ReturnValue);
+    }
+
+    [Fact]
+    public void E2E_RegexSplit_NoMatches_ReturnsSingleElement()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:SplitRegex:pub}
+              §I{string:s}
+              §O{i32}
+              §R (len (regex-split s "NOMATCH"))
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "SplitRegex", new object[] { "hello world" });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(1, result.ReturnValue);
+    }
+
+    [Fact]
+    public void E2E_StringBuilderNew_EmptyToString_ReturnsEmpty()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:EmptyBuilder:pub}
+              §O{string}
+              §R (sb-tostring (sb-new))
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "EmptyBuilder");
+
+        Assert.Null(result.Exception);
+        Assert.Equal("", result.ReturnValue);
+    }
+
+    [Fact]
+    public void E2E_IndexOf_NotFound_ReturnsNegativeOne()
+    {
+        var source = """
+            §M{m001:Test}
+            §F{f001:FindIndex:pub}
+              §I{string:s}
+              §O{i32}
+              §R (indexof s "xyz")
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var result = Execute(source, "FindIndex", new object[] { "hello" });
+
+        Assert.Null(result.Exception);
+        Assert.Equal(-1, result.ReturnValue);
+    }
+
+    #endregion
+}

--- a/tests/Calor.Enforcement.Tests/TestHarness.cs
+++ b/tests/Calor.Enforcement.Tests/TestHarness.cs
@@ -104,6 +104,7 @@ public static class TestHarness
             // Add additional runtime references
             var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
             references.Add(MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")));
+            references.Add(MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Text.RegularExpressions.dll")));
 
             var compilation = CSharpCompilation.Create(
                 "TestAssembly",


### PR DESCRIPTION
## Summary

Add four new categories of string-related operations to Calor's native expression system:

- **Regex Operations (4 ops):** `regex-test`, `regex-match`, `regex-replace`, `regex-split`
- **Char Operations (10 ops):** `char-at`, `char-code`, `char-from-code`, `is-letter`, `is-digit`, `is-whitespace`, `is-upper`, `is-lower`, `char-upper`, `char-lower`
- **StringBuilder Operations (8 ops):** `sb-new`, `sb-append`, `sb-appendline`, `sb-insert`, `sb-remove`, `sb-clear`, `sb-tostring`, `sb-length`
- **StringComparison Modes:** `:ordinal`, `:ignore-case`, `:invariant`, `:invariant-ignore-case` on `contains`, `starts`, `ends`, `indexof`, `equals`

## Changes

### New Files
- `src/Calor.Compiler/Ast/CharOperationNode.cs` - Char operation AST node
- `src/Calor.Compiler/Ast/StringBuilderOperationNode.cs` - StringBuilder operation AST node
- `tests/Calor.Compiler.Tests/CharOperationTests.cs` - Char operation tests
- `tests/Calor.Compiler.Tests/RegexOperationTests.cs` - Regex operation tests
- `tests/Calor.Compiler.Tests/StringBuilderOperationTests.cs` - StringBuilder tests
- `tests/Calor.Compiler.Tests/StringOperationsE2ETests.cs` - E2E tests (97 tests)
- `docs/syntax-reference/string-operations.md` - Full documentation

### Modified Files
- Parser, CSharpEmitter, CalorEmitter, RoslynSyntaxVisitor, and all visitor implementations

## Test Plan

- [x] All 1945 tests pass
- [x] 97 E2E tests covering all operations
- [x] Negative tests for error cases (invalid index, invalid regex, etc.)
- [x] Edge case tests (empty strings, not found, etc.)
- [x] Migration tests for C# → Calor conversion

🤖 Generated with [Claude Code](https://claude.ai/code)