### PR TITLE
Bundle platform-specific language server with VS Code extension

### DIFF
--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -11,20 +11,55 @@ on:
         type: string
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            target: win32-x64
+          - os: windows-latest
+            target: win32-arm64
+          - os: macos-latest
+            target: darwin-x64
+          - os: macos-latest
+            target: darwin-arm64
+          - os: ubuntu-latest
+            target: linux-x64
+          - os: ubuntu-latest
+            target: linux-arm64
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
-      - name: Install vsce
-        run: npm install -g @vscode/vsce
+      - name: Build Language Server
+        run: |
+          cd editors/vscode
+          chmod +x scripts/build-server.sh
+          ./scripts/build-server.sh ${{ matrix.target }}
+        shell: bash
+
+      - name: Ensure server is executable (Unix)
+        if: runner.os != 'Windows'
+        run: chmod +x editors/vscode/server/calor-lsp
+        shell: bash
+
+      - name: Install dependencies
+        run: |
+          cd editors/vscode
+          npm ci
 
       - name: Update version (if specified)
         if: ${{ github.event.inputs.version != '' }}
@@ -32,16 +67,49 @@ jobs:
         run: |
           npm version ${{ github.event.inputs.version }} --no-git-tag-version
 
+      - name: Compile TypeScript
+        run: |
+          cd editors/vscode
+          npm run compile
+
+      - name: Install vsce
+        run: npm install -g @vscode/vsce
+
       - name: Package extension
-        working-directory: editors/vscode
-        run: vsce package
+        run: |
+          cd editors/vscode
+          vsce package --target ${{ matrix.target }}
 
-      - name: Publish to VS Code Marketplace
-        working-directory: editors/vscode
-        run: vsce publish -p ${{ secrets.VSCE_PAT }}
-
-      - name: Upload VSIX artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: vscode-extension
+          name: calor-${{ matrix.target }}
           path: editors/vscode/*.vsix
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: vsix-packages
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Publish all platforms
+        run: |
+          npm install -g @vscode/vsce
+          for vsix in vsix-packages/**/*.vsix; do
+            echo "Publishing $vsix"
+            vsce publish --packagePath "$vsix" -p ${{ secrets.VSCE_PAT }}
+          done
+
+      - name: Upload all VSIX artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-extension-all-platforms
+          path: vsix-packages/**/*.vsix

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ nunit-*.xml
 src/Calor.Compiler/z3/
 src/Calor.Compiler/runtimes/
 src/Calor.Compiler/.z3-temp/
+
+# VS Code extension build artifacts
+editors/vscode/server/
+editors/vscode/*.vsix

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,7 +1,17 @@
-.git/
-.github/
+# Source files (compiled to out/)
+src/**
+*.ts
+tsconfig.json
+
+# Development files
+.vscode/**
+scripts/**
+node_modules/**
+
+# Git files
+.git/**
 .gitignore
-*.md
-!README.md
-.vscode/
-node_modules/
+
+# Other
+*.map
+**/*.md

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,0 +1,140 @@
+{
+  "name": "calor",
+  "version": "0.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "calor",
+      "version": "0.3.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "vscode-languageclient": "^9.0.1"
+      },
+      "devDependencies": {
+        "@types/node": "^18.x",
+        "@types/vscode": "^1.75.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "vscode": "^1.75.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.109.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.109.0.tgz",
+      "integrity": "sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "engines": {
+        "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/editors/vscode/scripts/build-server.sh
+++ b/editors/vscode/scripts/build-server.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Build calor-lsp for a specific platform
+# Usage: ./build-server.sh <vscode-target>
+# Targets: win32-x64, win32-arm64, darwin-x64, darwin-arm64, linux-x64, linux-arm64
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VSCODE_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(dirname "$(dirname "$VSCODE_DIR")")"
+LSP_PROJECT="$REPO_ROOT/src/Calor.LanguageServer/Calor.LanguageServer.csproj"
+SERVER_DIR="$VSCODE_DIR/server"
+
+# Convert VS Code target to .NET RID
+get_dotnet_rid() {
+    case "$1" in
+        "win32-x64")    echo "win-x64" ;;
+        "win32-arm64")  echo "win-arm64" ;;
+        "darwin-x64")   echo "osx-x64" ;;
+        "darwin-arm64") echo "osx-arm64" ;;
+        "linux-x64")    echo "linux-x64" ;;
+        "linux-arm64")  echo "linux-arm64" ;;
+        *)              echo "" ;;
+    esac
+}
+
+build_for_target() {
+    local VSCODE_TARGET=$1
+    local DOTNET_RID
+    DOTNET_RID=$(get_dotnet_rid "$VSCODE_TARGET")
+
+    if [ -z "$DOTNET_RID" ]; then
+        echo "Unknown target: $VSCODE_TARGET"
+        echo "Valid targets: win32-x64, win32-arm64, darwin-x64, darwin-arm64, linux-x64, linux-arm64"
+        exit 1
+    fi
+
+    echo "Building for $VSCODE_TARGET (dotnet RID: $DOTNET_RID)..."
+
+    # Clean previous build
+    rm -rf "$SERVER_DIR"
+    mkdir -p "$SERVER_DIR"
+
+    dotnet publish "$LSP_PROJECT" \
+        -c Release \
+        -r "$DOTNET_RID" \
+        --self-contained true \
+        -p:PublishSingleFile=true \
+        -p:IncludeNativeLibrariesForSelfExtract=true \
+        -p:DebugType=none \
+        -o "$SERVER_DIR"
+
+    # Remove unnecessary files from server directory
+    rm -f "$SERVER_DIR"/*.pdb "$SERVER_DIR"/*.json
+
+    echo "Built server for $VSCODE_TARGET"
+}
+
+# If a specific target is provided, build only that one
+if [ -n "$1" ]; then
+    build_for_target "$1"
+else
+    echo "Usage: $0 <vscode-target>"
+    echo "Targets: win32-x64, win32-arm64, darwin-x64, darwin-arm64, linux-x64, linux-arm64"
+    exit 1
+fi

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,0 +1,122 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import {
+    LanguageClient,
+    LanguageClientOptions,
+    ServerOptions,
+    TransportKind
+} from 'vscode-languageclient/node';
+
+let client: LanguageClient | undefined;
+let outputChannel: vscode.OutputChannel;
+
+export function activate(context: vscode.ExtensionContext): void {
+    outputChannel = vscode.window.createOutputChannel('Calor Language Server');
+
+    const config = vscode.workspace.getConfiguration('calor');
+    const enabled = config.get<boolean>('languageServer.enabled', true);
+
+    if (!enabled) {
+        outputChannel.appendLine('Calor Language Server is disabled');
+        return;
+    }
+
+    const serverPath = findServerPath(context, config);
+    if (!serverPath) {
+        outputChannel.appendLine('Could not find calor-lsp. Please set calor.languageServer.path or add calor-lsp to your PATH.');
+        vscode.window.showWarningMessage('Calor Language Server not found. Configure calor.languageServer.path in settings.');
+        return;
+    }
+
+    outputChannel.appendLine(`Starting Calor Language Server: ${serverPath.command} ${serverPath.args?.join(' ') || ''}`);
+
+    const serverOptions: ServerOptions = {
+        command: serverPath.command,
+        args: serverPath.args,
+        transport: TransportKind.stdio
+    };
+
+    const clientOptions: LanguageClientOptions = {
+        documentSelector: [{ scheme: 'file', language: 'calor' }],
+        synchronize: {
+            fileEvents: vscode.workspace.createFileSystemWatcher('**/*.calr')
+        },
+        outputChannel: outputChannel
+    };
+
+    client = new LanguageClient(
+        'calorLanguageServer',
+        'Calor Language Server',
+        serverOptions,
+        clientOptions
+    );
+
+    client.start().then(() => {
+        outputChannel.appendLine('Calor Language Server started successfully');
+    }).catch((error) => {
+        outputChannel.appendLine(`Failed to start Calor Language Server: ${error}`);
+        vscode.window.showErrorMessage(`Failed to start Calor Language Server: ${error.message}`);
+    });
+}
+
+interface ServerPath {
+    command: string;
+    args?: string[];
+}
+
+function findServerPath(context: vscode.ExtensionContext, config: vscode.WorkspaceConfiguration): ServerPath | null {
+    // 1. Check explicit configuration (user override)
+    const configuredPath = config.get<string>('languageServer.path');
+    if (configuredPath) {
+        // Check if it's a DLL path (needs dotnet to run)
+        if (configuredPath.endsWith('.dll')) {
+            return { command: 'dotnet', args: [configuredPath] };
+        }
+        return { command: configuredPath };
+    }
+
+    // 2. Check bundled server (platform-specific binary)
+    const bundledPath = getBundledServerPath(context);
+    if (bundledPath && fs.existsSync(bundledPath)) {
+        outputChannel.appendLine(`Using bundled server: ${bundledPath}`);
+        return { command: bundledPath };
+    }
+
+    // 3. Check for calor-lsp in workspace (development scenario)
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (workspaceFolders) {
+        for (const folder of workspaceFolders) {
+            // Check for built DLL in typical locations
+            for (const buildConfig of ['Debug', 'Release']) {
+                const dllPath = path.join(
+                    folder.uri.fsPath,
+                    'src/Calor.LanguageServer/bin',
+                    buildConfig,
+                    'net8.0/calor-lsp.dll'
+                );
+                if (fs.existsSync(dllPath)) {
+                    outputChannel.appendLine(`Using workspace server: ${dllPath}`);
+                    return { command: 'dotnet', args: [dllPath] };
+                }
+            }
+        }
+    }
+
+    // 4. Fall back to PATH
+    outputChannel.appendLine('Attempting to use calor-lsp from PATH');
+    return { command: 'calor-lsp' };
+}
+
+function getBundledServerPath(context: vscode.ExtensionContext): string | null {
+    const serverName = process.platform === 'win32' ? 'calor-lsp.exe' : 'calor-lsp';
+    const serverPath = path.join(context.extensionPath, 'server', serverName);
+    return serverPath;
+}
+
+export function deactivate(): Thenable<void> | undefined {
+    if (!client) {
+        return undefined;
+    }
+    return client.stop();
+}

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", ".vscode-test"]
+}

--- a/src/Calor.Compiler/Calor.Compiler.csproj
+++ b/src/Calor.Compiler/Calor.Compiler.csproj
@@ -56,8 +56,8 @@
     <Exec Command="powershell -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)scripts\download-z3.ps1&quot;" Condition="'$(OS)' == 'Windows_NT'" />
   </Target>
 
-  <!-- Copy Microsoft.Z3.dll to output -->
-  <ItemGroup>
+  <!-- Copy Microsoft.Z3.dll to output (skip during publish since Reference already includes it) -->
+  <ItemGroup Condition="'$(PublishSingleFile)' != 'true'">
     <None Include="$(Z3Dir)\Microsoft.Z3.dll" CopyToOutputDirectory="PreserveNewest" Link="Microsoft.Z3.dll" Condition="Exists('$(Z3Dir)\Microsoft.Z3.dll')" />
   </ItemGroup>
 

--- a/src/Calor.LanguageServer/Calor.LanguageServer.csproj
+++ b/src/Calor.LanguageServer/Calor.LanguageServer.csproj
@@ -15,4 +15,12 @@
     <ProjectReference Include="..\Calor.Compiler\Calor.Compiler.csproj" />
   </ItemGroup>
 
+  <!-- Exclude Z3 native libraries from publish - LSP doesn't use verification features -->
+  <!-- The runtimes/ directory in Calor.Compiler contains only Z3 native libs (libz3.*) -->
+  <Target Name="ExcludeZ3FromPublish" BeforeTargets="ComputeResolvedFilesToPublishList">
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" Condition="$([System.String]::Copy('%(ResolvedFileToPublish.RelativePath)').Contains('libz3'))" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
## Summary

- Add build script to compile `calor-lsp` as a self-contained single-file binary for each VS Code target platform
- Update `extension.ts` to discover bundled server in extension's `server/` directory
- Update CI workflow with matrix build for 6 platforms
- Exclude Z3 native libraries from LSP publish (not needed for LSP features)

## Platforms Supported

| Platform | VS Code Target | Approx Size |
|----------|----------------|-------------|
| Windows x64 | `win32-x64` | ~40 MB |
| Windows ARM64 | `win32-arm64` | ~40 MB |
| macOS Intel | `darwin-x64` | ~40 MB |
| macOS Apple Silicon | `darwin-arm64` | ~40 MB |
| Linux x64 | `linux-x64` | ~40 MB |
| Linux ARM64 | `linux-arm64` | ~40 MB |

## Server Discovery Priority

1. User-configured path (`calor.languageServer.path` setting)
2. Bundled server (`<extension>/server/calor-lsp`)
3. Workspace DLL (development scenario)
4. `calor-lsp` from PATH

## Test plan

- [ ] CI workflow builds for all 6 platforms
- [ ] Install VSIX and verify LSP starts correctly
- [ ] Verify bundled server is used (check output channel)

🤖 Generated with [Claude Code](https://claude.ai/code)