### PR TITLE
Fix benchmark to correctly count Calor-only metrics as wins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ All notable changes to this project will be documented in this file.
 
 ### Benchmark Results (Statistical: 30 runs)
 - **Overall Advantage**: 0.84x (C# leads on token economics)
-- **Metrics**: Calor wins 4, C# wins 4, Tie 3
+- **Metrics**: Calor wins 7, C# wins 4
 - **Highlights**:
   - Comprehension: 1.57x (Calor wins, large effect)
   - ErrorDetection: 1.51x (Calor wins, large effect)
   - RefactoringStability: 1.50x (Calor wins, large effect)
   - EditPrecision: 1.38x (Calor wins, large effect)
-  - ContractVerification, EffectSoundness, InteropEffectCoverage: Calor-exclusive features
+  - ContractVerification, EffectSoundness, InteropEffectCoverage: Calor-only features (C# has no equivalent)
 - **Programs Tested**: 36
 
 ### Added
@@ -26,6 +26,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Enum definitions now use `§EN{id:name}` instead of `§ENUM{id:name}` (both are accepted for backwards compatibility)
 - CI workflow now builds 6 platform-specific VSIX packages in parallel
+
+### Fixed
+- Benchmark framework now correctly counts Calor-only metrics (ContractVerification, EffectSoundness, InteropEffectCoverage) as Calor wins instead of ties
 
 ## [0.2.2] - 2026-02-10
 

--- a/tests/Calor.Evaluation/Benchmarks/BenchmarkRunner.cs
+++ b/tests/Calor.Evaluation/Benchmarks/BenchmarkRunner.cs
@@ -349,15 +349,22 @@ public class BenchmarkRunner
         summary.CalorPassCount = result.CaseResults.Count(c => c.CalorSuccess);
         summary.CSharpPassCount = result.CaseResults.Count(c => c.CSharpSuccess);
 
-        // Identify top categories (all categories where Calor wins)
+        // Identify Calor-only categories (where C# has no equivalent)
+        var calorOnlyCategories = result.Metrics
+            .Where(m => m.IsCalorOnly)
+            .Select(m => m.Category)
+            .Distinct()
+            .ToHashSet();
+
+        // Identify top categories (all categories where Calor wins, including Calor-only)
         summary.TopCalorCategories = summary.CategoryAdvantages
-            .Where(kv => kv.Value > 1.0)
+            .Where(kv => kv.Value > 1.0 || calorOnlyCategories.Contains(kv.Key))
             .OrderByDescending(kv => kv.Value)
             .Select(kv => kv.Key)
             .ToList();
 
         summary.CSharpAdvantageCategories = summary.CategoryAdvantages
-            .Where(kv => kv.Value < 1.0)
+            .Where(kv => kv.Value < 1.0 && !calorOnlyCategories.Contains(kv.Key))
             .OrderBy(kv => kv.Value)
             .Select(kv => kv.Key)
             .ToList();


### PR DESCRIPTION
## Summary

Fixes incorrect counting of Calor-only metrics (ContractVerification, EffectSoundness, InteropEffectCoverage) as "ties" instead of "Calor wins".

## Problem

Previously, metrics where C# has no equivalent were counted as ties because the advantage ratio was 1.0 (to avoid division by zero). This was misleading since Calor has actual capability while C# has none.

## Solution

- Add `IsCalorOnly`, `CalorWins`, `CSharpWins` properties to `MetricResult`
- Update `BenchmarkRunner.CalculateSummary` to include Calor-only categories in `TopCalorCategories`
- Update console output, markdown, and HTML reports to show correct winners
- Update CHANGELOG with correct win counts (7 Calor, 4 C#)

## Before/After

| Metric | Before | After |
|--------|--------|-------|
| Calor wins | 4 | 7 |
| C# wins | 4 | 4 |
| Ties | 3 | 0 |

🤖 Generated with [Claude Code](https://claude.ai/code)