### PR TITLE
Fix benchmark statistical mode to preserve isCalorOnly flag

### DIFF
--- a/tests/Calor.Evaluation/Benchmarks/BenchmarkRunner.cs
+++ b/tests/Calor.Evaluation/Benchmarks/BenchmarkRunner.cs
@@ -155,17 +155,28 @@ public class BenchmarkRunner
             statisticalSummaries.Add(summary);
         }
 
-        // Create aggregated result using means
-        var aggregatedMetrics = metricGroups.Select(g => new MetricResult(
-            g.Key.Category,
-            g.Key.MetricName,
-            StatisticalAnalysis.Mean(g.Value.Select(m => m.CalorScore)),
-            StatisticalAnalysis.Mean(g.Value.Select(m => m.CSharpScore)),
-            StatisticalAnalysis.Mean(g.Value.Select(m => m.AdvantageRatio)),
-            new Dictionary<string, object>
+        // Create aggregated result using means, preserving isCalorOnly flag
+        var aggregatedMetrics = metricGroups.Select(g =>
+        {
+            var details = new Dictionary<string, object>
             {
                 ["statisticalSampleCount"] = g.Value.Count
-            })).ToList();
+            };
+
+            // Preserve isCalorOnly flag from original metrics
+            if (g.Value.Any(m => m.IsCalorOnly))
+            {
+                details["isCalorOnly"] = true;
+            }
+
+            return new MetricResult(
+                g.Key.Category,
+                g.Key.MetricName,
+                StatisticalAnalysis.Mean(g.Value.Select(m => m.CalorScore)),
+                StatisticalAnalysis.Mean(g.Value.Select(m => m.CSharpScore)),
+                StatisticalAnalysis.Mean(g.Value.Select(m => m.AdvantageRatio)),
+                details);
+        }).ToList();
 
         var result = new EvaluationResult
         {


### PR DESCRIPTION
## Summary

Follow-up fix to #163. The previous fix didn't work for statistical mode because aggregated metrics were created without preserving the `isCalorOnly` flag.

## Problem

In statistical mode, metrics are aggregated from multiple runs into new `MetricResult` objects. The aggregation was creating a new `Details` dictionary with only `statisticalSampleCount`, dropping the `isCalorOnly` flag.

## Solution

Preserve the `isCalorOnly` flag when aggregating metrics from multiple runs.

## Verification

Before fix (statistical mode):
```
= ContractVerification: 1.00x (95% CI: [1.00, 1.00])
* ContractVerification: C# wins (d=0.41, small effect)
```

After fix (statistical mode):
```
+ ContractVerification: 1.00x (95% CI: [1.00, 1.00]) (Calor-only)
* ContractVerification: Calor wins (d=0.41, small effect)
```

🤖 Generated with [Claude Code](https://claude.ai/code)