### PR TITLE
feat(verification): add Z3 string and array theory support

### DIFF
--- a/src/Calor.Compiler/Verification/VerificationResult.cs
+++ b/src/Calor.Compiler/Verification/VerificationResult.cs
@@ -35,11 +35,13 @@ public enum ContractVerificationStatus
 /// Result of verifying a single contract.
 /// </summary>
 /// <param name="Status">The verification status.</param>
-/// <param name="CounterexampleDescription">Description of counterexample if Disproven.</param>
+/// <param name="CounterexampleDescription">Description of counterexample if Disproven, or diagnostic message if Unsupported.</param>
+/// <param name="Warnings">Non-fatal warnings about features that were silently handled differently than expected.</param>
 /// <param name="Duration">Time taken to verify.</param>
 public record ContractVerificationResult(
     ContractVerificationStatus Status,
     string? CounterexampleDescription = null,
+    IReadOnlyList<string>? Warnings = null,
     TimeSpan? Duration = null);
 
 /// <summary>

--- a/src/Calor.Compiler/Verification/Z3/Cache/VerificationCacheEntry.cs
+++ b/src/Calor.Compiler/Verification/Z3/Cache/VerificationCacheEntry.cs
@@ -54,8 +54,9 @@ public sealed class VerificationCacheEntry
     {
         return new ContractVerificationResult(
             Status,
-            CounterexampleDescription,
-            TimeSpan.FromMilliseconds(OriginalDurationMs));
+            CounterexampleDescription: CounterexampleDescription,
+            Warnings: null, // Warnings are not cached
+            Duration: TimeSpan.FromMilliseconds(OriginalDurationMs));
     }
 
     /// <summary>

--- a/src/Calor.Compiler/Verification/Z3/ContractTranslator.cs
+++ b/src/Calor.Compiler/Verification/Z3/ContractTranslator.cs
@@ -8,11 +8,27 @@ namespace Calor.Compiler.Verification.Z3;
 /// </summary>
 /// <remarks>
 /// <para>
+/// <b>Thread Safety:</b> This class is NOT thread-safe. Each instance maintains internal state
+/// (declared variables, expression metadata, warnings) that is modified during translation.
+/// Create a new instance for each verification operation, or synchronize access externally.
+/// The Z3 <see cref="Microsoft.Z3.Context"/> passed to the constructor should also be used
+/// from a single thread unless Z3 was configured for multi-threaded use.
+/// </para>
+/// <para>
 /// This translator uses Z3 bit-vectors instead of unbounded integers to correctly model
 /// fixed-width arithmetic with wrap-around overflow semantics (two's complement).
 /// </para>
 /// <para>
-/// <b>Supported types:</b> i8, i16, i32, i64, u8, u16, u32, u64, bool
+/// <b>Supported types:</b> i8, i16, i32, i64, u8, u16, u32, u64, bool, string, arrays
+/// </para>
+/// <para>
+/// <b>String support:</b> Uses Z3's native string theory for verification. Supported operations:
+/// Length, Contains, StartsWith, EndsWith, Equals, IsNullOrEmpty, IndexOf, Substring, Concat, Replace.
+/// </para>
+/// <para>
+/// <b>Array support:</b> Arrays are modeled with 64-bit indices and typed elements. Each array
+/// has an associated <c>$length</c> variable (e.g., <c>arr$length</c>) representing its length
+/// as an unsigned 32-bit value.
 /// </para>
 /// <para>
 /// <b>Limitation - Narrow type promotion:</b> Unlike C#, which promotes byte/sbyte/short/ushort
@@ -24,6 +40,21 @@ namespace Calor.Compiler.Verification.Z3;
 /// <para>
 /// <b>Limitation - Integer literals:</b> All integer literals are treated as signed 32-bit values.
 /// Literals outside the 32-bit range may be truncated.
+/// </para>
+/// <para>
+/// <b>Limitation - Null strings:</b> Z3 strings cannot be null - they are always valid sequences.
+/// The <c>IsNullOrEmpty</c> operation only checks if the string length equals zero. Code that
+/// relies on null string semantics may not verify correctly.
+/// </para>
+/// <para>
+/// <b>Limitation - String comparison modes:</b> The <see cref="StringComparisonMode"/> parameter
+/// on string operations is ignored. Z3's string theory uses ordinal comparison only; case-insensitive
+/// and culture-aware comparisons are not supported.
+/// </para>
+/// <para>
+/// <b>Limitation - Unsupported string operations:</b> ToUpper, ToLower, Trim, TrimStart, TrimEnd,
+/// PadLeft, PadRight, Split, Join, Format, ToString, and all Regex operations return null
+/// (marked as Unsupported) because Z3 lacks native support for these operations.
 /// </para>
 /// </remarks>
 public sealed class ContractTranslator
@@ -38,6 +69,35 @@ public sealed class ContractTranslator
     private readonly Dictionary<Expr, BitVecInfo> _exprInfo = new();
 
     private record struct BitVecInfo(uint Width, bool IsSigned);
+
+    /// <summary>
+    /// Tracks metadata for string expressions (nullable flag for future null handling).
+    /// </summary>
+    private record struct StringInfo(bool IsNullable);
+    private readonly Dictionary<Expr, StringInfo> _stringInfo = new();
+
+    /// <summary>
+    /// Tracks metadata for array expressions (element type and length expression).
+    /// </summary>
+    private record struct ArrayInfo(string ElementType, Expr? LengthExpr);
+    private readonly Dictionary<string, ArrayInfo> _arrayInfo = new();
+
+    /// <summary>
+    /// Collects warnings about features that were silently ignored during translation.
+    /// These don't cause translation failure but may result in unexpected verification behavior.
+    /// </summary>
+    private readonly List<string> _warnings = new();
+
+    /// <summary>
+    /// Gets warnings that were generated during translation.
+    /// Warnings indicate features that were silently handled in a potentially unexpected way.
+    /// </summary>
+    public IReadOnlyList<string> Warnings => _warnings;
+
+    /// <summary>
+    /// Clears accumulated warnings.
+    /// </summary>
+    public void ClearWarnings() => _warnings.Clear();
 
     public ContractTranslator(Context ctx)
     {
@@ -114,9 +174,13 @@ public sealed class ContractTranslator
             ExistsExpressionNode exists => TranslateExists(exists),
             ImplicationExpressionNode impl => TranslateImplication(impl),
             ArrayAccessNode arrayAccess => TranslateArrayAccess(arrayAccess),
+            ArrayLengthNode arrayLen => TranslateArrayLength(arrayLen),
+
+            // String support using Z3's native string theory
+            StringLiteralNode strLit => TrackString(_ctx.MkString(strLit.Value)),
+            StringOperationNode strOp => TranslateStringOperation(strOp),
 
             // Unsupported constructs - return null
-            StringLiteralNode => null,
             FloatLiteralNode => null,
             CallExpressionNode => null,
             _ => null
@@ -332,13 +396,13 @@ public sealed class ContractTranslator
             var arrayName = arrayRef.Name;
             if (!_variables.TryGetValue(arrayName, out var arrayVar))
             {
-                // Create an array sort: BitVec64 -> BitVec32 (64-bit index, 32-bit elements)
-                // Using 64-bit indices to support both i32 and i64 index types without truncation
-                var bv64Sort = _ctx.MkBitVecSort(64);
-                var bv32Sort = _ctx.MkBitVecSort(32);
-                var arrayExpr = _ctx.MkArrayConst(arrayName, bv64Sort, bv32Sort);
-                _variables[arrayName] = (arrayExpr, "array");
-                arrayVar = (arrayExpr, "array");
+                // Array not declared - create on-demand with default i32 element type
+                // This also creates the associated $length variable for consistency
+                var arrayExpr = CreateArrayVariable(arrayName, "i32");
+                if (arrayExpr == null)
+                    return null;
+                _variables[arrayName] = (arrayExpr, "array<i32>");
+                arrayVar = (arrayExpr, "array<i32>");
             }
 
             if (arrayVar.Expr is ArrayExpr arrExpr)
@@ -369,6 +433,13 @@ public sealed class ContractTranslator
         // Normalize type names
         var normalizedType = NormalizeTypeName(typeName);
 
+        // Check for array types (e.g., "i32[]", "int[]", "u8[]")
+        if (normalizedType.EndsWith("[]"))
+        {
+            var elementType = normalizedType[..^2]; // Remove "[]" suffix
+            return CreateArrayVariable(name, elementType);
+        }
+
         return normalizedType switch
         {
             // Signed integer types
@@ -384,11 +455,35 @@ public sealed class ContractTranslator
             "u64" or "ulong" => TrackBitVec(_ctx.MkBVConst(name, 64), 64, isSigned: false),
 
             "bool" => _ctx.MkBoolConst(name),
+            // String type - uses Z3's native string theory
+            "string" or "str" => TrackString((SeqExpr)_ctx.MkConst(name, _ctx.StringSort)),
             // Unsupported types
-            "string" or "str" => null,
             "f32" or "f64" or "float" or "double" => null,
             _ => null
         };
+    }
+
+    /// <summary>
+    /// Creates an array variable expression. Called internally from CreateVariableForType.
+    /// </summary>
+    private Expr? CreateArrayVariable(string name, string elementType)
+    {
+        var (elementWidth, _) = GetTypeWidthAndSignedness(elementType);
+        if (elementWidth == 0)
+            return null;
+
+        // Create array sort: BitVec64 (index) -> BitVec[elementWidth] (element)
+        var bv64Sort = _ctx.MkBitVecSort(64);
+        var elementSort = _ctx.MkBitVecSort(elementWidth);
+        var arrayExpr = _ctx.MkArrayConst(name, bv64Sort, elementSort);
+
+        // Create associated length variable (unsigned 32-bit)
+        var lengthVarName = $"{name}$length";
+        var lengthExpr = TrackBitVec(_ctx.MkBVConst(lengthVarName, 32), 32, isSigned: false);
+        _variables[lengthVarName] = (lengthExpr, "u32");
+
+        _arrayInfo[name] = new ArrayInfo(elementType, lengthExpr);
+        return arrayExpr;
     }
 
     private static string NormalizeTypeName(string typeName)
@@ -420,6 +515,15 @@ public sealed class ContractTranslator
     private BitVecExpr TrackBitVec(BitVecExpr expr, uint width, bool isSigned)
     {
         _exprInfo[expr] = new BitVecInfo(width, isSigned);
+        return expr;
+    }
+
+    /// <summary>
+    /// Tracks a string expression with metadata.
+    /// </summary>
+    private SeqExpr TrackString(SeqExpr expr, bool isNullable = false)
+    {
+        _stringInfo[expr] = new StringInfo(isNullable);
         return expr;
     }
 
@@ -565,5 +669,687 @@ public sealed class ContractTranslator
             return _ctx.MkEq(normalizedLeft, normalizedRight);
         }
         return _ctx.MkEq(left, right);
+    }
+
+    // ===========================================
+    // String Theory Support
+    // ===========================================
+
+    /// <summary>
+    /// Translates a string operation to a Z3 expression.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Supported operations: Length, Contains, StartsWith, EndsWith, Equals, IsNullOrEmpty,
+    /// IndexOf, Substring, SubstringFrom, Concat, Replace.
+    /// </para>
+    /// <para>
+    /// <b>Note:</b> The <see cref="StringOperationNode.ComparisonMode"/> property is ignored.
+    /// Z3's string theory only supports ordinal comparison; case-insensitive comparisons
+    /// (e.g., <c>:ignore-case</c>) cannot be modeled and will verify as if ordinal comparison
+    /// was specified.
+    /// </para>
+    /// </remarks>
+    private Expr? TranslateStringOperation(StringOperationNode node)
+    {
+        // Emit warning if comparison mode is specified but will be ignored
+        if (node.ComparisonMode.HasValue && node.ComparisonMode.Value != StringComparisonMode.Ordinal)
+        {
+            _warnings.Add(
+                $"String operation '{node.Operation}' specifies comparison mode '{node.ComparisonMode.Value}' " +
+                "which is ignored during verification. Z3 string theory only supports ordinal comparison; " +
+                "case-insensitive or culture-aware comparisons cannot be modeled. " +
+                "Verification will use ordinal comparison semantics.");
+        }
+
+        return node.Operation switch
+        {
+            StringOp.Length => TranslateStringLength(node),
+            StringOp.Contains => TranslateStringContains(node),
+            StringOp.StartsWith => TranslateStringStartsWith(node),
+            StringOp.EndsWith => TranslateStringEndsWith(node),
+            StringOp.Equals => TranslateStringEquals(node),
+            StringOp.IsNullOrEmpty => TranslateStringIsNullOrEmpty(node),
+            StringOp.IndexOf => TranslateStringIndexOf(node),
+            StringOp.Substring => TranslateStringSubstring(node),
+            StringOp.SubstringFrom => TranslateStringSubstringFrom(node),
+            StringOp.Concat => TranslateStringConcat(node),
+            StringOp.Replace => TranslateStringReplace(node),
+            // Unsupported operations - ToUpper, ToLower, Trim, Regex, etc.
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Translates string length operation: (len s) -> BitVecExpr (32-bit unsigned)
+    /// </summary>
+    private Expr? TranslateStringLength(StringOperationNode node)
+    {
+        if (node.Arguments.Count < 1)
+            return null;
+
+        var str = Translate(node.Arguments[0]);
+        if (str is not SeqExpr seqExpr)
+            return null;
+
+        // MkLength returns IntExpr, convert to 32-bit unsigned bit-vector
+        var lengthInt = _ctx.MkLength(seqExpr);
+        return TrackBitVec(_ctx.MkInt2BV(32, lengthInt), 32, isSigned: false);
+    }
+
+    /// <summary>
+    /// Translates string contains operation: (contains s "hello") -> BoolExpr
+    /// </summary>
+    private Expr? TranslateStringContains(StringOperationNode node)
+    {
+        if (node.Arguments.Count < 2)
+            return null;
+
+        var str = Translate(node.Arguments[0]);
+        var substr = Translate(node.Arguments[1]);
+
+        if (str is not SeqExpr strExpr || substr is not SeqExpr substrExpr)
+            return null;
+
+        return _ctx.MkContains(strExpr, substrExpr);
+    }
+
+    /// <summary>
+    /// Translates string starts-with operation: (starts s "prefix") -> BoolExpr
+    /// Note: Z3's MkPrefixOf takes (prefix, str) - prefix first!
+    /// </summary>
+    private Expr? TranslateStringStartsWith(StringOperationNode node)
+    {
+        if (node.Arguments.Count < 2)
+            return null;
+
+        var str = Translate(node.Arguments[0]);
+        var prefix = Translate(node.Arguments[1]);
+
+        if (str is not SeqExpr strExpr || prefix is not SeqExpr prefixExpr)
+            return null;
+
+        // MkPrefixOf takes prefix first, then string
+        return _ctx.MkPrefixOf(prefixExpr, strExpr);
+    }
+
+    /// <summary>
+    /// Translates string ends-with operation: (ends s "suffix") -> BoolExpr
+    /// Note: Z3's MkSuffixOf takes (suffix, str) - suffix first!
+    /// </summary>
+    private Expr? TranslateStringEndsWith(StringOperationNode node)
+    {
+        if (node.Arguments.Count < 2)
+            return null;
+
+        var str = Translate(node.Arguments[0]);
+        var suffix = Translate(node.Arguments[1]);
+
+        if (str is not SeqExpr strExpr || suffix is not SeqExpr suffixExpr)
+            return null;
+
+        // MkSuffixOf takes suffix first, then string
+        return _ctx.MkSuffixOf(suffixExpr, strExpr);
+    }
+
+    /// <summary>
+    /// Translates string equals operation: (equals s1 s2) -> BoolExpr
+    /// </summary>
+    private Expr? TranslateStringEquals(StringOperationNode node)
+    {
+        if (node.Arguments.Count < 2)
+            return null;
+
+        var str1 = Translate(node.Arguments[0]);
+        var str2 = Translate(node.Arguments[1]);
+
+        if (str1 is not SeqExpr str1Expr || str2 is not SeqExpr str2Expr)
+            return null;
+
+        return _ctx.MkEq(str1Expr, str2Expr);
+    }
+
+    /// <summary>
+    /// Translates string is-null-or-empty operation: (isempty s) -> BoolExpr.
+    /// </summary>
+    /// <remarks>
+    /// <b>Important:</b> Z3 strings cannot be null - they are always valid sequences.
+    /// This method only checks if the string length equals zero. Code that passes null
+    /// strings to <c>string.IsNullOrEmpty()</c> in C# will behave differently than this
+    /// Z3 translation, which cannot distinguish null from empty.
+    /// </remarks>
+    private Expr? TranslateStringIsNullOrEmpty(StringOperationNode node)
+    {
+        if (node.Arguments.Count < 1)
+            return null;
+
+        var str = Translate(node.Arguments[0]);
+        if (str is not SeqExpr seqExpr)
+            return null;
+
+        // Check if length equals 0
+        var length = _ctx.MkLength(seqExpr);
+        return _ctx.MkEq(length, _ctx.MkInt(0));
+    }
+
+    /// <summary>
+    /// Translates string index-of operation: (indexof s "search") or (indexof s "search" start) -> BitVecExpr (32-bit signed).
+    /// Returns -1 if not found.
+    /// </summary>
+    /// <remarks>
+    /// Supports both 2-argument form (searches from index 0) and 3-argument form (searches from specified start index).
+    /// </remarks>
+    private Expr? TranslateStringIndexOf(StringOperationNode node)
+    {
+        if (node.Arguments.Count < 2)
+            return null;
+
+        var str = Translate(node.Arguments[0]);
+        var search = Translate(node.Arguments[1]);
+
+        if (str is not SeqExpr strExpr || search is not SeqExpr searchExpr)
+            return null;
+
+        // Determine start index: use 3rd argument if provided, otherwise 0
+        IntExpr startIndex;
+        if (node.Arguments.Count >= 3)
+        {
+            var startArg = Translate(node.Arguments[2]);
+            var startInt = ConvertToIntExpr(startArg);
+            if (startInt == null)
+                return null;
+            startIndex = startInt;
+        }
+        else
+        {
+            startIndex = _ctx.MkInt(0);
+        }
+
+        // MkIndexOf takes (str, search, startIndex)
+        var indexInt = _ctx.MkIndexOf(strExpr, searchExpr, startIndex);
+        return TrackBitVec(_ctx.MkInt2BV(32, indexInt), 32, isSigned: true);
+    }
+
+    /// <summary>
+    /// Translates string substring operation: (substr s start len) -> SeqExpr
+    /// </summary>
+    private Expr? TranslateStringSubstring(StringOperationNode node)
+    {
+        if (node.Arguments.Count < 3)
+            return null;
+
+        var str = Translate(node.Arguments[0]);
+        var start = Translate(node.Arguments[1]);
+        var len = Translate(node.Arguments[2]);
+
+        if (str is not SeqExpr strExpr)
+            return null;
+
+        // Convert BitVec indices to Int
+        var startInt = ConvertToIntExpr(start);
+        var lenInt = ConvertToIntExpr(len);
+
+        if (startInt == null || lenInt == null)
+            return null;
+
+        return TrackString(_ctx.MkExtract(strExpr, startInt, lenInt));
+    }
+
+    /// <summary>
+    /// Translates string substring-from operation: (substr s start) -> SeqExpr
+    /// Gets substring from start to end of string
+    /// </summary>
+    private Expr? TranslateStringSubstringFrom(StringOperationNode node)
+    {
+        if (node.Arguments.Count < 2)
+            return null;
+
+        var str = Translate(node.Arguments[0]);
+        var start = Translate(node.Arguments[1]);
+
+        if (str is not SeqExpr strExpr)
+            return null;
+
+        var startInt = ConvertToIntExpr(start);
+        if (startInt == null)
+            return null;
+
+        // Length from start to end = total length - start
+        var totalLen = _ctx.MkLength(strExpr);
+        var remainingLen = _ctx.MkSub(totalLen, startInt) as IntExpr;
+        if (remainingLen == null)
+            return null;
+
+        return TrackString(_ctx.MkExtract(strExpr, startInt, remainingLen));
+    }
+
+    /// <summary>
+    /// Translates string concat operation: (concat s1 s2 ...) -> SeqExpr
+    /// </summary>
+    private Expr? TranslateStringConcat(StringOperationNode node)
+    {
+        if (node.Arguments.Count < 2)
+            return null;
+
+        var strings = new List<SeqExpr>();
+        foreach (var arg in node.Arguments)
+        {
+            var translated = Translate(arg);
+            if (translated is not SeqExpr seqExpr)
+                return null;
+            strings.Add(seqExpr);
+        }
+
+        return TrackString(_ctx.MkConcat(strings.ToArray()));
+    }
+
+    /// <summary>
+    /// Translates string replace operation: (replace s old new) -> SeqExpr
+    /// Replaces first occurrence only
+    /// </summary>
+    private Expr? TranslateStringReplace(StringOperationNode node)
+    {
+        if (node.Arguments.Count < 3)
+            return null;
+
+        var str = Translate(node.Arguments[0]);
+        var oldStr = Translate(node.Arguments[1]);
+        var newStr = Translate(node.Arguments[2]);
+
+        if (str is not SeqExpr strExpr ||
+            oldStr is not SeqExpr oldExpr ||
+            newStr is not SeqExpr newExpr)
+            return null;
+
+        return TrackString(_ctx.MkReplace(strExpr, oldExpr, newExpr));
+    }
+
+    /// <summary>
+    /// Converts a bit-vector expression to an IntExpr for Z3 string operations.
+    /// </summary>
+    private IntExpr? ConvertToIntExpr(Expr? expr)
+    {
+        if (expr is IntExpr intExpr)
+            return intExpr;
+
+        if (expr is BitVecExpr bvExpr)
+        {
+            // Use signed conversion for signed types, unsigned for unsigned
+            return _ctx.MkBV2Int(bvExpr, IsSigned(bvExpr));
+        }
+
+        return null;
+    }
+
+    // ===========================================
+    // Array Theory Enhancement
+    // ===========================================
+
+    /// <summary>
+    /// Translates array length access: arr.Length -> BitVecExpr (32-bit unsigned)
+    /// </summary>
+    private Expr? TranslateArrayLength(ArrayLengthNode node)
+    {
+        if (node.Array is ReferenceNode arrayRef)
+        {
+            var lengthVarName = $"{arrayRef.Name}$length";
+
+            // Check if we already have a length variable for this array
+            if (_variables.TryGetValue(lengthVarName, out var lengthVar))
+                return lengthVar.Expr;
+
+            // Create unsigned 32-bit length variable
+            var lengthExpr = TrackBitVec(_ctx.MkBVConst(lengthVarName, 32), 32, isSigned: false);
+            _variables[lengthVarName] = (lengthExpr, "u32");
+
+            return lengthExpr;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Declares an array variable with the given name and element type.
+    /// Also creates an associated length variable.
+    /// </summary>
+    /// <param name="name">Array variable name.</param>
+    /// <param name="elementType">The type of array elements (e.g., "i32", "u8").</param>
+    /// <returns>True if the array was declared successfully.</returns>
+    public bool DeclareArrayVariable(string name, string elementType)
+    {
+        var (elementWidth, elementSigned) = GetTypeWidthAndSignedness(elementType);
+        if (elementWidth == 0)
+            return false;
+
+        // Create array sort: BitVec64 (index) -> BitVec[elementWidth] (element)
+        var bv64Sort = _ctx.MkBitVecSort(64);
+        var elementSort = _ctx.MkBitVecSort(elementWidth);
+        var arrayExpr = _ctx.MkArrayConst(name, bv64Sort, elementSort);
+
+        _variables[name] = (arrayExpr, $"array<{elementType}>");
+
+        // Create associated length variable (unsigned 32-bit)
+        var lengthVarName = $"{name}$length";
+        var lengthExpr = TrackBitVec(_ctx.MkBVConst(lengthVarName, 32), 32, isSigned: false);
+        _variables[lengthVarName] = (lengthExpr, "u32");
+
+        _arrayInfo[name] = new ArrayInfo(elementType, lengthExpr);
+        return true;
+    }
+
+    /// <summary>
+    /// Gets the bit width and signedness for a type name.
+    /// </summary>
+    private (uint Width, bool IsSigned) GetTypeWidthAndSignedness(string typeName)
+    {
+        var normalizedType = NormalizeTypeName(typeName);
+        return normalizedType switch
+        {
+            "i8" or "sbyte" => (8, true),
+            "i16" or "short" => (16, true),
+            "i32" or "int" => (32, true),
+            "i64" or "long" => (64, true),
+            "u8" or "byte" => (8, false),
+            "u16" or "ushort" => (16, false),
+            "u32" or "uint" => (32, false),
+            "u64" or "ulong" => (64, false),
+            _ => (0, false) // Unsupported type
+        };
+    }
+
+    // ===========================================
+    // Diagnostic Support
+    // ===========================================
+
+    /// <summary>
+    /// Diagnoses why translation failed for an expression.
+    /// Returns a human-readable description of the first unsupported construct found.
+    /// </summary>
+    /// <param name="node">The expression that failed to translate.</param>
+    /// <returns>A diagnostic message, or null if no specific issue was identified.</returns>
+    public string? DiagnoseTranslationFailure(ExpressionNode node)
+    {
+        return DiagnoseNode(node);
+    }
+
+    private string? DiagnoseNode(ExpressionNode node)
+    {
+        return node switch
+        {
+            FloatLiteralNode f => $"Floating-point literal '{f.Value}' is not supported (Z3 bit-vector theory does not model floats)",
+            CallExpressionNode c => $"Function call '{c.Target}' is not supported (only built-in operations are verifiable)",
+            ReferenceNode r when !_variables.ContainsKey(r.Name) => $"Unknown variable '{r.Name}'",
+            StringOperationNode s => DiagnoseStringOperation(s),
+            BinaryOperationNode b => DiagnoseBinaryOp(b),
+            UnaryOperationNode u => DiagnoseUnaryOp(u),
+            ConditionalExpressionNode c => DiagnoseConditional(c),
+            ForallExpressionNode f => DiagnoseForall(f),
+            ExistsExpressionNode e => DiagnoseExists(e),
+            ImplicationExpressionNode i => DiagnoseImplication(i),
+            ArrayAccessNode a => DiagnoseArrayAccess(a),
+            ArrayLengthNode l => DiagnoseArrayLength(l),
+            _ => $"Unsupported expression type: {node.GetType().Name}"
+        };
+    }
+
+    private string? DiagnoseStringOperation(StringOperationNode node)
+    {
+        // Check if this is an unsupported string operation
+        var unsupportedOps = new[] {
+            StringOp.ToUpper, StringOp.ToLower, StringOp.Trim, StringOp.TrimStart, StringOp.TrimEnd,
+            StringOp.PadLeft, StringOp.PadRight, StringOp.Split, StringOp.Join, StringOp.Format,
+            StringOp.RegexTest, StringOp.IsNullOrWhiteSpace
+        };
+
+        if (unsupportedOps.Contains(node.Operation))
+        {
+            return $"String operation '{node.Operation}' is not supported (Z3 string theory lacks this operation)";
+        }
+
+        // Check arguments recursively
+        foreach (var arg in node.Arguments)
+        {
+            var argResult = Translate(arg);
+            if (argResult == null)
+            {
+                var argDiag = DiagnoseNode(arg);
+                if (argDiag != null)
+                    return argDiag;
+            }
+        }
+
+        // Check if arguments have wrong types
+        if (node.Arguments.Count > 0)
+        {
+            var firstArg = Translate(node.Arguments[0]);
+            if (firstArg != null && firstArg is not SeqExpr)
+            {
+                return $"String operation '{node.Operation}' requires a string argument, but got {firstArg.GetType().Name}";
+            }
+        }
+
+        // Check for operations that require integer arguments (IndexOf start, Substring indices)
+        if (node.Operation == StringOp.IndexOf && node.Arguments.Count >= 3)
+        {
+            var startArg = Translate(node.Arguments[2]);
+            if (startArg != null && startArg is not BitVecExpr && startArg is not IntExpr)
+            {
+                return $"IndexOf start index must be an integer, but got {startArg.GetType().Name}";
+            }
+        }
+
+        if (node.Operation == StringOp.Substring && node.Arguments.Count >= 3)
+        {
+            var startArg = Translate(node.Arguments[1]);
+            var lenArg = Translate(node.Arguments[2]);
+            if (startArg != null && startArg is not BitVecExpr && startArg is not IntExpr)
+            {
+                return $"Substring start index must be an integer, but got {startArg.GetType().Name}";
+            }
+            if (lenArg != null && lenArg is not BitVecExpr && lenArg is not IntExpr)
+            {
+                return $"Substring length must be an integer, but got {lenArg.GetType().Name}";
+            }
+        }
+
+        if (node.Operation == StringOp.SubstringFrom && node.Arguments.Count >= 2)
+        {
+            var startArg = Translate(node.Arguments[1]);
+            if (startArg != null && startArg is not BitVecExpr && startArg is not IntExpr)
+            {
+                return $"SubstringFrom start index must be an integer, but got {startArg.GetType().Name}";
+            }
+        }
+
+        return null;
+    }
+
+    private string? DiagnoseBinaryOp(BinaryOperationNode node)
+    {
+        var left = Translate(node.Left);
+        var right = Translate(node.Right);
+
+        if (left == null)
+            return DiagnoseNode(node.Left);
+        if (right == null)
+            return DiagnoseNode(node.Right);
+
+        // Check for type mismatches
+        return node.Operator switch
+        {
+            BinaryOperator.Add or BinaryOperator.Subtract or BinaryOperator.Multiply or
+            BinaryOperator.Divide or BinaryOperator.Modulo when left is not BitVecExpr || right is not BitVecExpr
+                => $"Arithmetic operator '{node.Operator}' requires integer operands, but got {left.GetType().Name} and {right.GetType().Name}",
+
+            BinaryOperator.And or BinaryOperator.Or when left is not BoolExpr || right is not BoolExpr
+                => $"Logical operator '{node.Operator}' requires boolean operands, but got {left.GetType().Name} and {right.GetType().Name}",
+
+            BinaryOperator.BitwiseAnd or BinaryOperator.BitwiseOr or BinaryOperator.BitwiseXor or
+            BinaryOperator.LeftShift or BinaryOperator.RightShift when left is not BitVecExpr || right is not BitVecExpr
+                => $"Bitwise operator '{node.Operator}' requires integer operands, but got {left.GetType().Name} and {right.GetType().Name}",
+
+            _ => null
+        };
+    }
+
+    private string? DiagnoseUnaryOp(UnaryOperationNode node)
+    {
+        var operand = Translate(node.Operand);
+        if (operand == null)
+            return DiagnoseNode(node.Operand);
+
+        return node.Operator switch
+        {
+            UnaryOperator.Not when operand is not BoolExpr
+                => $"Logical NOT requires a boolean operand, but got {operand.GetType().Name}",
+            UnaryOperator.Negate when operand is not BitVecExpr
+                => $"Negation requires an integer operand, but got {operand.GetType().Name}",
+            _ => null
+        };
+    }
+
+    private string? DiagnoseConditional(ConditionalExpressionNode node)
+    {
+        var cond = Translate(node.Condition);
+        if (cond == null)
+            return DiagnoseNode(node.Condition);
+        if (cond is not BoolExpr)
+            return $"Conditional expression requires boolean condition, but got {cond.GetType().Name}";
+
+        var whenTrue = Translate(node.WhenTrue);
+        if (whenTrue == null)
+            return DiagnoseNode(node.WhenTrue);
+
+        var whenFalse = Translate(node.WhenFalse);
+        if (whenFalse == null)
+            return DiagnoseNode(node.WhenFalse);
+
+        // Check for type mismatches between branches
+        if (whenTrue.GetType() != whenFalse.GetType())
+        {
+            // Allow BitVecExpr with different widths (they can be normalized)
+            if (whenTrue is BitVecExpr && whenFalse is BitVecExpr)
+                return null;
+
+            return $"Conditional branches have incompatible types: '{whenTrue.GetType().Name}' and '{whenFalse.GetType().Name}'";
+        }
+
+        return null;
+    }
+
+    private string? DiagnoseForall(ForallExpressionNode node)
+    {
+        foreach (var bv in node.BoundVariables)
+        {
+            var z3Var = CreateVariableForType(bv.Name, bv.TypeName);
+            if (z3Var == null)
+                return $"Unsupported type '{bv.TypeName}' for bound variable '{bv.Name}' in forall expression";
+        }
+
+        var bodyDiag = DiagnoseNode(node.Body);
+        if (bodyDiag != null)
+            return bodyDiag;
+
+        return null;
+    }
+
+    private string? DiagnoseExists(ExistsExpressionNode node)
+    {
+        foreach (var bv in node.BoundVariables)
+        {
+            var z3Var = CreateVariableForType(bv.Name, bv.TypeName);
+            if (z3Var == null)
+                return $"Unsupported type '{bv.TypeName}' for bound variable '{bv.Name}' in exists expression";
+        }
+
+        var bodyDiag = DiagnoseNode(node.Body);
+        if (bodyDiag != null)
+            return bodyDiag;
+
+        return null;
+    }
+
+    private string? DiagnoseImplication(ImplicationExpressionNode node)
+    {
+        var ante = Translate(node.Antecedent);
+        if (ante == null)
+            return DiagnoseNode(node.Antecedent);
+        if (ante is not BoolExpr)
+            return $"Implication antecedent must be boolean, but got {ante.GetType().Name}";
+
+        var cons = Translate(node.Consequent);
+        if (cons == null)
+            return DiagnoseNode(node.Consequent);
+        if (cons is not BoolExpr)
+            return $"Implication consequent must be boolean, but got {cons.GetType().Name}";
+
+        return null;
+    }
+
+    private string? DiagnoseArrayAccess(ArrayAccessNode node)
+    {
+        if (node.Array is not ReferenceNode)
+        {
+            var arrayType = node.Array.GetType().Name;
+            return $"Array access requires a simple variable reference, but got '{arrayType}' " +
+                   "(computed array expressions like method returns or nested accesses are not supported)";
+        }
+
+        var index = Translate(node.Index);
+        if (index == null)
+            return DiagnoseNode(node.Index);
+        if (index is not BitVecExpr)
+            return $"Array index must be an integer, but got {index.GetType().Name}";
+
+        return null;
+    }
+
+    private string? DiagnoseArrayLength(ArrayLengthNode node)
+    {
+        if (node.Array is not ReferenceNode)
+            return "Array length requires a simple variable reference";
+
+        return null;
+    }
+
+    /// <summary>
+    /// Diagnoses why a boolean expression translation failed.
+    /// This is useful when Translate succeeds but TranslateBoolExpr returns null.
+    /// </summary>
+    /// <param name="node">The expression that failed to translate to boolean.</param>
+    /// <returns>A diagnostic message.</returns>
+    public string? DiagnoseBoolExprFailure(ExpressionNode node)
+    {
+        var expr = Translate(node);
+        if (expr == null)
+            return DiagnoseTranslationFailure(node);
+
+        if (expr is not BoolExpr)
+        {
+            return $"Expression must be boolean for verification, but got {expr.GetType().Name}. " +
+                   "Boolean expressions include comparisons (==, !=, <, >, <=, >=), " +
+                   "logical operations (&&, ||, !), and boolean variables.";
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets a description of why a type is not supported.
+    /// </summary>
+    /// <param name="typeName">The type name that was not supported.</param>
+    /// <returns>A diagnostic message.</returns>
+    public static string DiagnoseUnsupportedType(string typeName)
+    {
+        var normalized = typeName.ToLowerInvariant();
+        return normalized switch
+        {
+            "f32" or "f64" or "float" or "double" or "single" or "decimal"
+                => $"Type '{typeName}' is not supported (floating-point types cannot be verified with bit-vector theory)",
+            "object" or "dynamic"
+                => $"Type '{typeName}' is not supported (reference/dynamic types cannot be statically verified)",
+            var t when t.Contains("func") || t.Contains("action") || t.Contains("delegate")
+                => $"Type '{typeName}' is not supported (function/delegate types cannot be verified)",
+            _ => $"Type '{typeName}' is not supported for verification"
+        };
     }
 }

--- a/tests/Calor.Compiler.Tests/VerificationCacheTests.cs
+++ b/tests/Calor.Compiler.Tests/VerificationCacheTests.cs
@@ -395,8 +395,8 @@ public class VerificationCacheTests : IDisposable
 
         var result = new ContractVerificationResult(
             ContractVerificationStatus.Disproven,
-            "x = -1",
-            TimeSpan.FromMilliseconds(100));
+            CounterexampleDescription: "x = -1",
+            Duration: TimeSpan.FromMilliseconds(100));
 
         // Write with one instance
         using (var cache = new VerificationCache(options))

--- a/tests/Calor.Verification.Tests/ImplicationProverTests.cs
+++ b/tests/Calor.Verification.Tests/ImplicationProverTests.cs
@@ -394,19 +394,20 @@ public class ImplicationProverTests
     #region Unsupported Construct Tests
 
     [SkippableFact]
-    public void Returns_Unsupported_ForStrings()
+    public void ProvesStringImplication()
     {
         Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
-        Returns_Unsupported_ForStrings_Core();
+        ProvesStringImplication_Core();
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void Returns_Unsupported_ForStrings_Core()
+    private void ProvesStringImplication_Core()
     {
         using var ctx = Z3ContextFactory.Create();
         using var prover = new Z3ImplicationProver(ctx);
 
-        // String contracts are unsupported
+        // String contracts are now supported via Z3's string theory
+        // s != "" -> s != "" is a tautology
         var parameters = new List<(string Name, string Type)> { ("s", "string") };
 
         var antecedent = new BinaryOperationNode(
@@ -423,7 +424,7 @@ public class ImplicationProverTests
 
         var result = prover.ProveImplication(parameters, antecedent, consequent);
 
-        Assert.Equal(ImplicationStatus.Unsupported, result.Status);
+        Assert.Equal(ImplicationStatus.Proven, result.Status);
     }
 
     [SkippableFact]

--- a/tests/Calor.Verification.Tests/TranslatorTests.cs
+++ b/tests/Calor.Verification.Tests/TranslatorTests.cs
@@ -487,14 +487,14 @@ public class TranslatorTests
     }
 
     [SkippableFact]
-    public void ReturnsNullForStringLiteral()
+    public void TranslatesStringLiteral()
     {
         Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
-        ReturnsNullForStringLiteralCore();
+        TranslatesStringLiteralCore();
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void ReturnsNullForStringLiteralCore()
+    private void TranslatesStringLiteralCore()
     {
         using var ctx = Z3ContextFactory.Create();
         var translator = new ContractTranslator(ctx);
@@ -503,7 +503,8 @@ public class TranslatorTests
 
         var result = translator.Translate(expr);
 
-        Assert.Null(result);
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.SeqExpr>(result);
     }
 
     [SkippableFact]
@@ -1097,5 +1098,1702 @@ public class TranslatorTests
         var resultStr = result.ToString().ToLower();
         Assert.True(resultStr.Contains("bvult") || resultStr.Contains("ult"),
             $"Expected unsigned comparison (bvult), got: {result}");
+    }
+
+    // ===========================================
+    // String Theory Tests
+    // ===========================================
+
+    [SkippableFact]
+    public void TranslatesStringVariable()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesStringVariableCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesStringVariableCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        var declared = translator.DeclareVariable("s", "string");
+        Assert.True(declared);
+
+        var expr = new ReferenceNode(TextSpan.Empty, "s");
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.SeqExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesStringLength()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesStringLengthCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesStringLengthCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (len s)
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Length,
+            new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") });
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        // String length returns a 32-bit unsigned bit-vector
+        Assert.IsType<Microsoft.Z3.BitVecExpr>(result);
+        var bvExpr = (Microsoft.Z3.BitVecExpr)result;
+        Assert.Equal(32u, bvExpr.SortSize);
+    }
+
+    [SkippableFact]
+    public void TranslatesStringContains()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesStringContainsCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesStringContainsCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (contains s "hello")
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Contains,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new StringLiteralNode(TextSpan.Empty, "hello")
+            });
+
+        var result = translator.TranslateBoolExpr(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.BoolExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesStringStartsWith()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesStringStartsWithCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesStringStartsWithCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (starts s "prefix")
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.StartsWith,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new StringLiteralNode(TextSpan.Empty, "prefix")
+            });
+
+        var result = translator.TranslateBoolExpr(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.BoolExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesStringEndsWith()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesStringEndsWithCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesStringEndsWithCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (ends s "suffix")
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.EndsWith,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new StringLiteralNode(TextSpan.Empty, "suffix")
+            });
+
+        var result = translator.TranslateBoolExpr(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.BoolExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesStringEquals()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesStringEqualsCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesStringEqualsCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s1", "string");
+        translator.DeclareVariable("s2", "string");
+
+        // (equals s1 s2)
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Equals,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s1"),
+                new ReferenceNode(TextSpan.Empty, "s2")
+            });
+
+        var result = translator.TranslateBoolExpr(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.BoolExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesStringIsNullOrEmpty()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesStringIsNullOrEmptyCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesStringIsNullOrEmptyCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (isempty s)
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.IsNullOrEmpty,
+            new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") });
+
+        var result = translator.TranslateBoolExpr(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.BoolExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesStringConcat()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesStringConcatCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesStringConcatCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s1", "string");
+        translator.DeclareVariable("s2", "string");
+
+        // (concat s1 s2)
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Concat,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s1"),
+                new ReferenceNode(TextSpan.Empty, "s2")
+            });
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.SeqExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesStringIndexOf()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesStringIndexOfCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesStringIndexOfCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (indexof s "hello")
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.IndexOf,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new StringLiteralNode(TextSpan.Empty, "hello")
+            });
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        // IndexOf returns a signed 32-bit bit-vector (can be -1 if not found)
+        Assert.IsType<Microsoft.Z3.BitVecExpr>(result);
+        var bvExpr = (Microsoft.Z3.BitVecExpr)result;
+        Assert.Equal(32u, bvExpr.SortSize);
+    }
+
+    [SkippableFact]
+    public void TranslatesStringIndexOfWithStartOffset()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesStringIndexOfWithStartOffsetCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesStringIndexOfWithStartOffsetCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (indexof s "hello" 5) - search starting from index 5
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.IndexOf,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new StringLiteralNode(TextSpan.Empty, "hello"),
+                new IntLiteralNode(TextSpan.Empty, 5)
+            });
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.BitVecExpr>(result);
+        var bvExpr = (Microsoft.Z3.BitVecExpr)result;
+        Assert.Equal(32u, bvExpr.SortSize);
+    }
+
+    [SkippableFact]
+    public void TranslatesStringSubstring()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesStringSubstringCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesStringSubstringCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (substr s 0 5) - substring from index 0, length 5
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Substring,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new IntLiteralNode(TextSpan.Empty, 0),
+                new IntLiteralNode(TextSpan.Empty, 5)
+            });
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.SeqExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesStringSubstringFrom()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesStringSubstringFromCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesStringSubstringFromCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (substr s 3) - substring from index 3 to end
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.SubstringFrom,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new IntLiteralNode(TextSpan.Empty, 3)
+            });
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.SeqExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesStringReplace()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesStringReplaceCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesStringReplaceCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (replace s "old" "new")
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Replace,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new StringLiteralNode(TextSpan.Empty, "old"),
+                new StringLiteralNode(TextSpan.Empty, "new")
+            });
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.SeqExpr>(result);
+    }
+
+    // ===========================================
+    // Array Theory Tests
+    // ===========================================
+
+    [SkippableFact]
+    public void TranslatesArrayLength()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesArrayLengthCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesArrayLengthCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        // (len arr) - ArrayLengthNode
+        var expr = new ArrayLengthNode(
+            TextSpan.Empty,
+            new ReferenceNode(TextSpan.Empty, "arr"));
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        // Array length returns a 32-bit unsigned bit-vector
+        Assert.IsType<Microsoft.Z3.BitVecExpr>(result);
+        var bvExpr = (Microsoft.Z3.BitVecExpr)result;
+        Assert.Equal(32u, bvExpr.SortSize);
+
+        // Verify the length variable was created
+        Assert.True(translator.Variables.ContainsKey("arr$length"));
+    }
+
+    [SkippableFact]
+    public void DeclareArrayVariableCreatesLengthVariable()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        DeclareArrayVariableCreatesLengthVariableCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void DeclareArrayVariableCreatesLengthVariableCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        var declared = translator.DeclareArrayVariable("arr", "i32");
+        Assert.True(declared);
+
+        // Array variable should exist
+        Assert.True(translator.Variables.ContainsKey("arr"));
+        Assert.IsType<Microsoft.Z3.ArrayExpr>(translator.Variables["arr"].Expr);
+
+        // Length variable should exist
+        Assert.True(translator.Variables.ContainsKey("arr$length"));
+        var lengthExpr = translator.Variables["arr$length"].Expr;
+        Assert.IsType<Microsoft.Z3.BitVecExpr>(lengthExpr);
+        Assert.Equal(32u, ((Microsoft.Z3.BitVecExpr)lengthExpr).SortSize);
+    }
+
+    [SkippableFact]
+    public void ArrayAccessCreatesLengthVariableOnDemand()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ArrayAccessCreatesLengthVariableOnDemandCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ArrayAccessCreatesLengthVariableOnDemandCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("i", "i32");
+
+        // Access array element without declaring the array first
+        // arr{i}
+        var expr = new ArrayAccessNode(
+            TextSpan.Empty,
+            new ReferenceNode(TextSpan.Empty, "arr"),
+            new ReferenceNode(TextSpan.Empty, "i"));
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        // Array should have been created on-demand
+        Assert.True(translator.Variables.ContainsKey("arr"));
+        // Length variable should also have been created
+        Assert.True(translator.Variables.ContainsKey("arr$length"));
+    }
+
+    // ===========================================
+    // Unsupported String Operation Tests
+    // ===========================================
+
+    [SkippableFact]
+    public void ReturnsNullForStringToUpper()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsNullForStringToUpperCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsNullForStringToUpperCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (upper s) - not supported by Z3
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.ToUpper,
+            new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") });
+
+        var result = translator.Translate(expr);
+
+        Assert.Null(result);
+    }
+
+    [SkippableFact]
+    public void ReturnsNullForStringToLower()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsNullForStringToLowerCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsNullForStringToLowerCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (lower s) - not supported by Z3
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.ToLower,
+            new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") });
+
+        var result = translator.Translate(expr);
+
+        Assert.Null(result);
+    }
+
+    [SkippableFact]
+    public void ReturnsNullForStringTrim()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsNullForStringTrimCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsNullForStringTrimCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (trim s) - not supported by Z3
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Trim,
+            new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") });
+
+        var result = translator.Translate(expr);
+
+        Assert.Null(result);
+    }
+
+    [SkippableFact]
+    public void ReturnsNullForStringRegexTest()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsNullForStringRegexTestCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsNullForStringRegexTestCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (regex-test s "\\d+") - not supported
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.RegexTest,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new StringLiteralNode(TextSpan.Empty, "\\d+")
+            });
+
+        var result = translator.Translate(expr);
+
+        Assert.Null(result);
+    }
+
+    [SkippableFact]
+    public void ReturnsNullForStringSplit()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsNullForStringSplitCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsNullForStringSplitCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (split s ",") - not supported (returns array)
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Split,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new StringLiteralNode(TextSpan.Empty, ",")
+            });
+
+        var result = translator.Translate(expr);
+
+        Assert.Null(result);
+    }
+
+    [SkippableFact]
+    public void ReturnsNullForStringIsNullOrWhiteSpace()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsNullForStringIsNullOrWhiteSpaceCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsNullForStringIsNullOrWhiteSpaceCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (isblank s) - not supported (requires whitespace theory)
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.IsNullOrWhiteSpace,
+            new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") });
+
+        var result = translator.Translate(expr);
+
+        Assert.Null(result);
+    }
+
+    // ===========================================
+    // String Edge Case Tests
+    // ===========================================
+
+    [SkippableFact]
+    public void TranslatesContainsWithEmptySearchString()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesContainsWithEmptySearchStringCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesContainsWithEmptySearchStringCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (contains s "") - should translate successfully
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Contains,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new StringLiteralNode(TextSpan.Empty, "")
+            });
+
+        var result = translator.TranslateBoolExpr(expr);
+
+        Assert.NotNull(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesReplaceWithEmptyStrings()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesReplaceWithEmptyStringsCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesReplaceWithEmptyStringsCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (replace s "" "x") - replace empty with "x"
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Replace,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new StringLiteralNode(TextSpan.Empty, ""),
+                new StringLiteralNode(TextSpan.Empty, "x")
+            });
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.SeqExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesIndexOfWithEmptySearchString()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesIndexOfWithEmptySearchStringCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesIndexOfWithEmptySearchStringCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (indexof s "") - should translate successfully
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.IndexOf,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new StringLiteralNode(TextSpan.Empty, "")
+            });
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.BitVecExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesSubstringWithZeroLength()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesSubstringWithZeroLengthCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesSubstringWithZeroLengthCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (substr s 0 0) - zero-length substring
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Substring,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new IntLiteralNode(TextSpan.Empty, 0),
+                new IntLiteralNode(TextSpan.Empty, 0)
+            });
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.SeqExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesArrayWithDifferentElementTypes()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesArrayWithDifferentElementTypesCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesArrayWithDifferentElementTypesCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        // Declare arrays with different element types
+        Assert.True(translator.DeclareVariable("arr8", "i8[]"));
+        Assert.True(translator.DeclareVariable("arr16", "i16[]"));
+        Assert.True(translator.DeclareVariable("arr32", "i32[]"));
+        Assert.True(translator.DeclareVariable("arr64", "i64[]"));
+        Assert.True(translator.DeclareVariable("arru8", "u8[]"));
+        Assert.True(translator.DeclareVariable("arru64", "u64[]"));
+
+        // Verify all arrays were created with length variables
+        Assert.True(translator.Variables.ContainsKey("arr8$length"));
+        Assert.True(translator.Variables.ContainsKey("arr16$length"));
+        Assert.True(translator.Variables.ContainsKey("arr32$length"));
+        Assert.True(translator.Variables.ContainsKey("arr64$length"));
+        Assert.True(translator.Variables.ContainsKey("arru8$length"));
+        Assert.True(translator.Variables.ContainsKey("arru64$length"));
+    }
+
+    // ===========================================
+    // Diagnostic Tests
+    // ===========================================
+
+    [SkippableFact]
+    public void DiagnosesUnsupportedFloatType()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        DiagnosesUnsupportedFloatTypeCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void DiagnosesUnsupportedFloatTypeCore()
+    {
+        var diagnostic = ContractTranslator.DiagnoseUnsupportedType("float");
+
+        Assert.NotNull(diagnostic);
+        Assert.Contains("float", diagnostic);
+        Assert.Contains("not supported", diagnostic);
+    }
+
+    [SkippableFact]
+    public void DiagnosesUnsupportedDoubleType()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        DiagnosesUnsupportedDoubleTypeCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void DiagnosesUnsupportedDoubleTypeCore()
+    {
+        var diagnostic = ContractTranslator.DiagnoseUnsupportedType("double");
+
+        Assert.NotNull(diagnostic);
+        Assert.Contains("double", diagnostic);
+        Assert.Contains("floating-point", diagnostic);
+    }
+
+    [SkippableFact]
+    public void DiagnosesFloatingPointLiteral()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        DiagnosesFloatingPointLiteralCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void DiagnosesFloatingPointLiteralCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        var expr = new FloatLiteralNode(TextSpan.Empty, 3.14);
+        var result = translator.Translate(expr);
+        Assert.Null(result);
+
+        var diagnostic = translator.DiagnoseTranslationFailure(expr);
+
+        Assert.NotNull(diagnostic);
+        Assert.Contains("Floating-point", diagnostic);
+        Assert.Contains("not supported", diagnostic);
+    }
+
+    [SkippableFact]
+    public void DiagnosesFunctionCall()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        DiagnosesFunctionCallCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void DiagnosesFunctionCallCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        var expr = new CallExpressionNode(
+            TextSpan.Empty,
+            "customFunc",
+            new List<ExpressionNode> { new IntLiteralNode(TextSpan.Empty, 42) });
+
+        var result = translator.Translate(expr);
+        Assert.Null(result);
+
+        var diagnostic = translator.DiagnoseTranslationFailure(expr);
+
+        Assert.NotNull(diagnostic);
+        Assert.Contains("customFunc", diagnostic);
+        Assert.Contains("not supported", diagnostic);
+    }
+
+    [SkippableFact]
+    public void DiagnosesUnknownVariable()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        DiagnosesUnknownVariableCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void DiagnosesUnknownVariableCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        var expr = new ReferenceNode(TextSpan.Empty, "unknownVar");
+        var result = translator.Translate(expr);
+        Assert.Null(result);
+
+        var diagnostic = translator.DiagnoseTranslationFailure(expr);
+
+        Assert.NotNull(diagnostic);
+        Assert.Contains("unknownVar", diagnostic);
+        Assert.Contains("Unknown variable", diagnostic);
+    }
+
+    [SkippableFact]
+    public void DiagnosesUnsupportedStringOperation()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        DiagnosesUnsupportedStringOperationCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void DiagnosesUnsupportedStringOperationCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.ToUpper,
+            new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") });
+
+        var result = translator.Translate(expr);
+        Assert.Null(result);
+
+        var diagnostic = translator.DiagnoseTranslationFailure(expr);
+
+        Assert.NotNull(diagnostic);
+        Assert.Contains("ToUpper", diagnostic);
+        Assert.Contains("not supported", diagnostic);
+    }
+
+    [SkippableFact]
+    public void DiagnosesTypeMismatchInArithmeticOp()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        DiagnosesTypeMismatchInArithmeticOpCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void DiagnosesTypeMismatchInArithmeticOpCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("b", "bool");
+
+        // b + 1 (boolean + integer should fail)
+        var expr = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.Add,
+            new ReferenceNode(TextSpan.Empty, "b"),
+            new IntLiteralNode(TextSpan.Empty, 1));
+
+        var result = translator.Translate(expr);
+        Assert.Null(result);
+
+        var diagnostic = translator.DiagnoseTranslationFailure(expr);
+
+        Assert.NotNull(diagnostic);
+        Assert.Contains("Add", diagnostic);
+        Assert.Contains("integer operands", diagnostic);
+    }
+
+    [SkippableFact]
+    public void DiagnosesTypeMismatchInLogicalOp()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        DiagnosesTypeMismatchInLogicalOpCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void DiagnosesTypeMismatchInLogicalOpCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("x", "i32");
+
+        // x && 1 (integer && integer should fail - needs bool)
+        var expr = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.And,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, 1));
+
+        var result = translator.Translate(expr);
+        Assert.Null(result);
+
+        var diagnostic = translator.DiagnoseTranslationFailure(expr);
+
+        Assert.NotNull(diagnostic);
+        Assert.Contains("And", diagnostic);
+        Assert.Contains("boolean operands", diagnostic);
+    }
+
+    [SkippableFact]
+    public void DiagnosesNestedFailure()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        DiagnosesNestedFailureCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void DiagnosesNestedFailureCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("x", "i32");
+
+        // x + unknownVar (nested unknown variable)
+        var expr = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.Add,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new ReferenceNode(TextSpan.Empty, "unknownVar"));
+
+        var result = translator.Translate(expr);
+        Assert.Null(result);
+
+        var diagnostic = translator.DiagnoseTranslationFailure(expr);
+
+        Assert.NotNull(diagnostic);
+        Assert.Contains("unknownVar", diagnostic);
+    }
+
+    [SkippableFact]
+    public void DiagnosesUnsupportedTypeInQuantifier()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        DiagnosesUnsupportedTypeInQuantifierCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void DiagnosesUnsupportedTypeInQuantifierCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        // (forall ((x f32)) (>= x 0)) - f32 is unsupported
+        var forallExpr = new ForallExpressionNode(
+            TextSpan.Empty,
+            new List<QuantifierVariableNode>
+            {
+                new QuantifierVariableNode(TextSpan.Empty, "x", "f32")
+            },
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(TextSpan.Empty, "x"),
+                new IntLiteralNode(TextSpan.Empty, 0)));
+
+        var result = translator.TranslateBoolExpr(forallExpr);
+        Assert.Null(result);
+
+        var diagnostic = translator.DiagnoseTranslationFailure(forallExpr);
+
+        Assert.NotNull(diagnostic);
+        Assert.Contains("f32", diagnostic);
+        Assert.Contains("Unsupported type", diagnostic);
+    }
+
+    [SkippableFact]
+    public void DiagnosesBoolExprFailureForNonBooleanExpression()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        DiagnosesBoolExprFailureForNonBooleanExpressionCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void DiagnosesBoolExprFailureForNonBooleanExpressionCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("x", "i32");
+
+        // x + 1 is an integer expression, not boolean
+        var expr = new BinaryOperationNode(
+            TextSpan.Empty,
+            BinaryOperator.Add,
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new IntLiteralNode(TextSpan.Empty, 1));
+
+        // Translate succeeds (returns BitVecExpr)
+        var result = translator.Translate(expr);
+        Assert.NotNull(result);
+
+        // TranslateBoolExpr fails (not a BoolExpr)
+        var boolResult = translator.TranslateBoolExpr(expr);
+        Assert.Null(boolResult);
+
+        // DiagnoseBoolExprFailure explains why
+        var diagnostic = translator.DiagnoseBoolExprFailure(expr);
+
+        Assert.NotNull(diagnostic);
+        Assert.Contains("must be boolean", diagnostic);
+        Assert.Contains("BitVec", diagnostic);
+    }
+
+    [SkippableFact]
+    public void DiagnosesConditionalTypeMismatch()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        DiagnosesConditionalTypeMismatchCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void DiagnosesConditionalTypeMismatchCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("p", "bool");
+        translator.DeclareVariable("x", "i32");
+        translator.DeclareVariable("s", "string");
+
+        // (if p x s) - branches have incompatible types (BitVecExpr vs SeqExpr)
+        var expr = new ConditionalExpressionNode(
+            TextSpan.Empty,
+            new ReferenceNode(TextSpan.Empty, "p"),
+            new ReferenceNode(TextSpan.Empty, "x"),
+            new ReferenceNode(TextSpan.Empty, "s"));
+
+        var diagnostic = translator.DiagnoseTranslationFailure(expr);
+
+        Assert.NotNull(diagnostic);
+        Assert.Contains("incompatible types", diagnostic);
+    }
+
+    [SkippableFact]
+    public void DiagnosesComplexArrayExpression()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        DiagnosesComplexArrayExpressionCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void DiagnosesComplexArrayExpressionCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        // arr{0}{1} - nested array access is not supported
+        var expr = new ArrayAccessNode(
+            TextSpan.Empty,
+            new ArrayAccessNode(
+                TextSpan.Empty,
+                new ReferenceNode(TextSpan.Empty, "arr"),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            new IntLiteralNode(TextSpan.Empty, 1));
+
+        var result = translator.Translate(expr);
+        Assert.Null(result);
+
+        var diagnostic = translator.DiagnoseTranslationFailure(expr);
+
+        Assert.NotNull(diagnostic);
+        Assert.Contains("simple variable reference", diagnostic);
+        Assert.Contains("computed array expressions", diagnostic);
+    }
+
+    // ===========================================
+    // Edge Case Tests
+    // ===========================================
+
+    [SkippableFact]
+    public void TranslatesUnicodeStringLiteral()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesUnicodeStringLiteralCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesUnicodeStringLiteralCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        // Unicode string with various characters
+        var expr = new StringLiteralNode(TextSpan.Empty, "Hello 世界 🌍 αβγ");
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.SeqExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesEscapeSequencesInString()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesEscapeSequencesInStringCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesEscapeSequencesInStringCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        // String with escape sequences
+        var expr = new StringLiteralNode(TextSpan.Empty, "Line1\nLine2\tTabbed\\Backslash\"Quote");
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.SeqExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesDeeplyNestedArithmeticExpression()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesDeeplyNestedArithmeticExpressionCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesDeeplyNestedArithmeticExpressionCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("x", "i32");
+
+        // Build deeply nested expression: ((((x + 1) + 1) + 1) + 1) ... 20 levels
+        ExpressionNode expr = new ReferenceNode(TextSpan.Empty, "x");
+        for (int i = 0; i < 20; i++)
+        {
+            expr = new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.Add,
+                expr,
+                new IntLiteralNode(TextSpan.Empty, 1));
+        }
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.BitVecExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesDeeplyNestedLogicalExpression()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesDeeplyNestedLogicalExpressionCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesDeeplyNestedLogicalExpressionCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("p", "bool");
+
+        // Build deeply nested expression: (((p && p) && p) && p) ... 20 levels
+        ExpressionNode expr = new ReferenceNode(TextSpan.Empty, "p");
+        for (int i = 0; i < 20; i++)
+        {
+            expr = new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.And,
+                expr,
+                new ReferenceNode(TextSpan.Empty, "p"));
+        }
+
+        var result = translator.TranslateBoolExpr(expr);
+
+        Assert.NotNull(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesDeeplyNestedStringConcat()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesDeeplyNestedStringConcatCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesDeeplyNestedStringConcatCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // Build concat with many arguments
+        var args = new List<ExpressionNode>();
+        for (int i = 0; i < 10; i++)
+        {
+            args.Add(new ReferenceNode(TextSpan.Empty, "s"));
+        }
+
+        var expr = new StringOperationNode(TextSpan.Empty, StringOp.Concat, args);
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.SeqExpr>(result);
+    }
+
+    [SkippableFact]
+    public void ReturnsNullForStringLengthWithNoArgs()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsNullForStringLengthWithNoArgsCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsNullForStringLengthWithNoArgsCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        // (len) with no arguments
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Length,
+            new List<ExpressionNode>());
+
+        var result = translator.Translate(expr);
+
+        Assert.Null(result);
+    }
+
+    [SkippableFact]
+    public void ReturnsNullForContainsWithOneArg()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsNullForContainsWithOneArgCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsNullForContainsWithOneArgCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (contains s) with only one argument
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Contains,
+            new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") });
+
+        var result = translator.Translate(expr);
+
+        Assert.Null(result);
+    }
+
+    [SkippableFact]
+    public void ReturnsNullForSubstringWithTwoArgs()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsNullForSubstringWithTwoArgsCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsNullForSubstringWithTwoArgsCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (substr s 0) with only two arguments - Substring requires 3
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Substring,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new IntLiteralNode(TextSpan.Empty, 0)
+            });
+
+        var result = translator.Translate(expr);
+
+        Assert.Null(result);
+    }
+
+    [SkippableFact]
+    public void ReturnsNullForConcatWithOneArg()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsNullForConcatWithOneArgCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsNullForConcatWithOneArgCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (concat s) with only one argument
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Concat,
+            new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") });
+
+        var result = translator.Translate(expr);
+
+        Assert.Null(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesArrayAccessWithNegativeIndex()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesArrayAccessWithNegativeIndexCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesArrayAccessWithNegativeIndexCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("i", "i32");
+        translator.DeclareArrayVariable("arr", "i32");
+
+        // arr{-1} - negative index is valid in Z3 (no bounds checking)
+        var expr = new ArrayAccessNode(
+            TextSpan.Empty,
+            new ReferenceNode(TextSpan.Empty, "arr"),
+            new IntLiteralNode(TextSpan.Empty, -1));
+
+        var result = translator.Translate(expr);
+
+        // Should translate (no bounds checking in Z3 array theory)
+        Assert.NotNull(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesEmptyStringLiteral()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesEmptyStringLiteralCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesEmptyStringLiteralCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        var expr = new StringLiteralNode(TextSpan.Empty, "");
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.SeqExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesVeryLongStringLiteral()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesVeryLongStringLiteralCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesVeryLongStringLiteralCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        // 1000 character string
+        var longString = new string('a', 1000);
+        var expr = new StringLiteralNode(TextSpan.Empty, longString);
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.SeqExpr>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesMaxIntLiteral()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesMaxIntLiteralCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesMaxIntLiteralCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        var expr = new IntLiteralNode(TextSpan.Empty, int.MaxValue);
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.BitVecNum>(result);
+    }
+
+    [SkippableFact]
+    public void TranslatesMinIntLiteral()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        TranslatesMinIntLiteralCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TranslatesMinIntLiteralCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        var expr = new IntLiteralNode(TextSpan.Empty, int.MinValue);
+
+        var result = translator.Translate(expr);
+
+        Assert.NotNull(result);
+        Assert.IsType<Microsoft.Z3.BitVecNum>(result);
+    }
+
+    // ===========================================
+    // Warnings Tests
+    // ===========================================
+
+    [SkippableFact]
+    public void EmitsWarningForIgnoreCaseComparisonMode()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        EmitsWarningForIgnoreCaseComparisonModeCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void EmitsWarningForIgnoreCaseComparisonModeCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (contains s "hello" :ignore-case) - comparison mode will be ignored
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Contains,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new StringLiteralNode(TextSpan.Empty, "hello")
+            },
+            StringComparisonMode.IgnoreCase);
+
+        var result = translator.TranslateBoolExpr(expr);
+
+        // Translation should succeed
+        Assert.NotNull(result);
+
+        // But a warning should be emitted
+        Assert.Single(translator.Warnings);
+        Assert.Contains("IgnoreCase", translator.Warnings[0]);
+        Assert.Contains("ignored", translator.Warnings[0]);
+    }
+
+    [SkippableFact]
+    public void NoWarningForOrdinalComparisonMode()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        NoWarningForOrdinalComparisonModeCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void NoWarningForOrdinalComparisonModeCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (contains s "hello" :ordinal) - ordinal is the default, no warning needed
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Contains,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new StringLiteralNode(TextSpan.Empty, "hello")
+            },
+            StringComparisonMode.Ordinal);
+
+        var result = translator.TranslateBoolExpr(expr);
+
+        Assert.NotNull(result);
+        Assert.Empty(translator.Warnings);
+    }
+
+    [SkippableFact]
+    public void NoWarningForNoComparisonMode()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        NoWarningForNoComparisonModeCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void NoWarningForNoComparisonModeCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // (contains s "hello") - no comparison mode specified
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Contains,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new StringLiteralNode(TextSpan.Empty, "hello")
+            });
+
+        var result = translator.TranslateBoolExpr(expr);
+
+        Assert.NotNull(result);
+        Assert.Empty(translator.Warnings);
+    }
+
+    [SkippableFact]
+    public void ClearWarningsRemovesAccumulatedWarnings()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ClearWarningsRemovesAccumulatedWarningsCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ClearWarningsRemovesAccumulatedWarningsCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(ctx);
+
+        translator.DeclareVariable("s", "string");
+
+        // Emit a warning
+        var expr = new StringOperationNode(
+            TextSpan.Empty,
+            StringOp.Contains,
+            new List<ExpressionNode>
+            {
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new StringLiteralNode(TextSpan.Empty, "hello")
+            },
+            StringComparisonMode.IgnoreCase);
+
+        translator.TranslateBoolExpr(expr);
+        Assert.Single(translator.Warnings);
+
+        // Clear warnings
+        translator.ClearWarnings();
+        Assert.Empty(translator.Warnings);
     }
 }

--- a/tests/Calor.Verification.Tests/VerifierTests.cs
+++ b/tests/Calor.Verification.Tests/VerifierTests.cs
@@ -905,4 +905,1651 @@ public class VerifierTests
         // This should be proven - INT_MIN / -1 = INT_MIN in bit-vector arithmetic
         Assert.Equal(ContractVerificationStatus.Proven, result.Status);
     }
+
+    // ===========================================
+    // String Theory Verification Tests
+    // ===========================================
+
+    [SkippableFact]
+    public void ProvesStringLengthNonNegative()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesStringLengthNonNegativeCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesStringLengthNonNegativeCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Postcondition: (>= (len s) 0)
+        // Should be PROVEN because string length is always >= 0 (unsigned)
+        var parameters = new List<(string Name, string Type)> { ("s", "string") };
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterOrEqual,
+                new StringOperationNode(
+                    TextSpan.Empty,
+                    StringOp.Length,
+                    new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") }),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void ProvesEmptyStringHasZeroLength()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesEmptyStringHasZeroLengthCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesEmptyStringHasZeroLengthCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Precondition: (isempty s)
+        // Postcondition: (== (len s) 0)
+        // Should be PROVEN because empty string has length 0
+        var parameters = new List<(string Name, string Type)> { ("s", "string") };
+
+        var precondition = new RequiresNode(
+            TextSpan.Empty,
+            new StringOperationNode(
+                TextSpan.Empty,
+                StringOp.IsNullOrEmpty,
+                new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") }),
+            null,
+            new AttributeCollection());
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.Equal,
+                new StringOperationNode(
+                    TextSpan.Empty,
+                    StringOp.Length,
+                    new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") }),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            new[] { precondition },
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void ProvesPrefixImpliesContains()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesPrefixImpliesContainsCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesPrefixImpliesContainsCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Precondition: (starts s "hello")
+        // Postcondition: (contains s "hello")
+        // Should be PROVEN because a prefix is always contained
+        var parameters = new List<(string Name, string Type)> { ("s", "string") };
+
+        var precondition = new RequiresNode(
+            TextSpan.Empty,
+            new StringOperationNode(
+                TextSpan.Empty,
+                StringOp.StartsWith,
+                new List<ExpressionNode>
+                {
+                    new ReferenceNode(TextSpan.Empty, "s"),
+                    new StringLiteralNode(TextSpan.Empty, "hello")
+                }),
+            null,
+            new AttributeCollection());
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new StringOperationNode(
+                TextSpan.Empty,
+                StringOp.Contains,
+                new List<ExpressionNode>
+                {
+                    new ReferenceNode(TextSpan.Empty, "s"),
+                    new StringLiteralNode(TextSpan.Empty, "hello")
+                }),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "bool",
+            new[] { precondition },
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void ProvesSuffixImpliesContains()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesSuffixImpliesContainsCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesSuffixImpliesContainsCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Precondition: (ends s "world")
+        // Postcondition: (contains s "world")
+        // Should be PROVEN because a suffix is always contained
+        var parameters = new List<(string Name, string Type)> { ("s", "string") };
+
+        var precondition = new RequiresNode(
+            TextSpan.Empty,
+            new StringOperationNode(
+                TextSpan.Empty,
+                StringOp.EndsWith,
+                new List<ExpressionNode>
+                {
+                    new ReferenceNode(TextSpan.Empty, "s"),
+                    new StringLiteralNode(TextSpan.Empty, "world")
+                }),
+            null,
+            new AttributeCollection());
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new StringOperationNode(
+                TextSpan.Empty,
+                StringOp.Contains,
+                new List<ExpressionNode>
+                {
+                    new ReferenceNode(TextSpan.Empty, "s"),
+                    new StringLiteralNode(TextSpan.Empty, "world")
+                }),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "bool",
+            new[] { precondition },
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void ProvesStringEqualsReflexive()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesStringEqualsReflexiveCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesStringEqualsReflexiveCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Postcondition: (equals s s)
+        // Should be PROVEN because equality is reflexive
+        var parameters = new List<(string Name, string Type)> { ("s", "string") };
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new StringOperationNode(
+                TextSpan.Empty,
+                StringOp.Equals,
+                new List<ExpressionNode>
+                {
+                    new ReferenceNode(TextSpan.Empty, "s"),
+                    new ReferenceNode(TextSpan.Empty, "s")
+                }),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "bool",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    // ===========================================
+    // Array Theory Verification Tests
+    // ===========================================
+
+    [SkippableFact]
+    public void ProvesArrayLengthNonNegative()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesArrayLengthNonNegativeCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesArrayLengthNonNegativeCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Postcondition: (>= (len arr) 0)
+        // Should be PROVEN because array length is unsigned (always >= 0)
+        var parameters = new List<(string Name, string Type)> { ("arr", "i32[]") };
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterOrEqual,
+                new ArrayLengthNode(
+                    TextSpan.Empty,
+                    new ReferenceNode(TextSpan.Empty, "arr")),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    // ===========================================
+    // Edge Case Tests
+    // ===========================================
+
+    [SkippableFact]
+    public void ProvesEmptyStringLiteralHasZeroLength()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesEmptyStringLiteralHasZeroLengthCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesEmptyStringLiteralHasZeroLengthCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Postcondition: (== (len "") 0)
+        // Should be PROVEN because empty string literal has length 0
+        var parameters = new List<(string Name, string Type)>();
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.Equal,
+                new StringOperationNode(
+                    TextSpan.Empty,
+                    StringOp.Length,
+                    new List<ExpressionNode> { new StringLiteralNode(TextSpan.Empty, "") }),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void ProvesStringLiteralLengthMatchesActualLength()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesStringLiteralLengthMatchesActualLengthCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesStringLiteralLengthMatchesActualLengthCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Postcondition: (== (len "hello") 5)
+        // Should be PROVEN because "hello" has 5 characters
+        var parameters = new List<(string Name, string Type)>();
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.Equal,
+                new StringOperationNode(
+                    TextSpan.Empty,
+                    StringOp.Length,
+                    new List<ExpressionNode> { new StringLiteralNode(TextSpan.Empty, "hello") }),
+                new IntLiteralNode(TextSpan.Empty, 5)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void ProvesStringVariableEqualityWithBinaryOperator()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesStringVariableEqualityWithBinaryOperatorCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesStringVariableEqualityWithBinaryOperatorCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Postcondition: s == s (using binary operator, not StringOp.Equals)
+        // Should be PROVEN because equality is reflexive
+        var parameters = new List<(string Name, string Type)> { ("s", "string") };
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.Equal,
+                new ReferenceNode(TextSpan.Empty, "s"),
+                new ReferenceNode(TextSpan.Empty, "s")),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "bool",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void ProvesConcatLengthIsSum()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesConcatLengthIsSumCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesConcatLengthIsSumCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Postcondition: (== (len (concat "ab" "cd")) 4)
+        // Should be PROVEN because concat of "ab" and "cd" has length 4
+        var parameters = new List<(string Name, string Type)>();
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.Equal,
+                new StringOperationNode(
+                    TextSpan.Empty,
+                    StringOp.Length,
+                    new List<ExpressionNode>
+                    {
+                        new StringOperationNode(
+                            TextSpan.Empty,
+                            StringOp.Concat,
+                            new List<ExpressionNode>
+                            {
+                                new StringLiteralNode(TextSpan.Empty, "ab"),
+                                new StringLiteralNode(TextSpan.Empty, "cd")
+                            })
+                    }),
+                new IntLiteralNode(TextSpan.Empty, 4)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void ProvesContainsLiteralInLiteral()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesContainsLiteralInLiteralCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesContainsLiteralInLiteralCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Postcondition: (contains "hello world" "world")
+        // Should be PROVEN because "hello world" contains "world"
+        var parameters = new List<(string Name, string Type)>();
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new StringOperationNode(
+                TextSpan.Empty,
+                StringOp.Contains,
+                new List<ExpressionNode>
+                {
+                    new StringLiteralNode(TextSpan.Empty, "hello world"),
+                    new StringLiteralNode(TextSpan.Empty, "world")
+                }),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "bool",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void DisprovesContainsNotPresent()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        DisprovesContainsNotPresentCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void DisprovesContainsNotPresentCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Postcondition: (contains "hello" "xyz")
+        // Should be DISPROVEN because "hello" does not contain "xyz"
+        var parameters = new List<(string Name, string Type)>();
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new StringOperationNode(
+                TextSpan.Empty,
+                StringOp.Contains,
+                new List<ExpressionNode>
+                {
+                    new StringLiteralNode(TextSpan.Empty, "hello"),
+                    new StringLiteralNode(TextSpan.Empty, "xyz")
+                }),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "bool",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Disproven, result.Status);
+    }
+
+    [SkippableFact]
+    public void ProvesArrayLengthConstraintWithAccess()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesArrayLengthConstraintWithAccessCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesArrayLengthConstraintWithAccessCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Precondition: (> (len arr) 0)
+        // Postcondition: (>= (len arr) 1)
+        // Should be PROVEN
+        var parameters = new List<(string Name, string Type)> { ("arr", "i32[]") };
+
+        var precondition = new RequiresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterThan,
+                new ArrayLengthNode(
+                    TextSpan.Empty,
+                    new ReferenceNode(TextSpan.Empty, "arr")),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            null,
+            new AttributeCollection());
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterOrEqual,
+                new ArrayLengthNode(
+                    TextSpan.Empty,
+                    new ReferenceNode(TextSpan.Empty, "arr")),
+                new IntLiteralNode(TextSpan.Empty, 1)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            new[] { precondition },
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    // ===========================================
+    // String Edge Case Verification Tests
+    // ===========================================
+
+    [SkippableFact]
+    public void ProvesEveryStringContainsEmptyString()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesEveryStringContainsEmptyStringCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesEveryStringContainsEmptyStringCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Postcondition: (contains s "")
+        // Should be PROVEN because every string contains the empty string
+        var parameters = new List<(string Name, string Type)> { ("s", "string") };
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new StringOperationNode(
+                TextSpan.Empty,
+                StringOp.Contains,
+                new List<ExpressionNode>
+                {
+                    new ReferenceNode(TextSpan.Empty, "s"),
+                    new StringLiteralNode(TextSpan.Empty, "")
+                }),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "bool",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void ProvesIndexOfEmptyStringReturnsZero()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesIndexOfEmptyStringReturnsZeroCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesIndexOfEmptyStringReturnsZeroCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Postcondition: (== (indexof s "") 0)
+        // Should be PROVEN because empty string is found at index 0
+        var parameters = new List<(string Name, string Type)> { ("s", "string") };
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.Equal,
+                new StringOperationNode(
+                    TextSpan.Empty,
+                    StringOp.IndexOf,
+                    new List<ExpressionNode>
+                    {
+                        new ReferenceNode(TextSpan.Empty, "s"),
+                        new StringLiteralNode(TextSpan.Empty, "")
+                    }),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void ProvesZeroLengthSubstringIsEmpty()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesZeroLengthSubstringIsEmptyCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesZeroLengthSubstringIsEmptyCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Postcondition: (== (len (substr s 0 0)) 0)
+        // Should be PROVEN because zero-length substring has length 0
+        var parameters = new List<(string Name, string Type)> { ("s", "string") };
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.Equal,
+                new StringOperationNode(
+                    TextSpan.Empty,
+                    StringOp.Length,
+                    new List<ExpressionNode>
+                    {
+                        new StringOperationNode(
+                            TextSpan.Empty,
+                            StringOp.Substring,
+                            new List<ExpressionNode>
+                            {
+                                new ReferenceNode(TextSpan.Empty, "s"),
+                                new IntLiteralNode(TextSpan.Empty, 0),
+                                new IntLiteralNode(TextSpan.Empty, 0)
+                            })
+                    }),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void ProvesReplaceEmptyWithCharInsertsAtStart()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesReplaceEmptyWithCharInsertsAtStartCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesReplaceEmptyWithCharInsertsAtStartCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Postcondition: (starts (replace s "" "X") "X")
+        // Should be PROVEN because replacing empty string inserts at the beginning
+        var parameters = new List<(string Name, string Type)> { ("s", "string") };
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new StringOperationNode(
+                TextSpan.Empty,
+                StringOp.StartsWith,
+                new List<ExpressionNode>
+                {
+                    new StringOperationNode(
+                        TextSpan.Empty,
+                        StringOp.Replace,
+                        new List<ExpressionNode>
+                        {
+                            new ReferenceNode(TextSpan.Empty, "s"),
+                            new StringLiteralNode(TextSpan.Empty, ""),
+                            new StringLiteralNode(TextSpan.Empty, "X")
+                        }),
+                    new StringLiteralNode(TextSpan.Empty, "X")
+                }),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "bool",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void ProvesIndexOfWithOffsetSkipsEarlierMatches()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesIndexOfWithOffsetSkipsEarlierMatchesCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesIndexOfWithOffsetSkipsEarlierMatchesCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Postcondition: (>= (indexof "abcabc" "b" 3) 3)
+        // Should be PROVEN because searching from index 3 finds "b" at index 4, which is >= 3
+        var parameters = new List<(string Name, string Type)>();
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterOrEqual,
+                new StringOperationNode(
+                    TextSpan.Empty,
+                    StringOp.IndexOf,
+                    new List<ExpressionNode>
+                    {
+                        new StringLiteralNode(TextSpan.Empty, "abcabc"),
+                        new StringLiteralNode(TextSpan.Empty, "b"),
+                        new IntLiteralNode(TextSpan.Empty, 3)
+                    }),
+                new IntLiteralNode(TextSpan.Empty, 3)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    // ===========================================
+    // Diagnostic Integration Tests
+    // ===========================================
+
+    [SkippableFact]
+    public void ReturnsUnsupportedWithDiagnosticForFloatParameter()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsUnsupportedWithDiagnosticForFloatParameterCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsUnsupportedWithDiagnosticForFloatParameterCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // Parameter type f32 is not supported
+        var parameters = new List<(string Name, string Type)> { ("x", "f32") };
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(TextSpan.Empty, "x"),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "f32",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Unsupported, result.Status);
+        Assert.NotNull(result.CounterexampleDescription);
+        Assert.Contains("f32", result.CounterexampleDescription);
+        Assert.Contains("not supported", result.CounterexampleDescription);
+    }
+
+    [SkippableFact]
+    public void ReturnsUnsupportedWithDiagnosticForFloatResultType()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsUnsupportedWithDiagnosticForFloatResultTypeCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsUnsupportedWithDiagnosticForFloatResultTypeCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        // Result type double is not supported
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterOrEqual,
+                new ReferenceNode(TextSpan.Empty, "result"),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "double",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Unsupported, result.Status);
+        Assert.NotNull(result.CounterexampleDescription);
+        Assert.Contains("double", result.CounterexampleDescription);
+        Assert.Contains("floating-point", result.CounterexampleDescription);
+    }
+
+    [SkippableFact]
+    public void ReturnsUnsupportedWithDiagnosticForFunctionCallInPostcondition()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsUnsupportedWithDiagnosticForFunctionCallInPostconditionCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsUnsupportedWithDiagnosticForFunctionCallInPostconditionCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        // Function call customFunc is not supported
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterThan,
+                new CallExpressionNode(
+                    TextSpan.Empty,
+                    "customFunc",
+                    new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "x") }),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Unsupported, result.Status);
+        Assert.NotNull(result.CounterexampleDescription);
+        Assert.Contains("customFunc", result.CounterexampleDescription);
+        Assert.Contains("not supported", result.CounterexampleDescription);
+    }
+
+    [SkippableFact]
+    public void ReturnsUnsupportedWithDiagnosticForUnsupportedStringOpInPrecondition()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsUnsupportedWithDiagnosticForUnsupportedStringOpInPreconditionCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsUnsupportedWithDiagnosticForUnsupportedStringOpInPreconditionCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var parameters = new List<(string Name, string Type)> { ("s", "string") };
+
+        // ToUpper is not supported
+        var precondition = new RequiresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.Equal,
+                new StringOperationNode(
+                    TextSpan.Empty,
+                    StringOp.ToUpper,
+                    new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") }),
+                new StringLiteralNode(TextSpan.Empty, "HELLO")),
+            null,
+            new AttributeCollection());
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterThan,
+                new StringOperationNode(
+                    TextSpan.Empty,
+                    StringOp.Length,
+                    new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") }),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "bool",
+            new[] { precondition },
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Unsupported, result.Status);
+        Assert.NotNull(result.CounterexampleDescription);
+        Assert.Contains("ToUpper", result.CounterexampleDescription);
+        Assert.Contains("not supported", result.CounterexampleDescription);
+    }
+
+    [SkippableFact]
+    public void ReturnsUnsupportedWithDiagnosticForUnknownVariableInPostcondition()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsUnsupportedWithDiagnosticForUnknownVariableInPostconditionCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsUnsupportedWithDiagnosticForUnknownVariableInPostconditionCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        // References unknownVar which is not declared
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.Equal,
+                new ReferenceNode(TextSpan.Empty, "x"),
+                new ReferenceNode(TextSpan.Empty, "unknownVar")),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Unsupported, result.Status);
+        Assert.NotNull(result.CounterexampleDescription);
+        Assert.Contains("unknownVar", result.CounterexampleDescription);
+        Assert.Contains("Unknown variable", result.CounterexampleDescription);
+    }
+
+    [SkippableFact]
+    public void ReturnsUnsupportedWithDiagnosticForFloatLiteralInPostcondition()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsUnsupportedWithDiagnosticForFloatLiteralInPostconditionCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsUnsupportedWithDiagnosticForFloatLiteralInPostconditionCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        // Float literal 3.14 is not supported
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterThan,
+                new ReferenceNode(TextSpan.Empty, "x"),
+                new FloatLiteralNode(TextSpan.Empty, 3.14)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Unsupported, result.Status);
+        Assert.NotNull(result.CounterexampleDescription);
+        Assert.Contains("Floating-point", result.CounterexampleDescription);
+        Assert.Contains("not supported", result.CounterexampleDescription);
+    }
+
+    [SkippableFact]
+    public void ReturnsUnsupportedWithDiagnosticForPreconditionWithFunctionCall()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsUnsupportedWithDiagnosticForPreconditionWithFunctionCallCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsUnsupportedWithDiagnosticForPreconditionWithFunctionCallCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        // Precondition with function call
+        var precondition = new RequiresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterThan,
+                new CallExpressionNode(
+                    TextSpan.Empty,
+                    "validate",
+                    new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "x") }),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPrecondition(parameters, precondition);
+
+        Assert.Equal(ContractVerificationStatus.Unsupported, result.Status);
+        Assert.NotNull(result.CounterexampleDescription);
+        Assert.Contains("validate", result.CounterexampleDescription);
+        Assert.Contains("not supported", result.CounterexampleDescription);
+    }
+
+    [SkippableFact]
+    public void ReturnsUnsupportedWithDiagnosticForTypeMismatch()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsUnsupportedWithDiagnosticForTypeMismatchCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsUnsupportedWithDiagnosticForTypeMismatchCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var parameters = new List<(string Name, string Type)> { ("b", "bool") };
+
+        // b + 1 is a type mismatch (bool + int)
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterThan,
+                new BinaryOperationNode(
+                    TextSpan.Empty,
+                    BinaryOperator.Add,
+                    new ReferenceNode(TextSpan.Empty, "b"),
+                    new IntLiteralNode(TextSpan.Empty, 1)),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Unsupported, result.Status);
+        Assert.NotNull(result.CounterexampleDescription);
+        Assert.Contains("Add", result.CounterexampleDescription);
+        Assert.Contains("integer operands", result.CounterexampleDescription);
+    }
+
+    // ===========================================
+    // Warnings Integration Tests
+    // ===========================================
+
+    [SkippableFact]
+    public void ReturnsWarningForIgnoreCaseComparisonMode()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsWarningForIgnoreCaseComparisonModeCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsWarningForIgnoreCaseComparisonModeCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var parameters = new List<(string Name, string Type)> { ("s", "string") };
+
+        // Postcondition using :ignore-case which will be ignored
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new StringOperationNode(
+                TextSpan.Empty,
+                StringOp.Contains,
+                new List<ExpressionNode>
+                {
+                    new ReferenceNode(TextSpan.Empty, "s"),
+                    new StringLiteralNode(TextSpan.Empty, "hello")
+                },
+                StringComparisonMode.IgnoreCase),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "bool",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        // Verification should proceed (not Unsupported)
+        Assert.NotEqual(ContractVerificationStatus.Unsupported, result.Status);
+
+        // Should have a warning about ignored comparison mode
+        Assert.NotNull(result.Warnings);
+        Assert.Single(result.Warnings);
+        Assert.Contains("IgnoreCase", result.Warnings[0]);
+        Assert.Contains("ignored", result.Warnings[0]);
+    }
+
+    [SkippableFact]
+    public void NoWarningsForStandardVerification()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        NoWarningsForStandardVerificationCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void NoWarningsForStandardVerificationCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.Equal,
+                new ReferenceNode(TextSpan.Empty, "x"),
+                new ReferenceNode(TextSpan.Empty, "x")),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+        Assert.Null(result.Warnings);
+    }
+
+    [SkippableFact]
+    public void PreconditionReturnsWarningForIgnoreCaseComparisonMode()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        PreconditionReturnsWarningForIgnoreCaseComparisonModeCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void PreconditionReturnsWarningForIgnoreCaseComparisonModeCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var parameters = new List<(string Name, string Type)> { ("s", "string") };
+
+        // Precondition using :ignore-case which will be ignored
+        var precondition = new RequiresNode(
+            TextSpan.Empty,
+            new StringOperationNode(
+                TextSpan.Empty,
+                StringOp.Contains,
+                new List<ExpressionNode>
+                {
+                    new ReferenceNode(TextSpan.Empty, "s"),
+                    new StringLiteralNode(TextSpan.Empty, "hello")
+                },
+                StringComparisonMode.IgnoreCase),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPrecondition(parameters, precondition);
+
+        // Verification should proceed (precondition is satisfiable)
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+
+        // Should have a warning about ignored comparison mode
+        Assert.NotNull(result.Warnings);
+        Assert.Single(result.Warnings);
+        Assert.Contains("IgnoreCase", result.Warnings[0]);
+    }
+
+    [SkippableFact]
+    public void AccumulatesMultipleWarnings()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        AccumulatesMultipleWarningsCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void AccumulatesMultipleWarningsCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var parameters = new List<(string Name, string Type)> { ("s", "string") };
+
+        // Precondition with :ignore-case
+        var precondition = new RequiresNode(
+            TextSpan.Empty,
+            new StringOperationNode(
+                TextSpan.Empty,
+                StringOp.StartsWith,
+                new List<ExpressionNode>
+                {
+                    new ReferenceNode(TextSpan.Empty, "s"),
+                    new StringLiteralNode(TextSpan.Empty, "hello")
+                },
+                StringComparisonMode.IgnoreCase),
+            null,
+            new AttributeCollection());
+
+        // Postcondition with :invariant-ignore-case (different mode)
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new StringOperationNode(
+                TextSpan.Empty,
+                StringOp.EndsWith,
+                new List<ExpressionNode>
+                {
+                    new ReferenceNode(TextSpan.Empty, "s"),
+                    new StringLiteralNode(TextSpan.Empty, "world")
+                },
+                StringComparisonMode.InvariantIgnoreCase),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "bool",
+            new[] { precondition },
+            postcondition);
+
+        // Should have warnings for both ignored comparison modes
+        Assert.NotNull(result.Warnings);
+        Assert.Equal(2, result.Warnings.Count);
+        Assert.Contains(result.Warnings, w => w.Contains("IgnoreCase"));
+        Assert.Contains(result.Warnings, w => w.Contains("InvariantIgnoreCase"));
+    }
+
+    // ===========================================
+    // Quantifier with String/Array Tests
+    // ===========================================
+
+    [SkippableFact]
+    public void ProvesStringPrefixImpliesNotEmpty()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesStringPrefixImpliesNotEmptyCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesStringPrefixImpliesNotEmptyCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var parameters = new List<(string Name, string Type)> { ("s", "string") };
+
+        // Precondition: (starts s "hello")
+        var precondition = new RequiresNode(
+            TextSpan.Empty,
+            new StringOperationNode(
+                TextSpan.Empty,
+                StringOp.StartsWith,
+                new List<ExpressionNode>
+                {
+                    new ReferenceNode(TextSpan.Empty, "s"),
+                    new StringLiteralNode(TextSpan.Empty, "hello")
+                }),
+            null,
+            new AttributeCollection());
+
+        // Postcondition: (not (isempty s))
+        // If s starts with "hello", then s is not empty
+        // Using IsNullOrEmpty (negated) stays in Z3's integer domain, avoiding
+        // complex theory interactions with bit-vector conversion
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new UnaryOperationNode(
+                TextSpan.Empty,
+                UnaryOperator.Not,
+                new StringOperationNode(
+                    TextSpan.Empty,
+                    StringOp.IsNullOrEmpty,
+                    new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") })),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "bool",
+            new[] { precondition },
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void ProvesExistsWithStringOperation()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesExistsWithStringOperationCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesExistsWithStringOperationCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        // No parameters needed for this test
+        var parameters = new List<(string Name, string Type)>();
+
+        // Postcondition: There exists a string equal to "test"
+        // (exists ((x string)) (equals x "test"))
+        // This should be proven - such a string exists
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new ExistsExpressionNode(
+                TextSpan.Empty,
+                new List<QuantifierVariableNode>
+                {
+                    new QuantifierVariableNode(TextSpan.Empty, "x", "string")
+                },
+                new StringOperationNode(
+                    TextSpan.Empty,
+                    StringOp.Equals,
+                    new List<ExpressionNode>
+                    {
+                        new ReferenceNode(TextSpan.Empty, "x"),
+                        new StringLiteralNode(TextSpan.Empty, "test")
+                    })),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "bool",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void ProvesForallWithArrayAndStringLength()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ProvesForallWithArrayAndStringLengthCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProvesForallWithArrayAndStringLengthCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var parameters = new List<(string Name, string Type)>
+        {
+            ("arr", "i32[]"),
+            ("s", "string")
+        };
+
+        // Precondition: array length > 0 AND string length > 0
+        var precondition1 = new RequiresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterThan,
+                new ArrayLengthNode(TextSpan.Empty, new ReferenceNode(TextSpan.Empty, "arr")),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            null,
+            new AttributeCollection());
+
+        var precondition2 = new RequiresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterThan,
+                new StringOperationNode(
+                    TextSpan.Empty,
+                    StringOp.Length,
+                    new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") }),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            null,
+            new AttributeCollection());
+
+        // Postcondition: array length >= 1 AND string length >= 1
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.And,
+                new BinaryOperationNode(
+                    TextSpan.Empty,
+                    BinaryOperator.GreaterOrEqual,
+                    new ArrayLengthNode(TextSpan.Empty, new ReferenceNode(TextSpan.Empty, "arr")),
+                    new IntLiteralNode(TextSpan.Empty, 1)),
+                new BinaryOperationNode(
+                    TextSpan.Empty,
+                    BinaryOperator.GreaterOrEqual,
+                    new StringOperationNode(
+                        TextSpan.Empty,
+                        StringOp.Length,
+                        new List<ExpressionNode> { new ReferenceNode(TextSpan.Empty, "s") }),
+                    new IntLiteralNode(TextSpan.Empty, 1))),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "bool",
+            new[] { precondition1, precondition2 },
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    // ===========================================
+    // Robustness and Exception Handling Tests
+    // ===========================================
+
+    [SkippableFact]
+    public void ReturnsUnprovenOnSolverTimeout()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ReturnsUnprovenOnSolverTimeoutCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ReturnsUnprovenOnSolverTimeoutCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        // Use very short timeout to trigger Unproven status
+        using var verifier = new Z3Verifier(ctx, timeoutMs: 1);
+
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        // Complex postcondition that might timeout with 1ms timeout
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.GreaterOrEqual,
+                new BinaryOperationNode(
+                    TextSpan.Empty,
+                    BinaryOperator.Multiply,
+                    new ReferenceNode(TextSpan.Empty, "x"),
+                    new ReferenceNode(TextSpan.Empty, "x")),
+                new IntLiteralNode(TextSpan.Empty, 0)),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        // Result should be either Proven (if Z3 is fast enough) or Unproven (timeout)
+        // Both are valid - the test verifies no exception is thrown
+        Assert.True(
+            result.Status == ContractVerificationStatus.Proven ||
+            result.Status == ContractVerificationStatus.Unproven,
+            $"Expected Proven or Unproven but got {result.Status}");
+    }
+
+    [SkippableFact]
+    public void HandlesEmptyParameterList()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        HandlesEmptyParameterListCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void HandlesEmptyParameterListCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var parameters = new List<(string Name, string Type)>();
+
+        // Trivially true postcondition: true
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BoolLiteralNode(TextSpan.Empty, true),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            null,
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void HandlesNullOutputType()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        HandlesNullOutputTypeCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void HandlesNullOutputTypeCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        // Postcondition not using 'result' variable
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.Equal,
+                new ReferenceNode(TextSpan.Empty, "x"),
+                new ReferenceNode(TextSpan.Empty, "x")),
+            null,
+            new AttributeCollection());
+
+        // Pass null for outputType
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            null,
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void ResultIncludesDuration()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        ResultIncludesDurationCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ResultIncludesDurationCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var parameters = new List<(string Name, string Type)> { ("x", "i32") };
+
+        var postcondition = new EnsuresNode(
+            TextSpan.Empty,
+            new BinaryOperationNode(
+                TextSpan.Empty,
+                BinaryOperator.Equal,
+                new ReferenceNode(TextSpan.Empty, "x"),
+                new ReferenceNode(TextSpan.Empty, "x")),
+            null,
+            new AttributeCollection());
+
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "i32",
+            Array.Empty<RequiresNode>(),
+            postcondition);
+
+        // Duration should be recorded
+        Assert.NotNull(result.Duration);
+        Assert.True(result.Duration.Value.TotalMilliseconds >= 0);
+    }
 }


### PR DESCRIPTION
## Summary

- Add comprehensive Z3 string theory support (literals, variables, length, contains, startsWith, endsWith, equals, isNullOrEmpty, indexOf, substring, concat, replace)
- Enhance array theory with ArrayLengthNode translation and length tracking
- Add warnings system for silently ignored features (e.g., non-ordinal string comparison modes)
- Add diagnostic methods for translation failures with meaningful error messages
- Add graceful Z3Exception handling in verifier
- Add thread safety documentation

## Test plan

- [x] All 195 verification tests pass
- [x] 80+ new translator tests for string/array operations
- [x] 50+ new verifier tests including edge cases
- [x] Robustness tests for timeout and exception handling
- [x] `dotnet test tests/Calor.Verification.Tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)