### PR TITLE
feat(verification): add configurable Z3 timeout for contract verification

### DIFF
--- a/src/Calor.Compiler/Commands/VerifyCommand.cs
+++ b/src/Calor.Compiler/Commands/VerifyCommand.cs
@@ -40,8 +40,16 @@ public static class VerifyCommand
 
         var timeoutOption = new Option<int>(
             aliases: ["--timeout", "-t"],
-            getDefaultValue: () => 5000,
-            description: "Z3 solver timeout per contract in milliseconds");
+            getDefaultValue: () => (int)VerificationOptions.DefaultTimeoutMs,
+            description: "Z3 solver timeout per contract in milliseconds (default: 5000)");
+        timeoutOption.AddValidator(result =>
+        {
+            var value = result.GetValueOrDefault<int>();
+            if (value <= 0)
+            {
+                result.ErrorMessage = "Timeout must be a positive integer";
+            }
+        });
 
         var noCacheOption = new Option<bool>(
             aliases: ["--no-cache"],
@@ -182,7 +190,8 @@ public static class VerifyCommand
             Verbose = verbose,
             VerifyContracts = true,
             ProjectDirectory = Path.GetDirectoryName(file.FullName),
-            VerificationCacheOptions = cacheOptions
+            VerificationCacheOptions = cacheOptions,
+            VerificationTimeoutMs = (uint)timeout
         };
 
         var result = Program.Compile(source, file.FullName, options);

--- a/src/Calor.Compiler/Verification/ContractInheritanceChecker.cs
+++ b/src/Calor.Compiler/Verification/ContractInheritanceChecker.cs
@@ -17,27 +17,32 @@ public sealed class ContractInheritanceChecker : IDisposable
     private readonly DiagnosticBag _diagnostics;
     private readonly Z3ImplicationProver? _z3Prover;
     private readonly bool _useZ3;
+    private readonly uint _timeoutMs;
     private bool _z3UnavailableReported;
     private bool _disposed;
 
-    public ContractInheritanceChecker(DiagnosticBag diagnostics, bool useZ3 = true)
+    public ContractInheritanceChecker(
+        DiagnosticBag diagnostics,
+        bool useZ3 = true,
+        uint timeoutMs = VerificationOptions.DefaultTimeoutMs)
     {
         _diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
         _useZ3 = useZ3 && Z3ContextFactory.IsAvailable;
+        _timeoutMs = timeoutMs;
 
         if (_useZ3)
         {
-            _z3Prover = CreateZ3Prover();
+            _z3Prover = CreateZ3Prover(_timeoutMs);
         }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static Z3ImplicationProver? CreateZ3Prover()
+    private static Z3ImplicationProver? CreateZ3Prover(uint timeoutMs)
     {
         try
         {
             var ctx = Z3ContextFactory.Create();
-            return new Z3ImplicationProver(ctx);
+            return new Z3ImplicationProver(ctx, timeoutMs);
         }
         catch
         {


### PR DESCRIPTION
## Summary

- Add `--verification-timeout` CLI flag to main compile command (default: 5000ms)
- Fix `verify --timeout` flag that was previously accepted but ignored
- Add `VerificationTimeoutMs` property to `CompilationOptions`
- Wire timeout through verification pipeline and `ContractInheritanceChecker`
- Add input validation to reject non-positive timeout values

## Problem

Without proper timeout configuration, a single pathological contract could stall compilation indefinitely. The existing `--timeout` flag in the verify command was completely ignored, and the main compile command had no timeout option at all.

## Changes

| File | Change |
|------|--------|
| `Program.cs` | Add `--verification-timeout` option, `VerificationTimeoutMs` property, wire through pipeline |
| `VerifyCommand.cs` | Fix unused timeout parameter, add validation |
| `ContractInheritanceChecker.cs` | Accept and use timeout parameter |

## Test plan

- [x] Build succeeds with no warnings
- [x] `calor --help` shows `--verification-timeout` option
- [x] `calor verify --help` shows `--timeout` option  
- [x] Negative timeout values are rejected with clear error message
- [x] All 2567 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)