### PR TITLE
feat(benchmarks): add Z3 verification benchmarks for overflow, strings, and arrays

### DIFF
--- a/tests/TestData/Benchmarks/ContractVerification/ArrayContracts.calr
+++ b/tests/TestData/Benchmarks/ContractVerification/ArrayContracts.calr
@@ -1,0 +1,62 @@
+§M{m001:ArrayContracts}
+§F{f001:ValidIndex:pub}
+  §I{i32:length}
+  §I{i32:index}
+  §O{bool}
+  §Q (> length 0)
+  §S (== result (&& (>= index 0) (< index length)))
+  §R (&& (>= index 0) (< index length))
+§/F{f001}
+
+§F{f002:LastValidIndex:pub}
+  §I{i32:length}
+  §O{i32}
+  §Q (> length 0)
+  §S (>= result 0)
+  §S (< result length)
+  §R (- length 1)
+§/F{f002}
+
+§F{f003:LengthNonNegative:pub}
+  §I{i32:length}
+  §O{bool}
+  §Q (>= length 0)
+  §S (== result true)
+  §R (>= length 0)
+§/F{f003}
+
+§F{f004:SafeIndexRange:pub}
+  §I{i32:length}
+  §I{i32:start}
+  §I{i32:count}
+  §O{bool}
+  §Q (> length 0)
+  §Q (>= start 0)
+  §Q (> count 0)
+  §S (== result (<= (+ start count) length))
+  §R (<= (+ start count) length)
+§/F{f004}
+
+§F{f005:MidpointIndex:pub}
+  §I{i32:low}
+  §I{i32:high}
+  §O{i32}
+  §Q (>= low 0)
+  §Q (> high low)
+  §S (>= result low)
+  §S (< result high)
+  §R (+ low (/ (- high low) 2))
+§/F{f005}
+
+§F{f006:BinarySearchBounds:pub}
+  §I{i32:length}
+  §I{i32:low}
+  §I{i32:high}
+  §O{bool}
+  §Q (> length 0)
+  §Q (>= low 0)
+  §Q (<= high length)
+  §S (== result (<= low high))
+  §R (<= low high)
+§/F{f006}
+§/M{m001}

--- a/tests/TestData/Benchmarks/ContractVerification/ArrayContracts.cs
+++ b/tests/TestData/Benchmarks/ContractVerification/ArrayContracts.cs
@@ -1,0 +1,56 @@
+namespace ArrayContracts;
+
+/// <summary>
+/// Functions with array-related contracts (using length/index parameters) that can be
+/// verified using Z3. These model common array access patterns and bounds checking.
+/// C# has no equivalent contract verification - this is Calor-only.
+/// </summary>
+public static class ArrayContracts
+{
+    // Bounds check: index >= 0 && index < length
+    public static bool ValidIndex(int length, int index)
+    {
+        if (length <= 0) throw new ArgumentOutOfRangeException(nameof(length));
+        return index >= 0 && index < length;
+    }
+
+    // Last valid index is length - 1, which is >= 0 and < length
+    public static int LastValidIndex(int length)
+    {
+        if (length <= 0) throw new ArgumentOutOfRangeException(nameof(length));
+        return length - 1;
+    }
+
+    // Length is always non-negative
+    public static bool LengthNonNegative(int length)
+    {
+        if (length < 0) throw new ArgumentOutOfRangeException(nameof(length));
+        return length >= 0;
+    }
+
+    // Check if a range [start, start+count) fits within [0, length)
+    public static bool SafeIndexRange(int length, int start, int count)
+    {
+        if (length <= 0) throw new ArgumentOutOfRangeException(nameof(length));
+        if (start < 0) throw new ArgumentOutOfRangeException(nameof(start));
+        if (count <= 0) throw new ArgumentOutOfRangeException(nameof(count));
+        return start + count <= length;
+    }
+
+    // Binary search midpoint calculation (avoids overflow compared to (low+high)/2)
+    public static int MidpointIndex(int low, int high)
+    {
+        if (low < 0) throw new ArgumentOutOfRangeException(nameof(low));
+        if (high <= low) throw new ArgumentOutOfRangeException(nameof(high));
+        return low + (high - low) / 2;
+    }
+
+    // Binary search loop invariant: low <= high
+    public static bool BinarySearchBounds(int length, int low, int high)
+    {
+        if (length <= 0) throw new ArgumentOutOfRangeException(nameof(length));
+        if (low < 0) throw new ArgumentOutOfRangeException(nameof(low));
+        if (high > length) throw new ArgumentOutOfRangeException(nameof(high));
+        return low <= high;
+    }
+}

--- a/tests/TestData/Benchmarks/ContractVerification/OverflowSafe.calr
+++ b/tests/TestData/Benchmarks/ContractVerification/OverflowSafe.calr
@@ -1,0 +1,63 @@
+§M{m001:OverflowSafe}
+§F{f001:IncrementSafe:pub}
+  §I{i32:x}
+  §O{i32}
+  §Q (< x 2147483647)
+  §S (> result x)
+  §R (+ x 1)
+§/F{f001}
+
+§F{f002:DecrementSafe:pub}
+  §I{i32:x}
+  §O{i32}
+  §Q (> x -2147483648)
+  §S (< result x)
+  §R (- x 1)
+§/F{f002}
+
+§F{f003:DoubleSafe:pub}
+  §I{i32:x}
+  §O{i32}
+  §Q (> x 0)
+  §Q (< x 1073741824)
+  §S (> result x)
+  §R (* x 2)
+§/F{f003}
+
+§F{f004:SquareSafe:pub}
+  §I{i32:x}
+  §O{i32}
+  §Q (>= x 0)
+  §Q (<= x 46340)
+  §S (>= result 0)
+  §R (* x x)
+§/F{f004}
+
+§F{f005:NegateSafe:pub}
+  §I{i32:x}
+  §O{i32}
+  §Q (< x 0)
+  §Q (> x -2147483648)
+  §S (> result 0)
+  §R (- 0 x)
+§/F{f005}
+
+§F{f006:AddPositivesSafe:pub}
+  §I{i32:x}
+  §I{i32:y}
+  §O{i32}
+  §Q (> x 0)
+  §Q (< x 1073741824)
+  §Q (> y 0)
+  §Q (< y 1073741824)
+  §S (> result 0)
+  §R (+ x y)
+§/F{f006}
+
+§F{f007:UnsignedNonNegative:pub}
+  §I{u32:x}
+  §O{bool}
+  §S (== result true)
+  §R (>= x 0)
+§/F{f007}
+§/M{m001}

--- a/tests/TestData/Benchmarks/ContractVerification/OverflowSafe.cs
+++ b/tests/TestData/Benchmarks/ContractVerification/OverflowSafe.cs
@@ -1,0 +1,55 @@
+namespace OverflowSafe;
+
+/// <summary>
+/// Functions with contracts that CAN be proven because they include
+/// proper bounds that prevent overflow.
+/// C# has no equivalent contract verification - this is Calor-only.
+/// </summary>
+public static class OverflowSafe
+{
+    // x + 1 > x is TRUE when x < int.MaxValue (no overflow possible)
+    public static int IncrementSafe(int x)
+    {
+        if (x >= int.MaxValue) throw new ArgumentOutOfRangeException(nameof(x));
+        return x + 1;
+    }
+
+    // x - 1 < x is TRUE when x > int.MinValue (no underflow possible)
+    public static int DecrementSafe(int x)
+    {
+        if (x <= int.MinValue) throw new ArgumentOutOfRangeException(nameof(x));
+        return x - 1;
+    }
+
+    // With bounds x < 1B, x * 2 > x can be proven
+    public static int DoubleSafe(int x)
+    {
+        if (x <= 0 || x >= 1073741824) throw new ArgumentOutOfRangeException(nameof(x));
+        return x * 2;
+    }
+
+    // With bounds x <= 46340, x * x >= 0 can be proven (46340^2 < int.MaxValue)
+    public static int SquareSafe(int x)
+    {
+        if (x < 0 || x > 46340) throw new ArgumentOutOfRangeException(nameof(x));
+        return x * x;
+    }
+
+    // -x > 0 when x < 0 && x > int.MinValue is TRUE
+    public static int NegateSafe(int x)
+    {
+        if (x >= 0 || x <= int.MinValue) throw new ArgumentOutOfRangeException(nameof(x));
+        return -x;
+    }
+
+    // With proper bounds, x + y > 0 can be proven
+    public static int AddPositivesSafe(int x, int y)
+    {
+        if (x <= 0 || x >= 1073741824) throw new ArgumentOutOfRangeException(nameof(x));
+        if (y <= 0 || y >= 1073741824) throw new ArgumentOutOfRangeException(nameof(y));
+        return x + y;
+    }
+
+    // For unsigned types, x >= 0 is always true
+    public static bool UnsignedNonNegative(uint x) => x >= 0;
+}

--- a/tests/TestData/Benchmarks/ContractVerification/OverflowUnsafe.calr
+++ b/tests/TestData/Benchmarks/ContractVerification/OverflowUnsafe.calr
@@ -1,0 +1,49 @@
+§M{m001:OverflowUnsafe}
+§F{f001:IncrementUnsafe:pub}
+  §I{i32:x}
+  §O{i32}
+  §S (> result x)
+  §R (+ x 1)
+§/F{f001}
+
+§F{f002:DecrementUnsafe:pub}
+  §I{i32:x}
+  §O{i32}
+  §S (< result x)
+  §R (- x 1)
+§/F{f002}
+
+§F{f003:DoubleUnsafe:pub}
+  §I{i32:x}
+  §O{i32}
+  §Q (> x 0)
+  §S (> result x)
+  §R (* x 2)
+§/F{f003}
+
+§F{f004:SquareUnsafe:pub}
+  §I{i32:x}
+  §O{i32}
+  §Q (>= x 0)
+  §S (>= result 0)
+  §R (* x x)
+§/F{f004}
+
+§F{f005:NegateUnsafe:pub}
+  §I{i32:x}
+  §O{i32}
+  §Q (< x 0)
+  §S (> result 0)
+  §R (- 0 x)
+§/F{f005}
+
+§F{f006:AddPositivesUnsafe:pub}
+  §I{i32:x}
+  §I{i32:y}
+  §O{i32}
+  §Q (> x 0)
+  §Q (> y 0)
+  §S (> result 0)
+  §R (+ x y)
+§/F{f006}
+§/M{m001}

--- a/tests/TestData/Benchmarks/ContractVerification/OverflowUnsafe.cs
+++ b/tests/TestData/Benchmarks/ContractVerification/OverflowUnsafe.cs
@@ -1,0 +1,28 @@
+namespace OverflowUnsafe;
+
+/// <summary>
+/// Functions with contracts that CANNOT be proven due to potential overflow.
+/// These contracts are mathematically true for unbounded integers but false
+/// for fixed-width integers due to wraparound behavior.
+/// C# has no equivalent contract verification - this is Calor-only.
+/// </summary>
+public static class OverflowUnsafe
+{
+    // x + 1 > x is FALSE when x = int.MaxValue (wraps to int.MinValue)
+    public static int IncrementUnsafe(int x) => x + 1;
+
+    // x - 1 < x is FALSE when x = int.MinValue (wraps to int.MaxValue)
+    public static int DecrementUnsafe(int x) => x - 1;
+
+    // x > 0 does NOT imply x * 2 > x (overflow possible)
+    public static int DoubleUnsafe(int x) => x * 2;
+
+    // x >= 0 does NOT imply x * x >= 0 (overflow can make it negative)
+    public static int SquareUnsafe(int x) => x * x;
+
+    // x < 0 does NOT imply -x > 0 (int.MinValue case: -int.MinValue = int.MinValue)
+    public static int NegateUnsafe(int x) => -x;
+
+    // x > 0 && y > 0 does NOT imply x + y > 0 (overflow possible)
+    public static int AddPositivesUnsafe(int x, int y) => x + y;
+}

--- a/tests/TestData/Benchmarks/ContractVerification/StringContracts.calr
+++ b/tests/TestData/Benchmarks/ContractVerification/StringContracts.calr
@@ -1,0 +1,50 @@
+§M{m001:StringContracts}
+§F{f001:NonEmptyLength:pub}
+  §I{str:s}
+  §O{i32}
+  §Q (! (isempty s))
+  §S (> result 0)
+  §R (len s)
+§/F{f001}
+
+§F{f002:EmptyStringLength:pub}
+  §I{str:s}
+  §O{bool}
+  §S (== result (== (len s) 0))
+  §R (isempty s)
+§/F{f002}
+
+§F{f003:ConcatLonger:pub}
+  §I{str:a}
+  §I{str:b}
+  §O{str}
+  §Q (! (isempty a))
+  §S (> (len result) (len b))
+  §R (concat a b)
+§/F{f003}
+
+§F{f004:ContainsImpliesLength:pub}
+  §I{str:haystack}
+  §I{str:needle}
+  §O{bool}
+  §Q (! (isempty needle))
+  §S (|| (! result) (>= (len haystack) (len needle)))
+  §R (contains haystack needle)
+§/F{f004}
+
+§F{f005:PrefixLength:pub}
+  §I{str:s}
+  §I{str:prefix}
+  §O{bool}
+  §S (|| (! result) (>= (len s) (len prefix)))
+  §R (starts s prefix)
+§/F{f005}
+
+§F{f006:SuffixLength:pub}
+  §I{str:s}
+  §I{str:suffix}
+  §O{bool}
+  §S (|| (! result) (>= (len s) (len suffix)))
+  §R (ends s suffix)
+§/F{f006}
+§/M{m001}

--- a/tests/TestData/Benchmarks/ContractVerification/StringContracts.cs
+++ b/tests/TestData/Benchmarks/ContractVerification/StringContracts.cs
@@ -1,0 +1,38 @@
+namespace StringContracts;
+
+/// <summary>
+/// Functions with string operation contracts that can be verified using Z3's string theory.
+/// C# has no equivalent contract verification - this is Calor-only.
+/// </summary>
+public static class StringContracts
+{
+    // Non-empty string has length > 0
+    public static int NonEmptyLength(string s)
+    {
+        if (string.IsNullOrEmpty(s)) throw new ArgumentException("String cannot be empty", nameof(s));
+        return s.Length;
+    }
+
+    // Empty string check is equivalent to length == 0
+    public static bool EmptyStringLength(string s) => s == "";
+
+    // Concatenating non-empty string makes result longer than second operand
+    public static string ConcatLonger(string a, string b)
+    {
+        if (string.IsNullOrEmpty(a)) throw new ArgumentException("String cannot be empty", nameof(a));
+        return a + b;
+    }
+
+    // If haystack contains needle, haystack must be at least as long as needle
+    public static bool ContainsImpliesLength(string haystack, string needle)
+    {
+        if (string.IsNullOrEmpty(needle)) throw new ArgumentException("Needle cannot be empty", nameof(needle));
+        return haystack.Contains(needle);
+    }
+
+    // If s starts with prefix, s must be at least as long as prefix
+    public static bool PrefixLength(string s, string prefix) => s.StartsWith(prefix);
+
+    // If s ends with suffix, s must be at least as long as suffix
+    public static bool SuffixLength(string s, string suffix) => s.EndsWith(suffix);
+}

--- a/tests/TestData/Benchmarks/manifest.json
+++ b/tests/TestData/Benchmarks/manifest.json
@@ -314,6 +314,46 @@
       "notes": "Mix of provable and unprovable contracts"
     },
     {
+      "id": "cv004",
+      "name": "OverflowUnsafe",
+      "category": "ContractVerification",
+      "calorFile": "ContractVerification/OverflowUnsafe.calr",
+      "csharpFile": "ContractVerification/OverflowUnsafe.cs",
+      "level": 3,
+      "features": ["contracts", "z3", "verification", "overflow", "bit-vectors", "disproven"],
+      "notes": "Contracts that must be DISPROVEN due to integer overflow (validates bit-vector soundness)"
+    },
+    {
+      "id": "cv005",
+      "name": "OverflowSafe",
+      "category": "ContractVerification",
+      "calorFile": "ContractVerification/OverflowSafe.calr",
+      "csharpFile": "ContractVerification/OverflowSafe.cs",
+      "level": 3,
+      "features": ["contracts", "z3", "verification", "overflow", "bit-vectors", "proven"],
+      "notes": "Contracts with proper bounds that CAN be proven (no overflow possible)"
+    },
+    {
+      "id": "cv006",
+      "name": "StringContracts",
+      "category": "ContractVerification",
+      "calorFile": "ContractVerification/StringContracts.calr",
+      "csharpFile": "ContractVerification/StringContracts.cs",
+      "level": 3,
+      "features": ["contracts", "z3", "verification", "strings", "string-theory"],
+      "notes": "String operation contracts using Z3 string theory (length, contains, startswith, etc.)"
+    },
+    {
+      "id": "cv007",
+      "name": "ArrayContracts",
+      "category": "ContractVerification",
+      "calorFile": "ContractVerification/ArrayContracts.calr",
+      "csharpFile": "ContractVerification/ArrayContracts.cs",
+      "level": 3,
+      "features": ["contracts", "z3", "verification", "arrays", "bounds-checking"],
+      "notes": "Array index and bounds contracts (valid index, safe ranges, binary search invariants)"
+    },
+    {
       "id": "es001",
       "name": "CorrectEffects",
       "category": "EffectSoundness",


### PR DESCRIPTION
## Summary

- Add 4 new contract verification benchmarks to measure Z3 enhancement impact
- Benchmarks exercise features from PR #165 (bit-vectors) and PR #170 (string theory)
- Total benchmarks increased from 36 to 40

## New Benchmarks

| ID | Name | Purpose |
|----|------|---------|
| cv004 | OverflowUnsafe | Contracts that MUST be disproven due to integer overflow |
| cv005 | OverflowSafe | Contracts with proper bounds that CAN be proven |
| cv006 | StringContracts | String operation contracts (len, contains, starts, ends) |
| cv007 | ArrayContracts | Array index/bounds contracts (valid index, safe ranges) |

## Test Results

All benchmarks pass:
- cv004 OverflowUnsafe: 1.22x advantage
- cv005 OverflowSafe: 1.14x advantage  
- cv006 StringContracts: 1.09x advantage
- cv007 ArrayContracts: 1.11x advantage

## Test plan

- [x] All 40 benchmarks pass
- [x] New Calor files compile successfully
- [x] Contract verification produces expected results

🤖 Generated with [Claude Code](https://claude.com/claude-code)