### PR TITLE
docs: clarify Calor positioning vs proof assistants

### DIFF
--- a/website/content/philosophy/static-verification.mdx
+++ b/website/content/philosophy/static-verification.mdx
@@ -184,6 +184,50 @@ Static verification complements runtime checking—it doesn't replace it. Unprov
 
 ---
 
+## What Calor Is Not
+
+Calor is **not** a proof assistant like LEAN, Isabelle, or Rocq. The distinction matters:
+
+| Aspect | Proof Assistants | Calor |
+|:-------|:-----------------|:------|
+| You write | Proofs (tactics, lemmas) | Contracts (§Q, §S) |
+| Verification | Must complete to compile | Falls back to runtime if unproven |
+| Scope | Arbitrary mathematical properties | Practical software contracts |
+| Expertise | Type theory, proof tactics | Software engineering |
+
+### No Proofs Required
+
+In LEAN, proving a function returns a positive number requires explicit proof:
+
+```lean
+theorem sqrt_positive (x : ℝ) (h : x ≥ 0) : √x ≥ 0 := by
+  exact Real.sqrt_nonneg x
+```
+
+In Calor, you declare the contract and Z3 handles verification automatically:
+
+```calor
+§F{f001:Sqrt}(x: f64) -> f64
+  §Q (>= x 0.0)
+  §S (>= result 0.0)
+  (* x x)
+§/F{}
+```
+
+If Z3 can't prove it, the runtime check remains. Your code compiles and runs safely.
+
+### Lightweight by Design
+
+Calor's verification is deliberately bounded:
+
+- **5-second timeout** per contract (configurable via `--verification-timeout`)
+- **Arithmetic and boolean logic** (not arbitrary math)
+- **Graceful degradation** to runtime checks
+
+This is a feature, not a limitation. Verification never blocks your build indefinitely, and you don't need expertise in formal methods to benefit from it.
+
+---
+
 ## Z3 Installation
 
 Z3 is bundled with the Calor compiler via the `Microsoft.Z3` NuGet package. No separate installation is required.

--- a/website/content/philosophy/tradeoffs.mdx
+++ b/website/content/philosophy/tradeoffs.mdx
@@ -143,6 +143,10 @@ if (x > 0) return x;
 
 Calor compiles to C#, so interop is possible, but native library support doesn't exist.
 
+### 4. You Need Full Formal Methods
+
+If you need to prove arbitrary mathematical properties—cryptographic protocols, compiler correctness, or complex algorithms—use a proof assistant like LEAN, Isabelle, or Rocq. Calor provides lightweight verification for software contracts, not a theorem prover. It targets software engineers writing business logic, not mathematicians writing proofs.
+
 ---
 
 ## Measuring the Tradeoff

--- a/website/src/components/landing/CompetitivePositioning.tsx
+++ b/website/src/components/landing/CompetitivePositioning.tsx
@@ -82,6 +82,37 @@ const comparisons = [
       },
     ],
   },
+  {
+    title: 'vs LEAN / Isabelle / Rocq',
+    subtitle: 'Proof assistants for theorem proving',
+    rows: [
+      {
+        feature: 'Primary Purpose',
+        calor: 'Verified software engineering',
+        others: 'Mathematical theorem proving',
+      },
+      {
+        feature: 'Developer Effort',
+        calor: 'Write contracts, Z3 verifies automatically',
+        others: 'Write proofs (tactics, lemmas, induction)',
+      },
+      {
+        feature: 'Target Domain',
+        calor: 'Business logic, APIs, .NET apps',
+        others: 'Math libraries, cryptography, compilers',
+      },
+      {
+        feature: 'When Verification Fails',
+        calor: 'Falls back to runtime check (safe)',
+        others: 'Blocks compilation until proof complete',
+      },
+      {
+        feature: 'Learning Curve',
+        calor: 'Familiar .NET concepts',
+        others: 'Type theory, proof tactics',
+      },
+    ],
+  },
 ];
 
 export function CompetitivePositioning() {


### PR DESCRIPTION
## Summary

- Add "vs LEAN / Isabelle / Rocq" comparison section to the Competitive Positioning page
- Add "What Calor Is Not" section to static-verification.mdx explaining the distinction
- Add brief mention in tradeoffs.mdx for when proof assistants are the better choice

This addresses feedback from formal methods experts who might conflate Calor's lightweight contract verification with theorem proving tools.

## Test plan

- [x] Website builds successfully (`npm run build`)
- [x] New comparison section renders correctly with existing visual style

🤖 Generated with [Claude Code](https://claude.com/claude-code)