### PR TITLE
docs: reinforce AI-first messaging across website

### DIFF
--- a/website/content/cli/compile.mdx
+++ b/website/content/cli/compile.mdx
@@ -56,7 +56,7 @@ The recommended convention for generated C# files is the `.g.cs` extension:
 MyModule.calr → MyModule.g.cs
 ```
 
-This indicates "generated C#" and helps distinguish Calor-generated code from hand-written C#.
+This indicates "generated C#" and helps distinguish Calor-generated code from existing C# in your project.
 
 ---
 

--- a/website/content/getting-started/hello-world.mdx
+++ b/website/content/getting-started/hello-world.mdx
@@ -5,7 +5,7 @@ order: 2
 ---
 
 
-Calor is designed to be written by AI agents, not typed by hand. This guide shows you how to instruct an AI to generate Calor code.
+Calor is designed to be written by AI agents, not humans. This guide shows you how to instruct an AI to generate Calor code—you won't be writing Calor yourself, but understanding the output helps you verify that contracts match your intent.
 
 ---
 

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -24,7 +24,7 @@ your_code.calr → Calor Compiler → your_code.g.cs → .NET Build → executab
 
 1. **[Installation](/getting-started/installation/)** - Set up the Calor compiler
 2. **[Hello World](/getting-started/hello-world/)** - Write and run your first Calor program
-3. **[How It Works](/getting-started/how-it-works/)** - How AI learns Calor without being trained on it
+3. **[How It Works](/getting-started/how-it-works/)** - How AI agents work with Calor using in-context examples
 4. **[Claude Integration](/getting-started/claude-integration/)** - Use Calor with Claude Code (enforced Calor-first)
 5. **[Codex Integration](/getting-started/codex-integration/)** - Use Calor with OpenAI Codex CLI
 6. **[Gemini Integration](/getting-started/gemini-integration/)** - Use Calor with Google Gemini CLI (enforced Calor-first)

--- a/website/content/getting-started/installation.mdx
+++ b/website/content/getting-started/installation.mdx
@@ -135,7 +135,13 @@ sudo apt-get install -y dotnet-sdk-8.0
 
 ---
 
-## Clone and Build (For Contributors)
+## For Contributors
+
+The sections below are for developers who want to contribute to Calor or build from source. **End users can skip this**—the global tool install above is all you need.
+
+---
+
+## Clone and Build
 
 If you want to contribute to Calor or build from source:
 

--- a/website/content/philosophy/index.mdx
+++ b/website/content/philosophy/index.mdx
@@ -150,7 +150,7 @@ Think of it this way: you don't need to learn assembly language to write softwar
 
 ### "Do I still need to do code reviews?"
 
-**Not in the traditional sense.** Instead of reviewing implementation details line-by-line, you focus on:
+**No.** Instead of reviewing implementation details line-by-line, you focus on:
 - **Defining outcomes**: What should this function guarantee? What preconditions must callers satisfy?
 - **Specifying contracts**: The AI writes the code, but you approve the contracts (`§Q` preconditions, `§S` postconditions)
 - **Reviewing verification results**: Did Z3 prove the contracts? Are there counterexamples?
@@ -159,7 +159,7 @@ The compiler and verifier do the tedious work of checking implementation correct
 
 ### "What if I want to understand the code?"
 
-Calor compiles to readable C# code. If you need to inspect implementation details, look at the generated `.cs` files—they're standard, idiomatic C# that any .NET developer can understand. The Calor source is the "agent-facing" representation; the C# output is the "human-facing" representation.
+Calor compiles to readable C# code. For debugging or auditing purposes, you can inspect the generated `.cs` files—they're standard, idiomatic C# that any .NET developer can understand. But this is the exception, not the workflow: normally you review contracts and verification results, not implementation. The Calor source is the "agent-facing" representation; the C# output exists for tooling compatibility and the rare cases when you need to investigate behavior.
 
 ### "This seems verbose compared to C#"
 
@@ -171,7 +171,7 @@ Adoption is gradual and low-risk:
 1. **Start with AI-generated modules**—let your coding agent write Calor for new features
 2. **Review contracts, not code**—approve what the software should do, not how it does it
 3. **Interoperate seamlessly**—Calor compiles to standard .NET assemblies that work with existing C# code
-4. **Fall back anytime**—the generated C# is always available if you need to maintain it manually
+4. **Organizational flexibility**—the generated C# is always available if your organization requires it for compliance, auditing, or legacy integration
 
 ### "What about tooling? IDE support?"
 

--- a/website/content/philosophy/tradeoffs.mdx
+++ b/website/content/philosophy/tradeoffs.mdx
@@ -145,7 +145,7 @@ Calor compiles to C#, so interop is possible, but native library support doesn't
 
 ### 4. You Need Full Formal Methods
 
-If you need to prove arbitrary mathematical properties—cryptographic protocols, compiler correctness, or complex algorithms—use a proof assistant like LEAN, Isabelle, or Rocq. Calor provides lightweight verification for software contracts, not a theorem prover. It targets software engineers writing business logic, not mathematicians writing proofs.
+If you need to prove arbitrary mathematical properties—cryptographic protocols, compiler correctness, or complex algorithms—use a proof assistant like LEAN, Isabelle, or Rocq. Calor provides lightweight verification for software contracts, not a theorem prover. It targets development teams defining business logic requirements that AI agents implement, not mathematicians writing proofs.
 
 ---
 

--- a/website/content/semantics/index.mdx
+++ b/website/content/semantics/index.mdx
@@ -6,6 +6,8 @@ hasChildren: true
 ---
 
 
+> **Audience:** This section documents Calor's operational semantics for tooling developers, language contributors, and those building AI agents that generate Calor. End users typically don't need to reference this—the contracts you approve and the verification results you review are sufficient for normal workflows.
+
 **An agent-friendly language needs a spec that is tighter than "it emits C#."**
 
 Emitting C# can hide a lot of semantic gaps. When an agent writes Calor code, it needs to know *exactly* what that code will do—not what the C# compiler happens to do today, or what one version of the .NET runtime does differently than another.

--- a/website/content/syntax-reference/index.mdx
+++ b/website/content/syntax-reference/index.mdx
@@ -8,7 +8,7 @@ hasChildren: true
 
 Complete reference for Calor syntax. Calor uses Lisp-style expressions for all operations.
 
-> **Note for Human Readers:** Calor's syntax is intentionally optimized for AI agent comprehension, not human aesthetics. The notation may look unusual at first, but each design choice serves a specific purpose: unique IDs enable precise references, matched tags eliminate scope ambiguity, and Lisp-style expressions allow direct AST manipulation.
+> **Why this syntax?** Calor's notation is optimized for AI agents, not human aesthetics. You don't need to learn this syntax—AI coding agents write Calor, not humans. This reference exists to help you understand what the AI generates and verify that contracts match your intent. Each design choice serves verification: unique IDs enable precise references, matched tags eliminate scope ambiguity, and Lisp-style expressions allow direct AST manipulation.
 
 ---
 


### PR DESCRIPTION
## Summary
- Update 8 documentation files to consistently reinforce Calor's core message
- Users don't write Calor—AI coding agents do
- Verification replaces traditional code review
- Human role is defining requirements and approving contracts

## Changes (10 fixes across 8 files)

### HIGH Priority
- **syntax-reference/index.mdx**: Reframe "Note for Human Readers" as "Why this syntax?"
- **philosophy/index.mdx**: Change hedging "Not in the traditional sense" to direct "No"
- **philosophy/index.mdx**: Reframe C# inspection as debugging/auditing exception
- **philosophy/index.mdx**: Change "fall back" framing to organizational flexibility

### MEDIUM Priority
- **getting-started/hello-world.mdx**: Clarify this is for understanding, not learning to write
- **cli/compile.mdx**: Change "hand-written C#" to "existing C#"
- **philosophy/tradeoffs.mdx**: Fix "software engineers writing" to "teams defining"
- **getting-started/index.mdx**: Reframe "How AI learns" to "How AI agents work with"

### LOW Priority
- **getting-started/installation.mdx**: Add contributor section separator
- **semantics/index.mdx**: Add audience note for tooling developers

## Test plan
- [x] Website builds successfully (`npm run build`)
- [x] All modified files reviewed for consistency with core message

🤖 Generated with [Claude Code](https://claude.com/claude-code)