### PR TITLE
docs: add Calor-only benchmark metric pages

### DIFF
--- a/website/content/benchmarking/index.mdx
+++ b/website/content/benchmarking/index.mdx
@@ -28,9 +28,9 @@ These metrics measure capabilities unique to Calor that have no C# equivalent:
 
 | Category | What It Measures | Why It Matters |
 |:---------|:-----------------|:---------------|
-| **Contract Verification** | Z3 static contract verification rates | Are preconditions/postconditions provably correct? |
-| **Effect Soundness** | Effect declarations match actual behavior | Do declared effects accurately describe side effects? |
-| **Interop Coverage** | BCL methods covered by effect manifests | How well are .NET interop effects documented? |
+| [**Contract Verification**](/benchmarking/metrics/contract-verification/) | Z3 static contract verification rates | Are preconditions/postconditions provably correct? |
+| [**Effect Soundness**](/benchmarking/metrics/effect-soundness/) | Effect declarations match actual behavior | Do declared effects accurately describe side effects? |
+| [**Interop Coverage**](/benchmarking/metrics/interop-effect-coverage/) | BCL methods covered by effect manifests | How well are .NET interop effects documented? |
 
 ---
 

--- a/website/content/benchmarking/metrics/contract-verification.mdx
+++ b/website/content/benchmarking/metrics/contract-verification.mdx
@@ -1,0 +1,187 @@
+---
+title: "Contract Verification"
+section: "benchmarking"
+order: 10
+---
+
+
+**Category:** Contract Verification (Calor-only)
+**Result:** N/A (no C# equivalent)
+**What it measures:** Z3 static contract verification rates
+
+---
+
+## Overview
+
+Calor uses Microsoft's Z3 SMT solver to prove contracts at compile time. When you write a precondition or postcondition, the compiler can mathematically verify that it holds for all possible inputs—catching bugs before the code ever runs.
+
+This is fundamentally different from constrained decoding approaches, which only ensure syntactic validity. Z3 verification proves semantic correctness.
+
+---
+
+## Why It Matters
+
+Static contract verification catches entire categories of bugs at compile time:
+
+- **Division by zero** - Z3 proves divisors are never zero
+- **Bounds violations** - Array indices proven within range
+- **Integer overflow** - Arithmetic proven to stay within bounds
+- **Null dereferences** - References proven non-null before use
+- **Invalid state** - Invariants proven to hold
+
+These bugs cannot be caught by grammar-constrained generation—syntax doesn't encode invariants.
+
+---
+
+## How It's Measured
+
+Contracts fall into four categories after verification:
+
+| Result | Meaning | Runtime Check |
+|:-------|:--------|:--------------|
+| **Proven** | Z3 mathematically proved the contract always holds | Elided (optional) |
+| **Unproven** | Z3 couldn't determine (timeout or complexity) | Preserved |
+| **Disproven** | Z3 found a counterexample | Preserved + Warning |
+| **Unsupported** | Contract uses unsupported constructs | Preserved |
+
+The metric tracks the distribution across these categories.
+
+---
+
+## Example
+
+Consider a division function with a precondition:
+
+```calor
+§F{f001:Divide:pub}
+  §I{i32:a}
+  §I{i32:b}
+  §O{i32}
+  §Q (!= b 0)              // Precondition: b must not be zero
+  §R (/ a b)
+§/F{f001}
+```
+
+When compiled with `--verify`, Z3 checks whether the division can ever fail:
+
+```bash
+calor -i math.calr -o math.g.cs --verify
+```
+
+If code calls `Divide` with a potentially-zero argument:
+
+```calor
+§V{v001:i32:result} §C{Divide} x (- y y) §/C    // (y - y) = 0!
+```
+
+Z3 detects this at compile time:
+
+```
+warning Calor0702: Precondition may be violated in call to 'Divide'.
+  Counterexample: y=5 (b = y - y = 0)
+```
+
+---
+
+## Verification Categories
+
+### What Z3 Catches
+
+| Bug Category | Contract | Detection |
+|:-------------|:---------|:----------|
+| Division by zero | `§Q (!= divisor 0)` | Proven safe or counterexample |
+| Negative index | `§Q (>= index 0)` | Proven safe or counterexample |
+| Out of bounds | `§Q (< index len)` | Proven safe or counterexample |
+| Invalid range | `§S (>= result 0)` | Postcondition verified |
+| Integer overflow | `§S (< result MAX_INT)` | Arithmetic bounds checked |
+
+### Postcondition Verification
+
+Z3 can prove that implementations satisfy their postconditions:
+
+```calor
+§F{f001:Square:pub}
+  §I{i32:x}
+  §O{i32}
+  §Q (>= x 0)
+  §S (>= result 0)         // Z3 proves: x² ≥ 0 when x ≥ 0
+  §R (* x x)
+§/F{f001}
+```
+
+```
+// PROVEN: Postcondition statically verified: (result >= 0)
+```
+
+---
+
+## Supported Constructs
+
+Z3 verification supports:
+
+| Calor | Z3 | Description |
+|:------|:---|:------------|
+| `(+ a b)` | `a + b` | Addition |
+| `(- a b)` | `a - b` | Subtraction |
+| `(* a b)` | `a * b` | Multiplication |
+| `(/ a b)` | `a div b` | Division |
+| `(% a b)` | `a mod b` | Modulo |
+| `(== a b)` | `a = b` | Equality |
+| `(!= a b)` | `a ≠ b` | Inequality |
+| `(< a b)` | `a < b` | Less than |
+| `(<= a b)` | `a ≤ b` | Less or equal |
+| `(> a b)` | `a > b` | Greater than |
+| `(>= a b)` | `a ≥ b` | Greater or equal |
+| `(and p q)` | `p ∧ q` | Logical and |
+| `(or p q)` | `p ∨ q` | Logical or |
+| `(not p)` | `¬p` | Logical not |
+
+**Supported types:** `i32`, `i64`, `bool`
+
+**Unsupported:** Function calls, strings, floating-point, arrays, objects
+
+---
+
+## Comparison with Runtime-Only
+
+| Aspect | Runtime Only | Static + Runtime |
+|:-------|:-------------|:-----------------|
+| When bugs found | At runtime | At compile time |
+| Verification cost | None | Compile time (cached) |
+| Runtime overhead | Always | Reduced for proven contracts |
+| Coverage | All contracts | Supported constructs |
+
+Static verification complements runtime checking—it doesn't replace it. Unproven and unsupported contracts still have runtime checks.
+
+---
+
+## Why C# Cannot Do This
+
+C# Code Contracts (2008-2015) attempted similar verification but was abandoned:
+
+- Static analyzer was slow and unreliable
+- Developers didn't write contracts consistently
+- No integration with the language syntax
+
+Calor's advantage: when AI agents write code, they generate contracts for free. The annotation burden that killed C# Code Contracts doesn't exist.
+
+---
+
+## Configuration
+
+```bash
+# Enable verification (recommended)
+calor -i app.calr -o app.g.cs --verify
+
+# Custom timeout (default: 5 seconds per contract)
+calor -i app.calr -o app.g.cs --verify --verification-timeout 10
+
+# Skip caching (for debugging)
+calor -i app.calr -o app.g.cs --verify --no-cache
+```
+
+---
+
+## Next
+
+- [Effect Soundness](/benchmarking/metrics/effect-soundness/) - Verifying declared effects match actual behavior

--- a/website/content/benchmarking/metrics/effect-soundness.mdx
+++ b/website/content/benchmarking/metrics/effect-soundness.mdx
@@ -1,0 +1,261 @@
+---
+title: "Effect Soundness"
+section: "benchmarking"
+order: 11
+---
+
+
+**Category:** Effect Soundness (Calor-only)
+**Result:** N/A (no C# equivalent)
+**What it measures:** Effect declarations match actual behavior
+
+---
+
+## Overview
+
+Calor's compiler enforces that declared effects match actual effects through interprocedural analysis. A function marked `§E{}` (pure) cannot contain I/O operations, and a function calling code with effects must declare those effects.
+
+This catches hidden side effects at compile time—something impossible with constrained decoding or traditional type systems.
+
+---
+
+## Why It Matters
+
+Hidden side effects cause real bugs:
+
+- **Testing failures** - "Pure" functions that secretly log make tests non-deterministic
+- **Concurrency bugs** - Functions assumed safe for parallel execution have hidden state
+- **Performance surprises** - What looks like a calculation actually hits the network
+- **Security issues** - Code assumed side-effect-free modifies databases
+
+Effect soundness means:
+- You can trust effect declarations
+- Refactoring is safe (move "pure" code anywhere)
+- Testing strategy follows directly from effects
+
+---
+
+## How It's Measured
+
+The compiler traces effect violations through the entire call graph:
+
+1. **Direct effects** - Does the function body contain effectful operations?
+2. **Transitive effects** - Do called functions have effects?
+3. **Declaration match** - Are all effects properly declared in `§E{...}`?
+
+Violations produce compile errors with full call chains:
+
+```
+error Calor0410: Function 'ProcessOrder' uses effect 'network'
+                 but does not declare it
+  Call chain: ProcessOrder → NotifyCustomer → SendEmail → HttpClient.PostAsync
+```
+
+---
+
+## Example
+
+A function declared with only database effects:
+
+```calor
+§F{f001:ProcessOrder:pub}
+  §I{Order:order}
+  §O{bool}
+  §E{db:rw}                    // Declares: only database effects
+
+  §C{SaveOrder} order          // OK: SaveOrder has db effect
+  §C{SendConfirmation} order   // ERROR: has network effect!
+  §R true
+§/F{f001}
+```
+
+The compiler catches this:
+
+```
+error Calor0410: Function 'ProcessOrder' uses effect 'net:w'
+                 but does not declare it
+  Call chain: ProcessOrder → SendConfirmation → EmailService.Send → HttpClient.PostAsync
+```
+
+To fix, either:
+1. Add the effect: `§E{db:rw,net:w}`
+2. Remove the effectful call
+3. Use a different implementation without network effects
+
+---
+
+## What It Catches
+
+### Hidden Network Calls
+
+```calor
+§F{f001:Calculate:pub}
+  §O{i32}
+  §E{}                         // Claims to be pure
+
+  §V{v001:i32:rate} §C{FetchExchangeRate} §/C  // ERROR: network!
+  §R (* 100 rate)
+§/F{f001}
+```
+
+### Undeclared Database Writes
+
+```calor
+§F{f001:GetUser:pub}
+  §I{i32:id}
+  §O{User}
+  §E{db:r}                     // Claims read-only
+
+  §V{v001:User:user} §C{Repository.GetById} id §/C
+  §C{AuditLog.Write} id        // ERROR: this is db:w!
+  §R user
+§/F{f001}
+```
+
+### Logging in "Pure" Functions
+
+```calor
+§F{f001:ValidateEmail:pub}
+  §I{str:email}
+  §O{bool}
+  §E{}                         // Claims no effects
+
+  §C{Logger.Debug} email       // ERROR: console write!
+  §R §C{IsValidFormat} email §/C
+§/F{f001}
+```
+
+---
+
+## Effect Propagation
+
+Callers must include all effects of their callees:
+
+```calor
+// Callee has console write effect
+§F{f002:LogMessage:pri}
+  §I{str:msg}
+  §O{void}
+  §E{cw}
+  §P msg
+§/F{f002}
+
+// Caller MUST include cw effect
+§F{f001:ProcessAndLog:pub}
+  §I{Data:data}
+  §O{void}
+  §E{db:rw,cw}                 // Must include cw because we call LogMessage
+
+  §C{SaveData} data
+  §C{f002:LogMessage} "Saved"
+§/F{f001}
+```
+
+If `ProcessAndLog` declared only `§E{db:rw}`, the compiler would error:
+
+```
+error Calor0410: Function 'ProcessAndLog' uses effect 'cw'
+                 but does not declare it
+  Call chain: ProcessAndLog → LogMessage → Console.WriteLine
+```
+
+---
+
+## Effect Checking Modes
+
+### Default Mode (Warnings)
+
+Unknown external calls produce warnings:
+
+```bash
+calor -i app.calr -o app.g.cs
+```
+
+```
+warning Calor0411: Unknown effects for call to 'ThirdParty.DoSomething'
+```
+
+### Strict Mode (Errors)
+
+Promote unknown effects to errors:
+
+```bash
+calor -i app.calr -o app.g.cs --strict-effects
+```
+
+```
+error Calor0411: Unknown effects for call to 'ThirdParty.DoSomething'
+  Add effect declaration to manifest or declare pessimistic effects
+```
+
+---
+
+## Comparison with Implicit Effects
+
+| Aspect | C# (Implicit) | Calor (Explicit) |
+|:-------|:--------------|:-----------------|
+| Side effects visible? | No - must read implementation | Yes - in function signature |
+| Compiler enforcement | None | Full interprocedural analysis |
+| "Pure" guarantee | Convention only | Compiler-verified |
+| Refactoring safety | Must manually verify | Compiler catches violations |
+| Testing strategy | Guesswork | Follows from effects |
+
+### C# Example
+
+```csharp
+// C#: What effects does this have?
+public async Task<User> GetUser(int id)
+{
+    var user = await _repository.GetById(id);  // Database? Memory?
+    _logger.Log($"Retrieved user {id}");        // Console? File? Network?
+    await _cache.Set(user);                      // Memory? Redis?
+    return user;
+}
+// Answer: You have NO IDEA without reading every dependency
+```
+
+### Calor Equivalent
+
+```calor
+§F{f001:GetUser:pub}
+  §I{i32:id}
+  §O{User}
+  §E{db:r,cw,net:rw}           // EXPLICIT: database read, console, network
+
+  §V{v001:User:user} §C{GetById} id §/C
+  §C{Log} (concat "Retrieved user " (str id))
+  §C{CacheSet} user
+  §R user
+§/F{f001}
+```
+
+---
+
+## Benefits for AI Agents
+
+### 1. Filtering by Effect
+
+Find all functions that access the database:
+```
+// Agent searches for §E{..db..}
+```
+
+### 2. Refactoring Safety
+
+Move pure functions anywhere without side-effect concerns:
+```
+// If §E{} is declared, the function is provably safe to parallelize
+```
+
+### 3. Test Planning
+
+- `§E{}` - Unit test directly
+- `§E{cw}` - Mock console
+- `§E{db:rw}` - Mock database
+- `§E{net:rw}` - Mock HTTP
+
+---
+
+## Next
+
+- [Interop Effect Coverage](/benchmarking/metrics/interop-effect-coverage/) - BCL methods covered by effect manifests

--- a/website/content/benchmarking/metrics/interop-effect-coverage.mdx
+++ b/website/content/benchmarking/metrics/interop-effect-coverage.mdx
@@ -1,0 +1,263 @@
+---
+title: "Interop Effect Coverage"
+section: "benchmarking"
+order: 12
+---
+
+
+**Category:** Interop Effect Coverage (Calor-only)
+**Result:** N/A (no C# equivalent)
+**What it measures:** BCL methods covered by effect manifests
+
+---
+
+## Overview
+
+Effect soundness requires knowing what effects external .NET methods have. The BCL (Base Class Library) effect manifest tracks which .NET methods have effect annotations, enabling verification even when Calor code calls external libraries.
+
+This metric measures the coverage of that manifest—how many commonly-used .NET methods have documented effects.
+
+---
+
+## Why It Matters
+
+Without effect coverage for external code, the effect system has gaps:
+
+- Calling `Console.WriteLine` without knowing it has `cw` effect breaks soundness
+- Calling `HttpClient.GetAsync` without knowing it has `net:r` effect allows hidden network calls
+- Calling `File.ReadAllText` without knowing it has `fs:r` effect makes filesystem access invisible
+
+High interop coverage means:
+- Effect declarations remain accurate across .NET interop boundaries
+- AI agents can reason about effects even for external library calls
+- Strict mode (`--strict-effects`) becomes practical for real projects
+
+---
+
+## How It's Measured
+
+The metric evaluates:
+
+1. **Built-in catalog coverage** - Hardcoded effects for common BCL types
+2. **Manifest coverage** - Types and methods declared in effect manifest files
+3. **Namespace coverage** - Default effects for entire namespaces
+
+Coverage percentage = (Methods with declared effects) / (Total methods called)
+
+---
+
+## The BCL Effect Manifest
+
+Calor includes a built-in manifest for .NET Base Class Library methods:
+
+### Console I/O
+
+| Type | Method | Effects |
+|:-----|:-------|:--------|
+| `System.Console` | `WriteLine` | `cw` |
+| `System.Console` | `Write` | `cw` |
+| `System.Console` | `ReadLine` | `cr` |
+| `System.Console` | `Read` | `cr` |
+
+### Filesystem
+
+| Type | Method | Effects |
+|:-----|:-------|:--------|
+| `System.IO.File` | `ReadAllText` | `fs:r` |
+| `System.IO.File` | `ReadAllBytes` | `fs:r` |
+| `System.IO.File` | `WriteAllText` | `fs:w` |
+| `System.IO.File` | `WriteAllBytes` | `fs:w` |
+| `System.IO.File` | `Copy` | `fs:rw` |
+| `System.IO.File` | `Delete` | `fs:w` |
+| `System.IO.File` | `Exists` | `fs:r` |
+
+### Network
+
+| Type | Method | Effects |
+|:-----|:-------|:--------|
+| `System.Net.Http.HttpClient` | `GetAsync` | `net:r` |
+| `System.Net.Http.HttpClient` | `GetStringAsync` | `net:r` |
+| `System.Net.Http.HttpClient` | `PostAsync` | `net:w` |
+| `System.Net.Http.HttpClient` | `SendAsync` | `net:rw` |
+
+### Environment
+
+| Type | Method | Effects |
+|:-----|:-------|:--------|
+| `System.Environment` | `GetEnvironmentVariable` | `env:r` |
+| `System.Environment` | `SetEnvironmentVariable` | `env:w` |
+
+### Nondeterminism
+
+| Type | Method | Effects |
+|:-----|:-------|:--------|
+| `System.DateTime` | `Now` | `time` |
+| `System.DateTime` | `UtcNow` | `time` |
+| `System.Random` | `Next` | `rand` |
+| `System.Guid` | `NewGuid` | `rand` |
+
+---
+
+## Coverage Categories
+
+### Fully Covered
+
+Types where all commonly-used methods have effect declarations:
+- `System.Console`
+- `System.IO.File`
+- `System.Net.Http.HttpClient`
+- `System.Environment`
+
+### Partially Covered
+
+Types where key methods are covered but some overloads or less-common methods may be missing:
+- `System.IO.FileStream`
+- `System.Net.Sockets.TcpClient`
+- `System.Data.SqlClient.SqlCommand`
+
+### Namespace Defaults
+
+For types without specific mappings, namespace defaults provide fallback effects:
+
+```json
+{
+  "namespaceDefaults": {
+    "System.IO": ["fs:rw"],
+    "System.Net": ["net:rw"],
+    "System.Data": ["db:rw"]
+  }
+}
+```
+
+---
+
+## Example: Calling HttpClient
+
+Calor code that makes an HTTP request:
+
+```calor
+§F{f001:FetchData:pub}
+  §I{str:url}
+  §O{str!str}
+  §E{net:r}                    // Must declare network read
+
+  §V{v001:HttpClient:client} §NEW{HttpClient} §/N
+  §V{v002:str:response} §AWAIT §C{client.GetStringAsync} url §/C
+  §R §OK response
+§/F{f001}
+```
+
+The compiler looks up `HttpClient.GetStringAsync` in the effect manifest:
+1. Finds it has `net:r` effect
+2. Verifies the function declares `§E{net:r}`
+3. Compilation succeeds
+
+If `§E{net:r}` was missing:
+
+```
+error Calor0410: Function 'FetchData' uses effect 'net:r'
+                 but does not declare it
+  Call chain: FetchData → HttpClient.GetStringAsync
+```
+
+---
+
+## Contributing to Coverage
+
+You can extend effect coverage with custom manifest files.
+
+### Project-Local Manifest
+
+Create `.calor-effects.json` in your project root:
+
+```json
+{
+  "version": "1.0",
+  "description": "Effects for project dependencies",
+  "mappings": [
+    {
+      "type": "ThirdParty.EmailService",
+      "methods": {
+        "SendAsync": ["net:w"],
+        "ValidateAddress": []
+      }
+    },
+    {
+      "type": "MyApp.DataAccess.Repository",
+      "defaultEffects": ["db:rw"],
+      "methods": {
+        "GetById": ["db:r"],
+        "GetAll": ["db:r"]
+      }
+    }
+  ]
+}
+```
+
+### Manifest Search Locations
+
+Manifests are loaded from (later sources override earlier):
+
+1. **Built-in** - Embedded BCL manifests (lowest priority)
+2. **User-level** - `~/.calor/manifests/*.calor-effects.json`
+3. **Solution-level** - `{solution}/.calor-effects/*.calor-effects.json`
+4. **Project-local** - `.calor-effects.json` (highest priority)
+
+### CLI Commands
+
+```bash
+# Check what effects are resolved for a method
+calor effects resolve HttpClient.GetAsync
+
+# Validate all manifests
+calor effects validate
+
+# List all types with effect declarations
+calor effects list
+```
+
+---
+
+## Effect Taxonomy
+
+The full effect taxonomy used in manifests:
+
+| Code | Effect | Description |
+|:-----|:-------|:------------|
+| `cw` | Console write | Output to console |
+| `cr` | Console read | Input from console |
+| `fs:r` | Filesystem read | Read files |
+| `fs:w` | Filesystem write | Write files |
+| `fs:rw` | Filesystem read/write | Both read and write |
+| `net:r` | Network read | HTTP GET, receive data |
+| `net:w` | Network write | HTTP POST, send data |
+| `net:rw` | Network read/write | Bidirectional network |
+| `db:r` | Database read | SELECT queries |
+| `db:w` | Database write | INSERT/UPDATE/DELETE |
+| `db:rw` | Database read/write | Full database access |
+| `env:r` | Environment read | Read env variables |
+| `env:w` | Environment write | Set env variables |
+| `time` | Time | Time-dependent operations |
+| `rand` | Random | Random number generation |
+| `proc` | Process | Process operations |
+| `mut` | Mutation | Heap mutation |
+| `throw` | Exception | May throw exceptions |
+
+---
+
+## Strict Effects Mode
+
+For maximum safety, enable strict effects to error on unknown external calls:
+
+```bash
+calor -i app.calr -o app.g.cs --strict-effects
+```
+
+This requires all external method calls to have declared effects in manifests.
+
+---
+
+## Next
+
+- [Benchmarking Overview](/benchmarking/) - Return to metrics summary
+- [Methodology](/benchmarking/methodology/) - How all benchmarks work


### PR DESCRIPTION
## Summary

- Add dedicated pages for the three Calor-only benchmark metrics
- Update benchmarking index with links to new pages

### New Pages

1. **Contract Verification** (`/benchmarking/metrics/contract-verification/`)
   - Z3 static contract verification rates
   - Verification spectrum (Proven/Unproven/Disproven/Unsupported)
   - Supported constructs and examples

2. **Effect Soundness** (`/benchmarking/metrics/effect-soundness/`)
   - Interprocedural effect analysis
   - Effect propagation requirements
   - Comparison with C#'s implicit effects

3. **Interop Effect Coverage** (`/benchmarking/metrics/interop-effect-coverage/`)
   - BCL effect manifest coverage
   - Effect taxonomy reference
   - How to contribute custom manifests

## Test plan

- [x] Website builds successfully (`npm run build`)
- [x] All three new pages are generated
- [x] Navigation links work between metric pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)