### PR TITLE
feat(skills): add /calor-analyze skill for deep code analysis

### DIFF
--- a/src/Calor.Compiler/Init/ClaudeInitializer.cs
+++ b/src/Calor.Compiler/Init/ClaudeInitializer.cs
@@ -41,10 +41,15 @@ public class ClaudeInitializer : IAiInitializer
             var semanticsSkillDir = Path.Combine(targetDirectory, ".claude", "skills", "calor-semantics");
             Directory.CreateDirectory(semanticsSkillDir);
 
+            // Create .claude/skills/calor-analyze/ directory
+            var analyzeSkillDir = Path.Combine(targetDirectory, ".claude", "skills", "calor-analyze");
+            Directory.CreateDirectory(analyzeSkillDir);
+
             // Write skill files (Claude uses SKILL.md format with YAML frontmatter)
             var calorSkillPath = Path.Combine(calorSkillDir, "SKILL.md");
             var convertSkillPath = Path.Combine(convertSkillDir, "SKILL.md");
             var semanticsSkillPath = Path.Combine(semanticsSkillDir, "SKILL.md");
+            var analyzeSkillPath = Path.Combine(analyzeSkillDir, "SKILL.md");
 
             if (await WriteFileIfNeeded(calorSkillPath, EmbeddedResourceHelper.ReadSkill("claude-calor-SKILL.md"), force))
             {
@@ -71,6 +76,15 @@ public class ClaudeInitializer : IAiInitializer
             else
             {
                 warnings.Add($"Skipped existing file: {semanticsSkillPath}");
+            }
+
+            if (await WriteFileIfNeeded(analyzeSkillPath, EmbeddedResourceHelper.ReadSkill("claude-calor-analyze-SKILL.md"), force))
+            {
+                createdFiles.Add(analyzeSkillPath);
+            }
+            else
+            {
+                warnings.Add($"Skipped existing file: {analyzeSkillPath}");
             }
 
             // Create or update CLAUDE.md from template with section-aware handling

--- a/src/Calor.Compiler/Init/CodexInitializer.cs
+++ b/src/Calor.Compiler/Init/CodexInitializer.cs
@@ -28,9 +28,14 @@ public class CodexInitializer : IAiInitializer
             var convertSkillDir = Path.Combine(targetDirectory, ".codex", "skills", "calor-convert");
             Directory.CreateDirectory(convertSkillDir);
 
+            // Create .codex/skills/calor-analyze/ directory
+            var analyzeSkillDir = Path.Combine(targetDirectory, ".codex", "skills", "calor-analyze");
+            Directory.CreateDirectory(analyzeSkillDir);
+
             // Write skill files (Codex uses SKILL.md format with YAML frontmatter)
             var calorSkillPath = Path.Combine(calorSkillDir, "SKILL.md");
             var convertSkillPath = Path.Combine(convertSkillDir, "SKILL.md");
+            var analyzeSkillPath = Path.Combine(analyzeSkillDir, "SKILL.md");
 
             if (await WriteFileIfNeeded(calorSkillPath, EmbeddedResourceHelper.ReadSkill("codex-calor-SKILL.md"), force))
             {
@@ -48,6 +53,15 @@ public class CodexInitializer : IAiInitializer
             else
             {
                 warnings.Add($"Skipped existing file: {convertSkillPath}");
+            }
+
+            if (await WriteFileIfNeeded(analyzeSkillPath, EmbeddedResourceHelper.ReadSkill("codex-calor-analyze-SKILL.md"), force))
+            {
+                createdFiles.Add(analyzeSkillPath);
+            }
+            else
+            {
+                warnings.Add($"Skipped existing file: {analyzeSkillPath}");
             }
 
             // Create or update AGENTS.md from template with section-aware handling

--- a/src/Calor.Compiler/Init/GeminiInitializer.cs
+++ b/src/Calor.Compiler/Init/GeminiInitializer.cs
@@ -29,9 +29,14 @@ public class GeminiInitializer : IAiInitializer
             var convertSkillDir = Path.Combine(targetDirectory, ".gemini", "skills", "calor-convert");
             Directory.CreateDirectory(convertSkillDir);
 
+            // Create .gemini/skills/calor-analyze/ directory
+            var analyzeSkillDir = Path.Combine(targetDirectory, ".gemini", "skills", "calor-analyze");
+            Directory.CreateDirectory(analyzeSkillDir);
+
             // Write skill files (Gemini uses SKILL.md format with YAML frontmatter)
             var calorSkillPath = Path.Combine(calorSkillDir, "SKILL.md");
             var convertSkillPath = Path.Combine(convertSkillDir, "SKILL.md");
+            var analyzeSkillPath = Path.Combine(analyzeSkillDir, "SKILL.md");
 
             if (await WriteFileIfNeeded(calorSkillPath, EmbeddedResourceHelper.ReadSkill("gemini-calor-SKILL.md"), force))
             {
@@ -49,6 +54,15 @@ public class GeminiInitializer : IAiInitializer
             else
             {
                 warnings.Add($"Skipped existing file: {convertSkillPath}");
+            }
+
+            if (await WriteFileIfNeeded(analyzeSkillPath, EmbeddedResourceHelper.ReadSkill("gemini-calor-analyze-SKILL.md"), force))
+            {
+                createdFiles.Add(analyzeSkillPath);
+            }
+            else
+            {
+                warnings.Add($"Skipped existing file: {analyzeSkillPath}");
             }
 
             // Create or update GEMINI.md from template with section-aware handling

--- a/src/Calor.Compiler/Init/GitHubCopilotInitializer.cs
+++ b/src/Calor.Compiler/Init/GitHubCopilotInitializer.cs
@@ -28,9 +28,14 @@ public class GitHubCopilotInitializer : IAiInitializer
             var convertSkillDir = Path.Combine(targetDirectory, ".github", "copilot", "skills", "calor-convert");
             Directory.CreateDirectory(convertSkillDir);
 
+            // Create .github/copilot/skills/calor-analyze/ directory
+            var analyzeSkillDir = Path.Combine(targetDirectory, ".github", "copilot", "skills", "calor-analyze");
+            Directory.CreateDirectory(analyzeSkillDir);
+
             // Write skill files (GitHub Copilot uses SKILL.md format with YAML frontmatter)
             var calorSkillPath = Path.Combine(calorSkillDir, "SKILL.md");
             var convertSkillPath = Path.Combine(convertSkillDir, "SKILL.md");
+            var analyzeSkillPath = Path.Combine(analyzeSkillDir, "SKILL.md");
 
             if (await WriteFileIfNeeded(calorSkillPath, EmbeddedResourceHelper.ReadSkill("github-calor-SKILL.md"), force))
             {
@@ -48,6 +53,15 @@ public class GitHubCopilotInitializer : IAiInitializer
             else
             {
                 warnings.Add($"Skipped existing file: {convertSkillPath}");
+            }
+
+            if (await WriteFileIfNeeded(analyzeSkillPath, EmbeddedResourceHelper.ReadSkill("github-calor-analyze-SKILL.md"), force))
+            {
+                createdFiles.Add(analyzeSkillPath);
+            }
+            else
+            {
+                warnings.Add($"Skipped existing file: {analyzeSkillPath}");
             }
 
             // Create or update copilot-instructions.md from template with section-aware handling

--- a/src/Calor.Compiler/Resources/Skills/calor-analyze.md
+++ b/src/Calor.Compiler/Resources/Skills/calor-analyze.md
@@ -1,0 +1,50 @@
+---
+name: calor-analyze
+description: Run deep security and bug analysis on Calor code
+---
+
+# /calor-analyze - Deep Code Analysis
+
+Use this skill to find security vulnerabilities, bugs, and code quality issues.
+
+## Command
+```bash
+calor --input <file.calr> --verify --analyze --verbose
+```
+
+**Note:** Use `--verbose` to see analysis results. Without it, warnings are only shown if compilation fails.
+
+## What It Detects
+
+### Security Vulnerabilities (Taint Analysis)
+- **Calor0981** SQL Injection - User input flowing to database queries
+- **Calor0982** Command Injection - User input in shell commands
+- **Calor0983** Path Traversal - User input in file paths
+- **Calor0984** Cross-Site Scripting (XSS) - User input in HTML output
+
+### Bug Patterns
+- **Calor0920** Division by Zero
+- **Calor0921** Index Out of Bounds
+- **Calor0922** Null/None Dereference
+- **Calor0923** Integer Overflow
+
+### Dataflow Issues
+- **Calor0900** Uninitialized Variable
+- **Calor0901** Dead Code (unreachable)
+- **Calor0902** Dead Store (unused assignment)
+
+### Contract Verification
+- Proves preconditions and postconditions with Z3 SMT solver
+- Reports counterexamples for failed proofs
+
+## When to Use
+1. Before committing security-sensitive code
+2. After writing functions with complex control flow
+3. When handling user input that flows to sinks
+4. To verify loop termination and bounds
+
+## Example Output
+```
+file.calr(12,5): warning Calor0981: Potential SQL injection: tainted data from 'user_input' flows to database sink
+file.calr(25,10): warning Calor0920: Potential division by zero: divisor can be zero
+```

--- a/src/Calor.Compiler/Resources/Skills/claude-calor-analyze-SKILL.md
+++ b/src/Calor.Compiler/Resources/Skills/claude-calor-analyze-SKILL.md
@@ -1,0 +1,103 @@
+---
+name: calor-analyze
+description: Run deep security and bug analysis on Calor code using Z3 verification, taint analysis, and bug pattern detection.
+---
+
+# /calor-analyze - Deep Code Analysis
+
+Use this skill to find security vulnerabilities, bugs, and code quality issues in Calor code.
+
+## Command
+```bash
+calor --input <file.calr> --verify --analyze --verbose
+```
+
+**Note:** Use `--verbose` to see analysis results. Without it, warnings are only shown if compilation fails.
+
+## What It Detects
+
+### Security Vulnerabilities (Taint Analysis)
+| Code | Issue | Description |
+|------|-------|-------------|
+| **Calor0981** | SQL Injection | User input flowing to database queries |
+| **Calor0982** | Command Injection | User input in shell commands |
+| **Calor0983** | Path Traversal | User input in file paths |
+| **Calor0984** | XSS | User input in HTML output |
+
+### Bug Patterns
+| Code | Issue | Description |
+|------|-------|-------------|
+| **Calor0920** | Division by Zero | Divisor can be zero at runtime |
+| **Calor0921** | Index Out of Bounds | Array access may exceed bounds |
+| **Calor0922** | Null Dereference | Potential null/None access |
+| **Calor0923** | Integer Overflow | Arithmetic may overflow |
+
+### Dataflow Issues
+| Code | Issue | Description |
+|------|-------|-------------|
+| **Calor0900** | Uninitialized Variable | Variable used before assignment |
+| **Calor0901** | Dead Code | Unreachable code path |
+| **Calor0902** | Dead Store | Assignment never read |
+
+### Contract Verification (Z3)
+- Proves preconditions (`§Q`) and postconditions (`§S`) using Z3 SMT solver
+- Reports counterexamples when proofs fail
+- Verifies loop invariants and termination
+
+## When to Use
+
+1. **Before committing security-sensitive code** - Catch injection vulnerabilities
+2. **After writing functions with complex control flow** - Find dead code and unreachable paths
+3. **When handling user input** - Track tainted data to sinks
+4. **To verify contracts** - Prove preconditions and postconditions
+
+## Workflow
+
+```bash
+# 1. Write or modify .calr file
+# 2. Run deep analysis
+calor --input myfile.calr --verify --analyze --verbose
+
+# 3. Fix reported issues
+# 4. Re-run until clean
+```
+
+## Example Output
+
+```
+file.calr(12,5): warning Calor0981: Potential SQL injection: tainted data from 'user_input' flows to database sink
+file.calr(25,10): warning Calor0920: Potential division by zero: divisor can be zero
+file.calr(30,3): warning Calor0901: Dead code: this branch is unreachable
+```
+
+## Taint Sources and Sinks
+
+### Sources (User Input)
+- Function parameters marked with user input effects
+- Console/stdin reads
+- HTTP request data
+- File reads from user-specified paths
+
+### Sinks (Dangerous Operations)
+- Database queries (`§E{db:w}`)
+- Shell commands (`§E{exec}`)
+- File system writes (`§E{fs:w}`)
+- HTML output (`§E{html}`)
+
+## Contract Verification Example
+
+```calor
+§F{f001:SafeDivide:pub}
+  §I{i32:a}
+  §I{i32:b}
+  §O{i32}
+  §Q (!= b 0)           // Precondition: b cannot be zero
+  §S (>= result 0)      // Postcondition: result is non-negative
+  §R (/ a b)
+§/F{f001}
+```
+
+Running `calor --verify --analyze` will:
+1. Verify the precondition is sufficient to prevent division by zero
+2. Check if the postcondition can be violated with valid inputs
+3. Report counterexamples if verification fails

--- a/src/Calor.Compiler/Resources/Skills/codex-calor-analyze-SKILL.md
+++ b/src/Calor.Compiler/Resources/Skills/codex-calor-analyze-SKILL.md
@@ -1,0 +1,107 @@
+---
+name: calor-analyze
+description: Run deep security and bug analysis on Calor code using Z3 verification, taint analysis, and bug pattern detection.
+---
+
+# $calor-analyze - Deep Code Analysis
+
+Use this skill to find security vulnerabilities, bugs, and code quality issues in Calor code.
+
+## Command
+```bash
+calor --input <file.calr> --verify --analyze --verbose
+```
+
+**Note:** Use `--verbose` to see analysis results. Without it, warnings are only shown if compilation fails.
+
+## What It Detects
+
+### Security Vulnerabilities (Taint Analysis)
+| Code | Issue | Description |
+|------|-------|-------------|
+| **Calor0981** | SQL Injection | User input flowing to database queries |
+| **Calor0982** | Command Injection | User input in shell commands |
+| **Calor0983** | Path Traversal | User input in file paths |
+| **Calor0984** | XSS | User input in HTML output |
+
+### Bug Patterns
+| Code | Issue | Description |
+|------|-------|-------------|
+| **Calor0920** | Division by Zero | Divisor can be zero at runtime |
+| **Calor0921** | Index Out of Bounds | Array access may exceed bounds |
+| **Calor0922** | Null Dereference | Potential null/None access |
+| **Calor0923** | Integer Overflow | Arithmetic may overflow |
+
+### Dataflow Issues
+| Code | Issue | Description |
+|------|-------|-------------|
+| **Calor0900** | Uninitialized Variable | Variable used before assignment |
+| **Calor0901** | Dead Code | Unreachable code path |
+| **Calor0902** | Dead Store | Assignment never read |
+
+### Contract Verification (Z3)
+- Proves preconditions (`§Q`) and postconditions (`§S`) using Z3 SMT solver
+- Reports counterexamples when proofs fail
+- Verifies loop invariants and termination
+
+## When to Use
+
+1. **Before committing security-sensitive code** - Catch injection vulnerabilities
+2. **After writing functions with complex control flow** - Find dead code and unreachable paths
+3. **When handling user input** - Track tainted data to sinks
+4. **To verify contracts** - Prove preconditions and postconditions
+
+## Workflow
+
+```bash
+# 1. Write or modify .calr file
+# 2. Run deep analysis
+calor --input myfile.calr --verify --analyze --verbose
+
+# 3. Fix reported issues
+# 4. Re-run until clean
+```
+
+## Example Output
+
+```
+file.calr(12,5): warning Calor0981: Potential SQL injection: tainted data from 'user_input' flows to database sink
+file.calr(25,10): warning Calor0920: Potential division by zero: divisor can be zero
+file.calr(30,3): warning Calor0901: Dead code: this branch is unreachable
+```
+
+## Taint Sources and Sinks
+
+### Sources (User Input)
+- Function parameters marked with user input effects
+- Console/stdin reads
+- HTTP request data
+- File reads from user-specified paths
+
+### Sinks (Dangerous Operations)
+- Database queries (`§E{db:w}`)
+- Shell commands (`§E{exec}`)
+- File system writes (`§E{fs:w}`)
+- HTML output (`§E{html}`)
+
+## Contract Verification Example
+
+```calor
+§F{f001:SafeDivide:pub}
+  §I{i32:a}
+  §I{i32:b}
+  §O{i32}
+  §Q (!= b 0)           // Precondition: b cannot be zero
+  §S (>= result 0)      // Postcondition: result is non-negative
+  §R (/ a b)
+§/F{f001}
+```
+
+Running `calor --verify --analyze` will:
+1. Verify the precondition is sufficient to prevent division by zero
+2. Check if the postcondition can be violated with valid inputs
+3. Report counterexamples if verification fails
+
+## Note
+
+Codex does not support hooks, so always run analysis manually after writing code.

--- a/src/Calor.Compiler/Resources/Skills/gemini-calor-analyze-SKILL.md
+++ b/src/Calor.Compiler/Resources/Skills/gemini-calor-analyze-SKILL.md
@@ -1,0 +1,103 @@
+---
+name: calor-analyze
+description: Run deep security and bug analysis on Calor code using Z3 verification, taint analysis, and bug pattern detection.
+---
+
+# @calor-analyze - Deep Code Analysis
+
+Use this skill to find security vulnerabilities, bugs, and code quality issues in Calor code.
+
+## Command
+```bash
+calor --input <file.calr> --verify --analyze --verbose
+```
+
+**Note:** Use `--verbose` to see analysis results. Without it, warnings are only shown if compilation fails.
+
+## What It Detects
+
+### Security Vulnerabilities (Taint Analysis)
+| Code | Issue | Description |
+|------|-------|-------------|
+| **Calor0981** | SQL Injection | User input flowing to database queries |
+| **Calor0982** | Command Injection | User input in shell commands |
+| **Calor0983** | Path Traversal | User input in file paths |
+| **Calor0984** | XSS | User input in HTML output |
+
+### Bug Patterns
+| Code | Issue | Description |
+|------|-------|-------------|
+| **Calor0920** | Division by Zero | Divisor can be zero at runtime |
+| **Calor0921** | Index Out of Bounds | Array access may exceed bounds |
+| **Calor0922** | Null Dereference | Potential null/None access |
+| **Calor0923** | Integer Overflow | Arithmetic may overflow |
+
+### Dataflow Issues
+| Code | Issue | Description |
+|------|-------|-------------|
+| **Calor0900** | Uninitialized Variable | Variable used before assignment |
+| **Calor0901** | Dead Code | Unreachable code path |
+| **Calor0902** | Dead Store | Assignment never read |
+
+### Contract Verification (Z3)
+- Proves preconditions (`§Q`) and postconditions (`§S`) using Z3 SMT solver
+- Reports counterexamples when proofs fail
+- Verifies loop invariants and termination
+
+## When to Use
+
+1. **Before committing security-sensitive code** - Catch injection vulnerabilities
+2. **After writing functions with complex control flow** - Find dead code and unreachable paths
+3. **When handling user input** - Track tainted data to sinks
+4. **To verify contracts** - Prove preconditions and postconditions
+
+## Workflow
+
+```bash
+# 1. Write or modify .calr file
+# 2. Run deep analysis
+calor --input myfile.calr --verify --analyze --verbose
+
+# 3. Fix reported issues
+# 4. Re-run until clean
+```
+
+## Example Output
+
+```
+file.calr(12,5): warning Calor0981: Potential SQL injection: tainted data from 'user_input' flows to database sink
+file.calr(25,10): warning Calor0920: Potential division by zero: divisor can be zero
+file.calr(30,3): warning Calor0901: Dead code: this branch is unreachable
+```
+
+## Taint Sources and Sinks
+
+### Sources (User Input)
+- Function parameters marked with user input effects
+- Console/stdin reads
+- HTTP request data
+- File reads from user-specified paths
+
+### Sinks (Dangerous Operations)
+- Database queries (`§E{db:w}`)
+- Shell commands (`§E{exec}`)
+- File system writes (`§E{fs:w}`)
+- HTML output (`§E{html}`)
+
+## Contract Verification Example
+
+```calor
+§F{f001:SafeDivide:pub}
+  §I{i32:a}
+  §I{i32:b}
+  §O{i32}
+  §Q (!= b 0)           // Precondition: b cannot be zero
+  §S (>= result 0)      // Postcondition: result is non-negative
+  §R (/ a b)
+§/F{f001}
+```
+
+Running `calor --verify --analyze` will:
+1. Verify the precondition is sufficient to prevent division by zero
+2. Check if the postcondition can be violated with valid inputs
+3. Report counterexamples if verification fails

--- a/src/Calor.Compiler/Resources/Skills/github-calor-analyze-SKILL.md
+++ b/src/Calor.Compiler/Resources/Skills/github-calor-analyze-SKILL.md
@@ -1,0 +1,108 @@
+---
+name: calor-analyze
+description: Run deep security and bug analysis on Calor code using Z3 verification, taint analysis, and bug pattern detection.
+---
+
+# calor-analyze - Deep Code Analysis
+
+Use this skill to find security vulnerabilities, bugs, and code quality issues in Calor code.
+
+## Command
+```bash
+calor --input <file.calr> --verify --analyze --verbose
+```
+
+**Note:** Use `--verbose` to see analysis results. Without it, warnings are only shown if compilation fails.
+
+## What It Detects
+
+### Security Vulnerabilities (Taint Analysis)
+| Code | Issue | Description |
+|------|-------|-------------|
+| **Calor0981** | SQL Injection | User input flowing to database queries |
+| **Calor0982** | Command Injection | User input in shell commands |
+| **Calor0983** | Path Traversal | User input in file paths |
+| **Calor0984** | XSS | User input in HTML output |
+
+### Bug Patterns
+| Code | Issue | Description |
+|------|-------|-------------|
+| **Calor0920** | Division by Zero | Divisor can be zero at runtime |
+| **Calor0921** | Index Out of Bounds | Array access may exceed bounds |
+| **Calor0922** | Null Dereference | Potential null/None access |
+| **Calor0923** | Integer Overflow | Arithmetic may overflow |
+
+### Dataflow Issues
+| Code | Issue | Description |
+|------|-------|-------------|
+| **Calor0900** | Uninitialized Variable | Variable used before assignment |
+| **Calor0901** | Dead Code | Unreachable code path |
+| **Calor0902** | Dead Store | Assignment never read |
+
+### Contract Verification (Z3)
+- Proves preconditions (`§Q`) and postconditions (`§S`) using Z3 SMT solver
+- Reports counterexamples when proofs fail
+- Verifies loop invariants and termination
+
+## When to Use
+
+1. **Before committing security-sensitive code** - Catch injection vulnerabilities
+2. **After writing functions with complex control flow** - Find dead code and unreachable paths
+3. **When handling user input** - Track tainted data to sinks
+4. **To verify contracts** - Prove preconditions and postconditions
+
+## Workflow
+
+```bash
+# 1. Write or modify .calr file
+# 2. Run deep analysis
+calor --input myfile.calr --verify --analyze --verbose
+
+# 3. Fix reported issues
+# 4. Re-run until clean
+```
+
+## Example Output
+
+```
+file.calr(12,5): warning Calor0981: Potential SQL injection: tainted data from 'user_input' flows to database sink
+file.calr(25,10): warning Calor0920: Potential division by zero: divisor can be zero
+file.calr(30,3): warning Calor0901: Dead code: this branch is unreachable
+```
+
+## Taint Sources and Sinks
+
+### Sources (User Input)
+- Function parameters marked with user input effects
+- Console/stdin reads
+- HTTP request data
+- File reads from user-specified paths
+
+### Sinks (Dangerous Operations)
+- Database queries (`§E{db:w}`)
+- Shell commands (`§E{exec}`)
+- File system writes (`§E{fs:w}`)
+- HTML output (`§E{html}`)
+
+## Contract Verification Example
+
+```calor
+§F{f001:SafeDivide:pub}
+  §I{i32:a}
+  §I{i32:b}
+  §O{i32}
+  §Q (!= b 0)           // Precondition: b cannot be zero
+  §S (>= result 0)      // Postcondition: result is non-negative
+  §R (/ a b)
+§/F{f001}
+```
+
+Running `calor --verify --analyze` will:
+1. Verify the precondition is sufficient to prevent division by zero
+2. Check if the postcondition can be violated with valid inputs
+3. Report counterexamples if verification fails
+
+## Note
+
+GitHub Copilot does not support hooks. Always run analysis manually after writing code.
+See `.github/copilot/skills/calor-analyze/SKILL.md` for the full skill reference.

--- a/src/Calor.Compiler/Resources/Templates/AGENTS.md.template
+++ b/src/Calor.Compiler/Resources/Templates/AGENTS.md.template
@@ -46,12 +46,14 @@ This is an **Calor-first project**. All new code MUST be written in Calor. Exist
 #### Available Skills
 - `$calor` - Write Calor code with v2+ syntax
 - `$calor-convert` - Convert C# to Calor
+- `$calor-analyze` - Deep security and bug analysis (taint, Z3 verification)
 
 #### Key Commands
 ```bash
 calor analyze <path>                 # Score files for Calor migration potential
 calor diagnose <file.calr>           # Validate syntax - shows ALL errors at once
 calor --input file.calr -o file.g.cs # Compile Calor to C#
+calor --input file.calr --verify --analyze -v  # Deep analysis (security, bugs, contracts)
 calor convert file.cs                # Convert C# to Calor
 calor convert file.calr              # Convert Calor to C#
 ```

--- a/src/Calor.Compiler/Resources/Templates/CLAUDE.md.template
+++ b/src/Calor.Compiler/Resources/Templates/CLAUDE.md.template
@@ -56,12 +56,14 @@ All tasks must pass (2/3 runs succeed). If tests fail, investigate before procee
 #### Available Skills
 - `/calor` - Write Calor code with v2+ syntax
 - `/calor-convert` - Convert C# to Calor
+- `/calor-analyze` - Deep security and bug analysis (taint, Z3 verification)
 
 #### Key Commands
 ```bash
 calor analyze <path>                 # Score files for Calor migration potential
 calor diagnose <file.calr>           # Validate syntax - shows ALL errors at once
 calor --input file.calr -o file.g.cs # Compile Calor to C#
+calor --input file.calr --verify --analyze -v  # Deep analysis (security, bugs, contracts)
 calor convert file.cs                # Convert C# to Calor
 calor convert file.calr              # Convert Calor to C#
 ```

--- a/src/Calor.Compiler/Resources/Templates/GEMINI.md.template
+++ b/src/Calor.Compiler/Resources/Templates/GEMINI.md.template
@@ -34,11 +34,13 @@ This is an **Calor-first project**. All new code MUST be written in Calor. Exist
 #### Available Skills
 - `@calor` - Write Calor code with v2+ syntax
 - `@calor-convert` - Convert C# to Calor
+- `@calor-analyze` - Deep security and bug analysis (taint, Z3 verification)
 
 #### Key Commands
 ```bash
 calor analyze <path>                 # Score files for Calor migration potential
 calor --input file.calr -o file.g.cs # Compile Calor to C#
+calor --input file.calr --verify --analyze -v  # Deep analysis (security, bugs, contracts)
 calor convert file.cs                # Convert C# to Calor
 calor convert file.calr              # Convert Calor to C#
 ```

--- a/src/Calor.Compiler/Resources/Templates/copilot-instructions.md.template
+++ b/src/Calor.Compiler/Resources/Templates/copilot-instructions.md.template
@@ -46,12 +46,14 @@ This is an **Calor-first project**. All new code MUST be written in Calor. Exist
 #### Available Skills
 - `calor` - Write Calor code with v2+ syntax (see `.github/copilot/skills/calor/SKILL.md`)
 - `calor-convert` - Convert C# to Calor (see `.github/copilot/skills/calor-convert/SKILL.md`)
+- `calor-analyze` - Deep security and bug analysis (see `.github/copilot/skills/calor-analyze/SKILL.md`)
 
 #### Key Commands
 ```bash
 calor analyze <path>                 # Score files for Calor migration potential
 calor diagnose <file.calr>           # Validate syntax - shows ALL errors at once
 calor --input file.calr -o file.g.cs # Compile Calor to C#
+calor --input file.calr --verify --analyze -v  # Deep analysis (security, bugs, contracts)
 calor convert file.cs                # Convert C# to Calor
 calor convert file.calr              # Convert Calor to C#
 ```


### PR DESCRIPTION
## Summary

- Add new `/calor-analyze` skill that teaches AI coding agents how to use deep code analysis
- Skill documents `calor --verify --analyze --verbose` for security and bug detection
- Deployed to all 4 supported agents (Claude, Codex, Gemini, GitHub Copilot)

## What the skill teaches

### Security Vulnerabilities (Taint Analysis)
- **Calor0981** SQL Injection
- **Calor0982** Command Injection
- **Calor0983** Path Traversal
- **Calor0984** Cross-Site Scripting (XSS)

### Bug Patterns
- **Calor0920** Division by Zero
- **Calor0921** Index Out of Bounds
- **Calor0922** Null/None Dereference
- **Calor0923** Integer Overflow

### Dataflow Issues
- **Calor0900** Uninitialized Variable
- **Calor0901** Dead Code
- **Calor0902** Dead Store

## Files changed

| Action | Files |
|--------|-------|
| Created | 5 skill files (`*-calor-analyze-SKILL.md`) |
| Modified | 4 initializers to deploy the skill |
| Modified | 4 documentation templates to list the skill |

## Test plan

- [x] Build passes
- [x] Init tests pass (156 tests)
- [x] Manual verification: `calor init --ai claude` deploys skill
- [x] Manual verification: taint analysis detects SQL injection with `--verbose`

🤖 Generated with [Claude Code](https://claude.ai/code)