### PR TITLE
feat(compiler): add expression support for arrays and IF conditionals

### DIFF
--- a/src/Calor.Compiler/Resources/Skills/calor.md
+++ b/src/Calor.Compiler/Resources/Skills/calor.md
@@ -72,12 +72,21 @@ ReadDict<K,V>         IReadOnlyDictionary<K,V>
 ### Array Operations
 
 ```
-§ARR elem1 elem2 §/ARR    Array literal
-§IDX array index          Array access (array[index])
-§IDX array §^ n           Index from end (array[^n])
-§^ n                      Index from end operator (^n)
-§LEN array                Array length (array.Length)
-§SETIDX{array} idx val    Set element at index (array[idx] = val)
+§ARR elem1 elem2 §/ARR       Array literal
+§ARR{id:type:size}           Sized array: new type[size]
+§ARR{id:type:(len arr)}      Sized array with expression: new type[arr.Length]
+§IDX array index             Array access (array[index])
+§IDX array §^ n              Index from end (array[^n])
+§^ n                         Index from end operator (^n)
+§LEN array                   Array length (array.Length)
+§SETIDX{array} idx val       Set element at index (array[idx] = val)
+```
+
+**Array creation patterns:**
+```
+§B{[i32]:result} §ARR{a001:i32:n}          Variable size: new int[n]
+§B{[i32]:result} §ARR{a001:i32:10}         Literal size: new int[10]
+§B{[i32]:result} §ARR{a001:i32:(len data)} Expression size: new int[data.Length]
 ```
 
 **CRITICAL: Don't mix tag-style (§IDX) inside Lisp expressions:**
@@ -247,18 +256,27 @@ Multi-line form:
 §/I{id}
 ```
 
-**CRITICAL: §IF is a STATEMENT, not an expression.**
-```
-// WRONG - cannot use §IF to assign a value
-§B{x} §IF{if1} (< n 0) → (- 0 n) §EL → n §/I{if1}  ← ERROR
+### IF as Expression (Conditional/Ternary)
 
-// CORRECT - use separate branches
-§IF{if1} (< n 0)
-  §B{x} (- 0 n)
-§EL
-  §B{x} n
-§/I{if1}
+§IF can be used as an expression to return a value (like C#'s ternary `?:`):
+
 ```
+§B{x} §IF{id} condition → thenValue §EL → elseValue §/I{id}
+```
+
+**Example - Conditional assignment:**
+```
+§B{minLen} §IF{if1} (<= lenA lenB) → lenA §EL → lenB §/I{if1}
+// Compiles to: var minLen = (lenA <= lenB) ? lenA : lenB;
+```
+
+**Example - Absolute value:**
+```
+§B{abs} §IF{if1} (< n 0) → (- 0 n) §EL → n §/I{if1}
+// Compiles to: var abs = (n < 0) ? (0 - n) : n;
+```
+
+**Note:** Both `→ thenValue` and `§EL → elseValue` are required for IF expressions.
 
 ## Contracts
 

--- a/tests/Calor.Evaluation/Skills/calor-language-skills.md
+++ b/tests/Calor.Evaluation/Skills/calor-language-skills.md
@@ -285,8 +285,14 @@ Use contracts to express requirements and guarantees mentioned in the task:
 
 **Array Creation:**
 ```calor
-// Sized array
+// Sized array with literal
 §B{[i32]:arr} §ARR{a001:i32:5}              // Create int[5]
+
+// Sized array with variable
+§B{[i32]:arr} §ARR{a001:i32:n}              // Create int[n]
+
+// Sized array with expression
+§B{[i32]:result} §ARR{a001:i32:(len data)}  // Create int[data.Length]
 
 // Initialized array
 §B{[i32]:arr} §ARR{a001:i32} 1 2 3 §/ARR{a001}  // Create [1, 2, 3]
@@ -380,24 +386,31 @@ Calor has two styles for if statements. Choosing the wrong one causes compilatio
 - No arrow after the condition
 - Statements go on following lines
 
-**COMMON MISTAKE - Using §IF as an expression:**
+**§IF as Expression (Conditional/Ternary):**
+
+§IF can be used as an expression to return a value (like C#'s ternary `?:`):
+
 ```calor
-// WRONG - §IF is a STATEMENT, not an expression
-§B{x} §IF{if1} (< n 0) → (- 0 n) §EL → n §/I{if1}  // ❌ ERROR
+// Syntax: §IF{id} condition → thenValue §EL → elseValue §/I{id}
+§B{x} §IF{if1} (< n 0) → (- 0 n) §EL → n §/I{if1}
+// Compiles to: var x = (n < 0) ? (0 - n) : n;
+
+// Conditional assignment - minimum of two values
+§B{minLen} §IF{if1} (<= lenA lenB) → lenA §EL → lenB §/I{if1}
+// Compiles to: var minLen = (lenA <= lenB) ? lenA : lenB;
 ```
 
-**CORRECT - Use explicit branches with §R or §ASSIGN:**
+**IMPORTANT:** Both `→ thenValue` and `§EL → elseValue` are required for IF expressions.
+
+**Alternative - Use explicit branches for complex logic:**
 ```calor
-// CORRECT: Use if statement to assign different values
+// For complex logic with multiple statements, use block syntax
 §IF{if1} (< n 0)
   §B{x} (- 0 n)
 §EL
   §B{x} n
 §/I{if1}
 // Now use x
-
-// OR compute absolute value with a function
-§B{absN} §C{Abs} §A n §/C
 ```
 
 **COMMON MISTAKE - Arrow syntax with statements after:**
@@ -845,20 +858,22 @@ These examples show correct patterns for common string tasks:
 §R (^ hash elem)                    // ✓ elem is a simple identifier
 ```
 
-### If-Statement-as-Expression Mistakes
+### If-Expression Patterns (Ternary/Conditional)
 
-**WRONG - Using §IF as an expression to assign a value:**
+**§IF as Expression - NOW SUPPORTED:**
 ```calor
-// WRONG: §IF is a STATEMENT, not an expression
-§B{absX} §IF{if1} (< x 0) → (- 0 x) §EL → x §/I{if1}  // ❌ ERROR
+// IF expression for conditional values (compiles to C# ternary)
+§B{absX} §IF{if1} (< x 0) → (- 0 x) §EL → x §/I{if1}
+// Compiles to: var absX = (x < 0) ? (0 - x) : x;
 
-// WRONG: Inline ternary-style if
-§R §IF{if1} (< a b) → (- 0 1) §EL → 1 §/I{if1}        // ❌ ERROR
+// IF expression in return
+§R §IF{if1} (< a b) → (- 0 1) §EL → 1 §/I{if1}
+// Compiles to: return (a < b) ? (0 - 1) : 1;
 ```
 
-**CORRECT - Use separate branches:**
+**Alternative - Block syntax for complex logic:**
 ```calor
-// CORRECT: Use if statement with separate assignments
+// When you need multiple statements, use block syntax
 §B{absX} 0
 §IF{if1} (< x 0)
   §ASSIGN absX (- 0 x)
@@ -866,7 +881,7 @@ These examples show correct patterns for common string tasks:
   §ASSIGN absX x
 §/I{if1}
 
-// CORRECT: For simple returns, use arrow syntax
+// Or arrow syntax with statements
 §IF{if1} (< a b) → §R (- 0 1)
 §EL → §R 1
 §/I{if1}


### PR DESCRIPTION
## Summary

Adds two parser enhancements that fix Effect Discipline benchmark failures:

1. **Array size expressions**: The parser now supports expressions in the array size position
2. **IF as expression**: The parser now supports IF as a conditional expression (like C#'s ternary `?:`)

## Changes

### Parser Enhancements

| Feature | Syntax | Compiles To |
|---------|--------|-------------|
| Array size expression | `§ARR{id:type:(len data)}` | `new type[data.Length]` |
| IF expression | `§IF{id} cond → val1 §EL → val2 §/I{id}` | `cond ? val1 : val2` |

### New Methods

- `ParseEmbeddedExpression`: Re-lexes and parses an expression string from attribute values
- `ParseIfExpression`: Parses IF as a conditional expression returning `ConditionalExpressionNode`

### Skills File Updates

- Documented array creation with expressions
- Documented IF as expression (ternary-style conditional)
- Updated previously incorrect documentation that said IF cannot be used as an expression

## Benchmark Impact

| Task | Before | After |
|------|--------|-------|
| security-010 | ❌ Compilation error (`lendata` not found) | ✅ Compiles |
| transparency-004 | ❌ 0% correctness | ✅ 100% correctness |

## Test plan

- [x] All 2328 compiler tests pass
- [x] Manual test: `§ARR{a001:i32:(len data)}` generates `new int[data.Length]`
- [x] Manual test: `§IF{if1} (<= a b) → a §EL → b §/I{if1}` generates `(a <= b) ? a : b`
- [x] Benchmark tasks security-010 and transparency-004 now compile and run correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)