### PR TITLE
fix(skills): add guidance for variable redeclaration and character constants

### DIFF
--- a/src/Calor.Compiler/Resources/Skills/calor.md
+++ b/src/Calor.Compiler/Resources/Skills/calor.md
@@ -145,6 +145,21 @@ ReadDict<K,V>         IReadOnlyDictionary<K,V>
 | 'A'  | 65   | 'Z'  | 90   |
 | 'a'  | 97   | 'z'  | 122  |
 | '-'  | 45   | '_'  | 95   |
+| '='  | 61   | '+'  | 43   |
+| '/'  | 47   | ' '  | 32   |
+
+**Getting character constants (without single quotes):**
+```
+// Use char-from-code to create character values
+§B{equalChar} (char-from-code 61)    // '='
+§B{plusChar} (char-from-code 43)     // '+'
+§B{spaceChar} (char-from-code 32)    // ' '
+
+// Or extract from a string
+§B{equalChar} (char-at "=" 0)        // '='
+§B{padChars} "=+"
+§B{equalChar} (char-at padChars 0)   // '='
+```
 | ' '  | 32   | '.'  | 46   |
 
 ### String Operations
@@ -192,12 +207,22 @@ ReadDict<K,V>         IReadOnlyDictionary<K,V>
 ## Statements
 
 ```
-§B{name} expr         Bind variable
+§B{name} expr         Bind variable (declare and initialize)
 §B{type:name} expr    Bind with explicit type
 §R expr               Return value
 §P expr               Print line (Console.WriteLine)
 §Pf expr              Print without newline (Console.Write)
-§ASSIGN target val    Assignment statement
+§ASSIGN target val    Assignment statement (for existing variables)
+```
+
+**CRITICAL: §B declares a NEW variable. Use §ASSIGN to update existing variables.**
+```
+§B{k} (% rng n)              // First use: declare k
+§ASSIGN k (+ k offset)       // Update: use §ASSIGN, not §B
+
+// WRONG - variable redeclaration error:
+§B{k} (% rng n)
+§B{k} (abs k)                // ERROR: k already defined in this scope
 ```
 
 ### Explicit Body Markers

--- a/tests/Calor.Evaluation/Skills/calor-language-skills.md
+++ b/tests/Calor.Evaluation/Skills/calor-language-skills.md
@@ -781,6 +781,34 @@ These examples show correct patterns for common string tasks:
 §B{next} (indexof rest "@")           // ✓ Search in substring
 ```
 
+### Variable Redeclaration Mistakes
+
+**WRONG - Using §B to update an existing variable:**
+```calor
+// WRONG: Can't redeclare a variable in the same scope
+§B{k} (% rng n)                 // First use: declares k
+§B{k} (abs k)                   // ❌ ERROR - 'k' already defined
+
+// WRONG: Redeclaring in conditional
+§B{result} 0
+§IF{if1} (< n 0)
+  §B{result} (- 0 n)            // ❌ ERROR - 'result' already exists
+§/I{if1}
+```
+
+**CORRECT - Use §ASSIGN to update existing variables:**
+```calor
+// CORRECT: §B to declare, §ASSIGN to update
+§B{k} (% rng n)                 // Declare k
+§ASSIGN k (abs k)               // ✓ Update k
+
+// CORRECT: Update in conditional
+§B{result} 0
+§IF{if1} (< n 0)
+  §ASSIGN result (- 0 n)        // ✓ Update existing result
+§/I{if1}
+```
+
 ### Character Literal Mistakes
 
 **WRONG - Single-quoted character literals (cause "Unexpected character '''" error):**
@@ -789,9 +817,10 @@ These examples show correct patterns for common string tasks:
 §IF{if1} (== c '0')             // ❌ ERROR
 §IF{if2} (== c '-')             // ❌ ERROR
 §IF{if3} (&& (>= c '0') (<= c '9'))  // ❌ ERROR
+§B{pad} '='                     // ❌ ERROR - can't use single quotes
 ```
 
-**CORRECT - Use character predicates or code comparisons:**
+**CORRECT - Use character predicates, codes, or string extraction:**
 ```calor
 // CORRECT: Use (is-digit c) for digit check
 §IF{if1} (is-digit c)           // ✓ Check if digit
@@ -802,7 +831,23 @@ These examples show correct patterns for common string tasks:
 // CORRECT: Use codes for range check
 §B{code} (char-code c)
 §IF{if3} (&& (>= code 48) (<= code 57))  // ✓ Check if '0'-'9'
+
+// CORRECT: Get character constant using char-from-code
+§B{equalChar} (char-from-code 61)   // ✓ '=' character (code 61)
+§B{plusChar} (char-from-code 43)    // ✓ '+' character (code 43)
+
+// CORRECT: Get character from string
+§B{equalChar} (char-at "=" 0)       // ✓ '=' from string
 ```
+
+**Common Character Codes:**
+| Char | Code | Char | Code |
+|------|------|------|------|
+| '='  | 61   | '+'  | 43   |
+| '-'  | 45   | '/'  | 47   |
+| '0'  | 48   | '9'  | 57   |
+| 'A'  | 65   | 'Z'  | 90   |
+| 'a'  | 97   | 'z'  | 122  |
 
 ### Array Syntax Mistakes
 


### PR DESCRIPTION
## Summary

Adds documentation to help the LLM avoid two common code generation mistakes found in the Effect Discipline benchmark.

## Issues Addressed

### 1. Variable Redeclaration (flaky-006)
The LLM was generating:
```calor
§B{k} (% rng n)     // Declare k
§B{k} (abs k)       // ERROR: k already defined
```

**Fix:** Added explicit guidance that `§B` declares NEW variables, while `§ASSIGN` updates existing ones.

### 2. Single-Quoted Characters (security-005)
The LLM was generating:
```calor
§B{pad} '='         // ERROR: Single quotes not supported
```

**Fix:** Added patterns for creating character constants:
- `(char-from-code 61)` for '='
- `(char-at "=" 0)` for extracting from string
- Expanded character code reference table

## Test plan

- [x] Documentation builds without errors
- [ ] Re-run benchmark after cache refresh to verify LLM improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)