### PR TITLE
fix(evaluation): fix array type conversion and document unavailable operators

### DIFF
--- a/src/Calor.Compiler/Resources/Skills/calor.md
+++ b/src/Calor.Compiler/Resources/Skills/calor.md
@@ -204,6 +204,14 @@ ReadDict<K,V>         IReadOnlyDictionary<K,V>
 (! a)                 Logical not
 ```
 
+### Unavailable Operators - Use IF Expressions
+
+**CRITICAL: These operators do NOT exist:**
+- `(abs x)` - Use IF expression: `§IF{id} (< x 0) → (- 0 x) §EL → x §/I{id}`
+- `(max a b)` - Use IF expression: `§IF{id} (> a b) → a §EL → b §/I{id}`
+- `(min a b)` - Use IF expression: `§IF{id} (< a b) → a §EL → b §/I{id}`
+- `(sqrt x)`, `(pow a b)` - Not available
+
 ## Statements
 
 ```

--- a/tests/Calor.Evaluation/LlmTasks/Execution/CodeExecutor.cs
+++ b/tests/Calor.Evaluation/LlmTasks/Execution/CodeExecutor.cs
@@ -409,6 +409,24 @@ public sealed class CodeExecutor : IDisposable
             {
                 converted[i] = arg;
             }
+            else if (paramType.IsArray && arg is object[] objArray)
+            {
+                // Convert object[] to the proper typed array (e.g., int[], string[])
+                var elementType = paramType.GetElementType()!;
+                var typedArray = Array.CreateInstance(elementType, objArray.Length);
+                for (int j = 0; j < objArray.Length; j++)
+                {
+                    try
+                    {
+                        typedArray.SetValue(Convert.ChangeType(objArray[j], elementType), j);
+                    }
+                    catch
+                    {
+                        typedArray.SetValue(objArray[j], j);
+                    }
+                }
+                converted[i] = typedArray;
+            }
             else
             {
                 // Try to convert numeric types

--- a/tests/Calor.Evaluation/Skills/calor-language-skills.md
+++ b/tests/Calor.Evaluation/Skills/calor-language-skills.md
@@ -134,6 +134,27 @@ Use contracts to express requirements and guarantees mentioned in the task:
 (! a)         // NOT a
 ```
 
+#### Unavailable Operators - Use IF Expressions Instead
+
+**CRITICAL: The following operators do NOT exist in Calor:**
+- `(abs x)` - absolute value
+- `(max a b)` - maximum
+- `(min a b)` - minimum
+- `(sqrt x)` - square root
+- `(pow a b)` - power
+
+**Use IF expressions to implement these:**
+```calor
+// Absolute value - NO (abs x) operator!
+§B{absVal} §IF{if1} (< x 0) → (- 0 x) §EL → x §/I{if1}
+
+// Maximum - NO (max a b) operator!
+§B{maxVal} §IF{if1} (> a b) → a §EL → b §/I{if1}
+
+// Minimum - NO (min a b) operator!
+§B{minVal} §IF{if1} (< a b) → a §EL → b §/I{if1}
+```
+
 #### String Operations
 
 **IMPORTANT: Use these operations for string manipulation. Do NOT invent syntax.**
@@ -787,7 +808,7 @@ These examples show correct patterns for common string tasks:
 ```calor
 // WRONG: Can't redeclare a variable in the same scope
 §B{k} (% rng n)                 // First use: declares k
-§B{k} (abs k)                   // ❌ ERROR - 'k' already defined
+§B{k} (+ k 1)                   // ❌ ERROR - 'k' already defined
 
 // WRONG: Redeclaring in conditional
 §B{result} 0
@@ -800,7 +821,7 @@ These examples show correct patterns for common string tasks:
 ```calor
 // CORRECT: §B to declare, §ASSIGN to update
 §B{k} (% rng n)                 // Declare k
-§ASSIGN k (abs k)               // ✓ Update k
+§ASSIGN k (+ k 1)               // ✓ Update k
 
 // CORRECT: Update in conditional
 §B{result} 0


### PR DESCRIPTION
## Summary
- Fix `CodeExecutor.ConvertArguments` to convert `object[]` to typed arrays (`int[]`, `string[]`) when invoking generated methods
- Add documentation that `abs`, `max`, `min`, `sqrt`, `pow` operators don't exist in Calor
- Show IF expression patterns as alternatives for these operations
- Fix examples that incorrectly used `(abs k)` to use `(+ k 1)` instead

## Test plan
- [x] Run effect discipline benchmark - Calor correctness improved from 78.3% to 90.0%
- [x] Verify flaky-002 now compiles (was failing due to `(abs seed)`)
- [x] Verify array-based tests now pass (flaky-002, flaky-006, security-004, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)