### PR TITLE
fix(compiler): fix format string interpolation and test expected values

### DIFF
--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -479,14 +479,14 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(StringLiteralNode node)
     {
-        // Check if this is an interpolated string (contains ${...})
-        if (node.Value.Contains("${"))
+        // Check if this is an interpolated string (contains ${identifier})
+        // Only match Calor interpolation syntax: ${identifier}, not format placeholders ${0}
+        // Calor interpolation uses identifiers (letters, underscores), not numbers
+        var interpolationRegex = new System.Text.RegularExpressions.Regex(@"\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}");
+        if (interpolationRegex.IsMatch(node.Value))
         {
             // Convert Calor interpolation ${expr} to C# interpolation {expr}
-            var converted = System.Text.RegularExpressions.Regex.Replace(
-                node.Value,
-                @"\$\{([^}]+)\}",
-                "{$1}");
+            var converted = interpolationRegex.Replace(node.Value, "{$1}");
 
             // Escape for C# string literal (but not the interpolation braces)
             var escaped = converted

--- a/tests/Calor.Evaluation/Tasks/task-manifest-effects.json
+++ b/tests/Calor.Evaluation/Tasks/task-manifest-effects.json
@@ -225,7 +225,7 @@
       "difficulty": 2,
       "prompt": "Write a public function named CreateFixture that takes a string 'name' and an integer 'seed', and returns a fixture ID. Must be deterministic. Return the seed XOR'd with the sum of char codes of name.",
       "testCases": [
-        { "input": ["test", 100], "expected": 548 },
+        { "input": ["test", 100], "expected": 420 },
         { "input": ["abc", 0], "expected": 294 },
         { "input": ["", 42], "expected": 42 }
       ],
@@ -785,10 +785,10 @@
       "name": "Cacheable Hash Function",
       "category": "cache-safety",
       "difficulty": 2,
-      "prompt": "Write a public function named HashString that takes a string 'input' and returns a deterministic hash integer. This is used as a cache key - must be consistent. Use sum of (char code * position).",
+      "prompt": "Write a public function named HashString that takes a string 'input' and returns a deterministic hash integer. This is used as a cache key - must be consistent. Use sum of (char code * position) where position is 0-indexed.",
       "testCases": [
-        { "input": ["abc"], "expected": 302 },
-        { "input": ["hello"], "expected": 808 },
+        { "input": ["abc"], "expected": 296 },
+        { "input": ["hello"], "expected": 1085 },
         { "input": [""], "expected": 0 }
       ],
       "scoring": { "compilation": 0.2, "testCases": 0.4, "contracts": 0.4 },


### PR DESCRIPTION
## Summary
- Fix `CSharpEmitter` to distinguish Calor interpolation `${identifier}` from format placeholders `${0}`
- Fix incorrect expected values in task manifest for flaky-010 and cache-003

## Problem
Format strings like `"${0}.{1:D2}"` were incorrectly converted to C# interpolation `$"{0}.{1:D2}"` instead of staying as format string `"${0}.{1:D2}"`. This caused the transparency-003 task to fail with output "0.01" instead of "$1.50".

## Test plan
- [x] Run effect discipline benchmark - Calor correctness improved from 92.5% to 95.0%
- [x] Verify transparency-003 now passes
- [x] Verify flaky-010 and cache-003 now pass with corrected expected values

🤖 Generated with [Claude Code](https://claude.com/claude-code)