### PR TITLE
fix(website): display tied benchmark results with salmon color

### DIFF
--- a/website/src/components/benchmarks/BenchmarkDashboard.tsx
+++ b/website/src/components/benchmarks/BenchmarkDashboard.tsx
@@ -23,7 +23,7 @@ interface BenchmarkData {
     cSharpWins: number;
     statisticalRunCount: number;
   };
-  metrics: Record<string, { ratio: number; winner: 'calor' | 'csharp'; isCalorOnly?: boolean }>;
+  metrics: Record<string, { ratio: number; winner: 'calor' | 'csharp' | 'tie'; isCalorOnly?: boolean }>;
   programs: Array<{
     id: string;
     name: string;
@@ -171,6 +171,10 @@ export function BenchmarkDashboard() {
           <div className="flex items-center gap-2">
             <div className="w-3 h-3 rounded-full bg-calor-pink" />
             <span>Calor better</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 rounded-full bg-calor-salmon" />
+            <span>Tie</span>
           </div>
           <div className="flex items-center gap-2">
             <div className="w-3 h-3 rounded-full bg-calor-cerulean" />

--- a/website/src/components/benchmarks/BenchmarkSummaryTable.tsx
+++ b/website/src/components/benchmarks/BenchmarkSummaryTable.tsx
@@ -91,10 +91,12 @@ export function BenchmarkSummaryTable() {
                       ? 'text-calor-pink font-medium'
                       : metric.winner === 'calor'
                         ? 'text-calor-pink font-medium'
-                        : 'text-calor-cerulean'
+                        : metric.winner === 'tie'
+                          ? 'text-calor-salmon font-medium'
+                          : 'text-calor-cerulean'
                   }
                 >
-                  {metric.isCalorOnly ? 'Calor only' : metric.winner === 'calor' ? 'Calor' : 'C#'}
+                  {metric.isCalorOnly ? 'Calor only' : metric.winner === 'calor' ? 'Calor' : metric.winner === 'tie' ? 'Tie' : 'C#'}
                 </span>
               </td>
             </tr>

--- a/website/src/components/benchmarks/MetricCard.tsx
+++ b/website/src/components/benchmarks/MetricCard.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils';
 interface MetricCardProps {
   name: string;
   ratio: number;
-  winner: 'calor' | 'csharp';
+  winner: 'calor' | 'csharp' | 'tie';
   description?: string;
   isCalorOnly?: boolean;
 }
@@ -39,59 +39,74 @@ const metricDisplayNames: Record<string, string> = {
 };
 
 // Brief interpretations for each metric
-const metricInterpretations: Record<string, { calor: string; csharp: string }> = {
+const metricInterpretations: Record<string, { calor: string; csharp: string; tie: string }> = {
   TokenEconomics: {
     calor: 'More compact representation',
     csharp: "Calor's explicit syntax uses more tokens",
+    tie: 'Similar code size in both languages',
   },
   GenerationAccuracy: {
     calor: 'Better code generation from prompts',
     csharp: 'Mature tooling, familiar patterns',
+    tie: 'Similar generation accuracy',
   },
   Comprehension: {
     calor: 'Explicit structure aids understanding',
     csharp: 'Familiar syntax easier to follow',
+    tie: 'Both languages equally understandable',
   },
   EditPrecision: {
     calor: 'Unique IDs enable targeted changes',
     csharp: 'Established editing patterns',
+    tie: 'Similar edit precision',
   },
   ErrorDetection: {
     calor: 'Contracts surface invariant violations',
     csharp: 'Mature error handling ecosystem',
+    tie: 'Similar error detection capability',
   },
   InformationDensity: {
     calor: 'More semantic content per token',
     csharp: 'Calor trades density for explicitness',
+    tie: 'Similar information density',
   },
   TaskCompletion: {
     calor: 'Better task completion rate',
     csharp: 'Ecosystem maturity advantage',
+    tie: 'Similar task completion rate',
   },
   RefactoringStability: {
     calor: 'More stable during refactoring',
     csharp: 'Better refactoring support',
+    tie: 'Similar refactoring stability',
   },
   Safety: {
     calor: 'Contracts catch more bugs with better error messages',
     csharp: 'Guard clauses require manual implementation',
+    tie: 'Similar safety characteristics',
   },
   EffectDiscipline: {
     calor: 'Effect system prevents hidden side effect bugs',
     csharp: 'Side effect discipline relies on conventions',
+    tie: 'Similar effect discipline',
   },
   Correctness: {
     calor: 'Contracts help prevent edge case bugs',
     csharp: 'Guard clauses require explicit implementation',
+    tie: 'Similar correctness handling',
   },
 };
 
 export function MetricCard({ name, ratio, winner, description, isCalorOnly }: MetricCardProps) {
   const displayName = metricDisplayNames[name] || name;
-  const defaultInterpretation =
-    winner === 'calor'
-      ? metricInterpretations[name]?.calor
-      : metricInterpretations[name]?.csharp;
+  let defaultInterpretation: string | undefined;
+  if (winner === 'calor') {
+    defaultInterpretation = metricInterpretations[name]?.calor;
+  } else if (winner === 'tie') {
+    defaultInterpretation = metricInterpretations[name]?.tie;
+  } else {
+    defaultInterpretation = metricInterpretations[name]?.csharp;
+  }
   const interpretation = description || defaultInterpretation || '';
 
   return (
@@ -106,10 +121,12 @@ export function MetricCard({ name, ratio, winner, description, isCalorOnly }: Me
                 ? 'bg-calor-pink/20 text-calor-pink'
                 : winner === 'calor'
                   ? 'bg-calor-pink/20 text-calor-pink'
-                  : 'bg-calor-cerulean/20 text-calor-cerulean'
+                  : winner === 'tie'
+                    ? 'bg-calor-salmon/20 text-calor-salmon'
+                    : 'bg-calor-cerulean/20 text-calor-cerulean'
             )}
           >
-            {isCalorOnly ? 'Calor only' : winner === 'calor' ? 'Calor wins' : 'C# wins'}
+            {isCalorOnly ? 'Calor only' : winner === 'calor' ? 'Calor wins' : winner === 'tie' ? 'Tie' : 'C# wins'}
           </span>
         </div>
         <span className="font-mono font-bold">{formatRatio(ratio, isCalorOnly)}</span>
@@ -123,7 +140,9 @@ export function MetricCard({ name, ratio, winner, description, isCalorOnly }: Me
               ? 'bg-gradient-to-r from-calor-pink to-calor-pink/60'
               : winner === 'calor'
                 ? 'bg-gradient-to-r from-calor-pink to-calor-pink/80'
-                : 'bg-gradient-to-r from-calor-cerulean to-calor-cerulean/80'
+                : winner === 'tie'
+                  ? 'bg-gradient-to-r from-calor-salmon to-calor-salmon/80'
+                  : 'bg-gradient-to-r from-calor-cerulean to-calor-cerulean/80'
           )}
           style={{ width: isCalorOnly ? '100%' : `${getBarWidth(ratio)}%` }}
         />

--- a/website/src/components/landing/BenchmarkChart.tsx
+++ b/website/src/components/landing/BenchmarkChart.tsx
@@ -28,75 +28,93 @@ interface BenchmarkData {
 // Human-readable metric names and interpretations
 const metricDisplayInfo: Record<
   string,
-  { name: string; calorInterpretation: string; csharpInterpretation: string }
+  { name: string; calorInterpretation: string; csharpInterpretation: string; tieInterpretation: string }
 > = {
   TokenEconomics: {
     name: 'Code Size',
     calorInterpretation: 'Calor code is more compact',
     csharpInterpretation: 'Calor\'s explicit rules add some overhead',
+    tieInterpretation: 'Both languages produce similar code size',
   },
   GenerationAccuracy: {
     name: 'First-Try Success',
     calorInterpretation: 'AI generates correct code more often',
     csharpInterpretation: 'AI knows C# better (for now)',
+    tieInterpretation: 'AI generates correct code at similar rates',
   },
   Comprehension: {
     name: 'Understanding Code',
     calorInterpretation: 'AI understands Calor code 1.5x better',
     csharpInterpretation: 'C# familiarity helps AI follow along',
+    tieInterpretation: 'AI understands both languages equally well',
   },
   EditPrecision: {
     name: 'Accurate Edits',
     calorInterpretation: 'AI makes precise changes without breaking things',
     csharpInterpretation: 'C# editing patterns are well-established',
+    tieInterpretation: 'AI makes equally precise edits in both languages',
   },
   ErrorDetection: {
     name: 'Finding Bugs',
     calorInterpretation: 'AI spots 22% more bugs in Calor code',
     csharpInterpretation: 'C# has mature debugging tools',
+    tieInterpretation: 'AI spots bugs equally well in both languages',
   },
   InformationDensity: {
     name: 'Meaning Per Line',
     calorInterpretation: 'Each line carries more information',
     csharpInterpretation: 'Calor trades brevity for clarity',
+    tieInterpretation: 'Both languages convey similar meaning per line',
   },
   TaskCompletion: {
     name: 'Finishing Tasks',
     calorInterpretation: 'AI completes more tasks successfully',
     csharpInterpretation: 'More libraries and examples help AI',
+    tieInterpretation: 'AI completes tasks at similar rates',
   },
   RefactoringStability: {
     name: 'Safe Refactoring',
     calorInterpretation: 'Code stays correct after restructuring',
     csharpInterpretation: 'C# has better refactoring tools',
+    tieInterpretation: 'Both languages maintain stability during refactoring',
   },
   Safety: {
     name: 'Bug Catching',
     calorInterpretation: 'Contracts catch more bugs with better error messages',
     csharpInterpretation: 'Guard clauses require manual implementation',
+    tieInterpretation: 'Both approaches catch bugs equally well',
   },
   EffectDiscipline: {
     name: 'Side Effect Control',
     calorInterpretation: 'Effect system prevents hidden side effect bugs',
     csharpInterpretation: 'Relies on conventions, no enforcement',
+    tieInterpretation: 'Both approaches manage side effects equally',
   },
   Correctness: {
     name: 'Edge Case Handling',
     calorInterpretation: 'Contracts help prevent edge case bugs',
     csharpInterpretation: 'Guard clauses require explicit implementation',
+    tieInterpretation: 'Both languages handle edge cases equally well',
   },
 };
 
 function transformMetrics(data: BenchmarkData): BenchmarkResult[] {
   return Object.entries(data.metrics)
     .map(([key, metric]) => {
-      const info = metricDisplayInfo[key] || { name: key, calorInterpretation: '', csharpInterpretation: '' };
+      const info = metricDisplayInfo[key] || { name: key, calorInterpretation: '', csharpInterpretation: '', tieInterpretation: '' };
+      let interpretation: string;
+      if (metric.winner === 'calor') {
+        interpretation = info.calorInterpretation;
+      } else if (metric.winner === 'tie') {
+        interpretation = info.tieInterpretation;
+      } else {
+        interpretation = info.csharpInterpretation;
+      }
       return {
         category: info.name,
         ratio: metric.ratio,
         winner: metric.winner,
-        interpretation:
-          metric.winner === 'calor' ? info.calorInterpretation : info.csharpInterpretation,
+        interpretation,
         isCalorOnly: metric.isCalorOnly,
       };
     })
@@ -170,10 +188,12 @@ export function BenchmarkChart() {
                           ? 'bg-calor-pink/20 text-calor-pink'
                           : result.winner === 'calor'
                             ? 'bg-calor-pink/20 text-calor-pink'
-                            : 'bg-calor-cerulean/20 text-calor-cerulean'
+                            : result.winner === 'tie'
+                              ? 'bg-calor-salmon/20 text-calor-salmon'
+                              : 'bg-calor-cerulean/20 text-calor-cerulean'
                       )}
                     >
-                      {result.isCalorOnly ? 'Calor only' : result.winner === 'calor' ? 'Calor wins' : 'C# wins'}
+                      {result.isCalorOnly ? 'Calor only' : result.winner === 'calor' ? 'Calor wins' : result.winner === 'tie' ? 'Tie' : 'C# wins'}
                     </span>
                   </div>
                   <span className="font-mono font-bold">
@@ -189,7 +209,9 @@ export function BenchmarkChart() {
                         ? 'bg-gradient-to-r from-calor-pink to-calor-pink/60'
                         : result.winner === 'calor'
                           ? 'bg-gradient-to-r from-calor-pink to-calor-pink/80'
-                          : 'bg-gradient-to-r from-calor-cerulean to-calor-cerulean/80'
+                          : result.winner === 'tie'
+                            ? 'bg-gradient-to-r from-calor-salmon to-calor-salmon/80'
+                            : 'bg-gradient-to-r from-calor-cerulean to-calor-cerulean/80'
                     )}
                     style={{ width: result.isCalorOnly ? '100%' : `${getBarWidth(result.ratio)}%` }}
                   />
@@ -211,6 +233,10 @@ export function BenchmarkChart() {
             <div className="flex items-center gap-2">
               <div className="w-3 h-3 rounded-full bg-calor-pink" />
               <span>Calor better</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded-full bg-calor-salmon" />
+              <span>Tie</span>
             </div>
             <div className="flex items-center gap-2">
               <div className="w-3 h-3 rounded-full bg-calor-cerulean" />


### PR DESCRIPTION
## Summary
- Show benchmark ties as "Tie" instead of incorrectly showing "C# wins"
- Use the calor-salmon color (#FF8E77) for tie badges and progress bars
- Add tie interpretations for all metrics
- Update legends on both home page and documentation to include "Tie"

## Files Changed
- `website/src/components/landing/BenchmarkChart.tsx` - Home page benchmark display
- `website/src/components/benchmarks/BenchmarkDashboard.tsx` - Docs dashboard
- `website/src/components/benchmarks/BenchmarkSummaryTable.tsx` - Docs summary table
- `website/src/components/benchmarks/MetricCard.tsx` - Reusable metric card component

## Test plan
- [ ] Verify home page shows "Tie" with salmon color for Information Density and Correctness metrics
- [ ] Verify docs benchmark page shows "Tie" with salmon color
- [ ] Verify legends include "Tie" indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)