### PR TITLE
refactor(evaluation): remove obsolete static fallbacks from LLM metrics

### DIFF
--- a/tests/Calor.Evaluation/Benchmarks/BenchmarkRunner.cs
+++ b/tests/Calor.Evaluation/Benchmarks/BenchmarkRunner.cs
@@ -20,10 +20,12 @@ public class BenchmarkRunner
         var benchmarkPath = TestDataAdapter.GetBenchmarkPath();
         _adapter = new TestDataAdapter(testDataPath, benchmarkPath);
 
-        // Initialize all calculators
+        // Initialize static metrics only
+        // LLM-based metrics (TaskCompletion, Safety, EffectDiscipline) require
+        // an LLM provider and must be run separately via their dedicated commands
         _calculators = new List<IMetricCalculator>
         {
-            // Static metrics
+            // Static metrics - can run without LLM provider
             new TokenEconomicsCalculator(),
             new GenerationAccuracyCalculator(),
             new ComprehensionCalculator(),
@@ -31,13 +33,14 @@ public class BenchmarkRunner
             new ErrorDetectionCalculator(),
             new InformationDensityCalculator(),
             new RefactoringStabilityCalculator(),
-            // LLM-based metrics (use estimation mode by default if no provider configured)
-            new TaskCompletionCalculator(),
-            new SafetyCalculator(),
-            new EffectDisciplineCalculator(),
-            // Fair comparison metric - pure pass/fail on test cases
+            // Correctness uses code execution, not LLM generation
             new CorrectnessCalculator()
         };
+
+        // Note: LLM-based metrics are NOT included here:
+        // - TaskCompletionCalculator: run via 'llm-tasks' command
+        // - SafetyCalculator: run via 'safety-benchmark' command
+        // - EffectDisciplineCalculator: run via 'effect-discipline' command
     }
 
     /// <summary>

--- a/tests/Calor.Evaluation/Metrics/TaskCompletionCalculator.cs
+++ b/tests/Calor.Evaluation/Metrics/TaskCompletionCalculator.cs
@@ -12,9 +12,8 @@ namespace Calor.Evaluation.Metrics;
 /// This provides empirical evidence for whether Calor's explicit structure
 /// and contracts help AI agents write more correct code.
 ///
-/// Note: Previously there was a static TaskCompletionCalculator that estimated
-/// completion potential based on code structure. This has been replaced with
-/// this LLM-based implementation that actually generates and tests code.
+/// IMPORTANT: This metric requires an LLM provider. It cannot be used
+/// without configuring a provider (e.g., Claude API).
 /// </summary>
 public class TaskCompletionCalculator : IMetricCalculator
 {
@@ -23,35 +22,27 @@ public class TaskCompletionCalculator : IMetricCalculator
     public string Description =>
         "Measures AI agent task completion rates by generating and executing code in both languages";
 
-    private readonly ILlmProvider? _provider;
+    private readonly ILlmProvider _provider;
     private readonly LlmResponseCache? _cache;
-    private readonly LlmTaskManifest? _manifest;
+    private readonly LlmTaskManifest _manifest;
     private readonly LlmTaskRunnerOptions _runnerOptions;
     private LlmTaskRunResults? _lastResults;
 
     /// <summary>
-    /// Creates a calculator with default settings (uses mock provider if no API key).
+    /// Creates a calculator with specified provider and manifest.
     /// </summary>
-    public TaskCompletionCalculator()
-    {
-        _runnerOptions = new LlmTaskRunnerOptions
-        {
-            DryRun = true, // Default to dry run to avoid API costs
-            UseCache = true
-        };
-    }
-
-    /// <summary>
-    /// Creates a calculator with specified provider and options.
-    /// </summary>
+    /// <param name="provider">The LLM provider to use for code generation.</param>
+    /// <param name="manifest">The task manifest containing task definitions.</param>
+    /// <param name="options">Optional runner configuration.</param>
+    /// <param name="cache">Optional response cache for reducing API costs.</param>
     public TaskCompletionCalculator(
         ILlmProvider provider,
         LlmTaskManifest manifest,
         LlmTaskRunnerOptions? options = null,
         LlmResponseCache? cache = null)
     {
-        _provider = provider;
-        _manifest = manifest;
+        _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        _manifest = manifest ?? throw new ArgumentNullException(nameof(manifest));
         _cache = cache;
         _runnerOptions = options ?? new LlmTaskRunnerOptions();
     }
@@ -63,12 +54,6 @@ public class TaskCompletionCalculator : IMetricCalculator
 
     public async Task<MetricResult> CalculateAsync(EvaluationContext context)
     {
-        // If no provider or manifest configured, return estimation based on context
-        if (_provider == null || _manifest == null)
-        {
-            return CalculateEstimatedMetric(context);
-        }
-
         // Run actual LLM tasks
         using var runner = new LlmTaskRunner(_provider, _cache);
         _lastResults = await runner.RunAllAsync(_manifest, _runnerOptions);
@@ -93,108 +78,14 @@ public class TaskCompletionCalculator : IMetricCalculator
 
         return MetricResult.CreateHigherIsBetter(
             Category,
-            "ActualCompletion",
+            "TaskCompletion",
             summary.AverageCalorScore,
             summary.AverageCSharpScore,
             details);
     }
 
     /// <summary>
-    /// Calculates an estimated metric based on code characteristics when
-    /// actual LLM evaluation is not available.
-    /// </summary>
-    private MetricResult CalculateEstimatedMetric(EvaluationContext context)
-    {
-        // Estimate completion potential based on structural characteristics
-        var calorScore = EstimateCalorCompletionScore(context);
-        var csharpScore = EstimateCSharpCompletionScore(context);
-
-        var details = new Dictionary<string, object>
-        {
-            ["estimated"] = true,
-            ["reason"] = "No LLM provider configured - using structural estimation",
-            ["calorFactors"] = new Dictionary<string, object>
-            {
-                ["compiles"] = context.CalorCompilation.Success,
-                ["hasContracts"] = context.CalorSource.Contains("§REQ") ||
-                                   context.CalorSource.Contains("§ENS"),
-                ["hasExplicitTypes"] = context.CalorSource.Contains("§O{")
-            },
-            ["csharpFactors"] = new Dictionary<string, object>
-            {
-                ["compiles"] = context.CSharpCompilation.Success,
-                ["hasReturnStatements"] = context.CSharpSource.Contains("return ")
-            }
-        };
-
-        return MetricResult.CreateHigherIsBetter(
-            Category,
-            "EstimatedCompletion",
-            calorScore,
-            csharpScore,
-            details);
-    }
-
-    private static double EstimateCalorCompletionScore(EvaluationContext context)
-    {
-        var score = 0.0;
-
-        // Base compilation score
-        if (context.CalorCompilation.Success)
-            score += 0.4;
-
-        // Structure completeness
-        var source = context.CalorSource;
-        if (source.Contains("§M{") && source.Contains("§/M{"))
-            score += 0.1;
-        if (source.Contains("§F{") && source.Contains("§/F{"))
-            score += 0.1;
-        if (source.Contains("§B{") && source.Contains("§/B{"))
-            score += 0.1;
-
-        // Contracts provide additional correctness guarantees
-        if (source.Contains("§REQ") || source.Contains("§REQUIRE"))
-            score += 0.15;
-        if (source.Contains("§ENS") || source.Contains("§ENSURE"))
-            score += 0.15;
-
-        return Math.Min(score, 1.0);
-    }
-
-    private static double EstimateCSharpCompletionScore(EvaluationContext context)
-    {
-        var score = 0.0;
-
-        // Base compilation score
-        if (context.CSharpCompilation.Success)
-            score += 0.4;
-
-        // Structure completeness
-        var source = context.CSharpSource;
-        if (source.Contains("class ") || source.Contains("struct "))
-            score += 0.1;
-        if (source.Contains("public ") || source.Contains("private "))
-            score += 0.05;
-        if (source.Contains("return "))
-            score += 0.15;
-
-        // Method completeness
-        if (source.Contains("(") && source.Contains(")") && source.Contains("{"))
-            score += 0.1;
-
-        // Exception handling (equivalent to contracts)
-        if (source.Contains("throw ") || source.Contains("ArgumentException"))
-            score += 0.1;
-
-        // Documentation
-        if (source.Contains("///") || source.Contains("//"))
-            score += 0.05;
-
-        return Math.Min(score, 0.95); // Cap lower than Calor to reflect lack of contracts
-    }
-
-    /// <summary>
-    /// Creates a calculator configured for actual LLM evaluation.
+    /// Creates a calculator configured for LLM evaluation.
     /// </summary>
     public static TaskCompletionCalculator CreateWithProvider(
         ILlmProvider provider,

--- a/tests/Calor.Evaluation/Tests/BenchmarkRunnerTests.cs
+++ b/tests/Calor.Evaluation/Tests/BenchmarkRunnerTests.cs
@@ -71,7 +71,7 @@ public class BenchmarkRunnerTests
     }
 
     [Fact]
-    public void BenchmarkRunner_GetCalculators_ReturnsAllCalculators()
+    public void BenchmarkRunner_GetCalculators_ReturnsStaticCalculators()
     {
         // Arrange
         var runner = new BenchmarkRunner();
@@ -79,8 +79,10 @@ public class BenchmarkRunnerTests
         // Act
         var calculators = runner.GetCalculators();
 
-        // Assert - 11 calculators: 7 static + 3 LLM-based + 1 Calor-only
-        Assert.Equal(11, calculators.Count);
+        // Assert - 8 calculators: 7 static + 1 Correctness
+        // LLM-based metrics (TaskCompletion, Safety, EffectDiscipline) require
+        // an LLM provider and are run via dedicated commands
+        Assert.Equal(8, calculators.Count);
         // Static metrics
         Assert.Contains(calculators, c => c.Category == "TokenEconomics");
         Assert.Contains(calculators, c => c.Category == "GenerationAccuracy");
@@ -89,12 +91,13 @@ public class BenchmarkRunnerTests
         Assert.Contains(calculators, c => c.Category == "ErrorDetection");
         Assert.Contains(calculators, c => c.Category == "InformationDensity");
         Assert.Contains(calculators, c => c.Category == "RefactoringStability");
-        // LLM-based metrics
-        Assert.Contains(calculators, c => c.Category == "TaskCompletion");
-        Assert.Contains(calculators, c => c.Category == "Safety");
-        Assert.Contains(calculators, c => c.Category == "EffectDiscipline");
-        // Fair comparison metric
+        // Correctness uses code execution, not LLM generation
         Assert.Contains(calculators, c => c.Category == "Correctness");
+
+        // LLM-based metrics are NOT included by default
+        Assert.DoesNotContain(calculators, c => c.Category == "TaskCompletion");
+        Assert.DoesNotContain(calculators, c => c.Category == "Safety");
+        Assert.DoesNotContain(calculators, c => c.Category == "EffectDiscipline");
     }
 
     #endregion

--- a/tests/Calor.Evaluation/Tests/MetricCalculatorTests.cs
+++ b/tests/Calor.Evaluation/Tests/MetricCalculatorTests.cs
@@ -269,31 +269,9 @@ namespace Calculator
 
     #endregion
 
-    #region Task Completion Tests
-
-    [Fact]
-    public async Task TaskCompletionCalculator_CalculatesCompletionPotential()
-    {
-        // Arrange
-        var calculator = new TaskCompletionCalculator();
-        var context = CreateContext(
-            calor: @"§M{m001:Task}
-§F{f001:Run:pub}
-  §O{void}
-§/F{f001}
-§/M{m001}",
-            csharp: @"namespace Task { public class TaskModule { public void Run() { } } }");
-
-        // Act
-        var result = await calculator.CalculateAsync(context);
-
-        // Assert
-        Assert.Equal("TaskCompletion", result.Category);
-        Assert.True(result.Details.ContainsKey("calorFactors"));
-        Assert.True(result.Details.ContainsKey("csharpFactors"));
-    }
-
-    #endregion
+    // Note: Task Completion tests removed - this is now an LLM-only metric
+    // that requires an LLM provider and is tested via dedicated LLM task tests
+    // in LlmTaskTests.cs. The metric calculator tests focus on static metrics.
 
     #region MetricResult Tests
 


### PR DESCRIPTION
## Summary

- Remove obsolete static estimation fallbacks from LLM-based metric calculators
- These metrics now **require an LLM provider** - they cannot be used without one

## Problem

The TaskCompletion, Safety, and EffectDiscipline calculators had static fallback methods that:
1. Were biased (e.g., C# capped at 0.85-0.95 while Calor could reach 1.0)
2. Didn't actually measure what the metrics claim to measure
3. Gave the false impression that these benchmarks could run without LLM

## Changes

| File | Lines Removed | What Was Removed |
|------|---------------|------------------|
| `TaskCompletionCalculator.cs` | ~60 | `EstimateCalorCompletionScore`, `EstimateCSharpCompletionScore`, `CalculateEstimatedMetric` |
| `SafetyCalculator.cs` | ~60 | `EstimateCalorSafetyScore`, `EstimateCSharpSafetyScore`, `CalculateEstimatedMetric` |
| `EffectDisciplineCalculator.cs` | ~60 | `EstimateCalorDisciplineScore`, `EstimateCSharpDisciplineScore`, `CalculateEstimatedMetric` |
| `BenchmarkRunner.cs` | ~10 | Removed LLM calculators from default list |

**Net change: -308 lines of biased/obsolete code**

## How to Run LLM Metrics

These metrics must now be run via their dedicated commands:

```bash
# TaskCompletion
dotnet run --project tests/Calor.Evaluation -- llm-tasks -m tasks/task-manifest.json

# Safety  
dotnet run --project tests/Calor.Evaluation -- safety-benchmark -m tasks/task-manifest-safety.json

# EffectDiscipline
dotnet run --project tests/Calor.Evaluation -- effect-discipline -m tasks/task-manifest-effects.json
```

## Test plan

- [x] All 142 tests pass
- [x] Build succeeds with no warnings
- [x] LLM metrics still work via dedicated commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)