### PR TITLE
feat(mcp): add lint, format, diagnose, and ids tools

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -25,6 +25,10 @@ The `mcp` command starts an MCP server that exposes Calor compiler capabilities 
 - **Analyze** code for security vulnerabilities and bugs
 - **Convert** C# code to Calor
 - **Get syntax help** for Calor features
+- **Lint** code for agent-optimal format compliance
+- **Format** code to canonical style
+- **Diagnose** code with machine-readable diagnostics
+- **Manage IDs** (check and assign declaration IDs)
 
 The server communicates over stdio using the [Model Context Protocol](https://modelcontextprotocol.io/) specification.
 
@@ -41,7 +45,7 @@ The server communicates over stdio using the [Model Context Protocol](https://mo
 
 ## Available Tools
 
-The MCP server exposes five tools:
+The MCP server exposes nine tools:
 
 ### calor_compile
 
@@ -121,6 +125,68 @@ Get syntax documentation for a specific Calor feature.
 
 **Output:** Relevant syntax documentation and examples.
 
+### calor_lint
+
+Check Calor source code for agent-optimal format compliance.
+
+**Input Schema:**
+```json
+{
+  "source": "string (required) - Calor source code to lint",
+  "fix": "boolean - Return auto-fixed code in the response (default: false)"
+}
+```
+
+**Output:** Parse success status, lint issues with line numbers and messages, and optionally the fixed code.
+
+### calor_format
+
+Format Calor source code to canonical style.
+
+**Input Schema:**
+```json
+{
+  "source": "string (required) - Calor source code to format"
+}
+```
+
+**Output:** Formatted code and whether it changed from the original.
+
+### calor_diagnose
+
+Get machine-readable diagnostics from Calor source code.
+
+**Input Schema:**
+```json
+{
+  "source": "string (required) - Calor source code to diagnose",
+  "options": {
+    "strictApi": "boolean - Enable strict API checking (default: false)",
+    "requireDocs": "boolean - Require documentation on public functions (default: false)"
+  }
+}
+```
+
+**Output:** Errors and warnings with severity, code, message, line, and column.
+
+### calor_ids
+
+Manage Calor declaration IDs. Check for missing, duplicate, or invalid IDs and optionally assign new ones.
+
+**Input Schema:**
+```json
+{
+  "source": "string (required) - Calor source code to check/process",
+  "action": "string - 'check' validates IDs, 'assign' adds missing IDs (default: 'check')",
+  "options": {
+    "allowTestIds": "boolean - Allow test IDs (f001, m001) without flagging as issues (default: false)",
+    "fixDuplicates": "boolean - When assigning, also fix duplicate IDs (default: false)"
+  }
+}
+```
+
+**Output:** For 'check': ID issues with type, line, kind, name, and message. For 'assign': Modified code and list of assignments.
+
 ---
 
 ## Configuration
@@ -161,7 +227,7 @@ When you run `calor init --ai claude`, the MCP server is automatically configure
 
 This configures two servers:
 - **calor-lsp**: Language server for IDE features (diagnostics, hover, go-to-definition)
-- **calor**: MCP server with tools for compile, verify, analyze, convert, and syntax help
+- **calor**: MCP server with tools for compile, verify, analyze, convert, syntax help, lint, format, diagnose, and IDs
 
 ### VS Code
 

--- a/docs/getting-started/claude-integration.md
+++ b/docs/getting-started/claude-integration.md
@@ -45,6 +45,10 @@ In addition to skills and hooks, `calor init --ai claude` configures **MCP serve
 | `calor_analyze` | Analyze code for security vulnerabilities and bugs |
 | `calor_convert` | Convert C# code to Calor programmatically |
 | `calor_syntax_help` | Get syntax help for specific Calor features |
+| `calor_lint` | Check code for agent-optimal format compliance |
+| `calor_format` | Format code to canonical style |
+| `calor_diagnose` | Get machine-readable diagnostics with precise locations |
+| `calor_ids` | Check/assign declaration IDs (detect missing, duplicates, invalid) |
 
 These tools allow Claude to:
 - **Verify** your contracts are satisfiable before you run the code

--- a/src/Calor.Compiler/Mcp/McpMessageHandler.cs
+++ b/src/Calor.Compiler/Mcp/McpMessageHandler.cs
@@ -27,6 +27,10 @@ public sealed class McpMessageHandler
         RegisterTool(new AnalyzeTool());
         RegisterTool(new ConvertTool());
         RegisterTool(new SyntaxHelpTool());
+        RegisterTool(new LintTool());
+        RegisterTool(new FormatTool());
+        RegisterTool(new DiagnoseTool());
+        RegisterTool(new IdsTool());
     }
 
     private void RegisterTool(IMcpTool tool)

--- a/src/Calor.Compiler/Mcp/Tools/DiagnoseTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/DiagnoseTool.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Calor.Compiler.Mcp.Tools;
+
+/// <summary>
+/// MCP tool for getting machine-readable diagnostics from Calor source code.
+/// </summary>
+public sealed class DiagnoseTool : McpToolBase
+{
+    public override string Name => "calor_diagnose";
+
+    public override string Description =>
+        "Get machine-readable diagnostics from Calor source code. Returns errors and warnings with precise locations.";
+
+    protected override string GetInputSchemaJson() => """
+        {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": "Calor source code to diagnose"
+                },
+                "options": {
+                    "type": "object",
+                    "properties": {
+                        "strictApi": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Enable strict API checking"
+                        },
+                        "requireDocs": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Require documentation on public functions"
+                        }
+                    }
+                }
+            },
+            "required": ["source"]
+        }
+        """;
+
+    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var source = GetString(arguments, "source");
+        if (string.IsNullOrEmpty(source))
+        {
+            return Task.FromResult(McpToolResult.Error("Missing required parameter: source"));
+        }
+
+        var options = GetOptions(arguments);
+        var strictApi = GetBool(options, "strictApi");
+        var requireDocs = GetBool(options, "requireDocs");
+
+        try
+        {
+            var compileOptions = new CompilationOptions
+            {
+                StrictApi = strictApi,
+                RequireDocs = requireDocs
+            };
+
+            var result = Program.Compile(source, "mcp-input.calr", compileOptions);
+
+            var diagnostics = result.Diagnostics.Select(d => new DiagnosticOutput
+            {
+                Severity = d.IsError ? "error" : "warning",
+                Code = d.Code.ToString(),
+                Message = d.Message,
+                Line = d.Span.Line,
+                Column = d.Span.Column
+            }).ToList();
+
+            var output = new DiagnoseToolOutput
+            {
+                Success = !result.HasErrors,
+                ErrorCount = diagnostics.Count(d => d.Severity == "error"),
+                WarningCount = diagnostics.Count(d => d.Severity == "warning"),
+                Diagnostics = diagnostics
+            };
+
+            return Task.FromResult(McpToolResult.Json(output, isError: result.HasErrors));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(McpToolResult.Error($"Diagnose failed: {ex.Message}"));
+        }
+    }
+
+    private sealed class DiagnoseToolOutput
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; init; }
+
+        [JsonPropertyName("errorCount")]
+        public int ErrorCount { get; init; }
+
+        [JsonPropertyName("warningCount")]
+        public int WarningCount { get; init; }
+
+        [JsonPropertyName("diagnostics")]
+        public required List<DiagnosticOutput> Diagnostics { get; init; }
+    }
+
+    private sealed class DiagnosticOutput
+    {
+        [JsonPropertyName("severity")]
+        public required string Severity { get; init; }
+
+        [JsonPropertyName("code")]
+        public required string Code { get; init; }
+
+        [JsonPropertyName("message")]
+        public required string Message { get; init; }
+
+        [JsonPropertyName("line")]
+        public int Line { get; init; }
+
+        [JsonPropertyName("column")]
+        public int Column { get; init; }
+    }
+}

--- a/src/Calor.Compiler/Mcp/Tools/FormatTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/FormatTool.cs
@@ -1,0 +1,130 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Formatting;
+using Calor.Compiler.Parsing;
+
+namespace Calor.Compiler.Mcp.Tools;
+
+/// <summary>
+/// MCP tool for formatting Calor source code to canonical style.
+/// </summary>
+public sealed class FormatTool : McpToolBase
+{
+    public override string Name => "calor_format";
+
+    public override string Description =>
+        "Format Calor source code to canonical style. Returns the formatted code.";
+
+    protected override string GetInputSchemaJson() => """
+        {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": "Calor source code to format"
+                }
+            },
+            "required": ["source"]
+        }
+        """;
+
+    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var source = GetString(arguments, "source");
+        if (string.IsNullOrEmpty(source))
+        {
+            return Task.FromResult(McpToolResult.Error("Missing required parameter: source"));
+        }
+
+        try
+        {
+            var result = FormatSource(source);
+
+            var output = new FormatToolOutput
+            {
+                Success = result.Success,
+                FormattedCode = result.Formatted,
+                IsChanged = result.Original != result.Formatted,
+                Errors = result.Errors.Count > 0 ? result.Errors : null
+            };
+
+            return Task.FromResult(McpToolResult.Json(output, isError: !result.Success));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(McpToolResult.Error($"Format failed: {ex.Message}"));
+        }
+    }
+
+    private static FormatResult FormatSource(string source)
+    {
+        // Parse the source
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath("mcp-input.calr");
+
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+
+        if (diagnostics.HasErrors)
+        {
+            return new FormatResult
+            {
+                Success = false,
+                Original = source,
+                Formatted = source,
+                Errors = diagnostics.Errors.Select(e => e.Message).ToList()
+            };
+        }
+
+        var parser = new Parser(tokens, diagnostics);
+        var ast = parser.Parse();
+
+        if (diagnostics.HasErrors)
+        {
+            return new FormatResult
+            {
+                Success = false,
+                Original = source,
+                Formatted = source,
+                Errors = diagnostics.Errors.Select(e => e.Message).ToList()
+            };
+        }
+
+        // Format the AST
+        var formatter = new CalorFormatter();
+        var formatted = formatter.Format(ast);
+
+        return new FormatResult
+        {
+            Success = true,
+            Original = source,
+            Formatted = formatted,
+            Errors = new List<string>()
+        };
+    }
+
+    private sealed class FormatResult
+    {
+        public bool Success { get; init; }
+        public required string Original { get; init; }
+        public required string Formatted { get; init; }
+        public required List<string> Errors { get; init; }
+    }
+
+    private sealed class FormatToolOutput
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; init; }
+
+        [JsonPropertyName("formattedCode")]
+        public required string FormattedCode { get; init; }
+
+        [JsonPropertyName("isChanged")]
+        public bool IsChanged { get; init; }
+
+        [JsonPropertyName("errors")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string>? Errors { get; init; }
+    }
+}

--- a/src/Calor.Compiler/Mcp/Tools/IdsTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/IdsTool.cs
@@ -1,0 +1,311 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Ids;
+using Calor.Compiler.Parsing;
+
+namespace Calor.Compiler.Mcp.Tools;
+
+/// <summary>
+/// MCP tool for managing Calor declaration IDs (check for issues, assign missing IDs).
+/// </summary>
+public sealed class IdsTool : McpToolBase
+{
+    public override string Name => "calor_ids";
+
+    public override string Description =>
+        "Manage Calor declaration IDs. Check for missing, duplicate, or invalid IDs and optionally assign new ones.";
+
+    protected override string GetInputSchemaJson() => """
+        {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": "Calor source code to check/process"
+                },
+                "action": {
+                    "type": "string",
+                    "enum": ["check", "assign"],
+                    "default": "check",
+                    "description": "Action to perform: 'check' validates IDs, 'assign' adds missing IDs"
+                },
+                "options": {
+                    "type": "object",
+                    "properties": {
+                        "allowTestIds": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Allow test IDs (f001, m001) without flagging as issues"
+                        },
+                        "fixDuplicates": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "When assigning, also fix duplicate IDs"
+                        }
+                    }
+                }
+            },
+            "required": ["source"]
+        }
+        """;
+
+    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var source = GetString(arguments, "source");
+        if (string.IsNullOrEmpty(source))
+        {
+            return Task.FromResult(McpToolResult.Error("Missing required parameter: source"));
+        }
+
+        var action = GetString(arguments, "action") ?? "check";
+        var options = GetOptions(arguments);
+        var allowTestIds = GetBool(options, "allowTestIds");
+        var fixDuplicates = GetBool(options, "fixDuplicates");
+
+        try
+        {
+            return action.ToLowerInvariant() switch
+            {
+                "assign" => Task.FromResult(AssignIds(source, allowTestIds, fixDuplicates)),
+                _ => Task.FromResult(CheckIds(source, allowTestIds))
+            };
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(McpToolResult.Error($"ID operation failed: {ex.Message}"));
+        }
+    }
+
+    private static McpToolResult CheckIds(string source, bool allowTestIds)
+    {
+        var entries = ScanSource(source);
+        if (entries == null)
+        {
+            return McpToolResult.Error("Failed to parse source code");
+        }
+
+        var result = IdChecker.Check(entries, allowTestIds);
+
+        var issues = new List<IdIssueOutput>();
+
+        foreach (var entry in result.MissingIds)
+        {
+            issues.Add(new IdIssueOutput
+            {
+                Type = "missing",
+                Line = entry.Span.Line,
+                Kind = entry.Kind.ToString(),
+                Name = entry.Name,
+                Message = $"Missing ID for {entry.Kind} '{entry.Name}'"
+            });
+        }
+
+        foreach (var entry in result.InvalidFormatIds)
+        {
+            issues.Add(new IdIssueOutput
+            {
+                Type = "invalid_format",
+                Line = entry.Span.Line,
+                Kind = entry.Kind.ToString(),
+                Name = entry.Name,
+                Id = entry.Id,
+                Message = $"Invalid ID format: '{entry.Id}'"
+            });
+        }
+
+        foreach (var entry in result.WrongPrefixIds)
+        {
+            issues.Add(new IdIssueOutput
+            {
+                Type = "wrong_prefix",
+                Line = entry.Span.Line,
+                Kind = entry.Kind.ToString(),
+                Name = entry.Name,
+                Id = entry.Id,
+                Message = $"Wrong prefix for {entry.Kind}: '{entry.Id}'"
+            });
+        }
+
+        foreach (var entry in result.TestIdsInProduction)
+        {
+            issues.Add(new IdIssueOutput
+            {
+                Type = "test_id",
+                Line = entry.Span.Line,
+                Kind = entry.Kind.ToString(),
+                Name = entry.Name,
+                Id = entry.Id,
+                Message = $"Test ID in production code: '{entry.Id}'"
+            });
+        }
+
+        foreach (var group in result.DuplicateGroups)
+        {
+            foreach (var entry in group.Skip(1)) // First one is the original
+            {
+                issues.Add(new IdIssueOutput
+                {
+                    Type = "duplicate",
+                    Line = entry.Span.Line,
+                    Kind = entry.Kind.ToString(),
+                    Name = entry.Name,
+                    Id = entry.Id,
+                    Message = $"Duplicate ID: '{entry.Id}' (first used at line {group.First().Span.Line})"
+                });
+            }
+        }
+
+        var output = new IdsCheckOutput
+        {
+            Success = result.IsValid,
+            TotalIds = entries.Count,
+            IssueCount = result.TotalIssues,
+            Issues = issues
+        };
+
+        return McpToolResult.Json(output, isError: !result.IsValid);
+    }
+
+    private static McpToolResult AssignIds(string source, bool allowTestIds, bool fixDuplicates)
+    {
+        var existingIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (!fixDuplicates)
+        {
+            var entries = ScanSource(source);
+            if (entries != null)
+            {
+                foreach (var entry in entries.Where(e => !string.IsNullOrEmpty(e.Id)))
+                {
+                    if (allowTestIds && entry.IsTestId)
+                        continue;
+                    existingIds.Add(entry.Id);
+                }
+            }
+        }
+
+        var (newContent, assignments) = IdAssigner.AssignIds(source, "mcp-input.calr", fixDuplicates, existingIds);
+
+        // Update closing tags
+        if (assignments.Count > 0)
+        {
+            newContent = IdAssigner.UpdateClosingTags(newContent, assignments);
+        }
+
+        var output = new IdsAssignOutput
+        {
+            Success = true,
+            AssignedCount = assignments.Count(a => string.IsNullOrEmpty(a.OldId)),
+            DuplicatesFixedCount = assignments.Count(a => !string.IsNullOrEmpty(a.OldId)),
+            ModifiedCode = newContent,
+            Assignments = assignments.Select(a => new IdAssignmentOutput
+            {
+                Line = a.Line,
+                Kind = a.Kind.ToString(),
+                Name = a.Name,
+                OldId = string.IsNullOrEmpty(a.OldId) ? null : a.OldId,
+                NewId = a.NewId
+            }).ToList()
+        };
+
+        return McpToolResult.Json(output);
+    }
+
+    private static IReadOnlyList<IdEntry>? ScanSource(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath("mcp-input.calr");
+
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+
+        if (diagnostics.HasErrors)
+            return null;
+
+        var parser = new Parser(tokens, diagnostics);
+        var module = parser.Parse();
+
+        if (diagnostics.HasErrors)
+            return null;
+
+        var scanner = new IdScanner();
+        return scanner.Scan(module, "mcp-input.calr");
+    }
+
+    // Output types for check action
+    private sealed class IdsCheckOutput
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; init; }
+
+        [JsonPropertyName("totalIds")]
+        public int TotalIds { get; init; }
+
+        [JsonPropertyName("issueCount")]
+        public int IssueCount { get; init; }
+
+        [JsonPropertyName("issues")]
+        public required List<IdIssueOutput> Issues { get; init; }
+    }
+
+    private sealed class IdIssueOutput
+    {
+        [JsonPropertyName("type")]
+        public required string Type { get; init; }
+
+        [JsonPropertyName("line")]
+        public int Line { get; init; }
+
+        [JsonPropertyName("kind")]
+        public required string Kind { get; init; }
+
+        [JsonPropertyName("name")]
+        public required string Name { get; init; }
+
+        [JsonPropertyName("id")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Id { get; init; }
+
+        [JsonPropertyName("message")]
+        public required string Message { get; init; }
+    }
+
+    // Output types for assign action
+    private sealed class IdsAssignOutput
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; init; }
+
+        [JsonPropertyName("assignedCount")]
+        public int AssignedCount { get; init; }
+
+        [JsonPropertyName("duplicatesFixedCount")]
+        public int DuplicatesFixedCount { get; init; }
+
+        [JsonPropertyName("modifiedCode")]
+        public required string ModifiedCode { get; init; }
+
+        [JsonPropertyName("assignments")]
+        public required List<IdAssignmentOutput> Assignments { get; init; }
+    }
+
+    private sealed class IdAssignmentOutput
+    {
+        [JsonPropertyName("line")]
+        public int Line { get; init; }
+
+        [JsonPropertyName("kind")]
+        public required string Kind { get; init; }
+
+        [JsonPropertyName("name")]
+        public required string Name { get; init; }
+
+        [JsonPropertyName("oldId")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? OldId { get; init; }
+
+        [JsonPropertyName("newId")]
+        public required string NewId { get; init; }
+    }
+}

--- a/src/Calor.Compiler/Mcp/Tools/LintTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/LintTool.cs
@@ -1,0 +1,230 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Formatting;
+using Calor.Compiler.Parsing;
+
+namespace Calor.Compiler.Mcp.Tools;
+
+/// <summary>
+/// MCP tool for linting Calor source code for agent-optimal format compliance.
+/// </summary>
+public sealed class LintTool : McpToolBase
+{
+    public override string Name => "calor_lint";
+
+    public override string Description =>
+        "Check Calor source code for agent-optimal format compliance. Returns lint issues and optionally the fixed code.";
+
+    protected override string GetInputSchemaJson() => """
+        {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": "Calor source code to lint"
+                },
+                "fix": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Return auto-fixed code in the response"
+                }
+            },
+            "required": ["source"]
+        }
+        """;
+
+    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var source = GetString(arguments, "source");
+        if (string.IsNullOrEmpty(source))
+        {
+            return Task.FromResult(McpToolResult.Error("Missing required parameter: source"));
+        }
+
+        var fix = GetBool(arguments, "fix");
+
+        try
+        {
+            var result = LintSource(source);
+
+            var output = new LintToolOutput
+            {
+                Success = result.ParseSuccess && result.Issues.Count == 0,
+                ParseSuccess = result.ParseSuccess,
+                IssueCount = result.Issues.Count,
+                Issues = result.Issues.Select(i => new LintIssueOutput
+                {
+                    Line = i.Line,
+                    Message = i.Message
+                }).ToList(),
+                ParseErrors = result.ParseErrors,
+                FixedCode = fix ? result.FixedContent : null
+            };
+
+            return Task.FromResult(McpToolResult.Json(output, isError: !result.ParseSuccess));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(McpToolResult.Error($"Lint failed: {ex.Message}"));
+        }
+    }
+
+    private static LintResult LintSource(string source)
+    {
+        var issues = new List<LintIssue>();
+
+        // Check source-level issues before parsing
+        var lines = source.Split('\n');
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var lineNum = i + 1;
+
+            // Check for leading whitespace (indentation)
+            if (line.Length > 0 && char.IsWhiteSpace(line[0]) && line.TrimStart().Length > 0)
+            {
+                issues.Add(new LintIssue(lineNum, "Line has leading whitespace (indentation not allowed)"));
+            }
+
+            // Check for trailing whitespace
+            if (line.Length > 0 && line.TrimEnd('\r') != line.TrimEnd('\r').TrimEnd())
+            {
+                issues.Add(new LintIssue(lineNum, "Line has trailing whitespace"));
+            }
+
+            // Check for non-abbreviated IDs: m001, f001, etc.
+            var paddedIdMatch = Regex.Match(line, @"§[A-Z/]+\{([a-zA-Z]+)(0+)(\d+)");
+            if (paddedIdMatch.Success)
+            {
+                var prefix = paddedIdMatch.Groups[1].Value;
+                var zeros = paddedIdMatch.Groups[2].Value;
+                var number = paddedIdMatch.Groups[3].Value;
+                var oldId = prefix + zeros + number;
+                var newId = prefix + number;
+                issues.Add(new LintIssue(lineNum, $"ID should be abbreviated: use '{newId}' instead of '{oldId}'"));
+            }
+
+            // Check for verbose loop/condition IDs: for1, if1, while1, do1
+            var verboseIdPatterns = new[]
+            {
+                (@"§L\{(for)(\d+)", "l"),
+                (@"§/L\{(for)(\d+)", "l"),
+                (@"§IF\{(if)(\d+)", "i"),
+                (@"§/I\{(if)(\d+)", "i"),
+                (@"§WHILE\{(while)(\d+)", "w"),
+                (@"§/WHILE\{(while)(\d+)", "w"),
+                (@"§DO\{(do)(\d+)", "d"),
+                (@"§/DO\{(do)(\d+)", "d")
+            };
+
+            foreach (var (pattern, replacement) in verboseIdPatterns)
+            {
+                var match = Regex.Match(line, pattern);
+                if (match.Success)
+                {
+                    var oldId = match.Groups[1].Value + match.Groups[2].Value;
+                    var newId = replacement + match.Groups[2].Value;
+                    issues.Add(new LintIssue(lineNum, $"ID should be abbreviated: use '{newId}' instead of '{oldId}'"));
+                }
+            }
+
+            // Check for blank lines (empty or whitespace-only)
+            if (string.IsNullOrWhiteSpace(line.TrimEnd('\r')))
+            {
+                issues.Add(new LintIssue(lineNum, "Blank lines not allowed in agent-optimized format"));
+            }
+        }
+
+        // Parse the file to generate fixed content
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath("mcp-input.calr");
+
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+
+        if (diagnostics.HasErrors)
+        {
+            return new LintResult
+            {
+                ParseSuccess = false,
+                ParseErrors = diagnostics.Errors.Select(e => e.Message).ToList(),
+                Issues = issues,
+                OriginalContent = source,
+                FixedContent = source
+            };
+        }
+
+        var parser = new Parser(tokens, diagnostics);
+        var ast = parser.Parse();
+
+        if (diagnostics.HasErrors)
+        {
+            return new LintResult
+            {
+                ParseSuccess = false,
+                ParseErrors = diagnostics.Errors.Select(e => e.Message).ToList(),
+                Issues = issues,
+                OriginalContent = source,
+                FixedContent = source
+            };
+        }
+
+        // Format the AST to get the canonical (fixed) version
+        var formatter = new CalorFormatter();
+        var fixedContent = formatter.Format(ast);
+
+        return new LintResult
+        {
+            ParseSuccess = true,
+            ParseErrors = new List<string>(),
+            Issues = issues,
+            OriginalContent = source,
+            FixedContent = fixedContent
+        };
+    }
+
+    private sealed class LintResult
+    {
+        public bool ParseSuccess { get; init; }
+        public required List<string> ParseErrors { get; init; }
+        public required List<LintIssue> Issues { get; init; }
+        public required string OriginalContent { get; init; }
+        public required string FixedContent { get; init; }
+    }
+
+    private sealed record LintIssue(int Line, string Message);
+
+    private sealed class LintToolOutput
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; init; }
+
+        [JsonPropertyName("parseSuccess")]
+        public bool ParseSuccess { get; init; }
+
+        [JsonPropertyName("issueCount")]
+        public int IssueCount { get; init; }
+
+        [JsonPropertyName("issues")]
+        public required List<LintIssueOutput> Issues { get; init; }
+
+        [JsonPropertyName("parseErrors")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string>? ParseErrors { get; init; }
+
+        [JsonPropertyName("fixedCode")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? FixedCode { get; init; }
+    }
+
+    private sealed class LintIssueOutput
+    {
+        [JsonPropertyName("line")]
+        public int Line { get; init; }
+
+        [JsonPropertyName("message")]
+        public required string Message { get; init; }
+    }
+}


### PR DESCRIPTION
## Summary

- Add 4 missing MCP tools: `calor_lint`, `calor_format`, `calor_diagnose`, `calor_ids`
- Update MCP server to register all 9 tools (was 5)
- Update documentation in `docs/cli/mcp.md` and `docs/getting-started/claude-integration.md`

## Test plan

- [x] All 79 MCP tests pass
- [x] Project builds successfully
- [ ] Verify tools work via MCP protocol manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)