### PR TITLE
fix(ci): run all benchmarks on release and use human-readable metric names

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,6 +4,9 @@ on:
   # Run weekly on Sunday at midnight UTC
   schedule:
     - cron: '0 0 * * 0'
+  # Run on releases - includes all benchmarks (LLM included)
+  release:
+    types: [created]
   # Allow manual trigger
   workflow_dispatch:
     inputs:
@@ -71,7 +74,7 @@ jobs:
 
       # LLM Benchmarks - run on schedule, or when not skipped
       - name: Restore LLM response cache
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.skip_llm != 'true')
+        if: github.event_name == 'schedule' || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.skip_llm != 'true')
         uses: actions/cache@v4
         with:
           path: ~/.calor/llm-cache
@@ -80,7 +83,7 @@ jobs:
             llm-cache-
 
       - name: Run TaskCompletion benchmark (LLM)
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.skip_llm != 'true')
+        if: github.event_name == 'schedule' || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.skip_llm != 'true')
         continue-on-error: true
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -96,7 +99,7 @@ jobs:
             --verbose
 
       - name: Run Safety benchmark (LLM)
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.skip_llm != 'true')
+        if: github.event_name == 'schedule' || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.skip_llm != 'true')
         continue-on-error: true
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -111,7 +114,7 @@ jobs:
             --verbose
 
       - name: Run EffectDiscipline benchmark (LLM)
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.skip_llm != 'true')
+        if: github.event_name == 'schedule' || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.skip_llm != 'true')
         continue-on-error: true
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -131,7 +134,7 @@ jobs:
           node-version: '20'
 
       - name: Merge LLM results into benchmark-results.json
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.skip_llm != 'true')
+        if: github.event_name == 'schedule' || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.skip_llm != 'true')
         run: |
           node scripts/merge-llm-results.js
 

--- a/tests/Calor.Evaluation/Program.cs
+++ b/tests/Calor.Evaluation/Program.cs
@@ -830,6 +830,27 @@ public static class Program
         await File.WriteAllTextAsync(outputPath, html);
     }
 
+    // Human-readable metric names for HTML dashboard
+    private static readonly Dictionary<string, string> MetricDisplayNames = new()
+    {
+        ["TokenEconomics"] = "Token Economics",
+        ["GenerationAccuracy"] = "Generation Accuracy",
+        ["Comprehension"] = "Comprehension",
+        ["EditPrecision"] = "Edit Precision",
+        ["ErrorDetection"] = "Error Detection",
+        ["InformationDensity"] = "Information Density",
+        ["TaskCompletion"] = "Task Completion",
+        ["RefactoringStability"] = "Refactoring Stability",
+        ["Safety"] = "Safety",
+        ["EffectDiscipline"] = "Effect Discipline",
+        ["Correctness"] = "Correctness",
+    };
+
+    private static string GetMetricDisplayName(string category)
+    {
+        return MetricDisplayNames.TryGetValue(category, out var displayName) ? displayName : category;
+    }
+
     private static string GenerateMetricRows(EvaluationResult result)
     {
         var rows = new System.Text.StringBuilder();
@@ -854,8 +875,9 @@ public static class Program
                 ciStr = $"<span class=\"ci\">[{ci.Lower:F2}, {ci.Upper:F2}]</span>";
             }
 
+            var displayName = GetMetricDisplayName(category);
             rows.AppendLine($@"                    <tr>
-                        <td>{category}</td>
+                        <td>{displayName}</td>
                         <td class=""{winnerClass}"">{advantage:F2}x</td>
                         <td><span class=""badge {badgeClass}"">{winner}</span></td>
                         <td>{ciStr}</td>


### PR DESCRIPTION
## Summary
- Add `release` trigger to benchmark workflow to run all 11 benchmarks on release
- LLM benchmarks (TaskCompletion, Safety, EffectDiscipline) now run on release events
- Add human-readable metric names to HTML dashboard generator

## Changes

### `.github/workflows/benchmark.yml`
- Added `release: [created]` trigger
- Updated LLM benchmark conditions to include `github.event_name == 'release'`

### `tests/Calor.Evaluation/Program.cs`
- Added `MetricDisplayNames` dictionary with human-readable names
- Updated `GenerateMetricRows` to use display names (e.g., "TokenEconomics" -> "Token Economics")

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Create a test release to verify all 11 benchmarks run
- [ ] Check HTML dashboard shows human-readable names

🤖 Generated with [Claude Code](https://claude.com/claude-code)