### PR TITLE
feat(mcp): add calor_assess tool for C# migration analysis

### DIFF
--- a/docs/cli/benchmark.md
+++ b/docs/cli/benchmark.md
@@ -332,7 +332,7 @@ Measures end-to-end success:
 
 ## See Also
 
-- [calor analyze](/calor/cli/analyze/) - Score files for migration potential
+- [calor assess](/calor/cli/assess/) - Score files for migration potential
 - [calor convert](/calor/cli/convert/) - Convert files with benchmark option
 - [Benchmarking](/calor/benchmarking/) - Detailed methodology documentation
 - [Results](/calor/benchmarking/results/) - Published benchmark results

--- a/docs/cli/convert.md
+++ b/docs/cli/convert.md
@@ -258,6 +258,6 @@ Review the warnings and manually adjust as needed.
 ## See Also
 
 - [calor migrate](/calor/cli/migrate/) - Convert entire projects
-- [calor analyze](/calor/cli/analyze/) - Find best conversion candidates
+- [calor assess](/calor/cli/assess/) - Find best conversion candidates
 - [calor benchmark](/calor/cli/benchmark/) - Detailed metrics comparison
 - [Adding Calor to Existing Projects](/calor/guides/adding-calor-to-existing-projects/) - Complete migration guide

--- a/docs/cli/diagnose.md
+++ b/docs/cli/diagnose.md
@@ -344,4 +344,4 @@ fi
 
 - [calor format](/calor/cli/format/) - Format Calor source files
 - [calor compile](/calor/cli/compile/) - Compile with error reporting
-- [calor analyze](/calor/cli/analyze/) - Analyze C# for migration potential
+- [calor assess](/calor/cli/assess/) - Assess C# for migration potential

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -33,7 +33,7 @@ dotnet tool update -g calor
 | Command | Description |
 |:--------|:------------|
 | `calor` (default) | Compile Calor source files to C# |
-| [`calor analyze`](/calor/cli/analyze/) | Score C# files for Calor migration potential |
+| [`calor assess`](/calor/cli/assess/) | Score C# files for Calor migration potential |
 | [`calor init`](/calor/cli/init/) | Initialize Calor with AI agent support and .csproj integration |
 | [`calor convert`](/calor/cli/convert/) | Convert single files between C# and Calor |
 | [`calor migrate`](/calor/cli/migrate/) | Migrate entire projects between C# and Calor |

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -207,7 +207,7 @@ This means:
 - Codex *should* create `.calr` files based on the instructions
 - However, enforcement is not automatic - Codex may occasionally create `.cs` files
 - Review file extensions after code generation
-- Use `calor analyze` to find any unconverted `.cs` files
+- Use `calor assess` to find any unconverted `.cs` files
 
 After initialization, use these Codex commands:
 
@@ -302,7 +302,7 @@ This means:
 - Copilot *should* create `.calr` files based on the instructions
 - However, enforcement is not automatic - Copilot may occasionally create `.cs` files
 - Review file extensions after code generation
-- Use `calor analyze` to find any unconverted `.cs` files
+- Use `calor assess` to find any unconverted `.cs` files
 
 After initialization, reference the Calor skills when asking Copilot about Calor syntax or converting C# code.
 
@@ -473,7 +473,7 @@ cd ~/projects/MyApp
 calor init
 
 # Analyze codebase for migration candidates
-calor analyze ./src --top 10
+calor assess ./src --top 10
 ```
 
 ### Initialize with Claude Code
@@ -584,7 +584,7 @@ calor init --solution MyApp.sln --ai claude
 
 - [Adding Calor to Existing Projects](/calor/guides/adding-calor-to-existing-projects/) - Complete migration guide
 - [calor convert](/calor/cli/convert/) - Convert individual files
-- [calor analyze](/calor/cli/analyze/) - Find migration candidates
+- [calor assess](/calor/cli/assess/) - Find migration candidates
 - [Claude Integration](/calor/getting-started/claude-integration/) - Using Calor with Claude Code
 - [Codex Integration](/calor/getting-started/codex-integration/) - Using Calor with OpenAI Codex CLI
 - [Gemini Integration](/calor/getting-started/gemini-integration/) - Using Calor with Google Gemini CLI

--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -29,6 +29,7 @@ The `mcp` command starts an MCP server that exposes Calor compiler capabilities 
 - **Format** code to canonical style
 - **Diagnose** code with machine-readable diagnostics
 - **Manage IDs** (check and assign declaration IDs)
+- **Assess** C# code for Calor migration potential
 
 The server communicates over stdio using the [Model Context Protocol](https://modelcontextprotocol.io/) specification.
 
@@ -45,7 +46,7 @@ The server communicates over stdio using the [Model Context Protocol](https://mo
 
 ## Available Tools
 
-The MCP server exposes nine tools:
+The MCP server exposes ten tools:
 
 ### calor_compile
 
@@ -186,6 +187,33 @@ Manage Calor declaration IDs. Check for missing, duplicate, or invalid IDs and o
 ```
 
 **Output:** For 'check': ID issues with type, line, kind, name, and message. For 'assign': Modified code and list of assignments.
+
+### calor_assess
+
+Assess C# source code for Calor migration potential. Returns scores across 8 dimensions plus detection of unsupported C# constructs.
+
+**Input Schema:**
+```json
+{
+  "source": "string - C# source code to assess (single file mode)",
+  "files": "array - Multiple C# files to assess (multi-file mode), each with 'path' and 'source'",
+  "options": {
+    "threshold": "integer - Minimum score (0-100) to include in results (default: 0)"
+  }
+}
+```
+
+**Scoring Dimensions:**
+- **ContractPotential** (18%): Argument validation, assertions -> contracts
+- **EffectPotential** (13%): I/O, network, database calls -> effect declarations
+- **NullSafetyPotential** (18%): Nullable types, null checks -> Option&lt;T&gt;
+- **ErrorHandlingPotential** (18%): Try/catch, throw -> Result&lt;T,E&gt;
+- **PatternMatchPotential** (8%): Switch statements -> exhaustiveness checking
+- **ApiComplexityPotential** (13%): Undocumented public APIs
+- **AsyncPotential** (6%): async/await, Task&lt;T&gt; returns
+- **LinqPotential** (6%): LINQ method usage
+
+**Output:** Summary with average score and priority breakdown, plus per-file details including scores, dimensions, and unsupported constructs.
 
 ---
 

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -317,6 +317,6 @@ fi
 ## See Also
 
 - [calor convert](/calor/cli/convert/) - Convert single files
-- [calor analyze](/calor/cli/analyze/) - Find migration candidates
+- [calor assess](/calor/cli/assess/) - Find migration candidates
 - [calor benchmark](/calor/cli/benchmark/) - Detailed metrics comparison
 - [Adding Calor to Existing Projects](/calor/guides/adding-calor-to-existing-projects/) - Complete migration guide

--- a/docs/getting-started/claude-integration.md
+++ b/docs/getting-started/claude-integration.md
@@ -49,12 +49,14 @@ In addition to skills and hooks, `calor init --ai claude` configures **MCP serve
 | `calor_format` | Format code to canonical style |
 | `calor_diagnose` | Get machine-readable diagnostics with precise locations |
 | `calor_ids` | Check/assign declaration IDs (detect missing, duplicates, invalid) |
+| `calor_assess` | Assess C# code for Calor migration potential (scores across 8 dimensions) |
 
 These tools allow Claude to:
 - **Verify** your contracts are satisfiable before you run the code
 - **Catch bugs** through static analysis during code generation
 - **Convert** existing C# code to Calor on-the-fly
 - **Look up** Calor syntax without leaving the conversation
+- **Assess** C# files to prioritize which ones benefit most from Calor migration
 
 The MCP servers are configured in `.claude/settings.json`:
 

--- a/docs/getting-started/codex-integration.md
+++ b/docs/getting-started/codex-integration.md
@@ -39,7 +39,7 @@ Unlike Claude Code which uses hooks to enforce Calor-first development, **Codex 
 - Codex *should* follow the instructions in AGENTS.md and create `.calr` files
 - However, enforcement is not automatic - Codex may occasionally create `.cs` files
 - Always review file extensions after code generation
-- Use `calor analyze` to find any unconverted `.cs` files
+- Use `calor assess` to find any unconverted `.cs` files
 
 ---
 
@@ -222,7 +222,7 @@ Since Codex doesn't enforce Calor-first automatically, periodically check for un
 
 ```bash
 # Find C# files that might need conversion
-calor analyze ./src --top 10
+calor assess ./src --top 10
 
 # Check for any new .cs files that should be .calr
 find . -name "*.cs" -not -name "*.g.cs" -not -path "./obj/*"
@@ -235,7 +235,7 @@ find . -name "*.cs" -not -name "*.g.cs" -not -path "./obj/*"
 1. **Review generated files** - Always check that Codex created `.calr` files, not `.cs`
 2. **Use explicit instructions** - Be specific about wanting Calor output
 3. **Include skill reference** - Start prompts with `$calor` or `$calor-convert`
-4. **Run analysis regularly** - Use `calor analyze` to find migration candidates
+4. **Run analysis regularly** - Use `calor assess` to find migration candidates
 5. **Convert promptly** - If Codex creates a `.cs` file, convert it immediately
 
 ---

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -119,7 +119,7 @@ See [Hello World](/calor/getting-started/hello-world/) for a detailed explanatio
 For existing C# codebases, analyze which files are good candidates for migration:
 
 ```bash
-calor analyze ./src --top 10
+calor assess ./src --top 10
 ```
 
 Then convert high-scoring files:

--- a/docs/guides/adding-calor-to-existing-projects.md
+++ b/docs/guides/adding-calor-to-existing-projects.md
@@ -60,20 +60,20 @@ After this step, you can immediately start writing `.calr` files and they'll com
 
 ## Step 2: Analyze Your Codebase
 
-Use `calor analyze` to find C# files that would benefit most from Calor:
+Use `calor assess` to find C# files that would benefit most from Calor:
 
 ```bash
 # Analyze your source directory
-calor analyze ./src
+calor assess ./src
 
 # Show top 10 candidates with detailed scores
-calor analyze ./src --top 10 --verbose
+calor assess ./src --top 10 --verbose
 ```
 
 ### Understanding the Output
 
 ```
-=== Calor Migration Analysis ===
+=== Calor Migration Assessment ===
 
 Analyzed: 42 files
 Average Score: 34.2/100
@@ -296,7 +296,7 @@ MyProject/
 
 ### What to Convert First
 
-1. **High-scoring files** from `calor analyze`
+1. **High-scoring files** from `calor assess`
 2. **Files with complex validation** - benefit from contracts
 3. **Files with error handling** - benefit from `Result<T,E>`
 4. **Files with side effects** - benefit from effect declarations
@@ -360,5 +360,5 @@ Review these manually and adjust the Calor code as needed.
 - [Syntax Reference](/calor/syntax-reference/) - Complete Calor language reference
 - [Contracts](/calor/syntax-reference/contracts/) - Writing preconditions and postconditions
 - [Effects](/calor/syntax-reference/effects/) - Declaring side effects
-- [calor analyze](/calor/cli/analyze/) - Understanding migration scores
+- [calor assess](/calor/cli/assess/) - Understanding migration scores
 - [calor benchmark](/calor/cli/benchmark/) - Comparing Calor vs C# metrics

--- a/docs/index.md
+++ b/docs/index.md
@@ -132,16 +132,16 @@ dotnet run --project samples/HelloWorld
 
 ---
 
-## Migration Analysis
+## Migration Assessment
 
-Have an existing C# codebase? Use `calor analyze` to find files that would benefit most from Calor:
+Have an existing C# codebase? Use `calor assess` to find files that would benefit most from Calor:
 
 ```bash
 # Score C# files for migration potential
-calor analyze ./src
+calor assess ./src
 
 # Output:
-# === Calor Migration Analysis ===
+# === Calor Migration Assessment ===
 # Analyzed: 42 files
 # Average Score: 34.2/100
 #
@@ -151,9 +151,9 @@ calor analyze ./src
 #   ...
 ```
 
-The analyzer scores files based on patterns like null handling, error handling, and argument validation that map to Calor features.
+The tool scores files based on patterns like null handling, error handling, async/await, and LINQ usage that map to Calor features.
 
-[Learn more about analyze](/calor/cli/analyze/){: .btn .btn-outline }
+[Learn more about assess](/calor/cli/assess/){: .btn .btn-outline }
 
 ---
 

--- a/docs/philosophy/index.md
+++ b/docs/philosophy/index.md
@@ -138,7 +138,7 @@ Calor targets a specific workflow: AI agents as primary code authors with human 
 
 ### "My team will never adopt this."
 
-Calor doesn't require team-wide adoption. It can target specific modules where correctness matters most — financial calculations, state machines, data validation — while the rest of your codebase stays in C#. The `calor analyze` command identifies which files would benefit most.
+Calor doesn't require team-wide adoption. It can target specific modules where correctness matters most — financial calculations, state machines, data validation — while the rest of your codebase stays in C#. The `calor assess` command identifies which files would benefit most.
 
 ### "Is this production-ready?"
 

--- a/src/Calor.Compiler/Analysis/MigrationScore.cs
+++ b/src/Calor.Compiler/Analysis/MigrationScore.cs
@@ -33,7 +33,17 @@ public enum ScoreDimension
     /// <summary>
     /// Public APIs, undocumented methods → Calor metadata.
     /// </summary>
-    ApiComplexityPotential
+    ApiComplexityPotential,
+
+    /// <summary>
+    /// async/await patterns, Task&lt;T&gt; returns → Calor has different async model.
+    /// </summary>
+    AsyncPotential,
+
+    /// <summary>
+    /// LINQ methods (Where, Select, OrderBy) → Calor uses different collection patterns.
+    /// </summary>
+    LinqPotential
 }
 
 /// <summary>
@@ -50,12 +60,14 @@ public sealed class DimensionScore
 
     public static double GetWeight(ScoreDimension dimension) => dimension switch
     {
-        ScoreDimension.ContractPotential => 0.20,
-        ScoreDimension.EffectPotential => 0.15,
-        ScoreDimension.NullSafetyPotential => 0.20,
-        ScoreDimension.ErrorHandlingPotential => 0.20,
-        ScoreDimension.PatternMatchPotential => 0.10,
-        ScoreDimension.ApiComplexityPotential => 0.15,
+        ScoreDimension.ContractPotential => 0.18,
+        ScoreDimension.EffectPotential => 0.13,
+        ScoreDimension.NullSafetyPotential => 0.18,
+        ScoreDimension.ErrorHandlingPotential => 0.18,
+        ScoreDimension.PatternMatchPotential => 0.08,
+        ScoreDimension.ApiComplexityPotential => 0.13,
+        ScoreDimension.AsyncPotential => 0.06,
+        ScoreDimension.LinqPotential => 0.06,
         _ => 0.0
     };
 }

--- a/src/Calor.Compiler/Mcp/McpMessageHandler.cs
+++ b/src/Calor.Compiler/Mcp/McpMessageHandler.cs
@@ -31,6 +31,7 @@ public sealed class McpMessageHandler
         RegisterTool(new FormatTool());
         RegisterTool(new DiagnoseTool());
         RegisterTool(new IdsTool());
+        RegisterTool(new AssessTool());
     }
 
     private void RegisterTool(IMcpTool tool)

--- a/src/Calor.Compiler/Mcp/Tools/AssessTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/AssessTool.cs
@@ -1,0 +1,268 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Calor.Compiler.Analysis;
+
+namespace Calor.Compiler.Mcp.Tools;
+
+/// <summary>
+/// MCP tool for assessing C# code for Calor migration potential.
+/// </summary>
+public sealed class AssessTool : McpToolBase
+{
+    public override string Name => "calor_assess";
+
+    public override string Description =>
+        "Assess C# source code for Calor migration potential. Returns scores across 8 dimensions " +
+        "(contracts, effects, null safety, error handling, pattern matching, API complexity, async, LINQ) " +
+        "plus detection of unsupported C# constructs.";
+
+    protected override string GetInputSchemaJson() => """
+        {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": "C# source code to assess (single file mode)"
+                },
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": { "type": "string", "description": "File path/name for identification" },
+                            "source": { "type": "string", "description": "C# source code content" }
+                        },
+                        "required": ["path", "source"]
+                    },
+                    "description": "Multiple C# files to assess (multi-file mode)"
+                },
+                "options": {
+                    "type": "object",
+                    "properties": {
+                        "threshold": {
+                            "type": "integer",
+                            "default": 0,
+                            "description": "Minimum score (0-100) to include in results"
+                        }
+                    }
+                }
+            }
+        }
+        """;
+
+    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var source = GetString(arguments, "source");
+        var filesElement = GetArray(arguments, "files");
+        var options = GetOptions(arguments);
+        var threshold = GetInt(options, "threshold", 0);
+
+        // Validate input - need either source or files
+        if (string.IsNullOrEmpty(source) && filesElement == null)
+        {
+            return Task.FromResult(McpToolResult.Error(
+                "Missing required parameter: provide either 'source' (single file) or 'files' (multi-file)"));
+        }
+
+        try
+        {
+            var analyzer = new MigrationAnalyzer();
+            var files = new List<AssessFileResult>();
+
+            if (!string.IsNullOrEmpty(source))
+            {
+                // Single file mode
+                var result = analyzer.AnalyzeSource(source, "input.cs", "input.cs");
+                if (!result.WasSkipped && result.TotalScore >= threshold)
+                {
+                    files.Add(CreateFileResult(result));
+                }
+            }
+            else if (filesElement != null)
+            {
+                // Multi-file mode
+                foreach (var fileElement in filesElement.Value.EnumerateArray())
+                {
+                    var path = fileElement.TryGetProperty("path", out var pathProp)
+                        ? pathProp.GetString() ?? "unknown.cs"
+                        : "unknown.cs";
+                    var fileSource = fileElement.TryGetProperty("source", out var sourceProp)
+                        ? sourceProp.GetString() ?? ""
+                        : "";
+
+                    if (string.IsNullOrEmpty(fileSource)) continue;
+
+                    var result = analyzer.AnalyzeSource(fileSource, path, path);
+                    if (!result.WasSkipped && result.TotalScore >= threshold)
+                    {
+                        files.Add(CreateFileResult(result));
+                    }
+                }
+            }
+
+            // Sort by score descending
+            files.Sort((a, b) => b.Score.CompareTo(a.Score));
+
+            // Calculate summary
+            var summary = new AssessSummary
+            {
+                TotalFiles = files.Count,
+                AverageScore = files.Count > 0 ? Math.Round(files.Average(f => f.Score), 1) : 0,
+                PriorityBreakdown = new PriorityBreakdown
+                {
+                    Critical = files.Count(f => f.Priority == "critical"),
+                    High = files.Count(f => f.Priority == "high"),
+                    Medium = files.Count(f => f.Priority == "medium"),
+                    Low = files.Count(f => f.Priority == "low")
+                }
+            };
+
+            var output = new AssessToolOutput
+            {
+                Success = true,
+                Summary = summary,
+                Files = files
+            };
+
+            return Task.FromResult(McpToolResult.Json(output));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(McpToolResult.Error($"Assessment failed: {ex.Message}"));
+        }
+    }
+
+    private static AssessFileResult CreateFileResult(FileMigrationScore score)
+    {
+        var dimensions = new Dictionary<string, DimensionResult>();
+        foreach (var (dimension, dimScore) in score.Dimensions)
+        {
+            dimensions[dimension.ToString()] = new DimensionResult
+            {
+                Score = (int)Math.Round(dimScore.RawScore),
+                Patterns = dimScore.PatternCount
+            };
+        }
+
+        var unsupported = score.UnsupportedConstructs.Select(c => new UnsupportedConstructResult
+        {
+            Name = c.Name,
+            Count = c.Count,
+            Description = c.Description
+        }).ToList();
+
+        return new AssessFileResult
+        {
+            Path = score.RelativePath,
+            Score = (int)Math.Round(score.TotalScore),
+            Priority = FileMigrationScore.GetPriorityLabel(score.Priority).ToLowerInvariant(),
+            Dimensions = dimensions,
+            UnsupportedConstructs = unsupported,
+            LineCount = score.LineCount,
+            MethodCount = score.MethodCount,
+            TypeCount = score.TypeCount
+        };
+    }
+
+    /// <summary>
+    /// Helper to get an array property from arguments.
+    /// </summary>
+    private static JsonElement? GetArray(JsonElement? arguments, string propertyName)
+    {
+        if (arguments == null || arguments.Value.ValueKind != JsonValueKind.Object)
+            return null;
+
+        if (arguments.Value.TryGetProperty(propertyName, out var prop) && prop.ValueKind == JsonValueKind.Array)
+            return prop;
+
+        return null;
+    }
+
+    // Output DTOs
+    private sealed class AssessToolOutput
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; init; }
+
+        [JsonPropertyName("summary")]
+        public required AssessSummary Summary { get; init; }
+
+        [JsonPropertyName("files")]
+        public required List<AssessFileResult> Files { get; init; }
+    }
+
+    private sealed class AssessSummary
+    {
+        [JsonPropertyName("totalFiles")]
+        public int TotalFiles { get; init; }
+
+        [JsonPropertyName("averageScore")]
+        public double AverageScore { get; init; }
+
+        [JsonPropertyName("priorityBreakdown")]
+        public required PriorityBreakdown PriorityBreakdown { get; init; }
+    }
+
+    private sealed class PriorityBreakdown
+    {
+        [JsonPropertyName("critical")]
+        public int Critical { get; init; }
+
+        [JsonPropertyName("high")]
+        public int High { get; init; }
+
+        [JsonPropertyName("medium")]
+        public int Medium { get; init; }
+
+        [JsonPropertyName("low")]
+        public int Low { get; init; }
+    }
+
+    private sealed class AssessFileResult
+    {
+        [JsonPropertyName("path")]
+        public required string Path { get; init; }
+
+        [JsonPropertyName("score")]
+        public int Score { get; init; }
+
+        [JsonPropertyName("priority")]
+        public required string Priority { get; init; }
+
+        [JsonPropertyName("dimensions")]
+        public required Dictionary<string, DimensionResult> Dimensions { get; init; }
+
+        [JsonPropertyName("unsupportedConstructs")]
+        public required List<UnsupportedConstructResult> UnsupportedConstructs { get; init; }
+
+        [JsonPropertyName("lineCount")]
+        public int LineCount { get; init; }
+
+        [JsonPropertyName("methodCount")]
+        public int MethodCount { get; init; }
+
+        [JsonPropertyName("typeCount")]
+        public int TypeCount { get; init; }
+    }
+
+    private sealed class DimensionResult
+    {
+        [JsonPropertyName("score")]
+        public int Score { get; init; }
+
+        [JsonPropertyName("patterns")]
+        public int Patterns { get; init; }
+    }
+
+    private sealed class UnsupportedConstructResult
+    {
+        [JsonPropertyName("name")]
+        public required string Name { get; init; }
+
+        [JsonPropertyName("count")]
+        public int Count { get; init; }
+
+        [JsonPropertyName("description")]
+        public required string Description { get; init; }
+    }
+}

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -181,7 +181,7 @@ public class Program
         rootCommand.AddCommand(FormatCommand.Create());
         rootCommand.AddCommand(LintCommand.Create());
         rootCommand.AddCommand(DiagnoseCommand.Create());
-        rootCommand.AddCommand(AnalyzeCommand.Create());
+        rootCommand.AddCommand(AssessCommand.Create());
         rootCommand.AddCommand(HookCommand.Create());
         rootCommand.AddCommand(IdsCommand.Create());
         rootCommand.AddCommand(EffectsCommand.Create());
@@ -220,7 +220,7 @@ public class Program
                 Console.WriteLine("  calor --input <file.calr> [--output <file.cs>]  Compile Calor to C#");
                 Console.WriteLine("  calor convert <file>                           Convert between C# and Calor");
                 Console.WriteLine("  calor migrate <project>                        Migrate entire project");
-                Console.WriteLine("  calor analyze <directory>                      Analyze C# for migration potential");
+                Console.WriteLine("  calor assess <directory>                       Assess C# for migration potential");
                 Console.WriteLine("  calor benchmark [options]                      Compare token economics");
                 Console.WriteLine("  calor init --ai <agent>                        Initialize for AI coding agents");
                 Console.WriteLine("  calor format <files>                           Format Calor source files");

--- a/tests/Calor.Compiler.Tests/Mcp/AssessToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/AssessToolTests.cs
@@ -1,0 +1,594 @@
+using System.Text.Json;
+using Calor.Compiler.Mcp.Tools;
+using Xunit;
+
+namespace Calor.Compiler.Tests.Mcp;
+
+public class AssessToolTests
+{
+    private readonly AssessTool _tool = new();
+
+    [Fact]
+    public void Name_ReturnsCalorAssess()
+    {
+        Assert.Equal("calor_assess", _tool.Name);
+    }
+
+    [Fact]
+    public void Description_ContainsAssessInfo()
+    {
+        Assert.Contains("Assess", _tool.Description);
+        Assert.Contains("C#", _tool.Description);
+        Assert.Contains("migration", _tool.Description);
+    }
+
+    [Fact]
+    public void GetInputSchema_ReturnsValidSchema()
+    {
+        var schema = _tool.GetInputSchema();
+
+        Assert.Equal(JsonValueKind.Object, schema.ValueKind);
+        Assert.True(schema.TryGetProperty("properties", out var props));
+        Assert.True(props.TryGetProperty("source", out _));
+        Assert.True(props.TryGetProperty("files", out _));
+        Assert.True(props.TryGetProperty("options", out _));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithMissingInput_ReturnsError()
+    {
+        var args = JsonDocument.Parse("""{}""").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+        var text = result.Content[0].Text!;
+        Assert.Contains("source", text.ToLower());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithSimpleClass_ReturnsScores()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "public class Calculator { public int Add(int a, int b) => a + b; }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        Assert.Contains("success", text);
+        Assert.Contains("summary", text);
+        Assert.Contains("files", text);
+        Assert.Contains("totalFiles", text);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithAsyncCode_DetectsAsyncPatterns()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "public class Service { public async Task<int> GetValueAsync() { return await Task.FromResult(42); } }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        Assert.Contains("AsyncPotential", text);
+        // The async patterns should be detected
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+        Assert.True(files.GetArrayLength() > 0);
+        var file = files[0];
+        var dimensions = file.GetProperty("dimensions");
+        Assert.True(dimensions.TryGetProperty("AsyncPotential", out var asyncDim));
+        var patterns = asyncDim.GetProperty("patterns").GetInt32();
+        Assert.True(patterns > 0, "Should detect async patterns");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithLinqCode_DetectsLinqPatterns()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "using System.Linq; public class DataProcessor { public int[] Process(int[] data) { return data.Where(x => x > 0).Select(x => x * 2).ToArray(); } }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        Assert.Contains("LinqPotential", text);
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+        Assert.True(files.GetArrayLength() > 0);
+        var file = files[0];
+        var dimensions = file.GetProperty("dimensions");
+        Assert.True(dimensions.TryGetProperty("LinqPotential", out var linqDim));
+        var patterns = linqDim.GetProperty("patterns").GetInt32();
+        Assert.True(patterns > 0, "Should detect LINQ patterns");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithNullChecks_DetectsNullSafetyPatterns()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "public class Validator { public string? Name { get; set; } public bool IsValid() { return Name != null && Name.Length > 0; } }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        Assert.Contains("NullSafetyPotential", text);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithErrorHandling_DetectsErrorPatterns()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "public class Parser { public int Parse(string s) { try { return int.Parse(s); } catch (Exception ex) { throw new InvalidOperationException(\"Failed\", ex); } } }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        Assert.Contains("ErrorHandlingPotential", text);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithUnsupportedConstructs_ReportsConstruct()
+    {
+        // Primary constructors are unsupported
+        var args = JsonDocument.Parse("""
+            {
+                "source": "public class Point(int x, int y) { public int X => x; public int Y => y; }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        Assert.Contains("unsupportedConstructs", text);
+        Assert.Contains("PrimaryConstructor", text);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MultiFileMode_AnalyzesAllFiles()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "files": [
+                    { "path": "Calculator.cs", "source": "public class Calculator { public int Add(int a, int b) => a + b; }" },
+                    { "path": "Validator.cs", "source": "public class Validator { public bool IsValid(string? s) => s != null; }" }
+                ]
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+        var summary = json.RootElement.GetProperty("summary");
+        var totalFiles = summary.GetProperty("totalFiles").GetInt32();
+        Assert.Equal(2, totalFiles);
+
+        var files = json.RootElement.GetProperty("files");
+        Assert.Equal(2, files.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithThreshold_FiltersLowScores()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "files": [
+                    { "path": "Simple.cs", "source": "public class Simple { }" },
+                    { "path": "Complex.cs", "source": "public class Complex { public async Task<string?> ProcessAsync(string input) { if (input == null) throw new ArgumentNullException(nameof(input)); try { return await Task.FromResult(input.ToUpper()); } catch { return null; } } }" }
+                ],
+                "options": { "threshold": 50 }
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+        // Files below threshold should be filtered out
+        foreach (var file in files.EnumerateArray())
+        {
+            var score = file.GetProperty("score").GetInt32();
+            Assert.True(score >= 50, $"File score {score} should be >= 50");
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsPriorityBreakdown()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "public class Service { public async Task<int> GetValueAsync() { return await Task.FromResult(42); } }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        Assert.Contains("priorityBreakdown", text);
+        Assert.Contains("critical", text);
+        Assert.Contains("high", text);
+        Assert.Contains("medium", text);
+        Assert.Contains("low", text);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithContractValidation_DetectsContractPatterns()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "public class Guard { public void Validate(int value) { if (value < 0) throw new ArgumentOutOfRangeException(nameof(value)); if (value > 100) throw new ArgumentException(\"Too large\", nameof(value)); } }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        Assert.Contains("ContractPotential", text);
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+        var file = files[0];
+        var dimensions = file.GetProperty("dimensions");
+        var contractDim = dimensions.GetProperty("ContractPotential");
+        var patterns = contractDim.GetProperty("patterns").GetInt32();
+        Assert.True(patterns > 0, "Should detect contract patterns");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsDimensionScoresAndPatternCounts()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "public class Test { public void Method() { } }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+        var file = files[0];
+        var dimensions = file.GetProperty("dimensions");
+
+        // Check all 8 dimensions are present
+        Assert.True(dimensions.TryGetProperty("ContractPotential", out _));
+        Assert.True(dimensions.TryGetProperty("EffectPotential", out _));
+        Assert.True(dimensions.TryGetProperty("NullSafetyPotential", out _));
+        Assert.True(dimensions.TryGetProperty("ErrorHandlingPotential", out _));
+        Assert.True(dimensions.TryGetProperty("PatternMatchPotential", out _));
+        Assert.True(dimensions.TryGetProperty("ApiComplexityPotential", out _));
+        Assert.True(dimensions.TryGetProperty("AsyncPotential", out _));
+        Assert.True(dimensions.TryGetProperty("LinqPotential", out _));
+
+        // Each dimension should have score and patterns
+        var firstDim = dimensions.GetProperty("ContractPotential");
+        Assert.True(firstDim.TryGetProperty("score", out _));
+        Assert.True(firstDim.TryGetProperty("patterns", out _));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsFileMetadata()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "public class Test { public void Method1() { } public void Method2() { } }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+        var file = files[0];
+
+        Assert.True(file.TryGetProperty("lineCount", out _));
+        Assert.True(file.TryGetProperty("methodCount", out var methodCount));
+        Assert.True(file.TryGetProperty("typeCount", out var typeCount));
+
+        Assert.Equal(2, methodCount.GetInt32());
+        Assert.Equal(1, typeCount.GetInt32());
+    }
+
+    #region Edge Case Tests
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptySource_ReturnsEmptyResults()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": ""
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        // Empty source should be treated as missing
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithBothSourceAndFiles_PrioritizesSource()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "public class FromSource { }",
+                "files": [
+                    { "path": "FromFiles.cs", "source": "public class FromFiles { }" }
+                ]
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+
+        // Should only have the source file (input.cs), not the files array
+        Assert.Equal(1, files.GetArrayLength());
+        Assert.Equal("input.cs", files[0].GetProperty("path").GetString());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithParseErrors_SkipsFile()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "files": [
+                    { "path": "Valid.cs", "source": "public class Valid { }" },
+                    { "path": "Invalid.cs", "source": "public class { invalid syntax" }
+                ]
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+
+        // Only the valid file should be included (invalid file is skipped)
+        Assert.Equal(1, files.GetArrayLength());
+        Assert.Equal("Valid.cs", files[0].GetProperty("path").GetString());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptyFileInArray_SkipsEmptyFile()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "files": [
+                    { "path": "Valid.cs", "source": "public class Valid { }" },
+                    { "path": "Empty.cs", "source": "" }
+                ]
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+
+        // Only the valid file should be included
+        Assert.Equal(1, files.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithAsyncLambda_DetectsAsyncPattern()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "using System; public class Test { public void Run() { Func<Task> f = async () => await Task.Delay(1); } }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+        var dimensions = files[0].GetProperty("dimensions");
+        var asyncDim = dimensions.GetProperty("AsyncPotential");
+        var patterns = asyncDim.GetProperty("patterns").GetInt32();
+        Assert.True(patterns > 0, "Should detect async lambda pattern");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithCancellationToken_DetectsAsyncPattern()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "using System.Threading; public class Service { public void Process(CancellationToken token) { } }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+        var dimensions = files[0].GetProperty("dimensions");
+        var asyncDim = dimensions.GetProperty("AsyncPotential");
+        var patterns = asyncDim.GetProperty("patterns").GetInt32();
+        Assert.True(patterns > 0, "Should detect CancellationToken pattern");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithConfigureAwait_DetectsAsyncPattern()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "using System.Threading.Tasks; public class Service { public async Task ProcessAsync() { await Task.Delay(1).ConfigureAwait(false); } }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+        var dimensions = files[0].GetProperty("dimensions");
+        var asyncDim = dimensions.GetProperty("AsyncPotential");
+        var patterns = asyncDim.GetProperty("patterns").GetInt32();
+        // Should detect: async modifier, Task return, await, ConfigureAwait
+        Assert.True(patterns >= 3, $"Should detect multiple async patterns, got {patterns}");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithLinqQuerySyntax_DetectsLinqPattern()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "using System.Linq; public class Query { public int[] Filter(int[] data) { return (from x in data where x > 0 select x * 2).ToArray(); } }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+        var dimensions = files[0].GetProperty("dimensions");
+        var linqDim = dimensions.GetProperty("LinqPotential");
+        var patterns = linqDim.GetProperty("patterns").GetInt32();
+        // Should detect: query expression, where clause, ToArray
+        Assert.True(patterns >= 2, $"Should detect LINQ query syntax patterns, got {patterns}");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithIAsyncEnumerable_DetectsAsyncPattern()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "using System.Collections.Generic; public class Stream { public async IAsyncEnumerable<int> GetItemsAsync() { yield return 1; } }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+        var dimensions = files[0].GetProperty("dimensions");
+        var asyncDim = dimensions.GetProperty("AsyncPotential");
+        var patterns = asyncDim.GetProperty("patterns").GetInt32();
+        Assert.True(patterns >= 2, $"Should detect IAsyncEnumerable pattern, got {patterns}");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithAwaitForeach_DetectsAsyncPattern()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "using System.Collections.Generic; using System.Threading.Tasks; public class Processor { public async Task ProcessAsync(IAsyncEnumerable<int> items) { await foreach (var item in items) { } } }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+        var dimensions = files[0].GetProperty("dimensions");
+        var asyncDim = dimensions.GetProperty("AsyncPotential");
+        var patterns = asyncDim.GetProperty("patterns").GetInt32();
+        // Should detect: async modifier, Task return, IAsyncEnumerable param, await foreach
+        Assert.True(patterns >= 3, $"Should detect await foreach pattern, got {patterns}");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithAwaitUsing_DetectsAsyncPattern()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "using System; using System.Threading.Tasks; public class Resource { public async Task UseAsync() { await using var r = new AsyncRes(); } } public class AsyncRes : IAsyncDisposable { public ValueTask DisposeAsync() => default; }"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+        var dimensions = files[0].GetProperty("dimensions");
+        var asyncDim = dimensions.GetProperty("AsyncPotential");
+        var patterns = asyncDim.GetProperty("patterns").GetInt32();
+        // Should detect: async modifier, Task return, await using, IAsyncDisposable, ValueTask
+        Assert.True(patterns >= 3, $"Should detect await using pattern, got {patterns}");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FilesSortedByScoreDescending()
+    {
+        // Create files with different complexity levels
+        var args = JsonDocument.Parse("""
+            {
+                "files": [
+                    { "path": "Simple.cs", "source": "public class Simple { }" },
+                    { "path": "Complex.cs", "source": "public class Complex { public async Task<string?> ProcessAsync(string input) { if (input == null) throw new ArgumentNullException(nameof(input)); try { return await Task.FromResult(input.ToUpper()); } catch { return null; } } }" },
+                    { "path": "Medium.cs", "source": "public class Medium { public string? Name { get; set; } public bool IsValid() => Name != null; }" }
+                ]
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+        var files = json.RootElement.GetProperty("files");
+
+        // Verify files are sorted by score descending
+        var scores = files.EnumerateArray()
+            .Select(f => f.GetProperty("score").GetInt32())
+            .ToList();
+
+        for (int i = 0; i < scores.Count - 1; i++)
+        {
+            Assert.True(scores[i] >= scores[i + 1],
+                $"Files should be sorted by score descending: {scores[i]} >= {scores[i + 1]}");
+        }
+    }
+
+    #endregion
+}

--- a/tests/Calor.Compiler.Tests/MigrationAnalyzerTests.cs
+++ b/tests/Calor.Compiler.Tests/MigrationAnalyzerTests.cs
@@ -626,12 +626,14 @@ public class MigrationAnalyzerTests
     #region Dimension Weights
 
     [Theory]
-    [InlineData(ScoreDimension.ContractPotential, 0.20)]
-    [InlineData(ScoreDimension.EffectPotential, 0.15)]
-    [InlineData(ScoreDimension.NullSafetyPotential, 0.20)]
-    [InlineData(ScoreDimension.ErrorHandlingPotential, 0.20)]
-    [InlineData(ScoreDimension.PatternMatchPotential, 0.10)]
-    [InlineData(ScoreDimension.ApiComplexityPotential, 0.15)]
+    [InlineData(ScoreDimension.ContractPotential, 0.18)]
+    [InlineData(ScoreDimension.EffectPotential, 0.13)]
+    [InlineData(ScoreDimension.NullSafetyPotential, 0.18)]
+    [InlineData(ScoreDimension.ErrorHandlingPotential, 0.18)]
+    [InlineData(ScoreDimension.PatternMatchPotential, 0.08)]
+    [InlineData(ScoreDimension.ApiComplexityPotential, 0.13)]
+    [InlineData(ScoreDimension.AsyncPotential, 0.06)]
+    [InlineData(ScoreDimension.LinqPotential, 0.06)]
     public void DimensionScore_GetWeight_ReturnsCorrectWeight(ScoreDimension dimension, double expected)
     {
         Assert.Equal(expected, DimensionScore.GetWeight(dimension));


### PR DESCRIPTION
## Summary

- Add new MCP tool `calor_assess` that exposes C# migration analysis capability to AI agents
- Add 2 new scoring dimensions: AsyncPotential (6%) and LinqPotential (6%)
- Rename CLI `calor analyze` to `calor assess` with backwards-compatible alias
- Update all documentation to use new naming

## New Features

### `calor_assess` MCP Tool
- Single-file mode (`source` parameter)
- Multi-file mode (`files` array parameter)
- Threshold filtering option
- Returns scores, dimensions, unsupported constructs, and priority breakdown

### Enhanced Pattern Detection
**Async patterns:**
- `async`/`await` keywords
- `Task<T>`, `ValueTask<T>` returns
- `ConfigureAwait()`, `WhenAll()`, `WhenAny()`
- `CancellationToken` parameters
- `IAsyncEnumerable<T>`, `IAsyncDisposable`
- `await foreach`, `await using`
- Async lambdas

**LINQ patterns:**
- Method syntax (`.Where()`, `.Select()`, etc.)
- Query syntax (`from x in collection where... select...`)

### Updated Scoring Weights
| Dimension | Old | New |
|-----------|-----|-----|
| ContractPotential | 20% | 18% |
| EffectPotential | 15% | 13% |
| NullSafetyPotential | 20% | 18% |
| ErrorHandlingPotential | 20% | 18% |
| PatternMatchPotential | 10% | 8% |
| ApiComplexityPotential | 15% | 13% |
| AsyncPotential | - | 6% |
| LinqPotential | - | 6% |

## Test plan
- [x] All 2,451 tests pass
- [x] 31 AssessTool-specific tests
- [x] MCP integration tests for single-file and multi-file modes
- [x] Edge case tests (empty source, parse errors, threshold filtering)
- [x] Manual MCP protocol verification

🤖 Generated with [Claude Code](https://claude.ai/code)