### PR TITLE
Add Ask Calor GPT link to website

### DIFF
--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -4,7 +4,7 @@ import { CatchBugs } from '@/components/landing/CatchBugs';
 import { FeatureGrid } from '@/components/landing/FeatureGrid';
 import { BenchmarkChart } from '@/components/landing/BenchmarkChart';
 import { QuickStart } from '@/components/landing/QuickStart';
-import { ProjectStatus } from '@/components/landing/ProjectStatus';
+import { AskCalor } from '@/components/landing/AskCalor';
 import { ScrollDepthTracker } from '@/components/landing/ScrollDepthTracker';
 
 export default function HomePage() {
@@ -17,7 +17,7 @@ export default function HomePage() {
       <FeatureGrid />
       <BenchmarkChart />
       <QuickStart />
-      <ProjectStatus />
+      <AskCalor />
     </div>
   );
 }

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import Link from 'next/link';
 import packageJson from '../../package.json';
+import { trackAskCalorClick } from '@/lib/analytics';
 
 const footerLinks = {
   documentation: [
@@ -15,6 +18,7 @@ const footerLinks = {
   community: [
     { name: 'GitHub', href: 'https://github.com/juanmicrosoft/calor', external: true },
     { name: 'Issues', href: 'https://github.com/juanmicrosoft/calor/issues', external: true },
+    { name: 'Ask Calor', href: 'https://chatgpt.com/g/g-6994cc69517c8191a0dc7be0bfc00186-ask-calor', external: true },
   ],
 };
 
@@ -74,6 +78,7 @@ export function Footer() {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-sm text-muted-foreground hover:text-primary"
+                    onClick={link.name === 'Ask Calor' ? () => trackAskCalorClick('footer') : undefined}
                   >
                     {link.name}
                   </a>

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -4,10 +4,10 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import { useState } from 'react';
-import { Menu, X, Github, Moon, Sun } from 'lucide-react';
+import { Menu, X, Github, Moon, Sun, MessageCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn, getBasePath } from '@/lib/utils';
-import { trackDarkModeToggle, trackOutboundLink } from '@/lib/analytics';
+import { trackDarkModeToggle, trackOutboundLink, trackAskCalorClick } from '@/lib/analytics';
 
 // basePath needed for pathname comparison since usePathname returns full path
 const basePath = getBasePath();
@@ -95,6 +95,17 @@ export function Header() {
                 <span className="sr-only">GitHub</span>
               </a>
             </Button>
+            <Button variant="ghost" size="icon" asChild>
+              <a
+                href="https://chatgpt.com/g/g-6994cc69517c8191a0dc7be0bfc00186-ask-calor"
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => trackAskCalorClick('header')}
+              >
+                <MessageCircle className="h-5 w-5" />
+                <span className="sr-only">Ask Calor</span>
+              </a>
+            </Button>
           </div>
         </nav>
       </header>
@@ -157,6 +168,16 @@ export function Header() {
                       onClick={() => trackOutboundLink('https://github.com/juanmicrosoft/calor')}
                     >
                       <Github className="h-5 w-5" />
+                    </a>
+                  </Button>
+                  <Button variant="ghost" size="icon" asChild>
+                    <a
+                      href="https://chatgpt.com/g/g-6994cc69517c8191a0dc7be0bfc00186-ask-calor"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={() => trackAskCalorClick('mobile_menu')}
+                    >
+                      <MessageCircle className="h-5 w-5" />
                     </a>
                   </Button>
                 </div>

--- a/website/src/components/landing/AskCalor.tsx
+++ b/website/src/components/landing/AskCalor.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { MessageCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { trackAskCalorClick } from '@/lib/analytics';
+
+export function AskCalor() {
+  return (
+    <section className="py-16">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <div className="flex justify-center mb-6">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-calor-pink">
+              <MessageCircle className="h-8 w-8 text-white" />
+            </div>
+          </div>
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
+            Ask Calor
+          </h2>
+          <p className="mt-4 text-lg text-muted-foreground">
+            Have questions about Calor? Chat with our custom GPT to learn about syntax,
+            best practices, and how to get the most out of the language.
+          </p>
+          <div className="mt-8">
+            <Button size="lg" asChild>
+              <a
+                href="https://chatgpt.com/g/g-6994cc69517c8191a0dc7be0bfc00186-ask-calor"
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => trackAskCalorClick('homepage')}
+              >
+                <MessageCircle className="mr-2 h-5 w-5" />
+                Start a Conversation
+              </a>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/lib/analytics.ts
+++ b/website/src/lib/analytics.ts
@@ -21,6 +21,10 @@ export function trackCtaClick(button: 'get_started' | 'github') {
   sendEvent({ action: 'cta_click', category: 'engagement', label: button });
 }
 
+export function trackAskCalorClick(location: 'header' | 'footer' | 'mobile_menu' | 'homepage') {
+  sendEvent({ action: 'ask_calor_click', category: 'conversion', label: location });
+}
+
 export function trackInstallCommandCopy(step: string) {
   sendEvent({ action: 'install_command_copy', category: 'conversion', label: step });
 }


### PR DESCRIPTION
## Summary
- Add "Ask Calor" custom GPT link to header, footer, and homepage
- Track all clicks with Google Analytics for conversion metrics
- Remove ProjectStatus section from homepage

## Changes
- **Analytics**: New `trackAskCalorClick` function with location labels (header, footer, mobile_menu, homepage)
- **Header**: MessageCircle icon button next to GitHub (desktop and mobile)
- **Footer**: "Ask Calor" link in Community section
- **Homepage**: New AskCalor section with CTA button before footer

## Test plan
- [ ] Verify chat icon appears in header next to GitHub
- [ ] Verify chat icon appears in mobile menu
- [ ] Verify "Ask Calor" link appears in footer Community section
- [ ] Verify Ask Calor section appears on homepage with pink icon
- [ ] Verify all links open https://chatgpt.com/g/g-6994cc69517c8191a0dc7be0bfc00186-ask-calor in new tab
- [ ] Verify GA events fire with correct labels in DevTools Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)