### PR TITLE
fix(init): write MCP servers to .mcp.json instead of settings.json

### DIFF
--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -45,8 +45,9 @@ This is ideal for multi-project solutions where you want consistent Calor toolin
 MySolution/
 ├── MySolution.sln
 ├── CLAUDE.md                    # AI config in solution root
+├── .mcp.json                    # MCP server configuration
 ├── .claude/
-│   ├── settings.json
+│   ├── settings.json            # Hooks configuration
 │   └── skills/calor/SKILL.md
 ├── src/
 │   ├── Core/
@@ -70,8 +71,9 @@ This is ideal for standalone projects or when you need different AI configuratio
 MyProject/
 ├── MyProject.csproj             # Has Calor MSBuild targets
 ├── CLAUDE.md                    # AI config in project root
+├── .mcp.json                    # MCP server configuration
 └── .claude/
-    ├── settings.json
+    ├── settings.json            # Hooks configuration
     └── skills/calor/SKILL.md
 ```
 
@@ -126,21 +128,24 @@ Creates the following files:
 | `.claude/skills/calor-convert/SKILL.md` | C# to Calor conversion skill |
 | `.claude/skills/calor-semantics/SKILL.md` | Calor semantics and verification skill |
 | `.claude/skills/calor-analyze/SKILL.md` | C# analysis for Calor migration skill |
-| `.claude/settings.json` | **Hooks + MCP servers** - enforces Calor-first development and provides tools |
+| `.claude/settings.json` | **Hooks** - enforces Calor-first development with pre-tool-use hooks |
+| `.mcp.json` | **MCP servers** - provides Calor compiler tools to Claude |
 | `CLAUDE.md` | Project documentation (creates new or updates Calor section) |
 
 #### MCP Server Integration
 
-The `.claude/settings.json` file configures **two MCP servers**:
+The `.mcp.json` file configures **two MCP servers**:
 
 ```json
 {
   "mcpServers": {
     "calor-lsp": {
+      "type": "stdio",
       "command": "calor",
       "args": ["lsp"]
     },
     "calor": {
+      "type": "stdio",
       "command": "calor",
       "args": ["mcp", "--stdio"]
     }
@@ -164,7 +169,7 @@ See [`calor mcp`](/calor/cli/mcp/) for full tool documentation.
 
 #### Calor-First Enforcement
 
-The `.claude/settings.json` file configures a `PreToolUse` hook that **blocks Claude from creating `.cs` files**. When Claude tries to write a C# file, it will see:
+The `.claude/settings.json` file configures a `PreToolUse` hook that **blocks Claude from creating `.cs` files** (MCP servers are in the separate `.mcp.json` file). When Claude tries to write a C# file, it will see:
 
 ```
 BLOCKED: Cannot create C# file 'MyClass.cs'
@@ -516,6 +521,7 @@ Solution: MySolution.sln (3 projects)
 
 Created files:
   CLAUDE.md
+  .mcp.json
   .claude/skills/calor/SKILL.md
   .claude/skills/calor-convert/SKILL.md
   .claude/settings.json

--- a/docs/getting-started/claude-integration.md
+++ b/docs/getting-started/claude-integration.md
@@ -27,7 +27,8 @@ This creates:
 | `.claude/skills/calor-convert/SKILL.md` | Teaches Claude how to convert C# to Calor |
 | `.claude/skills/calor-semantics/SKILL.md` | Teaches Claude about Calor semantics and verification |
 | `.claude/skills/calor-analyze/SKILL.md` | Teaches Claude how to analyze C# for Calor migration |
-| `.claude/settings.json` | **Hooks + MCP servers** - blocks `.cs` file creation and provides tools |
+| `.claude/settings.json` | **Hooks** - blocks `.cs` file creation with pre-tool-use hooks |
+| `.mcp.json` | **MCP servers** - provides Calor compiler tools to Claude |
 | `CLAUDE.md` | Project documentation with Calor reference and conventions |
 
 You can run this command again anytime to update the Calor documentation section in CLAUDE.md without losing your custom content.
@@ -58,16 +59,18 @@ These tools allow Claude to:
 - **Look up** Calor syntax without leaving the conversation
 - **Assess** C# files to prioritize which ones benefit most from Calor migration
 
-The MCP servers are configured in `.claude/settings.json`:
+The MCP servers are configured in `.mcp.json` (project root):
 
 ```json
 {
   "mcpServers": {
     "calor-lsp": {
+      "type": "stdio",
       "command": "calor",
       "args": ["lsp"]
     },
     "calor": {
+      "type": "stdio",
       "command": "calor",
       "args": ["mcp", "--stdio"]
     }
@@ -107,7 +110,7 @@ The hook allows:
 
 ### Disabling Enforcement
 
-If you need to temporarily allow `.cs` file creation, remove or rename `.claude/settings.json`. Re-run `calor init --ai claude` to restore enforcement.
+If you need to temporarily allow `.cs` file creation, remove or rename `.claude/settings.json` (hooks are in this file). Re-run `calor init --ai claude` to restore enforcement. Note: MCP servers are in `.mcp.json` and can be managed separately.
 
 ---
 

--- a/src/Calor.Compiler/Commands/InitCommand.cs
+++ b/src/Calor.Compiler/Commands/InitCommand.cs
@@ -295,6 +295,7 @@ public static class InitCommand
             Console.WriteLine();
             Console.WriteLine("Agent configuration:");
             Console.WriteLine("  - MCP server 'calor-lsp' configured for language features");
+            Console.WriteLine("  - MCP server 'calor' configured for AI agent tools (compile, verify, analyze, convert, assess)");
         }
 
         // Show skipped/already initialized info
@@ -317,7 +318,7 @@ public static class InitCommand
         // Show next steps
         Console.WriteLine();
         Console.WriteLine("Next steps:");
-        Console.WriteLine("  1. Run 'calor analyze ./src' to find migration candidates");
+        Console.WriteLine("  1. Run 'calor assess ./src' to find migration candidates");
         Console.WriteLine("  2. Create .calr files in your projects");
         Console.WriteLine("  3. Run 'dotnet build' to compile Calor to C#");
         if (agentNames.Count == 0)
@@ -506,7 +507,7 @@ public static class InitCommand
         // Show next steps
         Console.WriteLine();
         Console.WriteLine("Next steps:");
-        Console.WriteLine("  1. Run 'calor analyze ./src' to find migration candidates");
+        Console.WriteLine("  1. Run 'calor assess ./src' to find migration candidates");
         Console.WriteLine("  2. Create .calr files in your project");
         Console.WriteLine("  3. Run 'dotnet build' to compile Calor to C#");
         if (agentNames.Count == 0)

--- a/src/Calor.Compiler/Init/ClaudeInitializer.cs
+++ b/src/Calor.Compiler/Init/ClaudeInitializer.cs
@@ -103,7 +103,7 @@ public class ClaudeInitializer : IAiInitializer
                 updatedFiles.Add(claudeMdPath);
             }
 
-            // Configure Claude Code hooks for Calor-first enforcement
+            // Configure Claude Code hooks for Calor-first enforcement (in .claude/settings.json)
             var settingsPath = Path.Combine(targetDirectory, ".claude", "settings.json");
             var settingsResult = await ConfigureHooksAsync(settingsPath, force);
             if (settingsResult == HookSettingsResult.Created)
@@ -113,6 +113,18 @@ public class ClaudeInitializer : IAiInitializer
             else if (settingsResult == HookSettingsResult.Updated)
             {
                 updatedFiles.Add(settingsPath);
+            }
+
+            // Configure MCP servers in .mcp.json (Claude Code reads MCP configs from here, not settings.json)
+            var mcpJsonPath = Path.Combine(targetDirectory, ".mcp.json");
+            var mcpResult = await ConfigureMcpServersAsync(mcpJsonPath, force);
+            if (mcpResult == McpConfigResult.Created)
+            {
+                createdFiles.Add(mcpJsonPath);
+            }
+            else if (mcpResult == McpConfigResult.Updated)
+            {
+                updatedFiles.Add(mcpJsonPath);
             }
 
             var allModifiedFiles = createdFiles.Concat(updatedFiles).ToList();
@@ -261,26 +273,13 @@ public class ClaudeInitializer : IAiInitializer
 
         if (!File.Exists(settingsPath))
         {
-            // Create new settings file with hook and MCP server configuration
+            // Create new settings file with hook configuration (MCP servers go in .mcp.json)
             var settings = new ClaudeSettings
             {
                 Hooks = new ClaudeHooksConfig
                 {
                     PreToolUse = new[] { writePreHookConfig, editPreHookConfig },
                     PostToolUse = new[] { writePostHookConfig }
-                },
-                McpServers = new Dictionary<string, McpServerConfig>
-                {
-                    ["calor-lsp"] = new McpServerConfig
-                    {
-                        Command = "calor",
-                        Args = new[] { "lsp" }
-                    },
-                    ["calor"] = new McpServerConfig
-                    {
-                        Command = "calor",
-                        Args = new[] { "mcp", "--stdio" }
-                    }
                 }
             };
 
@@ -307,19 +306,6 @@ public class ClaudeInitializer : IAiInitializer
                     {
                         PreToolUse = new[] { writePreHookConfig, editPreHookConfig },
                         PostToolUse = new[] { writePostHookConfig }
-                    },
-                    McpServers = new Dictionary<string, McpServerConfig>
-                    {
-                        ["calor-lsp"] = new McpServerConfig
-                        {
-                            Command = "calor",
-                            Args = new[] { "lsp" }
-                        },
-                        ["calor"] = new McpServerConfig
-                        {
-                            Command = "calor",
-                            Args = new[] { "mcp", "--stdio" }
-                        }
                     }
                 };
                 await File.WriteAllTextAsync(settingsPath, JsonSerializer.Serialize(settings, JsonOptions));
@@ -376,27 +362,6 @@ public class ClaudeInitializer : IAiInitializer
 
         existingSettings.Hooks.PostToolUse = existingPostHooks.ToArray();
 
-        // Configure MCP servers for language server and AI agent tools
-        existingSettings.McpServers ??= new Dictionary<string, McpServerConfig>();
-        if (!existingSettings.McpServers.ContainsKey("calor-lsp"))
-        {
-            existingSettings.McpServers["calor-lsp"] = new McpServerConfig
-            {
-                Command = "calor",
-                Args = new[] { "lsp" }
-            };
-            updated = true;
-        }
-        if (!existingSettings.McpServers.ContainsKey("calor"))
-        {
-            existingSettings.McpServers["calor"] = new McpServerConfig
-            {
-                Command = "calor",
-                Args = new[] { "mcp", "--stdio" }
-            };
-            updated = true;
-        }
-
         if (!updated)
         {
             return HookSettingsResult.Unchanged;
@@ -413,17 +378,113 @@ public class ClaudeInitializer : IAiInitializer
         await File.WriteAllTextAsync(settingsPath, newJson);
         return HookSettingsResult.Updated;
     }
+
+    private enum McpConfigResult
+    {
+        Created,
+        Updated,
+        Unchanged
+    }
+
+    private static async Task<McpConfigResult> ConfigureMcpServersAsync(string mcpJsonPath, bool force)
+    {
+        // MCP server configurations with required "type": "stdio"
+        var calorLspConfig = new McpServerConfig
+        {
+            Type = "stdio",
+            Command = "calor",
+            Args = new[] { "lsp" }
+        };
+
+        var calorMcpConfig = new McpServerConfig
+        {
+            Type = "stdio",
+            Command = "calor",
+            Args = new[] { "mcp", "--stdio" }
+        };
+
+        if (!File.Exists(mcpJsonPath))
+        {
+            // Create new .mcp.json file
+            var mcpConfig = new McpJsonConfig
+            {
+                McpServers = new Dictionary<string, McpServerConfig>
+                {
+                    ["calor-lsp"] = calorLspConfig,
+                    ["calor"] = calorMcpConfig
+                }
+            };
+
+            await File.WriteAllTextAsync(mcpJsonPath, JsonSerializer.Serialize(mcpConfig, JsonOptions));
+            return McpConfigResult.Created;
+        }
+
+        // Read existing .mcp.json
+        var existingJson = await File.ReadAllTextAsync(mcpJsonPath);
+        McpJsonConfig? existingConfig;
+
+        try
+        {
+            existingConfig = JsonSerializer.Deserialize<McpJsonConfig>(existingJson, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            if (force)
+            {
+                var mcpConfig = new McpJsonConfig
+                {
+                    McpServers = new Dictionary<string, McpServerConfig>
+                    {
+                        ["calor-lsp"] = calorLspConfig,
+                        ["calor"] = calorMcpConfig
+                    }
+                };
+                await File.WriteAllTextAsync(mcpJsonPath, JsonSerializer.Serialize(mcpConfig, JsonOptions));
+                return McpConfigResult.Updated;
+            }
+            return McpConfigResult.Unchanged;
+        }
+
+        existingConfig ??= new McpJsonConfig();
+        existingConfig.McpServers ??= new Dictionary<string, McpServerConfig>();
+
+        var updated = false;
+
+        if (!existingConfig.McpServers.ContainsKey("calor-lsp"))
+        {
+            existingConfig.McpServers["calor-lsp"] = calorLspConfig;
+            updated = true;
+        }
+
+        if (!existingConfig.McpServers.ContainsKey("calor"))
+        {
+            existingConfig.McpServers["calor"] = calorMcpConfig;
+            updated = true;
+        }
+
+        if (!updated)
+        {
+            return McpConfigResult.Unchanged;
+        }
+
+        var newJson = JsonSerializer.Serialize(existingConfig, JsonOptions);
+
+        if (newJson.TrimEnd() == existingJson.TrimEnd())
+        {
+            return McpConfigResult.Unchanged;
+        }
+
+        await File.WriteAllTextAsync(mcpJsonPath, newJson);
+        return McpConfigResult.Updated;
+    }
 }
 
-// JSON structure classes for Claude Code settings
+// JSON structure classes for Claude Code settings (.claude/settings.json)
 // Note: Claude Code expects "hooks" and "PreToolUse" in specific casing
 internal class ClaudeSettings
 {
     [JsonPropertyName("hooks")]
     public ClaudeHooksConfig? Hooks { get; set; }
-
-    [JsonPropertyName("mcpServers")]
-    public Dictionary<string, McpServerConfig>? McpServers { get; set; }
 }
 
 internal class ClaudeHooksConfig
@@ -453,8 +514,19 @@ internal class ClaudeHook
     public string? Command { get; set; }
 }
 
+// JSON structure for .mcp.json (MCP server configuration)
+// Claude Code reads MCP servers from .mcp.json, not settings.json
+internal class McpJsonConfig
+{
+    [JsonPropertyName("mcpServers")]
+    public Dictionary<string, McpServerConfig>? McpServers { get; set; }
+}
+
 internal class McpServerConfig
 {
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
     [JsonPropertyName("command")]
     public string? Command { get; set; }
 

--- a/tests/Calor.Compiler.Tests/ClaudeInitializerMcpTests.cs
+++ b/tests/Calor.Compiler.Tests/ClaudeInitializerMcpTests.cs
@@ -20,34 +20,50 @@ public class ClaudeInitializerMcpTests : IDisposable
     }
 
     [Fact]
-    public async Task Initialize_ConfiguresMcpServer_InNewSettingsJson()
+    public async Task Initialize_ConfiguresMcpServer_InMcpJson()
     {
         var initializer = new ClaudeInitializer();
         await initializer.InitializeAsync(_testDir, force: false);
 
-        var settingsPath = Path.Combine(_testDir, ".claude", "settings.json");
-        var content = await File.ReadAllTextAsync(settingsPath);
+        // MCP servers should be in .mcp.json, not settings.json
+        var mcpJsonPath = Path.Combine(_testDir, ".mcp.json");
+        Assert.True(File.Exists(mcpJsonPath), ".mcp.json should be created");
+
+        var content = await File.ReadAllTextAsync(mcpJsonPath);
 
         Assert.Contains("mcpServers", content);
         Assert.Contains("calor-lsp", content);
         Assert.Contains("\"command\": \"calor\"", content);
         Assert.Contains("\"lsp\"", content);
+        Assert.Contains("\"type\": \"stdio\"", content);
+    }
+
+    [Fact]
+    public async Task Initialize_SettingsJson_DoesNotContainMcpServers()
+    {
+        var initializer = new ClaudeInitializer();
+        await initializer.InitializeAsync(_testDir, force: false);
+
+        // settings.json should only contain hooks, not MCP servers
+        var settingsPath = Path.Combine(_testDir, ".claude", "settings.json");
+        var content = await File.ReadAllTextAsync(settingsPath);
+
+        Assert.Contains("hooks", content);
+        Assert.DoesNotContain("mcpServers", content);
     }
 
     [Fact]
     public async Task Initialize_PreservesExistingMcpServers()
     {
-        // Pre-create settings with existing MCP server
-        var claudeDir = Path.Combine(_testDir, ".claude");
-        Directory.CreateDirectory(claudeDir);
+        // Pre-create .mcp.json with existing MCP server
         await File.WriteAllTextAsync(
-            Path.Combine(claudeDir, "settings.json"),
-            "{\"mcpServers\": {\"existing-server\": {\"command\": \"existing\"}}}");
+            Path.Combine(_testDir, ".mcp.json"),
+            "{\"mcpServers\": {\"existing-server\": {\"type\": \"stdio\", \"command\": \"existing\"}}}");
 
         var initializer = new ClaudeInitializer();
         await initializer.InitializeAsync(_testDir, force: false);
 
-        var content = await File.ReadAllTextAsync(Path.Combine(claudeDir, "settings.json"));
+        var content = await File.ReadAllTextAsync(Path.Combine(_testDir, ".mcp.json"));
 
         Assert.Contains("existing-server", content);
         Assert.Contains("calor-lsp", content);
@@ -63,8 +79,8 @@ public class ClaudeInitializerMcpTests : IDisposable
         // Second initialization
         await initializer.InitializeAsync(_testDir, force: false);
 
-        var settingsPath = Path.Combine(_testDir, ".claude", "settings.json");
-        var content = await File.ReadAllTextAsync(settingsPath);
+        var mcpJsonPath = Path.Combine(_testDir, ".mcp.json");
+        var content = await File.ReadAllTextAsync(mcpJsonPath);
 
         // Count occurrences of calor-lsp - should only appear once
         var count = content.Split("calor-lsp").Length - 1;
@@ -87,25 +103,24 @@ public class ClaudeInitializerMcpTests : IDisposable
         var initializer = new ClaudeInitializer();
         await initializer.InitializeAsync(_testDir, force: false);
 
-        var settingsPath = Path.Combine(_testDir, ".claude", "settings.json");
-        var content = await File.ReadAllTextAsync(settingsPath);
+        var mcpJsonPath = Path.Combine(_testDir, ".mcp.json");
+        var content = await File.ReadAllTextAsync(mcpJsonPath);
 
         // Verify the JSON structure matches expected Claude Code format
         Assert.Contains("\"mcpServers\"", content);
         Assert.Contains("\"calor-lsp\"", content);
+        Assert.Contains("\"type\": \"stdio\"", content);
         Assert.Contains("\"command\": \"calor\"", content);
         Assert.Contains("\"args\"", content);
         Assert.Contains("[", content); // args should be an array
     }
 
     [Fact]
-    public async Task Initialize_WithForce_OverwritesInvalidJson()
+    public async Task Initialize_WithForce_OverwritesInvalidMcpJson()
     {
-        // Pre-create invalid settings file
-        var claudeDir = Path.Combine(_testDir, ".claude");
-        Directory.CreateDirectory(claudeDir);
+        // Pre-create invalid .mcp.json file
         await File.WriteAllTextAsync(
-            Path.Combine(claudeDir, "settings.json"),
+            Path.Combine(_testDir, ".mcp.json"),
             "{ invalid json }");
 
         var initializer = new ClaudeInitializer();
@@ -113,47 +128,29 @@ public class ClaudeInitializerMcpTests : IDisposable
 
         Assert.True(result.Success);
 
-        var content = await File.ReadAllTextAsync(Path.Combine(claudeDir, "settings.json"));
+        var content = await File.ReadAllTextAsync(Path.Combine(_testDir, ".mcp.json"));
         Assert.Contains("mcpServers", content);
         Assert.Contains("calor-lsp", content);
     }
 
     [Fact]
-    public async Task Initialize_PreservesExistingHooks_WhenAddingMcpServer()
+    public async Task Initialize_HooksAndMcpServers_InSeparateFiles()
     {
-        // Pre-create settings with hooks but no MCP servers
-        var claudeDir = Path.Combine(_testDir, ".claude");
-        Directory.CreateDirectory(claudeDir);
-        var existingSettings = @"{
-  ""hooks"": {
-    ""PreToolUse"": [
-      {
-        ""matcher"": ""Write"",
-        ""hooks"": [
-          {
-            ""type"": ""command"",
-            ""command"": ""calor hook validate-write $TOOL_INPUT""
-          }
-        ]
-      }
-    ]
-  }
-}";
-        await File.WriteAllTextAsync(Path.Combine(claudeDir, "settings.json"), existingSettings);
-
         var initializer = new ClaudeInitializer();
         await initializer.InitializeAsync(_testDir, force: false);
 
-        var content = await File.ReadAllTextAsync(Path.Combine(claudeDir, "settings.json"));
+        // Hooks should be in .claude/settings.json
+        var settingsPath = Path.Combine(_testDir, ".claude", "settings.json");
+        var settingsContent = await File.ReadAllTextAsync(settingsPath);
+        Assert.Contains("hooks", settingsContent);
+        Assert.Contains("PreToolUse", settingsContent);
+        Assert.Contains("calor hook validate-write", settingsContent);
 
-        // Should preserve hooks
-        Assert.Contains("hooks", content);
-        Assert.Contains("PreToolUse", content);
-        Assert.Contains("calor hook validate-write", content);
-
-        // Should add MCP servers
-        Assert.Contains("mcpServers", content);
-        Assert.Contains("calor-lsp", content);
+        // MCP servers should be in .mcp.json
+        var mcpJsonPath = Path.Combine(_testDir, ".mcp.json");
+        var mcpContent = await File.ReadAllTextAsync(mcpJsonPath);
+        Assert.Contains("mcpServers", mcpContent);
+        Assert.Contains("calor-lsp", mcpContent);
     }
 
     // Edge case tests
@@ -161,57 +158,52 @@ public class ClaudeInitializerMcpTests : IDisposable
     [Fact]
     public async Task Initialize_WithEmptyMcpServersObject_AddsCalorLsp()
     {
-        // Pre-create settings with empty mcpServers object
-        var claudeDir = Path.Combine(_testDir, ".claude");
-        Directory.CreateDirectory(claudeDir);
+        // Pre-create .mcp.json with empty mcpServers object
         await File.WriteAllTextAsync(
-            Path.Combine(claudeDir, "settings.json"),
+            Path.Combine(_testDir, ".mcp.json"),
             "{\"mcpServers\": {}}");
 
         var initializer = new ClaudeInitializer();
         await initializer.InitializeAsync(_testDir, force: false);
 
-        var content = await File.ReadAllTextAsync(Path.Combine(claudeDir, "settings.json"));
+        var content = await File.ReadAllTextAsync(Path.Combine(_testDir, ".mcp.json"));
         Assert.Contains("calor-lsp", content);
     }
 
     [Fact]
     public async Task Initialize_WithNullMcpServers_AddsCalorLsp()
     {
-        // Pre-create settings with null mcpServers
-        var claudeDir = Path.Combine(_testDir, ".claude");
-        Directory.CreateDirectory(claudeDir);
+        // Pre-create .mcp.json with null mcpServers
         await File.WriteAllTextAsync(
-            Path.Combine(claudeDir, "settings.json"),
+            Path.Combine(_testDir, ".mcp.json"),
             "{\"mcpServers\": null}");
 
         var initializer = new ClaudeInitializer();
         await initializer.InitializeAsync(_testDir, force: false);
 
-        var content = await File.ReadAllTextAsync(Path.Combine(claudeDir, "settings.json"));
+        var content = await File.ReadAllTextAsync(Path.Combine(_testDir, ".mcp.json"));
         Assert.Contains("calor-lsp", content);
     }
 
     [Fact]
     public async Task Initialize_WithExistingCalorLsp_DoesNotOverwrite()
     {
-        // Pre-create settings with calor-lsp already configured with custom args
-        var claudeDir = Path.Combine(_testDir, ".claude");
-        Directory.CreateDirectory(claudeDir);
-        var existingSettings = @"{
+        // Pre-create .mcp.json with calor-lsp already configured with custom args
+        var existingConfig = @"{
   ""mcpServers"": {
     ""calor-lsp"": {
+      ""type"": ""stdio"",
       ""command"": ""custom-calor"",
       ""args"": [""custom-arg""]
     }
   }
 }";
-        await File.WriteAllTextAsync(Path.Combine(claudeDir, "settings.json"), existingSettings);
+        await File.WriteAllTextAsync(Path.Combine(_testDir, ".mcp.json"), existingConfig);
 
         var initializer = new ClaudeInitializer();
         await initializer.InitializeAsync(_testDir, force: false);
 
-        var content = await File.ReadAllTextAsync(Path.Combine(claudeDir, "settings.json"));
+        var content = await File.ReadAllTextAsync(Path.Combine(_testDir, ".mcp.json"));
 
         // Should preserve the existing custom calor-lsp configuration
         Assert.Contains("custom-calor", content);
@@ -222,58 +214,55 @@ public class ClaudeInitializerMcpTests : IDisposable
     }
 
     [Fact]
-    public async Task Initialize_WithOnlyMcpServers_PreservesAndAddsHooks()
+    public async Task Initialize_WithOnlyMcpServers_HooksAddedToSettingsJson()
     {
-        // Pre-create settings with only mcpServers (no hooks)
-        var claudeDir = Path.Combine(_testDir, ".claude");
-        Directory.CreateDirectory(claudeDir);
+        // Pre-create .mcp.json with only mcpServers
         await File.WriteAllTextAsync(
-            Path.Combine(claudeDir, "settings.json"),
-            "{\"mcpServers\": {\"other-server\": {\"command\": \"other\"}}}");
+            Path.Combine(_testDir, ".mcp.json"),
+            "{\"mcpServers\": {\"other-server\": {\"type\": \"stdio\", \"command\": \"other\"}}}");
 
         var initializer = new ClaudeInitializer();
         await initializer.InitializeAsync(_testDir, force: false);
 
-        var content = await File.ReadAllTextAsync(Path.Combine(claudeDir, "settings.json"));
-
+        var mcpContent = await File.ReadAllTextAsync(Path.Combine(_testDir, ".mcp.json"));
         // Should preserve existing MCP server
-        Assert.Contains("other-server", content);
+        Assert.Contains("other-server", mcpContent);
         // Should add calor-lsp
-        Assert.Contains("calor-lsp", content);
+        Assert.Contains("calor-lsp", mcpContent);
+
+        var settingsContent = await File.ReadAllTextAsync(Path.Combine(_testDir, ".claude", "settings.json"));
         // Should add hooks
-        Assert.Contains("hooks", content);
-        Assert.Contains("PreToolUse", content);
+        Assert.Contains("hooks", settingsContent);
+        Assert.Contains("PreToolUse", settingsContent);
     }
 
     [Fact]
-    public async Task Initialize_WithEmptySettingsObject_AddsAllConfiguration()
+    public async Task Initialize_WithEmptyMcpJsonObject_AddsAllMcpServers()
     {
-        // Pre-create empty settings object
-        var claudeDir = Path.Combine(_testDir, ".claude");
-        Directory.CreateDirectory(claudeDir);
+        // Pre-create empty .mcp.json object
         await File.WriteAllTextAsync(
-            Path.Combine(claudeDir, "settings.json"),
+            Path.Combine(_testDir, ".mcp.json"),
             "{}");
 
         var initializer = new ClaudeInitializer();
         await initializer.InitializeAsync(_testDir, force: false);
 
-        var content = await File.ReadAllTextAsync(Path.Combine(claudeDir, "settings.json"));
+        var content = await File.ReadAllTextAsync(Path.Combine(_testDir, ".mcp.json"));
 
-        // Should add both hooks and MCP servers
-        Assert.Contains("hooks", content);
+        // Should add MCP servers
         Assert.Contains("mcpServers", content);
         Assert.Contains("calor-lsp", content);
+        Assert.Contains("calor", content);
     }
 
     [Fact]
-    public async Task Initialize_SettingsJsonHasCorrectJsonStructure()
+    public async Task Initialize_McpJsonHasCorrectJsonStructure()
     {
         var initializer = new ClaudeInitializer();
         await initializer.InitializeAsync(_testDir, force: false);
 
-        var settingsPath = Path.Combine(_testDir, ".claude", "settings.json");
-        var content = await File.ReadAllTextAsync(settingsPath);
+        var mcpJsonPath = Path.Combine(_testDir, ".mcp.json");
+        var content = await File.ReadAllTextAsync(mcpJsonPath);
 
         // Verify it's valid JSON by parsing it
         var jsonDoc = System.Text.Json.JsonDocument.Parse(content);
@@ -282,10 +271,39 @@ public class ClaudeInitializerMcpTests : IDisposable
         // Verify mcpServers structure
         Assert.True(root.TryGetProperty("mcpServers", out var mcpServers));
         Assert.True(mcpServers.TryGetProperty("calor-lsp", out var calorLsp));
+        Assert.True(calorLsp.TryGetProperty("type", out var type));
+        Assert.Equal("stdio", type.GetString());
         Assert.True(calorLsp.TryGetProperty("command", out var command));
         Assert.Equal("calor", command.GetString());
         Assert.True(calorLsp.TryGetProperty("args", out var args));
         Assert.Equal(System.Text.Json.JsonValueKind.Array, args.ValueKind);
         Assert.Equal("lsp", args[0].GetString());
+    }
+
+    [Fact]
+    public async Task Initialize_ConfiguresBothCalorMcpServers()
+    {
+        var initializer = new ClaudeInitializer();
+        await initializer.InitializeAsync(_testDir, force: false);
+
+        var mcpJsonPath = Path.Combine(_testDir, ".mcp.json");
+        var content = await File.ReadAllTextAsync(mcpJsonPath);
+
+        // Should configure both calor-lsp and calor MCP servers
+        Assert.Contains("calor-lsp", content);
+        Assert.Contains("\"calor\":", content);
+
+        // Verify the calor MCP server has correct args
+        var jsonDoc = System.Text.Json.JsonDocument.Parse(content);
+        var mcpServers = jsonDoc.RootElement.GetProperty("mcpServers");
+
+        // calor-lsp runs "calor lsp"
+        var calorLsp = mcpServers.GetProperty("calor-lsp");
+        Assert.Equal("lsp", calorLsp.GetProperty("args")[0].GetString());
+
+        // calor runs "calor mcp --stdio"
+        var calor = mcpServers.GetProperty("calor");
+        Assert.Equal("mcp", calor.GetProperty("args")[0].GetString());
+        Assert.Equal("--stdio", calor.GetProperty("args")[1].GetString());
     }
 }


### PR DESCRIPTION
## Summary

- Fixes MCP server configuration location: Claude Code reads from `.mcp.json`, not `.claude/settings.json`
- Adds required `"type": "stdio"` property to MCP server entries
- Updates output messages and documentation

## Problem

`calor init --ai claude` was writing MCP server configurations to `.claude/settings.json`, but Claude Code expects them in `.mcp.json` at the project root. This caused Claude Code's `/mcp` command to not show any configured servers.

## Changes

- **ClaudeInitializer.cs**: Write MCP servers to `.mcp.json` with correct format
- **InitCommand.cs**: Show both MCP servers in output, use "calor assess" in next steps
- **Documentation**: Updated to reflect new file locations and format
- **Tests**: Updated to verify MCP config in `.mcp.json`

## Test plan

- [x] All existing tests pass (2439 passed)
- [x] Manual test: `calor init --ai claude --force` creates `.mcp.json` with correct format
- [x] Manual test: Claude Code's `/mcp` shows configured servers

🤖 Generated with [Claude Code](https://claude.ai/code)