### PR TITLE
feat(migration): add graceful fallback and explain mode for C# conversion

### DIFF
--- a/src/Calor.Compiler/Ast/AstNode.cs
+++ b/src/Calor.Compiler/Ast/AstNode.cs
@@ -182,6 +182,9 @@ public interface IAstVisitor
     void Visit(CharOperationNode node);
     // Native StringBuilder Operations
     void Visit(StringBuilderOperationNode node);
+    // Fallback nodes for unsupported C# constructs
+    void Visit(FallbackExpressionNode node);
+    void Visit(FallbackCommentNode node);
 }
 
 /// <summary>
@@ -348,6 +351,9 @@ public interface IAstVisitor<T>
     T Visit(CharOperationNode node);
     // Native StringBuilder Operations
     T Visit(StringBuilderOperationNode node);
+    // Fallback nodes for unsupported C# constructs
+    T Visit(FallbackExpressionNode node);
+    T Visit(FallbackCommentNode node);
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Ast/ExpressionNodes.cs
+++ b/src/Calor.Compiler/Ast/ExpressionNodes.cs
@@ -172,3 +172,36 @@ public static class UnaryOperatorExtensions
         };
     }
 }
+
+/// <summary>
+/// Represents a fallback expression for unsupported C# constructs.
+/// Emitted as §ERR{"TODO: feature"} /* C#: originalCode */ in Calor output.
+/// </summary>
+public sealed class FallbackExpressionNode : ExpressionNode
+{
+    /// <summary>
+    /// The original C# code that could not be converted.
+    /// </summary>
+    public string OriginalCSharp { get; }
+
+    /// <summary>
+    /// The name of the unsupported feature (e.g., "implicit-new-with-args", "stackalloc").
+    /// </summary>
+    public string FeatureName { get; }
+
+    /// <summary>
+    /// Optional suggestion for how to manually convert this construct.
+    /// </summary>
+    public string? Suggestion { get; }
+
+    public FallbackExpressionNode(TextSpan span, string originalCSharp, string featureName, string? suggestion = null)
+        : base(span)
+    {
+        OriginalCSharp = originalCSharp ?? throw new ArgumentNullException(nameof(originalCSharp));
+        FeatureName = featureName ?? throw new ArgumentNullException(nameof(featureName));
+        Suggestion = suggestion;
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}

--- a/src/Calor.Compiler/Ast/StatementNodes.cs
+++ b/src/Calor.Compiler/Ast/StatementNodes.cs
@@ -76,3 +76,36 @@ public sealed class PrintStatementNode : StatementNode
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
     public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
+
+/// <summary>
+/// Represents a fallback comment for unsupported C# statements.
+/// Emitted as // TODO: Manual conversion needed [feature] with original C# code.
+/// </summary>
+public sealed class FallbackCommentNode : StatementNode
+{
+    /// <summary>
+    /// The original C# code that could not be converted.
+    /// </summary>
+    public string OriginalCSharp { get; }
+
+    /// <summary>
+    /// The name of the unsupported feature (e.g., "goto", "stackalloc").
+    /// </summary>
+    public string FeatureName { get; }
+
+    /// <summary>
+    /// Optional suggestion for how to manually convert this construct.
+    /// </summary>
+    public string? Suggestion { get; }
+
+    public FallbackCommentNode(TextSpan span, string originalCSharp, string featureName, string? suggestion = null)
+        : base(span)
+    {
+        OriginalCSharp = originalCSharp ?? throw new ArgumentNullException(nameof(originalCSharp));
+        FeatureName = featureName ?? throw new ArgumentNullException(nameof(featureName));
+        Suggestion = suggestion;
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -3130,6 +3130,28 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         };
     }
 
+    // Fallback nodes for unsupported C# constructs (from C# to Calor conversion)
+
+    public string Visit(FallbackExpressionNode node)
+    {
+        // Emit the original C# code with a TODO comment
+        return $"/* TODO: {node.FeatureName} */ {node.OriginalCSharp}";
+    }
+
+    public string Visit(FallbackCommentNode node)
+    {
+        // Emit as a comment block
+        var escapedCode = node.OriginalCSharp.Replace("*/", "* /");
+        AppendLine($"/* TODO: Manual conversion needed [{node.FeatureName}]");
+        AppendLine($"   C#: {escapedCode}");
+        if (!string.IsNullOrEmpty(node.Suggestion))
+        {
+            AppendLine($"   Suggestion: {node.Suggestion}");
+        }
+        AppendLine("*/");
+        return "";
+    }
+
     /// <summary>
     /// Represents a single variable's finite range.
     /// </summary>

--- a/src/Calor.Compiler/Ids/IdScanner.cs
+++ b/src/Calor.Compiler/Ids/IdScanner.cs
@@ -259,4 +259,6 @@ public sealed class IdScanner : IAstVisitor
     public void Visit(StringOperationNode node) { }
     public void Visit(CharOperationNode node) { }
     public void Visit(StringBuilderOperationNode node) { }
+    public void Visit(FallbackExpressionNode node) { }
+    public void Visit(FallbackCommentNode node) { }
 }

--- a/src/Calor.Compiler/Mcp/Tools/ConvertTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/ConvertTool.cs
@@ -25,6 +25,14 @@ public sealed class ConvertTool : McpToolBase
                 "moduleName": {
                     "type": "string",
                     "description": "Module name for the generated Calor code"
+                },
+                "fallback": {
+                    "type": "boolean",
+                    "description": "Enable graceful fallback for unsupported constructs (default: true)"
+                },
+                "explain": {
+                    "type": "boolean",
+                    "description": "Include detailed explanation of unsupported features in output (default: false)"
                 }
             },
             "required": ["source"]
@@ -40,6 +48,8 @@ public sealed class ConvertTool : McpToolBase
         }
 
         var moduleName = GetString(arguments, "moduleName");
+        var fallback = GetBool(arguments, "fallback", defaultValue: true);
+        var explain = GetBool(arguments, "explain", defaultValue: false);
 
         try
         {
@@ -47,11 +57,38 @@ public sealed class ConvertTool : McpToolBase
             {
                 ModuleName = moduleName,
                 PreserveComments = true,
-                AutoGenerateIds = true
+                AutoGenerateIds = true,
+                GracefulFallback = fallback,
+                Explain = explain
             };
 
             var converter = new CSharpToCalorConverter(options);
             var result = converter.Convert(source);
+
+            // Build explanation if requested
+            ExplanationOutput? explanationOutput = null;
+            if (explain)
+            {
+                var explanation = result.Context.GetExplanation();
+                explanationOutput = new ExplanationOutput
+                {
+                    UnsupportedFeatures = explanation.UnsupportedFeatures
+                        .Select(kvp => new UnsupportedFeatureOutput
+                        {
+                            Feature = kvp.Key,
+                            Count = kvp.Value.Count,
+                            Instances = kvp.Value.Select(i => new FeatureInstanceOutput
+                            {
+                                Code = i.Code,
+                                Line = i.Line,
+                                Suggestion = i.Suggestion
+                            }).ToList()
+                        }).ToList(),
+                    TotalUnsupportedCount = explanation.TotalUnsupportedCount,
+                    PartialFeatures = explanation.PartialFeatures,
+                    ManualRequiredFeatures = explanation.ManualRequiredFeatures
+                };
+            }
 
             var output = new ConvertToolOutput
             {
@@ -73,7 +110,8 @@ public sealed class ConvertTool : McpToolBase
                     PropertiesConverted = result.Context.Stats.PropertiesConverted,
                     FieldsConverted = result.Context.Stats.FieldsConverted,
                     DurationMs = (int)result.Duration.TotalMilliseconds
-                }
+                },
+                Explanation = explanationOutput
             };
 
             return Task.FromResult(McpToolResult.Json(output, isError: !result.Success));
@@ -98,6 +136,50 @@ public sealed class ConvertTool : McpToolBase
 
         [JsonPropertyName("stats")]
         public required ConversionStatsOutput Stats { get; init; }
+
+        [JsonPropertyName("explanation")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public ExplanationOutput? Explanation { get; init; }
+    }
+
+    private sealed class ExplanationOutput
+    {
+        [JsonPropertyName("unsupportedFeatures")]
+        public required List<UnsupportedFeatureOutput> UnsupportedFeatures { get; init; }
+
+        [JsonPropertyName("totalUnsupportedCount")]
+        public int TotalUnsupportedCount { get; init; }
+
+        [JsonPropertyName("partialFeatures")]
+        public required List<string> PartialFeatures { get; init; }
+
+        [JsonPropertyName("manualRequiredFeatures")]
+        public required List<string> ManualRequiredFeatures { get; init; }
+    }
+
+    private sealed class UnsupportedFeatureOutput
+    {
+        [JsonPropertyName("feature")]
+        public required string Feature { get; init; }
+
+        [JsonPropertyName("count")]
+        public int Count { get; init; }
+
+        [JsonPropertyName("instances")]
+        public required List<FeatureInstanceOutput> Instances { get; init; }
+    }
+
+    private sealed class FeatureInstanceOutput
+    {
+        [JsonPropertyName("code")]
+        public required string Code { get; init; }
+
+        [JsonPropertyName("line")]
+        public int Line { get; init; }
+
+        [JsonPropertyName("suggestion")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Suggestion { get; init; }
     }
 
     private sealed class ConversionIssueOutput

--- a/src/Calor.Compiler/Migration/CSharpToCalorConverter.cs
+++ b/src/Calor.Compiler/Migration/CSharpToCalorConverter.cs
@@ -50,6 +50,19 @@ public sealed class ConversionOptions
     /// Whether to auto-generate unique IDs for Calor elements.
     /// </summary>
     public bool AutoGenerateIds { get; set; } = true;
+
+    /// <summary>
+    /// Whether to emit graceful fallback comments for unsupported constructs.
+    /// When true, unsupported C# code is emitted as TODO comments instead of invalid Calor.
+    /// Default is true.
+    /// </summary>
+    public bool GracefulFallback { get; set; } = true;
+
+    /// <summary>
+    /// Whether to include explanation details about unsupported features.
+    /// When true, conversion results include a detailed explanation of what was not converted.
+    /// </summary>
+    public bool Explain { get; set; }
 }
 
 /// <summary>
@@ -212,7 +225,8 @@ public sealed class CSharpToCalorConverter
             IncludeBenchmark = _options.IncludeBenchmark,
             PreserveComments = _options.PreserveComments,
             AutoGenerateIds = _options.AutoGenerateIds,
-            ModuleName = _options.ModuleName
+            ModuleName = _options.ModuleName,
+            GracefulFallback = _options.GracefulFallback
         };
     }
 

--- a/src/Calor.Compiler/Migration/FeatureSupport.cs
+++ b/src/Calor.Compiler/Migration/FeatureSupport.cs
@@ -304,6 +304,78 @@ public static class FeatureSupport
             Description = "Explicit conversions require manual handling",
             Workaround = "Use explicit conversion methods"
         },
+
+        // Fallback features (for explain mode)
+        ["unknown-expression"] = new FeatureInfo
+        {
+            Name = "unknown-expression",
+            Support = SupportLevel.NotSupported,
+            Description = "Unknown or unsupported expression syntax",
+            Workaround = "Review and manually convert the expression"
+        },
+        ["unknown-literal"] = new FeatureInfo
+        {
+            Name = "unknown-literal",
+            Support = SupportLevel.NotSupported,
+            Description = "Unknown or unsupported literal type",
+            Workaround = "Use a supported literal type"
+        },
+        ["complex-is-pattern"] = new FeatureInfo
+        {
+            Name = "complex-is-pattern",
+            Support = SupportLevel.NotSupported,
+            Description = "Complex 'is' pattern matching expression",
+            Workaround = "Break down into simpler type checks or use match expression"
+        },
+        ["collection-spread"] = new FeatureInfo
+        {
+            Name = "collection-spread",
+            Support = SupportLevel.NotSupported,
+            Description = "Collection spread operator (..)",
+            Workaround = "Use explicit collection concatenation methods"
+        },
+        ["implicit-new-with-args"] = new FeatureInfo
+        {
+            Name = "implicit-new-with-args",
+            Support = SupportLevel.NotSupported,
+            Description = "Target-typed new with arguments: new(args)",
+            Workaround = "Use explicit type: new TypeName(args)"
+        },
+        ["binary pattern (and/or)"] = new FeatureInfo
+        {
+            Name = "binary pattern (and/or)",
+            Support = SupportLevel.NotSupported,
+            Description = "Pattern combinators: pattern1 and pattern2, pattern1 or pattern2",
+            Workaround = "Use separate match cases or if-else with explicit conditions"
+        },
+        ["unary pattern (not)"] = new FeatureInfo
+        {
+            Name = "unary pattern (not)",
+            Support = SupportLevel.NotSupported,
+            Description = "Negated patterns: not null, not 0",
+            Workaround = "Use guard clause with negated condition"
+        },
+        ["unknown-pattern"] = new FeatureInfo
+        {
+            Name = "unknown-pattern",
+            Support = SupportLevel.NotSupported,
+            Description = "Unrecognized pattern syntax",
+            Workaround = "Simplify pattern or use if-else with explicit conditions"
+        },
+        ["complex-recursive-pattern"] = new FeatureInfo
+        {
+            Name = "complex-recursive-pattern",
+            Support = SupportLevel.NotSupported,
+            Description = "Complex recursive pattern without clear type",
+            Workaround = "Use positional or property patterns with explicit type"
+        },
+        ["postfix-operator"] = new FeatureInfo
+        {
+            Name = "postfix-operator",
+            Support = SupportLevel.NotSupported,
+            Description = "Postfix increment/decrement as expression: i++, i--",
+            Workaround = "Use as statement or rewrite as x = x + 1"
+        },
     };
 
     /// <summary>

--- a/src/Calor.Compiler/Verification/ExpressionSimplifier.cs
+++ b/src/Calor.Compiler/Verification/ExpressionSimplifier.cs
@@ -1350,5 +1350,9 @@ public sealed class ExpressionSimplifier : IAstVisitor<ExpressionNode>
         return new StringBuilderOperationNode(node.Span, node.Operation, simplifiedArgs);
     }
 
+    // Fallback nodes - cannot be simplified, just return as-is
+    public ExpressionNode Visit(FallbackExpressionNode node) => node;
+    public ExpressionNode Visit(FallbackCommentNode node) => throw new InvalidOperationException();
+
     #endregion
 }

--- a/src/Calor.LanguageServer/Utilities/AstPositionVisitor.cs
+++ b/src/Calor.LanguageServer/Utilities/AstPositionVisitor.cs
@@ -209,4 +209,8 @@ public abstract class AstPositionVisitor<T> : IAstVisitor<T> where T : class?
     public virtual T Visit(StringOperationNode node) => DefaultVisit(node)!;
     public virtual T Visit(CharOperationNode node) => DefaultVisit(node)!;
     public virtual T Visit(StringBuilderOperationNode node) => DefaultVisit(node)!;
+
+    // Fallback nodes
+    public virtual T Visit(FallbackExpressionNode node) => DefaultVisit(node)!;
+    public virtual T Visit(FallbackCommentNode node) => DefaultVisit(node)!;
 }


### PR DESCRIPTION
## Summary

- Add `FallbackExpressionNode` and `FallbackCommentNode` AST nodes to handle unsupported C# constructs gracefully
- Emit `§ERR{"TODO: feature"}` for unsupported expressions (valid Calor that roundtrips)
- Emit `// TODO: Manual conversion needed` comments for unsupported statements
- Add `--explain` CLI flag to show summary of unsupported features after conversion
- Add `--no-fallback` CLI flag to fail conversion when encountering unsupported constructs
- Add `fallback` and `explain` parameters to MCP `calor_convert` tool
- Fix pattern matching fallbacks to emit wildcards instead of raw C# text
- Track unsupported features in `ConversionContext` for reporting

## Problem

The `calor convert` command was producing invalid Calor code when encountering unsupported C# constructs:
- `§ASSIGN Id (+ id throw new ArgumentNullException(nameof(id)))` - Invalid
- `§K string s and { Length: > 5 }` - Invalid pattern syntax

Root cause: `RoslynSyntaxVisitor` fell back to `ReferenceNode(expression.ToString())` which embedded raw C# into Calor output.

## Test plan

- [x] All 2444 existing tests pass
- [x] 7 new tests for fallback functionality
- [x] Manual testing of `--explain` and `--no-fallback` flags
- [x] E2E roundtrip tests pass (including `03_contracts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)