### PR TITLE
feat(mcp): add calor_typecheck and calor_verify_contracts tools

### DIFF
--- a/src/Calor.Compiler/Mcp/McpMessageHandler.cs
+++ b/src/Calor.Compiler/Mcp/McpMessageHandler.cs
@@ -33,6 +33,8 @@ public sealed class McpMessageHandler
         RegisterTool(new IdsTool());
         RegisterTool(new AssessTool());
         RegisterTool(new SyntaxLookupTool());
+        RegisterTool(new TypeCheckTool());
+        RegisterTool(new VerifyContractsTool());
     }
 
     private void RegisterTool(IMcpTool tool)

--- a/src/Calor.Compiler/Mcp/Tools/TypeCheckTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/TypeCheckTool.cs
@@ -1,0 +1,132 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Calor.Compiler.Diagnostics;
+
+namespace Calor.Compiler.Mcp.Tools;
+
+/// <summary>
+/// MCP tool for type checking Calor source code.
+/// </summary>
+public sealed class TypeCheckTool : McpToolBase
+{
+    public override string Name => "calor_typecheck";
+
+    public override string Description =>
+        "Type check Calor source code. Returns type errors with precise locations and categories.";
+
+    protected override string GetInputSchemaJson() => """
+        {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": "Calor source code to type check"
+                },
+                "filePath": {
+                    "type": "string",
+                    "description": "Optional file path for diagnostic messages"
+                }
+            },
+            "required": ["source"]
+        }
+        """;
+
+    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var source = GetString(arguments, "source");
+        if (string.IsNullOrEmpty(source))
+        {
+            return Task.FromResult(McpToolResult.Error("Missing required parameter: source"));
+        }
+
+        var filePath = GetString(arguments, "filePath") ?? "mcp-typecheck.calr";
+
+        try
+        {
+            var options = new CompilationOptions
+            {
+                EnableTypeChecking = true
+            };
+
+            var result = Program.Compile(source, filePath, options);
+
+            var typeErrors = new List<TypeErrorOutput>();
+            foreach (var diag in result.Diagnostics)
+            {
+                typeErrors.Add(new TypeErrorOutput
+                {
+                    Code = diag.Code,
+                    Message = diag.Message,
+                    Line = diag.Span.Line,
+                    Column = diag.Span.Column,
+                    Severity = diag.Severity switch
+                    {
+                        DiagnosticSeverity.Error => "error",
+                        DiagnosticSeverity.Warning => "warning",
+                        _ => "info"
+                    },
+                    Category = CategorizeError(diag.Code)
+                });
+            }
+
+            var output = new TypeCheckToolOutput
+            {
+                Success = !result.HasErrors,
+                ErrorCount = typeErrors.Count(e => e.Severity == "error"),
+                WarningCount = typeErrors.Count(e => e.Severity == "warning"),
+                TypeErrors = typeErrors
+            };
+
+            return Task.FromResult(McpToolResult.Json(output, isError: result.HasErrors));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(McpToolResult.Error($"Type checking failed: {ex.Message}"));
+        }
+    }
+
+    private static string CategorizeError(string code) => code switch
+    {
+        DiagnosticCode.TypeMismatch => "type_mismatch",
+        DiagnosticCode.UndefinedReference => "undefined_reference",
+        DiagnosticCode.DuplicateDefinition => "duplicate_definition",
+        DiagnosticCode.InvalidReference => "invalid_reference",
+        _ => "other"
+    };
+
+    private sealed class TypeCheckToolOutput
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; init; }
+
+        [JsonPropertyName("errorCount")]
+        public int ErrorCount { get; init; }
+
+        [JsonPropertyName("warningCount")]
+        public int WarningCount { get; init; }
+
+        [JsonPropertyName("typeErrors")]
+        public required List<TypeErrorOutput> TypeErrors { get; init; }
+    }
+
+    private sealed class TypeErrorOutput
+    {
+        [JsonPropertyName("code")]
+        public required string Code { get; init; }
+
+        [JsonPropertyName("message")]
+        public required string Message { get; init; }
+
+        [JsonPropertyName("line")]
+        public int Line { get; init; }
+
+        [JsonPropertyName("column")]
+        public int Column { get; init; }
+
+        [JsonPropertyName("severity")]
+        public required string Severity { get; init; }
+
+        [JsonPropertyName("category")]
+        public required string Category { get; init; }
+    }
+}

--- a/src/Calor.Compiler/Mcp/Tools/VerifyContractsTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/VerifyContractsTool.cs
@@ -1,0 +1,190 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Calor.Compiler.Verification.Z3;
+using Calor.Compiler.Verification.Z3.Cache;
+
+namespace Calor.Compiler.Mcp.Tools;
+
+/// <summary>
+/// MCP tool for verifying Calor contracts with Z3 SMT solver.
+/// This is an alias for calor_verify with improved discoverability.
+/// </summary>
+public sealed class VerifyContractsTool : McpToolBase
+{
+    public override string Name => "calor_verify_contracts";
+
+    public override string Description =>
+        "Verify Calor contracts using Z3 SMT solver. Returns verification results with counterexamples for failed contracts.";
+
+    protected override string GetInputSchemaJson() => """
+        {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": "Calor source code to verify"
+                },
+                "timeout": {
+                    "type": "integer",
+                    "default": 5000,
+                    "description": "Z3 solver timeout per contract in milliseconds"
+                }
+            },
+            "required": ["source"]
+        }
+        """;
+
+    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var source = GetString(arguments, "source");
+        if (string.IsNullOrEmpty(source))
+        {
+            return Task.FromResult(McpToolResult.Error("Missing required parameter: source"));
+        }
+
+        var timeout = GetInt(arguments, "timeout", 5000);
+        if (timeout <= 0) timeout = 5000;
+
+        try
+        {
+            var options = new CompilationOptions
+            {
+                VerifyContracts = true,
+                VerificationTimeoutMs = (uint)timeout,
+                VerificationCacheOptions = new VerificationCacheOptions { Enabled = false }
+            };
+
+            var result = Program.Compile(source, "mcp-verify-contracts.calr", options);
+
+            var verificationResults = options.VerificationResults;
+            var summary = verificationResults?.GetSummary() ?? new VerificationSummary(0, 0, 0, 0, 0);
+
+            var functions = new List<FunctionVerificationOutput>();
+            if (verificationResults != null)
+            {
+                foreach (var funcResult in verificationResults.Functions)
+                {
+                    var contracts = new List<ContractVerificationOutput>();
+
+                    for (var i = 0; i < funcResult.PreconditionResults.Count; i++)
+                    {
+                        var r = funcResult.PreconditionResults[i];
+                        contracts.Add(new ContractVerificationOutput
+                        {
+                            Type = "precondition",
+                            Index = i,
+                            Status = r.Status.ToString().ToLowerInvariant(),
+                            Counterexample = r.CounterexampleDescription
+                        });
+                    }
+
+                    for (var i = 0; i < funcResult.PostconditionResults.Count; i++)
+                    {
+                        var r = funcResult.PostconditionResults[i];
+                        contracts.Add(new ContractVerificationOutput
+                        {
+                            Type = "postcondition",
+                            Index = i,
+                            Status = r.Status.ToString().ToLowerInvariant(),
+                            Counterexample = r.CounterexampleDescription
+                        });
+                    }
+
+                    functions.Add(new FunctionVerificationOutput
+                    {
+                        FunctionId = funcResult.FunctionId,
+                        FunctionName = funcResult.FunctionName,
+                        Contracts = contracts
+                    });
+                }
+            }
+
+            var output = new VerifyContractsToolOutput
+            {
+                Success = !result.HasErrors && summary.Disproven == 0,
+                Summary = new VerificationSummaryOutput
+                {
+                    Total = summary.Total,
+                    Proven = summary.Proven,
+                    Unproven = summary.Unproven,
+                    Disproven = summary.Disproven,
+                    Unsupported = summary.Unsupported,
+                    Skipped = summary.Skipped
+                },
+                Functions = functions,
+                CompilationErrors = result.Diagnostics.Errors.Select(d => d.Message).ToList()
+            };
+
+            return Task.FromResult(McpToolResult.Json(output, isError: !output.Success));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(McpToolResult.Error($"Contract verification failed: {ex.Message}"));
+        }
+    }
+
+    private sealed class VerifyContractsToolOutput
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; init; }
+
+        [JsonPropertyName("summary")]
+        public required VerificationSummaryOutput Summary { get; init; }
+
+        [JsonPropertyName("functions")]
+        public required List<FunctionVerificationOutput> Functions { get; init; }
+
+        [JsonPropertyName("compilationErrors")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string>? CompilationErrors { get; init; }
+    }
+
+    private sealed class VerificationSummaryOutput
+    {
+        [JsonPropertyName("total")]
+        public int Total { get; init; }
+
+        [JsonPropertyName("proven")]
+        public int Proven { get; init; }
+
+        [JsonPropertyName("unproven")]
+        public int Unproven { get; init; }
+
+        [JsonPropertyName("disproven")]
+        public int Disproven { get; init; }
+
+        [JsonPropertyName("unsupported")]
+        public int Unsupported { get; init; }
+
+        [JsonPropertyName("skipped")]
+        public int Skipped { get; init; }
+    }
+
+    private sealed class FunctionVerificationOutput
+    {
+        [JsonPropertyName("functionId")]
+        public required string FunctionId { get; init; }
+
+        [JsonPropertyName("functionName")]
+        public required string FunctionName { get; init; }
+
+        [JsonPropertyName("contracts")]
+        public required List<ContractVerificationOutput> Contracts { get; init; }
+    }
+
+    private sealed class ContractVerificationOutput
+    {
+        [JsonPropertyName("type")]
+        public required string Type { get; init; }
+
+        [JsonPropertyName("index")]
+        public int Index { get; init; }
+
+        [JsonPropertyName("status")]
+        public required string Status { get; init; }
+
+        [JsonPropertyName("counterexample")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Counterexample { get; init; }
+    }
+}

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -378,6 +378,27 @@ public class Program
             return new CompilationResult(diagnostics, ast, "");
         }
 
+        // Type checking (optional)
+        if (options.EnableTypeChecking)
+        {
+            phaseSw.Restart();
+            var typeChecker = new TypeChecking.TypeChecker(diagnostics);
+            typeChecker.Check(ast);
+            phaseSw.Stop();
+            telemetry?.TrackPhase("TypeChecker", phaseSw.ElapsedMilliseconds, !diagnostics.HasErrors);
+
+            if (options.Verbose)
+            {
+                Console.WriteLine("Type checking completed");
+            }
+
+            if (diagnostics.HasErrors)
+            {
+                TrackDiagnostics(telemetry, diagnostics);
+                return new CompilationResult(diagnostics, ast, "");
+            }
+        }
+
         // Pattern exhaustiveness checking
         phaseSw.Restart();
         var patternChecker = new PatternChecker(diagnostics);
@@ -636,6 +657,11 @@ public sealed class CompilationOptions
     /// Results from verification analyses.
     /// </summary>
     public Analysis.VerificationAnalysisResult? VerificationAnalysisResult { get; internal set; }
+
+    /// <summary>
+    /// Enable type checking phase.
+    /// </summary>
+    public bool EnableTypeChecking { get; init; }
 }
 
 /// <summary>

--- a/tests/Calor.Compiler.Tests/Mcp/McpServerTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/McpServerTests.cs
@@ -131,6 +131,8 @@ public class McpServerTests
         Assert.Contains("calor_syntax_help", json);
         Assert.Contains("calor_syntax_lookup", json);
         Assert.Contains("calor_assess", json);
+        Assert.Contains("calor_typecheck", json);
+        Assert.Contains("calor_verify_contracts", json);
     }
 
     [Fact]
@@ -446,6 +448,8 @@ public class McpServerTests
         Assert.Contains("calor_syntax_help", response);
         Assert.Contains("calor_syntax_lookup", response);
         Assert.Contains("calor_assess", response);
+        Assert.Contains("calor_typecheck", response);
+        Assert.Contains("calor_verify_contracts", response);
     }
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/Mcp/TypeCheckToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/TypeCheckToolTests.cs
@@ -1,0 +1,317 @@
+using System.Text.Json;
+using Calor.Compiler.Mcp.Tools;
+using Xunit;
+
+namespace Calor.Compiler.Tests.Mcp;
+
+public class TypeCheckToolTests
+{
+    private readonly TypeCheckTool _tool = new();
+
+    [Fact]
+    public void Name_ReturnsCalorTypecheck()
+    {
+        Assert.Equal("calor_typecheck", _tool.Name);
+    }
+
+    [Fact]
+    public void Description_ContainsTypeCheckInfo()
+    {
+        Assert.Contains("Type check", _tool.Description);
+        Assert.Contains("Calor", _tool.Description);
+    }
+
+    [Fact]
+    public void GetInputSchema_ReturnsValidSchema()
+    {
+        var schema = _tool.GetInputSchema();
+
+        Assert.Equal(JsonValueKind.Object, schema.ValueKind);
+        Assert.True(schema.TryGetProperty("properties", out var props));
+        Assert.True(props.TryGetProperty("source", out _));
+        Assert.True(props.TryGetProperty("filePath", out _));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithValidSource_ReturnsSuccess()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "§M{m001:Test}\n§F{f001:Add:pub}\n§I{i32:a}\n§I{i32:b}\n§O{i32}\n§R (+ a b)\n§/F{f001}\n§/M{m001}"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        Assert.NotEmpty(result.Content);
+
+        var text = result.Content[0].Text;
+        Assert.NotNull(text);
+        Assert.Contains("success", text);
+        Assert.Contains("true", text.ToLower());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithMissingSource_ReturnsError()
+    {
+        var args = JsonDocument.Parse("""{}""").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+        var text = result.Content[0].Text!;
+        Assert.Contains("source", text.ToLower());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithNullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithFilePath_UsesInDiagnostics()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "§M{m001:Test}\n§F{f001:Add:pub}\n§I{i32:a}\n§I{i32:b}\n§O{i32}\n§R (+ a b)\n§/F{f001}\n§/M{m001}",
+                "filePath": "test-file.calr"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        Assert.Contains("typeErrors", text);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsStructuredOutput()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "§M{m001:Test}\n§F{f001:Add:pub}\n§I{i32:a}\n§I{i32:b}\n§O{i32}\n§R (+ a b)\n§/F{f001}\n§/M{m001}"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+
+        Assert.True(json.RootElement.TryGetProperty("success", out _));
+        Assert.True(json.RootElement.TryGetProperty("errorCount", out _));
+        Assert.True(json.RootElement.TryGetProperty("warningCount", out _));
+        Assert.True(json.RootElement.TryGetProperty("typeErrors", out _));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithSyntaxError_ReportsError()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "§M{m001:Test}\n§F{f001:Bad} invalid syntax"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+        var text = result.Content[0].Text!;
+        Assert.Contains("typeErrors", text);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithUndefinedReference_ReportsUndefinedReferenceCategory()
+    {
+        // Source with undefined variable reference
+        var args = JsonDocument.Parse("""
+            {
+                "source": "§M{m001:Test}\n§F{f001:Test:pub}\n§O{i32}\n§B{counter} 0\n§R undefinedVar\n§/F{f001}\n§/M{m001}"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.True(json.RootElement.GetProperty("errorCount").GetInt32() > 0);
+
+        var typeErrors = json.RootElement.GetProperty("typeErrors");
+        Assert.True(typeErrors.GetArrayLength() > 0);
+
+        // Find the undefined reference error
+        var hasUndefinedRef = false;
+        foreach (var error in typeErrors.EnumerateArray())
+        {
+            if (error.GetProperty("category").GetString() == "undefined_reference")
+            {
+                hasUndefinedRef = true;
+                Assert.Equal("Calor0200", error.GetProperty("code").GetString());
+                Assert.Contains("undefinedVar", error.GetProperty("message").GetString());
+                Assert.Equal("error", error.GetProperty("severity").GetString());
+                break;
+            }
+        }
+        Assert.True(hasUndefinedRef, "Expected undefined_reference category error");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithTypeMismatch_ReportsTypeMismatchCategory()
+    {
+        // Source with type mismatch: WHILE condition must be BOOL, not INT
+        // §WH{id} (condition) is the correct WHILE syntax
+        var args = JsonDocument.Parse("""
+            {
+                "source": "§M{m001:Test}\n§F{f001:Test:pub}\n§O{i32}\n§B{x} 0\n§WH{wh1} (+ x 1)\n  §B{x} (+ x 1)\n§/WH{wh1}\n§R x\n§/F{f001}\n§/M{m001}"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+
+        var typeErrors = json.RootElement.GetProperty("typeErrors");
+        Assert.True(typeErrors.GetArrayLength() > 0);
+
+        // Find the type mismatch error
+        var hasTypeMismatch = false;
+        foreach (var error in typeErrors.EnumerateArray())
+        {
+            if (error.GetProperty("category").GetString() == "type_mismatch")
+            {
+                hasTypeMismatch = true;
+                Assert.Equal("Calor0202", error.GetProperty("code").GetString());
+                Assert.Contains("BOOL", error.GetProperty("message").GetString());
+                break;
+            }
+        }
+        Assert.True(hasTypeMismatch, "Expected type_mismatch category error");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithMultipleErrors_ReportsAllErrors()
+    {
+        // Source with multiple errors: undefined var AND type mismatch (WHILE condition not BOOL)
+        var args = JsonDocument.Parse("""
+            {
+                "source": "§M{m001:Test}\n§F{f001:Test:pub}\n§O{i32}\n§B{x} 0\n§WH{wh1} (+ x 1)\n  §B{y} undefinedVar\n§/WH{wh1}\n§R x\n§/F{f001}\n§/M{m001}"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+
+        var errorCount = json.RootElement.GetProperty("errorCount").GetInt32();
+        Assert.True(errorCount >= 2, $"Expected at least 2 errors, got {errorCount}");
+
+        var typeErrors = json.RootElement.GetProperty("typeErrors");
+        var categories = new HashSet<string>();
+        foreach (var error in typeErrors.EnumerateArray())
+        {
+            categories.Add(error.GetProperty("category").GetString()!);
+        }
+
+        Assert.Contains("type_mismatch", categories);
+        Assert.Contains("undefined_reference", categories);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ErrorsIncludeLineAndColumn()
+    {
+        // Source with error on specific line
+        var args = JsonDocument.Parse("""
+            {
+                "source": "§M{m001:Test}\n§F{f001:Test:pub}\n§O{i32}\n§R undefinedVar\n§/F{f001}\n§/M{m001}"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+
+        var typeErrors = json.RootElement.GetProperty("typeErrors");
+        Assert.True(typeErrors.GetArrayLength() > 0);
+
+        var firstError = typeErrors[0];
+        Assert.True(firstError.TryGetProperty("line", out var line));
+        Assert.True(firstError.TryGetProperty("column", out var column));
+        Assert.True(line.GetInt32() > 0, "Line should be positive");
+        Assert.True(column.GetInt32() >= 0, "Column should be non-negative");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_IfConditionTypeMismatch_ReportsError()
+    {
+        // IF condition must be BOOL, using INT should fail
+        // §IF{id} condition syntax
+        var args = JsonDocument.Parse("""
+            {
+                "source": "§M{m001:Test}\n§F{f001:Test:pub}\n§I{i32:x}\n§O{i32}\n§IF{if1} (+ x 1)\n  §R 1\n§/I{if1}\n§R 0\n§/F{f001}\n§/M{m001}"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+        var text = result.Content[0].Text!;
+        Assert.Contains("type_mismatch", text);
+        Assert.Contains("BOOL", text);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ForLoopWithNonNumericBounds_ReportsError()
+    {
+        // FOR loop bounds must be numeric
+        // §L{id:var:from:to:step} syntax - using BOOL:true as from should fail
+        var args = JsonDocument.Parse("""
+            {
+                "source": "§M{m001:Test}\n§F{f001:Test:pub}\n§O{i32}\n§B{x} 0\n§L{l1:i:BOOL:true:10:1}\n  §B{x} (+ x i)\n§/L{l1}\n§R x\n§/F{f001}\n§/M{m001}"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+        var text = result.Content[0].Text!;
+        Assert.Contains("type_mismatch", text);
+        Assert.Contains("numeric", text.ToLower());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ValidComplexSource_NoErrors()
+    {
+        // Complex but valid source with multiple constructs
+        // Using correct IF syntax: §IF{id} condition ... §EL ... §/I{id}
+        // Using correct FOR syntax: §L{id:var:from:to:step} ... §/L{id}
+        var args = JsonDocument.Parse("""
+            {
+                "source": "§M{m001:Test}\n§F{f001:Complex:pub}\n§I{i32:a}\n§I{i32:b}\n§O{i32}\n§B{result} 0\n§IF{if1} (> a b)\n  §B{result} a\n§EL\n  §B{result} b\n§/I{if1}\n§L{l1:i:0:result:1}\n  §B{result} (+ result i)\n§/L{l1}\n§R result\n§/F{f001}\n§/M{m001}"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal(0, json.RootElement.GetProperty("errorCount").GetInt32());
+    }
+}

--- a/tests/Calor.Compiler.Tests/Mcp/VerifyContractsToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/VerifyContractsToolTests.cs
@@ -1,0 +1,152 @@
+using System.Text.Json;
+using Calor.Compiler.Mcp.Tools;
+using Xunit;
+
+namespace Calor.Compiler.Tests.Mcp;
+
+public class VerifyContractsToolTests
+{
+    private readonly VerifyContractsTool _tool = new();
+
+    [Fact]
+    public void Name_ReturnsCalorVerifyContracts()
+    {
+        Assert.Equal("calor_verify_contracts", _tool.Name);
+    }
+
+    [Fact]
+    public void Description_ContainsVerifyInfo()
+    {
+        Assert.Contains("Verify", _tool.Description);
+        Assert.Contains("contract", _tool.Description.ToLower());
+        Assert.Contains("Z3", _tool.Description);
+    }
+
+    [Fact]
+    public void GetInputSchema_ReturnsValidSchema()
+    {
+        var schema = _tool.GetInputSchema();
+
+        Assert.Equal(JsonValueKind.Object, schema.ValueKind);
+        Assert.True(schema.TryGetProperty("properties", out var props));
+        Assert.True(props.TryGetProperty("source", out _));
+        Assert.True(props.TryGetProperty("timeout", out _));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithValidSource_ReturnsStructuredResult()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "§M{m001:Test}\n§F{f001:Add:pub}\n§I{i32:a}\n§I{i32:b}\n§O{i32}\n§R (+ a b)\n§/F{f001}\n§/M{m001}"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.NotEmpty(result.Content);
+        var text = result.Content[0].Text;
+        Assert.NotNull(text);
+
+        var json = JsonDocument.Parse(text);
+        Assert.True(json.RootElement.TryGetProperty("success", out _));
+        Assert.True(json.RootElement.TryGetProperty("summary", out var summary));
+        Assert.True(summary.TryGetProperty("total", out _));
+        Assert.True(summary.TryGetProperty("proven", out _));
+        Assert.True(summary.TryGetProperty("disproven", out _));
+        Assert.True(json.RootElement.TryGetProperty("functions", out _));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithMissingSource_ReturnsError()
+    {
+        var args = JsonDocument.Parse("""{}""").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+        var text = result.Content[0].Text!;
+        Assert.Contains("source", text.ToLower());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithNullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithContract_VerifiesContract()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "§M{m001:Test}\n§F{f001:Div:pub}\n§I{i32:a}\n§I{i32:b}\n§O{i32}\n§Q (!= b 0)\n§R (/ a b)\n§/F{f001}\n§/M{m001}"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        var text = result.Content[0].Text!;
+        Assert.Contains("summary", text);
+        Assert.Contains("functions", text);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithTimeout_UsesCustomTimeout()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "§M{m001:Test}\n§F{f001:Add:pub}\n§I{i32:a}\n§I{i32:b}\n§O{i32}\n§R (+ a b)\n§/F{f001}\n§/M{m001}",
+                "timeout": 1000
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.NotEmpty(result.Content);
+        var text = result.Content[0].Text;
+        Assert.NotNull(text);
+        Assert.Contains("success", text);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithSyntaxError_ReportsCompilationErrors()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "source": "§M{m001:Test}\n§F{f001:Bad} invalid syntax"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+        var text = result.Content[0].Text!;
+        Assert.Contains("compilationErrors", text);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ContractStatusValues()
+    {
+        // Test that contract verification returns expected status values
+        var args = JsonDocument.Parse("""
+            {
+                "source": "§M{m001:Test}\n§F{f001:Div:pub}\n§I{i32:a}\n§I{i32:b}\n§O{i32}\n§Q (!= b 0)\n§R (/ a b)\n§/F{f001}\n§/M{m001}"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+        var text = result.Content[0].Text!;
+        var json = JsonDocument.Parse(text);
+
+        // Check summary contains expected fields
+        var summary = json.RootElement.GetProperty("summary");
+        Assert.True(summary.TryGetProperty("proven", out _));
+        Assert.True(summary.TryGetProperty("unproven", out _));
+        Assert.True(summary.TryGetProperty("disproven", out _));
+        Assert.True(summary.TryGetProperty("unsupported", out _));
+        Assert.True(summary.TryGetProperty("skipped", out _));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `calor_typecheck` MCP tool for type checking Calor source code with structured error output
- Add `calor_verify_contracts` MCP tool as an alias for contract verification with improved discoverability
- Integrate TypeChecker into compilation pipeline via `EnableTypeChecking` option

## Details

### calor_typecheck
- Input: `source` (required), `filePath` (optional)
- Output: `success`, `errorCount`, `warningCount`, `typeErrors[]`
- Error categories: `type_mismatch`, `undefined_reference`, `duplicate_definition`, `invalid_reference`

### calor_verify_contracts
- Input: `source` (required), `timeout` (optional, default 5000ms)
- Output: `success`, `summary`, `functions[]` with `contracts[]`
- Contract statuses: `proven`, `unproven`, `disproven`, `unsupported`, `skipped`

## Test plan

- [x] All 16 TypeCheckTool tests pass (including type mismatch and undefined reference detection)
- [x] All 9 VerifyContractsTool tests pass
- [x] All 138 MCP tests pass
- [x] All 2580 compiler tests pass
- [x] New tools appear in `tools/list` response

🤖 Generated with [Claude Code](https://claude.ai/code)