### PR TITLE
fix(init): remove incorrect calor-lsp MCP configuration

### DIFF
--- a/src/Calor.Compiler/Init/ClaudeInitializer.cs
+++ b/src/Calor.Compiler/Init/ClaudeInitializer.cs
@@ -133,8 +133,7 @@ public class ClaudeInitializer : IAiInitializer
             if (allModifiedFiles.Count > 0)
             {
                 messages.Add($"Initialized Calor project for Claude Code (calor v{version})");
-                messages.Add("  - MCP server 'calor-lsp' configured for language features");
-                messages.Add("  - MCP server 'calor' configured for AI agent tools (compile, verify, analyze, convert)");
+                messages.Add("  - MCP server 'calor' configured for AI agent tools (compile, verify, analyze, convert, typecheck)");
             }
             else
             {
@@ -388,14 +387,7 @@ public class ClaudeInitializer : IAiInitializer
 
     private static async Task<McpConfigResult> ConfigureMcpServersAsync(string mcpJsonPath, bool force)
     {
-        // MCP server configurations with required "type": "stdio"
-        var calorLspConfig = new McpServerConfig
-        {
-            Type = "stdio",
-            Command = "calor",
-            Args = new[] { "lsp" }
-        };
-
+        // MCP server configuration - only the MCP server, not LSP (LSP is a different protocol)
         var calorMcpConfig = new McpServerConfig
         {
             Type = "stdio",
@@ -410,7 +402,6 @@ public class ClaudeInitializer : IAiInitializer
             {
                 McpServers = new Dictionary<string, McpServerConfig>
                 {
-                    ["calor-lsp"] = calorLspConfig,
                     ["calor"] = calorMcpConfig
                 }
             };
@@ -435,7 +426,6 @@ public class ClaudeInitializer : IAiInitializer
                 {
                     McpServers = new Dictionary<string, McpServerConfig>
                     {
-                        ["calor-lsp"] = calorLspConfig,
                         ["calor"] = calorMcpConfig
                     }
                 };
@@ -450,9 +440,10 @@ public class ClaudeInitializer : IAiInitializer
 
         var updated = false;
 
-        if (!existingConfig.McpServers.ContainsKey("calor-lsp"))
+        // Remove the incorrect calor-lsp entry if it exists (LSP is not MCP)
+        if (existingConfig.McpServers.ContainsKey("calor-lsp"))
         {
-            existingConfig.McpServers["calor-lsp"] = calorLspConfig;
+            existingConfig.McpServers.Remove("calor-lsp");
             updated = true;
         }
 

--- a/tests/Calor.Compiler.Tests/InitCommandE2ETests.cs
+++ b/tests/Calor.Compiler.Tests/InitCommandE2ETests.cs
@@ -112,19 +112,14 @@ public class InitCommandE2ETests : IDisposable
         Assert.True(File.Exists(mcpJsonPath));
         var mcpJsonContent = await File.ReadAllTextAsync(mcpJsonPath);
 
-        // Verify MCP servers - both LSP and MCP
+        // Verify MCP server (only calor MCP, not calor-lsp which is LSP not MCP)
         Assert.Contains("mcpServers", mcpJsonContent);
-        Assert.Contains("calor-lsp", mcpJsonContent);
         Assert.Contains("\"calor\":", mcpJsonContent); // The MCP server entry
+        Assert.DoesNotContain("calor-lsp", mcpJsonContent); // LSP is not MCP
 
         // Parse JSON to verify structure
         var mcpJson = JsonDocument.Parse(mcpJsonContent);
         var mcpServers = mcpJson.RootElement.GetProperty("mcpServers");
-
-        Assert.True(mcpServers.TryGetProperty("calor-lsp", out var lspServer));
-        Assert.Equal("stdio", lspServer.GetProperty("type").GetString());
-        Assert.Equal("calor", lspServer.GetProperty("command").GetString());
-        Assert.Contains("lsp", lspServer.GetProperty("args").EnumerateArray().Select(a => a.GetString()));
 
         Assert.True(mcpServers.TryGetProperty("calor", out var mcpServer));
         Assert.Equal("stdio", mcpServer.GetProperty("type").GetString());

--- a/tests/Calor.Compiler.Tests/InitCommandIntegrationTests.cs
+++ b/tests/Calor.Compiler.Tests/InitCommandIntegrationTests.cs
@@ -320,11 +320,12 @@ public class InitCommandIntegrationTests : IDisposable
 
         var content = await File.ReadAllTextAsync(mcpJsonPath);
         Assert.Contains("mcpServers", content);
-        Assert.Contains("calor-lsp", content);
+        Assert.Contains("\"calor\"", content);
         Assert.Contains("\"type\": \"stdio\"", content);
         Assert.Contains("\"command\": \"calor\"", content);
         Assert.Contains("\"args\"", content);
-        Assert.Contains("\"lsp\"", content);
+        Assert.Contains("\"mcp\"", content);
+        Assert.Contains("\"--stdio\"", content);
     }
 
     [Fact]
@@ -359,7 +360,7 @@ public class InitCommandIntegrationTests : IDisposable
         // Both servers should exist
         Assert.Contains("existing-server", content);
         Assert.Contains("existing-command", content);
-        Assert.Contains("calor-lsp", content);
+        Assert.Contains("\"calor\"", content);
         Assert.Contains("\"command\": \"calor\"", content);
     }
 
@@ -401,7 +402,7 @@ public class InitCommandIntegrationTests : IDisposable
         // MCP server should be added to .mcp.json (separate file)
         var mcpContent = await File.ReadAllTextAsync(Path.Combine(_testDirectory, ".mcp.json"));
         Assert.Contains("mcpServers", mcpContent);
-        Assert.Contains("calor-lsp", mcpContent);
+        Assert.Contains("\"calor\"", mcpContent);
     }
 
     [Fact]
@@ -420,8 +421,8 @@ public class InitCommandIntegrationTests : IDisposable
         var mcpJsonPath = Path.Combine(_testDirectory, ".mcp.json");
         var content = await File.ReadAllTextAsync(mcpJsonPath);
 
-        // calor-lsp should only appear once
-        var count = CountOccurrences(content, "calor-lsp");
+        // "calor": should only appear once (the key, not in args)
+        var count = CountOccurrences(content, "\"calor\":");
         Assert.Equal(1, count);
     }
 
@@ -437,6 +438,6 @@ public class InitCommandIntegrationTests : IDisposable
 
         // Assert
         Assert.True(result.Success);
-        Assert.Contains(result.Messages, m => m.Contains("MCP server") || m.Contains("calor-lsp"));
+        Assert.Contains(result.Messages, m => m.Contains("MCP server"));
     }
 }


### PR DESCRIPTION
## Summary
- LSP (Language Server Protocol) and MCP (Model Context Protocol) are different protocols
- The `calor-lsp` entry was incorrectly configuring `calor lsp` as an MCP server, causing Claude to fail when loading MCP servers from `.mcp.json`
- This fix removes the incorrect calor-lsp configuration and only configures the actual MCP server (`calor mcp --stdio`)

## Changes
- Remove calor-lsp from MCP server configuration (LSP is not MCP)
- Add logic to remove existing calor-lsp entries during `calor init` (cleans up previously broken configurations)
- Update all related tests to verify correct behavior

## Test plan
- [x] All 2641 tests pass
- [x] `calor init --ai claude` creates correct `.mcp.json` with only `calor` MCP server
- [x] Existing incorrect `calor-lsp` entries are removed during init

🤖 Generated with [Claude Code](https://claude.com/claude-code)