### PR TITLE
fix(mcp): handle notifications/initialized correctly

### DIFF
--- a/src/Calor.Compiler/Mcp/McpMessageHandler.cs
+++ b/src/Calor.Compiler/Mcp/McpMessageHandler.cs
@@ -56,7 +56,7 @@ public sealed class McpMessageHandler
             return request.Method switch
             {
                 "initialize" => HandleInitialize(request),
-                "initialized" => null, // Notification, no response
+                "notifications/initialized" => null, // Notification, no response
                 "tools/list" => HandleToolsList(request),
                 "tools/call" => await HandleToolsCallAsync(request),
                 "ping" => HandlePing(request),

--- a/tests/Calor.Compiler.Tests/Mcp/McpServerTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/McpServerTests.cs
@@ -99,7 +99,7 @@ public class McpServerTests
         var handler = new McpMessageHandler();
         var request = new JsonRpcRequest
         {
-            Method = "initialized"
+            Method = "notifications/initialized"
         };
 
         var response = await handler.HandleRequestAsync(request);


### PR DESCRIPTION
## Summary
- The MCP protocol uses `notifications/initialized` as the method name for the initialized notification
- The server was incorrectly checking for `initialized` (without the `notifications/` prefix)
- This caused Claude Code to fail to connect because the server returned an error instead of accepting the notification

## Root Cause
The MCP handshake sequence is:
1. Client sends `initialize` request
2. Server responds with capabilities
3. Client sends `notifications/initialized` notification ← **This was failing**
4. Client can now call tools

The server was looking for method `"initialized"` but receiving `"notifications/initialized"`, so it fell through to the unknown method error handler.

## Test plan
- [x] MCP tests pass
- [x] Manual test with full MCP handshake sequence works
- [ ] Test in Claude Code after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)