### PR TITLE
fix(init): write MCP servers to ~/.claude.json instead of .mcp.json

### DIFF
--- a/src/Calor.Compiler/Commands/InitCommand.cs
+++ b/src/Calor.Compiler/Commands/InitCommand.cs
@@ -294,8 +294,7 @@ public static class InitCommand
         {
             Console.WriteLine();
             Console.WriteLine("Agent configuration:");
-            Console.WriteLine("  - MCP server 'calor-lsp' configured for language features");
-            Console.WriteLine("  - MCP server 'calor' configured for AI agent tools (compile, verify, analyze, convert, assess)");
+            Console.WriteLine("  - MCP server 'calor' configured in ~/.claude.json (compile, verify, analyze, convert, assess, typecheck)");
         }
 
         // Show skipped/already initialized info


### PR DESCRIPTION
## Summary

- Claude Code reads MCP server configuration from `~/.claude.json` in the per-project section, not from `.mcp.json` in the project directory
- `calor init --ai claude` now correctly writes MCP config to `~/.claude.json`
- Removed incorrect `.mcp.json` file creation

## Changes

- `ClaudeInitializer.cs`: Write to `~/.claude.json` projects[path].mcpServers
- Added `ClaudeJsonPathOverride` property for test isolation
- Updated all MCP-related tests to verify new behavior

## Test plan

- [x] All 2803 tests pass
- [x] Manual verification: `calor init` writes to `~/.claude.json`
- [x] Manual verification: `claude mcp list` shows connected status
- [x] No `.mcp.json` file created in project directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)