### PR TITLE
feat(mcp): add LSP-style navigation tools for AI agents

### DIFF
--- a/src/Calor.Compiler/Mcp/McpMessageHandler.cs
+++ b/src/Calor.Compiler/Mcp/McpMessageHandler.cs
@@ -37,6 +37,13 @@ public sealed class McpMessageHandler
         RegisterTool(new VerifyContractsTool());
         RegisterTool(new ValidateSnippetTool());
         RegisterTool(new CompatCheckTool());
+
+        // LSP-style navigation tools
+        RegisterTool(new GotoDefinitionTool());
+        RegisterTool(new FindReferencesTool());
+        RegisterTool(new SymbolInfoTool());
+        RegisterTool(new DocumentOutlineTool());
+        RegisterTool(new FindSymbolTool());
     }
 
     private void RegisterTool(IMcpTool tool)

--- a/src/Calor.Compiler/Mcp/Tools/CalorSourceHelper.cs
+++ b/src/Calor.Compiler/Mcp/Tools/CalorSourceHelper.cs
@@ -1,0 +1,147 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+
+namespace Calor.Compiler.Mcp.Tools;
+
+/// <summary>
+/// Helper for parsing Calor source code in MCP tools.
+/// </summary>
+internal static class CalorSourceHelper
+{
+    /// <summary>
+    /// Parses Calor source code and returns the AST if successful.
+    /// </summary>
+    public static ParseResult Parse(string source, string? filePath = null)
+    {
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath(filePath ?? "mcp-input.calr");
+
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+
+        if (diagnostics.HasErrors)
+        {
+            return ParseResult.Failed(diagnostics.Errors.Select(e => e.Message).ToList());
+        }
+
+        var parser = new Parser(tokens, diagnostics);
+        var ast = parser.Parse();
+
+        if (diagnostics.HasErrors)
+        {
+            return ParseResult.Failed(diagnostics.Errors.Select(e => e.Message).ToList());
+        }
+
+        return ParseResult.Success(ast, source);
+    }
+
+    /// <summary>
+    /// Reads a file and parses it.
+    /// </summary>
+    public static async Task<ParseResult> ParseFileAsync(string filePath)
+    {
+        if (!File.Exists(filePath))
+        {
+            return ParseResult.Failed(new List<string> { $"File not found: {filePath}" });
+        }
+
+        var source = await File.ReadAllTextAsync(filePath);
+        return Parse(source, filePath);
+    }
+
+    /// <summary>
+    /// Converts 1-based line/column to character offset.
+    /// </summary>
+    public static int GetOffset(string source, int line, int column)
+    {
+        var currentLine = 1;
+        var offset = 0;
+
+        for (var i = 0; i < source.Length; i++)
+        {
+            if (currentLine == line)
+            {
+                return offset + column - 1;
+            }
+
+            if (source[i] == '\n')
+            {
+                currentLine++;
+                offset = i + 1;
+            }
+        }
+
+        if (currentLine == line)
+        {
+            return offset + column - 1;
+        }
+
+        return source.Length;
+    }
+
+    /// <summary>
+    /// Converts character offset to 1-based line/column.
+    /// </summary>
+    public static (int Line, int Column) GetPosition(string source, int offset)
+    {
+        var line = 1;
+        var column = 1;
+
+        for (var i = 0; i < Math.Min(offset, source.Length); i++)
+        {
+            if (source[i] == '\n')
+            {
+                line++;
+                column = 1;
+            }
+            else
+            {
+                column++;
+            }
+        }
+
+        return (line, column);
+    }
+
+    /// <summary>
+    /// Gets a preview of source code around a position.
+    /// </summary>
+    public static string GetPreview(string source, int line, int maxLength = 80)
+    {
+        var lines = source.Split('\n');
+        if (line < 1 || line > lines.Length)
+            return "";
+
+        var lineContent = lines[line - 1].TrimEnd('\r');
+        if (lineContent.Length > maxLength)
+            return lineContent.Substring(0, maxLength) + "...";
+
+        return lineContent;
+    }
+}
+
+/// <summary>
+/// Result of parsing Calor source code.
+/// </summary>
+internal sealed class ParseResult
+{
+    public bool IsSuccess { get; }
+    public ModuleNode? Ast { get; }
+    public string? Source { get; }
+    public IReadOnlyList<string> Errors { get; }
+
+    private ParseResult(bool success, ModuleNode? ast, string? source, IReadOnlyList<string> errors)
+    {
+        IsSuccess = success;
+        Ast = ast;
+        Source = source;
+        Errors = errors;
+    }
+
+    public static ParseResult Success(ModuleNode ast, string source)
+        => new(true, ast, source, Array.Empty<string>());
+
+    public static ParseResult Failed(IReadOnlyList<string> errors)
+        => new(false, null, null, errors);
+}

--- a/src/Calor.Compiler/Mcp/Tools/DocumentOutlineTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/DocumentOutlineTool.cs
@@ -1,0 +1,416 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Calor.Compiler.Ast;
+
+namespace Calor.Compiler.Mcp.Tools;
+
+/// <summary>
+/// MCP tool for getting a structured outline of all symbols in a Calor file.
+/// Returns a hierarchical list of functions, classes, methods, etc.
+/// </summary>
+public sealed class DocumentOutlineTool : McpToolBase
+{
+    public override string Name => "calor_document_outline";
+
+    public override string Description =>
+        "Get a structured outline of all symbols in a Calor source file. " +
+        "Returns a hierarchical tree of modules, classes, functions, methods, fields, etc. " +
+        "Useful for understanding file structure before making changes.";
+
+    protected override string GetInputSchemaJson() => """
+        {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": "Calor source code (use this OR filePath)"
+                },
+                "filePath": {
+                    "type": "string",
+                    "description": "Path to a .calr file (use this OR source)"
+                },
+                "includeDetails": {
+                    "type": "boolean",
+                    "description": "Include detailed information like parameter types and contracts (default: true)"
+                }
+            }
+        }
+        """;
+
+    public override async Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var source = GetString(arguments, "source");
+        var filePath = GetString(arguments, "filePath");
+        var includeDetails = GetBool(arguments, "includeDetails", true);
+
+        if (string.IsNullOrEmpty(source) && string.IsNullOrEmpty(filePath))
+        {
+            return McpToolResult.Error("Either 'source' or 'filePath' is required");
+        }
+
+        ParseResult parseResult;
+        if (!string.IsNullOrEmpty(filePath))
+        {
+            parseResult = await CalorSourceHelper.ParseFileAsync(filePath);
+        }
+        else
+        {
+            parseResult = CalorSourceHelper.Parse(source!, filePath);
+        }
+
+        if (!parseResult.IsSuccess)
+        {
+            return McpToolResult.Json(new DocumentOutlineOutput
+            {
+                Success = false,
+                Errors = parseResult.Errors.ToList()
+            }, isError: true);
+        }
+
+        var outline = BuildOutline(parseResult.Ast!, includeDetails);
+
+        return McpToolResult.Json(new DocumentOutlineOutput
+        {
+            Success = true,
+            ModuleName = parseResult.Ast!.Name,
+            ModuleId = parseResult.Ast.Id,
+            FilePath = filePath,
+            Symbols = outline,
+            Summary = BuildSummary(parseResult.Ast)
+        });
+    }
+
+    private static List<OutlineSymbol> BuildOutline(ModuleNode ast, bool includeDetails)
+    {
+        var symbols = new List<OutlineSymbol>();
+
+        // Functions
+        foreach (var func in ast.Functions)
+        {
+            var funcSymbol = new OutlineSymbol
+            {
+                Name = func.Name,
+                Kind = "function",
+                Line = func.Span.Line,
+                Detail = includeDetails ? BuildFunctionDetail(func) : null,
+                Children = includeDetails ? BuildFunctionChildren(func) : null
+            };
+            symbols.Add(funcSymbol);
+        }
+
+        // Classes
+        foreach (var cls in ast.Classes)
+        {
+            var classSymbol = new OutlineSymbol
+            {
+                Name = cls.Name,
+                Kind = "class",
+                Line = cls.Span.Line,
+                Detail = includeDetails ? BuildClassDetail(cls) : null,
+                Children = BuildClassChildren(cls, includeDetails)
+            };
+            symbols.Add(classSymbol);
+        }
+
+        // Interfaces
+        foreach (var iface in ast.Interfaces)
+        {
+            var ifaceSymbol = new OutlineSymbol
+            {
+                Name = iface.Name,
+                Kind = "interface",
+                Line = iface.Span.Line,
+                Children = includeDetails ? BuildInterfaceChildren(iface) : null
+            };
+            symbols.Add(ifaceSymbol);
+        }
+
+        // Enums
+        foreach (var enumDef in ast.Enums)
+        {
+            var enumSymbol = new OutlineSymbol
+            {
+                Name = enumDef.Name,
+                Kind = "enum",
+                Line = enumDef.Span.Line,
+                Detail = enumDef.UnderlyingType,
+                Children = includeDetails ? BuildEnumChildren(enumDef) : null
+            };
+            symbols.Add(enumSymbol);
+        }
+
+        // Delegates
+        foreach (var del in ast.Delegates)
+        {
+            var delSymbol = new OutlineSymbol
+            {
+                Name = del.Name,
+                Kind = "delegate",
+                Line = del.Span.Line,
+                Detail = includeDetails ? BuildDelegateDetail(del) : null
+            };
+            symbols.Add(delSymbol);
+        }
+
+        return symbols;
+    }
+
+    private static string BuildFunctionDetail(FunctionNode func)
+    {
+        var parameters = string.Join(", ", func.Parameters.Select(p => $"{p.Name}: {p.TypeName}"));
+        var returnType = func.Output?.TypeName ?? "void";
+        var asyncPrefix = func.IsAsync ? "async " : "";
+        return $"{asyncPrefix}({parameters}) -> {returnType}";
+    }
+
+    private static List<OutlineSymbol>? BuildFunctionChildren(FunctionNode func)
+    {
+        var children = new List<OutlineSymbol>();
+
+        foreach (var param in func.Parameters)
+        {
+            children.Add(new OutlineSymbol
+            {
+                Name = param.Name,
+                Kind = "parameter",
+                Line = param.Span.Line,
+                Detail = param.TypeName
+            });
+        }
+
+        // Add contracts as children for visibility
+        foreach (var pre in func.Preconditions)
+        {
+            children.Add(new OutlineSymbol
+            {
+                Name = "requires",
+                Kind = "contract",
+                Line = pre.Span.Line,
+                Detail = "precondition"
+            });
+        }
+
+        foreach (var post in func.Postconditions)
+        {
+            children.Add(new OutlineSymbol
+            {
+                Name = "ensures",
+                Kind = "contract",
+                Line = post.Span.Line,
+                Detail = "postcondition"
+            });
+        }
+
+        return children.Count > 0 ? children : null;
+    }
+
+    private static string BuildClassDetail(ClassDefinitionNode cls)
+    {
+        var parts = new List<string>();
+        if (cls.IsAbstract) parts.Add("abstract");
+        if (cls.IsSealed) parts.Add("sealed");
+        if (cls.IsStatic) parts.Add("static");
+        if (cls.BaseClass != null) parts.Add($": {cls.BaseClass}");
+        return string.Join(" ", parts);
+    }
+
+    private static List<OutlineSymbol>? BuildClassChildren(ClassDefinitionNode cls, bool includeDetails)
+    {
+        var children = new List<OutlineSymbol>();
+
+        // Fields
+        foreach (var field in cls.Fields)
+        {
+            children.Add(new OutlineSymbol
+            {
+                Name = field.Name,
+                Kind = "field",
+                Line = field.Span.Line,
+                Detail = includeDetails ? $"{field.Visibility.ToString().ToLower()} {field.TypeName}" : null
+            });
+        }
+
+        // Properties
+        foreach (var prop in cls.Properties)
+        {
+            children.Add(new OutlineSymbol
+            {
+                Name = prop.Name,
+                Kind = "property",
+                Line = prop.Span.Line,
+                Detail = includeDetails ? prop.TypeName : null
+            });
+        }
+
+        // Constructors
+        foreach (var ctor in cls.Constructors)
+        {
+            children.Add(new OutlineSymbol
+            {
+                Name = cls.Name,
+                Kind = "constructor",
+                Line = ctor.Span.Line,
+                Detail = includeDetails ? BuildConstructorDetail(ctor) : null
+            });
+        }
+
+        // Methods
+        foreach (var method in cls.Methods)
+        {
+            children.Add(new OutlineSymbol
+            {
+                Name = method.Name,
+                Kind = "method",
+                Line = method.Span.Line,
+                Detail = includeDetails ? BuildMethodDetail(method) : null
+            });
+        }
+
+        return children.Count > 0 ? children : null;
+    }
+
+    private static string BuildConstructorDetail(ConstructorNode ctor)
+    {
+        var parameters = string.Join(", ", ctor.Parameters.Select(p => $"{p.Name}: {p.TypeName}"));
+        return $"({parameters})";
+    }
+
+    private static string BuildMethodDetail(MethodNode method)
+    {
+        var parameters = string.Join(", ", method.Parameters.Select(p => $"{p.Name}: {p.TypeName}"));
+        var returnType = method.Output?.TypeName ?? "void";
+        var modifiers = new List<string>();
+        if (method.IsStatic) modifiers.Add("static");
+        if (method.IsVirtual) modifiers.Add("virtual");
+        if (method.IsOverride) modifiers.Add("override");
+        if (method.IsAbstract) modifiers.Add("abstract");
+        if (method.IsAsync) modifiers.Add("async");
+        var modifierStr = modifiers.Count > 0 ? string.Join(" ", modifiers) + " " : "";
+        return $"{modifierStr}({parameters}) -> {returnType}";
+    }
+
+    private static List<OutlineSymbol>? BuildInterfaceChildren(InterfaceDefinitionNode iface)
+    {
+        var children = new List<OutlineSymbol>();
+
+        foreach (var method in iface.Methods)
+        {
+            var parameters = string.Join(", ", method.Parameters.Select(p => $"{p.Name}: {p.TypeName}"));
+            var returnType = method.Output?.TypeName ?? "void";
+            children.Add(new OutlineSymbol
+            {
+                Name = method.Name,
+                Kind = "method signature",
+                Line = method.Span.Line,
+                Detail = $"({parameters}) -> {returnType}"
+            });
+        }
+
+        return children.Count > 0 ? children : null;
+    }
+
+    private static List<OutlineSymbol>? BuildEnumChildren(EnumDefinitionNode enumDef)
+    {
+        var children = new List<OutlineSymbol>();
+
+        foreach (var member in enumDef.Members)
+        {
+            children.Add(new OutlineSymbol
+            {
+                Name = member.Name,
+                Kind = "enum member",
+                Line = member.Span.Line,
+                Detail = member.Value
+            });
+        }
+
+        return children.Count > 0 ? children : null;
+    }
+
+    private static string BuildDelegateDetail(DelegateDefinitionNode del)
+    {
+        var parameters = string.Join(", ", del.Parameters.Select(p => $"{p.Name}: {p.TypeName}"));
+        var returnType = del.Output?.TypeName ?? "void";
+        return $"({parameters}) -> {returnType}";
+    }
+
+    private static OutlineSummary BuildSummary(ModuleNode ast)
+    {
+        return new OutlineSummary
+        {
+            FunctionCount = ast.Functions.Count,
+            ClassCount = ast.Classes.Count,
+            InterfaceCount = ast.Interfaces.Count,
+            EnumCount = ast.Enums.Count,
+            DelegateCount = ast.Delegates.Count
+        };
+    }
+
+    private sealed class DocumentOutlineOutput
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; init; }
+
+        [JsonPropertyName("moduleName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? ModuleName { get; init; }
+
+        [JsonPropertyName("moduleId")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? ModuleId { get; init; }
+
+        [JsonPropertyName("filePath")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? FilePath { get; init; }
+
+        [JsonPropertyName("symbols")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<OutlineSymbol>? Symbols { get; init; }
+
+        [JsonPropertyName("summary")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public OutlineSummary? Summary { get; init; }
+
+        [JsonPropertyName("errors")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string>? Errors { get; init; }
+    }
+
+    private sealed class OutlineSymbol
+    {
+        [JsonPropertyName("name")]
+        public required string Name { get; init; }
+
+        [JsonPropertyName("kind")]
+        public required string Kind { get; init; }
+
+        [JsonPropertyName("line")]
+        public int Line { get; init; }
+
+        [JsonPropertyName("detail")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Detail { get; init; }
+
+        [JsonPropertyName("children")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<OutlineSymbol>? Children { get; init; }
+    }
+
+    private sealed class OutlineSummary
+    {
+        [JsonPropertyName("functionCount")]
+        public int FunctionCount { get; init; }
+
+        [JsonPropertyName("classCount")]
+        public int ClassCount { get; init; }
+
+        [JsonPropertyName("interfaceCount")]
+        public int InterfaceCount { get; init; }
+
+        [JsonPropertyName("enumCount")]
+        public int EnumCount { get; init; }
+
+        [JsonPropertyName("delegateCount")]
+        public int DelegateCount { get; init; }
+    }
+}

--- a/src/Calor.Compiler/Mcp/Tools/FindReferencesTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/FindReferencesTool.cs
@@ -1,0 +1,372 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Calor.Compiler.Ast;
+
+namespace Calor.Compiler.Mcp.Tools;
+
+/// <summary>
+/// MCP tool for finding all references to a symbol.
+/// Given a position, finds the symbol and all places it's used.
+/// </summary>
+public sealed class FindReferencesTool : McpToolBase
+{
+    public override string Name => "calor_find_references";
+
+    public override string Description =>
+        "Find all references to a symbol at a given position. " +
+        "Returns all locations where the symbol is used, including the definition. " +
+        "Useful for understanding impact before refactoring.";
+
+    protected override string GetInputSchemaJson() => """
+        {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": "Calor source code (use this OR filePath)"
+                },
+                "filePath": {
+                    "type": "string",
+                    "description": "Path to a .calr file (use this OR source)"
+                },
+                "line": {
+                    "type": "integer",
+                    "description": "Line number (1-based) where the symbol is located"
+                },
+                "column": {
+                    "type": "integer",
+                    "description": "Column number (1-based) where the symbol is located"
+                },
+                "includeDefinition": {
+                    "type": "boolean",
+                    "description": "Include the definition location in results (default: true)"
+                }
+            },
+            "required": ["line", "column"]
+        }
+        """;
+
+    public override async Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var source = GetString(arguments, "source");
+        var filePath = GetString(arguments, "filePath");
+        var line = GetInt(arguments, "line", 0);
+        var column = GetInt(arguments, "column", 0);
+        var includeDefinition = GetBool(arguments, "includeDefinition", true);
+
+        if (string.IsNullOrEmpty(source) && string.IsNullOrEmpty(filePath))
+        {
+            return McpToolResult.Error("Either 'source' or 'filePath' is required");
+        }
+
+        if (line <= 0 || column <= 0)
+        {
+            return McpToolResult.Error("Both 'line' and 'column' must be positive integers");
+        }
+
+        ParseResult parseResult;
+        if (!string.IsNullOrEmpty(filePath))
+        {
+            parseResult = await CalorSourceHelper.ParseFileAsync(filePath);
+        }
+        else
+        {
+            parseResult = CalorSourceHelper.Parse(source!, filePath);
+        }
+
+        if (!parseResult.IsSuccess)
+        {
+            return McpToolResult.Json(new FindReferencesOutput
+            {
+                Success = false,
+                Errors = parseResult.Errors.ToList()
+            }, isError: true);
+        }
+
+        // First, find what symbol is at the given position
+        var identifier = ExtractIdentifierAtPosition(parseResult.Source!, line, column);
+        if (string.IsNullOrEmpty(identifier))
+        {
+            return McpToolResult.Json(new FindReferencesOutput
+            {
+                Success = false,
+                Message = $"No symbol found at line {line}, column {column}"
+            });
+        }
+
+        // Find all references to this identifier
+        var references = FindReferences(parseResult.Ast!, parseResult.Source!, identifier, filePath, includeDefinition);
+
+        return McpToolResult.Json(new FindReferencesOutput
+        {
+            Success = true,
+            SymbolName = identifier,
+            ReferenceCount = references.Count,
+            References = references
+        });
+    }
+
+    private static List<ReferenceLocation> FindReferences(ModuleNode ast, string source, string symbolName, string? filePath, bool includeDefinition)
+    {
+        var references = new List<ReferenceLocation>();
+
+        // Find the definition first
+        var definitionKind = FindDefinitionKind(ast, symbolName);
+
+        // Scan the entire source for occurrences of the identifier
+        var lines = source.Split('\n');
+        for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+        {
+            var lineContent = lines[lineIndex];
+            var searchStart = 0;
+
+            while (true)
+            {
+                var pos = lineContent.IndexOf(symbolName, searchStart, StringComparison.Ordinal);
+                if (pos < 0)
+                    break;
+
+                // Check that it's a complete identifier (not part of a larger word)
+                var charBefore = pos > 0 ? lineContent[pos - 1] : ' ';
+                var charAfter = pos + symbolName.Length < lineContent.Length ? lineContent[pos + symbolName.Length] : ' ';
+
+                if (!IsIdentifierChar(charBefore) && !IsIdentifierChar(charAfter))
+                {
+                    var refLine = lineIndex + 1;
+                    var refColumn = pos + 1;
+
+                    // Determine if this is the definition
+                    var isDefinition = IsDefinitionLocation(ast, symbolName, refLine);
+
+                    if (isDefinition && !includeDefinition)
+                    {
+                        searchStart = pos + 1;
+                        continue;
+                    }
+
+                    // Get context - the line content trimmed
+                    var context = lineContent.Trim();
+                    if (context.Length > 100)
+                        context = context.Substring(0, 100) + "...";
+
+                    references.Add(new ReferenceLocation
+                    {
+                        FilePath = filePath,
+                        Line = refLine,
+                        Column = refColumn,
+                        IsDefinition = isDefinition,
+                        Context = context,
+                        Kind = isDefinition ? definitionKind : "reference"
+                    });
+                }
+
+                searchStart = pos + 1;
+            }
+        }
+
+        // Sort by line number
+        references.Sort((a, b) => a.Line.CompareTo(b.Line));
+
+        return references;
+    }
+
+    private static string? FindDefinitionKind(ModuleNode ast, string name)
+    {
+        foreach (var func in ast.Functions)
+        {
+            if (func.Name == name)
+                return "function";
+        }
+
+        foreach (var cls in ast.Classes)
+        {
+            if (cls.Name == name)
+                return "class";
+
+            foreach (var method in cls.Methods)
+            {
+                if (method.Name == name)
+                    return "method";
+            }
+
+            foreach (var field in cls.Fields)
+            {
+                if (field.Name == name)
+                    return "field";
+            }
+
+            foreach (var prop in cls.Properties)
+            {
+                if (prop.Name == name)
+                    return "property";
+            }
+        }
+
+        foreach (var iface in ast.Interfaces)
+        {
+            if (iface.Name == name)
+                return "interface";
+        }
+
+        foreach (var enumDef in ast.Enums)
+        {
+            if (enumDef.Name == name)
+                return "enum";
+        }
+
+        return null;
+    }
+
+    private static bool IsDefinitionLocation(ModuleNode ast, string name, int line)
+    {
+        // Check if this line contains a definition of the symbol
+
+        foreach (var func in ast.Functions)
+        {
+            if (func.Name == name && func.Span.Line == line)
+                return true;
+
+            // Check parameters (defined on the same line as function)
+            foreach (var param in func.Parameters)
+            {
+                if (param.Name == name && param.Span.Line == line)
+                    return true;
+            }
+
+            // Check local bindings
+            foreach (var stmt in func.Body)
+            {
+                if (stmt is BindStatementNode bind && bind.Name == name && bind.Span.Line == line)
+                    return true;
+            }
+        }
+
+        foreach (var cls in ast.Classes)
+        {
+            if (cls.Name == name && cls.Span.Line == line)
+                return true;
+
+            foreach (var field in cls.Fields)
+            {
+                if (field.Name == name && field.Span.Line == line)
+                    return true;
+            }
+
+            foreach (var prop in cls.Properties)
+            {
+                if (prop.Name == name && prop.Span.Line == line)
+                    return true;
+            }
+
+            foreach (var method in cls.Methods)
+            {
+                if (method.Name == name && method.Span.Line == line)
+                    return true;
+
+                foreach (var param in method.Parameters)
+                {
+                    if (param.Name == name && param.Span.Line == line)
+                        return true;
+                }
+
+                foreach (var stmt in method.Body)
+                {
+                    if (stmt is BindStatementNode bind && bind.Name == name && bind.Span.Line == line)
+                        return true;
+                }
+            }
+        }
+
+        foreach (var iface in ast.Interfaces)
+        {
+            if (iface.Name == name && iface.Span.Line == line)
+                return true;
+        }
+
+        foreach (var enumDef in ast.Enums)
+        {
+            if (enumDef.Name == name && enumDef.Span.Line == line)
+                return true;
+
+            foreach (var member in enumDef.Members)
+            {
+                if (member.Name == name && member.Span.Line == line)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string? ExtractIdentifierAtPosition(string source, int line, int column)
+    {
+        var offset = CalorSourceHelper.GetOffset(source, line, column);
+        if (offset < 0 || offset >= source.Length)
+            return null;
+
+        var start = offset;
+        while (start > 0 && IsIdentifierChar(source[start - 1]))
+            start--;
+
+        var end = offset;
+        while (end < source.Length && IsIdentifierChar(source[end]))
+            end++;
+
+        if (start == end)
+            return null;
+
+        return source.Substring(start, end - start);
+    }
+
+    private static bool IsIdentifierChar(char c) => char.IsLetterOrDigit(c) || c == '_';
+
+    private sealed class FindReferencesOutput
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; init; }
+
+        [JsonPropertyName("symbolName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? SymbolName { get; init; }
+
+        [JsonPropertyName("referenceCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public int ReferenceCount { get; init; }
+
+        [JsonPropertyName("references")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<ReferenceLocation>? References { get; init; }
+
+        [JsonPropertyName("message")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Message { get; init; }
+
+        [JsonPropertyName("errors")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string>? Errors { get; init; }
+    }
+
+    private sealed class ReferenceLocation
+    {
+        [JsonPropertyName("filePath")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? FilePath { get; init; }
+
+        [JsonPropertyName("line")]
+        public int Line { get; init; }
+
+        [JsonPropertyName("column")]
+        public int Column { get; init; }
+
+        [JsonPropertyName("isDefinition")]
+        public bool IsDefinition { get; init; }
+
+        [JsonPropertyName("kind")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Kind { get; init; }
+
+        [JsonPropertyName("context")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Context { get; init; }
+    }
+}

--- a/src/Calor.Compiler/Mcp/Tools/FindSymbolTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/FindSymbolTool.cs
@@ -1,0 +1,408 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+
+namespace Calor.Compiler.Mcp.Tools;
+
+/// <summary>
+/// MCP tool for searching symbols by name across Calor files.
+/// Can search a single file or a directory of .calr files.
+/// </summary>
+public sealed class FindSymbolTool : McpToolBase
+{
+    public override string Name => "calor_find_symbol";
+
+    public override string Description =>
+        "Search for symbols by name in Calor source files. " +
+        "Can search in inline source, a single file, or a directory of .calr files. " +
+        "Returns matching symbols with their kind, location, and file path.";
+
+    protected override string GetInputSchemaJson() => """
+        {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Symbol name to search for (case-insensitive partial match)"
+                },
+                "source": {
+                    "type": "string",
+                    "description": "Calor source code to search in"
+                },
+                "filePath": {
+                    "type": "string",
+                    "description": "Path to a .calr file to search in"
+                },
+                "directory": {
+                    "type": "string",
+                    "description": "Directory to search for .calr files (recursive)"
+                },
+                "kind": {
+                    "type": "string",
+                    "description": "Filter by symbol kind: function, class, interface, enum, method, field, property"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of results to return (default: 50)"
+                }
+            },
+            "required": ["query"]
+        }
+        """;
+
+    public override async Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var query = GetString(arguments, "query");
+        var source = GetString(arguments, "source");
+        var filePath = GetString(arguments, "filePath");
+        var directory = GetString(arguments, "directory");
+        var kindFilter = GetString(arguments, "kind");
+        var limit = GetInt(arguments, "limit", 50);
+
+        if (string.IsNullOrEmpty(query))
+        {
+            return McpToolResult.Error("Missing required parameter: query");
+        }
+
+        if (string.IsNullOrEmpty(source) && string.IsNullOrEmpty(filePath) && string.IsNullOrEmpty(directory))
+        {
+            return McpToolResult.Error("At least one of 'source', 'filePath', or 'directory' is required");
+        }
+
+        var results = new List<SymbolMatch>();
+
+        // Search inline source
+        if (!string.IsNullOrEmpty(source))
+        {
+            var parseResult = CalorSourceHelper.Parse(source, "inline");
+            if (parseResult.IsSuccess)
+            {
+                SearchAst(parseResult.Ast!, null, query, kindFilter, results);
+            }
+        }
+
+        // Search single file
+        if (!string.IsNullOrEmpty(filePath))
+        {
+            await SearchFileAsync(filePath, query, kindFilter, results);
+        }
+
+        // Search directory
+        if (!string.IsNullOrEmpty(directory))
+        {
+            await SearchDirectoryAsync(directory, query, kindFilter, results, limit);
+        }
+
+        // Apply limit
+        if (results.Count > limit)
+        {
+            results = results.Take(limit).ToList();
+        }
+
+        return McpToolResult.Json(new FindSymbolOutput
+        {
+            Success = true,
+            Query = query,
+            MatchCount = results.Count,
+            Matches = results
+        });
+    }
+
+    private static async Task SearchFileAsync(string filePath, string query, string? kindFilter, List<SymbolMatch> results)
+    {
+        if (!File.Exists(filePath))
+            return;
+
+        var parseResult = await CalorSourceHelper.ParseFileAsync(filePath);
+        if (parseResult.IsSuccess)
+        {
+            SearchAst(parseResult.Ast!, filePath, query, kindFilter, results);
+        }
+    }
+
+    private static async Task SearchDirectoryAsync(string directory, string query, string? kindFilter, List<SymbolMatch> results, int limit)
+    {
+        if (!Directory.Exists(directory))
+            return;
+
+        var files = Directory.GetFiles(directory, "*.calr", SearchOption.AllDirectories);
+
+        foreach (var file in files)
+        {
+            if (results.Count >= limit)
+                break;
+
+            await SearchFileAsync(file, query, kindFilter, results);
+        }
+    }
+
+    private static void SearchAst(ModuleNode ast, string? filePath, string query, string? kindFilter, List<SymbolMatch> results)
+    {
+        var queryLower = query.ToLowerInvariant();
+
+        // Search functions
+        if (kindFilter == null || kindFilter == "function")
+        {
+            foreach (var func in ast.Functions)
+            {
+                if (MatchesQuery(func.Name, queryLower))
+                {
+                    results.Add(new SymbolMatch
+                    {
+                        Name = func.Name,
+                        Kind = "function",
+                        FilePath = filePath,
+                        Line = func.Span.Line,
+                        Column = func.Span.Column,
+                        Detail = BuildFunctionDetail(func)
+                    });
+                }
+            }
+        }
+
+        // Search classes
+        if (kindFilter == null || kindFilter == "class")
+        {
+            foreach (var cls in ast.Classes)
+            {
+                if (MatchesQuery(cls.Name, queryLower))
+                {
+                    results.Add(new SymbolMatch
+                    {
+                        Name = cls.Name,
+                        Kind = "class",
+                        FilePath = filePath,
+                        Line = cls.Span.Line,
+                        Column = cls.Span.Column,
+                        Detail = cls.BaseClass != null ? $": {cls.BaseClass}" : null
+                    });
+                }
+
+                // Search class members
+                if (kindFilter == null || kindFilter == "method")
+                {
+                    foreach (var method in cls.Methods)
+                    {
+                        if (MatchesQuery(method.Name, queryLower))
+                        {
+                            results.Add(new SymbolMatch
+                            {
+                                Name = method.Name,
+                                Kind = "method",
+                                ContainerName = cls.Name,
+                                FilePath = filePath,
+                                Line = method.Span.Line,
+                                Column = method.Span.Column,
+                                Detail = BuildMethodDetail(method)
+                            });
+                        }
+                    }
+                }
+
+                if (kindFilter == null || kindFilter == "field")
+                {
+                    foreach (var field in cls.Fields)
+                    {
+                        if (MatchesQuery(field.Name, queryLower))
+                        {
+                            results.Add(new SymbolMatch
+                            {
+                                Name = field.Name,
+                                Kind = "field",
+                                ContainerName = cls.Name,
+                                FilePath = filePath,
+                                Line = field.Span.Line,
+                                Column = field.Span.Column,
+                                Detail = field.TypeName
+                            });
+                        }
+                    }
+                }
+
+                if (kindFilter == null || kindFilter == "property")
+                {
+                    foreach (var prop in cls.Properties)
+                    {
+                        if (MatchesQuery(prop.Name, queryLower))
+                        {
+                            results.Add(new SymbolMatch
+                            {
+                                Name = prop.Name,
+                                Kind = "property",
+                                ContainerName = cls.Name,
+                                FilePath = filePath,
+                                Line = prop.Span.Line,
+                                Column = prop.Span.Column,
+                                Detail = prop.TypeName
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        // Search interfaces
+        if (kindFilter == null || kindFilter == "interface")
+        {
+            foreach (var iface in ast.Interfaces)
+            {
+                if (MatchesQuery(iface.Name, queryLower))
+                {
+                    results.Add(new SymbolMatch
+                    {
+                        Name = iface.Name,
+                        Kind = "interface",
+                        FilePath = filePath,
+                        Line = iface.Span.Line,
+                        Column = iface.Span.Column
+                    });
+                }
+
+                // Search interface methods
+                if (kindFilter == null || kindFilter == "method")
+                {
+                    foreach (var method in iface.Methods)
+                    {
+                        if (MatchesQuery(method.Name, queryLower))
+                        {
+                            results.Add(new SymbolMatch
+                            {
+                                Name = method.Name,
+                                Kind = "method signature",
+                                ContainerName = iface.Name,
+                                FilePath = filePath,
+                                Line = method.Span.Line,
+                                Column = method.Span.Column
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        // Search enums
+        if (kindFilter == null || kindFilter == "enum")
+        {
+            foreach (var enumDef in ast.Enums)
+            {
+                if (MatchesQuery(enumDef.Name, queryLower))
+                {
+                    results.Add(new SymbolMatch
+                    {
+                        Name = enumDef.Name,
+                        Kind = "enum",
+                        FilePath = filePath,
+                        Line = enumDef.Span.Line,
+                        Column = enumDef.Span.Column,
+                        Detail = enumDef.UnderlyingType
+                    });
+                }
+
+                // Search enum members
+                foreach (var member in enumDef.Members)
+                {
+                    if (MatchesQuery(member.Name, queryLower))
+                    {
+                        results.Add(new SymbolMatch
+                        {
+                            Name = member.Name,
+                            Kind = "enum member",
+                            ContainerName = enumDef.Name,
+                            FilePath = filePath,
+                            Line = member.Span.Line,
+                            Column = member.Span.Column,
+                            Detail = member.Value
+                        });
+                    }
+                }
+            }
+        }
+
+        // Search delegates
+        if (kindFilter == null || kindFilter == "delegate")
+        {
+            foreach (var del in ast.Delegates)
+            {
+                if (MatchesQuery(del.Name, queryLower))
+                {
+                    results.Add(new SymbolMatch
+                    {
+                        Name = del.Name,
+                        Kind = "delegate",
+                        FilePath = filePath,
+                        Line = del.Span.Line,
+                        Column = del.Span.Column,
+                        Detail = BuildDelegateDetail(del)
+                    });
+                }
+            }
+        }
+    }
+
+    private static bool MatchesQuery(string name, string queryLower)
+    {
+        return name.ToLowerInvariant().Contains(queryLower);
+    }
+
+    private static string BuildFunctionDetail(FunctionNode func)
+    {
+        var returnType = func.Output?.TypeName ?? "void";
+        return $"-> {returnType}";
+    }
+
+    private static string BuildMethodDetail(MethodNode method)
+    {
+        var returnType = method.Output?.TypeName ?? "void";
+        return $"-> {returnType}";
+    }
+
+    private static string BuildDelegateDetail(DelegateDefinitionNode del)
+    {
+        var returnType = del.Output?.TypeName ?? "void";
+        return $"-> {returnType}";
+    }
+
+    private sealed class FindSymbolOutput
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; init; }
+
+        [JsonPropertyName("query")]
+        public required string Query { get; init; }
+
+        [JsonPropertyName("matchCount")]
+        public int MatchCount { get; init; }
+
+        [JsonPropertyName("matches")]
+        public required List<SymbolMatch> Matches { get; init; }
+    }
+
+    private sealed class SymbolMatch
+    {
+        [JsonPropertyName("name")]
+        public required string Name { get; init; }
+
+        [JsonPropertyName("kind")]
+        public required string Kind { get; init; }
+
+        [JsonPropertyName("containerName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? ContainerName { get; init; }
+
+        [JsonPropertyName("filePath")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? FilePath { get; init; }
+
+        [JsonPropertyName("line")]
+        public int Line { get; init; }
+
+        [JsonPropertyName("column")]
+        public int Column { get; init; }
+
+        [JsonPropertyName("detail")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Detail { get; init; }
+    }
+}

--- a/src/Calor.Compiler/Mcp/Tools/GotoDefinitionTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/GotoDefinitionTool.cs
@@ -1,0 +1,331 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Calor.Compiler.Ast;
+
+namespace Calor.Compiler.Mcp.Tools;
+
+/// <summary>
+/// MCP tool for finding the definition of a symbol at a given position.
+/// Returns the file path, line, column, and a preview of the definition.
+/// </summary>
+public sealed class GotoDefinitionTool : McpToolBase
+{
+    public override string Name => "calor_goto_definition";
+
+    public override string Description =>
+        "Find the definition of a symbol at a given position in Calor source code. " +
+        "Provide either 'source' for inline code or 'filePath' to read from file. " +
+        "Returns the definition location with file path, line, column, and preview.";
+
+    protected override string GetInputSchemaJson() => """
+        {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": "Calor source code (use this OR filePath)"
+                },
+                "filePath": {
+                    "type": "string",
+                    "description": "Path to a .calr file (use this OR source)"
+                },
+                "line": {
+                    "type": "integer",
+                    "description": "Line number (1-based) where the symbol is located"
+                },
+                "column": {
+                    "type": "integer",
+                    "description": "Column number (1-based) where the symbol is located"
+                }
+            },
+            "required": ["line", "column"]
+        }
+        """;
+
+    public override async Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var source = GetString(arguments, "source");
+        var filePath = GetString(arguments, "filePath");
+        var line = GetInt(arguments, "line", 0);
+        var column = GetInt(arguments, "column", 0);
+
+        if (string.IsNullOrEmpty(source) && string.IsNullOrEmpty(filePath))
+        {
+            return McpToolResult.Error("Either 'source' or 'filePath' is required");
+        }
+
+        if (line <= 0 || column <= 0)
+        {
+            return McpToolResult.Error("Both 'line' and 'column' must be positive integers");
+        }
+
+        ParseResult parseResult;
+        if (!string.IsNullOrEmpty(filePath))
+        {
+            parseResult = await CalorSourceHelper.ParseFileAsync(filePath);
+        }
+        else
+        {
+            parseResult = CalorSourceHelper.Parse(source!, filePath);
+        }
+
+        if (!parseResult.IsSuccess)
+        {
+            return McpToolResult.Json(new GotoDefinitionOutput
+            {
+                Found = false,
+                Errors = parseResult.Errors.ToList()
+            }, isError: true);
+        }
+
+        var definition = FindDefinitionAtPosition(parseResult.Ast!, parseResult.Source!, line, column);
+
+        if (definition == null)
+        {
+            return McpToolResult.Json(new GotoDefinitionOutput
+            {
+                Found = false,
+                Message = $"No symbol found at line {line}, column {column}"
+            });
+        }
+
+        return McpToolResult.Json(new GotoDefinitionOutput
+        {
+            Found = true,
+            FilePath = filePath,
+            Line = definition.Line,
+            Column = definition.Column,
+            SymbolName = definition.Name,
+            SymbolKind = definition.Kind,
+            Preview = definition.Preview
+        });
+    }
+
+    private static DefinitionInfo? FindDefinitionAtPosition(ModuleNode ast, string source, int line, int column)
+    {
+        // Extract identifier at position
+        var identifier = ExtractIdentifierAtPosition(source, line, column);
+        if (string.IsNullOrEmpty(identifier))
+            return null;
+
+        // Search for definition in order of specificity
+
+        // 1. Check if inside a function - look for parameters and locals
+        foreach (var func in ast.Functions)
+        {
+            if (IsPositionInNode(line, func.Span))
+            {
+                // Check function name
+                if (func.Name == identifier)
+                {
+                    return CreateDefinitionInfo(func.Name, "function", func.Span, source);
+                }
+
+                // Check parameters
+                foreach (var param in func.Parameters)
+                {
+                    if (param.Name == identifier)
+                    {
+                        return CreateDefinitionInfo(param.Name, "parameter", param.Span, source);
+                    }
+                }
+
+                // Check local bindings
+                foreach (var stmt in func.Body)
+                {
+                    if (stmt is BindStatementNode bind && bind.Name == identifier && bind.Span.Line <= line)
+                    {
+                        return CreateDefinitionInfo(bind.Name, bind.IsMutable ? "mutable variable" : "variable", bind.Span, source);
+                    }
+                }
+            }
+        }
+
+        // 2. Check if inside a class
+        foreach (var cls in ast.Classes)
+        {
+            if (IsPositionInNode(line, cls.Span))
+            {
+                if (cls.Name == identifier)
+                {
+                    return CreateDefinitionInfo(cls.Name, "class", cls.Span, source);
+                }
+
+                foreach (var field in cls.Fields)
+                {
+                    if (field.Name == identifier)
+                    {
+                        return CreateDefinitionInfo(field.Name, "field", field.Span, source);
+                    }
+                }
+
+                foreach (var prop in cls.Properties)
+                {
+                    if (prop.Name == identifier)
+                    {
+                        return CreateDefinitionInfo(prop.Name, "property", prop.Span, source);
+                    }
+                }
+
+                foreach (var method in cls.Methods)
+                {
+                    if (method.Name == identifier)
+                    {
+                        return CreateDefinitionInfo(method.Name, "method", method.Span, source);
+                    }
+
+                    // Check method parameters and locals
+                    if (IsPositionInNode(line, method.Span))
+                    {
+                        foreach (var param in method.Parameters)
+                        {
+                            if (param.Name == identifier)
+                            {
+                                return CreateDefinitionInfo(param.Name, "parameter", param.Span, source);
+                            }
+                        }
+
+                        foreach (var stmt in method.Body)
+                        {
+                            if (stmt is BindStatementNode bind && bind.Name == identifier && bind.Span.Line <= line)
+                            {
+                                return CreateDefinitionInfo(bind.Name, bind.IsMutable ? "mutable variable" : "variable", bind.Span, source);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // 3. Search module-level definitions
+        foreach (var func in ast.Functions)
+        {
+            if (func.Name == identifier)
+            {
+                return CreateDefinitionInfo(func.Name, "function", func.Span, source);
+            }
+        }
+
+        foreach (var cls in ast.Classes)
+        {
+            if (cls.Name == identifier)
+            {
+                return CreateDefinitionInfo(cls.Name, "class", cls.Span, source);
+            }
+        }
+
+        foreach (var iface in ast.Interfaces)
+        {
+            if (iface.Name == identifier)
+            {
+                return CreateDefinitionInfo(iface.Name, "interface", iface.Span, source);
+            }
+        }
+
+        foreach (var enumDef in ast.Enums)
+        {
+            if (enumDef.Name == identifier)
+            {
+                return CreateDefinitionInfo(enumDef.Name, "enum", enumDef.Span, source);
+            }
+        }
+
+        foreach (var del in ast.Delegates)
+        {
+            if (del.Name == identifier)
+            {
+                return CreateDefinitionInfo(del.Name, "delegate", del.Span, source);
+            }
+        }
+
+        return null;
+    }
+
+    private static string? ExtractIdentifierAtPosition(string source, int line, int column)
+    {
+        var offset = CalorSourceHelper.GetOffset(source, line, column);
+        if (offset < 0 || offset >= source.Length)
+            return null;
+
+        // Find the start of the identifier
+        var start = offset;
+        while (start > 0 && IsIdentifierChar(source[start - 1]))
+            start--;
+
+        // Find the end of the identifier
+        var end = offset;
+        while (end < source.Length && IsIdentifierChar(source[end]))
+            end++;
+
+        if (start == end)
+            return null;
+
+        return source.Substring(start, end - start);
+    }
+
+    private static bool IsIdentifierChar(char c) => char.IsLetterOrDigit(c) || c == '_';
+
+    private static bool IsPositionInNode(int line, Parsing.TextSpan span)
+    {
+        return line >= span.Line;
+    }
+
+    private static DefinitionInfo CreateDefinitionInfo(string name, string kind, Parsing.TextSpan span, string source)
+    {
+        return new DefinitionInfo
+        {
+            Name = name,
+            Kind = kind,
+            Line = span.Line,
+            Column = span.Column,
+            Preview = CalorSourceHelper.GetPreview(source, span.Line)
+        };
+    }
+
+    private sealed class DefinitionInfo
+    {
+        public required string Name { get; init; }
+        public required string Kind { get; init; }
+        public int Line { get; init; }
+        public int Column { get; init; }
+        public string? Preview { get; init; }
+    }
+
+    private sealed class GotoDefinitionOutput
+    {
+        [JsonPropertyName("found")]
+        public bool Found { get; init; }
+
+        [JsonPropertyName("filePath")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? FilePath { get; init; }
+
+        [JsonPropertyName("line")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public int Line { get; init; }
+
+        [JsonPropertyName("column")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public int Column { get; init; }
+
+        [JsonPropertyName("symbolName")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? SymbolName { get; init; }
+
+        [JsonPropertyName("symbolKind")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? SymbolKind { get; init; }
+
+        [JsonPropertyName("preview")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Preview { get; init; }
+
+        [JsonPropertyName("message")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Message { get; init; }
+
+        [JsonPropertyName("errors")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string>? Errors { get; init; }
+    }
+}

--- a/src/Calor.Compiler/Mcp/Tools/SymbolInfoTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/SymbolInfoTool.cs
@@ -1,0 +1,496 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Calor.Compiler.Ast;
+
+namespace Calor.Compiler.Mcp.Tools;
+
+/// <summary>
+/// MCP tool for getting type information and contracts for a symbol at a given position.
+/// Similar to LSP hover but returns structured data for AI agents.
+/// </summary>
+public sealed class SymbolInfoTool : McpToolBase
+{
+    public override string Name => "calor_symbol_info";
+
+    public override string Description =>
+        "Get type information, contracts, and documentation for a symbol at a given position. " +
+        "Returns structured information including type, kind, contracts (preconditions/postconditions), " +
+        "and a formatted signature.";
+
+    protected override string GetInputSchemaJson() => """
+        {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": "Calor source code (use this OR filePath)"
+                },
+                "filePath": {
+                    "type": "string",
+                    "description": "Path to a .calr file (use this OR source)"
+                },
+                "line": {
+                    "type": "integer",
+                    "description": "Line number (1-based) where the symbol is located"
+                },
+                "column": {
+                    "type": "integer",
+                    "description": "Column number (1-based) where the symbol is located"
+                }
+            },
+            "required": ["line", "column"]
+        }
+        """;
+
+    public override async Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var source = GetString(arguments, "source");
+        var filePath = GetString(arguments, "filePath");
+        var line = GetInt(arguments, "line", 0);
+        var column = GetInt(arguments, "column", 0);
+
+        if (string.IsNullOrEmpty(source) && string.IsNullOrEmpty(filePath))
+        {
+            return McpToolResult.Error("Either 'source' or 'filePath' is required");
+        }
+
+        if (line <= 0 || column <= 0)
+        {
+            return McpToolResult.Error("Both 'line' and 'column' must be positive integers");
+        }
+
+        ParseResult parseResult;
+        if (!string.IsNullOrEmpty(filePath))
+        {
+            parseResult = await CalorSourceHelper.ParseFileAsync(filePath);
+        }
+        else
+        {
+            parseResult = CalorSourceHelper.Parse(source!, filePath);
+        }
+
+        if (!parseResult.IsSuccess)
+        {
+            return McpToolResult.Json(new SymbolInfoOutput
+            {
+                Found = false,
+                Errors = parseResult.Errors.ToList()
+            }, isError: true);
+        }
+
+        var info = GetSymbolInfoAtPosition(parseResult.Ast!, parseResult.Source!, line, column);
+
+        if (info == null)
+        {
+            return McpToolResult.Json(new SymbolInfoOutput
+            {
+                Found = false,
+                Message = $"No symbol found at line {line}, column {column}"
+            });
+        }
+
+        return McpToolResult.Json(info);
+    }
+
+    private static SymbolInfoOutput? GetSymbolInfoAtPosition(ModuleNode ast, string source, int line, int column)
+    {
+        var identifier = ExtractIdentifierAtPosition(source, line, column);
+        if (string.IsNullOrEmpty(identifier))
+            return null;
+
+        // Search for symbol in context
+
+        // 1. Check functions
+        foreach (var func in ast.Functions)
+        {
+            if (func.Name == identifier)
+            {
+                return BuildFunctionInfo(func);
+            }
+
+            if (IsPositionInNode(line, func.Span))
+            {
+                // Check parameters
+                foreach (var param in func.Parameters)
+                {
+                    if (param.Name == identifier)
+                    {
+                        return new SymbolInfoOutput
+                        {
+                            Found = true,
+                            Name = param.Name,
+                            Kind = "parameter",
+                            Type = param.TypeName,
+                            Signature = $"(parameter) {param.Name}: {param.TypeName}"
+                        };
+                    }
+                }
+
+                // Check local bindings
+                foreach (var stmt in func.Body)
+                {
+                    if (stmt is BindStatementNode bind && bind.Name == identifier && bind.Span.Line <= line)
+                    {
+                        return new SymbolInfoOutput
+                        {
+                            Found = true,
+                            Name = bind.Name,
+                            Kind = bind.IsMutable ? "mutable variable" : "variable",
+                            Type = bind.TypeName,
+                            Signature = $"({(bind.IsMutable ? "mutable " : "")}variable) {bind.Name}: {bind.TypeName ?? "inferred"}"
+                        };
+                    }
+                }
+            }
+        }
+
+        // 2. Check classes
+        foreach (var cls in ast.Classes)
+        {
+            if (cls.Name == identifier)
+            {
+                return BuildClassInfo(cls);
+            }
+
+            if (IsPositionInNode(line, cls.Span))
+            {
+                foreach (var field in cls.Fields)
+                {
+                    if (field.Name == identifier)
+                    {
+                        return new SymbolInfoOutput
+                        {
+                            Found = true,
+                            Name = field.Name,
+                            Kind = "field",
+                            Type = field.TypeName,
+                            Visibility = field.Visibility.ToString().ToLower(),
+                            Signature = $"(field) {field.Name}: {field.TypeName}"
+                        };
+                    }
+                }
+
+                foreach (var prop in cls.Properties)
+                {
+                    if (prop.Name == identifier)
+                    {
+                        return new SymbolInfoOutput
+                        {
+                            Found = true,
+                            Name = prop.Name,
+                            Kind = "property",
+                            Type = prop.TypeName,
+                            Signature = $"(property) {prop.Name}: {prop.TypeName}"
+                        };
+                    }
+                }
+
+                foreach (var method in cls.Methods)
+                {
+                    if (method.Name == identifier)
+                    {
+                        return BuildMethodInfo(method);
+                    }
+
+                    if (IsPositionInNode(line, method.Span))
+                    {
+                        foreach (var param in method.Parameters)
+                        {
+                            if (param.Name == identifier)
+                            {
+                                return new SymbolInfoOutput
+                                {
+                                    Found = true,
+                                    Name = param.Name,
+                                    Kind = "parameter",
+                                    Type = param.TypeName,
+                                    Signature = $"(parameter) {param.Name}: {param.TypeName}"
+                                };
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // 3. Check interfaces
+        foreach (var iface in ast.Interfaces)
+        {
+            if (iface.Name == identifier)
+            {
+                return new SymbolInfoOutput
+                {
+                    Found = true,
+                    Name = iface.Name,
+                    Kind = "interface",
+                    Signature = $"interface {iface.Name}",
+                    MemberCount = iface.Methods.Count
+                };
+            }
+        }
+
+        // 4. Check enums
+        foreach (var enumDef in ast.Enums)
+        {
+            if (enumDef.Name == identifier)
+            {
+                return new SymbolInfoOutput
+                {
+                    Found = true,
+                    Name = enumDef.Name,
+                    Kind = "enum",
+                    Type = enumDef.UnderlyingType,
+                    Signature = $"enum {enumDef.Name}" + (enumDef.UnderlyingType != null ? $" : {enumDef.UnderlyingType}" : ""),
+                    MemberCount = enumDef.Members.Count,
+                    EnumMembers = enumDef.Members.Select(m => m.Name).ToList()
+                };
+            }
+
+            // Check enum members
+            foreach (var member in enumDef.Members)
+            {
+                if (member.Name == identifier)
+                {
+                    return new SymbolInfoOutput
+                    {
+                        Found = true,
+                        Name = member.Name,
+                        Kind = "enum member",
+                        Type = enumDef.Name,
+                        Signature = $"{enumDef.Name}.{member.Name}" + (member.Value != null ? $" = {member.Value}" : "")
+                    };
+                }
+            }
+        }
+
+        // 5. Check delegates
+        foreach (var del in ast.Delegates)
+        {
+            if (del.Name == identifier)
+            {
+                var parameters = string.Join(", ", del.Parameters.Select(p => $"{p.Name}: {p.TypeName}"));
+                var returnType = del.Output?.TypeName ?? "void";
+                return new SymbolInfoOutput
+                {
+                    Found = true,
+                    Name = del.Name,
+                    Kind = "delegate",
+                    Type = returnType,
+                    Signature = $"delegate {del.Name}({parameters}) -> {returnType}"
+                };
+            }
+        }
+
+        return null;
+    }
+
+    private static SymbolInfoOutput BuildFunctionInfo(FunctionNode func)
+    {
+        var parameters = string.Join(", ", func.Parameters.Select(p => $"{p.Name}: {p.TypeName}"));
+        var returnType = func.Output?.TypeName ?? "void";
+        var asyncPrefix = func.IsAsync ? "async " : "";
+
+        var contracts = new List<ContractInfo>();
+        foreach (var pre in func.Preconditions)
+        {
+            contracts.Add(new ContractInfo { Type = "requires", Expression = FormatExpression(pre.Condition) });
+        }
+        foreach (var post in func.Postconditions)
+        {
+            contracts.Add(new ContractInfo { Type = "ensures", Expression = FormatExpression(post.Condition) });
+        }
+
+        var effects = func.Effects?.Effects.Values.ToList();
+
+        return new SymbolInfoOutput
+        {
+            Found = true,
+            Name = func.Name,
+            Kind = "function",
+            Type = returnType,
+            Visibility = func.Visibility.ToString().ToLower(),
+            IsAsync = func.IsAsync,
+            Signature = $"{asyncPrefix}function {func.Name}({parameters}) -> {returnType}",
+            Parameters = func.Parameters.Select(p => new ParameterInfo { Name = p.Name, Type = p.TypeName }).ToList(),
+            Contracts = contracts.Count > 0 ? contracts : null,
+            Effects = effects?.Count > 0 ? effects : null
+        };
+    }
+
+    private static SymbolInfoOutput BuildMethodInfo(MethodNode method)
+    {
+        var parameters = string.Join(", ", method.Parameters.Select(p => $"{p.Name}: {p.TypeName}"));
+        var returnType = method.Output?.TypeName ?? "void";
+
+        var modifiers = new List<string>();
+        if (method.IsStatic) modifiers.Add("static");
+        if (method.IsVirtual) modifiers.Add("virtual");
+        if (method.IsOverride) modifiers.Add("override");
+        if (method.IsAbstract) modifiers.Add("abstract");
+        if (method.IsAsync) modifiers.Add("async");
+
+        var contracts = new List<ContractInfo>();
+        foreach (var pre in method.Preconditions)
+        {
+            contracts.Add(new ContractInfo { Type = "requires", Expression = FormatExpression(pre.Condition) });
+        }
+        foreach (var post in method.Postconditions)
+        {
+            contracts.Add(new ContractInfo { Type = "ensures", Expression = FormatExpression(post.Condition) });
+        }
+
+        return new SymbolInfoOutput
+        {
+            Found = true,
+            Name = method.Name,
+            Kind = "method",
+            Type = returnType,
+            Visibility = method.Visibility.ToString().ToLower(),
+            IsAsync = method.IsAsync,
+            Modifiers = modifiers.Count > 0 ? modifiers : null,
+            Signature = $"method {method.Name}({parameters}) -> {returnType}",
+            Parameters = method.Parameters.Select(p => new ParameterInfo { Name = p.Name, Type = p.TypeName }).ToList(),
+            Contracts = contracts.Count > 0 ? contracts : null
+        };
+    }
+
+    private static SymbolInfoOutput BuildClassInfo(ClassDefinitionNode cls)
+    {
+        var modifiers = new List<string>();
+        if (cls.IsAbstract) modifiers.Add("abstract");
+        if (cls.IsSealed) modifiers.Add("sealed");
+        if (cls.IsStatic) modifiers.Add("static");
+        if (cls.IsPartial) modifiers.Add("partial");
+
+        return new SymbolInfoOutput
+        {
+            Found = true,
+            Name = cls.Name,
+            Kind = "class",
+            Modifiers = modifiers.Count > 0 ? modifiers : null,
+            BaseClass = cls.BaseClass,
+            Interfaces = cls.ImplementedInterfaces.Count > 0 ? cls.ImplementedInterfaces.ToList() : null,
+            Signature = $"class {cls.Name}" + (cls.BaseClass != null ? $" : {cls.BaseClass}" : ""),
+            MemberCount = cls.Fields.Count + cls.Properties.Count + cls.Methods.Count
+        };
+    }
+
+    private static string FormatExpression(ExpressionNode? expr)
+    {
+        if (expr == null) return "...";
+        // Simple string representation - could be enhanced
+        return expr.ToString() ?? "...";
+    }
+
+    private static string? ExtractIdentifierAtPosition(string source, int line, int column)
+    {
+        var offset = CalorSourceHelper.GetOffset(source, line, column);
+        if (offset < 0 || offset >= source.Length)
+            return null;
+
+        var start = offset;
+        while (start > 0 && IsIdentifierChar(source[start - 1]))
+            start--;
+
+        var end = offset;
+        while (end < source.Length && IsIdentifierChar(source[end]))
+            end++;
+
+        if (start == end)
+            return null;
+
+        return source.Substring(start, end - start);
+    }
+
+    private static bool IsIdentifierChar(char c) => char.IsLetterOrDigit(c) || c == '_';
+
+    private static bool IsPositionInNode(int line, Parsing.TextSpan span) => line >= span.Line;
+
+    private sealed class SymbolInfoOutput
+    {
+        [JsonPropertyName("found")]
+        public bool Found { get; init; }
+
+        [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Name { get; init; }
+
+        [JsonPropertyName("kind")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Kind { get; init; }
+
+        [JsonPropertyName("type")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Type { get; init; }
+
+        [JsonPropertyName("visibility")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Visibility { get; init; }
+
+        [JsonPropertyName("isAsync")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public bool IsAsync { get; init; }
+
+        [JsonPropertyName("modifiers")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string>? Modifiers { get; init; }
+
+        [JsonPropertyName("signature")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Signature { get; init; }
+
+        [JsonPropertyName("parameters")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<ParameterInfo>? Parameters { get; init; }
+
+        [JsonPropertyName("contracts")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<ContractInfo>? Contracts { get; init; }
+
+        [JsonPropertyName("effects")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string>? Effects { get; init; }
+
+        [JsonPropertyName("baseClass")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? BaseClass { get; init; }
+
+        [JsonPropertyName("interfaces")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string>? Interfaces { get; init; }
+
+        [JsonPropertyName("memberCount")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public int MemberCount { get; init; }
+
+        [JsonPropertyName("enumMembers")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string>? EnumMembers { get; init; }
+
+        [JsonPropertyName("message")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Message { get; init; }
+
+        [JsonPropertyName("errors")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string>? Errors { get; init; }
+    }
+
+    private sealed class ParameterInfo
+    {
+        [JsonPropertyName("name")]
+        public required string Name { get; init; }
+
+        [JsonPropertyName("type")]
+        public required string Type { get; init; }
+    }
+
+    private sealed class ContractInfo
+    {
+        [JsonPropertyName("type")]
+        public required string Type { get; init; }
+
+        [JsonPropertyName("expression")]
+        public required string Expression { get; init; }
+    }
+}

--- a/tests/Calor.Compiler.Tests/Mcp/LspMcpToolsTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/LspMcpToolsTests.cs
@@ -1,0 +1,467 @@
+using System.Text.Json;
+using Calor.Compiler.Mcp;
+using Calor.Compiler.Mcp.Tools;
+using Xunit;
+
+namespace Calor.Compiler.Tests.Mcp;
+
+/// <summary>
+/// Tests for LSP-style MCP tools: goto_definition, find_references, symbol_info, document_outline, find_symbol.
+/// </summary>
+public class LspMcpToolsTests
+{
+    private static readonly string SampleSource = """
+        §M{m001:UserModule}
+          §F{f001:calculateTotal:pub}
+            §I{f64:total}
+            §O{f64}
+            §R total
+          §/F{f001}
+
+          §CL{c001:Item:pub}
+            §FLD{f64:Price:pub}
+            §FLD{str:Name:pub}
+          §/CL{c001}
+
+          §F{f002:greet:pub}
+            §I{str:name}
+            §O{str}
+            §R name
+          §/F{f002}
+        §/M{m001}
+        """;
+
+    #region GotoDefinitionTool Tests
+
+    [Fact]
+    public async Task GotoDefinition_FindsFunction()
+    {
+        var tool = new GotoDefinitionTool();
+        var args = CreateArgs(SampleSource, line: 13, column: 15); // "greet" on function definition
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var output = ParseOutput(result.Content);
+        Assert.True(output.GetProperty("found").GetBoolean());
+        Assert.Equal("greet", output.GetProperty("symbolName").GetString());
+        Assert.Equal("function", output.GetProperty("symbolKind").GetString());
+    }
+
+    [Fact]
+    public async Task GotoDefinition_FindsParameter()
+    {
+        var tool = new GotoDefinitionTool();
+        var args = CreateArgs(SampleSource, line: 3, column: 17); // "total" parameter
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var output = ParseOutput(result.Content);
+        Assert.True(output.GetProperty("found").GetBoolean());
+        Assert.Equal("total", output.GetProperty("symbolName").GetString());
+        Assert.Equal("parameter", output.GetProperty("symbolKind").GetString());
+    }
+
+    [Fact]
+    public async Task GotoDefinition_FindsClass()
+    {
+        var tool = new GotoDefinitionTool();
+        var args = CreateArgs(SampleSource, line: 8, column: 15); // "Item" class
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var output = ParseOutput(result.Content);
+        Assert.True(output.GetProperty("found").GetBoolean());
+        Assert.Equal("Item", output.GetProperty("symbolName").GetString());
+        Assert.Equal("class", output.GetProperty("symbolKind").GetString());
+    }
+
+    [Fact]
+    public async Task GotoDefinition_ReturnsNotFound_WhenNoSymbol()
+    {
+        var tool = new GotoDefinitionTool();
+        var args = CreateArgs(SampleSource, line: 1, column: 1); // Start of file, on §
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var output = ParseOutput(result.Content);
+        Assert.False(output.GetProperty("found").GetBoolean());
+    }
+
+    [Fact]
+    public async Task GotoDefinition_RequiresSourceOrFilePath()
+    {
+        var tool = new GotoDefinitionTool();
+        var args = JsonDocument.Parse(@"{""line"": 1, ""column"": 1}").RootElement;
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region SymbolInfoTool Tests
+
+    [Fact]
+    public async Task SymbolInfo_ReturnsFunctionInfo()
+    {
+        var tool = new SymbolInfoTool();
+        var args = CreateArgs(SampleSource, line: 2, column: 15); // "calculateTotal"
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var output = ParseOutput(result.Content);
+        Assert.True(output.GetProperty("found").GetBoolean());
+        Assert.Equal("calculateTotal", output.GetProperty("name").GetString());
+        Assert.Equal("function", output.GetProperty("kind").GetString());
+        // Type can be returned as "FLOAT" or "f64" depending on normalization
+        var typeVal = output.GetProperty("type").GetString();
+        Assert.True(typeVal == "f64" || typeVal == "FLOAT", $"Expected f64 or FLOAT, got {typeVal}");
+    }
+
+    [Fact]
+    public async Task SymbolInfo_ReturnsClassInfo()
+    {
+        var tool = new SymbolInfoTool();
+        var args = CreateArgs(SampleSource, line: 8, column: 15); // "Item" class
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var output = ParseOutput(result.Content);
+        Assert.True(output.GetProperty("found").GetBoolean());
+        Assert.Equal("Item", output.GetProperty("name").GetString());
+        Assert.Equal("class", output.GetProperty("kind").GetString());
+        Assert.Equal(2, output.GetProperty("memberCount").GetInt32()); // 2 fields
+    }
+
+    [Fact]
+    public async Task SymbolInfo_ReturnsFieldInfo()
+    {
+        var tool = new SymbolInfoTool();
+        var args = CreateArgs(SampleSource, line: 9, column: 17); // "Price" field
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var output = ParseOutput(result.Content);
+        Assert.True(output.GetProperty("found").GetBoolean());
+        Assert.Equal("Price", output.GetProperty("name").GetString());
+        Assert.Equal("field", output.GetProperty("kind").GetString());
+        // Type can be returned as "FLOAT" or "f64" depending on normalization
+        var typeVal = output.GetProperty("type").GetString();
+        Assert.True(typeVal == "f64" || typeVal == "FLOAT", $"Expected f64 or FLOAT, got {typeVal}");
+    }
+
+    #endregion
+
+    #region DocumentOutlineTool Tests
+
+    [Fact]
+    public async Task DocumentOutline_ReturnsStructure()
+    {
+        var tool = new DocumentOutlineTool();
+        var args = CreateSourceArgs(SampleSource);
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var output = ParseOutput(result.Content);
+        Assert.True(output.GetProperty("success").GetBoolean());
+        Assert.Equal("UserModule", output.GetProperty("moduleName").GetString());
+
+        var symbols = output.GetProperty("symbols");
+        Assert.Equal(3, symbols.GetArrayLength()); // 2 functions + 1 class
+
+        var summary = output.GetProperty("summary");
+        Assert.Equal(2, summary.GetProperty("functionCount").GetInt32());
+        Assert.Equal(1, summary.GetProperty("classCount").GetInt32());
+    }
+
+    [Fact]
+    public async Task DocumentOutline_IncludesClassChildren()
+    {
+        var tool = new DocumentOutlineTool();
+        var args = CreateSourceArgs(SampleSource);
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var output = ParseOutput(result.Content);
+        var symbols = output.GetProperty("symbols");
+
+        // Find the Item class
+        JsonElement? classSymbol = null;
+        foreach (var symbol in symbols.EnumerateArray())
+        {
+            if (symbol.GetProperty("name").GetString() == "Item")
+            {
+                classSymbol = symbol;
+                break;
+            }
+        }
+
+        Assert.NotNull(classSymbol);
+        Assert.True(classSymbol.Value.TryGetProperty("children", out var children));
+        Assert.Equal(2, children.GetArrayLength()); // Price and Name fields
+    }
+
+    [Fact]
+    public async Task DocumentOutline_WithoutDetails()
+    {
+        var tool = new DocumentOutlineTool();
+        var args = CreateArgsWithOptions(SampleSource, ("includeDetails", "false"));
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var output = ParseOutput(result.Content);
+        Assert.True(output.GetProperty("success").GetBoolean());
+
+        // Functions should not have children (parameters) when includeDetails is false
+        var symbols = output.GetProperty("symbols");
+        foreach (var symbol in symbols.EnumerateArray())
+        {
+            if (symbol.GetProperty("kind").GetString() == "function")
+            {
+                // Children should be null or not present when includeDetails is false
+                Assert.False(symbol.TryGetProperty("children", out _));
+            }
+        }
+    }
+
+    #endregion
+
+    #region FindSymbolTool Tests
+
+    [Fact]
+    public async Task FindSymbol_FindsByName()
+    {
+        var tool = new FindSymbolTool();
+        var args = CreateFindSymbolArgs(SampleSource, "calculate");
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var output = ParseOutput(result.Content);
+        Assert.True(output.GetProperty("success").GetBoolean());
+        Assert.True(output.GetProperty("matchCount").GetInt32() >= 1);
+
+        var matches = output.GetProperty("matches");
+        var found = false;
+        foreach (var match in matches.EnumerateArray())
+        {
+            if (match.GetProperty("name").GetString() == "calculateTotal")
+            {
+                found = true;
+                Assert.Equal("function", match.GetProperty("kind").GetString());
+            }
+        }
+        Assert.True(found);
+    }
+
+    [Fact]
+    public async Task FindSymbol_FiltersByKind()
+    {
+        var tool = new FindSymbolTool();
+        var args = CreateFindSymbolArgsWithKind(SampleSource, "Item", "class");
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var output = ParseOutput(result.Content);
+        Assert.True(output.GetProperty("success").GetBoolean());
+        Assert.Equal(1, output.GetProperty("matchCount").GetInt32());
+
+        var matches = output.GetProperty("matches");
+        var match = matches[0];
+        Assert.Equal("Item", match.GetProperty("name").GetString());
+        Assert.Equal("class", match.GetProperty("kind").GetString());
+    }
+
+    [Fact]
+    public async Task FindSymbol_RespectsLimit()
+    {
+        var tool = new FindSymbolTool();
+        var args = CreateFindSymbolArgsWithLimit(SampleSource, "e", 2);
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var output = ParseOutput(result.Content);
+        Assert.True(output.GetProperty("success").GetBoolean());
+        Assert.True(output.GetProperty("matchCount").GetInt32() <= 2);
+    }
+
+    #endregion
+
+    #region FindReferencesTool Tests
+
+    [Fact]
+    public async Task FindReferences_FindsAllUsages()
+    {
+        var tool = new FindReferencesTool();
+        var args = CreateArgs(SampleSource, line: 3, column: 17); // "total" parameter
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var output = ParseOutput(result.Content);
+        Assert.True(output.GetProperty("success").GetBoolean());
+        Assert.Equal("total", output.GetProperty("symbolName").GetString());
+
+        // "total" appears in parameter and return
+        var references = output.GetProperty("references");
+        Assert.True(references.GetArrayLength() >= 2);
+    }
+
+    [Fact]
+    public async Task FindReferences_MarksDefinition()
+    {
+        var tool = new FindReferencesTool();
+        var args = CreateArgs(SampleSource, line: 3, column: 17); // "total" parameter
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var output = ParseOutput(result.Content);
+        var references = output.GetProperty("references");
+
+        // At least one reference should be marked as definition
+        var hasDefinition = false;
+        foreach (var reference in references.EnumerateArray())
+        {
+            if (reference.GetProperty("isDefinition").GetBoolean())
+            {
+                hasDefinition = true;
+                break;
+            }
+        }
+        Assert.True(hasDefinition);
+    }
+
+    [Fact]
+    public async Task FindReferences_ExcludesDefinition_WhenRequested()
+    {
+        var tool = new FindReferencesTool();
+        var args = CreateFindReferencesArgs(SampleSource, 3, 17, includeDefinition: false);
+
+        var result = await tool.ExecuteAsync(args);
+
+        Assert.False(result.IsError);
+        var output = ParseOutput(result.Content);
+        var references = output.GetProperty("references");
+
+        // No reference should be marked as definition
+        foreach (var reference in references.EnumerateArray())
+        {
+            Assert.False(reference.GetProperty("isDefinition").GetBoolean());
+        }
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static JsonElement CreateArgs(string source, int line, int column)
+    {
+        var obj = new Dictionary<string, object>
+        {
+            ["source"] = source,
+            ["line"] = line,
+            ["column"] = column
+        };
+        var json = JsonSerializer.Serialize(obj);
+        return JsonDocument.Parse(json).RootElement;
+    }
+
+    private static JsonElement CreateSourceArgs(string source)
+    {
+        var obj = new Dictionary<string, object>
+        {
+            ["source"] = source
+        };
+        var json = JsonSerializer.Serialize(obj);
+        return JsonDocument.Parse(json).RootElement;
+    }
+
+    private static JsonElement CreateArgsWithOptions(string source, params (string key, string value)[] options)
+    {
+        var obj = new Dictionary<string, object>
+        {
+            ["source"] = source
+        };
+        foreach (var (key, value) in options)
+        {
+            if (value == "false")
+                obj[key] = false;
+            else if (value == "true")
+                obj[key] = true;
+            else
+                obj[key] = value;
+        }
+        var json = JsonSerializer.Serialize(obj);
+        return JsonDocument.Parse(json).RootElement;
+    }
+
+    private static JsonElement CreateFindSymbolArgs(string source, string query)
+    {
+        var obj = new Dictionary<string, object>
+        {
+            ["source"] = source,
+            ["query"] = query
+        };
+        var json = JsonSerializer.Serialize(obj);
+        return JsonDocument.Parse(json).RootElement;
+    }
+
+    private static JsonElement CreateFindSymbolArgsWithKind(string source, string query, string kind)
+    {
+        var obj = new Dictionary<string, object>
+        {
+            ["source"] = source,
+            ["query"] = query,
+            ["kind"] = kind
+        };
+        var json = JsonSerializer.Serialize(obj);
+        return JsonDocument.Parse(json).RootElement;
+    }
+
+    private static JsonElement CreateFindSymbolArgsWithLimit(string source, string query, int limit)
+    {
+        var obj = new Dictionary<string, object>
+        {
+            ["source"] = source,
+            ["query"] = query,
+            ["limit"] = limit
+        };
+        var json = JsonSerializer.Serialize(obj);
+        return JsonDocument.Parse(json).RootElement;
+    }
+
+    private static JsonElement CreateFindReferencesArgs(string source, int line, int column, bool includeDefinition)
+    {
+        var obj = new Dictionary<string, object>
+        {
+            ["source"] = source,
+            ["line"] = line,
+            ["column"] = column,
+            ["includeDefinition"] = includeDefinition
+        };
+        var json = JsonSerializer.Serialize(obj);
+        return JsonDocument.Parse(json).RootElement;
+    }
+
+    private static JsonElement ParseOutput(IReadOnlyList<Calor.Compiler.Mcp.McpContent> content)
+    {
+        var text = content[0].Text ?? throw new InvalidOperationException("No text content");
+        return JsonDocument.Parse(text).RootElement;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Add five new MCP tools that provide LSP-like functionality for AI agents to navigate and understand Calor code:

| Tool | Description |
|------|-------------|
| `calor_goto_definition` | Find where a symbol is defined |
| `calor_find_references` | Find all usages of a symbol |
| `calor_symbol_info` | Get type info, contracts, and documentation |
| `calor_document_outline` | Get hierarchical file structure |
| `calor_find_symbol` | Search symbols by name across files |

## Why

These tools help AI agents (like Claude Code) understand and navigate Calor code without needing a full LSP connection. Each tool:
- Works with inline source code or file paths
- Returns structured JSON for easy parsing
- Provides context like line numbers, previews, and symbol kinds

## New Files

- `CalorSourceHelper.cs` - Shared parsing utilities
- `GotoDefinitionTool.cs` - Find definition locations
- `FindReferencesTool.cs` - Find all symbol usages
- `SymbolInfoTool.cs` - Get type/contract information
- `DocumentOutlineTool.cs` - Get file structure
- `FindSymbolTool.cs` - Search symbols by name
- `LspMcpToolsTests.cs` - 17 tests covering all tools

## Test plan

- [x] All 2820 tests pass (17 new tests added)
- [x] Manual verification of tool responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)