### PR TITLE
feat(init): add MCP server support to Codex initializer

### DIFF
--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -202,15 +202,31 @@ Creates the following files:
 |:-----|:--------|
 | `.codex/skills/calor/SKILL.md` | Calor code writing skill with YAML frontmatter |
 | `.codex/skills/calor-convert/SKILL.md` | C# to Calor conversion skill |
+| `.codex/config.toml` | MCP server configuration for Calor tools |
 | `AGENTS.md` | Project documentation with Calor-first guidelines |
 
-#### Guidance-Based Enforcement
+#### MCP Server Integration
 
-**Important:** Codex CLI does not support hooks like Claude Code. Calor-first development is **guidance-based only**, relying on instructions in `AGENTS.md` and the skill files.
+The `.codex/config.toml` file configures an MCP server that gives Codex direct access to Calor compiler tools (`calor_typecheck`, `calor_verify_contracts`, `calor_analyze`, `calor_convert`, and more):
+
+```toml
+# BEGIN CalorC MCP SECTION - DO NOT EDIT
+[mcp_servers.calor]
+command = "calor"
+args = ["mcp", "--stdio"]
+# END CalorC MCP SECTION
+```
+
+See [`calor mcp`](/calor/cli/mcp/) for the complete list of available tools.
+
+#### Enforcement
+
+Codex CLI does not support hooks like Claude Code. MCP tools provide direct access to Calor compiler features, and Calor-first development is **guidance-based**, relying on instructions in `AGENTS.md` and the skill files.
 
 This means:
 - Codex *should* create `.calr` files based on the instructions
-- However, enforcement is not automatic - Codex may occasionally create `.cs` files
+- MCP tools give Codex native access to compile, verify, and convert
+- Hooks are not supported, so enforcement is not automatic
 - Review file extensions after code generation
 - Use `calor assess` to find any unconverted `.cs` files
 
@@ -226,6 +242,7 @@ After initialization, use these Codex commands:
 ```
 project/
 ├── .codex/
+│   ├── config.toml
 │   └── skills/
 │       ├── calor/
 │       │   └── SKILL.md

--- a/docs/getting-started/codex-integration.md
+++ b/docs/getting-started/codex-integration.md
@@ -25,20 +25,58 @@ This creates:
 |:-----|:--------|
 | `.codex/skills/calor/SKILL.md` | Teaches Codex Calor syntax for writing new code |
 | `.codex/skills/calor-convert/SKILL.md` | Teaches Codex how to convert C# to Calor |
+| `.codex/config.toml` | MCP server configuration for Calor tools |
 | `AGENTS.md` | Project documentation with Calor-first guidelines |
 
 You can run this command again anytime to update the Calor documentation section in AGENTS.md without losing your custom content.
 
 ---
 
-## Important: Guidance-Based Enforcement
+## MCP Server Integration
 
-Unlike Claude Code which uses hooks to enforce Calor-first development, **Codex CLI does not support hooks**. This means:
+The init command also configures an **MCP (Model Context Protocol) server** that gives Codex direct access to the Calor compiler. This enables Codex to:
 
-- Calor-first development is **guidance-based only**
+- **Type check** code and get semantic errors
+- **Verify contracts** using the Z3 SMT solver
+- **Analyze** code for bugs and migration potential
+- **Convert** between C# and Calor
+
+### How It Works
+
+When you open the project in Codex CLI, the MCP server starts automatically based on the `.codex/config.toml` configuration:
+
+```toml
+# BEGIN CalorC MCP SECTION - DO NOT EDIT
+[mcp_servers.calor]
+command = "calor"
+args = ["mcp", "--stdio"]
+# END CalorC MCP SECTION
+```
+
+### Available Tools
+
+| Tool | Purpose |
+|:-----|:--------|
+| `calor_typecheck` | Semantic type checking with error categorization |
+| `calor_verify_contracts` | Z3-based contract verification |
+| `calor_compile` | Compile Calor source to C# |
+| `calor_analyze` | Advanced bug detection |
+| `calor_convert` | Convert between C# and Calor |
+| `calor_format` | Format source to canonical style |
+| `calor_lint` | Check agent-optimized format issues |
+
+See [`calor mcp`](/calor/cli/mcp/) for the complete list of 19 available tools.
+
+---
+
+## Enforcement
+
+Codex CLI does not support hooks like Claude Code. However, with MCP tools providing direct access to the Calor compiler, Codex can compile, verify, and convert code natively. Calor-first enforcement is still **guidance-based**, relying on instructions in `AGENTS.md` and the skill files:
+
+- MCP tools give Codex direct access to compile, verify, and convert Calor code
 - Codex *should* follow the instructions in AGENTS.md and create `.calr` files
-- However, enforcement is not automatic - Codex may occasionally create `.cs` files
-- Always review file extensions after code generation
+- Hooks are not supported, so enforcement is not automatic
+- Review file extensions after code generation
 - Use `calor assess` to find any unconverted `.cs` files
 
 ---
@@ -133,7 +171,8 @@ The Calor skills teach Codex:
 | Skill file format | `calor.md` | `SKILL.md` with YAML frontmatter |
 | Project instructions | `CLAUDE.md` | `AGENTS.md` |
 | Skill invocation | `/calor` | `$calor` |
-| Calor-first enforcement | **Hooks (enforced)** | **Guidance only** |
+| MCP Tools | Yes | Yes |
+| Calor-first enforcement | **Hooks (enforced)** | **Guidance + MCP tools** |
 | Blocks `.cs` creation | Yes | No |
 
 ---
@@ -218,7 +257,7 @@ Convert src/Services/PaymentService.cs to Calor, adding:
 
 ### Verifying Calor-First Compliance
 
-Since Codex doesn't enforce Calor-first automatically, periodically check for unconverted files:
+Since Codex doesn't have hooks for Calor-first enforcement, periodically check for unconverted files:
 
 ```bash
 # Find C# files that might need conversion
@@ -232,11 +271,12 @@ find . -name "*.cs" -not -name "*.g.cs" -not -path "./obj/*"
 
 ## Best Practices
 
-1. **Review generated files** - Always check that Codex created `.calr` files, not `.cs`
-2. **Use explicit instructions** - Be specific about wanting Calor output
-3. **Include skill reference** - Start prompts with `$calor` or `$calor-convert`
-4. **Run analysis regularly** - Use `calor assess` to find migration candidates
-5. **Convert promptly** - If Codex creates a `.cs` file, convert it immediately
+1. **Use MCP tools** - Leverage MCP tools for compilation and verification
+2. **Review generated files** - Always check that Codex created `.calr` files, not `.cs`
+3. **Use explicit instructions** - Be specific about wanting Calor output
+4. **Include skill reference** - Start prompts with `$calor` or `$calor-convert`
+5. **Run analysis regularly** - Use `calor assess` to find migration candidates
+6. **Convert promptly** - If Codex creates a `.cs` file, convert it immediately
 
 ---
 
@@ -266,4 +306,5 @@ ls -la .codex/skills/calor-convert/SKILL.md
 - [Syntax Reference](/calor/syntax-reference/) - Complete language reference
 - [Adding Calor to Existing Projects](/calor/guides/adding-calor-to-existing-projects/) - Migration guide
 - [calor init](/calor/cli/init/) - Full init command documentation
+- [calor mcp](/calor/cli/mcp/) - MCP server tool documentation
 - [Claude Integration](/calor/getting-started/claude-integration/) - Alternative with enforced Calor-first

--- a/tests/Calor.Compiler.Tests/CodexInitializerMcpTests.cs
+++ b/tests/Calor.Compiler.Tests/CodexInitializerMcpTests.cs
@@ -1,0 +1,321 @@
+using Calor.Compiler.Init;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+public class CodexInitializerMcpTests : IDisposable
+{
+    private readonly string _testDir;
+
+    public CodexInitializerMcpTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), $"calor-codex-mcp-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir))
+        {
+            Directory.Delete(_testDir, recursive: true);
+        }
+    }
+
+    // --- Basic functionality ---
+
+    [Fact]
+    public async Task Initialize_CreatesConfigToml_WithMcpServer()
+    {
+        var initializer = new CodexInitializer();
+        var result = await initializer.InitializeAsync(_testDir, force: false);
+
+        var configPath = Path.Combine(_testDir, ".codex", "config.toml");
+        Assert.True(File.Exists(configPath), "config.toml should be created");
+        Assert.Contains(configPath, result.CreatedFiles);
+
+        var content = await File.ReadAllTextAsync(configPath);
+        Assert.Contains("[mcp_servers.calor]", content);
+        Assert.Contains("command = \"calor\"", content);
+        Assert.Contains("args = [\"mcp\", \"--stdio\"]", content);
+    }
+
+    [Fact]
+    public async Task Initialize_ConfigToml_HasSectionMarkers()
+    {
+        var initializer = new CodexInitializer();
+        await initializer.InitializeAsync(_testDir, force: false);
+
+        var configPath = Path.Combine(_testDir, ".codex", "config.toml");
+        var content = await File.ReadAllTextAsync(configPath);
+
+        Assert.Contains("# BEGIN CalorC MCP SECTION - DO NOT EDIT", content);
+        Assert.Contains("# END CalorC MCP SECTION", content);
+    }
+
+    [Fact]
+    public async Task Initialize_ConfigToml_HasValidTomlSyntax()
+    {
+        var initializer = new CodexInitializer();
+        await initializer.InitializeAsync(_testDir, force: false);
+
+        var configPath = Path.Combine(_testDir, ".codex", "config.toml");
+        var content = await File.ReadAllTextAsync(configPath);
+
+        // Values should be properly quoted
+        Assert.Contains("command = \"calor\"", content);
+        // Array should use brackets
+        Assert.Contains("args = [\"mcp\", \"--stdio\"]", content);
+        // Table header should use dot notation
+        Assert.Contains("[mcp_servers.calor]", content);
+    }
+
+    // --- Idempotency ---
+
+    [Fact]
+    public async Task Initialize_DoesNotDuplicateMcpServer_WhenAlreadyConfigured()
+    {
+        var initializer = new CodexInitializer();
+
+        await initializer.InitializeAsync(_testDir, force: false);
+        await initializer.InitializeAsync(_testDir, force: false);
+
+        var configPath = Path.Combine(_testDir, ".codex", "config.toml");
+        var content = await File.ReadAllTextAsync(configPath);
+
+        var count = content.Split("[mcp_servers.calor]").Length - 1;
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task Initialize_RunsMultipleTimesIdempotently()
+    {
+        var initializer = new CodexInitializer();
+        var configPath = Path.Combine(_testDir, ".codex", "config.toml");
+
+        await initializer.InitializeAsync(_testDir, force: false);
+        var contentAfterFirst = await File.ReadAllTextAsync(configPath);
+
+        await initializer.InitializeAsync(_testDir, force: false);
+        var contentAfterSecond = await File.ReadAllTextAsync(configPath);
+
+        await initializer.InitializeAsync(_testDir, force: false);
+        var contentAfterThird = await File.ReadAllTextAsync(configPath);
+
+        Assert.Equal(contentAfterFirst, contentAfterSecond);
+        Assert.Equal(contentAfterSecond, contentAfterThird);
+    }
+
+    [Fact]
+    public async Task Initialize_ConfigToml_NotInCreatedOrUpdated_WhenUnchanged()
+    {
+        var initializer = new CodexInitializer();
+        var configPath = Path.Combine(_testDir, ".codex", "config.toml");
+
+        // First run creates it
+        await initializer.InitializeAsync(_testDir, force: false);
+
+        // Second run should not report it as created or updated
+        var result = await initializer.InitializeAsync(_testDir, force: false);
+
+        Assert.DoesNotContain(configPath, result.CreatedFiles);
+        Assert.DoesNotContain(configPath, result.UpdatedFiles);
+    }
+
+    // --- Preserving existing content ---
+
+    [Fact]
+    public async Task Initialize_PreservesExistingConfigToml_Content()
+    {
+        var configPath = Path.Combine(_testDir, ".codex", "config.toml");
+        Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
+
+        var existingContent = "model = \"o3\"\nprovider = \"openai\"\n";
+        await File.WriteAllTextAsync(configPath, existingContent);
+
+        var initializer = new CodexInitializer();
+        await initializer.InitializeAsync(_testDir, force: false);
+
+        var content = await File.ReadAllTextAsync(configPath);
+
+        Assert.Contains("model = \"o3\"", content);
+        Assert.Contains("provider = \"openai\"", content);
+        Assert.Contains("[mcp_servers.calor]", content);
+    }
+
+    [Fact]
+    public async Task Initialize_PreservesUserTomlBeforeAndAfterMarkers()
+    {
+        var configPath = Path.Combine(_testDir, ".codex", "config.toml");
+        Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
+
+        var existingContent = """
+            model = "o3"
+
+            # BEGIN CalorC MCP SECTION - DO NOT EDIT
+            [mcp_servers.calor]
+            command = "old-calor"
+            args = ["old-arg"]
+            # END CalorC MCP SECTION
+
+            [some_other_section]
+            key = "value"
+            """;
+        await File.WriteAllTextAsync(configPath, existingContent);
+
+        var initializer = new CodexInitializer();
+        await initializer.InitializeAsync(_testDir, force: false);
+
+        var content = await File.ReadAllTextAsync(configPath);
+
+        // Before markers preserved
+        Assert.Contains("model = \"o3\"", content);
+        // After markers preserved
+        Assert.Contains("[some_other_section]", content);
+        Assert.Contains("key = \"value\"", content);
+        // Old content replaced
+        Assert.DoesNotContain("old-calor", content);
+        Assert.DoesNotContain("old-arg", content);
+        // New content present
+        Assert.Contains("command = \"calor\"", content);
+        Assert.Contains("args = [\"mcp\", \"--stdio\"]", content);
+    }
+
+    [Fact]
+    public async Task Initialize_AppendsToExistingConfigWithoutMarkers()
+    {
+        var configPath = Path.Combine(_testDir, ".codex", "config.toml");
+        Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
+
+        var existingContent = "model = \"o3\"\nprovider = \"openai\"\n";
+        await File.WriteAllTextAsync(configPath, existingContent);
+
+        var initializer = new CodexInitializer();
+        await initializer.InitializeAsync(_testDir, force: false);
+
+        var content = await File.ReadAllTextAsync(configPath);
+
+        // Original content preserved at the top
+        Assert.Contains("model = \"o3\"", content);
+        Assert.Contains("provider = \"openai\"", content);
+
+        // MCP section appended
+        Assert.Contains("# BEGIN CalorC MCP SECTION - DO NOT EDIT", content);
+        Assert.Contains("[mcp_servers.calor]", content);
+
+        // MCP section comes after original content
+        var originalIdx = content.IndexOf("provider = \"openai\"");
+        var mcpIdx = content.IndexOf("# BEGIN CalorC MCP SECTION");
+        Assert.True(mcpIdx > originalIdx);
+    }
+
+    // --- Result tracking ---
+
+    [Fact]
+    public async Task Initialize_ConfigToml_InCreatedFiles_WhenNew()
+    {
+        var initializer = new CodexInitializer();
+        var result = await initializer.InitializeAsync(_testDir, force: false);
+
+        var configPath = Path.Combine(_testDir, ".codex", "config.toml");
+        Assert.Contains(configPath, result.CreatedFiles);
+    }
+
+    [Fact]
+    public async Task Initialize_ConfigToml_InUpdatedFiles_WhenModified()
+    {
+        var configPath = Path.Combine(_testDir, ".codex", "config.toml");
+        Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
+
+        // Pre-create without MCP section
+        await File.WriteAllTextAsync(configPath, "model = \"o3\"\n");
+
+        var initializer = new CodexInitializer();
+        var result = await initializer.InitializeAsync(_testDir, force: false);
+
+        Assert.Contains(configPath, result.UpdatedFiles);
+    }
+
+    [Fact]
+    public async Task Initialize_MessagesMentionMcpServer()
+    {
+        var initializer = new CodexInitializer();
+        var result = await initializer.InitializeAsync(_testDir, force: false);
+
+        Assert.True(result.Success);
+        Assert.Contains(result.Messages, m => m.Contains("MCP server"));
+    }
+
+    [Fact]
+    public async Task Initialize_DoesNotShowOldWarning()
+    {
+        var initializer = new CodexInitializer();
+        var result = await initializer.InitializeAsync(_testDir, force: false);
+
+        Assert.DoesNotContain(result.Messages, m => m.Contains("WARNING: OpenAI Codex cannot enforce"));
+    }
+
+    // --- Edge cases ---
+
+    [Fact]
+    public async Task Initialize_CreatesConfigToml_EvenIfSkillsExist()
+    {
+        // Pre-create skills directory without config.toml
+        var skillDir = Path.Combine(_testDir, ".codex", "skills", "calor");
+        Directory.CreateDirectory(skillDir);
+        await File.WriteAllTextAsync(Path.Combine(skillDir, "SKILL.md"), "custom skill");
+
+        var initializer = new CodexInitializer();
+        var result = await initializer.InitializeAsync(_testDir, force: false);
+
+        var configPath = Path.Combine(_testDir, ".codex", "config.toml");
+        Assert.True(File.Exists(configPath));
+        Assert.Contains(configPath, result.CreatedFiles);
+    }
+
+    [Fact]
+    public async Task Initialize_HandlesEmptyConfigToml()
+    {
+        var configPath = Path.Combine(_testDir, ".codex", "config.toml");
+        Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
+
+        // Pre-create empty config.toml
+        await File.WriteAllTextAsync(configPath, "");
+
+        var initializer = new CodexInitializer();
+        var result = await initializer.InitializeAsync(_testDir, force: false);
+
+        var content = await File.ReadAllTextAsync(configPath);
+        Assert.Contains("[mcp_servers.calor]", content);
+        Assert.Contains(configPath, result.UpdatedFiles);
+    }
+
+    [Fact]
+    public async Task Initialize_ReplacesStaleSection_WithUpdatedContent()
+    {
+        var configPath = Path.Combine(_testDir, ".codex", "config.toml");
+        Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
+
+        // Pre-create with stale/wrong MCP section
+        var staleContent = """
+            # BEGIN CalorC MCP SECTION - DO NOT EDIT
+            [mcp_servers.calor]
+            command = "wrong-command"
+            args = ["wrong-arg"]
+            # END CalorC MCP SECTION
+            """;
+        await File.WriteAllTextAsync(configPath, staleContent);
+
+        var initializer = new CodexInitializer();
+        await initializer.InitializeAsync(_testDir, force: false);
+
+        var content = await File.ReadAllTextAsync(configPath);
+
+        // Old values replaced
+        Assert.DoesNotContain("wrong-command", content);
+        Assert.DoesNotContain("wrong-arg", content);
+
+        // Correct values present
+        Assert.Contains("command = \"calor\"", content);
+        Assert.Contains("args = [\"mcp\", \"--stdio\"]", content);
+    }
+}

--- a/tests/Calor.Compiler.Tests/CodexInitializerTests.cs
+++ b/tests/Calor.Compiler.Tests/CodexInitializerTests.cs
@@ -335,7 +335,7 @@ This should be preserved.
         Assert.True(result.Success);
         Assert.NotEmpty(result.Messages);
         Assert.Contains(result.Messages, m => m.Contains("OpenAI Codex"));
-        Assert.Contains(result.Messages, m => m.Contains("cannot enforce Calor-first development"));
+        Assert.Contains(result.Messages, m => m.Contains("MCP server"));
     }
 
     [Fact]

--- a/website/content/cli/init.mdx
+++ b/website/content/cli/init.mdx
@@ -99,15 +99,31 @@ Creates the following files:
 |:-----|:--------|
 | `.codex/skills/calor/SKILL.md` | Calor code writing skill with YAML frontmatter |
 | `.codex/skills/calor-convert/SKILL.md` | C# to Calor conversion skill |
+| `.codex/config.toml` | MCP server configuration for Calor tools |
 | `AGENTS.md` | Project documentation with Calor-first guidelines |
 
-#### Guidance-Based Enforcement
+#### MCP Server Integration
 
-**Important:** Codex CLI does not support hooks like Claude Code. Calor-first development is **guidance-based only**.
+The `.codex/config.toml` file configures an MCP server that gives Codex direct access to Calor compiler tools (`calor_typecheck`, `calor_verify_contracts`, `calor_analyze`, `calor_convert`, and more):
+
+```toml
+# BEGIN CalorC MCP SECTION - DO NOT EDIT
+[mcp_servers.calor]
+command = "calor"
+args = ["mcp", "--stdio"]
+# END CalorC MCP SECTION
+```
+
+See [calor mcp](/cli/mcp/) for the complete list of available tools.
+
+#### Enforcement
+
+Codex CLI does not support hooks like Claude Code. MCP tools provide direct access to Calor compiler features, and Calor-first development is **guidance-based**, relying on `AGENTS.md` and the skill files.
 
 This means:
 - Codex *should* create `.calr` files based on the instructions
-- Enforcement is not automatic - review file extensions after generation
+- MCP tools give Codex native access to compile, verify, and convert
+- Hooks are not supported, so enforcement is not automatic
 - Use `calor analyze` to find any unconverted `.cs` files
 
 After initialization, use these Codex commands:

--- a/website/content/getting-started/codex-integration.mdx
+++ b/website/content/getting-started/codex-integration.mdx
@@ -23,17 +23,56 @@ This creates:
 |:-----|:--------|
 | `.codex/skills/calor/SKILL.md` | Teaches Codex Calor syntax |
 | `.codex/skills/calor-convert/SKILL.md` | Teaches Codex C# to Calor conversion |
+| `.codex/config.toml` | MCP server configuration for Calor tools |
 | `AGENTS.md` | Project documentation with Calor-first guidelines |
 
 ---
 
-## Important: Guidance-Based Enforcement
+## MCP Server Integration
 
-Unlike Claude Code which uses hooks to enforce Calor-first development, **Codex CLI does not support hooks**. This means:
+The init command also configures an **MCP (Model Context Protocol) server** that gives Codex direct access to the Calor compiler. This enables Codex to:
 
-- Calor-first development is **guidance-based only**
+- **Type check** code and get semantic errors
+- **Verify contracts** using the Z3 SMT solver
+- **Analyze** code for bugs and migration potential
+- **Convert** between C# and Calor
+
+### How It Works
+
+When you open the project in Codex CLI, the MCP server starts automatically based on the `.codex/config.toml` configuration:
+
+```toml
+# BEGIN CalorC MCP SECTION - DO NOT EDIT
+[mcp_servers.calor]
+command = "calor"
+args = ["mcp", "--stdio"]
+# END CalorC MCP SECTION
+```
+
+### Available Tools
+
+| Tool | Purpose |
+|:-----|:--------|
+| `calor_typecheck` | Semantic type checking with error categorization |
+| `calor_verify_contracts` | Z3-based contract verification |
+| `calor_compile` | Compile Calor source to C# |
+| `calor_analyze` | Advanced bug detection |
+| `calor_convert` | Convert between C# and Calor |
+| `calor_format` | Format source to canonical style |
+| `calor_lint` | Check agent-optimized format issues |
+
+See [calor mcp](/cli/mcp/) for the complete list of 19 available tools.
+
+---
+
+## Enforcement
+
+Codex CLI does not support hooks like Claude Code. However, MCP tools provide direct access to the Calor compiler, and Calor-first development is **guidance-based**, relying on instructions in `AGENTS.md` and the skill files:
+
+- MCP tools give Codex native access to compile, verify, and convert Calor code
 - Codex *should* follow the instructions and create `.calr` files
-- Enforcement is not automatic - review file extensions after generation
+- Hooks are not supported, so enforcement is not automatic
+- Review file extensions after generation
 - Use `calor analyze` to find any unconverted `.cs` files
 
 ---
@@ -76,16 +115,18 @@ public class Calculator
 | Skills directory | `.claude/skills/` | `.codex/skills/<name>/` |
 | Project instructions | `CLAUDE.md` | `AGENTS.md` |
 | Skill invocation | `/calor` | `$calor` |
-| Enforcement | **Hooks (enforced)** | **Guidance only** |
+| MCP Tools | Yes | Yes |
+| Enforcement | **Hooks (enforced)** | **Guidance + MCP tools** |
 
 ---
 
 ## Best Practices
 
-1. **Review generated files** - Check that Codex created `.calr` files, not `.cs`
-2. **Use explicit instructions** - Be specific about wanting Calor output
-3. **Start with skill reference** - Begin prompts with `$calor` or `$calor-convert`
-4. **Run analysis regularly** - Use `calor analyze` to find migration candidates
+1. **Use MCP tools** - Leverage MCP tools for compilation and verification
+2. **Review generated files** - Check that Codex created `.calr` files, not `.cs`
+3. **Use explicit instructions** - Be specific about wanting Calor output
+4. **Start with skill reference** - Begin prompts with `$calor` or `$calor-convert`
+5. **Run analysis regularly** - Use `calor analyze` to find migration candidates
 
 ---
 
@@ -93,4 +134,5 @@ public class Calculator
 
 - [Syntax Reference](/syntax-reference/) - Complete language reference
 - [calor init](/cli/init/) - Full init command documentation
+- [calor mcp](/cli/mcp/) - MCP server tool documentation
 - [Claude Integration](/getting-started/claude-integration/) - Alternative with enforced Calor-first


### PR DESCRIPTION
## Summary

- Add MCP server configuration to `calor init --ai codex` via `.codex/config.toml`, giving Codex the same Calor compiler tool access as Claude (compile, verify, analyze, convert, typecheck)
- Use section-marker pattern (`# BEGIN/END CalorC MCP SECTION`) for idempotent TOML generation — no TOML NuGet dependency needed
- Update docs and website pages to document MCP integration, align tool names with the new `mcp.mdx` reference, and soften enforcement wording

## Test plan

- [x] 16 new tests in `CodexInitializerMcpTests.cs` covering creation, idempotency, content preservation, result tracking, and edge cases
- [x] Updated existing test assertion in `CodexInitializerTests.cs` for new message wording
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — all 3,759 tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)