### PR TITLE
feat(init): add MCP server support to Gemini CLI

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -301,6 +301,37 @@ This configures two servers:
 - **calor-lsp**: Language server for IDE features (diagnostics, hover, go-to-definition)
 - **calor**: MCP server with tools for compile, verify, analyze, convert, syntax help, lint, format, diagnose, and IDs
 
+### Gemini CLI (via calor init)
+
+When you run `calor init --ai gemini`, the MCP server is automatically configured in `.gemini/settings.json` alongside hooks:
+
+```json
+{
+  "mcpServers": {
+    "calor": {
+      "command": "calor",
+      "args": ["mcp", "--stdio"]
+    }
+  },
+  "hooks": {
+    "BeforeTool": [
+      {
+        "matcher": "write_file|replace",
+        "hooks": [
+          {
+            "name": "calor-validate-write",
+            "type": "command",
+            "command": "calor hook validate-write --format gemini $TOOL_INPUT"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Note: Unlike Claude Code, Gemini CLI's MCP config does not require a `type` field, and configuration is project-level (`.gemini/settings.json`) rather than user-level.
+
 ### VS Code
 
 Add to `.vscode/mcp.json`:
@@ -352,4 +383,5 @@ The server implements [MCP 2024-11-05](https://spec.modelcontextprotocol.io/) wi
 
 - [calor init](/calor/cli/init/) - Initialize project with MCP server configuration
 - [Claude Integration](/calor/getting-started/claude-integration/) - Using Calor with Claude Code
+- [Gemini Integration](/calor/getting-started/gemini-integration/) - Using Calor with Google Gemini CLI
 - [Model Context Protocol](https://modelcontextprotocol.io/) - MCP specification

--- a/docs/getting-started/gemini-integration.md
+++ b/docs/getting-started/gemini-integration.md
@@ -25,7 +25,7 @@ This creates:
 |:-----|:--------|
 | `.gemini/skills/calor/SKILL.md` | Teaches Gemini Calor syntax for writing new code |
 | `.gemini/skills/calor-convert/SKILL.md` | Teaches Gemini how to convert C# to Calor |
-| `.gemini/settings.json` | **Hook configuration** - enforces Calor-first development |
+| `.gemini/settings.json` | **MCP server + hooks** - AI agent tools and Calor-first enforcement |
 | `GEMINI.md` | Project documentation with Calor-first guidelines |
 
 You can run this command again anytime to update the Calor documentation section in GEMINI.md without losing your custom content.
@@ -52,6 +52,40 @@ Gemini will then automatically retry with an `.calr` file.
 - `.calr` files (Calor source code)
 - `.g.cs` files (generated C# from Calor)
 - Files in `obj/` directory (build artifacts)
+
+---
+
+## MCP Tools
+
+Gemini CLI now has access to Calor's MCP (Model Context Protocol) tools, enabling direct compilation, verification, and analysis from within Gemini conversations.
+
+The MCP server is automatically configured in `.gemini/settings.json` alongside hooks:
+
+```json
+{
+  "mcpServers": {
+    "calor": {
+      "command": "calor",
+      "args": ["mcp", "--stdio"]
+    }
+  },
+  "hooks": { ... }
+}
+```
+
+**Available tools:**
+- `calor_compile` — Compile `.calr` files to C#
+- `calor_verify` — Verify contracts and semantics
+- `calor_analyze` — Analyze code quality and complexity
+- `calor_convert` — Convert C# to Calor
+- `calor_typecheck` — Type-check Calor source
+- `calor_syntax_help` — Get Calor syntax reference
+- `calor_lint` — Lint Calor source for style issues
+- `calor_format` — Format Calor source code
+- `calor_diagnose` — Diagnose compilation errors
+- `calor_ids` — List and validate Calor IDs
+
+Gemini can use these tools autonomously during conversations to compile, verify, and fix Calor code without leaving the chat.
 
 ---
 
@@ -148,7 +182,7 @@ The Calor skills teach Gemini:
 | Calor-first enforcement | **Hooks (enforced)** | **Hooks (enforced)** | Guidance only |
 | Blocks `.cs` creation | Yes | Yes | No |
 | Hook mechanism | `PreToolUse` | `BeforeTool` | N/A |
-| **MCP tools** | **Yes** (compile, verify, analyze, convert) | No | No |
+| **MCP tools** | **Yes** (compile, verify, analyze, convert, etc.) | **Yes** (compile, verify, analyze, convert, etc.) | No |
 
 ---
 
@@ -320,5 +354,6 @@ ls -la .gemini/skills/calor-convert/SKILL.md
 - [Syntax Reference](/calor/syntax-reference/) - Complete language reference
 - [Adding Calor to Existing Projects](/calor/guides/adding-calor-to-existing-projects/) - Migration guide
 - [calor init](/calor/cli/init/) - Full init command documentation
+- [MCP Server](/calor/cli/mcp/) - MCP tools documentation
 - [Claude Integration](/calor/getting-started/claude-integration/) - Alternative with Claude Code
 - [Codex Integration](/calor/getting-started/codex-integration/) - Alternative with OpenAI Codex CLI

--- a/src/Calor.Compiler/Resources/Templates/gemini-settings.json.template
+++ b/src/Calor.Compiler/Resources/Templates/gemini-settings.json.template
@@ -1,4 +1,10 @@
 {
+  "mcpServers": {
+    "calor": {
+      "command": "calor",
+      "args": ["mcp", "--stdio"]
+    }
+  },
   "hooks": {
     "BeforeTool": [
       {

--- a/website/content/cli/mcp.mdx
+++ b/website/content/cli/mcp.mdx
@@ -70,6 +70,28 @@ Claude Code will automatically start the MCP server when you open the project.
 
 ---
 
+## Gemini CLI Integration
+
+When you run `calor init --ai gemini`, the MCP server is automatically configured in `.gemini/settings.json` alongside hooks:
+
+```json
+{
+  "mcpServers": {
+    "calor": {
+      "command": "calor",
+      "args": ["mcp", "--stdio"]
+    }
+  },
+  "hooks": {
+    "BeforeTool": [ ... ]
+  }
+}
+```
+
+Unlike Claude Code, Gemini CLI's MCP config does not require a `type` field, and configuration is project-level (`.gemini/settings.json`) rather than user-level.
+
+---
+
 ## Available Tools
 
 The MCP server exposes 19 tools organized by category:
@@ -366,5 +388,6 @@ tail -f mcp.log
 ## See Also
 
 - [Claude Integration](/getting-started/claude-integration/) - Full Claude Code setup guide
+- [Gemini Integration](/getting-started/gemini-integration/) - Google Gemini CLI setup guide
 - [calor init](/cli/init/) - Initialize project with MCP configuration
 - [calor diagnose](/cli/diagnose/) - Standalone diagnostics

--- a/website/content/getting-started/gemini-integration.mdx
+++ b/website/content/getting-started/gemini-integration.mdx
@@ -23,7 +23,7 @@ This creates:
 |:-----|:--------|
 | `.gemini/skills/calor/SKILL.md` | Teaches Gemini Calor syntax |
 | `.gemini/skills/calor-convert/SKILL.md` | Teaches Gemini C# to Calor conversion |
-| `.gemini/settings.json` | **Hook configuration** - enforces Calor-first development |
+| `.gemini/settings.json` | **MCP server + hooks** - AI agent tools and Calor-first enforcement |
 | `GEMINI.md` | Project documentation with Calor-first guidelines |
 
 ---
@@ -43,6 +43,75 @@ When Gemini tries to create a `.cs` file, the hook blocks the operation and retu
 ```
 
 Gemini will then automatically retry with an `.calr` file.
+
+---
+
+## MCP Server Integration
+
+The init command also configures an **MCP (Model Context Protocol) server** that gives Gemini direct access to the Calor compiler. This enables Gemini to:
+
+- **Type check** code and get semantic errors
+- **Verify contracts** using the Z3 SMT solver
+- **Navigate code** with goto-definition and find-references
+- **Analyze** code for bugs and migration potential
+
+### How It Works
+
+The MCP server is configured in `.gemini/settings.json` alongside hooks:
+
+```json
+{
+  "mcpServers": {
+    "calor": {
+      "command": "calor",
+      "args": ["mcp", "--stdio"]
+    }
+  },
+  "hooks": { ... }
+}
+```
+
+When you start Gemini CLI in the project, it discovers the MCP server and can use tools like:
+
+```
+calor_typecheck     - Check for type errors
+calor_verify        - Verify function contracts
+calor_goto_definition - Navigate to symbol definitions
+calor_find_references - Find all usages of a symbol
+```
+
+### Example: Contract Verification
+
+Gemini can verify your contracts are correct:
+
+```
+You: Does this function have any contract violations?
+
+§F{f001:Divide:pub}
+  §I{i32:a}
+  §I{i32:b}
+  §O{i32}
+  §Q (!= b 0)
+  §R (/ a b)
+§/F{f001}
+
+Gemini: [Uses calor_verify_contracts tool]
+The precondition §Q (!= b 0) is proven correct by Z3.
+This ensures division by zero cannot occur.
+```
+
+### Available Tools
+
+| Tool | Purpose |
+|:-----|:--------|
+| `calor_typecheck` | Semantic type checking with error categorization |
+| `calor_verify_contracts` | Z3-based contract verification |
+| `calor_goto_definition` | Navigate to symbol definitions |
+| `calor_find_references` | Find all usages of a symbol |
+| `calor_document_outline` | Get file structure |
+| `calor_analyze` | Advanced bug detection |
+
+See [calor mcp](/cli/mcp/) for the complete list of 19 available tools.
 
 ---
 
@@ -86,6 +155,7 @@ public class Calculator
 | Skill invocation | `/calor` | `@calor` | `$calor` |
 | Enforcement | **Hooks (enforced)** | **Hooks (enforced)** | Guidance only |
 | Hook mechanism | `PreToolUse` | `BeforeTool` | N/A |
+| **MCP tools** | **Yes** (compile, verify, analyze, convert, etc.) | **Yes** (compile, verify, analyze, convert, etc.) | No |
 
 ---
 
@@ -125,5 +195,6 @@ export PATH="$PATH:$HOME/.dotnet/tools"
 
 - [Syntax Reference](/syntax-reference/) - Complete language reference
 - [calor init](/cli/init/) - Full init command documentation
+- [MCP Server](/cli/mcp/) - MCP tools documentation
 - [Claude Integration](/getting-started/claude-integration/) - Alternative with Claude Code
 - [Codex Integration](/getting-started/codex-integration/) - Alternative with OpenAI Codex CLI


### PR DESCRIPTION
## Summary

- Registers the `calor` MCP server in `.gemini/settings.json` when running `calor init --ai gemini`, giving Gemini CLI access to all MCP tools (compile, verify, analyze, convert, typecheck, etc.)
- Handles fresh install (template writes both), upgrade (merge adds `mcpServers` to existing hooks-only settings), and force paths
- Updates docs and website to reflect Gemini MCP parity with Claude Code

## Test plan

- [x] 13 new unit tests covering MCP config structure, no `type` field, idempotency, upgrade path, force, invalid JSON recovery, existing server preservation
- [x] Updated E2E test verifies `mcpServers` in settings.json with correct structure
- [x] Full test suite passes (2832 compiler tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)