### PR TITLE
feat: implement is, as, cast type operators

### DIFF
--- a/src/Calor.Compiler/Ast/AstNode.cs
+++ b/src/Calor.Compiler/Ast/AstNode.cs
@@ -182,6 +182,8 @@ public interface IAstVisitor
     void Visit(CharOperationNode node);
     // Native StringBuilder Operations
     void Visit(StringBuilderOperationNode node);
+    // Native Type Operations
+    void Visit(TypeOperationNode node);
     // Fallback nodes for unsupported C# constructs
     void Visit(FallbackExpressionNode node);
     void Visit(FallbackCommentNode node);
@@ -351,6 +353,8 @@ public interface IAstVisitor<T>
     T Visit(CharOperationNode node);
     // Native StringBuilder Operations
     T Visit(StringBuilderOperationNode node);
+    // Native Type Operations
+    T Visit(TypeOperationNode node);
     // Fallback nodes for unsupported C# constructs
     T Visit(FallbackExpressionNode node);
     T Visit(FallbackCommentNode node);

--- a/src/Calor.Compiler/Ast/TypeOperationNode.cs
+++ b/src/Calor.Compiler/Ast/TypeOperationNode.cs
@@ -1,0 +1,74 @@
+using Calor.Compiler.Parsing;
+
+namespace Calor.Compiler.Ast;
+
+/// <summary>
+/// Type operations supported by Calor: cast, is, as.
+/// </summary>
+public enum TypeOp
+{
+    Cast,   // (cast Type expr)  → (Type)expr
+    Is,     // (is expr Type)    → expr is Type
+    As,     // (as expr Type)    → expr as Type
+}
+
+/// <summary>
+/// Represents a type operation expression.
+/// Examples: (cast i32 x), (is x str), (as x MyClass)
+/// </summary>
+public sealed class TypeOperationNode : ExpressionNode
+{
+    public TypeOp Operation { get; }
+    public ExpressionNode Operand { get; }
+    public string TargetType { get; }
+
+    public TypeOperationNode(
+        TextSpan span,
+        TypeOp operation,
+        ExpressionNode operand,
+        string targetType)
+        : base(span)
+    {
+        Operation = operation;
+        Operand = operand ?? throw new ArgumentNullException(nameof(operand));
+        TargetType = targetType ?? throw new ArgumentNullException(nameof(targetType));
+    }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Helper methods for TypeOp enum.
+/// </summary>
+public static class TypeOpExtensions
+{
+    /// <summary>
+    /// Parses a type operation name to its enum value.
+    /// Returns null if the name is not a recognized type operation.
+    /// </summary>
+    public static TypeOp? FromString(string? name)
+    {
+        return name?.ToLowerInvariant() switch
+        {
+            "cast" => TypeOp.Cast,
+            "is" => TypeOp.Is,
+            "as" => TypeOp.As,
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Converts a TypeOp enum value back to its Calor syntax name.
+    /// </summary>
+    public static string ToCalorName(this TypeOp op)
+    {
+        return op switch
+        {
+            TypeOp.Cast => "cast",
+            TypeOp.Is => "is",
+            TypeOp.As => "as",
+            _ => throw new ArgumentOutOfRangeException(nameof(op), op, "Unknown type operation")
+        };
+    }
+}

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -3126,6 +3126,21 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         };
     }
 
+    // Native Type Operations
+
+    public string Visit(TypeOperationNode node)
+    {
+        var operand = node.Operand.Accept(this);
+        var csharpType = MapTypeName(node.TargetType);
+        return node.Operation switch
+        {
+            TypeOp.Cast => $"({csharpType}){operand}",
+            TypeOp.Is => $"{operand} is {csharpType}",
+            TypeOp.As => $"{operand} as {csharpType}",
+            _ => throw new NotSupportedException($"Unknown type operation: {node.Operation}")
+        };
+    }
+
     // Native StringBuilder Operations
 
     public string Visit(StringBuilderOperationNode node)

--- a/src/Calor.Compiler/Formatting/CalorFormatter.cs
+++ b/src/Calor.Compiler/Formatting/CalorFormatter.cs
@@ -516,6 +516,13 @@ public sealed class CalorFormatter
             NullConditionalNode nc => $"{FormatExpression(nc.Target)}?.{nc.MemberName}",
             ThisExpressionNode => "§THIS",
             BaseExpressionNode => "§BASE",
+            TypeOperationNode typeOp => typeOp.Operation switch
+            {
+                TypeOp.Cast => $"(cast {typeOp.TargetType} {FormatExpression(typeOp.Operand)})",
+                TypeOp.Is => $"(is {FormatExpression(typeOp.Operand)} {typeOp.TargetType})",
+                TypeOp.As => $"(as {FormatExpression(typeOp.Operand)} {typeOp.TargetType})",
+                _ => $"/* TypeOp {typeOp.Operation} */"
+            },
             _ => $"/* {expr.GetType().Name} */"
         };
     }

--- a/src/Calor.Compiler/Ids/IdScanner.cs
+++ b/src/Calor.Compiler/Ids/IdScanner.cs
@@ -258,6 +258,7 @@ public sealed class IdScanner : IAstVisitor
     public void Visit(ImplicationExpressionNode node) { }
     public void Visit(StringOperationNode node) { }
     public void Visit(CharOperationNode node) { }
+    public void Visit(TypeOperationNode node) { }
     public void Visit(StringBuilderOperationNode node) { }
     public void Visit(FallbackExpressionNode node) { }
     public void Visit(FallbackCommentNode node) { }

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -2064,6 +2064,18 @@ public sealed class CalorEmitter : IAstVisitor<string>
         return args.Any() ? $"({opName} {argsStr})" : $"({opName})";
     }
 
+    public string Visit(TypeOperationNode node)
+    {
+        var operand = node.Operand.Accept(this);
+        return node.Operation switch
+        {
+            TypeOp.Cast => $"(cast {node.TargetType} {operand})",
+            TypeOp.Is => $"(is {operand} {node.TargetType})",
+            TypeOp.As => $"(as {operand} {node.TargetType})",
+            _ => throw new NotSupportedException($"Unknown type operation: {node.Operation}")
+        };
+    }
+
     // Fallback nodes for unsupported C# constructs
 
     public string Visit(FallbackExpressionNode node)

--- a/src/Calor.Compiler/Parsing/OperatorSuggestions.cs
+++ b/src/Calor.Compiler/Parsing/OperatorSuggestions.cs
@@ -234,7 +234,7 @@ public static class OperatorSuggestions
     {
         return "arithmetic (+, -, *, /, %), comparison (==, !=, <, <=, >, >=), " +
                "logical (&&, ||, !), string (len, contains, substr, ...), " +
-               "or char (char-at, is-letter, ...)";
+               "char (char-at, is-letter, ...), or type (cast, is, as)";
     }
 
     /// <summary>
@@ -310,6 +310,20 @@ public static class OperatorSuggestions
             "sb-clear" => "(sb-clear builder)",
             "sb-tostring" => "(sb-tostring builder)",
             "sb-length" => "(sb-length builder)",
+            _ => $"({opName} ...)"
+        };
+    }
+
+    /// <summary>
+    /// Gets a usage example for a type operation.
+    /// </summary>
+    public static string GetTypeOpExample(string opName)
+    {
+        return opName.ToLowerInvariant() switch
+        {
+            "cast" => "(cast i32 expr)",
+            "is" => "(is expr MyType)",
+            "as" => "(as expr str)",
             _ => $"({opName} ...)"
         };
     }

--- a/src/Calor.Compiler/Verification/ExpressionSimplifier.cs
+++ b/src/Calor.Compiler/Verification/ExpressionSimplifier.cs
@@ -1343,6 +1343,12 @@ public sealed class ExpressionSimplifier : IAstVisitor<ExpressionNode>
         return new CharOperationNode(node.Span, node.Operation, simplifiedArgs);
     }
 
+    public ExpressionNode Visit(TypeOperationNode node)
+    {
+        var simplifiedOperand = node.Operand.Accept(this);
+        return new TypeOperationNode(node.Span, node.Operation, simplifiedOperand, node.TargetType);
+    }
+
     public ExpressionNode Visit(StringBuilderOperationNode node)
     {
         // Simplify arguments but preserve the StringBuilder operation

--- a/src/Calor.LanguageServer/Utilities/AstPositionVisitor.cs
+++ b/src/Calor.LanguageServer/Utilities/AstPositionVisitor.cs
@@ -208,6 +208,7 @@ public abstract class AstPositionVisitor<T> : IAstVisitor<T> where T : class?
     // Native operations
     public virtual T Visit(StringOperationNode node) => DefaultVisit(node)!;
     public virtual T Visit(CharOperationNode node) => DefaultVisit(node)!;
+    public virtual T Visit(TypeOperationNode node) => DefaultVisit(node)!;
     public virtual T Visit(StringBuilderOperationNode node) => DefaultVisit(node)!;
 
     // Fallback nodes

--- a/tests/Calor.Compiler.Tests/TypeOperationTests.cs
+++ b/tests/Calor.Compiler.Tests/TypeOperationTests.cs
@@ -1,0 +1,607 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Migration;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+public class TypeOperationTests
+{
+    private static ModuleNode Parse(string source, out DiagnosticBag diagnostics)
+    {
+        diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+        return parser.Parse();
+    }
+
+    private static string WrapInFunction(string body, string inputType = "object", string outputType = "object")
+    {
+        return $$"""
+            §M{m001:Test}
+            §F{f001:Main:pub}
+              §I{{{inputType}}:x}
+              §O{{{outputType}}}
+              {{body}}
+            §/F{f001}
+            §/M{m001}
+            """;
+    }
+
+    private static TypeOperationNode GetReturnTypeExpression(ModuleNode module)
+    {
+        var func = module.Functions[0];
+        var returnStmt = func.Body[0] as ReturnStatementNode;
+        Assert.NotNull(returnStmt);
+        var typeOp = returnStmt!.Expression as TypeOperationNode;
+        Assert.NotNull(typeOp);
+        return typeOp!;
+    }
+
+    #region AST Tests
+
+    [Fact]
+    public void Parse_Cast_ReturnsTypeOperationNode()
+    {
+        var source = WrapInFunction("§R (cast i32 x)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var typeOp = GetReturnTypeExpression(module);
+        Assert.Equal(TypeOp.Cast, typeOp.Operation);
+        Assert.Equal("i32", typeOp.TargetType);
+        Assert.IsType<ReferenceNode>(typeOp.Operand);
+        Assert.Equal("x", ((ReferenceNode)typeOp.Operand).Name);
+    }
+
+    [Fact]
+    public void Parse_Is_ReturnsTypeOperationNode()
+    {
+        var source = WrapInFunction("§R (is x str)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var typeOp = GetReturnTypeExpression(module);
+        Assert.Equal(TypeOp.Is, typeOp.Operation);
+        Assert.Equal("str", typeOp.TargetType);
+        Assert.IsType<ReferenceNode>(typeOp.Operand);
+        Assert.Equal("x", ((ReferenceNode)typeOp.Operand).Name);
+    }
+
+    [Fact]
+    public void Parse_As_ReturnsTypeOperationNode()
+    {
+        var source = WrapInFunction("§R (as x str)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var typeOp = GetReturnTypeExpression(module);
+        Assert.Equal(TypeOp.As, typeOp.Operation);
+        Assert.Equal("str", typeOp.TargetType);
+        Assert.IsType<ReferenceNode>(typeOp.Operand);
+        Assert.Equal("x", ((ReferenceNode)typeOp.Operand).Name);
+    }
+
+    [Fact]
+    public void Parse_Cast_WithCustomType_ReturnsTypeOperationNode()
+    {
+        var source = WrapInFunction("§R (cast MyClass x)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var typeOp = GetReturnTypeExpression(module);
+        Assert.Equal(TypeOp.Cast, typeOp.Operation);
+        Assert.Equal("MyClass", typeOp.TargetType);
+    }
+
+    #endregion
+
+    #region C# Emission Tests
+
+    [Theory]
+    [InlineData("(cast i32 x)", "(int)x")]
+    [InlineData("(cast f64 x)", "(double)x")]
+    [InlineData("(cast str x)", "(string)x")]
+    [InlineData("(is x str)", "x is string")]
+    [InlineData("(is x i32)", "x is int")]
+    [InlineData("(as x str)", "x as string")]
+    [InlineData("(as x MyClass)", "x as MyClass")]
+    public void Emit_TypeOperation_ProducesCorrectCSharp(string calor, string expectedCSharp)
+    {
+        var source = WrapInFunction($"§R {calor}");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(module);
+
+        Assert.Contains(expectedCSharp, code);
+    }
+
+    #endregion
+
+    #region Round-Trip Tests
+
+    [Theory]
+    [InlineData("(cast i32 x)")]
+    [InlineData("(cast f64 x)")]
+    [InlineData("(cast str x)")]
+    [InlineData("(is x str)")]
+    [InlineData("(is x i32)")]
+    [InlineData("(is x MyClass)")]
+    [InlineData("(as x str)")]
+    [InlineData("(as x MyClass)")]
+    public void RoundTrip_TypeOp_ProducesValidCalor(string op)
+    {
+        var source = WrapInFunction($"§R {op}");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var calorEmitter = new CalorEmitter();
+        var roundTripped = calorEmitter.Emit(module);
+
+        Assert.Contains(op, roundTripped);
+    }
+
+    #endregion
+
+    #region Error Tests
+
+    [Fact]
+    public void Parse_Cast_NoArgs_ReportsError()
+    {
+        var source = WrapInFunction("§R (cast)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("requires exactly 2 arguments"));
+    }
+
+    [Fact]
+    public void Parse_Cast_OneArg_ReportsError()
+    {
+        var source = WrapInFunction("§R (cast i32)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("requires exactly 2 arguments"));
+    }
+
+    [Fact]
+    public void Parse_Cast_ThreeArgs_ReportsError()
+    {
+        var source = WrapInFunction("§R (cast i32 x y)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("requires exactly 2 arguments"));
+    }
+
+    [Fact]
+    public void Parse_Is_NoArgs_ReportsError()
+    {
+        var source = WrapInFunction("§R (is)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("requires exactly 2 arguments"));
+    }
+
+    [Fact]
+    public void Parse_As_OneArg_ReportsError()
+    {
+        var source = WrapInFunction("§R (as x)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("requires exactly 2 arguments"));
+    }
+
+    [Fact]
+    public void Parse_Cast_NonIdentifierType_ReportsError()
+    {
+        var source = WrapInFunction("§R (cast 42 x)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("Expected a type name"));
+    }
+
+    [Fact]
+    public void Parse_Is_NonIdentifierType_ReportsError()
+    {
+        var source = WrapInFunction("§R (is x 42)");
+        Parse(source, out var diagnostics);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics, d => d.Message.Contains("Expected a type name"));
+    }
+
+    #endregion
+
+    #region Extension Tests
+
+    [Theory]
+    [InlineData("cast", TypeOp.Cast)]
+    [InlineData("is", TypeOp.Is)]
+    [InlineData("as", TypeOp.As)]
+    public void FromString_ValidOperator_ReturnsCorrectEnum(string name, TypeOp expected)
+    {
+        var result = TypeOpExtensions.FromString(name);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void FromString_InvalidOperator_ReturnsNull()
+    {
+        var result = TypeOpExtensions.FromString("invalid");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void FromString_Null_ReturnsNull()
+    {
+        var result = TypeOpExtensions.FromString(null);
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData(TypeOp.Cast, "cast")]
+    [InlineData(TypeOp.Is, "is")]
+    [InlineData(TypeOp.As, "as")]
+    public void ToCalorName_ReturnsCorrectName(TypeOp op, string expected)
+    {
+        var result = op.ToCalorName();
+        Assert.Equal(expected, result);
+    }
+
+    #endregion
+
+    #region Migration Tests
+
+    private static TypeOperationNode? FindTypeOperationInResult(ConversionResult result)
+    {
+        if (!result.Success || result.Ast == null) return null;
+
+        foreach (var func in result.Ast.Functions)
+        {
+            var found = FindTypeOperationInBody(func.Body);
+            if (found != null) return found;
+        }
+
+        foreach (var cls in result.Ast.Classes)
+        {
+            foreach (var method in cls.Methods)
+            {
+                var found = FindTypeOperationInBody(method.Body);
+                if (found != null) return found;
+            }
+        }
+
+        return null;
+    }
+
+    private static TypeOperationNode? FindTypeOperationInBody(IReadOnlyList<StatementNode> body)
+    {
+        foreach (var stmt in body)
+        {
+            var found = FindTypeOperationInStatement(stmt);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    private static TypeOperationNode? FindTypeOperationInStatement(StatementNode stmt)
+    {
+        if (stmt is ReturnStatementNode ret)
+            return FindTypeOperationInExpression(ret.Expression);
+        if (stmt is BindStatementNode bind)
+            return FindTypeOperationInExpression(bind.Initializer);
+        return null;
+    }
+
+    private static TypeOperationNode? FindTypeOperationInExpression(ExpressionNode? expr)
+    {
+        if (expr == null) return null;
+        if (expr is TypeOperationNode typeOp) return typeOp;
+        return null;
+    }
+
+    [Fact]
+    public void Migration_CSharpCast_ConvertsToTypeOperationNode()
+    {
+        var csharp = "public class Test { public int M(object x) { return (int)x; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var typeOp = FindTypeOperationInResult(result);
+        Assert.NotNull(typeOp);
+        Assert.Equal(TypeOp.Cast, typeOp!.Operation);
+        Assert.Equal("i32", typeOp.TargetType);
+    }
+
+    [Fact]
+    public void Migration_CSharpIs_ConvertsToTypeOperationNode()
+    {
+        var csharp = "public class Test { public bool M(object x) { return x is string; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var typeOp = FindTypeOperationInResult(result);
+        Assert.NotNull(typeOp);
+        Assert.Equal(TypeOp.Is, typeOp!.Operation);
+        Assert.Equal("str", typeOp.TargetType);
+    }
+
+    [Fact]
+    public void Migration_CSharpAs_ConvertsToTypeOperationNode()
+    {
+        var csharp = "public class Test { public string M(object x) { return x as string; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var typeOp = FindTypeOperationInResult(result);
+        Assert.NotNull(typeOp);
+        Assert.Equal(TypeOp.As, typeOp!.Operation);
+        Assert.Equal("str", typeOp.TargetType);
+    }
+
+    [Fact]
+    public void Migration_CSharpCast_RoundTripsToCalor()
+    {
+        var csharp = "public class Test { public int M(object x) { return (int)x; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+
+        Assert.Contains("(cast i32 x)", calor);
+    }
+
+    [Fact]
+    public void Migration_CSharpAs_RoundTripsToCalor()
+    {
+        var csharp = "public class Test { public string M(object x) { return x as string; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+
+        Assert.Contains("(as x str)", calor);
+    }
+
+    [Fact]
+    public void Migration_CSharpIs_RoundTripsToCalor()
+    {
+        var csharp = "public class Test { public bool M(object x) { return x is string; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+
+        Assert.Contains("(is x str)", calor);
+    }
+
+    [Fact]
+    public void Migration_CSharpIsDeclaration_ConvertsToTypeOperationNode()
+    {
+        // "x is string s" — declaration pattern, variable binding is not preserved but type check is
+        var csharp = "public class Test { public bool M(object x) { if (x is string s) return true; return false; } }";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success, string.Join(", ", result.Issues));
+
+        var calorEmitter = new CalorEmitter();
+        var calor = calorEmitter.Emit(result.Ast!);
+
+        Assert.Contains("(is x str)", calor);
+    }
+
+    #endregion
+
+    #region Composition Tests
+
+    [Fact]
+    public void Parse_CastWithBinaryOp_Works()
+    {
+        var source = WrapInFunction("§R (cast i32 (+ x 1))");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var typeOp = GetReturnTypeExpression(module);
+        Assert.Equal(TypeOp.Cast, typeOp.Operation);
+        Assert.IsType<BinaryOperationNode>(typeOp.Operand);
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(module);
+        Assert.Contains("(int)(x + 1)", code);
+    }
+
+    [Fact]
+    public void Parse_AsInReturnExpression_Works()
+    {
+        var source = WrapInFunction("§R (as x str)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(module);
+        Assert.Contains("x as string", code);
+    }
+
+    [Fact]
+    public void Parse_NestedCast_Works()
+    {
+        // (cast i32 (cast f64 x)) — cast to f64 then to i32
+        var source = WrapInFunction("§R (cast i32 (cast f64 x))");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var outer = GetReturnTypeExpression(module);
+        Assert.Equal(TypeOp.Cast, outer.Operation);
+        Assert.Equal("i32", outer.TargetType);
+
+        var inner = Assert.IsType<TypeOperationNode>(outer.Operand);
+        Assert.Equal(TypeOp.Cast, inner.Operation);
+        Assert.Equal("f64", inner.TargetType);
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(module);
+        Assert.Contains("(int)(double)x", code);
+    }
+
+    [Fact]
+    public void Parse_IsNestedInCast_Works()
+    {
+        // Unusual but valid: (cast i32 (is x str)) — cast bool result to int
+        var source = WrapInFunction("§R (cast i32 (is x str))");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+        var outer = GetReturnTypeExpression(module);
+        Assert.Equal(TypeOp.Cast, outer.Operation);
+        Assert.Equal("i32", outer.TargetType);
+
+        var inner = Assert.IsType<TypeOperationNode>(outer.Operand);
+        Assert.Equal(TypeOp.Is, inner.Operation);
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(module);
+        Assert.Contains("(int)x is string", code);
+    }
+
+    [Fact]
+    public void RoundTrip_NestedCast_PreservesStructure()
+    {
+        var source = WrapInFunction("§R (cast i32 (cast f64 x))");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var calorEmitter = new CalorEmitter();
+        var roundTripped = calorEmitter.Emit(module);
+
+        Assert.Contains("(cast i32 (cast f64 x))", roundTripped);
+    }
+
+    #endregion
+
+    #region Type Checker Tests
+
+    [Fact]
+    public void TypeChecker_AsWithValueType_ReportsWarning()
+    {
+        var source = WrapInFunction("§R (as x i32)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var typeChecker = new Calor.Compiler.TypeChecking.TypeChecker(diagnostics);
+        typeChecker.Check(module);
+
+        Assert.Contains(diagnostics, d =>
+            d.Message.Contains("'as' operator cannot be used with value type") &&
+            d.Message.Contains("i32"));
+    }
+
+    [Fact]
+    public void TypeChecker_AsWithReferenceType_NoWarning()
+    {
+        var source = WrapInFunction("§R (as x str)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var typeChecker = new Calor.Compiler.TypeChecking.TypeChecker(diagnostics);
+        typeChecker.Check(module);
+
+        Assert.DoesNotContain(diagnostics, d =>
+            d.Message.Contains("'as' operator cannot be used with value type"));
+    }
+
+    [Fact]
+    public void TypeChecker_AsWithBool_ReportsWarning()
+    {
+        var source = WrapInFunction("§R (as x bool)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var typeChecker = new Calor.Compiler.TypeChecking.TypeChecker(diagnostics);
+        typeChecker.Check(module);
+
+        Assert.Contains(diagnostics, d =>
+            d.Message.Contains("'as' operator cannot be used with value type"));
+    }
+
+    [Fact]
+    public void TypeChecker_AsWithFloat_ReportsWarning()
+    {
+        var source = WrapInFunction("§R (as x f64)");
+        var module = Parse(source, out var diagnostics);
+
+        Assert.False(diagnostics.HasErrors, string.Join(", ", diagnostics.Select(d => d.Message)));
+
+        var typeChecker = new Calor.Compiler.TypeChecking.TypeChecker(diagnostics);
+        typeChecker.Check(module);
+
+        Assert.Contains(diagnostics, d =>
+            d.Message.Contains("'as' operator cannot be used with value type"));
+    }
+
+    #endregion
+
+    #region OperatorSuggestions Tests
+
+    [Fact]
+    public void GetTypeOpExample_Cast_ReturnsExample()
+    {
+        var example = OperatorSuggestions.GetTypeOpExample("cast");
+        Assert.Equal("(cast i32 expr)", example);
+    }
+
+    [Fact]
+    public void GetTypeOpExample_Is_ReturnsExample()
+    {
+        var example = OperatorSuggestions.GetTypeOpExample("is");
+        Assert.Equal("(is expr MyType)", example);
+    }
+
+    [Fact]
+    public void GetTypeOpExample_As_ReturnsExample()
+    {
+        var example = OperatorSuggestions.GetTypeOpExample("as");
+        Assert.Equal("(as expr str)", example);
+    }
+
+    [Fact]
+    public void GetOperatorCategories_IncludesTypeOperations()
+    {
+        var categories = OperatorSuggestions.GetOperatorCategories();
+        Assert.Contains("type (cast, is, as)", categories);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Add `TypeOperationNode` AST node with `TypeOp` enum (Cast, Is, As) and `TypeOpExtensions` for string↔enum conversion
- Implement full parser support: `(cast Type expr)`, `(is expr Type)`, `(as expr Type)` with arg-count and type-name validation
- Add Visit methods across all 7 visitors/emitters (CSharpEmitter, CalorEmitter, CalorFormatter, IdScanner, ExpressionSimplifier, AstPositionVisitor, TypeChecker)
- Fix broken C#→Calor migration: cast no longer falls back to `CallExpressionNode`, `is` no longer produces raw `ReferenceNode` strings, `as` no longer defaults to `BinaryOperator.Add`
- Handle `DeclarationPatternSyntax` (`x is Type varName`) in migration — emits type check, notes variable binding limitation
- Type checker warns when `as` is used with value types (i32, f64, bool), suggesting `cast` instead
- 54 new tests covering AST parsing, C# emission, round-trips, error cases, extensions, migration, nested composition, and type checker diagnostics

## Test plan

- [x] All 54 `TypeOperation` tests pass
- [x] All 182 migration tests pass (no regressions)
- [x] Full test suite: 3288 passed, 0 failed, 16 pre-existing skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)