### PR TITLE
fix(docs,lexer): correct §EACH docs and double-slash error

### DIFF
--- a/src/Calor.Compiler/Parsing/Lexer.cs
+++ b/src/Calor.Compiler/Parsing/Lexer.cs
@@ -567,7 +567,7 @@ public sealed class Lexer
             }
 
             // Unknown closing tag - provide helpful suggestions
-            ReportUnknownSectionMarker(keyword, isClosing: true);
+            ReportUnknownSectionMarker(keyword);
             return MakeToken(TokenKind.Error);
         }
 
@@ -606,20 +606,17 @@ public sealed class Lexer
         }
 
         // Unknown section keyword - provide helpful suggestions
-        ReportUnknownSectionMarker(fullKeyword, isClosing: false);
+        ReportUnknownSectionMarker(fullKeyword);
         return MakeToken(TokenKind.Error);
     }
 
     /// <summary>
     /// Reports an unknown section marker with helpful suggestions.
     /// </summary>
-    private void ReportUnknownSectionMarker(string keyword, bool isClosing)
+    private void ReportUnknownSectionMarker(string keyword)
     {
-        var displayKeyword = isClosing ? $"/{keyword}" : keyword;
-        var lookupKeyword = isClosing ? $"/{keyword}" : keyword;
-
         // Try to find a similar marker
-        var suggestion = SectionMarkerSuggestions.FindSimilarMarker(lookupKeyword);
+        var suggestion = SectionMarkerSuggestions.FindSimilarMarker(keyword);
 
         if (suggestion != null)
         {
@@ -628,12 +625,12 @@ public sealed class Lexer
                 ? $" ({desc})"
                 : "";
             _diagnostics.ReportError(CurrentSpan(), Diagnostics.DiagnosticCode.UnexpectedCharacter,
-                $"Unknown section marker '§{displayKeyword}'. Did you mean '§{suggestion}'{description}?");
+                $"Unknown section marker '§{keyword}'. Did you mean '§{suggestion}'{description}?");
         }
         else
         {
             _diagnostics.ReportError(CurrentSpan(), Diagnostics.DiagnosticCode.UnexpectedCharacter,
-                $"Unknown section marker '§{displayKeyword}'. Common markers: {SectionMarkerSuggestions.GetCommonMarkers()}");
+                $"Unknown section marker '§{keyword}'. Common markers: {SectionMarkerSuggestions.GetCommonMarkers()}");
         }
     }
 

--- a/src/Calor.Compiler/Resources/Skills/calor-convert.md
+++ b/src/Calor.Compiler/Resources/Skills/calor-convert.md
@@ -318,7 +318,7 @@ tags.Remove("review");
 foreach (var item in collection) { ... }
 ```
 ```calor
-§EACH{e1:item:collection}
+§EACH{e1:item} collection
 ...
 §/EACH{e1}
 ```
@@ -330,7 +330,7 @@ foreach (var kv in dict) {
 }
 ```
 ```calor
-§EACHKV{e1:k:v:dict}
+§EACHKV{e1:k:v} dict
 §P k
 §P v
 §/EACHKV{e1}

--- a/src/Calor.Compiler/Resources/Skills/calor.md
+++ b/src/Calor.Compiler/Resources/Skills/calor.md
@@ -768,7 +768,8 @@ Task: Return `"{prefix}-{sequence:D6}"` (6-digit zero-padded)
 ### Iterating Collections
 
 ```calor
-§EACH{id:var} collection  // Foreach over collection
+§EACH{id:var} collection      // Foreach (type inferred)
+§EACH{id:var:type} collection  // Foreach (explicit type)
   ...body...
 §/EACH{id}
 

--- a/src/Calor.Compiler/Resources/Skills/claude-calor-SKILL.md
+++ b/src/Calor.Compiler/Resources/Skills/claude-calor-SKILL.md
@@ -655,7 +655,8 @@ Inline form: `§C{Target} §A arg §/C`
 
 ### Iteration
 ```
-§EACH{id:var} collection      Foreach over collection
+§EACH{id:var} collection      Foreach (type inferred)
+§EACH{id:var:type} collection  Foreach (explicit type)
   ...body...
 §/EACH{id}
 

--- a/src/Calor.Compiler/Resources/Skills/claude-calor-convert-SKILL.md
+++ b/src/Calor.Compiler/Resources/Skills/claude-calor-convert-SKILL.md
@@ -325,7 +325,7 @@ tags.Remove("review");
 foreach (var item in collection) { ... }
 ```
 ```calor
-§EACH{e1:item:collection}
+§EACH{e1:item} collection
 ...
 §/EACH{e1}
 ```
@@ -337,7 +337,7 @@ foreach (var kv in dict) {
 }
 ```
 ```calor
-§EACHKV{e1:k:v:dict}
+§EACHKV{e1:k:v} dict
 §P k
 §P v
 §/EACHKV{e1}

--- a/src/Calor.Compiler/Resources/Skills/codex-calor-SKILL.md
+++ b/src/Calor.Compiler/Resources/Skills/codex-calor-SKILL.md
@@ -665,7 +665,8 @@ Async functions and methods use `§AF` and `§AMT` tags:
 ### Iterating Collections
 
 ```
-§EACH{id:var} collection  Foreach over collection
+§EACH{id:var} collection      Foreach (type inferred)
+§EACH{id:var:type} collection  Foreach (explicit type)
   ...body...
 §/EACH{id}
 

--- a/src/Calor.Compiler/Resources/Skills/codex-calor-convert-SKILL.md
+++ b/src/Calor.Compiler/Resources/Skills/codex-calor-convert-SKILL.md
@@ -325,7 +325,7 @@ tags.Remove("review");
 foreach (var item in collection) { ... }
 ```
 ```calor
-§EACH{e1:item:collection}
+§EACH{e1:item} collection
 ...
 §/EACH{e1}
 ```
@@ -337,7 +337,7 @@ foreach (var kv in dict) {
 }
 ```
 ```calor
-§EACHKV{e1:k:v:dict}
+§EACHKV{e1:k:v} dict
 §P k
 §P v
 §/EACHKV{e1}

--- a/src/Calor.Compiler/Resources/Skills/gemini-calor-SKILL.md
+++ b/src/Calor.Compiler/Resources/Skills/gemini-calor-SKILL.md
@@ -665,7 +665,8 @@ Async functions and methods use `§AF` and `§AMT` tags:
 ### Iterating Collections
 
 ```
-§EACH{id:var} collection  Foreach over collection
+§EACH{id:var} collection      Foreach (type inferred)
+§EACH{id:var:type} collection  Foreach (explicit type)
   ...body...
 §/EACH{id}
 

--- a/src/Calor.Compiler/Resources/Skills/gemini-calor-convert-SKILL.md
+++ b/src/Calor.Compiler/Resources/Skills/gemini-calor-convert-SKILL.md
@@ -325,7 +325,7 @@ tags.Remove("review");
 foreach (var item in collection) { ... }
 ```
 ```calor
-§EACH{e1:item:collection}
+§EACH{e1:item} collection
 ...
 §/EACH{e1}
 ```
@@ -337,7 +337,7 @@ foreach (var kv in dict) {
 }
 ```
 ```calor
-§EACHKV{e1:k:v:dict}
+§EACHKV{e1:k:v} dict
 §P k
 §P v
 §/EACHKV{e1}

--- a/src/Calor.Compiler/Resources/Skills/github-calor-SKILL.md
+++ b/src/Calor.Compiler/Resources/Skills/github-calor-SKILL.md
@@ -665,7 +665,8 @@ Async functions and methods use `§AF` and `§AMT` tags:
 ### Iterating Collections
 
 ```
-§EACH{id:var} collection  Foreach over collection
+§EACH{id:var} collection      Foreach (type inferred)
+§EACH{id:var:type} collection  Foreach (explicit type)
   ...body...
 §/EACH{id}
 

--- a/src/Calor.Compiler/Resources/Skills/github-calor-convert-SKILL.md
+++ b/src/Calor.Compiler/Resources/Skills/github-calor-convert-SKILL.md
@@ -325,7 +325,7 @@ tags.Remove("review");
 foreach (var item in collection) { ... }
 ```
 ```calor
-§EACH{e1:item:collection}
+§EACH{e1:item} collection
 ...
 §/EACH{e1}
 ```
@@ -337,7 +337,7 @@ foreach (var kv in dict) {
 }
 ```
 ```calor
-§EACHKV{e1:k:v:dict}
+§EACHKV{e1:k:v} dict
 §P k
 §P v
 §/EACHKV{e1}

--- a/src/Calor.Compiler/Resources/calor-syntax-documentation.json
+++ b/src/Calor.Compiler/Resources/calor-syntax-documentation.json
@@ -1190,8 +1190,8 @@
     },
     "§EACH": {
       "name": "Foreach",
-      "syntax": "§EACH{item:collection} body §/EACH",
-      "description": "Iterates over each element. Alternative to §L{item:collection}.",
+      "syntax": "§EACH{id:var} collection body §/EACH{id}",
+      "description": "Iterates over each element in a collection. Type is inferred automatically. Use three-field form §EACH{id:var:type} for explicit typing.",
       "csharpEquivalent": "foreach (var item in collection) { body }"
     },
     "§IV": {

--- a/tests/Calor.Compiler.Tests/Diagnostics/SuggestionTests.cs
+++ b/tests/Calor.Compiler.Tests/Diagnostics/SuggestionTests.cs
@@ -201,6 +201,33 @@ public class SuggestionTests
     }
 
     [Fact]
+    public void Lexer_UnknownClosingTag_ErrorMessage_ShowsSingleSlash()
+    {
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer("§/NEW", diagnostics);
+        lexer.TokenizeAll();
+
+        Assert.True(diagnostics.HasErrors);
+        var error = diagnostics.First(d => d.IsError);
+        Assert.Contains("§/NEW", error.Message);
+        Assert.DoesNotContain("§//NEW", error.Message);
+    }
+
+    [Fact]
+    public void Lexer_UnknownClosingTag_WithSuggestion_ShowsSingleSlash()
+    {
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer("§M{test} §/MOD{test}", diagnostics);
+        lexer.TokenizeAll();
+
+        Assert.True(diagnostics.HasErrors);
+        var error = diagnostics.First(d => d.IsError);
+        Assert.Contains("§/MOD", error.Message);
+        Assert.DoesNotContain("§//MOD", error.Message);
+        Assert.Contains("Did you mean", error.Message);
+    }
+
+    [Fact]
     public void Lexer_UnknownSectionMarker_NoSuggestion_ShowsCommonMarkers()
     {
         var diagnostics = new DiagnosticBag();

--- a/tests/Calor.Evaluation/Skills/calor-language-skills.md
+++ b/tests/Calor.Evaluation/Skills/calor-language-skills.md
@@ -768,7 +768,8 @@ Task: Return `"{prefix}-{sequence:D6}"` (6-digit zero-padded)
 ### Iterating Collections
 
 ```calor
-§EACH{id:var} collection  // Foreach over collection
+§EACH{id:var} collection      // Foreach (type inferred)
+§EACH{id:var:type} collection  // Foreach (explicit type)
   ...body...
 §/EACH{id}
 


### PR DESCRIPTION
## Summary
- **§EACH/§EACHKV documentation fix**: Corrected syntax across all 12 doc files (skill files, convert files, JSON syntax reference, test mirror) — collection/dict was incorrectly inside the braces. Now shows correct `§EACH{id:var} collection` form with explicit-type variant as secondary.
- **Double-slash error message fix**: `ReportUnknownSectionMarker` in `Lexer.cs` was prepending a redundant `/` to closing-tag keywords that already contained one, producing `§//X` instead of `§/X`. Removed the `isClosing` parameter entirely and inlined the keyword directly.
- **Two new tests**: Covers both the no-suggestion path (`§/NEW`) and suggestion path (`§/MOD`) to assert single-slash in error messages.

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — all 3,839 tests pass (0 failures)
- [x] New `Lexer_UnknownClosingTag_ErrorMessage_ShowsSingleSlash` test passes
- [x] New `Lexer_UnknownClosingTag_WithSuggestion_ShowsSingleSlash` test passes
- [x] Existing closing-tag suggestion tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)