### PR TITLE
feat: improve C#→Calor converter fidelity and fix emission bugs

### DIFF
--- a/src/Calor.Compiler/Formatting/CalorFormatter.cs
+++ b/src/Calor.Compiler/Formatting/CalorFormatter.cs
@@ -504,7 +504,7 @@ public sealed class CalorFormatter
             NoneExpressionNode none => none.TypeName != null ? $"§NN{{{none.TypeName}}}" : "§NN",
             OkExpressionNode ok => $"§OK {FormatExpression(ok.Value)}",
             ErrExpressionNode err => $"§ERR {FormatExpression(err.Error)}",
-            NewExpressionNode newExpr => $"§NEW{{{newExpr.TypeName}}} {string.Join(" ", newExpr.Arguments.Select(FormatExpression))}".TrimEnd(),
+            NewExpressionNode newExpr => $"§NEW{{{newExpr.TypeName}}} {string.Join(" ", newExpr.Arguments.Select(FormatExpression))} §/NEW".TrimEnd(),
             RecordCreationNode rec => FormatRecordCreation(rec),
             FieldAccessNode field => $"{FormatExpression(field.Target)}.{field.FieldName}",
             ArrayAccessNode arr => $"{FormatExpression(arr.Array)}[{FormatExpression(arr.Index)}]",
@@ -547,7 +547,7 @@ public sealed class CalorFormatter
     private string FormatRecordCreation(RecordCreationNode rec)
     {
         var fields = string.Join(" ", rec.Fields.Select(f => $"§SET{{{f.FieldName}}} {FormatExpression(f.Value)}"));
-        return $"§NEW{{{rec.TypeName}}} {fields}".TrimEnd();
+        return $"§NEW{{{rec.TypeName}}} {fields} §/NEW".TrimEnd();
     }
 
     private string FormatLambda(LambdaExpressionNode lambda)

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -1220,6 +1220,10 @@ public sealed class CalorEmitter : IAstVisitor<string>
     public string Visit(FieldAccessNode node)
     {
         var target = node.Target.Accept(this);
+        if (node.Target is ThisExpressionNode)
+            target = "this";
+        else if (node.Target is BaseExpressionNode)
+            target = "base";
         return $"{target}.{node.FieldName}";
     }
 
@@ -1240,7 +1244,7 @@ public sealed class CalorEmitter : IAstVisitor<string>
             initStr = $" {{ {string.Join(", ", inits)} }}";
         }
 
-        return $"§NEW{{{node.TypeName}{typeArgs}}}{argsStr}{initStr}";
+        return $"§NEW{{{node.TypeName}{typeArgs}}}{argsStr}{initStr} §/NEW";
     }
 
     public string Visit(CallExpressionNode node)

--- a/src/Calor.Compiler/Migration/FeatureSupport.cs
+++ b/src/Calor.Compiler/Migration/FeatureSupport.cs
@@ -379,16 +379,16 @@ public static class FeatureSupport
         ["target-typed-new"] = new FeatureInfo
         {
             Name = "target-typed-new",
-            Support = SupportLevel.NotSupported,
-            Description = "Target-typed new expressions (new()) are not supported",
-            Workaround = "Use explicit type in new expression: new TypeName()"
+            Support = SupportLevel.Partial,
+            Description = "Target-typed new with arguments is converted using 'object' placeholder type",
+            Workaround = "Review and replace 'object' with the correct type name"
         },
         ["null-conditional-method"] = new FeatureInfo
         {
             Name = "null-conditional-method",
-            Support = SupportLevel.NotSupported,
-            Description = "Null-conditional method calls (obj?.Method()) are not supported",
-            Workaround = "Use explicit null check: if (obj != null) obj.Method()"
+            Support = SupportLevel.Partial,
+            Description = "Null-conditional method calls (obj?.Method()) are converted with AST-based args",
+            Workaround = "Review converted null-conditional method calls for correctness"
         },
         ["named-argument"] = new FeatureInfo
         {
@@ -400,16 +400,16 @@ public static class FeatureSupport
         ["declaration-pattern"] = new FeatureInfo
         {
             Name = "declaration-pattern",
-            Support = SupportLevel.NotSupported,
-            Description = "Declaration patterns (is Type varName) are not supported",
-            Workaround = "Check type separately and cast to a new variable"
+            Support = SupportLevel.Partial,
+            Description = "Declaration patterns (is Type varName) are converted via TypeOperationNode",
+            Workaround = "Review converted type checks for variable binding correctness"
         },
         ["throw-expression"] = new FeatureInfo
         {
             Name = "throw-expression",
-            Support = SupportLevel.NotSupported,
-            Description = "Throw expressions (?? throw new ...) are not supported",
-            Workaround = "Use explicit if-throw statement"
+            Support = SupportLevel.Partial,
+            Description = "Throw expressions are converted to §ERR nodes",
+            Workaround = "Review converted §ERR expressions for error semantics"
         },
         ["nested-generic-type"] = new FeatureInfo
         {

--- a/src/Calor.Compiler/Parsing/Lexer.cs
+++ b/src/Calor.Compiler/Parsing/Lexer.cs
@@ -127,6 +127,7 @@ public sealed class Lexer
         ["BASE"] = TokenKind.Base,
         ["/BASE"] = TokenKind.EndBase,
         ["NEW"] = TokenKind.New,
+        ["/NEW"] = TokenKind.EndNew,
         ["FLD"] = TokenKind.FieldDef,
 
         // Properties and Constructors

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -4734,7 +4734,7 @@ public sealed class Parser
 
         // Check for optional end tag
         var endSpan = startToken.Span;
-        if (Check(TokenKind.Identifier) && Current.Text == "/NEW")
+        if (Check(TokenKind.EndNew))
         {
             endSpan = Advance().Span;
         }

--- a/src/Calor.Compiler/Parsing/Token.cs
+++ b/src/Calor.Compiler/Parsing/Token.cs
@@ -161,6 +161,7 @@ public enum TokenKind
     Base,
     EndBase,
     New,
+    EndNew,
     FieldDef,
 
     // Phase 9: Properties and Constructors

--- a/tests/Calor.Compiler.Tests/Diagnostics/SuggestionTests.cs
+++ b/tests/Calor.Compiler.Tests/Diagnostics/SuggestionTests.cs
@@ -204,13 +204,13 @@ public class SuggestionTests
     public void Lexer_UnknownClosingTag_ErrorMessage_ShowsSingleSlash()
     {
         var diagnostics = new DiagnosticBag();
-        var lexer = new Lexer("§/NEW", diagnostics);
+        var lexer = new Lexer("§/NEWX", diagnostics);
         lexer.TokenizeAll();
 
         Assert.True(diagnostics.HasErrors);
         var error = diagnostics.First(d => d.IsError);
-        Assert.Contains("§/NEW", error.Message);
-        Assert.DoesNotContain("§//NEW", error.Message);
+        Assert.Contains("§/NEWX", error.Message);
+        Assert.DoesNotContain("§//NEWX", error.Message);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- **Reduce §ERR fallbacks**: throw expressions → `ErrExpressionNode`, `default`/`default(T)` → concrete literals, target-typed `new(args)` → `NewExpressionNode`, null-conditional method calls → AST-based arg conversion
- **Fix §/NEW emission**: CalorEmitter and CalorFormatter now emit closing `§/NEW` tag; added `EndNew` token to lexer/parser so the tag is recognized
- **Fix §THIS in member access**: `FieldAccessNode` visitor emits `this.Member` / `base.Member` instead of `§THIS.Member` / `§BASE.Member`

## Test plan
- [x] 25 new tests in `ConverterImprovementTests.cs` covering all changes
- [x] Edge cases: throw-of-variable, default-of-custom-type, new-with-initializer, zero-arg new
- [x] Negative tests: verify `FallbackExpressionNode` is absent for converted constructs
- [x] Parser roundtrip: `§/NEW` with args, without args, and backward compat (no closing tag)
- [x] Full emitter→parser roundtrip: C# → Calor → C# compilation
- [x] All 3325 existing tests pass (2939 compiler + 386 LSP), 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)