### PR TITLE
feat: add §USE syntax, --validate-codegen, ctor arg preservation, version auto-detect

### DIFF
--- a/src/Calor.Compiler/Ast/PropertyNodes.cs
+++ b/src/Calor.Compiler/Ast/PropertyNodes.cs
@@ -292,6 +292,7 @@ public sealed class CompoundAssignmentStatementNode : StatementNode
 /// </summary>
 public sealed class UsingStatementNode : StatementNode
 {
+    public string? Id { get; }
     public string? VariableName { get; }
     public string? VariableType { get; }
     public ExpressionNode Resource { get; }
@@ -303,8 +304,20 @@ public sealed class UsingStatementNode : StatementNode
         string? variableType,
         ExpressionNode resource,
         IReadOnlyList<StatementNode> body)
+        : this(span, null, variableName, variableType, resource, body)
+    {
+    }
+
+    public UsingStatementNode(
+        TextSpan span,
+        string? id,
+        string? variableName,
+        string? variableType,
+        ExpressionNode resource,
+        IReadOnlyList<StatementNode> body)
         : base(span)
     {
+        Id = id;
         VariableName = variableName;
         VariableType = variableType;
         Resource = resource ?? throw new ArgumentNullException(nameof(resource));

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -318,6 +318,13 @@ public static class DiagnosticCode
     /// Info: Sanitizer applied to tainted data.
     /// </summary>
     public const string TaintSanitized = "Calor0986";
+
+    // Code generation validation (Calor1000-1009)
+
+    /// <summary>
+    /// Warning: Generated C# code contains syntax errors.
+    /// </summary>
+    public const string CodeGenSyntaxError = "Calor1000";
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Diagnostics/DiagnosticFormatter.cs
+++ b/src/Calor.Compiler/Diagnostics/DiagnosticFormatter.cs
@@ -401,6 +401,7 @@ public sealed class SarifDiagnosticFormatter : IDiagnosticFormatter
         DiagnosticCode.DuplicatePattern => "Duplicate pattern",
         DiagnosticCode.MissingDocComment => "Missing documentation comment",
         DiagnosticCode.BreakingChangeWithoutMarker => "Breaking change without marker",
+        DiagnosticCode.CodeGenSyntaxError => "Generated C# code contains syntax errors",
         _ => "Calor compiler diagnostic"
     };
 

--- a/src/Calor.Compiler/Init/CsprojInitializer.cs
+++ b/src/Calor.Compiler/Init/CsprojInitializer.cs
@@ -170,7 +170,7 @@ public sealed class CsprojInitializer
         var runtimePropertyGroup = new XElement("PropertyGroup",
             new XElement("CalorToolVersion",
                 new XAttribute("Condition", "'$(CalorToolVersion)' == ''"),
-                "0.1.6"),
+                EmbeddedResourceHelper.GetVersion()),
             new XElement("CalorRuntimePath",
                 @"$(HOME)/.dotnet/tools/.store/calor/$(CalorToolVersion)/calor/$(CalorToolVersion)/tools/net8.0/any/Calor.Runtime.dll"));
 
@@ -264,7 +264,7 @@ public sealed class CsprojInitializer
     /// </summary>
     public static string GenerateCalorTargetsXml()
     {
-        return """
+        return $"""
             <!-- Calor Compilation Configuration -->
             <PropertyGroup>
               <CalorOutputDirectory Condition="'$(CalorOutputDirectory)' == ''">$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\calor\</CalorOutputDirectory>
@@ -272,7 +272,7 @@ public sealed class CsprojInitializer
             </PropertyGroup>
 
             <PropertyGroup>
-              <CalorToolVersion Condition="'$(CalorToolVersion)' == ''">0.1.6</CalorToolVersion>
+              <CalorToolVersion Condition="'$(CalorToolVersion)' == ''">{EmbeddedResourceHelper.GetVersion()}</CalorToolVersion>
               <CalorRuntimePath>$(HOME)/.dotnet/tools/.store/calor/$(CalorToolVersion)/calor/$(CalorToolVersion)/tools/net8.0/any/Calor.Runtime.dll</CalorRuntimePath>
             </PropertyGroup>
 

--- a/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
+++ b/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
@@ -1422,6 +1422,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
 
         return new UsingStatementNode(
             GetTextSpan(node),
+            _context.GenerateId("use"),
             variableName,
             variableType,
             resource,
@@ -2227,15 +2228,19 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                 .ToList();
 
             // Check for collection types and convert to appropriate nodes
-            if (typeName == "List" && typeArgs.Count == 1)
+            // Skip collection-specific converters when constructor args are present,
+            // as they only handle initializer elements and would drop the arguments.
+            var hasCtorArgs = objCreation.ArgumentList?.Arguments.Count > 0;
+
+            if (typeName == "List" && typeArgs.Count == 1 && !hasCtorArgs)
             {
                 return ConvertListCreation(objCreation, typeArgs[0]);
             }
-            else if (typeName == "Dictionary" && typeArgs.Count == 2)
+            else if (typeName == "Dictionary" && typeArgs.Count == 2 && !hasCtorArgs)
             {
                 return ConvertDictionaryCreation(objCreation, typeArgs[0], typeArgs[1]);
             }
-            else if (typeName == "HashSet" && typeArgs.Count == 1)
+            else if (typeName == "HashSet" && typeArgs.Count == 1 && !hasCtorArgs)
             {
                 return ConvertHashSetCreation(objCreation, typeArgs[0]);
             }

--- a/src/Calor.Compiler/Parsing/Lexer.cs
+++ b/src/Calor.Compiler/Parsing/Lexer.cs
@@ -73,6 +73,10 @@ public sealed class Lexer
         ["FL"] = TokenKind.Field,           // §FL = Field
         ["IV"] = TokenKind.Invariant,       // §IV = Invariant
 
+        // Using statement (block form)
+        ["USE"] = TokenKind.Use,            // §USE = using statement open
+        ["/USE"] = TokenKind.EndUse,        // §/USE = using statement close
+
         // Arrays and Collections
         ["ARR"] = TokenKind.Array,
         ["/ARR"] = TokenKind.EndArray,

--- a/src/Calor.Compiler/Parsing/Token.cs
+++ b/src/Calor.Compiler/Parsing/Token.cs
@@ -107,6 +107,8 @@ public enum TokenKind
 
     // Phase 5: Using Statements (.NET Interop)
     Using,
+    Use,                // §USE - using statement open
+    EndUse,             // §/USE - using statement close
 
     // Phase 6: Arrays and Collections
     Array,

--- a/tests/Calor.Compiler.Tests/CsprojInitializerTests.cs
+++ b/tests/Calor.Compiler.Tests/CsprojInitializerTests.cs
@@ -1,5 +1,6 @@
 using Calor.Compiler.Init;
 using Xunit;
+using System.Text.RegularExpressions;
 
 namespace Calor.Compiler.Tests;
 
@@ -256,6 +257,34 @@ public class CsprojInitializerTests : IDisposable
           </PropertyGroup>
         </Project>
         """;
+
+    [Fact]
+    public async Task InitializeAsync_UsesActualAssemblyVersion()
+    {
+        // Arrange
+        var csprojPath = Path.Combine(_testDir, "Test.csproj");
+        await File.WriteAllTextAsync(csprojPath, SdkStyleCsproj);
+        var expectedVersion = EmbeddedResourceHelper.GetVersion();
+
+        // Act
+        var result = await _initializer.InitializeAsync(csprojPath);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        var content = await File.ReadAllTextAsync(csprojPath);
+        Assert.Contains(expectedVersion, content);
+        Assert.DoesNotContain("0.1.6", content);
+    }
+
+    [Fact]
+    public void GenerateCalorTargetsXml_UsesActualAssemblyVersion()
+    {
+        var xml = CsprojInitializer.GenerateCalorTargetsXml();
+        var expectedVersion = EmbeddedResourceHelper.GetVersion();
+
+        Assert.Contains(expectedVersion, xml);
+        Assert.DoesNotContain("0.1.6", xml);
+    }
 
     private const string LegacyStyleCsproj = """
         <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
## Summary

- **§USE{id:var:type}** — New parser construct for C# `using` statements, replacing the CalorEmitter try/finally workaround with native `§USE`/`§/USE` block syntax
- **--validate-codegen** — Opt-in flag for `calor diagnose` that parses generated C# with Roslyn and reports syntax errors as `Calor1000` warnings
- **Constructor arg preservation** — `calor convert` no longer drops constructor arguments from `new List<int>(existing)`, `new Dictionary<K,V>(old)`, `new HashSet<T>(source)`
- **Version auto-detect** — `CsprojInitializer` uses `EmbeddedResourceHelper.GetVersion()` instead of hardcoded `"0.1.6"`

## Files changed (14)

**§USE syntax** (6 files): Token.cs, Lexer.cs, Parser.cs, PropertyNodes.cs, CalorEmitter.cs, RoslynSyntaxVisitor.cs
**--validate-codegen** (3 files): DiagnoseCommand.cs, Diagnostic.cs, DiagnosticFormatter.cs
**Constructor args** (1 file): RoslynSyntaxVisitor.cs
**Version auto-detect** (1 file): CsprojInitializer.cs
**Tests** (4 files): 18 new tests, 3 updated tests across CSharpToCalorConversionTests, CsprojInitializerTests, EndToEndTests, ExceptionHandlingTests

## Test plan

- [x] All 2890 tests pass (0 failures, 14 pre-existing skips)
- [x] Full solution builds clean (0 warnings, 0 errors)
- [x] Round-trip tests: C# using → Calor §USE → C# using (plain, typed, generic)
- [x] Mismatched §USE ID produces diagnostic error
- [x] Constructor arg tests: List, Dictionary, HashSet with ctor args; no-arg regression check
- [x] Version tests: both code paths (XElement + raw string) use actual assembly version
- [x] Codegen validation: valid program → no errors; invalid C# → Calor1000 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)