### PR TITLE
feat(build): add CalorCompilerOverride MSBuild property

### DIFF
--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -393,6 +393,36 @@ For example: `obj/Debug/net8.0/calor/MyModule.g.cs`
 
 This keeps generated files out of your source tree while still making them part of the build.
 
+### MSBuild Properties
+
+The following properties control Calor build behavior. Set them in your `.csproj` or pass via `-p:` on the command line.
+
+| Property | Default | Description |
+|:---------|:--------|:------------|
+| `CalorCompilerPath` | `calor` | Path to the Calor CLI executable |
+| `CalorOutputDirectory` | `obj/<Config>/<TFM>/calor/` | Directory for generated `.g.cs` files |
+| `CalorCompilerOverride` | *(empty)* | Override path for a locally-built compiler (see below) |
+
+#### CalorCompilerOverride
+
+When set, `CalorCompilerOverride` derives `CalorCompilerPath` automatically. This is intended for developers working on the Calor compiler itself who want to test local changes without modifying project files:
+
+```bash
+dotnet build -p:CalorCompilerOverride=path/to/Calor.Compiler/bin/Debug/net8.0/calor
+```
+
+**Precedence** (highest to lowest):
+1. Explicit `CalorCompilerPath` set in the project file
+2. `CalorCompilerOverride` (derives `CalorCompilerPath`)
+3. Default (`calor`)
+
+When `CalorCompilerOverride` is set, the build emits a warning confirming which compiler is being used. If the path does not exist, the build fails with an error.
+
+> **Note:** For projects using `Calor.Sdk` (MSBuild task integration) rather than `calor init`, `CalorCompilerOverride` derives `CalorTasksAssembly` instead. Point it at your local `Calor.Tasks.dll`:
+> ```bash
+> dotnet build -p:CalorCompilerOverride=path/to/Calor.Tasks/bin/Debug/net8.0/Calor.Tasks.dll
+> ```
+
 ---
 
 ## Calor/C# Coexistence

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -180,6 +180,22 @@ Then create a pull request on GitHub.
 3. Register in evaluation runner
 4. Add documentation
 
+### Testing Local Compiler Changes
+
+Set `CalorCompilerOverride` to use a locally-built compiler:
+
+```bash
+# For projects using Calor.Sdk (MSBuild task integration)
+dotnet build -p:CalorCompilerOverride=path/to/Calor.Tasks/bin/Debug/net8.0/Calor.Tasks.dll
+
+# For projects using calor init (CLI integration)
+dotnet build -p:CalorCompilerOverride=path/to/Calor.Compiler/bin/Debug/net8.0/calor
+```
+
+This overrides the compiler path without modifying project files. If an explicit
+`CalorTasksAssembly` (SDK path) or `CalorCompilerPath` (CLI path) is already set,
+those take precedence over `CalorCompilerOverride`.
+
 ### Adding a Benchmark
 
 See [Adding Benchmarks](/calor/contributing/adding-benchmarks/).

--- a/docs/guides/adding-calor-to-existing-projects.md
+++ b/docs/guides/adding-calor-to-existing-projects.md
@@ -346,6 +346,16 @@ Warning: Complex LINQ expression at line 42 - manual review recommended
 
 Review these manually and adjust the Calor code as needed.
 
+### Testing a Locally-Built Compiler
+
+If you're developing changes to the Calor compiler itself, use `CalorCompilerOverride` to test your local build without modifying any project files:
+
+```bash
+dotnet build -p:CalorCompilerOverride=path/to/Calor.Compiler/bin/Debug/net8.0/calor
+```
+
+The build will emit a warning confirming the override is active. See [`calor init` - MSBuild Properties](/calor/cli/init/#msbuild-properties) for details.
+
 ### Test Failures After Conversion
 
 1. Compare the generated C# with the original

--- a/src/Calor.Sdk/Sdk/Sdk.targets
+++ b/src/Calor.Sdk/Sdk/Sdk.targets
@@ -3,10 +3,21 @@
 
   <!-- Import the Calor.Tasks assembly -->
   <PropertyGroup>
+    <!-- CalorCompilerOverride: point at a local Calor.Tasks.dll to use a dev-built compiler -->
+    <CalorTasksAssembly Condition="'$(CalorCompilerOverride)' != '' and '$(CalorTasksAssembly)' == ''">$(CalorCompilerOverride)</CalorTasksAssembly>
     <CalorTasksAssembly Condition="'$(CalorTasksAssembly)' == ''">$(MSBuildThisFileDirectory)..\tasks\net8.0\Calor.Tasks.dll</CalorTasksAssembly>
   </PropertyGroup>
 
   <UsingTask TaskName="Calor.Tasks.CompileCalor" AssemblyFile="$(CalorTasksAssembly)" />
+
+  <!-- Validate CalorCompilerOverride (runs unconditionally, not subject to incremental build skip) -->
+  <Target Name="ValidateCalorCompilerOverride"
+          BeforeTargets="CompileCalorFiles"
+          Condition="'$(CalorCompilerOverride)' != '' and '@(CalorCompile)' != ''">
+    <Error Condition="!Exists('$(CalorCompilerOverride)')"
+           Text="CalorCompilerOverride points to '$(CalorCompilerOverride)' which does not exist." />
+    <Warning Text="CalorCompilerOverride is set — using local compiler from '$(CalorCompilerOverride)'" />
+  </Target>
 
   <!-- Target to compile Calor files and add them to compilation -->
   <Target Name="CompileCalorFiles"

--- a/tests/Calor.Compiler.Tests/CsprojInitializerTests.cs
+++ b/tests/Calor.Compiler.Tests/CsprojInitializerTests.cs
@@ -1,3 +1,4 @@
+using System.Xml.Linq;
 using Calor.Compiler.Init;
 using Xunit;
 using System.Text.RegularExpressions;
@@ -200,12 +201,106 @@ public class CsprojInitializerTests : IDisposable
     }
 
     [Fact]
+    public async Task InitializeAsync_ContainsCalorCompilerOverride()
+    {
+        // Arrange
+        var csprojPath = Path.Combine(_testDir, "Test.csproj");
+        await File.WriteAllTextAsync(csprojPath, SdkStyleCsproj);
+
+        // Act
+        await _initializer.InitializeAsync(csprojPath);
+
+        // Assert
+        var content = await File.ReadAllTextAsync(csprojPath);
+        Assert.Contains("CalorCompilerOverride", content);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_ContainsValidateCalorCompilerOverrideTarget()
+    {
+        // Arrange
+        var csprojPath = Path.Combine(_testDir, "Test.csproj");
+        await File.WriteAllTextAsync(csprojPath, SdkStyleCsproj);
+
+        // Act
+        await _initializer.InitializeAsync(csprojPath);
+
+        // Assert - parse XML and verify the validation target
+        var content = await File.ReadAllTextAsync(csprojPath);
+        var doc = XDocument.Parse(content);
+
+        var validateTarget = doc.Descendants("Target")
+            .FirstOrDefault(t => t.Attribute("Name")?.Value == "ValidateCalorCompilerOverride");
+
+        Assert.NotNull(validateTarget);
+        Assert.Equal("CompileCalorFiles", validateTarget.Attribute("BeforeTargets")?.Value);
+        Assert.Equal("'$(CalorCompilerOverride)' != '' and '@(CalorCompile)' != ''",
+            validateTarget.Attribute("Condition")?.Value);
+
+        // Should have Error and Warning child elements
+        var errorElement = validateTarget.Element("Error");
+        Assert.NotNull(errorElement);
+        Assert.Equal("!Exists('$(CalorCompilerOverride)')", errorElement.Attribute("Condition")?.Value);
+
+        var warningElement = validateTarget.Element("Warning");
+        Assert.NotNull(warningElement);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_CalorCompilerOverride_HasCorrectConditionsAndOrdering()
+    {
+        // Arrange
+        var csprojPath = Path.Combine(_testDir, "Test.csproj");
+        await File.WriteAllTextAsync(csprojPath, SdkStyleCsproj);
+
+        // Act
+        await _initializer.InitializeAsync(csprojPath);
+
+        // Assert - parse XML and verify CalorCompilerPath elements
+        var content = await File.ReadAllTextAsync(csprojPath);
+        var doc = XDocument.Parse(content);
+
+        var compilerPathElements = doc.Descendants("CalorCompilerPath").ToList();
+        Assert.Equal(2, compilerPathElements.Count);
+
+        // First element: override condition
+        var overrideElement = compilerPathElements[0];
+        Assert.Equal("$(CalorCompilerOverride)", overrideElement.Value);
+        Assert.Equal(
+            "'$(CalorCompilerOverride)' != '' and '$(CalorCompilerPath)' == ''",
+            overrideElement.Attribute("Condition")?.Value);
+
+        // Second element: default fallback
+        var defaultElement = compilerPathElements[1];
+        Assert.Equal("calor", defaultElement.Value);
+        Assert.Equal(
+            "'$(CalorCompilerPath)' == ''",
+            defaultElement.Attribute("Condition")?.Value);
+    }
+
+    [Fact]
+    public void GenerateCalorTargetsXml_CalorCompilerOverride_HasCorrectConditionsAndOrdering()
+    {
+        // Act
+        var xml = CsprojInitializer.GenerateCalorTargetsXml();
+
+        // Assert - verify the override line appears before the default line
+        var overrideIndex = xml.IndexOf("'$(CalorCompilerOverride)' != '' and '$(CalorCompilerPath)' == ''", StringComparison.Ordinal);
+        var defaultIndex = xml.IndexOf("<CalorCompilerPath Condition=\"'$(CalorCompilerPath)' == ''\">calor</CalorCompilerPath>", StringComparison.Ordinal);
+
+        Assert.True(overrideIndex >= 0, "Override condition not found in template");
+        Assert.True(defaultIndex >= 0, "Default condition not found in template");
+        Assert.True(overrideIndex < defaultIndex, "Override must appear before default in template");
+    }
+
+    [Fact]
     public void GenerateCalorTargetsXml_ReturnsValidXml()
     {
         // Act
         var xml = CsprojInitializer.GenerateCalorTargetsXml();
 
         // Assert
+        Assert.Contains("ValidateCalorCompilerOverride", xml);
         Assert.Contains("CompileCalorFiles", xml);
         Assert.Contains("IncludeCalorGeneratedFiles", xml);
         Assert.Contains("CleanCalorFiles", xml);
@@ -213,6 +308,7 @@ public class CsprojInitializerTests : IDisposable
         Assert.Contains("calor", xml);
         Assert.Contains("Inputs=\"@(CalorCompile)\"", xml);
         Assert.Contains("Outputs=\"@(CalorCompile->'$(CalorOutputDirectory)%(RecursiveDir)%(Filename).g.cs')\"", xml);
+        Assert.Contains("CalorCompilerOverride", xml);
     }
 
     [Fact]
@@ -228,13 +324,80 @@ public class CsprojInitializerTests : IDisposable
 
         // Assert - should only have one of each target
         var content = await File.ReadAllTextAsync(csprojPath);
+        var validateTargetCount = CountOccurrences(content, "Name=\"ValidateCalorCompilerOverride\"");
         var compileTargetCount = CountOccurrences(content, "Name=\"CompileCalorFiles\"");
         var includeTargetCount = CountOccurrences(content, "Name=\"IncludeCalorGeneratedFiles\"");
         var cleanTargetCount = CountOccurrences(content, "Name=\"CleanCalorFiles\"");
 
+        Assert.Equal(1, validateTargetCount);
         Assert.Equal(1, compileTargetCount);
         Assert.Equal(1, includeTargetCount);
         Assert.Equal(1, cleanTargetCount);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithForce_CleansUpManualCalorCompilerOverridePropertyGroup()
+    {
+        // Arrange - a csproj with a manually-added CalorCompilerOverride in a separate PropertyGroup
+        var csprojPath = Path.Combine(_testDir, "Test.csproj");
+        await File.WriteAllTextAsync(csprojPath, SdkStyleCsproj);
+
+        // First initialization
+        await _initializer.InitializeAsync(csprojPath);
+
+        // Manually inject a separate PropertyGroup with CalorCompilerOverride
+        var content = await File.ReadAllTextAsync(csprojPath);
+        var doc = XDocument.Parse(content);
+        doc.Root!.Add(new XElement("PropertyGroup",
+            new XElement("CalorCompilerOverride", "/some/local/path/to/calor")));
+        await File.WriteAllTextAsync(csprojPath, doc.ToString());
+
+        // Verify the manual override element is present before force
+        var beforeDoc = XDocument.Parse(await File.ReadAllTextAsync(csprojPath));
+        Assert.Single(beforeDoc.Descendants("CalorCompilerOverride"));
+
+        // Act - re-initialize with force
+        var result = await _initializer.InitializeAsync(csprojPath, force: true);
+
+        // Assert - manual override PropertyGroup should be removed, only the standard one remains
+        Assert.True(result.IsSuccess);
+        var afterDoc = XDocument.Parse(await File.ReadAllTextAsync(csprojPath));
+
+        // Should have no standalone CalorCompilerOverride element (only the condition reference in CalorCompilerPath)
+        var overrideElements = afterDoc.Descendants("CalorCompilerOverride").ToList();
+        Assert.Empty(overrideElements);
+
+        // CalorCompilerPath should still exist with the standard override condition
+        var compilerPathElements = afterDoc.Descendants("CalorCompilerPath").ToList();
+        Assert.Equal(2, compilerPathElements.Count);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithForce_CleansUpSeparateCalorCompilerPathPropertyGroup()
+    {
+        // Arrange - a csproj with CalorCompilerPath manually added in a separate PropertyGroup
+        var csprojPath = Path.Combine(_testDir, "Test.csproj");
+        await File.WriteAllTextAsync(csprojPath, SdkStyleCsproj);
+
+        // First initialization
+        await _initializer.InitializeAsync(csprojPath);
+
+        // Manually inject a separate PropertyGroup with CalorCompilerPath
+        var content = await File.ReadAllTextAsync(csprojPath);
+        var doc = XDocument.Parse(content);
+        doc.Root!.Add(new XElement("PropertyGroup",
+            new XElement("CalorCompilerPath", "/custom/path/to/calor")));
+        await File.WriteAllTextAsync(csprojPath, doc.ToString());
+
+        // Act - re-initialize with force
+        var result = await _initializer.InitializeAsync(csprojPath, force: true);
+
+        // Assert - should have exactly 2 CalorCompilerPath elements (override + default), not 3
+        Assert.True(result.IsSuccess);
+        var afterContent = await File.ReadAllTextAsync(csprojPath);
+        var afterDoc = XDocument.Parse(afterContent);
+        var compilerPathElements = afterDoc.Descendants("CalorCompilerPath").ToList();
+        Assert.Equal(2, compilerPathElements.Count);
     }
 
     private static int CountOccurrences(string source, string substring)

--- a/tests/Calor.Compiler.Tests/CsprojUpdaterTests.cs
+++ b/tests/Calor.Compiler.Tests/CsprojUpdaterTests.cs
@@ -1,0 +1,177 @@
+using System.Xml.Linq;
+using Calor.Compiler.Migration.Project;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+public class CsprojUpdaterTests : IDisposable
+{
+    private readonly string _testDir;
+    private readonly CsprojUpdater _updater;
+
+    public CsprojUpdaterTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), $"calor-updater-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDir);
+        _updater = new CsprojUpdater();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir))
+        {
+            Directory.Delete(_testDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateForCalorAsync_WithCalrFiles_ContainsCalorCompilerOverride()
+    {
+        // Arrange
+        var csprojPath = Path.Combine(_testDir, "Test.csproj");
+        await File.WriteAllTextAsync(csprojPath, SdkStyleCsproj);
+        // UpdateForCalorAsync only adds targets when .calr files exist
+        await File.WriteAllTextAsync(Path.Combine(_testDir, "test.calr"), "");
+
+        // Act
+        var result = await _updater.UpdateForCalorAsync(csprojPath);
+
+        // Assert
+        Assert.True(result.Success);
+        var content = await File.ReadAllTextAsync(csprojPath);
+        Assert.Contains("CalorCompilerOverride", content);
+    }
+
+    [Fact]
+    public async Task UpdateForCalorAsync_CalorCompilerOverride_HasCorrectConditionsAndOrdering()
+    {
+        // Arrange
+        var csprojPath = Path.Combine(_testDir, "Test.csproj");
+        await File.WriteAllTextAsync(csprojPath, SdkStyleCsproj);
+        await File.WriteAllTextAsync(Path.Combine(_testDir, "test.calr"), "");
+
+        // Act
+        await _updater.UpdateForCalorAsync(csprojPath);
+
+        // Assert
+        var content = await File.ReadAllTextAsync(csprojPath);
+        var doc = XDocument.Parse(content);
+
+        var compilerPathElements = doc.Descendants("CalorCompilerPath").ToList();
+        Assert.Equal(2, compilerPathElements.Count);
+
+        // First: override condition
+        var overrideElement = compilerPathElements[0];
+        Assert.Equal("$(CalorCompilerOverride)", overrideElement.Value);
+        Assert.Equal(
+            "'$(CalorCompilerOverride)' != '' and '$(CalorCompilerPath)' == ''",
+            overrideElement.Attribute("Condition")?.Value);
+
+        // Second: default fallback
+        var defaultElement = compilerPathElements[1];
+        Assert.Equal("calor", defaultElement.Value);
+        Assert.Equal(
+            "'$(CalorCompilerPath)' == ''",
+            defaultElement.Attribute("Condition")?.Value);
+    }
+
+    [Fact]
+    public async Task CreateCalorProjectAsync_ContainsCalorCompilerOverride()
+    {
+        // Arrange
+        var projectDir = Path.Combine(_testDir, "NewProject");
+
+        // Act
+        var result = await _updater.CreateCalorProjectAsync(projectDir, "NewProject");
+
+        // Assert
+        Assert.True(result.Success);
+        var csprojPath = Path.Combine(projectDir, "NewProject.csproj");
+        var content = await File.ReadAllTextAsync(csprojPath);
+        Assert.Contains("CalorCompilerOverride", content);
+    }
+
+    [Fact]
+    public async Task CreateCalorProjectAsync_CalorCompilerOverride_HasCorrectConditionsAndOrdering()
+    {
+        // Arrange
+        var projectDir = Path.Combine(_testDir, "NewProject");
+
+        // Act
+        await _updater.CreateCalorProjectAsync(projectDir, "NewProject");
+
+        // Assert
+        var csprojPath = Path.Combine(projectDir, "NewProject.csproj");
+        var content = await File.ReadAllTextAsync(csprojPath);
+        var doc = XDocument.Parse(content);
+
+        var compilerPathElements = doc.Descendants("CalorCompilerPath").ToList();
+        Assert.Equal(2, compilerPathElements.Count);
+
+        // First: override condition
+        var overrideElement = compilerPathElements[0];
+        Assert.Equal("$(CalorCompilerOverride)", overrideElement.Value);
+        Assert.Equal(
+            "'$(CalorCompilerOverride)' != '' and '$(CalorCompilerPath)' == ''",
+            overrideElement.Attribute("Condition")?.Value);
+
+        // Second: default fallback
+        var defaultElement = compilerPathElements[1];
+        Assert.Equal("calor", defaultElement.Value);
+        Assert.Equal(
+            "'$(CalorCompilerPath)' == ''",
+            defaultElement.Attribute("Condition")?.Value);
+    }
+
+    [Fact]
+    public async Task UpdateForCalorAsync_ContainsValidateCalorCompilerOverrideTarget()
+    {
+        // Arrange
+        var csprojPath = Path.Combine(_testDir, "Test.csproj");
+        await File.WriteAllTextAsync(csprojPath, SdkStyleCsproj);
+        await File.WriteAllTextAsync(Path.Combine(_testDir, "test.calr"), "");
+
+        // Act
+        await _updater.UpdateForCalorAsync(csprojPath);
+
+        // Assert
+        var doc = XDocument.Parse(await File.ReadAllTextAsync(csprojPath));
+        var validateTarget = doc.Descendants("Target")
+            .FirstOrDefault(t => t.Attribute("Name")?.Value == "ValidateCalorCompilerOverride");
+
+        Assert.NotNull(validateTarget);
+        Assert.Equal("CompileCalorFiles", validateTarget.Attribute("BeforeTargets")?.Value);
+        Assert.NotNull(validateTarget.Element("Error"));
+        Assert.NotNull(validateTarget.Element("Warning"));
+    }
+
+    [Fact]
+    public async Task CreateCalorProjectAsync_ContainsValidateCalorCompilerOverrideTarget()
+    {
+        // Arrange
+        var projectDir = Path.Combine(_testDir, "NewProject2");
+
+        // Act
+        await _updater.CreateCalorProjectAsync(projectDir, "NewProject2");
+
+        // Assert
+        var csprojPath = Path.Combine(projectDir, "NewProject2.csproj");
+        var doc = XDocument.Parse(await File.ReadAllTextAsync(csprojPath));
+        var validateTarget = doc.Descendants("Target")
+            .FirstOrDefault(t => t.Attribute("Name")?.Value == "ValidateCalorCompilerOverride");
+
+        Assert.NotNull(validateTarget);
+        Assert.Equal("CompileCalorFiles", validateTarget.Attribute("BeforeTargets")?.Value);
+        Assert.NotNull(validateTarget.Element("Error"));
+        Assert.NotNull(validateTarget.Element("Warning"));
+    }
+
+    private const string SdkStyleCsproj = """
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <OutputType>Exe</OutputType>
+            <TargetFramework>net8.0</TargetFramework>
+          </PropertyGroup>
+        </Project>
+        """;
+}


### PR DESCRIPTION
## Summary

- Adds `CalorCompilerOverride` MSBuild property — a single, unified way to point builds at a locally-built compiler for development testing
- **SDK path** (`Calor.Sdk`): derives `CalorTasksAssembly` from the override
- **CLI path** (`calor init`): derives `CalorCompilerPath` from the override
- Validation target (`ValidateCalorCompilerOverride`) emits a warning when active and an error when the path doesn't exist; runs outside incremental build so it fires even on no-op builds
- `--force` cleanup properly removes override-related elements
- Documentation added to `docs/cli/init.md`, `docs/contributing/development-setup.md`, and `docs/guides/adding-calor-to-existing-projects.md`

## Usage

```bash
# SDK-based projects
dotnet build -p:CalorCompilerOverride=path/to/Calor.Tasks/bin/Debug/net8.0/Calor.Tasks.dll

# CLI-based projects
dotnet build -p:CalorCompilerOverride=path/to/Calor.Compiler/bin/Debug/net8.0/calor
```

## Files changed

| File | Change |
|:-----|:-------|
| `src/Calor.Sdk/Sdk/Sdk.targets` | Override → `CalorTasksAssembly` + validation target |
| `src/Calor.Compiler/Init/CsprojInitializer.cs` | Override → `CalorCompilerPath` + validation target + `--force` cleanup |
| `src/Calor.Compiler/Migration/Project/CsprojUpdater.cs` | Override → `CalorCompilerPath` + validation target |
| `tests/Calor.Compiler.Tests/CsprojInitializerTests.cs` | 7 new tests (XML-parsed conditions, ordering, validation target, force cleanup) |
| `tests/Calor.Compiler.Tests/CsprojUpdaterTests.cs` | New file — 6 tests covering both `UpdateForCalorAsync` and `CreateCalorProjectAsync` |
| `docs/cli/init.md` | MSBuild Properties reference section |
| `docs/contributing/development-setup.md` | Testing Local Compiler Changes section |
| `docs/guides/adding-calor-to-existing-projects.md` | Troubleshooting entry |

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test tests/Calor.Compiler.Tests` — 2936 passed, 0 failed
- [x] Integration: invalid path → build error with clear message
- [x] Integration: valid path → build warning confirming override
- [x] Integration: incremental (no-op) build → warning still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)