### PR TITLE
Fix §IDX codegen, converter heuristics, and documentation gaps

### DIFF
--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -1346,8 +1346,8 @@ public sealed class CalorEmitter : IAstVisitor<string>
     {
         var array = node.Array.Accept(this);
         var index = node.Index.Accept(this);
-        // Use §IDX syntax for element access
-        return $"§IDX{{{array}}} {index}";
+        // Use §IDX syntax for element access (no braces — parser expects space-separated)
+        return $"§IDX {array} {index}";
     }
 
     public string Visit(ArrayLengthNode node)

--- a/src/Calor.Compiler/Resources/calor-syntax-documentation.json
+++ b/src/Calor.Compiler/Resources/calor-syntax-documentation.json
@@ -1117,10 +1117,16 @@
       "csharpEquivalent": "public record Name { ... }"
     },
     "§STR": {
-      "name": "String Interpolation",
-      "syntax": "§STR{text {expression} text}§/STR",
-      "description": "String interpolation with embedded expressions.",
+      "name": "String Interpolation (alias)",
+      "syntax": "§STR ... §/STR",
+      "description": "Alias for §INTERP. See §INTERP for correct syntax.",
       "csharpEquivalent": "$\"text {expression} text\""
+    },
+    "§INTERP": {
+      "name": "String Interpolation",
+      "syntax": "§INTERP \"literal\" §EXP expr \"literal\" §/INTERP",
+      "description": "Builds an interpolated string from literal parts and §EXP expression parts. Strings are opaque — expressions cannot be embedded inside quotes. Use separate \"literal\" and §EXP expr parts.",
+      "csharpEquivalent": "$\"literal{expr}literal\""
     },
     "§M": {
       "name": "Module",
@@ -1137,7 +1143,7 @@
     "§U": {
       "name": "Using Import",
       "syntax": "§U{namespace} or §U{alias:namespace}",
-      "description": "Imports a namespace or creates an alias.",
+      "description": "Imports a namespace or creates an alias. Must appear inside a module (§M) block.",
       "csharpEquivalent": "using Namespace; or using Alias = Namespace;"
     },
     "§SM": {


### PR DESCRIPTION
## Summary

- **§IDX emitter fix**: CalorEmitter now emits `§IDX arr index` (space-separated) instead of `§IDX{arr} index` which the parser misinterpreted as a collection initializer (`new object[] { arr }[index]`). Parser also now reports a clear error with recovery when braces are used.
- **ConvertElementAccess fix**: Flipped default from `char-at` to `§IDX` for all element access. Only string *literals* (`"hello"[0]`) produce `char-at` — without a semantic model, array/list indexing is the safer default.
- **Loop bounds adjustment**: `for (i = 0; i < n; i++)` now correctly produces `to = (- n 1)` since Calor loops are inclusive (`<=`). Also handles `>` → `(+ n 1)`.
- **Mutable variable tracking**: Two-pass approach scans for reassignments/increments before converting. Variables default to `§LET`; only actually-reassigned variables emit `§MUT`.
- **Documentation**: Fixed §INTERP to show correct `"literal" §EXP expr` multi-part syntax; added §INTERP entry to JSON docs; noted §U must appear inside §M block.

## Test plan

- [x] §IDX space format parses correctly
- [x] CalorEmitter emits no-brace format
- [x] Brace format produces diagnostic + recovers to valid AST
- [x] Emit→reparse roundtrip preserves §IDX
- [x] `args[0]` and `list[i]` convert to §IDX
- [x] `"hello"[0]` converts to char-at
- [x] `i < n` loop adjusts bound to `(- n 1)`
- [x] `i < arr.Length` compound bound adjusts correctly
- [x] `i <= n` loop has no adjustment
- [x] `i > n` loop adjusts bound to `(+ n 1)`
- [x] Never-reassigned variable → §LET
- [x] Reassigned variable → §MUT
- [x] Incremented variable → §MUT
- [x] Full regression: 2963 passed, 0 failed, 14 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)