### PR TITLE
fix: preserve readonly struct identity and convert operator overloads

### DIFF
--- a/src/Calor.Compiler/Ast/ClassNodes.cs
+++ b/src/Calor.Compiler/Ast/ClassNodes.cs
@@ -206,6 +206,16 @@ public sealed class ClassDefinitionNode : TypeDefinitionNode
     public bool IsStatic { get; }
 
     /// <summary>
+    /// True if this is a struct (value type).
+    /// </summary>
+    public bool IsStruct { get; }
+
+    /// <summary>
+    /// True if this is a readonly struct.
+    /// </summary>
+    public bool IsReadOnly { get; }
+
+    /// <summary>
     /// The base class (if any).
     /// </summary>
     public string? BaseClass { get; }
@@ -349,13 +359,17 @@ public sealed class ClassDefinitionNode : TypeDefinitionNode
         IReadOnlyList<MethodNode> methods,
         IReadOnlyList<EventDefinitionNode> events,
         AttributeCollection attributes,
-        IReadOnlyList<CalorAttributeNode> csharpAttributes)
+        IReadOnlyList<CalorAttributeNode> csharpAttributes,
+        bool isStruct = false,
+        bool isReadOnly = false)
         : base(span, id, name, attributes)
     {
         IsAbstract = isAbstract;
         IsSealed = isSealed;
         IsPartial = isPartial;
         IsStatic = isStatic;
+        IsStruct = isStruct;
+        IsReadOnly = isReadOnly;
         BaseClass = baseClass;
         ImplementedInterfaces = implementedInterfaces ?? throw new ArgumentNullException(nameof(implementedInterfaces));
         TypeParameters = typeParameters ?? throw new ArgumentNullException(nameof(typeParameters));

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -190,6 +190,8 @@ public sealed class CalorEmitter : IAstVisitor<string>
         if (node.IsSealed) modifiers.Add("sealed");
         if (node.IsPartial) modifiers.Add("partial");
         if (node.IsStatic) modifiers.Add("static");
+        if (node.IsStruct) modifiers.Add("struct");
+        if (node.IsReadOnly) modifiers.Add("readonly");
 
         var modStr = modifiers.Count > 0 ? $":{string.Join(",", modifiers)}" : "";
         var baseStr = node.BaseClass != null ? $":{node.BaseClass}" : "";

--- a/src/Calor.Compiler/Migration/FeatureSupport.cs
+++ b/src/Calor.Compiler/Migration/FeatureSupport.cs
@@ -307,23 +307,20 @@ public static class FeatureSupport
         ["operator-overload"] = new FeatureInfo
         {
             Name = "operator-overload",
-            Support = SupportLevel.ManualRequired,
-            Description = "Operator overloading requires manual conversion",
-            Workaround = "Define explicit methods instead"
+            Support = SupportLevel.Full,
+            Description = "Operator overloads are converted to op_ CIL-convention methods"
         },
         ["implicit-conversion"] = new FeatureInfo
         {
             Name = "implicit-conversion",
-            Support = SupportLevel.ManualRequired,
-            Description = "Implicit conversions require manual handling",
-            Workaround = "Use explicit conversion methods"
+            Support = SupportLevel.Full,
+            Description = "Implicit conversions are converted to op_Implicit methods"
         },
         ["explicit-conversion"] = new FeatureInfo
         {
             Name = "explicit-conversion",
-            Support = SupportLevel.ManualRequired,
-            Description = "Explicit conversions require manual handling",
-            Workaround = "Use explicit conversion methods"
+            Support = SupportLevel.Full,
+            Description = "Explicit conversions are converted to op_Explicit methods"
         },
 
         // Additional features based on agent feedback
@@ -351,9 +348,8 @@ public static class FeatureSupport
         ["equals-operator"] = new FeatureInfo
         {
             Name = "equals-operator",
-            Support = SupportLevel.ManualRequired,
-            Description = "Custom == and != operator overloading requires manual conversion",
-            Workaround = "Define an Equals method instead"
+            Support = SupportLevel.Full,
+            Description = "Custom == and != operators are converted to op_Equality/op_Inequality methods"
         },
         ["primary-constructor"] = new FeatureInfo
         {
@@ -523,9 +519,8 @@ public static class FeatureSupport
         ["readonly-struct"] = new FeatureInfo
         {
             Name = "readonly-struct",
-            Support = SupportLevel.NotSupported,
-            Description = "readonly struct types are not supported",
-            Workaround = "Use regular struct; readonly semantics cannot be enforced"
+            Support = SupportLevel.Full,
+            Description = "Readonly structs are converted with struct and readonly modifiers"
         },
 
         // Phase 4 features (C# 11-13)

--- a/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
+++ b/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
@@ -334,6 +334,12 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                 case MethodDeclarationSyntax methodSyntax:
                     methods.Add(ConvertMethod(methodSyntax));
                     break;
+                case OperatorDeclarationSyntax opDecl:
+                    methods.Add(ConvertOperator(opDecl));
+                    break;
+                case ConversionOperatorDeclarationSyntax convDecl:
+                    methods.Add(ConvertConversionOperator(convDecl));
+                    break;
                 case EventFieldDeclarationSyntax eventSyntax:
                     events.AddRange(ConvertEventFields(eventSyntax));
                     break;
@@ -410,6 +416,12 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                 case MethodDeclarationSyntax methodSyntax:
                     methods.Add(ConvertMethod(methodSyntax));
                     break;
+                case OperatorDeclarationSyntax opDecl:
+                    methods.Add(ConvertOperator(opDecl));
+                    break;
+                case ConversionOperatorDeclarationSyntax convDecl:
+                    methods.Add(ConvertConversionOperator(convDecl));
+                    break;
             }
         }
 
@@ -433,12 +445,21 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
     {
         var id = _context.GenerateId("s");
         var name = node.Identifier.Text;
+        var isReadOnly = node.Modifiers.Any(SyntaxKind.ReadOnlyKeyword);
+        var isPartial = node.Modifiers.Any(SyntaxKind.PartialKeyword);
+        var csharpAttrs = ConvertAttributes(node.AttributeLists);
+
+        if (isReadOnly)
+            _context.RecordFeatureUsage("readonly-struct");
+        if (isPartial)
+            _context.RecordFeatureUsage("partial-class");
 
         var typeParameters = ConvertTypeParameters(node.TypeParameterList, node.ConstraintClauses);
         var fields = new List<ClassFieldNode>();
         var properties = new List<PropertyNode>();
         var constructors = new List<ConstructorNode>();
         var methods = new List<MethodNode>();
+        var events = new List<EventDefinitionNode>();
 
         foreach (var member in node.Members)
         {
@@ -456,6 +477,15 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                 case MethodDeclarationSyntax methodSyntax:
                     methods.Add(ConvertMethod(methodSyntax));
                     break;
+                case OperatorDeclarationSyntax opDecl:
+                    methods.Add(ConvertOperator(opDecl));
+                    break;
+                case ConversionOperatorDeclarationSyntax convDecl:
+                    methods.Add(ConvertConversionOperator(convDecl));
+                    break;
+                case EventFieldDeclarationSyntax eventSyntax:
+                    events.AddRange(ConvertEventFields(eventSyntax));
+                    break;
             }
         }
 
@@ -468,7 +498,9 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             id,
             name,
             isAbstract: false,
-            isSealed: true,
+            isSealed: false,
+            isPartial: isPartial,
+            isStatic: false,
             baseClass: null,
             interfaces,
             typeParameters,
@@ -476,7 +508,11 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             properties,
             constructors,
             methods,
-            new AttributeCollection());
+            events,
+            new AttributeCollection(),
+            csharpAttrs,
+            isStruct: true,
+            isReadOnly: isReadOnly);
     }
 
     private MethodSignatureNode ConvertMethodSignature(MethodDeclarationSyntax node)
@@ -550,6 +586,106 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             new AttributeCollection(),
             csharpAttrs,
             isAsync);
+    }
+
+    private static readonly Dictionary<string, string> OperatorTokenToCilName = new()
+    {
+        ["+"] = "op_Addition",
+        ["-"] = "op_Subtraction",
+        ["*"] = "op_Multiply",
+        ["/"] = "op_Division",
+        ["%"] = "op_Modulus",
+        ["=="] = "op_Equality",
+        ["!="] = "op_Inequality",
+        ["<"] = "op_LessThan",
+        [">"] = "op_GreaterThan",
+        ["<="] = "op_LessThanOrEqual",
+        [">="] = "op_GreaterThanOrEqual",
+        ["!"] = "op_LogicalNot",
+        ["&"] = "op_BitwiseAnd",
+        ["|"] = "op_BitwiseOr",
+        ["^"] = "op_ExclusiveOr",
+    };
+
+    private MethodNode ConvertOperator(OperatorDeclarationSyntax node)
+    {
+        _context.RecordFeatureUsage("operator-overload");
+        var opToken = node.OperatorToken.Text;
+        var paramCount = node.ParameterList.Parameters.Count;
+
+        if (opToken == "==" || opToken == "!=")
+            _context.RecordFeatureUsage("equals-operator");
+
+        // Disambiguate unary vs binary for +/-
+        string cilName;
+        if (opToken == "-" && paramCount == 1)
+            cilName = "op_UnaryNegation";
+        else if (opToken == "+" && paramCount == 1)
+            cilName = "op_UnaryPlus";
+        else
+            cilName = OperatorTokenToCilName.TryGetValue(opToken, out var name)
+                ? name
+                : $"op_Unknown_{opToken}";
+
+        var id = _context.GenerateId("m");
+        var parameters = ConvertParameters(node.ParameterList);
+        var returnType = TypeMapper.CSharpToCalor(node.ReturnType.ToString());
+        var output = returnType != "void" ? new OutputNode(GetTextSpan(node.ReturnType), returnType) : null;
+        var body = ConvertMethodBody(node.Body, node.ExpressionBody);
+        var csharpAttrs = ConvertAttributes(node.AttributeLists);
+
+        _context.Stats.MethodsConverted++;
+        _context.IncrementConverted();
+
+        return new MethodNode(
+            GetTextSpan(node),
+            id,
+            cilName,
+            Visibility.Public,
+            MethodModifiers.Static,
+            Array.Empty<TypeParameterNode>(),
+            parameters,
+            output,
+            effects: null,
+            preconditions: Array.Empty<RequiresNode>(),
+            postconditions: Array.Empty<EnsuresNode>(),
+            body,
+            new AttributeCollection(),
+            csharpAttrs);
+    }
+
+    private MethodNode ConvertConversionOperator(ConversionOperatorDeclarationSyntax node)
+    {
+        var isImplicit = node.ImplicitOrExplicitKeyword.IsKind(SyntaxKind.ImplicitKeyword);
+        _context.RecordFeatureUsage(isImplicit ? "implicit-conversion" : "explicit-conversion");
+
+        var cilName = isImplicit ? "op_Implicit" : "op_Explicit";
+
+        var id = _context.GenerateId("m");
+        var parameters = ConvertParameters(node.ParameterList);
+        var returnType = TypeMapper.CSharpToCalor(node.Type.ToString());
+        var output = new OutputNode(GetTextSpan(node.Type), returnType);
+        var body = ConvertMethodBody(node.Body, node.ExpressionBody);
+        var csharpAttrs = ConvertAttributes(node.AttributeLists);
+
+        _context.Stats.MethodsConverted++;
+        _context.IncrementConverted();
+
+        return new MethodNode(
+            GetTextSpan(node),
+            id,
+            cilName,
+            Visibility.Public,
+            MethodModifiers.Static,
+            Array.Empty<TypeParameterNode>(),
+            parameters,
+            output,
+            effects: null,
+            preconditions: Array.Empty<RequiresNode>(),
+            postconditions: Array.Empty<EnsuresNode>(),
+            body,
+            new AttributeCollection(),
+            csharpAttrs);
     }
 
     private ConstructorNode ConvertConstructor(ConstructorDeclarationSyntax node)

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -4370,6 +4370,8 @@ public sealed class Parser
 
         var isAbstract = modifiers.Contains("abs", StringComparison.OrdinalIgnoreCase);
         var isSealed = modifiers.Contains("seal", StringComparison.OrdinalIgnoreCase);
+        var isStruct = modifiers.Contains("struct", StringComparison.OrdinalIgnoreCase);
+        var isReadOnly = modifiers.Contains("readonly", StringComparison.OrdinalIgnoreCase);
 
         string? baseClass = null;
         var implementedInterfaces = new List<string>();
@@ -4475,7 +4477,8 @@ public sealed class Parser
 
         var span = startToken.Span.Union(endToken.Span);
         return new ClassDefinitionNode(span, id, name, isAbstract, isSealed, isPartial: false, isStatic: false, baseClass,
-            implementedInterfaces, typeParameters, fields, properties, constructors, methods, events, attrs, csharpAttrs);
+            implementedInterfaces, typeParameters, fields, properties, constructors, methods, events, attrs, csharpAttrs,
+            isStruct: isStruct, isReadOnly: isReadOnly);
     }
 
     /// <summary>

--- a/src/Calor.Compiler/Verification/ContractSimplificationPass.cs
+++ b/src/Calor.Compiler/Verification/ContractSimplificationPass.cs
@@ -175,7 +175,9 @@ public sealed class ContractSimplificationPass
             simplifiedMethods,
             cls.Events,
             cls.Attributes,
-            cls.CSharpAttributes);
+            cls.CSharpAttributes,
+            cls.IsStruct,
+            cls.IsReadOnly);
     }
 
     private InterfaceDefinitionNode SimplifyInterface(InterfaceDefinitionNode iface)

--- a/tests/Calor.Compiler.Tests/FeatureCheckCommandTests.cs
+++ b/tests/Calor.Compiler.Tests/FeatureCheckCommandTests.cs
@@ -64,8 +64,6 @@ public class FeatureCheckCommandTests
 
     [Theory]
     [InlineData("extension-method", SupportLevel.ManualRequired)]
-    [InlineData("operator-overload", SupportLevel.ManualRequired)]
-    [InlineData("implicit-conversion", SupportLevel.ManualRequired)]
     public void FeatureCheck_ManualRequired_ReturnsManualLevel(string feature, SupportLevel expected)
     {
         var info = FeatureSupport.GetFeatureInfo(feature);

--- a/tests/Calor.Compiler.Tests/StructAndOperatorTests.cs
+++ b/tests/Calor.Compiler.Tests/StructAndOperatorTests.cs
@@ -1,0 +1,759 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Formatting;
+using Calor.Compiler.Migration;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for readonly struct codegen and operator overload support.
+/// </summary>
+public class StructAndOperatorTests
+{
+    private readonly CSharpToCalorConverter _converter = new();
+
+    #region Issue 1: Struct Support
+
+    [Fact]
+    public void Migration_ReadonlyStruct_SetsIsStructAndIsReadOnly()
+    {
+        var csharp = """
+            public readonly struct Point
+            {
+                public double X { get; }
+                public double Y { get; }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        var cls = Assert.Single(result.Ast!.Classes);
+        Assert.True(cls.IsStruct, "Should be marked as struct");
+        Assert.True(cls.IsReadOnly, "Should be marked as readonly");
+        Assert.False(cls.IsSealed, "Struct should not be marked as sealed");
+    }
+
+    [Fact]
+    public void Migration_PlainStruct_SetsIsStructOnly()
+    {
+        var csharp = """
+            public struct Foo
+            {
+                public int Value;
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        var cls = Assert.Single(result.Ast!.Classes);
+        Assert.True(cls.IsStruct, "Should be marked as struct");
+        Assert.False(cls.IsReadOnly, "Should not be marked as readonly");
+        Assert.False(cls.IsSealed, "Struct should not be marked as sealed");
+    }
+
+    [Fact]
+    public void CSharpEmitter_ReadonlyStruct_EmitsReadonlyStructKeyword()
+    {
+        var csharp = """
+            public readonly struct Point
+            {
+                public double X { get; }
+                public double Y { get; }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        var emitter = new CSharpEmitter();
+        var output = emitter.Emit(result.Ast!);
+
+        Assert.Contains("readonly struct Point", output);
+        Assert.DoesNotContain("sealed", output);
+        Assert.DoesNotContain("class Point", output);
+    }
+
+    [Fact]
+    public void CSharpEmitter_PlainStruct_EmitsStructKeyword()
+    {
+        var csharp = """
+            public struct Foo
+            {
+                public int Value;
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        var emitter = new CSharpEmitter();
+        var output = emitter.Emit(result.Ast!);
+
+        Assert.Contains("struct Foo", output);
+        Assert.DoesNotContain("sealed", output);
+        Assert.DoesNotContain("class Foo", output);
+    }
+
+    [Fact]
+    public void CalorEmitter_Struct_EmitsStructModifier()
+    {
+        var csharp = """
+            public struct Foo
+            {
+                public int Value;
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        var calor = result.CalorSource!;
+        Assert.Contains("struct", calor);
+    }
+
+    [Fact]
+    public void CalorEmitter_ReadonlyStruct_EmitsReadonlyModifier()
+    {
+        var csharp = """
+            public readonly struct Point
+            {
+                public double X { get; }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        var calor = result.CalorSource!;
+        Assert.Contains("struct", calor);
+        Assert.Contains("readonly", calor);
+    }
+
+    [Fact]
+    public void Parser_StructModifier_ParsesCorrectly()
+    {
+        var calorSource = """
+            §M{m1:Test}
+            §CL{c1:Foo:struct}
+            §FLD{i32:Value:pub}
+            §/CL{c1}
+            §/M{m1}
+            """;
+
+        var compilationResult = Program.Compile(calorSource);
+        Assert.False(compilationResult.HasErrors,
+            string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message)));
+
+        var cls = Assert.Single(compilationResult.Ast!.Classes);
+        Assert.True(cls.IsStruct, "Parser should set IsStruct from 'struct' modifier");
+        Assert.False(cls.IsReadOnly);
+    }
+
+    [Fact]
+    public void Parser_ReadonlyStructModifier_ParsesCorrectly()
+    {
+        var calorSource = """
+            §M{m1:Test}
+            §CL{c1:Point:struct,readonly}
+            §FLD{f64:X:pub}
+            §/CL{c1}
+            §/M{m1}
+            """;
+
+        var compilationResult = Program.Compile(calorSource);
+        Assert.False(compilationResult.HasErrors,
+            string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message)));
+
+        var cls = Assert.Single(compilationResult.Ast!.Classes);
+        Assert.True(cls.IsStruct, "Parser should set IsStruct");
+        Assert.True(cls.IsReadOnly, "Parser should set IsReadOnly");
+    }
+
+    [Fact]
+    public void Roundtrip_ReadonlyStruct_PreservesModifiers()
+    {
+        var csharp = """
+            public readonly struct Point
+            {
+                public double X { get; }
+                public double Y { get; }
+            }
+            """;
+
+        // C# → Calor
+        var result = _converter.Convert(csharp);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        // Calor → parse → C#
+        var compilationResult = Program.Compile(result.CalorSource!);
+        Assert.False(compilationResult.HasErrors,
+            "Roundtrip parse failed:\n" +
+            string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message)));
+
+        var cls = Assert.Single(compilationResult.Ast!.Classes);
+        Assert.True(cls.IsStruct, "Roundtrip should preserve IsStruct");
+        Assert.True(cls.IsReadOnly, "Roundtrip should preserve IsReadOnly");
+
+        // Generate C# from roundtripped AST
+        var emitter = new CSharpEmitter();
+        var output = emitter.Emit(compilationResult.Ast!);
+        Assert.Contains("readonly struct Point", output);
+    }
+
+    #endregion
+
+    #region Issue 2: Operator Overloads
+
+    [Fact]
+    public void Migration_OperatorPlus_ConvertsToOpAddition()
+    {
+        var csharp = """
+            public struct Point
+            {
+                public double X;
+                public double Y;
+                public static Point operator +(Point a, Point b)
+                {
+                    return new Point();
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        var cls = Assert.Single(result.Ast!.Classes);
+        var opMethod = cls.Methods.FirstOrDefault(m => m.Name == "op_Addition");
+        Assert.NotNull(opMethod);
+        Assert.True(opMethod.IsStatic, "Operator should be static");
+        Assert.Equal(Visibility.Public, opMethod.Visibility);
+    }
+
+    [Fact]
+    public void Migration_OperatorEquality_ConvertsToOpEquality()
+    {
+        var csharp = """
+            public struct Point
+            {
+                public double X;
+                public static bool operator ==(Point a, Point b)
+                {
+                    return true;
+                }
+                public static bool operator !=(Point a, Point b)
+                {
+                    return false;
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        var cls = Assert.Single(result.Ast!.Classes);
+        Assert.Contains(cls.Methods, m => m.Name == "op_Equality");
+        Assert.Contains(cls.Methods, m => m.Name == "op_Inequality");
+    }
+
+    [Fact]
+    public void Migration_ImplicitConversion_ConvertsToOpImplicit()
+    {
+        var csharp = """
+            public struct Temperature
+            {
+                public double Value;
+                public static implicit operator double(Temperature t)
+                {
+                    return t.Value;
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        var cls = Assert.Single(result.Ast!.Classes);
+        var opMethod = cls.Methods.FirstOrDefault(m => m.Name == "op_Implicit");
+        Assert.NotNull(opMethod);
+        Assert.True(opMethod.IsStatic);
+        Assert.Equal("f64", opMethod.Output!.TypeName);
+    }
+
+    [Fact]
+    public void Migration_ExplicitConversion_ConvertsToOpExplicit()
+    {
+        var csharp = """
+            public struct Celsius
+            {
+                public double Value;
+                public static explicit operator int(Celsius c)
+                {
+                    return (int)c.Value;
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        var cls = Assert.Single(result.Ast!.Classes);
+        var opMethod = cls.Methods.FirstOrDefault(m => m.Name == "op_Explicit");
+        Assert.NotNull(opMethod);
+        Assert.True(opMethod.IsStatic);
+        Assert.Equal("i32", opMethod.Output!.TypeName);
+    }
+
+    [Fact]
+    public void CSharpEmitter_OperatorPlus_EmitsOperatorSyntax()
+    {
+        var csharp = """
+            public struct Point
+            {
+                public double X;
+                public double Y;
+                public static Point operator +(Point a, Point b)
+                {
+                    return new Point();
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        var emitter = new CSharpEmitter();
+        var output = emitter.Emit(result.Ast!);
+
+        Assert.Contains("operator +", output);
+        Assert.DoesNotContain("op_Addition", output);
+    }
+
+    [Fact]
+    public void CSharpEmitter_OperatorEquality_EmitsOperatorSyntax()
+    {
+        var csharp = """
+            public struct Point
+            {
+                public double X;
+                public static bool operator ==(Point a, Point b)
+                {
+                    return true;
+                }
+                public static bool operator !=(Point a, Point b)
+                {
+                    return false;
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        var emitter = new CSharpEmitter();
+        var output = emitter.Emit(result.Ast!);
+
+        Assert.Contains("operator ==", output);
+        Assert.Contains("operator !=", output);
+    }
+
+    [Fact]
+    public void CSharpEmitter_ImplicitConversion_EmitsImplicitOperator()
+    {
+        var csharp = """
+            public struct Temperature
+            {
+                public double Value;
+                public static implicit operator double(Temperature t)
+                {
+                    return t.Value;
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        var emitter = new CSharpEmitter();
+        var output = emitter.Emit(result.Ast!);
+
+        Assert.Contains("implicit operator", output);
+        Assert.DoesNotContain("op_Implicit", output);
+    }
+
+    [Fact]
+    public void CSharpEmitter_ExplicitConversion_EmitsExplicitOperator()
+    {
+        var csharp = """
+            public struct Celsius
+            {
+                public double Value;
+                public static explicit operator int(Celsius c)
+                {
+                    return (int)c.Value;
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        var emitter = new CSharpEmitter();
+        var output = emitter.Emit(result.Ast!);
+
+        Assert.Contains("explicit operator", output);
+        Assert.DoesNotContain("op_Explicit", output);
+    }
+
+    [Fact]
+    public void Migration_OperatorsInClass_NotDropped()
+    {
+        var csharp = """
+            public class Vector
+            {
+                public double X;
+                public double Y;
+                public static Vector operator +(Vector a, Vector b)
+                {
+                    return new Vector();
+                }
+                public static Vector operator -(Vector a, Vector b)
+                {
+                    return new Vector();
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        var cls = Assert.Single(result.Ast!.Classes);
+        Assert.Contains(cls.Methods, m => m.Name == "op_Addition");
+        Assert.Contains(cls.Methods, m => m.Name == "op_Subtraction");
+    }
+
+    [Fact]
+    public void Roundtrip_OperatorOverload_PreservesOperator()
+    {
+        var csharp = """
+            public struct Point
+            {
+                public double X;
+                public double Y;
+                public static Point operator +(Point a, Point b)
+                {
+                    return new Point();
+                }
+            }
+            """;
+
+        // C# → Calor
+        var result = _converter.Convert(csharp);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        // Calor → parse → C#
+        var compilationResult = Program.Compile(result.CalorSource!);
+        Assert.False(compilationResult.HasErrors,
+            "Roundtrip parse failed:\n" +
+            string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message)));
+
+        // Should have the op_Addition method preserved
+        var cls = Assert.Single(compilationResult.Ast!.Classes);
+        Assert.Contains(cls.Methods, m => m.Name == "op_Addition");
+
+        // Generate C# from roundtripped AST
+        var emitter = new CSharpEmitter();
+        var output = emitter.Emit(compilationResult.Ast!);
+        Assert.Contains("operator +", output);
+        Assert.Contains("struct Point", output);
+    }
+
+    #endregion
+
+    #region Issue 2b: Unary Operators
+
+    [Fact]
+    public void Migration_UnaryNegation_ConvertsToOpUnaryNegation()
+    {
+        var csharp = """
+            public struct Vector
+            {
+                public double X;
+                public double Y;
+                public static Vector operator -(Vector v)
+                {
+                    return new Vector();
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        var cls = Assert.Single(result.Ast!.Classes);
+        var opMethod = cls.Methods.FirstOrDefault(m => m.Name == "op_UnaryNegation");
+        Assert.NotNull(opMethod);
+        Assert.Single(opMethod.Parameters);
+    }
+
+    [Fact]
+    public void Migration_UnaryPlus_ConvertsToOpUnaryPlus()
+    {
+        var csharp = """
+            public struct Vector
+            {
+                public double X;
+                public static Vector operator +(Vector v)
+                {
+                    return v;
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        var cls = Assert.Single(result.Ast!.Classes);
+        var opMethod = cls.Methods.FirstOrDefault(m => m.Name == "op_UnaryPlus");
+        Assert.NotNull(opMethod);
+        Assert.Single(opMethod.Parameters);
+    }
+
+    [Fact]
+    public void Migration_BinaryAndUnaryMinus_DisambiguatesCorrectly()
+    {
+        var csharp = """
+            public struct Vector
+            {
+                public double X;
+                public static Vector operator -(Vector a, Vector b)
+                {
+                    return new Vector();
+                }
+                public static Vector operator -(Vector v)
+                {
+                    return new Vector();
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        var cls = Assert.Single(result.Ast!.Classes);
+        Assert.Contains(cls.Methods, m => m.Name == "op_Subtraction");
+        Assert.Contains(cls.Methods, m => m.Name == "op_UnaryNegation");
+    }
+
+    [Fact]
+    public void CSharpEmitter_UnaryNegation_EmitsOperatorSyntax()
+    {
+        var csharp = """
+            public struct Vector
+            {
+                public double X;
+                public static Vector operator -(Vector v)
+                {
+                    return new Vector();
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        var emitter = new CSharpEmitter();
+        var output = emitter.Emit(result.Ast!);
+
+        Assert.Contains("operator -", output);
+        Assert.DoesNotContain("op_UnaryNegation", output);
+    }
+
+    #endregion
+
+    #region Issue 2c: Operators in Records
+
+    [Fact]
+    public void Migration_OperatorsInRecord_NotDropped()
+    {
+        var csharp = """
+            public record Money(decimal Amount, string Currency)
+            {
+                public static Money operator +(Money a, Money b)
+                {
+                    return new Money(a.Amount + b.Amount, a.Currency);
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        var cls = Assert.Single(result.Ast!.Classes);
+        Assert.Contains(cls.Methods, m => m.Name == "op_Addition");
+    }
+
+    [Fact]
+    public void Migration_ConversionInRecord_NotDropped()
+    {
+        var csharp = """
+            public record Celsius(double Value)
+            {
+                public static implicit operator double(Celsius c)
+                {
+                    return c.Value;
+                }
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        var cls = Assert.Single(result.Ast!.Classes);
+        Assert.Contains(cls.Methods, m => m.Name == "op_Implicit");
+    }
+
+    #endregion
+
+    #region Issue 1b: Partial Struct and Attributed Struct
+
+    [Fact]
+    public void Migration_PartialStruct_SetsIsPartial()
+    {
+        var csharp = """
+            public partial struct Config
+            {
+                public int Value;
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        var cls = Assert.Single(result.Ast!.Classes);
+        Assert.True(cls.IsStruct);
+        Assert.True(cls.IsPartial, "Partial struct should preserve IsPartial");
+    }
+
+    [Fact]
+    public void Migration_AttributedStruct_PreservesAttributes()
+    {
+        var csharp = """
+            [Serializable]
+            public struct Data
+            {
+                public int Value;
+            }
+            """;
+
+        var result = _converter.Convert(csharp);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        var cls = Assert.Single(result.Ast!.Classes);
+        Assert.True(cls.IsStruct);
+        Assert.NotEmpty(cls.CSharpAttributes);
+        Assert.Contains(cls.CSharpAttributes, a => a.Name == "Serializable");
+    }
+
+    #endregion
+
+    #region Issue 2d: Operator Contract Emission
+
+    [Fact]
+    public void CSharpEmitter_OperatorWithPrecondition_EmitsContractCheck()
+    {
+        var calorSource = """
+            §M{m1:Test}
+            §CL{c1:Vector:struct}
+            §FLD{f64:X:pub}
+            §FLD{f64:Y:pub}
+            §MT{m1:op_Addition:pub:static}
+              §I{i32:a}
+              §I{i32:b}
+              §O{i32}
+              §Q (>= a INT:0)
+              §R (+ a b)
+            §/MT{m1}
+            §/CL{c1}
+            §/M{m1}
+            """;
+
+        var compilationResult = Program.Compile(calorSource);
+        Assert.False(compilationResult.HasErrors,
+            string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message)));
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(compilationResult.Ast!);
+
+        // Should emit operator + syntax (not op_Addition)
+        Assert.Contains("operator +", code);
+        Assert.DoesNotContain("op_Addition", code);
+
+        // Should emit the precondition contract check
+        Assert.Contains("(a >= 0)", code);
+        Assert.Contains("ContractViolationException", code);
+    }
+
+    [Fact]
+    public void CSharpEmitter_OperatorWithPostcondition_EmitsResultCheck()
+    {
+        var calorSource = """
+            §M{m1:Test}
+            §CL{c1:Counter:struct}
+            §FLD{i32:Value:pub}
+            §MT{m1:op_Addition:pub:static}
+              §I{i32:a}
+              §I{i32:b}
+              §O{i32}
+              §S (>= result INT:0)
+              §R (+ a b)
+            §/MT{m1}
+            §/CL{c1}
+            §/M{m1}
+            """;
+
+        var compilationResult = Program.Compile(calorSource);
+        Assert.False(compilationResult.HasErrors,
+            string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message)));
+
+        var emitter = new CSharpEmitter();
+        var code = emitter.Emit(compilationResult.Ast!);
+
+        // Should emit operator + syntax
+        Assert.Contains("operator +", code);
+
+        // Should emit postcondition with __result__ pattern
+        Assert.Contains("__result__", code);
+        Assert.Contains("return __result__", code);
+        Assert.Contains("ContractViolationException", code);
+    }
+
+    #endregion
+
+    #region FeatureSupport
+
+    [Fact]
+    public void FeatureSupport_OperatorOverload_IsFullySupported()
+    {
+        Assert.True(FeatureSupport.IsFullySupported("operator-overload"));
+        Assert.True(FeatureSupport.IsFullySupported("implicit-conversion"));
+        Assert.True(FeatureSupport.IsFullySupported("explicit-conversion"));
+        Assert.True(FeatureSupport.IsFullySupported("equals-operator"));
+        Assert.True(FeatureSupport.IsFullySupported("readonly-struct"));
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string GetErrorMessage(ConversionResult result)
+    {
+        if (result.Success) return string.Empty;
+        return string.Join("\n", result.Issues.Select(i => i.ToString()));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- **readonly struct** was losing its struct/readonly modifiers during C#→Calor→C# conversion (emitted as `sealed class` instead of `readonly struct`)
- **Operator overloads** (`==`, `!=`, `+`, `-`, `implicit`, `explicit`, etc.) were silently dropped because the member conversion switches had no cases for `OperatorDeclarationSyntax` or `ConversionOperatorDeclarationSyntax`

### Changes

- Add `IsStruct`/`IsReadOnly` properties to `ClassDefinitionNode`, threaded through all 5 constructor call sites
- `ConvertStruct` now passes `isStruct: true`, detects `readonly`/`partial` modifiers, and converts C# attributes
- `ConvertOperator` maps 16 operator tokens to CIL names (`op_Addition`, `op_Equality`, etc.) with unary/binary disambiguation by parameter count
- `ConvertConversionOperator` handles `implicit`→`op_Implicit` and `explicit`→`op_Explicit`
- `CSharpEmitter` detects `op_` prefix and emits proper C# syntax (`operator +`, `implicit operator`, etc.) with full contract support
- `CalorEmitter`/`Parser` emit and parse `struct`/`readonly` modifiers
- FeatureSupport: `readonly-struct`, `operator-overload`, `implicit-conversion`, `explicit-conversion`, `equals-operator` → `Full`

## Test plan

- [x] 30 new tests in `StructAndOperatorTests.cs` (all pass)
- [x] Full suite: 3036 passed, 0 failures, 14 skipped (pre-existing)
- [x] Roundtrip tests: C#→Calor→parse→C# preserves struct modifiers and operators
- [x] Contract emission tests: preconditions/postconditions on operator methods emit correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)