### PR TITLE
fix: class inheritance, static class, and string interpolation codegen bugs

### DIFF
--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -487,7 +487,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         // Check if this is an interpolated string (contains ${identifier})
         // Only match Calor interpolation syntax: ${identifier}, not format placeholders ${0}
         // Calor interpolation uses identifiers (letters, underscores), not numbers
-        var interpolationRegex = new System.Text.RegularExpressions.Regex(@"\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}");
+        var interpolationRegex = new System.Text.RegularExpressions.Regex(@"\$\{([a-zA-Z_][a-zA-Z0-9_]*(?:\??\.[a-zA-Z_][a-zA-Z0-9_]*)*)\}");
         if (interpolationRegex.IsMatch(node.Value))
         {
             // Convert Calor interpolation ${expr} to C# interpolation {expr}
@@ -1679,6 +1679,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var modifiers = "public";
         if (node.IsAbstract) modifiers += " abstract";
         if (!node.IsStruct && node.IsSealed) modifiers += " sealed";
+        if (node.IsStatic) modifiers += " static";
         if (node.IsReadOnly) modifiers += " readonly";
 
         var keyword = node.IsStruct ? "struct" : "class";

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -194,25 +194,30 @@ public sealed class CalorEmitter : IAstVisitor<string>
         if (node.IsReadOnly) modifiers.Add("readonly");
 
         var modStr = modifiers.Count > 0 ? $":{string.Join(",", modifiers)}" : "";
-        var baseStr = node.BaseClass != null ? $":{node.BaseClass}" : "";
 
         var typeParams = node.TypeParameters.Count > 0
             ? $"<{string.Join(",", node.TypeParameters.Select(tp => tp.Name))}>"
             : "";
         var attrs = EmitCSharpAttributes(node.CSharpAttributes);
 
-        AppendLine($"§CL{{{node.Id}:{node.Name}{typeParams}{baseStr}{modStr}}}{attrs}");
+        AppendLine($"§CL{{{node.Id}:{node.Name}{typeParams}{modStr}}}{attrs}");
         Indent();
 
         // Emit type parameter constraints
         EmitTypeParameterConstraints(node.TypeParameters);
+
+        // Emit base class as §EXT tag (not positional)
+        if (node.BaseClass != null)
+        {
+            AppendLine($"§EXT{{{node.BaseClass}}}");
+        }
 
         // Emit implemented interfaces
         foreach (var iface in node.ImplementedInterfaces)
         {
             AppendLine($"§IMPL{{{iface}}}");
         }
-        if (node.ImplementedInterfaces.Count > 0 || node.TypeParameters.Any(tp => tp.Constraints.Count > 0))
+        if (node.BaseClass != null || node.ImplementedInterfaces.Count > 0 || node.TypeParameters.Any(tp => tp.Constraints.Count > 0))
             AppendLine();
 
         // Emit fields

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -4354,10 +4354,11 @@ public sealed class Parser
         var attrs = ParseAttributes();
         var csharpAttrs = ParseCSharpAttributes();
 
-        // Positional: [id:name:modifiers?]
+        // Positional: [id:name:modifiers?] or [id:name:baseClass:modifiers?]
         var id = attrs["_pos0"] ?? "";
         var name = attrs["_pos1"] ?? "";
-        var modifiers = attrs["_pos2"] ?? "";
+        var pos2 = attrs["_pos2"] ?? "";
+        var pos3 = attrs["_pos3"];
 
         if (string.IsNullOrEmpty(id))
         {
@@ -4368,12 +4369,47 @@ public sealed class Parser
             _diagnostics.ReportMissingRequiredAttribute(startToken.Span, "CLASS", "name");
         }
 
+        // Disambiguate positionals:
+        // 4 positionals (pos3 exists): pos2 is baseClass (or visibility to ignore), pos3 is modifiers
+        // 3 positionals (pos3 null): if pos2 is all known modifiers/visibility → modifiers; else baseClass
+        string modifiers;
+        string? baseClass = null;
+
+        if (pos3 != null)
+        {
+            // 4 positionals: §CL{id:name:BaseClass:modifiers}
+            if (IsVisibilityKeyword(pos2))
+            {
+                // pos2 is a visibility like "pub" — ignore it, modifiers = pos3
+                modifiers = pos3;
+            }
+            else
+            {
+                baseClass = pos2;
+                modifiers = pos3;
+            }
+        }
+        else
+        {
+            // 3 positionals: §CL{id:name:modifiers_or_base}
+            if (IsClassModifierOrVisibility(pos2))
+            {
+                modifiers = pos2;
+            }
+            else
+            {
+                // Not a known modifier — treat as base class
+                baseClass = string.IsNullOrEmpty(pos2) ? null : pos2;
+                modifiers = "";
+            }
+        }
+
         var isAbstract = modifiers.Contains("abs", StringComparison.OrdinalIgnoreCase);
         var isSealed = modifiers.Contains("seal", StringComparison.OrdinalIgnoreCase);
+        var isStatic = modifiers.Contains("stat", StringComparison.OrdinalIgnoreCase);
+        var isPartial = modifiers.Contains("partial", StringComparison.OrdinalIgnoreCase);
         var isStruct = modifiers.Contains("struct", StringComparison.OrdinalIgnoreCase);
         var isReadOnly = modifiers.Contains("readonly", StringComparison.OrdinalIgnoreCase);
-
-        string? baseClass = null;
         var implementedInterfaces = new List<string>();
 
         // NEW: Parse optional type parameters §CL{...}<T, U>
@@ -4476,7 +4512,7 @@ public sealed class Parser
         }
 
         var span = startToken.Span.Union(endToken.Span);
-        return new ClassDefinitionNode(span, id, name, isAbstract, isSealed, isPartial: false, isStatic: false, baseClass,
+        return new ClassDefinitionNode(span, id, name, isAbstract, isSealed, isPartial, isStatic, baseClass,
             implementedInterfaces, typeParameters, fields, properties, constructors, methods, events, attrs, csharpAttrs,
             isStruct: isStruct, isReadOnly: isReadOnly);
     }
@@ -6732,6 +6768,45 @@ public sealed class Parser
 
         var span = startToken.Span.Union(endToken.Span);
         return new EnumExtensionNode(span, id, enumName, methods, attrs);
+    }
+
+    #endregion
+
+    #region Class Modifier Helpers
+
+    private static bool IsVisibilityKeyword(string value)
+    {
+        return value.Equals("pub", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("pri", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("pro", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("int", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("public", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("private", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("protected", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("internal", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static readonly HashSet<string> ClassModifierKeywords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "abs", "abstract", "seal", "sealed", "stat", "static",
+        "partial", "struct", "readonly",
+        "pub", "pri", "pro", "int",
+        "public", "private", "protected", "internal"
+    };
+
+    private static bool IsClassModifierOrVisibility(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return true; // empty string is "no modifiers" — treat as modifiers field
+
+        // value may be comma-separated ("abs,sealed") or space-separated ("abs seal")
+        foreach (var part in value.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = part.Trim();
+            if (trimmed.Length > 0 && !ClassModifierKeywords.Contains(trimmed))
+                return false;
+        }
+        return true;
     }
 
     #endregion

--- a/src/Calor.Compiler/Resources/SelfTest/09_codegen_bugfixes.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/09_codegen_bugfixes.g.cs
@@ -12,7 +12,7 @@ using System.Text;
 
 namespace Transliterator
 {
-    public class TransliteratorBase
+    public abstract class TransliteratorBase
     {
         public abstract string Name { get; set; }
 

--- a/tests/Calor.Compiler.Tests/CodegenBug3_5_6_Tests.cs
+++ b/tests/Calor.Compiler.Tests/CodegenBug3_5_6_Tests.cs
@@ -1,0 +1,390 @@
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Migration;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for codegen bugs #3 (class inheritance lost), #5 (string interpolation dotted access),
+/// and #6 (static class not emitted).
+/// </summary>
+public class CodegenBug3_5_6_Tests
+{
+    private readonly CSharpToCalorConverter _converter = new();
+
+    #region Bug 6: static class not emitted
+
+    [Fact]
+    public void Bug6_Parser_StaticModifier_SetsIsStatic()
+    {
+        var source = @"
+§M{m1:Test}
+§CL{c1:Helper:static}
+§/CL{c1}
+§/M{m1}
+";
+        var module = ParseModule(source);
+        var cls = Assert.Single(module.Classes);
+        Assert.True(cls.IsStatic, "IsStatic should be true");
+        Assert.False(cls.IsAbstract);
+        Assert.False(cls.IsSealed);
+    }
+
+    [Fact]
+    public void Bug6_ParseAndEmit_StaticClass_EmitsStaticKeyword()
+    {
+        var source = @"
+§M{m1:Test}
+§CL{c1:Helper:static}
+§/CL{c1}
+§/M{m1}
+";
+        var result = ParseAndEmit(source);
+        Assert.Contains("public static class Helper", result);
+    }
+
+    [Fact]
+    public void Bug6_CSharpRoundtrip_StaticClass()
+    {
+        var csharp = """
+            public static class StringExtensions
+            {
+            }
+            """;
+        var convResult = _converter.Convert(csharp);
+        Assert.True(convResult.Success, GetErrorMessage(convResult));
+        var cls = Assert.Single(convResult.Ast!.Classes);
+        Assert.True(cls.IsStatic, "Converter should set IsStatic");
+
+        // Roundtrip: Calor → C#
+        var compilationResult = Program.Compile(convResult.CalorSource!);
+        Assert.False(compilationResult.HasErrors,
+            "Roundtrip parse failed:\n" +
+            string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message)));
+        Assert.Contains("static class StringExtensions", compilationResult.GeneratedCode);
+    }
+
+    [Fact]
+    public void Bug6_Parser_PartialModifier_SetsIsPartial()
+    {
+        var source = @"
+§M{m1:Test}
+§CL{c1:MyClass:partial}
+§/CL{c1}
+§/M{m1}
+";
+        var module = ParseModule(source);
+        var cls = Assert.Single(module.Classes);
+        Assert.True(cls.IsPartial, "IsPartial should be true");
+    }
+
+    #endregion
+
+    #region Bug 3: Class inheritance lost in roundtrip
+
+    [Fact]
+    public void Bug3_Parser_FourPositionals_ParsesBaseClassAndModifiers()
+    {
+        // §CL{id:name:BaseClass:modifiers}
+        var source = @"
+§M{m1:Test}
+§CL{c1:Child:Parent:sealed}
+§/CL{c1}
+§/M{m1}
+";
+        var module = ParseModule(source);
+        var cls = Assert.Single(module.Classes);
+        Assert.Equal("Parent", cls.BaseClass);
+        Assert.True(cls.IsSealed, "IsSealed should be true");
+    }
+
+    [Fact]
+    public void Bug3_Parser_ThreePositionals_ModifiersOnly_BackwardCompat()
+    {
+        // §CL{id:name:abs} — original 3-positional format
+        var source = @"
+§M{m1:Test}
+§CL{c1:Shape:abs}
+§/CL{c1}
+§/M{m1}
+";
+        var module = ParseModule(source);
+        var cls = Assert.Single(module.Classes);
+        Assert.True(cls.IsAbstract, "IsAbstract should be true");
+        Assert.Null(cls.BaseClass);
+    }
+
+    [Fact]
+    public void Bug3_ExtTag_StillWorks()
+    {
+        // §EXT{Parent} as child tag
+        var source = @"
+§M{m1:Test}
+§CL{c1:Child}
+§EXT{Parent}
+§/CL{c1}
+§/M{m1}
+";
+        var module = ParseModule(source);
+        var cls = Assert.Single(module.Classes);
+        Assert.Equal("Parent", cls.BaseClass);
+    }
+
+    [Fact]
+    public void Bug3_CalorEmitter_EmitsExtTag_NotPositional()
+    {
+        var csharp = """
+            public class Child : Parent
+            {
+            }
+            """;
+        var convResult = _converter.Convert(csharp);
+        Assert.True(convResult.Success, GetErrorMessage(convResult));
+
+        var calor = convResult.CalorSource!;
+        // Should contain §EXT{Parent} as a child tag
+        Assert.Contains("§EXT{Parent}", calor);
+        // The §CL line should NOT have Parent as a positional
+        // (it should be §CL{...:Child} or §CL{...:Child:modifiers}, not §CL{...:Child:Parent:...})
+        var clLine = calor.Split('\n').First(l => l.Contains("§CL{"));
+        Assert.DoesNotContain(":Parent", clLine);
+    }
+
+    [Fact]
+    public void Bug3_CSharpRoundtrip_ClassWithBaseClass()
+    {
+        var csharp = """
+            public class MyAttribute : Attribute
+            {
+            }
+            """;
+        var convResult = _converter.Convert(csharp);
+        Assert.True(convResult.Success, GetErrorMessage(convResult));
+
+        // Roundtrip: Calor → C#
+        var compilationResult = Program.Compile(convResult.CalorSource!);
+        Assert.False(compilationResult.HasErrors,
+            "Roundtrip parse failed:\n" +
+            string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message)));
+        Assert.Contains(": Attribute", compilationResult.GeneratedCode);
+    }
+
+    [Fact]
+    public void Bug3_CSharpRoundtrip_SealedClassWithBaseClass()
+    {
+        var csharp = """
+            public sealed class ConcreteService : BaseService
+            {
+            }
+            """;
+        var convResult = _converter.Convert(csharp);
+        Assert.True(convResult.Success, GetErrorMessage(convResult));
+
+        var compilationResult = Program.Compile(convResult.CalorSource!);
+        Assert.False(compilationResult.HasErrors,
+            "Roundtrip parse failed:\n" +
+            string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message)));
+        Assert.Contains("sealed class ConcreteService", compilationResult.GeneratedCode);
+        Assert.Contains(": BaseService", compilationResult.GeneratedCode);
+    }
+
+    [Fact]
+    public void Bug3_FourPositionals_VisibilityInPos2_IgnoredCorrectly()
+    {
+        // §CL{c0:Foo:pub:abs} — pos2 is visibility keyword, should be ignored; pos3 is modifiers
+        var source = @"
+§M{m1:Test}
+§CL{c0:Foo:pub:abs}
+§/CL{c0}
+§/M{m1}
+";
+        var module = ParseModule(source);
+        var cls = Assert.Single(module.Classes);
+        Assert.True(cls.IsAbstract, "IsAbstract should be true from pos3");
+        Assert.Null(cls.BaseClass); // Visibility keyword 'pub' in pos2 should not become base class
+    }
+
+    [Fact]
+    public void Bug3_FourPositionals_BaseClassInPos2_ParsedCorrectly()
+    {
+        // §CL{c0:Foo:MyBase:sealed} — pos2 is base class, pos3 is modifiers
+        var source = @"
+§M{m1:Test}
+§CL{c0:Foo:MyBase:sealed}
+§/CL{c0}
+§/M{m1}
+";
+        var module = ParseModule(source);
+        var cls = Assert.Single(module.Classes);
+        Assert.Equal("MyBase", cls.BaseClass);
+        Assert.True(cls.IsSealed);
+    }
+
+    [Fact]
+    public void Bug3_ThreePositionals_SpaceSeparatedModifiers()
+    {
+        // §CL{c1:Base:abs seal} — space-separated modifiers in 3-positional format
+        var source = @"
+§M{m1:Test}
+§CL{c1:Base:abs seal}
+§/CL{c1}
+§/M{m1}
+";
+        var module = ParseModule(source);
+        var cls = Assert.Single(module.Classes);
+        Assert.True(cls.IsAbstract);
+        Assert.True(cls.IsSealed);
+        Assert.Null(cls.BaseClass);
+    }
+
+    [Fact]
+    public void Bug3_ThreePositionals_BaseClassNamedLikeKeyword_TreatedAsModifier()
+    {
+        // Known limitation: a 3-positional where pos2 happens to be a keyword name
+        // (e.g., a class named "Partial") will be misinterpreted as a modifier.
+        // This only affects legacy Calor files; the new CalorEmitter uses §EXT tags,
+        // and old files with base classes always used 4 positionals.
+        var source = @"
+§M{m1:Test}
+§CL{c1:Foo:partial}
+§/CL{c1}
+§/M{m1}
+";
+        var module = ParseModule(source);
+        var cls = Assert.Single(module.Classes);
+        // "partial" is a known modifier keyword, so it's treated as a modifier, not a base class
+        Assert.True(cls.IsPartial);
+        Assert.Null(cls.BaseClass);
+    }
+
+    [Fact]
+    public void Bug3_ThreePositionals_NonKeywordPos2_TreatedAsBaseClass()
+    {
+        // §CL{c1:Child:ParentWidget} — "ParentWidget" is not a known modifier → treated as base class
+        var source = @"
+§M{m1:Test}
+§CL{c1:Child:ParentWidget}
+§/CL{c1}
+§/M{m1}
+";
+        var module = ParseModule(source);
+        var cls = Assert.Single(module.Classes);
+        Assert.Equal("ParentWidget", cls.BaseClass);
+        Assert.False(cls.IsAbstract);
+        Assert.False(cls.IsSealed);
+    }
+
+    #endregion
+
+    #region Bug 5: String interpolation drops dotted access
+
+    [Fact]
+    public void Bug5_DottedAccess_InterpolatedCorrectly()
+    {
+        var source = """
+            §M{m1:Test}
+            §F{f001:Greet:pub}
+              §O{str}
+              §B{~result:str} STR:"Hello ${p.Name}"
+            §/F{f001}
+            §/M{m1}
+            """;
+
+        var result = ParseAndEmit(source);
+        Assert.Contains("$\"Hello {p.Name}\"", result);
+    }
+
+    [Fact]
+    public void Bug5_MultiLevelDottedAccess()
+    {
+        var source = """
+            §M{m1:Test}
+            §F{f001:Get:pub}
+              §O{str}
+              §B{~result:str} STR:"${a.B.C}"
+            §/F{f001}
+            §/M{m1}
+            """;
+
+        var result = ParseAndEmit(source);
+        Assert.Contains("$\"{a.B.C}\"", result);
+    }
+
+    [Fact]
+    public void Bug5_NullConditionalAccess()
+    {
+        var source = """
+            §M{m1:Test}
+            §F{f001:Get:pub}
+              §O{str}
+              §B{~result:str} STR:"${x?.Y}"
+            §/F{f001}
+            §/M{m1}
+            """;
+
+        var result = ParseAndEmit(source);
+        Assert.Contains("$\"{x?.Y}\"", result);
+    }
+
+    [Fact]
+    public void Bug5_SimpleInterpolation_BackwardCompat()
+    {
+        var source = """
+            §M{m1:Test}
+            §F{f001:Get:pub}
+              §O{str}
+              §B{~result:str} STR:"Hello ${name}"
+            §/F{f001}
+            §/M{m1}
+            """;
+
+        var result = ParseAndEmit(source);
+        Assert.Contains("$\"Hello {name}\"", result);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static Ast.ModuleNode ParseModule(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath("test.calr");
+
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+
+        var parser = new Parser(tokens, diagnostics);
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        return module;
+    }
+
+    private static string ParseAndEmit(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath("test.calr");
+
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+
+        var parser = new Parser(tokens, diagnostics);
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+
+        var emitter = new CSharpEmitter();
+        return emitter.Emit(module);
+    }
+
+    private static string GetErrorMessage(ConversionResult result)
+    {
+        if (result.Success) return string.Empty;
+        return string.Join("\n", result.Issues.Select(i => i.ToString()));
+    }
+
+    #endregion
+}

--- a/tests/E2E/scenarios/09_codegen_bugfixes/output.g.cs
+++ b/tests/E2E/scenarios/09_codegen_bugfixes/output.g.cs
@@ -12,7 +12,7 @@ using System.Text;
 
 namespace Transliterator
 {
-    public class TransliteratorBase
+    public abstract class TransliteratorBase
     {
         public abstract string Name { get; set; }
 


### PR DESCRIPTION
## Summary

- **Bug 3 (Critical):** Class inheritance lost in roundtrip — CalorEmitter embedded base class as positional in `§CL{...}` tag, but Parser expected 3 positionals. Now emits `§EXT{BaseClass}` child tag; Parser also handles backward-compat 4-positional format with disambiguation.
- **Bug 5:** String interpolation drops dotted access — `${obj.Property}` was output as literal text. Extended regex to support `${obj.Prop}`, `${a.B.C}`, and `${x?.Y}`.
- **Bug 6:** `static class` not emitted — Parser now extracts `isStatic`/`isPartial` from modifier string instead of hardcoding false; CSharpEmitter emits `static` keyword.

## Test plan

- [x] 19 new targeted tests in `CodegenBug3_5_6_Tests.cs`
- [x] Full suite: 3152 passed, 0 failed, 14 skipped
- [x] E2E scenario `09_codegen_bugfixes` expected output updated (was itself reflecting Bug 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)