### PR TITLE
fix(codegen,converter): var binding, auto-usings, decimal literals, object initializers, array emitter

### DIFF
--- a/src/Calor.Compiler/Ast/ExpressionNodes.cs
+++ b/src/Calor.Compiler/Ast/ExpressionNodes.cs
@@ -91,9 +91,20 @@ public sealed class FloatLiteralNode : ExpressionNode
 {
     public double Value { get; }
 
+    /// <summary>
+    /// When true, this literal represents a C# decimal (suffix m) rather than a double.
+    /// </summary>
+    public bool IsDecimal { get; }
+
     public FloatLiteralNode(TextSpan span, double value) : base(span)
     {
         Value = value;
+    }
+
+    public FloatLiteralNode(TextSpan span, double value, bool isDecimal) : base(span)
+    {
+        Value = value;
+        IsDecimal = isDecimal;
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);

--- a/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
+++ b/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
@@ -1874,6 +1874,8 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                 new FloatLiteralNode(GetTextSpan(literal), doubleVal),
             SyntaxKind.NumericLiteralExpression when literal.Token.Value is float floatVal =>
                 new FloatLiteralNode(GetTextSpan(literal), floatVal),
+            SyntaxKind.NumericLiteralExpression when literal.Token.Value is decimal decVal =>
+                new FloatLiteralNode(GetTextSpan(literal), (double)decVal, isDecimal: true),
             SyntaxKind.NumericLiteralExpression when literal.Token.Value is long longVal =>
                 new IntLiteralNode(GetTextSpan(literal), (int)longVal),
             SyntaxKind.StringLiteralExpression =>
@@ -2014,6 +2016,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                 SyntaxKind.NumericLiteralExpression when literal.Token.Value is long => "i64",
                 SyntaxKind.NumericLiteralExpression when literal.Token.Value is float => "f32",
                 SyntaxKind.NumericLiteralExpression when literal.Token.Value is double => "f64",
+                SyntaxKind.NumericLiteralExpression when literal.Token.Value is decimal => "decimal",
                 SyntaxKind.TrueLiteralExpression or SyntaxKind.FalseLiteralExpression => "bool",
                 SyntaxKind.CharacterLiteralExpression => "char",
                 _ => null

--- a/src/Calor.Compiler/Parsing/AttributeHelper.cs
+++ b/src/Calor.Compiler/Parsing/AttributeHelper.cs
@@ -158,7 +158,7 @@ public static class AttributeHelper
             "i8" or "i16" or "i32" or "i64" => true,
             "u8" or "u16" or "u32" or "u64" => true,
             "f32" or "f64" => true,
-            "int" or "float" or "str" or "string" or "bool" or "void" or "char" => true,
+            "int" or "float" or "str" or "string" or "bool" or "void" or "char" or "var" => true,
             _ => value.StartsWith('?') || value.Contains('!') || value.Contains('<')
                  || IsLikelyPascalCaseType(value)
         };

--- a/src/Calor.Compiler/Parsing/Token.cs
+++ b/src/Calor.Compiler/Parsing/Token.cs
@@ -279,6 +279,7 @@ public enum TokenKind
     StrLiteral,         // STR:"hello"
     BoolLiteral,        // BOOL:true
     FloatLiteral,       // FLOAT:3.14
+    DecimalLiteral,     // DEC:21.35
 
     // Identifiers and values
     Identifier,
@@ -311,7 +312,7 @@ public readonly struct Token : IEquatable<Token>
     public bool IsKeyword => Kind is >= TokenKind.Module and <= TokenKind.DateMarker;
 
     public bool IsLiteral => Kind is TokenKind.IntLiteral or TokenKind.StrLiteral
-        or TokenKind.BoolLiteral or TokenKind.FloatLiteral;
+        or TokenKind.BoolLiteral or TokenKind.FloatLiteral or TokenKind.DecimalLiteral;
 
     public bool IsTrivia => Kind is TokenKind.Whitespace or TokenKind.Newline;
 

--- a/src/Calor.Compiler/Resources/SelfTest/01_hello_world.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/01_hello_world.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Hello
 {

--- a/src/Calor.Compiler/Resources/SelfTest/02_fizzbuzz.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/02_fizzbuzz.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace FizzBuzz
 {

--- a/src/Calor.Compiler/Resources/SelfTest/03_contracts.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/03_contracts.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Contracts
 {

--- a/src/Calor.Compiler/Resources/SelfTest/04_option_result.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/04_option_result.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace TypeSystem
 {

--- a/src/Calor.Compiler/Resources/SelfTest/05_skill_syntax.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/05_skill_syntax.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SkillSyntax
 {

--- a/src/Calor.Compiler/Resources/SelfTest/06_pattern_matching.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/06_pattern_matching.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace PatternDemo
 {

--- a/src/Calor.Compiler/Resources/SelfTest/07_collections.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/07_collections.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Collections
 {

--- a/src/Calor.Compiler/Resources/SelfTest/07_quantifiers.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/07_quantifiers.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace QuantifierDemo
 {

--- a/src/Calor.Compiler/Resources/SelfTest/08_contract_inheritance_z3.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/08_contract_inheritance_z3.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace ContractZ3Test
 {

--- a/src/Calor.Compiler/Resources/SelfTest/09_codegen_bugfixes.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/09_codegen_bugfixes.g.cs
@@ -8,6 +8,7 @@
 using System;
 using Calor.Runtime;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Transliterator

--- a/tests/Calor.Compiler.Tests/CSharpToCalorConversionTests.cs
+++ b/tests/Calor.Compiler.Tests/CSharpToCalorConversionTests.cs
@@ -453,9 +453,9 @@ public class CSharpToCalorConversionTests
         Assert.True(result.Success, GetErrorMessage(result));
         Assert.NotNull(result.CalorSource);
         Assert.Contains("§NEW{Person}", result.CalorSource);
-        Assert.Contains("Name:", result.CalorSource);
-        Assert.Contains("Age:", result.CalorSource);
-        Assert.Contains("City:", result.CalorSource);
+        Assert.Contains("§INIT{Name}", result.CalorSource);
+        Assert.Contains("§INIT{Age}", result.CalorSource);
+        Assert.Contains("§INIT{City}", result.CalorSource);
         Assert.Contains("object-initializer", result.Context.UsedFeatures);
     }
 
@@ -471,8 +471,8 @@ public class CSharpToCalorConversionTests
         Assert.True(result.Success, GetErrorMessage(result));
         Assert.NotNull(result.CalorSource);
         Assert.Contains("§NEW{Settings}", result.CalorSource);
-        Assert.Contains("Timeout:", result.CalorSource);
-        Assert.Contains("Enabled:", result.CalorSource);
+        Assert.Contains("§INIT{Timeout}", result.CalorSource);
+        Assert.Contains("§INIT{Enabled}", result.CalorSource);
     }
 
     [Fact]
@@ -491,8 +491,8 @@ public class CSharpToCalorConversionTests
         Assert.True(result.Success, GetErrorMessage(result));
         Assert.NotNull(result.CalorSource);
         Assert.Contains("Order", result.CalorSource);
-        Assert.Contains("Customer:", result.CalorSource);
-        Assert.Contains("Total:", result.CalorSource);
+        Assert.Contains("§INIT{Customer}", result.CalorSource);
+        Assert.Contains("§INIT{Total}", result.CalorSource);
     }
 
     #endregion

--- a/tests/Calor.Compiler.Tests/CodegenBatchFixTests.cs
+++ b/tests/Calor.Compiler.Tests/CodegenBatchFixTests.cs
@@ -1,0 +1,536 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for batch codegen/converter bug fixes:
+/// Fix 1: §B{var:name} generates correct C#
+/// Fix 2: Auto-using System.Collections.Generic and System.Linq
+/// Fix 3: Decimal literal support (DEC: prefix)
+/// Fix 4: Object initializer roundtrip with §INIT tags
+/// Fix 5: Array initializer CalorEmitter uses §ARR tags
+/// </summary>
+public class CodegenBatchFixTests
+{
+    // ========== Fix 1: §B{var:name} ==========
+
+    [Fact]
+    public void Fix1_BindVarType_GeneratesVarBeforeName()
+    {
+        // §B{var:myList} should produce "var myList = ..." not "myList var = ..."
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+  §B{var:myList} §NEW{List<i32>} §/NEW
+§/F{f001}
+§/M{m1}
+";
+
+        var result = ParseAndEmit(source);
+
+        Assert.Contains("var myList", result);
+        Assert.DoesNotContain("myList var", result);
+    }
+
+    [Fact]
+    public void Fix1_BindStrType_BackwardCompat()
+    {
+        // §B{str:name} should still work as type:name format
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+  §B{str:name} ""hello""
+§/F{f001}
+§/M{m1}
+";
+
+        var result = ParseAndEmit(source);
+
+        Assert.Contains("string name", result);
+    }
+
+    [Fact]
+    public void Fix1_BindInferredType_BackwardCompat()
+    {
+        // §B{myVar} with inferred type should still work
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+  §B{myVar} 42
+§/F{f001}
+§/M{m1}
+";
+
+        var result = ParseAndEmit(source);
+
+        Assert.Contains("myVar", result);
+    }
+
+    // ========== Fix 2: Auto-using ==========
+
+    [Fact]
+    public void Fix2_GeneratedCSharp_ContainsCollectionsGenericUsing()
+    {
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+§/F{f001}
+§/M{m1}
+";
+
+        var result = ParseAndEmit(source);
+
+        Assert.Contains("using System.Collections.Generic;", result);
+    }
+
+    [Fact]
+    public void Fix2_GeneratedCSharp_ContainsLinqUsing()
+    {
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+§/F{f001}
+§/M{m1}
+";
+
+        var result = ParseAndEmit(source);
+
+        Assert.Contains("using System.Linq;", result);
+    }
+
+    // ========== Fix 3: Decimal literals ==========
+
+    [Fact]
+    public void Fix3_DecimalLiteral_EmitsMSuffix()
+    {
+        // DEC:21.35 in Calor should produce 21.35m in C#
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+  §B{~price} DEC:21.35
+§/F{f001}
+§/M{m1}
+";
+
+        var result = ParseAndEmit(source);
+
+        Assert.Contains("21.35m", result);
+    }
+
+    [Fact]
+    public void Fix3_DecimalIntegerValue_EmitsMSuffix()
+    {
+        // DEC:18 should produce 18m in C#
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+  §B{~amount} DEC:18
+§/F{f001}
+§/M{m1}
+";
+
+        var result = ParseAndEmit(source);
+
+        Assert.Contains("18m", result);
+    }
+
+    [Fact]
+    public void Fix3_FloatLiteral_BackwardCompat_NoMSuffix()
+    {
+        // FLOAT:3.14 should still produce 3.14 (no m suffix)
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+  §B{~pi} FLOAT:3.14
+§/F{f001}
+§/M{m1}
+";
+
+        var result = ParseAndEmit(source);
+
+        Assert.Contains("3.14", result);
+        Assert.DoesNotContain("3.14m", result);
+    }
+
+    [Fact]
+    public void Fix3_DecimalLiteral_RoundtripThroughCalorEmitter()
+    {
+        // DEC:21.35 should parse, then CalorEmitter should produce DEC:21.35
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+  §B{~price} DEC:21.35
+§/F{f001}
+§/M{m1}
+";
+
+        var module = ParseModule(source);
+        var calorEmitter = new Migration.CalorEmitter();
+        var calorOutput = calorEmitter.Emit(module);
+
+        Assert.Contains("DEC:21.35", calorOutput);
+    }
+
+    // ========== Fix 4: Object initializer §INIT ==========
+
+    [Fact]
+    public void Fix4_NewWithInit_GeneratesObjectInitializer()
+    {
+        // §NEW{Customer} §INIT{Name} STR:"John" §INIT{Age} 30 §/NEW
+        // should produce new Customer() { Name = "John", Age = 30 }
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+  §B{~c} §NEW{Customer} §INIT{Name} STR:""John"" §INIT{Age} 30 §/NEW
+§/F{f001}
+§/M{m1}
+";
+
+        var result = ParseAndEmit(source);
+
+        Assert.Contains("Name = \"John\"", result);
+        Assert.Contains("Age = 30", result);
+        Assert.Contains("new Customer()", result);
+    }
+
+    [Fact]
+    public void Fix4_NewWithoutInit_BackwardCompat()
+    {
+        // §NEW{Customer} §/NEW should still produce new Customer()
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+  §B{~c} §NEW{Customer} §/NEW
+§/F{f001}
+§/M{m1}
+";
+
+        var result = ParseAndEmit(source);
+
+        Assert.Contains("new Customer()", result);
+    }
+
+    [Fact]
+    public void Fix4_NewWithArgsAndInit_GeneratesBoth()
+    {
+        // §NEW{Person} §A STR:"base" §INIT{Name} STR:"John" §/NEW
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+  §B{~p} §NEW{Person} §A STR:""base"" §INIT{Name} STR:""John"" §/NEW
+§/F{f001}
+§/M{m1}
+";
+
+        var result = ParseAndEmit(source);
+
+        Assert.Contains("new Person(\"base\")", result);
+        Assert.Contains("Name = \"John\"", result);
+    }
+
+    [Fact]
+    public void Fix4_InitRoundtrip_CalorEmitterProducesInitTags()
+    {
+        // Parse §INIT tags, then CalorEmitter should produce §INIT tags
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+  §B{~c} §NEW{Customer} §INIT{Name} STR:""John"" §/NEW
+§/F{f001}
+§/M{m1}
+";
+
+        var module = ParseModule(source);
+        var calorEmitter = new Migration.CalorEmitter();
+        var calorOutput = calorEmitter.Emit(module);
+
+        Assert.Contains("§INIT{Name}", calorOutput);
+    }
+
+    // ========== Fix 5: Array initializer CalorEmitter ==========
+
+    [Fact]
+    public void Fix5_ArrayInitializer_CalorEmitterProducesArrTags()
+    {
+        // When CalorEmitter emits an array with initializers, it should use §ARR tag syntax
+        // We create the AST directly for this test
+        var span = new TextSpan(0, 0, 0, 0);
+        var elements = new List<ExpressionNode>
+        {
+            new IntLiteralNode(span, 1),
+            new IntLiteralNode(span, 2),
+            new IntLiteralNode(span, 3)
+        };
+        var arrayNode = new ArrayCreationNode(span, "arr", "arr", "int", null, elements, new AttributeCollection());
+
+        var calorEmitter = new Migration.CalorEmitter();
+        var result = arrayNode.Accept(calorEmitter);
+
+        Assert.Contains("§ARR{", result);
+        Assert.Contains("§A 1", result);
+        Assert.Contains("§A 2", result);
+        Assert.Contains("§A 3", result);
+        Assert.Contains("§/ARR{", result);
+        Assert.DoesNotContain("{1, 2, 3}", result);
+    }
+
+    [Fact]
+    public void Fix5_ArrayInitializer_RoundtripThroughParser()
+    {
+        // §ARR{i32:nums} §A 1 §A 2 §A 3 §/ARR{nums} should parse and generate correct C#
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+  §B{[i32]:nums} §ARR{i32:nums} §A 1 §A 2 §A 3 §/ARR{nums}
+§/F{f001}
+§/M{m1}
+";
+
+        var result = ParseAndEmit(source);
+
+        Assert.Contains("new int[]", result);
+        Assert.Contains("1", result);
+        Assert.Contains("2", result);
+        Assert.Contains("3", result);
+    }
+
+    // ========== Gap-closing: Converter-level tests ==========
+
+    [Fact]
+    public void Gap_Converter_DecimalLiteral_ProducesDECPrefix()
+    {
+        // C# decimal literal → converter → Calor should contain DEC:
+        var converter = new Migration.CSharpToCalorConverter();
+        var result = converter.Convert("decimal price = 21.35m;");
+
+        Assert.True(result.Success, string.Join("\n", result.Issues.Select(i => i.Message)));
+        Assert.NotNull(result.CalorSource);
+        Assert.Contains("DEC:21.35", result.CalorSource);
+        Assert.DoesNotContain("§ERR", result.CalorSource);
+    }
+
+    [Fact]
+    public void Gap_Converter_DecimalLiteral_FullRoundtrip()
+    {
+        // C# decimal → converter → Calor → parse → emit C# should contain 'm' suffix
+        var converter = new Migration.CSharpToCalorConverter();
+        var conversionResult = converter.Convert("decimal price = 21.35m;");
+
+        Assert.True(conversionResult.Success, string.Join("\n", conversionResult.Issues.Select(i => i.Message)));
+
+        var compilationResult = Program.Compile(conversionResult.CalorSource!);
+        Assert.False(compilationResult.HasErrors,
+            $"Roundtrip failed:\n{string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message))}");
+        Assert.Contains("21.35m", compilationResult.GeneratedCode);
+    }
+
+    [Fact]
+    public void Gap_Converter_DecimalZero_ProducesDECPrefix()
+    {
+        // C# 0.00m → converter → Calor should contain DEC:0
+        var converter = new Migration.CSharpToCalorConverter();
+        var result = converter.Convert("decimal zero = 0.00m;");
+
+        Assert.True(result.Success, string.Join("\n", result.Issues.Select(i => i.Message)));
+        Assert.NotNull(result.CalorSource);
+        Assert.Contains("DEC:0", result.CalorSource);
+    }
+
+    [Fact]
+    public void Gap_Converter_ArrayInitializer_ProducesArrTags()
+    {
+        // C# new int[] { 1, 2, 3 } → converter → CalorEmitter → should contain §ARR not bare {}
+        var converter = new Migration.CSharpToCalorConverter();
+        var result = converter.Convert("int[] nums = new int[] { 1, 2, 3 };");
+
+        Assert.True(result.Success, string.Join("\n", result.Issues.Select(i => i.Message)));
+        Assert.NotNull(result.CalorSource);
+        Assert.Contains("§ARR{", result.CalorSource);
+        Assert.DoesNotContain("{1, 2, 3}", result.CalorSource);
+    }
+
+    [Fact]
+    public void Gap_Converter_ArrayInitializer_FullRoundtrip()
+    {
+        // C# array init → converter → Calor → parse → emit C# → should contain new int[]
+        var converter = new Migration.CSharpToCalorConverter();
+        var conversionResult = converter.Convert("int[] nums = new int[] { 1, 2, 3 };");
+
+        Assert.True(conversionResult.Success, string.Join("\n", conversionResult.Issues.Select(i => i.Message)));
+
+        var compilationResult = Program.Compile(conversionResult.CalorSource!);
+        Assert.False(compilationResult.HasErrors,
+            $"Roundtrip failed:\n{string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message))}");
+        Assert.Contains("new int[]", compilationResult.GeneratedCode);
+    }
+
+    [Fact]
+    public void Gap_Converter_ObjectInitializer_FullRoundtrip()
+    {
+        // C# object initializer → converter → Calor → parse → emit C# → should have initializers
+        var csharpSource = """
+            public class Person { public string Name { get; set; } public int Age { get; set; } }
+            public class Program {
+                public static void Main() {
+                    var p = new Person { Name = "John", Age = 30 };
+                }
+            }
+            """;
+
+        var converter = new Migration.CSharpToCalorConverter();
+        var conversionResult = converter.Convert(csharpSource);
+
+        Assert.True(conversionResult.Success, string.Join("\n", conversionResult.Issues.Select(i => i.Message)));
+        Assert.Contains("§INIT{Name}", conversionResult.CalorSource);
+
+        var compilationResult = Program.Compile(conversionResult.CalorSource!);
+        Assert.False(compilationResult.HasErrors,
+            $"Roundtrip failed:\n{string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message))}");
+        Assert.Contains("Name = ", compilationResult.GeneratedCode);
+        Assert.Contains("Age = ", compilationResult.GeneratedCode);
+    }
+
+    // ========== Gap-closing: §INIT inside §C arg context ==========
+
+    [Fact]
+    public void Gap_InitInsideCallArg_ParsesCorrectly()
+    {
+        // §INIT inside §NEW that is inside a §C argument should parse correctly
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+  §C{Process}
+    §A §NEW{Widget} §INIT{Name} STR:""test"" §/NEW
+    §A 42
+  §/C
+§/F{f001}
+§/M{m1}
+";
+
+        var result = ParseAndEmit(source);
+
+        Assert.Contains("Name = \"test\"", result);
+        Assert.Contains("new Widget()", result);
+        Assert.Contains("Process(", result);
+        Assert.Contains(", 42)", result);
+    }
+
+    [Fact]
+    public void Gap_InitInsideCallArg_MultipleInits()
+    {
+        // Multiple §INIT inside §NEW inside §C
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+  §C{Save}
+    §A §NEW{Config} §INIT{Host} STR:""localhost"" §INIT{Port} 8080 §/NEW
+  §/C
+§/F{f001}
+§/M{m1}
+";
+
+        var result = ParseAndEmit(source);
+
+        Assert.Contains("Host = \"localhost\"", result);
+        Assert.Contains("Port = 8080", result);
+        Assert.Contains("Save(new Config()", result);
+    }
+
+    // ========== Gap-closing: Decimal precision limitation ==========
+
+    [Fact]
+    public void Gap_DecimalPrecision_StandardValues_RoundtripCorrectly()
+    {
+        // Common monetary/business values should roundtrip without precision loss
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+  §B{~a} DEC:0.01
+  §B{~b} DEC:99.99
+  §B{~c} DEC:1234567890.12
+§/F{f001}
+§/M{m1}
+";
+
+        var result = ParseAndEmit(source);
+
+        Assert.Contains("0.01m", result);
+        Assert.Contains("99.99m", result);
+        Assert.Contains("1234567890.12m", result);
+    }
+
+    [Fact]
+    public void Gap_DecimalNegativeValue_RoundtripsCorrectly()
+    {
+        var source = @"
+§M{m1:Test}
+§F{f001:Main:pub}
+  §O{void}
+  §B{~x} DEC:-42.5
+§/F{f001}
+§/M{m1}
+";
+
+        var result = ParseAndEmit(source);
+
+        Assert.Contains("-42.5m", result);
+    }
+
+    #region Helpers
+
+    private static string ParseAndEmit(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath("test.calr");
+
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+
+        var parser = new Parser(tokens, diagnostics);
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+
+        var emitter = new CSharpEmitter();
+        return emitter.Emit(module);
+    }
+
+    private static ModuleNode ParseModule(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath("test.calr");
+
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+
+        var parser = new Parser(tokens, diagnostics);
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+
+        return module;
+    }
+
+    #endregion
+}

--- a/tests/Calor.Enforcement.Tests/TestHarness.cs
+++ b/tests/Calor.Enforcement.Tests/TestHarness.cs
@@ -104,6 +104,7 @@ public static class TestHarness
             // Add additional runtime references
             var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
             references.Add(MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")));
+            references.Add(MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Linq.dll")));
             references.Add(MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Text.RegularExpressions.dll")));
 
             var compilation = CSharpCompilation.Create(

--- a/tests/Calor.Semantics.Tests/SemanticsTestHarness.cs
+++ b/tests/Calor.Semantics.Tests/SemanticsTestHarness.cs
@@ -296,6 +296,7 @@ public static class SideEffectTracker
 
         var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
         references.Add(MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")));
+        references.Add(MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Linq.dll")));
 
         return references;
     }

--- a/tests/E2E/scenarios/01_hello_world/output.g.cs
+++ b/tests/E2E/scenarios/01_hello_world/output.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Hello
 {

--- a/tests/E2E/scenarios/02_fizzbuzz/output.g.cs
+++ b/tests/E2E/scenarios/02_fizzbuzz/output.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace FizzBuzz
 {

--- a/tests/E2E/scenarios/03_contracts/output.g.cs
+++ b/tests/E2E/scenarios/03_contracts/output.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Contracts
 {

--- a/tests/E2E/scenarios/04_option_result/output.g.cs
+++ b/tests/E2E/scenarios/04_option_result/output.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace TypeSystem
 {

--- a/tests/E2E/scenarios/05_skill_syntax/output.g.cs
+++ b/tests/E2E/scenarios/05_skill_syntax/output.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SkillSyntax
 {

--- a/tests/E2E/scenarios/06_pattern_matching/output.g.cs
+++ b/tests/E2E/scenarios/06_pattern_matching/output.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace PatternDemo
 {

--- a/tests/E2E/scenarios/07_collections/output.g.cs
+++ b/tests/E2E/scenarios/07_collections/output.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Collections
 {

--- a/tests/E2E/scenarios/07_quantifiers/output.g.cs
+++ b/tests/E2E/scenarios/07_quantifiers/output.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace QuantifierDemo
 {

--- a/tests/E2E/scenarios/08_contract_inheritance_z3/output.g.cs
+++ b/tests/E2E/scenarios/08_contract_inheritance_z3/output.g.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Calor.Runtime;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace ContractZ3Test
 {

--- a/tests/E2E/scenarios/09_codegen_bugfixes/output.g.cs
+++ b/tests/E2E/scenarios/09_codegen_bugfixes/output.g.cs
@@ -8,6 +8,7 @@
 using System;
 using Calor.Runtime;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Transliterator


### PR DESCRIPTION
## Summary

- **Fix 1 — `§B{var:name}`**: Added `"var"` to `IsLikelyType()` so `§B{var:myList}` generates `var myList = ...` instead of reversed `myList var = ...`
- **Fix 2 — Auto-usings**: `System.Collections.Generic` and `System.Linq` now always included in generated C# (needed by virtually all non-trivial programs). Updated all 20 self-test/E2E expected outputs and both test harnesses.
- **Fix 3 — Decimal literals**: Full pipeline support — `DEC:` prefix in Calor, `m` suffix in C#, new `DecimalLiteral` token kind, converter handles C# `decimal` values without producing `§ERR`
- **Fix 4 — Object initializer roundtrip**: Changed CalorEmitter from unparseable brace syntax `{ Name: "John" }` to `§INIT{Name} STR:"John"` tag syntax. Parser now handles `§INIT` inside `§NEW`. CSharpEmitter emits `{ Name = "John" }` initializer blocks.
- **Fix 5 — Array initializer emitter**: CalorEmitter now emits `§ARR{type:id} §A elem §/ARR{id}` instead of bare `{1, 2, 3}` for initialized arrays, enabling proper roundtrip.

## Test plan

- [x] 25 new tests in `CodegenBatchFixTests.cs` covering all 5 fixes + gap-closing converter-level and edge case tests
- [x] Full compiler test suite: 3191 passed, 0 failed, 14 skipped
- [x] Enforcement tests: 96 passed
- [x] Semantics tests: 29 passed
- [x] Converter-level roundtrip tests: C# → Calor → C# for decimals, arrays, object initializers
- [x] `§INIT` inside `§C` arg context verified working

🤖 Generated with [Claude Code](https://claude.com/claude-code)