### PR TITLE
fix(codegen): preserve decimal point in whole-number float literals

### DIFF
--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -550,6 +550,12 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     public string Visit(FloatLiteralNode node)
     {
         var str = node.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        // Ensure float literals always contain a decimal point so they aren't
+        // reinterpreted as integers in the generated C# code.
+        if (!node.IsDecimal && !str.Contains('.') && !str.Contains('E') && !str.Contains('e'))
+        {
+            str += ".0";
+        }
         return node.IsDecimal ? str + "m" : str;
     }
 


### PR DESCRIPTION
## Summary
- Float literals like `1.0` were emitted as bare `1` because `double.ToString()` drops the decimal for whole numbers, silently changing the runtime type from `double` to `int`
- Added a guard in `CSharpEmitter.Visit(FloatLiteralNode)` to append `.0` when the string has no decimal point or scientific notation
- Added 5 tests covering whole numbers, negative whole numbers, fractions, scientific notation, and list-of-object context

## Test plan
- [x] `Fix6_FloatLiteral_WholeNumber_EmitsDecimalPoint` — `FLOAT:1.0` emits `1.0`
- [x] `Fix6_FloatLiteral_NegativeWholeNumber_EmitsDecimalPoint` — `FLOAT:-1.0` emits `-1.0`
- [x] `Fix6_FloatLiteral_InListObject_PreservesType` — floats in `§LIST{:object}` keep decimal
- [x] `Fix6_FloatLiteral_WithFraction_Unchanged` — `FLOAT:3.14` stays `3.14`
- [x] `Fix6_FloatLiteral_ScientificNotation_Unchanged` — `FLOAT:1E10` stays as-is
- [x] Full test suite: 3256 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)