### PR TITLE
fix: update stale comment about static class modifier

### DIFF
--- a/tests/Calor.Compiler.Tests/InheritanceTests.cs
+++ b/tests/Calor.Compiler.Tests/InheritanceTests.cs
@@ -206,8 +206,7 @@ public class InheritanceTests
     [Fact]
     public void CodeGen_StaticMethod_GeneratesValidCSharp()
     {
-        // Note: static class modifier is not fully implemented in the parser
-        // This test verifies static methods work correctly
+        // This test verifies static methods in a non-static class (class uses :pub, not :static)
         var source = @"
 §M{m1:Test}
 §CL{c1:MathUtils:pub}


### PR DESCRIPTION
## Summary
- Updated an outdated comment in `InheritanceTests.cs` that incorrectly stated static class modifier was not fully implemented in the parser
- Static class support (`§CL{id:name:static}`) is fully implemented across parser, AST, code generation, and C# import

## Test plan
- [x] All Bug6 static class tests pass (10/10)
- [x] `CodeGen_StaticMethod_GeneratesValidCSharp` test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)