### PR TITLE
fix(migration): convert bare array initializers instead of emitting §ERR

### DIFF
--- a/src/Calor.Compiler/Migration/FeatureSupport.cs
+++ b/src/Calor.Compiler/Migration/FeatureSupport.cs
@@ -186,6 +186,12 @@ public static class FeatureSupport
             Support = SupportLevel.Full,
             Description = "LINQ query syntax is desugared to equivalent method chains"
         },
+        ["array-initializer"] = new FeatureInfo
+        {
+            Name = "array-initializer",
+            Support = SupportLevel.Full,
+            Description = "Bare array initializers are converted to Calor array nodes"
+        },
         ["ref-parameter"] = new FeatureInfo
         {
             Name = "ref-parameter",

--- a/tests/Calor.Compiler.Tests/LinqSupportTests.cs
+++ b/tests/Calor.Compiler.Tests/LinqSupportTests.cs
@@ -158,6 +158,95 @@ public class LinqSupportTests
         Assert.NotNull(result.CalorSource);
     }
 
+    [Fact]
+    public void ArrayInitializer_Converter_BareDoubleArray()
+    {
+        var csharpSource = """
+            double[] arr = { 1.7, 2.3, 1.9 };
+            """;
+
+        var result = _converter.Convert(csharpSource);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        Assert.NotNull(result.CalorSource);
+        Assert.Contains("§ARR{", result.CalorSource);
+        Assert.DoesNotContain("§ERR", result.CalorSource);
+    }
+
+    [Fact]
+    public void ArrayInitializer_Converter_BareIntArray()
+    {
+        var csharpSource = """
+            int[] nums = { 1, 2, 3, 4, 5 };
+            """;
+
+        var result = _converter.Convert(csharpSource);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        Assert.NotNull(result.CalorSource);
+        Assert.DoesNotContain("§ERR", result.CalorSource);
+    }
+
+    [Fact]
+    public void ArrayInitializer_Converter_BareStringArray()
+    {
+        var csharpSource = """
+            string[] names = { "Alice", "Bob" };
+            """;
+
+        var result = _converter.Convert(csharpSource);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        Assert.NotNull(result.CalorSource);
+        Assert.DoesNotContain("§ERR", result.CalorSource);
+    }
+
+    [Fact]
+    public void ArrayInitializer_Converter_UseDeclaredTypeOverLiteralInference()
+    {
+        // int literals in a double[] should infer f64 from declaration, not i32 from literals
+        var csharpSource = """
+            double[] arr = { 1, 2, 3 };
+            """;
+
+        var result = _converter.Convert(csharpSource);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        Assert.NotNull(result.CalorSource);
+        Assert.DoesNotContain("§ERR", result.CalorSource);
+        Assert.Contains("§ARR{arr:f64}", result.CalorSource);
+    }
+
+    [Fact]
+    public void ArrayInitializer_Converter_EmptyArray()
+    {
+        var csharpSource = """
+            int[] arr = { };
+            """;
+
+        var result = _converter.Convert(csharpSource);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        Assert.NotNull(result.CalorSource);
+        Assert.DoesNotContain("§ERR", result.CalorSource);
+        Assert.Contains("§ARR{i32:", result.CalorSource);
+    }
+
+    [Fact]
+    public void ArrayInitializer_Converter_MultiDimensionalUsesCorrectElementType()
+    {
+        var csharpSource = """
+            int[,] matrix = { { 1, 2 }, { 3, 4 } };
+            """;
+
+        var result = _converter.Convert(csharpSource);
+
+        Assert.True(result.Success, GetErrorMessage(result));
+        Assert.NotNull(result.CalorSource);
+        // Element type should be inferred from the int[,] declaration
+        Assert.Contains("§ARR{matrix:i32}", result.CalorSource);
+    }
+
     #endregion
 
     #region Feature 3: Object Initializers
@@ -410,6 +499,12 @@ public class LinqSupportTests
     public void FeatureSupport_LinqQuery_IsFullySupported()
     {
         Assert.True(FeatureSupport.IsFullySupported("linq-query"));
+    }
+
+    [Fact]
+    public void FeatureSupport_ArrayInitializer_IsFullySupported()
+    {
+        Assert.True(FeatureSupport.IsFullySupported("array-initializer"));
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Bare array initializers (`double[] arr = { 1.7, 2.3, 1.9 };`) were producing `§ERR{"TODO: unknown-expression"}` because `InitializerExpressionSyntax` was missing from the `ConvertExpression` switch
- Added `ConvertInitializerExpression` method that reads the declared element type from the parent `VariableDeclarationSyntax`, falling back to literal inference when no declaration is available
- Extended `TryGetDeclaredArrayElementType` to handle multi-dimensional arrays (`int[,]`, `int[,,]`)
- Applied declared-type inference to `ConvertImplicitArrayCreation` for consistency
- Registered `array-initializer` as a fully supported feature in `FeatureSupport.cs`

## Test plan
- [x] `ArrayInitializer_Converter_BareDoubleArray` — `double[]` with float literals
- [x] `ArrayInitializer_Converter_BareIntArray` — `int[]` with int literals
- [x] `ArrayInitializer_Converter_BareStringArray` — `string[]` with string literals
- [x] `ArrayInitializer_Converter_UseDeclaredTypeOverLiteralInference` — `double[] arr = { 1, 2, 3 }` uses `f64` not `i32`
- [x] `ArrayInitializer_Converter_EmptyArray` — `int[] arr = { }` reads type from declaration
- [x] `ArrayInitializer_Converter_MultiDimensionalUsesCorrectElementType` — `int[,]` extracts element type
- [x] `FeatureSupport_ArrayInitializer_IsFullySupported` — feature registry
- [x] Full suite: 3,264 passed, 0 failed, 13 skipped (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)