### PR TITLE
fix: resolve converter and parser gaps from LINQ partitioning conversion

### DIFF
--- a/docs/cli/convert.md
+++ b/docs/cli/convert.md
@@ -231,6 +231,46 @@ Review the converted file src/Services/UserService.calr and:
 
 ---
 
+## File Coexistence (.cs and .calr)
+
+After converting a `.cs` file to `.calr`, both files will exist in your project. When you compile the `.calr` file, Calor generates a `.g.cs` file. If the original `.cs` file is still included in compilation, you will get **CS0101 duplicate type** errors because both files define the same types.
+
+### Resolution strategies
+
+**1. Exclude originals from compilation (recommended for incremental migration)**
+
+Add the original `.cs` files to your `.csproj` exclusion list:
+
+```xml
+<ItemGroup>
+  <Compile Remove="MyService.cs" />
+</ItemGroup>
+```
+
+**2. Move originals to a reference directory**
+
+```bash
+mkdir -p .csharp-originals
+mv MyService.cs .csharp-originals/
+```
+
+This preserves the originals for reference while removing them from compilation.
+
+**3. Delete originals after verification**
+
+Once you've verified the Calor version roundtrips correctly:
+
+```bash
+# Verify roundtrip first
+calor convert MyService.calr -o /tmp/MyService.check.cs
+diff MyService.cs /tmp/MyService.check.cs
+
+# If satisfied, remove the original
+rm MyService.cs
+```
+
+---
+
 ## Limitations
 
 The converter may not perfectly handle:

--- a/docs/syntax-reference/structure-tags.md
+++ b/docs/syntax-reference/structure-tags.md
@@ -232,50 +232,61 @@ Emits: `var data = await client.GetAsync(url).ConfigureAwait(false);`
 
 ## Lambda Expressions
 
-Lambda expressions create anonymous functions.
+Lambda expressions create anonymous functions using `§LAM`/`§/LAM` blocks.
 
-### Inline Lambda Syntax
-
-For simple expression-body lambdas:
+### Syntax
 
 ```
-(param) → expression
-(param1, param2) → expression
-() → expression
+§LAM{id:param1:type1}              // single parameter
+§LAM{id:param1:type1:param2:type2} // multiple parameters
+§LAM{id}                           // no parameters
 ```
 
-### Examples
+The header encodes parameters as colon-separated `name:type` pairs after the ID.
+Parameters without known types use `object` as the default type.
 
-**Single parameter:**
-```
-§B{doubler} (x) → (* x 2)
-```
-
-Emits: `var doubler = x => x * 2;`
-
-**Multiple parameters:**
-```
-§B{add} (a, b) → (+ a b)
-```
-
-Emits: `var add = (a, b) => a + b;`
-
-**No parameters:**
-```
-§B{getTime} () → §C{DateTime.Now} §/C
-```
-
-### Block Lambda Syntax
-
-For statement-body lambdas, use `§LAM`/`§/LAM`:
+### Single Parameter
 
 ```
-§LAM{id:param1:type1:param2:type2}
-  // statements
-§/LAM{id}
+§B{doubler} §LAM{lam1:x:i32} (* x 2) §/LAM{lam1}
 ```
 
-**Example:**
+Emits: `var doubler = (int x) => x * 2;`
+
+### Multiple Parameters
+
+Parameters are listed as consecutive `name:type` pairs:
+
+```
+§B{add} §LAM{lam1:a:i32:b:i32} (+ a b) §/LAM{lam1}
+```
+
+Emits: `var add = (int a, int b) => a + b;`
+
+**Three parameters:**
+```
+§B{combine} §LAM{lam1:x:i32:y:str:z:bool} §C{Process} §A x §A y §A z §/C §/LAM{lam1}
+```
+
+### No Parameters
+
+```
+§B{getTime} §LAM{lam1} §C{DateTime.Now} §/C §/LAM{lam1}
+```
+
+### As LINQ Arguments
+
+Lambdas are commonly used as arguments inside `§C{...}` calls:
+
+```
+§C{numbers.Where} §A §LAM{lam1:n:i32} (!= (% n 3) 0) §/LAM{lam1} §/C
+§C{items.Select} §A §LAM{lam2:x:i32} (* x 2) §/LAM{lam2} §/C
+```
+
+### Statement Body Lambdas
+
+For multi-statement bodies, include statements between the tags:
+
 ```
 §B{printer} §LAM{lam1:x:i32}
   §P x
@@ -285,7 +296,7 @@ For statement-body lambdas, use `§LAM`/`§/LAM`:
 
 ### Async Lambdas
 
-Add `async` before parameters:
+Add `async` after the ID, before parameters:
 
 ```
 §LAM{lam1:async:x:i32}
@@ -293,6 +304,10 @@ Add `async` before parameters:
   §R result
 §/LAM{lam1}
 ```
+
+> **Note:** `§I{type:name}` inline parameter declarations are NOT supported inside
+> `§LAM` headers. All parameters must be encoded in the header using the
+> `name:type` pair format.
 
 ---
 

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -4624,14 +4624,18 @@ public sealed class Parser
             }
         }
 
-        var isAbstract = modifiers.Contains("abs", StringComparison.OrdinalIgnoreCase);
-        var isSealed = modifiers.Contains("seal", StringComparison.OrdinalIgnoreCase);
-        var isStatic = modifiers.Contains("stat", StringComparison.OrdinalIgnoreCase)
-                    || modifiers.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries)
-                        .Any(p => p.Equals("st", StringComparison.OrdinalIgnoreCase));
-        var isPartial = modifiers.Contains("partial", StringComparison.OrdinalIgnoreCase);
-        var isStruct = modifiers.Contains("struct", StringComparison.OrdinalIgnoreCase);
-        var isReadOnly = modifiers.Contains("readonly", StringComparison.OrdinalIgnoreCase);
+        // Token-based matching: split modifiers and check each token against known abbreviations
+        var modifierTokens = modifiers.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        var isAbstract = modifierTokens.Any(t => t.Equals("abs", StringComparison.OrdinalIgnoreCase)
+            || t.Equals("abstract", StringComparison.OrdinalIgnoreCase));
+        var isSealed = modifierTokens.Any(t => t.Equals("seal", StringComparison.OrdinalIgnoreCase)
+            || t.Equals("sealed", StringComparison.OrdinalIgnoreCase));
+        var isStatic = modifierTokens.Any(t => t.Equals("st", StringComparison.OrdinalIgnoreCase)
+            || t.Equals("stat", StringComparison.OrdinalIgnoreCase)
+            || t.Equals("static", StringComparison.OrdinalIgnoreCase));
+        var isPartial = modifierTokens.Any(t => t.Equals("partial", StringComparison.OrdinalIgnoreCase));
+        var isStruct = modifierTokens.Any(t => t.Equals("struct", StringComparison.OrdinalIgnoreCase));
+        var isReadOnly = modifierTokens.Any(t => t.Equals("readonly", StringComparison.OrdinalIgnoreCase));
 
         // Structs cannot be abstract
         if (isStruct && isAbstract)
@@ -5025,13 +5029,33 @@ public sealed class Parser
     private static MethodModifiers ParseMethodModifiers(string modStr)
     {
         var mods = MethodModifiers.None;
-        if (modStr.Contains("virt", StringComparison.OrdinalIgnoreCase)) mods |= MethodModifiers.Virtual;
-        if (modStr.Contains("over", StringComparison.OrdinalIgnoreCase)) mods |= MethodModifiers.Override;
-        if (modStr.Contains("abs", StringComparison.OrdinalIgnoreCase)) mods |= MethodModifiers.Abstract;
-        if (modStr.Contains("seal", StringComparison.OrdinalIgnoreCase)) mods |= MethodModifiers.Sealed;
-        if (modStr.Contains("stat", StringComparison.OrdinalIgnoreCase)) mods |= MethodModifiers.Static;
-        if (modStr.Contains("const", StringComparison.OrdinalIgnoreCase)) mods |= MethodModifiers.Const;
-        if (modStr.Contains("readonly", StringComparison.OrdinalIgnoreCase)) mods |= MethodModifiers.Readonly;
+        // Token-based matching: split on commas/spaces and check each token
+        var tokens = modStr.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var token in tokens)
+        {
+            if (token.Equals("vr", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("virt", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("virtual", StringComparison.OrdinalIgnoreCase))
+                mods |= MethodModifiers.Virtual;
+            else if (token.Equals("ov", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("over", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("override", StringComparison.OrdinalIgnoreCase))
+                mods |= MethodModifiers.Override;
+            else if (token.Equals("abs", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("abstract", StringComparison.OrdinalIgnoreCase))
+                mods |= MethodModifiers.Abstract;
+            else if (token.Equals("seal", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("sealed", StringComparison.OrdinalIgnoreCase))
+                mods |= MethodModifiers.Sealed;
+            else if (token.Equals("st", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("stat", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("static", StringComparison.OrdinalIgnoreCase))
+                mods |= MethodModifiers.Static;
+            else if (token.Equals("const", StringComparison.OrdinalIgnoreCase))
+                mods |= MethodModifiers.Const;
+            else if (token.Equals("readonly", StringComparison.OrdinalIgnoreCase))
+                mods |= MethodModifiers.Readonly;
+        }
         return mods;
     }
 

--- a/src/Calor.Compiler/Resources/calor-syntax-documentation.json
+++ b/src/Calor.Compiler/Resources/calor-syntax-documentation.json
@@ -603,6 +603,27 @@
       ]
     },
     {
+      "id": "array_creation",
+      "csharpConstruct": "Array Creation/Initialization",
+      "keywords": ["array", "initializer", "initialization", "collection", "new array", "int[]", "string[]"],
+      "calorSyntax": "§ARR{id:type} elements §/ARR{id}",
+      "description": "Creates and initializes a fixed-size array. The element type is specified in the header. Elements are space-separated between the opening and closing tags. Supports both explicit (new int[] { ... }) and bare ({ ... }) initializer syntax.",
+      "examples": [
+        {
+          "csharp": "int[] numbers = { 5, 4, 1, 3 };",
+          "calor": "§B{[i32]:numbers} §ARR{a001:i32} 5 4 1 3 §/ARR{a001}"
+        },
+        {
+          "csharp": "var items = new int[] { 1, 2, 3 };",
+          "calor": "§B{items} §ARR{a001:i32} 1 2 3 §/ARR{a001}"
+        },
+        {
+          "csharp": "string[] names = new[] { \"Alice\", \"Bob\" };",
+          "calor": "§B{names} §ARR{a001:str} \"Alice\" \"Bob\" §/ARR{a001}"
+        }
+      ]
+    },
+    {
       "id": "static_class",
       "csharpConstruct": "static class",
       "keywords": ["static", "static class", "utility", "helper"],


### PR DESCRIPTION
## Summary

- **Lambda emission rewrite**: CalorEmitter now emits `§LAM{id:p1:t1:p2:t2} body §/LAM{id}` blocks instead of unparseable `(paramList) → body` arrow syntax
- **Modifier parsing fix**: Both class and method modifier parsing in Parser.cs now use token-based equality instead of substring `Contains`, fixing `:st` (and `:vr`, `:ov`) abbreviations being silently ignored
- **Lambda type inference**: Converter now creates a `CSharpCompilation` for semantic model access, inferring actual parameter types (e.g., `i32`) instead of defaulting to `object`
- **Documentation**: Added `§ARR` array creation construct to syntax lookup JSON, documented multi-parameter `§LAM` shorthand, and added `.cs`/`.calr` coexistence guidance

## Verification

- All 7 LINQ partitioning samples convert with zero `§ERR` markers, zero arrow syntax, and correct `static` preservation
- Roundtrip (C# → Calor → C#) confirmed for all sample files
- 3335 tests pass, 0 failures, 0 regressions (20 new tests added)

## Test plan

- [x] `dotnet test tests/Calor.Compiler.Tests/` — full suite passes (3335 tests)
- [x] Convert all 7 partitioning `.cs` files — no `§ERR`, no `→`, `:st` preserved
- [x] Compile converted `.calr` files back to C# — `static class` and `static void` present
- [x] Lambda param types inferred as `i32` instead of `object` on `int[]` collections
- [x] Parser accepts `:st`, `:vr`, `:ov` abbreviations on both classes and methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)