### PR TITLE
fix(converter): resolve 5 LINQ ordering conversion issues

### DIFF
--- a/src/Calor.Compiler/Ast/ModernOperatorNodes.cs
+++ b/src/Calor.Compiler/Ast/ModernOperatorNodes.cs
@@ -55,11 +55,15 @@ public sealed class InterpolatedStringTextNode : InterpolatedStringPartNode
 public sealed class InterpolatedStringExpressionNode : InterpolatedStringPartNode
 {
     public ExpressionNode Expression { get; }
+    public string? FormatSpecifier { get; }
+    public string? AlignmentClause { get; }
 
-    public InterpolatedStringExpressionNode(TextSpan span, ExpressionNode expression)
+    public InterpolatedStringExpressionNode(TextSpan span, ExpressionNode expression, string? formatSpecifier = null, string? alignmentClause = null)
         : base(span)
     {
         Expression = expression ?? throw new ArgumentNullException(nameof(expression));
+        FormatSpecifier = formatSpecifier;
+        AlignmentClause = alignmentClause;
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -2734,6 +2734,16 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             {
                 sb.Append("{");
                 sb.Append(exprPart.Expression.Accept(this));
+                if (!string.IsNullOrEmpty(exprPart.AlignmentClause))
+                {
+                    sb.Append(",");
+                    sb.Append(exprPart.AlignmentClause);
+                }
+                if (!string.IsNullOrEmpty(exprPart.FormatSpecifier))
+                {
+                    sb.Append(":");
+                    sb.Append(exprPart.FormatSpecifier);
+                }
                 sb.Append("}");
             }
         }
@@ -2751,7 +2761,9 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     public string Visit(InterpolatedStringExpressionNode node)
     {
         // This is typically only called standalone, not as part of interpolation
-        return node.Expression.Accept(this);
+        var alignment = !string.IsNullOrEmpty(node.AlignmentClause) ? $",{node.AlignmentClause}" : "";
+        var format = !string.IsNullOrEmpty(node.FormatSpecifier) ? $":{node.FormatSpecifier}" : "";
+        return $"{node.Expression.Accept(this)}{alignment}{format}";
     }
 
     public string Visit(NullCoalesceNode node)

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -1574,6 +1574,16 @@ public sealed class CalorEmitter : IAstVisitor<string>
             {
                 parts.Append("${");
                 parts.Append(exprPart.Expression.Accept(this));
+                if (!string.IsNullOrEmpty(exprPart.AlignmentClause))
+                {
+                    parts.Append(",");
+                    parts.Append(exprPart.AlignmentClause);
+                }
+                if (!string.IsNullOrEmpty(exprPart.FormatSpecifier))
+                {
+                    parts.Append(":");
+                    parts.Append(exprPart.FormatSpecifier);
+                }
                 parts.Append("}");
             }
         }
@@ -1589,7 +1599,9 @@ public sealed class CalorEmitter : IAstVisitor<string>
 
     public string Visit(InterpolatedStringExpressionNode node)
     {
-        return $"${{{node.Expression.Accept(this)}}}";
+        var alignment = !string.IsNullOrEmpty(node.AlignmentClause) ? $",{node.AlignmentClause}" : "";
+        var format = !string.IsNullOrEmpty(node.FormatSpecifier) ? $":{node.FormatSpecifier}" : "";
+        return $"${{{node.Expression.Accept(this)}{alignment}{format}}}";
     }
 
     public string Visit(NullCoalesceNode node)

--- a/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
+++ b/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
@@ -3444,9 +3444,13 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                     break;
 
                 case InterpolationSyntax interp:
+                    var formatSpec = interp.FormatClause?.FormatStringToken.Text;
+                    var alignmentClause = interp.AlignmentClause?.Value.ToString();
                     parts.Add(new InterpolatedStringExpressionNode(
                         GetTextSpan(interp),
-                        ConvertExpression(interp.Expression)));
+                        ConvertExpression(interp.Expression),
+                        formatSpec,
+                        alignmentClause));
                     break;
             }
         }
@@ -3805,6 +3809,14 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
 
         _context.RecordUnsupportedFeature(featureName, node.ToString(), line, suggestion);
 
+        // Also populate the issues list so fallback nodes are visible in conversion results
+        if (_context.GracefulFallback)
+        {
+            _context.AddWarning(
+                $"Unsupported feature [{featureName}] replaced with fallback: {(node.ToString().Length > 80 ? node.ToString().Substring(0, 77) + "..." : node.ToString())}",
+                feature: featureName, line: line, suggestion: suggestion);
+        }
+
         return new FallbackExpressionNode(GetTextSpan(node), node.ToString(), featureName, suggestion);
     }
 
@@ -3819,6 +3831,14 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         var suggestion = FeatureSupport.GetWorkaround(featureName);
 
         _context.RecordUnsupportedFeature(featureName, node.ToString(), line, suggestion);
+
+        // Also populate the issues list so fallback nodes are visible in conversion results
+        if (_context.GracefulFallback)
+        {
+            _context.AddWarning(
+                $"Unsupported feature [{featureName}] replaced with fallback: {(node.ToString().Length > 80 ? node.ToString().Substring(0, 77) + "..." : node.ToString())}",
+                feature: featureName, line: line, suggestion: suggestion);
+        }
 
         return new FallbackCommentNode(GetTextSpan(node), node.ToString(), featureName, suggestion);
     }

--- a/src/Calor.Compiler/Migration/TypeMapper.cs
+++ b/src/Calor.Compiler/Migration/TypeMapper.cs
@@ -43,9 +43,9 @@ public static class TypeMapper
         ["double"] = "f64",
         ["Double"] = "f64",
         ["System.Double"] = "f64",
-        ["decimal"] = "decimal",
-        ["Decimal"] = "decimal",
-        ["System.Decimal"] = "decimal",
+        ["decimal"] = "dec",
+        ["Decimal"] = "dec",
+        ["System.Decimal"] = "dec",
 
         // Boolean
         ["bool"] = "bool",
@@ -141,6 +141,7 @@ public static class TypeMapper
         // Calor floating point
         ["f32"] = "float",
         ["f64"] = "double",
+        ["dec"] = "decimal",
         ["decimal"] = "decimal",
 
         // C# floating point (for backward compatibility)

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -5100,6 +5100,21 @@ public sealed class Parser
             }
         }
 
+        // Handle optional empty parens: §NEW{X}() — consume silently
+        if (Check(TokenKind.OpenParen))
+        {
+            var saved = _position;
+            Advance(); // consume '('
+            if (Check(TokenKind.CloseParen))
+            {
+                Advance(); // consume ')'
+            }
+            else
+            {
+                _position = saved; // not empty parens — backtrack
+            }
+        }
+
         // Parse arguments — only when not inside an argument context
         // (avoids stealing §A tokens that belong to the enclosing §C)
         var arguments = new List<ExpressionNode>();

--- a/tests/Calor.Compiler.Tests/ConverterBugfixTests.cs
+++ b/tests/Calor.Compiler.Tests/ConverterBugfixTests.cs
@@ -1,4 +1,7 @@
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Diagnostics;
 using Calor.Compiler.Migration;
+using Calor.Compiler.Parsing;
 using Xunit;
 
 namespace Calor.Compiler.Tests;
@@ -247,6 +250,368 @@ public class Test
 
         // Generated C# should contain valid chained method calls
         Assert.Contains("GetHashCode()", compilationResult.GeneratedCode);
+    }
+
+    #endregion
+
+    #region Issue 3: st modifier alias for static
+
+    [Fact]
+    public void Parser_StModifier_OnClass_SetsIsStatic()
+    {
+        var source = @"
+§M{m1:Test}
+§CL{c1:Helper:st}
+§/CL{c1}
+§/M{m1}";
+        var module = ParseModule(source);
+        var cls = Assert.Single(module.Classes);
+        Assert.True(cls.IsStatic);
+    }
+
+    [Fact]
+    public void Parser_StModifier_OnMethod_SetsIsStatic()
+    {
+        var source = @"
+§M{m1:Test}
+§CL{c1:Helper}
+§MT{m1:Greet:pub:st}
+§/MT{m1}
+§/CL{c1}
+§/M{m1}";
+        var module = ParseModule(source);
+        var method = module.Classes[0].Methods[0];
+        Assert.True(method.Modifiers.HasFlag(Calor.Compiler.Ast.MethodModifiers.Static));
+    }
+
+    [Fact]
+    public void Parser_StModifier_OnClass_EmitsStaticInCSharp()
+    {
+        var source = @"
+§M{m1:Test}
+§CL{c1:Helper:st}
+§/CL{c1}
+§/M{m1}";
+        var csharp = ParseAndEmit(source);
+        Assert.Contains("static class Helper", csharp);
+    }
+
+    #endregion
+
+    #region Issue 11: Interpolated string format specifiers
+
+    [Fact]
+    public void Converter_InterpolatedString_PreservesFormatSpecifier()
+    {
+        var csharp = @"
+public class Test
+{
+    public string M(decimal price)
+    {
+        return $""{price:C}"";
+    }
+}";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        // The Calor output should contain the format specifier
+        var emitter = new CalorEmitter();
+        var calor = emitter.Emit(result.Ast!);
+        Assert.Contains(":C}", calor);
+    }
+
+    [Fact]
+    public void Converter_InterpolatedString_FormatSpecifierRoundtrips()
+    {
+        var csharp = @"
+public class Test
+{
+    public string M(double value)
+    {
+        return $""{value:F2}"";
+    }
+}";
+        var converter = new CSharpToCalorConverter();
+        var conversionResult = converter.Convert(csharp);
+        Assert.True(conversionResult.Success, GetErrorMessage(conversionResult));
+
+        // Round-trip: compile Calor → C#
+        var compilationResult = Program.Compile(conversionResult.CalorSource!, "roundtrip.calr",
+            new CompilationOptions { EnforceEffects = false });
+
+        Assert.False(compilationResult.HasErrors,
+            $"Roundtrip compilation failed:\n" +
+            string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message)));
+
+        // Generated C# should contain the format specifier
+        Assert.Contains(":F2}", compilationResult.GeneratedCode);
+    }
+
+    #endregion
+
+    #region Issue 6: Fallback nodes populate issues list
+
+    [Fact]
+    public void Converter_FallbackNode_PopulatesIssuesList_WhenGracefulFallbackEnabled()
+    {
+        var csharp = @"
+public class Test
+{
+    void M()
+    {
+        var x = stackalloc int[10];
+    }
+}";
+        var converter = new CSharpToCalorConverter(new ConversionOptions { GracefulFallback = true });
+        var result = converter.Convert(csharp);
+
+        Assert.True(result.Success);
+        // Issues should contain a warning about the fallback
+        Assert.True(result.Issues.Count > 0, "Expected at least one issue for fallback nodes");
+        Assert.Contains(result.Issues, i =>
+            i.Severity == ConversionIssueSeverity.Warning &&
+            i.Message.Contains("fallback"));
+    }
+
+    #endregion
+
+    #region Issue 10: dec type alias for decimal
+
+    [Fact]
+    public void TypeMapper_DecimalMapsToDec()
+    {
+        var csharp = @"
+public class Test
+{
+    public decimal GetPrice() { return 0m; }
+}";
+        var calor = ConvertToCalor(csharp);
+        // Calor should use 'dec' alias for decimal
+        Assert.Contains("dec", calor);
+    }
+
+    [Fact]
+    public void TypeMapper_DecRoundtripsToDecimal()
+    {
+        var source = @"
+§M{m1:Test}
+§CL{c1:Calc}
+§MT{m1:GetPrice:pub}
+  §O{dec}
+  §R 0
+§/MT{m1}
+§/CL{c1}
+§/M{m1}";
+        var csharp = ParseAndEmit(source);
+        Assert.Contains("decimal", csharp);
+    }
+
+    #endregion
+
+    #region Issue 8: §NEW{X}() with empty parens
+
+    [Fact]
+    public void Parser_NewExpression_EmptyParens_ParsesWithoutError()
+    {
+        var source = @"
+§M{m1:Test}
+§CL{c1:MyClass}
+§MT{m1:Create:pub}
+  §R §NEW{MyClass}()§/NEW
+§/MT{m1}
+§/CL{c1}
+§/M{m1}";
+        var module = ParseModule(source);
+        Assert.NotNull(module);
+    }
+
+    [Fact]
+    public void Parser_NewExpression_EmptyParens_EquivalentToWithout()
+    {
+        var sourceWithParens = @"
+§M{m1:Test}
+§CL{c1:MyClass}
+§MT{m1:Create:pub}
+  §R §NEW{MyClass}()§/NEW
+§/MT{m1}
+§/CL{c1}
+§/M{m1}";
+        var sourceWithout = @"
+§M{m1:Test}
+§CL{c1:MyClass}
+§MT{m1:Create:pub}
+  §R §NEW{MyClass}§/NEW
+§/MT{m1}
+§/CL{c1}
+§/M{m1}";
+        var csharp1 = ParseAndEmit(sourceWithParens);
+        var csharp2 = ParseAndEmit(sourceWithout);
+
+        Assert.Equal(csharp1, csharp2);
+    }
+
+    #endregion
+
+    #region Edge cases: st + struct interaction
+
+    [Fact]
+    public void Parser_StStruct_DoesNotProduceStaticStruct()
+    {
+        // "st struct" should parse as static struct, not double-stat
+        var source = @"
+§M{m1:Test}
+§CL{c1:Point:st struct}
+§/CL{c1}
+§/M{m1}";
+        var module = ParseModule(source);
+        var cls = Assert.Single(module.Classes);
+        Assert.True(cls.IsStatic, "Should be static");
+        Assert.True(cls.IsStruct, "Should be struct");
+    }
+
+    [Fact]
+    public void Parser_StructAlone_IsNotStatic()
+    {
+        var source = @"
+§M{m1:Test}
+§CL{c1:Point:struct}
+§/CL{c1}
+§/M{m1}";
+        var module = ParseModule(source);
+        var cls = Assert.Single(module.Classes);
+        Assert.False(cls.IsStatic, "struct alone should not be static");
+        Assert.True(cls.IsStruct, "Should be struct");
+    }
+
+    #endregion
+
+    #region Edge cases: §NEW{X}() with trailing member access
+
+    [Fact]
+    public void Parser_NewExpression_EmptyParens_WithTrailingMemberAccess()
+    {
+        var source = @"
+§M{m1:Test}
+§CL{c1:MyClass}
+§MT{m1:GetName:pub}
+  §R §NEW{MyClass}()§/NEW.ToString
+§/MT{m1}
+§/CL{c1}
+§/M{m1}";
+        var csharp = ParseAndEmit(source);
+        // Should produce new MyClass().ToString() in the output
+        Assert.Contains("new MyClass()", csharp);
+        Assert.Contains("ToString", csharp);
+    }
+
+    #endregion
+
+    #region Edge cases: alignment clause in interpolated strings
+
+    [Fact]
+    public void Converter_InterpolatedString_PreservesAlignmentAndFormat()
+    {
+        var csharp = @"
+public class Test
+{
+    public string M(double value)
+    {
+        return $""{value,10:F2}"";
+    }
+}";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        // Calor output should contain alignment and format
+        var emitter = new CalorEmitter();
+        var calor = emitter.Emit(result.Ast!);
+        Assert.Contains(",10:F2}", calor);
+    }
+
+    [Fact]
+    public void Converter_InterpolatedString_AlignmentOnlyNoFormat()
+    {
+        var csharp = @"
+public class Test
+{
+    public string M(string name)
+    {
+        return $""{name,-20}"";
+    }
+}";
+        var converter = new CSharpToCalorConverter();
+        var result = converter.Convert(csharp);
+        Assert.True(result.Success, GetErrorMessage(result));
+
+        // Calor output should contain alignment
+        var emitter = new CalorEmitter();
+        var calor = emitter.Emit(result.Ast!);
+        Assert.Contains(",-20}", calor);
+    }
+
+    [Fact]
+    public void Converter_InterpolatedString_AlignmentAndFormatRoundtrip()
+    {
+        var csharp = @"
+public class Test
+{
+    public string M(double value)
+    {
+        return $""{value,10:F2}"";
+    }
+}";
+        var converter = new CSharpToCalorConverter();
+        var conversionResult = converter.Convert(csharp);
+        Assert.True(conversionResult.Success, GetErrorMessage(conversionResult));
+
+        // Round-trip: compile Calor → C#
+        var compilationResult = Program.Compile(conversionResult.CalorSource!, "roundtrip.calr",
+            new CompilationOptions { EnforceEffects = false });
+
+        Assert.False(compilationResult.HasErrors,
+            $"Roundtrip compilation failed:\n" +
+            string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message)));
+
+        // Generated C# should contain both alignment and format
+        Assert.Contains(",10:F2}", compilationResult.GeneratedCode);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static Ast.ModuleNode ParseModule(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath("test.calr");
+
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+
+        var parser = new Parser(tokens, diagnostics);
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+        return module;
+    }
+
+    private static string ParseAndEmit(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath("test.calr");
+
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+
+        var parser = new Parser(tokens, diagnostics);
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+
+        var emitter = new CSharpEmitter();
+        return emitter.Emit(module);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- **`st` modifier alias**: Already fixed upstream via token-based matching; this branch adds the remaining 4 fixes
- **Interpolated string format specifiers**: Preserve `:C`, `:F2` and alignment clauses (`,10`) through Roslyn→AST→CSharp/Calor emitter pipeline
- **Fallback/§ERR in issues list**: `CreateFallbackExpression`/`CreateFallbackStatement` now emit warnings when `GracefulFallback=true`, so fallback nodes surface in `Issues`
- **`dec` type alias**: Bidirectional `decimal`↔`dec` mapping in TypeMapper
- **`§NEW{X}()` empty parens**: Parser silently consumes empty `()` after type name, treating `§NEW{X}()` identically to `§NEW{X}`

## Test plan
- [x] 16 new tests in `ConverterBugfixTests.cs` covering all changes + edge cases
- [x] `st struct` combo correctly produces static struct
- [x] `§NEW{Foo}().Method` trailing member access after empty parens
- [x] `{val,10:F2}` alignment + format roundtrip
- [x] Full suite: 4382 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)