### PR TITLE
fix: emit default: instead of case _: for wildcard switch cases

### DIFF
--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -1221,8 +1221,15 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         foreach (var matchCase in node.Cases)
         {
-            var pattern = EmitPattern(matchCase.Pattern);
-            AppendLine($"case {pattern}:");
+            if (matchCase.Pattern is WildcardPatternNode)
+            {
+                AppendLine("default:");
+            }
+            else
+            {
+                var pattern = EmitPattern(matchCase.Pattern);
+                AppendLine($"case {pattern}:");
+            }
             Indent();
 
             foreach (var stmt in matchCase.Body)

--- a/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
+++ b/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
@@ -1,0 +1,100 @@
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for fixes discovered during the C# to Calor conversion campaign.
+/// Each test corresponds to a GitHub issue from the campaign.
+/// </summary>
+public class ConversionCampaignFixTests
+{
+    #region Helpers
+
+    private static string ParseAndEmit(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath("test.calr");
+
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+
+        var parser = new Parser(tokens, diagnostics);
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+
+        var emitter = new CSharpEmitter();
+        return emitter.Emit(module);
+    }
+
+    private static DiagnosticBag ParseWithDiagnostics(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath("test.calr");
+
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+
+        var parser = new Parser(tokens, diagnostics);
+        parser.Parse();
+
+        return diagnostics;
+    }
+
+    #endregion
+
+    #region Issue 289: Emit default: instead of case _: in switch
+
+    [Fact]
+    public void Emit_WildcardMatchCase_EmitsDefault()
+    {
+        var source = @"
+§M{m001:Test}
+§F{f001:MatchTest:pub}
+§I{i32:x}
+§O{str}
+§W{m1} x
+§K 1
+§R ""one""
+§K _
+§R ""other""
+§/W{m1}
+§/F{f001}
+§/M{m001}
+";
+        var csharp = ParseAndEmit(source);
+        Assert.Contains("default:", csharp);
+        Assert.DoesNotContain("case _:", csharp);
+    }
+
+    [Fact]
+    public void Emit_MatchWithMultipleCasesAndWildcard_OnlyWildcardIsDefault()
+    {
+        var source = @"
+§M{m001:Test}
+§F{f001:MatchTest:pub}
+§I{i32:x}
+§O{str}
+§W{m1} x
+§K 1
+§R ""one""
+§K 2
+§R ""two""
+§K _
+§R ""other""
+§/W{m1}
+§/F{f001}
+§/M{m001}
+";
+        var csharp = ParseAndEmit(source);
+        Assert.Contains("case 1:", csharp);
+        Assert.Contains("case 2:", csharp);
+        Assert.Contains("default:", csharp);
+        Assert.DoesNotContain("case _:", csharp);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Fixes #289
- The CSharp emitter was generating `case _:` for wildcard patterns in switch statements, which is not valid C#
- Now correctly emits `default:` for `WildcardPatternNode` in match statements
- Match expressions (switch expressions) still correctly use `_` pattern

## Test plan
- [x] Added 2 regression tests in `ConversionCampaignFixTests.cs`
- [x] All 3,471 tests pass
- [x] All 10/10 self-test scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)