### PR TITLE
fix: read-only properties emit { get; } instead of { get; set; }

### DIFF
--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -2332,14 +2332,17 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         // Auto-property with default value
         if (node.IsAutoProperty)
         {
+            var accessors = node.Setter != null ? "get; set;" :
+                            node.Initer != null ? "get; init;" :
+                            "get;";
             if (node.DefaultValue != null)
             {
                 var defaultVal = node.DefaultValue.Accept(this);
-                AppendLine($"{modifierStr} {typeName} {propName} {{ get; set; }} = {defaultVal};");
+                AppendLine($"{modifierStr} {typeName} {propName} {{ {accessors} }} = {defaultVal};");
             }
             else
             {
-                AppendLine($"{modifierStr} {typeName} {propName} {{ get; set; }}");
+                AppendLine($"{modifierStr} {typeName} {propName} {{ {accessors} }}");
             }
             return "";
         }

--- a/src/Calor.Compiler/Resources/SelfTest/09_codegen_bugfixes.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/09_codegen_bugfixes.g.cs
@@ -15,14 +15,14 @@ namespace Transliterator
 {
     public abstract class TransliteratorBase
     {
-        public abstract string Name { get; set; }
+        public abstract string Name { get; }
 
     }
 
     public class CyrillicToLatin : TransliteratorBase
     {
         private string _mappings;
-        public override string Name { get; set; }
+        public override string Name { get; }
 
         public CyrillicToLatin(string name)
         {

--- a/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
+++ b/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
@@ -1,0 +1,72 @@
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for fixes discovered during the C# to Calor conversion campaign.
+/// Each test corresponds to a GitHub issue from the campaign.
+/// </summary>
+public class ConversionCampaignFixTests
+{
+    #region Helpers
+
+    private static string ParseAndEmit(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath("test.calr");
+
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+
+        var parser = new Parser(tokens, diagnostics);
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+
+        var emitter = new CSharpEmitter();
+        return emitter.Emit(module);
+    }
+
+    #endregion
+
+    #region Issue 290: Read-only properties should emit { get; } not { get; set; }
+
+    [Fact]
+    public void Emit_ReadOnlyAutoProperty_EmitsGetOnly()
+    {
+        var source = @"
+§M{m001:Test}
+§CL{c001:Foo:pub}
+§PROP{p001:Name:str:pub}
+§GET §/GET
+§/PROP{p001}
+§/CL{c001}
+§/M{m001}
+";
+        var csharp = ParseAndEmit(source);
+        Assert.Contains("{ get; }", csharp);
+        Assert.DoesNotContain("get; set;", csharp);
+    }
+
+    [Fact]
+    public void Emit_ReadWriteAutoProperty_EmitsGetSet()
+    {
+        var source = @"
+§M{m001:Test}
+§CL{c001:Foo:pub}
+§PROP{p001:Name:str:pub}
+§GET §/GET
+§SET §/SET
+§/PROP{p001}
+§/CL{c001}
+§/M{m001}
+";
+        var csharp = ParseAndEmit(source);
+        Assert.Contains("get; set;", csharp);
+    }
+
+    #endregion
+}

--- a/tests/E2E/scenarios/09_codegen_bugfixes/output.g.cs
+++ b/tests/E2E/scenarios/09_codegen_bugfixes/output.g.cs
@@ -15,14 +15,14 @@ namespace Transliterator
 {
     public abstract class TransliteratorBase
     {
-        public abstract string Name { get; set; }
+        public abstract string Name { get; }
 
     }
 
     public class CyrillicToLatin : TransliteratorBase
     {
         private string _mappings;
-        public override string Name { get; set; }
+        public override string Name { get; }
 
         public CyrillicToLatin(string name)
         {


### PR DESCRIPTION
## Summary
- Fixes #290
- Auto-properties with only `§GET` (no `§SET`/`§INIT`) now emit `{ get; }` instead of `{ get; set; }`
- Properties with `§INIT` emit `{ get; init; }`
- Updated golden files for `09_codegen_bugfixes` scenario

## Test plan
- [x] Added 2 regression tests in `ConversionCampaignFixTests.cs`
- [x] All 3,471 tests pass
- [x] All 10/10 self-test scenarios pass
- [x] Golden files updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)