### PR TITLE
feat: support §PROP inside §IFACE for interface properties

### DIFF
--- a/src/Calor.Compiler/Ast/ClassNodes.cs
+++ b/src/Calor.Compiler/Ast/ClassNodes.cs
@@ -32,6 +32,11 @@ public sealed class InterfaceDefinitionNode : TypeDefinitionNode
     public IReadOnlyList<MethodSignatureNode> Methods { get; }
 
     /// <summary>
+    /// Interface properties.
+    /// </summary>
+    public IReadOnlyList<PropertyNode> Properties { get; }
+
+    /// <summary>
     /// Interfaces this interface extends.
     /// </summary>
     public IReadOnlyList<string> BaseInterfaces { get; }
@@ -53,7 +58,7 @@ public sealed class InterfaceDefinitionNode : TypeDefinitionNode
         IReadOnlyList<string> baseInterfaces,
         IReadOnlyList<MethodSignatureNode> methods,
         AttributeCollection attributes)
-        : this(span, id, name, baseInterfaces, Array.Empty<TypeParameterNode>(), methods, attributes, Array.Empty<CalorAttributeNode>())
+        : this(span, id, name, baseInterfaces, Array.Empty<TypeParameterNode>(), methods, Array.Empty<PropertyNode>(), attributes, Array.Empty<CalorAttributeNode>())
     {
     }
 
@@ -65,7 +70,7 @@ public sealed class InterfaceDefinitionNode : TypeDefinitionNode
         IReadOnlyList<MethodSignatureNode> methods,
         AttributeCollection attributes,
         IReadOnlyList<CalorAttributeNode> csharpAttributes)
-        : this(span, id, name, baseInterfaces, Array.Empty<TypeParameterNode>(), methods, attributes, csharpAttributes)
+        : this(span, id, name, baseInterfaces, Array.Empty<TypeParameterNode>(), methods, Array.Empty<PropertyNode>(), attributes, csharpAttributes)
     {
     }
 
@@ -78,11 +83,26 @@ public sealed class InterfaceDefinitionNode : TypeDefinitionNode
         IReadOnlyList<MethodSignatureNode> methods,
         AttributeCollection attributes,
         IReadOnlyList<CalorAttributeNode> csharpAttributes)
+        : this(span, id, name, baseInterfaces, typeParameters, methods, Array.Empty<PropertyNode>(), attributes, csharpAttributes)
+    {
+    }
+
+    public InterfaceDefinitionNode(
+        TextSpan span,
+        string id,
+        string name,
+        IReadOnlyList<string> baseInterfaces,
+        IReadOnlyList<TypeParameterNode> typeParameters,
+        IReadOnlyList<MethodSignatureNode> methods,
+        IReadOnlyList<PropertyNode> properties,
+        AttributeCollection attributes,
+        IReadOnlyList<CalorAttributeNode> csharpAttributes)
         : base(span, id, name, attributes)
     {
         BaseInterfaces = baseInterfaces ?? throw new ArgumentNullException(nameof(baseInterfaces));
         TypeParameters = typeParameters ?? throw new ArgumentNullException(nameof(typeParameters));
         Methods = methods ?? throw new ArgumentNullException(nameof(methods));
+        Properties = properties ?? Array.Empty<PropertyNode>();
         CSharpAttributes = csharpAttributes ?? Array.Empty<CalorAttributeNode>();
     }
 

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -1752,6 +1752,12 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         AppendLine("{");
         Indent();
 
+        foreach (var prop in node.Properties)
+        {
+            Visit(prop);
+            AppendLine();
+        }
+
         foreach (var method in node.Methods)
         {
             Visit(method);

--- a/src/Calor.Compiler/Formatting/CalorFormatter.cs
+++ b/src/Calor.Compiler/Formatting/CalorFormatter.cs
@@ -188,6 +188,11 @@ public sealed class CalorFormatter
             : "";
         AppendLine($"§IFACE{{{ifaceId}:{iface.Name}{baseList}}}");
 
+        foreach (var prop in iface.Properties)
+        {
+            FormatProperty(prop);
+        }
+
         foreach (var method in iface.Methods)
         {
             FormatMethodSignature(method);

--- a/src/Calor.Compiler/Ids/IdScanner.cs
+++ b/src/Calor.Compiler/Ids/IdScanner.cs
@@ -74,6 +74,9 @@ public sealed class IdScanner : IAstVisitor
     {
         AddEntry(node.Id, IdKind.Interface, node.Name, node.Span);
 
+        foreach (var prop in node.Properties)
+            prop.Accept(this);
+
         foreach (var method in node.Methods)
             method.Accept(this);
     }

--- a/src/Calor.Compiler/Mcp/Tools/DocumentOutlineTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/DocumentOutlineTool.cs
@@ -293,6 +293,17 @@ public sealed class DocumentOutlineTool : McpToolBase
     {
         var children = new List<OutlineSymbol>();
 
+        foreach (var prop in iface.Properties)
+        {
+            children.Add(new OutlineSymbol
+            {
+                Name = prop.Name,
+                Kind = "property",
+                Line = prop.Span.Line,
+                Detail = prop.TypeName
+            });
+        }
+
         foreach (var method in iface.Methods)
         {
             var parameters = string.Join(", ", method.Parameters.Select(p => $"{p.Name}: {p.TypeName}"));

--- a/src/Calor.Compiler/Mcp/Tools/FindSymbolTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/FindSymbolTool.cs
@@ -260,6 +260,26 @@ public sealed class FindSymbolTool : McpToolBase
                     });
                 }
 
+                // Search interface properties
+                if (kindFilter == null || kindFilter == "property")
+                {
+                    foreach (var prop in iface.Properties)
+                    {
+                        if (MatchesQuery(prop.Name, queryLower))
+                        {
+                            results.Add(new SymbolMatch
+                            {
+                                Name = prop.Name,
+                                Kind = "property",
+                                ContainerName = iface.Name,
+                                FilePath = filePath,
+                                Line = prop.Span.Line,
+                                Column = prop.Span.Column
+                            });
+                        }
+                    }
+                }
+
                 // Search interface methods
                 if (kindFilter == null || kindFilter == "method")
                 {

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -157,6 +157,11 @@ public sealed class CalorEmitter : IAstVisitor<string>
         AppendLine($"§IFACE{{{node.Id}:{node.Name}{baseList}}}{attrs}");
         Indent();
 
+        foreach (var prop in node.Properties)
+        {
+            Visit(prop);
+        }
+
         foreach (var method in node.Methods)
         {
             Visit(method);

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -4439,6 +4439,7 @@ public sealed class Parser
 
         var baseInterfaces = new List<string>();
         var methods = new List<MethodSignatureNode>();
+        var properties = new List<PropertyNode>();
 
         while (!IsAtEnd && !Check(TokenKind.EndInterface))
         {
@@ -4464,9 +4465,13 @@ public sealed class Parser
             {
                 methods.Add(ParseMethodSignature());
             }
+            else if (Check(TokenKind.Property))
+            {
+                properties.Add(ParseProperty());
+            }
             else
             {
-                _diagnostics.ReportUnexpectedToken(Current.Span, "EXT, METHOD, or END_IFACE", Current.Kind);
+                _diagnostics.ReportUnexpectedToken(Current.Span, "EXT, METHOD, PROP, or END_IFACE", Current.Kind);
                 Advance();
             }
         }
@@ -4481,7 +4486,7 @@ public sealed class Parser
         }
 
         var span = startToken.Span.Union(endToken.Span);
-        return new InterfaceDefinitionNode(span, id, name, baseInterfaces, typeParameters, methods, attrs, csharpAttrs);
+        return new InterfaceDefinitionNode(span, id, name, baseInterfaces, typeParameters, methods, properties, attrs, csharpAttrs);
     }
 
     /// <summary>

--- a/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
+++ b/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
@@ -1,0 +1,80 @@
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for fixes discovered during the C# to Calor conversion campaign.
+/// Each test corresponds to a GitHub issue from the campaign.
+/// </summary>
+public class ConversionCampaignFixTests
+{
+    #region Helpers
+
+    private static string ParseAndEmit(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath("test.calr");
+
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+
+        var parser = new Parser(tokens, diagnostics);
+        var module = parser.Parse();
+
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Select(d => d.Message)));
+
+        var emitter = new CSharpEmitter();
+        return emitter.Emit(module);
+    }
+
+    #endregion
+
+    #region Issue 294: Support §PROP inside §IFACE for interface properties
+
+    [Fact]
+    public void Emit_InterfaceWithProperty_EmitsPropertyNotMethod()
+    {
+        var source = @"
+§M{m001:Test}
+§IFACE{i001:IOrder}
+§PROP{p001:Purchased:datetime:pub}
+§GET §/GET
+§/PROP{p001}
+§/IFACE{i001}
+§/M{m001}
+";
+        var csharp = ParseAndEmit(source);
+        Assert.Contains("interface IOrder", csharp);
+        // Property should appear (either get-only or get-set depending on branch)
+        Assert.Contains("DateTime Purchased", csharp);
+        Assert.Contains("get;", csharp);
+        Assert.DoesNotContain("DateTime Purchased()", csharp);
+    }
+
+    [Fact]
+    public void Emit_InterfaceWithPropertyAndMethod_EmitsBoth()
+    {
+        var source = @"
+§M{m001:Test}
+§IFACE{i001:IOrder}
+§PROP{p001:Cost:f64:pub}
+§GET §/GET
+§/PROP{p001}
+§MT{m001:GetDescription}
+§O{str}
+§/MT{m001}
+§/IFACE{i001}
+§/M{m001}
+";
+        var csharp = ParseAndEmit(source);
+        Assert.Contains("interface IOrder", csharp);
+        Assert.Contains("double Cost", csharp);
+        Assert.Contains("get;", csharp);
+        Assert.Contains("string GetDescription()", csharp);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Fixes #294
- Interface definitions (`§IFACE`) now support `§PROP` for property declarations
- Properties emit as proper C# interface properties (`DateTime Purchased { get; }`) instead of requiring `§MT` which emits as methods
- Updated 8 files across AST, Parser, Emitter, Formatter, and MCP tools

## Changes
- **AST**: Added `Properties` collection to `InterfaceDefinitionNode` (backwards-compatible)
- **Parser**: Accept `§PROP` inside `§IFACE` blocks (reuses existing `ParseProperty()`)
- **Emitter**: Emit interface properties before methods
- **Formatter**: Format interface properties in Calor output
- **IdScanner**: Scan property IDs inside interfaces
- **FindSymbolTool**: Search for properties in interfaces
- **DocumentOutlineTool**: Show properties in interface outlines

## Test plan
- [x] Added 2 regression tests (property-only and property+method interface)
- [x] All 3,471 tests pass
- [x] All 10/10 self-test scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)