### PR TITLE
fix: convert postfix/prefix increment to compound assignment

### DIFF
--- a/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
+++ b/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
@@ -1,0 +1,65 @@
+using Calor.Compiler.Migration;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for fixes discovered during the C# to Calor conversion campaign.
+/// </summary>
+public class ConversionCampaignFixTests
+{
+    private readonly CSharpToCalorConverter _converter = new();
+
+    #region Issue 300: Convert postfix/prefix increment to compound assignment
+
+    [Fact]
+    public void Convert_PostfixIncrement_ProducesCompoundAssignment()
+    {
+        var result = _converter.Convert(@"
+public class Test
+{
+    public void Count()
+    {
+        int i = 0;
+        i++;
+    }
+}");
+        Assert.True(result.Success, string.Join("\n", result.Issues));
+        Assert.DoesNotContain("§ERR", result.CalorSource);
+        Assert.DoesNotContain("postfix", result.CalorSource?.ToLower() ?? "");
+    }
+
+    [Fact]
+    public void Convert_PostfixDecrement_ProducesCompoundAssignment()
+    {
+        var result = _converter.Convert(@"
+public class Test
+{
+    public void CountDown()
+    {
+        int i = 10;
+        i--;
+    }
+}");
+        Assert.True(result.Success, string.Join("\n", result.Issues));
+        Assert.DoesNotContain("§ERR", result.CalorSource);
+    }
+
+    [Fact]
+    public void Convert_PrefixIncrement_ProducesCompoundAssignment()
+    {
+        var result = _converter.Convert(@"
+public class Test
+{
+    public void Count()
+    {
+        int i = 0;
+        ++i;
+    }
+}");
+        Assert.True(result.Success, string.Join("\n", result.Issues));
+        Assert.DoesNotContain("§ERR", result.CalorSource);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Fixes #300
- `i++`/`i--` and `++i`/`--i` now properly convert instead of generating `§ERR{"TODO: postfix-operator"}`
- As statements: converts to `CompoundAssignmentStatementNode` (`i += 1`)
- As expressions: converts to `UnaryOperationNode` (`PostIncrement`/`PostDecrement`)

## Test plan
- [x] Added 3 regression tests (postfix++, postfix--, prefix++)
- [x] All 3,472 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)