### PR TITLE
fix: emit §MT instead of §SIG for interface method signatures

### DIFF
--- a/src/Calor.Compiler/Formatting/CalorFormatter.cs
+++ b/src/Calor.Compiler/Formatting/CalorFormatter.cs
@@ -199,10 +199,18 @@ public sealed class CalorFormatter
     private void FormatMethodSignature(MethodSignatureNode method)
     {
         var methodId = AbbreviateId(method.Id);
-        var output = method.Output != null ? CompactTypeName(method.Output.TypeName) : "void";
-        var paramList = string.Join(",", method.Parameters.Select(p =>
-            $"{CompactTypeName(p.TypeName)}:{p.Name}"));
-        AppendLine($"§SIG{{{methodId}:{method.Name}}} ({paramList}) → {output}");
+        AppendLine($"§MT{{{methodId}:{method.Name}}}");
+
+        foreach (var param in method.Parameters)
+        {
+            AppendLine($"§I{{{CompactTypeName(param.TypeName)}:{param.Name}}}");
+        }
+        if (method.Output != null)
+        {
+            AppendLine($"§O{{{CompactTypeName(method.Output.TypeName)}}}");
+        }
+
+        AppendLine($"§/MT{{{methodId}}}");
     }
 
     private void FormatClass(ClassDefinitionNode cls)

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -173,13 +173,22 @@ public sealed class CalorEmitter : IAstVisitor<string>
         var typeParams = node.TypeParameters.Count > 0
             ? $"<{string.Join(",", node.TypeParameters.Select(tp => tp.Name))}>"
             : "";
-
-        var output = node.Output != null ? TypeMapper.CSharpToCalor(node.Output.TypeName) : "void";
-        var paramList = string.Join(",", node.Parameters.Select(p =>
-            $"{TypeMapper.CSharpToCalor(p.TypeName)}:{p.Name}"));
         var attrs = EmitCSharpAttributes(node.CSharpAttributes);
 
-        AppendLine($"§SIG{{{node.Id}:{node.Name}{typeParams}}}{attrs} ({paramList}) → {output}");
+        AppendLine($"§MT{{{node.Id}:{node.Name}{typeParams}}}{attrs}");
+        Indent();
+
+        foreach (var param in node.Parameters)
+        {
+            AppendLine($"§I{{{TypeMapper.CSharpToCalor(param.TypeName)}:{param.Name}}}");
+        }
+        if (node.Output != null)
+        {
+            AppendLine($"§O{{{TypeMapper.CSharpToCalor(node.Output.TypeName)}}}");
+        }
+
+        Dedent();
+        AppendLine($"§/MT{{{node.Id}}}");
 
         return "";
     }

--- a/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
+++ b/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
@@ -1,0 +1,45 @@
+using Calor.Compiler.Migration;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for fixes discovered during the C# to Calor conversion campaign.
+/// </summary>
+public class ConversionCampaignFixTests
+{
+    private readonly CSharpToCalorConverter _converter = new();
+
+    #region Issue 302: Emit §MT instead of §SIG for interface method signatures
+
+    [Fact]
+    public void Convert_InterfaceMethod_EmitsMTNotSIG()
+    {
+        var result = _converter.Convert(@"
+public interface IAnimal
+{
+    string Speak();
+}");
+        Assert.True(result.Success, string.Join("\n", result.Issues));
+        Assert.Contains("§MT{", result.CalorSource);
+        Assert.Contains("§/MT{", result.CalorSource);
+        Assert.DoesNotContain("§SIG", result.CalorSource);
+    }
+
+    [Fact]
+    public void Convert_InterfaceMethodWithParams_EmitsMTWithParams()
+    {
+        var result = _converter.Convert(@"
+public interface ICalculator
+{
+    int Add(int a, int b);
+}");
+        Assert.True(result.Success, string.Join("\n", result.Issues));
+        Assert.Contains("§MT{", result.CalorSource);
+        Assert.Contains("§I{", result.CalorSource);
+        Assert.Contains("§O{", result.CalorSource);
+        Assert.DoesNotContain("§SIG", result.CalorSource);
+    }
+
+    #endregion
+}

--- a/tests/Calor.Compiler.Tests/Mcp/ConvertToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/ConvertToolTests.cs
@@ -115,10 +115,9 @@ public class ConvertToolTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithInterface_ReportsParseValidationIssues()
+    public async Task ExecuteAsync_WithInterface_SucceedsWithMTTags()
     {
-        // Interface conversion generates §SIG tags that the parser doesn't yet recognize.
-        // Post-conversion validation (R5) now correctly reports this instead of false success.
+        // Interface conversion now generates §MT tags (not §SIG) which the parser recognizes.
         var args = JsonDocument.Parse("""
             {
                 "source": "public interface IService { void Process(); string GetValue(); }"
@@ -127,10 +126,9 @@ public class ConvertToolTests
 
         var result = await _tool.ExecuteAsync(args);
 
-        Assert.True(result.IsError);
+        Assert.False(result.IsError);
         var text = result.Content[0].Text!;
-        Assert.Contains("issues", text);
-        Assert.Contains("Generated Calor failed to parse", text);
+        Assert.Contains("success", text);
         Assert.Contains("interfacesConverted", text);
     }
 }


### PR DESCRIPTION
## Summary
- Changes CalorEmitter and CalorFormatter to emit `§MT`/`§/MT` block format instead of `§SIG` one-line format for interface method signatures
- Fixes parse validation failure when converting C# interfaces (the parser expects `§MT`, not `§SIG`)
- Updates existing ConvertToolTests to reflect that interface conversion now succeeds

Closes #302

## Test plan
- [x] New regression tests in ConversionCampaignFixTests.cs
- [x] Updated ConvertToolTests.ExecuteAsync_WithInterface_SucceedsWithMTTags
- [x] `dotnet test -c Release` passes (3,471 passed)
- [x] `calor_self_test` passes (10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)