### PR TITLE
fix: emit §FLD instead of §DICT/§LIST for collection fields

### DIFF
--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -270,7 +270,15 @@ public sealed class CalorEmitter : IAstVisitor<string>
     {
         var visibility = GetVisibilityShorthand(node.Visibility);
         var typeName = TypeMapper.CSharpToCalor(node.TypeName);
-        var defaultVal = node.DefaultValue != null ? $" = {node.DefaultValue.Accept(this)}" : "";
+        // For collection creation defaults (Dict/List/Set), emit "= default" instead of
+        // the full §DICT/§LIST/§SET block, since the type is already on the §FLD tag.
+        string defaultVal;
+        if (node.DefaultValue is DictionaryCreationNode or ListCreationNode or SetCreationNode)
+            defaultVal = " = default";
+        else if (node.DefaultValue != null)
+            defaultVal = $" = {node.DefaultValue.Accept(this)}";
+        else
+            defaultVal = "";
         var attrs = EmitCSharpAttributes(node.CSharpAttributes);
 
         var modifiers = new List<string>();

--- a/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
+++ b/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
@@ -1,0 +1,58 @@
+using Calor.Compiler.Migration;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for fixes discovered during the C# to Calor conversion campaign.
+/// </summary>
+public class ConversionCampaignFixTests
+{
+    private readonly CSharpToCalorConverter _converter = new();
+
+    #region Issue 303: Convert §DICT/§LIST to §FLD inside class bodies
+
+    [Fact]
+    public void Convert_DictionaryField_EmitsFLDNotDICT()
+    {
+        var result = _converter.Convert(@"
+public class Cache
+{
+    private Dictionary<string, int> _lookup = new();
+}");
+        Assert.True(result.Success, string.Join("\n", result.Issues));
+        Assert.Contains("§FLD{", result.CalorSource);
+        Assert.DoesNotContain("§DICT{", result.CalorSource);
+        Assert.DoesNotContain("§/DICT{", result.CalorSource);
+    }
+
+    [Fact]
+    public void Convert_ListField_EmitsFLDNotLIST()
+    {
+        var result = _converter.Convert(@"
+public class Service
+{
+    private List<string> _items = new();
+}");
+        Assert.True(result.Success, string.Join("\n", result.Issues));
+        Assert.Contains("§FLD{", result.CalorSource);
+        Assert.DoesNotContain("§LIST{", result.CalorSource);
+        Assert.DoesNotContain("§/LIST{", result.CalorSource);
+    }
+
+    [Fact]
+    public void Convert_ComplexDictionaryField_EmitsFLDNotDICT()
+    {
+        var result = _converter.Convert(@"
+public class Cache
+{
+    private readonly Dictionary<string, List<int>> _cache = new Dictionary<string, List<int>>();
+}");
+        Assert.True(result.Success, string.Join("\n", result.Issues));
+        Assert.Contains("§FLD{", result.CalorSource);
+        Assert.DoesNotContain("§DICT{", result.CalorSource);
+        Assert.DoesNotContain("§/DICT{", result.CalorSource);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- When a class field has a collection initializer (Dict/List/Set), the emitter now outputs `§FLD` with `= default` instead of emitting spurious `§DICT`/`§LIST` blocks alongside the `§FLD` tag
- Fixes parser rejection of converter output for classes with collection fields

Closes #303

## Test plan
- [x] New regression tests in ConversionCampaignFixTests.cs (3 tests)
- [x] `dotnet test -c Release` passes (3,472 passed)
- [x] `calor_self_test` passes (10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)