### PR TITLE
fix: convert tuple deconstruction to individual §ASSIGN statements

### DIFF
--- a/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
+++ b/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
@@ -1,0 +1,57 @@
+using Calor.Compiler.Migration;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for fixes discovered during the C# to Calor conversion campaign.
+/// </summary>
+public class ConversionCampaignFixTests
+{
+    private readonly CSharpToCalorConverter _converter = new();
+
+    #region Issue 304: Convert tuple deconstruction to individual §ASSIGN statements
+
+    [Fact]
+    public void Convert_TupleDeconstruction_EmitsIndividualAssignments()
+    {
+        var result = _converter.Convert(@"
+public class Example
+{
+    private int _a;
+    private int _b;
+
+    public void SetValues(int x, int y)
+    {
+        (_a, _b) = (x, y);
+    }
+}");
+        Assert.True(result.Success, string.Join("\n", result.Issues));
+        var source = result.CalorSource ?? "";
+        // Should have two §ASSIGN statements, not §ERR
+        Assert.DoesNotContain("§ERR", source);
+        Assert.Contains("§ASSIGN", source);
+    }
+
+    [Fact]
+    public void Convert_TupleDeconstruction_ThreeElements()
+    {
+        var result = _converter.Convert(@"
+public class Example
+{
+    private int _a;
+    private int _b;
+    private int _c;
+
+    public void SetValues(int x, int y, int z)
+    {
+        (_a, _b, _c) = (x, y, z);
+    }
+}");
+        Assert.True(result.Success, string.Join("\n", result.Issues));
+        var source = result.CalorSource ?? "";
+        Assert.DoesNotContain("§ERR", source);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Tuple deconstruction like `(_a, _b) = (x, y)` is now expanded to individual `§ASSIGN` statements instead of falling through to `§ERR`
- Handled in `ConvertBlock` using the same multi-statement expansion pattern as chained calls

Closes #304

## Test plan
- [x] New regression tests in ConversionCampaignFixTests.cs (2 tests)
- [x] `dotnet test -c Release` passes (3,471 passed)
- [x] No golden file changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)