### PR TITLE
fix: strip @ prefix from C# verbatim identifiers

### DIFF
--- a/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
+++ b/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
@@ -812,7 +812,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
 
             fields.Add(new ClassFieldNode(
                 GetTextSpan(variable),
-                variable.Identifier.Text,
+                variable.Identifier.ValueText,
                 typeName,
                 visibility,
                 modifiers,
@@ -843,7 +843,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             events.Add(new EventDefinitionNode(
                 GetTextSpan(variable),
                 id,
-                variable.Identifier.Text,
+                variable.Identifier.ValueText,
                 visibility,
                 delegateType,
                 new AttributeCollection()));
@@ -1403,17 +1403,17 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         foreach (var assignment in scope.DescendantNodes().OfType<AssignmentExpressionSyntax>())
         {
             if (assignment.Left is IdentifierNameSyntax id)
-                reassigned.Add(id.Identifier.Text);
+                reassigned.Add(id.Identifier.ValueText);
         }
         foreach (var unary in scope.DescendantNodes().OfType<PostfixUnaryExpressionSyntax>())
         {
             if (unary.Operand is IdentifierNameSyntax id)
-                reassigned.Add(id.Identifier.Text);
+                reassigned.Add(id.Identifier.ValueText);
         }
         foreach (var unary in scope.DescendantNodes().OfType<PrefixUnaryExpressionSyntax>())
         {
             if (unary.Operand is IdentifierNameSyntax id)
-                reassigned.Add(id.Identifier.Text);
+                reassigned.Add(id.Identifier.ValueText);
         }
         return reassigned;
     }
@@ -1423,7 +1423,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         _context.IncrementConverted();
 
         var variable = node.Declaration.Variables.First();
-        var name = variable.Identifier.Text;
+        var name = variable.Identifier.ValueText;
         var typeName = node.Declaration.Type.IsVar
             ? null
             : TypeMapper.CSharpToCalor(node.Declaration.Type.ToString());
@@ -1451,7 +1451,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         foreach (var variable in node.Declaration.Variables)
         {
             _context.IncrementConverted();
-            var name = variable.Identifier.Text;
+            var name = variable.Identifier.ValueText;
             var isMutable = _reassignedVariables.Contains(name);
             var initializer = variable.Initializer != null
                 ? ConvertExpression(variable.Initializer.Value)
@@ -1583,7 +1583,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         _context.RecordFeatureUsage("linq-method-chain");
 
         var variable = node.Declaration.Variables.First();
-        var finalName = variable.Identifier.Text;
+        var finalName = variable.Identifier.ValueText;
         var finalTypeName = node.Declaration.Type.IsVar
             ? null
             : TypeMapper.CSharpToCalor(node.Declaration.Type.ToString());
@@ -1987,7 +1987,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             if (node.Declaration.Variables.Count > 0)
             {
                 var variable = node.Declaration.Variables[0];
-                variableName = variable.Identifier.Text;
+                variableName = variable.Identifier.ValueText;
                 resource = variable.Initializer != null
                     ? ConvertExpression(variable.Initializer.Value)
                     : new ReferenceNode(GetTextSpan(variable), variableName);
@@ -2252,7 +2252,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         return expression switch
         {
             LiteralExpressionSyntax literal => ConvertLiteral(literal),
-            IdentifierNameSyntax identifier => new ReferenceNode(GetTextSpan(identifier), identifier.Identifier.Text),
+            IdentifierNameSyntax identifier => new ReferenceNode(GetTextSpan(identifier), identifier.Identifier.ValueText),
             BinaryExpressionSyntax binary => ConvertBinaryExpression(binary),
             PrefixUnaryExpressionSyntax prefix => ConvertPrefixUnaryExpression(prefix),
             PostfixUnaryExpressionSyntax postfix => ConvertPostfixUnaryExpression(postfix),
@@ -3639,7 +3639,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                 if (p.Modifiers.Any(SyntaxKind.ParamsKeyword)) modifier |= ParameterModifier.Params;
                 return new ParameterNode(
                     GetTextSpan(p),
-                    p.Identifier.Text,
+                    p.Identifier.ValueText,
                     TypeMapper.CSharpToCalor(p.Type?.ToString() ?? "any"),
                     modifier,
                     new AttributeCollection(),
@@ -3992,7 +3992,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             LiteralExpressionSyntax literal => literal.Token.Value ?? literal.Token.Text,
             TypeOfExpressionSyntax typeOf => new TypeOfReference(typeOf.Type.ToString()),
             MemberAccessExpressionSyntax memberAccess => new MemberAccessReference(memberAccess.ToString()),
-            IdentifierNameSyntax identifier => identifier.Identifier.Text,
+            IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
             _ => expression.ToString()
         };
     }

--- a/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
+++ b/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
@@ -1,0 +1,53 @@
+using Calor.Compiler.Migration;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for fixes discovered during the C# to Calor conversion campaign.
+/// </summary>
+public class ConversionCampaignFixTests
+{
+    private readonly CSharpToCalorConverter _converter = new();
+
+    #region Issue 309: Handle @-prefixed C# parameter names
+
+    [Fact]
+    public void Convert_AtPrefixedParam_StripsAtPrefix()
+    {
+        var result = _converter.Convert(@"
+public class Example
+{
+    public void Process(string @class, int @event)
+    {
+        var x = @class;
+    }
+}");
+        Assert.True(result.Success, string.Join("\n", result.Issues));
+        var source = result.CalorSource ?? "";
+        // Parameters should not have @ prefix in Calor
+        Assert.Contains("§I{str:class}", source);
+        Assert.Contains("§I{i32:event}", source);
+        Assert.DoesNotContain("@class", source);
+        Assert.DoesNotContain("@event", source);
+    }
+
+    [Fact]
+    public void Convert_AtPrefixedLocalVariable_StripsAtPrefix()
+    {
+        var result = _converter.Convert(@"
+public class Example
+{
+    public void Process()
+    {
+        var @object = 42;
+    }
+}");
+        Assert.True(result.Success, string.Join("\n", result.Issues));
+        var source = result.CalorSource ?? "";
+        Assert.Contains("object", source);
+        Assert.DoesNotContain("@object", source);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Uses `Identifier.ValueText` instead of `Identifier.Text` for parameters, variables, fields, and references
- Strips the `@` prefix that C# uses for keyword-as-identifier (e.g., `@class` → `class`, `@event` → `event`)

Closes #309

## Test plan
- [x] New regression tests in ConversionCampaignFixTests.cs (2 tests)
- [x] `dotnet test -c Release` passes (3,471 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)