### PR TITLE
fix: decimal type bind attribute parsing (#293)

### DIFF
--- a/src/Calor.Compiler/Parsing/AttributeHelper.cs
+++ b/src/Calor.Compiler/Parsing/AttributeHelper.cs
@@ -169,8 +169,8 @@ public static class AttributeHelper
         {
             "i8" or "i16" or "i32" or "i64" => true,
             "u8" or "u16" or "u32" or "u64" => true,
-            "f32" or "f64" => true,
-            "int" or "float" or "str" or "string" or "bool" or "void" or "char" or "var" => true,
+            "f32" or "f64" or "dec" or "decimal" => true,
+            "int" or "float" or "double" or "str" or "string" or "bool" or "void" or "char" or "var" => true,
             _ => value.StartsWith('?') || value.Contains('!') || value.Contains('<')
                  || IsLikelyPascalCaseType(value)
         };

--- a/tests/Calor.Enforcement.Tests/EffectEnforcementTests.cs
+++ b/tests/Calor.Enforcement.Tests/EffectEnforcementTests.cs
@@ -123,6 +123,27 @@ public class EffectEnforcementTests
     }
 
     [Fact]
+    public void DecimalType_BindAndReturn_CompilesCorrectly()
+    {
+        // §B{dec:x} should be parsed as type=decimal, name=x (not name=dec, type=x)
+        var source = @"
+§M{m001:Test}
+§F{f001:GetDecimal:pub}
+  §O{dec}
+  §B{dec:x} 3.14m
+  §R x
+§/F{f001}
+§/M{m001}
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.False(result.HasErrors,
+            $"Decimal bind should compile. Errors: {string.Join("; ", result.Diagnostics.Errors.Select(e => e.Message))}");
+        Assert.Contains("decimal x = 3.14m", result.GeneratedCode);
+        Assert.Contains("decimal GetDecimal()", result.GeneratedCode);
+    }
+
+    [Fact]
     public void PureFunction_WithNoEffects_Compiles()
     {
         var source = @"


### PR DESCRIPTION
## Summary
- Adds `dec`, `decimal`, and `double` to `IsLikelyType` in `AttributeHelper.cs`
- Fixes `§B{dec:x}` being parsed as name=dec, type=x (swapped) instead of type=decimal, name=x
- This caused C# emission like `x dec = 3.14m` instead of `decimal x = 3.14m`

## Root cause
`IsLikelyType` had `f32`/`f64`/`float` but was missing `dec`/`decimal`/`double`, so the bind attribute format detector couldn't distinguish `{type:name}` from `{name:type}` for these types.

## Test plan
- [x] New test verifying `§B{dec:x} 3.14m` emits `decimal x = 3.14m`
- [x] All 4,406 tests pass (0 failures)
- [x] All 10 self-test golden file scenarios pass

Fixes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)