### PR TITLE
fix: break Calor0100 into specific error codes

### DIFF
--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -34,6 +34,14 @@ public static class DiagnosticCode
     public const string InvalidOperator = "Calor0106";
     public const string InvalidModifier = "Calor0107";
 
+    // Parser validation errors (Calor0110-0119)
+    public const string OperatorArgumentCount = "Calor0110";
+    public const string InvalidComparisonMode = "Calor0111";
+    public const string InvalidCharLiteral = "Calor0112";
+    public const string ExpectedTypeName = "Calor0113";
+    public const string InvalidLispExpression = "Calor0114";
+    public const string TypeParameterNotFound = "Calor0115";
+
     // Semantic errors (Calor0200-0299)
     public const string UndefinedReference = "Calor0200";
     public const string DuplicateDefinition = "Calor0201";

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -1294,7 +1294,7 @@ public sealed class Parser
         }
         if (opText == "??")
         {
-            _diagnostics.ReportError(span, DiagnosticCode.UnexpectedToken,
+            _diagnostics.ReportError(span, DiagnosticCode.OperatorArgumentCount,
                 $"Null-coalescing '??' requires exactly 2 operands, got {args.Count}");
             return args.Count > 0 ? args[0] : new IntLiteralNode(span, 0);
         }
@@ -1331,7 +1331,7 @@ public sealed class Parser
             if (binaryOp.HasValue)
             {
                 // This is likely an error - binary op with only one argument
-                _diagnostics.ReportError(span, DiagnosticCode.UnexpectedToken,
+                _diagnostics.ReportError(span, DiagnosticCode.OperatorArgumentCount,
                     $"Binary operator '{opText}' requires at least two operands");
                 return args[0];
             }
@@ -1360,12 +1360,12 @@ public sealed class Parser
                 comparisonMode = StringComparisonModeExtensions.FromKeyword(keywordArg.Name);
                 if (comparisonMode == null)
                 {
-                    _diagnostics.ReportError(keywordArg.Span, DiagnosticCode.UnexpectedToken,
+                    _diagnostics.ReportError(keywordArg.Span, DiagnosticCode.InvalidComparisonMode,
                         $"Unknown comparison mode ':{keywordArg.Name}'. Valid modes: ordinal, ignore-case, invariant, invariant-ignore-case");
                 }
                 else if (!StringOperationNode.SupportsComparisonMode(stringOp.Value))
                 {
-                    _diagnostics.ReportError(keywordArg.Span, DiagnosticCode.UnexpectedToken,
+                    _diagnostics.ReportError(keywordArg.Span, DiagnosticCode.InvalidComparisonMode,
                         $"Operation '{opText}' does not support comparison modes");
                     comparisonMode = null;
                 }
@@ -1396,13 +1396,13 @@ public sealed class Parser
             if (nonKeywordArgs.Count < minArgs)
             {
                 var example = OperatorSuggestions.GetStringOpExample(opText);
-                _diagnostics.ReportError(span, DiagnosticCode.UnexpectedToken,
+                _diagnostics.ReportError(span, DiagnosticCode.OperatorArgumentCount,
                     $"String operation '{opText}' requires at least {minArgs} argument(s), got {nonKeywordArgs.Count}. Example: {example}");
             }
             else if (nonKeywordArgs.Count > maxArgs)
             {
                 var example = OperatorSuggestions.GetStringOpExample(opText);
-                _diagnostics.ReportError(span, DiagnosticCode.UnexpectedToken,
+                _diagnostics.ReportError(span, DiagnosticCode.OperatorArgumentCount,
                     $"String operation '{opText}' accepts at most {maxArgs} argument(s), got {nonKeywordArgs.Count}. Example: {example}");
             }
 
@@ -1419,13 +1419,13 @@ public sealed class Parser
             if (args.Count < minArgs)
             {
                 var example = OperatorSuggestions.GetCharOpExample(opText);
-                _diagnostics.ReportError(span, DiagnosticCode.UnexpectedToken,
+                _diagnostics.ReportError(span, DiagnosticCode.OperatorArgumentCount,
                     $"Char operation '{opText}' requires at least {minArgs} argument(s), got {args.Count}. Example: {example}");
             }
             else if (args.Count > maxArgs)
             {
                 var example = OperatorSuggestions.GetCharOpExample(opText);
-                _diagnostics.ReportError(span, DiagnosticCode.UnexpectedToken,
+                _diagnostics.ReportError(span, DiagnosticCode.OperatorArgumentCount,
                     $"Char operation '{opText}' accepts at most {maxArgs} argument(s), got {args.Count}. Example: {example}");
             }
 
@@ -1438,13 +1438,13 @@ public sealed class Parser
                     // so a single character is always length 1
                     if (strLit.Value.Length != 1)
                     {
-                        _diagnostics.ReportError(span, DiagnosticCode.UnexpectedToken,
+                        _diagnostics.ReportError(span, DiagnosticCode.InvalidCharLiteral,
                             $"char-lit requires a single character, got \"{strLit.Value}\" ({strLit.Value.Length} characters). Example: (char-lit \"Y\")");
                     }
                 }
                 else
                 {
-                    _diagnostics.ReportError(span, DiagnosticCode.UnexpectedToken,
+                    _diagnostics.ReportError(span, DiagnosticCode.InvalidCharLiteral,
                         "char-lit requires a string literal argument. Example: (char-lit \"Y\")");
                 }
             }
@@ -1462,13 +1462,13 @@ public sealed class Parser
             if (args.Count < minArgs)
             {
                 var example = OperatorSuggestions.GetStringBuilderOpExample(opText);
-                _diagnostics.ReportError(span, DiagnosticCode.UnexpectedToken,
+                _diagnostics.ReportError(span, DiagnosticCode.OperatorArgumentCount,
                     $"StringBuilder operation '{opText}' requires at least {minArgs} argument(s), got {args.Count}. Example: {example}");
             }
             else if (args.Count > maxArgs)
             {
                 var example = OperatorSuggestions.GetStringBuilderOpExample(opText);
-                _diagnostics.ReportError(span, DiagnosticCode.UnexpectedToken,
+                _diagnostics.ReportError(span, DiagnosticCode.OperatorArgumentCount,
                     $"StringBuilder operation '{opText}' accepts at most {maxArgs} argument(s), got {args.Count}. Example: {example}");
             }
 
@@ -1482,7 +1482,7 @@ public sealed class Parser
             if (args.Count != 2)
             {
                 var example = OperatorSuggestions.GetTypeOpExample(opText);
-                _diagnostics.ReportError(span, DiagnosticCode.UnexpectedToken,
+                _diagnostics.ReportError(span, DiagnosticCode.OperatorArgumentCount,
                     $"Type operation '{opText}' requires exactly 2 arguments, got {args.Count}. Example: {example}");
                 return args.Count > 0 ? args[0] : new IntLiteralNode(span, 0);
             }
@@ -1497,7 +1497,7 @@ public sealed class Parser
             // Type argument must be a simple identifier (ReferenceNode)
             if (typeArg is not ReferenceNode typeRef)
             {
-                _diagnostics.ReportError(typeArg.Span, DiagnosticCode.UnexpectedToken,
+                _diagnostics.ReportError(typeArg.Span, DiagnosticCode.ExpectedTypeName,
                     $"Expected a type name, got {typeArg.GetType().Name}");
                 return operandArg;
             }
@@ -1664,7 +1664,7 @@ public sealed class Parser
                         "Unexpected closing parenthesis. Check parentheses balance.",
                     _ => $"Valid operators: {OperatorSuggestions.GetOperatorCategories()}"
                 };
-                _diagnostics.ReportError(span, DiagnosticCode.UnexpectedToken,
+                _diagnostics.ReportError(span, DiagnosticCode.InvalidLispExpression,
                     $"Expected operator in Lisp expression, found '{token.Text}'. {hint}");
                 Advance();
                 return (token.Kind, text, span);
@@ -1775,7 +1775,7 @@ public sealed class Parser
                 return new KeywordArgNode(span, keywordName);
             }
             // Standalone colon - error
-            _diagnostics.ReportError(colonToken.Span, DiagnosticCode.UnexpectedToken,
+            _diagnostics.ReportError(colonToken.Span, DiagnosticCode.InvalidLispExpression,
                 "Expected identifier after ':' for keyword argument");
             return new IntLiteralNode(colonToken.Span, 0);
         }
@@ -1839,7 +1839,7 @@ public sealed class Parser
                         "Unexpected closing parenthesis. Check expression structure.",
                     _ => "Expected a value (number, string, variable) or nested expression"
                 };
-                _diagnostics.ReportError(Current.Span, DiagnosticCode.UnexpectedToken,
+                _diagnostics.ReportError(Current.Span, DiagnosticCode.InvalidLispExpression,
                     $"Unexpected token '{Current.Text}' in expression argument. {hint}");
                 Advance();
                 expr = new IntLiteralNode(Current.Span, 0); // Recovery: return dummy value
@@ -1906,7 +1906,7 @@ public sealed class Parser
     {
         if (!Check(TokenKind.Identifier))
         {
-            _diagnostics.ReportError(Current.Span, DiagnosticCode.UnexpectedToken,
+            _diagnostics.ReportError(Current.Span, DiagnosticCode.ExpectedTypeName,
                 $"Expected type name, found '{Current.Text}'");
             return "object";
         }
@@ -2630,7 +2630,7 @@ public sealed class Parser
         // Expect arrow and then expression
         if (!Check(TokenKind.Arrow))
         {
-            _diagnostics.ReportError(Current.Span, "Calor0100", "Expected '→' after IF condition in expression context");
+            _diagnostics.ReportError(Current.Span, DiagnosticCode.ExpectedExpression, "Expected '→' after IF condition in expression context");
             return new IntLiteralNode(startToken.Span, 0);
         }
         Advance(); // consume →
@@ -4311,7 +4311,7 @@ public sealed class Parser
         var typeParamIndex = typeParameters.FindIndex(tp => tp.Name == typeParamName);
         if (typeParamIndex < 0)
         {
-            _diagnostics.ReportError(startToken.Span, DiagnosticCode.UnexpectedToken,
+            _diagnostics.ReportError(startToken.Span, DiagnosticCode.TypeParameterNotFound,
                 $"Type parameter '{typeParamName}' not found");
             return;
         }

--- a/tests/Calor.Compiler.Tests/DiagnosticCodeClassificationTests.cs
+++ b/tests/Calor.Compiler.Tests/DiagnosticCodeClassificationTests.cs
@@ -1,0 +1,312 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests verifying that specific parser errors produce the correct diagnostic codes
+/// instead of the catch-all Calor0100 (UnexpectedToken).
+/// </summary>
+public class DiagnosticCodeClassificationTests
+{
+    private static ModuleNode Parse(string source, out DiagnosticBag diagnostics)
+    {
+        diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+        return parser.Parse();
+    }
+
+    private static string WrapInFunction(string body, string inputType = "string", string outputType = "object")
+    {
+        return $$"""
+            §M{m001:Test}
+            §F{f001:Main:pub}
+              §I{{{inputType}}:x}
+              §O{{{outputType}}}
+              {{body}}
+            §/F{f001}
+            §/M{m001}
+            """;
+    }
+
+    #region Calor0110 — OperatorArgumentCount
+
+    [Fact]
+    public void NullCoalescing_WrongOperandCount_ProducesCalor0110()
+    {
+        var source = WrapInFunction("§R (?? a b c)", inputType: "object");
+        Parse(source, out var diagnostics);
+
+        var error = Assert.Single(diagnostics.Errors, d => d.Code == DiagnosticCode.OperatorArgumentCount);
+        Assert.Contains("??", error.Message);
+    }
+
+    [Fact]
+    public void BinaryOperator_OneOperand_ProducesCalor0110()
+    {
+        var source = WrapInFunction("§R (+ a)", inputType: "int", outputType: "int");
+        Parse(source, out var diagnostics);
+
+        var error = Assert.Single(diagnostics.Errors, d => d.Code == DiagnosticCode.OperatorArgumentCount);
+        Assert.Contains("Binary operator", error.Message);
+    }
+
+    [Fact]
+    public void StringOp_TooFewArgs_ProducesCalor0110()
+    {
+        // contains requires 2 args (string + substring)
+        var source = WrapInFunction("§R (contains x)");
+        Parse(source, out var diagnostics);
+
+        var error = Assert.Single(diagnostics.Errors, d => d.Code == DiagnosticCode.OperatorArgumentCount);
+        Assert.Contains("String operation", error.Message);
+    }
+
+    [Fact]
+    public void CharOp_TooFewArgs_ProducesCalor0110()
+    {
+        // char-at requires 2 args (string + index)
+        var source = WrapInFunction("§R (char-at x)");
+        Parse(source, out var diagnostics);
+
+        var error = Assert.Single(diagnostics.Errors, d => d.Code == DiagnosticCode.OperatorArgumentCount);
+        Assert.Contains("Char operation", error.Message);
+    }
+
+    [Fact]
+    public void StringBuilderOp_TooFewArgs_ProducesCalor0110()
+    {
+        // sb-append requires 2 args
+        var source = WrapInFunction("§R (sb-append x)", inputType: "StringBuilder", outputType: "object");
+        Parse(source, out var diagnostics);
+
+        var error = Assert.Single(diagnostics.Errors, d => d.Code == DiagnosticCode.OperatorArgumentCount);
+        Assert.Contains("StringBuilder operation", error.Message);
+    }
+
+    [Fact]
+    public void TypeOp_WrongArgCount_ProducesCalor0110()
+    {
+        // cast requires exactly 2 args
+        var source = WrapInFunction("§R (cast x)", inputType: "object");
+        Parse(source, out var diagnostics);
+
+        var error = Assert.Single(diagnostics.Errors, d => d.Code == DiagnosticCode.OperatorArgumentCount);
+        Assert.Contains("Type operation", error.Message);
+    }
+
+    [Fact]
+    public void StringOp_TooManyArgs_ProducesCalor0110()
+    {
+        // contains accepts at most 2 args
+        var source = WrapInFunction("""§R (contains x "a" "b" "c")""");
+        Parse(source, out var diagnostics);
+
+        var error = Assert.Single(diagnostics.Errors, d => d.Code == DiagnosticCode.OperatorArgumentCount);
+        Assert.Contains("at most", error.Message);
+    }
+
+    [Fact]
+    public void CharOp_TooManyArgs_ProducesCalor0110()
+    {
+        // char-at accepts at most 2 args
+        var source = WrapInFunction("§R (char-at x 0 1)");
+        Parse(source, out var diagnostics);
+
+        var error = Assert.Single(diagnostics.Errors, d => d.Code == DiagnosticCode.OperatorArgumentCount);
+        Assert.Contains("at most", error.Message);
+    }
+
+    [Fact]
+    public void StringBuilderOp_TooManyArgs_ProducesCalor0110()
+    {
+        // sb-append accepts at most 2 args
+        var source = WrapInFunction("""§R (sb-append x "a" "b")""", inputType: "StringBuilder", outputType: "object");
+        Parse(source, out var diagnostics);
+
+        var error = Assert.Single(diagnostics.Errors, d => d.Code == DiagnosticCode.OperatorArgumentCount);
+        Assert.Contains("at most", error.Message);
+    }
+
+    #endregion
+
+    #region Calor0111 — InvalidComparisonMode
+
+    [Fact]
+    public void UnknownComparisonMode_ProducesCalor0111()
+    {
+        var source = WrapInFunction("§R (contains x \"a\" :bogus)");
+        Parse(source, out var diagnostics);
+
+        var error = Assert.Single(diagnostics.Errors, d => d.Code == DiagnosticCode.InvalidComparisonMode);
+        Assert.Contains("Unknown comparison mode", error.Message);
+    }
+
+    [Fact]
+    public void UnsupportedComparisonMode_ProducesCalor0111()
+    {
+        // len does not support comparison modes
+        var source = WrapInFunction("§R (len x :ordinal)");
+        Parse(source, out var diagnostics);
+
+        var error = Assert.Single(diagnostics.Errors, d => d.Code == DiagnosticCode.InvalidComparisonMode);
+        Assert.Contains("does not support comparison modes", error.Message);
+    }
+
+    #endregion
+
+    #region Calor0112 — InvalidCharLiteral
+
+    [Fact]
+    public void CharLit_MultiCharString_ProducesCalor0112()
+    {
+        var source = WrapInFunction("""§R (char-lit "AB")""");
+        Parse(source, out var diagnostics);
+
+        var error = Assert.Single(diagnostics.Errors, d => d.Code == DiagnosticCode.InvalidCharLiteral);
+        Assert.Contains("single character", error.Message);
+    }
+
+    [Fact]
+    public void CharLit_NonStringArg_ProducesCalor0112()
+    {
+        var source = WrapInFunction("§R (char-lit 42)", inputType: "int");
+        Parse(source, out var diagnostics);
+
+        var error = Assert.Single(diagnostics.Errors, d => d.Code == DiagnosticCode.InvalidCharLiteral);
+        Assert.Contains("string literal argument", error.Message);
+    }
+
+    #endregion
+
+    #region Calor0113 — ExpectedTypeName
+
+    [Fact]
+    public void TypeOp_NonIdentifierTypeArg_ProducesCalor0113()
+    {
+        // (cast 42 x) — 42 is not a type name
+        var source = WrapInFunction("§R (cast 42 x)", inputType: "object");
+        Parse(source, out var diagnostics);
+
+        var error = Assert.Single(diagnostics.Errors, d => d.Code == DiagnosticCode.ExpectedTypeName);
+        Assert.Contains("Expected a type name", error.Message);
+    }
+
+    [Fact]
+    public void TypeOf_NonIdentifierArg_ProducesCalor0113()
+    {
+        // (typeof 42) — 42 is not a type name, triggers ParseLispTypeName path
+        var source = WrapInFunction("§R (typeof 42)", inputType: "object");
+        Parse(source, out var diagnostics);
+
+        Assert.Contains(diagnostics.Errors, d => d.Code == DiagnosticCode.ExpectedTypeName);
+    }
+
+    #endregion
+
+    #region Calor0114 — InvalidLispExpression
+
+    [Fact]
+    public void InvalidOperatorInLispExpression_ProducesCalor0114()
+    {
+        // Use a literal where an operator is expected
+        var source = WrapInFunction("§R (42 x)", inputType: "int", outputType: "int");
+        Parse(source, out var diagnostics);
+
+        var error = Assert.Single(diagnostics.Errors, d => d.Code == DiagnosticCode.InvalidLispExpression);
+        Assert.Contains("Expected operator in Lisp expression", error.Message);
+    }
+
+    [Fact]
+    public void StandaloneColon_ProducesCalor0114()
+    {
+        // A colon followed by a non-identifier (close paren) inside a lisp expression
+        var source = WrapInFunction("§R (+ 1 :)");
+        Parse(source, out var diagnostics);
+
+        Assert.Contains(diagnostics.Errors, d => d.Code == DiagnosticCode.InvalidLispExpression);
+    }
+
+    [Fact]
+    public void OperatorInValuePosition_ProducesCalor0114()
+    {
+        // An operator token (==) where a value argument is expected
+        var source = WrapInFunction("§R (+ 1 ==)");
+        Parse(source, out var diagnostics);
+
+        Assert.Contains(diagnostics.Errors, d => d.Code == DiagnosticCode.InvalidLispExpression);
+    }
+
+    #endregion
+
+    #region Calor0115 — TypeParameterNotFound
+
+    [Fact]
+    public void WhereClause_UnknownTypeParam_ProducesCalor0115()
+    {
+        var source = """
+            §M{m001:Test}
+            §CL{c001:MyClass:pub}<T>
+              §WHERE U : class
+              §FLD{T:_item:pri}
+            §/CL{c001}
+            §/M{m001}
+            """;
+        Parse(source, out var diagnostics);
+
+        var error = Assert.Single(diagnostics.Errors, d => d.Code == DiagnosticCode.TypeParameterNotFound);
+        Assert.Contains("U", error.Message);
+        Assert.Contains("not found", error.Message);
+    }
+
+    #endregion
+
+    #region Calor0104 — ExpectedExpression (reclassified from hardcoded "Calor0100")
+
+    [Fact]
+    public void IfExpression_MissingArrow_ProducesCalor0104()
+    {
+        // IF condition without → should produce ExpectedExpression
+        var source = WrapInFunction("§R §IF{i001} true §/I{i001}", inputType: "bool", outputType: "int");
+        Parse(source, out var diagnostics);
+
+        Assert.Contains(diagnostics.Errors, d => d.Code == DiagnosticCode.ExpectedExpression);
+    }
+
+    #endregion
+
+    #region Verify Calor0100 is NOT produced for reclassified errors
+
+    [Fact]
+    public void OperatorArgCountErrors_DoNotProduceCalor0100()
+    {
+        var source = WrapInFunction("§R (?? a b c)", inputType: "object");
+        Parse(source, out var diagnostics);
+
+        Assert.DoesNotContain(diagnostics.Errors, d => d.Code == DiagnosticCode.UnexpectedToken);
+    }
+
+    [Fact]
+    public void ComparisonModeErrors_DoNotProduceCalor0100()
+    {
+        var source = WrapInFunction("§R (contains x \"a\" :bogus)");
+        Parse(source, out var diagnostics);
+
+        Assert.DoesNotContain(diagnostics.Errors, d => d.Code == DiagnosticCode.UnexpectedToken);
+    }
+
+    [Fact]
+    public void CharLitErrors_DoNotProduceCalor0100()
+    {
+        var source = WrapInFunction("""§R (char-lit "AB")""");
+        Parse(source, out var diagnostics);
+
+        Assert.DoesNotContain(diagnostics.Errors, d => d.Code == DiagnosticCode.UnexpectedToken);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Splits 20 misclassified `Calor0100` (UnexpectedToken) call sites into 6 new specific diagnostic codes: `Calor0110`–`Calor0115`
- Fixes a hardcoded `"Calor0100"` string that should be `Calor0104` (ExpectedExpression)
- Keeps the 13 genuine `ReportUnexpectedToken` calls as `Calor0100`
- Adds 23 tests verifying each new code is produced for the right scenario

## New Diagnostic Codes

| Code | Name | Sites | Description |
|------|------|-------|-------------|
| Calor0110 | OperatorArgumentCount | 9 | Wrong arg count for operators (string, char, StringBuilder, type, binary, null-coalescing) |
| Calor0111 | InvalidComparisonMode | 2 | Unknown or unsupported string comparison mode |
| Calor0112 | InvalidCharLiteral | 2 | char-lit with non-single character or non-string argument |
| Calor0113 | ExpectedTypeName | 2 | Expected type name but found something else |
| Calor0114 | InvalidLispExpression | 3 | Invalid operator/token in Lisp expression |
| Calor0115 | TypeParameterNotFound | 1 | Referenced type parameter doesn't exist |

## Test plan
- [x] 23 new classification tests pass (`DiagnosticCodeClassificationTests`)
- [x] Full test suite passes (3,532 passed, 0 failures)
- [x] No remaining direct `DiagnosticCode.UnexpectedToken` uses in Parser.cs
- [x] Exactly 13 genuine `ReportUnexpectedToken` calls remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)