### PR TITLE
fix: split Calor0001 into distinct diagnostic codes

### DIFF
--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -23,6 +23,8 @@ public static class DiagnosticCode
     public const string InvalidTypedLiteral = "Calor0003";
     public const string InvalidEscapeSequence = "Calor0004";
     public const string UnterminatedRawBlock = "Calor0005";
+    public const string UnknownSectionMarker = "Calor0006";
+    public const string InvalidSectionOperator = "Calor0007";
 
     // Parser errors (Calor0100-0199)
     public const string UnexpectedToken = "Calor0100";

--- a/src/Calor.Compiler/Diagnostics/DiagnosticFormatter.cs
+++ b/src/Calor.Compiler/Diagnostics/DiagnosticFormatter.cs
@@ -391,6 +391,8 @@ public sealed class SarifDiagnosticFormatter : IDiagnosticFormatter
     private static string GetRuleDescription(string code) => code switch
     {
         DiagnosticCode.UnexpectedCharacter => "Unexpected character in source",
+        DiagnosticCode.UnknownSectionMarker => "Unknown section marker",
+        DiagnosticCode.InvalidSectionOperator => "Invalid section operator",
         DiagnosticCode.UnterminatedString => "Unterminated string literal",
         DiagnosticCode.UnexpectedToken => "Unexpected token",
         DiagnosticCode.MismatchedId => "Mismatched construct IDs",

--- a/src/Calor.Compiler/Parsing/Lexer.cs
+++ b/src/Calor.Compiler/Parsing/Lexer.cs
@@ -614,7 +614,8 @@ public sealed class Lexer
                 return MakeToken(TokenKind.NullConditional);
             }
             // Unknown §? pattern - report error
-            _diagnostics.ReportUnexpectedCharacter(CurrentSpan(), '?');
+            _diagnostics.ReportError(CurrentSpan(), Diagnostics.DiagnosticCode.InvalidSectionOperator,
+                "Invalid section operator '§?'. Expected '§??' (null-coalesce) or '§?.' (null-conditional).");
             return MakeToken(TokenKind.Error);
         }
 
@@ -695,7 +696,7 @@ public sealed class Lexer
         // Special case: §CAST is a common mistake — casting uses Lisp syntax
         if (keyword.Equals("CAST", StringComparison.OrdinalIgnoreCase))
         {
-            _diagnostics.ReportError(CurrentSpan(), Diagnostics.DiagnosticCode.UnexpectedCharacter,
+            _diagnostics.ReportError(CurrentSpan(), Diagnostics.DiagnosticCode.UnknownSectionMarker,
                 $"Unknown section marker '§{keyword}'. Calor uses Lisp syntax for casts: " +
                 $"(cast TargetType expr). Example: (cast i32 myFloat)");
             return;
@@ -710,12 +711,12 @@ public sealed class Lexer
                 suggestion.TrimStart('/'), out var desc)
                 ? $" ({desc})"
                 : "";
-            _diagnostics.ReportError(CurrentSpan(), Diagnostics.DiagnosticCode.UnexpectedCharacter,
+            _diagnostics.ReportError(CurrentSpan(), Diagnostics.DiagnosticCode.UnknownSectionMarker,
                 $"Unknown section marker '§{keyword}'. Did you mean '§{suggestion}'{description}?");
         }
         else
         {
-            _diagnostics.ReportError(CurrentSpan(), Diagnostics.DiagnosticCode.UnexpectedCharacter,
+            _diagnostics.ReportError(CurrentSpan(), Diagnostics.DiagnosticCode.UnknownSectionMarker,
                 $"Unknown section marker '§{keyword}'. Common markers: {SectionMarkerSuggestions.GetCommonMarkers()}");
         }
     }

--- a/tests/Calor.Compiler.Tests/Diagnostics/SuggestionTests.cs
+++ b/tests/Calor.Compiler.Tests/Diagnostics/SuggestionTests.cs
@@ -265,6 +265,58 @@ public class SuggestionTests
         Assert.Contains("(cast", error.Message);
     }
 
+    [Fact]
+    public void Lexer_UnknownSectionMarker_EmitsCalor0006()
+    {
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer("§UNKNOWN", diagnostics);
+        lexer.TokenizeAll();
+
+        Assert.True(diagnostics.HasErrors);
+        var error = diagnostics.First(d => d.IsError);
+        Assert.Equal(DiagnosticCode.UnknownSectionMarker, error.Code);
+    }
+
+    [Fact]
+    public void Lexer_CastSectionMarker_EmitsCalor0006()
+    {
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer("§CAST", diagnostics);
+        lexer.TokenizeAll();
+
+        Assert.True(diagnostics.HasErrors);
+        var error = diagnostics.First(d => d.IsError);
+        Assert.Equal(DiagnosticCode.UnknownSectionMarker, error.Code);
+    }
+
+    [Fact]
+    public void Lexer_InvalidSectionOperator_EmitsCalor0007()
+    {
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer("§?X", diagnostics);
+        lexer.TokenizeAll();
+
+        Assert.True(diagnostics.HasErrors);
+        var error = diagnostics.First(d => d.IsError);
+        Assert.Equal(DiagnosticCode.InvalidSectionOperator, error.Code);
+        Assert.Contains("§?", error.Message);
+        Assert.Contains("§??", error.Message);
+        Assert.Contains("§?.", error.Message);
+    }
+
+    [Fact]
+    public void Lexer_TrulyUnexpectedCharacter_StillEmitsCalor0001()
+    {
+        var diagnostics = new DiagnosticBag();
+        // Use a character that isn't handled by any lexer branch
+        var lexer = new Lexer("©", diagnostics);
+        lexer.TokenizeAll();
+
+        Assert.True(diagnostics.HasErrors);
+        var error = diagnostics.First(d => d.IsError);
+        Assert.Equal(DiagnosticCode.UnexpectedCharacter, error.Code);
+    }
+
     #endregion
 
     #region Fix Generation Tests


### PR DESCRIPTION
## Summary

- Split the catch-all `Calor0001` (`UnexpectedCharacter`) into 3 distinct diagnostic codes so each failure category can be tracked and triaged independently
- `Calor0001` remains for truly unexpected characters (e.g., `©` in code)
- `Calor0006` (`UnknownSectionMarker`) for unknown `§` markers like `§CAST`, `§FUNC`, `§XYZQWERTY`
- `Calor0007` (`InvalidSectionOperator`) for invalid `§?X` patterns (expected `§??` or `§?.`)

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — all 4,217 tests pass, 0 failures
- [x] New test: `§UNKNOWN` emits `Calor0006`
- [x] New test: `§CAST` emits `Calor0006`
- [x] New test: `§?X` emits `Calor0007`
- [x] New test: `©` still emits `Calor0001`

🤖 Generated with [Claude Code](https://claude.com/claude-code)