### PR TITLE
Handle PredefinedTypeSyntax for string.Empty, int.MaxValue

### DIFF
--- a/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
+++ b/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
@@ -668,4 +668,43 @@ public class Example
     }
 
     #endregion
+
+    #region Issue 374: int.MaxValue / primitive type static members
+
+    [Fact]
+    public void Convert_IntMaxValue_EmitsLiteral()
+    {
+        var csharp = @"
+class Test
+{
+    int GetMax()
+    {
+        return int.MaxValue;
+    }
+}";
+        var result = _converter.Convert(csharp, "test");
+        var calor = result.CalorSource;
+
+        Assert.DoesNotContain("§ERR", calor);
+        Assert.Contains("2147483647", calor);
+    }
+
+    [Fact]
+    public void Convert_StringEmpty_NoError()
+    {
+        var csharp = @"
+class Test
+{
+    string GetEmpty()
+    {
+        return string.Empty;
+    }
+}";
+        var result = _converter.Convert(csharp, "test");
+        var calor = result.CalorSource;
+
+        Assert.DoesNotContain("§ERR", calor);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- `string.Empty` no longer produces `§ERR` — now correctly resolved to `""`
- `int.MaxValue`, `int.MinValue`, `byte.MaxValue/MinValue`, `short.MaxValue/MinValue` now emit literal constants
- `PredefinedTypeSyntax` (C# keyword types used as expressions) added to the expression conversion switch

## Root cause
When `string.Empty` was encountered, `string` (a `PredefinedTypeSyntax`) fell through to `CreateFallbackExpression` → `§ERR`. The existing `string.Empty` handler at line 2974 never matched because the target was already an ERR node.

## Test plan
- [x] 2 new tests (int.MaxValue, string.Empty)
- [x] Full test suite passes (3511 + 386 = 3897)
- [x] Self-test passes

Fixes #374, fixes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)