### PR TITLE
fix: declaration patterns, out var, and method groups

### DIFF
--- a/src/Calor.Compiler/Migration/FeatureSupport.cs
+++ b/src/Calor.Compiler/Migration/FeatureSupport.cs
@@ -437,9 +437,9 @@ public static class FeatureSupport
         ["out-var"] = new FeatureInfo
         {
             Name = "out-var",
-            Support = SupportLevel.NotSupported,
-            Description = "Inline out variable declarations (out var x) are not supported",
-            Workaround = "Declare the variable before the method call"
+            Support = SupportLevel.Full,
+            Description = "Inline out variable declarations (out var x) are pre-declared as bindings",
+            Workaround = null
         },
 
         // Phase 2 features


### PR DESCRIPTION
## Summary
Three high-impact converter fixes:

- **Declaration pattern variable binding** (`is Type var`): Pattern variables are now hoisted as `§B{var} (cast Type expr)` bindings inside the if-then body. Previously the type check was emitted but the variable was never bound, causing broken references in the body. (8/10 projects affected)
- **`out var` / `out Type` support**: Inline out variable declarations are pre-declared as mutable bindings and passed as variable references instead of producing `§ERR`. Updated FeatureSupport from NotSupported to Full. (6/10 projects affected)
- **Method groups on predefined types**: `char.IsUpper` etc. no longer produce `§ERR` since `PredefinedTypeSyntax` is handled in expression conversion.

## Test plan
- [x] `Convert_DeclarationPattern_BindsVariable` — verifies §B and (is) emitted
- [x] `Convert_DeclarationPattern_CastsVariable` — verifies cast and variable name
- [x] `Convert_OutVar_PreDeclaresVariable` — out var with int.TryParse
- [x] `Convert_OutVarTyped_PreDeclaresVariable` — typed out parameter
- [x] `Convert_MethodGroupOnPredefinedType_NoERR` — char.IsUpper as method group
- [x] Full test suite: 3529 + 386 passed, 0 failed
- [x] Golden file self-test: 10/10 passed

Fixes #346, #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)