### PR TITLE
fix: primary constructor parameters to readonly fields

### DIFF
--- a/src/Calor.Compiler/Migration/FeatureSupport.cs
+++ b/src/Calor.Compiler/Migration/FeatureSupport.cs
@@ -374,9 +374,9 @@ public static class FeatureSupport
         ["primary-constructor"] = new FeatureInfo
         {
             Name = "primary-constructor",
-            Support = SupportLevel.NotSupported,
-            Description = "Primary constructors (class Foo(int x)) are not supported",
-            Workaround = "Use traditional constructor syntax"
+            Support = SupportLevel.Full,
+            Description = "Primary constructors (class Foo(int x)) are converted to readonly fields",
+            Workaround = null
         },
         ["range-expression"] = new FeatureInfo
         {

--- a/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
+++ b/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
@@ -1099,4 +1099,48 @@ class Test
     }
 
     #endregion
+
+    #region Issue 355: Primary constructor parameters lost
+
+    [Fact]
+    public void Convert_PrimaryConstructor_EmitsFields()
+    {
+        var csharp = @"
+public class Service(string name, int retries)
+{
+    public string GetName() => name;
+    public int GetRetries() => retries;
+}";
+        var result = _converter.Convert(csharp);
+        Assert.NotNull(result.CalorSource);
+        var calor = result.CalorSource!;
+
+        // Primary constructor parameters should appear as fields
+        Assert.Contains("name", calor);
+        Assert.Contains("retries", calor);
+        // Should contain field declarations
+        Assert.Contains("§FLD", calor);
+    }
+
+    [Fact]
+    public void Convert_PrimaryConstructor_WithBase_EmitsFields()
+    {
+        var csharp = @"
+public class BaseService
+{
+}
+
+public class DerivedService(string connectionString) : BaseService
+{
+    public string GetConnection() => connectionString;
+}";
+        var result = _converter.Convert(csharp);
+        Assert.NotNull(result.CalorSource);
+        var calor = result.CalorSource!;
+
+        Assert.Contains("connectionString", calor);
+        Assert.Contains("§FLD", calor);
+    }
+
+    #endregion
 }

--- a/tests/Calor.Compiler.Tests/FeatureCheckCommandTests.cs
+++ b/tests/Calor.Compiler.Tests/FeatureCheckCommandTests.cs
@@ -45,7 +45,6 @@ public class FeatureCheckCommandTests
     [Theory]
     [InlineData("goto", SupportLevel.NotSupported)]
     [InlineData("unsafe", SupportLevel.NotSupported)]
-    [InlineData("primary-constructor", SupportLevel.NotSupported)]
     [InlineData("lock-statement", SupportLevel.NotSupported)]
     [InlineData("await-foreach", SupportLevel.NotSupported)]
     [InlineData("collection-expression", SupportLevel.NotSupported)]
@@ -117,7 +116,6 @@ public class FeatureCheckCommandTests
 
     [Theory]
     [InlineData("goto")]
-    [InlineData("primary-constructor")]
     [InlineData("lock-statement")]
     [InlineData("collection-expression")]
     public void FeatureCheck_UnsupportedFeature_HasWorkaround(string feature)


### PR DESCRIPTION
## Summary
C# 12 primary constructor parameters (`class Foo(string name, int retries)`) were completely lost during conversion — method bodies referenced the parameters but they didn't exist in the output.

Now they are emitted as private readonly fields (`§FLD`) so method bodies have valid references.

## Test plan
- [x] `Convert_PrimaryConstructor_EmitsFields` — simple primary ctor
- [x] `Convert_PrimaryConstructor_WithBase_EmitsFields` — with base class
- [x] Updated FeatureCheckCommandTests to remove primary-constructor from NotSupported list
- [x] Full test suite: 3529 + 386 passed, 0 failed

Fixes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)