### PR TITLE
fix: protected internal, unchecked blocks, default params, chained assignments

### DIFF
--- a/src/Calor.Compiler/Ast/FunctionNode.cs
+++ b/src/Calor.Compiler/Ast/FunctionNode.cs
@@ -10,6 +10,7 @@ public enum Visibility
     Private,
     Protected,
     Internal,
+    ProtectedInternal,
     Public
 }
 
@@ -257,12 +258,17 @@ public sealed class ParameterNode : AstNode
     /// </summary>
     public IReadOnlyList<CalorAttributeNode> CSharpAttributes { get; }
 
+    /// <summary>
+    /// Optional default value for the parameter (from C# = value syntax).
+    /// </summary>
+    public ExpressionNode? DefaultValue { get; }
+
     public ParameterNode(
         TextSpan span,
         string name,
         string typeName,
         AttributeCollection attributes)
-        : this(span, name, typeName, ParameterModifier.None, attributes, Array.Empty<CalorAttributeNode>())
+        : this(span, name, typeName, ParameterModifier.None, attributes, Array.Empty<CalorAttributeNode>(), null)
     {
     }
 
@@ -272,7 +278,7 @@ public sealed class ParameterNode : AstNode
         string typeName,
         AttributeCollection attributes,
         IReadOnlyList<CalorAttributeNode> csharpAttributes)
-        : this(span, name, typeName, ParameterModifier.None, attributes, csharpAttributes)
+        : this(span, name, typeName, ParameterModifier.None, attributes, csharpAttributes, null)
     {
     }
 
@@ -283,6 +289,18 @@ public sealed class ParameterNode : AstNode
         ParameterModifier modifier,
         AttributeCollection attributes,
         IReadOnlyList<CalorAttributeNode> csharpAttributes)
+        : this(span, name, typeName, modifier, attributes, csharpAttributes, null)
+    {
+    }
+
+    public ParameterNode(
+        TextSpan span,
+        string name,
+        string typeName,
+        ParameterModifier modifier,
+        AttributeCollection attributes,
+        IReadOnlyList<CalorAttributeNode> csharpAttributes,
+        ExpressionNode? defaultValue)
         : base(span)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
@@ -290,6 +308,7 @@ public sealed class ParameterNode : AstNode
         Modifier = modifier;
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
         CSharpAttributes = csharpAttributes ?? Array.Empty<CalorAttributeNode>();
+        DefaultValue = defaultValue;
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -346,7 +346,9 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var visibility = node.Visibility switch
         {
             Visibility.Public => "public",
+            Visibility.ProtectedInternal => "protected internal",
             Visibility.Internal => "internal",
+            Visibility.Protected => "protected",
             Visibility.Private => "private",
             _ => "private"
         };
@@ -478,7 +480,12 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         if (node.Modifier.HasFlag(ParameterModifier.Out)) prefix += "out ";
         if (node.Modifier.HasFlag(ParameterModifier.In)) prefix += "in ";
         if (node.Modifier.HasFlag(ParameterModifier.Params)) prefix += "params ";
-        return $"{prefix}{MapTypeName(node.TypeName)} {SanitizeIdentifier(node.Name)}";
+        var result = $"{prefix}{MapTypeName(node.TypeName)} {SanitizeIdentifier(node.Name)}";
+        if (node.DefaultValue != null)
+        {
+            result += $" = {node.DefaultValue.Accept(this)}";
+        }
+        return result;
     }
 
     public string Visit(CallStatementNode node)
@@ -1011,7 +1018,9 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var visibility = method.Visibility switch
         {
             Visibility.Public => "public",
+            Visibility.ProtectedInternal => "protected internal",
             Visibility.Internal => "internal",
+            Visibility.Protected => "protected",
             Visibility.Private => "private",
             _ => "public"
         };
@@ -1842,6 +1851,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var modifiers = node.Visibility switch
         {
             Visibility.Public => "public",
+            Visibility.ProtectedInternal => "protected internal",
             Visibility.Internal => "internal",
             Visibility.Protected => "protected",
             Visibility.Private => "private",
@@ -1941,6 +1951,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var visibility = node.Visibility switch
         {
             Visibility.Public => "public",
+            Visibility.ProtectedInternal => "protected internal",
             Visibility.Internal => "internal",
             Visibility.Protected => "protected",
             Visibility.Private => "private",
@@ -1979,6 +1990,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var visibility = node.Visibility switch
         {
             Visibility.Public => "public",
+            Visibility.ProtectedInternal => "protected internal",
             Visibility.Internal => "internal",
             Visibility.Protected => "protected",
             Visibility.Private => "private",
@@ -2326,7 +2338,9 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var visibility = node.Visibility switch
         {
             Visibility.Public => "public",
+            Visibility.ProtectedInternal => "protected internal",
             Visibility.Internal => "internal",
+            Visibility.Protected => "protected",
             Visibility.Private => "private",
             _ => "public"
         };
@@ -2399,6 +2413,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var visibilityPrefix = node.Visibility switch
         {
             Visibility.Private => "private ",
+            Visibility.ProtectedInternal => "protected internal ",
             Visibility.Internal => "internal ",
             Visibility.Protected => "protected ",
             _ => ""
@@ -2444,6 +2459,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var visibility = node.Visibility switch
         {
             Visibility.Public => "public",
+            Visibility.ProtectedInternal => "protected internal",
             Visibility.Internal => "internal",
             Visibility.Protected => "protected",
             Visibility.Private => "private",
@@ -2685,7 +2701,9 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var visibility = node.Visibility switch
         {
             Visibility.Public => "public",
+            Visibility.ProtectedInternal => "protected internal",
             Visibility.Internal => "internal",
+            Visibility.Protected => "protected",
             Visibility.Private => "private",
             _ => "public"
         };

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -2051,6 +2051,7 @@ public sealed class CalorEmitter : IAstVisitor<string>
         return visibility switch
         {
             Visibility.Public => "pub",
+            Visibility.ProtectedInternal => "prot-int",
             Visibility.Protected => "prot",
             Visibility.Internal => "int",
             Visibility.Private => "priv",

--- a/src/Calor.Compiler/Migration/FeatureSupport.cs
+++ b/src/Calor.Compiler/Migration/FeatureSupport.cs
@@ -453,9 +453,9 @@ public static class FeatureSupport
         ["checked-block"] = new FeatureInfo
         {
             Name = "checked-block",
-            Support = SupportLevel.NotSupported,
-            Description = "checked/unchecked blocks are not supported",
-            Workaround = "Remove checked/unchecked wrapper; handle overflow manually if needed"
+            Support = SupportLevel.Partial,
+            Description = "checked/unchecked wrapper stripped, body statements preserved",
+            Workaround = "Handle overflow manually if needed; body code is preserved"
         },
         ["with-expression"] = new FeatureInfo
         {

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -3061,6 +3061,14 @@ public sealed class Parser
                 }
             }
 
+            // Handle hyphenated identifiers like prot-int (protected internal)
+            while (Check(TokenKind.Minus) && Peek(1).Kind == TokenKind.Identifier)
+            {
+                sb.Append('-');
+                Advance(); // consume '-'
+                sb.Append(Advance().Text); // consume identifier
+            }
+
             // Handle comma-separated values like partial,static for modifiers
             // Only consume comma if followed by an identifier (not a colon or close brace)
             while (Check(TokenKind.Comma) && Peek(1).Kind == TokenKind.Identifier)
@@ -3459,6 +3467,7 @@ public sealed class Parser
         return value?.ToLowerInvariant() switch
         {
             "public" or "pub" => Visibility.Public,
+            "protected-internal" or "prot-int" => Visibility.ProtectedInternal,
             "internal" or "int" => Visibility.Internal,
             "protected" or "prot" => Visibility.Protected,
             "private" or "priv" => Visibility.Private,


### PR DESCRIPTION
## Summary
- **#385**: `protected internal` compound modifier now fully round-trips through converter → Calor → C# (new `ProtectedInternal` visibility enum value, parser hyphenated-identifier support, emitter updates)
- **#369**: `checked`/`unchecked` blocks: wrapper stripped, body statements preserved inline
- **#361**: Default parameter values captured in AST (`ParameterNode.DefaultValue`) and emitted in C# output
- **#379**: Chained assignment expressions (`a = b = value`) now convert to sequential assignments instead of producing ERR

## Test plan
- [x] 7 new tests in ConversionCampaignFixTests
- [x] All 3535 existing tests pass
- [x] All 10 self-test scenarios pass
- [x] Full round-trip verified for protected internal

🤖 Generated with [Claude Code](https://claude.com/claude-code)