### PR TITLE
fix: explicit interface, postfix sub-expr, target-typed new, cast-then-call

### DIFF
--- a/tests/Calor.Compiler.Tests/ConverterImprovementTests.cs
+++ b/tests/Calor.Compiler.Tests/ConverterImprovementTests.cs
@@ -192,7 +192,7 @@ public class ConverterImprovementTests
         // First statement should be a bind statement with a NewExpressionNode
         var bindStmt = Assert.IsType<BindStatementNode>(method.Body[0]);
         var newExpr = Assert.IsType<NewExpressionNode>(bindStmt.Initializer);
-        Assert.Equal("object", newExpr.TypeName);
+        Assert.Equal("List<i32>", newExpr.TypeName); // Type inferred from declaration
         Assert.Single(newExpr.Arguments);
     }
 
@@ -414,7 +414,7 @@ public class ConverterImprovementTests
         var method = Assert.Single(service.Methods);
         var bindStmt = Assert.IsType<BindStatementNode>(method.Body[0]);
         var newExpr = Assert.IsType<NewExpressionNode>(bindStmt.Initializer);
-        Assert.Equal("object", newExpr.TypeName);
+        Assert.Equal("Options", newExpr.TypeName); // Type inferred from declaration
         Assert.Single(newExpr.Arguments);
         Assert.Single(newExpr.Initializers);
         Assert.Equal("Verbose", newExpr.Initializers[0].PropertyName);


### PR DESCRIPTION
## Summary
- **#362**: Explicit interface implementation now preserves qualifier (`IDisposable.Dispose` instead of just `Dispose`)
- **#390**: Postfix `i++`/`i--` as sub-expressions hoisted to temp variables instead of producing invalid `UnaryOperationNode`
- **#364**: Target-typed `new()` now infers type from variable declaration context (`List<string> items = new()` → `§NEW{List<str>}`)
- **#387**: Cast-then-call `((Type)expr).Method()` hoisted to temp bind for clean call target

## Test plan
- [x] 4 new tests in ConversionCampaignFixTests
- [x] 2 existing tests updated for improved target-typed new behavior
- [x] All 3539 tests pass
- [x] All 10 self-test scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)