### PR TITLE
fix: tuple deconstruction, generic static access, variance modifiers

### DIFF
--- a/src/Calor.Compiler/Ast/GenericNodes.cs
+++ b/src/Calor.Compiler/Ast/GenericNodes.cs
@@ -3,6 +3,19 @@ using Calor.Compiler.Parsing;
 namespace Calor.Compiler.Ast;
 
 /// <summary>
+/// Variance modifier for type parameters.
+/// </summary>
+public enum VarianceKind
+{
+    /// <summary>No variance (invariant)</summary>
+    None,
+    /// <summary>Covariant (out T)</summary>
+    Out,
+    /// <summary>Contravariant (in T)</summary>
+    In
+}
+
+/// <summary>
 /// Represents a type parameter declaration.
 /// New syntax: §F{id:name:pub}&lt;T&gt; or §CL{id:name:pub}&lt;T, U&gt;
 /// Legacy: §TP[T] (no longer supported in new code)
@@ -15,15 +28,21 @@ public sealed class TypeParameterNode : AstNode
     public string Name { get; }
 
     /// <summary>
+    /// The variance modifier (in/out) for this type parameter.
+    /// </summary>
+    public VarianceKind Variance { get; }
+
+    /// <summary>
     /// The constraints on this type parameter (from WHERE clauses).
     /// </summary>
     public IReadOnlyList<TypeConstraintNode> Constraints { get; }
 
-    public TypeParameterNode(TextSpan span, string name, IReadOnlyList<TypeConstraintNode> constraints)
+    public TypeParameterNode(TextSpan span, string name, IReadOnlyList<TypeConstraintNode> constraints, VarianceKind variance = VarianceKind.None)
         : base(span)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
         Constraints = constraints ?? throw new ArgumentNullException(nameof(constraints));
+        Variance = variance;
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -377,7 +377,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var whereClause = "";
         if (node.TypeParameters.Count > 0)
         {
-            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(tp => tp.Name)) + ">";
+            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(tp => tp.Accept(this))) + ">";
 
             // Build where clauses
             var whereClauses = new List<string>();
@@ -1066,7 +1066,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var whereClause = "";
         if (method.TypeParameters.Count > 0)
         {
-            typeParams = "<" + string.Join(", ", method.TypeParameters.Select(tp => tp.Name)) + ">";
+            typeParams = "<" + string.Join(", ", method.TypeParameters.Select(tp => tp.Accept(this))) + ">";
 
             var whereClauses = new List<string>();
             foreach (var tp in method.TypeParameters)
@@ -1695,7 +1695,13 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     public string Visit(TypeParameterNode node)
     {
         // Type parameters are handled in function/method signature emission
-        return node.Name;
+        var variance = node.Variance switch
+        {
+            VarianceKind.In => "in ",
+            VarianceKind.Out => "out ",
+            _ => ""
+        };
+        return $"{variance}{node.Name}";
     }
 
     public string Visit(TypeConstraintNode node)
@@ -1742,7 +1748,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var whereClause = "";
         if (node.TypeParameters.Count > 0)
         {
-            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(tp => tp.Name)) + ">";
+            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(tp => tp.Accept(this))) + ">";
 
             // Build where clauses
             var whereClauses = new List<string>();
@@ -1817,7 +1823,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var whereClause = "";
         if (node.TypeParameters.Count > 0)
         {
-            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(tp => tp.Name)) + ">";
+            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(tp => tp.Accept(this))) + ">";
 
             // Build where clauses
             var whereClauses = new List<string>();
@@ -1870,7 +1876,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var whereClause = "";
         if (node.TypeParameters.Count > 0)
         {
-            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(tp => tp.Name)) + ">";
+            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(tp => tp.Accept(this))) + ">";
 
             var whereClauses = new List<string>();
             foreach (var tp in node.TypeParameters)
@@ -2025,7 +2031,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var whereClause = "";
         if (node.TypeParameters.Count > 0)
         {
-            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(tp => tp.Name)) + ">";
+            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(tp => tp.Accept(this))) + ">";
 
             var whereClauses = new List<string>();
             foreach (var tp in node.TypeParameters)


### PR DESCRIPTION
## Summary
- **#358**: Handle `var (a, b) = expr` tuple deconstruction by hoisting to temp bind and extracting `Item1`/`Item2`
- **#360**: Handle `GenericNameSyntax` in expression switch and member access for generic static members like `EqualityComparer<T>.Default`
- **#376**: Add `VarianceKind` enum to AST, extract `in`/`out` from Roslyn type parameters, emit in CSharp and Calor, parse in Parser with legacy name extraction
- **#381**: Handle `System.String.Empty` → `""` conversion (in addition to existing `string.Empty`)
- **Bonus**: Interface type parameter extraction in `VisitInterfaceDeclaration`, CalorEmitter interface type param emission, Parser space preservation between consecutive identifiers in generic type arguments

## Test plan
- [x] 6 new tests in ConversionCampaignFixTests (all pass)
- [x] Full test suite: 3545 passed, 0 failed
- [x] Self-tests: 10/10 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)