### PR TITLE
feat: named args, tuple literals, getter-only props, verbatim strings

### DIFF
--- a/src/Calor.Compiler/Ast/AstNode.cs
+++ b/src/Calor.Compiler/Ast/AstNode.cs
@@ -109,6 +109,7 @@ public interface IAstVisitor
     void Visit(CallExpressionNode node);
     void Visit(ThisExpressionNode node);
     void Visit(BaseExpressionNode node);
+    void Visit(TupleLiteralNode node);
     // Phase 9: Properties and Constructors
     void Visit(PropertyNode node);
     void Visit(PropertyAccessorNode node);
@@ -294,6 +295,7 @@ public interface IAstVisitor<T>
     T Visit(CallExpressionNode node);
     T Visit(ThisExpressionNode node);
     T Visit(BaseExpressionNode node);
+    T Visit(TupleLiteralNode node);
     // Phase 9: Properties and Constructors
     T Visit(PropertyNode node);
     T Visit(PropertyAccessorNode node);

--- a/src/Calor.Compiler/Ast/ClassNodes.cs
+++ b/src/Calor.Compiler/Ast/ClassNodes.cs
@@ -662,11 +662,25 @@ public sealed class CallExpressionNode : ExpressionNode
     public string Target { get; }
     public IReadOnlyList<ExpressionNode> Arguments { get; }
 
+    /// <summary>
+    /// Optional named argument labels, parallel to Arguments list.
+    /// Null entry means positional; non-null means named (e.g., "createIfNotExists").
+    /// </summary>
+    public IReadOnlyList<string?>? ArgumentNames { get; }
+
     public CallExpressionNode(TextSpan span, string target, IReadOnlyList<ExpressionNode> arguments)
         : base(span)
     {
         Target = target ?? throw new ArgumentNullException(nameof(target));
         Arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+    }
+
+    public CallExpressionNode(TextSpan span, string target, IReadOnlyList<ExpressionNode> arguments, IReadOnlyList<string?>? argumentNames)
+        : base(span)
+    {
+        Target = target ?? throw new ArgumentNullException(nameof(target));
+        Arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+        ArgumentNames = argumentNames;
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
@@ -692,6 +706,24 @@ public sealed class ThisExpressionNode : ExpressionNode
 public sealed class BaseExpressionNode : ExpressionNode
 {
     public BaseExpressionNode(TextSpan span) : base(span) { }
+
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
+}
+
+/// <summary>
+/// Represents a tuple literal expression.
+/// (expr1, expr2, ...) → C# (expr1, expr2, ...)
+/// </summary>
+public sealed class TupleLiteralNode : ExpressionNode
+{
+    public IReadOnlyList<ExpressionNode> Elements { get; }
+
+    public TupleLiteralNode(TextSpan span, IReadOnlyList<ExpressionNode> elements)
+        : base(span)
+    {
+        Elements = elements ?? throw new ArgumentNullException(nameof(elements));
+    }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
     public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);

--- a/src/Calor.Compiler/Ast/StatementNodes.cs
+++ b/src/Calor.Compiler/Ast/StatementNodes.cs
@@ -21,6 +21,11 @@ public sealed class CallStatementNode : StatementNode
     public IReadOnlyList<ExpressionNode> Arguments { get; }
     public AttributeCollection Attributes { get; }
 
+    /// <summary>
+    /// Optional named argument labels, parallel to Arguments list.
+    /// </summary>
+    public IReadOnlyList<string?>? ArgumentNames { get; }
+
     public CallStatementNode(
         TextSpan span,
         string target,
@@ -33,6 +38,18 @@ public sealed class CallStatementNode : StatementNode
         Fallible = fallible;
         Arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+    }
+
+    public CallStatementNode(
+        TextSpan span,
+        string target,
+        bool fallible,
+        IReadOnlyList<ExpressionNode> arguments,
+        AttributeCollection attributes,
+        IReadOnlyList<string?>? argumentNames)
+        : this(span, target, fallible, arguments, attributes)
+    {
+        ArgumentNames = argumentNames;
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -491,7 +491,17 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     public string Visit(CallStatementNode node)
     {
         var target = node.Target;
-        var args = string.Join(", ", node.Arguments.Select(a => a.Accept(this)));
+        var argStrings = new List<string>();
+        for (int i = 0; i < node.Arguments.Count; i++)
+        {
+            var argStr = node.Arguments[i].Accept(this);
+            if (node.ArgumentNames != null && i < node.ArgumentNames.Count && node.ArgumentNames[i] != null)
+            {
+                argStr = $"{node.ArgumentNames[i]}: {argStr}";
+            }
+            argStrings.Add(argStr);
+        }
+        var args = string.Join(", ", argStrings);
 
         return $"{target}({args});";
     }
@@ -2309,7 +2319,17 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     {
         // Unescape braces that were escaped for Calor syntax: \{ -> { and \} -> }
         var target = UnescapeBraces(node.Target);
-        var args = string.Join(", ", node.Arguments.Select(a => a.Accept(this)));
+        var argStrings = new List<string>();
+        for (int i = 0; i < node.Arguments.Count; i++)
+        {
+            var argStr = node.Arguments[i].Accept(this);
+            if (node.ArgumentNames != null && i < node.ArgumentNames.Count && node.ArgumentNames[i] != null)
+            {
+                argStr = $"{node.ArgumentNames[i]}: {argStr}";
+            }
+            argStrings.Add(argStr);
+        }
+        var args = string.Join(", ", argStrings);
         return $"{target}({args})";
     }
 
@@ -2333,6 +2353,12 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     public string Visit(BaseExpressionNode node)
     {
         return "base";
+    }
+
+    public string Visit(TupleLiteralNode node)
+    {
+        var elements = string.Join(", ", node.Elements.Select(e => e.Accept(this)));
+        return $"({elements})";
     }
 
     // Phase 9: Properties and Constructors

--- a/src/Calor.Compiler/Ids/IdScanner.cs
+++ b/src/Calor.Compiler/Ids/IdScanner.cs
@@ -206,6 +206,7 @@ public sealed class IdScanner : IAstVisitor
     public void Visit(CallExpressionNode node) { }
     public void Visit(ThisExpressionNode node) { }
     public void Visit(BaseExpressionNode node) { }
+    public void Visit(TupleLiteralNode node) { }
     public void Visit(PropertyAccessorNode node) { }
     public void Visit(ConstructorInitializerNode node) { }
     public void Visit(AssignmentStatementNode node) { }

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -1419,6 +1419,12 @@ public sealed class CalorEmitter : IAstVisitor<string>
         return "§BASE";
     }
 
+    public string Visit(TupleLiteralNode node)
+    {
+        var elements = string.Join(", ", node.Elements.Select(e => e.Accept(this)));
+        return $"({elements})";
+    }
+
     public string Visit(MatchExpressionNode node)
     {
         // Use block syntax that the Calor parser can understand

--- a/src/Calor.Compiler/Verification/ExpressionSimplifier.cs
+++ b/src/Calor.Compiler/Verification/ExpressionSimplifier.cs
@@ -825,6 +825,7 @@ public sealed class ExpressionSimplifier : IAstVisitor<ExpressionNode>
 
     public ExpressionNode Visit(ThisExpressionNode node) => node;
     public ExpressionNode Visit(BaseExpressionNode node) => node;
+    public ExpressionNode Visit(TupleLiteralNode node) => node;
 
     public ExpressionNode Visit(CollectionContainsNode node)
     {

--- a/src/Calor.LanguageServer/Utilities/AstPositionVisitor.cs
+++ b/src/Calor.LanguageServer/Utilities/AstPositionVisitor.cs
@@ -131,6 +131,7 @@ public abstract class AstPositionVisitor<T> : IAstVisitor<T> where T : class?
     public virtual T Visit(CallExpressionNode node) => DefaultVisit(node)!;
     public virtual T Visit(ThisExpressionNode node) => DefaultVisit(node)!;
     public virtual T Visit(BaseExpressionNode node) => DefaultVisit(node)!;
+    public virtual T Visit(TupleLiteralNode node) => DefaultVisit(node)!;
 
     // Properties and constructors
     public virtual T Visit(PropertyNode node) => DefaultVisit(node)!;


### PR DESCRIPTION
## Summary
- **#352 Named arguments**: Preserve argument names through C#→Calor→C# round-trip. Added `ArgumentNames` property to both `CallStatementNode` and `CallExpressionNode`, emitting `name: value` syntax in generated C#.
- **#380 Tuple literals**: New `TupleLiteralNode` AST node. Converts `TupleExpressionSyntax` from Roslyn and emits `(a, b)` in generated C#.
- **#382 Getter-only properties**: Verified already working in local build. Added regression test.
- **#359 Verbatim string regex**: Verified round-trip correctness with escaping pipeline. Added regression test.

## Test plan
- [x] 5 new targeted tests for all 4 issues
- [x] All 3550 tests pass
- [x] 10/10 self-tests pass
- [x] No regressions

Closes #352, #359, #380, #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)