### PR TITLE
feat: notnull constraint and static lambda support

### DIFF
--- a/src/Calor.Compiler/Ast/GenericNodes.cs
+++ b/src/Calor.Compiler/Ast/GenericNodes.cs
@@ -65,7 +65,9 @@ public enum TypeConstraintKind
     /// <summary>Type must derive from a base class</summary>
     BaseClass,
     /// <summary>Type must be or derive from the specified type</summary>
-    TypeName
+    TypeName,
+    /// <summary>Type must not be null (notnull constraint)</summary>
+    NotNull
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Ast/LambdaNodes.cs
+++ b/src/Calor.Compiler/Ast/LambdaNodes.cs
@@ -32,6 +32,7 @@ public sealed class LambdaExpressionNode : ExpressionNode
     public IReadOnlyList<LambdaParameterNode> Parameters { get; }
     public EffectsNode? Effects { get; }
     public bool IsAsync { get; }
+    public bool IsStatic { get; }
 
     /// <summary>
     /// The body can be either an expression (for expression lambdas)
@@ -50,13 +51,15 @@ public sealed class LambdaExpressionNode : ExpressionNode
         bool isAsync,
         ExpressionNode? expressionBody,
         IReadOnlyList<StatementNode>? statementBody,
-        AttributeCollection attributes)
+        AttributeCollection attributes,
+        bool isStatic = false)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
         Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
         Effects = effects;
         IsAsync = isAsync;
+        IsStatic = isStatic;
         ExpressionBody = expressionBody;
         StatementBody = statementBody;
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -1741,6 +1741,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             TypeConstraintKind.Interface => constraint.TypeName ?? "object",
             TypeConstraintKind.BaseClass => constraint.TypeName ?? "object",
             TypeConstraintKind.TypeName => MapTypeName(constraint.TypeName ?? "object"),
+            TypeConstraintKind.NotNull => "notnull",
             _ => "object"
         };
     }
@@ -2689,6 +2690,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(LambdaExpressionNode node)
     {
+        var staticMod = node.IsStatic ? "static " : "";
         var async = node.IsAsync ? "async " : "";
         var parameters = node.Parameters.Count switch
         {
@@ -2700,12 +2702,12 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         if (node.IsExpressionLambda && node.ExpressionBody != null)
         {
             var body = node.ExpressionBody.Accept(this);
-            return $"{async}{parameters} => {body}";
+            return $"{staticMod}{async}{parameters} => {body}";
         }
         else if (node.StatementBody != null && node.StatementBody.Count > 0)
         {
             var sb = new StringBuilder();
-            sb.Append($"{async}{parameters} => {{\n");
+            sb.Append($"{staticMod}{async}{parameters} => {{\n");
             foreach (var stmt in node.StatementBody)
             {
                 sb.Append($"    {stmt.Accept(this)}\n");
@@ -2714,7 +2716,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             return sb.ToString();
         }
 
-        return $"{async}{parameters} => default";
+        return $"{staticMod}{async}{parameters} => default";
     }
 
     public string Visit(DelegateDefinitionNode node)

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -1523,6 +1523,10 @@ public sealed class CalorEmitter : IAstVisitor<string>
         // Build §LAM{id:p1:t1:p2:t2} header
         // Format: §LAM{id[:async]:param1:type1[:param2:type2:...]}
         var headerParts = new List<string> { node.Id };
+        if (node.IsStatic)
+        {
+            headerParts.Add("static");
+        }
         if (node.IsAsync)
         {
             headerParts.Add("async");
@@ -1832,6 +1836,7 @@ public sealed class CalorEmitter : IAstVisitor<string>
             TypeConstraintKind.Interface => node.TypeName ?? "",
             TypeConstraintKind.BaseClass => node.TypeName ?? "",
             TypeConstraintKind.TypeName => node.TypeName ?? "",
+            TypeConstraintKind.NotNull => "notnull",
             _ => node.TypeName ?? ""
         };
     }


### PR DESCRIPTION
## Summary
- **#396 notnull constraint**: Full round-trip support for `where T : notnull`. Added `NotNull` to `TypeConstraintKind` enum, detect in Roslyn converter (matches `TypeConstraintSyntax` with type "notnull"), emit in CSharpEmitter and CalorEmitter, parse in Parser WHERE clauses.
- **#392 static lambdas**: Full round-trip support for `static` lambda modifier. Added `IsStatic` property to `LambdaExpressionNode`, extract from Roslyn `Modifiers`, emit `static` prefix in C# output, parse `static` keyword in §LAM headers.

## Test plan
- [x] 5 new targeted tests (2 notnull, 2 static lambda, 1 combined constraints)
- [x] All 3555 tests pass
- [x] 10/10 self-tests pass
- [x] No regressions

Closes #392, #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)