### PR TITLE
feat: delegate emission, parameter attributes, generic interface overloads

### DIFF
--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -474,13 +474,23 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(ParameterNode node)
     {
+        var attrPrefix = "";
+        if (node.CSharpAttributes.Count > 0)
+        {
+            var attrs = node.CSharpAttributes.Select(a =>
+            {
+                var args = a.Arguments.Count > 0 ? $"({string.Join(", ", a.Arguments)})" : "";
+                return $"[{a.Name}{args}]";
+            });
+            attrPrefix = string.Join(" ", attrs) + " ";
+        }
         var prefix = "";
         if (node.Modifier.HasFlag(ParameterModifier.This)) prefix += "this ";
         if (node.Modifier.HasFlag(ParameterModifier.Ref)) prefix += "ref ";
         if (node.Modifier.HasFlag(ParameterModifier.Out)) prefix += "out ";
         if (node.Modifier.HasFlag(ParameterModifier.In)) prefix += "in ";
         if (node.Modifier.HasFlag(ParameterModifier.Params)) prefix += "params ";
-        var result = $"{prefix}{MapTypeName(node.TypeName)} {SanitizeIdentifier(node.Name)}";
+        var result = $"{attrPrefix}{prefix}{MapTypeName(node.TypeName)} {SanitizeIdentifier(node.Name)}";
         if (node.DefaultValue != null)
         {
             result += $" = {node.DefaultValue.Accept(this)}";

--- a/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
+++ b/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
@@ -4256,13 +4256,14 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                 ExpressionNode? defaultValue = p.Default != null
                     ? ConvertExpression(p.Default.Value)
                     : null;
+                var paramAttrs = ConvertAttributes(p.AttributeLists);
                 return new ParameterNode(
                     GetTextSpan(p),
                     p.Identifier.ValueText,
                     TypeMapper.CSharpToCalor(p.Type?.ToString() ?? "any"),
                     modifier,
                     new AttributeCollection(),
-                    Array.Empty<CalorAttributeNode>(),
+                    paramAttrs,
                     defaultValue);
             })
             .ToList();

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -621,7 +621,8 @@ public sealed class Parser
             if (semantic.Contains("params", StringComparison.OrdinalIgnoreCase)) modifier |= ParameterModifier.Params;
         }
 
-        return new ParameterNode(startToken.Span, paramName, typeName, modifier, attrs, Array.Empty<CalorAttributeNode>());
+        var csharpAttrs = ParseCSharpAttributes();
+        return new ParameterNode(startToken.Span, paramName, typeName, modifier, attrs, csharpAttrs);
     }
 
     private OutputNode ParseOutput()


### PR DESCRIPTION
## Summary
- **#378 Delegate declarations**: CalorEmitter now emits `§DEL{id:name}` blocks in module output with proper `§I`/`§O`/`§E` children. Previously delegates were collected in the AST but silently omitted from Calor text output.
- **#386 Parameter attributes**: Full pipeline — converter extracts C# attributes from parameters via `ConvertAttributes(p.AttributeLists)`, CSharpEmitter emits `[Attr] type name` prefix, CalorEmitter appends `[@Attr]` suffix to `§I` tags, Parser calls `ParseCSharpAttributes()` after `§I` to reconstruct them.
- **#348 Generic interface overloads**: Verified both `IValidator` and `IValidator<T>` coexist in AST with separate IDs and type parameters. Test confirms both are preserved.
- **#384 String interpolation**: Verified already working end-to-end (C# `$"..."` → Calor `"...${expr}..."` → C# `$"...{expr}..."`). Closed as fixed.

## Test plan
- [x] 5 new targeted tests for 4 issues
- [x] All 3559 tests pass
- [x] 10/10 self-tests pass
- [x] No regressions

Closes #348, #378, #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)