### PR TITLE
feat: required modifier and partial method declarations

### DIFF
--- a/src/Calor.Compiler/Ast/ClassNodes.cs
+++ b/src/Calor.Compiler/Ast/ClassNodes.cs
@@ -15,7 +15,9 @@ public enum MethodModifiers
     Sealed = 8,
     Static = 16,
     Const = 32,
-    Readonly = 64
+    Readonly = 64,
+    Required = 128,
+    Partial = 256
 }
 
 /// <summary>
@@ -425,6 +427,7 @@ public sealed class ClassFieldNode : AstNode
     public Visibility Visibility { get; }
     public MethodModifiers Modifiers { get; }
     public bool IsStatic => Modifiers.HasFlag(MethodModifiers.Static);
+    public bool IsRequired => Modifiers.HasFlag(MethodModifiers.Required);
     public ExpressionNode? DefaultValue { get; }
     public AttributeCollection Attributes { get; }
 
@@ -570,6 +573,7 @@ public sealed class MethodNode : AstNode
     public bool IsAbstract => (Modifiers & MethodModifiers.Abstract) != 0;
     public bool IsSealed => (Modifiers & MethodModifiers.Sealed) != 0;
     public bool IsStatic => (Modifiers & MethodModifiers.Static) != 0;
+    public bool IsPartial => (Modifiers & MethodModifiers.Partial) != 0;
     public bool HasContracts => Preconditions.Count > 0 || Postconditions.Count > 0;
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);

--- a/src/Calor.Compiler/Ast/PropertyNodes.cs
+++ b/src/Calor.Compiler/Ast/PropertyNodes.cs
@@ -33,6 +33,7 @@ public sealed class PropertyNode : AstNode
     public bool IsAbstract => Modifiers.HasFlag(MethodModifiers.Abstract);
     public bool IsStatic => Modifiers.HasFlag(MethodModifiers.Static);
     public bool IsSealed => Modifiers.HasFlag(MethodModifiers.Sealed);
+    public bool IsRequired => Modifiers.HasFlag(MethodModifiers.Required);
 
     public PropertyNode(
         TextSpan span,

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -1985,7 +1985,9 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             _ => "private"
         };
 
-        var parts = new List<string> { visibility };
+        var parts = new List<string>();
+        if (node.IsRequired) parts.Add("required");
+        parts.Add(visibility);
         if (node.Modifiers.HasFlag(MethodModifiers.Const)) parts.Add("const");
         else if (node.IsStatic) parts.Add("static");
         if (node.Modifiers.HasFlag(MethodModifiers.Readonly)) parts.Add("readonly");
@@ -2026,6 +2028,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         var modifiers = new List<string> { visibility };
         if (node.IsStatic) modifiers.Add("static");
+        if (node.IsPartial) modifiers.Add("partial");
         if (node.IsAsync) modifiers.Add("async");
         if (node.IsAbstract) modifiers.Add("abstract");
         else if (node.IsVirtual) modifiers.Add("virtual");
@@ -2077,8 +2080,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             return EmitOperatorMethod(node, modifiers, mappedReturnType, parameters);
         }
 
-        // Abstract methods have no body
-        if (node.IsAbstract)
+        // Abstract methods and partial method stubs have no body
+        if (node.IsAbstract || (node.IsPartial && node.Body.Count == 0))
         {
             AppendLine($"{string.Join(" ", modifiers)} {mappedReturnType} {methodName}{typeParams}({parameters}){whereClause};");
             return "";
@@ -2388,7 +2391,9 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             _ => "public"
         };
 
-        var modifiers = new List<string> { visibility };
+        var modifiers = new List<string>();
+        if (node.IsRequired) modifiers.Add("required");
+        modifiers.Add(visibility);
         if (node.IsStatic) modifiers.Add("static");
         if (node.IsAbstract) modifiers.Add("abstract");
         else if (node.IsVirtual) modifiers.Add("virtual");

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -308,6 +308,7 @@ public sealed class CalorEmitter : IAstVisitor<string>
         var attrs = EmitCSharpAttributes(node.CSharpAttributes);
 
         var modifiers = new List<string>();
+        if (node.IsRequired) modifiers.Add("req");
         if (node.Modifiers.HasFlag(MethodModifiers.Static)) modifiers.Add("stat");
         if (node.Modifiers.HasFlag(MethodModifiers.Const)) modifiers.Add("const");
         if (node.Modifiers.HasFlag(MethodModifiers.Readonly)) modifiers.Add("readonly");
@@ -326,6 +327,7 @@ public sealed class CalorEmitter : IAstVisitor<string>
         var defaultVal = node.DefaultValue != null ? $" = {node.DefaultValue.Accept(this)}" : "";
 
         var modifiers = new List<string>();
+        if (node.IsRequired) modifiers.Add("req");
         if (node.IsVirtual) modifiers.Add("virt");
         if (node.IsOverride) modifiers.Add("over");
         if (node.IsAbstract) modifiers.Add("abs");
@@ -458,6 +460,7 @@ public sealed class CalorEmitter : IAstVisitor<string>
         var visibility = GetVisibilityShorthand(node.Visibility);
         var modifiers = new List<string>();
 
+        if (node.IsPartial) modifiers.Add("part");
         if (node.IsVirtual) modifiers.Add("virt");
         if (node.IsOverride) modifiers.Add("over");
         if (node.IsAbstract) modifiers.Add("abs");

--- a/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
+++ b/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
@@ -830,6 +830,8 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             modifiers |= MethodModifiers.Static;
         if (node.Modifiers.Any(SyntaxKind.ReadOnlyKeyword))
             modifiers |= MethodModifiers.Readonly;
+        if (node.Modifiers.Any(SyntaxKind.RequiredKeyword))
+            modifiers |= MethodModifiers.Required;
 
         foreach (var variable in node.Declaration.Variables)
         {
@@ -4460,6 +4462,10 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             result |= MethodModifiers.Sealed;
         if (modifiers.Any(SyntaxKind.StaticKeyword))
             result |= MethodModifiers.Static;
+        if (modifiers.Any(SyntaxKind.RequiredKeyword))
+            result |= MethodModifiers.Required;
+        if (modifiers.Any(SyntaxKind.PartialKeyword))
+            result |= MethodModifiers.Partial;
 
         return result;
     }

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -5140,6 +5140,12 @@ public sealed class Parser
                 mods |= MethodModifiers.Const;
             else if (token.Equals("readonly", StringComparison.OrdinalIgnoreCase))
                 mods |= MethodModifiers.Readonly;
+            else if (token.Equals("req", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("required", StringComparison.OrdinalIgnoreCase))
+                mods |= MethodModifiers.Required;
+            else if (token.Equals("part", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("partial", StringComparison.OrdinalIgnoreCase))
+                mods |= MethodModifiers.Partial;
         }
         return mods;
     }


### PR DESCRIPTION
## Summary
- Add `required` modifier support for C# properties and fields (#323)
- Add `partial` method declaration support so stubs aren't silently dropped (#398)
- Full pipeline: converter extracts → Calor emitter uses `req`/`part` shorthand → parser recognizes → C# emitter restores original keywords
- 5 new tests covering AST extraction and round-trip compilation

## Test plan
- [x] 3564 tests pass, 0 failures
- [x] 10/10 golden file scenarios pass
- [x] Required property: AST flag set, Calor contains `req`, C# round-trip contains `required`
- [x] Required field: same pipeline
- [x] Partial method stub: not dropped, emits `partial void Method();` (semicolon, no braces)

Closes #323, closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)