### PR TITLE
Release v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-02-21
+
+### Benchmark Results (Statistical: 30 runs)
+- **Overall Advantage**: 1.18x (Calor leads)
+- **Metrics**: Calor wins 6, C# wins 2
+- **Highlights**:
+  - Comprehension: 1.55x (Calor wins, large effect)
+  - EditPrecision: 1.37x (Calor wins, large effect)
+  - RefactoringStability: 1.37x (Calor wins, large effect)
+  - ErrorDetection: 1.24x (Calor wins, large effect)
+- **Programs Tested**: 40
+
+### Added
+- **Unsupported feature telemetry** — Track unsupported C# constructs (goto, unsafe, etc.) in Application Insights during conversion, enabling data-driven prioritization of converter improvements
+- **Pattern combinators** — `not`, `or`, and `and` pattern combinators and negated type patterns in C# converter
+- **Collection spread-only conversion** — Spread expressions and fluent chain-on-new hoisting in converter
+- **Required modifier and partial methods** — Support for `required` property modifier and partial method declarations
+- **Delegate emission** — Delegate types, parameter attributes, and generic interface overloads in converter
+- **Named arguments and tuple literals** — Named arguments, tuple literals, getter-only properties, and verbatim strings
+- **Primary constructor parameters** — C# 12 primary constructors converted to readonly fields
+- **`notnull` generic constraint** — Support for `notnull` constraint and static lambda conversion
+- **Permissive effect inference** — New mode for converted code to avoid strict effect enforcement on generated output
+
+### Fixed
+- **Converter**: null-coalescing `??` → conditional (not arithmetic), declaration pattern variable binding, `out var` support, method groups, explicit interface implementations, target-typed new inference, cast-then-call chains, `protected internal`, `unchecked` blocks, default parameters, chained assignments, `typeof`, `lock`, lambda assignment, expression-bodied constructors, `int.MaxValue`, `ValueTask`, empty `[]`, static properties
+- **Diagnostics**: Broke monolithic `Calor0100` (UnexpectedToken) into 6 specific error codes for clearer error messages
+- **Parser**: `§HAS`/`§IDX`/`§LEN`/`§CNT` inside lisp expressions, tuple deconstruction, generic static access, variance modifiers, interface type params
+- **Converter hoisting**: Chain bindings hoisted before `if` conditions, `§NEW` args hoisted to temp vars
+
 ## [0.2.8] - 2026-02-21
 
 ### Benchmark Results (Statistical: 30 runs)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.2.8</Version>
+    <Version>0.2.9</Version>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "calor",
   "displayName": "Calor Language",
   "description": "Language support for the Calor programming language",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "publisher": "calor-dev",
   "license": "Apache-2.0",
   "icon": "icons/calor-icon.png",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calor-website",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/website/public/data/benchmark-results.json
+++ b/website/public/data/benchmark-results.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
-  "timestamp": "2026-02-21T13:10:19.285461Z",
-  "commit": "433ef4e",
+  "timestamp": "2026-02-21T20:03:56.733797Z",
+  "commit": "f084caa",
   "frameworkVersion": "1.0.0",
   "summary": {
     "overallAdvantage": 1.18,


### PR DESCRIPTION
## Summary
- Bump version to 0.2.9
- Update CHANGELOG.md with release date and benchmark results
- Update benchmark results JSON for website dashboard

## Benchmark Results
- **Overall Advantage**: 1.18x (Calor leads)
- **Metrics**: Calor wins 6, C# wins 2
- **Key highlights**: Comprehension 1.55x, EditPrecision 1.37x, RefactoringStability 1.37x, ErrorDetection 1.24x
- **Programs Tested**: 40

## Checklist
- [x] Version updated in Directory.Build.props
- [x] Version updated in editors/vscode/package.json
- [x] Version updated in website/package.json
- [x] CHANGELOG.md updated with version, date, and benchmark summary
- [x] website/public/data/benchmark-results.json updated with latest results