### PR TITLE
fix: Phase 6A conversion fixes — WHERE constraints, generics, @ and !

### DIFF
--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -2079,7 +2079,8 @@ public sealed class CalorEmitter : IAstVisitor<string>
             sb.Append($"§NEW{{{node.TypeName}{typeArgs}}}{argsStr}");
             foreach (var (propName, valueStr) in evalInits)
             {
-                sb.Append($"\n{indent}  {propName} = {valueStr}");
+                var safeName = propName.StartsWith("@") ? propName[1..] : propName;
+                sb.Append($"\n{indent}  {safeName} = {valueStr}");
             }
             sb.Append($"\n{indent}§/NEW");
             return sb.ToString();
@@ -2099,7 +2100,9 @@ public sealed class CalorEmitter : IAstVisitor<string>
             // Hoist values containing section markers
             if (ContainsSectionMarker(value))
                 value = HoistToTempVar(value);
-            sb.Append($"\n{indent}  {init.PropertyName} = {value}");
+            // Strip @ prefix from verbatim C# identifiers (e.g., @class, @checked, @Version)
+            var propName = init.PropertyName.StartsWith("@") ? init.PropertyName[1..] : init.PropertyName;
+            sb.Append($"\n{indent}  {propName} = {value}");
         }
         sb.Append($"\n{indent}§/ANON");
         return sb.ToString();

--- a/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
+++ b/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
@@ -54,6 +54,9 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
     /// </summary>
     public ModuleNode Convert(CompilationUnitSyntax root, string moduleName)
     {
+        // Sanitize module name: strip backtick (C# generic arity indicator e.g. MyType`2)
+        // and @ prefix to avoid lexer conflicts
+        moduleName = moduleName.Replace("`", "").Replace("@", "");
         _usings.Clear();
         _interfaces.Clear();
         _classes.Clear();
@@ -4336,7 +4339,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         // Handle invocation expressions (method calls)
         if (expr is InvocationExpressionSyntax invocation)
         {
-            var target = invocation.Expression.ToString();
+            var target = invocation.Expression.ToString().Replace("!", "");
             var args = invocation.ArgumentList.Arguments
                 .Select(a => ConvertExpression(a.Expression))
                 .ToList();
@@ -4512,7 +4515,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         if (expr is ConditionalAccessExpressionSyntax condAccess)
         {
             _context.RecordFeatureUsage("null-conditional");
-            var targetExpr = condAccess.Expression.ToString();
+            var targetExpr = condAccess.Expression.ToString().Replace("!", "");
             var targetSpan = GetTextSpan(node);
 
             // If the target contains indexers, method calls, or other complex expressions,
@@ -7466,7 +7469,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
 
     private ExpressionNode ConvertInvocationExpression(InvocationExpressionSyntax invocation)
     {
-        var target = invocation.Expression.ToString();
+        var target = invocation.Expression.ToString().Replace("!", "");
         var args = invocation.ArgumentList.Arguments
             .Select(a => ConvertExpression(a.Expression))
             .ToList();
@@ -9124,7 +9127,9 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                 new TypeConstraintNode(span, TypeConstraintKind.NotNull),
 
             TypeConstraintSyntax typeConstraint =>
-                new TypeConstraintNode(span, TypeConstraintKind.TypeName, typeConstraint.Type.ToString()),
+                new TypeConstraintNode(span, TypeConstraintKind.TypeName,
+                    System.Text.RegularExpressions.Regex.Replace(
+                        typeConstraint.Type.ToString(), @"\s+", " ").Trim()),
 
             DefaultConstraintSyntax =>
                 // 'default' constraint (C# 9+) - no direct Calor equivalent, skip

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -4127,13 +4127,38 @@ public sealed class Parser
                             genericDepth -= 2;
                             Advance();
                         }
-                        else if (Check(TokenKind.Identifier))
+                        else if (Check(TokenKind.Identifier) || Current.IsKeyword)
                         {
                             sb.Append(Advance().Text);
                         }
                         else if (Check(TokenKind.Comma))
                         {
                             sb.Append(',');
+                            Advance();
+                        }
+                        else if (Check(TokenKind.Question))
+                        {
+                            sb.Append('?');
+                            Advance();
+                        }
+                        else if (Check(TokenKind.Star))
+                        {
+                            sb.Append('*');
+                            Advance();
+                        }
+                        else if (Check(TokenKind.OpenBracket))
+                        {
+                            sb.Append('[');
+                            Advance();
+                        }
+                        else if (Check(TokenKind.CloseBracket))
+                        {
+                            sb.Append(']');
+                            Advance();
+                        }
+                        else if (Check(TokenKind.Dot))
+                        {
+                            sb.Append('.');
                             Advance();
                         }
                         else


### PR DESCRIPTION
## Summary

Phase 6A fixes targeting the top failure patterns from the full 51-project pipeline run (349 failures / 262,150 files).

## Changes

- **WHERE constraint whitespace** — Normalize multiline Roslyn `ToString()` output to single-line (`\s+` → ` `) (~80-120 failures)
- **Nullable `?` in array-type generics** — Add `?`, `*`, `[]`, `.` token handling in `ParseValue()` array-bracket generic loop (~10-21 failures)
- **`@` prefix stripping** — Strip verbatim `@` from ANON and NEW initializer property names (~8 failures)
- **`!` null-forgiving stripping** — Strip `!` from `.ToString()` target strings in invocation/conditional access (~4 failures)
- **Backtick sanitization** — Strip `` ` `` from module names (C# generic arity indicator) (~2 failures)

## Test plan

- [x] All 6,161 unit tests pass
- [x] PowerShell: 1384/1391 (7 fail, -1 from before)
- [x] PowerToys: 3261/3270 (9 fail, -1 from before)
- [ ] Full 51-project pipeline verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)