### PR TITLE
fix: Phase 6B+C — WHERE dot-nested types, ANON keys, HSET hoisting

### DIFF
--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -1628,12 +1628,31 @@ public sealed class CalorEmitter : IAstVisitor<string>
     {
         var elementType = TypeMapper.CSharpToCalor(node.ElementType);
 
+        // Pre-evaluate elements to flush hoisted bindings before the §HSET block
+        var evaluatedElements = new List<string>();
+        var allHoisted = new List<string>();
+        foreach (var element in node.Elements)
+        {
+            var val = element.Accept(this);
+            if (_pendingHoistedLines.Count > 0)
+            {
+                allHoisted.AddRange(_pendingHoistedLines);
+                _pendingHoistedLines.Clear();
+            }
+            evaluatedElements.Add(val);
+        }
+
+        foreach (var hoisted in allHoisted)
+        {
+            AppendLine(hoisted);
+        }
+
         AppendLine($"§HSET{{{node.Id}:{elementType}}}");
         Indent();
 
-        foreach (var element in node.Elements)
+        foreach (var val in evaluatedElements)
         {
-            AppendLine(element.Accept(this));
+            AppendLine(val);
         }
 
         Dedent();

--- a/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
+++ b/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
@@ -8094,7 +8094,12 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
 
         foreach (var init in anonObj.Initializers)
         {
-            var name = init.NameEquals?.Name.Identifier.Text ?? init.Expression.ToString();
+            // Use explicit name if present; otherwise infer from the last simple identifier.
+            // Complex expressions (indexers, invocations) get a generated safe name.
+            var name = init.NameEquals?.Name.Identifier.Text
+                ?? (init.Expression is IdentifierNameSyntax id ? id.Identifier.ValueText
+                    : init.Expression is MemberAccessExpressionSyntax m ? m.Name.Identifier.ValueText
+                    : $"_prop{_context.GenerateId("p")}");
             var value = ConvertExpression(init.Expression);
             // Hoist block-level values (§LIST, §DICT, §SET) that can't appear inline
             if (IsBlockLevelCollection(value))
@@ -9183,7 +9188,8 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             return literal.Token.Text;
 
         // For compound expressions (bitwise OR, shifts, etc.), use ToString()
-        return equalsValue.Value.ToString();
+        // Strip global:: prefix which the parser doesn't handle
+        return equalsValue.Value.ToString().Replace("global::", "");
     }
 
     private static Visibility GetVisibility(SyntaxTokenList modifiers)

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -6035,15 +6035,61 @@ public sealed class Parser
                     sb.Append('.');
                     Advance();
                 }
-                else if (Check(TokenKind.Identifier))
+                else if (Check(TokenKind.Identifier) || Current.IsKeyword)
                 {
                     sb.Append(Current.Text);
+                    Advance();
+                }
+                else if (Check(TokenKind.Question))
+                {
+                    sb.Append('?');
+                    Advance();
+                }
+                else if (Check(TokenKind.Star))
+                {
+                    sb.Append('*');
+                    Advance();
+                }
+                else if (Check(TokenKind.OpenBracket))
+                {
+                    sb.Append('[');
+                    Advance();
+                }
+                else if (Check(TokenKind.CloseBracket))
+                {
+                    sb.Append(']');
                     Advance();
                 }
                 else
                 {
                     // Unknown token - stop parsing
                     break;
+                }
+            }
+        }
+
+        // Handle dot-qualified nested types after generics: Type<T>.NestedType
+        while (Check(TokenKind.Dot) && (Peek(1).Kind == TokenKind.Identifier || Peek(1).IsKeyword))
+        {
+            sb.Append('.');
+            Advance(); // consume .
+            sb.Append(Advance().Text);
+            // Handle another generic level on the nested type: Outer<T>.Inner<U>
+            if (Check(TokenKind.Less))
+            {
+                sb.Append('<');
+                Advance();
+                var innerDepth = 1;
+                while (!IsAtEnd && innerDepth > 0)
+                {
+                    if (Check(TokenKind.Less)) { sb.Append('<'); innerDepth++; Advance(); }
+                    else if (Check(TokenKind.Greater)) { sb.Append('>'); innerDepth--; Advance(); }
+                    else if (Check(TokenKind.GreaterGreater)) { sb.Append(">>"); innerDepth -= 2; Advance(); }
+                    else if (Check(TokenKind.Comma)) { sb.Append(", "); Advance(); }
+                    else if (Check(TokenKind.Dot)) { sb.Append('.'); Advance(); }
+                    else if (Check(TokenKind.Identifier)) { sb.Append(Current.Text); Advance(); }
+                    else if (Check(TokenKind.Question)) { sb.Append('?'); Advance(); }
+                    else break;
                 }
             }
         }


### PR DESCRIPTION
## Summary

Phase 6B+C fixes targeting ~24 more conversion failures from the 51-project pipeline.

## Changes

- **WHERE dot-after-generic** — `Type<T>.NestedType` now parsed in constraint types (~15 failures)
- **WHERE generic loop** — Add `?`, `*`, `[]`, keyword token handling inside `<...>` in constraints
- **ANON implicit property names** — Use last simple identifier instead of complex `ToString()` output (~5 failures)
- **Enum `global::` prefix** — Strip from enum member values (~2 failures)
- **HSET hoisting** — Add pre-evaluation + hoist pattern to `Visit(SetCreationNode)` matching List/Dict (~2 failures)

## Test plan

- [x] All 6,161 unit tests pass
- [ ] Full 51-project pipeline verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)