### PR TITLE
fix: Phase 6D — ulong literals, VAR in tuple patterns

### DIFF
--- a/src/Calor.Compiler/Parsing/Lexer.cs
+++ b/src/Calor.Compiler/Parsing/Lexer.cs
@@ -1835,6 +1835,13 @@ public sealed class Lexer
             {
                 return MakeToken(TokenKind.IntLiteral, longValue);
             }
+
+            // Fall back to ulong for values outside long range (e.g., UInt64.MaxValue)
+            if (ulong.TryParse(numericText, out var ulongValue))
+            {
+                return MakeToken(TokenKind.IntLiteral,
+                    new IntLiteralInfo(unchecked((long)ulongValue), IsHex: false, IsUnsigned: true, ulongValue));
+            }
         }
 
         _diagnostics.ReportInvalidTypedLiteral(CurrentSpan(), "number");

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -3469,13 +3469,27 @@ public sealed class Parser
         // Handle parenthesized patterns: (nameof x), (§PREL{gte} 5, _, _), (cast Type x), etc.
         if (Check(TokenKind.OpenParen))
         {
-            // Check if content looks like a pattern (contains §PREL, §VAR, commas for tuple patterns, etc.)
-            // In that case, consume the balanced parens as an opaque pattern
+            // Check if content looks like a pattern (contains §VAR, §PREL, etc. anywhere inside)
+            // Scan ahead through balanced parens to detect pattern tokens
             var saved = _position;
             Advance(); // consume (
-            // Check if first token inside is a pattern token
-            if (Check(TokenKind.RelationalPattern) || Check(TokenKind.Var) || Check(TokenKind.ListPattern)
-                || Check(TokenKind.PropertyPattern) || Check(TokenKind.PositionalPattern))
+            var scanDepth = 1;
+            var containsPatternToken = false;
+            while (!IsAtEnd && scanDepth > 0)
+            {
+                if (Check(TokenKind.OpenParen)) scanDepth++;
+                else if (Check(TokenKind.CloseParen)) { scanDepth--; if (scanDepth == 0) break; }
+                else if (Check(TokenKind.RelationalPattern) || Check(TokenKind.Var)
+                    || Check(TokenKind.ListPattern) || Check(TokenKind.PropertyPattern)
+                    || Check(TokenKind.PositionalPattern))
+                {
+                    containsPatternToken = true;
+                    break;
+                }
+                Advance();
+            }
+
+            if (containsPatternToken)
             {
                 // This is a parenthesized pattern group — consume balanced parens
                 _position = saved;


### PR DESCRIPTION
## Summary

- Add ulong fallback for plain decimal integers > long.MaxValue (~2 failures)
- Fix §VAR{} detection in tuple pattern arms — scan all tokens inside (), not just first (~4 failures)

## Test plan
- [x] All 6,161 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)