### PR TITLE
fix: Phase 6E — array ID mismatch, match indentation, delegate*

### DIFF
--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -1111,16 +1111,21 @@ public sealed class CalorEmitter : IAstVisitor<string>
         // Parser expects: §B[type:name] expression (no = sign)
         var initPart = node.Initializer != null ? $" {node.Initializer.Accept(this)}" : "";
 
+        // Simplify function pointer types (delegate* unmanaged[...]<...>) that break attribute parsing
+        var mappedType = node.TypeName != null ? TypeMapper.CSharpToCalor(node.TypeName) : null;
+        if (mappedType != null && mappedType.Contains("delegate*"))
+            mappedType = "nint"; // function pointers are pointer-sized; use nint as safe placeholder
+
         if (node.IsMutable)
         {
             // Mutable: {~name} or {~name:type}
-            var typePostfix = node.TypeName != null ? $":{TypeMapper.CSharpToCalor(node.TypeName)}" : "";
+            var typePostfix = mappedType != null ? $":{mappedType}" : "";
             AppendLine($"§B{{~{EscapeCalorIdentifier(node.Name)}{typePostfix}}}{initPart}");
         }
         else
         {
             // Immutable: {name} or {type:name}
-            var typePrefix = node.TypeName != null ? $"{TypeMapper.CSharpToCalor(node.TypeName)}:" : "";
+            var typePrefix = mappedType != null ? $"{mappedType}:" : "";
             AppendLine($"§B{{{typePrefix}{EscapeCalorIdentifier(node.Name)}}}{initPart}");
         }
         return "";
@@ -1268,7 +1273,7 @@ public sealed class CalorEmitter : IAstVisitor<string>
         }
         else
         {
-            AppendLine($"§ARR{{{elementType}:{variableName}}}");
+            AppendLine($"§ARR{{{elementType}:{variableName}:0}}");
             if (originalTarget != variableName)
                 AppendLine($"§ASSIGN {originalTarget} {variableName}");
         }
@@ -2314,9 +2319,16 @@ public sealed class CalorEmitter : IAstVisitor<string>
                 var stmtStr = CaptureStatementOutput(stmt);
                 if (!string.IsNullOrWhiteSpace(stmtStr))
                 {
-                    sb.AppendLine($"    {stmtStr.Trim()}");
+                    // Indent ALL lines of multi-line statements (e.g., §LIST blocks)
+                    var trimmed = stmtStr.Trim();
+                    var lines = trimmed.Split('\n');
+                    foreach (var line in lines)
+                    {
+                        sb.AppendLine($"    {line.TrimEnd()}");
+                    }
                 }
             }
+            sb.AppendLine("  §/K");
         }
 
         sb.Append($"§/W{{{id}}}");
@@ -2370,7 +2382,10 @@ public sealed class CalorEmitter : IAstVisitor<string>
         }
         else
         {
-            return $"§ARR{{{elementType}:{id}}}";
+            // Emit with explicit size 0 so the parser treats this as size-specified (3 positionals)
+            // and doesn't look for §/ARR closing tag. Without the :0, the 2-positional form
+            // §ARR{type:id} is parsed as an initialized array that expects §/ARR.
+            return $"§ARR{{{elementType}:{id}:0}}";
         }
     }
 


### PR DESCRIPTION
## Summary

Final batch of conversion fixes targeting the last ~28 fixable failures.

## Changes

- **Empty array size 0** — Arrays with no size/initializer in expression context emit `:0` to prevent parser from looking for §/ARR closing tag (~20 failures)
- **Match expression indentation** — Multi-line statements in match arms now properly indent ALL lines + emit §/K closing tags (~3 failures)
- **delegate* → nint** — Function pointer types simplified to `nint` in bind attribute blocks (~5 failures)

## Test plan
- [x] All 6,161 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)