### PR TITLE
fix: empty arrays use Array.Empty<T>() for nested array fix

### DIFF
--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -1274,7 +1274,7 @@ public sealed class CalorEmitter : IAstVisitor<string>
         }
         else
         {
-            AppendLine($"§ARR{{{elementType}:{variableName}:0}}");
+            AppendLine($"§B{{[{elementType}]:{variableName}}} §C{{Array.Empty<{elementType}>}} §/C");
             if (originalTarget != variableName)
                 AppendLine($"§ASSIGN {originalTarget} {variableName}");
         }
@@ -2386,10 +2386,8 @@ public sealed class CalorEmitter : IAstVisitor<string>
         }
         else
         {
-            // Emit with explicit size 0 so the parser treats this as size-specified (3 positionals)
-            // and doesn't look for §/ARR closing tag. Without the :0, the 2-positional form
-            // §ARR{type:id} is parsed as an initialized array that expects §/ARR.
-            return $"§ARR{{{elementType}:{id}:0}}";
+            // Empty array — use Array.Empty<T>() to avoid nested array parsing issues
+            return $"§C{{Array.Empty<{elementType}>}} §/C";
         }
     }
 

--- a/tests/Calor.Compiler.Tests/LinqSupportTests.cs
+++ b/tests/Calor.Compiler.Tests/LinqSupportTests.cs
@@ -229,7 +229,8 @@ public class LinqSupportTests
         Assert.True(result.Success, GetErrorMessage(result));
         Assert.NotNull(result.CalorSource);
         Assert.DoesNotContain("§ERR", result.CalorSource);
-        Assert.Contains("§ARR{i32:", result.CalorSource);
+        // Empty arrays use Array.Empty<T>() to avoid nested array parsing issues
+        Assert.Contains("Array.Empty<i32>", result.CalorSource);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Empty arrays now emit `§C{Array.Empty<T>} §/C` instead of `§ARR{type:id:0}` to fix nested array ID mismatch (~8 failures).

## Test plan
- [x] All 6,203 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)