### PR TITLE
feat: add ecosystem library effect manifests (Serilog, Newtonsoft, Dapper, MediatR, etc.)

### DIFF
--- a/src/Calor.Compiler/Effects/EffectEnforcementPass.cs
+++ b/src/Calor.Compiler/Effects/EffectEnforcementPass.cs
@@ -311,6 +311,28 @@ public sealed class EffectEnforcementPass
         "ControllerBase" => "Microsoft.AspNetCore.Mvc.ControllerBase",
         "Results" => "Microsoft.AspNetCore.Http.Results",
         "TypedResults" => "Microsoft.AspNetCore.Http.TypedResults",
+        // Serilog
+        "Log" => "Serilog.Log",
+        "SerilogLog" => "Serilog.Log",
+        // Newtonsoft.Json
+        "JsonConvert" => "Newtonsoft.Json.JsonConvert",
+        "JObject" => "Newtonsoft.Json.Linq.JObject",
+        "JArray" => "Newtonsoft.Json.Linq.JArray",
+        "JToken" => "Newtonsoft.Json.Linq.JToken",
+        // Dapper
+        "SqlMapper" => "Dapper.SqlMapper",
+        // MediatR
+        "IMediator" => "MediatR.IMediator",
+        "ISender" => "MediatR.ISender",
+        "Mediator" => "MediatR.Mediator",
+        // AutoMapper
+        "IMapper" => "AutoMapper.IMapper",
+        "Mapper" => "AutoMapper.Mapper",
+        // FluentValidation
+        "IValidator" => "FluentValidation.IValidator",
+        // Polly
+        "Policy" => "Polly.Policy",
+        "ResiliencePipeline" => "Polly.ResiliencePipeline",
         _ => shortName
     };
 

--- a/src/Calor.Compiler/Manifests/ecosystem-dapper.calor-effects.json
+++ b/src/Calor.Compiler/Manifests/ecosystem-dapper.calor-effects.json
@@ -1,0 +1,65 @@
+{
+  "version": "1.0",
+  "description": "Effect declarations for Dapper micro-ORM",
+  "library": "Dapper",
+  "confidence": "reviewed",
+  "mappings": [
+    {
+      "type": "Dapper.SqlMapper",
+      "methods": {
+        "Query": ["db:r"],
+        "QueryAsync": ["db:r"],
+        "QueryFirst": ["db:r"],
+        "QueryFirstAsync": ["db:r"],
+        "QueryFirstOrDefault": ["db:r"],
+        "QueryFirstOrDefaultAsync": ["db:r"],
+        "QuerySingle": ["db:r"],
+        "QuerySingleAsync": ["db:r"],
+        "QuerySingleOrDefault": ["db:r"],
+        "QuerySingleOrDefaultAsync": ["db:r"],
+        "QueryMultiple": ["db:r"],
+        "QueryMultipleAsync": ["db:r"],
+        "Execute": ["db:w"],
+        "ExecuteAsync": ["db:w"],
+        "ExecuteScalar": ["db:r"],
+        "ExecuteScalarAsync": ["db:r"],
+        "ExecuteReader": ["db:r"],
+        "ExecuteReaderAsync": ["db:r"]
+      }
+    },
+    {
+      "type": "Dapper.SqlMapper+GridReader",
+      "methods": {
+        "Read": ["db:r"],
+        "ReadAsync": ["db:r"],
+        "ReadFirst": ["db:r"],
+        "ReadFirstAsync": ["db:r"],
+        "ReadFirstOrDefault": ["db:r"],
+        "ReadFirstOrDefaultAsync": ["db:r"],
+        "ReadSingle": ["db:r"],
+        "ReadSingleAsync": ["db:r"],
+        "ReadSingleOrDefault": ["db:r"],
+        "ReadSingleOrDefaultAsync": ["db:r"],
+        "Dispose": [],
+        "DisposeAsync": []
+      }
+    },
+    {
+      "type": "Dapper.DynamicParameters",
+      "defaultEffects": [],
+      "methods": {
+        "Add": ["mut"],
+        "Get": [],
+        "*": []
+      }
+    },
+    {
+      "type": "Dapper.CommandDefinition",
+      "defaultEffects": [],
+      "methods": { "*": [] }
+    }
+  ],
+  "namespaceDefaults": {
+    "Dapper": ["db:rw"]
+  }
+}

--- a/src/Calor.Compiler/Manifests/ecosystem-mediatr-automap-validation-polly.calor-effects.json
+++ b/src/Calor.Compiler/Manifests/ecosystem-mediatr-automap-validation-polly.calor-effects.json
@@ -1,0 +1,170 @@
+{
+  "version": "1.0",
+  "description": "Effect declarations for MediatR, AutoMapper, FluentValidation, and Polly",
+  "confidence": "reviewed",
+  "mappings": [
+    {
+      "type": "MediatR.IMediator",
+      "methods": {
+        "Send": [],
+        "Publish": [],
+        "CreateStream": []
+      }
+    },
+    {
+      "type": "MediatR.ISender",
+      "methods": {
+        "Send": [],
+        "CreateStream": []
+      }
+    },
+    {
+      "type": "MediatR.IPublisher",
+      "methods": {
+        "Publish": []
+      }
+    },
+    {
+      "type": "MediatR.Mediator",
+      "methods": {
+        "Send": [],
+        "Publish": [],
+        "CreateStream": []
+      }
+    },
+    {
+      "type": "AutoMapper.IMapper",
+      "defaultEffects": [],
+      "methods": {
+        "Map": [],
+        "ProjectTo": []
+      }
+    },
+    {
+      "type": "AutoMapper.Mapper",
+      "defaultEffects": [],
+      "methods": {
+        "Map": [],
+        "ProjectTo": []
+      }
+    },
+    {
+      "type": "AutoMapper.MapperConfiguration",
+      "defaultEffects": [],
+      "methods": {
+        "CreateMapper": [],
+        "AssertConfigurationIsValid": []
+      }
+    },
+    {
+      "type": "FluentValidation.AbstractValidator`1",
+      "defaultEffects": [],
+      "methods": {
+        "Validate": [],
+        "ValidateAsync": [],
+        "ValidateAndThrow": ["throw"],
+        "ValidateAndThrowAsync": ["throw"]
+      }
+    },
+    {
+      "type": "FluentValidation.IValidator",
+      "defaultEffects": [],
+      "methods": {
+        "Validate": [],
+        "ValidateAsync": []
+      }
+    },
+    {
+      "type": "FluentValidation.IValidator`1",
+      "defaultEffects": [],
+      "methods": {
+        "Validate": [],
+        "ValidateAsync": []
+      }
+    },
+    {
+      "type": "FluentValidation.Results.ValidationResult",
+      "defaultEffects": [],
+      "methods": { "*": [] },
+      "getters": {
+        "IsValid": [],
+        "Errors": []
+      }
+    },
+    {
+      "type": "Polly.Policy",
+      "defaultEffects": [],
+      "methods": {
+        "Handle": [],
+        "HandleResult": [],
+        "Execute": [],
+        "ExecuteAsync": [],
+        "ExecuteAndCapture": [],
+        "ExecuteAndCaptureAsync": [],
+        "WaitAndRetry": [],
+        "WaitAndRetryAsync": [],
+        "WaitAndRetryForever": [],
+        "WaitAndRetryForeverAsync": [],
+        "Retry": [],
+        "RetryAsync": [],
+        "RetryForever": [],
+        "RetryForeverAsync": [],
+        "CircuitBreaker": [],
+        "CircuitBreakerAsync": [],
+        "AdvancedCircuitBreaker": [],
+        "AdvancedCircuitBreakerAsync": [],
+        "Fallback": [],
+        "FallbackAsync": [],
+        "Timeout": [],
+        "TimeoutAsync": [],
+        "Bulkhead": [],
+        "BulkheadAsync": [],
+        "Wrap": [],
+        "WrapAsync": [],
+        "NoOp": [],
+        "NoOpAsync": []
+      }
+    },
+    {
+      "type": "Polly.ISyncPolicy",
+      "methods": {
+        "Execute": [],
+        "ExecuteAndCapture": []
+      }
+    },
+    {
+      "type": "Polly.IAsyncPolicy",
+      "methods": {
+        "ExecuteAsync": [],
+        "ExecuteAndCaptureAsync": []
+      }
+    },
+    {
+      "type": "Polly.ResiliencePipeline",
+      "methods": {
+        "Execute": [],
+        "ExecuteAsync": []
+      }
+    },
+    {
+      "type": "Polly.ResiliencePipelineBuilder",
+      "defaultEffects": [],
+      "methods": {
+        "AddRetry": [],
+        "AddCircuitBreaker": [],
+        "AddTimeout": [],
+        "AddRateLimiter": [],
+        "AddFallback": [],
+        "AddHedging": [],
+        "AddConcurrencyLimiter": [],
+        "Build": []
+      }
+    }
+  ],
+  "namespaceDefaults": {
+    "AutoMapper": [],
+    "FluentValidation": [],
+    "FluentValidation.Results": [],
+    "Polly": []
+  }
+}

--- a/src/Calor.Compiler/Manifests/ecosystem-newtonsoft-json.calor-effects.json
+++ b/src/Calor.Compiler/Manifests/ecosystem-newtonsoft-json.calor-effects.json
@@ -1,0 +1,172 @@
+{
+  "version": "1.0",
+  "description": "Effect declarations for Newtonsoft.Json (Json.NET) serialization library",
+  "library": "Newtonsoft.Json",
+  "confidence": "reviewed",
+  "mappings": [
+    {
+      "type": "Newtonsoft.Json.JsonConvert",
+      "defaultEffects": [],
+      "methods": {
+        "SerializeObject": [],
+        "DeserializeObject": [],
+        "PopulateObject": ["mut"],
+        "ToString": [],
+        "SerializeXmlNode": [],
+        "DeserializeXmlNode": [],
+        "*": []
+      }
+    },
+    {
+      "type": "Newtonsoft.Json.JsonSerializer",
+      "methods": {
+        "Serialize": ["cw"],
+        "Deserialize": ["cr"],
+        "Populate": ["mut"],
+        "Create": [],
+        "CreateDefault": []
+      }
+    },
+    {
+      "type": "Newtonsoft.Json.Linq.JObject",
+      "defaultEffects": [],
+      "methods": {
+        "Parse": [],
+        "FromObject": [],
+        "Load": ["cr"],
+        "LoadAsync": ["cr"],
+        "WriteTo": ["cw"],
+        "WriteToAsync": ["cw"],
+        "Add": ["mut"],
+        "Remove": ["mut"],
+        "TryGetValue": [],
+        "GetValue": [],
+        "Property": [],
+        "Properties": [],
+        "ToString": [],
+        "ToObject": [],
+        "SelectToken": [],
+        "SelectTokens": [],
+        "Merge": ["mut"],
+        "DeepClone": []
+      },
+      "getters": {
+        "Count": [],
+        "Type": [],
+        "HasValues": [],
+        "First": [],
+        "Last": [],
+        "Item": []
+      }
+    },
+    {
+      "type": "Newtonsoft.Json.Linq.JArray",
+      "defaultEffects": [],
+      "methods": {
+        "Parse": [],
+        "FromObject": [],
+        "Load": ["cr"],
+        "LoadAsync": ["cr"],
+        "WriteTo": ["cw"],
+        "WriteToAsync": ["cw"],
+        "Add": ["mut"],
+        "Remove": ["mut"],
+        "RemoveAt": ["mut"],
+        "Insert": ["mut"],
+        "Clear": ["mut"],
+        "ToString": [],
+        "ToObject": [],
+        "SelectToken": [],
+        "SelectTokens": [],
+        "DeepClone": []
+      }
+    },
+    {
+      "type": "Newtonsoft.Json.Linq.JToken",
+      "defaultEffects": [],
+      "methods": {
+        "Parse": [],
+        "FromObject": [],
+        "Load": ["cr"],
+        "LoadAsync": ["cr"],
+        "WriteTo": ["cw"],
+        "WriteToAsync": ["cw"],
+        "ToString": [],
+        "ToObject": [],
+        "SelectToken": [],
+        "SelectTokens": [],
+        "Value": [],
+        "Values": [],
+        "Children": [],
+        "DeepClone": [],
+        "Replace": ["mut"]
+      }
+    },
+    {
+      "type": "Newtonsoft.Json.Linq.JValue",
+      "defaultEffects": [],
+      "methods": {
+        "*": []
+      }
+    },
+    {
+      "type": "Newtonsoft.Json.JsonReader",
+      "methods": {
+        "Read": ["cr"],
+        "ReadAsync": ["cr"],
+        "ReadAsString": ["cr"],
+        "ReadAsInt32": ["cr"],
+        "ReadAsBoolean": ["cr"],
+        "Close": [],
+        "Dispose": []
+      }
+    },
+    {
+      "type": "Newtonsoft.Json.JsonWriter",
+      "methods": {
+        "WriteStartObject": ["cw"],
+        "WriteEndObject": ["cw"],
+        "WriteStartArray": ["cw"],
+        "WriteEndArray": ["cw"],
+        "WritePropertyName": ["cw"],
+        "WriteValue": ["cw"],
+        "WriteNull": ["cw"],
+        "WriteRawValue": ["cw"],
+        "WriteRaw": ["cw"],
+        "Flush": ["cw"],
+        "FlushAsync": ["cw"],
+        "Close": [],
+        "CloseAsync": [],
+        "Dispose": []
+      }
+    },
+    {
+      "type": "Newtonsoft.Json.JsonTextReader",
+      "methods": {
+        "Read": ["cr"],
+        "ReadAsync": ["cr"],
+        "Close": [],
+        "Dispose": []
+      },
+      "constructors": {
+        "(TextReader)": []
+      }
+    },
+    {
+      "type": "Newtonsoft.Json.JsonTextWriter",
+      "methods": {
+        "Flush": ["cw"],
+        "FlushAsync": ["cw"],
+        "Close": [],
+        "Dispose": []
+      },
+      "constructors": {
+        "(TextWriter)": []
+      }
+    }
+  ],
+  "namespaceDefaults": {
+    "Newtonsoft.Json.Linq": [],
+    "Newtonsoft.Json.Serialization": []
+  }
+}

--- a/src/Calor.Compiler/Manifests/ecosystem-serilog.calor-effects.json
+++ b/src/Calor.Compiler/Manifests/ecosystem-serilog.calor-effects.json
@@ -1,0 +1,74 @@
+{
+  "version": "1.0",
+  "description": "Effect declarations for Serilog structured logging library",
+  "library": "Serilog",
+  "confidence": "reviewed",
+  "mappings": [
+    {
+      "type": "Serilog.Log",
+      "methods": {
+        "Verbose": ["cw"],
+        "Debug": ["cw"],
+        "Information": ["cw"],
+        "Warning": ["cw"],
+        "Error": ["cw"],
+        "Fatal": ["cw"],
+        "Write": ["cw"],
+        "CloseAndFlush": ["cw"],
+        "ForContext": [],
+        "Logger": []
+      },
+      "getters": {
+        "Logger": []
+      }
+    },
+    {
+      "type": "Serilog.ILogger",
+      "methods": {
+        "Verbose": ["cw"],
+        "Debug": ["cw"],
+        "Information": ["cw"],
+        "Warning": ["cw"],
+        "Error": ["cw"],
+        "Fatal": ["cw"],
+        "Write": ["cw"],
+        "ForContext": [],
+        "BindMessageTemplate": [],
+        "BindProperty": [],
+        "IsEnabled": []
+      }
+    },
+    {
+      "type": "Serilog.LoggerConfiguration",
+      "defaultEffects": [],
+      "methods": {
+        "MinimumLevel": [],
+        "WriteTo": [],
+        "Enrich": [],
+        "Filter": [],
+        "Destructure": [],
+        "ReadFrom": [],
+        "AuditTo": [],
+        "CreateLogger": []
+      }
+    },
+    {
+      "type": "Serilog.Core.Logger",
+      "methods": {
+        "Verbose": ["cw"],
+        "Debug": ["cw"],
+        "Information": ["cw"],
+        "Warning": ["cw"],
+        "Error": ["cw"],
+        "Fatal": ["cw"],
+        "Write": ["cw"],
+        "ForContext": [],
+        "Dispose": []
+      }
+    }
+  ],
+  "namespaceDefaults": {
+    "Serilog": ["cw"],
+    "Serilog.Events": []
+  }
+}

--- a/tests/Calor.Enforcement.Tests/EffectResolverTests.cs
+++ b/tests/Calor.Enforcement.Tests/EffectResolverTests.cs
@@ -577,4 +577,129 @@ public class EffectResolverTests
         Assert.Equal(EffectResolutionStatus.Resolved, result.Status);
         Assert.Contains(result.Effects.Effects, e => e.Value == expectedValue);
     }
+
+    // ========================================================================
+    // Ecosystem manifest tests: Serilog
+    // ========================================================================
+
+    [Theory]
+    [InlineData("Serilog.Log", "Information", "console_write")]
+    [InlineData("Serilog.Log", "Warning", "console_write")]
+    [InlineData("Serilog.Log", "Error", "console_write")]
+    [InlineData("Serilog.Log", "Fatal", "console_write")]
+    [InlineData("Serilog.Log", "Debug", "console_write")]
+    [InlineData("Serilog.ILogger", "Information", "console_write")]
+    [InlineData("Serilog.ILogger", "Write", "console_write")]
+    public void Ecosystem_Serilog_LogMethods_ResolveToCw(string type, string method, string expectedValue)
+    {
+        var resolver = new EffectResolver();
+        resolver.Initialize();
+        var result = resolver.Resolve(type, method);
+        Assert.NotEqual(EffectResolutionStatus.Unknown, result.Status);
+        Assert.Contains(result.Effects.Effects, e => e.Value == expectedValue);
+    }
+
+    [Fact]
+    public void Ecosystem_Serilog_IsEnabled_IsPure()
+    {
+        var resolver = new EffectResolver();
+        resolver.Initialize();
+        var result = resolver.Resolve("Serilog.ILogger", "IsEnabled");
+        Assert.Equal(EffectResolutionStatus.PureExplicit, result.Status);
+    }
+
+    // ========================================================================
+    // Ecosystem manifest tests: Newtonsoft.Json
+    // ========================================================================
+
+    [Theory]
+    [InlineData("Newtonsoft.Json.JsonConvert", "SerializeObject")]
+    [InlineData("Newtonsoft.Json.JsonConvert", "DeserializeObject")]
+    [InlineData("Newtonsoft.Json.Linq.JObject", "Parse")]
+    [InlineData("Newtonsoft.Json.Linq.JArray", "Parse")]
+    [InlineData("Newtonsoft.Json.Linq.JToken", "Parse")]
+    public void Ecosystem_NewtonsoftJson_PureMethods(string type, string method)
+    {
+        var resolver = new EffectResolver();
+        resolver.Initialize();
+        var result = resolver.Resolve(type, method);
+        Assert.Equal(EffectResolutionStatus.PureExplicit, result.Status);
+    }
+
+    [Theory]
+    [InlineData("Newtonsoft.Json.Linq.JObject", "Add", "heap_write")]
+    [InlineData("Newtonsoft.Json.Linq.JObject", "Remove", "heap_write")]
+    [InlineData("Newtonsoft.Json.Linq.JArray", "Add", "heap_write")]
+    [InlineData("Newtonsoft.Json.JsonConvert", "PopulateObject", "heap_write")]
+    public void Ecosystem_NewtonsoftJson_MutationMethods(string type, string method, string expectedValue)
+    {
+        var resolver = new EffectResolver();
+        resolver.Initialize();
+        var result = resolver.Resolve(type, method);
+        Assert.Equal(EffectResolutionStatus.Resolved, result.Status);
+        Assert.Contains(result.Effects.Effects, e => e.Value == expectedValue);
+    }
+
+    // ========================================================================
+    // Ecosystem manifest tests: Dapper
+    // ========================================================================
+
+    [Theory]
+    [InlineData("Dapper.SqlMapper", "Query", "database_read")]
+    [InlineData("Dapper.SqlMapper", "QueryAsync", "database_read")]
+    [InlineData("Dapper.SqlMapper", "QueryFirst", "database_read")]
+    [InlineData("Dapper.SqlMapper", "QueryFirstOrDefault", "database_read")]
+    [InlineData("Dapper.SqlMapper", "QuerySingle", "database_read")]
+    [InlineData("Dapper.SqlMapper", "ExecuteScalar", "database_read")]
+    public void Ecosystem_Dapper_ReadMethods(string type, string method, string expectedValue)
+    {
+        var resolver = new EffectResolver();
+        resolver.Initialize();
+        var result = resolver.Resolve(type, method);
+        Assert.Equal(EffectResolutionStatus.Resolved, result.Status);
+        Assert.Contains(result.Effects.Effects, e => e.Value == expectedValue);
+    }
+
+    [Theory]
+    [InlineData("Dapper.SqlMapper", "Execute", "database_write")]
+    [InlineData("Dapper.SqlMapper", "ExecuteAsync", "database_write")]
+    public void Ecosystem_Dapper_WriteMethods(string type, string method, string expectedValue)
+    {
+        var resolver = new EffectResolver();
+        resolver.Initialize();
+        var result = resolver.Resolve(type, method);
+        Assert.Equal(EffectResolutionStatus.Resolved, result.Status);
+        Assert.Contains(result.Effects.Effects, e => e.Value == expectedValue);
+    }
+
+    // ========================================================================
+    // Ecosystem manifest tests: MediatR, AutoMapper, FluentValidation, Polly
+    // ========================================================================
+
+    [Theory]
+    [InlineData("MediatR.IMediator", "Send")]
+    [InlineData("MediatR.IMediator", "Publish")]
+    [InlineData("AutoMapper.IMapper", "Map")]
+    [InlineData("AutoMapper.IMapper", "ProjectTo")]
+    [InlineData("FluentValidation.IValidator", "Validate")]
+    [InlineData("FluentValidation.IValidator", "ValidateAsync")]
+    [InlineData("Polly.Policy", "Execute")]
+    [InlineData("Polly.Policy", "ExecuteAsync")]
+    public void Ecosystem_MediatR_AutoMapper_FluentValidation_Polly_ArePure(string type, string method)
+    {
+        var resolver = new EffectResolver();
+        resolver.Initialize();
+        var result = resolver.Resolve(type, method);
+        Assert.Equal(EffectResolutionStatus.PureExplicit, result.Status);
+    }
+
+    [Fact]
+    public void Ecosystem_FluentValidation_ValidateAndThrow_HasThrowEffect()
+    {
+        var resolver = new EffectResolver();
+        resolver.Initialize();
+        var result = resolver.Resolve("FluentValidation.AbstractValidator`1", "ValidateAndThrow");
+        Assert.Equal(EffectResolutionStatus.Resolved, result.Status);
+        Assert.Contains(result.Effects.Effects, e => e.Value == "intentional");
+    }
 }


### PR DESCRIPTION
## Summary

- Add effect manifests for 6 popular .NET ecosystem libraries
- Add 15+ short name mappings for ecosystem types
- 34 new resolver tests, all 210 enforcement tests pass

## Libraries covered

| Library | Key types | Effects |
|---------|-----------|---------|
| **Serilog** | `Log`, `ILogger` | `cw` for all log methods |
| **Newtonsoft.Json** | `JsonConvert`, `JObject`, `JArray`, `JToken` | Pure for serialize/parse, `mut` for Add/Remove |
| **Dapper** | `SqlMapper` | `db:r` for Query, `db:w` for Execute |
| **MediatR** | `IMediator`, `ISender` | Pure (handler effects are user-specified) |
| **AutoMapper** | `IMapper` | Pure |
| **FluentValidation** | `IValidator`, `AbstractValidator` | Pure for Validate, `throw` for ValidateAndThrow |
| **Polly** | `Policy`, `ResiliencePipeline` | Pure (delegates to wrapped call) |

## Test plan

- [x] 34 new ecosystem resolver tests covering all libraries
- [x] All 210 enforcement tests pass
- [x] All compiler tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)