### PR TITLE
feat: add changelog page and What's New banner

### DIFF
--- a/website/content/changelog.mdx
+++ b/website/content/changelog.mdx
@@ -1,0 +1,61 @@
+---
+title: "Changelog"
+order: 99
+---
+
+
+All notable changes to Calor, organized by release.
+
+---
+
+## [0.4.7] - 2026-04-20
+
+### Added
+- **Static analysis for class members** — The `--analyze` flag now examines methods, constructors, property accessors, operators, indexers, and event accessors (previously only top-level functions were analyzed)
+- **Verification-gated reporting** — `--analyze` only reports proven findings by default (Z3-confirmed or constant analysis); use `--all-findings` for lower-confidence results
+- **Taint hop-count tracking** — Taint analysis tracks propagation steps; single-hop parameter-to-sink flows filtered by default to reduce false positives
+- **Bug pattern detection in class members** — Division by zero, null dereference, integer overflow, off-by-one, path traversal, command injection, and SQL injection detection now covers all class member bodies
+- **Arity-aware overload resolution** — Correct overload resolved by argument count, preventing wrong return types from flowing into Z3
+- **Constructor initializer binding** — `: base()`/`: this()` arguments visible to bug pattern checkers
+- **33 new unit tests** for class member binding, scope, overloads, dataflow, and end-to-end analysis
+- **New `--all-findings` CLI flag** for showing all analysis findings including inconclusive results
+- **New [static analysis documentation](/cli/static-analysis/)** page
+
+### Fixed
+- **False positive elimination** — Unhandled expression types return opaque expressions instead of literal zero, eliminating false division-by-zero reports
+- **this.field shadowing** — `this.field` resolves from class scope, not method scope
+- **Throw-to-catch CFG edges** — Throw statements inside try blocks now flow to catch blocks
+- **Assignment dataflow** — `x = 1` no longer reports `x` as used before write
+
+### Validated
+- **47 open-source projects scanned** — 23 verified findings, ~90% true positive rate
+- **Real findings**: ILSpy null dereferences, FluentFTP path traversal, ASP.NET Core path traversal
+
+---
+
+## [0.4.6] - 2026-04-18
+
+### Added
+- **Effect system: .NET framework manifests** — Tier B effect manifests for 30+ common .NET framework interfaces (ILogger, DbContext, HttpClient, ControllerBase, etc.)
+- **Effect system: ecosystem library manifests** — Manifests for Serilog, Newtonsoft.Json, Dapper, MediatR, AutoMapper, FluentValidation, Polly
+- **Effect system: BCL manifest expansion** — New manifests for System.Text.Json, Regex, Concurrent collections, Crypto types
+- **Effect system: variable type resolution** — Enforcement pass resolves instance method calls via initializer tracking
+- 95 new enforcement tests (210 total)
+
+### Fixed
+- **Effect system: unified resolver** — Consolidated three parallel effect systems into a single manifest-based resolver
+- **Parser: compound effect codes** — Fixed silent mis-parsing of chained compound codes
+
+---
+
+## [0.4.5] - 2026-04-16
+
+### Fixed
+- Restrict expression-only match case to lambda-only patterns
+- PLIST nested call depth, call-as-pattern, OPTION compaction
+
+---
+
+## Earlier Releases
+
+See the [full changelog on GitHub](https://github.com/juanmicrosoft/calor/blob/main/CHANGELOG.md) for versions prior to 0.4.5.

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { DM_Sans, Raleway, JetBrains_Mono, VT323 } from 'next/font/google';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import { Header } from '@/components/Header';
 import { Footer } from '@/components/Footer';
+import { WhatsNewBanner } from '@/components/landing/WhatsNewBanner';
 import './globals.css';
 
 const dmSans = DM_Sans({
@@ -74,6 +75,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className={`${dmSans.variable} ${displayFont.variable} ${jetbrainsMono.variable} ${vt323.variable} font-body antialiased`}>
         <div className="relative flex min-h-screen flex-col">
+          <WhatsNewBanner />
           <Header />
           <main className="flex-1">{children}</main>
           <Footer />

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -16,6 +16,7 @@ const navigation = [
   { name: 'Docs', href: '/docs/', path: `${basePath}/docs/` },
   { name: 'Getting Started', href: '/docs/getting-started/', path: `${basePath}/docs/getting-started/` },
   { name: 'Benchmarks', href: '/docs/benchmarking/', path: `${basePath}/docs/benchmarking/` },
+  { name: 'Changelog', href: '/docs/changelog/', path: `${basePath}/docs/changelog/` },
 ];
 
 export function Header() {

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import { X, Sparkles } from 'lucide-react';
+
+export function WhatsNewBanner() {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) return null;
+
+  return (
+    <div className="relative bg-gradient-to-r from-calor-cerulean/10 via-calor-cyan/10 to-calor-cerulean/10 border-b">
+      <div className="mx-auto max-w-7xl px-4 py-2.5 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-center gap-3 text-sm">
+          <Sparkles className="h-4 w-4 text-calor-cerulean flex-shrink-0" />
+          <p className="text-center">
+            <span className="font-semibold text-calor-cerulean">v0.4.7</span>
+            <span className="text-muted-foreground mx-1.5">&mdash;</span>
+            <span className="text-foreground">Static analysis for class members: find null derefs, injection bugs, and more.</span>
+            <Link
+              href="/docs/changelog/"
+              className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"
+            >
+              See what&apos;s new
+            </Link>
+          </p>
+          <button
+            onClick={() => setDismissed(true)}
+            className="ml-2 flex-shrink-0 rounded-full p-1 hover:bg-muted transition-colors"
+            aria-label="Dismiss banner"
+          >
+            <X className="h-3.5 w-3.5 text-muted-foreground" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/docs/changelog/` page with recent release notes (v0.4.5-0.4.7)
- Dismissible "What's New" banner at the top of every page highlighting v0.4.7
- "Changelog" link added to header navigation

## Changes

**New files:**
- `website/content/changelog.mdx` — Changelog page with curated release highlights
- `website/src/components/landing/WhatsNewBanner.tsx` — Gradient banner with version, description, dismiss button

**Updated files:**
- `website/src/app/layout.tsx` — Banner imported and placed above Header
- `website/src/components/Header.tsx` — "Changelog" added to navigation array

## Test plan
- [ ] Website builds successfully
- [ ] Changelog page renders at /docs/changelog/
- [ ] Banner appears on landing page and docs pages
- [ ] Banner dismisses when X is clicked
- [ ] "Changelog" nav link works
- [ ] "See what's new" link in banner navigates to changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)