### PR TITLE
fix: update WhatsNewBanner to v0.4.8

### DIFF
--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -15,9 +15,9 @@ export function WhatsNewBanner() {
         <div className="flex items-center justify-center gap-3 text-sm">
           <Sparkles className="h-4 w-4 text-calor-cerulean flex-shrink-0" />
           <p className="text-center">
-            <span className="font-semibold text-calor-cerulean">v0.4.7</span>
+            <span className="font-semibold text-calor-cerulean">v0.4.8</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">Static analysis for class members: find null derefs, injection bugs, and more.</span>
+            <span className="text-foreground">New: <code className="text-xs">calor effects suggest</code> — auto-generate manifest templates for unresolved .NET calls.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"


### PR DESCRIPTION
Update the landing page banner from v0.4.7 to v0.4.8 with the new `calor effects suggest` command highlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)