### PR TITLE
fix: escape MDX angle bracket in IL analysis guide

### DIFF
--- a/website/content/guides/il-analysis.mdx
+++ b/website/content/guides/il-analysis.mdx
@@ -157,7 +157,7 @@ When IL analysis is enabled, changes to referenced assemblies (e.g., updating a 
 **Don't bother if:**
 - All your external calls are to .NET framework types already covered by manifests
 - Your project is small enough that a few custom manifest entries are easy to maintain
-- Build time is critical and every millisecond matters (though the overhead is <5ms)
+- Build time is critical and every millisecond matters (though the overhead is under 5ms)
 
 ## Relationship to Manifests
 


### PR DESCRIPTION
## Summary
- `<5ms` in the IL analysis guide was being parsed as an HTML/JSX tag by the MDX compiler, causing the website build to fail
- This is why the v0.4.9 website deployment failed — both the release-triggered and manual workflow runs hit this error
- Changed to "under 5ms"

## Root cause
MDX treats `<` followed by a character as an HTML tag opener. `<5ms` → MDX tries to parse `5ms` as a tag name → fails with "Unexpected character 5 before name".

## After merge
Trigger the website deployment workflow to publish the v0.4.9 changelog and banner:
```
gh workflow run nextjs-gh-pages.yml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)