### PR TITLE
feat: wire autoFix and MCP resources into agent instructions

### DIFF
--- a/src/Calor.Compiler/Mcp/Tools/CompileTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/CompileTool.cs
@@ -17,7 +17,9 @@ public sealed class CompileTool : McpToolBase
     public override int TimeoutSeconds => 120;
 
     public override string Description =>
-        "Compile Calor source code to C#. Accepts inline 'source', a 'filePath' to a .calr file on disk, or batch modes via 'files'/'projectPath'. Returns generated C# code and any compilation diagnostics.";
+        "Compile Calor source code to C#. Use autoFix: true to auto-fix parser, ID, and effect errors (up to 3 passes). " +
+        "Each diagnostic includes a fix field with concrete edits. " +
+        "Typically the first tool called after writing .calr code. Follow with calor_verify for contract checking.";
 
     public override McpToolAnnotations? Annotations => new() { ReadOnlyHint = true, IdempotentHint = true };
 

--- a/src/Calor.Compiler/Resources/Templates/CLAUDE.md.template
+++ b/src/Calor.Compiler/Resources/Templates/CLAUDE.md.template
@@ -5,9 +5,11 @@ This is an **Calor-first project**. All new code MUST be written in Calor. Exist
 
 ### MANDATORY Rules for AI Agents
 
-**Rule 0: Look up syntax reference before writing Calor**
+**Rule 0: Read the primer and look up syntax before writing Calor**
+- At session start, read the `calor://primer` MCP resource for canonical Calor examples
 - Before writing ANY `.calr` code, use `calor_help` MCP tool for syntax guidance
-- These provide the authoritative syntax reference on-demand
+- Look up effect codes via `calor://effects` resource before writing `§E{...}` declarations
+- Look up ID prefixes via `calor://id-prefixes` resource before creating IDs
 - Applies to: new files, conversions, and edits to existing .calr files
 
 **Rule 1: Never create new `.cs` files**
@@ -25,18 +27,21 @@ This is an **Calor-first project**. All new code MUST be written in Calor. Exist
 - Files ending in `.g.cs` are auto-generated from Calor - do not edit them
 - If you need to change generated output, edit the source `.calr` file instead
 
-**Rule 4: Validate syntax after writing**
-- After writing or editing ANY `.calr` file, run `calor diagnose <file.calr>`
-- Fix any reported errors before proceeding
-- This catches ALL syntax mistakes at once (build only shows first error)
+**Rule 4: Compile with autoFix after writing**
+- After writing or editing ANY `.calr` file, use `calor_compile` with `autoFix: true`
+- This auto-fixes parser errors, ID issues, and missing/wrong effect declarations in up to 3 passes
+- If errors remain after autoFix, read the diagnostics — each includes a `fix` field with concrete edits
+- Apply the fix edits directly instead of re-reasoning about the error
 
 ### Workflow for Any Code Change
 
-1. **Always first** → Use `calor_help` MCP tool to get syntax reference
-2. **New feature/file?** → Create `.calr` file
-3. **Modify existing `.calr` file?** → Edit directly
-4. **Modify existing `.cs` file?** → Convert to `.calr` first
-5. **After any .calr change** → Run `calor diagnose` to validate
+1. **Session start** → Read `calor://primer` resource for syntax examples
+2. **Before writing effects** → Read `calor://effects` resource for valid effect codes
+3. **New feature/file?** → Create `.calr` file, use `calor_help` for syntax
+4. **Modify existing `.calr` file?** → Edit directly
+5. **Modify existing `.cs` file?** → Convert to `.calr` first using `calor_convert`
+6. **After any .calr change** → `calor_compile` with `autoFix: true` — fixes most errors automatically
+7. **If errors remain** → Apply the `fix.edits` from each diagnostic directly
 
 ### Pre-PR Agent Testing
 
@@ -56,7 +61,7 @@ All tasks must pass (2/3 runs succeed). If tests fail, investigate before procee
 #### Available MCP Tools
 
 **Compilation & Verification:**
-- `calor_compile` - Compile Calor files to C#
+- `calor_compile` - Compile Calor files to C# (use `autoFix: true` to auto-fix parser, ID, and effect errors)
 - `calor_verify` - Verify contracts and correctness
 - `calor_verify_contracts` - Verify function contracts
 
@@ -90,6 +95,16 @@ All tasks must pass (2/3 runs succeed). If tests fail, investigate before procee
 
 **Testing:**
 - `calor_self_test` - Run Calor self-test suite
+
+#### MCP Resources (read at session start)
+
+- `calor://primer` - Canonical Calor examples (module, function, effects, contracts, class, IDs)
+- `calor://effects` - All valid effect codes with descriptions (read before writing §E{...})
+- `calor://tags` - Section tag grammar with opening/closing forms (§/I not §/IF for if-blocks)
+- `calor://id-prefixes` - ULID ID prefixes for each declaration kind
+- `calor://workflows` - Step-by-step decision trees for common tasks
+- `calor://syntax-reference` - Complete syntax documentation
+- `calor://error-catalog` - All diagnostic codes with fix patterns
 
 #### Key Commands
 ```bash


### PR DESCRIPTION
## Summary

Connects Phase 0 (resources) and Phase 1 (autoFix) to the agent's workflow — without this, the features exist but the agent doesn't know to use them.

### Changes

**CLAUDE.md.template:**
- Rule 0: "Read `calor://primer` at session start" + "Look up effect codes via `calor://effects`"
- Rule 4: Changed from "run `calor diagnose`" to "use `calor_compile` with `autoFix: true`"
- Workflow: 7-step flow starting with primer, ending with fix.edits application
- New "MCP Resources" section listing all 7 available resources
- Tool listing: `calor_compile` now mentions autoFix

**CompileTool.cs:**
- MCP description updated with workflow hint: "Use autoFix: true to auto-fix parser, ID, and effect errors"

### Why this matters

The agent only follows instructions it sees. Phase 0 added 6 MCP resources and Phase 1 added autoFix, but the agent's CLAUDE.md still said "run calor diagnose" — a manual fix workflow. Now the agent is told to:
1. Read the primer (preventing syntax errors)
2. Look up effects (preventing wrong §E{} declarations)
3. Compile with autoFix (auto-resolving errors the compiler can fix)
4. Apply fix.edits for remaining errors (no re-reasoning needed)

## Test plan

- [x] Full solution: 0 warnings, 0 errors
- [x] Template references verified: 5× autoFix, 3× calor://primer, 3× calor://effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)