### PR TITLE
feat: experiment registry query CLI (Phase 0h)

### DIFF
--- a/src/Calor.Compiler/Commands/EvaluationCommand.cs
+++ b/src/Calor.Compiler/Commands/EvaluationCommand.cs
@@ -1,0 +1,150 @@
+using System.CommandLine;
+using System.Text.Json;
+using Calor.Compiler.Experiments;
+
+namespace Calor.Compiler.Commands;
+
+/// <summary>
+/// Top-level <c>calor evaluation</c> command — home for the research-plan evaluation
+/// harness. Currently provides <c>registry</c> for querying
+/// <c>docs/experiments/registry.json</c>. <c>ab</c> (paired baseline-vs-candidate
+/// benchmark runner) will land in a later sub-phase of the type-system research plan.
+/// </summary>
+public static class EvaluationCommand
+{
+    public static Command Create()
+    {
+        var command = new Command("evaluation", "Evaluation harness for the Calor-native type-system research plan (Phase 0+).");
+
+        command.AddCommand(CreateRegistryCommand());
+
+        return command;
+    }
+
+    // ========================================================================
+    // registry subcommand
+    // ========================================================================
+
+    private static Command CreateRegistryCommand()
+    {
+        var fileOption = new Option<FileInfo?>(
+            aliases: ["--file", "-f"],
+            description: "Path to the registry JSON file. Defaults to ./docs/experiments/registry.json.");
+
+        var queryOption = new Option<string?>(
+            aliases: ["--query", "-q"],
+            description: "Query mode: current-state | two-kill-risk | held-owned-by | stale-holds | audit-trail")
+        { IsRequired = true };
+
+        var hypothesisOption = new Option<string?>(
+            aliases: ["--hypothesis"],
+            description: "Hypothesis ID (required for current-state, audit-trail).");
+
+        var tupleOption = new Option<string?>(
+            aliases: ["--tuple"],
+            description: "Identity tuple for two-kill-risk: '<tag>/<code-class>/<direction>'.");
+
+        var userOption = new Option<string?>(
+            aliases: ["--user"],
+            description: "GitHub username (required for held-owned-by).");
+
+        var prettyOption = new Option<bool>(
+            aliases: ["--pretty"],
+            description: "Pretty-print JSON output (default: false — compact for machine consumption).",
+            getDefaultValue: () => false);
+
+        var command = new Command("registry", "Query the experimental hypothesis registry.")
+        {
+            fileOption,
+            queryOption,
+            hypothesisOption,
+            tupleOption,
+            userOption,
+            prettyOption
+        };
+
+        command.SetHandler(ExecuteRegistry,
+            fileOption, queryOption, hypothesisOption, tupleOption, userOption, prettyOption);
+
+        return command;
+    }
+
+    private static async Task ExecuteRegistry(
+        FileInfo? file,
+        string? query,
+        string? hypothesis,
+        string? tuple,
+        string? user,
+        bool pretty)
+    {
+        await Task.Yield(); // keep signature async-compatible for future I/O
+
+        var path = file?.FullName ?? Path.Combine(Directory.GetCurrentDirectory(), "docs", "experiments", "registry.json");
+        var registry = Registry.Load(path);
+
+        var jsonOptions = new JsonSerializerOptions { WriteIndented = pretty };
+
+        switch (query)
+        {
+            case "current-state":
+                if (string.IsNullOrWhiteSpace(hypothesis))
+                {
+                    Console.Error.WriteLine("--hypothesis is required for current-state");
+                    Environment.ExitCode = 2;
+                    return;
+                }
+                Console.WriteLine(JsonSerializer.Serialize(registry.CurrentState(hypothesis), jsonOptions));
+                break;
+
+            case "two-kill-risk":
+                if (string.IsNullOrWhiteSpace(tuple))
+                {
+                    Console.Error.WriteLine("--tuple is required for two-kill-risk (format: tag/code-class/direction)");
+                    Environment.ExitCode = 2;
+                    return;
+                }
+                var parts = tuple.Split('/', 3);
+                if (parts.Length != 3)
+                {
+                    Console.Error.WriteLine("--tuple must have three slash-separated parts: tag/code-class/direction");
+                    Environment.ExitCode = 2;
+                    return;
+                }
+                var matches = registry.TwoKillRisk(parts[0].Trim(), parts[1].Trim(), parts[2].Trim());
+                Console.WriteLine(JsonSerializer.Serialize(new { matches }, jsonOptions));
+                break;
+
+            case "held-owned-by":
+                if (string.IsNullOrWhiteSpace(user))
+                {
+                    Console.Error.WriteLine("--user is required for held-owned-by");
+                    Environment.ExitCode = 2;
+                    return;
+                }
+                var owned = registry.HeldOwnedBy(user);
+                Console.WriteLine(JsonSerializer.Serialize(new { held = owned }, jsonOptions));
+                break;
+
+            case "stale-holds":
+                var stale = registry.StaleHolds();
+                Console.WriteLine(JsonSerializer.Serialize(new { stale }, jsonOptions));
+                break;
+
+            case "audit-trail":
+                if (string.IsNullOrWhiteSpace(hypothesis))
+                {
+                    Console.Error.WriteLine("--hypothesis is required for audit-trail");
+                    Environment.ExitCode = 2;
+                    return;
+                }
+                var trail = registry.AuditTrail(hypothesis);
+                Console.WriteLine(JsonSerializer.Serialize(new { trail }, jsonOptions));
+                break;
+
+            default:
+                Console.Error.WriteLine($"Unknown --query value '{query}'. Valid: current-state | two-kill-risk | held-owned-by | stale-holds | audit-trail");
+                Environment.ExitCode = 2;
+                return;
+        }
+    }
+}

--- a/src/Calor.Compiler/Experiments/Registry.cs
+++ b/src/Calor.Compiler/Experiments/Registry.cs
@@ -1,0 +1,284 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Calor.Compiler.Experiments;
+
+/// <summary>
+/// Terminal lifecycle statuses — entries with these statuses will never change state.
+/// </summary>
+public static class RegistryStatus
+{
+    public const string PreRegisteredStage1 = "pre-registered-stage-1";
+    public const string PreRegisteredStage2 = "pre-registered-stage-2";
+    public const string BehindFlag = "behind-flag";
+    public const string Promoted = "promoted";
+    public const string Held = "held";
+    public const string Dropped = "dropped";
+
+    public static readonly IReadOnlyCollection<string> Terminal = new[] { Promoted, Held, Dropped };
+
+    public static bool IsTerminal(string? status) => status != null && Terminal.Contains(status);
+}
+
+/// <summary>
+/// In-memory registry providing the five queries from §5.0h of the Calor-native
+/// type-system research plan.
+///
+/// Load once (<see cref="Load"/> or <see cref="Empty"/>), then query repeatedly.
+/// Target: all queries complete under 200ms on a 1000-entry registry.
+/// </summary>
+public sealed class Registry
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true
+    };
+
+    private readonly List<RegistryEntry> _entries;
+    private readonly Dictionary<string, RegistryEntry> _byId;
+
+    private Registry(List<RegistryEntry> entries)
+    {
+        _entries = entries;
+        _byId = entries.ToDictionary(e => e.Id, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// An empty registry — convenient default for projects that haven't started Phase 0 work.
+    /// </summary>
+    public static Registry Empty => new(new List<RegistryEntry>());
+
+    /// <summary>
+    /// Load registry from a JSON file. Missing file returns an empty registry; malformed file throws.
+    /// </summary>
+    public static Registry Load(string path)
+    {
+        if (!File.Exists(path))
+            return Empty;
+
+        var json = File.ReadAllText(path);
+        var doc = JsonSerializer.Deserialize<RegistryDocument>(json, JsonOptions)
+                  ?? new RegistryDocument();
+        return new Registry(doc.Entries);
+    }
+
+    /// <summary>
+    /// All entries, in file order.
+    /// </summary>
+    public IReadOnlyList<RegistryEntry> Entries => _entries;
+
+    public int Count => _entries.Count;
+
+    // ========================================================================
+    // Query 1: current-state — walk supersedes chain back to origin.
+    // ========================================================================
+
+    /// <summary>
+    /// Walks the supersedes chain starting from the latest entry with the given ID
+    /// (or any descendant via supersedes linkage), returning all entries in the chain
+    /// from latest to origin.
+    /// </summary>
+    public CurrentStateResult CurrentState(string hypothesisId)
+    {
+        // Find the latest entry whose chain reaches this id.
+        // A hypothesis identified by <hypothesisId> may appear as the ID itself or as
+        // an ancestor via supersedes links.
+        var chain = BuildChain(hypothesisId);
+        if (chain.Count == 0)
+        {
+            return new CurrentStateResult(hypothesisId, null, null, Array.Empty<RegistryEntry>());
+        }
+
+        // Latest entry in the chain is the head (first element since we walk backwards).
+        var head = chain[0];
+        return new CurrentStateResult(hypothesisId, head.Status, head.Id, chain);
+    }
+
+    /// <summary>
+    /// Build the full supersedes chain anchored at any entry whose chain passes through
+    /// <paramref name="hypothesisId"/>. Returns entries ordered latest → origin.
+    /// Empty list if no entry matches.
+    /// </summary>
+    private List<RegistryEntry> BuildChain(string hypothesisId)
+    {
+        // Find the head: an entry whose chain (itself + supersedes links) contains the id.
+        // Head = entry that is not superseded by any other entry AND whose chain contains id.
+        var supersededIds = _entries
+            .Where(e => e.Supersedes != null)
+            .Select(e => e.Supersedes!)
+            .ToHashSet(StringComparer.Ordinal);
+
+        RegistryEntry? head = null;
+        foreach (var entry in _entries)
+        {
+            if (supersededIds.Contains(entry.Id))
+                continue; // Not a head — something supersedes it.
+
+            // Walk this entry's chain to see if it contains hypothesisId.
+            if (ChainContains(entry, hypothesisId))
+            {
+                head = entry;
+                break;
+            }
+        }
+
+        if (head == null)
+            return new List<RegistryEntry>();
+
+        var chain = new List<RegistryEntry>();
+        var current = head;
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        while (current != null)
+        {
+            if (!visited.Add(current.Id))
+                break; // Cycle guard.
+            chain.Add(current);
+            current = current.Supersedes != null && _byId.TryGetValue(current.Supersedes, out var prev)
+                ? prev
+                : null;
+        }
+        return chain;
+    }
+
+    private bool ChainContains(RegistryEntry head, string hypothesisId)
+    {
+        var current = head;
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        while (current != null)
+        {
+            if (!visited.Add(current.Id))
+                return false;
+            if (string.Equals(current.Id, hypothesisId, StringComparison.Ordinal))
+                return true;
+            current = current.Supersedes != null && _byId.TryGetValue(current.Supersedes, out var prev)
+                ? prev
+                : null;
+        }
+        return false;
+    }
+
+    // ========================================================================
+    // Query 2: two-kill-risk — find dropped entries matching a tuple.
+    // ========================================================================
+
+    /// <summary>
+    /// Return all dropped entries whose (tag, code class, effect direction) tuple
+    /// matches the given tuple. Used by the two-kill-rule reviewer gate (§4.5) to
+    /// detect metric-substitution evasion attempts mechanically.
+    /// </summary>
+    public IReadOnlyList<RegistryEntry> TwoKillRisk(string tag, string codeClass, string effectDirection)
+    {
+        return _entries
+            .Where(e => string.Equals(e.Status, RegistryStatus.Dropped, StringComparison.Ordinal))
+            .Where(e =>
+                string.Equals(e.Tag, tag, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(e.TupleCodeClass, codeClass, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(e.TupleEffectDirection, effectDirection, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    // ========================================================================
+    // Query 3: held-owned-by — held features with given owner.
+    // ========================================================================
+
+    /// <summary>
+    /// List held features with <c>hold_owner == user</c>, sorted by quarterly-review-due date ascending.
+    /// Entries with no due date sort last.
+    /// </summary>
+    public IReadOnlyList<RegistryEntry> HeldOwnedBy(string user)
+    {
+        return _entries
+            .Where(e => string.Equals(e.Status, RegistryStatus.Held, StringComparison.Ordinal))
+            .Where(e => string.Equals(e.HoldOwner, user, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(e => ParseDate(e.QuarterlyReviewDue) ?? DateTime.MaxValue)
+            .ToList();
+    }
+
+    // ========================================================================
+    // Query 4: stale-holds — held features with missing owner or overdue review.
+    // ========================================================================
+
+    /// <summary>
+    /// List held features whose <c>hold_owner</c> is absent, OR whose <c>quarterly_review_due</c>
+    /// is in the past. Feeds the §4.4 auto-drop rule.
+    /// </summary>
+    public IReadOnlyList<StaleHoldReason> StaleHolds(DateTime? asOf = null)
+    {
+        var cutoff = asOf ?? DateTime.UtcNow;
+        var result = new List<StaleHoldReason>();
+
+        foreach (var entry in _entries)
+        {
+            if (!string.Equals(entry.Status, RegistryStatus.Held, StringComparison.Ordinal))
+                continue;
+
+            if (string.IsNullOrWhiteSpace(entry.HoldOwner))
+            {
+                result.Add(new StaleHoldReason(entry, "no-owner"));
+                continue;
+            }
+
+            var due = ParseDate(entry.QuarterlyReviewDue);
+            if (due.HasValue && due.Value < cutoff)
+            {
+                result.Add(new StaleHoldReason(entry, "review-overdue"));
+            }
+        }
+
+        return result;
+    }
+
+    // ========================================================================
+    // Query 5: audit-trail — chronological record for a hypothesis.
+    // ========================================================================
+
+    /// <summary>
+    /// Return all entries in the supersedes chain of the given hypothesis, ordered
+    /// chronologically (earliest <c>merged_at</c> first). Entries without a <c>merged_at</c>
+    /// sort first in file-order as a conservative default.
+    /// </summary>
+    public IReadOnlyList<RegistryEntry> AuditTrail(string hypothesisId)
+    {
+        var chain = BuildChain(hypothesisId);
+        if (chain.Count == 0)
+            return Array.Empty<RegistryEntry>();
+
+        // Chronological order: oldest first.
+        return chain
+            .OrderBy(e => ParseDate(e.MergedAt) ?? DateTime.MinValue)
+            .ThenBy(e => _entries.IndexOf(e))
+            .ToList();
+    }
+
+    // ========================================================================
+    // Helpers
+    // ========================================================================
+
+    private static DateTime? ParseDate(string? iso)
+    {
+        if (string.IsNullOrWhiteSpace(iso))
+            return null;
+        return DateTime.TryParse(iso, System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal,
+            out var dt)
+            ? dt
+            : (DateTime?)null;
+    }
+}
+
+/// <summary>
+/// Result of a current-state query: the hypothesis's latest status, the chain head's ID,
+/// and the full supersedes chain from latest to origin.
+/// </summary>
+public sealed record CurrentStateResult(
+    string QueriedId,
+    string? CurrentStatus,
+    string? HeadEntryId,
+    IReadOnlyList<RegistryEntry> Chain);
+
+/// <summary>
+/// A held entry flagged as stale, with the reason: <c>no-owner</c> or <c>review-overdue</c>.
+/// </summary>
+public sealed record StaleHoldReason(RegistryEntry Entry, string Reason);

--- a/src/Calor.Compiler/Experiments/RegistryEntry.cs
+++ b/src/Calor.Compiler/Experiments/RegistryEntry.cs
@@ -1,0 +1,128 @@
+using System.Text.Json.Serialization;
+
+namespace Calor.Compiler.Experiments;
+
+/// <summary>
+/// One entry in <c>docs/experiments/registry.json</c>. The registry is append-only —
+/// edits to existing entries are rejected by CI (see <c>docs/plans/calor-native-type-system-v2.md</c>
+/// §5.0f). Lineage through supersedes chains carries hypothesis state across lifecycle
+/// transitions (Stage 1 → Stage 2 → behind-flag → promoted/held/dropped).
+///
+/// Field names use snake_case on the wire to match the plan's YAML examples and so
+/// humans who edit the JSON can match the plan 1:1.
+/// </summary>
+public sealed class RegistryEntry
+{
+    /// <summary>
+    /// Unique identifier, e.g., <c>TIER1A-flow-option-tracking</c> or <c>TIER1A-flow-option-tracking-stage2</c>.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = "";
+
+    /// <summary>
+    /// Engineering domain tag: <c>Dataflow</c>, <c>Pattern</c>, <c>Elaboration</c>,
+    /// <c>TypeSystem</c>, or <c>Codegen</c>. Used for tuple-based hypothesis identity.
+    /// </summary>
+    [JsonPropertyName("tag")]
+    public string Tag { get; set; } = "";
+
+    /// <summary>
+    /// Plain-English hypothesis claim.
+    /// </summary>
+    [JsonPropertyName("hypothesis")]
+    public string Hypothesis { get; set; } = "";
+
+    /// <summary>
+    /// Target code class for tuple-based hypothesis identity — what category of code
+    /// the hypothesis affects (e.g., <c>unwrap-sites</c>, <c>option-match-sites</c>).
+    /// Part of the two-kill-rule identity tuple.
+    /// </summary>
+    [JsonPropertyName("tuple_code_class")]
+    public string TupleCodeClass { get; set; } = "";
+
+    /// <summary>
+    /// Expected direction of effect on the primary metric: <c>up</c> or <c>down</c>.
+    /// Part of the two-kill-rule identity tuple.
+    /// </summary>
+    [JsonPropertyName("tuple_effect_direction")]
+    public string TupleEffectDirection { get; set; } = "";
+
+    /// <summary>
+    /// Lifecycle status:
+    /// <c>pre-registered-stage-1</c> | <c>pre-registered-stage-2</c> | <c>behind-flag</c>
+    /// | <c>promoted</c> | <c>held</c> | <c>dropped</c>.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = "";
+
+    /// <summary>
+    /// ID of the predecessor entry this supersedes, or null for origin entries.
+    /// Chain walks back to null.
+    /// </summary>
+    [JsonPropertyName("supersedes")]
+    public string? Supersedes { get; set; }
+
+    /// <summary>
+    /// For held entries: the engineer responsible for the quarterly review.
+    /// Null or empty means the entry has no owner — the §4.4 auto-drop rule applies.
+    /// </summary>
+    [JsonPropertyName("hold_owner")]
+    public string? HoldOwner { get; set; }
+
+    /// <summary>
+    /// For held entries: ISO-8601 date when the entry entered Held state.
+    /// Null outside Held.
+    /// </summary>
+    [JsonPropertyName("hold_started")]
+    public string? HoldStarted { get; set; }
+
+    /// <summary>
+    /// For held entries: ISO-8601 date when the next quarterly review is due.
+    /// The §4.4 stale-holds rule fires when the date is in the past.
+    /// </summary>
+    [JsonPropertyName("quarterly_review_due")]
+    public string? QuarterlyReviewDue { get; set; }
+
+    /// <summary>
+    /// For re-proposals (§4.5 anti-evasion): rationale for why the original hypothesis'
+    /// metric was wrong. Required on metric-substitution re-proposals.
+    /// </summary>
+    [JsonPropertyName("metric_change_rationale")]
+    public string? MetricChangeRationale { get; set; }
+
+    /// <summary>
+    /// CI-filled: git commit SHA of the PR that introduced this entry.
+    /// Not author-controlled (prevents <c>--date</c> backdating).
+    /// </summary>
+    [JsonPropertyName("commit_sha")]
+    public string? CommitSha { get; set; }
+
+    /// <summary>
+    /// CI-filled: ISO-8601 timestamp from the GitHub API at PR merge.
+    /// Not author-controlled. Used for audit-trail chronological ordering.
+    /// </summary>
+    [JsonPropertyName("merged_at")]
+    public string? MergedAt { get; set; }
+
+    /// <summary>
+    /// Optional: link to the decision memo PR for entries that reached a terminal state.
+    /// </summary>
+    [JsonPropertyName("decision_memo_url")]
+    public string? DecisionMemoUrl { get; set; }
+
+    /// <summary>
+    /// Optional: for human-override cases where a reviewer chose a different action than
+    /// the agent recommended — the rationale is tracked here for later calibration analysis.
+    /// </summary>
+    [JsonPropertyName("override_rationale")]
+    public string? OverrideRationale { get; set; }
+}
+
+/// <summary>
+/// Root document for <c>registry.json</c>. A flat array of entries, append-only.
+/// </summary>
+public sealed class RegistryDocument
+{
+    [JsonPropertyName("entries")]
+    public List<RegistryEntry> Entries { get; set; } = new();
+}

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -217,6 +217,7 @@ public class Program
         rootCommand.AddCommand(FeatureCheckCommand.Create());
         rootCommand.AddCommand(CoverageCommand.Create());
         rootCommand.AddCommand(SelfTestCommand.Create());
+        rootCommand.AddCommand(EvaluationCommand.Create());
 
         // Initialize telemetry for subcommands
         // Parse --no-telemetry early from args

--- a/tests/Calor.Compiler.Tests/Experiments/RegistryTests.cs
+++ b/tests/Calor.Compiler.Tests/Experiments/RegistryTests.cs
@@ -1,0 +1,351 @@
+using System.Text.Json;
+using Calor.Compiler.Experiments;
+using Xunit;
+
+namespace Calor.Compiler.Tests.Experiments;
+
+/// <summary>
+/// Tests for the Registry query API (§5.0h of the Calor-native type-system research plan).
+/// Uses fixture registries with known ground-truth so assertions are mechanical.
+/// </summary>
+public class RegistryTests
+{
+    // ========================================================================
+    // Fixture helpers
+    // ========================================================================
+
+    private static Registry FromEntries(params RegistryEntry[] entries)
+    {
+        var doc = new RegistryDocument { Entries = entries.ToList() };
+        var tmp = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tmp, JsonSerializer.Serialize(doc, new JsonSerializerOptions { WriteIndented = true }));
+            return Registry.Load(tmp);
+        }
+        finally
+        {
+            try { File.Delete(tmp); } catch { /* best-effort */ }
+        }
+    }
+
+    private static RegistryEntry Stage1(string id, string tag = "Dataflow", string codeClass = "unwrap", string dir = "up") => new()
+    {
+        Id = id,
+        Tag = tag,
+        Hypothesis = "test",
+        TupleCodeClass = codeClass,
+        TupleEffectDirection = dir,
+        Status = RegistryStatus.PreRegisteredStage1
+    };
+
+    private static RegistryEntry Terminal(string id, string status, string? supersedes = null, string tag = "Dataflow", string codeClass = "unwrap", string dir = "up")
+        => new()
+        {
+            Id = id,
+            Tag = tag,
+            Hypothesis = "test",
+            TupleCodeClass = codeClass,
+            TupleEffectDirection = dir,
+            Status = status,
+            Supersedes = supersedes
+        };
+
+    // ========================================================================
+    // Empty / missing-file behavior
+    // ========================================================================
+
+    [Fact]
+    public void Empty_ReturnsZeroEntries()
+    {
+        var r = Registry.Empty;
+        Assert.Equal(0, r.Count);
+        Assert.Empty(r.Entries);
+    }
+
+    [Fact]
+    public void Load_MissingFile_ReturnsEmpty()
+    {
+        var r = Registry.Load(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".json"));
+        Assert.Equal(0, r.Count);
+    }
+
+    [Fact]
+    public void CurrentState_EmptyRegistry_NoMatch()
+    {
+        var result = Registry.Empty.CurrentState("anything");
+        Assert.Null(result.CurrentStatus);
+        Assert.Empty(result.Chain);
+    }
+
+    // ========================================================================
+    // Query 1: current-state — chain walking
+    // ========================================================================
+
+    [Fact]
+    public void CurrentState_SingleEntry_ReturnsStatusAndSingletonChain()
+    {
+        var r = FromEntries(Stage1("TIER1A"));
+        var result = r.CurrentState("TIER1A");
+        Assert.Equal(RegistryStatus.PreRegisteredStage1, result.CurrentStatus);
+        Assert.Equal("TIER1A", result.HeadEntryId);
+        Assert.Single(result.Chain);
+    }
+
+    [Fact]
+    public void CurrentState_ChainOfThree_ReturnsLatestStatusAndOrderedChain()
+    {
+        var r = FromEntries(
+            Stage1("TIER1A"),
+            Terminal("TIER1A-stage2", RegistryStatus.PreRegisteredStage2, supersedes: "TIER1A"),
+            Terminal("TIER1A-promoted", RegistryStatus.Promoted, supersedes: "TIER1A-stage2"));
+
+        var result = r.CurrentState("TIER1A");
+        Assert.Equal(RegistryStatus.Promoted, result.CurrentStatus);
+        Assert.Equal("TIER1A-promoted", result.HeadEntryId);
+        Assert.Equal(3, result.Chain.Count);
+        // Chain ordered latest → origin
+        Assert.Equal("TIER1A-promoted", result.Chain[0].Id);
+        Assert.Equal("TIER1A-stage2", result.Chain[1].Id);
+        Assert.Equal("TIER1A", result.Chain[2].Id);
+    }
+
+    [Fact]
+    public void CurrentState_QueriedByMiddleEntry_ReturnsHeadChain()
+    {
+        var r = FromEntries(
+            Stage1("TIER1A"),
+            Terminal("TIER1A-stage2", RegistryStatus.PreRegisteredStage2, supersedes: "TIER1A"),
+            Terminal("TIER1A-promoted", RegistryStatus.Promoted, supersedes: "TIER1A-stage2"));
+
+        // Querying by middle entry's ID should still find the head chain.
+        var result = r.CurrentState("TIER1A-stage2");
+        Assert.Equal(RegistryStatus.Promoted, result.CurrentStatus);
+        Assert.Equal(3, result.Chain.Count);
+    }
+
+    [Fact]
+    public void CurrentState_UnknownId_ReturnsNull()
+    {
+        var r = FromEntries(Stage1("TIER1A"));
+        var result = r.CurrentState("TIER-UNKNOWN");
+        Assert.Null(result.CurrentStatus);
+        Assert.Empty(result.Chain);
+    }
+
+    [Fact]
+    public void CurrentState_CycleDetection_TerminatesWithoutInfiniteLoop()
+    {
+        // Deliberate cycle: A supersedes B supersedes A. Should not hang.
+        var r = FromEntries(
+            new RegistryEntry { Id = "A", Tag = "Dataflow", TupleCodeClass = "x", TupleEffectDirection = "up", Status = RegistryStatus.Held, Supersedes = "B" },
+            new RegistryEntry { Id = "B", Tag = "Dataflow", TupleCodeClass = "x", TupleEffectDirection = "up", Status = RegistryStatus.Held, Supersedes = "A" });
+
+        var result = r.CurrentState("A");
+        // A is superseded by B; B is superseded by A — neither is a "head" by the strict
+        // "not superseded by anyone" rule, so the chain is empty. Ensures no infinite loop either way.
+        Assert.Empty(result.Chain);
+    }
+
+    // ========================================================================
+    // Query 2: two-kill-risk
+    // ========================================================================
+
+    [Fact]
+    public void TwoKillRisk_FindsDroppedMatchingTuple()
+    {
+        var r = FromEntries(
+            Terminal("H1", RegistryStatus.Dropped, tag: "Dataflow", codeClass: "unwrap", dir: "up"),
+            Terminal("H2", RegistryStatus.Promoted, tag: "Dataflow", codeClass: "unwrap", dir: "up"),
+            Terminal("H3", RegistryStatus.Dropped, tag: "Pattern", codeClass: "unwrap", dir: "up"),
+            Terminal("H4", RegistryStatus.Dropped, tag: "Dataflow", codeClass: "option-match", dir: "up"));
+
+        var matches = r.TwoKillRisk("Dataflow", "unwrap", "up");
+        Assert.Single(matches);
+        Assert.Equal("H1", matches[0].Id);
+    }
+
+    [Fact]
+    public void TwoKillRisk_CaseInsensitiveTuple()
+    {
+        var r = FromEntries(Terminal("H1", RegistryStatus.Dropped, tag: "Dataflow", codeClass: "unwrap", dir: "up"));
+        var matches = r.TwoKillRisk("DATAFLOW", "UNWRAP", "UP");
+        Assert.Single(matches);
+    }
+
+    [Fact]
+    public void TwoKillRisk_NoDroppedEntries_ReturnsEmpty()
+    {
+        var r = FromEntries(
+            Terminal("H1", RegistryStatus.Promoted),
+            Terminal("H2", RegistryStatus.Held));
+        Assert.Empty(r.TwoKillRisk("Dataflow", "unwrap", "up"));
+    }
+
+    // ========================================================================
+    // Query 3: held-owned-by
+    // ========================================================================
+
+    [Fact]
+    public void HeldOwnedBy_FiltersByStatusAndOwner_SortsByDueDate()
+    {
+        var r = FromEntries(
+            new RegistryEntry { Id = "H1", Status = RegistryStatus.Held, HoldOwner = "alice", QuarterlyReviewDue = "2026-06-01" },
+            new RegistryEntry { Id = "H2", Status = RegistryStatus.Held, HoldOwner = "alice", QuarterlyReviewDue = "2026-05-01" },
+            new RegistryEntry { Id = "H3", Status = RegistryStatus.Held, HoldOwner = "bob", QuarterlyReviewDue = "2026-04-01" },
+            new RegistryEntry { Id = "H4", Status = RegistryStatus.Promoted, HoldOwner = "alice" });
+
+        var result = r.HeldOwnedBy("alice");
+        Assert.Equal(2, result.Count);
+        // Sorted by due date ascending.
+        Assert.Equal("H2", result[0].Id);
+        Assert.Equal("H1", result[1].Id);
+    }
+
+    [Fact]
+    public void HeldOwnedBy_CaseInsensitive()
+    {
+        var r = FromEntries(new RegistryEntry { Id = "H1", Status = RegistryStatus.Held, HoldOwner = "Alice" });
+        Assert.Single(r.HeldOwnedBy("ALICE"));
+    }
+
+    [Fact]
+    public void HeldOwnedBy_NullDueDates_SortLast()
+    {
+        var r = FromEntries(
+            new RegistryEntry { Id = "H1", Status = RegistryStatus.Held, HoldOwner = "alice", QuarterlyReviewDue = null },
+            new RegistryEntry { Id = "H2", Status = RegistryStatus.Held, HoldOwner = "alice", QuarterlyReviewDue = "2026-05-01" });
+
+        var result = r.HeldOwnedBy("alice");
+        Assert.Equal(2, result.Count);
+        Assert.Equal("H2", result[0].Id); // has due date → sorts first
+        Assert.Equal("H1", result[1].Id); // no due date → sorts last
+    }
+
+    // ========================================================================
+    // Query 4: stale-holds
+    // ========================================================================
+
+    [Fact]
+    public void StaleHolds_FlagsMissingOwner()
+    {
+        var r = FromEntries(
+            new RegistryEntry { Id = "H1", Status = RegistryStatus.Held, HoldOwner = null, QuarterlyReviewDue = "2099-01-01" },
+            new RegistryEntry { Id = "H2", Status = RegistryStatus.Held, HoldOwner = "alice", QuarterlyReviewDue = "2099-01-01" });
+
+        var stale = r.StaleHolds(new DateTime(2026, 4, 21));
+        Assert.Single(stale);
+        Assert.Equal("H1", stale[0].Entry.Id);
+        Assert.Equal("no-owner", stale[0].Reason);
+    }
+
+    [Fact]
+    public void StaleHolds_FlagsOverdueReview()
+    {
+        var r = FromEntries(
+            new RegistryEntry { Id = "H1", Status = RegistryStatus.Held, HoldOwner = "alice", QuarterlyReviewDue = "2026-01-01" },
+            new RegistryEntry { Id = "H2", Status = RegistryStatus.Held, HoldOwner = "bob", QuarterlyReviewDue = "2099-01-01" });
+
+        var stale = r.StaleHolds(new DateTime(2026, 4, 21));
+        Assert.Single(stale);
+        Assert.Equal("H1", stale[0].Entry.Id);
+        Assert.Equal("review-overdue", stale[0].Reason);
+    }
+
+    [Fact]
+    public void StaleHolds_IgnoresNonHeldEntries()
+    {
+        var r = FromEntries(
+            new RegistryEntry { Id = "H1", Status = RegistryStatus.Promoted, HoldOwner = null },
+            new RegistryEntry { Id = "H2", Status = RegistryStatus.Dropped, HoldOwner = null });
+        Assert.Empty(r.StaleHolds(new DateTime(2026, 4, 21)));
+    }
+
+    [Fact]
+    public void StaleHolds_NoOwnerWins_OverdueStillFlaggedAsNoOwner()
+    {
+        // If an entry has no owner AND an overdue date, we report it once, with no-owner reason.
+        var r = FromEntries(
+            new RegistryEntry { Id = "H1", Status = RegistryStatus.Held, HoldOwner = null, QuarterlyReviewDue = "2026-01-01" });
+
+        var stale = r.StaleHolds(new DateTime(2026, 4, 21));
+        var reason = Assert.Single(stale);
+        Assert.Equal("no-owner", reason.Reason);
+    }
+
+    // ========================================================================
+    // Query 5: audit-trail
+    // ========================================================================
+
+    [Fact]
+    public void AuditTrail_ReturnsChainInChronologicalOrder()
+    {
+        var r = FromEntries(
+            new RegistryEntry { Id = "H1-promoted", Status = RegistryStatus.Promoted, Supersedes = "H1-stage2", MergedAt = "2026-06-01T00:00:00Z" },
+            new RegistryEntry { Id = "H1-stage2", Status = RegistryStatus.PreRegisteredStage2, Supersedes = "H1", MergedAt = "2026-05-01T00:00:00Z" },
+            new RegistryEntry { Id = "H1", Status = RegistryStatus.PreRegisteredStage1, MergedAt = "2026-04-01T00:00:00Z" });
+
+        var trail = r.AuditTrail("H1");
+        Assert.Equal(3, trail.Count);
+        // Oldest → newest
+        Assert.Equal("H1", trail[0].Id);
+        Assert.Equal("H1-stage2", trail[1].Id);
+        Assert.Equal("H1-promoted", trail[2].Id);
+    }
+
+    [Fact]
+    public void AuditTrail_UnknownHypothesis_ReturnsEmpty()
+    {
+        var r = FromEntries(Stage1("X"));
+        Assert.Empty(r.AuditTrail("nonexistent"));
+    }
+
+    // ========================================================================
+    // Performance — §5.0h acceptance: all queries under 200ms on 1000 entries
+    // ========================================================================
+
+    [Fact]
+    public void Performance_AllQueriesUnder200msOn1000EntryRegistry()
+    {
+        // Build 1000 entries in a mix of terminal states.
+        var rnd = new Random(42);
+        var statuses = new[] { RegistryStatus.Held, RegistryStatus.Promoted, RegistryStatus.Dropped, RegistryStatus.BehindFlag };
+        var entries = new List<RegistryEntry>(1000);
+        for (int i = 0; i < 1000; i++)
+        {
+            entries.Add(new RegistryEntry
+            {
+                Id = $"H{i:D4}",
+                Tag = i % 5 == 0 ? "Dataflow" : "Pattern",
+                Hypothesis = "test",
+                TupleCodeClass = i % 3 == 0 ? "unwrap" : "option-match",
+                TupleEffectDirection = i % 2 == 0 ? "up" : "down",
+                Status = statuses[rnd.Next(statuses.Length)],
+                HoldOwner = i % 4 == 0 ? "alice" : "bob",
+                QuarterlyReviewDue = DateTime.UtcNow.AddDays(rnd.Next(-200, 200)).ToString("yyyy-MM-dd"),
+                MergedAt = DateTime.UtcNow.AddDays(-rnd.Next(0, 365)).ToString("O")
+            });
+        }
+        var tmp = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tmp, JsonSerializer.Serialize(new RegistryDocument { Entries = entries }));
+            var registry = Registry.Load(tmp);
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            registry.CurrentState("H0500");
+            registry.TwoKillRisk("Dataflow", "unwrap", "up");
+            registry.HeldOwnedBy("alice");
+            registry.StaleHolds();
+            registry.AuditTrail("H0500");
+            sw.Stop();
+
+            Assert.True(sw.ElapsedMilliseconds < 200,
+                $"All 5 queries took {sw.ElapsedMilliseconds}ms on a 1000-entry registry (budget: 200ms).");
+        }
+        finally
+        {
+            try { File.Delete(tmp); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `calor evaluation registry` subcommand with 5 queries over the append-only experiment registry at `docs/experiments/registry.json`.
- Infrastructure for the Calor-native type-system research plan's governance pipeline (§5.0h of `docs/plans/calor-native-type-system-v2.md`).
- No behavior change on existing compiler flows; this is a net-new query tool for a registry file that doesn't exist yet in the repo. Empty-registry and missing-file cases return clean empty results.

## Queries
| `--query` | Purpose |
|---|---|
| `current-state` | Walks supersedes chain → latest status + full lineage |
| `two-kill-risk` | Finds dropped entries matching an identity tuple (§4.5 anti-evasion) |
| `held-owned-by` | Held features owned by user, sorted by quarterly-review-due date |
| `stale-holds` | Held entries with missing owner or overdue review (§4.4 auto-drop input) |
| `audit-trail` | Chronological lineage of a hypothesis |

## Shape of the registry
`RegistryEntry` POCO with snake_case JSON bindings matching the plan's YAML examples. Flat array (`RegistryDocument.Entries`) — append-only. Cycle-guarded chain walks. Case-insensitive tuple and user matches.

## Test plan
- [x] 21 tests on fixture registries with known ground-truth.
- [x] Empty / missing-file / unknown-id behaviors.
- [x] Chain walking: singleton, length-3, queried by middle entry, cycle detection (doesn't infinite-loop).
- [x] Tuple matching case-insensitive; only dropped entries returned.
- [x] Held-owned-by case-insensitive; sort by due date; null dates last.
- [x] Stale-holds: no-owner, overdue, non-held ignored, no-owner-wins-over-overdue.
- [x] Audit-trail chronological ordering.
- [x] **Performance acceptance**: all 5 queries under 200ms on 1000-entry registry (§5.0h acceptance criterion).
- [x] CLI smoke-tested end-to-end: `calor evaluation registry --query stale-holds --file <nonexistent>` → `{"stale":[]}` exit 0.
- [x] Full suite: **6,495 passing, 0 warnings**.
- [ ] CI green on this PR.

## Out of scope
- No tamper-evidence enforcement yet — that's §5.0f (CI workflow + pre-commit hook), a separate sub-phase.
- No AB subcommand — that's §5.0c.
- No registry file committed yet; queries return empty until §5.0f creates one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)