### PR TITLE
fix: address PR #601 critique — autoFix default, tiered resources, thin CLAUDE.md

### DIFF
--- a/src/Calor.Compiler/Mcp/Tools/CompileTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/CompileTool.cs
@@ -17,10 +17,10 @@ public sealed class CompileTool : McpToolBase
     public override int TimeoutSeconds => 120;
 
     public override string Description =>
-        "Compile Calor source code to C#. Use autoFix: true to auto-fix parser, ID, and effect errors (up to 3 passes). " +
-        "Each diagnostic includes a fix field with concrete edits. " +
-        "Typically the first tool called after writing .calr code. Follow with calor_verify for contract checking.";
+        "Compile Calor source code to C#. Auto-fixes parser, ID, and effect errors by default. Follow with calor_verify for contracts.";
 
+    // ReadOnlyHint: true — no disk writes (autoFix returns fixed source in response, doesn't write).
+    // IdempotentHint: true — same input produces same output (autoFix is deterministic).
     public override McpToolAnnotations? Annotations => new() { ReadOnlyHint = true, IdempotentHint = true };
 
 
@@ -72,8 +72,8 @@ public sealed class CompileTool : McpToolBase
                         },
                         "autoFix": {
                             "type": "boolean",
-                            "default": false,
-                            "description": "Auto-fix high-confidence errors (parser, ID, effects). Compile → apply fixes → recompile, up to 3 passes. Returns fixed source and fix history."
+                            "default": true,
+                            "description": "Auto-fix high-confidence errors (parser, ID, effects). Set to false to skip auto-fix."
                         }
                     }
                 },
@@ -158,7 +158,7 @@ public sealed class CompileTool : McpToolBase
 
         var verify = GetBool(options, "verify");
         var analyze = GetBool(options, "analyze");
-        var autoFix = GetBool(options, "autoFix");
+        var autoFix = GetBool(options, "autoFix", defaultValue: true);
         var contractModeStr = GetString(options, "contractMode") ?? "debug";
         var effectModeStr = GetString(options, "effectMode") ?? "default";
 

--- a/src/Calor.Compiler/Resources/Templates/CLAUDE.md.template
+++ b/src/Calor.Compiler/Resources/Templates/CLAUDE.md.template
@@ -5,12 +5,9 @@ This is an **Calor-first project**. All new code MUST be written in Calor. Exist
 
 ### MANDATORY Rules for AI Agents
 
-**Rule 0: Read the primer and look up syntax before writing Calor**
-- At session start, read the `calor://primer` MCP resource for canonical Calor examples
-- Before writing ANY `.calr` code, use `calor_help` MCP tool for syntax guidance
-- Look up effect codes via `calor://effects` resource before writing `§E{...}` declarations
-- Look up ID prefixes via `calor://id-prefixes` resource before creating IDs
-- Applies to: new files, conversions, and edits to existing .calr files
+**Rule 0: Read the primer before writing Calor**
+- At session start, read `calor://primer` MCP resource for canonical Calor examples
+- Use `calor_help` MCP tool for syntax guidance when needed
 
 **Rule 1: Never create new `.cs` files**
 - All new code MUST be written in Calor (`.calr` files)
@@ -27,21 +24,23 @@ This is an **Calor-first project**. All new code MUST be written in Calor. Exist
 - Files ending in `.g.cs` are auto-generated from Calor - do not edit them
 - If you need to change generated output, edit the source `.calr` file instead
 
-**Rule 4: Compile with autoFix after writing**
-- After writing or editing ANY `.calr` file, use `calor_compile` with `autoFix: true`
-- This auto-fixes parser errors, ID issues, and missing/wrong effect declarations in up to 3 passes
-- If errors remain after autoFix, read the diagnostics — each includes a `fix` field with concrete edits
-- Apply the fix edits directly instead of re-reasoning about the error
+**Rule 4: Compile after writing**
+- After writing or editing ANY `.calr` file, use `calor_compile` (autoFix is on by default)
+- If errors remain, diagnostics with a `fix` field contain concrete edits — apply them directly
+- Diagnostics without a `fix` field require reasoning about the error message
 
 ### Workflow for Any Code Change
 
-1. **Session start** → Read `calor://primer` resource for syntax examples
-2. **Before writing effects** → Read `calor://effects` resource for valid effect codes
-3. **New feature/file?** → Create `.calr` file, use `calor_help` for syntax
-4. **Modify existing `.calr` file?** → Edit directly
-5. **Modify existing `.cs` file?** → Convert to `.calr` first using `calor_convert`
-6. **After any .calr change** → `calor_compile` with `autoFix: true` — fixes most errors automatically
-7. **If errors remain** → Apply the `fix.edits` from each diagnostic directly
+1. **Session start** → Read `calor://primer` for syntax examples
+2. **New feature/file?** → Create `.calr` file
+3. **Modify existing `.cs` file?** → Convert to `.calr` first using `calor_convert`
+4. **After any .calr change** → `calor_compile` (auto-fixes most errors)
+5. **If errors remain** → Apply `fix` edits from diagnostics, or reason about the message
+
+**On-demand resources** (read when needed, not at session start):
+- `calor://effects` — before writing `§E{...}` declarations
+- `calor://tags` — when unsure about opening/closing tag forms
+- `calor://id-prefixes` — when creating new IDs
 
 ### Pre-PR Agent Testing
 
@@ -61,7 +60,7 @@ All tasks must pass (2/3 runs succeed). If tests fail, investigate before procee
 #### Available MCP Tools
 
 **Compilation & Verification:**
-- `calor_compile` - Compile Calor files to C# (use `autoFix: true` to auto-fix parser, ID, and effect errors)
+- `calor_compile` - Compile Calor files to C# (autoFix on by default)
 - `calor_verify` - Verify contracts and correctness
 - `calor_verify_contracts` - Verify function contracts
 
@@ -96,13 +95,18 @@ All tasks must pass (2/3 runs succeed). If tests fail, investigate before procee
 **Testing:**
 - `calor_self_test` - Run Calor self-test suite
 
-#### MCP Resources (read at session start)
+#### MCP Resources
 
+**Read at session start:**
 - `calor://primer` - Canonical Calor examples (module, function, effects, contracts, class, IDs)
-- `calor://effects` - All valid effect codes with descriptions (read before writing §E{...})
-- `calor://tags` - Section tag grammar with opening/closing forms (§/I not §/IF for if-blocks)
-- `calor://id-prefixes` - ULID ID prefixes for each declaration kind
-- `calor://workflows` - Step-by-step decision trees for common tasks
+
+**Read on demand:**
+- `calor://effects` - Valid effect codes (before writing `§E{...}`)
+- `calor://tags` - Section tag opening/closing forms (before creating blocks)
+- `calor://id-prefixes` - ULID prefixes (before creating IDs)
+- `calor://workflows` - Decision trees for common tasks
+
+**Reference (use `calor_help` instead for quick lookups):**
 - `calor://syntax-reference` - Complete syntax documentation
 - `calor://error-catalog` - All diagnostic codes with fix patterns
 


### PR DESCRIPTION
## Summary

Addresses critique feedback on PR #601 from both reviewers.

### Changes

1. **autoFix is now default (true)** — If it's safe enough to always recommend, it should be the default. Schema default changed from false to true. GetBool reads with `defaultValue: true`. Agents no longer need to opt in.

2. **Resources tiered** — Only `calor://primer` (~2KB) is "read at session start." Effects/tags/id-prefixes are "read on demand" (when the agent needs them). syntax-reference and error-catalog are "reference only" (use calor_help).

3. **CLAUDE.md is a thin pointer list** — Rule 0 is 2 lines (was 5). Workflow is 5 steps (was 7). No overclaim about fix fields — says "diagnostics with a fix field" not "each diagnostic."

4. **CompileTool.Description is one sentence** — Removed workflow narrative. calor://workflows is the source of truth for decision trees.

5. **IdempotentHint comment** — Explains why the annotation is correct despite autoFix.

### What's NOT changed (from critique — deferred)

- calor://agent-instructions as a hot-fixable MCP resource (architectural, deferred)
- Template version marker / `calor upgrade-claude-md` (good idea, deferred)
- Resource URI validation test (good idea, follow-up)
- `calor diagnose` deprecation (separate concern)

## Test plan

- [x] Builds with 0 warnings, 0 errors
- [x] 249 enforcement tests pass
- [x] Benchmark: 13/14 pass (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)