### PR TITLE
fix: remove 13 phantom MCP tools from agent templates + add drift validation

### DIFF
--- a/src/Calor.Compiler/Mcp/McpMessageHandler.cs
+++ b/src/Calor.Compiler/Mcp/McpMessageHandler.cs
@@ -730,8 +730,8 @@ public sealed class McpMessageHandler
                     Content = new McpContent
                     {
                         Type = "text",
-                        Text = $"Convert this C# code to Calor. Use calor_convert first, then calor_diagnose to validate. " +
-                               $"If there are §CSHARP interop blocks, check calor_syntax_lookup for native equivalents.\n\n" +
+                        Text = $"Convert this C# code to Calor. Use calor_convert first, then calor_compile to validate (autoFix is on by default). " +
+                               $"If there are §CSHARP interop blocks, use calor_help to check for native equivalents.\n\n" +
                                $"```csharp\n{args?.GetValueOrDefault("csharpSource", "// paste C# here")}\n```"
                     }
                 }
@@ -808,23 +808,34 @@ public sealed class McpMessageHandler
         RULES:
         1. All new code MUST be written in Calor (.calr files), never raw C# (.cs).
         2. Before modifying a .cs file, convert it to .calr first using calor_convert.
-        3. After writing any .calr code, validate with calor_diagnose.
+        3. After writing any .calr code, compile with calor_compile (autoFix is on by default).
         4. Never edit .g.cs files — they are auto-generated from .calr sources.
 
         SYNTAX ESSENTIALS:
         - Module: §M{id:Name} ... §/M{id}
-        - Function: §F{id:name:returnType:vis} ... §/F{id}
+        - Function: §F{id:Name:vis} ... §/F{id}
         - Binding: §B{name:type} expr (immutable), §B{~name:type} expr (mutable)
         - Loop: §L{id:var:from:to:step} ... §/L{id}
-        - Conditional: §IF{id} (cond) → §R expr
+        - Conditional: §IF{id} (cond) ... §/I{id} (NOTE: close with §/I, not §/IF)
         - Typed literals: INT:42, STR:"hello", BOOL:true, FLOAT:3.14
         - Expressions use prefix notation: (+ a b), (== x 0), (% i 15)
         - Types: i32, i64, str, bool, f64, void, ?i32 (option), i32!str (result)
         - Contracts: §Q (precondition), §S (postcondition)
-        - Effects: §E{cw,db,net}
+        - Effects: §E{cw,db:w,net:rw}
 
-        WORKFLOW: Use calor_syntax_lookup for any unfamiliar construct. Use calor_verify for contract checking. Use calor_explain_error for diagnostic help.
+        WORKFLOW: Read calor://primer at session start. Use calor_help for unfamiliar syntax. Use calor_verify for contract checking.
         """;
+
+    // ── Test helpers (for McpRegistryValidationTests) ──────────────
+
+    internal HashSet<string> GetRegisteredToolNamesForTest()
+        => new(_tools.Keys, StringComparer.Ordinal);
+
+    internal HashSet<string> GetRegisteredResourceUrisForTest()
+        => new(_resources.Keys, StringComparer.Ordinal);
+
+    internal string GetServerInstructionsForTest()
+        => GetServerInstructions();
 
     private void Log(string message)
     {

--- a/src/Calor.Compiler/Mcp/Tools/BatchTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/BatchTool.cs
@@ -29,7 +29,7 @@ public sealed class BatchTool : McpToolBase
         "action='convert': Convert an entire C# project to Calor in a single call. " +
         "Discovers .cs files, converts each to Calor, and writes output files. " +
         "Module names are derived from C# namespace declarations. Use moduleNameOverride to force a specific namespace. " +
-        "IMPORTANT: If results contain §CSHARP interop blocks, check calor_syntax_lookup or calor_feature_support. " +
+        "IMPORTANT: If results contain §CSHARP interop blocks, use calor_help to check for native equivalents. " +
         "action='analyze': Analyze convertibility of an entire C# project directory. " +
         "Returns aggregate scores, tier breakdowns, and top blockers across the project. " +
         "action='compile': Compile .calr files in batch. Discovers files via directory, explicit paths, or glob pattern. " +
@@ -289,7 +289,7 @@ public sealed class BatchTool : McpToolBase
                 recommendations.Add(
                     "Some files contain §CSHARP interop blocks. Many C# constructs have native Calor equivalents " +
                     "(foreach, switch, async/await, yield, structs, delegates, events, operators, preprocessor directives). " +
-                    "Use calor_syntax_lookup or calor_feature_support to check before leaving code in §CSHARP blocks.");
+                    "Use calor_help to check for native equivalents before leaving code in §CSHARP blocks.");
             }
 
             var totalCsharpBlocks = fileResults.Sum(f => f.CsharpBlockCount);

--- a/src/Calor.Compiler/Resources/Templates/AGENTS.md.template
+++ b/src/Calor.Compiler/Resources/Templates/AGENTS.md.template
@@ -43,43 +43,38 @@ This is an **Calor-first project**. All new code MUST be written in Calor. Exist
 - `.g.cs` - Generated C# files (never edit)
 - `.cs` - Legacy C# files (**convert to Calor before modifying**)
 
-#### Available MCP Tools
+#### Available MCP Tools (15 tools)
 
 **Compilation & Verification:**
-- `calor_compile` - Compile Calor files to C#
-- `calor_verify` - Verify contracts and correctness
-- `calor_verify_contracts` - Verify function contracts
+- `calor_compile` - Compile Calor to C# (autoFix on by default)
+- `calor_verify` - Verify contracts with Z3 SMT solver
+- `calor_check` - Diagnostics, lint, typecheck, or snippet validation (use action: "diagnose", "lint", "typecheck", "validate")
 
-**Analysis & Security:**
-- `calor_analyze` - Analyze files for migration potential
-- `calor_assess` - Assess code quality and security
+**Analysis:**
+- `calor_analyze` - Security/bug patterns, migration assessment, or interop minimization
 
 **Code Transformation:**
-- `calor_convert` - Convert between C# and Calor
-- `calor_format` - Format Calor source files
-- `calor_lint` - Lint Calor source files
+- `calor_convert` - Convert C# to Calor
+- `calor_format` - Format Calor source code or manage IDs (action: "format" or "ids")
+- `calor_fix` - Auto-fix compilation errors and ID conflicts
+- `calor_migrate` - Full C# → Calor migration pipeline (assess + convert + compile + fix)
 
-**Diagnostics & Validation:**
-- `calor_diagnose` - Validate syntax and show all errors at once
-- `calor_typecheck` - Type-check Calor source files
-- `calor_validate_snippet` - Validate a Calor code snippet inline
-- `calor_compile_check_compat` - Check compilation compatibility
+**Batch Operations:**
+- `calor_batch` - Batch compile/convert multiple files or a project directory
+
+**Navigation:**
+- `calor_navigate` - Go to definition, find references, search symbols (action: "definition", "references", "find", "symbol", "scope")
+- `calor_structure` - Document outline, call graph, or change impact analysis
 
 **Syntax & Documentation:**
-- `calor_help` - Get help with Calor syntax, feature support, error explanations, or working examples
+- `calor_help` - Syntax reference, feature support, error explanations, working examples
 
-**Navigation (LSP-style):**
-- `calor_goto_definition` - Go to symbol definition
-- `calor_find_references` - Find all references to a symbol
-- `calor_symbol_info` - Get information about a symbol
-- `calor_document_outline` - Get document outline/structure
-- `calor_find_symbol` - Find symbols by name
-
-**ID Management:**
-- `calor_ids` - Manage Calor block IDs
+**Preview & Refinement:**
+- `calor_edit_preview` - Preview edit effects before committing
+- `calor_refine` - Refinement type analysis (obligations, bounds checking)
 
 **Testing:**
-- `calor_self_test` - Run Calor self-test suite
+- `calor_self_test` - Run compiler self-test suite
 
 #### Key Commands
 ```bash

--- a/src/Calor.Compiler/Resources/Templates/CLAUDE.md.template
+++ b/src/Calor.Compiler/Resources/Templates/CLAUDE.md.template
@@ -57,43 +57,38 @@ All tasks must pass (2/3 runs succeed). If tests fail, investigate before procee
 - `.g.cs` - Generated C# files (never edit)
 - `.cs` - Legacy C# files (**convert to Calor before modifying**)
 
-#### Available MCP Tools
+#### Available MCP Tools (15 tools)
 
 **Compilation & Verification:**
-- `calor_compile` - Compile Calor files to C# (autoFix on by default)
-- `calor_verify` - Verify contracts and correctness
-- `calor_verify_contracts` - Verify function contracts
+- `calor_compile` - Compile Calor to C# (autoFix on by default)
+- `calor_verify` - Verify contracts with Z3 SMT solver
+- `calor_check` - Diagnostics, lint, typecheck, or snippet validation (use action: "diagnose", "lint", "typecheck", "validate")
 
-**Analysis & Security:**
-- `calor_analyze` - Analyze files for migration potential
-- `calor_assess` - Assess code quality and security
+**Analysis:**
+- `calor_analyze` - Security/bug patterns, migration assessment, or interop minimization
 
 **Code Transformation:**
-- `calor_convert` - Convert between C# and Calor
-- `calor_format` - Format Calor source files
-- `calor_lint` - Lint Calor source files
+- `calor_convert` - Convert C# to Calor
+- `calor_format` - Format Calor source code or manage IDs (action: "format" or "ids")
+- `calor_fix` - Auto-fix compilation errors and ID conflicts
+- `calor_migrate` - Full C# → Calor migration pipeline (assess + convert + compile + fix)
 
-**Diagnostics & Validation:**
-- `calor_diagnose` - Validate syntax and show all errors at once
-- `calor_typecheck` - Type-check Calor source files
-- `calor_validate_snippet` - Validate a Calor code snippet inline
-- `calor_compile_check_compat` - Check compilation compatibility
+**Batch Operations:**
+- `calor_batch` - Batch compile/convert multiple files or a project directory
+
+**Navigation:**
+- `calor_navigate` - Go to definition, find references, search symbols (action: "definition", "references", "find", "symbol", "scope")
+- `calor_structure` - Document outline, call graph, or change impact analysis
 
 **Syntax & Documentation:**
-- `calor_help` - Get help with Calor syntax, feature support, error explanations, or working examples
+- `calor_help` - Syntax reference, feature support, error explanations, working examples
 
-**Navigation (LSP-style):**
-- `calor_goto_definition` - Go to symbol definition
-- `calor_find_references` - Find all references to a symbol
-- `calor_symbol_info` - Get information about a symbol
-- `calor_document_outline` - Get document outline/structure
-- `calor_find_symbol` - Find symbols by name
-
-**ID Management:**
-- `calor_ids` - Manage Calor block IDs
+**Preview & Refinement:**
+- `calor_edit_preview` - Preview edit effects before committing
+- `calor_refine` - Refinement type analysis (obligations, bounds checking)
 
 **Testing:**
-- `calor_self_test` - Run Calor self-test suite
+- `calor_self_test` - Run compiler self-test suite
 
 #### MCP Resources
 

--- a/src/Calor.Compiler/Resources/Templates/GEMINI.md.template
+++ b/src/Calor.Compiler/Resources/Templates/GEMINI.md.template
@@ -37,40 +37,38 @@ This is an **Calor-first project**. All new code MUST be written in Calor. Exist
 - `.g.cs` - Generated C# files (never edit)
 - `.cs` - Legacy C# files (**convert to Calor before modifying**)
 
-#### Available MCP Tools
+#### Available MCP Tools (15 tools)
 
 **Compilation & Verification:**
-- `calor_compile` - Compile Calor files to C#
-- `calor_verify` - Verify contracts and correctness
-- `calor_verify_contracts` - Verify function contracts
+- `calor_compile` - Compile Calor to C# (autoFix on by default)
+- `calor_verify` - Verify contracts with Z3 SMT solver
+- `calor_check` - Diagnostics, lint, typecheck, or snippet validation
 
-**Analysis & Security:**
-- `calor_analyze` - Analyze files for migration potential
-- `calor_assess` - Assess code quality and security
+**Analysis:**
+- `calor_analyze` - Security/bug patterns, migration assessment, or interop minimization
 
 **Code Transformation:**
-- `calor_convert` - Convert between C# and Calor
-- `calor_format` - Format Calor source files
-- `calor_lint` - Lint Calor source files
+- `calor_convert` - Convert C# to Calor
+- `calor_format` - Format Calor source code or manage IDs
+- `calor_fix` - Auto-fix compilation errors and ID conflicts
+- `calor_migrate` - Full C# → Calor migration pipeline
 
-**Diagnostics & Validation:**
-- `calor_diagnose` - Validate syntax and show all errors at once
-- `calor_typecheck` - Type-check Calor source files
-- `calor_validate_snippet` - Validate a Calor code snippet inline
-- `calor_compile_check_compat` - Check compilation compatibility
+**Batch Operations:**
+- `calor_batch` - Batch compile/convert multiple files or a project directory
+
+**Navigation:**
+- `calor_navigate` - Go to definition, find references, search symbols
+- `calor_structure` - Document outline, call graph, or change impact analysis
 
 **Syntax & Documentation:**
-- `calor_help` - Get help with Calor syntax, feature support, error explanations, or working examples
+- `calor_help` - Syntax reference, feature support, error explanations, working examples
 
-**Navigation (LSP-style):**
-- `calor_goto_definition` - Go to symbol definition
-- `calor_find_references` - Find all references to a symbol
-- `calor_symbol_info` - Get information about a symbol
-- `calor_document_outline` - Get document outline/structure
-- `calor_find_symbol` - Find symbols by name
+**Preview & Refinement:**
+- `calor_edit_preview` - Preview edit effects before committing
+- `calor_refine` - Refinement type analysis
 
-**ID Management:**
-- `calor_ids` - Manage Calor block IDs
+**Testing:**
+- `calor_self_test` - Run compiler self-test suite
 
 **Testing:**
 - `calor_self_test` - Run Calor self-test suite

--- a/tests/Calor.Compiler.Tests/McpRegistryValidationTests.cs
+++ b/tests/Calor.Compiler.Tests/McpRegistryValidationTests.cs
@@ -1,0 +1,108 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Validates that CLAUDE.md.template, AGENTS.md.template, GEMINI.md.template,
+/// and server instructions only reference MCP tools and resources that actually exist.
+/// Prevents tool-name drift when tools are renamed or consolidated.
+/// </summary>
+public class McpRegistryValidationTests
+{
+    private static readonly HashSet<string> RegisteredTools = GetRegisteredToolNames();
+    private static readonly HashSet<string> RegisteredResources = GetRegisteredResourceUris();
+
+    [Fact]
+    public void ClaudeMdTemplate_ReferencesOnlyRegisteredTools()
+    {
+        var template = LoadEmbeddedTemplate("CLAUDE.md.template");
+        AssertNoPhantomTools(template, "CLAUDE.md.template");
+    }
+
+    [Fact]
+    public void AgentsMdTemplate_ReferencesOnlyRegisteredTools()
+    {
+        var template = LoadEmbeddedTemplate("AGENTS.md.template");
+        AssertNoPhantomTools(template, "AGENTS.md.template");
+    }
+
+    [Fact]
+    public void GeminiMdTemplate_ReferencesOnlyRegisteredTools()
+    {
+        var template = LoadEmbeddedTemplate("GEMINI.md.template");
+        AssertNoPhantomTools(template, "GEMINI.md.template");
+    }
+
+    [Fact]
+    public void Templates_ReferenceOnlyRegisteredResources()
+    {
+        var claude = LoadEmbeddedTemplate("CLAUDE.md.template");
+        AssertNoPhantomResources(claude, "CLAUDE.md.template");
+    }
+
+    [Fact]
+    public void ServerInstructions_ReferenceOnlyRegisteredTools()
+    {
+        // Construct a real handler to get the live server instructions
+        // The handler registers tools in its constructor — this tests the real path
+        var handler = new Calor.Compiler.Mcp.McpMessageHandler(verbose: false);
+        var instructions = handler.GetServerInstructionsForTest();
+        AssertNoPhantomTools(instructions, "GetServerInstructions()");
+    }
+
+    private static void AssertNoPhantomTools(string content, string source)
+    {
+        var toolRefs = Regex.Matches(content, @"calor_[a-z_]+")
+            .Select(m => m.Value)
+            .Distinct()
+            .ToList();
+
+        var phantoms = toolRefs.Where(t => !RegisteredTools.Contains(t)).ToList();
+
+        Assert.True(phantoms.Count == 0,
+            $"{source} references {phantoms.Count} phantom tool(s): {string.Join(", ", phantoms)}. " +
+            $"Registered tools: {string.Join(", ", RegisteredTools.OrderBy(t => t))}");
+    }
+
+    private static void AssertNoPhantomResources(string content, string source)
+    {
+        var uriRefs = Regex.Matches(content, @"calor://[a-z\-]+")
+            .Select(m => m.Value)
+            .Distinct()
+            .ToList();
+
+        var phantoms = uriRefs.Where(u => !RegisteredResources.Contains(u)).ToList();
+
+        Assert.True(phantoms.Count == 0,
+            $"{source} references {phantoms.Count} phantom resource(s): {string.Join(", ", phantoms)}. " +
+            $"Registered resources: {string.Join(", ", RegisteredResources.OrderBy(u => u))}");
+    }
+
+    private static string LoadEmbeddedTemplate(string templateName)
+    {
+        var assembly = typeof(Program).Assembly;
+        var resourceName = $"Calor.Compiler.Resources.Templates.{templateName}";
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"Embedded resource not found: {resourceName}");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    /// <summary>
+    /// Gets tool names by constructing a real McpMessageHandler (which registers all tools
+    /// in its constructor) and extracting the names. Tests the live registry, not a parallel list.
+    /// </summary>
+    private static HashSet<string> GetRegisteredToolNames()
+    {
+        var handler = new Calor.Compiler.Mcp.McpMessageHandler(verbose: false);
+        return handler.GetRegisteredToolNamesForTest();
+    }
+
+    private static HashSet<string> GetRegisteredResourceUris()
+    {
+        var handler = new Calor.Compiler.Mcp.McpMessageHandler(verbose: false);
+        return handler.GetRegisteredResourceUrisForTest();
+    }
+}


### PR DESCRIPTION
## Summary

Agents were being told to call 13 MCP tools that don't exist and didn't know about 8 tools that do.

### The problem

The CLAUDE.md, AGENTS.md, and GEMINI.md templates listed phantom tools like `calor_diagnose`, `calor_verify_contracts`, `calor_goto_definition`, etc. — these are actions on existing tools (e.g., `calor_check action="diagnose"`, `calor_navigate action="definition"`), not standalone tools. Agents calling the phantom names got tool-not-found errors.

Meanwhile 8 real tools (`calor_check`, `calor_navigate`, `calor_structure`, `calor_fix`, `calor_migrate`, `calor_batch`, `calor_edit_preview`, `calor_refine`) were missing from templates entirely.

Server instructions and BatchTool also referenced `calor_syntax_lookup`, `calor_explain_error`, `calor_feature_support` — all non-existent.

### The fix

- All 3 agent templates rewritten with the 15 actual registered tools
- Action dispatch hints included (e.g., `calor_check` with `action: "diagnose", "lint", "typecheck", "validate"`)
- Server instructions and prompts fixed
- **5 new validation tests** prevent future drift: every tool/resource name in templates is asserted against the live MCP registry

### Validation tests

| Test | What it validates |
|------|-------------------|
| `ClaudeMdTemplate_ReferencesOnlyRegisteredTools` | No phantom tools in CLAUDE.md |
| `AgentsMdTemplate_ReferencesOnlyRegisteredTools` | No phantom tools in AGENTS.md |
| `GeminiMdTemplate_ReferencesOnlyRegisteredTools` | No phantom tools in GEMINI.md |
| `Templates_ReferenceOnlyRegisteredResources` | No phantom resource URIs |
| `ServerInstructions_ReferenceOnlyRegisteredTools` | No phantom tools in server instructions |

Tests construct a real `McpMessageHandler` to test against the live registry — not a parallel list.

## Test plan

- [x] Full solution: 0 warnings, 0 errors
- [x] 5 new validation tests pass
- [x] Zero phantom tool references in source files (verified by repo-wide grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)