### PR TITLE
feat: template version marker for CLAUDE.md staleness detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ report.json
 
 # Plan drafts and critique archives (working artifacts, not deliverables)
 docs/plans/archive/
+
+# Calor template backup files
+CLAUDE.md.bak

--- a/src/Calor.Compiler/Init/ClaudeInitializer.cs
+++ b/src/Calor.Compiler/Init/ClaudeInitializer.cs
@@ -18,6 +18,8 @@ public class ClaudeInitializer : IAiInitializer
     };
     private const string SectionStart = "<!-- BEGIN CalorC SECTION - DO NOT EDIT -->";
     private const string SectionEnd = "<!-- END CalorC SECTION -->";
+    private const int TemplateVersion = 1;
+    private const string VersionPrefix = "<!-- calor-template-version: ";
 
     /// <summary>
     /// Atomically writes content to a file by writing to a temp file in the same
@@ -138,8 +140,7 @@ public class ClaudeInitializer : IAiInitializer
     {
         if (!File.Exists(path))
         {
-            // No file exists - create with just the Calor section
-            await File.WriteAllTextAsync(path, calorSection);
+            await AtomicWriteAsync(path, calorSection);
             return ClaudeMdUpdateResult.Created;
         }
 
@@ -147,29 +148,60 @@ public class ClaudeInitializer : IAiInitializer
         var startIdx = existingContent.IndexOf(SectionStart, StringComparison.Ordinal);
         var endIdx = existingContent.IndexOf(SectionEnd, StringComparison.Ordinal);
 
+        // Check existing template version for staleness reporting
+        if (startIdx >= 0 && endIdx > startIdx)
+        {
+            var existingSection = existingContent[startIdx..(endIdx + SectionEnd.Length)];
+            var existingVersion = ParseTemplateVersion(existingSection);
+
+            if (existingVersion > 0 && existingVersion < TemplateVersion)
+            {
+                Console.WriteLine($"  Updating agent instructions (v{existingVersion} → v{TemplateVersion})");
+            }
+        }
+
         string newContent;
         if (startIdx >= 0 && endIdx > startIdx)
         {
-            // Replace existing section
             var before = existingContent[..startIdx];
             var after = existingContent[(endIdx + SectionEnd.Length)..];
             newContent = before + calorSection + after;
         }
         else
         {
-            // Append section at the end
             newContent = existingContent.TrimEnd() + "\n\n" + calorSection + "\n";
         }
 
-        // Normalize trailing whitespace for comparison
         if (newContent.TrimEnd() == existingContent.TrimEnd())
         {
             return ClaudeMdUpdateResult.Unchanged;
         }
 
-        await File.WriteAllTextAsync(path, newContent);
+        await AtomicWriteAsync(path, newContent);
         return ClaudeMdUpdateResult.Updated;
     }
+
+    /// <summary>
+    /// Parses the template version from a managed section.
+    /// Returns 0 if no version marker is found.
+    /// </summary>
+    internal static int ParseTemplateVersion(string section)
+    {
+        var idx = section.IndexOf(VersionPrefix, StringComparison.Ordinal);
+        if (idx < 0) return 0;
+
+        var start = idx + VersionPrefix.Length;
+        var end = section.IndexOf("-->", start, StringComparison.Ordinal);
+        if (end < 0) return 0;
+
+        var versionStr = section[start..end].Trim();
+        return int.TryParse(versionStr, out var version) ? version : 0;
+    }
+
+    /// <summary>
+    /// Current template version. Bump when template changes affect agent behavior.
+    /// </summary>
+    internal static int CurrentTemplateVersion => TemplateVersion;
 
     private enum HookSettingsResult
     {

--- a/src/Calor.Compiler/Resources/Templates/CLAUDE.md.template
+++ b/src/Calor.Compiler/Resources/Templates/CLAUDE.md.template
@@ -1,4 +1,5 @@
 <!-- BEGIN CalorC SECTION - DO NOT EDIT -->
+<!-- calor-template-version: 1 -->
 ## Calor-First Project
 
 This is an **Calor-first project**. All new code MUST be written in Calor. Existing C# files should be converted to Calor before modification.

--- a/tests/Calor.Compiler.Tests/TemplateVersionTests.cs
+++ b/tests/Calor.Compiler.Tests/TemplateVersionTests.cs
@@ -1,0 +1,49 @@
+using Xunit;
+using Calor.Compiler.Init;
+
+namespace Calor.Compiler.Tests;
+
+public class TemplateVersionTests
+{
+    [Fact]
+    public void ParseTemplateVersion_ValidVersion_ReturnsVersion()
+    {
+        var section = "<!-- BEGIN CalorC SECTION -->\n<!-- calor-template-version: 1 -->\n## Content";
+        Assert.Equal(1, ClaudeInitializer.ParseTemplateVersion(section));
+    }
+
+    [Fact]
+    public void ParseTemplateVersion_HigherVersion_ReturnsVersion()
+    {
+        var section = "<!-- calor-template-version: 42 -->";
+        Assert.Equal(42, ClaudeInitializer.ParseTemplateVersion(section));
+    }
+
+    [Fact]
+    public void ParseTemplateVersion_NoMarker_ReturnsZero()
+    {
+        var section = "<!-- BEGIN CalorC SECTION -->\n## Content\n<!-- END CalorC SECTION -->";
+        Assert.Equal(0, ClaudeInitializer.ParseTemplateVersion(section));
+    }
+
+    [Fact]
+    public void ParseTemplateVersion_MalformedMarker_ReturnsZero()
+    {
+        var section = "<!-- calor-template-version: abc -->";
+        Assert.Equal(0, ClaudeInitializer.ParseTemplateVersion(section));
+    }
+
+    [Fact]
+    public void CurrentTemplateVersion_IsPositive()
+    {
+        Assert.True(ClaudeInitializer.CurrentTemplateVersion >= 1);
+    }
+
+    [Fact]
+    public void Template_ContainsVersionMarker()
+    {
+        var template = EmbeddedResourceHelper.ReadTemplate("CLAUDE.md.template");
+        var version = ClaudeInitializer.ParseTemplateVersion(template);
+        Assert.Equal(ClaudeInitializer.CurrentTemplateVersion, version);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a version marker (`<!-- calor-template-version: 1 -->`) inside the managed section of CLAUDE.md. When `calor init` runs on a project with an older template version, it reports the upgrade.

### How it works

- `TemplateVersion = 1` constant in `ClaudeInitializer` — bumped when template changes affect agent behavior
- `ParseTemplateVersion()` extracts the version from existing CLAUDE.md
- When stale: prints "Updating agent instructions (v1 → v2)"
- Auto-updates unmodified sections (preserves existing behavior — no breaking change)
- `CLAUDE.md.bak` added to `.gitignore`

### Tests (6 new)

- `ParseTemplateVersion_ValidVersion_ReturnsVersion`
- `ParseTemplateVersion_HigherVersion_ReturnsVersion`
- `ParseTemplateVersion_NoMarker_ReturnsZero` (old CLAUDE.md without version)
- `ParseTemplateVersion_MalformedMarker_ReturnsZero`
- `CurrentTemplateVersion_IsPositive`
- `Template_ContainsVersionMarker` (embedded template matches constant)

## Test plan

- [x] Builds with 0 warnings, 0 errors
- [x] 6 new tests pass
- [x] Existing McpRegistryValidation tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)