### PR TITLE
chore: deprecate calor diagnose CLI command (removal in v0.6.0)

### DIFF
--- a/src/Calor.Compiler/Commands/ConvertCommand.cs
+++ b/src/Calor.Compiler/Commands/ConvertCommand.cs
@@ -225,7 +225,7 @@ public static class ConvertCommand
                     Console.Error.WriteLine($"  {err}");
                 if (validationErrors.Count > 5)
                     Console.Error.WriteLine($"  ... and {validationErrors.Count - 5} more");
-                Console.Error.WriteLine("Output written but may not compile. Use calor diagnose for full report.");
+                Console.Error.WriteLine("Output written but may not compile. Use calor_compile MCP tool with autoFix for validation.");
             }
         }
 

--- a/src/Calor.Compiler/Commands/DiagnoseCommand.cs
+++ b/src/Calor.Compiler/Commands/DiagnoseCommand.cs
@@ -73,6 +73,11 @@ public static class DiagnoseCommand
         bool validateCodegen,
         bool permissiveEffects)
     {
+        // Deprecation notice — print first so it's not buried under diagnostic output
+        Console.Error.WriteLine("Note: 'calor diagnose' is deprecated. Use the calor_compile MCP tool (autoFix is on by default) for automatic error correction.");
+        Console.Error.WriteLine("      Removal planned for v0.6.0.");
+        Console.Error.WriteLine();
+
         var telemetry = CalorTelemetry.IsInitialized ? CalorTelemetry.Instance : null;
         telemetry?.SetCommand("diagnose");
         if (telemetry != null && files.Length > 0)

--- a/src/Calor.Compiler/Resources/Templates/AGENTS.md.template
+++ b/src/Calor.Compiler/Resources/Templates/AGENTS.md.template
@@ -25,10 +25,9 @@ This is an **Calor-first project**. All new code MUST be written in Calor. Exist
 - Files ending in `.g.cs` are auto-generated from Calor - do not edit them
 - If you need to change generated output, edit the source `.calr` file instead
 
-**Rule 4: Validate syntax after writing**
-- After writing or editing ANY `.calr` file, run `calor diagnose <file.calr>`
-- Fix any reported errors before proceeding
-- This catches ALL syntax mistakes at once (build only shows first error)
+**Rule 4: Compile after writing**
+- After writing or editing ANY `.calr` file, use `calor_compile` (autoFix is on by default)
+- If errors remain, diagnostics with a `fix` field contain concrete edits — apply them directly
 
 ### Workflow for Any Code Change
 
@@ -36,7 +35,7 @@ This is an **Calor-first project**. All new code MUST be written in Calor. Exist
 2. **New feature/file?** → Create `.calr` file
 3. **Modify existing `.calr` file?** → Edit directly
 4. **Modify existing `.cs` file?** → Convert to `.calr` first
-5. **After any .calr change** → Run `calor diagnose` to validate
+5. **After any .calr change** → `calor_compile` (auto-fixes most errors)
 
 ### File Types
 - `.calr` - Calor source files (**use this for all code**)
@@ -79,7 +78,6 @@ This is an **Calor-first project**. All new code MUST be written in Calor. Exist
 #### Key Commands
 ```bash
 calor analyze <path>                 # Score files for Calor migration potential
-calor diagnose <file.calr>           # Validate syntax - shows ALL errors at once
 calor --input file.calr -o file.g.cs # Compile Calor to C#
 calor --input file.calr --verify --analyze -v  # Deep analysis (security, bugs, contracts)
 calor convert file.cs                # Convert C# to Calor

--- a/src/Calor.Compiler/Resources/Templates/CLAUDE.md.template
+++ b/src/Calor.Compiler/Resources/Templates/CLAUDE.md.template
@@ -108,7 +108,6 @@ All tasks must pass (2/3 runs succeed). If tests fail, investigate before procee
 #### Key Commands
 ```bash
 calor analyze <path>                 # Score files for Calor migration potential
-calor diagnose <file.calr>           # Validate syntax - shows ALL errors at once
 calor --input file.calr -o file.g.cs # Compile Calor to C#
 calor --input file.calr --verify --analyze -v  # Deep analysis (security, bugs, contracts)
 calor convert file.cs                # Convert C# to Calor


### PR DESCRIPTION
## Summary

Deprecates `calor diagnose` CLI command in favor of `calor_compile` MCP tool (which has autoFix on by default).

### Changes

- **Deprecation notice** printed first (before diagnostic output) so it's not buried:
  ```
  Note: 'calor diagnose' is deprecated. Use the calor_compile MCP tool (autoFix is on by default) for automatic error correction.
        Removal planned for v0.6.0.
  ```
- **No behavior change** — the command still works, just warns
- **Template cleanup** — removed `calor diagnose` from CLAUDE.md and AGENTS.md Key Commands sections
- **AGENTS.md Rule 4** updated from "run calor diagnose" to "use calor_compile"
- **ConvertCommand** stale reference to "calor diagnose" updated

### Why Option A (warning only)

Option B (route through autoFix) would change the output contract for json/sarif consumers. CI pipelines parsing `calor diagnose --format sarif` would get unexpected fields. Option A is safe — existing consumers unaffected.

## Test plan

- [x] Builds with 0 warnings, 0 errors
- [x] 5 MCP validation tests pass (no phantom tool references)
- [x] `calor diagnose` still works (just prints deprecation notice first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)