### PR TITLE
fix: address PR critique for #607/#608/#609

### DIFF
--- a/src/Calor.Compiler/Commands/ConvertCommand.cs
+++ b/src/Calor.Compiler/Commands/ConvertCommand.cs
@@ -225,7 +225,7 @@ public static class ConvertCommand
                     Console.Error.WriteLine($"  {err}");
                 if (validationErrors.Count > 5)
                     Console.Error.WriteLine($"  ... and {validationErrors.Count - 5} more");
-                Console.Error.WriteLine("Output written but may not compile. Use calor_compile MCP tool with autoFix for validation.");
+                Console.Error.WriteLine("Output written but may not compile. Use 'calor --input <file>' to compile, or calor_compile MCP tool (autoFix on by default).");
             }
         }
 

--- a/src/Calor.Compiler/Commands/DiagnoseCommand.cs
+++ b/src/Calor.Compiler/Commands/DiagnoseCommand.cs
@@ -12,6 +12,7 @@ namespace Calor.Compiler.Commands;
 /// CLI command for outputting machine-readable diagnostics.
 /// This enables automated fix application by AI agents and tools.
 /// </summary>
+// TODO(v0.6.0): Remove this command — deprecated in PR #609. Use calor_compile MCP tool with autoFix instead.
 public static class DiagnoseCommand
 {
     public static Command Create()

--- a/src/Calor.Compiler/Init/ClaudeInitializer.cs
+++ b/src/Calor.Compiler/Init/ClaudeInitializer.cs
@@ -154,9 +154,12 @@ public class ClaudeInitializer : IAiInitializer
             var existingSection = existingContent[startIdx..(endIdx + SectionEnd.Length)];
             var existingVersion = ParseTemplateVersion(existingSection);
 
-            if (existingVersion > 0 && existingVersion < TemplateVersion)
+            if (existingVersion < TemplateVersion)
             {
-                Console.WriteLine($"  Updating agent instructions (v{existingVersion} → v{TemplateVersion})");
+                if (existingVersion == 0)
+                    Console.Error.WriteLine($"  Installing v{TemplateVersion} agent instructions (no prior version marker)");
+                else
+                    Console.Error.WriteLine($"  Updating agent instructions (v{existingVersion} → v{TemplateVersion})");
             }
         }
 

--- a/src/Calor.Compiler/Resources/Templates/GEMINI.md.template
+++ b/src/Calor.Compiler/Resources/Templates/GEMINI.md.template
@@ -70,9 +70,6 @@ This is an **Calor-first project**. All new code MUST be written in Calor. Exist
 **Testing:**
 - `calor_self_test` - Run compiler self-test suite
 
-**Testing:**
-- `calor_self_test` - Run Calor self-test suite
-
 #### Key Commands
 ```bash
 calor analyze <path>                 # Score files for Calor migration potential

--- a/tests/Calor.Compiler.Tests/McpRegistryValidationTests.cs
+++ b/tests/Calor.Compiler.Tests/McpRegistryValidationTests.cs
@@ -35,11 +35,14 @@ public class McpRegistryValidationTests
         AssertNoPhantomTools(template, "GEMINI.md.template");
     }
 
-    [Fact]
-    public void Templates_ReferenceOnlyRegisteredResources()
+    [Theory]
+    [InlineData("CLAUDE.md.template")]
+    [InlineData("AGENTS.md.template")]
+    [InlineData("GEMINI.md.template")]
+    public void Templates_ReferenceOnlyRegisteredResources(string templateName)
     {
-        var claude = LoadEmbeddedTemplate("CLAUDE.md.template");
-        AssertNoPhantomResources(claude, "CLAUDE.md.template");
+        var template = LoadEmbeddedTemplate(templateName);
+        AssertNoPhantomResources(template, templateName);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes issues identified in consolidated critique of PRs #607, #608, #609.

### Fixes

| Source PR | Issue | Fix |
|-----------|-------|-----|
| **#608** | `existingVersion > 0` gate excludes pre-marker CLAUDE.md files | Changed to `existingVersion < TemplateVersion`. Messages to stderr. Branch on v0 vs vN. |
| **#607** | Duplicate "Testing:" section in GEMINI.md.template | Removed duplicate |
| **#607** | Resource validation only covers CLAUDE.md | Expanded to `[Theory]` covering all 3 templates |
| **#609** | No tracking for v0.6.0 removal | Added `TODO(v0.6.0)` comment on DiagnoseCommand |
| **#609** | ConvertCommand points CLI users to MCP-only solution | Updated to include both CLI and MCP options |

### Not addressed (acceptable scope reductions, documented)

- #608 --force backup logic: plan item, not implemented. `<!-- DO NOT EDIT -->` marker signals hand-edits are unsupported.
- #608 CI guardrail for version bump: deferred.
- #607 McpRegistryInfo extraction: follow-up.
- #607 Tool description drift validation: follow-up.

## Test plan

- [x] Builds with 0 warnings, 0 errors
- [x] 13 validation + version tests pass (5 + 2 new resource + 6 version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)