### PR TITLE
chore: upgrade Roslyn 4.8.0 → 5.3.0 for C# 14 support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,6 @@ Benchmarks live in `benchmarks/`. When writing or modifying benchmarks, ensure t
 
 ## Dependencies
 
-- **Microsoft.CodeAnalysis.CSharp 4.8.0** — Roslyn, for C# parsing in the migration pipeline
+- **Microsoft.CodeAnalysis.CSharp 5.3.0** — Roslyn, for C# parsing in the migration pipeline (supports C# 14)
 - **System.CommandLine 2.0.0-beta4** — CLI argument parsing
 - **Z3 4.15.7** — SMT solver for contract verification (custom ARM64 build)

--- a/src/Calor.Compiler/Calor.Compiler.csproj
+++ b/src/Calor.Compiler/Calor.Compiler.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.3" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageReference Include="Ulid" Version="1.3.4" />
   </ItemGroup>
 

--- a/src/Calor.Compiler/Migration/CSharpToCalorConverter.cs
+++ b/src/Calor.Compiler/Migration/CSharpToCalorConverter.cs
@@ -135,8 +135,9 @@ public sealed class CSharpToCalorConverter
                 }
             }
 
-            // Step 1: Parse C# with Roslyn
-            var syntaxTree = CSharpSyntaxTree.ParseText(csharpSource);
+            // Step 1: Parse C# with Roslyn (use Latest language version to accept all C# features)
+            var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
+            var syntaxTree = CSharpSyntaxTree.ParseText(csharpSource, parseOptions);
             var root = syntaxTree.GetCompilationUnitRoot();
 
             // Check for parse errors.

--- a/tests/Calor.Conversion.Tests/Calor.Conversion.Tests.csproj
+++ b/tests/Calor.Conversion.Tests/Calor.Conversion.Tests.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Calor.Enforcement.Tests/Calor.Enforcement.Tests.csproj
+++ b/tests/Calor.Enforcement.Tests/Calor.Enforcement.Tests.csproj
@@ -20,7 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Calor.Evaluation/Calor.Evaluation.csproj
+++ b/tests/Calor.Evaluation/Calor.Evaluation.csproj
@@ -20,7 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageReference Include="DiffPlex" Version="1.7.2" />
   </ItemGroup>
 

--- a/tests/Calor.Semantics.Tests/Calor.Semantics.Tests.csproj
+++ b/tests/Calor.Semantics.Tests/Calor.Semantics.Tests.csproj
@@ -20,7 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Calor.RoundTrip.Harness/Calor.RoundTrip.Harness.csproj
+++ b/tools/Calor.RoundTrip.Harness/Calor.RoundTrip.Harness.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Upgrades Microsoft.CodeAnalysis.CSharp from 4.8.0 to 5.3.0 across all projects
- Adds `CSharpParseOptions(LanguageVersion.Preview)` to the C# → Calor migration pipeline to accept latest C# syntax
- Fixes conversion failures on modern C# files using lambda `out` parameters (`(_, out properties) =>` — C# 14 syntax found in Avalonia)

## Motivation
The converter was using Roslyn 4.8.0 (C# 12 era, shipped with .NET 8). Files from modern .NET projects using C# 13/14 features failed with parse errors like `Identifier expected` on lambda parameter modifiers. Since Calor targets .NET 10, the Roslyn dependency should support the same C# version the SDK ships.

## Validation
- 6,513 unit tests pass (0 failures)
- 280 conversion snapshot tests pass
- 100/100 random-sample conversion+compilation across 52 GitHub projects (0 failures)
- Avalonia `IFramebufferPlatformSurface.cs` (previously failing) now converts successfully

## Test plan
- [x] Full test suite passes (`dotnet test`)
- [x] Conversion snapshot tests pass
- [x] Random 100-file sample from 52 projects: 100%
- [x] Previously failing file (Avalonia lambda `out` params) converts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)