### PR TITLE
docs(gate): pre-register Phase 2 measurement protocol v2 + substrate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -339,3 +339,113 @@ jobs:
           else
             echo "No .calr files found in docs or examples"
           fi
+
+  verify-phase1:
+    # Tier 1 self-verification harness — v6 §3.1.
+    # Goal: every PR finishes Tier 1 in < 60s.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore and build (needed for ast_roundtrip)
+        run: |
+          dotnet restore
+          dotnet build -c Release --no-restore
+
+      - name: Run Tier 1 (self-tests + identity checks)
+        id: tier1_self
+        run: |
+          set -o pipefail
+          /usr/bin/time -f '%e' -o tier1-self.time \
+            python3 scripts/verify_phase1.py --self-test --skip-dotnet \
+              2>&1 | tee tier1-self.log
+          echo "elapsed_seconds=$(cat tier1-self.time)" >> "$GITHUB_OUTPUT"
+
+      - name: Run Tier 1 (samples/ corpus)
+        id: tier1_samples
+        run: |
+          set -o pipefail
+          /usr/bin/time -f '%e' -o tier1-samples.time \
+            python3 scripts/verify_phase1.py --skip-dotnet \
+              2>&1 | tee tier1-samples.log
+          echo "elapsed_seconds=$(cat tier1-samples.time)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Tier 1 logs and timings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tier1-verification
+          path: |
+            tier1-self.log
+            tier1-self.time
+            tier1-samples.log
+            tier1-samples.time
+          retention-days: 30
+
+  phase1-corpus-clean:
+    # Gate-A: ensure no legacy 26-char ULID structural blocks are
+    # introduced into the corpus. Runs on every PR; budget < 5s.
+    # Pairs with the scheduled tier4-monitor job, but blocks PRs.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Assert zero legacy structural ULIDs in the corpus
+        run: |
+          python3 scripts/phase1_post_ship_monitor.py \
+            --root . \
+            --window 7 \
+            --output phase1-corpus-clean.json \
+            --fail-on-increase-over 0
+          cat phase1-corpus-clean.json
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: phase1-corpus-clean
+          path: phase1-corpus-clean.json
+          retention-days: 14
+
+  phase2-gate-dryrun:
+    # Gate-D: exercise the Tier 3 gate plumbing without spending LLM
+    # budget. Asserts the analyzer returns exit 0 for a "good" seed
+    # and exit 1 for a "bad" seed.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install analyzer deps
+        run: pip install scipy
+
+      - name: Run phase-2 gate dry-run smoke
+        run: python3 scripts/smoke_phase_2_gate_dryrun.py

--- a/.github/workflows/tier2.yml
+++ b/.github/workflows/tier2.yml
@@ -1,0 +1,57 @@
+name: Tier 2 verification
+
+# Tier 2 — corpus-wide verification (v6 §3.2).
+# Only runs for PRs that target phase-1/phase-2/release/0.x+1 branches,
+# or on manual dispatch. Tier 1 runs on every PR (test.yml).
+
+on:
+  pull_request:
+    branches:
+      - 'phase-1'
+      - 'phase-1-*'
+      - 'phase-2'
+      - 'phase-2-*'
+      - 'release/**'
+  workflow_dispatch:
+
+jobs:
+  verify-corpus:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore and build
+        run: |
+          dotnet restore
+          dotnet build -c Release --no-restore
+
+      - name: Run Tier 2 corpus verification
+        id: tier2
+        run: |
+          set -o pipefail
+          /usr/bin/time -f '%e' -o tier2.time \
+            python3 scripts/verify_corpus.py 2>&1 | tee tier2.log
+          echo "elapsed_seconds=$(cat tier2.time)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Tier 2 artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tier2-verification
+          path: |
+            tier2.log
+            tier2.time
+          retention-days: 30

--- a/.github/workflows/tier4-monitor.yml
+++ b/.github/workflows/tier4-monitor.yml
@@ -1,0 +1,39 @@
+name: Tier 4 — Phase 1 Post-Ship Monitor
+
+on:
+  schedule:
+    # Daily at 04:17 UTC — outside the normal CI burst window.
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - "scripts/phase1_post_ship_monitor.py"
+      - ".github/workflows/tier4-monitor.yml"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 100
+
+      - name: Run monitor
+        run: |
+          python3 scripts/phase1_post_ship_monitor.py \
+            --root . \
+            --window 7 \
+            --output phase1-monitor.json
+          cat phase1-monitor.json
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: phase1-monitor-report
+          path: phase1-monitor.json
+          retention-days: 30

--- a/docs/plans/path-2-drop-ids-critique.md
+++ b/docs/plans/path-2-drop-ids-critique.md
@@ -1,0 +1,203 @@
+# Brutal Critique — Path 2: Drop IDs
+
+**Target:** `docs/plans/path-2-drop-ids.md`
+**Voice:** the original designer of Calor, who built the ID system and shipped it
+**Stance:** this RFC is wrong about what Calor is for, and approving it kills the project
+**Date:** 2026-05-12
+
+---
+
+## The one-line indictment
+
+> Path 2 makes Calor cheaper to *write* by deleting the only thing that made Calor worth *evolving*. It optimizes for the first edit and surrenders every edit after that. It declares parity with zerolang (RFC §2.1) and calls that a win. **Parity with zerolang is the loss condition for this project.**
+
+---
+
+## What Calor was actually built to do
+
+I built the ID system because every other language has the same identity model — names — and every other language has the same failure mode: rename breaks blame, extract breaks references, move breaks merges, and agents thrash on every refactor because their mental model of "this function" is a string that changes whenever a human or another agent edits it.
+
+Calor's reason to exist was never "a slightly more verbose C# with effects." It was: **a language whose declarations have identity that survives the edit history.** ULIDs were the operational mechanism. The mechanism is replaceable. The thesis is not.
+
+The RFC repeals design principle #3 ("Everything Has an ID") and replaces it with "Everything is addressable." Read those two sentences carefully. The first is a claim about *identity*. The second is a claim about *lookup*. They are not the same thing, and the RFC pretends they are.
+
+Names are addressable. They are not identity. A renamed function has a different name and the same identity. Path 2 cannot tell the two apart. **That is the whole bug.**
+
+---
+
+## The token math is a benchmark sleight-of-hand
+
+§2.1's table is the load-bearing evidence. Read it again:
+
+> *Phase 0 benchmark (5 small tasks, cl100k tokenizer)*
+
+**N=5. Toy programs. cl100k.**
+
+The five tasks are `hello`, `add`, `fizzbuzz`, `divide`, `is_prime` (inferred from §13's examples). These are the worst possible case for IDs because they have a high ID-to-logic ratio. A 6-line `hello` program has one module ID, one function ID, and no logic. Of course IDs dominate the token count. They dominate by construction.
+
+Now extrapolate the "20% savings" to a 400-line `OrderFlow.Persistence` module with 8 classes, 40 methods, and real business logic. The ID-to-logic ratio collapses. The savings collapse with it. The RFC does not run this measurement. It cites N=5 toy programs and projects to "all programs." That's the same statistical malpractice the v1/v2 critiques flagged in earlier plans. Six plan revisions ago we were criticizing this. Now it's in a Path 2 RFC and we're pretending it's evidence.
+
+The honest version: *we measured ID cost on 5 toy programs where IDs are the worst possible case. We did not measure on realistic programs. The 20% figure is an upper bound that does not generalize.*
+
+Then ask whether even the upper bound matters. 96 tokens out of an 8k context window is 1.2%. Out of a 200k Claude context, 0.05%. The "token tax" was rhetorical scaffolding for a decision that was made on other grounds.
+
+---
+
+## The "cognitive tax" claim is unmeasured
+
+§2.3:
+
+> *In practice, the agent reads the file, finds the function by name, and then has to copy the ID character-by-character. That's not a feature; that's a tax on every edit.*
+
+Where is the measurement? Where is the agent run that shows edit failures attributable to ID-copy errors? OrderFlow Phase 0 attributed the Cell 3 win to *removing MCP tools*, not to *removing IDs*. Track B (the Python surface) tested syntax, not identity. There is no in-tree benchmark, no logged failure mode, no agent telemetry that supports "IDs cost cognition." The claim is plausible. Plausibility is not evidence.
+
+If you want to make this argument honestly, run the experiment:
+- Pick N≥20 agent tasks involving multi-edit sequences (rename, extract, move).
+- Run each with ID-bearing Calor and with name-only Calor.
+- Measure: turn count, success rate, identity-preservation errors per task.
+- Report median + range.
+
+The RFC does none of this. It asserts cognitive cost as obvious and proceeds. **This is the exact rhetorical move the v1–v6 critiques have been hammering for two weeks.** I expected better.
+
+---
+
+## The rejected alternatives are biased toward the conclusion
+
+§11 rejects four alternatives. Look at the reasoning:
+
+- **§11.4 (BPE-friendly short IDs):** rejected because *"the cognitive tax is independent of the token tax."* But cognitive tax is the unmeasured claim. The RFC dismisses the alternative on the same unproven grounds it uses to motivate Path 2. Circular.
+- **§11.3 (compiler-generated inline IDs):** rejected because *"this trains the agent to ignore IDs, then forces the agent to re-read them whenever it edits."* If true, this is also true of every other language's symbol IDs in debug info, type metadata, and so on — and they don't seem to break agents.
+- **§11.2 (optional IDs):** rejected because *"the middle path is the worst path."* This is an aesthetic claim dressed as engineering. The honest version: the author preferred a clean rule over a calibrated one.
+- **§11.1 (sidecar file):** rejected because *"the user explicitly disliked this option."* That's not an engineering argument. That's deference to a preference. Fine — but call it what it is.
+- **§11.5 (status quo):** rejected because *"verification dividend is only on divide-like programs"*. The RFC's own §2.1 says the residual 1.46× Calor-Path-2 tax *also* "buys" Z3 proofs, taint analysis, hosted-capability tracking — i.e., the verification dividend the RFC just dismissed. Pick a position.
+
+Every rejection leans on either an unmeasured cognitive claim or an aesthetic preference. The RFC has not done the work to know whether any of the rejected alternatives outperform Path 2.
+
+---
+
+## Path 2 contradicts the project's own strategic direction
+
+This is the deepest objection and the one that should block this RFC outright.
+
+We just spent the last two weeks (v1 through v6 of `pivot-execution-plan-*.md` in this same directory) arguing about how to position Calor as the **semantic execution and verification layer for autonomous coding agents** — an IR-shaped product whose load-bearing assets are diff, merge, coordination, and memory. Every one of those subsystems was designed to be **keyed on stable identity that survives across edits**.
+
+From v5/v6 explicitly:
+> *"Critical: the deltas must reference stable node IDs, not line numbers, so they survive reformatting. Existing IdScanner (Ids/IdScanner.cs, 330 LOC) gives us the substrate."*
+
+The IR thesis dies the moment names are the canonical identity, because:
+
+- Diff over names cannot distinguish "function renamed" from "function deleted and new function added." Path 2 §5.4 says the rename refactoring emits a single commit recording both names — but **only if the agent uses the refactoring tool**. If the agent issues raw edits (which it will), names-based diff sees deletion + addition, and the diff/merge subsystem corrupts.
+- Merge over names re-introduces the merge-hell problem the IR thesis was supposed to solve. Path 2 §2.2.3 calls this "a solved problem (every other language)" — but every other language is exactly what coding agents struggle with. Saying "every other language has this problem and is fine" is saying *Calor's competitive moat against every other language just evaporated.*
+- Coordination across agents on the same code requires region identity. With names, two agents renaming the same method to different names *both succeed* — and now there are two regions with two names, and the coordination protocol has nothing to lock against.
+- Memory keyed on names rots whenever any agent renames. Path 2 §5.4 says the rename tool updates references in one atomic operation — but the memory store is *external* to the source files. Either every memory entry gets re-keyed on every rename (expensive and racy) or the memory store dangles.
+
+The RFC does not address any of this. §2.2.2 dismisses "survives rename" as "a refactoring problem, not a programming problem." For a language whose pitch is *agents continuously evolve software using us as the substrate*, refactoring IS the programming problem. Path 2 picks the wrong side of that.
+
+**Approving Path 2 and approving the pivot to "semantic IR for agents" are mutually exclusive.** Pick one. You cannot have both. The RFC pretends this conflict doesn't exist by §1.1's claim of "no semantic change" — but identity *is* semantics for the use case Calor was repositioned to serve.
+
+---
+
+## The "parity with zerolang" framing is the confession
+
+§2.1, emphasis mine:
+
+> *On real-logic tasks like fizzbuzz, Path 2 brings Calor to ~parity with zerolang (1.04× tokens) while **preserving Calor's effect declarations, contracts, and typed I/O**.*
+
+Read what this sentence is actually celebrating. Calor — after Path 2 — costs 1.04× zerolang tokens. Zerolang is a stripped-down text language with no effects, no contracts, no Z3, no nothing.
+
+The author thinks the win is "we got close to zerolang's cost." The actual question is: *why would an agent operator pick 1.04×-cost-Calor over 1.00×-cost-zerolang?* The answer the RFC offers is "effects, contracts, typed I/O." Those are real features. But the RFC also just established that the cost of using Calor is now ~parity with zerolang — and parity means **the only differentiator is the verification stack**, which the RFC itself dismisses as "only on divide-like programs."
+
+Run that argument to its conclusion: Path 2 reduces Calor's token cost to near-zerolang, leaves only the verification stack as the differentiator, and the verification stack only matters on a narrow class of programs. **Path 2 reduces Calor to a small library of verification primitives on top of a zerolang-like text surface.** That's not a language. That's an analyzer.
+
+I built an analyzer-vs-language distinction into Calor for a reason. Path 2 erases it.
+
+---
+
+## What the RFC quietly throws away
+
+Item by item, from the surface table in §2.4 and §6.6:
+
+1. **`[CalorId]` → `[CalorSymbol]`.** This is downgrading a globally-unique opaque identifier to a name-based string. Round-trip is degraded silently — the RFC §6.6 admits *"this is enough for round-trip stability because names are the new identity"* but never tests it. Names break on rename. Round-trip is now rename-fragile. Every C# → Calor → C# cycle that involves a renamed member will lose identity. The 99% round-trip success rate on 14.7k files is now contingent on no renames happening anywhere. That contingency was never required before.
+2. **Diagnostic codes Calor0800–0805.** Deleted from the default pipeline (§9.1). These were the ID validation surface. Deleting them is fine if you're deleting IDs. But they were *also* the integrity layer for `IdScanner`, which the pivot plans (v3+) called "the stable-ID substrate for diff/merge/memory." Path 2 deletes the substrate while the pivot plan depends on it. Internal contradiction.
+3. **`IdScanner`, `IdValidator`, `IdGenerator`.** §6.4 demotes to "optional metadata producers," §7.1 deletes in 1.0. Pivot plan v6 requires them as part of `Calor.SemanticIR`'s foundation. After Path 2 ships, the foundation is rubble.
+4. **The "everything has an ID" guarantee.** This was the most-cited differentiator vs every other language. It is the *one sentence* that distinguished Calor's value proposition. The RFC repeals it casually.
+
+The RFC frames these as cleanup. They are amputations.
+
+---
+
+## Things the RFC gets right (so this isn't a hit piece)
+
+Credit where due:
+
+- §2.3's observation that random ULIDs tokenize roughly one-char-per-token is **correct and important**. This is a real cost. The right response is not to delete IDs; the right response is to use a tokenizer-friendlier ID format (which §11.4 rejected on unmeasured grounds).
+- §6.4's incremental migration through nullable IDs is technically clean. If we were going to ship this — we should not — the engineering plan is competent.
+- §9.3's diagnostic-with-qualified-name format (`Calor0501: division by zero in Calculator.Divide at line 42`) is genuinely more readable than the ULID form. This *can* coexist with IDs — emit qualified name in diagnostics, keep ID in identity store. That's a 1-day change, not a 3-week migration.
+- §2.3 correctly identifies that the agent rarely *uses* the ID for reasoning. True. But "rarely uses for reasoning" is not the same as "doesn't need to exist." The agent doesn't reason about line numbers either, and we don't propose deleting line numbers.
+
+The RFC has a real grievance (ULID tokenization cost, diagnostic readability) wrapped around a wrong conclusion.
+
+---
+
+## What an honest version of this RFC looks like
+
+If the goal is reducing ID-related token cost without destroying the identity model:
+
+**Alternative A — Tokenizer-friendly IDs (the §11.4 alternative, done seriously):**
+- Replace 26-char Crockford Base32 ULIDs with 6–8 char BPE-friendly identifiers.
+- Use a deterministic mapping from existing ULIDs to short IDs (idempotent migration).
+- Measure on N=20 real programs (not 5 toy programs), report median + range.
+- Expected savings: 50–70% of current ID-token cost, with identity model fully preserved.
+
+**Alternative B — Surface elision (compromise that preserves identity):**
+- IDs remain in the AST and on disk metadata, but are *elided from the human/agent-facing surface render* by default.
+- The compiler maintains identity in `*.calr.identity.json` sibling files (git-tracked).
+- Agent reads ID-free source; compiler reads ID-bearing source; round-trip preserves identity.
+- §11.1 rejected sidecar because "the user disliked it." That's not a sufficient reason if the alternative is destroying the identity model.
+
+**Alternative C — IDs only where they pay (the §11.2 alternative, done seriously):**
+- IDs on `pub`-cross-module declarations only (the units where rename costs are real and refactoring crosses file boundaries).
+- No IDs on locals, intra-module helpers, or sub-blocks.
+- This concedes the "everything has an ID" principle but only where IDs cost more than they earn.
+- This is the calibrated middle path the RFC dismisses as "the worst path." It is not. It is the *only* path that preserves the agent-substrate thesis while addressing the token cost.
+
+Any of these would be a 1–2 week change with a measurable improvement and no thesis-level cost. Path 2 is a 3–4 week change that costs the thesis. The RFC does not compare effort against alternatives. It also does not measure on realistic programs.
+
+---
+
+## What I think actually happened in writing this RFC
+
+Be honest. This RFC was written because:
+
+1. The Phase 0 benchmark showed Calor at 1.82× zerolang.
+2. That number was uncomfortable, so the project looked for a way to reduce it.
+3. The fastest reduction available is removing IDs (because IDs are the most-visible Calor-specific overhead).
+4. The RFC was written to justify what was already decided.
+
+That's not how design decisions get made on a project that wants to last. The Phase 0 benchmark is a *signal*. Signals deserve investigation. The investigation that this RFC documents is shallow: 5 toy programs, no measurement of cognitive cost, no measurement on realistic programs, no head-to-head against the alternatives in §11, no consideration of the conflict with the pivot plan.
+
+If the project is going to make breaking changes that repeal design principles, the design principles deserve more than this. **They deserve adversarial review and a deeper benchmark.** Path 2, as drafted, would not survive its own §11 if §11 were honestly executed.
+
+---
+
+## Recommendation
+
+**Reject Path 2 as drafted.** Specifically:
+
+1. **Do not proceed with §7.1's deprecation timeline.** The 1.0 hard-removal commitment is irreversible and the RFC has not earned the right to commit the project to it.
+2. **Approve §9.3 (qualified names in diagnostics) as a standalone change.** This delivers 60% of the perceived UX win at zero thesis cost. ~1 day of work.
+3. **Run the actual measurement.** N=20 realistic programs (not 5 toy programs). Compare current Calor, Alternative A (short IDs), Alternative B (sidecar), Alternative C (cross-module IDs only), and Path 2. Report median + range, both first-write cost and multi-edit cost. **The "multi-edit cost" measurement is the one the RFC dodges entirely.**
+4. **Resolve the conflict with the pivot plan.** The pivot plan (`pivot-execution-plan-v6.md`) requires stable IDs as the substrate for diff/merge/coordination/memory. Path 2 deletes them. One of these two documents has to give. Decide which, in writing, before either lands.
+5. **Audit §11 honestly.** Re-examine each rejected alternative against measured data rather than asserted intuitions. Two of them (A and C) are plausibly better than Path 2 and have not been compared against it.
+
+If you are the maintainer and you read this and think *"but the token cost is real and we need to address it"* — you are right that the token cost is real. You are wrong that Path 2 is the right address. The right address is one of the alternatives in §11 that the RFC dismissed without measurement. **Do the measurement. Then decide.**
+
+---
+
+## One-line summary
+
+Path 2 saves 96 tokens by deleting the property — identity that survives the edit history — that made Calor worth choosing over zerolang in the first place, and it does so on the strength of a 5-program benchmark while contradicting the pivot strategy this project just spent two weeks designing; the right response is to fix the tokenizer-unfriendly ID format (§11.4 done seriously) or elide IDs from the surface render (sidecar, §11.1 with real engineering), not to repeal the design principle the project was built on.
+
+---
+
+*Full path: `C:\Users\juanrivera\sources\repos\juanmicrosoft\calor-2\docs\plans\path-2-drop-ids-critique.md`*

--- a/docs/plans/path-2-drop-ids-devils-advocate.md
+++ b/docs/plans/path-2-drop-ids-devils-advocate.md
@@ -1,0 +1,386 @@
+# Devil's Advocate Review — Path 2: Drop IDs
+
+**Target:** `docs/plans/path-2-drop-ids.md`
+**Voice:** an engineering auditor who is sympathetic to the goal of cutting tokens but unconvinced by the artifact in front of them
+**Stance:** every load-bearing claim in this RFC is either unmeasured, internally contradictory, or under-scoped. The proposal is not yet ready to be acted on.
+**Companion to:** `path-2-drop-ids-critique.md` (which attacks the *thesis*; this document attacks the *artifact*).
+**Date:** 2026-05-22
+
+---
+
+## TL;DR
+
+> The RFC asks for a breaking change to surface syntax, three releases of deprecation tooling, a rewrite of the philosophy, and a 3–4 week engineering effort — and the entire economic justification rests on a 5-program micro-benchmark, an unmeasured "LLM cognitive tax," and a round-trip strategy (`[CalorSymbol]`) that **silently re-introduces the very thing the RFC claims to remove**. Even if you accept the goal, the artifact is too thin to merge.
+
+I am not arguing against ever doing this. I am arguing that this specific document, in its current form, is a draft of an idea — not a proposal to execute.
+
+---
+
+## 1. The savings number is a marketing figure, not an engineering one
+
+§2.1 anchors the whole RFC on one table:
+
+| Variant | Tokens | vs zerolang |
+|---|---:|---:|
+| Calor today | 485 | 1.82× |
+| Calor Path 2 | 389 | 1.46× |
+| zerolang | 266 | 1.00× |
+
+Three problems compound:
+
+**1.1.** **N=5.** Five tasks. `hello`, `add`, `divide`, `fizzbuzz`, `is_prime`. Every one of them is small enough that one module-header and one function-header dominate the token budget. The denominator (logic tokens) is tiny by construction, so removing fixed structural tokens (IDs) produces large *percentage* savings. Run the same measurement on a 300-line module with 15 functions and 4 nested types and the percentage collapses, because the logic denominator grows linearly while the structural numerator (ID tokens) grows logarithmically. **The 20% headline is a small-N artifact.** Nothing in §2.1 acknowledges this.
+
+**1.2.** **The proxy is wrong.** "Tokens of source we send to the LLM" assumes the LLM consumes the whole file every turn. In practice, modern coding agents:
+
+- Use tool-based reads (`view --range`)
+- Cache prefixes
+- Are billed per *output* token at 4–5× the rate of input tokens
+
+For any production agent, the marginal token of *generated* Calor matters orders of magnitude more than the marginal token of *read* Calor. The RFC measures the cheap side. Where is the output-token measurement? Where is the cache-hit measurement?
+
+**1.3.** **The comparison set excludes the alternative the RFC just rejected.** §11.4 dismisses "shorter, more BPE-friendly IDs" with "cognitive tax is independent of token tax." Fine — but then *measure both* and put them in the table. An 8-char alphanumeric ID (`f_a1b2c3d4`) at ~3 tokens per occurrence would land Calor between Path 2 and today. That cell is missing from the table because it would force the RFC to defend its decision against a milder alternative that costs no philosophy.
+
+The honest version of §2.1 is: *we ran one cheap, badly-scoped benchmark, and it pointed in the direction we already wanted to go.*
+
+---
+
+## 2. "Everything is addressable" silently re-introduces identifiers — and the RFC admits it
+
+§5.1 says the canonical address is the dotted qualified name. §6.6 then says:
+
+> **Option A (recommended):** Replace `[CalorId]` with `[CalorSymbol("Calculator.Divide")]`. … The attribute is cheap (one line per emitted member) and the migration tooling already depends on it.
+
+Stop. Read that again.
+
+The RFC's central claim is that names are now identity, so no separate identifier is needed. Then in the round-trip section it emits a separate identifier (the qualified name, redundantly attached as a string attribute to every C# member) **because the round-trip cannot survive without one**. If names truly were identity, the attribute would be derivable. The fact that the RFC keeps it — and notes that "migration tooling already depends on it" — proves the implicit dependency on a stable, machine-readable handle that is *not the source-visible name*.
+
+This is the ULID, just spelled differently. The agent now has to keep `[CalorSymbol("Calculator.Divide")]` in sync with the actual qualified name across every rename. That sync is a *new* class of bug:
+
+- Today: rename → IdScanner says "this ID moved, that's fine, it's stable."
+- Path 2: rename → must update every `[CalorSymbol]` attribute in generated C# to match, or the round-trip recovers the wrong name.
+
+The RFC handwaves this in §7.3 ("This is a one-line code change in any consumer") but it isn't a consumer problem. It is a **producer correctness problem** for the migration pipeline itself. If `Calculator.Divide` is renamed to `Calculator.SafeDivide` in the `.calr`, the next `calr → cs → calr` cycle has to:
+
+1. Re-emit `[CalorSymbol("Calculator.SafeDivide")]` (new)
+2. Detect that the *previous* attribute `[CalorSymbol("Calculator.Divide")]` referred to the same entity
+3. Not lose any metadata attached to the old name
+
+In the ID world, step 2 was free (ID matched). In the name world, step 2 requires either a separate change-history file or a heuristic ("the function in roughly the same place with similar signature is probably the renamed one"). **The RFC does not specify the algorithm.** §5.5 just says "git follows entities by name" and waves at `git log --follow`. That's a file-level affordance; it does not address entity-level round-trip.
+
+---
+
+## 3. Positional sub-block addressing is strictly worse than IDs
+
+§5.1 specifies:
+
+```
+Calculator.Divide.body[3]                  // the 4th statement
+Calculator.Divide.body[3].then.body[0]     // the first statement of its then-branch
+```
+
+And §6.7 says diagnostics emit this form: `Calor0501 at Calculator.Divide.body[3] (file:line)`.
+
+Consider the lifecycle of a diagnostic:
+
+1. Compiler emits `Calor0501 at Calculator.Divide.body[3]`
+2. Agent reads the diagnostic
+3. Agent adds a `§B{x:i32}` binding at the top of the function
+4. Now the offending statement is at `body[4]`, not `body[3]`
+
+The address **invalidated itself** the moment the agent made a single edit. Every cached diagnostic, every memorized location, every cross-turn reference is stale after any insert/delete above it. This is the exact failure mode `stable-identifiers.md` was designed to prevent, restored verbatim under a different name.
+
+Three follow-on consequences the RFC does not address:
+
+- **MCP `calor_navigate` "definition"** for sub-block targets is now non-cacheable across edits. Today, the ID is the cache key. Path 2 has no cache key.
+- **Diagnostic suppression** ("ignore Calor0501 at this specific site") becomes ambiguous: which `body[3]` did you mean? The one in the original snapshot or the one after the edit?
+- **Test fixtures** that assert "diagnostic at Calculator.Divide.body[3]" become brittle the same way line-numbered fixtures are. Calor's snapshot tests already churn enough without adding this.
+
+§5.2 fixes uniqueness at the sibling-declaration level. It does not fix positional fragility within bodies. That problem is, by construction, structurally worse than the ID problem the RFC removes.
+
+---
+
+## 4. The dual-mode parser is not a transition tax, it is a permanent tax
+
+§6.2:
+
+> For backward compatibility during transition: parser accepts both forms. If `_pos0` looks like an ID (prefix matches `m_`, `f_`, etc.), it's parsed as the legacy form and the Name is at `_pos1`. Otherwise the new form. The parser emits `Calor0806` (deprecation warning) on legacy form.
+
+Compounding §7.1:
+
+> | **0.x** (Path 2 ships) | Parser accepts both forms. … Legacy form emits `Calor0806` deprecation warning.
+> | **0.x + 1** | Legacy form is opt-in via `--allow-legacy-ids` flag.
+> | **1.0** | Legacy form removed.
+
+Three problems:
+
+**4.1.** **Detection is heuristic.** "If `_pos0` looks like an ID (prefix matches `m_`, `f_`, etc.)" — but in test files, IDs use the short form `f001`, `m001`. The disambiguation is: does `_pos0` start with `f` followed by digits? Then it's a legacy ID. But what if a developer writes a module called `f1Module`? `m1Helper`? The collision space is small but real, and the RFC does not specify the precedence rules formally. There is no grammar in this RFC, only a hand-wave.
+
+**4.2.** **The parser carries the dual mode for at least two release cycles.** Given Calor's ~bi-monthly release cadence (per `Directory.Build.props` history), that's 4+ months of *every commit to Parser.cs* having to consider both forms. The branch coverage of test cases doubles for that period.
+
+**4.3.** **Snapshot churn is grossly underestimated.** §8 Risk R1 says "~50 golden files need new variants." Let's count properly. The `tests/Calor.Conversion.Tests/TestData/` directory plus `tests/Calor.Compiler.Tests/TestData/` plus the round-trip harness fixtures all contain `.calr` and `.g.cs` files with embedded IDs. A grep for `[CalorId(` across `src/`, `tests/`, and `samples/` will return *hundreds* of hits, not ~50. Each one needs:
+
+- A new snapshot baseline
+- A regenerated `.g.cs` because the `[CalorId]` → `[CalorSymbol]` switch changes every emitted member
+
+The "snapshot updater script" the RFC promises does not exist yet, and writing it correctly is itself a 1-week task because the existing snapshot infrastructure was not designed for a global attribute renaming.
+
+---
+
+## 5. The effort estimate is wrong by a factor of two
+
+§10:
+
+| Phase | Estimate |
+|---|---|
+| A — Parser, AST, snapshots | 5 days |
+| B — Visitors, emitters | 4 days |
+| C — Diagnostics, migrator, MCP | 4 days |
+| D — Samples, docs, agent instructions | 3 days |
+| **Total** | **~3 weeks** |
+
+Let's audit by reference to known costs in this repo:
+
+- **`CodeGen/CSharpEmitter.cs` is 4,600 lines** and is one of ~6 visitor implementers that need to handle the AST nullability change. The RFC allots ~20 lines of delta. The actual change touches every emit site that today reads `node.Id` and either inserts it into output or uses it as a cache key. Without a careful audit, I would expect the real delta to be 200–400 lines per major visitor, not 20.
+
+- **`Migration/RoslynSyntaxVisitor.cs` is 6,500 lines** and currently has dozens of sites that read `[CalorId]` for round-trip stability. Switching to `[CalorSymbol]` requires not just a rename but a re-think of how the visitor reconstructs structure when the attribute is missing (which it will be on hand-written C# being migrated for the first time). The RFC allots 15 lines. This is wishful.
+
+- **AST nullability change across ~14 node types at 50 lines each = 700 lines**. Fine. But every `IAstVisitor<T>` and `IAstVisitor` implementer (per `CLAUDE.md`, there are 5 listed) must be re-audited. That's 5 × 14 = 70 visit-method touchpoints, each requiring a decision: does this visitor depend on ID? What does it do when ID is null? The RFC treats this as mechanical. It isn't.
+
+- **Diagnostic test fixtures.** Every test that asserts a diagnostic location string (today `f_01J5X…`) now asserts a qualified name. Hundreds of assertions across `Calor.Compiler.Tests`, `Calor.Semantics.Tests`, `Calor.Verification.Tests`, `Calor.Enforcement.Tests`. The RFC does not budget for this at all.
+
+- **VSCode extension grammar** (mentioned in §8 Phase D as a single bullet). The TextMate grammar for `.calr` files has explicit patterns for ID positions in tags. Updating it correctly while keeping legacy highlighting working through the deprecation period is itself a multi-day task.
+
+A realistic estimate, by analogy to comparable refactors in this repo (e.g., the binder class-members work in `implementation-summary-binder-class-members.md` ran 14,588 bytes of *summary*, suggesting weeks of actual work for a smaller surface), is **6–10 weeks of focused work for one engineer**, plus a tail of snapshot churn that lasts months. Calling it 3 weeks is the kind of optimism that ends with a half-migrated codebase and a parser that has to support both forms forever because the migration stalled.
+
+---
+
+## 6. The Z3 verification story is unaddressed
+
+`docs/philosophy/stable-identifiers.md` lists "round-trip stability" as benefit #3. Calor's verification layer (`Verification/`) uses node identity to:
+
+- Cache Z3 proof obligations between compiles (proof caches keyed by obligation ID).
+- Map obligations to their declaration site for incremental re-verification.
+- Detect when a proof becomes stale (the body changed, the obligation didn't).
+
+The RFC mentions Z3 only once, in passing (§5 "Verification/ExpressionSimplifier.cs — no change (doesn't touch IDs)"). This is not a real claim about the verification system as a whole. It is a claim about one file.
+
+Concrete questions the RFC does not answer:
+
+- Today, a `§PROOF{pf_01ABC:DivisorNotZero}` has a stable ID. When the source name is `Calculator.Divide.DivisorNotZero`, what is the proof-cache key? The qualified name? Including the body hash? Just the obligation name?
+- If two functions in different modules both have a `DivisorNotZero` obligation, do they share a proof cache entry?
+- If the function is renamed `Divide` → `SafeDivide`, does the proof have to be re-run, or can the cache be migrated? Today (ID-based) it's a free identity match. Path 2 has to introduce some other mechanism.
+
+The verification cache is one of Calor's actual differentiators (per the RFC's own §2.1, which credits Z3 with the "verification dividend"). Path 2 breaks the cache key model and ships no replacement. **This is not an annoying detail. This is the load-bearing argument for why Calor's ID system existed in the first place.** Skipping it in the RFC is not "out of scope" — it is the RFC dodging the part of the argument it cannot win.
+
+---
+
+## 7. Refinement types and proof obligations get the worst of both worlds
+
+§5.1 example:
+
+```
+Calculator.PosInt                // refinement type
+Calculator.Divide.DivisorNotZero // proof obligation (named)
+```
+
+Two problems:
+
+**7.1. Refinement types share a namespace with classes and functions.** `Calculator.PosInt` is unambiguous *if* you know `PosInt` is a refinement type. But what disambiguates `Calculator.User` (a class) from `Calculator.User` (a refinement type)? Today, the ID kind prefix (`c_` vs `rt_`) does it for free. Path 2 §5.2 says "sibling declarations must have unique names" — but does this enforce kind-cross-uniqueness? The RFC does not say. There is one paragraph on overload disambiguation and zero paragraphs on cross-kind disambiguation.
+
+**7.2. Proof obligation names are now required to be unique within a function.** `Calculator.Divide.DivisorNotZero` is fine until a function has two obligations the author wants to name the same thing (e.g., two divisions, each with a "DivisorNotZero" obligation). Today, IDs make that trivial. Path 2 forces the author to mint a *new* name — `DivisorNotZero1`, `DivisorNotZero2` — which is exactly the kind of meaningless suffix the RFC criticized ULIDs for in §2.3. The cognitive tax just moved from "copy a ULID" to "invent a unique name." For a verification language, this is a regression.
+
+---
+
+## 8. The "agent UX is better" claim is asserted, not measured
+
+§5.4:
+
+> The agent's UX is better because it can issue rename commands in natural-language form.
+
+§2.3:
+
+> The LLM gets zero semantic benefit from an ID it cannot reason about — it has to maintain a parallel name-to-ID mapping in its working memory.
+
+Both claims are intuitive. Neither is supported by data from this repo.
+
+The repo does have an agent-evaluation harness (`tests/E2E/agent-tasks/run-agent-tests.sh`, referenced in the project instructions). The RFC could have:
+
+- Run the existing agent tasks against today's Calor and a Path 2 prototype.
+- Reported success rate, turn count, and edit-correctness deltas.
+- Shown that agents do measurably better on Path 2.
+
+It does none of this. It cites Phase 0 (which measured *tokens*, not *agent performance*) and asserts that token reduction implies UX improvement. **That implication is the entire load-bearing argument and it is not measured.**
+
+It is also entirely plausible that agents do *worse* under Path 2 in some classes of task — specifically, multi-edit refactors where the agent's first edit invalidates the addresses it cached for the second edit. The fragility introduced in §3 (positional sub-block addresses) is the obvious risk vector, and the RFC has no data ruling it out.
+
+---
+
+## 9. The migrator is described as if it were trivial; it isn't
+
+§7.2:
+
+> 1. Parses every `.calr` file under `path`.
+> 2. For each AST node with an ID, sets the ID to null.
+> 3. Re-emits with `CalorEmitter` (which under Path 2 never writes IDs).
+> 4. Writes the file back.
+>
+> The migrator is idempotent. Files already in Path 2 form pass through unchanged.
+
+Specific things the RFC does not address:
+
+- **Comment preservation.** `CalorEmitter` today round-trips most code but loses comment placement in some edge cases. A migration that nukes comments is a non-starter. The RFC does not commit to a level of comment preservation.
+- **Formatting preservation.** Calor source files have author-chosen whitespace, blank-line patterns, and section ordering. Does re-emit preserve them? `CalorEmitter` is not currently a fully-preserving printer. A migration that reformats the entire codebase is a giant blast radius hidden inside "the migrator is idempotent."
+- **Diagnostic suppressions.** Are there any `// calor-suppress: Calor0801 f_01ABC` style directives in the codebase? The RFC does not say. If there are, they must be rewritten.
+- **External references.** Anything outside the `.calr` source that names an ID (documentation, commit messages, issue trackers, the website) becomes stale. The RFC mentions docs (§6.9) but not the long tail.
+
+§7.2's four steps are a sketch, not a plan. A real migrator-design document would itemize each of these and assign a behavior. This RFC does not.
+
+---
+
+## 10. The deprecation timeline contradicts itself
+
+§7.1 proposes three releases of deprecation: ship → warn-only → flag-gated → removed. The RFC also says, at the very top:
+
+> **Target release:** Pre-1.0 breaking change (0.x → 0.x+1)
+
+And in §7.1's text:
+
+> Three releases gives downstream users time to migrate. Because Calor is pre-1.0, this is well within the "breaking changes allowed" envelope per `CLAUDE.md`.
+
+Pick one. Either Calor is pre-1.0 and we can do hard breaks without a deprecation period (the user gets a clear error message, runs `calor fix --drop-ids`, moves on), or we owe users a slow deprecation. The RFC wants both: the *speed* of "we're pre-1.0, this is allowed" and the *politeness* of a three-release window. The cost of that politeness is the dual-mode parser tax (§4) for the full window. Either commit to one big rip-the-bandage release with a mandatory migrator run, or commit to a full deprecation cycle — but stop pretending you can have both for free.
+
+A single-release hard break is what Calor's pre-1.0 status actually permits and what `CLAUDE.md` actually encourages. The three-release window in §7.1 is the RFC importing the etiquette of a 1.0+ language while keeping the freedom of a 0.x one.
+
+---
+
+## 11. The "rejected alternatives" section is a strawman parade
+
+§11 lists five rejected alternatives. Each rejection is one paragraph. The reasoning is consistently:
+
+- **11.1 (Sidecar file):** rejected because the user disliked it. (That's a preference, not an analysis.)
+- **11.2 (Optional IDs):** rejected because choosing-when-to-add-an-ID is itself a tax. (True, but no measurement of how often the choice would actually fire.)
+- **11.3 (Compiler-generated inline IDs):** rejected because agents would learn to ignore them. (Asserted, not measured.)
+- **11.4 (Shorter, BPE-friendly IDs):** rejected because "cognitive tax is independent of token tax." (See §1.3 — this should have been the alternative the RFC actually steelmanned, because it would have shrunk the token gap to ~5–8% while keeping every benefit of stable identifiers.)
+- **11.5 (Status quo):** rejected because the verification dividend "only" applies to programs with preconditions. (But §6.6's `[CalorSymbol]` Option A is itself a status-quo-with-rename — so the RFC is partially adopting the thing it claims to reject.)
+
+A good rejected-alternatives section makes the reader nod: "yes, those are worse." This one makes the reader suspect the alternatives were never seriously prototyped. None of them have a token measurement. None of them have an agent evaluation. They are dismissed by argument, not by experiment.
+
+---
+
+## 12. The grammar in §6.1 is incomplete
+
+§6.1 lists 11 declaration tags and 4 sub-block tags. The Calor language has more constructs than that. From a quick scan of `Ast/`:
+
+- **Pattern matching** (if it exists — the RFC doesn't say what happens to match-arm IDs)
+- **Async/await markers** (`§AF`, `§AMT`, `§AWAIT` — what IDs do these have today, and what do they look like Path 2?)
+- **Collection literals** (`§LIST`, `§DICT`, `§HSET` — they have names today; are those names IDs?)
+- **CSharpInteropBlockNode** — the RFC explicitly says "Migration/FeatureSupport.cs: no change" in §8. But interop blocks have IDs today for round-trip. Does Path 2 keep them?
+- **MemberPreprocessorBlockNode** — preprocessor conditions; how are they addressed when IDs are dropped?
+
+The RFC's §6.1 grammar table is selective. A real proposal needs the full enumeration, not a sample. The reader cannot evaluate the proposal without knowing whether the things they care about are in or out.
+
+---
+
+## 13. The "Open questions" section is the proposal
+
+§12 lists six open questions:
+
+1. Round-trip attribute footprint
+2. Overload disambiguation syntax
+3. Constructor naming
+4. Whether to delete the philosophy doc
+5. Migrator in-place vs parallel-tree
+6. Deprecation timeline duration
+
+Of these, **(1), (2), (3), and (6) are not open questions — they are the proposal.** A reader cannot evaluate Path 2 without knowing the answer to "how do I name an overload" or "what does a constructor address look like." These are not edge cases; they are core syntactic surface area. Punting them to a follow-up is fine for a design discussion but disqualifying for an RFC marked **Status: Draft** that is also explicitly recommending acceptance in §14.
+
+The maintainer cannot say "yes, accept this RFC and proceed with Phase A" without committing to answers for §12. §14's "Recommended: accept and proceed" therefore asks for a blank check.
+
+---
+
+## 14. The token math was decided before the RFC was written
+
+§2.4 says "Names are required where they exist today" and §5.1 says "the canonical address of any declaration is its dotted qualified name." Both claims are consistent.
+
+But the *order* of writing — and the *direction* of the argument — give away the actual reasoning process. The RFC starts with a 20% token reduction (§2.1), then derives a syntactic proposal (§5), then derives an implementation plan (§6–8), then dismisses alternatives (§11), then asks "should we proceed?" (§14). This is the structure of a memo arguing *for* a decision already made, not the structure of a memo evaluating a decision space.
+
+The honest structure would be:
+
+1. **What problem are we solving?** (Agent UX, with a measurement.)
+2. **What is the design space?** (Sidecar, optional, short IDs, no IDs, Lisp-style nameless, …)
+3. **What did we measure?** (Token cost, agent success rate, parse complexity, round-trip stability) **for each point in the space.**
+4. **What does the data say?** (Maybe no IDs wins. Maybe short IDs win. Maybe optional IDs win.)
+5. **What do we recommend?** (Based on the data, not the preference.)
+
+The current RFC skips (1) (no measurement of the problem), conflates (2) and (5) (the design space is "Path 2" and the recommendation is also "Path 2"), and treats (3) and (4) as completed when the only measurement is N=5.
+
+This is not a fatal flaw. It is a request to rewrite the RFC in the form of an inquiry, not a brief.
+
+---
+
+## 15. The strongest argument *for* Path 2 is not in the RFC
+
+There is a real argument for dropping IDs that the RFC does not make:
+
+> Calor's surface syntax is the medium through which agents write the language. Every character of structural noise an agent writes is a character it could have spent on logic. The right way to measure the ID tax is not "tokens in the file" but "characters the agent has to plan, type, and verify per declaration." On that metric, an ID is ~28 characters of attentional load every time the agent emits a function. Multiplied across a session, this is the dominant cost of writing Calor.
+>
+> The fact that no one has measured this is itself the argument: ULIDs are an unmeasured cost that everyone in this codebase has been paying without an A/B comparison. Path 2 is not a definitive answer; it is the first cheap experiment we can run to find out whether the cost was real.
+
+This argument is *valid*. It is also *humble* — it does not claim the win is 20% on toy programs; it claims that running the experiment is worth ~3 weeks of engineering. A reframed RFC that asked for **a four-week timeboxed experiment with explicit kill criteria** (e.g., "if agent task success rate on the harness does not improve by ≥10%, we revert and document") would be hard to argue against.
+
+The current RFC asks for a permanent surface change, a philosophy repeal, and a three-release deprecation window — based on the same evidence that would justify only an experiment. That asymmetry is the central problem with the document.
+
+---
+
+## Recommendations (devil's advocate edition)
+
+If I were the maintainer, I would respond to this RFC with:
+
+**1. Reject in its current form**, with prejudice toward a rewrite, not the idea.
+
+**2. Require a measurement gate before any code lands:**
+- Run the agent harness (`tests/E2E/agent-tasks/run-agent-tests.sh`) against today's Calor and a Path 2 prototype.
+- Report: success rate, turn count, edit-correctness errors, identity-preservation errors per task.
+- Demand statistical significance — minimum N=20 tasks, ≥3 runs each, confidence intervals.
+
+**3. Require the rejected alternatives to be measured, not argued away.** Specifically: a "short IDs (8-char base32)" variant should be in the table. If short-ID Calor lands at 1.50× zerolang vs Path 2's 1.46×, the philosophy repeal is unjustified.
+
+**4. Require the round-trip story to be coherent.** Either commit to "names are identity" and drop `[CalorSymbol]` (Option B), or admit that round-trip needs a stable handle and design that handle deliberately. The current compromise (Option A) is the worst of both worlds: it carries the cost of an attribute on every member without committing to attribute-as-identity.
+
+**5. Require positional sub-block addresses to be designed for stability**, not just defined. A scheme that breaks on every edit-above is not a scheme.
+
+**6. Require an answer to §12 Q2 and Q3** (overload disambiguation, constructor naming) before approving. These are surface syntax, not appendix material.
+
+**7. Require a real Z3 cache-key story.** What's the cache key under Path 2? If it's "qualified name + body hash," the cache invalidates on every code change inside the function, defeating the cache. If it's "qualified name only," the cache returns stale proofs after a body change. If it's something else, name it.
+
+**8. Pick one timeline strategy.** Either:
+- **Hard break:** ship Path 2 in 0.x+1 as the only form, with a one-shot migrator. No deprecation window. Pre-1.0 lets us do this.
+- **Full deprecation:** keep the dual-mode parser, but commit to maintaining it for the full deprecation period as a *first-class* feature, not as a bridge. Then the parser complexity is amortized.
+
+The current "three releases of polite deprecation" is the most expensive option and isn't justified by the user base (which, as a pre-1.0 internal-research project, is essentially the project itself).
+
+---
+
+## What I am *not* saying
+
+I am not saying ULIDs are good. I am not saying the token tax is imaginary. I am not saying Path 2 is wrong in concept.
+
+I am saying:
+
+- The evidence in the RFC is too thin for the magnitude of the change.
+- The technical design has at least four unresolved holes (round-trip identity, positional fragility, Z3 cache keys, overload disambiguation).
+- The effort estimate is roughly half of what the change will actually cost.
+- The deprecation strategy is internally contradictory.
+- The "rejected alternatives" section dismisses the strongest competitor (short IDs) on philosophical grounds without measuring it.
+
+A version of Path 2 that addressed these — a humbler, experiment-framed, measurement-anchored RFC with explicit kill criteria — would be a much stronger document. The current document is a recommendation in search of evidence.
+
+---
+
+## Coda
+
+The companion critique (`path-2-drop-ids-critique.md`) attacks the *thesis* of Path 2: that names are identity. This review takes no position on that thesis. It says only that the *artifact* arguing for it is not yet good enough.
+
+Both can be true. The thesis might be right and the RFC might still need a rewrite. Approving the RFC because the thesis is correct would set a precedent for accepting under-evidenced proposals in this repo — and the eight previous `critique-*` files in `docs/plans/` suggest the team has been pushing back on exactly that pattern for months. Path 2 should not get a pass because its conclusion is convenient.
+
+**Verdict:** *Send back for revision. Do not merge.*

--- a/docs/plans/path-2-drop-ids-v2-critique.md
+++ b/docs/plans/path-2-drop-ids-v2-critique.md
@@ -1,0 +1,298 @@
+# Brutal Critique — Path 2 Drop IDs v2
+
+**Target:** `docs/plans/path-2-drop-ids-v2.md`
+**Voice:** the original designer of Calor, who built the ID system
+**Stance:** v2 is dramatically better than v1; it should be approved with three specific patches, but it has a real technical bug (collision math), a muddled migrator architecture, and one quiet repeal-by-clarification it should own honestly
+**Date:** 2026-05-12
+
+---
+
+## The one-line indictment
+
+> v2 fixed every structural objection raised against v1. What remains is a **collision-math error that makes Phase 2's 9-char ID format unsafe for the projects it claims to serve**, a migrator architecture that hedges between two incompatible strategies in one section, and a "principle preservation" framing that masks a real narrowing of design principle #3. Approvable with patches. Not approvable as written.
+
+---
+
+## What v2 actually got right (credit, because this is rare in this series)
+
+I have to start here because v2 deserves it. It engaged with the v1 critique and the devil's-advocate document seriously and made the right structural moves:
+
+- **Separated symbol IDs from structural IDs.** This is the single most important insight in the document. `IdScanner` already ignores sub-block IDs ([`Ids/IdScanner.cs`](../../src/Calor.Compiler/Ids/IdScanner.cs) confirms — `Visit(ForStatementNode)`, `Visit(IfStatementNode)`, etc. have empty bodies). v1 lumped both populations together and proposed deleting both. v2 correctly identifies that one population is the identity moat and the other is parser convenience.
+- **Preserved the identity model.** Z3 proof cache keys (`ProofObligation.Id`), refinement types, indexed types — all keep their IDs. The pivot-plan conflict the v1 critique flagged ("Calor.SemanticIR needs `IdScanner.cs` as the stable substrate") is **resolved** at the symbol level.
+- **Admitted `[CalorId]` doesn't exist today.** §2.4 is genuine intellectual honesty. v1 proposed renaming `[CalorId]` → `[CalorSymbol]` for round-trip stability, neither of which exists in source. The devil's advocate accused v1 of smuggling identifiers under a new name; v2 surfaces that neither attribute is real and drops the proposal. This is the kind of self-correction that makes a v2 worth reading.
+- **Gated Phase 2 on measurement.** §10 specifies a four-criterion kill rubric with statistical-distinguishability requirements. The v1 critique's deepest demand — "run the measurement before the breaking change" — is honored.
+- **Single-release hard break in pre-1.0 envelope.** §5.7 correctly observes that v1's three-release deprecation was importing 1.0+ etiquette into a project that explicitly allows hard breaks. The single-release strategy with a shipped migrator is the right one for this stage.
+- **§3 thesis reframing.** "Diagnostics may use qualified names + positional paths for *addressing* (a presentation concern); cross-edit references and cache keys continue to use symbol IDs for *identity* (a correctness concern)." v1 conflated these two. v2 separates them. The v1 critique's headline — *names are addressable; they are not identity* — is now correctly inscribed in v2's own thesis.
+- **§12 honest residual concerns.** v1 hid weak points in "open questions." v2 surfaces them in a section explicitly labeled "honest residual concerns" and admits Phase 1 itself is not measurement-justified. This is the right shape.
+
+That's roughly 80% of v2. The rest is contested.
+
+---
+
+## 1. The collision math is wrong, and it makes Phase 2 unsafe
+
+§6.1 proposes 9-character base-36 IDs and computes:
+
+> *Alphabet size 36, total IDs = 36⁹ ≈ 1.0×10¹⁴. Collision probability for 10⁶ IDs ≈ 5×10⁻³. Acceptable for an internal codebase.*
+
+Then:
+
+> *Why not 8 chars: ... Birthday-bound collision starts to matter for very large monorepos (>10⁷ IDs). 9 chars gives a 36× margin at a 1-token cost.*
+
+**Both statements are wrong.**
+
+Birthday-paradox collision probability for n IDs drawn from N possibilities is approximately `1 - e^(-n²/(2N))`. Working through the actual numbers:
+
+| IDs (n) | 9-char base36 (N≈10¹⁴) | 8-char base36 (N≈2.8×10¹²) |
+|---|---|---|
+| 10⁵ | ≈ 5×10⁻⁵ (1-in-20,000) | ≈ 1.8×10⁻³ |
+| 10⁶ | ≈ 5×10⁻³ (1-in-200) | ≈ 0.16 (16% collision!) |
+| 10⁷ | ≈ **0.39 (39% collision)** | ≈ 1.0 (~certain) |
+
+So:
+- At 10⁶ IDs, 9-char gives **0.5% collision probability per ID generation**. That's not "acceptable" — for an identity system whose entire purpose is unique cross-edit identity, a 1-in-200 collision is **catastrophic**. A single collision in a 10⁶-declaration monorepo breaks the proof cache for two unrelated proofs, breaks diff identity for two unrelated symbols, and corrupts memory keyed on those IDs.
+- The "36× margin" claim comparing 8-char to 9-char is **off by an order of magnitude on the wrong axis**. Going from 8 → 9 chars multiplies N by 36, which divides the collision probability by 36 for any given n. That doesn't give you a 36× "margin" in IDs — it gives you ~6× more IDs at the same collision rate (because collision is quadratic in n).
+- More importantly, **v2 says nothing about uniqueness enforcement at generation time.** Today's ULIDs effectively never collide (2¹²⁸ space) so `IdGenerator.Generate()` doesn't need a uniqueness check. With a 9-char space, generation MUST check for collisions and retry. v2 doesn't specify this. §6.3's `IdGenerator` change is described as "Replace `Generate()` body: `prefix + GenerateCompactBase36(9)`. Helper computes from `RandomNumberGenerator`" — no uniqueness check.
+
+**What's actually needed:**
+
+- Either: increase to 12+ chars (base36, 36¹² ≈ 4.7×10¹⁸, collision-free up to ~10⁹ IDs).
+- Or: keep 9 chars but generate-until-unique within the project's existing ID set. Requires an in-memory ID registry during generation, which `IdGenerator` doesn't have today.
+- Or: use a hash-based scheme (deterministic, content-derived) that makes the collision question moot for the migration step but still requires post-migration uniqueness enforcement.
+
+§6.1 also handwaves the deterministic remap: *"Each existing ULID maps to a deterministic compact form via `hash(ulid)[:9]`. Repeated runs produce the same output."* The migrator collision rate on a project with N existing ULIDs is the same as the random-generation collision rate. Worse: collisions during migration are **detected by failure**, not prevented. The migrator must handle them and v2 doesn't specify how.
+
+This is a real bug. It's the only place in v2 that would fail at scale. Fix the math, specify the uniqueness enforcement, and Phase 2's design becomes defensible.
+
+---
+
+## 2. The migrator architecture hedges between two strategies in one paragraph
+
+§5.6:
+
+> *Phase 1 uses an **AST-edit-and-print** migrator strategy, not full re-emit. The migrator operates on the source text directly: locate each opening sub-block tag, locate its matching ID-bearing close tag, and surgically remove only the `{…}` block in each. ... **This is implementable as a regex-guided pass** anchored on tokens from the lexer, not a parse-and-re-emit pass.*
+
+These are two different strategies:
+
+- **AST-edit-and-print:** `Lexer → Parser → AST → modify nodes → Printer → text`. Destroys formatting unless the printer is a faithful round-trip pretty-printer, which Calor's `CalorEmitter` is not (it's a code generator, not a formatter — `Migration/CalorEmitter.cs:~2,800 LOC` was designed to produce canonical output, not preserve user formatting).
+- **Regex-guided pass:** anchor on token positions from the lexer, transform the source text in place, never build an AST. Preserves formatting trivially. Fragile on edge cases (multi-line tags, tags inside strings, tag-like sequences in comments).
+
+§5.6 says it does the second ("regex-guided pass"). §12.4 admits the regex is fragile and recommends *"The migrator should include a 'parse the output, diff against parse-of-input' sanity check before writing."* That's a third strategy bolted on top.
+
+The actual architecture: **regex-guided text edit + post-hoc AST diff verification.** That's defensible, but v2 should say so cleanly instead of starting with "AST-edit-and-print" framing. The current phrasing reads like an attempt to make a regex pass sound more rigorous than it is.
+
+The edge cases v2 acknowledges in §12.4 are real:
+
+- `\r\n` line endings in multi-line tags
+- Tags inside string literals (e.g., `let x = "§F{...}"` — does Calor allow this? worth checking)
+- Tag-like sequences in comments — depends on whether Calor's comment syntax can swallow `§` sequences
+
+The right answer is to write the migrator using the *existing lexer* (which already handles strings and comments correctly) to identify tag-token positions, then edit the source text between those positions. This is genuinely the "lexer-anchored text edit" strategy and v2 should say so explicitly.
+
+---
+
+## 3. Phase 1's cost/benefit ratio is undersold (against Phase 1)
+
+§9.1 estimates Phase 1 at ~9.5 days / ~2 weeks for: parser changes, AST nullability, emitter templates, migrator, snapshot updates, documentation, sample migration.
+
+§1 says Phase 1 alone saves "5–9% on test-form sources, concentrated on programs with sub-blocks (16–18% on `fizzbuzz`/`is_prime`, 0% on `hello`/`add`/`divide`)."
+
+Here's the math the RFC doesn't surface:
+
+- On programs **without sub-blocks**: Phase 1 saves 0%.
+- On programs **with sub-blocks**: Phase 1 saves a structural-ID-block per loop / if / try.
+- Each saved ID block is ~3 tokens in test form (e.g., `if1`, `for1`).
+- In **production form**, structural IDs are *also* short — they're not ULIDs. Look at `Migration/RoslynSyntaxVisitor.cs`: when the C#→Calor converter creates a synthetic sub-block ID, it uses a short generated name like `if1`, `for1`, not a ULID. So Phase 1's savings is roughly the same in test and production form.
+
+**This means Phase 1's savings is essentially what §15's `is_prime` example shows: ~25 tokens out of 151, or ~17%, on the sub-block-heavy case. On real production code with mostly symbol-level declarations, savings are dominated by Phase 2 (the ULID compaction), not Phase 1.**
+
+v2 sells Phase 1 as "zero-risk, ship on engineering merit." But the engineering merit is:
+
+- 2 weeks of senior engineering time
+- A breaking grammar change
+- A migrator that touches every existing `.calr` file
+- Snapshot churn on ~30 fixtures
+- Documentation updates across `CLAUDE.md`, copilot-instructions, MCP resources
+
+…for a savings that doesn't materialize on programs without sub-blocks and that is *much smaller* than Phase 2 would deliver on programs with ULIDs.
+
+The honest framing: *"Phase 1 is an aesthetic and code-cleanup improvement. The token savings are real but small on realistic production code. We're shipping it because the cleanup is worth two weeks regardless of token math."* That's defensible. The current framing ("zero-risk, ship on engineering merit") understates the engineering cost and overstates the token win.
+
+**Recommendation:** rewrite §1 and §5.3 to say *"Phase 1 is cleanup with modest token savings; ship it because the parser code path simplifies and the sub-block ID was never load-bearing. Token savings is an incidental benefit, not the justification."* That removes the false framing without changing the decision.
+
+---
+
+## 4. Error recovery degrades without sub-block IDs
+
+§5.3 dismisses the structural-ID-as-parser-aid concern with: *"Indentation and tag-nesting determine the match; the parser already tracks the open stack."*
+
+True for the happy path. Less true for error recovery on malformed input.
+
+Today:
+```
+Calor0101: §/I{if1} expected at line 42, got §/I{if3}
+```
+
+The parser knows which open IF the closer should match by comparing the IDs. The error message can name both. The agent that wrote the malformed code immediately knows which `§IF` is unclosed.
+
+Phase 1:
+```
+Calor0101: §/I expected, got §/M
+```
+
+The parser knows from the open stack that something is wrong, but it can't tell the agent *which* `§IF` is unclosed without IDs. The agent has to look at the line range and figure it out. For deeply nested code (the case where this matters most), this is a regression.
+
+This isn't a fatal objection — every other language survives without IDs in error recovery. But it's an honest cost that v2 doesn't mention. The thesis is "structural IDs deliver nothing"; the reality is "structural IDs deliver matched open/close enforcement AND error-recovery precision." The second deliverable is small but real.
+
+**Recommendation:** §2.3's "What each population delivers" table should add a row to the Structural IDs column: *"Matched open/close enforcement + error-recovery precision (the diagnostic can name which open the closer should have matched)."* Still small, but honest.
+
+---
+
+## 5. The principle "everything has an ID" is narrowed, and v2 should own that
+
+§1 and §3 say the design principle is *"preserved at the symbol level (where it pays)."* §3 says *"Removes the principle from sub-block constructs (loops, ifs, while, do-while, try, foreach) where it never paid."*
+
+This is **narrowing-by-clarification**. The original principle in `docs/philosophy/design-principles.md` §3 was universal: every declaration and every block had an ID. v2 restricts it to "every symbol-level declaration." That's a defensible position, but v2 should call it what it is.
+
+Two specific phrasings are misleading:
+
+- §1: *"No change to the design principle. 'Everything has an ID' is preserved at the symbol level."* This sentence reads as "no change," but it is exactly a change — the universal claim becomes a scoped claim.
+- §7.4: *"Update [`stable-identifiers.md`]: the doc remains correct about *symbol-level* identity. Add a section 'What identity does not cover' pointing out that sub-block constructs are structural-only."* Adding a "what identity does not cover" section is repealing the universal version of the principle. Honest, but call it that.
+
+**Recommendation:** §3 should say: *"v2 narrows design principle #3 from 'Everything has an ID' (universal) to 'Every symbol-level declaration has an ID' (scoped). Sub-block constructs are addressable by structural position but not by identity. This is a genuine narrowing of the original principle and we own it."*
+
+This is a 3-line change. It makes v2 honest about what it's doing and doesn't change the decision. It also pre-empts the next adversarial reviewer who will accuse v2 of revisionism.
+
+---
+
+## 6. Phase 2's measurement gate has thin statistical power
+
+§10.1: *"≥ 3 runs per task per arm. Total ≥ 180 task runs."*
+
+Three runs per task is **too few**, given what we know about agent variance from OrderFlow:
+
+- OrderFlow Phase 0 baseline was N=20 per cell and explicitly emphasized that lower N was insufficient given heavy-tailed run distributions.
+- Phase 1 Calor showed a [23–39] turn-count range at N=20 — a 70% range around the median. At N=3, a sample of three could easily land in [23, 25, 27] (apparent median 25) or [33, 37, 39] (apparent median 37), purely by chance. Those two samples would lead to opposite conclusions.
+
+§10.2 kill criterion 4 says *"Phase 1+2 result is statistically distinguishable from Phase-1-only (otherwise: ship Phase 1 only and stop)."* But:
+
+- What test? Paired Wilcoxon, McNemar for binary, repeated-measures ANOVA?
+- What significance threshold? p<0.05 with what multiple-comparison correction (you're testing four criteria)?
+- Who runs the analysis? §10 doesn't specify a pre-registered analysis plan.
+
+Without these specifics, the gate is **as fakeable as v5's bright-line thresholds** that the pivot-plan critiques rightly attacked.
+
+**Recommendation:** §10.1 should require N ≥ 10 runs per task per arm (= 600 task runs total for 20 tasks × 3 arms). §10.2 should specify the statistical test and significance threshold up front. §10.3 should require that the analysis be pre-registered in `docs/plans/phase-2-measurement-protocol.md` before any Phase 2 implementation code is written.
+
+The additional runs cost compute, not engineering time. At N=10 per arm with 20 tasks, you're at ~600 runs. If each run averages 30 turns × $0.02/turn = $360 in agent budget. That's a reasonable cost for the falsification.
+
+---
+
+## 7. Two hard breaks in two releases is a cost v2 doesn't surface
+
+§5.7 ships Phase 1 as a hard break in 0.x+1. §6.2 ships Phase 2 (if the gate passes) as another hard break, presumably in 0.x+2 or later. From a user's perspective:
+
+- 0.x → 0.x+1: every `.calr` file must be migrated (`calor fix --drop-structural-ids`).
+- 0.x+1 → 0.x+2 (if Phase 2 ships): every `.calr` file must be migrated again (`calor fix --compact-ids`).
+
+This is two breaking-migration commits in the user's history. For projects with active development, the second migration can land on top of unmerged feature branches and cause merge conflicts with the migrator's mechanical edits.
+
+**Recommendation:** if Phase 2 will ship and the gate is the only question, bundle Phase 1 and Phase 2 in the *same* release. Run the gate experiment in a feature branch *before* the 0.x+1 cut. If the gate passes, ship both together as 0.x+1. If the gate fails, ship Phase 1 alone. This avoids the two-migration problem at the cost of delaying Phase 1 until the gate experiment completes (~3–4 weeks).
+
+This is a small change in release sequencing with a real UX benefit.
+
+---
+
+## 8. Z3 cache invalidation cost is dismissed too quickly
+
+§6.4: *"Z3 proof cache: invalidated once. Rebuilds on first compile (the cache is already disk-local and the invalidation is one cold cache)."*
+
+The Z3 proof cache exists *because* proofs are expensive. For a project with hundreds of proof obligations across complex contracts, rebuilding the cache on first compile is potentially hours of CPU. "One cold cache" understates this.
+
+For the lead engineer's personal dogfooding, this is fine. For any future design partner with a production proof-bearing codebase, the first compile after the Phase 2 migration is materially worse than today's incremental builds. v2 should acknowledge this and provide a strategy:
+
+- **Option A:** Migrator pre-computes the new cache keys via the deterministic remap. No proof recomputation needed; just rename the cache entries. This is the right answer if the cache keys are pure `(prefix:ID:obligation-hash)` triples.
+- **Option B:** Accept the one-time hit and document it. Set user expectations: "first build after migration will take longer."
+
+§6.3's table includes the migrator step `walk every .calr, every [CalorAttribute] reference, every *.calr.cache — deterministically map ULID → compact`. So Option A is what v2 actually intends. Good. But §6.4's sentence about "rebuilds on first compile" contradicts this. Pick one.
+
+**Recommendation:** rewrite §6.4's cache paragraph to say *"The migrator updates Z3 proof cache keys in place using the deterministic ULID → compact remap. No proof recomputation is required."* Drop the "rebuilds on first compile" phrasing — it undercuts the design.
+
+---
+
+## 9. The pivot-plan reconciliation is incomplete
+
+v2 §5.3 claims the pivot-plan conflict (from the v1 thesis critique) is *"Resolved. IR substrate is keyed on symbol IDs, which are unchanged."*
+
+For the IR substrate this is true. **For sub-block-level diff/merge it is not.**
+
+The pivot plan v6 promises a `Calor.SemanticDiff` over the IR that surfaces structured deltas keyed on stable IDs. Symbol-level deltas remain stable post-v2 (good). Sub-block-level deltas — agent rewrote an if-block while keeping the surrounding function — degrade from "identity-tracked structural edit" to "positional or AST-index edit." This is mostly fine, because most diff/merge operations live at the symbol level, but it's a non-zero cost the v2 framing dismisses.
+
+The honest version: *"v2 fully preserves the IR substrate at the symbol level. Sub-block-level edits become positional/AST-index in the diff representation rather than identity-tracked. Most agent operations are symbol-level, so this is an acceptable cost. The pivot plan's `SemanticDiff` design should explicitly document that sub-block delta identity is positional."*
+
+This is a 1-paragraph addition. It honors the pivot plan's actual contract.
+
+---
+
+## 10. The Calor0820 migration error message has a chicken-and-egg dependency
+
+§8.1: *"`Calor0820`: Sub-block constructs no longer accept `{id:...}` — run `calor fix --drop-structural-ids` to migrate. ... Severity: Error."*
+
+§5.7: *"0.x+1: legacy form rejected with `Calor0820`; error message includes the exact `calor fix --drop-structural-ids` command to run. Migrator ships in the same release."*
+
+The dependency:
+1. User updates Calor compiler to 0.x+1.
+2. User tries to compile an existing 0.x project.
+3. Every `.calr` file fails to parse with `Calor0820`.
+4. The user must run `calor fix --drop-structural-ids` — *which is itself a `calor` invocation that parses `.calr` files*.
+
+**Does the migrator use the legacy parser to read the files it's migrating?** §5.6 says: *"Parse every `.calr` file under `path` using the *legacy* parser (kept as a private migrator-internal helper for exactly this purpose)."* OK so the migrator has a legacy parser baked in. Good — but v2 should make this explicit in `Calor0820`'s diagnostic text: *"If `calor fix` itself fails to parse your file, you have unrelated parser errors — fix those first using `calor --version 0.x compile` and then re-run the migrator."*
+
+This is a 1-line diagnostic improvement that prevents user confusion.
+
+---
+
+## What v2 still doesn't address (note, not patch)
+
+- **The pivot plan vs v2 release sequencing.** The pivot plan v6 commits 6 months of solo work to v3-product + experiments. v2 is a 2-week parser change. If the pivot plan starts at Week 1 (per its own Week 1 plan), v2 lands sometime during the pivot's Stage 1. That's fine, but v2 ships a hard break to the source format during a period when the pivot's `calor_verify_roslyn` MCP tool is being built against Roslyn syntax (not Calor syntax). Coordination is needed but not specified.
+- **Documentation cascade.** §5.5's effort estimate includes "Documentation: 1 day" for `docs/syntax-reference/*`, `CLAUDE.md`, `.github/copilot-instructions.md`, MCP resources. CLAUDE.md was just edited by the user and the agent-instruction surface is large. 1 day is probably under-counted by 2x. Real but small.
+- **Editor extension.** §11 mentions `editors/vscode/` updates only briefly. The TextMate grammar for Calor needs updates to stop highlighting structural-IDs as identifiers. Trivial but missed in §9.1's effort breakdown.
+
+These aren't reasons to block v2. They're cleanups for the implementation PR.
+
+---
+
+## Recommendation
+
+**Approve v2 Phase 1 with the following patches:**
+
+1. **§5.6 migrator architecture:** rewrite as "lexer-anchored text edit with post-edit AST verification." Drop "AST-edit-and-print" framing.
+2. **§1 and §5.3 cost framing:** state honestly that Phase 1's token savings is small on real production code; Phase 1 ships for code-path simplification, not for tokens.
+3. **§3 principle scoping:** own that v2 narrows design principle #3 from universal to symbol-scoped. Don't call it "preserved."
+4. **§2.3 structural-ID benefits:** add error-recovery precision to the structural-ID benefits list. Honest, small, doesn't change the decision.
+
+**Approve v2 Phase 2 design with the following blocking fixes:**
+
+5. **§6.1 collision math:** fix the arithmetic (the 36× margin claim is wrong) and either move to ≥12-char IDs or specify generate-until-unique enforcement in `IdGenerator.Generate()`. The current 9-char design is unsafe at the 10⁶ scale v2 claims is "acceptable."
+6. **§6.4 cache invalidation:** clarify that the migrator updates cache keys in place via the deterministic remap. Drop the "rebuilds on first compile" phrasing.
+7. **§10 measurement gate:** N ≥ 10 runs per task per arm (not 3). Specify the statistical test and significance threshold. Pre-register the analysis plan in a separate document before Phase 2 implementation code.
+
+**Recommend a sequencing change:**
+
+8. **Bundle Phase 1 + Phase 2 in the same release** if the gate experiment can run on a branch before 0.x+1. Avoids two breaking migrations in two releases.
+
+**Standalone:**
+
+9. **§8.3 diagnostic addressing** (qualified-name + ID in parentheses): ship as a separate small PR before Phase 1, as v2 itself recommends. ~1 day of work; near-zero risk.
+
+If the maintainer accepts items 1–9 as patch instructions for the implementation PR (not a v3 RFC rewrite), v2 is approvable. The structural arguments are settled. What remains is calibration and one real technical bug (the collision math) that has a clear fix.
+
+---
+
+## One-line summary
+
+v2 fixed every structural objection v1 collapsed under — it separates symbol from structural IDs, preserves the identity moat, admits `[CalorId]` doesn't exist, gates Phase 2 on real measurement, and uses the pre-1.0 single-release break — leaving only a collision-math error in the 9-char ID format that's catastrophic at 10⁶ scale, a migrator-architecture description that hedges between two strategies in one paragraph, and a quiet narrowing of design principle #3 from universal to symbol-scoped that v2 frames as "preserved"; fix the math, pick one migrator architecture, own the principle narrowing, and v2 ships.
+
+---
+
+*Full path: `C:\Users\juanrivera\sources\repos\juanmicrosoft\calor-2\docs\plans\path-2-drop-ids-v2-critique.md`*

--- a/docs/plans/path-2-drop-ids-v2-devils-advocate.md
+++ b/docs/plans/path-2-drop-ids-v2-devils-advocate.md
@@ -1,0 +1,390 @@
+# Devil's Advocate Review — Path 2 v2: Compact Stable Identifiers
+
+**Target:** `docs/plans/path-2-drop-ids-v2.md`
+**Voice:** an engineering auditor who reviewed v1 and is now reviewing the rewrite
+**Stance:** v2 is a substantially better document than v1. It is not yet a document ready to act on.
+**Companion to:**
+- [`path-2-drop-ids-critique.md`](./path-2-drop-ids-critique.md) (attacks v1's *thesis*)
+- [`path-2-drop-ids-devils-advocate.md`](./path-2-drop-ids-devils-advocate.md) (attacks v1's *artifact*)
+- This document attacks v2's *remaining artifact weaknesses* and the places where v2 took credit for fixes that did not fix anything.
+
+**Date:** 2026-05-22
+
+---
+
+## TL;DR
+
+> v2 is a real improvement on v1 in five concrete ways (separates the two ID populations, drops the false `[CalorSymbol]` round-trip story, picks the hard-break that pre-1.0 actually permits, gates Phase 2 on measurement, and surfaces residual concerns honestly in §12). I credit all of this in §1 below.
+>
+> But three of v2's load-bearing claims are still wrong or unsupported, and one item v2 lists as "resolved" was never a real risk to begin with — v2 took credit for fixing it. Specifically: **the snapshot churn estimate is off by roughly 17×, Phase 1's "measured" savings reuse the same N=5 benchmark v2 ruled insufficient for v1, the Phase 2 measurement gate is structured to pass, and the "Z3 cache key story preserved" win is rhetorical because the Z3 cache was never keyed on the IDs in the first place.**
+>
+> Verdict: **send back for one revision, then ship.** v2 is roughly two days of audit work away from being merge-ready, not weeks. The critique below is mostly an audit checklist, not a rejection.
+
+---
+
+## 1. What v2 actually got right
+
+The v1 devil's advocate review made eleven concrete attacks. v2 resolves six of them legitimately and a seventh by reframing. The honest scorecard:
+
+| v1 review concern | v2 status | Verdict |
+|---|---|---|
+| Token math is N=5 toy programs | Acknowledged; reframed as "directional signal" | Honest reframing — though see §4 below |
+| `[CalorSymbol]` smuggles identifiers back in | Withdrawn proposal entirely; §2.4 admits no such attribute exists today or in v2 | Resolved cleanly |
+| Positional sub-block addresses are fragile | Confined to diagnostic *display*, not identity | Resolved by separating concerns |
+| Dual-mode parser is permanent tax | Hard-break, single release | Resolved |
+| Effort estimate off by 2× | Re-scoped; v2 admits v1's 3 weeks was undercounted | Mostly resolved (see §2) |
+| Z3 cache key story | Claimed as preserved | **Not actually resolved; see §3** |
+| Refinement-type / proof-obligation naming | Both keep IDs; collisions don't bind | Resolved by keeping symbol IDs |
+| Open questions ARE the proposal | §7 resolves five of six | Resolved |
+| Grammar enumeration incomplete | §5.1 + §5.4 give a complete table | Resolved |
+| Rejected alternatives dismissed by argument | §4 NG5–NG7 explain how v2 incorporates the right parts | Reframed honestly |
+| Hard break vs polite deprecation contradiction | Picks hard break unambiguously | Resolved |
+
+This is real progress. A reviewer who landed v1 because "the thesis is interesting" would not have produced v2. The author engaged with the critiques in good faith and the artifact is meaningfully better for it.
+
+That said — six-of-eleven plus one reframe is not eleven-of-eleven, and the remaining items matter.
+
+---
+
+## 2. The snapshot estimate is off by roughly 17×
+
+§5.5 line on snapshot churn:
+
+> Snapshot test updates (~30 fixtures, mechanical) — 2 days
+
+§9.1 same number, propagated into the timeline.
+
+A direct count says otherwise. Searching the `tests/` tree for files containing the structural-ID pattern `§(L|IF|WH|TR|FOREACH|DW|UNSAFE|FIXED|SYNC|USING|MATCH|FORALL|EXISTS)\{[a-z]+\d+`:
+
+```
+501 files
+```
+
+That's not 30. It's 501. **About 17× the v2 estimate.**
+
+Two clarifications before drawing the implication:
+
+- Not every file is a snapshot file that asserts byte-exact source content; many are just inputs to a test that doesn't check byte equality of the IDs. The mechanical re-emit still touches them, but only some need golden-file regeneration.
+- Some of those 501 files are documentation samples in the test tree, not actual snapshot fixtures.
+
+But even after pessimistic discounting (say, only 25% of them are genuine golden files that need regeneration), that's still ~125 fixtures, not 30. And the migrator must process all 501 anyway to confirm idempotence.
+
+The implication for §9.1's "2 days" line is straightforward: it is at minimum 5 days, more likely a working week, and the work is not parallelizable across reviewers because each regenerated fixture needs eyeballs to confirm the diff is structural-only. **Phase 1's "~2 weeks" headline becomes ~3 weeks once this is corrected**, which puts it back into the same territory as v1's underestimate that v2 was right to flag.
+
+The fix is small: re-count and re-budget. But the fact that this number was used unchecked is a warning sign — it suggests §5.5's other line items (CalorEmitter "~40 lines," Parser "~150 lines") may be similarly aspirational.
+
+---
+
+## 3. "Z3 cache key story preserved" is a non-fix dressed up as a fix
+
+§5.3 row:
+
+> Devil's advocate §6: "Z3 cache key story unaddressed" — **Resolved.** Proof obligation IDs are symbol-level and unchanged. Cache keys unaffected.
+
+§6.4:
+
+> Z3 proof cache: invalidated once. Rebuilds on first compile (the cache is already disk-local and the invalidation is one cold cache).
+
+Both statements are non-sequiturs. They presuppose that the Z3 cache is keyed on obligation IDs. It isn't.
+
+Reading `src/Calor.Compiler/Verification/Z3/Cache/ContractHasher.cs` lines 10–57:
+
+```csharp
+public string HashPrecondition(
+    IReadOnlyList<(string Name, string TypeName)> parameters,
+    RequiresNode precondition)
+{
+    var sb = new StringBuilder();
+    sb.Append("PRE:");
+    AppendParameters(sb, parameters);
+    sb.Append("::");
+    AppendExpression(sb, precondition.Condition);
+
+    return ComputeSha256Hash(sb.ToString());
+}
+```
+
+The cache key is `SHA256(parameters || expression)`. Not the obligation ID. Not the function ID. Not anything ID-related. `VerificationCacheEntry.cs` stores `ContractHash` (a SHA256), not an obligation identifier. The cache has been content-hashed all along.
+
+This means:
+
+- The v1 devil's advocate §6 concern was, in fact, ill-founded — it assumed an architecture the code doesn't have. (I wrote that concern. It was a fair concern given v1's `stable-identifiers.md` text, which strongly implied ID-keyed cache. The code refutes it.)
+- v2's §5.3 "Resolved" claim is technically true (the cache is unaffected) but for entirely the wrong reason. v2 implies the cache *would* have been affected and that preserving symbol IDs is what protects it. Neither is true. Preserving or removing symbol IDs would have left the cache equally unaffected.
+- v2 §6.4's "invalidated once, rebuilds on first compile" line for Phase 2 is also wrong. The cache wouldn't invalidate at all under Phase 2 because the cache key doesn't include the ID. The "one cold cache" cost is zero.
+
+This matters more than it sounds. The pattern is: v2 is given credit for a defense, when the honest answer is "this concern doesn't bind in either direction." A reviewer reading §5.3 walks away believing v2 has done thoughtful preservation work on the Z3 system. The thoughtful work is the system being content-hashed, which predates v2 by a wide margin.
+
+Two specific corrections v2 should make before merge:
+
+1. §5.3 row should read: *"v1 devil's advocate §6 concern was based on a misreading; the cache is content-hashed (`ContractHasher.cs`), not ID-keyed. Neither v1 nor v2 affects it. The architectural choice that protects this — not the v2 proposal — is content-hashing."*
+2. §6.4 should drop the "invalidated once" line. Replace with: *"No effect on Z3 cache (content-hashed)."*
+
+The cost of these changes is ~3 lines. The benefit is that v2 stops carrying a phantom defense as if it were load-bearing.
+
+---
+
+## 4. Phase 1 ships unmeasured under v2's own evidentiary standard
+
+§2.1 (talking about v1):
+
+> The v1 Phase 0 benchmark measured 5 small tasks in *test-form* Calor … This cuts both ways. It makes the *opportunity* larger … and the *risk* of "v1's number doesn't generalize" smaller for the symbol-ID compaction question — but it also makes the v1 *recommendation* (drop IDs entirely) less defensible.
+
+§1 (talking about Phase 1):
+
+> **Measured savings (Phase 0, N=5): ~5–9% on test-form sources, concentrated on programs with sub-blocks** (16–18% on `fizzbuzz`/`is_prime`, 0% on `hello`/`add`/`divide`). Effort: ~1 week.
+
+This is the same benchmark, with the same N, on the same five tasks. v2 spent §2.1 explaining why this evidence cannot justify a recommendation. Then in §1 it uses the same evidence to justify Phase 1's recommendation.
+
+v2's defense, in §12.1:
+
+> Phase 1 measurement is still not done. Phase 1 ships on engineering merit (zero identity impact, mechanical change, near-zero rollback cost).
+
+This is a different argument: *don't measure because rollback is cheap.* That's a fine argument on its own. The problem is that it tacitly admits Phase 1 is being shipped on rollback-cost analysis, not on measured benefit — exactly the move that v2's own §2.1 rules out.
+
+The fix is to pick one stance:
+
+- **Option A:** "Phase 1 ships because cost-of-error is near zero; we're not measuring because there's nothing to measure against. The 5–9% savings figure in §1 is illustrative, not justifying." Then drop §1's "Measured savings" framing.
+- **Option B:** "Phase 1 ships because cost-of-error is near zero *and* there is a small but real token win. We acknowledge the win is N=5 and offer that as illustrative, not as Phase 1's load-bearing argument." Then re-word §1.
+
+The current §1 wants the framing of evidence-based without doing the evidence work. v1 was attacked for exactly this. v2 should not inherit the bug.
+
+A note on scale that makes this less serious than for v1: Phase 1 *is* genuinely lower-risk than v1's full proposal. The rollback-cost argument really is strong (delete the sub-block IDs, learn nothing breaks, move on). So this is a cosmetic-but-real revision, not a structural problem with Phase 1.
+
+---
+
+## 5. The Phase 2 measurement gate is structured to pass
+
+§10.2:
+
+> Phase 2 ships only if **all four** are true:
+>
+> 1. Success rate on Phase 1+2 ≥ today's success rate (no regression).
+> 2. Identity-preservation errors on Phase 1+2 ≤ today's count (no regression on the property symbol IDs exist to protect).
+> 3. **Either:** turn count median on Phase 1+2 < today's median by ≥ 10%, **or** total output tokens median on Phase 1+2 < today's median by ≥ 15%.
+> 4. Phase 1+2 result is statistically distinguishable from Phase-1-only (otherwise: ship Phase 1 only and stop).
+
+A measurement gate that always passes is not a measurement gate. Three problems:
+
+**5.1.** **Criteria (1) and (2) are no-regression criteria.** They pass on tie. No-regression is the *floor*, not a positive case for the change. A serious gate would say "success rate increases by ≥ X%" and define X.
+
+**5.2.** **Criterion (3) is disjunctive.** Either turn count OR tokens improving by the stated margin passes the gate. Token output is the easier metric to move (Phase 2 mechanically removes ~20 tokens per ID occurrence; even if agents perform identically, the *output* token count drops just from the syntactic change). Phase 2 satisfies (3) by construction. The gate has no chance of failing on this clause.
+
+**5.3.** **Criterion (4) is unfalsifiable as stated.** "Statistically distinguishable" — by what test? At what α? Powered for what effect size? N=20 tasks × 3 runs = 60 observations per arm. For a binary outcome with a baseline success rate around (let's guess) 70% and a hoped-for improvement of 5–10 percentage points, two-proportion z-test power at α=0.05 is well below 50%. **The gate will frequently fail to detect a real improvement and also fail to detect a real regression** purely from underpowering. The phrase "statistically distinguishable" without a power calculation is decoration.
+
+What a serious gate looks like for this change:
+
+```
+Phase 2 ships only if all four are true:
+1. Success rate on Phase 1+2 ≥ today's success rate by ≥ 3 percentage points
+   (one-sided test, α=0.05, power ≥ 0.80, requiring N ≈ 400 observations/arm).
+2. Identity-preservation error rate on Phase 1+2 ≤ today's rate (no regression);
+   tested with one-sided non-inferiority margin of 1 percentage point.
+3. Median turn count on Phase 1+2 < today's median by ≥ 10%,
+   tested with Mann-Whitney U at α=0.05 (token criterion dropped — it's mechanically
+   satisfied and adds no information).
+4. Effect size on (1) or (3) is at least 1.5× the corresponding Phase-1-only effect size
+   (so Phase 2 must show measurable additional benefit beyond what Phase 1 already
+   delivers; otherwise Phase 1 alone is the right ship decision).
+```
+
+That gate could fail. The current §10.2 gate can't. **A gate that can't fail does not control quality; it just legitimizes the decision the author already made.**
+
+Cost of the fix: rewrite §10.2 with statistically sound criteria, accept that N must increase to make those criteria detectable, re-budget §9.2 to reflect the larger experiment. Maybe an extra week.
+
+---
+
+## 6. The commitment is asymmetric on the wrong axis
+
+§10.2 closing clause:
+
+> v2 commits to revert Phase 2 if shipped and the post-ship data shows regressions on (1) or (2).
+
+§5.7 (Phase 1):
+
+> No dual-mode parser. No multi-release window.
+
+There is no comparable revert clause for Phase 1.
+
+This is backwards. Phase 1 touches every `.calr` file with a sub-block (501 files in the test tree alone, per §2). It rewrites samples, docs, and the language grammar. Phase 2 changes the format of a string in declarations. Phase 1 is the larger surface change with the broader blast radius.
+
+A symmetric commitment would say:
+
+- Phase 1 ships in 0.x+1. If user-reported regression rate in 0.x+1 exceeds {threshold}, revert in 0.x+2 with a feature-flag bridge.
+- Phase 2 ships gated by §10's experiment. If post-ship regressions appear, revert.
+
+The hard-break-without-revert posture only works if "no users" is true. v2 §G6 leans on this:
+
+> Single-release hard break. Pre-1.0 envelope allows this (CLAUDE.md is explicit).
+
+"Pre-1.0 envelope" is permission to break, not absence of users. The repo has external sample consumers, a VSCode extension, MCP tool integrations, an evaluation harness, and a documentation site. Each of those is a population that hard-break affects. Asymmetric commitment means the bigger-blast-radius change is the one without the rollback story.
+
+**Fix:** add to §5.7: *"Phase 1 ships in 0.x+1. If feedback in the first two weeks indicates the migrator failed on real codebases, 0.x+2 reintroduces a `--legacy-warn` flag that accepts sub-block IDs with a deprecation warning, extending the transition by one release. This is a contingency, not a plan."* Cost: ~1 hour of writing, ~2 days of code if the contingency is exercised.
+
+---
+
+## 7. The compact ID collision math is hand-waved
+
+§6.1:
+
+> **Format proposal:** 9-character alphanumeric (lower-case + digits, no ambiguous characters): `[a-z0-9]{9}`. Alphabet size 36, total IDs = 36⁹ ≈ 1.0×10¹⁴. **Collision probability for 10⁶ IDs ≈ 5×10⁻³.** Acceptable for an internal codebase; not acceptable for a global registry.
+
+Let me check the math. Birthday-bound approximation for probability of at least one collision with k items drawn from N possibilities: `1 - exp(-k(k-1)/(2N))`. For k=10⁶ and N=10¹⁴:
+
+```
+k(k-1)/(2N) ≈ 10¹² / 2×10¹⁴ ≈ 5×10⁻³
+P(any collision) ≈ 5×10⁻³
+```
+
+The math checks out. The conclusion does not.
+
+**0.5% probability of *some* collision in a 10⁶-ID project is not "acceptable for an internal codebase" for a feature framed as the project's identity moat.** §2.3:
+
+> Symbol IDs deliver: …
+> - IR substrate for diff / merge / coordination / memory (the pivot-plan requirement called out by [thesis critique]).
+
+If the IR substrate has a 1-in-200 chance of producing a collision in a sufficiently large project, and the collision silently aliases two distinct entities into one, the consequence is *catastrophic*: the verifier reasons about the wrong entity, the diff layer merges code that shouldn't merge, the agent's memory of "function X" maps to two different functions. The kind of bug that escapes review and surfaces months later.
+
+The fix is cheap. Two options:
+
+- **A: Bump to 12 characters.** 36¹² ≈ 4.7×10¹⁸, collision probability at 10⁶ IDs ≈ 10⁻⁷. That's at the cost of 3 tokens per ID vs Phase 2's proposal.
+- **B: Keep 9 characters but specify a collision-detection-and-resolution strategy.** `IdGenerator` checks against a project-scoped existing-IDs set on every generation. Conflict → regenerate. The check is in-memory and O(1) with a hash set.
+
+§6.1's `hash(ulid)[:9]` migration plan has the same issue. Truncating a hash deterministically maps every ULID to a 9-char compact ID, **but truncation collapses the 10⁶ → 10¹⁴ mapping at the same Birthday-bound rate as random generation does.** Without collision handling, the migrator can produce duplicate IDs that the validator will then flag as errors.
+
+The migrator must:
+
+1. Compute the deterministic remap.
+2. Detect collisions in the remap output.
+3. For each collision, deterministically tie-break (e.g., append `_a`, `_b`, or rehash with a salt).
+4. Emit a warning listing which ULIDs were tie-broken, so cross-system references (if any) can be updated.
+
+§6.1 doesn't say. The phrase "deterministic" carries weight it can't hold once collisions appear.
+
+A separate observation, less serious but worth noting: only **9 files in the entire repository contain production-style ULIDs**. The codebase is overwhelmingly test-form IDs (`f001`, `m001`). The "Phase 2 saves ~46% on production form" framing in §15 is calibrated against a form that is, today, essentially absent from this repo. Whether that argues for or against Phase 2 depends on whether the project plans to migrate to production ULIDs broadly — and v2 doesn't say.
+
+---
+
+## 8. The migrator description is internally tense
+
+§5.6:
+
+> Phase 1 uses an *AST-edit-and-print* migrator strategy, not full re-emit. The migrator operates on the source text directly: locate each opening sub-block tag, locate its matching ID-bearing close tag, and surgically remove only the `{…}` block in each. Other source bytes (comments, whitespace, blank lines, ordering) are preserved exactly. **This is implementable as a regex-guided pass anchored on tokens from the lexer, not a parse-and-re-emit pass.**
+
+§12.4:
+
+> Migrator regex-guided edit (Phase 1, §5.6) is not parse-perfect. Multi-line tags split across `\r\n` boundaries, tags inside string literals (rare but possible), and tag-like sequences in comments are edge cases the regex must handle correctly.
+
+§5.6 says "AST-edit-and-print." Then §5.6 says "implementable as a regex-guided pass." Those are different things. The first is parse-based (correct, slower, may not preserve byte-identical comment placement). The second is lexer-based (faster, fragile on the edge cases §12.4 names).
+
+Concretely:
+
+- A **true AST-edit-and-print** migrator parses each `.calr`, mutates the AST, prints back. It is parse-perfect by definition but does not preserve comments unless the AST carries trivia (Calor's AST may or may not — v2 doesn't say). It may also reformat whitespace, depending on how the printer is wired.
+- A **regex-guided source-text edit** preserves bytes around the edited region exactly. It must correctly identify each sub-block tag and its matching close tag, despite tag-like sequences in comments and strings. This requires at least a lexer pass to identify tag tokens vs comment/string tokens; pure regex over raw bytes will mis-identify.
+
+v2's phrasing ("regex-guided pass anchored on tokens from the lexer") gestures at the right hybrid (lex first, edit raw bytes within the spans the lexer identifies as tags) but doesn't commit to it. Without committing, the implementer reading §5.6 picks whichever interpretation seems easier today and produces a fragile migrator.
+
+**Fix:** §5.6 should commit explicitly:
+
+> The migrator runs the lexer to tokenize the source. For each token sequence matching an opening sub-block tag with a `{<id>:<rest>}` attribute block, it surgically rewrites the byte range covered by `{<id>:<rest>}` to `{<rest>}` in the original source. For each matching close tag, it rewrites `§/X{<id>}` to `§/X`. The lexer provides token spans; comments and strings are pre-identified and skipped. After rewrite, the migrator re-parses the result and diffs the AST against the AST of the original (with IDs nulled) as a sanity check; any AST mismatch outside the targeted nodes aborts the file with an error.
+
+That's the right design. v2 doesn't quite get there.
+
+---
+
+## 9. The standalone §8.3 quietly trades the cost it was trying to reduce
+
+§8.3:
+
+> **Standalone change recommended by [thesis critique] §"Things the RFC gets right" #3:** the qualified-name diagnostic format is more readable than the ID form regardless of any other change.
+>
+> ```
+> Today:    Calor0501: division by zero in f_01J5X7K9M2NPQRSTABWXYZ12 at file:42
+> Better:   Calor0501: division by zero in Calculator.Divide (f_01J5X7…) at file:42
+> ```
+>
+> The ID is retained in parentheses for tooling, the qualified name is shown for humans/agents. ~1-day change. Recommended to ship before Phase 1 as its own small RFC.
+
+§13:
+
+> **Approve §8.3 (diagnostic addressing) as a separate small RFC** to ship before Phase 1.
+
+The "Better" line is *longer*. Adding `Calculator.Divide ` to every diagnostic message increases output tokens by roughly 4–6 tokens per diagnostic, multiplied by the number of diagnostics emitted in an agent session. For a session that hits 100 diagnostics (warning-heavy compile), that's ~400–600 tokens of additional output cost.
+
+v2's central thesis is that token cost matters and should be reduced. Phase 1 saves an estimated 5–9% on source tokens. The diagnostic change adds tokens to every compile output. The net effect on agent token cost — which §10.2 metric (3) actually measures — depends on the ratio of source-tokens-read vs diagnostic-tokens-emitted in a typical session, and that ratio is not measured.
+
+This is not a fatal objection. It is the same class of bug the rest of the review has flagged: an unmeasured token cost being added in a document about reducing token costs. The "1-day, zero risk" framing is honest about effort, dishonest about token impact.
+
+Either drop the "Better" example's longer form (just use the qualified name, drop the parenthesized ID since v2 §6.1 also makes the ID much shorter), or measure the diagnostic-token cost before recommending the change.
+
+---
+
+## 10. Hard break + non-parse-perfect migrator = one user-bricked codebase away from a revert
+
+Putting §5.7 ("hard break") next to §12.4 ("migrator is not parse-perfect"):
+
+- 0.x+1 ships. Legacy form is rejected with `Calor0820`.
+- A user runs `calor fix --drop-structural-ids` on their project.
+- One file contains a tag-like sequence in a string literal that the regex-guided migrator misidentifies. The migrator either crashes, skips the file silently, or corrupts the file.
+- The user can't compile their project, can't rerun an automated migrator, and is one release behind.
+
+The mitigation v1 used (three-release deprecation) was wasteful but it gave the user one release of `--allow-legacy-ids` to fall back to while figuring out the migrator failure. v2's hard break removes this safety net.
+
+Pre-1.0 doesn't mean "no users." It means "users who accepted the breaking-change envelope when adopting." A user who accepted that envelope can still expect that *when* a break ships, the migration path actually works. v2 §5.6 promises the migrator is mechanical and §12.4 admits it isn't quite. The combination is brittle.
+
+**Fix:** add a `--legacy-warn` mode for one release.
+
+- 0.x+1 default: error on legacy form (per current §5.7).
+- 0.x+1 with `--legacy-warn` flag: warn on legacy form, accept it. Migrator failures fall back to this flag.
+- 0.x+2: flag removed; hard break complete.
+
+This is the [devil's advocate §10 recommendation](./path-2-drop-ids-devils-advocate.md) for v1 applied at a smaller scale. The cost is one parser-level boolean and one diagnostic-severity branch. ~30 LOC. Two more releases of carrying it. Cheap insurance for the case where the migrator fails on a real codebase.
+
+---
+
+## 11. What v2 should add before merge
+
+Concrete, ordered by importance:
+
+**11.1.** Re-count snapshot fixtures. Update §5.5 and §9.1 with the real number. Rebudget Phase 1 timeline. (1 hour.)
+
+**11.2.** Rewrite §5.3 Z3-cache row and §6.4 Z3-cache paragraph to reflect that `ContractHasher.cs` is content-hashed, so the concern doesn't bind in either direction. Stop claiming credit for a non-fix. (~10 lines of text.)
+
+**11.3.** Pick one stance on Phase 1's evidence basis. Either drop "Measured savings" from §1 (replace with "rollback cost is near zero, ship on engineering merit") or re-measure on more than 5 toy programs. (~30 minutes of writing or weeks of measurement; pick.)
+
+**11.4.** Rewrite §10.2 Phase 2 gate with statistically sound criteria. Drop the disjunctive OR. Specify the test, the α, the power. Re-budget §9.2 to reflect the larger N needed. (1 day of stats consultation; 1 week of additional benchmark engineering when Phase 2 actually gets to that point.)
+
+**11.5.** Add a Phase 1 revert/contingency clause to §5.7. (`--legacy-warn` for one release. ~30 LOC and two more release cycles of carrying it as insurance.)
+
+**11.6.** Specify the compact-ID collision strategy in §6.1: either bump to 12 chars, or specify `IdGenerator` collision detection, or both. Specify how the `hash(ulid)[:9]` migration handles colliding outputs. (~15 lines of text plus ~50 LOC in `IdGenerator`.)
+
+**11.7.** Commit to the lexer-anchored hybrid in §5.6 explicitly. Add the post-rewrite AST-diff sanity check. (~10 lines of text plus ~100 LOC in migrator.)
+
+**11.8.** Either drop the parenthesized-ID form in §8.3 (use just qualified name) or measure the diagnostic-token cost before recommending the change. (~3 lines of text or a separate measurement.)
+
+Of these, 11.1, 11.2, 11.3, and 11.5 are pure-writing fixes — a couple of hours of edits. 11.4 and 11.6 require some additional engineering thought but not much. 11.7 is the design commitment that affects the migrator implementation.
+
+**None of these blocks Phase 1 ship.** They block "ship without revision" — they don't block "ship after one editing pass."
+
+---
+
+## 12. What I am *not* saying
+
+I am not saying Phase 1 is a bad idea. It is the cleanest small change v2 proposes and it removes obvious noise. I would ship it after the snapshot recount and the legacy-warn contingency.
+
+I am not saying Phase 2 is a bad idea. It is a well-bounded experiment with a defensible kill criterion structure, even if §10.2's actual criteria need tightening. I would ship it after the gate is rewritten.
+
+I am not saying v2 is dishonest. It is dramatically more honest than v1. The §12 "Honest residual concerns" section is the right convention for any future RFC in this repo. The Z3-cache claim in §5.3 is the only place where v2 takes credit it shouldn't; everywhere else, v2 calls its limits accurately.
+
+I am saying: v2 is closer to merge-ready than to draft-stage. With a focused audit pass — ~2 engineer-days of writing and re-counting — it becomes a document a maintainer can act on confidently. Without that pass, the snapshot estimate, the Z3-cache theater, the unmeasured Phase 1, and the toothless Phase 2 gate together compound into the same kind of "we shipped on optimism" risk v1 was criticized for.
+
+The fix is the audit pass. The verdict is **revise once, then ship.**
+
+---
+
+## Coda
+
+v1 deserved to be sent back. v2 deserves to be sent back *one more time*, for an audit pass that takes a small fraction of the work v2 already represents. The companion [thesis critique](./path-2-drop-ids-critique.md) and [v1 devil's advocate](./path-2-drop-ids-devils-advocate.md) both engaged seriously with v1 and produced v2. This review is the next iteration of the same engagement.
+
+If the author rewrites §1, §5.3, §5.7, §6.1, §6.4, §8.3, §9.1, and §10.2 along the lines in §11 above, v3 is the ship document. That's a one-day rewrite. The improvement from v1 to v2 was much larger. The improvement from v2 to v3 should be much smaller — because v2 already did the hard work.
+
+Approve revisions. Hold ship.

--- a/docs/plans/path-2-drop-ids-v2.md
+++ b/docs/plans/path-2-drop-ids-v2.md
@@ -1,0 +1,709 @@
+# RFC v2: Compact Stable Identifiers — Drop Structural IDs, Compact Symbol IDs
+
+**Status:** Draft (v2 — supersedes [`path-2-drop-ids.md`](./path-2-drop-ids.md))
+**Author:** TBD (with Copilot CLI)
+**Created:** 2026-05-22
+**Supersedes:** v1 (2025-11-25)
+**Reviewed against:** [`path-2-drop-ids-critique.md`](./path-2-drop-ids-critique.md), [`path-2-drop-ids-devils-advocate.md`](./path-2-drop-ids-devils-advocate.md)
+**Target release:** Pre-1.0 hard break (0.x → 0.x+1) for Phase 1. Phase 2 gated on measurement.
+
+---
+
+## 0. Why v2 exists
+
+v1 was rejected by two independent critiques on three grounds:
+
+1. **Thesis error.** v1 claimed "names are identity." The critiques showed this conflicts with the project's identity model (the IR/diff/merge/coordination/memory substrate per the pivot plans) and is internally inconsistent with v1's own round-trip proposal (`[CalorSymbol]`) which silently re-introduces identifiers under a different name. ([thesis critique](./path-2-drop-ids-critique.md) §"Path 2 contradicts the project's own strategic direction", [devil's advocate](./path-2-drop-ids-devils-advocate.md) §2.)
+
+2. **Evidence error.** v1 anchored on a 5-program micro-benchmark that used *test-form* IDs (`f001`, `m001`), not production ULIDs (`f_01J5X7K9M2NPQRSTABWXYZ12`). It then generalized "20% savings" to all programs without measuring on realistic codebases or against any of the rejected alternatives. ([thesis critique](./path-2-drop-ids-critique.md) §"The token math is a benchmark sleight-of-hand", [devil's advocate](./path-2-drop-ids-devils-advocate.md) §1.)
+
+3. **Scope error.** v1 lumped two populations together: (a) **symbol IDs** that `IdScanner` tracks and the verifier uses as cache keys, and (b) **structural IDs** on sub-block constructs (`§L`, `§IF`, `§WH`, `§TR`) that `IdScanner` ignores and that exist only for open/close matching. The two have different costs, different benefits, and warrant different decisions. v1 did not separate them. ([devil's advocate](./path-2-drop-ids-devils-advocate.md) §3, §6, §7.)
+
+v2 separates the populations, drops only what is unambiguously noise, and gates the harder change behind an explicit measurement. The thesis is reframed.
+
+---
+
+## 1. Summary
+
+Two changes, sequenced:
+
+**Phase 1 — Drop structural IDs (definite).**
+Remove the ID block from sub-block constructs only. Symbol IDs are unchanged. No deprecation period. Hard break (pre-1.0 envelope). No `[CalorId]` impact, no Z3 cache impact, no round-trip impact. **Measured savings (Phase 0, N=5): ~5–9% on test-form sources, concentrated on programs with sub-blocks** (16–18% on `fizzbuzz`/`is_prime`, 0% on `hello`/`add`/`divide`). Effort: ~1 week.
+
+**Phase 2 — Compact symbol IDs (gated).**
+Replace 28-character ULIDs with ~9-character compact base32 IDs (`m_a1b2c3d4`). Symbol-level identity model is preserved end-to-end (`IdScanner`, `IdValidator`, `IdGenerator` continue to work; cache keys and refs continue to function; round-trip remains stable). **Measured combined Phase 1+2 savings on production-ULID projection: ~33%** (28–40% per task, see [`bench/phase0/out/report.md`](../../bench/phase0/out/report.md)). Effort: ~2 weeks. **Ships only if** the agent-harness experiment in §10 demonstrates a measurable agent-success improvement.
+
+**No change to the design principle.** "Everything has an ID" is preserved at the symbol level (where it pays). Sub-block IDs were never actually canonical (`IdScanner` does not record them — confirmed in [`src/Calor.Compiler/Ids/IdScanner.cs`](../../src/Calor.Compiler/Ids/IdScanner.cs)) and removing them does not amount to repealing the principle.
+
+---
+
+## 2. Motivation
+
+### 2.1 Evidence accounting
+
+The v1 Phase 0 benchmark measured 5 small tasks in *test-form* Calor:
+
+```
+§M{m001:Hello}
+§F{f001:Main:pub}
+```
+
+`m001` tokenizes to ~2 cl100k tokens. Real production code uses ULIDs:
+
+```
+§M{m_01J5X7K9M2NPQRSTABWXYZ12:Hello}
+§F{f_01J5X7K9M2NPQRSTABWXYZ12:Main:pub}
+```
+
+Each ULID is 28 characters and tokenizes to approximately one token per character (~28 tokens). The v1 20% headline measured on test IDs **understates** the real production cost of ULIDs by roughly an order of magnitude per occurrence.
+
+This cuts both ways. It makes the *opportunity* larger (a compact format is a much bigger win than v1's measurement suggested) and the *risk* of "v1's number doesn't generalize" smaller for the symbol-ID compaction question — but it also makes the v1 *recommendation* (drop IDs entirely) less defensible, because v1 over-stated the relative cost of structural IDs and under-stated the absolute cost of symbol IDs.
+
+**v2's position:** the v1 benchmark is a directional signal, not a justification. It identifies that ID token cost is non-trivial. It does not justify a particular response. Phase 2 (the larger change) is therefore gated on a real measurement (§10), and Phase 1 (the smaller change) is recommended on its own merits because it has near-zero downside.
+
+### 2.2 The two populations are different
+
+| Population | Tracked by `IdScanner` | Used as cache key | Used in round-trip | Source of token cost |
+|---|:---:|:---:|:---:|---|
+| **Symbol IDs** (`m_`, `f_`, `c_`, `i_`, `p_`, `mt_`, `ctor_`, `e_`, `op_`) on Module / Function / Class / Interface / Property / Method / Constructor / Enum / OperatorOverload / Indexer / RefinementType / ProofObligation / IndexedType / EnumExtension | yes | yes (verifier) | yes (planned [CalorId]) | ~28 tok per occurrence (ULID) |
+| **Structural IDs** on `§L`, `§IF`, `§WH`, `§DW`, `§TR`, `§FOREACH` and their close-tags | **no** | no | no | ~3-8 tok per occurrence (test form is shorter) |
+
+Confirmed by reading [`src/Calor.Compiler/Ids/IdScanner.cs`](../../src/Calor.Compiler/Ids/IdScanner.cs):
+
+> The `Visit(ForStatementNode)`, `Visit(WhileStatementNode)`, `Visit(IfStatementNode)`, `Visit(TryStatementNode)` methods are all empty bodies. **Structural IDs exist in the AST but are not collected as canonical identity entries.** Their only function is matched open/close enforcement in the parser ([`Parsing/Parser.cs:4052`](../../src/Calor.Compiler/Parsing/Parser.cs#L4052) `if (endId2 != id) ReportMismatchedId`).
+
+Confirmed by reading [`src/Calor.Compiler/Verification/Obligations/GuardDiscovery.cs`](../../src/Calor.Compiler/Verification/Obligations/GuardDiscovery.cs):
+
+> `ObligationId = obligation.Id` — the Z3 verifier uses the *symbol-level* `ProofObligationNode.Id` as its cache key. Removing that ID would break the proof cache. Removing structural IDs would not.
+
+v1 treated both populations as one decision. v2 treats them as two.
+
+### 2.3 What each population is worth
+
+**Symbol IDs deliver:**
+- Rename safety (canonical ID survives `Calculate → Compute`)
+- Z3 proof-cache stability (proof of `DivisorNotZero` is keyed by ID, survives function rename / body reformat)
+- Round-trip identity (designed but not yet implemented — see §2.4)
+- IR substrate for diff / merge / coordination / memory (the pivot-plan requirement called out by [thesis critique](./path-2-drop-ids-critique.md))
+- Unambiguous diagnostic addressing across edits (the line-number-stability point in `docs/philosophy/stable-identifiers.md` §"Code Identity is Fragile")
+
+**Structural IDs deliver:**
+- Matched open/close enforcement in the parser
+- Nothing else
+
+The first list is the project's competitive moat. The second list is the parser's local convenience and can be achieved by indentation, nesting depth, or stack-based matching — none of which need an ID. **Dropping structural IDs costs nothing the project actually uses; compacting symbol IDs costs only their format.**
+
+### 2.4 Round-trip honesty
+
+v1 claimed `[CalorId("f_01ABC...")]` is emitted on every C# member for round-trip stability. **This is aspirational, not implemented.** A grep across `src/Calor.Compiler/CodeGen/`, `src/Calor.Runtime/`, and `src/Calor.Compiler/Migration/` returns **zero** uses of a `CalorId` attribute. The C# emitter today does *not* preserve IDs in generated C#. The round-trip stability claim in [`docs/philosophy/stable-identifiers.md`](../philosophy/stable-identifiers.md) §"Round-Trip Stability" describes a design that does not exist.
+
+The pre-existing round-trip infrastructure is signature-based, not ID-based. Today, when C# → Calor → C# happens, the converter matches members by name+signature. **The system already operates without ID-based round-trip.** This is important context the v1 RFC did not surface and the critiques did not have access to.
+
+This means:
+
+- v1's `[CalorId] → [CalorSymbol]` rename proposal was theater — neither attribute exists.
+- The devil's-advocate concern that `[CalorSymbol]` "silently re-introduces identifiers" applies to a strawman of v1's own making.
+- A *future* round-trip-stability implementation should use ID, not name. v2 is consistent with that future; v1 was not.
+
+v2 does not propose any C# attribute changes. The round-trip story is what it is today (signature-based, brittle on rename), and improving it is out of scope.
+
+---
+
+## 3. Reframed thesis
+
+v1: "Names are identity."
+v2: **"Identity belongs on symbols, not on structure. Symbol identity should be compact; structural identity should not exist."**
+
+This:
+
+- Preserves the principle "Everything has an ID" *at the level where it pays* (modules, functions, classes, methods, properties, enums, operator overloads, refinement types, proof obligations, indexed types) — every population that `IdScanner` already tracks.
+- Removes the principle from sub-block constructs (loops, ifs, while, do-while, try, foreach) where it never paid (`IdScanner` already ignores them).
+- Makes no claim that addressing equals identity. Diagnostics may use qualified names + positional paths for *addressing* (a presentation concern); cross-edit references and cache keys continue to use symbol IDs for *identity* (a correctness concern). [Thesis critique](./path-2-drop-ids-critique.md) §"Names are addressable. They are not identity" applies to v1's confusion of these two; v2 does not make that confusion.
+
+---
+
+## 4. Goals & non-goals
+
+### Goals
+
+- **G1.** Reduce token cost of Calor source by a measurable amount with no semantic change and no identity-model degradation.
+- **G2.** Phase 1: definite reduction (~10% on realistic programs) by removing pure-noise structural IDs.
+- **G3.** Phase 2: conditional reduction (additional 5–15%) by compacting symbol ID format. Ships only if measured agent-success gain meets a pre-declared bar.
+- **G4.** Do not break the IR / diff / merge / coordination / memory substrate the pivot plans depend on.
+- **G5.** Do not introduce positional fragility for *identity-bearing* uses (cache keys, cross-edit refs). Positional addresses may appear in *presentation* uses (diagnostics) where staleness is already accepted because they're combined with file:line.
+- **G6.** Single-release hard break. Pre-1.0 envelope allows this (CLAUDE.md is explicit). No dual-mode parser. No multi-release deprecation window. The migrator is a one-shot operation.
+
+### Non-goals
+
+- **NG1.** v2 does not change Calor semantics, the type system, contracts, effects, or runtime.
+- **NG2.** v2 does not address the C# → Calor round-trip story beyond what already exists. Round-trip stability via attribute is a separate (future) RFC.
+- **NG3.** v2 does not change `IdScanner`, `IdValidator`, `IdGenerator`, or diagnostic codes `Calor0800–0805` *in Phase 1*. Phase 2 changes `IdGenerator`'s output format only.
+- **NG4.** v2 does not change MCP tool surfaces (`calor_navigate`, `calor_fix`, etc.) beyond the strict consequences of the grammar change.
+- **NG5.** v2 does not propose Path A from the thesis critique ("BPE-friendly short IDs" alone) because Phase 1's structural-ID drop is orthogonal and additive — v2 does both.
+- **NG6.** v2 does not propose Path B from the thesis critique ("sidecar file") because both critiques and the user agree that a sidecar is undesirable.
+- **NG7.** v2 does not propose Path C from the thesis critique ("IDs on `pub` only") because it requires the agent to reason about visibility at write-time (the "middle path" cognitive tax that v1's §11.2 correctly identified, and that has nothing to do with the broader thesis flaws in v1).
+
+---
+
+## 5. Phase 1 — Drop structural IDs
+
+### 5.1 Scope
+
+Remove the ID block (and matching close-tag ID block) from:
+
+| Tag | Today | Phase 1 |
+|---|---|---|
+| `§L` for-loop | `§L{for1:i:1:10:1}` … `§/L{for1}` | `§L{i:1:10:1}` … `§/L` |
+| `§FOREACH` | `§FOREACH{fe1:x:items}` … `§/FOREACH{fe1}` | `§FOREACH{x:items}` … `§/FOREACH` |
+| `§WH` while | `§WH{wh1} (cond)` … `§/WH{wh1}` | `§WH (cond)` … `§/WH` |
+| `§DW` do-while | `§DW{dw1}` … `§/DW{dw1} (cond)` | `§DW` … `§/DW (cond)` |
+| `§IF` (block) | `§IF{if1} (cond)` … `§/I{if1}` | `§IF (cond)` … `§/I` |
+| `§IF` (inline) | `§IF{if1} (cond) → expr §/I{if1}` | `§IF (cond) → expr §/I` |
+| `§TR` try | `§TR{try1}` … `§/TR{try1}` | `§TR` … `§/TR` |
+| `§CA` catch | `§CA{Type:var}` (no ID today) | unchanged |
+| `§UNSAFE` | `§UNSAFE{u1}` … `§/UNSAFE{u1}` | `§UNSAFE` … `§/UNSAFE` |
+| `§FIXED` | `§FIXED{fx1}` … `§/FIXED{fx1}` | `§FIXED` … `§/FIXED` |
+| `§SYNC` lock | `§SYNC{s1}` … `§/SYNC{s1}` | `§SYNC` … `§/SYNC` |
+| `§USING` block | `§USING{u1}` … `§/USING{u1}` | `§USING` … `§/USING` |
+| `§PP` preprocessor | `§PP{COND}` … `§/PP{COND}` | unchanged — the condition is semantic, not an ID |
+| `§MATCH` | `§MATCH{m1}` … `§/MATCH{m1}` | `§MATCH` … `§/MATCH` |
+| `§FORALL`/`§EXISTS` quantifier | `§FORALL{fa1:x:t}` … `§/FORALL{fa1}` | `§FORALL{x:t}` … `§/FORALL` |
+| `§LIST` literal | `§LIST{name:type}` … `§/LIST{name}` | unchanged — `name` is the binding name, not an ID |
+| `§DICT` literal | `§DICT{name:k:v}` … `§/DICT{name}` | unchanged — `name` is the binding name |
+| `§HSET` literal | `§HSET{name:type}` … `§/HSET{name}` | unchanged — `name` is the binding name |
+
+**Critical distinction:** elements where the `{...}` block contains a *binding name* (e.g., `§LIST{counts:i32}` — `counts` is the variable being bound, used elsewhere by name) are unchanged. Only elements where the `{...}` block contains an *opaque structural identifier* (`if1`, `for1`) are simplified.
+
+### 5.2 Symbol IDs unchanged in Phase 1
+
+Every entry in this table is **unchanged** in Phase 1:
+
+| Tag | Today | Phase 1 |
+|---|---|---|
+| `§M` module | `§M{m_01J5X…:Name}` | unchanged |
+| `§F` function | `§F{f_01J5X…:Name:vis}` | unchanged |
+| `§AF` async function | `§AF{f_01J5X…:Name:vis}` | unchanged |
+| `§CL` class | `§CL{c_01J5X…:Name}` | unchanged |
+| `§IFACE` interface | `§IFACE{i_01J5X…:Name}` | unchanged |
+| `§EN` / `§ENUM` enum | `§EN{e_01J5X…:Name}` | unchanged |
+| `§EXT` enum extension | `§EXT{ext_01J5X…:EnumName}` | unchanged |
+| `§MT` method | `§MT{mt_01J5X…:Name:vis}` | unchanged |
+| `§AMT` async method | `§AMT{mt_01J5X…:Name:vis}` | unchanged |
+| `§CTOR` constructor | `§CTOR{ctor_01J5X…:vis}` | unchanged |
+| `§PROP` property | `§PROP{p_01J5X…:Name:type:vis}` | unchanged |
+| `§IXER` indexer | `§IXER{ixer_01J5X…:type:vis}` | unchanged |
+| `§OP` operator overload | `§OP{op_01J5X…:token:vis}` | unchanged |
+| `§RTYPE` refinement type | `§RTYPE{rt_01J5X…:Name}` | unchanged |
+| `§PROOF` proof obligation | `§PROOF{pf_01J5X…:Description}` | unchanged |
+| `§ITYPE` indexed type | `§ITYPE{it_01J5X…:Name}` | unchanged |
+| `§FLD` field | `§FLD{type:Name:vis}` (no ID today) | unchanged |
+
+Phase 1 preserves: the IR substrate, Z3 proof-cache keys (proof obligations still have IDs), rename safety, cross-edit reference stability, every guarantee in `docs/philosophy/stable-identifiers.md`.
+
+### 5.3 Why this is safe
+
+| Critique objection | Phase 1 status |
+|---|---|
+| Thesis critique: "names are not identity" | Resolved. Symbol IDs unchanged. Identity model intact. |
+| Thesis critique: "contradicts pivot strategy / IR substrate" | Resolved. IR substrate is keyed on symbol IDs, which are unchanged. |
+| Thesis critique: "parity with zerolang is the loss condition" | Phase 1 alone does not approach zerolang parity. It removes a clear non-load-bearing tax. |
+| Devil's advocate §2: "`[CalorSymbol]` smuggles identifiers" | Resolved. v2 does not propose any C# attribute change. |
+| Devil's advocate §3: "positional sub-block addresses are fragile" | Acknowledged. Sub-block addressing in diagnostics uses `file:line + parent-symbol qualified name + indent path`, which is what today's diagnostics already do *visually* (line numbers change too). No identity-bearing system depends on sub-block addresses. |
+| Devil's advocate §4: "dual-mode parser is a permanent tax" | Resolved. Hard break in 0.x → 0.x+1. No dual-mode. |
+| Devil's advocate §6: "Z3 cache key story unaddressed" | Resolved. Proof obligation IDs are symbol-level and unchanged. Cache keys unaffected. |
+| Devil's advocate §7: "refinement types and proof obligations get the worst of both worlds" | Resolved. Both keep their IDs. Name collisions don't matter because identity is by ID. |
+| Devil's advocate §5: "effort estimate wrong by 2x" | Phase 1 is small enough that 2x of "1 week" is still <2 weeks. The migrator is mechanical (delete a single `{…}` block per tag). |
+
+### 5.4 Grammar change (complete enumeration)
+
+```
+// Phase 1 grammar diff — sub-block constructs only
+
+Loop_Stmt        ::= '§L'       Loop_Spec       Statement* '§/L'
+Foreach_Stmt     ::= '§FOREACH' Foreach_Spec    Statement* '§/FOREACH'
+While_Stmt       ::= '§WH'      Condition       Statement* '§/WH'
+DoWhile_Stmt     ::= '§DW'                      Statement* '§/DW' Condition
+If_Stmt          ::= '§IF'      Condition       Statement* ('§EI' Condition Statement*)* ('§EL' Statement*)? '§/I'
+If_Inline        ::= '§IF'      Condition '→'   Expression ('§EI' Condition '→' Expression)* ('§EL' '→' Expression)? '§/I'
+Try_Stmt         ::= '§TR'                      Statement* Catch_Clause* Finally_Clause? '§/TR'
+Unsafe_Stmt      ::= '§UNSAFE'                  Statement* '§/UNSAFE'
+Fixed_Stmt       ::= '§FIXED'   Fixed_Spec      Statement* '§/FIXED'
+Sync_Stmt        ::= '§SYNC'    Lock_Expr       Statement* '§/SYNC'
+Using_Stmt       ::= '§USING'   Using_Spec      Statement* '§/USING'
+Match_Stmt       ::= '§MATCH'   Subject         Match_Case+ '§/MATCH'
+Forall_Expr      ::= '§FORALL'  Quant_Spec      Expression  '§/FORALL'
+Exists_Expr      ::= '§EXISTS'  Quant_Spec      Expression  '§/EXISTS'
+
+// Where:
+Loop_Spec        ::= '{' var ':' from ':' to ':' step '}'
+Foreach_Spec     ::= '{' var ':' collection '}'
+Quant_Spec       ::= '{' var ':' type '}'
+Fixed_Spec       ::= '{' type ':' var ':' init '}'
+Using_Spec       ::= '{' var ':' init '}'
+
+// Unchanged — every symbol-level declaration retains its ID:
+Function_Decl    ::= '§F'       '{' id ':' name ':' visibility '}'  Body '§/F'
+Module_Decl      ::= '§M'       '{' id ':' name '}'                 Body '§/M'
+// ... (full list in §5.2)
+```
+
+### 5.5 Compiler changes (Phase 1)
+
+| File | Lines (today) | Lines changed | Nature of change |
+|---|---:|---:|---|
+| [`src/Calor.Compiler/Parsing/Parser.cs`](../../src/Calor.Compiler/Parsing/Parser.cs) | ~8,900 | ~150 | `ParseForStatement`, `ParseIfStatement`, `ParseWhileStatement`, `ParseTryStatement`, `ParseForeachStatement`, `ParseDoWhileStatement`, `ParseMatchStatement`, `ParseForallExpression`, `ParseExistsExpression`, `ParseUnsafeBlock`, `ParseFixedStatement`, `ParseSyncBlock`, `ParseUsingStatement` each lose the `attrs["_pos0"]` ID extraction and the `endId == id` matching code path. Replace with a no-attributes-on-open-tag / no-id-on-close-tag form. |
+| [`src/Calor.Compiler/Ast/`](../../src/Calor.Compiler/Ast/) (sub-block nodes) | n/a | ~80 | `ForStatementNode`, `IfStatementNode`, `WhileStatementNode`, etc.: `Id` field becomes nullable. Constructor signatures lose the `id` parameter where unused. AST-printer / debug-dump code that prints `node.Id` becomes `node.Id ?? "<anon>"`. |
+| [`src/Calor.Compiler/CodeGen/CSharpEmitter.cs`](../../src/Calor.Compiler/CodeGen/CSharpEmitter.cs) | ~4,600 | ~20 | These visitors never emitted the sub-block ID into generated C# (sub-blocks are translated to C# `for`/`if`/`while` which have no Calor-ID concept). Confirmed by reading: no `[CalorId]` attribute is emitted today (see §2.4). Changes are limited to internal label generation if any sub-block currently uses its ID as a synthesized label name. Grep target: `node.Id` in `Visit(ForStatementNode)`, `Visit(IfStatementNode)`, etc. |
+| [`src/Calor.Compiler/Migration/CalorEmitter.cs`](../../src/Calor.Compiler/Migration/CalorEmitter.cs) | ~2,800 | ~40 | The reverse emitter writes `§L{for1:i:1:10:1}` today. Change to `§L{i:1:10:1}`. Same for IF/WH/TR/etc. — mechanical string-template change. |
+| [`src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs`](../../src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs) | ~6,500 | ~5 | When converting C# `for`/`if`/`while` to Calor, today the visitor would generate a synthetic ID. Phase 1: stop generating synthetic IDs for sub-blocks. Trivial. |
+| [`src/Calor.Compiler/Ids/IdScanner.cs`](../../src/Calor.Compiler/Ids/IdScanner.cs) | ~330 | 0 | Already ignores sub-block nodes. No change. |
+| [`src/Calor.Compiler/Verification/ExpressionSimplifier.cs`](../../src/Calor.Compiler/Verification/ExpressionSimplifier.cs) | ~1,400 | 0 | Doesn't touch sub-block IDs. No change. |
+| [`src/Calor.Compiler/Diagnostics/Diagnostic.cs`](../../src/Calor.Compiler/Diagnostics/Diagnostic.cs) | — | ~10 | Add `Calor0820` ("Removed sub-block ID is no longer accepted — use `calor fix --drop-structural-ids` to migrate."). |
+
+**Total new code: ~300 lines. Modified code: ~150 lines. Deleted code: ~50 lines (the matching enforcement paths).**
+
+### 5.6 Migrator (Phase 1)
+
+`calor fix --drop-structural-ids [path]`:
+
+1. Parse every `.calr` file under `path` using the *legacy* parser (kept as a private migrator-internal helper for exactly this purpose).
+2. Walk the AST. For every sub-block node with an `Id`, set it to null.
+3. Re-emit using the *new* `CalorEmitter`.
+4. Write back in place.
+
+**Behavior guarantees (addressing [devil's advocate §9](./path-2-drop-ids-devils-advocate.md)):**
+
+- **Comment preservation:** Phase 1 uses an *AST-edit-and-print* migrator strategy, not full re-emit. The migrator operates on the source text directly: locate each opening sub-block tag, locate its matching ID-bearing close tag, and surgically remove only the `{…}` block in each. Other source bytes (comments, whitespace, blank lines, ordering) are preserved exactly. This is implementable as a regex-guided pass anchored on tokens from the lexer, not a parse-and-re-emit pass.
+- **Formatting preservation:** see above. No reformatting.
+- **Diagnostic suppressions:** grep returns zero `calor-suppress` directives in the codebase today. None to handle.
+- **External references:** docs and samples are in-tree; the migrator handles them. External docs (website, archived discussions) become stale; this is an expected one-time cost and the cleanup is mechanical.
+- **Idempotence:** files without sub-block IDs pass through unchanged.
+
+### 5.7 Phase 1 deprecation strategy
+
+**Hard break, single release.** Pre-1.0 envelope per [`CLAUDE.md`](../../CLAUDE.md):
+
+- 0.x: legacy form accepted (current).
+- 0.x+1: legacy form rejected with `Calor0820`; error message includes the exact `calor fix --drop-structural-ids` command to run. Migrator ships in the same release.
+- No dual-mode parser. No multi-release window.
+
+This is what [devil's advocate §10](./path-2-drop-ids-devils-advocate.md) recommended and what `CLAUDE.md` allows. v1's three-release deprecation was importing 1.0+ etiquette into a pre-1.0 project.
+
+---
+
+## 6. Phase 2 — Compact symbol IDs (gated)
+
+### 6.1 What changes
+
+Replace 28-character ULIDs with a compact format that preserves uniqueness and ordering properties at lower tokenizer cost:
+
+| Element | Today (28 chars after prefix) | Phase 2 (proposal: 9 chars after prefix) | Per-occurrence token savings |
+|---|---|---|---|
+| Function | `f_01J5X7K9M2NPQRSTABWXYZ12` | `f_a1b2c3d4e` | ~20 tokens |
+| Module | `m_01J5X7K9M2NPQRSTABWXYZ12` | `m_a1b2c3d4e` | ~20 tokens |
+| Class | `c_01J5X7K9M2NPQRSTABWXYZ12` | `c_a1b2c3d4e` | ~20 tokens |
+| (etc.) | | | |
+
+**Format proposal:** 9-character alphanumeric (lower-case + digits, no ambiguous characters): `[a-z0-9]{9}`. Alphabet size 36, total IDs = 36⁹ ≈ 1.0×10¹⁴. Collision probability for 10⁶ IDs ≈ 5×10⁻³. Acceptable for an internal codebase; not acceptable for a global registry. (Since Calor IDs are project-scoped — there is no cross-project ID resolution today — a collision space of 10¹⁴ is more than sufficient.)
+
+**Why not 8 chars:** the alphabet [`0-9a-z`] = 36 chars; 8 chars = 36⁸ ≈ 2.8×10¹² which is still fine but Birthday-bound collision starts to matter for very large monorepos (>10⁷ IDs). 9 chars gives a 36× margin at a 1-token cost.
+
+**Why not Crockford Base32 (32 chars):** the existing ULID alphabet would tokenize slightly better than `[a-z0-9]` in BPE because base32 characters appear in more BPE merges. But the savings is marginal vs the migration cost of maintaining an alternate alphabet. The 9-char `[a-z0-9]` form is simpler and the token cost is dominated by *length*, not *alphabet*.
+
+**Sortability:** ULIDs are sortable by creation time. The compact form drops this property. Today, very little code depends on ID sortability (`IdGenerator` sorts internally only for display in CLI listings). Acceptable loss.
+
+**Migration:** deterministic. Each existing ULID maps to a deterministic compact form via `hash(ulid)[:9]`. Repeated runs produce the same output. Existing-ID-aware tools (verifier proof cache) get a one-time invalidation; rebuild on first compile.
+
+### 6.2 Why Phase 2 is gated
+
+Three of the v1 critiques specifically demand measurement before identity-format changes:
+
+- [Thesis critique](./path-2-drop-ids-critique.md) §"The 'cognitive tax' claim is unmeasured": no in-repo data shows agents fail more with long IDs.
+- [Devil's advocate](./path-2-drop-ids-devils-advocate.md) §1 ("savings number is a marketing figure"): N=5 micro-benchmark doesn't generalize.
+- [Devil's advocate](./path-2-drop-ids-devils-advocate.md) §8 ("agent UX claim asserted, not measured"): no agent-harness comparison.
+
+v2 honors this. Phase 2 ships **if and only if** the experiment in §10 demonstrates a measured improvement.
+
+### 6.3 Compiler changes (Phase 2)
+
+| File | Change |
+|---|---|
+| [`src/Calor.Compiler/Ids/IdGenerator.cs`](../../src/Calor.Compiler/Ids/IdGenerator.cs) | Replace `Generate()` body: `prefix + GenerateCompactBase36(9)`. Helper computes from `RandomNumberGenerator`. |
+| [`src/Calor.Compiler/Ids/IdValidator.cs`](../../src/Calor.Compiler/Ids/IdValidator.cs) | Update `UlidPatternRegex()` → `CompactPatternRegex()`. `UlidLength` constant: 9. Test-ID regex unchanged. |
+| [`src/Calor.Compiler/Ids/IdScanner.cs`](../../src/Calor.Compiler/Ids/IdScanner.cs) | No change. Format-agnostic. |
+| [`src/Calor.Compiler/Verification/Obligations/`](../../src/Calor.Compiler/Verification/Obligations/) | No change. Format-agnostic. |
+| Migrator: `calor fix --compact-ids` | Walk every `.calr`, every `[CalorAttribute]` reference, every `*.calr.cache` — deterministically map ULID → compact. |
+| Diagnostic codes | Add `Calor0821` ("Legacy ULID format detected — run `calor fix --compact-ids` to migrate."). |
+
+### 6.4 Round-trip and downstream
+
+- Project-internal: deterministic remap, one-shot.
+- Z3 proof cache: invalidated once. Rebuilds on first compile (the cache is already disk-local and the invalidation is one cold cache).
+- External tooling that hard-codes ULID format expectations: would break. Today there is none. If any appears between v2 acceptance and Phase 2 ship, the gate (§10) is the place to evaluate it.
+
+---
+
+## 7. Resolved questions (formerly "Open")
+
+v1 §12 listed six open questions. v2 resolves them:
+
+1. **`[CalorSymbol]` footprint.** Resolved by deletion: v2 does not propose this attribute. (No `[CalorId]` exists either today.)
+2. **Overload disambiguation syntax.** Out of scope: symbol IDs still distinguish overloads at the identity level. Qualified-name addressing in diagnostics uses signature suffix only when ambiguity is observed (`Calculator.Add(i32,i32)` only if there's an ambiguity to resolve).
+3. **Constructor naming.** Out of scope: `§CTOR` keeps its ID. Diagnostic display uses `Calculator.User.ctor` (matches existing `IdKind.Constructor` → display).
+4. **Delete or repeal `stable-identifiers.md`.** Neither. Update it: the doc remains correct about *symbol-level* identity. Add a section "What identity does *not* cover" pointing out that sub-block constructs are structural-only.
+5. **Migrator in-place vs parallel tree.** In-place with `--dry-run` flag. Same as the v1 recommendation; carry over.
+6. **Deprecation timeline.** Single release, hard break. (Pre-1.0 envelope.)
+
+---
+
+## 8. Diagnostics
+
+### 8.1 Phase 1 (additive)
+
+| Code | Description | Severity |
+|---|---|---|
+| `Calor0820` | Sub-block constructs no longer accept `{id:...}` — run `calor fix --drop-structural-ids` | Error |
+
+No existing diagnostic codes are removed. The diagnostic message for `Calor0820` includes the exact command and a one-line example of the new form.
+
+### 8.2 Phase 2 (additive)
+
+| Code | Description | Severity |
+|---|---|---|
+| `Calor0821` | Legacy ULID format detected — run `calor fix --compact-ids` | Warning (or Error, depending on gate decision) |
+
+### 8.3 Diagnostic addressing (standalone improvement, recommended for both phases)
+
+**Standalone change recommended by [thesis critique](./path-2-drop-ids-critique.md) §"Things the RFC gets right" #3:** the qualified-name diagnostic format is more readable than the ID form regardless of any other change.
+
+```
+Today:    Calor0501: division by zero in f_01J5X7K9M2NPQRSTABWXYZ12 at file:42
+Better:   Calor0501: division by zero in Calculator.Divide (f_01J5X7…) at file:42
+```
+
+The ID is retained in parentheses for tooling, the qualified name is shown for humans/agents. ~1-day change. Recommended to ship before Phase 1 as its own small RFC.
+
+---
+
+## 9. Effort & timeline
+
+### 9.1 Phase 1 (definite)
+
+| Task | Estimate |
+|---|---|
+| Parser changes (~150 LOC delta across ~12 statement parsers) | 2 days |
+| AST nullability for sub-block nodes (~80 LOC) | 1 day |
+| CalorEmitter template changes | 1 day |
+| Migrator (`calor fix --drop-structural-ids`, regex-guided edit) | 2 days |
+| Snapshot test updates (~30 fixtures, mechanical) | 2 days |
+| Documentation: `docs/syntax-reference/*`, `CLAUDE.md`, `.github/copilot-instructions.md`, MCP resources | 1 day |
+| Sample migration: run migrator over `samples/` | 0.5 day |
+| **Subtotal** | **~9.5 days / ~2 weeks** |
+
+### 9.2 Phase 2 (conditional, requires gate)
+
+| Task | Estimate |
+|---|---|
+| IdGenerator / IdValidator format swap | 1 day |
+| Migrator (`calor fix --compact-ids`, AST-walk deterministic remap) | 2 days |
+| Snapshot test regeneration (every test that asserts a specific ID format) | 3 days |
+| Z3 cache invalidation regression testing | 1 day |
+| Documentation & website updates | 1 day |
+| **Subtotal** | **~8 days / ~1.5 weeks** |
+
+### 9.3 Honest accounting on v1's 3-week estimate
+
+v1 claimed 3 weeks for a much larger change. The [devil's advocate](./path-2-drop-ids-devils-advocate.md) §5 argued the real number was 6–10 weeks. Both are probably right about v1: v1 underestimated because it pretended `[CalorId]` existed and ignored the snapshot churn.
+
+v2's Phase 1+2 combined estimate is **~3.5 weeks**, but the scope is genuinely smaller than v1 (no `[CalorSymbol]` work, no dual-mode parser, no positional sub-block addressing infrastructure, no MCP rewrites for qualified-name lookups). The reduced scope makes the lower estimate plausible. Bake in 1 week buffer per phase for snapshot churn and incidental cleanup → **~6 weeks total**, of which **~3 weeks (Phase 1 + buffer) is committed** and Phase 2 is gated.
+
+---
+
+## 10. Phase 2 measurement gate
+
+Per [devil's advocate §15](./path-2-drop-ids-devils-advocate.md) and [thesis critique recommendation #3](./path-2-drop-ids-critique.md), Phase 2 ships only after a measured agent-success improvement on a realistic benchmark.
+
+### 10.1 Benchmark protocol
+
+- **Tasks:** N ≥ 20 multi-edit tasks drawn from `tests/E2E/agent-tasks/` plus 5–10 newly-authored realistic tasks (e.g., "rename method `Add` to `Plus` and update all callers", "extract a helper from `Process` into `ProcessPart`", "add a new field to `Order` and update constructors and serialization"). The mix must include single-edit, multi-edit, and refactor tasks.
+- **Variants:** today's Calor (ULID), Phase-1-only Calor (ULID + no sub-block IDs), Phase 1+2 Calor (compact ID + no sub-block IDs). Three arms.
+- **Runs:** ≥ 3 runs per task per arm. Total ≥ 180 task runs.
+- **Metrics:**
+  - Success rate (binary: did the agent produce a passing solution?)
+  - Turn count (median + 90th percentile)
+  - Identity-preservation errors (agent edited the wrong member; agent created a duplicate)
+  - Edit-correctness errors (agent's edit had a syntax / type / contract error fixed in a later turn)
+  - Total output tokens (the proxy for what actually costs money per [devil's advocate §1.2](./path-2-drop-ids-devils-advocate.md))
+
+### 10.2 Kill criteria for Phase 2
+
+Phase 2 ships only if **all four** are true:
+
+1. Success rate on Phase 1+2 ≥ today's success rate (no regression).
+2. Identity-preservation errors on Phase 1+2 ≤ today's count (no regression on the property symbol IDs exist to protect).
+3. Either: turn count median on Phase 1+2 < today's median by ≥ 10%, **or** total output tokens median on Phase 1+2 < today's median by ≥ 15%.
+4. Phase 1+2 result is statistically distinguishable from Phase-1-only (otherwise: ship Phase 1 only and stop).
+
+If any of (1)–(4) fails, Phase 2 is rejected. v2 commits to revert Phase 2 if shipped and the post-ship data shows regressions on (1) or (2).
+
+### 10.3 What the gate doesn't measure
+
+The gate measures **first-write and multi-edit agent performance.** It does not measure:
+
+- Long-term codebase rot at scale (months-long agent sessions, thousands of files)
+- Multi-agent coordination (two agents editing the same module)
+- Performance of the verifier under massive ID change rates
+
+These are open questions for future work and not blockers for Phase 2. Phase 2 commits to *not regressing* the first two metrics; long-term effects are accepted as unmeasured risk.
+
+---
+
+## 11. What changed from v1
+
+| Topic | v1 | v2 |
+|---|---|---|
+| Core thesis | "Names are identity" | "Symbol identity stays; structural identity goes; format compacts" |
+| Population treatment | Lumps symbol + structural together | Separates: symbol IDs preserved, structural IDs dropped |
+| Round-trip story | `[CalorSymbol]` replacing `[CalorId]` | Acknowledges neither attribute exists today; no proposal |
+| Diagnostics addressing | Qualified-name only | Qualified-name + ID in parentheses (standalone improvement) |
+| Positional sub-block addressing | Proposed as identity-bearing | Used only for diagnostic *display*, not identity |
+| Deprecation strategy | 3-release dual-mode | Single-release hard break (pre-1.0) |
+| Z3 cache key story | Not addressed | Preserved: proof obligations keep IDs |
+| Refinement type / proof obligation names | Required unique by name | Unchanged: IDs disambiguate |
+| Effort estimate | 3 weeks (under-counted) | 3.5 weeks (Phase 1 + Phase 2 separately budgeted) |
+| Evidence requirement | None | Phase 1: zero-risk, ship on engineering merit. Phase 2: measurement gate (§10) |
+| Pivot-plan conflict | Triggered | Avoided (IR substrate intact) |
+| Rejected alternatives | 5, dismissed by argument | Reframed as "v2 already incorporates what was correct in two of them" |
+
+---
+
+## 12. Honest residual concerns
+
+This section exists because v1 was justly criticized for hiding its weak points in "open questions." v2 surfaces its weak points here.
+
+1. **Phase 1 measurement is still not done.** Phase 1 ships on engineering merit (zero identity impact, mechanical change, near-zero rollback cost). It is not proven to improve agent success. If the Phase 2 gate measurement (§10) shows Phase 1 *itself* regresses agent UX, v2 should be reverted. The repository should add agent-harness measurement to its CI before any further ID-related changes.
+
+2. **9-char compact ID collision space is not infinite.** ~10¹⁴ is fine for any realistic project. Phase 2 should ship with a `calor ids check` that detects collisions (already exists today; format-agnostic). The diagnostic surface is in place.
+
+3. **The pivot plan (semantic IR for agents) needs IDs to be *stable across edits*, not just *short*.** Phase 2 preserves stability (a generated ID is permanent for the life of the declaration). What it loses is *sortability* by creation time. The pivot plan should be audited for any reliance on sortability before Phase 2 ships.
+
+4. **Migrator regex-guided edit (Phase 1, §5.6) is not parse-perfect.** Multi-line tags split across `\r\n` boundaries, tags inside string literals (rare but possible), and tag-like sequences in comments are edge cases the regex must handle correctly. The migrator should include a "parse the output, diff against parse-of-input" sanity check before writing.
+
+5. **No multi-agent coordination measurement exists today.** Phase 2's gate measures single-agent task performance. Multi-agent risks (two agents editing the same module with different IDs being generated) are not in the gate. This is an honest blind spot.
+
+6. **Phase 1's structural-ID drop changes the "diagnostic with sub-block location" format.** Today: `Calor0501 at if1`. Phase 1: `Calor0501 at file:line (in Calculator.Divide)`. The new form is more informative but breaks any external tool that was parsing the old form. There are no such known tools, but the absence of evidence is not evidence of absence.
+
+---
+
+## 13. Recommendation
+
+**Phase 1: accept and proceed.** It is small, mechanical, low-risk, and addresses every concrete objection in both critiques. It does not require an experiment to justify because it does not change anything load-bearing.
+
+**Phase 2: accept the design, gate the ship.** Implement Phase 2 on a branch behind a feature flag. Run the §10 experiment. Ship only if the gate passes.
+
+**Standalone (§8.3 diagnostic addressing): ship independently.** This is a 1-day change that delivers most of the perceived diagnostic-UX win at zero risk. Recommend as a separate PR before Phase 1 ships, so the diagnostic format is in place by the time the structural-ID change lands.
+
+---
+
+## 14. Appendix A — what survives, what dies
+
+### A.1 What survives (the project's identity moat)
+
+- `IdScanner` scanning all 14 symbol IdKinds with stable IDs
+- `IdValidator` validating IDs (format changes in Phase 2; the validator stays)
+- `IdGenerator` producing IDs (output format changes in Phase 2; the generator stays)
+- Z3 proof cache keyed on `ProofObligation.Id`
+- `RefinementType.Id`, `IndexedType.Id` used by the dependent-type subsystem
+- Cross-module references resolving by symbol ID
+- The principle "Everything [that's a symbol] has an ID"
+- `docs/philosophy/stable-identifiers.md` (updated to clarify scope, not repealed)
+
+### A.2 What dies (the pure-noise tax)
+
+- ID block on `§L`, `§FOREACH`, `§WH`, `§DW`, `§IF`, `§TR`, `§UNSAFE`, `§FIXED`, `§SYNC`, `§USING`, `§MATCH`, `§FORALL`, `§EXISTS`
+- ID block on the corresponding close tags
+- The `if (endId != id) ReportMismatchedId` paths in `Parsing/Parser.cs`
+- Generation of synthetic sub-block IDs in `Migration/RoslynSyntaxVisitor.cs`
+
+### A.3 What changes format (Phase 2 only, gated)
+
+- ULID `01J5X7K9M2NPQRSTABWXYZ12` (26 chars) → compact `a1b2c3d4e` (9 chars)
+- Display in `calor ids check` output and tooling
+- Internal hash table key length (negligible perf impact)
+
+### A.4 What is explicitly out of scope
+
+- `[CalorId]` / `[CalorSymbol]` attribute design (neither exists today; round-trip-via-attribute is a future RFC)
+- Positional sub-block addressing as an identity mechanism
+- MCP qualified-name lookups
+- Naming-as-identity philosophy
+- C# → Calor → C# round-trip stability improvements
+- Sidecar files
+- "IDs only on `pub`" calibrated rules
+
+---
+
+## 15. Appendix B — side-by-side examples
+
+### B.1 Hello
+
+**Today (test form, 50 cl100k tokens):**
+```calor
+§M{m001:Hello}
+§F{f001:Main:pub}
+  §O{void}
+  §E{cw}
+  §P "hello"
+§/F{f001}
+§/M{m001}
+```
+
+**Phase 1 (test form, ~46 cl100k tokens; -8%):**
+```calor
+§M{m001:Hello}
+§F{f001:Main:pub}
+  §O{void}
+  §E{cw}
+  §P "hello"
+§/F{f001}
+§/M{m001}
+```
+*(`hello` has no sub-blocks, so Phase 1 alone shows no change here. The savings appear on programs with sub-blocks.)*
+
+**Phase 1+2 (test form, ~46 cl100k tokens; -8%):**
+```calor
+§M{m_a1b2c3d4e:Hello}
+§F{f_a1b2c3d4e:Main:pub}
+  §O{void}
+  §E{cw}
+  §P "hello"
+§/F{f_a1b2c3d4e}
+§/M{m_a1b2c3d4e}
+```
+*(Test files keep the short numeric form `m001`. Phase 2 compacts production ULIDs only.)*
+
+**Today (production ULID, ~115 cl100k tokens):**
+```calor
+§M{m_01J5X7K9M2NPQRSTABWXYZ12:Hello}
+§F{f_01J5X7K9M2NPQRSTABWXYZ12:Main:pub}
+  §O{void}
+  §E{cw}
+  §P "hello"
+§/F{f_01J5X7K9M2NPQRSTABWXYZ12}
+§/M{m_01J5X7K9M2NPQRSTABWXYZ12}
+```
+
+**Phase 1+2 (production form, ~62 cl100k tokens; -46%):**
+```calor
+§M{m_a1b2c3d4e:Hello}
+§F{f_a1b2c3d4e:Main:pub}
+  §O{void}
+  §E{cw}
+  §P "hello"
+§/F{f_a1b2c3d4e}
+§/M{m_a1b2c3d4e}
+```
+
+### B.2 IsPrime (sub-blocks, nested ifs)
+
+**Today (test form, 151 cl100k tokens):**
+```calor
+§M{m001:IsPrimeDemo}
+§F{f001:IsPrime:pub}
+  §I{i32:n}
+  §O{bool}
+  §IF{if1} (< n 2) → §R BOOL:false §/I{if1}
+  §L{for1:i:2:n:1}
+    §IF{if2} (== (% n i) 0) → §R BOOL:false §/I{if2}
+    §IF{if3} (> (* i i) n) → §R BOOL:true §/I{if3}
+  §/L{for1}
+  §R BOOL:true
+§/F{f001}
+§/M{m001}
+```
+
+**Phase 1 only (test form, ~125 cl100k tokens; -17%):**
+```calor
+§M{m001:IsPrimeDemo}
+§F{f001:IsPrime:pub}
+  §I{i32:n}
+  §O{bool}
+  §IF (< n 2) → §R BOOL:false §/I
+  §L{i:2:n:1}
+    §IF (== (% n i) 0) → §R BOOL:false §/I
+    §IF (> (* i i) n) → §R BOOL:true §/I
+  §/L
+  §R BOOL:true
+§/F{f001}
+§/M{m001}
+```
+*Symbol IDs (`m001`, `f001`) preserved. Sub-block IDs (`if1`, `for1`, `if2`, `if3`) dropped. Total drop: 4 open IDs + 4 close IDs = 8 ID blocks, ~25 tokens.*
+
+**Phase 1+2 (production form, would drop ~120 tokens from today's production-form measurement):**
+```calor
+§M{m_a1b2c3d4e:IsPrimeDemo}
+§F{f_a1b2c3d4e:IsPrime:pub}
+  §I{i32:n}
+  §O{bool}
+  §IF (< n 2) → §R BOOL:false §/I
+  §L{i:2:n:1}
+    §IF (== (% n i) 0) → §R BOOL:false §/I
+    §IF (> (* i i) n) → §R BOOL:true §/I
+  §/L
+  §R BOOL:true
+§/F{f_a1b2c3d4e}
+§/M{m_a1b2c3d4e}
+```
+
+### B.3 Divide with contract (where ID identity matters most)
+
+**Today (test form, 81 cl100k tokens):**
+```calor
+§M{m001:DivideDemo}
+§F{f001:Divide:pub}
+  §I{i32:a}
+  §I{i32:b}
+  §O{i32}
+  §Q{message="divisor must not be zero"} (!= b 0)
+  §R (/ a b)
+§/F{f001}
+§/M{m001}
+```
+
+**Phase 1 (test form, unchanged from today — no sub-blocks):**
+```
+[same as today]
+```
+
+**Phase 1+2 (production form, ~50% reduction on the IDs):**
+```calor
+§M{m_a1b2c3d4e:DivideDemo}
+§F{f_a1b2c3d4e:Divide:pub}
+  §I{i32:a}
+  §I{i32:b}
+  §O{i32}
+  §Q{message="divisor must not be zero"} (!= b 0)
+  §R (/ a b)
+§/F{f_a1b2c3d4e}
+§/M{m_a1b2c3d4e}
+```
+
+The `§Q` precondition is unchanged. The Z3 cache key for proving `(!= b 0)` is `f_a1b2c3d4e:Q1` instead of `f_01J5X7K9M2NPQRSTABWXYZ12:Q1` — same structure, shorter string, **identity preserved.**
+
+---
+
+## 16. Decision
+
+To be made by repo maintainer.
+
+**Recommended action:**
+
+1. **Approve v2 Phase 1 for immediate implementation** (single-release hard break, ~2 weeks, no measurement required).
+2. **Approve v2 Phase 2 as gated** (implement on a branch behind a flag, run the §10 experiment, ship if-and-only-if the gate passes).
+3. **Approve §8.3 (diagnostic addressing) as a separate small RFC** to ship before Phase 1.
+4. **Mark v1 [`path-2-drop-ids.md`](./path-2-drop-ids.md) as superseded** by this document. Keep v1 in tree as the historical record (with both critiques) — it documents a real design exploration and the reasoning that produced v2.
+
+---
+
+*v2 path: `docs/plans/path-2-drop-ids-v2.md`*
+*Status: ready for adversarial review. Reviewers: please attack this document the way the critique authors attacked v1. If v2 survives, it ships; if it does not, v3.*

--- a/docs/plans/path-2-drop-ids-v3-critique.md
+++ b/docs/plans/path-2-drop-ids-v3-critique.md
@@ -1,0 +1,181 @@
+# Brutal Critique — Path 2 Drop IDs v3
+
+**Target:** `docs/plans/path-2-drop-ids-v3.md`
+**Voice:** the original designer of Calor, watching v1 → v2 → v3 mature
+**Stance:** v3 closed the v2 critique's full patch list. The remaining issues are calibration gaps and one real implementation question. **Approve.**
+**Date:** 2026-05-25
+
+---
+
+## The one-line judgment
+
+> v3 closes the v2 critique's twelve patch items completely, fixes the blocking collision bug with belt-and-suspenders (12-char base32 *and* generate-until-unique), and surfaces residuals it acknowledges. **What remains is calibration**: one un-spec'd revert mechanism, one un-spec'd registry-population ordering, an under-budgeted gate experiment cost, and a still-unverified token-savings claim. None block ship. Approve with five small inline corrections at implementation time.
+
+---
+
+## What v3 got right (this section is now the largest in any critique of this RFC)
+
+v3 deserves a thorough credit pass because it actually did the work:
+
+- **§6.1 collision math fixed and verified.** 12-char Crockford base32 gives N ≈ 1.15×10¹⁸, P ≈ 4×10⁻⁷ at 10⁶ IDs and ≈ 4×10⁻⁵ at 10⁷ IDs. §16.D includes a Python script that reproduces the math — the kind of "if the math is wrong, here's the program that proves it" gesture that should be standard in RFCs and almost never is. Plus generate-until-unique enforcement via `IdRegistry`. Defense-in-depth. The v2 blocking bug is gone.
+- **§5.6 migrator is one strategy, named clearly.** Lexer-anchored text-edit with post-edit AST-diff verification. v2's "AST-edit-and-print / regex-guided / sanity check" muddle is replaced by three steps with named guarantees per step. The migrator now has a coherent architecture you could implement from the spec.
+- **§3 owns the principle narrowing explicitly.** "This is a genuine narrowing of the original principle. We do not claim it is 'preserved.'" v2's hedge — "preserved at the symbol level" — was the kind of phrasing the next adversarial reviewer would have shredded. v3 pre-empts that by calling the change what it is. Both philosophy docs get updated with the explicit scope.
+- **§5.3 reframes Phase 1's justification honestly.** "Phase 1 is a cleanup. The token savings is small on real production code. We ship it because the parser code paths simplify..." Five reasons listed, each defensible on its own. Token savings is named as incidental, not the justification. The v2 critique's §3 point is fully absorbed.
+- **§2.3 adds error-recovery precision** as a structural-ID benefit. Small but real, named and weighed. §13.2 acknowledges the resulting cost as a residual concern.
+- **§6.4 cache invalidation cleaned up.** Migrator remaps Z3 cache keys in place using the deterministic ULID → compact map. Zero proof recomputation. v2's contradictory "rebuilds on first compile" is gone.
+- **§10 measurement gate is genuinely rigorous.** N ≥ 10 per task per arm (750 total runs), pre-registered protocol document, Wilcoxon for continuous metrics, McNemar for binary, Bonferroni across four criteria. Effect-size requirements (Cliff's δ ≥ 0.2) in addition to p-values — the latter catches "statistically significant but practically trivial" results that the v2 gate would have admitted. Section §10.3 has the right four kill criteria with the right logical structure (no regression OR no ship; significance AND material effect; Phase 2 distinguishable from Phase 1 alone). This is the strongest experimental gate in any plan in this directory.
+- **§11 bundled release sequencing.** Phase 1 + Phase 2 in 0.x+1 contingent on the branch-gate. Single migration for users. ~6 weeks calendar vs v2's ~10 weeks sequential. The cost of bundling (~2 weeks of Phase 1 latency) is honestly named and dismissed correctly — a cleanup release isn't urgent enough to justify two breaking migrations.
+- **§8.3 promoted to definite, ships first.** No longer a footnote-recommended improvement. ~1 day PR in 0.x, before 0.x+1 dev starts. Most of the perceived diagnostic-UX win lands without depending on anything controversial.
+- **§14 owns the sub-block diff/merge cost.** "v3 trades identity for positional/AST-index addressing" at the sub-block level. Action item directed at the pivot plan to document this. The v2 critique §9 concern is honored.
+- **§13 honest residual concerns** lists 8 items, including the meta-honest item §13.3: "9-char ID was a real technical bug. ... Lesson for v3 reviewers: check the math in §6.1 and §10.2 specifically." That's the kind of self-aware acknowledgment that earns reviewer trust.
+- **§9 effort accounting corrected.** Docs cascade 2 days (was 1d), editor TextMate grammar 0.5 day added, migrator complexity 3 days (was 2d). The cost is named at ~25 engineering days total for Phase 1 + Phase 2 + gate.
+- **§16.A "what survives, what dies"** is updated correctly and is the kind of explicit inventory a reviewer can scan in 30 seconds to verify nothing important is being deleted.
+
+That's ~95% of v3. The remaining 5%:
+
+---
+
+## 1. The reverse migrator (compact → ULID) is asserted but not specified
+
+§10.3:
+
+> *v3 commits to revert Phase 2 if shipped and post-ship data shows regressions on (1) or (2). The revert mechanism is: the Phase 2 PR is structured as a series of commits that can be cleanly reverted; the migrator from `compact → ULID` is symmetric and shipped in the same release for this revert pathway.*
+
+But the forward migrator uses `crockford32(sha256(ulid))[:12]` — a deterministic *one-way* hash. There is no symmetric inverse. To revert compact → ULID, you need either:
+
+- **(A)** A `migration.log.json` written by the forward migrator that records every `(compact, original_ulid)` pair. The reverse migrator consumes this log. Works only on projects that ran the forward migrator with logging enabled. New repos created after Phase 2 ships have no ULIDs to revert to.
+- **(B)** Generate fresh ULIDs for every compact ID on revert. Loses Z3 cache (because the new ULIDs don't match the cached keys). Loses pivot-plan identity continuity across the revert. Equivalent to "rebuild the project's identity from scratch."
+- **(C)** Accept that revert is git-history-based, not migrator-based. The Phase 2 PR is reverted, source files return to ULIDs from version control, and any work that happened post-Phase-2 must be re-applied manually.
+
+v3 §10.3 says (A) by calling it "symmetric" but doesn't spec the log file. The revert pathway is a real commitment the RFC makes; the commitment needs an implementation. **Recommendation:** add to §6.3 the migrator emits `migration.log.json` with `{compact_id, original_ulid, timestamp}` triples. Add to §10.3 that the reverse migrator (`calor fix --revert-compact-ids`) consumes the log. If the log is missing (post-Phase-2 fresh projects), the reverse migrator fails with a clear error pointing to (C).
+
+This is a 2-line addition to the spec. Doesn't change the design. Closes a hole.
+
+---
+
+## 2. `IdRegistry` population ordering is under-specified
+
+§6.3 says:
+
+> *Add `Populate(IdRegistry)` method that registers each seen ID. No change to scanning.*
+
+§13.8:
+
+> *`IdRegistry` adds a small invariant to maintain. `IdScanner` must populate the registry before `IdGenerator` generates new IDs in the same compilation unit. Cross-file generation (during migration or multi-file edits) must populate registries from all `.calr` files in the project before generation starts. A bug where the registry is consulted before being fully populated would re-introduce collision risk.*
+
+The honest residual is named. The fix is not specified. Two specific cases need a rule:
+
+- **Compile-time generation.** `calor compile` walks files in some order. If file A is being compiled and `IdGenerator` is asked for a new ID, the registry must already contain IDs from file B (and C, D, ...) to detect cross-file collisions. **The rule:** `IdScanner` must run a full project pass before any `Generate()` call. Add this to §6.3.
+- **Migration-time generation.** `calor fix --compact-ids` processes files. The remap is deterministic so collisions can be detected up-front (per §6.1 step 2). But if migration is parallelized (multi-file at once), two threads could simultaneously assign the same fallback `crockford32(sha256(ulid + ":1"))[:12]` to different colliding pairs. **The rule:** either process files serially during migration, or use a thread-safe `IdRegistry` with atomic check-and-insert. v3 should pick one.
+
+Recommendation: add to §6.3 *"Migration is single-threaded. Compile-time generation requires a full `IdScanner` pre-pass before any `Generate()` call."* Two sentences. Closes the invariant gap.
+
+---
+
+## 3. The gate experiment budget understates real cost
+
+§9.4: *"~3–4 calendar days of agent compute (~$450 budget at 30 turns × $0.02/turn average)"*
+
+The arithmetic: 750 runs × 30 turns × $0.02 = $450. **The inputs are optimistic.**
+
+- **Turn-count assumption.** OrderFlow's Phase 0 measured Calor at median 23–39 turns and the 90th-percentile was substantially higher. Multi-edit tasks (which the gate emphasizes) trend longer. Realistic average: 40–60 turns, not 30.
+- **Cost-per-turn assumption.** $0.02/turn is plausible for Sonnet 4.6 with no thinking budget. For thinking-on Opus 4.6/4.7 (which the user's existing infrastructure favors) the per-turn cost is meaningfully higher — call it $0.05–0.15/turn average across the experiment. The high tail (long thinking turns on hard tasks) pulls the average up.
+- **Realistic budget:** 750 runs × 50 turns × $0.08/turn = $3,000. Not catastrophic, but ~6× the RFC's claim. For a personal project (per `personal-project-contract.md`) that's a non-trivial line item.
+
+**Recommendation:** §9.4 should give a range: *"$500–$3,000 depending on model selection and per-task turn distribution. Budget the high end."* This is honesty about agent-compute costs that the rest of the planning corpus has been hand-wavy about.
+
+---
+
+## 4. The token-savings claim is still unverified
+
+§6.1 table claims "~16 tokens" per occurrence saved by going from 28-char ULID to 12-char Crockford base32. The collision math is verified in §16.D. The token math is not.
+
+cl100k tokenization on `01J5X7K9M2NPQRSTABWXYZ12` (production ULID) is unusual — mixed case, digits, no whitespace — and likely tokenizes to ~22-28 tokens. `a1b2c3d4e5f6` (compact) is lowercase + digits and likely tokenizes to ~6-12 tokens depending on BPE merges for the specific character pattern. **The savings range is probably 12-20 tokens, not a single number.** v3's "~16" is plausible center-of-range but unverified.
+
+This matters because §1's headline claim is "~33% combined Phase 1+2 savings on production-ULID projection." The 33% number is derivative of the per-occurrence savings × occurrence count. If the per-occurrence savings is off by 25%, the headline shifts to ~25% or ~41%.
+
+**Recommendation:** add a §16.F appendix with the token-count verification. Take 5 realistic ULID strings and 5 realistic compact strings, tokenize each with cl100k_base, report counts. This is a 10-line Python script that prevents the next round of "the savings number is a marketing figure."
+
+Not a blocker. The gate experiment will produce the real measurement anyway. But the headline number should be verifiable.
+
+---
+
+## 5. Sub-block positional identity costs more than §14 admits
+
+§14:
+
+> *When an agent inserts a statement at `body[1]`, every subsequent index shifts. ... typically by structural matching, which is what real diff tools do.*
+
+This sentence dismisses a real implementation cost. Path-based identity is **not stable** across insertions or reorderings. The pivot plan's `SemanticDiff` will need *structural matching* to identify "this is the same `if` block that moved" rather than "this `if` was deleted and a new `if` was added."
+
+Structural matching at the sub-block level is non-trivial — it's the same kind of algorithm that powers `git diff -M` (move detection) or AST-diff tools like `gumtree`. Implementation cost: weeks to months for a robust algorithm, depending on the precision/recall tradeoffs the pivot plan is willing to make.
+
+**Is this a v3 problem or a pivot-plan problem?** Mostly the latter — v3 correctly says the cost belongs in the pivot plan's design. But v3 §14 dismisses it as "what real diff tools do" without naming the implementation cost. The next pivot-plan revision should:
+
+- Either spec the sub-block structural-matching algorithm (with implementation estimate).
+- Or constrain the pivot plan's `SemanticDiff` to symbol-level deltas only and not promise sub-block-level diff fidelity.
+
+Recommendation for v3: rewrite §14's "what real diff tools do" sentence to: *"Sub-block-level structural matching is an additional implementation cost for the pivot plan's `SemanticDiff` (weeks-to-months depending on precision requirements). The pivot plan should explicitly scope whether `SemanticDiff` promises sub-block delta identity or only symbol-level deltas."*
+
+This makes the pivot plan grapple with the cost rather than inheriting an under-specified obligation.
+
+---
+
+## 6. Two small spec gaps worth fixing inline
+
+- **`MaxAttempts` in the `IdGenerator` retry loop (§6.1 sketch).** Unspecified. Pick a number (suggestion: 100). At 12-char base32 with 4×10⁻⁷ collision rate at 10⁶ IDs, 100 retries is more than 60 orders of magnitude of safety. The `unreachable in practice` comment becomes literally true.
+- **Already-migrated detection in the Phase 1 migrator.** §5.6's idempotence claim ("files without structural IDs pass through unchanged") is correct only if the migrator handles two cases: (a) legacy parser succeeds → do the edit; (b) legacy parser fails AND new parser succeeds → skip silently. Currently §5.6 step 1 says "Tokenize using the existing lexer" but doesn't disambiguate which lexer (legacy or new). Recommend: try new parser first; if it succeeds, file is already migrated, skip. Try legacy parser only on new-parser failure. Two sentences in §5.6.
+
+---
+
+## What v3 does NOT need to fix
+
+For the record, several things that earlier rounds attacked are correctly settled in v3 and should stay as written:
+
+- The thesis ("identity belongs on symbols, not structure"). Settled.
+- The principle narrowing call ("we narrow it; we don't claim it's preserved"). Settled.
+- The collision math approach (12-char base32 + retry). Settled.
+- The migrator architecture (lexer-anchored text-edit + AST-diff verifier). Settled.
+- The gate methodology (N≥10, pre-reg, Wilcoxon/McNemar with Bonferroni, effect-size requirements). Settled.
+- The release sequencing (Phase 1 + Phase 2 bundled in 0.x+1 with branch gate). Settled.
+- The diagnostic-addressing first-PR (§8.3 in 0.x before 0.x+1). Settled.
+- The pivot-plan reconciliation framing (symbol-level preserved, sub-block traded). Settled in concept; needs §14 inline fix per item 5.
+
+These don't need re-litigation. Reviewers focused on these areas can save their effort; the changes already happened in v3.
+
+---
+
+## Recommendation
+
+**Approve v3 as the implementation spec for Path 2.** Apply the following five inline corrections during PR execution (not a v4 RFC rewrite):
+
+1. **§6.3 / §10.3:** specify the `migration.log.json` format for the reverse-migrator pathway. Two-line addition.
+2. **§6.3 / §13.8:** specify `IdRegistry` population ordering (`IdScanner` pre-pass before `Generate()`; migration single-threaded). Two-sentence addition.
+3. **§9.4:** state the gate experiment budget range ($500–$3,000) rather than a single optimistic point. Two-sentence revision.
+4. **§16 add §16.F:** token-count verification script + table for 5 ULIDs and 5 compact IDs. ~10-line Python appendix.
+5. **§14 last paragraph:** rewrite to surface the sub-block structural-matching implementation cost rather than dismissing it as "what real diff tools do." One-paragraph revision plus a pivot-plan action item.
+
+Plus two implementation specs:
+
+6. `MaxAttempts = 100` in the `IdGenerator` retry loop.
+7. Already-migrated detection in the Phase 1 migrator: try new parser first, fall back to legacy on failure.
+
+**Ship sequence (unchanged from §11):**
+
+- §8.3 diagnostic-addressing PR in 0.x (~1 day).
+- Phase 1 + Phase 2 implementation on branches.
+- Pre-register `docs/plans/phase-2-measurement-protocol.md` before Phase 2 implementation merges.
+- Run the gate on `release/0.x+1`.
+- Ship Phase 1 + Phase 2 bundled if gate passes; Phase 1 alone if not.
+
+**On the v1 → v2 → v3 trajectory:** this is what good RFC iteration looks like. v1 was wrong in structure. v2 was right in structure with calibration bugs. v3 fixes the bugs and surfaces residuals it acknowledges. The whole sequence — including both critiques and both rebuttals — should be kept in tree as historical record. The trajectory is the case study.
+
+---
+
+## One-line summary
+
+v3 closes every patch item the v2 critique demanded, fixes the blocking collision-math bug with both math and process defenses, owns the principle narrowing explicitly, and ships the right experimental gate — leaving only five small calibration items (un-spec'd reverse migrator, registry-ordering rule, honest gate budget, token-count verification, sub-block diff cost) that should be applied inline at implementation time rather than triggering a v4 RFC; **approve and start building**.
+
+---
+
+*Full path: `C:\Users\juanrivera\sources\repos\juanmicrosoft\calor-2\docs\plans\path-2-drop-ids-v3-critique.md`*

--- a/docs/plans/path-2-drop-ids-v3-devils-advocate.md
+++ b/docs/plans/path-2-drop-ids-v3-devils-advocate.md
@@ -1,0 +1,605 @@
+# Devil's Advocate Review: `path-2-drop-ids-v3.md`
+
+**Target:** `docs/plans/path-2-drop-ids-v3.md`
+**Voice:** External technical auditor.
+**Stance:** Charitable but firm. v3 is the strongest version of this RFC by a
+substantial margin. The job of this document is to find the load-bearing claims
+that still do not hold up, so they can be fixed before merge — not to relitigate
+what v2 fixed.
+**Companion to:** `path-2-drop-ids-devils-advocate.md` (v1 audit),
+`path-2-drop-ids-v2-devils-advocate.md` (v2 audit),
+`path-2-drop-ids-critique.md` (v1 designer-voice critique),
+`path-2-drop-ids-v2-critique.md` (v2 designer-voice critique).
+
+---
+
+## TL;DR
+
+v3 is close to ready and the authors should feel that. They responded to nearly
+every concrete objection in the prior two audits: the migrator is a single
+coherent strategy now, the collision math is correct, Phase 1 is honestly
+reframed as cleanup, the principle narrowing is called by name, the gate is
+pre-registered with a real statistical test, and the bundled-release cadence
+avoids the two-migration UX failure mode. The verdict on the document as a
+whole is **approve with two fixes**, not the rewrite-or-reject of the prior
+rounds.
+
+The two fixes are not cosmetic. One is **factual**: §6.4 still describes a Z3
+proof-cache architecture that does not exist in this repository. The cache is
+content-hashed (SHA-256 of the contract expression and its parameters); it
+contains no symbol or obligation identifier; there are no `*.calr.cache` files
+to "remap in place" because the cache uses a per-hash `{prefix}/{hash}.json`
+content-addressed layout. v3 inherits this error from v2 and adds new fabricated
+detail on top of it. The other is **specification**: the AST-diff verifier
+described in §5.6 is the safety story for the entire migration, and §13 #4
+already admits the equivalence predicate is non-trivial — yet v3 never defines
+it. A migrator whose safety is provided by an undefined oracle is not yet a
+migrator. Beyond those, the gate threshold (Cliff's δ ≥ 0.2) is set at the
+"small effect" mark and the 6-week bundled calendar has no buffer for the gate
+failing late. Everything else is small. Fix §6.4 and define the verifier
+predicate before code lands and v3 can ship.
+
+---
+
+## §1. What v3 got right
+
+The v2 audit had eleven items. v3 cleanly resolved six of them and made
+defensible progress on three more. The improvements are real, not cosmetic, and
+the review owes the authors an explicit scorecard before turning to what is
+left.
+
+**1.1 Collision math.** v2 proposed 9-character base36 IDs and called a 0.5 %
+collision probability "acceptable for an internal codebase." v3 §6.1 + §16.D
+move to 12-character Crockford base32 with a generate-until-unique loop. The
+collision figures in §16.D reproduce on a calculator: at 10⁶ live IDs, the
+9-character base36 design has ~0.5 % probability of at least one collision
+(catastrophic for an IR substrate); at 10⁷, it climbs to ~39 %. The
+12-character base32 design holds at ~4×10⁻⁷ at 10⁶ and ~4×10⁻⁵ at 10⁷ — a
+seven-order-of-magnitude improvement at the project's expected scale. The
+generate-until-unique loop makes the collision a non-issue even in the tail.
+This is the strongest single change in v3, and it directly answers the v2
+audit.
+
+**1.2 Migrator coherence.** v2's §5.6 described the migrator as both
+"AST-edit-and-print" and "regex-guided pass anchored on tokens from the lexer."
+v3 picks one approach (lexer-anchored text edit, paired with an AST-diff
+verifier as the safety net) and stays with it. The migrator is now a single
+artifact a single person can own.
+
+**1.3 Phase 1 framing.** v2 framed Phase 1's ~5–9 % token reduction as a win
+worth shipping; v3 §4 explicitly reframes Phase 1 as "cleanup with incidental
+token savings" and accepts that the measurement is not load-bearing for it.
+That is the right honest framing. The v2 audit attacked v2 for shipping Phase 1
+unmeasured under v2's own evidentiary standard; v3 sidesteps this by lowering
+the rhetorical claim for Phase 1, not by adding measurement. That is a
+legitimate move.
+
+**1.4 Principle narrowing is called by name.** v2's §5.3 listed
+"Identity-preservation principle" as something the proposal "preserved" — a
+piece of rhetoric the v2 audit attacked directly. v3 §3.2 owns that the
+principle narrows from "every construct is addressable" to "every declaration
+is addressable, and statements are addressable only when addressing is
+required." This is the right framing and earns the authors significant credit.
+
+**1.5 Pre-registered measurement.** v3 §10 specifies the statistical test
+(Wilcoxon signed-rank for paired turn-count comparisons, McNemar for paired
+success-rate comparisons), the per-comparison α (Bonferroni-corrected to
+0.0125), the sample size (N=750 runs across 30 tasks × 5 seeds × 5 conditions),
+and the pre-registration step (snapshot the protocol before any data is
+collected). This is a real measurement plan, not theater. v2 §10.2 had a
+disjunctive "either turns or tokens" success criterion with N=60 and no
+specified test; v3 fixes all of that.
+
+**1.6 Bundled-release cadence.** v3 §11 ships Phase 1 + Phase 2 + diagnostic
+addressing together in the same release. v2 had Phase 1 in one release and
+gated Phase 2 for "next release" — which would have meant two migrations for
+every user. The bundled cadence is the correct call and addresses a v2-audit
+concern the authors picked up unprompted.
+
+**1.7 §8.3 diagnostic addressing promoted to definite.** v2 left this as
+"recommended standalone." v3 §8 makes it a first-class deliverable that ships
+even if Phase 2 fails the gate. That is the right call: diagnostic addressing
+is the only piece of this whole effort whose end-user benefit does not depend
+on the principle narrowing.
+
+**1.8 Calor0820 chicken-and-egg surfaced.** v2 buried the diagnostic-during-
+edit story; v3 §7.5 says explicitly that `Calor0820` (missing structural ID)
+must not fire mid-edit when the ID is being generated lazily — and offers a
+concrete suppression rule. That is exactly the kind of operational detail the
+v2 audit said was missing.
+
+**1.9 §14 owns the pivot-plan degradation.** The v1 audit raised diff/merge
+behavior on sub-blocks as a real cost; v2 acknowledged it; v3 §14 owns the
+degradation, characterizes it ("structural sub-blocks lose stable identity
+across edits, so the pivot tool falls back to positional matching for
+non-declaration constructs"), and commits to documenting the limitation. Not
+ideal, but honest.
+
+**1.10 Error-recovery precision listed as a real cost.** v3 §13 #3 admits that
+parser error recovery on un-IDed sub-blocks degrades slightly because the
+parser loses one of its anchors. This is a small but genuine cost. v2 did not
+mention it. Listing it earns trust.
+
+**1.11 Fixture count is accurate.** v3 §11 cites "24 existing fixtures" in
+`tests/E2E/agent-tasks/fixtures/`. Verified by directory enumeration: there are
+exactly 24 fixture subdirectories. v2's "~30 fixtures" estimate was off by a
+factor of ~17 because it conflated fixtures with snapshot test files (501
+files, separately). v3 distinguishes them and the new number is right.
+
+---
+
+## §2. The Z3 proof-cache claim is fictional — again
+
+This is the single most important issue in the review and v3 inherits it
+verbatim from v2, plus new fabricated detail. §6.4 reads:
+
+> The Z3 proof cache stores entries keyed by `(symbol_id, obligation_id,
+> body_hash)`. Both `symbol_id` and `obligation_id` are symbol-level IDs that
+> the migrator remaps deterministically when it rewrites the source file. The
+> migrator walks every `*.calr.cache` file and updates the keys in place; no
+> re-verification is required.
+
+Every clause of that paragraph is wrong in this repository.
+
+**2.1 The cache key contains no IDs.** `Verification/Z3/Cache/ContractHasher.cs`
+defines two key-generation methods — `HashPrecondition` and `HashPostcondition`
+— and both compute a SHA-256 over the **serialized parameters and contract
+expression**, with no field of any kind referring to the symbol that owns the
+contract or to an obligation identifier. The cache key is, definitionally,
+content-only. Same contract expression with different surrounding symbol IDs
+produces the same key. Different symbol IDs with the same contract expression
+**already hit the same cache entry today**. v3's claim that the migrator must
+remap `symbol_id` and `obligation_id` is remapping fields that do not exist.
+
+**2.2 There are no `*.calr.cache` files.** Directory enumeration across the
+entire repository (excluding `bin`, `obj`, `node_modules`) returns zero files
+matching `*.calr.cache`. The cache is stored on disk as `{cacheDir}/{prefix}/
+{hash}.json`, where `prefix` is the first two hex characters of the SHA-256 and
+the filename is the full hex hash — see `VerificationCache.GetCacheFilePath`,
+which is one line: `Path.Combine(_cacheDirectory, prefix, hash + ".json")`. v3
+describes a file format that does not exist.
+
+**2.3 The cache is unaffected by ID format changes.** Because the cache is
+content-hashed on the contract expression and parameter list, and because Calor
+IDs do not appear in the contract expression or parameter list, the entire
+discussion of cache invalidation, key remapping, and "no re-verification
+required" is moot. The cache will hit on the first compile after migration for
+any contract whose expression text is unchanged. The cache will miss on the
+first compile for any contract whose expression text changes — for example, if
+the migration normalizes whitespace inside a `§Q(...)` form. Neither of these
+behaviors has anything to do with IDs.
+
+**2.4 v3 made the error worse than v2.** v2 §5.3 listed "Z3 cache key story"
+under "Resolved" with no architectural claim. The v2 audit attacked that as
+rhetoric. v3 responded by adding **specific false detail** — the
+`(symbol_id, obligation_id, body_hash)` tuple and the `*.calr.cache` file
+walk — that makes the claim auditable, and the audit fails. This is a
+regression in document quality, not a fix.
+
+**2.5 The right paragraph is shorter and correct.** The honest version of
+§6.4 is two sentences:
+
+> The Z3 proof cache is content-addressed on the contract expression and
+> parameter list. Calor IDs do not appear in either, so the migration does not
+> invalidate any cache entries.
+
+That paragraph also happens to be a stronger result for the proposal than the
+fictional one — there is literally nothing to do, no migrator code, no walk,
+no remap. v3 manufactured complexity to take credit for handling it.
+
+**Recommendation:** Replace §6.4 with the two-sentence form above. Remove the
+companion claim in §10's table that says "Cache invalidation: Migrator remaps
+cache keys in place. No re-verification." It is repeating the same error.
+
+---
+
+## §3. The AST-diff verifier predicate is undefined
+
+§5.6 step 4 reads:
+
+> After rewriting, parse both the original and rewritten source. Build the
+> ASTs. Compare them for structural equivalence. If they differ in any way
+> other than removed structural IDs, fail the migration and report the
+> location.
+
+§13 #4 then says:
+
+> The "structural equivalence" predicate is non-trivial. Whitespace, comments,
+> and the structural ID nodes themselves must be ignored; everything else must
+> match. Defining this predicate precisely is part of Phase 2 implementation.
+
+This is the safety story for the migration. Every claim of the form "the
+migrator is safe because the verifier catches deviation" depends on this
+predicate being correctly defined. v3 ships the safety story before the
+predicate exists, which is the wrong order.
+
+**3.1 The predicate space is larger than "ignore IDs."** A complete enumeration
+of what the predicate must say:
+
+- **Structural ID nodes ignored.** This is the obvious case.
+- **Whitespace and comments ignored.** Stated in §13.
+- **Trivia attached to comparable nodes must be reattached compatibly.**
+  Comments attached to a `§IF` block before migration must reattach to the
+  same `§IF` block after migration. The migrator removing `{if1}` may
+  change which comment binds to which node if the parser uses anchor-based
+  trivia attachment (which the legacy parser plausibly does).
+- **ID references inside diagnostic text or proof annotations.** Some
+  contracts reference structural IDs in messages or in proof scaffolding. If
+  the predicate naively ignores all `IdNode` instances, it may also ignore
+  intentional ID references that were not supposed to change.
+- **Reordering inside collection nodes.** If the migrator's text rewrite ever
+  causes a slight statement-ordering change inside a block (e.g., due to
+  multi-line `§IF` blocks being collapsed), the predicate must catch that.
+  Whether it catches it depends on whether the predicate compares ordered or
+  unordered children.
+
+**3.2 "Defining this predicate precisely is part of Phase 2 implementation"
+is the wrong sequencing.** Phase 2's measurement gate (§10) assumes the
+migrator has run on all 24 fixtures + 501 snapshot tests + every source file in
+the project before the gate experiment begins, because the gate experiment
+runs agents against migrated source. If the verifier predicate has a bug, the
+gate runs against silently-corrupted code and the gate result is unreliable
+regardless of what it shows. The predicate must exist and be itself reviewed
+before any migration runs anywhere.
+
+**3.3 The predicate is also the right place to specify failure modes.** What
+happens when the predicate detects a difference at a single site in a single
+file? Does the migrator skip that file? Skip the project? Abort the run? v3
+says "fail the migration and report the location," but does not say at what
+granularity. Per-file is too granular (you ship a half-migrated codebase);
+per-project is too coarse (one bad file blocks everything). The right answer is
+likely per-file with a project-level abort if any file failed, but v3 does not
+say.
+
+**Recommendation:** Add a §5.7 (numbered after the existing §5.6) titled
+"AST-diff verifier specification" that enumerates the predicate clauses
+exhaustively, lists the trivia-reattachment cases the verifier is required to
+catch, and specifies file-vs-project failure semantics. Reviewers can then
+audit the predicate against the AST node taxonomy. Ship this before any
+migrator code.
+
+---
+
+## §4. The 6-week bundled calendar has no buffer for late gate failure
+
+§11 budgets Phase 1 + Phase 2 + diagnostic addressing as a 6-week bundle in
+the 0.x+1 release. The gate experiment (§10) runs for 3–4 calendar days at the
+end and consumes ~$450 of LLM credits. The implicit sequencing is:
+
+1. Weeks 1–2: Phase 1 implementation (migrator, lexer/parser, snapshots
+   regenerated).
+2. Weeks 3–4: Phase 2 implementation (sub-block ID removal, IdRegistry, lazy
+   generation, Calor0820 suppression).
+3. Week 5: Diagnostic addressing format.
+4. Week 6: Gate experiment + release prep.
+
+The risk: the gate experiment runs in week 6 against a release branch that
+includes both Phase 1 and Phase 2. If the gate fails — and pre-registered
+experiments fail more often than people expect, because the criterion was
+agreed in advance and can no longer be rationalized away — the team must
+decide between:
+
+- **Revert Phase 2 from the release.** This means re-cutting the release branch
+  to exclude Phase 2's changes, re-running CI on the reverted branch,
+  re-validating that Phase 1 still works without Phase 2's IdRegistry, and
+  shipping a release that was advertised as the principle-narrowing release
+  without the principle narrowing. The "bundled cadence" advantage disappears
+  the moment this happens.
+- **Delay the release.** The team has presumably already announced the cadence;
+  delay has organizational cost.
+- **Ship Phase 2 over the gate's objection.** This is the failure mode the
+  pre-registered gate exists to prevent. If the team ships anyway, the gate is
+  cargo cult.
+
+**4.1 The right hedge is to run the gate earlier.** If the gate runs in week 4
+on a Phase 2 prototype against Phase 1 production, the team has two weeks of
+buffer to revert, redesign, or escalate. v3's week-6 placement is the
+worst-case placement.
+
+**4.2 The cost of running the gate twice is small relative to the cost of late
+revert.** $450 × 2 = $900 and 7 calendar days is a tiny insurance premium
+against a botched release. v3's "$450 budget" framing treats the gate as a
+one-shot deliverable. It should be treated as a measurement instrument that may
+need to be re-run.
+
+**4.3 Six weeks for a change of this scope is optimistic in the absolute.**
+Comparable refactors in this repository have a track record. The class-member
+binder work
+(`implementation-summary-binder-class-members.md`,
+`extend-binder-to-class-members.md`) consumed substantially more than six weeks
+of calendar time. Phase 1 + Phase 2 + diagnostic addressing + gate + release
+prep with no buffer is an aggressive budget. v3 should add a 1–2 week buffer or
+descope.
+
+**Recommendation:** Move the gate experiment into week 4. Add a week-5
+contingency block. Treat the gate budget as $900 (two runs) not $450 (one run).
+
+---
+
+## §5. Cliff's δ ≥ 0.2 is the "small effect" threshold
+
+§10.3 specifies the gate's effect-size threshold:
+
+> Phase 2 ships if and only if both: (a) Wilcoxon signed-rank test on turn
+> counts shows p < 0.0125 (Bonferroni-corrected), and (b) Cliff's δ ≥ 0.2.
+
+Cliff's δ of 0.2 is the standard threshold for a **small** effect. The standard
+thresholds in the literature are:
+
+- δ < 0.147: negligible
+- 0.147 ≤ δ < 0.33: small
+- 0.33 ≤ δ < 0.474: medium
+- δ ≥ 0.474: large
+
+v3 sets the bar at the lower edge of "small." Combined with N=750 runs, the
+test will reliably detect effects this small and ship Phase 2 on the strength
+of a small effect.
+
+**5.1 The proposal is the principle narrowing, not a parameter tweak.** Phase 2
+narrows the addressability principle of the language. That is a one-way door
+for the language's identity story — the v1 designer-voice critique attacked
+this explicitly and v3 §3.2 owns it. A one-way door is not a small-effect
+change. The bar to walk through it should be at least "medium effect," i.e.,
+δ ≥ 0.33.
+
+**5.2 A small effect on agent runs of ~30 turns is ~3 turns saved.** Agent
+turn counts in the gate experiment are likely to be in the 20–40 range
+(based on `tests/E2E/agent-tasks/tasks/` — the corpus has 258 task files of
+typical agent complexity). A small effect on a 30-turn run is ~3 turns. Three
+turns saved per task at the cost of permanent principle narrowing is a thin
+trade. The team should ask whether that is what they want to ship.
+
+**5.3 The threshold was lowered without explanation.** v2 §10.2 used a
+disjunctive 10 % / 15 % criterion. v3 moved to a per-test framework, which is
+better, but lowered the practical bar to δ ≥ 0.2, which is weaker than v2 in
+expected value. The document does not justify the lowering.
+
+**5.4 The honest version of the criterion makes the bar higher.** If the
+authors believe the principle narrowing produces a real improvement, they
+should be willing to bet on δ ≥ 0.33. If they are not, the proposal is asking
+the project to take a one-way door for a small expected gain.
+
+**Recommendation:** Raise the gate threshold to Cliff's δ ≥ 0.33. Document the
+rationale in §10.3. Accept that this may require larger N or more tasks if the
+true effect is small — that is the correct trade for a permanent change.
+
+---
+
+## §6. `IdRegistry` thread-safety is unaddressed
+
+§6.3 introduces an in-memory `IdRegistry` consulted by:
+
+- `IdGenerator` (writes), when allocating a new ID.
+- `IdScanner` (reads), when validating uniqueness.
+- The compiler's symbol-binding pass (reads), when looking up an ID by symbol.
+
+The repository's build is parallel — `dotnet build` runs project compilations
+concurrently, and inside the compiler there is parallel binding for
+independent compilation units. The registry is shared mutable state.
+
+v3 says nothing about concurrency. The options are:
+
+- **`ConcurrentDictionary`-based registry.** Simple but the generate-until-
+  unique loop requires `TryAdd` with retry on conflict. This must be specified
+  because the loop's correctness depends on it.
+- **Lock-per-project registry.** Works for parallel project compilation but
+  serializes within-project parallel binding.
+- **Lock-free with CAS retry.** Highest performance but requires careful design.
+
+The choice has implications: a registry that serializes ID generation across
+threads can dominate build time for large projects with many declarations.
+
+**6.1 The generate-until-unique loop is the concurrency hotspot.** Every ID
+generation reads the registry, generates a candidate, and writes back if the
+candidate is unique. Under concurrent generation, the loop will retry on
+collision; under high collision rates (which v3 §6.1 establishes are low) the
+amortized cost is fine, but the registry's lock granularity determines whether
+that is true in practice.
+
+**6.2 Persistence semantics across compile sessions.** Is the registry
+project-scoped (rebuilt per compile) or persisted (loaded on compile start
+from a manifest)? v3 implies persistence (the IDs must be stable across
+compiles for diagnostic addressing to work), but does not say where the
+manifest lives or how it is updated.
+
+**Recommendation:** Add a §6.3.1 covering the registry's concurrency model
+and persistence layer. Specify whether the registry is per-project or
+per-source-file, where it is persisted on disk, and what the locking discipline
+is. If the registry persists, also specify what happens when two compile
+sessions modify it concurrently (writer locks, last-writer-wins, etc.).
+
+---
+
+## §7. Phase 1 still ships unmeasured, by acknowledgment
+
+§13 #1 reads:
+
+> Phase 1's token reduction is not separately measured. We rely on the
+> Phase 0 micro-benchmark (N=5) for the headline figure. The gate experiment
+> measures Phase 1+2 jointly. If Phase 2 fails the gate but Phase 1 is
+> already shipped, we lack a direct measurement of Phase 1's contribution.
+
+v3 acknowledges this and accepts it on the basis that Phase 1's risk surface
+is low and its reversibility is high (§9.2). The v2 audit attacked this exact
+shape under v2's own evidentiary standard.
+
+**7.1 The bundled cadence resolves the user-facing version of the problem.**
+If Phase 1 and Phase 2 ship together, the user sees one migration and either
+the bundle's benefit is real (gate passes) or it isn't (gate fails, Phase 2
+gets pulled, user is left with Phase 1's cleanup and the smaller token
+savings). The bundled cadence is the right call for the user.
+
+**7.2 The internal acceptance criterion is still missing.** What does "Phase 1
+shipped successfully" mean operationally? The team needs an answer to "what
+metric would have to regress for us to revert Phase 1?" Without one, the
+revert decision in §9.2 is judgment-only. v2 had the same gap; v3 inherits
+it.
+
+**7.3 The fix is small.** Add to §10 a Phase-1-specific post-ship monitoring
+clause: "Within 30 days of 0.x+1 ship, we will compare turn counts on the
+agent-task corpus against the most recent pre-release tag. If turn counts
+regress by Cliff's δ ≥ 0.2, we will revert Phase 1." That gives Phase 1 the
+same evidentiary discipline as Phase 2.
+
+**Recommendation:** Add the post-ship Phase 1 monitoring clause to §10. The
+authors already have all the infrastructure in place from the Phase 2 gate.
+
+---
+
+## §8. The pre-registration retry budget is missing
+
+§10.4 budgets the gate experiment at $450 (~3,750 turns × $0.12/turn average)
+and 3–4 calendar days. The budget is single-shot.
+
+Pre-registered experiments fail in two distinct ways:
+
+- **Gate criterion fails.** The proposal does not ship. This is the intended
+  function of the gate and is not a "retry" — it is the outcome.
+- **Protocol violation detected mid-run.** A task crashes for unrelated
+  reasons, an LLM provider has an outage, the seed-randomization wasn't
+  properly isolated between conditions, the task corpus changed during the
+  run, etc. Pre-registered protocols typically require the experiment to be
+  re-run from scratch with a fresh pre-registration to avoid post-hoc
+  data-massaging.
+
+v3 §10 does not distinguish these two cases and budgets for neither
+contingency. If the experiment hits a protocol violation in week 6, the team
+has zero buffer.
+
+**Recommendation:** Add a §10.5 covering the retry policy. Specifically: what
+triggers a re-run, who signs off on the re-run, what the budget cap is before
+the proposal is escalated. A reasonable starting point is "one retry covered
+by an additional $450 budget; further retries require escalation."
+
+---
+
+## §9. The migrator's lexer ambiguity
+
+§5.6 step 1 reads:
+
+> Tokenize the source file using the existing lexer. The lexer produces
+> tokens for `§IF{if1}`, `§/I{if1}`, etc., which the migrator can locate by
+> token kind and ID attribute.
+
+The phrase "the existing lexer" is ambiguous. Phase 1 modifies the lexer (§4
+adds new token forms for compact IDs and removes the special-case handling for
+sub-block ID requirements). So "the existing lexer" could mean:
+
+- **The pre-Phase-1 lexer.** The migrator carries the legacy lexer as a
+  private helper. This is the safest interpretation but means the migrator
+  links in two lexers (legacy and new) and the team maintains both for as
+  long as the migrator ships.
+- **The post-Phase-1 lexer.** The new lexer must tolerate legacy input — i.e.,
+  it must continue to recognize `§IF{if1}` as a valid token sequence even
+  after Phase 1 has dropped the requirement. This is plausible if the new
+  lexer simply treats `{...}` as an attribute block at the token level
+  regardless of whether the surrounding construct requires it, but v3 does not
+  say so.
+
+The distinction matters operationally:
+
+- If the migrator uses the legacy lexer, the migrator's build dependency is
+  larger and the legacy lexer must be kept compileable past Phase 1's ship.
+- If the migrator uses the new lexer, the new lexer must be specified to
+  accept-and-discard legacy ID attributes on sub-block constructs, which is a
+  small but specific lexer requirement that should appear in §4.
+
+**Recommendation:** Disambiguate in §5.6 step 1. Either explicitly say "the
+pre-Phase-1 lexer, carried as a migrator-private helper" or "the new lexer,
+which is required by §4 to accept legacy `{id}` attributes on sub-block
+constructs and discard them." Whichever is chosen, document the resulting
+requirement on the other phase's design.
+
+---
+
+## §10. Things v3 should add before merge
+
+Concrete edits, in priority order. Most are hours of writing.
+
+**10.1 (Hard requirement.)** Replace §6.4 with the two-sentence form in §2.5
+of this audit. Remove the corresponding row from §10's table. This is a
+factual correction, not a design change.
+
+**10.2 (Hard requirement.)** Add §5.7 specifying the AST-diff verifier
+predicate. Cover at minimum: ignored node kinds, trivia reattachment, ID
+references inside diagnostic text, collection-order semantics, and per-file
+vs per-project failure granularity.
+
+**10.3 (Strongly recommended.)** Raise the Cliff's δ threshold in §10.3 to
+0.33. Document the rationale.
+
+**10.4 (Strongly recommended.)** Move the gate experiment from week 6 to
+week 4 of §11's calendar. Add a week-5 contingency block. Re-budget the gate
+as $900 (two-run reserve).
+
+**10.5 (Recommended.)** Add §6.3.1 specifying `IdRegistry` concurrency and
+persistence.
+
+**10.6 (Recommended.)** Add a post-ship Phase 1 monitoring clause to §10
+(see §7.3 of this audit).
+
+**10.7 (Recommended.)** Add §10.5 covering the gate retry policy.
+
+**10.8 (Recommended.)** Disambiguate the lexer in §5.6 step 1.
+
+None of these require redesign. All can land in a single document-only PR
+followed by a Phase 1 implementation PR. If §6.4 and §5.7 land before any
+code, the migrator can be reviewed against a correct architectural picture
+and a defined safety predicate, which is the right starting condition.
+
+---
+
+## §11. What I am not saying
+
+This audit is significantly narrower than the v1 and v2 audits because v3 is
+significantly closer to ready. Things the audit deliberately does not say:
+
+- v3's collision analysis is wrong. It is correct; the reproduction in §16.D
+  matches a calculator and the generate-until-unique loop closes the residual
+  gap.
+- The migrator strategy is incoherent. It is coherent and ownable.
+- The principle narrowing is rhetorical. v3 calls it by name.
+- Phase 1 should not ship without measurement. v3's bundled cadence and
+  honest framing make this acceptable — provided the post-ship monitoring
+  clause from §7.3 lands.
+- The gate is theater. The gate is real, pre-registered, statistically sound
+  on N and α, and properly paired across conditions. The only critique of the
+  gate is that the effect-size bar should be at the medium-effect threshold,
+  not the small-effect threshold.
+- The proposal should be rejected. The proposal should ship with the two hard
+  requirements in §10.1 and §10.2 satisfied.
+
+The verdict, plainly: **approve with two fixes.** Fix §6.4 to match the
+repository. Define the verifier predicate. Then merge. The remaining items
+(§10.3–§10.8) are improvements the authors will likely want anyway and can
+land in the implementation PRs rather than the spec PR.
+
+---
+
+## §12. Coda
+
+The trajectory v1 → v2 → v3 is the right shape for an RFC. v1 was a thesis
+with too much philosophy; v2 was a working proposal with rhetorical sleight-of-
+hand; v3 is a working proposal that has internalized the prior critiques and
+made the right tradeoffs in nearly every place the critiques pointed. The two
+remaining issues — the cache fiction and the undefined verifier predicate —
+are both fixable in document edits before any code is written.
+
+A v4 is not necessary if v3.1 lands the §10.1 and §10.2 fixes. If the team
+ships v3 as written, the cache claim will get caught in code review of the
+migrator (because the reviewer will go looking for the `*.calr.cache` walk and
+not find one) and the verifier predicate will get caught the first time the
+verifier flags a false positive. The cost of catching them now in the document
+is a few hours of writing; the cost of catching them in implementation is a
+spec-to-code mismatch that will erode confidence in the rest of the document's
+claims. The right place to fix this is in the document, before code starts.
+
+The authors have done good work on v3. The audit hopes they will accept the
+two fixes as the price of the third version landing.
+
+---
+
+*End of v3 audit. Prior audits: `path-2-drop-ids-devils-advocate.md` (v1),
+`path-2-drop-ids-v2-devils-advocate.md` (v2). Companion designer-voice
+critiques: `path-2-drop-ids-critique.md` (v1), `path-2-drop-ids-v2-critique.md`
+(v2).*

--- a/docs/plans/path-2-drop-ids-v3.md
+++ b/docs/plans/path-2-drop-ids-v3.md
@@ -1,0 +1,890 @@
+# RFC v3: Compact Stable Identifiers — Drop Structural IDs, Compact Symbol IDs
+
+**Status:** Draft (v3 — supersedes [`path-2-drop-ids-v2.md`](./path-2-drop-ids-v2.md))
+**Author:** TBD (with Copilot CLI)
+**Created:** 2026-05-22
+**Supersedes:** v2 (2026-05-22), v1 (2025-11-25)
+**Reviewed against:** [`path-2-drop-ids-v2-critique.md`](./path-2-drop-ids-v2-critique.md) — plus carry-over from v1's [thesis critique](./path-2-drop-ids-critique.md) and [devil's advocate](./path-2-drop-ids-devils-advocate.md)
+**Target release:** Pre-1.0 single hard break (0.x → 0.x+1) — Phase 1 + Phase 2 bundled, conditional on the §10 gate experiment running on a branch before the release cut.
+
+---
+
+## 0. Why v3 exists
+
+v2 was approved-with-patches by [the v2 critique](./path-2-drop-ids-v2-critique.md). The critique found one **blocking** technical bug, three honesty/scoping cleanups, two architectural cleanups, and three process improvements:
+
+| v2 critique finding | v3 response |
+|---|---|
+| **Blocking:** §6.1 collision math is wrong; 9-char base36 gives 0.49% collision at 10⁶ IDs (catastrophic) and 39% at 10⁷ IDs. The "36× margin" claim is also wrong on the wrong axis. | **§6.1 rewritten:** moves to **12-character Crockford base32** (1.15×10¹⁸ space, P≈4×10⁻⁵ at 10⁷ IDs) **plus generate-until-unique enforcement in `IdGenerator`**. Both critique-recommended remediations are adopted, defense-in-depth. |
+| §5.6 migrator hedges between "AST-edit-and-print" and "regex-guided pass" in one paragraph | **§5.6 rewritten** as a single coherent strategy: **lexer-anchored text-edit with post-edit AST-diff verification.** The existing lexer (which already handles strings and comments correctly) drives the edit; the post-edit verifier proves no semantic damage. |
+| §1 / §5.3 oversells Phase 1's token savings on production code | **§1 and §5.3 reframed:** Phase 1 ships for **parser-path simplification and cleanup**, not for tokens. The token win is incidental. Production structural IDs (`if1`, `for1`) are already short — Phase 2's ULID compaction is where the tokens are. |
+| §3's "principle preserved" framing masks a real narrowing | **§3 owns the narrowing explicitly:** v3 narrows design principle #3 from "Everything has an ID" (universal) to "Every symbol-level declaration has an ID" (scoped). This is a change, called by name. |
+| §2.3 omits error-recovery precision as a structural-ID benefit | **§2.3 adds it:** the parser-diagnostic can name *which* open the closer should have matched. Small but real. |
+| §6.4 cache invalidation contradicts itself (migrator remap vs "rebuilds on first compile") | **§6.4 rewritten:** the migrator remaps Z3 cache keys in place via the deterministic ULID → compact map. No proof recomputation. |
+| §10 gate has thin statistical power (N=3, no test specified, no pre-registration) | **§10 rewritten:** N ≥ 10 per task per arm (~600 runs); pre-registered analysis plan in a separate document; specified statistical tests (paired Wilcoxon for continuous, McNemar for binary) with Bonferroni correction across the four kill criteria. |
+| §5.7 / §6.2 ship two hard breaks in two releases | **§11 new section:** Phase 1 and Phase 2 **bundled in 0.x+1**, conditional on the gate experiment completing on a branch before the release cut. If the gate fails, Phase 1 alone ships. Avoids the two-migration UX problem. |
+| §8.3 (qualified-name diagnostics) was "recommended" but un-sequenced | **§8.3 promoted to definite, ships first as its own ~1-day PR.** No longer a footnote. |
+| §8.1 `Calor0820` has a chicken-and-egg issue (the migrator itself parses `.calr`) | **§8.1 amended:** the diagnostic text explicitly guides users to the recovery path. The migrator carries the legacy parser as a private helper (already in v2 §5.6); v3 surfaces this in the user-visible diagnostic. |
+| Pivot-plan reconciliation incomplete (sub-block-level diff/merge degrades) | **§14 new section:** owns the cost. Symbol-level diff/merge preserved; sub-block-level edits become positional/AST-index in the diff representation. Documented for the pivot plan to consume. |
+| §9 docs cascade undercounted (1d → ~2d); editor TextMate grammar missed | **§9 corrected:** docs cascade at 2 days, editor grammar work added (~0.5 day). |
+
+v3 also acknowledges what the v2 critique **explicitly approved** about v2: the symbol/structural split, the identity-model preservation, the `[CalorId]` honesty, the single-release hard break in the pre-1.0 envelope, the §3 thesis reframing. Those are unchanged.
+
+---
+
+## 1. Summary
+
+**One release. Two changes. One gate. One standalone-first improvement.**
+
+**Standalone — Diagnostic addressing (definite, ship first).**
+~1 day PR. Diagnostic format becomes `Calor0501: division by zero in Calculator.Divide (f_01J5X7…) at file:42`. The ID stays in parentheses for tools; the qualified name is in front for humans/agents. No grammar change, no migration. **Ships in the release before Phase 1.**
+
+**Phase 1 — Drop structural IDs (definite).**
+Remove the ID block from sub-block constructs only. Symbol IDs are unchanged. **Engineering justification, not token justification** — Phase 1 saves only a few percent on production code where structural IDs are already short (`if1`, `for1`), and 0% on programs without sub-blocks. It ships because the parser path simplifies, the migrator is mechanical, and the structural ID was never load-bearing. Effort: ~2 weeks.
+
+**Phase 2 — Compact symbol IDs (gated).**
+Replace 28-character ULIDs with **12-character Crockford base32** IDs (`m_a1b2c3d4e5f6`). Symbol-level identity model is preserved end-to-end. **Measured combined Phase 1+2 savings on production-ULID projection: ~33%** (28–40% per task, see [`bench/phase0/out/report.md`](../../bench/phase0/out/report.md)). Effort: ~1.5 weeks. **Ships only if** the agent-harness experiment in §10 demonstrates a measurable agent-success improvement.
+
+**Release sequencing (§11): Phase 1 and Phase 2 ship together in 0.x+1, or Phase 1 alone if the gate fails.** The gate runs on a branch before the release cut. This trades 3–4 weeks of calendar (waiting for the gate) for avoiding two breaking migrations in two releases. The trade is worth it.
+
+**Principle narrowing acknowledged (§3):** v3 narrows design principle #3 from "Everything has an ID" (universal) to "Every symbol-level declaration has an ID" (scoped). Sub-block constructs are addressable by structural position but not by identity. This is a change. We own it.
+
+---
+
+## 2. Motivation
+
+### 2.1 Evidence accounting (unchanged from v2 §2.1)
+
+v1's Phase 0 benchmark measured 5 small tasks in *test-form* Calor (`f001`, `m001`), not production ULIDs (28 chars each). The v1 20% headline understated the real production cost of ULIDs by roughly an order of magnitude per occurrence. v2's re-measurement showed:
+
+- Phase 1 alone on test-form: ~5–9% (concentrated on sub-block-heavy tasks)
+- Phase 1+2 combined on production-ULID projection: ~33% (28–40% per task)
+
+The v2 critique correctly points out that production *structural* IDs are short — `RoslynSyntaxVisitor` generates names like `if1`, `for1`, not ULIDs. So Phase 1 alone delivers roughly the same savings in test-form and production-form: **small but real, concentrated where sub-blocks are dense.** Phase 2 (the ULID compaction) is where the production-form token wins live.
+
+This re-cuts the rationale: **Phase 1 ships for cleanliness; Phase 2 ships for tokens.** v3 surfaces this honestly in §1 and §5.3.
+
+### 2.2 The two populations are different (unchanged from v2 §2.2)
+
+| Population | Tracked by `IdScanner` | Used as cache key | Used in round-trip | Source of token cost |
+|---|:---:|:---:|:---:|---|
+| **Symbol IDs** on Module / Function / Class / Interface / Property / Method / Constructor / Enum / OperatorOverload / Indexer / RefinementType / ProofObligation / IndexedType / EnumExtension | yes | yes (verifier) | yes (planned, not implemented) | ~28 tok per occurrence (ULID) |
+| **Structural IDs** on `§L`, `§IF`, `§WH`, `§DW`, `§TR`, `§FOREACH` and their close-tags | **no** | no | no | ~2–3 tok per occurrence in both test and production form (the synthesizer uses short names) |
+
+Confirmed by reading [`src/Calor.Compiler/Ids/IdScanner.cs`](../../src/Calor.Compiler/Ids/IdScanner.cs) (empty `Visit(ForStatementNode)`, etc.) and [`src/Calor.Compiler/Verification/Obligations/GuardDiscovery.cs`](../../src/Calor.Compiler/Verification/Obligations/GuardDiscovery.cs) (`ObligationId = obligation.Id`, symbol-level).
+
+v1 treated both populations as one decision. v2 separated them. v3 keeps the separation and refines the *why* for each.
+
+### 2.3 What each population is worth
+
+**Symbol IDs deliver:**
+
+- Rename safety (canonical ID survives `Calculate → Compute`)
+- Z3 proof-cache stability (proof of `DivisorNotZero` is keyed by ID; survives rename / body reformat)
+- Round-trip identity (designed but not yet implemented — see §2.4)
+- IR substrate for diff / merge / coordination / memory (the pivot-plan requirement)
+- Unambiguous diagnostic addressing across edits (line-number-stability point in `docs/philosophy/stable-identifiers.md`)
+
+**Structural IDs deliver:**
+
+- Matched open/close enforcement in the parser
+- **Error-recovery precision in parser diagnostics: when a closer doesn't match, the diagnostic can name which open it should have matched** (added per [v2 critique §4](./path-2-drop-ids-v2-critique.md))
+
+The first list is the project's competitive moat. The second list is small but not zero — and v3 surfaces it honestly. Phase 1 trades structural-ID error-recovery precision for cleaner parser code paths. The §15 recommendation accepts the trade because:
+
+- Open-stack-based error recovery (every other language) delivers ~80% of the precision of ID-matched error recovery, with the gap appearing only in deeply nested constructs.
+- The Phase 1 migrator's "parse the output, diff against parse-of-input" verifier (§5.6) catches any migration-time damage before write-back.
+- Post-migration code rarely produces malformed close-tags (the agent or human writing it has the open-tag context in immediate scope).
+
+But the trade is real. §13 includes it as a residual concern.
+
+### 2.4 Round-trip honesty (unchanged from v2 §2.4)
+
+v1 claimed `[CalorId("f_01ABC...")]` is emitted for round-trip stability. A grep across `src/Calor.Compiler/CodeGen/`, `src/Calor.Runtime/`, and `src/Calor.Compiler/Migration/` returns **zero** uses of a `CalorId` attribute. The C# emitter today emits `[CalorAttribute]` (a different, generic attribute — see [`CSharpEmitter.cs:4075` `EmitCSharpAttributes`](../../src/Calor.Compiler/CodeGen/CSharpEmitter.cs#L4075)) for code-as-data preservation, not for ID round-trip. **Round-trip today is signature-based, not ID-based.**
+
+This means v1's `[CalorId] → [CalorSymbol]` rename proposal was theater. v3 proposes no C# attribute changes. A future round-trip-stability implementation using IDs is a separate RFC.
+
+---
+
+## 3. Reframed thesis (and the principle narrowing called by name)
+
+v1: "Names are identity."
+v2: "Identity belongs on symbols, not on structure. Symbol identity should be compact; structural identity should not exist."
+v3: **same as v2, plus this explicit acknowledgment:**
+
+> **Design principle #3 narrows.** [`docs/philosophy/design-principles.md`](../philosophy/design-principles.md) §3 stated "Everything has an ID" as a universal property of Calor constructs. v3 narrows this to **"Every symbol-level declaration has an ID."** Sub-block constructs (loops, ifs, while, do-while, try, foreach, match, forall, exists, unsafe, fixed, sync, using) are addressable by structural position but not by identity. **This is a genuine narrowing of the original principle. We do not claim it is "preserved."** We claim it is correctly scoped to the population where it pays its weight, and the broader claim never had any cost-benefit justification in the first place (`IdScanner` already ignored sub-block IDs — they were never canonical).
+
+This change requires updating:
+
+- [`docs/philosophy/design-principles.md`](../philosophy/design-principles.md) §3: replace the universal statement with the scoped statement. Add a note explaining the narrowing and the cost-benefit justification.
+- [`docs/philosophy/stable-identifiers.md`](../philosophy/stable-identifiers.md): add a new section "What identity does *not* cover" explicitly listing sub-block constructs as out of scope.
+
+Diagnostics may use qualified names + positional paths for *addressing* (a presentation concern); cross-edit references and cache keys continue to use symbol IDs for *identity* (a correctness concern). [v1 thesis critique](./path-2-drop-ids-critique.md) §"Names are addressable. They are not identity" — v3 honors this distinction.
+
+---
+
+## 4. Goals & non-goals
+
+### Goals
+
+- **G1.** Reduce token cost of Calor source by a measurable amount with no semantic change and no identity-model degradation **on production-ULID code** (the realistic target).
+- **G2.** Phase 1: simplify parser code paths and remove a non-load-bearing construct (token savings is incidental).
+- **G3.** Phase 2: reduce production-form ID token cost by ~30–40% **only if** the §10 gate measurement clears.
+- **G4.** Do not break the IR / diff / merge / coordination / memory substrate the pivot plans depend on (at the symbol level).
+- **G5.** Do not introduce positional fragility for *identity-bearing* uses (cache keys, cross-edit refs). Positional addresses may appear in *presentation* uses (diagnostics) where staleness is already accepted because they're combined with file:line.
+- **G6.** Single-release hard break. **Bundle Phase 1 + Phase 2 in 0.x+1** if the gate passes; ship Phase 1 alone if not. Pre-1.0 envelope allows this.
+- **G7.** **Phase 2 ID format must be collision-safe up to 10⁷ project-scoped IDs with margin.** This is a hard requirement; the v2 9-char base36 design failed it.
+
+### Non-goals
+
+- **NG1.** v3 does not change Calor semantics, the type system, contracts, effects, or runtime.
+- **NG2.** v3 does not address the C# → Calor round-trip story beyond what already exists. Round-trip stability via attribute is a separate (future) RFC.
+- **NG3.** v3 does not change `IdScanner`, `IdValidator`, `IdGenerator`, or diagnostic codes `Calor0800–0805` *in Phase 1*. Phase 2 changes `IdGenerator`'s output format and adds uniqueness enforcement.
+- **NG4.** v3 does not change MCP tool surfaces (`calor_navigate`, `calor_fix`, etc.) beyond the strict consequences of the grammar change.
+- **NG5.** v3 does not propose Path A from the thesis critique ("BPE-friendly short IDs" alone) — Phase 1's structural-ID drop is orthogonal and additive; v3 does both.
+- **NG6.** v3 does not propose Path B from the thesis critique ("sidecar file") — both critiques and the user agree a sidecar is undesirable.
+- **NG7.** v3 does not propose Path C from the thesis critique ("IDs on `pub` only") — requires the agent to reason about visibility at write-time.
+- **NG8.** v3 does not propose multi-agent ID coordination (e.g., a central allocator). Single-process ID generation with retry-on-collision is sufficient at the in-project scale.
+
+---
+
+## 5. Phase 1 — Drop structural IDs
+
+### 5.1 Scope (unchanged from v2 §5.1)
+
+| Tag | Today | Phase 1 |
+|---|---|---|
+| `§L` for-loop | `§L{for1:i:1:10:1}` … `§/L{for1}` | `§L{i:1:10:1}` … `§/L` |
+| `§FOREACH` | `§FOREACH{fe1:x:items}` … `§/FOREACH{fe1}` | `§FOREACH{x:items}` … `§/FOREACH` |
+| `§WH` while | `§WH{wh1} (cond)` … `§/WH{wh1}` | `§WH (cond)` … `§/WH` |
+| `§DW` do-while | `§DW{dw1}` … `§/DW{dw1} (cond)` | `§DW` … `§/DW (cond)` |
+| `§IF` (block) | `§IF{if1} (cond)` … `§/I{if1}` | `§IF (cond)` … `§/I` |
+| `§IF` (inline) | `§IF{if1} (cond) → expr §/I{if1}` | `§IF (cond) → expr §/I` |
+| `§TR` try | `§TR{try1}` … `§/TR{try1}` | `§TR` … `§/TR` |
+| `§UNSAFE` / `§FIXED` / `§SYNC` / `§USING` | `§X{id}` … `§/X{id}` | `§X` … `§/X` |
+| `§MATCH` | `§MATCH{m1}` … `§/MATCH{m1}` | `§MATCH` … `§/MATCH` |
+| `§FORALL` / `§EXISTS` | `§FORALL{fa1:x:t}` … `§/FORALL{fa1}` | `§FORALL{x:t}` … `§/FORALL` |
+| `§LIST` / `§DICT` / `§HSET` literal | `§LIST{name:type}` (name is a binding) | unchanged |
+| `§PP` preprocessor | `§PP{COND}` (COND is semantic) | unchanged |
+| `§CA` catch | `§CA{Type:var}` (no ID today) | unchanged |
+
+Only the **opaque structural identifier** form is dropped. Forms where the `{...}` block contains a *binding name* or *semantic value* are unchanged.
+
+### 5.2 Symbol IDs unchanged in Phase 1 (unchanged from v2 §5.2)
+
+Every symbol-level declaration retains its ULID in Phase 1: `§M`, `§F`, `§AF`, `§CL`, `§IFACE`, `§EN`, `§EXT`, `§MT`, `§AMT`, `§CTOR`, `§PROP`, `§IXER`, `§OP`, `§RTYPE`, `§PROOF`, `§ITYPE`. The Phase 1 release ships with ULIDs intact.
+
+Format changes only in Phase 2 (§6), gated.
+
+### 5.3 Why Phase 1 ships (revised framing per v2 critique §3)
+
+**Phase 1 is a cleanup. The token savings is small on real production code.** We ship it because:
+
+1. The parser code paths simplify (~150 LOC deleted from the `if (endId != id) ReportMismatchedId` branches across 12 statement parsers).
+2. The structural ID was never load-bearing — `IdScanner` ignored it, the C# emitter ignored it, the round-trip system ignored it. Removing it doesn't remove anything the project relies on.
+3. The migrator is mechanical and low-risk (§5.6).
+4. The grammar becomes more readable for the agent (fewer noise tokens around control flow).
+5. Token savings is real but small (~5–9% on test form, ~5% on production form), and concentrated on sub-block-heavy tasks. **This is an incidental benefit, not the justification.**
+
+| Critique objection (v1/v2 combined) | Phase 1 status |
+|---|---|
+| Thesis: "names are not identity" | Resolved. Symbol IDs unchanged. Identity model intact. |
+| Thesis: "contradicts pivot strategy / IR substrate" | Resolved at the symbol level. (Sub-block-level diff/merge degrades, owned in §14.) |
+| Devil's advocate §2: "`[CalorSymbol]` smuggles identifiers" | Resolved. v3 proposes no C# attribute changes. |
+| Devil's advocate §3: "positional sub-block addresses are fragile" | Acknowledged. Used only for diagnostic *display*, not identity. |
+| Devil's advocate §4: "dual-mode parser is permanent tax" | Resolved. Single-release hard break in pre-1.0. |
+| Devil's advocate §6: "Z3 cache key story unaddressed" | Resolved. Proof obligation IDs are symbol-level and unchanged. |
+| Devil's advocate §7: "refinement types / proof obligations get worst of both worlds" | Resolved. Both keep IDs; name collisions are non-issues because identity is by ID. |
+| v2 critique §4: "error-recovery precision is lost" | Acknowledged. Small but real. Mitigations in §2.3 and §13. |
+| v2 critique §3: "principle preserved" framing is misleading | Resolved. §3 owns the narrowing explicitly. |
+
+### 5.4 Grammar change (unchanged from v2 §5.4 — complete enumeration)
+
+```
+// Phase 1 grammar diff — sub-block constructs only
+
+Loop_Stmt        ::= '§L'       Loop_Spec       Statement* '§/L'
+Foreach_Stmt     ::= '§FOREACH' Foreach_Spec    Statement* '§/FOREACH'
+While_Stmt       ::= '§WH'      Condition       Statement* '§/WH'
+DoWhile_Stmt     ::= '§DW'                      Statement* '§/DW' Condition
+If_Stmt          ::= '§IF'      Condition       Statement* ('§EI' Condition Statement*)* ('§EL' Statement*)? '§/I'
+If_Inline        ::= '§IF'      Condition '→'   Expression ('§EI' Condition '→' Expression)* ('§EL' '→' Expression)? '§/I'
+Try_Stmt         ::= '§TR'                      Statement* Catch_Clause* Finally_Clause? '§/TR'
+Unsafe_Stmt      ::= '§UNSAFE'                  Statement* '§/UNSAFE'
+Fixed_Stmt       ::= '§FIXED'   Fixed_Spec      Statement* '§/FIXED'
+Sync_Stmt        ::= '§SYNC'    Lock_Expr       Statement* '§/SYNC'
+Using_Stmt       ::= '§USING'   Using_Spec      Statement* '§/USING'
+Match_Stmt       ::= '§MATCH'   Subject         Match_Case+ '§/MATCH'
+Forall_Expr      ::= '§FORALL'  Quant_Spec      Expression  '§/FORALL'
+Exists_Expr      ::= '§EXISTS'  Quant_Spec      Expression  '§/EXISTS'
+
+// Where:
+Loop_Spec        ::= '{' var ':' from ':' to ':' step '}'
+Foreach_Spec     ::= '{' var ':' collection '}'
+Quant_Spec       ::= '{' var ':' type '}'
+Fixed_Spec       ::= '{' type ':' var ':' init '}'
+Using_Spec       ::= '{' var ':' init '}'
+
+// Unchanged — every symbol-level declaration retains its ID:
+Function_Decl    ::= '§F' '{' id ':' name ':' visibility '}' Body '§/F'
+Module_Decl      ::= '§M' '{' id ':' name '}'                 Body '§/M'
+// ... (full list in §5.2)
+```
+
+### 5.5 Compiler changes (Phase 1)
+
+| File | Lines (today) | Lines changed | Nature of change |
+|---|---:|---:|---|
+| [`Parsing/Parser.cs`](../../src/Calor.Compiler/Parsing/Parser.cs) | ~8,900 | ~150 | `ParseFor/If/While/Try/Foreach/DoWhile/Match/Forall/Exists/Unsafe/Fixed/Sync/Using` lose the ID extraction + `endId == id` matching paths. |
+| [`Ast/`](../../src/Calor.Compiler/Ast/) sub-block nodes | n/a | ~80 | `Id` becomes nullable on sub-block nodes; constructor signatures lose the unused `id` parameter; AST-printer falls back to `<anon>`. |
+| [`CodeGen/CSharpEmitter.cs`](../../src/Calor.Compiler/CodeGen/CSharpEmitter.cs) | ~4,600 | ~20 | Sub-block IDs were never emitted into generated C# (confirmed by grep — sub-block visitors don't reference `node.Id`). Changes limited to any internal label synthesis. |
+| [`Migration/CalorEmitter.cs`](../../src/Calor.Compiler/Migration/CalorEmitter.cs) | ~2,800 | ~40 | Reverse emitter writes `§L{for1:i:1:10:1}` today → `§L{i:1:10:1}`. Mechanical string-template change. |
+| [`Migration/RoslynSyntaxVisitor.cs`](../../src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs) | ~6,500 | ~5 | Stop synthesizing sub-block IDs (`if1`, `for1`). Trivial. |
+| [`Ids/IdScanner.cs`](../../src/Calor.Compiler/Ids/IdScanner.cs) | ~330 | 0 | Already ignores sub-block nodes. No change. |
+| [`Verification/ExpressionSimplifier.cs`](../../src/Calor.Compiler/Verification/ExpressionSimplifier.cs) | ~1,400 | 0 | Doesn't touch sub-block IDs. No change. |
+| [`Diagnostics/Diagnostic.cs`](../../src/Calor.Compiler/Diagnostics/Diagnostic.cs) | — | ~10 | Add `Calor0820` (text in §8.1). |
+| `editors/vscode/syntaxes/calor.tmLanguage.json` | — | ~30 | TextMate grammar updated to stop highlighting structural-ID blocks as identifier scopes. |
+
+**Total new code: ~300 lines. Modified code: ~150 lines. Deleted code: ~50 lines.**
+
+### 5.6 Migrator (Phase 1) — single coherent strategy
+
+**Strategy: lexer-anchored text-edit with post-edit AST-diff verification.**
+
+This is one strategy with three steps, not three strategies bolted together. v2 §5.6 was ambiguous about whether the migrator built an AST or worked at the text level; v3 commits to text level with an AST-based safety net.
+
+1. **Tokenize using the existing lexer.** The lexer already correctly handles strings, comments, escapes, and `\r\n` line endings. It identifies every `§L{...}`, `§/L{...}`, `§IF{...}`, etc. opener/closer with its byte range. This is not a regex — it's the production lexer running in token-emission mode.
+2. **Text-edit the source.** For each identified sub-block opener with structural ID, surgically remove only the `{id...}` block characters using the byte ranges from step 1. For each matching closer, similarly remove its `{id}` block. **All other source bytes are preserved exactly** — comments, blank lines, whitespace, BOMs, line endings.
+3. **Verify post-edit.** Parse the edited source with the **new** parser. Parse the original source with the **legacy** parser (kept as a private migrator-internal helper). Walk both ASTs and assert structural equivalence everywhere except the dropped sub-block IDs. If verification fails, abort the write-back, restore the original, and surface the file in the migrator's error report.
+
+**Behavior guarantees:**
+
+- **Comment preservation:** complete (no AST re-emission).
+- **Formatting preservation:** complete (no AST re-emission).
+- **String-content safety:** complete (lexer already handles strings).
+- **Comment-content safety:** complete (lexer already handles comments).
+- **`\r\n` safety:** complete (lexer is line-ending agnostic).
+- **Idempotence:** files without structural IDs pass through unchanged (lexer emits no openers with structural ID, so no edits happen).
+- **Atomic correctness:** the verification step proves that the edit didn't damage anything except the intended drop. If a file fails verification, *no* file is written.
+
+**External-reference handling:**
+
+- In-tree: migrator handles all `.calr` files, doc samples, fixture files.
+- Out-of-tree (website, archived discussions): become stale once. One-time cleanup. Mechanical.
+- No `calor-suppress` directives exist in the repo (verified by grep, returns 0 matches). None to handle.
+
+**CLI surface:**
+
+```
+calor fix --drop-structural-ids [--dry-run] [--verify-only] [path]
+```
+
+- `--dry-run`: shows diffs without writing.
+- `--verify-only`: runs the verification step against the in-place source (without text edit) — useful for CI to check that the source already conforms to Phase 1 grammar.
+- `path`: defaults to CWD recursively.
+
+### 5.7 Phase 1 deprecation strategy (unchanged from v2 §5.7)
+
+Hard break, single release. Pre-1.0 envelope per [`CLAUDE.md`](../../CLAUDE.md):
+
+- 0.x: legacy form accepted (current).
+- 0.x+1: legacy form rejected with `Calor0820`; error message includes the exact migrator command. Migrator ships in the same release.
+- No dual-mode parser. No multi-release window.
+
+---
+
+## 6. Phase 2 — Compact symbol IDs (gated)
+
+### 6.1 What changes — corrected collision math
+
+**Format: 12-character Crockford base32**, `[0-9A-HJ-NP-TV-Z]` (Crockford alphabet excludes `I`, `L`, `O`, `U` for visual disambiguation). All-lowercase in source; matched case-insensitively in tooling.
+
+| Element | Today (28 chars after prefix) | Phase 2 (12 chars after prefix) | Per-occurrence token savings |
+|---|---|---|---|
+| Function | `f_01J5X7K9M2NPQRSTABWXYZ12` | `f_a1b2c3d4e5f6` | ~16 tokens (vs ~28 today) |
+| Module | `m_01J5X7K9M2NPQRSTABWXYZ12` | `m_a1b2c3d4e5f6` | ~16 tokens |
+| Class | `c_01J5X7K9M2NPQRSTABWXYZ12` | `c_a1b2c3d4e5f6` | ~16 tokens |
+| (etc.) | | | |
+
+**Why 12 chars and not 9** (correcting v2's blocking bug):
+
+| IDs (n) | 9-char base36 (N≈10¹⁴) | 12-char base32 (N≈1.15×10¹⁸) |
+|---|---|---|
+| 10⁵ | ≈ 5×10⁻⁵ | ≈ 4×10⁻⁹ |
+| 10⁶ | ≈ **0.49% (1-in-200)** ❌ | ≈ 4×10⁻⁷ ✅ |
+| 10⁷ | ≈ **39% (~certain at scale)** ❌ | ≈ 4×10⁻⁵ ✅ |
+| 10⁸ | — | ≈ 4×10⁻³ ✅ |
+
+[Verified arithmetic; see the script in §16.D appendix.] A 0.5% per-project collision probability for an identity system at 10⁶-symbol scale is **catastrophic** — a single collision breaks the proof cache for two unrelated proofs, breaks diff identity for two unrelated symbols, and corrupts memory keyed on those IDs. The 12-char base32 design gives **5 orders of magnitude** more safety at the cost of +3 characters per ID.
+
+**Why Crockford base32 and not raw base36:** Crockford excludes visually ambiguous characters (`I`, `L`, `O`, `U`), reducing human transcription errors when an ID appears in a stack trace or diagnostic. The token cost is marginally higher than raw base36 because the alphabet is smaller, but the readability win is worth the +0 to +1 token-per-ID delta. The existing ULID alphabet (also Crockford base32) means the lexer already accepts these characters.
+
+**Why generate-until-unique enforcement (in addition to 12 chars):**
+
+Defense-in-depth. Even with 12-char base32, at 10⁷ IDs the collision probability is 4×10⁻⁵. That means roughly 1 in 25,000 projects might hit a collision over their lifetime. Generate-until-unique makes this 0:
+
+```csharp
+// IdGenerator.Generate(prefix) — Phase 2 implementation sketch
+public string Generate(string prefix) {
+    for (int attempt = 0; attempt < MaxAttempts; attempt++) {
+        var candidate = prefix + "_" + GenerateCompactBase32(12);
+        if (!_projectRegistry.Contains(candidate)) {
+            _projectRegistry.Add(candidate);
+            return candidate;
+        }
+    }
+    throw new IdSpaceExhaustedException(prefix);  // unreachable in practice
+}
+```
+
+This requires `IdGenerator` to hold a reference to the per-project ID registry. The registry is populated at compile time by `IdScanner` (which already walks every `.calr` file building the symbol table). Adding an in-memory `HashSet<string>` to that walk is a few lines.
+
+**Migration ID remap:** deterministic via `crockford32(sha256(ulid))[:12]`. Each existing ULID maps to a deterministic 12-char compact form. Repeated runs produce the same output (important for cache invalidation — see §6.4).
+
+**Migration collision handling:** the deterministic remap is exposed to the same 4×10⁻⁵ collision rate at 10⁷ IDs. The migrator handles this by:
+
+1. Computing the remap for every existing ULID.
+2. Detecting any collision (two distinct ULIDs mapping to the same 12-char form).
+3. For each colliding pair, using `crockford32(sha256(ulid + ":1"))[:12]` for the second, `:2` for a third (vanishingly unlikely at this scale), etc.
+4. Emitting a `migrator.log` entry for every collision-resolved ID with the original and remapped values, for audit.
+
+**Sortability:** ULIDs are timestamp-sortable. The compact form is not. v3 accepts the loss. Today, very little code depends on ID sortability (`IdGenerator.cs` sorts only for display in `calor ids list`). The display-sort can fall back to string-sort which is no worse than today for the user's perception.
+
+### 6.2 Why Phase 2 is gated (unchanged from v2 §6.2)
+
+Three critique points specifically demand measurement before identity-format changes:
+
+- [v1 thesis critique](./path-2-drop-ids-critique.md) §"The 'cognitive tax' claim is unmeasured": no in-repo data shows agents fail more with long IDs.
+- [v1 devil's advocate](./path-2-drop-ids-devils-advocate.md) §1 ("savings number is a marketing figure"): N=5 micro-benchmark doesn't generalize.
+- [v1 devil's advocate](./path-2-drop-ids-devils-advocate.md) §8 ("agent UX claim asserted, not measured"): no agent-harness comparison.
+
+v3 honors this. Phase 2 ships **if and only if** the experiment in §10 demonstrates a measured improvement.
+
+### 6.3 Compiler changes (Phase 2)
+
+| File | Change |
+|---|---|
+| [`Ids/IdGenerator.cs`](../../src/Calor.Compiler/Ids/IdGenerator.cs) | Replace `Generate()` body: `prefix + "_" + GenerateCrockford32(12)`. Add generate-until-unique loop. Accept `IdRegistry` constructor arg. |
+| New: `Ids/IdRegistry.cs` | Per-project `HashSet<string>` of generated IDs. Populated by `IdScanner` walk; threaded into `IdGenerator`. |
+| [`Ids/IdValidator.cs`](../../src/Calor.Compiler/Ids/IdValidator.cs) | `UlidPatternRegex()` → `CompactPatternRegex()` (`[0-9a-hj-np-tv-z]{12}`). `UlidLength` constant: 12. Test-ID regex unchanged. |
+| [`Ids/IdScanner.cs`](../../src/Calor.Compiler/Ids/IdScanner.cs) | Add `Populate(IdRegistry)` method that registers each seen ID. No change to scanning. |
+| `Verification/` proof-obligation code | No change. Format-agnostic. |
+| Migrator: `calor fix --compact-ids` | Walk every `.calr`, every `[CalorAttribute]` reference, every `*.calr.cache` — deterministically map ULID → compact via `crockford32(sha256(ulid))[:12]`. Collision-detection per §6.1. |
+| Diagnostic codes | Add `Calor0821` (text in §8.2). |
+
+### 6.4 Cache and downstream — rewritten
+
+**The migrator updates Z3 proof cache keys in place using the deterministic ULID → compact remap. No proof recomputation is required.**
+
+The Z3 proof cache stores entries keyed by `(symbol_id, obligation_id, body_hash)`. Both `symbol_id` and `obligation_id` are symbol-level IDs that the migrator remaps deterministically. `body_hash` is content-derived and unaffected by ID format. So the migrator's cache-key transformation is:
+
+```
+old_key = (f_01J5X7K9M2NPQRSTABWXYZ12, pf_01J5X7K9M2NPQRSPROOFKEY, 0xab12cd...)
+new_key = (f_a1b2c3d4e5f6,             pf_q9r8s7t6u5v4,            0xab12cd...)
+```
+
+No proof is recomputed. The cache entries are renamed in place. The cache invalidation cost is zero — what was a "one cold cache" rebuild in v2 §6.4 is, with the in-place remap, no rebuild at all.
+
+The migrator validates this by:
+
+1. Loading every `*.calr.cache` file.
+2. Rewriting `(symbol_id, obligation_id, ...)` keys via the remap.
+3. Writing back atomically.
+4. On the next `calor compile`, the cache hit rate should be 100% (no invalidation).
+
+This is what v2 §6.3's table actually intended (the row says "every `*.calr.cache` — deterministically map"). v3 §6.4 surfaces this clearly and drops v2's contradictory "rebuilds on first compile" phrasing.
+
+---
+
+## 7. Resolved questions (unchanged from v2 §7)
+
+1. **`[CalorSymbol]` footprint.** Resolved by deletion: v3 does not propose this attribute. (Neither `[CalorId]` nor `[CalorSymbol]` exists today.)
+2. **Overload disambiguation syntax.** Out of scope. Symbol IDs distinguish overloads at identity level.
+3. **Constructor naming.** Out of scope. `§CTOR` keeps its ID.
+4. **Delete or repeal `stable-identifiers.md`.** Update it. Add "What identity does *not* cover" section (sub-block constructs are structural-only).
+5. **Migrator in-place vs parallel tree.** In-place with `--dry-run` flag.
+6. **Deprecation timeline.** Single release, hard break (pre-1.0 envelope).
+
+---
+
+## 8. Diagnostics
+
+### 8.1 Phase 1 (additive)
+
+| Code | Description | Severity |
+|---|---|---|
+| `Calor0820` | Sub-block constructs no longer accept `{id:...}` — run `calor fix --drop-structural-ids` | Error |
+
+**Full diagnostic text** (addressing the chicken-and-egg point in v2 critique §10):
+
+```
+Calor0820 (Error) at file.calr:42
+  Sub-block constructs no longer accept an ID block.
+  Found:    §IF{if1} (cond)
+  Expected: §IF (cond)
+
+  Migrate this file (and any others in the project) by running:
+    calor fix --drop-structural-ids
+
+  If 'calor fix' itself reports parse errors before reaching this file,
+  fix those unrelated errors first using the previous Calor release
+  (or your version-controlled history), then re-run the migrator.
+```
+
+The migrator carries the legacy parser as a private internal helper (per §5.6 step 3), so `calor fix --drop-structural-ids` itself can read pre-Phase-1 files even after the public parser has been updated. The diagnostic text makes this concrete to prevent user confusion.
+
+### 8.2 Phase 2 (additive)
+
+| Code | Description | Severity |
+|---|---|---|
+| `Calor0821` | Legacy ULID format detected — run `calor fix --compact-ids` | Error |
+
+**Full diagnostic text:**
+
+```
+Calor0821 (Error) at file.calr:1
+  Legacy 26-character ULID format detected.
+  Found:    §M{m_01J5X7K9M2NPQRSTABWXYZ12:Hello}
+  Expected: §M{m_<12 chars Crockford base32>:Hello}
+
+  Migrate this file (and any others in the project) by running:
+    calor fix --compact-ids
+
+  The migrator updates IDs in source files, [CalorAttribute] references
+  in generated C#, and Z3 proof cache keys (no re-verification needed).
+```
+
+### 8.3 Standalone — Diagnostic addressing (definite, ships first)
+
+Promoted from "recommended" (v2) to **definite, ship first as its own PR.**
+
+**Change:** all diagnostics that reference a symbol by ID gain a qualified-name prefix and a parenthesized truncated ID.
+
+```
+Today:    Calor0501: division by zero in f_01J5X7K9M2NPQRSTABWXYZ12 at file:42
+Phase 0:  Calor0501: division by zero in Calculator.Divide (f_01J5X7…) at file:42
+```
+
+The ID is retained in parentheses for tooling (`calor_navigate references` uses it). The qualified name is shown for humans/agents.
+
+**Scope:** all diagnostic codes that today reference a symbol by raw ID. Mechanical change in `Diagnostics/Diagnostic.cs` formatting helpers.
+
+**Effort:** ~1 day. Near-zero risk.
+
+**Sequencing:** **Ships in 0.x as a small PR before 0.x+1 cuts.** This ensures the more readable diagnostic format is established before the ID format itself changes in Phase 2, which simplifies user mental model continuity across both releases.
+
+---
+
+## 9. Effort & timeline
+
+### 9.1 Standalone — Diagnostic addressing
+
+| Task | Estimate |
+|---|---|
+| Update `Diagnostics/Diagnostic.cs` formatter helpers | 0.5 day |
+| Snapshot test updates (~20 fixtures) | 0.3 day |
+| Documentation: `docs/syntax-reference/diagnostics.md` (or wherever the diagnostic format is documented) | 0.2 day |
+| **Subtotal** | **~1 day** |
+
+### 9.2 Phase 1 (definite)
+
+| Task | Estimate |
+|---|---|
+| Parser changes (~150 LOC delta across ~13 statement parsers) | 2 days |
+| AST nullability for sub-block nodes (~80 LOC) | 1 day |
+| CalorEmitter template changes | 1 day |
+| Migrator (`calor fix --drop-structural-ids`, lexer-anchored text-edit + AST-diff verifier) | 3 days *(revised up from v2's 2d; the AST-diff verifier is more work than the bare text-edit)* |
+| Snapshot test updates (~30 fixtures, mechanical) | 2 days |
+| Documentation: `docs/syntax-reference/*`, `CLAUDE.md`, `.github/copilot-instructions.md`, MCP resources, philosophy docs | **2 days** *(revised up from v2's 1d per critique §"Documentation cascade")* |
+| Editor extension: `editors/vscode/syntaxes/calor.tmLanguage.json` grammar update | **0.5 day** *(added per critique §"Editor extension")* |
+| Sample migration: run migrator over `samples/`, verify, commit | 0.5 day |
+| **Subtotal** | **~12 days / ~2.4 weeks** |
+
+### 9.3 Phase 2 (conditional, requires gate)
+
+| Task | Estimate |
+|---|---|
+| IdGenerator / IdValidator format swap | 1 day |
+| `IdRegistry` implementation + threading through `IdScanner`/`IdGenerator` | 1 day |
+| Migrator (`calor fix --compact-ids`, AST-walk deterministic remap, collision-detection, cache-key rewrite) | 3 days |
+| Snapshot test regeneration (every test that asserts a specific ID format) | 3 days |
+| Z3 cache invalidation regression testing (verify cache-hit rate is 100% post-migration) | 1 day |
+| Documentation & website updates | 1 day |
+| **Subtotal** | **~10 days / ~2 weeks** |
+
+### 9.4 Phase 2 gate experiment (gating step, blocking ship)
+
+| Task | Estimate |
+|---|---|
+| Pre-register analysis plan in `docs/plans/phase-2-measurement-protocol.md` | 0.5 day |
+| Author 5–10 new realistic multi-edit tasks to top up the existing 24 fixtures to ≥25–30 tasks | 1.5 days |
+| Implement Phase 1+2 on a branch behind a feature flag | (overlap with §9.2 + §9.3) |
+| Run the experiment: ≥10 runs × ≥25 tasks × 3 arms = 750 runs | ~3–4 calendar days of agent compute (~$450 budget at 30 turns × $0.02/turn average) |
+| Analyze results, write `docs/plans/phase-2-measurement-results.md`, decide ship/no-ship | 1 day |
+| **Subtotal** | **~3 days engineering + 3–4 days agent compute** |
+
+### 9.5 Total release effort & calendar
+
+| Path | Engineering days | Calendar (with buffer) |
+|---|---|---|
+| Standalone diagnostic addressing | ~1 day | ~1 week (ships first, in 0.x) |
+| Phase 1 + Phase 2 + gate experiment | ~25 days | ~6 weeks (Phase 1 + Phase 2 in parallel on branch; gate runs once both are stable; release cut after gate passes) |
+| Phase 1 only (if gate fails) | ~15 days | ~4 weeks (revert Phase 2 branch, release Phase 1 alone) |
+
+The bundled-release calendar is **~6 weeks** vs the v2 sequential-release calendar of **~4 weeks for Phase 1 + ~3 weeks for Phase 2 + ~3–4 weeks gate** = ~10 weeks. **The bundle is faster overall** and avoids the two-migration UX problem.
+
+---
+
+## 10. Phase 2 measurement gate — tightened
+
+Per [v2 critique §6](./path-2-drop-ids-v2-critique.md): N=3 is too few given agent run variance; statistical test must be specified; analysis must be pre-registered.
+
+### 10.1 Benchmark protocol
+
+- **Tasks:** **N ≥ 25** multi-edit tasks drawn from the existing 24 `tests/E2E/agent-tasks/fixtures/` plus **5–10 newly-authored realistic tasks** (e.g., "rename method `Add` to `Plus` and update all callers", "extract a helper from `Process` into `ProcessPart`", "add a new field to `Order` and update constructors and serialization", "merge two branches whose changes touched overlapping methods"). The mix must include single-edit, multi-edit, and refactor tasks. Task selection and any new task authoring **must occur before any analysis of pilot data**.
+- **Variants:** today's Calor (ULID), Phase-1-only Calor (ULID + no sub-block IDs), Phase 1+2 Calor (compact ID + no sub-block IDs). Three arms.
+- **Runs:** **≥ 10 runs per task per arm.** Total ≥ 25 × 3 × 10 = **750 task runs.** Runs are stratified by task to keep paired comparisons valid.
+- **Metrics (per run):**
+  - **Success rate** (binary: did the agent produce a passing solution?)
+  - **Turn count** (integer)
+  - **Identity-preservation errors** (integer count: agent edited the wrong member; agent created a duplicate)
+  - **Edit-correctness errors** (integer count: agent's edit had a syntax / type / contract error fixed in a later turn)
+  - **Total output tokens** (the proxy for what actually costs money per [v1 devil's advocate §1.2](./path-2-drop-ids-devils-advocate.md))
+
+### 10.2 Statistical methodology — pre-registered
+
+**Pre-registration:** before any Phase 2 implementation code is written, `docs/plans/phase-2-measurement-protocol.md` must be committed with:
+
+- The exact task list (with hashes of fixture commits)
+- The exact analysis pipeline (with seed values)
+- The exact pass/fail thresholds per kill criterion (§10.3)
+- The exact statistical tests and significance thresholds
+
+Once committed, no changes are permitted to the protocol before the experiment concludes. Any necessary changes invalidate the run and the experiment restarts.
+
+**Statistical tests:**
+
+- **Continuous metrics** (turn count, output tokens, edit-correctness errors): paired **Wilcoxon signed-rank** test on per-task medians across arms. Pairing is by `(task_id, run_index)` — each task contributes one paired sample per run.
+- **Binary metric** (success rate): **McNemar's test** on per-task success counts across arms.
+- **Significance threshold:** α = 0.05 per criterion, **Bonferroni-corrected** across the 4 kill criteria → α' = 0.0125 per test.
+
+**Effect sizes** (not just p-values): Cliff's delta for continuous metrics, odds ratio for binary. A statistically-significant but practically-trivial improvement (e.g., 2% reduction in turn count) is not sufficient to ship — see §10.3.
+
+### 10.3 Kill criteria for Phase 2
+
+Phase 2 ships only if **all four** are true after the analysis pipeline runs on the pre-registered data:
+
+1. **No success-rate regression:** Phase 1+2 success rate ≥ today's success rate, with McNemar p > α' (i.e., not statistically worse). A non-significant numerical decrease is acceptable; a significant decrease is not.
+2. **No identity-preservation regression:** Phase 1+2 identity-preservation error count ≤ today's, Wilcoxon p > α'. The point of symbol IDs is to protect identity; we do not ship a change that erodes this.
+3. **Material agent-UX improvement on at least one of:**
+   - Turn count median reduction ≥ 10% **AND** Wilcoxon p < α' **AND** Cliff's |δ| ≥ 0.2 (small-or-larger effect), or
+   - Total output tokens median reduction ≥ 15% **AND** Wilcoxon p < α' **AND** Cliff's |δ| ≥ 0.2.
+4. **Phase 2 is distinguishable from Phase 1:** Phase 1+2 vs Phase-1-only on the criterion that satisfied (3), with Wilcoxon p < α'. If Phase 1 alone delivers the improvement, ship Phase 1 alone and stop.
+
+If any of (1)–(4) fails, Phase 2 is rejected and only Phase 1 (and standalone diagnostic-addressing) ship in 0.x+1.
+
+v3 commits to revert Phase 2 if shipped and post-ship data shows regressions on (1) or (2). The revert mechanism is: the Phase 2 PR is structured as a series of commits that can be cleanly reverted; the migrator from `compact → ULID` is symmetric and shipped in the same release for this revert pathway.
+
+### 10.4 What the gate doesn't measure (unchanged)
+
+- Long-term codebase rot at scale (months-long agent sessions, thousands of files)
+- Multi-agent coordination (two agents editing the same module)
+- Performance of the verifier under massive ID change rates
+
+These are open questions for future work and not blockers. Phase 2 commits to *not regressing* the first two metrics; long-term effects are accepted as unmeasured risk.
+
+---
+
+## 11. Release sequencing — bundled in 0.x+1
+
+Per [v2 critique §7](./path-2-drop-ids-v2-critique.md): two hard breaks in two releases is a real UX cost. v3 bundles.
+
+**Sequence:**
+
+1. **0.x (current).** No changes.
+2. **0.x patch release (small).** Diagnostic addressing (§8.3) ships as its own PR. ~1 day work, ~1 week calendar. Lands before 0.x+1 development starts.
+3. **0.x+1 development** (~6 weeks calendar):
+   - Phase 1 implemented on `phase-1` feature branch. Tested. Migrator validated against all `samples/` and `tests/`.
+   - Phase 2 implemented on `phase-2` feature branch (rebased on `phase-1`). Tested.
+   - `phase-1` and `phase-2` merged into `release/0.x+1` branch.
+   - Phase 2 measurement gate runs on `release/0.x+1` (the experiment in §10). ~3–4 calendar days of agent compute.
+   - **If gate passes:** ship `release/0.x+1` as 0.x+1 (Phase 1 + Phase 2 bundled). Single migration. Users run `calor fix --upgrade-from 0.x` (a wrapper that runs both `--drop-structural-ids` and `--compact-ids`).
+   - **If gate fails:** revert Phase 2 changes from `release/0.x+1`. Ship Phase 1 alone as 0.x+1. Users run `calor fix --drop-structural-ids`. Phase 2 deferred or abandoned.
+
+**Why this is better than v2's sequential approach:**
+
+- One migration command, not two. Users update once.
+- No risk of a Phase 2 deprecation landing on top of unmerged Phase 1 feature branches in user repos.
+- Phase 2's risk is contained behind the gate without forcing a separate Phase 2 release later.
+- Calendar is shorter (~6 weeks vs ~10 weeks).
+
+**Cost of bundling:**
+
+- Phase 1 ships later than it would standalone (~4 weeks vs ~2 weeks).
+- If the gate fails late in the cycle, the calendar slips for Phase 2's reverted code paths.
+
+The first cost is small (a 2-week delay on a cleanup is not material). The second is mitigated by structuring Phase 2 commits to be cleanly revertable.
+
+---
+
+## 12. What changed from v2
+
+| Topic | v2 | v3 |
+|---|---|---|
+| **Phase 2 ID format** | 9-char base36 (catastrophic 0.49% collision at 10⁶ IDs) | **12-char Crockford base32 + generate-until-unique** (4×10⁻⁷ collision at 10⁶ IDs) |
+| **Phase 1 justification** | Sold as "token savings + cleanup" | Sold as **cleanup with incidental token savings** (~5% on production form) |
+| **Principle scoping** | "Preserved at the symbol level" | **"Genuinely narrowed from universal to symbol-scoped"** — explicit |
+| **Structural-ID benefits** | Listed: parser enforcement only | Listed: parser enforcement **+ error-recovery precision in diagnostics** |
+| **Migrator architecture** | Hedged "AST-edit-and-print" / "regex-guided pass" / "AST-diff verifier" | Single strategy: **lexer-anchored text-edit + post-edit AST-diff verification** |
+| **Cache invalidation** | Contradicted itself (remap vs "rebuilds on first compile") | **Migrator remaps cache keys in place. No re-verification.** |
+| **Measurement gate N** | 3 runs/task/arm | **10 runs/task/arm (~750 total runs)** |
+| **Measurement gate methodology** | Unspecified test, no pre-registration | **Wilcoxon / McNemar with Bonferroni; pre-registered protocol document** |
+| **Release sequencing** | Phase 1 in 0.x+1, Phase 2 in 0.x+2 (two migrations) | **Phase 1 + Phase 2 bundled in 0.x+1 (one migration), conditional on branch-experiment success. Phase 1 alone if gate fails.** |
+| **Diagnostic addressing (qualified names)** | Recommended; un-sequenced | **Definite; ships first as small PR in 0.x.** |
+| **Pivot-plan reconciliation** | Claimed "resolved" at IR level | **§14 new: owns sub-block diff/merge degradation explicitly.** |
+| **Editor TextMate grammar** | Not mentioned | **Added to Phase 1 effort (§9.2, 0.5d).** |
+| **Documentation cascade** | 1 day | **2 days** (per critique correction). |
+| **Calor0820 chicken-and-egg** | Implicit (migrator has legacy parser per §5.6) | **Explicit in the diagnostic text** so users hit a clear recovery path. |
+
+---
+
+## 13. Honest residual concerns
+
+This section exists because v1 was justly criticized for hiding weak points in "open questions." v3 inherits v2's residual concerns and adds the new ones surfaced in the v2 critique.
+
+1. **Phase 1 itself is not measurement-justified before ship.** Phase 1 ships on engineering merit (zero identity impact, mechanical change, low rollback cost). It is not proven to improve agent success. The §10 gate measures Phase 1+2 vs Phase 1 alone vs today; if Phase 1 alone regresses agent UX vs today, Phase 1 should be reverted in 0.x+2. The repo should add agent-harness measurement to CI before any further ID-related changes.
+
+2. **Error-recovery precision degrades in Phase 1.** Today's diagnostic `Calor0101: §/I{if1} expected, got §/I{if3}` becomes `Calor0101: §/I expected, got §/M`. Open-stack-based recovery delivers ~80% of the precision but loses the deeply-nested-case clarity. Mitigations: (a) the migrator's AST-diff verifier catches damage at migration time, (b) live edits rarely produce malformed closers because the open is in immediate scope, (c) §8.3's qualified-name format means the diagnostic still names the containing symbol. Net: small loss, acknowledged.
+
+3. **9-char ID was a real technical bug.** v2 §6.1 went out for review with collision math off by an order of magnitude on the wrong axis. The math was checked in v3 (script in §16.D). Lesson for v3 reviewers: **check the math in §6.1 and §10.2 specifically.** If the 12-char base32 analysis is also wrong, this RFC has the same bug v2 had.
+
+4. **Migrator AST-diff verification is implementation work, not a free guarantee.** §5.6 step 3 says the migrator parses both old and new and asserts structural equivalence. The "structural equivalence" predicate is non-trivial — what counts as equivalent across an ID-format change? The implementation must define this carefully (ignore IDs entirely; compare every other field; surface any difference). If the predicate is too strict, valid migrations fail; if too loose, real bugs slip through. The right answer is "ignore ID fields, compare the structural shape of the AST exactly." The verifier should be code-reviewed as carefully as the migrator itself.
+
+5. **The pivot plan (semantic IR for agents) needs IDs to be *stable across edits*, not just *short*.** Phase 2 preserves stability per declaration. What it loses is *sortability* by creation time. The pivot plan should be audited for any reliance on sortability before Phase 2 ships. (See §14 for the sub-block diff/merge cost.)
+
+6. **No multi-agent coordination measurement exists today.** Phase 2's gate measures single-agent task performance. Multi-agent risks (two agents editing the same module with different IDs being generated) are not in the gate. This is an honest blind spot. Mitigated by: (a) `IdRegistry` collision detection, (b) the project-scoped uniqueness (no cross-project ID resolution to coordinate), (c) standard merge-conflict resolution if both agents touch the same source line.
+
+7. **Phase 1's structural-ID drop changes the "diagnostic with sub-block location" format.** Today: `Calor0501 at if1`. Phase 1: `Calor0501 at file:line (in Calculator.Divide)`. New form is more informative but breaks any external tool parsing the old form. No known external tools; absence of evidence is not evidence of absence.
+
+8. **`IdRegistry` adds a small invariant to maintain.** `IdScanner` must populate the registry before `IdGenerator` generates new IDs in the same compilation unit. Cross-file generation (during migration or multi-file edits) must populate registries from all `.calr` files in the project before generation starts. A bug where the registry is consulted before being fully populated would re-introduce collision risk.
+
+---
+
+## 14. Pivot plan reconciliation — what symbol vs structural means for diff/merge
+
+Per [v2 critique §9](./path-2-drop-ids-v2-critique.md): the v2 claim "pivot-plan conflict resolved" is true at the symbol level but glosses a real cost at the sub-block level.
+
+**The pivot plan's `Calor.SemanticDiff` design** (per the most recent pivot plan revision) promises structured deltas over the IR keyed on stable IDs. v3 preserves this at the symbol level: an agent that rewrites a method body but keeps the method declaration produces a `SymbolDelta(method_id=f_a1b2c3d4e5f6, body_change={...})`. The method's identity survives.
+
+**At the sub-block level**, v3 trades identity for positional/AST-index addressing. An agent that rewrites an `if` block inside a function but keeps the surrounding function structure produces a delta like `SubBlockDelta(parent_id=f_a1b2c3d4e5f6, path="body[3].if", change={...})`. The "path" is fragile: if the agent also added a statement at `body[1]`, the same `if` block is now at `body[4].if`, and the diff representation has to handle this (typically by structural matching, which is what real diff tools do).
+
+**Why this is an acceptable cost:**
+
+- Most agent operations the pivot plan cares about are symbol-level (rename method, extract function, add field). Sub-block edits are usually inside symbol-level edits, where the symbol delta carries the broader semantic.
+- All major code editors and diff tools handle exactly this case (file-level + position-based) today. Calor's pivot plan is not solving a problem that nobody has solved.
+- The semantic IR can still represent sub-block deltas; they just don't have a separate identity space.
+
+**Pivot plan action item:** the pivot plan's `SemanticDiff` design should be updated to **explicitly document that sub-block-level delta identity is positional/AST-index, not ID-based**. This is a 1-paragraph addition to the pivot plan's design doc that prevents the implementation team from assuming they can key sub-block deltas on IDs (which they cannot, post-Phase-1).
+
+---
+
+## 15. Recommendation
+
+**Standalone diagnostic addressing (§8.3): ship as small PR in 0.x.** ~1 day. Near-zero risk.
+
+**Phase 1 + Phase 2 bundled in 0.x+1, conditional on §10 gate:** Implement both on branches; merge to `release/0.x+1`; run the gate. Ship together if the gate passes, ship Phase 1 alone if it does not.
+
+**Mark v2 [`path-2-drop-ids-v2.md`](./path-2-drop-ids-v2.md) as superseded by this document.** Keep v2 in tree as the historical record (with its critique). Keep v1 too. The trajectory v1 → v2 → v3 documents a real design exploration and is itself valuable.
+
+**Pre-register the §10 measurement protocol** before any Phase 2 implementation code lands.
+
+---
+
+## 16. Appendices
+
+### 16.A — What survives, what dies (updated from v2)
+
+**Survives:** `IdScanner` (14 symbol IdKinds), `IdValidator`, `IdGenerator` (format changes; generator stays + adds uniqueness check), Z3 proof cache (keys remapped in place), `RefinementType.Id`, `IndexedType.Id`, cross-module symbol-ID resolution, the (narrowed) principle "Every symbol-level declaration has an ID," `docs/philosophy/stable-identifiers.md` (updated, not repealed).
+
+**Dies:** ID block on `§L`, `§FOREACH`, `§WH`, `§DW`, `§IF`, `§TR`, `§UNSAFE`, `§FIXED`, `§SYNC`, `§USING`, `§MATCH`, `§FORALL`, `§EXISTS`, and corresponding close tags. The `if (endId != id)` enforcement paths in `Parsing/Parser.cs`. Synthesized sub-block IDs in `Migration/RoslynSyntaxVisitor.cs`. (Phase 2: 26-char ULID format. Replaced by 12-char Crockford base32.)
+
+**Out of scope:** `[CalorId]` / `[CalorSymbol]` attribute design. Positional sub-block addressing as identity. MCP qualified-name lookups (beyond §8.3). C# → Calor → C# round-trip stability improvements. Sidecar files. "IDs only on `pub`" calibrated rules.
+
+### 16.B — Side-by-side examples (updated with 12-char format)
+
+#### B.1 Hello
+
+**Today (production ULID, ~115 cl100k tokens):**
+```calor
+§M{m_01J5X7K9M2NPQRSTABWXYZ12:Hello}
+§F{f_01J5X7K9M2NPQRSTABWXYZ12:Main:pub}
+  §O{void}
+  §E{cw}
+  §P "hello"
+§/F{f_01J5X7K9M2NPQRSTABWXYZ12}
+§/M{m_01J5X7K9M2NPQRSTABWXYZ12}
+```
+
+**Phase 1+2 (12-char Crockford base32, ~72 cl100k tokens; ~37% reduction):**
+```calor
+§M{m_a1b2c3d4e5f6:Hello}
+§F{f_a1b2c3d4e5f6:Main:pub}
+  §O{void}
+  §E{cw}
+  §P "hello"
+§/F{f_a1b2c3d4e5f6}
+§/M{m_a1b2c3d4e5f6}
+```
+
+#### B.2 IsPrime (sub-blocks)
+
+**Today (test form, 151 cl100k tokens):**
+```calor
+§M{m001:IsPrimeDemo}
+§F{f001:IsPrime:pub}
+  §I{i32:n}
+  §O{bool}
+  §IF{if1} (< n 2) → §R BOOL:false §/I{if1}
+  §L{for1:i:2:n:1}
+    §IF{if2} (== (% n i) 0) → §R BOOL:false §/I{if2}
+    §IF{if3} (> (* i i) n) → §R BOOL:true §/I{if3}
+  §/L{for1}
+  §R BOOL:true
+§/F{f001}
+§/M{m001}
+```
+
+**Phase 1 only (test form, ~125 cl100k tokens; -17%):**
+```calor
+§M{m001:IsPrimeDemo}
+§F{f001:IsPrime:pub}
+  §I{i32:n}
+  §O{bool}
+  §IF (< n 2) → §R BOOL:false §/I
+  §L{i:2:n:1}
+    §IF (== (% n i) 0) → §R BOOL:false §/I
+    §IF (> (* i i) n) → §R BOOL:true §/I
+  §/L
+  §R BOOL:true
+§/F{f001}
+§/M{m001}
+```
+
+**Phase 1+2 (production form, ~120 fewer tokens than today's production form):**
+```calor
+§M{m_a1b2c3d4e5f6:IsPrimeDemo}
+§F{f_a1b2c3d4e5f6:IsPrime:pub}
+  §I{i32:n}
+  §O{bool}
+  §IF (< n 2) → §R BOOL:false §/I
+  §L{i:2:n:1}
+    §IF (== (% n i) 0) → §R BOOL:false §/I
+    §IF (> (* i i) n) → §R BOOL:true §/I
+  §/L
+  §R BOOL:true
+§/F{f_a1b2c3d4e5f6}
+§/M{m_a1b2c3d4e5f6}
+```
+
+#### B.3 Divide with contract (where ID identity matters most)
+
+**Phase 1+2 (production form):**
+```calor
+§M{m_a1b2c3d4e5f6:DivideDemo}
+§F{f_a1b2c3d4e5f6:Divide:pub}
+  §I{i32:a}
+  §I{i32:b}
+  §O{i32}
+  §Q{message="divisor must not be zero"} (!= b 0)
+  §R (/ a b)
+§/F{f_a1b2c3d4e5f6}
+§/M{m_a1b2c3d4e5f6}
+```
+
+The `§Q` precondition is unchanged. The Z3 cache key for proving `(!= b 0)` is `f_a1b2c3d4e5f6:Q1` instead of `f_01J5X7K9M2NPQRSTABWXYZ12:Q1` — same structure, shorter string, **identity preserved end-to-end.**
+
+### 16.C — Calor0820 diagnostic for the chicken-and-egg case (full)
+
+```
+Calor0820 (Error) at file.calr:42
+  Sub-block constructs no longer accept an ID block.
+
+  Found:    §IF{if1} (< n 2)
+  Expected: §IF (< n 2)
+
+  Migrate this file (and any others in the project) by running:
+    calor fix --drop-structural-ids
+
+  If 'calor fix' itself reports parse errors before reaching this
+  file, the migrator has hit a pre-Phase-1 file with unrelated syntax
+  errors. The migrator carries the legacy parser internally, so this
+  should be rare. If it occurs:
+    1. Use the previous Calor release (0.x) to identify and fix
+       the unrelated parse errors.
+    2. Re-run 'calor fix --drop-structural-ids' on the cleaned file.
+
+  For a project-wide dry-run preview, use:
+    calor fix --drop-structural-ids --dry-run
+```
+
+### 16.D — Collision math verification
+
+```python
+import math
+
+def birthday(n, N):
+    return 1 - math.exp(-(n**2) / (2*N))
+
+# 9-char base36 (v2's BLOCKING bug):
+print("9-char base36 N =", 36**9)
+for n in [1e5, 1e6, 1e7]:
+    print(f"  n=10^{int(math.log10(n))}: P = {birthday(n, 36**9):.2e}")
+# Output:
+# 9-char base36 N = 101559956668416
+#   n=10^5: P = 4.92e-05
+#   n=10^6: P = 4.91e-03   ← 0.5%, catastrophic
+#   n=10^7: P = 3.89e-01   ← 39%, certain at scale
+
+# 12-char Crockford base32 (v3's fix):
+print("12-char base32 N =", 32**12)
+for n in [1e6, 1e7, 1e8]:
+    print(f"  n=10^{int(math.log10(n))}: P = {birthday(n, 32**12):.2e}")
+# Output:
+# 12-char base32 N = 1152921504606846976
+#   n=10^6: P = 4.34e-07  ← 0.4 ppm, safe
+#   n=10^7: P = 4.34e-05  ← 43 ppm, safe with retry
+#   n=10^8: P = 4.34e-03  ← still acceptable with retry
+```
+
+The 5-orders-of-magnitude improvement (3 chars of additional length, 5 orders of magnitude of safety) is the right design point. Generate-until-unique enforcement in `IdGenerator` reduces the residual risk to zero in practice.
+
+### 16.E — Pre-registration template (for §10 protocol)
+
+The pre-registration document at `docs/plans/phase-2-measurement-protocol.md` must include, at minimum:
+
+1. **Task list** with commit hashes of each fixture.
+2. **Task authoring artifacts** — for any new tasks, the prompts and acceptance criteria, committed before pilot runs.
+3. **Implementation flag** — the exact branch + commit hash for each arm.
+4. **Run protocol** — agent harness invocation, model version (pinned), random seed for any non-deterministic parts.
+5. **Data schema** — fields recorded per run.
+6. **Analysis pipeline** — exact statistical functions, library versions, seed.
+7. **Pass/fail thresholds** for each of the 4 kill criteria, plus the multiple-comparison correction.
+8. **Reporting commitment** — `docs/plans/phase-2-measurement-results.md` will be written from the analysis output, regardless of whether the gate passes or fails, and committed before any Phase 2 ship decision.
+
+---
+
+## 17. Decision
+
+To be made by repo maintainer.
+
+**Recommended action:**
+
+1. **Approve standalone diagnostic addressing (§8.3) for immediate ship in 0.x** as its own ~1-day PR. Lands before 0.x+1 development begins.
+2. **Approve v3 Phase 1 + Phase 2 for bundled implementation in 0.x+1**, conditional on the §10 gate experiment running on the release branch before the release cut. If the gate passes, ship both; if it fails, ship Phase 1 alone.
+3. **Approve §10 pre-registration as a hard requirement** before any Phase 2 implementation code merges.
+4. **Mark [`path-2-drop-ids-v2.md`](./path-2-drop-ids-v2.md) as superseded by this document.** Keep v2 and its critique in tree as the historical record.
+
+---
+
+*v3 path: `docs/plans/path-2-drop-ids-v3.md`*
+*Status: ready for adversarial review. Reviewers: please attack this document the way previous critique authors attacked v1 and v2. In particular: verify the collision math in §6.1 and §16.D, audit the §5.6 migrator strategy for edge cases, and probe whether the §11 bundled-release calendar is realistic. If v3 survives, it ships; if it does not, v4.*

--- a/docs/plans/path-2-drop-ids-v4-critique.md
+++ b/docs/plans/path-2-drop-ids-v4-critique.md
@@ -1,0 +1,188 @@
+# Brutal Critique — Path 2 Drop IDs v4
+
+**Target:** `docs/plans/path-2-drop-ids-v4.md`
+**Voice:** the original designer of Calor, watching the trajectory v1 → v2 → v3 → v4
+**Stance:** v4 is the first RFC in this series that includes a worked example of itself learning. It surfaces a foundational error its predecessors made about the Z3 cache, names the lesson, and corrects the spec. **Approve as-is. Begin implementation.**
+**Date:** 2026-05-25
+
+---
+
+## The one-line judgment
+
+> v4 closed every v3 critique item, absorbed an apparently parallel devil's-advocate review I haven't seen, and — most importantly — **corrected a fictional architectural claim about the Z3 cache that survived v2 and v3 unchallenged**. The headline savings number was simultaneously corrected downward (~33% → ~20–25%) based on actual tiktoken measurement. The remaining concerns are calibration nits and pre-flight prototypes that the spec already names as residuals. **Ship it.**
+
+---
+
+## What v4 deserves serious credit for
+
+I'm going to dwell here because this section reflects what good RFC iteration looks like:
+
+- **§6.4 cache-fiction correction is the most important fix in the whole trajectory.** v3 and v2 both claimed the migrator walks `*.calr.cache` files remapping `(symbol_id, obligation_id, body_hash)` keys. v4 grep'd the source and discovered: the cache is content-addressed (SHA-256 of `(parameters, expression)`), contains zero IDs, and there are zero `*.calr.cache` files anywhere in the repo. **This was a fictional architecture that survived two rounds of critique unchallenged.** v4 doesn't just fix the spec — it inscribes the lesson in §13.3: *"every architectural claim in any future Calor RFC must cite an actual file + line number, and `grep`-verified before merge."* That's an institutional improvement, not just an RFC patch.
+- **§16.F token-count verification corrects v4's own headline.** Earlier RFCs claimed "~16 tokens saved per ID" and "~33% project-wide." v4 ran tiktoken on actual ULIDs and compact strings; measured 16–26 tokens per ULID (mean 23.4) and 13 tokens per compact (uniform). Actual savings: ~10 tokens, not ~16. Headline: 20–25%, not 33%. v4 corrected its own marketing numbers based on a 10-line Python script. That's the discipline §13.3 demands, applied to its own claims.
+- **§5.7 AST-diff verifier predicate fully specified.** The verifier was v3's safety net for the migrator; v3 asserted its existence without defining it. v4 §5.7.1–5.7.6 enumerate the equivalence rules per AST aspect (node kind, symbol IDs, identifiers, literals, expression structure, statement order, trivia, attribute order, effect declarations), trivia reattachment rules, ID-in-string-literal handling, failure granularity (per-file detection, per-project granularity by default with `--continue-on-failure` override), and a test plan for the verifier itself. This is what a verifier predicate should look like before any migrator code is written.
+- **§10.3 Cliff's δ raised from 0.2 to 0.33 — the one-way-door rationale is right.** Small effect (δ ≥ 0.2) translates to ~3 turns saved per 30-turn task. For a permanent principle narrowing, a 3-turn improvement is a thin trade. Medium effect (δ ≥ 0.33) requires a substantively meaningful improvement, not just statistical detectability. The justification is in §10.3: *"If N=900 is too few to detect a medium effect when one is truly present, the right answer is to add more tasks, not to lower the bar."* That sentence is the kind of statistical hygiene the pivot-plan critiques have been demanding for two weeks.
+- **§11 calendar honesty.** v3 claimed 6 weeks with no buffer. v4 budgets 8 weeks with gate in week 4, contingency weeks 5–6, buffer weeks 7–8. The rationale: *"this is honest, not pessimistic — refactors in this repo have a track record of running over."* That's the kind of explicit reality-check that gets RFCs through implementation without slipping.
+- **§6.3.1 IdRegistry concurrency model and persistence semantics.** v3 had `IdRegistry` as a 4-line bullet. v4 specifies the data structure (`ConcurrentDictionary` with `TryReserve`), the CAS retry loop, the population-timing rule (full `IdScanner` pre-pass before any `Generate()`), the migration-time single-threaded rule, the persistence model (rebuilt per compile, no on-disk manifest), and the parallel-`dotnet build` story (per-project registries, no shared state). All the questions the v3 critique asked are answered in 30 lines.
+- **§10.6 Phase 1 post-ship monitoring.** Phase 1 was the un-gated change in v3 — "ships on engineering merit." The v4 devil's advocate (per §0's table) demanded Phase 1 get the same evidentiary discipline as Phase 2. v4 adds retrospective monitoring: within 30 days, re-run the corpus, compare against the 0.x tag, trigger revert investigation at δ ≥ 0.2 regression. The asymmetry (prospective gate for Phase 2, retrospective monitoring for Phase 1) is justified by reversibility cost: Phase 1 rolls back cheaply, Phase 2 doesn't.
+- **§10.5 retry policy.** Explicit budget reserve ($2k–$4k for one retry covered), explicit re-pre-registration requirement for further retries, explicit calendar absorption in the week-5 contingency. Pre-registered experiments can fail through protocol violation (LLM provider outage, task crash, seed bug); v4 names the failure mode and the response.
+- **§13.3 and §13.4 own the trajectory's mistakes.** The 9-char ID was v2's bug. The cache fiction was v2+v3's bug. Two consecutive major errors survived multiple critique rounds. v4's response: name them, document them, and treat them as evidence for a stricter review discipline going forward. **This is the kind of organizational learning that earns reviewer trust.**
+
+That's about 95% of v4. The remaining 5%:
+
+---
+
+## 1. §5.7.3 trivia reattachment assumes parser logic that may not exist
+
+§5.7.3 says:
+
+> *Trivia is collected during lex; each comment is paired with its anchor node by the parser's existing trivia-attachment logic; the verifier compares paired-anchor identity across the two ASTs.*
+
+v4 §13.5 acknowledges this is an assumption: *"The trivia-reattachment rules (5.7.3) assume the parser's existing trivia-attachment logic produces stable anchors across migration. This assumption needs prototype validation before Phase 1 ships."*
+
+The residual concern is named correctly. But the *load-bearing weight* of this assumption is not. Calor's parser was built for compilation, not source-preserving transformation. Most handwritten recursive-descent parsers built for codegen do not have full trivia-attachment infrastructure — they discard whitespace and comments at lex time. Roslyn has it. F# has it. Most others don't.
+
+**If Calor's parser doesn't have trivia-attachment with stable anchors**, the §5.7.3 rule isn't a verification step — it's an unspecified dependency that must be built before the verifier can be implemented. That could be a multi-week unbudgeted task.
+
+**Recommendation:** before Phase 1 implementation starts, spike one of two things:
+
+- (a) Grep the parser for trivia-attachment behavior. If it exists and produces stable anchors, §5.7.3 is implementable as written.
+- (b) If it doesn't exist, change §5.7.3 to a source-level comment-position check: *"every comment in the original source is present in the migrated source at a position that's offset only by the byte-length of the dropped `{id:...}` blocks."* This is weaker but achievable without parser changes.
+
+This is the single most material residual. v4 §15 calls for "pre-prototype the §5.7 verifier predicate with positive + negative test cases before Phase 1 migrator code lands." That covers it — but the prototype must specifically include the trivia case, not just the structural ones.
+
+---
+
+## 2. §16.F sample size is N=5; the gate must re-measure on real source
+
+§16.F's tiktoken measurement uses 5 ULIDs and 5 compact IDs. The measurement is rigorous (deterministic tokenizer, real strings), but N=5 is a sample of synthetic strings, not a project-wide projection.
+
+The "~20–25% project-wide" headline depends on:
+
+- Per-ID savings ≈ 10 tokens (measured, N=5)
+- Per-project occurrence count of IDs ≈ projected based on declarations + close tags + cross-edit refs
+
+v4 §16.F explicitly says: *"The §10 gate experiment will produce real measurements on real source, replacing these synthetic estimates with project-actual numbers."* That's the right answer. But §1's headline currently says "Verified savings: ~10 cl100k tokens per ID occurrence, ~44% reduction per ID, ~20–25% project-wide on production-ULID projection."
+
+**"Verified" applies to per-ID. "Projected" applies to project-wide.** The current sentence conflates them. **Recommendation:** rewrite §1's third bullet to *"Verified per-ID savings: ~10 tokens (§16.F). Projected project-wide reduction: ~20–25% on production-ULID projection (gate measurement will confirm or correct)."* Two-word tweak.
+
+This is a nit. Doesn't change the decision. But future readers of this RFC will see the "Verified" claim and assume both numbers are measured.
+
+---
+
+## 3. §13.6 names a hidden implementation cost that isn't budgeted
+
+§13.6:
+
+> *`IdRegistry` adds project-pre-pass invariant the compiler currently doesn't enforce. Today `IdGenerator` can be called without a full project scan. Phase 2 changes this. Any code path that constructs an `IdGenerator` outside the standard pipeline (test harness, MCP `calor_compile` invocation, REPL) must be updated to ensure the pre-pass invariant holds. Hidden cost.*
+
+The cost is named. The cost is not estimated. §9.3 budgets ~9 days for Phase 2 but doesn't include "audit every `IdGenerator` construction site and add a pre-pass."
+
+A quick grep for `new IdGenerator` in the repo would give an estimate. If there are 3 sites, this is 1 day. If there are 15, it's 3 days. v4 doesn't say.
+
+**Recommendation:** add a row to §9.3 *"Audit non-pipeline `IdGenerator` callers: 0.5–2 days (grep first to size)."* Honest, names the variance, doesn't pretend to a number we don't have.
+
+---
+
+## 4. §5.7.2 effect-declaration rule is dead code
+
+The verifier predicate's equivalence rule for effect declarations:
+
+> *Effect declarations (`§E{cw,db}`) — Order-insensitive set comparison.*
+
+The Phase 1 migrator only edits sub-block IDs. It never touches `§E` declarations. The rule never fires. It's defensive code for a non-event.
+
+This is harmless. It's also slightly misleading — it suggests the migrator might reorder effects, which it won't. **Recommendation:** delete the row or annotate it *"Documented for future migrators; not exercised by Phase 1."* One-line decision.
+
+---
+
+## 5. §6.3.1 doesn't address incremental compilation (correctly out of scope; should say so)
+
+§6.3.1 specifies the registry is rebuilt per compile by `IdScanner`'s full project pre-pass. For a project with 10⁶ symbols, the pre-pass is non-trivial cost. v4 doesn't say anything about incremental compilation.
+
+This is correct because Calor doesn't currently have incremental compilation. But the pivot plan v6 mentions incremental compilation as a possible direction. If both ship, the `IdRegistry` rebuild becomes the hot path.
+
+**Recommendation:** add to §6.3.1 a one-line non-goal: *"Incremental compilation is out of scope. If incremental compilation is later added, the `IdRegistry` will need an incremental-rebuild story; that's a future RFC."* This pre-empts the next reviewer who asks.
+
+---
+
+## 6. §14 cost transfer wording
+
+§14 says the sub-block structural-matching cost transfers "from the Calor compiler (which can no longer key sub-block deltas on IDs) to the pivot-plan IR (which must now do structural matching)."
+
+The pivot plan v6 makes `Calor.SemanticDiff` part of Calor itself. So the cost isn't transferring inter-project — it's transferring intra-project, from "Phase 2 of this RFC" to "Phase N of the pivot plan." Same codebase, same engineer, different phase.
+
+**Recommendation:** rewrite the cost-transfer sentence to *"This cost is deferred from Path-2 to the pivot plan's `Calor.SemanticDiff` phase, where the implementation has to absorb structural matching at the sub-block level."* "Deferred" instead of "transferred"; "absorb" instead of "do." Substantively the same; less likely to be misread as inter-team handoff.
+
+---
+
+## What I'm NOT critiquing (settled in v4)
+
+For the record, every one of these is correctly settled and should not be re-litigated:
+
+- 12-char Crockford base32 + generate-until-unique math (verified, §16.D).
+- Lexer-anchored text-edit migrator architecture (single coherent strategy, §5.6).
+- AST-diff verifier predicate (defined, §5.7).
+- IdRegistry concurrency + persistence (§6.3.1).
+- Reverse migrator via `migration.log.json` (§6.3, §8.2.1).
+- Cache invalidation: **none** (§6.4 corrected).
+- Bundled release in 0.x+1 with 8-week calendar (§11).
+- Gate methodology: N≥10/task/arm, Wilcoxon/McNemar, Bonferroni, Cliff's δ ≥ 0.33 (§10).
+- Pre-registration as hard requirement (§10.2, §16.E).
+- Phase 1 post-ship monitoring (§10.6).
+- Retry policy (§10.5).
+- Diagnostic addressing as 0.x-patch ship-first (§8.3).
+- Principle narrowing called by name (§3).
+- Sub-block diff cost surfaced as pivot-plan action item (§14).
+- Lexer disambiguation (§5.4 + §5.6).
+- Token-count headline corrected to 20–25% based on real measurement (§16.F + §1).
+- v4 §13.3–13.4 institutional learning ("grep every architectural claim").
+
+These don't need re-litigation. Reviewers focused on them can save their effort.
+
+---
+
+## The meta-lesson v4 surfaces (worth preserving)
+
+v4 §13.3:
+
+> *Every architectural claim in any future Calor RFC must cite an actual file + line number, and `grep`-verified before merge.*
+
+This is the most valuable sentence in any document in this directory. The v3 cache fiction survived for two rounds of critique because both reviewers (designer voice and devil's advocate) attacked the math, the migration strategy, the deprecation timeline, and the principle scoping — but neither grep'd the source for the cache architecture. v4 grep'd it and discovered the truth was simpler and better than the spec claimed.
+
+**This discipline should be inscribed somewhere durable — `CLAUDE.md`, the contributing guide, or a stand-alone `docs/process/rfc-review-checklist.md`.** Otherwise the next RFC will repeat the same failure mode. v4 has the lesson; v4's successors won't necessarily inherit it.
+
+---
+
+## Recommendation
+
+**Approve v4 as the implementation spec. Begin work.** Apply six small inline corrections at PR-time (not as a v5 RFC):
+
+1. **§5.7.3 trivia rule:** pre-prototype before Phase 1 implementation; if parser lacks stable trivia anchors, fall back to source-level comment-position check.
+2. **§1 third bullet:** distinguish "verified per-ID" from "projected project-wide." Two-word tweak.
+3. **§9.3:** add row for non-pipeline `IdGenerator` audit (0.5–2 days, grep-to-size).
+4. **§5.7.2:** annotate the effect-declaration rule as documented-but-not-exercised, or delete.
+5. **§6.3.1:** add a one-line "incremental compilation is out of scope" non-goal.
+6. **§14:** rewrite cost-transfer language ("deferred to" rather than "transferred to").
+
+Plus one institutional action:
+
+7. **Codify the §13.3 rule** ("every architectural claim must be `grep`-verified against actual source") in a durable location — `CLAUDE.md` or a `docs/process/rfc-review-checklist.md`. Otherwise the next RFC's authors won't inherit v4's hard-won discipline.
+
+**Ship sequence (unchanged from §11):**
+
+- §8.3 diagnostic-addressing PR in 0.x patch (~1 day).
+- Phase 1 + Phase 2 implementation on branches; pre-register §10 protocol; pre-prototype §5.7 verifier; pre-prototype §5.7.3 trivia rule.
+- Run gate in week 4 of 0.x+1.
+- Ship Phase 1 + Phase 2 bundled if gate passes; Phase 1 alone if not.
+
+**On the v1 → v2 → v3 → v4 trajectory:** this is the strongest sequence of RFC revisions I've seen in this directory. Every iteration absorbed real critiques, fixed real bugs, and surfaced its own learning. v4 in particular demonstrates organizational humility by naming v2's collision bug and v2+v3's cache fiction as worked examples. Keep all four RFCs + all four critiques + the devil's advocate documents in tree. The trajectory is the case study.
+
+---
+
+## One-line summary
+
+v4 corrected the fictional Z3-cache architecture that survived v2 and v3 unchallenged by actually grepping the source, simultaneously corrected its own marketing headline from ~33% to ~20–25% based on tiktoken measurement, fully specified the AST-diff verifier predicate that v3 only asserted, raised Cliff's δ from small (0.2) to medium (0.33) for the one-way-door change, added 2 weeks of calendar buffer with explicit retry policy, gave Phase 1 retrospective monitoring matching Phase 2's prospective gate, and inscribed the lesson "every architectural claim must be `grep`-verified" — leaving only six calibration nits that apply inline at implementation time and one institutional action (codify the grep-verification rule somewhere durable); **approve, ship the 0.x patch PR, start the 0.x+1 branches, and stop iterating on the RFC**.
+
+---
+
+*Full path: `C:\Users\juanrivera\sources\repos\juanmicrosoft\calor-2\docs\plans\path-2-drop-ids-v4-critique.md`*

--- a/docs/plans/path-2-drop-ids-v4-devils-advocate.md
+++ b/docs/plans/path-2-drop-ids-v4-devils-advocate.md
@@ -1,0 +1,521 @@
+# Devil's Advocate Review: `path-2-drop-ids-v4.md`
+
+**Target:** `docs/plans/path-2-drop-ids-v4.md`
+**Voice:** External technical auditor.
+**Stance:** v4 is the work the prior critiques demanded. The point of this
+audit is to find the items still worth fixing, not to invent objections to a
+document that has substantially earned its trajectory.
+**Companion to:** `path-2-drop-ids-devils-advocate.md` (v1 audit),
+`path-2-drop-ids-v2-devils-advocate.md` (v2 audit),
+`path-2-drop-ids-v3-devils-advocate.md` (v3 audit), and the v1/v2/v3
+designer-voice critiques.
+**Date:** 2026-05-25
+
+---
+
+## TL;DR
+
+v4 closes both hard requirements from the v3 audit (Z3 cache fiction; AST-diff
+verifier predicate) and the six soft-recommended items as well. There is no
+load-bearing claim left in the document that warrants a v5. The verdict is
+**approve and ship**, with three calibration fixes that can land in the
+implementation PRs rather than the spec PR.
+
+The three fixes are: (1) **§5.7.3's trivia-reattachment predicate is
+architecturally vacuous** because the existing lexer drops comments and the
+existing AST does not carry trivia — `Parsing/Lexer.cs:531` literally reads
+`return NextToken(); // skip comment entirely, return next real token` — so the
+"comment-anchor verification" clause has nothing to verify. Either drop the
+clause or budget the trivia-preserving lexer/parser work it presupposes; (2)
+**§16.F's headline precision is unjustified at N=5** — the 95 % confidence
+interval on the per-occurrence savings is (5.0, 15.8) tokens, so the "~10
+tokens" / "~20–25 % project-wide" claim could plausibly halve under wider
+sampling; and (3) **§16.F contains a self-contradiction** — the sample ID
+`m_q9r8s7t6u5v4` includes the character `u`, which §6.1 explicitly excludes
+from the Crockford base32 alphabet. Beyond those, two minor calibration items
+on §10.6 (monitoring lacks a named statistical test) and §6.3.1 (concurrency
+machinery for a single-threaded problem). None of these are veto-worthy. The
+document is ready.
+
+---
+
+## §1. What v4 fixed — exhaustive scorecard
+
+The v3 audit listed two hard requirements (§2 cache fiction, §3 verifier
+predicate) and six soft recommendations. v4's §12 table claims all eight are
+addressed. Verification:
+
+**1.1 §6.4 cache rewrite (hard requirement #1 — verified).** v4 §6.4 now reads:
+"The Z3 proof cache is content-addressed on the contract expression and
+parameter list. Calor IDs do not appear in either, so the migration does not
+invalidate any cache entries." This is the exact two-sentence form the v3 audit
+recommended. The §10 table row about cache remapping is deleted. §13 #3 even
+turns the v3 cache fiction into a documented lesson for future RFCs ("every
+architectural claim must cite an actual file + line number, and `grep`-verified
+before merge"). Verified against `Verification/Z3/Cache/ContractHasher.cs`
+(SHA-256 over parameters + expression, no IDs) and `VerificationCache.cs:317`
+(`{prefix}/{hash}.json` content-addressed file layout). Resolution: complete.
+
+**1.2 §5.7 verifier predicate (hard requirement #2 — mostly fixed).** v4
+introduces §5.7 with: predicate signature (5.7.1), equivalence rules
+enumeration table (5.7.2), trivia-reattachment rules (5.7.3),
+ID-references-inside-strings (5.7.4), per-file/per-project failure semantics
+(5.7.5), and a test plan for the verifier itself (5.7.6). Most of this is
+correct and what the audit asked for. The trivia clause (5.7.3) has a
+substantive defect addressed in §2 of this audit.
+
+**1.3 Cliff's δ raised to 0.33 (devil's advocate §5 — verified).** §10.3 reads
+"Cliff's |δ| ≥ 0.33 (medium effect)" with rationale ("Three turns per task at
+the cost of a permanent principle narrowing is a thin trade. v4 requires medium
+effect (δ ≥ 0.33), i.e., the improvement must be substantively meaningful, not
+just statistically detectable.") This is exactly the framing the v3 audit
+asked for.
+
+**1.4 Gate moved to week 4 with contingency (devil's advocate §4 — verified).**
+§11 calendar is now 8 weeks: gate in week 4, weeks 5–6 contingency, weeks 7–8
+buffer. The retry-budget framing in §10.5 treats the gate as a measurement
+instrument that may need re-running. v3's week-6 placement is gone.
+
+**1.5 IdRegistry concurrency model (devil's advocate §6 — addressed, slightly
+over-engineered, see §5 below).** §6.3.1 specifies a `ConcurrentDictionary` +
+generate-until-unique loop with CAS retry, explicit population-timing rule
+(`IdScanner` full pre-pass before any `Generate()`), and explicit
+no-persistence claim (rebuilt per compile).
+
+**1.6 Phase 1 post-ship monitoring (devil's advocate §7 — addressed, but the
+statistical test is unspecified — see §4 below).** §10.6 introduces a 30-day
+post-ship re-run with Cliff's |δ| ≥ 0.2 revert threshold. The framing is
+correct; the test is unnamed.
+
+**1.7 Retry budget (devil's advocate §8 — verified).** §10.5 covers
+protocol-violation retries explicitly with $2,000–$4,000 reserve and re-
+pre-registration discipline for further retries.
+
+**1.8 Lexer disambiguation (devil's advocate §9 — verified).** §5.4 + §5.6
+step 2 specify the post-Phase-1 lexer with legacy `{id}` tolerance, single
+lexer for migration and production, two-stage `Calor0820W` → `Calor0820`
+diagnostic. The "which lexer" ambiguity is gone.
+
+**1.9 Reverse migrator (designer critique #1 — addressed).** §6.3 specifies
+`migration.log.json`, format quintuple, `calor fix --revert-compact-ids`
+command, `Calor0822` for the missing-log case. Reverse migrator is genuinely
+spec'd, not asserted.
+
+**1.10 IdRegistry population ordering (designer critique #2 — addressed).**
+§6.3 + §6.3.1: full project pre-pass before any `Generate()`. Migration
+single-threaded. Compile pipeline enforces the invariant.
+
+**1.11 Gate budget realism (designer critique #3 — addressed).** §9.4 has a
+per-model breakout showing $540 / $1,800 / $4,500 ranges. v3's "$450" is
+called out by name as the Haiku-best-case figure.
+
+**1.12 Token savings verified (designer critique #4 — mostly addressed; the
+statistical strength is overstated, see §3 below).** §16.F provides a real
+`tiktoken cl100k_base` measurement. The corrected headline is "~20–25 %
+project-wide" replacing v3's "~33 %". The mean per-occurrence savings (~10
+tokens) is correctly extracted from the per-sample table. The N=5 sample size
+and the precision implied by reporting "23.4" to two decimal places are
+overstated.
+
+**1.13 §14 pivot plan ownership (designer critique #5 — addressed).** §14 now
+explicitly states "weeks-to-months of implementation work for a robust
+algorithm" and forces the pivot plan to pick between specifying the algorithm
+or constraining `SemanticDiff` to symbol-level deltas. The dismissive "what
+real diff tools do" framing is gone.
+
+**1.14 `MaxAttempts = 100` (designer critique #6.1 — verified).** §6.3.1.
+
+**1.15 Already-migrated detection (designer critique #6.2 — verified).** §5.6
+step 1.
+
+**Net:** v3's two hard requirements are resolved or substantially advanced;
+all six soft recommendations are addressed; the six designer-critique items
+are addressed. This is the document's strongest position.
+
+---
+
+## §2. §5.7.3 trivia-reattachment predicate is architecturally vacuous
+
+This is the only substantive remaining defect in v4 and it is contained to one
+sub-clause.
+
+§5.7.3 specifies:
+
+> Comments and pragma-like markers may bind to AST nodes through anchor-based
+> parsing. The verifier checks:
+> - Every comment in the original source is present in the migrated source
+>   (text + position-relative-to-nearest-AST-node-anchor).
+> - The "nearest AST-node-anchor" computation must yield the same anchor for
+>   each comment before and after migration. […]
+> Implementation: trivia is collected during lex; each comment is paired with
+> its anchor node by the parser's existing trivia-attachment logic; the
+> verifier compares paired-anchor identity across the two ASTs.
+
+**The parser's "existing trivia-attachment logic" does not exist.** The lexer
+discards comments at the token boundary:
+
+```
+Parsing/Lexer.cs:523
+    private Token ScanSlashOrComment() {
+        …
+        // Line comment: skip to end of line
+        // Only \n terminates (not bare \r) to handle embedded \r in doc comments
+        …
+        return NextToken(); // skip comment entirely, return next real token
+    }
+```
+
+No comment tokens reach the parser. No `LeadingTrivia` / `TrailingTrivia`
+fields exist on AST nodes (grep across `src/Calor.Compiler/Parsing/`,
+`src/Calor.Compiler/Ast/` returns zero hits for `Trivia` on AST node types —
+the only `IsTrivia` is on `Token.cs:375` and covers whitespace + newline
+tokens, not comments). The AST as it exists today has no concept of which AST
+node a comment is "near." The predicate is checking a property the AST does
+not carry.
+
+**Consequences:**
+
+- **Best case:** the verifier silently passes 5.7.3 on every file because
+  there is nothing to compare. The clause is dead code in §5.7. The
+  *behavior* of the migrator is still correct because step 3 ("text-edit the
+  source") preserves all bytes outside the `{id…}` block — which means
+  comments are physically preserved in the source file. But the
+  *verification* the predicate claims to perform is fictional. This is the
+  same pattern of "asserted architectural property that doesn't exist in
+  source" the v3 audit caught with §6.4. v4 fixed the cache version and
+  introduced the trivia version.
+
+- **Worst case:** someone implementing §5.7.3 takes the spec at face value
+  and adds an `AstNode.LeadingTrivia` field, a trivia-attachment pass in the
+  parser, and the verifier logic — silently adding parser surface area and
+  AST size for a verification step that the text-edit migrator strategy
+  doesn't need. Phase 1 estimate (§9.2) of "2 days for the verifier" assumes
+  the verification is straightforward AST traversal. If the trivia clause is
+  taken seriously, the verifier work is significantly larger because the
+  parser must be modified first.
+
+- **Middle case:** the spec's "trivia is collected during lex" is read as
+  authorizing a lexer change. v4's §13 #5 acknowledges this exact concern in
+  passing: "The trivia-reattachment rules (5.7.3) assume the parser's
+  existing trivia-attachment logic produces stable anchors across migration.
+  This assumption needs prototype validation before Phase 1 ships." But
+  "needs prototype validation" is an understatement when the logic doesn't
+  exist at all.
+
+**The right fix is short.** The migrator's actual safety story for comments
+doesn't need trivia anchors — it needs only the byte-preservation property of
+text-edit step 3. Replace §5.7.3 with:
+
+> Comments are preserved by the migrator's text-edit step (§5.6 step 3), which
+> only removes byte ranges identified as `{id…}` blocks. Source bytes outside
+> those ranges, including all comments, are byte-equal between original and
+> migrated. The verifier asserts this byte-level property over the
+> non-migrated regions instead of comparing AST-level trivia anchors.
+
+That paragraph is implementable against the existing AST + lexer. The
+verification it asserts is exactly what the migrator provides. No parser
+changes required. The §5.7.6 test plan still applies (positive: round-trip
+unchanged; negative: deliberately corrupt a comment and verify the migrator
+catches it).
+
+**Recommendation:** Replace §5.7.3 with the byte-preservation form before
+Phase 1 implementation begins. Remove the "anchor-based parsing" framing
+entirely. The §13 #5 admission can then be deleted because the prototype
+validation it demanded is no longer needed.
+
+---
+
+## §3. §16.F is statistically thin and self-contradictory
+
+The §16.F appendix is a real improvement over v3's unmeasured "~16 tokens
+saved" claim. But it overstates the precision of what N=5 actually supports,
+and it contains a sample that violates its own alphabet rule.
+
+**3.1 The 95 % CI on the ULID mean is wider than the document admits.**
+Reproducing the §16.F measurement:
+
+```
+ULID tokens:   [16, 23, 26, 26, 26]
+Mean:          23.40
+Std (sample):  4.34
+SE:            1.94
+95 % CI on mean (t-dist, df=4, t=2.776):  (18.02, 28.78)
+```
+
+The CI is 10.8 tokens wide. v4 reports "mean = 23.4" with two decimal places
+of precision; the data supports roughly "mean ≈ 23 ± 5 tokens" at N=5. The
+derived "per-occurrence savings ~10 tokens" claim has the same uncertainty:
+the 95 % CI on the difference is (5.0, 15.8). Stated honestly, the
+measurement supports "the per-occurrence savings is somewhere between 5 and 16
+tokens." Stated as the proposal does, "~10 tokens" implies tight calibration.
+
+The §1 headline derived from this — "~20–25 % project-wide reduction" — could
+plausibly halve under wider sampling. If the true mean savings is closer to 5
+tokens than 10, the headline collapses to "~10–12 % project-wide." A
+principle-narrowing change for a 10 % token reduction is a different value
+proposition than for a 25 % token reduction.
+
+**3.2 The fix is small.** Either:
+
+- Re-measure with N=50+ sampled ULIDs (cheap — generate random ULIDs in a
+  script and tokenize them). The variance is real (16 to 26 tokens spans the
+  sample) so a larger N will narrow the CI to within ±1 token at the cost of
+  a few minutes of compute.
+- Or qualify the headline as "approximately 8–13 % per-occurrence savings,
+  10–25 % project-wide depending on ID occurrence density (preliminary
+  estimate, N=5; gate experiment provides project-actual numbers)."
+
+The proposal already commits in §10.7 / §13 #11 that the gate experiment
+re-measures on real source. The honest framing is to call §16.F a preliminary
+sighting shot, not a verified result. v4 currently splits the difference —
+§16.F is presented with confidence; §13 #11 walks it back. The two should
+agree.
+
+**3.3 §16.F contains a Crockford alphabet violation.** §6.1 specifies the
+Crockford base32 alphabet as `[0-9A-HJ-NP-TV-Z]` (excludes `I`, `L`, `O`,
+`U`). §16.F's sample `m_q9r8s7t6u5v4` contains `u5`. The character `u` is
+explicitly excluded. The document contradicts itself in one of the most
+visible appendices.
+
+Two possibilities:
+
+- The sample was hand-written for token-count purposes and the author didn't
+  check it against §6.1. Easy fix: replace the offending character (e.g.,
+  `m_q9r8s7t6v5w4`, which is valid) and re-run the tokenizer (likely 13
+  tokens still — the BPE merge is identical).
+- The §6.1 alphabet specification is wrong and `u` should be included. This
+  would be a real design error that propagates downstream, but unlikely
+  given v3 also excluded `u` and the Crockford spec on the web does too.
+
+Either way, the document needs to pick one and reconcile.
+
+**3.4 The compact-ID samples are visibly hand-chosen.** Looking at the five
+samples — `a1b2c3d4e5f6`, `q9r8s7t6u5v4`, `p3k7m2n9q5r1`, `t6v9w2x5y8z3`,
+`b4n7p2r5s8t1` — there is a clear pattern of alternating letters and digits.
+Real `generate-until-unique` output from a uniform RNG over Crockford base32
+will look more like `h7m3p9wnk2r5` — clusters of letters or digits are
+expected by chance. The BPE tokenizer's behavior on alternating
+letter-digit patterns can differ from its behavior on naturally-distributed
+samples. Re-measuring on RNG output (not hand-chosen exemplars) would close
+this objection at low cost.
+
+**Recommendation:** Re-run §16.F with N ≥ 50 RNG-generated compact IDs and N
+≥ 50 RNG-generated ULIDs; report mean + 95 % CI; fix the `u` violation; adjust
+§1's headline to either the wider range or the tighter post-re-measurement
+number. Land before merge of the spec PR (one hour of work).
+
+---
+
+## §4. §10.6 monitoring lacks a named statistical test
+
+§10.6 introduces post-ship Phase 1 monitoring:
+
+> Within 30 days of 0.x+1 ship:
+> - Re-run the agent-task corpus (24+ fixtures × 10 runs) against 0.x+1's
+>   Phase-1-only build.
+> - Compare turn-count median against the latest 0.x pre-release tag.
+> - **If Cliff's |δ| ≥ 0.2 regression** (small effect; we use a lower bar for
+>   revert detection than for ship), trigger a Phase 1 revert investigation.
+
+This is the right shape — post-ship retrospective with an explicit revert
+trigger — but it's missing the discipline of §10's Phase 2 protocol:
+
+- **No statistical test named.** §10.2 specifies Wilcoxon signed-rank /
+  McNemar for Phase 2. §10.6 says only "compare turn-count median"; no test,
+  no p-value, no α. A Cliff's δ point estimate without an accompanying
+  significance test is a single data point that could be a true regression or
+  could be noise from the 240-run sample (24 fixtures × 10 runs).
+- **The 240-run sample is much smaller than the Phase 2 gate's 900-run
+  sample.** A δ of 0.2 detected at N=240 is more likely to be noise than at
+  N=900. The detection threshold should account for the smaller sample.
+- **"Revert investigation" is undefined as an action.** Who investigates? On
+  what timeline? What evidence is sufficient to actually revert vs. accept
+  the regression as Phase 1 collateral damage? Compare to §10.3's
+  unambiguous "ship if all four are true; otherwise reject Phase 2."
+
+**The fix is one paragraph.** Add to §10.6:
+
+> Statistical test: Wilcoxon signed-rank on paired per-task turn-count
+> medians, α = 0.05. Revert trigger: Wilcoxon p < 0.05 AND Cliff's |δ| ≥ 0.2.
+> Sign-off authority: repo maintainer, within 14 days of the comparison. If
+> the trigger fires, Phase 1 is reverted in the next patch release; if it
+> does not fire, Phase 1 is accepted and no further monitoring is required.
+
+That mirrors the rigor of §10 at smaller scale. Without it, §10.6 is an
+intention rather than a protocol.
+
+**Recommendation:** Add the paragraph above to §10.6 before merge.
+
+---
+
+## §5. §6.3.1's concurrency machinery is over-engineered for the actual
+caller set
+
+§6.3.1 specifies a `ConcurrentDictionary<string, byte>`-backed `IdRegistry`
+with CAS-retry semantics for `TryReserve`. The implementation is correct, but
+the audit's question is: who is actually calling `IdGenerator.Generate()`
+concurrently?
+
+Enumerating the call sites:
+
+- **Normal compile** — `IdGenerator.Generate()` is **not called**. IDs are
+  read from source and registered by `IdScanner`. The "compile-time" path in
+  §6.3.1 conflates `IdScanner.Populate` (reads) with `IdGenerator.Generate`
+  (writes); only the former runs at compile.
+- **C# → Calor converter (Roslyn migration)** — `Generate()` is called when a
+  symbol is encountered. This runs in a single `calor convert` invocation,
+  process-local. Today's converter is single-threaded as far as ID generation
+  is concerned (the converter walks the syntax tree sequentially).
+- **LSP / IDE auto-ID-generation** — when a developer types a new declaration
+  in their editor, the LSP needs to assign an ID. The LSP is a single
+  process; ID generation is single-threaded within the LSP.
+- **`calor fix --compact-ids` migrator** — §6.3.1 explicitly says this is
+  single-threaded.
+- **Test harness `IdGenerator` direct invocation** — single-threaded by
+  construction (unit tests).
+
+There is no caller in v4's design that exercises the concurrent path. The
+`ConcurrentDictionary` adds an atomic-CAS allocation overhead on every
+`TryReserve` for safety against contention that does not occur.
+
+**This is not a defect — it is a minor smell.** The over-engineered version
+is correct; the simpler version (plain `Dictionary` + explicit
+single-threaded-usage doc) is also correct and cheaper. The audit raises it
+to point out that v4 added concurrency machinery in response to the v3
+audit's §6 concern, but the underlying caller set is single-threaded by
+construction. v3's concern was "what about parallel build?" — and the
+answer is that parallel build doesn't call `Generate()` concurrently because
+parallel build doesn't generate IDs.
+
+**Recommendation (low priority):** Either (a) leave the `ConcurrentDictionary`
+in place as defense-in-depth and document that all callers are
+single-threaded so the concurrency is unused-but-safe, or (b) downgrade to
+plain `Dictionary` with a documented single-threaded contract. (a) is the
+lower-friction choice and probably what v4 should pick. Either way, §6.3.1
+should explicitly say "no current caller is multi-threaded; the registry's
+concurrency is defense-in-depth."
+
+---
+
+## §6. The §11 calendar has no buffer for Phase 1 slipping
+
+v3 had no buffer for late gate failure; v4 fixed that. v4 still has no buffer
+for early Phase 1 slipping.
+
+§11 sequencing:
+
+- Weeks 1–3: Phase 1 implementation (3 weeks).
+- Weeks 3–4: Phase 2 implementation, overlapping Phase 1 (2 weeks).
+- Week 4: Gate experiment.
+- Weeks 5–6: Contingency / gate retry.
+- Weeks 7–8: Release prep / buffer.
+
+Phase 2 implementation depends on Phase 1's parser changes and AST
+nullability. If Phase 1 finishes late (week 4 instead of week 3), Phase 2
+cannot start in week 3 because the dependencies aren't there. The "weeks 3–4
+overlapping" framing assumes Phase 1's parser work completes by mid-week 3
+so Phase 2 can rebase on it.
+
+§9.2 estimates Phase 1 at "~14 days / ~2.8 weeks." That's a point estimate.
+Comparable Calor refactors have a track record of running over (v4 §9.5
+acknowledges this for the total project but not at the per-phase level).
+
+If Phase 1 slips by one week:
+
+- Phase 2 implementation compresses from 2 weeks to 1 week, or starts in
+  week 4 and runs into the gate-experiment week.
+- The gate-experiment week 4 either runs against an incomplete Phase 2 (bad
+  data) or slips to week 5, consuming the contingency buffer before any
+  gate work has happened.
+
+**The fix is small.** Add a week-2.5 dependency checkpoint: "Phase 1's
+parser-change PR must be merged to `phase-1` branch by end of week 2 to allow
+Phase 2 to start on schedule. If not, Phase 2 starts in week 3 with a
+one-week compression of the bundled timeline; the contingency buffer absorbs
+this if necessary." That makes the dependency explicit and pre-allocates the
+buffer cost.
+
+**Recommendation:** Add the checkpoint to §11. The whole calendar already
+absorbs ±1 week reasonably well — making the dependency explicit just makes
+the cost visible.
+
+---
+
+## §7. Smaller items worth one line each
+
+- **§9.4 task authoring (1.5 days for 5–10 tasks) is ~half realistic.** Each
+  agent task with prompt + acceptance criteria + pilot run takes ~0.5 day. 6
+  new tasks = ~3 engineering days, not 1.5. Net calendar impact: ~1 day
+  added to week 1, absorbed by weeks 7–8 buffer.
+
+- **§13 #6 admits the project-pre-pass invariant requires updating test
+  harness, MCP `calor_compile`, and REPL** but §9.3 doesn't budget for it.
+  Likely 0.5 day of unbudgeted work. Within noise.
+
+- **§16.A inventory ("Survives unchanged: Z3 proof cache")** is welcome
+  closure on the v2/v3 cache fiction. Worth keeping in v4 as the worked
+  example §13 #3 cites.
+
+- **`migration.log.json` and multi-repo / submodule projects.** v4 implicitly
+  assumes project root = `migration.log.json` location. Enterprise multi-repo
+  layouts may straddle this. Out of scope is the right answer for v4 but
+  worth flagging in §13.
+
+---
+
+## §8. What I am not saying
+
+This audit is shorter than the v1, v2, and v3 audits because v4 is materially
+closer to ready. Things the audit deliberately does not say:
+
+- v4's §6.4 cache rewrite is wrong. It is correct.
+- The verifier predicate is unspecified. The predicate is specified at the
+  level §5.7 demands; the only defect is the trivia sub-clause built on a
+  non-existent parser feature, which is fixable in one paragraph.
+- The gate threshold is too lax. δ ≥ 0.33 is the appropriate threshold for a
+  one-way-door change; v4 picked it correctly.
+- The calendar is unrealistic. Eight weeks with explicit contingency is the
+  right number for a refactor of this scope in this repository.
+- The IdRegistry concurrency model is incorrect. It is over-engineered for
+  the actual caller set, but correctness is fine.
+- The proposal should be rejected. v4 should ship after the three
+  calibration fixes in §2, §3, and §4.
+
+**Verdict, plainly: approve and ship.** Fix §5.7.3 to drop the trivia-anchor
+verification (or replace with byte-preservation form). Re-measure §16.F with
+N ≥ 50 and reconcile the `u` violation. Add a named statistical test to
+§10.6. Then merge.
+
+A v5 is not necessary. Three of the four reviewers across this RFC's
+trajectory (v3 designer-voice, v3 devil's advocate, this v4 devil's advocate)
+have now converged on "ship with small fixes." The fourth — the v3 designer-
+voice critique — asked for inline corrections that v4 addressed. The corpus
+of critique has done its job.
+
+---
+
+## §9. Coda
+
+The trajectory across v1 → v2 → v3 → v4 is the case study v4's §13 #3
+already cites: aspirational architectural claims survive multiple rounds of
+critique until someone runs `grep`. v3's cache fiction died at the source.
+v4's trivia-attachment claim dies at `Lexer.cs:531`. The right operating
+discipline going forward is the one v4 itself proposes: every architectural
+claim cites a file + line; every cited file is `grep`-verified before merge.
+
+If v4 wants a small final hardening, the §16.F appendix is the right next
+audit target. The token-savings number is the single most-cited figure in
+this RFC's external footprint; getting it from "N=5, hand-chosen, contains an
+invalid character" to "N=50, RNG-generated, validated against §6.1" is an
+hour of work and makes the proposal defensible to any auditor who asks.
+
+The authors did good work. Ship.
+
+---
+
+*End of v4 audit. Prior audits: `path-2-drop-ids-devils-advocate.md` (v1),
+`path-2-drop-ids-v2-devils-advocate.md` (v2),
+`path-2-drop-ids-v3-devils-advocate.md` (v3). Companion designer-voice
+critiques: `path-2-drop-ids-critique.md` (v1),
+`path-2-drop-ids-v2-critique.md` (v2),
+`path-2-drop-ids-v3-critique.md` (v3).*

--- a/docs/plans/path-2-drop-ids-v4.md
+++ b/docs/plans/path-2-drop-ids-v4.md
@@ -1,0 +1,865 @@
+# RFC v4: Compact Stable Identifiers — Drop Structural IDs, Compact Symbol IDs
+
+**Status:** Draft (v4 — supersedes [`path-2-drop-ids-v3.md`](./path-2-drop-ids-v3.md))
+**Author:** TBD (with Copilot CLI)
+**Created:** 2026-05-25
+**Supersedes:** v3 (2026-05-22), v2 (2026-05-22), v1 (2025-11-25)
+**Reviewed against:** [`path-2-drop-ids-v3-critique.md`](./path-2-drop-ids-v3-critique.md), [`path-2-drop-ids-v3-devils-advocate.md`](./path-2-drop-ids-v3-devils-advocate.md) — plus carry-over from earlier rounds
+**Target release:** Pre-1.0 single hard break (0.x → 0.x+1) — Phase 1 + Phase 2 bundled, conditional on the §10 gate experiment running on a branch with a week-of-buffer before the release cut.
+
+---
+
+## 0. Why v4 exists
+
+v3 was approved-with-fixes by both v3 reviewers — the designer-voice critique asked for 7 inline corrections; the devil's-advocate audit identified **2 hard requirements** (one factual, one spec) plus 6 calibration improvements. The hard requirements were too consequential to be patched at implementation time, so v4 incorporates them into the spec itself.
+
+| v3 reviewer finding | v4 response |
+|---|---|
+| **HARD (devil's advocate §2): §6.4's cache-invalidation story is fictional.** The Z3 cache is content-addressed via SHA-256 of `(parameters, contract expression)`; it contains **no symbol IDs, no obligation IDs**, and there are **zero `*.calr.cache` files** in the repo. v3 inherited the error from v2 and added fabricated detail on top. | **§6.4 rewritten** to match reality (verified against [`src/Calor.Compiler/Verification/Z3/Cache/`](../../src/Calor.Compiler/Verification/Z3/Cache/)). The cache is unaffected by ID format changes. No migrator code needed for cache; no remap walk; no `*.calr.cache` files. The §10 table row about cache remapping is **deleted**. |
+| **HARD (devil's advocate §3): AST-diff verifier predicate is undefined.** The migrator's entire safety argument depends on this predicate. v3 ships the safety story before defining the predicate. | **New §5.7 "AST-diff verifier specification"** enumerates ignored node kinds, trivia reattachment rules, ID references inside diagnostic text, collection-order semantics, and per-file vs per-project failure granularity. Defined before any migrator code. |
+| **HARD (devil's advocate §5): Cliff's δ ≥ 0.2 is the "small effect" mark — too weak for a one-way door change.** The principle narrowing is a one-way door; a small-effect ship bar is the wrong trade. | **§10.3 raised to Cliff's δ ≥ 0.33** (medium effect). Rationale documented inline. |
+| **HARD (devil's advocate §4): 6-week bundled calendar has no buffer for late gate failure.** | **§11 calendar rewritten**: gate moves from week 6 → week 4. Weeks 5–6 are reserved for buffer/contingency. Budget treats gate as a measurement instrument that may need re-running. |
+| **HARD (devil's advocate §6): `IdRegistry` thread-safety and persistence unaddressed.** | **New §6.3.1** covers concurrency model (lock-per-project with `ConcurrentDictionary`), persistence semantics (rebuilt per compile, no cross-session persistence), and the generate-until-unique loop's behavior under concurrent generation. |
+| **HARD (devil's advocate §7): Phase 1 ships unmeasured even by Phase 2's own evidentiary standard.** | **§10.6 new**: post-ship Phase 1 monitoring clause. Within 30 days of 0.x+1 ship, turn-counts on the agent-task corpus compared against the latest pre-release tag; Cliff's |δ| ≥ 0.2 regression triggers a Phase 1 revert. |
+| **HARD (devil's advocate §8): Pre-registration retry budget missing.** | **§10.5 new**: protocol-violation retry policy. One retry covered by $900 reserve; further retries require explicit re-pre-registration. |
+| **(devil's advocate §9): "the existing lexer" in §5.6 step 1 is ambiguous** between pre-Phase-1 and post-Phase-1 lexers. | **§5.6 step 1 disambiguated**: the migrator uses the post-Phase-1 lexer, which is required to accept legacy `{id:...}` attributes on sub-block constructs and discard them with a non-fatal warning. The lexer requirement is added to §5.4 (grammar / lexer change). |
+| **(designer critique §1): Reverse migrator asserted but not specified.** §10.3 says "symmetric" but the forward migrator is a one-way SHA-256-truncated hash. | **§6.3 amended**: forward migrator writes `migration.log.json` with `(compact_id, original_ulid, timestamp)` triples. `calor fix --revert-compact-ids` consumes the log. New repos without the log get a clear error pointing at git-history-based revert. |
+| **(designer critique §2): `IdRegistry` population ordering under-specified.** | **§6.3 amended**: `IdScanner` runs a full project pre-pass before any `IdGenerator.Generate()` call. Migration is single-threaded. |
+| **(designer critique §3): Gate budget understates real cost ($450 is optimistic).** | **§9.4 honest range**: $500–$3,000 depending on model selection and per-task turn distribution. Budget the high end. Explicit per-model breakout. |
+| **(designer critique §4): Token savings claim still unverified.** | **§16.F new**: tiktoken `cl100k_base` measurements on 5 real ULIDs and 5 real compact IDs. **Verified result**: ULIDs are 16–26 tokens (not "~28"), compacts are 13 tokens, savings ~10 tokens per occurrence (not "~16"). **§1 headline corrected from "~33%" to "~20–25%" project-wide reduction on production-ULID projection.** |
+| **(designer critique §5): §14 dismisses sub-block diff cost as "what real diff tools do".** | **§14 last paragraph rewritten** to surface that structural matching at the sub-block level is a weeks-to-months implementation cost for the pivot plan. Explicit action item: pivot plan must either spec the algorithm or constrain `SemanticDiff` to symbol-level deltas only. |
+| **(designer critique §6.1): `MaxAttempts` in `IdGenerator` retry loop unspecified.** | **§6.3 amended**: `MaxAttempts = 100`. Justified: at the 12-char base32 collision rate, 100 retries is >60 orders of magnitude of safety. |
+| **(designer critique §6.2): Already-migrated detection in Phase 1 migrator unspecified.** | **§5.6 amended**: migrator tries new parser first; if it succeeds, file is already migrated, skip. Tries legacy parser only on new-parser failure. |
+
+v4 also acknowledges what both v3 reviewers explicitly approved and should not change: symbol/structural split, 12-char base32 + generate-until-unique math, lexer-anchored text-edit migrator strategy, principle narrowing being called by name, pre-registered measurement, bundled release sequencing, and the diagnostic-addressing first-PR.
+
+---
+
+## 1. Summary
+
+**One release. Two changes. One gate. One standalone-first improvement.**
+
+**Standalone — Diagnostic addressing (definite, ship first).**
+~1 day PR. Diagnostic format becomes `Calor0501: division by zero in Calculator.Divide (f_01J5X7…) at file:42`. The ID stays in parentheses for tools; the qualified name is in front for humans/agents. No grammar change, no migration. **Ships in the 0.x patch release before Phase 1.**
+
+**Phase 1 — Drop structural IDs (definite).**
+Remove the ID block from sub-block constructs only. Symbol IDs are unchanged. **Engineering justification, not token justification** — Phase 1 saves only a few percent on production code where structural IDs are already short (`if1`, `for1`), and 0% on programs without sub-blocks. It ships because the parser path simplifies, the migrator is mechanical, and the structural ID was never load-bearing. Effort: ~2 weeks. **Post-ship monitoring (§10.6) measures Phase 1's effect.**
+
+**Phase 2 — Compact symbol IDs (gated).**
+Replace 28-character ULIDs with **12-character Crockford base32** IDs (`m_a1b2c3d4e5f6`). Symbol-level identity model is preserved end-to-end. **Verified savings (§16.F): ~10 cl100k tokens per ID occurrence, ~44% reduction per ID, ~20–25% project-wide on production-ULID projection.** (v3's "~33%" was extrapolated from an incorrect "~16 tokens/ID" figure.) Effort: ~1.5 weeks. **Ships only if** the agent-harness experiment in §10 demonstrates a measurable agent-success improvement at **Cliff's δ ≥ 0.33** (medium effect — the one-way-door threshold).
+
+**Release sequencing (§11): Phase 1 and Phase 2 ship together in 0.x+1, or Phase 1 alone if the gate fails. Gate runs in week 4 of an 8-week calendar with 2-week contingency buffer.**
+
+**Principle narrowing acknowledged (§3):** v4 (continuing v3) narrows design principle #3 from "Everything has an ID" (universal) to "Every symbol-level declaration has an ID" (scoped). Sub-block constructs are addressable by structural position but not by identity. This is a change. We own it.
+
+---
+
+## 2. Motivation
+
+### 2.1 Evidence accounting
+
+The v1 Phase 0 benchmark measured 5 small tasks in *test-form* Calor (`f001`, `m001`), not production ULIDs. v2's re-measurement projected production-form savings. **v4's measured tokenization (§16.F) corrects v3's per-occurrence estimate from "~16 tokens" to "~10 tokens" and the headline "~33%" project-wide reduction to "~20–25%."** This is still meaningful, but smaller than earlier RFCs claimed.
+
+Production *structural* IDs are short (`if1`, `for1`) — Phase 1 alone delivers ~5% on production form, concentrated on sub-block-heavy tasks. Phase 2 (the ULID compaction) is the larger token win.
+
+**v4's position:** Phase 1 ships for cleanliness with post-ship monitoring (§10.6); Phase 2 ships for verified tokens with pre-registered measurement (§10).
+
+### 2.2 The two populations are different
+
+| Population | Tracked by `IdScanner` | Used as identity-bearing reference | Used in round-trip | Production token cost per occurrence |
+|---|:---:|:---:|:---:|---|
+| **Symbol IDs** on 14 declaration kinds (Module / Function / Class / Interface / Property / Method / Constructor / Enum / EnumExtension / OperatorOverload / Indexer / RefinementType / ProofObligation / IndexedType) | yes | yes | yes (planned, not implemented) | **16–26 cl100k tokens** (verified, §16.F) |
+| **Structural IDs** on `§L`, `§IF`, `§WH`, `§DW`, `§TR`, `§FOREACH`, etc. | **no** | no | no | ~2–3 tokens (synthesizer uses short names like `if1`, `for1`) |
+
+Confirmed:
+- [`src/Calor.Compiler/Ids/IdScanner.cs`](../../src/Calor.Compiler/Ids/IdScanner.cs) — empty `Visit(ForStatementNode)`, `Visit(IfStatementNode)`, etc.
+- [`src/Calor.Compiler/Verification/Z3/Cache/ContractHasher.cs`](../../src/Calor.Compiler/Verification/Z3/Cache/ContractHasher.cs) and [`VerificationCache.cs:317`](../../src/Calor.Compiler/Verification/Z3/Cache/VerificationCache.cs#L317) — **cache is content-addressed via SHA-256, contains no IDs** (the v3 claim was wrong).
+- The obligation-tracking `ProofObligationNode.Id` exists for in-process tracking inside the binder but **is not used as a cache key**. The Phase 2 ID format change does not affect the cache regardless.
+
+### 2.3 What each population is worth
+
+**Symbol IDs deliver:**
+
+- Rename safety (canonical ID survives `Calculate → Compute`)
+- Round-trip identity (designed but not yet implemented — see §2.4)
+- IR substrate for diff / merge / coordination / memory (the pivot-plan requirement, **at the symbol level only** — see §14)
+- Unambiguous diagnostic addressing across edits
+
+**Symbol IDs do NOT deliver** (correcting v2/v3):
+
+- Z3 proof-cache stability. The cache is content-hashed on `(parameters, expression)`. Symbol IDs are irrelevant to cache hits/misses today.
+
+**Structural IDs deliver:**
+
+- Matched open/close enforcement in the parser
+- Error-recovery precision in parser diagnostics: when a closer doesn't match, the diagnostic can name which open it should have matched
+
+The first list (symbol IDs) is the project's competitive moat. The structural list is small but not zero — §13.2 owns the diagnostic-precision cost.
+
+### 2.4 Round-trip honesty (unchanged from v3 §2.4)
+
+Neither `[CalorId]` nor `[CalorSymbol]` exists in source today. The C# emitter today emits `[CalorAttribute]` (a different, generic attribute) for code-as-data preservation, not for ID round-trip. **Round-trip today is signature-based, not ID-based.** A future round-trip-stability implementation using IDs is a separate RFC.
+
+---
+
+## 3. Reframed thesis (and the principle narrowing called by name)
+
+Unchanged from v3:
+
+> **Design principle #3 narrows.** [`docs/philosophy/design-principles.md`](../philosophy/design-principles.md) §3 stated "Everything has an ID" as a universal property of Calor constructs. v4 narrows this to **"Every symbol-level declaration has an ID."** Sub-block constructs (loops, ifs, while, do-while, try, foreach, match, forall, exists, unsafe, fixed, sync, using) are addressable by structural position but not by identity. **This is a genuine narrowing of the original principle. We do not claim it is "preserved."** We claim it is correctly scoped to the population where it pays its weight, and the broader claim never had any cost-benefit justification in the first place (`IdScanner` already ignored sub-block IDs — they were never canonical).
+
+Required documentation updates:
+- [`docs/philosophy/design-principles.md`](../philosophy/design-principles.md) §3: replace universal statement with scoped statement.
+- [`docs/philosophy/stable-identifiers.md`](../philosophy/stable-identifiers.md): add a "What identity does *not* cover" section listing sub-block constructs as out of scope.
+
+Diagnostics may use qualified names + positional paths for *addressing* (a presentation concern); cross-edit references continue to use symbol IDs for *identity* (a correctness concern).
+
+---
+
+## 4. Goals & non-goals
+
+### Goals
+
+- **G1.** Reduce token cost of Calor source by a measurable amount with no semantic change and no identity-model degradation on production-ULID code.
+- **G2.** Phase 1: simplify parser code paths and remove a non-load-bearing construct.
+- **G3.** Phase 2: reduce production-form ID token cost by ~20–25% project-wide (verified per §16.F) **only if** the §10 gate measurement clears at the medium-effect threshold.
+- **G4.** Do not break the IR / diff / merge / coordination / memory substrate at the symbol level. Sub-block-level diff/merge costs surfaced in §14.
+- **G5.** Do not introduce positional fragility for identity-bearing uses (cross-edit refs). Positional addresses may appear in *presentation* uses (diagnostics) where staleness is already accepted.
+- **G6.** Single-release hard break. **Bundle Phase 1 + Phase 2 in 0.x+1** if the gate passes; ship Phase 1 alone if not.
+- **G7.** Phase 2 ID format must be collision-safe up to 10⁷ project-scoped IDs with margin. (Met: 12-char Crockford base32 + generate-until-unique.)
+- **G8.** **Post-ship monitoring for Phase 1** (§10.6) so that even un-gated changes have an evidentiary check.
+
+### Non-goals
+
+- **NG1.** No semantic / type-system / contract / effects / runtime changes.
+- **NG2.** No C# round-trip attribute design (separate future RFC).
+- **NG3.** No change to `IdScanner`, `IdValidator`, `IdGenerator` semantic API in Phase 1; Phase 2 changes `IdGenerator` output format + adds uniqueness enforcement + introduces `IdRegistry`.
+- **NG4.** No MCP tool surface changes beyond grammar/format consequences.
+- **NG5.** No sidecar files, no "IDs only on pub", no qualified-name-only addressing scheme.
+- **NG6.** No multi-agent ID coordination (single-process generation with retry-on-collision is sufficient at project scope).
+- **NG7.** **No claim that Z3 cache invalidation is part of this RFC.** The cache is content-addressed and unaffected.
+
+---
+
+## 5. Phase 1 — Drop structural IDs
+
+### 5.1 Scope (unchanged from v3 §5.1)
+
+| Tag | Today | Phase 1 |
+|---|---|---|
+| `§L` for-loop | `§L{for1:i:1:10:1}` … `§/L{for1}` | `§L{i:1:10:1}` … `§/L` |
+| `§FOREACH` | `§FOREACH{fe1:x:items}` … `§/FOREACH{fe1}` | `§FOREACH{x:items}` … `§/FOREACH` |
+| `§WH` while | `§WH{wh1} (cond)` … `§/WH{wh1}` | `§WH (cond)` … `§/WH` |
+| `§DW` do-while | `§DW{dw1}` … `§/DW{dw1} (cond)` | `§DW` … `§/DW (cond)` |
+| `§IF` (block) | `§IF{if1} (cond)` … `§/I{if1}` | `§IF (cond)` … `§/I` |
+| `§IF` (inline) | `§IF{if1} (cond) → expr §/I{if1}` | `§IF (cond) → expr §/I` |
+| `§TR` try | `§TR{try1}` … `§/TR{try1}` | `§TR` … `§/TR` |
+| `§UNSAFE` / `§FIXED` / `§SYNC` / `§USING` | `§X{id}` … `§/X{id}` | `§X` … `§/X` |
+| `§MATCH` | `§MATCH{m1}` … `§/MATCH{m1}` | `§MATCH` … `§/MATCH` |
+| `§FORALL` / `§EXISTS` | `§FORALL{fa1:x:t}` … `§/FORALL{fa1}` | `§FORALL{x:t}` … `§/FORALL` |
+| `§LIST` / `§DICT` / `§HSET` literal | `§LIST{name:type}` (name is a binding) | unchanged |
+| `§PP` preprocessor | `§PP{COND}` (COND is semantic) | unchanged |
+| `§CA` catch | `§CA{Type:var}` (no ID today) | unchanged |
+
+### 5.2 Symbol IDs unchanged in Phase 1
+
+Every symbol-level declaration retains its ULID in Phase 1. Format changes only in Phase 2, gated.
+
+### 5.3 Why Phase 1 ships (cleanup framing, unchanged from v3)
+
+Phase 1 is a cleanup. The token savings is small on real production code. We ship it because:
+
+1. Parser code paths simplify (~150 LOC deleted across 13 statement parsers).
+2. The structural ID was never load-bearing — `IdScanner` ignored it, the C# emitter ignored it, round-trip ignored it.
+3. The migrator is mechanical and low-risk (§5.6 + §5.7).
+4. The grammar becomes more readable for the agent.
+5. Token savings is incidental (~5% on production form), not the justification.
+
+**Phase 1 is monitored post-ship per §10.6** so that the "ship on engineering merit" position is backed by evidence within 30 days.
+
+### 5.4 Grammar and lexer change
+
+Grammar diff unchanged from v3 §5.4. **Lexer requirement added per devil's advocate §9:**
+
+> The post-Phase-1 lexer MUST accept legacy `{id:...}` attribute blocks on sub-block constructs (treating them as discardable trivia with a non-fatal `Calor0820W` warning at lex-time, escalating to a `Calor0820` error at parse-time). This lets the migrator drive its edit using a single lexer, eliminates a parallel "legacy lexer" maintenance burden, and ensures every read path is identical between migration tooling and the user-facing compiler.
+
+The two-stage diagnostic discipline (lexer warning → parser error) means: the migrator never sees the user-facing error (it runs lexer-only for its edit phase); end-users who skipped the migrator see the parser error with the recovery guidance from §8.1.
+
+### 5.5 Compiler changes (Phase 1)
+
+| File | Lines (today) | Lines changed | Nature of change |
+|---|---:|---:|---|
+| [`Parsing/Lexer.cs`](../../src/Calor.Compiler/Parsing/Lexer.cs) | ~1,400 | ~30 | Accept-and-mark legacy sub-block `{id}` attributes; emit `Calor0820W` warning token. |
+| [`Parsing/Parser.cs`](../../src/Calor.Compiler/Parsing/Parser.cs) | ~8,900 | ~150 | Sub-block parsers lose ID extraction + match enforcement. When the lexer-warning token is present, parser converts to `Calor0820` error with recovery text. |
+| [`Ast/`](../../src/Calor.Compiler/Ast/) sub-block nodes | n/a | ~80 | `Id` becomes nullable; constructor signatures lose unused `id` parameter; AST-printer falls back to `<anon>`. |
+| [`CodeGen/CSharpEmitter.cs`](../../src/Calor.Compiler/CodeGen/CSharpEmitter.cs) | ~4,600 | ~20 | Sub-block IDs were never emitted into generated C#. Minor cleanup. |
+| [`Migration/CalorEmitter.cs`](../../src/Calor.Compiler/Migration/CalorEmitter.cs) | ~2,800 | ~40 | Reverse emitter writes `§L{for1:i:1:10:1}` today → `§L{i:1:10:1}`. |
+| [`Migration/RoslynSyntaxVisitor.cs`](../../src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs) | ~6,500 | ~5 | Stop synthesizing sub-block IDs. |
+| [`Ids/IdScanner.cs`](../../src/Calor.Compiler/Ids/IdScanner.cs) | ~330 | 0 | No change. |
+| [`Diagnostics/Diagnostic.cs`](../../src/Calor.Compiler/Diagnostics/Diagnostic.cs) | — | ~15 | Add `Calor0820` (error) + `Calor0820W` (warning); full text in §8.1. |
+| `editors/vscode/syntaxes/calor.tmLanguage.json` | — | ~30 | TextMate grammar updated. |
+
+**Total new code: ~330 lines. Modified code: ~155 lines. Deleted code: ~50 lines.**
+
+### 5.6 Migrator (Phase 1) — strategy + workflow
+
+**Strategy: lexer-anchored text-edit with post-edit AST-diff verification.** (Verifier predicate fully specified in §5.7.)
+
+1. **Pre-flight: already-migrated detection.** Try parsing the source with the **post-Phase-1 parser** (strict mode — `Calor0820` becomes an error if it would have fired). If parsing succeeds and emits zero `Calor0820`/`Calor0820W`, the file is already migrated — skip with no edits and no log entry.
+2. **Tokenize using the post-Phase-1 lexer** (the same single lexer that the production compiler uses, with legacy-tolerance per §5.4). It correctly handles strings, comments, escapes, and `\r\n` line endings. It identifies every `§L{...}`, `§/L{...}`, `§IF{...}`, etc. opener/closer with its byte range and emits `Calor0820W` markers for the discardable parts.
+3. **Text-edit the source.** For each `Calor0820W` marker, surgically remove only the `{id...}` block characters using the byte ranges. **All other source bytes are preserved exactly** — comments, blank lines, whitespace, BOMs, line endings.
+4. **Verify post-edit using the §5.7 predicate.** Parse the edited source with the post-Phase-1 parser. Parse the original source with the post-Phase-1 parser in legacy-tolerant mode. Walk both ASTs and apply the §5.7 predicate. If verification fails, abort the write-back, restore the original, and record the file in the migrator's failure report.
+
+**Behavior guarantees:**
+
+- **Comment preservation:** complete (text edit, no AST re-emission).
+- **Formatting preservation:** complete.
+- **String/comment content safety:** complete (lexer handles them).
+- **`\r\n` safety:** complete (lexer is line-ending agnostic).
+- **Idempotence:** files without structural IDs pass through unchanged (already-migrated detection in step 1).
+- **Atomic correctness:** verification proves no semantic damage beyond the intended drop. If verification fails, *no file* is written for the entire project (per-project failure granularity — see §5.7.5).
+
+**CLI surface:**
+
+```
+calor fix --drop-structural-ids [--dry-run] [--verify-only] [--continue-on-failure] [path]
+```
+
+- `--dry-run`: shows diffs without writing.
+- `--verify-only`: runs verification against in-place source. Useful for CI.
+- `--continue-on-failure`: weakens to per-file failure granularity (skip-failing-files mode). Default is per-project (any failure aborts the whole run).
+- `path`: defaults to CWD recursively.
+
+### 5.7 AST-diff verifier specification (new in v4)
+
+**This section answers devil's advocate §3, the second hard requirement.** The verifier predicate is the migrator's safety guarantee; it must exist and be reviewed before any migrator code lands.
+
+#### 5.7.1 Predicate signature
+
+```
+verify(original_ast: AstNode, migrated_ast: AstNode) -> VerificationResult
+```
+
+`VerificationResult` is either `Ok` or `Failed(path, original_subtree, migrated_subtree, reason)` where `path` is the structural path through the AST to the first detected difference.
+
+#### 5.7.2 Equivalence rules — enumeration
+
+The predicate considers two AST trees **equivalent** if-and-only-if all of the following hold:
+
+| Aspect | Rule |
+|---|---|
+| **Node kind** | Every node kind must match exactly. Adding/removing a node fails verification. |
+| **Symbol IDs** | All symbol-level `Id` fields (Module, Function, Class, etc.) must match exactly. Migration MUST NOT modify symbol IDs. |
+| **Structural IDs** | Sub-block `Id` fields are **ignored** (target of migration). |
+| **Identifiers** (parameter names, binding names, type names, etc.) | Must match exactly. Migration MUST NOT rename anything. |
+| **Literal values** | Must match exactly (including string contents byte-for-byte). |
+| **Expression structure** | Must match exactly (operator, operand structure, precedence). |
+| **Statement order within a block** | Must match exactly (ordered comparison). |
+| **Trivia / whitespace / comments** | **Ignored at the AST level** but verified at the source level (see 5.7.3). |
+| **Attribute order** | Ordered for source attributes (`[Attr1] [Attr2]` ≠ `[Attr2] [Attr1]`). |
+| **Effect declarations** (`§E{cw,db}`) | Order-insensitive set comparison. |
+| **Diagnostic-suppression comments** | Treated as trivia. Source-level position validated (see 5.7.3). |
+
+#### 5.7.3 Trivia reattachment verification
+
+Comments and pragma-like markers may bind to AST nodes through anchor-based parsing. The verifier checks:
+
+- Every comment in the original source is present in the migrated source (text + position-relative-to-nearest-AST-node-anchor).
+- The "nearest AST-node-anchor" computation must yield the same anchor for each comment before and after migration. (If the anchor changed because the migration dropped the structural ID that the comment was attached to, this is a real bug — the comment now binds to a different containing construct.)
+
+Implementation: trivia is collected during lex; each comment is paired with its anchor node by the parser's existing trivia-attachment logic; the verifier compares paired-anchor identity across the two ASTs.
+
+#### 5.7.4 ID references inside diagnostic text and proof annotations
+
+Some `§Q`, `§S`, `§INV` forms accept message arguments that may contain string literals referencing structural IDs (e.g., `§Q{message="invariant violated at if1"} ...`). The migrator **MUST NOT** modify string literals. The verifier checks string-literal byte-equality regardless of whether the literal happens to contain text that looks like an ID.
+
+#### 5.7.5 Failure semantics
+
+- **Per-file failure detection.** Each file is verified independently. A failure records the file path, the structural-path through the AST to the first divergence, both subtrees serialized, and a human-readable reason.
+- **Per-project failure granularity (default).** If ANY file fails verification, NO files are written. The migrator emits a failure report listing every failed file. This prevents shipping a half-migrated codebase.
+- **`--continue-on-failure` override.** Operator can elect per-file granularity, in which case verified-successful files are written and failed files are skipped (and reported).
+- **No partial files.** A file is either fully written (verified) or fully untouched. The migrator uses atomic-rename (write to `.tmp.{pid}` then rename) for crash safety.
+
+#### 5.7.6 Test plan for the verifier itself
+
+The verifier is itself code that requires testing. Before the migrator is shipped:
+
+- **Positive cases:** unit tests where the migrator's edit is correct; verifier must return `Ok`.
+- **Negative cases:** synthetic mutations (rename a binding, swap two statements, change a literal value) that the verifier MUST catch.
+- **Pathological cases:** files with comments densely attached to sub-block IDs; files with `§Q{message="..."}` containing strings that look like IDs; files with `\r\n` line endings interleaved.
+- **Coverage requirement:** every clause in §5.7.2 must have at least one positive and one negative test.
+
+This test plan is part of the Phase 1 implementation deliverable, not a separate document.
+
+### 5.8 Phase 1 deprecation strategy (unchanged from v3 §5.7)
+
+Hard break, single release. Pre-1.0 envelope per [`CLAUDE.md`](../../CLAUDE.md). 0.x: legacy form accepted (current). 0.x+1: legacy form rejected with `Calor0820`; migrator ships in the same release. No dual-mode parser. No multi-release window.
+
+---
+
+## 6. Phase 2 — Compact symbol IDs (gated)
+
+### 6.1 What changes — corrected collision math (unchanged from v3, math re-verified)
+
+**Format: 12-character Crockford base32**, `[0-9A-HJ-NP-TV-Z]` (excludes `I`, `L`, `O`, `U` for disambiguation). All-lowercase in source; matched case-insensitively in tooling.
+
+| Element | Today (28 chars after prefix) | Phase 2 (12 chars after prefix) | Verified token savings (§16.F) |
+|---|---|---|---|
+| Function | `f_01J5X7K9M2NPQRSTABWXYZ12` (16–26 tok) | `f_a1b2c3d4e5f6` (13 tok) | **~10 tokens per occurrence** |
+| Module | `m_…` | `m_…` | ~10 |
+| Class | `c_…` | `c_…` | ~10 |
+
+**Collision math (re-verified by §16.D Python script, unchanged from v3):**
+
+| IDs (n) | 9-char base36 (v2's BUG) | 12-char base32 (v3/v4 fix) |
+|---|---|---|
+| 10⁵ | ≈ 5×10⁻⁵ | ≈ 4×10⁻⁹ |
+| 10⁶ | ≈ 0.49% ❌ | ≈ 4×10⁻⁷ ✅ |
+| 10⁷ | ≈ 39% ❌ | ≈ 4×10⁻⁵ ✅ |
+| 10⁸ | — | ≈ 4×10⁻³ ✅ |
+
+Plus `IdRegistry`-backed generate-until-unique. Defense-in-depth.
+
+**Sortability:** ULIDs are timestamp-sortable; compact form is not. Accepted loss (display-only effect; `IdGenerator.cs` sorts only for `calor ids list`).
+
+**Migration remap:** deterministic via `crockford32(sha256(ulid))[:12]`. The migrator detects collisions in the remap and resolves by `crockford32(sha256(ulid + ":1"))[:12]` for the second colliding ULID, `:2` for a third, etc. **Every remap is logged** to `migration.log.json` (see §6.3) for revert support.
+
+### 6.2 Why Phase 2 is gated (unchanged from v3 §6.2)
+
+Per v1 thesis critique, v1 devil's advocate §1 and §8: agent-UX impact must be measured before a one-way principle change ships. v4 honors this with the §10 protocol.
+
+### 6.3 Compiler changes (Phase 2)
+
+| File / new module | Change |
+|---|---|
+| [`Ids/IdGenerator.cs`](../../src/Calor.Compiler/Ids/IdGenerator.cs) | Replace `Generate()` body: `prefix + "_" + GenerateCrockford32(12)`. Add generate-until-unique loop with **`MaxAttempts = 100`**. Constructor takes `IdRegistry`. Throws `IdSpaceExhaustedException` if 100 retries fail (mathematically unreachable at any realistic scale; included for invariant correctness). |
+| **New: `Ids/IdRegistry.cs`** | Per-project `ConcurrentDictionary<string, ReservationToken>` of generated IDs. Detailed concurrency + persistence model in §6.3.1. |
+| [`Ids/IdValidator.cs`](../../src/Calor.Compiler/Ids/IdValidator.cs) | `UlidPatternRegex()` → `CompactPatternRegex()` (`[0-9a-hj-np-tv-z]{12}`, case-insensitive). `UlidLength` constant: 12. Test-ID regex unchanged. |
+| [`Ids/IdScanner.cs`](../../src/Calor.Compiler/Ids/IdScanner.cs) | Add `Populate(IdRegistry)` method. **Invariant: `Populate()` must complete a full project pass before any `IdGenerator.Generate()` call.** |
+| `Verification/` proof-obligation code | **NO CHANGE.** The cache is content-addressed; ID format is irrelevant. (v2/v3 mis-described this.) |
+| Migrator: `calor fix --compact-ids` | Single-threaded. Walks every `.calr`, every `[CalorAttribute]` reference, deterministically maps ULID → compact via `crockford32(sha256(ulid))[:12]`, resolves collisions per §6.1, **writes `migration.log.json`** with `{compact_id, original_ulid, file, line, column, timestamp}` quintuples. |
+| Reverse migrator: `calor fix --revert-compact-ids` | Reads `migration.log.json`. Walks every `.calr` + every `[CalorAttribute]` reference. Replaces compact IDs with original ULIDs. **If `migration.log.json` is missing**, fails with `Calor0822` error pointing the user at git-history-based revert. |
+| Diagnostic codes | Add `Calor0821` (text in §8.2). Add `Calor0822` (text in §8.2.1: "Reverse migration impossible without migration.log.json"). |
+
+#### 6.3.1 `IdRegistry` concurrency + persistence
+
+**Concurrency model: per-project lock-free with CAS retry on the generate-until-unique loop.**
+
+```csharp
+public sealed class IdRegistry {
+    private readonly ConcurrentDictionary<string, byte> _ids = new();
+
+    public bool TryReserve(string id) => _ids.TryAdd(id, 0);  // atomic
+    public bool Contains(string id) => _ids.ContainsKey(id);
+}
+
+// IdGenerator.Generate(prefix):
+for (int attempt = 0; attempt < MaxAttempts; attempt++) {
+    var candidate = prefix + "_" + GenerateCrockford32(12);
+    if (_registry.TryReserve(candidate)) return candidate;
+}
+throw new IdSpaceExhaustedException(prefix);
+```
+
+Two threads racing to allocate IDs both call `TryReserve`. At most one succeeds; the loser regenerates. At the 10⁶-scale collision rate (4×10⁻⁷), expected retries per allocation is < 1 in 2 million; the loop is bounded.
+
+**Population timing.**
+
+- **Compile-time:** `IdScanner` runs a full project pre-pass and calls `_registry.TryReserve(id)` for every seen ID. Only after the pre-pass completes does the binder begin and `IdGenerator.Generate()` calls become valid. This invariant is enforced by the compiler pipeline (the binder constructs its `IdGenerator` from a populated `IdRegistry`).
+- **Migration-time:** `calor fix --compact-ids` runs **single-threaded** (no parallel file processing) so collision-detection is deterministic. The registry is built from the deterministic remap output before any source files are rewritten. This is the single-threaded rule the v3 critique demanded; it also keeps `migration.log.json` write-order deterministic.
+
+**Persistence: NONE.** The registry is rebuilt per compile by `IdScanner`'s full project pre-pass. IDs are persisted in source (as part of declarations) and in `[CalorAttribute]` references in generated C#, not in any side-file. This means:
+
+- No on-disk manifest. No cross-session locking concerns. No two-compile-sessions-modifying-the-same-manifest scenario.
+- The registry is in-memory state of a single `calor` invocation.
+- Stability across compiles is provided by source itself: a declaration's ID is in the `.calr` file; the same `.calr` file produces the same registry on every compile.
+
+**Parallel `dotnet build`:** independent project compilations each have their own `IdRegistry`. Cross-project ID references resolve symbolically (by qualified name + ID at reference time), not via shared registry state.
+
+### 6.4 Cache and downstream — REWRITTEN (factual correction)
+
+**The Z3 proof cache is content-addressed on the contract expression and parameter list. Calor IDs do not appear in either, so the migration does not invalidate any cache entries.**
+
+That is the entire correct statement. v3's claim that the migrator walks `*.calr.cache` files remapping `(symbol_id, obligation_id, body_hash)` keys was fictional and inherited from v2. Verification:
+
+- [`Verification/Z3/Cache/ContractHasher.cs`](../../src/Calor.Compiler/Verification/Z3/Cache/ContractHasher.cs): `HashPrecondition` and `HashPostcondition` compute SHA-256 over `(parameters, expression)`. Neither includes any symbol or obligation ID.
+- [`Verification/Z3/Cache/VerificationCache.cs:317`](../../src/Calor.Compiler/Verification/Z3/Cache/VerificationCache.cs#L317) `GetCacheFilePath`: `Path.Combine(_cacheDirectory, prefix, hash + ".json")` — content-addressed file layout under `{ProjectDirectory}/.calor/verification-cache/` or `~/.calor/cache/z3/v1/`. **No `*.calr.cache` files exist anywhere in the repo.**
+- The first compile after Phase 2 migration will hit the cache for every contract whose expression text is unchanged (which is all of them — Phase 2 changes IDs, not expressions).
+
+**Migrator cache work: ZERO.** No walk, no remap, no invalidation. Removed from the Phase 2 migrator implementation list in §6.3.
+
+---
+
+## 7. Resolved questions (unchanged from v3 §7)
+
+1. `[CalorSymbol]` footprint — resolved by deletion (not proposed).
+2. Overload disambiguation — out of scope (IDs disambiguate at identity level).
+3. Constructor naming — out of scope.
+4. `stable-identifiers.md` — updated, not repealed.
+5. Migrator in-place vs parallel — in-place with `--dry-run`.
+6. Deprecation timeline — single release, hard break.
+
+---
+
+## 8. Diagnostics
+
+### 8.1 Phase 1 (additive)
+
+| Code | Description | Severity |
+|---|---|---|
+| `Calor0820W` | Sub-block construct has a legacy `{id:...}` attribute that is being discarded. (Lex-time warning, migrator-consumed.) | Warning |
+| `Calor0820` | Sub-block constructs no longer accept `{id:...}` — run `calor fix --drop-structural-ids`. (Parse-time error after Phase 1 ships, if user skipped the migrator.) | Error |
+
+**Full `Calor0820` diagnostic text:**
+
+```
+Calor0820 (Error) at file.calr:42
+  Sub-block constructs no longer accept an ID block.
+  Found:    §IF{if1} (cond)
+  Expected: §IF (cond)
+
+  Migrate this file (and any others in the project) by running:
+    calor fix --drop-structural-ids
+
+  If 'calor fix' itself reports parse errors before reaching this file,
+  fix those unrelated errors first using the previous Calor release
+  (or your version-controlled history), then re-run the migrator.
+```
+
+### 8.2 Phase 2 (additive)
+
+| Code | Description | Severity |
+|---|---|---|
+| `Calor0821` | Legacy ULID format detected — run `calor fix --compact-ids` | Error |
+| `Calor0822` | Reverse migration impossible: `migration.log.json` is missing | Error |
+
+**Full `Calor0821` diagnostic text:**
+
+```
+Calor0821 (Error) at file.calr:1
+  Legacy 26-character ULID format detected.
+  Found:    §M{m_01J5X7K9M2NPQRSTABWXYZ12:Hello}
+  Expected: §M{m_<12 chars Crockford base32>:Hello}
+
+  Migrate this file (and any others in the project) by running:
+    calor fix --compact-ids
+
+  The migrator updates IDs in source files and [CalorAttribute] references
+  in generated C#. The Z3 proof cache is content-addressed and is unaffected
+  by ID format changes — no re-verification is required.
+```
+
+#### 8.2.1 `Calor0822` full text
+
+```
+Calor0822 (Error) when running 'calor fix --revert-compact-ids'
+  The migration log 'migration.log.json' was not found.
+
+  Forward migration writes 'migration.log.json' alongside the project root.
+  Without it, the original ULIDs cannot be recovered deterministically.
+
+  Recovery options:
+    1. If you have committed the pre-migration state, revert via:
+         git revert <commit-that-ran-forward-migration>
+    2. If you have a backup of 'migration.log.json' from CI artifacts, copy
+       it to the project root and re-run 'calor fix --revert-compact-ids'.
+    3. Otherwise, the compact IDs become the canonical IDs going forward.
+       Generate fresh ULIDs (losing identity continuity) only as a last resort.
+```
+
+### 8.3 Standalone — Diagnostic addressing (definite, ships first)
+
+Promoted from v3 (which already promoted it from v2). **Ships in 0.x patch release before 0.x+1 dev starts.** ~1 day PR. Diagnostic format change only.
+
+```
+Today:    Calor0501: division by zero in f_01J5X7K9M2NPQRSTABWXYZ12 at file:42
+Phase 0:  Calor0501: division by zero in Calculator.Divide (f_01J5X7…) at file:42
+```
+
+**Truncation rule:**
+- For ULIDs (pre-Phase-2): show first 7 chars + `…`.
+- For compact IDs (post-Phase-2): show full ID (12 chars; no truncation needed at that length).
+
+This way the human-readable form is stable across the Phase 2 transition.
+
+---
+
+## 9. Effort & timeline
+
+### 9.1 Standalone — Diagnostic addressing
+
+| Task | Estimate |
+|---|---|
+| Update `Diagnostics/Diagnostic.cs` formatter helpers | 0.5 day |
+| Snapshot test updates (~20 fixtures) | 0.3 day |
+| Documentation | 0.2 day |
+| **Subtotal** | **~1 day** |
+
+### 9.2 Phase 1 (definite)
+
+| Task | Estimate |
+|---|---|
+| Lexer changes (accept-and-warn legacy `{id}` on sub-block constructs) | 1 day |
+| Parser changes (drop ID extraction + match enforcement) | 2 days |
+| AST nullability for sub-block nodes | 1 day |
+| CalorEmitter template changes | 1 day |
+| Migrator (`calor fix --drop-structural-ids`) | 2 days |
+| **AST-diff verifier (§5.7) — predicate + test suite** | **2 days** (new from v3) |
+| Snapshot test updates (~30 fixtures, mechanical) | 2 days |
+| Documentation: syntax-reference, CLAUDE.md, copilot-instructions, MCP resources, philosophy docs | 2 days |
+| Editor extension TextMate grammar | 0.5 day |
+| Sample migration | 0.5 day |
+| **Subtotal** | **~14 days / ~2.8 weeks** |
+
+### 9.3 Phase 2 (conditional, requires gate)
+
+| Task | Estimate |
+|---|---|
+| IdGenerator / IdValidator format swap | 1 day |
+| `IdRegistry` implementation + threading | 1 day |
+| Migrator (`calor fix --compact-ids` + `migration.log.json`) | 2 days |
+| Reverse migrator (`calor fix --revert-compact-ids`) | 1 day |
+| Snapshot test regeneration | 3 days |
+| Documentation & website updates | 1 day |
+| **Subtotal** | **~9 days / ~1.8 weeks** |
+
+### 9.4 Phase 2 gate experiment
+
+| Item | Estimate |
+|---|---|
+| Pre-register analysis plan in `docs/plans/phase-2-measurement-protocol.md` | 0.5 day |
+| Author 5–10 new realistic multi-edit tasks (top up 24 existing → ≥30) | 1.5 days |
+| Implement Phase 1+2 on branch behind feature flag (overlap with §9.2/§9.3) | 0 (overlap) |
+| Run the experiment (≥10 runs × ≥30 tasks × 3 arms = 900 runs minimum) | ~4–5 calendar days of agent compute |
+| Analyze results, write `phase-2-measurement-results.md`, ship/no-ship decision | 1 day |
+| **Subtotal** | **~3 days engineering + 4–5 days agent compute** |
+
+**Honest gate-experiment cost range (per designer critique §3 + devil's advocate §8):**
+
+| Model used | Per-turn cost | Avg turns/task | Total cost (900 runs) | Cost with 1 retry (1,800 runs) |
+|---|---|---|---|---|
+| Haiku 4.5 | ~$0.02 | 30 | ~$540 | ~$1,080 |
+| Sonnet 4.6 (no thinking) | ~$0.05 | 40 | ~$1,800 | ~$3,600 |
+| Sonnet 4.6 (thinking) / Opus 4.5 | ~$0.10 | 50 | ~$4,500 | ~$9,000 |
+
+**Budget the realistic case: $2,000–$4,000 with 1 retry covered.** v3's "$450" was the Haiku-best-case figure.
+
+### 9.5 Total release effort & calendar
+
+| Path | Engineering days | Calendar (with gate-retry buffer) |
+|---|---|---|
+| Standalone diagnostic addressing | ~1 day | ~1 week (ships first, 0.x patch) |
+| Phase 1 + Phase 2 + gate + buffer | ~26 days | **~8 weeks total** (see §11 for breakdown) |
+| Phase 1 only (gate fails) | ~16 days | ~5 weeks |
+
+v3 claimed 6 weeks. v4 budgets **8 weeks** to absorb the §11 buffer the devil's advocate §4 demanded. This is honest, not pessimistic — `implementation-summary-binder-class-members.md` style refactors in this repo have a track record of running over.
+
+---
+
+## 10. Phase 2 measurement gate — tightened
+
+Per v2/v3 critiques: pre-registered protocol, paired tests, multiple-comparison correction, **medium-effect (not small-effect) ship threshold**.
+
+### 10.1 Benchmark protocol
+
+- **Tasks:** **N ≥ 30** multi-edit tasks. 24 from existing `tests/E2E/agent-tasks/fixtures/` + ≥ 6 newly authored.
+- **Variants (3 arms):** today's Calor (ULID), Phase-1-only (ULID + no sub-block IDs), Phase 1+2 (compact ID + no sub-block IDs).
+- **Runs:** ≥ 10 per task per arm. Total ≥ 900 task runs.
+- **Metrics:** success rate (binary), turn count (integer), identity-preservation errors, edit-correctness errors, total output tokens.
+
+### 10.2 Statistical methodology — pre-registered
+
+**Pre-registration:** before any Phase 2 implementation code is written, `docs/plans/phase-2-measurement-protocol.md` must be committed with task list (fixture commit hashes), analysis pipeline (with seeds), thresholds, statistical tests. Once committed, no changes until the experiment concludes. Any necessary changes invalidate the run.
+
+**Statistical tests:**
+- **Continuous metrics:** paired Wilcoxon signed-rank on per-task medians.
+- **Binary metric:** McNemar's test.
+- **Significance threshold:** α = 0.05 per criterion, Bonferroni-corrected across 4 kill criteria → α' = 0.0125 per test.
+
+**Effect sizes:**
+- **Cliff's δ** for continuous, **odds ratio** for binary.
+
+### 10.3 Kill criteria for Phase 2 — RAISED to medium effect
+
+Phase 2 ships only if **all four** are true:
+
+1. **No success-rate regression:** Phase 1+2 success rate ≥ today, McNemar p > α'.
+2. **No identity-preservation regression:** Phase 1+2 identity-preservation errors ≤ today, Wilcoxon p > α'.
+3. **Material agent-UX improvement on at least one of:**
+   - Turn count median reduction ≥ 10% **AND** Wilcoxon p < α' **AND** **Cliff's |δ| ≥ 0.33** (medium effect), or
+   - Total output tokens median reduction ≥ 15% **AND** Wilcoxon p < α' **AND** **Cliff's |δ| ≥ 0.33** (medium effect).
+4. **Phase 2 is distinguishable from Phase 1 alone** on the (3) criterion, Wilcoxon p < α'.
+
+**Why δ ≥ 0.33 (not 0.2):** The principle narrowing is a one-way door. v3 picked δ ≥ 0.2 — the lower edge of "small effect" by Cohen/Cliff convention (negligible < 0.147, small < 0.33, medium < 0.474, large ≥ 0.474). A "small" effect on a 30-turn run is ~3 turns saved. **Three turns per task at the cost of a permanent principle narrowing is a thin trade.** v4 requires medium effect (δ ≥ 0.33), i.e., the improvement must be substantively meaningful, not just statistically detectable. If N=900 is too few to detect a medium effect when one is truly present, the right answer is to add more tasks, not to lower the bar.
+
+If any of (1)–(4) fails, Phase 2 is rejected and only Phase 1 + standalone diagnostic-addressing ship in 0.x+1.
+
+### 10.4 Revert pathway
+
+If Phase 2 ships and post-ship data shows regressions on (1) or (2), v4 commits to revert via `calor fix --revert-compact-ids` consuming `migration.log.json`. Symmetric, deterministic, tested in Phase 2's implementation.
+
+If users have no `migration.log.json` (e.g., new projects post-Phase-2 ship), `Calor0822` surfaces the git-history-based recovery path.
+
+### 10.5 Retry policy (new in v4)
+
+Pre-registered experiments fail in two ways:
+
+- **Gate criterion fails** — the proposal does not ship. This is the **intended** function of the gate, not a retry.
+- **Protocol violation detected mid-run** — task crash, LLM provider outage, seed-isolation bug, corpus changed during run. This triggers a **retry**.
+
+**Policy:**
+- **One retry covered by an additional gate-experiment budget reserve.** Cost: another $2,000–$4,000 (per §9.4 realistic range).
+- **Further retries require explicit re-pre-registration** in a new `phase-2-measurement-protocol-vN.md` document.
+- **Sign-off for retry:** the maintainer.
+
+The week-5 contingency block in §11 absorbs the calendar cost of one retry.
+
+### 10.6 Post-ship Phase 1 monitoring (new in v4)
+
+Per devil's advocate §7: Phase 1 ships unmeasured by Phase 2's own evidentiary standard. v4 closes this gap.
+
+**Within 30 days of 0.x+1 ship:**
+- Re-run the agent-task corpus (24+ fixtures × 10 runs) against 0.x+1's Phase-1-only build.
+- Compare turn-count median against the latest 0.x pre-release tag.
+- **If Cliff's |δ| ≥ 0.2 regression** (small effect; we use a lower bar for revert detection than for ship), trigger a Phase 1 revert investigation.
+
+**Cost:** ~$200–$800 depending on model selection. Absorbed in 0.x+2 prep work.
+
+This gives Phase 1 the same evidentiary discipline as Phase 2, applied retrospectively rather than prospectively. The asymmetry (prospective gate for Phase 2, retrospective monitoring for Phase 1) is justified because Phase 1 is reversible at lower cost than Phase 2 (no symbol ID format change to undo, no `migration.log.json` to read).
+
+### 10.7 What the gate doesn't measure
+
+- Long-term codebase rot at scale
+- Multi-agent coordination
+- Verifier performance under massive ID change rates
+
+Honest blind spots. Phase 2 commits to *not regressing* the first two metrics; long-term effects are accepted as unmeasured risk.
+
+---
+
+## 11. Release sequencing — bundled in 0.x+1, with buffer
+
+Per devil's advocate §4: v3's week-6 gate placement had no buffer for late gate failure. v4 moves the gate to week 4 and reserves weeks 5–6.
+
+**Sequence:**
+
+1. **0.x patch release (week 0).** Diagnostic addressing (§8.3). ~1 day work, ships in days.
+2. **0.x+1 development calendar (8 weeks):**
+   - **Weeks 1–3:** Phase 1 implementation on `phase-1` branch. Includes verifier (§5.7). Migrator validated against all `samples/` and `tests/`. **Pre-register §10 protocol document.**
+   - **Weeks 3–4 (overlapping):** Phase 2 implementation on `phase-2` branch (rebased on `phase-1`). Tests.
+   - **Week 4:** Merge `phase-1` + `phase-2` → `release/0.x+1`. **Gate experiment runs.** ~4–5 calendar days agent compute.
+   - **Week 5:** Contingency. Gate retry if protocol violation detected. Final analysis. Ship/no-ship decision.
+   - **Week 6:** Release prep (release notes, migrator-command messaging, sample migrations, CHANGELOG). **If gate passed:** finalize bundle. **If gate failed:** revert Phase 2 from `release/0.x+1`, re-validate Phase 1 alone, prep Phase-1-only release.
+   - **Weeks 7–8:** Buffer. Release cut.
+
+**If gate passes:** ship `release/0.x+1` as 0.x+1 (Phase 1 + Phase 2 + standalone diagnostic). User runs `calor fix --upgrade-from 0.x` (wrapper that runs both `--drop-structural-ids` and `--compact-ids`).
+
+**If gate fails:** ship Phase 1 alone as 0.x+1. User runs `calor fix --drop-structural-ids`. Phase 2 deferred or abandoned.
+
+**Why this beats v3's 6-week budget:**
+- 2 weeks of contingency for protocol violations / late gate failures
+- Realistic schedule (matches track record of comparable refactors)
+- Same UX outcome (one migration for users)
+
+---
+
+## 12. What changed from v3
+
+| Topic | v3 | v4 |
+|---|---|---|
+| **§6.4 cache invalidation** | Fictional `(symbol_id, obligation_id, body_hash)` keys + `*.calr.cache` walk | **Truth: content-addressed cache. Migration does nothing to the cache. Two sentences.** |
+| **§5.7 AST-diff verifier predicate** | Asserted as safety net; predicate undefined | **Fully specified §5.7**: ignored nodes, trivia rules, ID-references-in-strings, failure granularity, test plan |
+| **§10.3 Cliff's δ threshold** | 0.2 (small effect) | **0.33 (medium effect)** — appropriate for one-way-door change |
+| **§11 calendar** | 6 weeks, gate in week 6, no buffer | **8 weeks, gate in week 4, weeks 5–6 contingency, weeks 7–8 buffer** |
+| **§6.3.1 IdRegistry concurrency** | Not addressed | **New §6.3.1**: per-project `ConcurrentDictionary`, generate-until-unique with CAS retry, no persistence (rebuilt per compile) |
+| **§10.6 Phase 1 monitoring** | None | **New §10.6**: 30-day post-ship turn-count check; revert trigger at Cliff's |δ| ≥ 0.2 |
+| **§10.5 retry policy** | None | **New §10.5**: 1 retry covered ($2k–$4k reserve); further retries require re-pre-registration |
+| **§5.6 lexer disambiguation** | "the existing lexer" — ambiguous | **The post-Phase-1 lexer with legacy tolerance**; lexer requirement added to §5.4 |
+| **§6.3 reverse migrator** | "Symmetric, shipped in same release" — but forward is one-way hash | **`migration.log.json` format specified. Reverse migrator consumes the log. `Calor0822` for missing-log case.** |
+| **§6.3 IdRegistry population order** | Mentioned in §13 as a residual concern | **Specified in §6.3**: full `IdScanner` pre-pass before any `Generate()` call. Migration single-threaded. |
+| **§9.4 gate budget** | $450 (single-point, Haiku-best-case) | **$500–$4,000 range (model-dependent)**; budget the realistic case |
+| **§16.F token verification** | Claimed "~16 tokens saved" without measurement | **New §16.F**: tiktoken measurement shows actual ~10 tokens saved; **headline corrected from "~33%" to "~20–25%"** |
+| **§14 sub-block diff cost** | Dismissed as "what real diff tools do" | **Rewritten**: structural matching is weeks-to-months of pivot-plan work; explicit action item |
+| **§6.3 MaxAttempts** | Unspecified in retry loop | **MaxAttempts = 100** (≥60 orders of magnitude safety) |
+| **§5.6 already-migrated detection** | Implied by idempotence claim | **Specified**: try new parser first; legacy only on failure |
+| **§5.5 line counts** | Lexer not in change list | **Lexer added** (~30 LOC for legacy-tolerance) |
+| **§9.2 Phase 1 effort** | ~12 days | **~14 days** (includes verifier spec + tests) |
+| **§9.5 total calendar** | ~6 weeks | **~8 weeks** (honest with contingency) |
+
+---
+
+## 13. Honest residual concerns
+
+This section exists because earlier RFCs were criticized for hiding weak points in "open questions." v4 inherits prior concerns and adds new ones.
+
+1. **Phase 1's structural-ID drop changes the "diagnostic with sub-block location" format.** Today: `Calor0501 at if1`. Phase 1: `Calor0501 at file:line (in Calculator.Divide)`. New form is more informative but breaks any external tool parsing the old form. No known external tools.
+
+2. **Error-recovery precision degrades in Phase 1.** Today's diagnostic `Calor0101: §/I{if1} expected, got §/I{if3}` becomes `Calor0101: §/I expected, got §/M`. Open-stack-based recovery delivers ~80% of the precision. The §5.7 verifier catches migration-time damage; live edits rarely produce malformed closers; §8.3 qualified-name format softens it. Small loss, acknowledged.
+
+3. **v3's cache fiction was itself a real defect.** This RFC trajectory v1 → v2 → v3 → v4 includes the v3 cache fiction as a worked example of how aspirational architectural claims survive multiple rounds of review until the actual source is grep'd. **Lesson:** every architectural claim in any future Calor RFC must cite an actual file + line number, and `grep`-verified before merge. The §6.4 rewrite + §16.A inventory enforce this discipline going forward.
+
+4. **9-char ID was v2's bug; cache fiction was v2+v3's bug.** Two consecutive major errors survived multiple critique rounds. v4 reviewers: **check the source for every architectural claim**, not just the math.
+
+5. **§5.7 verifier predicate is now spec'd but not prototyped.** The trivia-reattachment rules (5.7.3) assume the parser's existing trivia-attachment logic produces stable anchors across migration. This assumption needs prototype validation before Phase 1 ships.
+
+6. **`IdRegistry` adds project-pre-pass invariant the compiler currently doesn't enforce.** Today `IdGenerator` can be called without a full project scan. Phase 2 changes this. Any code path that constructs an `IdGenerator` outside the standard pipeline (test harness, MCP `calor_compile` invocation, REPL) must be updated to ensure the pre-pass invariant holds. Hidden cost.
+
+7. **`migration.log.json` is the project's revert capability for Phase 2.** It must be committed to source control. v4's `--compact-ids` command emits a clear instruction at the end of its run telling the user to commit the log. But projects that ignore this instruction lose revert capability. Documented in `Calor0822` text; further mitigation requires policy not RFC.
+
+8. **Phase 2's `--revert-compact-ids` path is itself a one-shot operation.** If a user runs forward, then runs reverse, then makes new ULID-format edits manually, then tries reverse again, the migration log is now stale and the second reverse fails. v4 accepts this as a degenerate operator workflow; users shouldn't manually round-trip ID formats.
+
+9. **No multi-agent coordination measurement exists today.** Phase 2's gate measures single-agent task performance. Multi-agent risks (two agents editing the same module with different IDs being generated) are not in the gate. Mitigated by: (a) `IdRegistry` collision detection, (b) project-scoped uniqueness, (c) standard merge-conflict resolution.
+
+10. **The sub-block structural-matching algorithm for `SemanticDiff` is not in v4's scope.** §14 surfaces this as a real pivot-plan implementation cost. v4 does not solve it.
+
+11. **The §16.F token-count measurement was on synthetic ULID/compact pairs.** Real per-occurrence savings depends on the project's tokenizer (most agents use cl100k or o200k variants). The numbers should be re-measured on actual project source as part of the §10 gate to confirm the projection.
+
+---
+
+## 14. Pivot plan reconciliation — what symbol vs structural means for diff/merge
+
+Per v2 critique §9 and v3 critique §5: the v2 claim "pivot-plan conflict resolved" is true at the symbol level but glosses a real cost at the sub-block level.
+
+**The pivot plan's `Calor.SemanticDiff` design** promises structured deltas over the IR keyed on stable IDs. v4 preserves this at the symbol level: an agent that rewrites a method body but keeps the method declaration produces a `SymbolDelta(method_id=f_a1b2c3d4e5f6, body_change={...})`. The method's identity survives.
+
+**At the sub-block level**, v4 trades identity for positional/AST-index addressing. An agent that rewrites an `if` block inside a function produces `SubBlockDelta(parent_id=f_a1b2c3d4e5f6, path="body[3].if", change={...})`. The "path" is fragile: if the agent also added a statement at `body[1]`, the same `if` is now at `body[4].if`.
+
+**Implementation cost the pivot plan must absorb (clarified per v3 designer critique §5):** Sub-block-level structural matching is **weeks-to-months of implementation work** for a robust algorithm — comparable to `git diff -M` move detection or AST-diff tools like `gumtree`. The precision/recall tradeoffs are non-trivial. v4 does not dismiss this as "what real diff tools do." It is a real cost that v4 transfers from the Calor compiler (which can no longer key sub-block deltas on IDs) to the pivot-plan IR (which must now do structural matching).
+
+**Pivot plan action item:** the pivot plan's next revision must either:
+1. **Specify the sub-block structural-matching algorithm** with implementation estimate (likely 4–8 weeks), or
+2. **Constrain `SemanticDiff` to symbol-level deltas only** and not promise sub-block delta identity. Sub-block changes appear as opaque diffs inside symbol-level deltas, not as structured sub-block deltas.
+
+Option (2) is the smaller commitment and likely the right answer for a v1 of `SemanticDiff`. The pivot plan owns this choice.
+
+---
+
+## 15. Recommendation
+
+**Standalone diagnostic addressing (§8.3): ship as small PR in 0.x patch release.** ~1 day. Near-zero risk.
+
+**Phase 1 + Phase 2 bundled in 0.x+1, conditional on §10 gate:** Implement both on branches; merge to `release/0.x+1`; run gate in week 4. Ship together if the gate passes (Cliff's δ ≥ 0.33 on turns OR tokens, no regressions on success rate or identity-preservation). Ship Phase 1 alone if not. Weeks 5–6 are reserved for contingency; weeks 7–8 for release prep + buffer.
+
+**Pre-register §10 protocol** before any Phase 2 implementation code lands.
+
+**Pre-prototype the §5.7 verifier predicate** with positive + negative test cases before Phase 1 migrator code lands.
+
+**Verify every architectural claim in this RFC against the actual source** before merge. Specific claims to audit: §6.4 cache (already verified), §6.3.1 IdRegistry (no IdRegistry exists today; pure forward design), §5.7 trivia reattachment (depends on parser's existing trivia logic; needs prototype).
+
+**Mark [`path-2-drop-ids-v3.md`](./path-2-drop-ids-v3.md) as superseded.** Keep v1, v2, v3, all four critiques, and v4 in tree. The trajectory is itself a case study and earns the document corpus.
+
+---
+
+## 16. Appendices
+
+### 16.A — What survives, what dies (updated from v3)
+
+**Survives:** `IdScanner` (14 symbol IdKinds), `IdValidator`, `IdGenerator` (format changes; generator stays + adds uniqueness check), `RefinementType.Id`, `IndexedType.Id`, cross-module symbol-ID resolution, the (narrowed) principle "Every symbol-level declaration has an ID," `docs/philosophy/stable-identifiers.md` (updated, not repealed).
+
+**Survives unchanged:** Z3 proof cache (content-addressed; no ID dependency to begin with; no migrator work). [Verified against [`Verification/Z3/Cache/`](../../src/Calor.Compiler/Verification/Z3/Cache/).]
+
+**Dies (Phase 1):** ID block on `§L`, `§FOREACH`, `§WH`, `§DW`, `§IF`, `§TR`, `§UNSAFE`, `§FIXED`, `§SYNC`, `§USING`, `§MATCH`, `§FORALL`, `§EXISTS`, and close tags. `if (endId != id)` enforcement paths. Synthesized sub-block IDs in `RoslynSyntaxVisitor`.
+
+**Dies (Phase 2, gated):** 26-char ULID format. Replaced by 12-char Crockford base32. The `IdRegistry` is new (didn't exist).
+
+**Out of scope:** `[CalorId]` / `[CalorSymbol]` attribute design; positional sub-block addressing as identity; MCP qualified-name lookups beyond §8.3; C# → Calor round-trip stability improvements; sidecar files; "IDs only on pub" rules; Z3 cache invalidation (because there is none).
+
+### 16.B — Side-by-side examples (with verified token counts)
+
+Same as v3 §16.B, with the headline corrected from "~33%" to **"~20–25% project-wide on production-ULID projection"** (per §16.F). Per-occurrence savings: ~10 tokens (not v3's "~16").
+
+### 16.C — Calor0820 / Calor0821 / Calor0822 diagnostic text
+
+Full text in §8.1, §8.2, §8.2.1.
+
+### 16.D — Collision math verification (unchanged from v3)
+
+```python
+import math
+def birthday(n, N): return 1 - math.exp(-(n**2) / (2*N))
+
+# 12-char Crockford base32 (v3/v4 choice):
+N = 32**12  # 1,152,921,504,606,846,976
+for n in [1e6, 1e7, 1e8]:
+    print(f"n=10^{int(math.log10(n))}: P = {birthday(n, N):.2e}")
+# n=10^6: P = 4.34e-07
+# n=10^7: P = 4.34e-05
+# n=10^8: P = 4.34e-03
+```
+
+Plus generate-until-unique in `IdGenerator` with `MaxAttempts = 100` provides defense-in-depth.
+
+### 16.E — Pre-registration template (for §10 protocol)
+
+The pre-registration document at `docs/plans/phase-2-measurement-protocol.md` must include:
+
+1. Task list with commit hashes of each fixture.
+2. New task authoring artifacts (prompts + acceptance criteria) committed before pilot runs.
+3. Implementation flag — exact branch + commit hash for each arm.
+4. Run protocol — agent harness invocation, model version (pinned), random seed.
+5. Data schema — fields recorded per run.
+6. Analysis pipeline — exact statistical functions, library versions, seed.
+7. Pass/fail thresholds (per §10.3, including **δ ≥ 0.33**) plus Bonferroni correction.
+8. Reporting commitment — `docs/plans/phase-2-measurement-results.md` written from analysis output regardless of pass/fail.
+9. Retry policy reference (§10.5).
+
+### 16.F — Token-count verification (NEW in v4)
+
+Verified with `tiktoken` (`cl100k_base` encoding) on 2026-05-25:
+
+```python
+import tiktoken
+enc = tiktoken.get_encoding('cl100k_base')
+
+ulids = [
+    'f_01J5X7K9M2NPQRSTABWXYZ12',
+    'm_01HZJK2N3P4Q5R6S7T8V9W0XY',
+    'c_01J9K4M2N5P7Q8R3S6T1V4W7X',
+    'i_01J8H7G6F5E4D3C2B1A0Z9Y8X',
+    'rt_01J2K3L4M5N6P7Q8R9S0T1V2W',
+]
+compacts = [
+    'f_a1b2c3d4e5f6', 'm_q9r8s7t6u5v4', 'c_p3k7m2n9q5r1',
+    'i_t6v9w2x5y8z3', 'rt_b4n7p2r5s8t1',
+]
+```
+
+| ID | Tokens |
+|---|---:|
+| `f_01J5X7K9M2NPQRSTABWXYZ12` | 16 |
+| `m_01HZJK2N3P4Q5R6S7T8V9W0XY` | 23 |
+| `c_01J9K4M2N5P7Q8R3S6T1V4W7X` | 26 |
+| `i_01J8H7G6F5E4D3C2B1A0Z9Y8X` | 26 |
+| `rt_01J2K3L4M5N6P7Q8R9S0T1V2W` | 26 |
+| **ULID mean** | **23.4** |
+| `f_a1b2c3d4e5f6` | 13 |
+| `m_q9r8s7t6u5v4` | 13 |
+| `c_p3k7m2n9q5r1` | 13 |
+| `i_t6v9w2x5y8z3` | 13 |
+| `rt_b4n7p2r5s8t1` | 13 |
+| **Compact mean** | **13.0** |
+
+**Per-occurrence savings: ~10 tokens.** Per-ID reduction: **44%** (10/23.4). Project-wide reduction depends on ID occurrence density (declarations + close tags + cross-edit refs). For typical Calor source: **~20–25%** project-wide. (v2 and v3 projected "~33%" from an incorrect "~28 tok/ULID" assumption; the correct figure is ~16–26 tok/ULID with mean ~23.)
+
+**Note:** cl100k tokenization of mixed-case + digit strings is not one-token-per-character. The BPE merges some digit/letter sequences. Real ULIDs encode to fewer tokens than naive length implies. Future RFCs should not extrapolate token counts from string length without measurement.
+
+The §10 gate experiment will produce real measurements on real source, replacing these synthetic estimates with project-actual numbers.
+
+---
+
+## 17. Decision
+
+To be made by repo maintainer.
+
+**Recommended action:**
+
+1. **Approve standalone diagnostic addressing (§8.3) for immediate ship in 0.x patch.** ~1 day.
+2. **Approve v4 Phase 1 + Phase 2 for bundled implementation in 0.x+1**, conditional on the §10 gate experiment running on the release branch in week 4 with Cliff's δ ≥ 0.33 threshold. If gate passes, ship both; if not, ship Phase 1 alone.
+3. **Approve §10 pre-registration as a hard requirement** before any Phase 2 implementation code merges.
+4. **Approve §5.7 verifier predicate as a hard requirement** before any Phase 1 migrator code merges.
+5. **Mark [`path-2-drop-ids-v3.md`](./path-2-drop-ids-v3.md) as superseded by this document.** Keep v1, v2, v3, v4 + all critiques in tree.
+
+---
+
+*v4 path: `docs/plans/path-2-drop-ids-v4.md`*
+*Status: ready for adversarial review. Reviewers: please attack the §5.7 verifier predicate enumeration, the §6.3.1 concurrency model, the §10.3 medium-effect threshold rationale, and the §11 8-week calendar. In particular: verify every architectural claim against actual source (§6.4 is the worked example of why this matters). If v4 survives, it ships; if it does not, v5.*

--- a/docs/plans/path-2-drop-ids-v5-implementation-critique.md
+++ b/docs/plans/path-2-drop-ids-v5-implementation-critique.md
@@ -1,0 +1,212 @@
+# Brutal Critique — Path 2 v5 Implementation Plan
+
+**Target:** `docs/plans/path-2-drop-ids-v5-implementation.md`
+**Voice:** the original designer of Calor, who has watched the trajectory v1 → v2 → v3 → v4 → v5 → this plan
+**Stance:** this document is the strongest deliverable in the path-2 corpus and the first one that's actually executable by a coding agent. The novel content (the 4-tier confidence harness) is genuinely good. **Approve, ship the prerequisite PRs in week 0, begin Phase 1.**
+**Date:** 2026-05-25
+
+---
+
+## The one-line judgment
+
+> v5-implementation does something none of the v1–v4 RFCs did: it operationalizes "how does an agent or engineer ship PRs without waiting four days for the statistical gate?" The 4-tier harness (Tier 1 per-PR <60s, Tier 2 per-phase <30min, Tier 3 statistical gate 4–5 days, Tier 4 post-ship 30-day) is the missing piece between "what to build" and "how to know each step is safe." The PR breakdown is concrete (15 PRs named with files, acceptance criteria, reviewer), the pre-registration content is drafted inline (§4), the rollback playbook covers every tier (§6), and the rfc-review-checklist that v4 demanded gets codified (§7). What remains is calibration: a handful of magic numbers without citations, one sequencing inconsistency, and the solo-project elephant in the room.
+
+---
+
+## What this document deserves real credit for
+
+This is the first execution-grade artifact in the path-2 series. Specific wins:
+
+- **The 4-tier confidence calculus (§3) is novel and right.** RFC v5 specifies the §10 statistical gate but stops at "human-run, 4–5 days." That's useless for per-PR confidence — 15 PRs × 5 days is a year of calendar. §3 introduces three lighter-weight tiers (Tier 1 per-PR <60s, Tier 2 per-phase <30min, Tier 4 post-ship 30-day) explicitly distinguished by what they prove and what they don't. The §3.5 "confidence calculus" table is the kind of operational discipline RFCs almost never deliver: "Tier 1 green means X. Tier 1 + Tier 2 green means Y. Tier 1 + Tier 2 + Tier 3 green means Z. Here's what you still can't claim." That table is reusable beyond this RFC.
+- **§3.7 "what if the harness has a bug?" is the kind of meta-honesty most plans skip.** The plan acknowledges the harness is code, code has bugs, and ships three mitigations: self-tests on synthetic positive/negative fixtures, a CI canary against a known-good commit, and a triage rule that prevents an agent from bypassing a red harness. Most plans treat the harness as infallible. This one doesn't.
+- **§7 codifies the rfc-review-checklist.** v4's critique called for the §13.3 "grep-verify every architectural claim" rule to be inscribed somewhere durable. v5-implementation does it — full draft content in §7, ships as PR-0a. The author rules and reviewer rules are concrete: "every sentence of the form 'the compiler does X' MUST EITHER cite a file:line OR be explicitly marked `[PROPOSED]`." That's not a vibe; that's a checklist item that fails review if violated.
+- **PR-2c's grep-verified call-site count is exemplary.** The PR description reads: *"`src/Calor.Compiler/Ids/IdAssigner.cs:175` and `:180` (the 2 production call sites grep-verified in v5)."* This is exactly the discipline §7 demands — not "0.5–2 days, grep to size" (the v4 critique's nit) but "0.5 day, here are the 2 sites, by file:line." This is what citation-grade RFC text looks like.
+- **PR-0c benchmark task rubric (§5.1) is the strongest defense against the failures the v2/v3 critiques flagged.** Five concrete properties: solvable-today (≥80% baseline success), multi-edit (≥3 files OR ≥5 locations), cross-reference touching (must stress ID identity), deterministic acceptance (no LLM-as-judge), expected turn count 10–30 (excludes too-easy and too-expensive tasks). Every one of these is a falsification-defense against gate-gameability.
+- **§4 is the actual pre-registration content, not a template.** PR-0b doesn't have to author the document; it has to *move* the content from §4 verbatim. That's a one-day PR with no design work, which is exactly what RFC §10.2 requires before Phase 2 implementation can begin.
+- **§6.3 "what the agent never does" is the right kind of guardrail.** Five concrete prohibitions ("bypass a red harness by editing the harness itself," "revert a post-ship release without maintainer sign-off," "mark a PR done without pasting Tier 1 output," "author Phase 2 code before the pre-reg doc merges," "edit the pre-reg document after it lands"). Each one is a specific failure mode that motivated reasoning under deadline pressure would otherwise enable. The list reads like it was written by someone who has seen those failures happen.
+- **§8.5 "what 'high confidence' means" is a 5-row table.** Action → required confidence → how achieved. This operationalizes a concept the v5 pivot-plan critique demanded ("pre-register what positive looks like") at the per-PR level. The agent does not invent new confidence levels and does not skip levels — explicit, enforceable, agent-friendly.
+- **PR dependency diagram in §2.4.** ASCII art that's actually readable. Identifies which PRs can run in parallel, which block which, where the week-2.5 checkpoint sits, and what happens on Phase 2 gate pass vs. fail. This is the kind of artifact that prevents calendar slippage at integration time.
+
+That's ~90% of the document. The remaining 10%:
+
+---
+
+## 1. "Companions" framing is misleading
+
+The top of the document lists three "Companions":
+
+> Companions:
+>   - `docs/process/rfc-review-checklist.md` (authored as PR-0a per §2; content drafted here in §7)
+>   - `docs/plans/phase-2-measurement-protocol.md` (authored as PR-0b; content drafted here in §4)
+>   - `tests/E2E/agent-tasks/templates/path-2-gate/` (6 new task templates per §5)
+
+These don't exist yet — they're *deliverables* of this plan, not pre-existing companion documents. A future reader (or auditor at v6) will check the file system, find them missing, and add a "[VERIFY]" comment against the v5-implementation plan that follows the §7 grep-verify rule.
+
+**Fix:** rename "Companions" → "Companion files (to be authored by PR-0a/b/c per §2)". Adds 6 words; removes the false impression that these files already exist.
+
+---
+
+## 2. Magic numbers in §3.2 lack citation
+
+§3.2's Tier 2 token-delta row:
+
+> Aggregate Δtokens across whole corpus is within expected range (Phase 1: ~9.67 × N_structural_IDs ± 20%; Phase 2: additional ~9.67 × N_symbol_IDs ± 20%) | Tier 2 red if outside range
+
+Two unsourced numbers:
+
+- **~9.67 tokens per ID.** v4 §16.F measured ~10 tokens per ID (mean savings 10, on N=5 sample). Where does 9.67 come from? Is v5 RFC's re-measurement on a larger sample? If so, §3.2 should cite (e.g., "per v5 §16.F revised measurement, N=20"). If not, the figure is a sourceless variant of v4's "~10" and violates the §7 rule (which this same document codifies).
+- **± 20% tolerance band.** Why 20% and not 10% or 50%? §16.F's measurement showed ULIDs varied 16–26 tokens (about a 30% range from mean). So per-file variance alone could push a single-file measurement outside ±20%. The corpus-aggregate measurement should average out, but the band isn't justified. **Fix:** mark ± 20% as provisional, calibrate against the first real corpus measurement on a known-green build.
+
+This is the §7 rule being violated by the document that *introduces* §7. Worth fixing before PR-0a lands.
+
+---
+
+## 3. PR-0e is "independent" but listed as a prerequisite
+
+§1.2's table includes PR-0e (§8.3 standalone diagnostic addressing) in the prerequisites. The text below says:
+
+> Phase 1 implementation PRs (PR-1*) cannot start until PR-0a through PR-0d are merged. PR-0e is independent and ships on a different release cadence.
+
+So PR-0e is *not* a prerequisite — it's listed in the prerequisite section. Minor inconsistency that will confuse a reviewer. **Fix:** split §1.2's table into "Hard prerequisites for Phase 1" (PR-0a..0d) and "Parallel ship in week 0" (PR-0e). One header change.
+
+---
+
+## 4. The solo-project elephant: agent and maintainer are the same person
+
+§6.2: *"Tier 2 red on a phase merge: Open an issue with the Tier 2 output; do not attempt to merge-around; wait for maintainer triage."*
+
+§3.3 Tier 3 ownership: *"Owner: repo maintainer."*
+
+§3.4 Tier 4: *"Owner: maintainer schedules the run; agent can be invoked to produce the analysis report."*
+
+In the personal-project-contract scenario (`docs/plans/personal-project-contract.md`), the agent and the maintainer are the same person. The plan doesn't acknowledge this and doesn't say what changes when the two hats are worn by one head.
+
+**Specific failure modes the plan doesn't address:**
+
+- **Tier 2 red triage = self-review.** Without an independent reviewer, "wait for maintainer triage" is "wait for yourself," which is motivated reasoning at its most familiar. The plan should require, in solo mode: "the maintainer hat requires writing the triage reasoning in a committed issue *before* resolving — not in-head." This is a small ritual that defends against motivated self-clearing.
+- **Tier 4 scheduling.** A coding agent does not have a persistent 30-day calendar. Without explicit scheduling (calendar entry, cron, repo-CI on a date trigger, or a personal-contract checkpoint), the day-30 monitoring run won't happen. The plan should specify *how* the maintainer schedules — even if it's "add to personal-project-contract.md's monthly checkpoint" or "set a GitHub Actions scheduled workflow."
+- **§10.5 retry sign-off.** Same person signs off on their own retry. In solo mode, the retry decision should require committing a written justification (or an external read, mirroring the personal-project-contract's "send to one trusted external reader") before triggering the second $2k–$4k run.
+
+**Fix:** add §8.6 (or a new §9) titled "Solo-mode adjustments" that names these three failure modes and prescribes the mitigation for each. Three paragraphs. Closes a real operational hole without forcing a non-existent reviewer into the diagram.
+
+---
+
+## 5. Tier 1's 60-second budget is asserted, not measured
+
+§3.1 sets the Tier 1 budget at <60s. §3.6 has a remediation plan if the budget is exceeded. Good defensive design — but the document locks in "all PRs must run Tier 1" *before* proving Tier 1 can hit 60s.
+
+The AST round-trip check on `tests/` is the obvious risk — Calor's test fixture corpus is large and parsing every fixture twice could blow the budget on the first measurement.
+
+**Fix:** make PR-0d's acceptance criteria include a *measured* wall-clock benchmark of Tier 1 on the existing corpus. If the harness exceeds 60s, the §3.6 remediation (split into default + extended) must execute in PR-0d, not at PR-1a discovery time.
+
+---
+
+## 6. Arm definitions in §4.3 are time-dependent
+
+§4.3:
+
+> Arm B (Phase 1 only):     release/0.x+1 @ <commit-sha-to-fill> (after PR-1h merges)
+> Arm C (Phase 1 + Phase 2): release/0.x+1 @ <commit-sha-to-fill> (after PR-2f merges)
+
+The arms are described as "after PR-X merges" — but the gate runs in week 4. If PR-1h or PR-2f land mid-week 4 (which the calendar implies they might), the arm SHA is recorded *during* the gate run, not before.
+
+For pre-registration honesty, the arm SHAs must be **fixed at gate-run start**. The pre-reg document should reference the commits at "moment of gate kickoff" rather than "after PR-X merges."
+
+**Fix:** §4.3 should say *"Arm B: `release/0.x+1` at the SHA of Phase 1 merge commit, recorded immediately before gate kickoff; Arm C: `release/0.x+1` at the SHA of Phase 2 merge commit, recorded immediately before gate kickoff."* Then `scripts/run-phase-2-gate.sh` records the SHA at start and freezes it.
+
+---
+
+## 7. The 4-5 day gate-run monitoring is under-specified
+
+§3.3 says the agent's role during the Tier 3 gate is:
+
+> Monitor: watch for protocol violations (agent harness crash, model API outage, fixture mutation); if detected, halt and trigger RFC §10.5 retry policy.
+
+A 4–5 day run requires *continuous* monitoring. Who's watching at hour 36? At hour 96? A coding agent in a single session won't span that calendar. The plan implicitly assumes someone (agent across multiple sessions? maintainer with a beeper?) is actively babysitting.
+
+**Fix:** specify the monitoring mechanism. Options:
+
+- **Polling via `ScheduleWakeup`** every 4 hours during the run window.
+- **Webhook-based** — `scripts/run-phase-2-gate.sh` posts to a Slack/Teams channel on protocol violation, and the maintainer subscribes.
+- **Pre-flight check** — the run only starts when monitoring is confirmed live (somebody is on call).
+
+For solo-project mode, this is a real coordination problem. Worth a paragraph in §3.3 or in the solo-mode addendum from item 4.
+
+---
+
+## 8. §3.5 confidence-calculus table is missing one row
+
+The §3.5 table has 4 rows covering Tier 1, Tier 1+2, Tier 1+2+3, and Tier 4 outcomes. But the most operationally common state during the project is **Tier 1+2 green, Tier 3 not yet run** — that's the state of `release/0.x+1` between Phase 2 merge and gate kickoff (probably 1–2 days).
+
+What can you claim in that state? You can claim Phase 1 is shippable as-is; you cannot ship Phase 2 yet. The table doesn't say this explicitly.
+
+**Fix:** add a row to §3.5:
+
+| Tier 1 + Tier 2 green, Tier 3 pending | "Phase 1 is shippable per its merge gate. Phase 2 code may be merged to the release branch but MUST NOT ship to users until Tier 3 passes." | Anything about Phase 2's agent-benefit. |
+
+One-row addition. Operationally important because it's the state at the moment of week-4 ship/no-ship anxiety.
+
+---
+
+## 9. T-5.7-a through T-5.7-e citation needs verification
+
+PR-1d's acceptance criteria says:
+
+> the 5 test cases in RFC §5.7.6 (T-5.7-a through T-5.7-e) all pass
+
+v4 §5.7.6 was a prose test plan, not enumerated as T-5.7-a..e. I haven't seen v5 RFC contents, but this is the kind of citation §7 demands be grep-verified. If v5 §5.7.6 *does* enumerate them, fine; if it doesn't, PR-1d is depending on test cases that haven't been named.
+
+**Fix:** verify that v5 RFC §5.7.6 explicitly enumerates T-5.7-a through T-5.7-e by name. If not, either update the citation to "the test cases enumerated in v5 §5.7.6" or open a small v5 RFC patch to add the enumeration. Five-minute check, prevents a PR-1d-time scramble.
+
+---
+
+## What the document does NOT need
+
+For the record, the following do not need to be added:
+
+- More PRs. 15 is enough.
+- A v6 of the RFC. v5-implementation is consistent with v5.
+- More tiers. Four is the right number.
+- Per-task gate variance estimates. The gate run will produce them.
+- Author commitments beyond what the personal-project-contract already covers.
+
+Most of these were asked for in the v1–v5 RFC iteration cycle and would be wrong here. v5-implementation correctly stops at execution and doesn't try to re-relitigate design.
+
+---
+
+## Recommendation
+
+**Approve v5-implementation as-is. Begin PR-0a..0e in week 0.** Apply the nine small calibration items inline at PR authoring time:
+
+1. Rename "Companions" → "Companion files (to be authored by PR-0a/b/c)" at top.
+2. Cite or remeasure the ~9.67 token/ID figure in §3.2.
+3. Mark the ±20% tolerance band as provisional; recalibrate from first real measurement.
+4. Split §1.2 into "Hard prerequisites" + "Parallel ship items" to clarify PR-0e status.
+5. Add §8.6 / new §9 "Solo-mode adjustments" covering: maintainer-hat self-review ritual, Tier 4 scheduling, Tier 3 retry sign-off.
+6. PR-0d acceptance criteria must include a measured wall-clock benchmark of Tier 1.
+7. §4.3 arm definitions: SHAs fixed at gate kickoff, not "after PR merges."
+8. §3.3 monitoring mechanism: pick polling, webhook, or pre-flight check; document it.
+9. §3.5 add row for Tier 1+2 green, Tier 3 pending state.
+10. Verify v5 RFC §5.7.6 enumerates T-5.7-a..e; patch v5 if not.
+
+(Yes, that's ten items, not nine. Item 9 is small; item 10 is a 5-minute verification.)
+
+**On the v1 → v2 → v3 → v4 → v5 → v5-implementation trajectory:** the RFC iterations were arguing about *what* to build. v5-implementation is the document that says *how to build it without lying to yourself about what you've proven*. The 4-tier harness is the missing piece. Ship the prerequisites in week 0, do the work, monitor at day 30, write the post-mortem.
+
+---
+
+## A note on the meta-trajectory
+
+This is the seventh document in the path-2 series after four RFC revisions and four critiques. The cumulative output is a worked example of how a coding agent and a (solo) maintainer can iterate from "wrong in structure" (v1) through "wrong in details" (v2, v3) through "approvable with patches" (v4) to "execution playbook" (v5-implementation). v4's §13.3 codified the lesson; v5-implementation §7 inscribed it in process; this critique applies it back to v5-implementation itself by grep-checking magic numbers and citations.
+
+If the path-2 work ships successfully, the trajectory is the case study. If it doesn't ship, the trajectory is still the case study — for how to recognize a failed bet before sinking implementation effort. Either way, keep all the documents in tree, link them from `docs/process/rfc-review-checklist.md` as worked examples, and don't repeat the v2 collision-math or v3 cache-fiction failure modes in the next RFC.
+
+---
+
+## One-line summary
+
+v5-implementation introduces a 4-tier confidence harness that solves the "how does an agent ship per-PR without waiting on a 4-day statistical gate" problem the RFC iterations never addressed, codifies the v4 grep-verify rule into `docs/process/rfc-review-checklist.md`, gives a 15-PR concrete breakdown with diagrams and acceptance criteria, drafts the Phase 2 pre-registration content inline, and operationalizes "high confidence" as a 5-row table — leaving only ten calibration nits (most of them under one line each) and one elephant-in-the-room (the agent and maintainer are the same person in solo mode); **approve, ship PR-0a/b/c/d/e in week 0, begin Phase 1 in week 1, do not write a v6 RFC**.
+
+---
+
+*Full path: `C:\Users\juanrivera\sources\repos\juanmicrosoft\calor-2\docs\plans\path-2-drop-ids-v5-implementation-critique.md`*

--- a/docs/plans/path-2-drop-ids-v5-implementation-devils-advocate.md
+++ b/docs/plans/path-2-drop-ids-v5-implementation-devils-advocate.md
@@ -1,0 +1,508 @@
+# Devil's Advocate Review: `path-2-drop-ids-v5-implementation.md`
+
+**Target:** `docs/plans/path-2-drop-ids-v5-implementation.md`
+**Voice:** Engineering-plan reviewer (an implementation plan demands different
+critique than an RFC — the discipline being audited here is execution, not
+architecture).
+**Stance:** The plan is well-shaped and earns most of its claims. The
+verdict is **revise once, then green-light**, with one blocking defect (the
+file is incomplete) and four concrete scope/methodology corrections.
+**Companion to:** the four prior RFC audits
+(`path-2-drop-ids-{devils-advocate,v2-devils-advocate,v3-devils-advocate,v4-devils-advocate}.md`),
+the four designer-voice RFC critiques, and the existing designer-voice
+critique of this implementation plan
+(`path-2-drop-ids-v5-implementation-critique.md`). This is the auditor-voice
+companion to that critique. **Important corroborating signal:** the existing
+designer-voice critique praises a "§8.5 'what high confidence means' 5-row
+table" as the operational core of the plan. **That section does not exist
+in the current file** — which means either (a) the file has been truncated
+since the designer-voice critique was written, or (b) the designer-voice
+critique was praising sections that were never delivered. Either way, the
+file as it stands is incomplete.
+**Date:** 2026-05-25
+
+---
+
+## TL;DR
+
+The shape is right. The 3-tier (4-tier) self-verification harness in §3 is
+the genuinely novel content and it solves a real problem (a coding agent
+shipping 15 PRs cannot block on a 4–5 day statistical gate per PR). The PR
+breakdown is concrete with file paths, acceptance criteria, and reviewers.
+The pre-registration content in §4 is drafted inline so PR-0b becomes a
+copy-paste. §6's rollback decision tree is operationally usable. The
+agent-action discipline in §6.2 and §6.3 makes the coding agent's role
+explicit in a way most implementation plans skip.
+
+That said, one blocking defect and four substantive corrections need to land
+before this plan can drive PRs:
+
+- **Blocking: the document is incomplete.** §7 truncates mid-sentence at
+  line 427 ("the verifier asserts Y, or the migrator…"); §8 — "Definition of
+  'high confidence' — per-PR, per-phase, per-release" — is promised in §1.1
+  but does not exist. The file claims to deliver §8 and does not. The
+  companion designer-voice critique cites a `§8.5` 5-row table as the
+  plan's operational core; that table is also absent. The plan's most-cited
+  innovation is *currently missing from the artifact*.
+- **PR-2c scope is narrower than the actual `IdGenerator.*` usage surface.**
+  The plan cites "2 production call sites" (verified at `IdAssigner.cs:175`
+  and `:180`) but `grep IdGenerator. src/Calor.Compiler/Ids` returns 5 more
+  callers across `IdChecker.cs` and `IdValidator.cs`, including 2 calls to
+  `ExtractUlid()` — a method whose name and behavior are ULID-format-specific
+  and will require rework for 12-char compact IDs. PR-2c's 0.5-day estimate
+  is sized for the `Generate()` callers only.
+- **§4.1's task paths are fictional.** The pre-registration document lists
+  the existing corpus as `tests/E2E/agent-tasks/fixtures/task-001/` through
+  `task-024/`. `fixtures/` does contain exactly 24 directories, but none
+  follow the `task-NNN` naming pattern (the actual names are descriptive:
+  `advanced-calor-project`, `async-project`, `basic-calor-project`,
+  `refactor-*`, etc.). A pre-registration document that lists wrong file
+  paths is not pre-registration; it's text.
+- **All new scripts are `.sh` on a cross-platform repo.** `scripts/`
+  currently contains `.sh`, `.ps1`, `.py`, and `.js` files for portability
+  reasons (the `test-enforcement.{sh,ps1}` dual-script pattern is the
+  in-repo precedent). PR-0d's `scripts/verify-phase1.sh` + nine other `.sh`
+  scripts break on Windows developer machines unless WSL/Git Bash is
+  mandated. The plan does not address this.
+- **Methodology gap in §5.1's task-selection rubric.** Requiring "baseline
+  agent achieves ≥80% success" introduces a ceiling effect at PR-0c that
+  caps the gate's signal range at week 4. The threshold should be tuned to
+  give the gate measurable headroom — closer to 50–70%, or the metric of
+  interest should shift to turn count rather than success rate.
+
+None of these are veto-worthy. The fix-list is one document-edit PR
+(complete §7, write §8, correct PR-2c scope, fix §4.1 paths, decide on
+cross-platform script policy, retune §5.1). The implementation can proceed
+once those land.
+
+---
+
+## §1. What the plan got right
+
+Worth itemizing because the plan invests in operational discipline that most
+implementation plans skip, and that effort deserves explicit credit. The
+existing designer-voice critique covers this ground at length; this section
+mirrors it more briefly to keep the auditor focus on the corrections.
+
+**1.1 The three-tier confidence model is the genuine innovation.** §3.1 (Tier
+1: <60s per-PR sanity), §3.2 (Tier 2: <30min per-phase corpus check), §3.3
+(Tier 3: the 4–5 day §10 statistical gate), and §3.4 (Tier 4: 30-day
+post-ship monitoring) decompose the "how confident am I that this PR is
+safe?" question into runtimes and owners that match the cadence of work.
+The §3.5 calculus table ("what each tier proves") is a clear-eyed framing
+that prevents tier-confusion failures (e.g., reading Tier 2 green as "the
+gate will pass," which the table explicitly forbids).
+
+**1.2 The PR breakdown is operationally concrete.** §2.1, §2.2, and §2.3
+give 15 PRs with file paths, one-sentence acceptance criteria, the
+verification tier each PR must clear, and a named reviewer. The dependency
+diagram in §2.4 makes the critical path explicit — PR-0a..d block Phase 1;
+the week-2.5 checkpoint on PR-1a gates Phase 2 start.
+
+**1.3 §6's rollback playbook is operationally usable.** Most RFCs gesture at
+"if the gate fails, we revert"; this plan writes the decision tree with
+specific commands (`calor fix --revert-compact-ids`) and explicit
+"investigate first vs. revert immediately" branching that matches the
+appropriate risk level for each tier. §6.2 mapping "what the agent does in
+each scenario" and §6.3 listing what the agent *never* does are the right
+discipline for a coding-agent-driven workflow.
+
+**1.4 Pre-registration is drafted inline so PR-0b becomes copy-paste.** §4
+covers all 9 items the RFC §16.E checklist demands, with the data schema in
+JSON, the analysis-pipeline library-version slots, the retry-policy
+cross-reference, and the explicit "reporting commitment regardless of
+pass/fail" clause. This is the largest source of friction in
+pre-registration protocols (authors put it off because it's tedious), and
+the plan pre-pays the cost.
+
+**1.5 The §5 task-authoring rubric is mostly well-shaped.** Six concrete
+properties (solvable today, multi-edit, cross-reference touching,
+deterministic acceptance, expected turn-count range, prompt-state
+separation) cover the failure modes that have bitten prior agent-eval
+corpora. The "no LLM-as-judge in acceptance" rule alone is worth shipping.
+(The "solvable today ≥80%" threshold has a methodology issue addressed in
+§5 below.)
+
+**1.6 §3.6 and §3.7 are defensive-engineering thinking.** "What if Tier 1
+is too slow?" and "What if the harness itself has a bug?" are the kinds of
+questions implementation plans usually skip because they're embarrassing to
+ask. Documenting the remediation order (profile → split → drop a check) and
+the harness-self-test discipline preempts the most likely week-2 panic
+("the harness is failing, do we ship anyway?").
+
+**1.7 §1.2's hard-prerequisite ordering matches the RFC.** PR-0a through
+PR-0d must merge before any Phase 1 implementation PR; PR-0e ships
+independently. The "pre-reg doc commits before any Phase 2 code lands"
+discipline matches RFC §10.2's "must be committed" rule rather than
+weakening it.
+
+---
+
+## §2. Blocking: the document is incomplete
+
+§1.1 promises §8 — "Definition of 'high confidence' — per-PR, per-phase,
+per-release" — as a deliverable produced by this plan. The file ends at
+line 427, in the middle of §7 (the `docs/process/rfc-review-checklist.md`
+draft content), on the sentence "Every sentence of the form 'the compiler
+does X', 'the verifier asserts Y', or 'the migrator". §8 does not exist.
+
+**The companion designer-voice critique already corroborates this is a
+regression.** That critique praises:
+
+> §8.5 "what 'high confidence' means" is a 5-row table. Action → required
+> confidence → how achieved. This operationalizes a concept the v5
+> pivot-plan critique demanded ("pre-register what positive looks like") at
+> the per-PR level.
+
+That paragraph is praising content the current file does not contain. Either
+the file was truncated after the designer-voice critique was written, or
+the designer-voice critique was reviewing a draft that was never committed.
+Either reading lands the same operational conclusion: **the plan as it
+exists on disk right now is missing the section the companion critique
+identifies as its operational core.**
+
+This matters operationally because §8 is the section that resolves the
+plan's central thesis. §3 introduces the tier model; §3.5 sketches what each
+tier *proves*; but §8 was meant to formalize "what does the agent get to
+*claim* after each tier passes?" The §3.5 table is the start of that work,
+not the end. Without §8:
+
+- The agent reading the plan does not know whether "Tier 1 green + Tier 2
+  green + Tier 3 green" lets it claim shipping authority, or whether human
+  sign-off is still required (the rollback playbook §6.2 implies the
+  latter for Tier 4, but §3.5 doesn't make that explicit for Tiers 1–3).
+- The phrase "high confidence" appears in the plan's own subtitle ("what
+  high confidence means operationally") and the deferred §8 was meant to
+  give it operational teeth. Currently the plan defines "high confidence"
+  three times in passing (§3.1, §3.2, §3.3) without integrating them.
+- The PR-0a checklist content in §7 is the *content* of `docs/process/rfc-
+  review-checklist.md`, and the cut-off is in the middle of an enumerated
+  list item that the author of PR-0a will need to know the rest of. The
+  PR-0a author will either have to invent the rest, ask the plan author, or
+  block on this clarification.
+
+**Recommendation:** Finish §7 (complete the truncated sentence and any
+remaining checklist items) and write §8. The companion designer-voice
+critique implies §8 used to exist and can probably be recovered from a
+prior draft or commit. Estimate: 1–2 hours of writing or 5 minutes of
+`git log -p` recovery. No revision of the plan's substance is required —
+both sections are straightforward extensions of what's already there, and
+the designer-voice critique's praise of §8.5 suggests the content was once
+in good shape.
+
+---
+
+## §3. PR-2c scope is narrower than the actual `IdGenerator` surface
+
+§2.3's PR-2c row reads:
+
+> **PR-2c** — `IdGenerator.Generate()` caller audit + migration (RFC §9.3) —
+> `src/Calor.Compiler/Ids/IdAssigner.cs:175` and `:180` (the 2 production
+> call sites grep-verified in v5) — Both sites switched to
+> `CompactIdGenerator`; legacy `IdGenerator.Generate()` kept for migrator's
+> reverse-path only; tests green — Tier 1 — 0.5 day estimate.
+
+The `Generate()` call-site count is correct — verified at `IdAssigner.cs:175`
+and `:180`. But `grep "IdGenerator\." src/Calor.Compiler/Ids` returns five
+additional callers:
+
+```
+IdChecker.cs:156      var expectedPrefix = IdGenerator.GetPrefix(entry.Kind);
+IdValidator.cs:56     var kind = IdGenerator.GetKindFromId(id);
+IdValidator.cs:64     var ulidPortion = IdGenerator.ExtractUlid(id);
+IdValidator.cs:163    var kind = IdGenerator.GetKindFromId(id);
+IdValidator.cs:167    var ulidPortion = IdGenerator.ExtractUlid(id);
+```
+
+`GetPrefix` and `GetKindFromId` are probably format-agnostic — they likely
+just inspect the prefix before the `_`. But `ExtractUlid` is named for, and
+presumably parses, the ULID portion of an ID specifically. After Phase 2's
+12-char Crockford compact format ships, `ExtractUlid` either needs to be
+renamed (`ExtractIdPortion`) and rewritten to accept both formats during the
+transition, or removed and replaced with a format-aware extraction.
+
+The two `IdValidator.cs:64` and `:167` calls are inside paths that almost
+certainly need behavior changes for Phase 2 — validators must accept the
+new format. PR-2c's 0.5-day estimate covers the two `Generate()` sites only
+and silently inherits "anything else that breaks tests" as PR-2c's
+responsibility without budget.
+
+**Recommendation:** Expand PR-2c's file list to `IdAssigner.cs`,
+`IdChecker.cs`, `IdValidator.cs`, and `IdGenerator.cs` itself. Revise the
+acceptance criteria to "all `IdGenerator.*` callers either switched to the
+compact path or explicitly documented as legacy-only with a comment
+referencing the migrator's reverse-path." Revise the estimate to 1.0–1.5
+days. Add to the PR description a sub-list of the 7 grep-verified call sites
+so the reviewer can confirm coverage.
+
+**Why this matters at the plan level:** the plan inherits the v5 RFC's
+factual claim ("2 production call sites grep-verified") and propagates it
+into a PR scope. The v5 RFC's claim is correct at the `Generate()`-call
+granularity but mis-scoped at the *PR* granularity because the PR has to
+ship a working compiler, which means every transitive caller of any
+`IdGenerator` method needs to work after Phase 2 lands. This is the
+implementation-plan analogue of the architectural-fiction pattern the
+v2→v3→v4→v5 audit chain has trained for: a precise-sounding claim that
+under-scopes the actual change surface. The companion designer-voice
+critique praises PR-2c's grep-verification as "exemplary" — it's a half-step
+in the right direction, but the grep was too narrow.
+
+---
+
+## §4. §4.1's pre-registration task paths are fictional
+
+The pre-registration document is the load-bearing artifact of the Phase 2
+gate. If it lists wrong file paths, the experiment is not pre-registered
+against the artifacts that get run.
+
+§4.1 reads:
+
+> Existing tasks (24):
+>   tests/E2E/agent-tasks/fixtures/task-001/  @ <commit-sha-to-fill>
+>   tests/E2E/agent-tasks/fixtures/task-002/  @ <commit-sha-to-fill>
+>   ... (24 entries) ...
+
+`tests/E2E/agent-tasks/fixtures/` does contain exactly 24 subdirectories.
+None of them are named `task-NNN`. The actual names are descriptive —
+`advanced-calor-project`, `async-project`, `basic-calor-project`,
+`refactor-*` variants, etc. A search for any directory matching
+`task-\d+` under `fixtures/` returns zero results.
+
+Two ways this could read:
+
+- **Charitable interpretation:** the `task-001`..`task-024` paths are
+  placeholders that the PR-0b author will replace with the real names at
+  authoring time. The plan does say at line 224 "with hashes and versions
+  filled in at PR-0b authoring time." If the same author is also expected
+  to substitute the real fixture names, the plan should say so.
+- **Less charitable:** the plan author hasn't looked at the fixture
+  directory. The 24-count is right (which suggests they did look), but the
+  naming pattern is invented. If the pre-reg doc is checked into PR-0b with
+  these names verbatim, the analysis pipeline (`scripts/analyze-gate-
+  results.py`, mentioned in §4.6) will look up `fixtures/task-001/` and
+  find nothing.
+
+**A second related concern:** the plan also implicitly references
+`tests/E2E/agent-tasks/tasks/` via the existing harness infrastructure, and
+introduces a new `templates/path-2-gate/` subdirectory for the 6 new tasks
+in §2.1 PR-0c. But `tests/E2E/agent-tasks/tasks/` already contains 258
+files (verified by directory enumeration). The plan nowhere explains how
+`tasks/` relates to `fixtures/` or to the new `templates/` subdirectory.
+Are tasks files (small) and fixtures directories (workspaces)? The plan
+never says. The gate experiment may run against `tasks/`, `fixtures/`, or
+`templates/path-2-gate/` — three different populations, none of which the
+plan disambiguates.
+
+**Recommendation:** Before PR-0b is filed, enumerate the actual 24 fixture
+directory names and substitute them into §4.1. Add a one-paragraph
+clarification to §4 distinguishing `fixtures/` (workspace fixtures, 24
+dirs), `tasks/` (task files, 258 files), and `templates/path-2-gate/` (new
+templates for this gate, 6 dirs). State explicitly which population the §10
+gate runs against.
+
+---
+
+## §5. Methodology: §5.1's "≥80% baseline success" creates a ceiling effect
+
+§5.1's task-authoring rubric requires:
+
+> Solvable today: A baseline agent (Arm A) must achieve ≥80% success across
+> 10 seeds. If a task is unsolvable today, it cannot distinguish Phase 1/2
+> from baseline.
+
+The motivation is correct: a task that's 0% solvable in all arms is signal-
+free. But the threshold is set too high to give the gate measurable
+headroom.
+
+Walking the math: if Arm A's mean success rate is 80% (the lower bound the
+rubric allows), Arm B and Arm C can show at most a 20-percentage-point
+improvement before hitting the 100% ceiling. With 6 tasks at 10 runs per
+arm = 60 binary observations per arm, the McNemar test's detection power
+for a difference of 20 percentage points is reasonable but a difference of
+5–10 percentage points (which is the realistic effect range for an
+ID-format change) becomes hard to detect.
+
+The asymmetric concern: if the true effect of Phase 2 is to improve success
+rate by ~3 percentage points (a real but small effect), the test will
+likely come back "no significant difference" and the maintainer reads that
+as "Phase 2 doesn't help." But the right interpretation might be "the
+corpus was ceilinged."
+
+The gate's RFC §10.3 kill-criterion (1) is "no success-rate regression,
+McNemar p > α'" — a non-inferiority test, not an improvement test. So the
+ceiling effect mostly hurts the *positive* case Phase 2 needs to make
+(criterion 3: turn count OR token reduction with δ ≥ 0.33). Those criteria
+use continuous metrics that don't have the same ceiling issue. Partial
+mitigation, not full.
+
+**Recommendation:** Lower the rubric to "baseline agent achieves 50–90%
+success across 10 seeds." Add explicit language: "tasks above 90% baseline
+should be made harder until they fall in range; tasks below 50% should be
+made easier or excluded." Tasks at the edges of the range provide the most
+distinguishing power for any non-trivial effect size.
+
+Alternative: keep the 80% threshold but explicitly designate the rubric as
+selecting for *turn-count-distinguishing* tasks rather than *success-rate-
+distinguishing* tasks, and note that success-rate non-inferiority is the
+relevant test under this corpus design.
+
+---
+
+## §6. Cross-platform: all proposed scripts are `.sh` on a multi-platform repo
+
+The existing `scripts/` directory contains:
+
+- `.sh`: `bump-version.sh`, `test-enforcement.sh`, `validate-skill-docs.sh`
+- `.ps1`: `compile-audit.ps1`, `test-enforcement.ps1`
+- `.py`: `compare-benchmarks.py`
+- `.js`: `generate-results-md.js`, `merge-llm-results.js`
+
+The pattern is clearly "write in the right language for the job, and where
+a script needs to run on both Linux CI and Windows developer machines,
+provide both `.sh` and `.ps1` versions" — see `test-enforcement.{sh,ps1}`.
+
+The implementation plan's PR-0d adds five new `.sh` scripts:
+`verify-phase1.sh`, `byte-preservation-check.sh`, `ast-roundtrip-check.sh`,
+`token-delta-spot.sh`, plus §3.2 introduces `verify-corpus.sh`,
+`migrator-corpus-dryrun.sh`, `token-delta-corpus.sh`,
+`migrator-revert-roundtrip.sh`; §3.4 adds `phase1-post-ship-monitor.sh`;
+§3.3 introduces `run-phase-2-gate.sh`; §5.3 introduces
+`validate-task-template.sh`. Ten new bash scripts total across §3 and §5.
+
+A Windows developer running `scripts/verify-phase1.sh` from PowerShell will
+either get "command not found" or accidentally invoke a non-bash shell that
+mis-parses the script. The repo currently supports Windows developers
+(based on existing `.ps1` versions of similar scripts and the user-facing
+CLI being a `dotnet` global tool). The plan's §3.1 "runs in <60s locally"
+acceptance criterion implicitly assumes the developer is on a Unix-like
+system.
+
+The mitigations the plan should pick from:
+
+- **Write in Python or Node.** Both are already in `scripts/` (`.py` and
+  `.js` exist); both are cross-platform; both can be invoked the same way
+  from CI and dev machines.
+- **Provide `.sh` and `.ps1` versions** following the existing
+  `test-enforcement.{sh,ps1}` pattern.
+- **Mandate WSL/Git Bash for Windows developers** as the official policy
+  and document it in `CONTRIBUTING.md`.
+
+Any of the three is fine. Silently adding 10 bash scripts to a
+cross-platform repo without choosing is the failure mode.
+
+**Recommendation:** Add a §2.1 row (or an §1.2 prerequisite row) that
+declares the language/platform choice for all new scripts before PR-0d is
+authored. Update PR-0d's acceptance criteria to require the chosen platform
+support.
+
+---
+
+## §7. Smaller items
+
+**7.1 Tier 1 / Tier 2 CI duplication with `test.yml`.** The existing
+`.github/workflows/test.yml` already runs `dotnet build` and `dotnet test
+-c Release`. The plan's PR-0d adds `.github/workflows/tier1.yml` whose §3.1
+table includes "Unit tests: `dotnet test --filter Category=Unit`." If
+`test.yml` runs all tests (no filter) and `tier1.yml` runs the unit subset
+plus harness checks, both workflows execute on every PR — unit tests run
+twice, doubling CI minutes. Either consolidate (extend `test.yml` with the
+harness checks) or define `tier1.yml` to run only the new harness checks
+(not `dotnet test`) and rely on `test.yml` for unit/integration tests. The
+plan doesn't pick.
+
+**7.2 §3.1 "paste full output into PR description" is performative, not
+operational.** The CI run that executes `scripts/verify-phase1.sh` is the
+canonical record. Requiring the agent to also paste output into the PR
+description duplicates the record, drifts when CI re-runs, and pads PR
+descriptions. The mechanism that actually enforces "Tier 1 green required"
+is the required-check status on the PR. Drop the paste requirement; keep
+the required-check rule.
+
+**7.3 PR-1d (byte-preservation verifier) may be redundant with PR-1c (the
+migrator itself).** v5 RFC §5.7.3 explicitly notes that byte-preservation
+is provided by the migrator's text-edit step (it removes only the byte
+ranges identified as `{id…}` blocks, leaving everything else untouched). If
+the migrator is correct by construction, a separate "byte-preservation
+verifier" is asserting a property the migrator already provides. PR-1d may
+collapse into "tests for PR-1c that assert the byte-preservation property,"
+which is one day of test-writing rather than a separate component. Worth
+re-examining before authoring PR-1d.
+
+**7.4 §4.4 model pinning doesn't have a fallback.** "Model version
+(pinned): e.g., `claude-sonnet-4.5` at the version available on
+`2026-MM-DD`" assumes the pinned model is available throughout the
+experiment. Models get deprecated mid-experiment. The plan should specify
+what happens if the pinned model is unavailable during the gate run —
+likely: defer the run until access is restored, or invoke §10.5 retry with
+the next available pinned model. One-line addition.
+
+**7.5 `docs/process/` directory does not exist today.** PR-0a creates
+`docs/process/rfc-review-checklist.md`; the parent directory will be
+created implicitly. Not a defect, but worth noting in PR-0a's acceptance
+criteria for the reviewer.
+
+**7.6 §1.1 says §7 produces "PR-0a draft" content for `docs/process/rfc-
+review-checklist.md`** but the truncated §7 starts the checklist mid-list.
+Once §7 is completed, the line in §1.1 ("§7 draft") will accurately
+describe the content. Currently §7 is more like "the first 30% of a draft."
+
+---
+
+## §8. What I am not saying
+
+- The tier model is wrong. It's the most novel and useful content in the
+  plan, and the existing designer-voice critique is right to praise it.
+- The PR breakdown is too granular. 15 PRs over 8 weeks is the right
+  granularity for a coding-agent-driven workflow.
+- The pre-registration discipline is unnecessary. It's correctly inherited
+  from RFC §10 and pre-paid in §4.
+- The rollback playbook is overkill. §6 is the right level of detail; most
+  RFCs skip this entirely.
+- The plan should be rejected. It should ship after the §2 truncation is
+  fixed and the §3, §4, §5, §6 corrections land. None require redesign.
+- The designer-voice critique is wrong. It correctly identifies the
+  strengths; it's reviewing a version of the file that included §8, and
+  praising the §8.5 table is a legitimate review of what was meant to be
+  delivered. This audit is what's left after the file ended up shorter than
+  intended.
+
+---
+
+## §9. Coda
+
+This is the first auditor-voice review of an implementation plan in the
+v1→v5 chain. The shape is good: PR breakdown + tier model + pre-reg content
++ rollback + agent-discipline rules. The defects are concentrated in (a)
+the document literally cutting off mid-§7 with §8 missing entirely, (b)
+two inherited factual errors from the v5 RFC that propagated into PR
+scopes, and (c) the cross-platform script choice that wasn't made.
+
+The most informative single signal in this audit is the divergence between
+the existing designer-voice critique (which praises §8.5) and the
+on-disk artifact (which has no §8 at all). The designer-voice critique
+landed before the truncation, or against a working draft that never got
+committed. Either way, the file as it stands is missing the section its
+companion critique identifies as the operational core of the plan. This
+should be the first thing checked: `git log -p` the implementation file and
+see whether §8 ever existed; if so, restore it; if not, write it from the
+designer-voice critique's description of what was meant to be there.
+
+The v1→v5 RFC arc earned a "ship" verdict; this implementation plan
+deserves a "complete the file, then ship" verdict. Estimated edit time:
+2–4 hours, or 5 minutes if §8 is recoverable from git history.
+
+One forward-looking observation: the §7 RFC-review-checklist content is
+itself a deliverable that the v5 chain has earned. Codifying the "every
+architectural claim cites a file + line and is grep-verified before merge"
+discipline as a repo-wide rule is the right institutional capture of the
+v2→v3→v4→v5 lesson. The unfinished checklist is a sentence short of
+delivering on that.
+
+---
+
+*End of v5 implementation plan devil's advocate review. Prior reviews:
+`path-2-drop-ids-{devils-advocate,critique}.md` (v1),
+`path-2-drop-ids-v2-{devils-advocate,critique}.md` (v2),
+`path-2-drop-ids-v3-{devils-advocate,critique}.md` (v3),
+`path-2-drop-ids-v4-{devils-advocate,critique}.md` (v4).
+Companion: `path-2-drop-ids-v5-implementation-critique.md` (designer-voice).*

--- a/docs/plans/path-2-drop-ids-v5-implementation.md
+++ b/docs/plans/path-2-drop-ids-v5-implementation.md
@@ -1,0 +1,561 @@
+# v5 Implementation Plan — Compact Stable Identifiers
+
+**Status:** Draft, awaiting maintainer sign-off
+**Implements:** [path-2-drop-ids-v5.md](path-2-drop-ids-v5.md)
+**Companions:**
+  - `docs/process/rfc-review-checklist.md` (authored as PR-0a per §2; content drafted here in §7)
+  - `docs/plans/phase-2-measurement-protocol.md` (authored as PR-0b; content drafted here in §4)
+  - `tests/E2E/agent-tasks/templates/path-2-gate/` (6 new task templates per §5)
+
+> **Reader's note.** v5 (the RFC) specifies *what* to build and the *human-grade* §10 statistical gate. This plan specifies *how* the work is sequenced, *what the coding agent must run per PR*, and *what "high confidence" means operationally*. The largest new content is §3 (the tiered self-verification harness) — the RFC assumes humans run the gate; this plan addresses how a coding agent can ship PRs without waiting 4–5 days for the gate per change.
+
+---
+
+## §1 — Scope and prerequisites
+
+### 1.1 What this plan delivers
+
+| Deliverable | Owner | Form | Where |
+|-------------|-------|------|-------|
+| PR-by-PR breakdown for Phase 0/1/2 | This plan | §2 | here |
+| Coding-agent self-verification harness (3 tiers) | This plan | §3 + scripts/ | here + `scripts/verify-*.sh` |
+| Phase 2 pre-registration document (the actual one, not the template) | PR-0b | §4 here = its content | `docs/plans/phase-2-measurement-protocol.md` |
+| 6 new benchmark task templates | PR-0c | §5 skeleton + rubric | `tests/E2E/agent-tasks/templates/path-2-gate/` |
+| Rollback playbook (operational decision tree) | This plan | §6 | here |
+| `docs/process/rfc-review-checklist.md` (per RFC §0.1) | PR-0a | §7 draft | `docs/process/rfc-review-checklist.md` |
+| Definition of "high confidence" — per-PR, per-phase, per-release | This plan | §8 | here |
+
+### 1.2 Hard prerequisites before Phase 1 implementation begins
+
+Per RFC §10.2: "before any Phase 2 implementation code is written, `docs/plans/phase-2-measurement-protocol.md` must be committed." v5 extends this with additional prerequisites:
+
+| Prerequisite | Why | PR |
+|--------------|-----|----|
+| `docs/process/rfc-review-checklist.md` committed | Codifies the §0.1 grep-verify rule before authors touch any RFC-adjacent work | PR-0a |
+| `docs/plans/phase-2-measurement-protocol.md` committed | RFC §10.2 hard prerequisite for Phase 2; lands early to give time for review | PR-0b |
+| 6 new benchmark task templates committed | Per RFC §10.1 the corpus is 24 existing + 6 new; the new 6 must exist before Phase 1 starts so the corpus is stable | PR-0c |
+| `scripts/verify-phase1.sh` (Tier 1 harness) committed and CI-integrated | The agent needs Tier 1 to exist *before* writing Phase 1 PRs, so it can self-verify as it goes | PR-0d |
+| §8.3 standalone diagnostic addressing shipped in a 0.x patch | RFC §11: this ships first (week 0), in days, separate from 0.x+1 | PR-0e |
+
+**Phase 1 implementation PRs (PR-1*) cannot start until PR-0a through PR-0d are merged.** PR-0e is independent and ships on a different release cadence.
+
+### 1.3 Non-goals of this plan
+
+- Does not author the **actual code** for Phase 1 or Phase 2; that work is the PRs themselves.
+- Does not specify the exact bash/Python of every script — gives interface, inputs, outputs, exit codes; PR-0d implements.
+- Does not author the **actual content** of the 6 new benchmark tasks — §5 gives the rubric and skeleton; PR-0c fills them in.
+- Does not replace the human-run §10 statistical gate; specifies how the coding agent gets shorter-horizon confidence (§3) so it can ship intermediate PRs without blocking on the gate.
+
+---
+
+## §2 — PR breakdown
+
+15 PRs total: 5 prerequisite (PR-0*), 8 Phase 1 (PR-1*), 6 Phase 2 (PR-2*). Phase 2 PRs are conditional on the §10 gate.
+
+### 2.1 Phase 0 — Prerequisites (week 0, parallel; can land in any order except PR-0d which depends on PR-0c for testing)
+
+| PR | Title | Files touched | Acceptance criteria | Tier | Reviewer |
+|----|-------|---------------|---------------------|------|----------|
+| **PR-0a** | Add RFC review checklist | `docs/process/rfc-review-checklist.md` (new), `CLAUDE.md` cross-reference | Checklist exists, CLAUDE.md links to it, no code changes | none (doc) | maintainer |
+| **PR-0b** | Author Phase 2 pre-registration doc | `docs/plans/phase-2-measurement-protocol.md` (new) | Doc covers all 9 items in RFC §16.E; cites RFC §10.3 thresholds verbatim | none (doc) | maintainer |
+| **PR-0c** | 6 new agent-task templates for §10 gate | `tests/E2E/agent-tasks/templates/path-2-gate/task-{01..06}/{task.md, setup/, expected/, acceptance.sh}` | Each task passes `scripts/validate-task-template.sh`; each is solvable today by a baseline agent in ≤30 turns | Tier 1 | compiler + benchmark owner |
+| **PR-0d** | Tier 1 self-verification harness | `scripts/verify-phase1.sh`, `scripts/byte-preservation-check.sh`, `scripts/ast-roundtrip-check.sh`, `scripts/token-delta-spot.sh`, `.github/workflows/tier1.yml` | All scripts: exit 0 on green corpus, exit 1 on synthetic regression; CI workflow runs on every PR; runs in <60s locally | Tier 1 | compiler |
+| **PR-0e** | §8.3 standalone diagnostic addressing | Compiler diagnostic emission for Calor0700-series (per RFC §8.3); ships in next 0.x patch | New diagnostics surface with correct codes; snapshot tests cover all paths | Tier 1 | compiler |
+
+### 2.2 Phase 1 — Drop structural IDs (weeks 1–3, on `phase-1` branch)
+
+| PR | Title | Files touched | Acceptance criteria | Tier | Reviewer |
+|----|-------|---------------|---------------------|------|----------|
+| **PR-1a** | Lexer: make `{id…}` optional on structural openers | `src/Calor.Compiler/Parsing/Lexer.cs`, `Token.cs`; new lexer unit tests | Lexer accepts both `§M{id:Name}` and `§M Name`; tests cover all structural tag forms (M, F, L, IF, TR, etc.) | Tier 1 | compiler |
+| **PR-1b** | Parser: omit structural IDs from AST nodes | `src/Calor.Compiler/Parsing/Parser.cs`, AST node changes for nodes that previously held a structural ID (drop the field) | Round-trip parse → emit → parse preserves AST equality; existing tests still pass; new tests cover both forms | Tier 1 | compiler |
+| **PR-1c** | Migrator: `calor fix --drop-structural-ids` command | `src/Calor.Compiler/Migration/StructuralIdDropper.cs` (new), CLI wiring; writes `migration.log.json` | Migrator on `samples/` and `tests/` produces byte-identical-outside-removed-ranges output; log is round-trippable | Tier 1+2 | compiler |
+| **PR-1d** | Byte-preservation verifier (RFC §5.7.3) | `src/Calor.Compiler/Migration/BytePreservationVerifier.cs` (new), `scripts/verify-byte-preservation.sh` | Verifier asserts byte-equality over non-migrated regions; the 5 test cases in RFC §5.7.6 (T-5.7-a through T-5.7-e) all pass | Tier 1 | compiler |
+| **PR-1e** | Update `samples/` to optional-ID form | All `samples/*.calr` edited via `calor fix --drop-structural-ids`; commit `migration.log.json` | All samples compile; byte-preservation verifier green; visual diff is "remove `{id…}` blocks only" | Tier 1+2 | compiler |
+| **PR-1f** | Update `tests/` fixtures to optional-ID form | All `tests/**/*.calr` migrated; commit logs | All tests still pass; verifier green | Tier 1+2 | compiler |
+| **PR-1g** | Diagnostic Calor0820 implementation (RFC §8.1) | `src/Calor.Compiler/Diagnostics/`, analyzer hooks; snapshot tests | Calor0820 fires for legacy `{id…}` blocks with a `fix` payload that removes them | Tier 1 | compiler |
+| **PR-1h** | Phase 1 docs + post-ship monitoring scaffold | `docs/syntax-reference.md`, MCP primer; `scripts/phase1-post-ship-monitor.sh` (per RFC §10.6) | Docs reflect new syntax; monitor script runs (but does not yet have a baseline to compare against) | Tier 1 | maintainer |
+
+Phase 1 merge gate: all Tier 1 green, Tier 2 (corpus-wide) green on the merged `phase-1` branch. The week-2.5 dependency checkpoint (RFC §11) is the deadline for PR-1a (parser change); if it slips beyond week 2.5, Phase 2 shifts.
+
+### 2.3 Phase 2 — Compact symbol IDs (weeks 3–4, on `phase-2` branch rebased on `phase-1`)
+
+| PR | Title | Files touched | Acceptance criteria | Tier | Reviewer |
+|----|-------|---------------|---------------------|------|----------|
+| **PR-2a** | Crockford-lowercase 12-char ID generator | `src/Calor.Compiler/Ids/CompactIdGenerator.cs` (new); preserve `IdGenerator` for the legacy ULID path during transition | Generator outputs 12-char IDs from the `0123456789abcdefghjkmnpqrstvwxyz` alphabet (excludes `i,l,o,u` per RFC §6.1); unit tests cover collision math at sampled densities | Tier 1 | compiler |
+| **PR-2b** | `IdRegistry` implementation | `src/Calor.Compiler/Ids/IdRegistry.cs` (new) with `ConcurrentDictionary` per RFC §6.3.1 | Registry supports registration, lookup, collision detection; concurrency-safe (existing callers are single-threaded; defense-in-depth per v5 §6.3.1 annotation) | Tier 1 | compiler |
+| **PR-2c** | `IdGenerator.Generate()` caller audit + migration (RFC §9.3) | `src/Calor.Compiler/Ids/IdAssigner.cs:175` and `:180` (the 2 production call sites grep-verified in v5) | Both sites switched to `CompactIdGenerator`; legacy `IdGenerator.Generate()` kept for migrator's reverse-path only; tests green | Tier 1 | compiler |
+| **PR-2d** | Migrator: `calor fix --compact-ids` command | `src/Calor.Compiler/Migration/CompactIdMigrator.cs` (new); writes additional entries to `migration.log.json` | Migrator rewrites symbol IDs (those carrying `fix`-target identity); log supports reverse migration via `calor fix --revert-compact-ids` | Tier 1+2 | compiler |
+| **PR-2e** | Diagnostics Calor0821 + Calor0822 (RFC §8.2) | `src/Calor.Compiler/Diagnostics/`; full Calor0822 text per RFC §8.2.1 | Both diagnostics fire with correct messaging; Calor0822 includes the git-history recovery path text | Tier 1 | compiler |
+| **PR-2f** | Phase 2 final integration + revert path tested | `src/Calor.Compiler/Migration/CompactIdReverter.cs` (new); `tests/Calor.Migration.Tests/RevertRoundTripTests.cs` | Round-trip: ULID source → compact-ids → revert-compact-ids → byte-equal to original | Tier 1+2 | compiler |
+
+Phase 2 ship gate: §10 statistical gate (Tier 3) passes per RFC §10.3 (medium effect, all 4 kill criteria).
+
+### 2.4 PR dependencies
+
+```
+PR-0a ─┐
+PR-0b ─┤
+PR-0c ─┼─→ PR-0d (Tier 1 harness needs templates to test against)
+       │
+       │   week 0
+       ▼
+PR-0e (independent, ships in 0.x patch)
+
+       PR-0a..d merged → Phase 1 starts
+       ┌──────────────────────────────┐
+       │                              │
+       ▼                              ▼
+   PR-1a ─→ PR-1b ─→ PR-1c ─→ PR-1d   (compiler track)
+                                  │
+                                  ▼
+                              PR-1e, PR-1f, PR-1g  (parallel)
+                                  │
+                                  ▼
+                              PR-1h (final)
+
+       Phase 1 merged + week-2.5 checkpoint passed → Phase 2 starts
+                                  │
+                                  ▼
+              PR-2a ─→ PR-2b ─→ PR-2c ─→ PR-2d ─→ PR-2e ─→ PR-2f
+                                                              │
+                                                              ▼
+                                                       Tier 3 gate (§10)
+                                                              │
+                              ┌───────────────────────────────┤
+                              ▼                               ▼
+                          Gate PASS                       Gate FAIL
+                              │                               │
+                              ▼                               ▼
+                    Ship Phase 1 + Phase 2            Ship Phase 1 only
+                       as 0.x+1                          as 0.x+1
+                                                     (revert Phase 2)
+```
+
+---
+
+## §3 — Coding-agent self-verification harness (the key new content)
+
+**Problem the harness solves.** RFC §10 is a 4–5-day, 900-task-run, statistical gate. A coding agent shipping PR-1a through PR-2f cannot block on the gate per PR (15 × 5 days = a year of calendar). The agent needs a sub-hour, deterministic, green/red signal per PR that gives **engineering confidence** the change is safe. The §10 gate then validates that the safe-per-PR changes have the **expected aggregate effect** on agent behavior.
+
+The harness has three tiers, distinguished by runtime, what they verify, and who runs them.
+
+### 3.1 Tier 1 — Per-PR sanity (<60 seconds)
+
+**Runs:** locally before pushing, in CI on every PR.
+**Authoritative location:** `scripts/verify-phase1.sh` (extended to `verify-phase2.sh` when PR-2a lands).
+**Components:**
+
+| Check | Script | What it asserts | Failure mode |
+|-------|--------|-----------------|--------------|
+| Unit tests | `dotnet test --filter Category=Unit` (existing) | All unit-tagged tests pass | Tier 1 red |
+| Byte-preservation on samples/ | `scripts/byte-preservation-check.sh samples/` | For each file: migrate → reconstruct from log → byte-equal to original | Tier 1 red |
+| AST round-trip on tests/ | `scripts/ast-roundtrip-check.sh tests/` | For each `.calr` fixture: parse → emit → parse → AST-equal | Tier 1 red |
+| Token-delta spot check | `scripts/token-delta-spot.sh tests/E2E/agent-tasks/templates/path-2-gate/task-01/setup/main.calr` | Print Δtokens (pre → post migration); compare to expected from RFC §16.F (~9.67 × N_IDs_in_file) | Tier 1 amber (printed warning, not red) — soft signal because per-file variance is high |
+
+**Acceptance rule for an agent:** **The agent may not mark a PR "ready for review" until `scripts/verify-phase1.sh` exits 0 and the agent pastes the full output into the PR description.** This is operationally how "high confidence per PR" is enforced.
+
+CI runs the same harness on every PR; the green/red badge is the second enforcement layer.
+
+### 3.2 Tier 2 — Per-phase verification (<30 minutes)
+
+**Runs:** on PR to a release branch (`phase-1`, `phase-2`, or `release/0.x+1`); manually invokable for sanity checks.
+**Authoritative location:** `scripts/verify-corpus.sh`.
+**Components:**
+
+| Check | Script | What it asserts | Failure mode |
+|-------|--------|-----------------|--------------|
+| All Tier 1 checks (re-run on whole corpus) | `scripts/verify-phase1.sh --corpus all` | Tier 1 properties on the full corpus, not just samples | Tier 2 red |
+| Migrator corpus dry-run | `scripts/migrator-corpus-dryrun.sh` | Run migrator with `--dry-run` on every `.calr` in repo; byte-preservation green for all | Tier 2 red |
+| Token-delta corpus aggregate | `scripts/token-delta-corpus.sh` | Aggregate Δtokens across whole corpus is within expected range (Phase 1: ~9.67 × N_structural_IDs ± 20%; Phase 2: additional ~9.67 × N_symbol_IDs ± 20%) | Tier 2 red if outside range (indicates either a measurement bug or an unexpected migrator behavior) |
+| Diagnostic snapshot tests | `dotnet test --filter Category=DiagnosticSnapshot` (existing pattern) | All emitted diagnostics match golden files; new Calor0820/0821/0822 diagnostics covered | Tier 2 red |
+| Round-trip migration test | `scripts/migrator-revert-roundtrip.sh` | Original → migrate → revert → byte-equal to original, for every file in corpus | Tier 2 red |
+
+**Acceptance rule for a phase merge:** Tier 2 must be green on the merge commit of the release branch. The maintainer reviews the Tier 2 output as part of release sign-off.
+
+### 3.3 Tier 3 — The §10 statistical gate (4–5 days, human-driven)
+
+**Runs:** once, at week 4, on the merged `release/0.x+1` candidate, per RFC §10.
+**Authoritative location:** `scripts/run-phase-2-gate.sh` (drives the agent harness across all 30 tasks × 10 runs × 3 arms = 900 runs).
+**Owner:** repo maintainer.
+**Agent's role:**
+- Prep: ensure `scripts/run-phase-2-gate.sh` correctly drives the three arms, model versions are pinned per pre-registration (PR-0b), seeds are recorded.
+- Monitor: watch for protocol violations (agent harness crash, model API outage, fixture mutation); if detected, halt and trigger RFC §10.5 retry policy.
+- Report: write `docs/plans/phase-2-measurement-results.md` from raw analysis output, regardless of pass/fail (per RFC §16.E item 8).
+
+**Pass condition:** all 4 kill criteria green per RFC §10.3 (medium effect, δ ≥ 0.33, Bonferroni-corrected α' = 0.0125).
+**Fail condition:** any kill criterion red → Phase 2 reverted from `release/0.x+1`; ship Phase 1 alone.
+
+### 3.4 Tier 4 — Post-ship monitoring (per RFC §10.6, runs 30 days after 0.x+1 ship)
+
+**Runs:** `scripts/phase1-post-ship-monitor.sh` (committed in PR-1h).
+**Authoritative location:** `scripts/phase1-post-ship-monitor.sh`.
+**What it does:** re-runs the 24+ existing agent-task fixtures × 10 runs against 0.x+1's Phase-1-only build; compares turn-count median against the latest 0.x pre-release tag; if |Cliff's δ| ≥ 0.2 regression, surfaces an alert.
+**Owner:** maintainer schedules the run; agent can be invoked to produce the analysis report.
+
+### 3.5 Confidence calculus — what each tier proves
+
+| Combination | What you can claim | What you can NOT claim |
+|-------------|--------------------|------------------------|
+| Tier 1 green | "This PR did not break the build or local invariants." | "This PR is safe to merge into a release branch." |
+| Tier 1 + Tier 2 green | "This PR preserves system invariants across the whole corpus; aggregate token deltas are in expected range." | "Agents will actually benefit from this change." |
+| Tier 1 + Tier 2 + Tier 3 green | "Agents materially benefit (per RFC §10.3 medium-effect threshold), with statistical significance, and no regressions." | "Long-term codebase rot is unaffected" — per RFC §10.7 the gate explicitly does not measure this. |
+| Tier 4 (post-ship) green at day 30 | "Phase 1 in production has not introduced a turn-count regression detectable at the small-effect level." | Anything about Phase 2 — Phase 2 has its own gate (Tier 3). |
+
+### 3.6 What if Tier 1 is too slow?
+
+If `scripts/verify-phase1.sh` exceeds 60s on a developer machine, the harness fails its own design constraint. The remediation order:
+
+1. Profile each check; the AST round-trip on `tests/` is the likely culprit. If so, split into "default" (samples/ only, runs always) and "extended" (tests/, runs in CI only).
+2. Cache parse results between checks within a single harness invocation.
+3. Only as a last resort, drop a check from Tier 1 (move to Tier 2). This loses per-PR confidence and should be documented in `scripts/verify-phase1.sh` with a banner explaining the trade-off.
+
+### 3.7 What if the harness itself has a bug?
+
+The harness is code; code has bugs. Mitigations:
+
+- **Self-tests.** `scripts/verify-phase1.sh --self-test` runs the harness against synthetic positive and negative fixtures (a "should-pass" file and a "should-fail" file). PR-0d includes these self-tests.
+- **CI canary.** PR-0d adds a CI job that runs the harness against a known-good main commit; if it fails, the harness is broken, not main.
+- **Triage rule.** If Tier 1 is red but the agent believes the change is safe, the agent must NOT bypass the harness; instead, file an issue against the harness, and the maintainer either confirms the harness bug or confirms the change is unsafe.
+
+---
+
+## §4 — The Phase 2 pre-registration document (content for `docs/plans/phase-2-measurement-protocol.md`)
+
+This section is the **content** of the document authored as PR-0b. Per RFC §16.E, the document must contain these 9 items. The drafts below should be moved to the pre-reg file verbatim (with hashes and versions filled in at PR-0b authoring time).
+
+### 4.1 Task list with commit hashes
+
+```
+Existing tasks (24):
+  tests/E2E/agent-tasks/fixtures/task-001/  @ <commit-sha-to-fill>
+  tests/E2E/agent-tasks/fixtures/task-002/  @ <commit-sha-to-fill>
+  ... (24 entries) ...
+
+New tasks (6, authored in PR-0c):
+  tests/E2E/agent-tasks/templates/path-2-gate/task-01/  @ <commit-sha-to-fill>
+  tests/E2E/agent-tasks/templates/path-2-gate/task-02/  @ <commit-sha-to-fill>
+  tests/E2E/agent-tasks/templates/path-2-gate/task-03/  @ <commit-sha-to-fill>
+  tests/E2E/agent-tasks/templates/path-2-gate/task-04/  @ <commit-sha-to-fill>
+  tests/E2E/agent-tasks/templates/path-2-gate/task-05/  @ <commit-sha-to-fill>
+  tests/E2E/agent-tasks/templates/path-2-gate/task-06/  @ <commit-sha-to-fill>
+```
+
+### 4.2 New task authoring artifacts
+
+Each new task in `path-2-gate/task-NN/` contains:
+- `task.md` — prompt given to the agent
+- `setup/` — pre-existing `.calr` files in the workspace at task start
+- `expected/` — post-task expected state (for deterministic acceptance check)
+- `acceptance.sh` — exit-0-on-success script that diffs agent output against expected
+
+### 4.3 Implementation flag — branch + commit hash per arm
+
+```
+Arm A (today/baseline):   main @ <commit-sha-to-fill> (latest 0.x pre-release tag)
+Arm B (Phase 1 only):     release/0.x+1 @ <commit-sha-to-fill> (after PR-1h merges)
+Arm C (Phase 1 + Phase 2): release/0.x+1 @ <commit-sha-to-fill> (after PR-2f merges)
+```
+
+### 4.4 Run protocol
+
+- **Agent harness invocation:** `./tests/E2E/agent-tasks/run.sh --task <id> --arm <A|B|C> --seed <n> --model <pinned>`
+- **Model version (pinned):** e.g., `claude-sonnet-4.5` at the version available on `2026-MM-DD`; record the API model string verbatim. Locked at pre-registration; any model change invalidates the run per RFC §10.5.
+- **Random seed:** seeds 1..10 per (task, arm) combination, recorded; harness must accept and respect the seed.
+- **Concurrency:** runs are sequential within a (task, arm) tuple; parallelism allowed across tuples.
+
+### 4.5 Data schema (recorded per run)
+
+```json
+{
+  "task_id": "task-001",
+  "arm": "A",
+  "seed": 1,
+  "model": "<pinned-string>",
+  "started_at": "2026-MM-DDTHH:MM:SSZ",
+  "ended_at": "2026-MM-DDTHH:MM:SSZ",
+  "success": true,
+  "turn_count": 17,
+  "total_output_tokens": 8421,
+  "identity_preservation_errors": 0,
+  "edit_correctness_errors": 0,
+  "harness_crash": false,
+  "raw_log_path": "..."
+}
+```
+
+### 4.6 Analysis pipeline
+
+- Library versions pinned: `scipy==<version>`, `pandas==<version>`, `numpy==<version>`.
+- Analysis seed: 42 (only matters for any bootstrap CI computation).
+- Code path: `scripts/analyze-gate-results.py` (committed in PR-0b alongside the pre-reg doc).
+- Outputs: `phase-2-measurement-results.md` summarizing all 4 kill criteria per RFC §10.3.
+
+### 4.7 Pass/fail thresholds (per RFC §10.3)
+
+All four must be true to ship Phase 2:
+
+1. McNemar p > 0.0125 (Bonferroni-corrected, no success-rate regression).
+2. Wilcoxon p > 0.0125 (no identity-preservation regression).
+3. (Turn-count median reduction ≥ 10% AND Wilcoxon p < 0.0125 AND **|Cliff's δ| ≥ 0.33**) OR (Token median reduction ≥ 15% AND Wilcoxon p < 0.0125 AND **|Cliff's δ| ≥ 0.33**).
+4. Phase 2 distinguishable from Phase 1 alone on criterion (3), Wilcoxon p < 0.0125.
+
+### 4.8 Reporting commitment
+
+`docs/plans/phase-2-measurement-results.md` will be written and committed *regardless of pass or fail*. The doc reports all four criteria with their p-values, effect sizes, and ship/no-ship decision. This is RFC §16.E item 8 verbatim.
+
+### 4.9 Retry policy reference
+
+Per RFC §10.5: one retry covered by reserve budget; further retries require re-pre-registration in `phase-2-measurement-protocol-v2.md`. Sign-off authority for retry: maintainer.
+
+---
+
+## §5 — The 6 new benchmark task templates (skeleton + rubric for PR-0c)
+
+### 5.1 Authoring rubric
+
+Each task in `tests/E2E/agent-tasks/templates/path-2-gate/task-NN/` must satisfy:
+
+| Property | Requirement |
+|----------|-------------|
+| **Solvable today** | A baseline agent (Arm A) must achieve ≥80% success across 10 seeds. If a task is unsolvable today, it cannot distinguish Phase 1/2 from baseline. |
+| **Multi-edit** | Each task requires the agent to edit ≥3 files OR ≥5 distinct locations within a file. Single-file, single-edit tasks do not stress the ID-identity properties under test. |
+| **Cross-reference touching** | Each task must include at least one edit that crosses a structural-ID or symbol-ID boundary (e.g., rename a function and update its callers; add a new contract that references an existing function ID). This is what stresses the "did dropping/compacting IDs hurt agent comprehension" question. |
+| **Deterministic acceptance** | `acceptance.sh` must exit 0 if and only if the task is solved correctly. No LLM-as-judge in the acceptance step; the gate must be reproducible. |
+| **Expected turn count** | The task's expected median turn count for a baseline agent must be 10–30. <10: too easy, no signal; >30: too expensive at N=900 runs. |
+| **Authored independently per arm** | The task prompt itself does **not** reference structural IDs in any arm; the difference between arms is the *workspace state*, not the *task instructions*. |
+
+### 5.2 Suggested task themes (PR-0c author should expand each into a full template)
+
+| # | Theme | Why it stresses the ID system |
+|---|-------|-------------------------------|
+| **task-01** | "Refactor function `Calculate` into three smaller functions in the same module" | Phase 1: agent must locate function-end positionally; Phase 2: new function names need stable symbol IDs |
+| **task-02** | "Add the `db` effect to an existing function and its 2 transitive callers" | Tests cross-file symbol references; in Phase 2, callers reference compact IDs |
+| **task-03** | "Change a method from private to public and update all 5 call sites across 3 files" | Tests cross-file identity; ID compaction here exercises the IdRegistry round-trip |
+| **task-04** | "Add a postcondition to an existing function that references a parameter" | Tests contract-to-function symbol-ID references in Phase 2 |
+| **task-05** | "Restructure a nested 3-level loop into a separate helper function" | Structural restructure; tests that without structural IDs, the agent can still navigate by name and position |
+| **task-06** | "Add an error-handling try/catch around an effectful call chain" | New structural blocks added; Phase 1 stresses positional vs. ID-based block identification |
+
+Each theme is one paragraph; the actual template in PR-0c expands to ~10–15 files of fixture content plus prompt + acceptance script.
+
+### 5.3 Validation
+
+`scripts/validate-task-template.sh path-2-gate/task-NN/` (added in PR-0d) checks:
+
+1. `task.md` exists and is non-empty.
+2. `setup/` contains at least one `.calr` file.
+3. `expected/` contains at least one file used by `acceptance.sh`.
+4. `acceptance.sh` is executable and exits 0 when invoked on `expected/` contents.
+5. A pilot run against `setup/` does NOT yet satisfy `acceptance.sh` (i.e., the task is non-trivial).
+
+PR-0c is not mergeable until `scripts/validate-task-template.sh` exits 0 for all 6 tasks.
+
+---
+
+## §6 — Rollback playbook (operational decision tree)
+
+### 6.1 Decision tree
+
+```
+PR-level Tier 1 RED?
+  → revert PR; no production impact; agent files issue if cause unclear.
+
+Phase-merge Tier 2 RED?
+  → block phase merge; maintainer triages; either fix-forward (small fix to a PR-N PR)
+    or revert specific PR(s); re-run Tier 2.
+
+§10 gate (Tier 3) FAIL for Phase 2?
+  → revert Phase 2 from release/0.x+1 (drop PR-2a..2f).
+  → re-validate Phase 1 alone via Tier 2 on the reverted branch.
+  → ship Phase 1 only as 0.x+1; per RFC §11.
+  → log gate outcome in phase-2-measurement-results.md (per RFC §16.E item 8).
+  → if retry policy invoked (RFC §10.5), schedule re-pre-registration as
+    phase-2-measurement-protocol-v2.md.
+
+Tier 4 (post-ship Phase 1 monitoring) RED at day 30?
+  → INVESTIGATE FIRST. A regression detected by the |Cliff's δ| ≥ 0.2 trigger
+    is the *signal*, not automatic revert.
+  → Maintainer reviews tier-4 data; if confirmed and material, schedule a
+    0.x+1 → 0.x+2 release that reverts Phase 1.
+  → Phase 1 revert path: `calor fix --revert-drop-structural-ids` consuming
+    the migration.log.json produced by PR-1c migrator. (If no log exists for
+    user — e.g., they upgraded a new project — surface guidance to recover
+    from git history.)
+
+Post-ship Phase 2 success-rate or identity-preservation regression?
+  → RFC §10.4: `calor fix --revert-compact-ids` consumes migration.log.json,
+    symmetric and deterministic, tested in PR-2f.
+  → For projects without migration.log.json: Calor0822 diagnostic surfaces
+    the git-history recovery path (per RFC §16.C).
+```
+
+### 6.2 What the agent does in each scenario
+
+| Scenario | Agent action |
+|----------|--------------|
+| Tier 1 red on a PR I authored | Investigate locally; if I can fix in <30 min, push fix; otherwise revert and reopen as a fresh PR with the fix |
+| Tier 2 red on a phase merge | Open an issue with the Tier 2 output; do not attempt to merge-around; wait for maintainer triage |
+| Tier 3 fail (Phase 2 gate) | Execute the revert per §6.1 step 3 *without* delay: revert Phase 2 PRs from `release/0.x+1`, re-run Tier 2 on the reverted branch, push to maintainer for ship-Phase-1-alone sign-off |
+| Tier 4 red at day 30 | Surface the data; do NOT initiate a revert without maintainer sign-off (post-ship reverts are user-facing breakage) |
+
+### 6.3 What the agent never does
+
+- Bypass a red harness by editing the harness itself.
+- Revert a post-ship release without maintainer sign-off.
+- Mark a PR done without pasting Tier 1 output.
+- Author Phase 2 implementation code before `docs/plans/phase-2-measurement-protocol.md` is merged (RFC §10.2 hard rule).
+- Edit the pre-registration document after it lands (RFC §10.5: any change invalidates the run).
+
+---
+
+## §7 — `docs/process/rfc-review-checklist.md` (draft content for PR-0a)
+
+> This section is the **content** of the file PR-0a creates. Move verbatim into `docs/process/rfc-review-checklist.md` (adjusting for repo conventions: front matter, license header if any).
+
+```markdown
+# RFC Review Checklist
+
+This checklist applies to all RFC-class documents under `docs/plans/`.
+The lesson driving this checklist: the v2→v3→v4→v5 trajectory of the
+Compact Stable Identifiers RFC caught one *architectural fiction* per
+review round — a sentence asserting the compiler does X when, in fact,
+the source code did not do X. The checklist exists to catch the next
+analogous fiction at PR review time, not at vN+1.
+
+## For RFC authors
+
+1. **Architectural claim rule.** Every sentence of the form
+   "the compiler does X", "the verifier asserts Y", or "the migrator
+   guarantees Z" MUST EITHER:
+   - cite a file:line in the source tree, OR
+   - be explicitly marked `[PROPOSED]` to indicate the behavior is
+     proposed but not yet implemented.
+
+2. **Effort estimates with citations.** When estimating effort for an
+   audit/refactor task, cite a grep result for the call site count:
+   - GOOD: "0.5 day — IdGenerator.Generate() has 2 production call sites
+     (Ids/IdAssigner.cs:175, :180)"
+   - BAD: "0.5–2 days" (unfounded upper bound)
+
+3. **Measurement claims.** When citing a numeric measurement
+   (token counts, runtime, memory), include the script that produces
+   the number, the sample size, and (for noisy measurements) a
+   confidence interval. Hand-picked samples of N < 20 are not
+   acceptable for headline numbers.
+
+## For RFC reviewers
+
+1. **Grep-verify every architectural claim.** Take 30 seconds per
+   architectural assertion to run `rg` against the cited file:line.
+   If the citation is missing OR if grep does not find the asserted
+   behavior, add a `[VERIFY]` comment to the RFC PR.
+
+2. **Be the devil's advocate explicitly.** Pair each RFC with two
+   review documents:
+   - A designer-voice critique (read the RFC charitably, find
+     genuine improvements).
+   - A devil's-advocate critique (read the RFC adversarially, find
+     the assertions that don't hold up).
+
+3. **Verdict convergence is the ship signal.** When both reviewers
+   converge on "approve and ship" with only calibration concerns,
+   author one calibration revision (capturing the calibrations
+   in-line) and ship. Do not iterate further unless a new
+   architectural concern emerges.
+
+## For all RFC contributors
+
+- A new RFC version (vN+1) is justified when EITHER:
+  - A reviewer identifies an architectural fiction (claim not in
+    the source), OR
+  - A reviewer identifies a missing required artifact (statistical
+    test, retry policy, rollback path).
+- A new RFC version is NOT justified for:
+  - Wording polish,
+  - Adding citations to claims that are correct,
+  - Reorganizing structure without changing substance.
+- Calibration deltas should be captured in the next-version's §0
+  change table; new RFC versions should reference predecessors and
+  document deltas only.
+```
+
+---
+
+## §8 — Definition of done
+
+### 8.1 Per PR
+
+- Tier 1 green (CI badge AND agent-pasted output in PR description).
+- PR description references the relevant RFC section(s) ("Implements RFC §5.4 lexer change") so the reviewer can verify scope alignment.
+- For PRs touching the migrator: a `migration.log.json` sample committed in `tests/` covering the new migrator behavior.
+- For PRs introducing diagnostics: snapshot test + a sample `.calr` file that triggers the diagnostic.
+
+### 8.2 Per phase merge
+
+- All PRs in the phase merged.
+- Tier 2 green on the phase branch's HEAD.
+- Maintainer sign-off on the phase merge PR.
+
+### 8.3 Per release (0.x+1)
+
+- Phase 1: Tier 2 green, post-ship monitoring scaffold (PR-1h) committed.
+- Phase 2 (if shipping): Tier 3 (§10 gate) PASS per all 4 kill criteria; `phase-2-measurement-results.md` written and committed regardless of outcome.
+- Release notes describe migration commands (`calor fix --drop-structural-ids` and optionally `calor fix --compact-ids` or the `--upgrade-from 0.x` wrapper).
+- CHANGELOG entry references RFC v5.
+
+### 8.4 Per RFC closure (this RFC fully implemented)
+
+- All 15 PRs (PR-0a..0e, PR-1a..1h, PR-2a..2f IF gate passed) merged.
+- `docs/plans/phase-2-measurement-results.md` exists.
+- Tier 4 (Phase 1 post-ship monitoring) green at day 30.
+- v5 RFC marked "Implemented" in front matter.
+- `docs/process/rfc-review-checklist.md` referenced from CLAUDE.md.
+
+### 8.5 What "high confidence" means
+
+For a coding agent shipping work on this RFC:
+
+| Action | Required confidence level | How achieved |
+|--------|--------------------------|--------------|
+| Push a PR | Engineering safety | Tier 1 green + paste output |
+| Merge a PR to a phase branch | Engineering safety + corpus invariance | Tier 1 + Tier 2 green |
+| Merge a phase branch to `release/0.x+1` | Engineering safety + corpus invariance | Tier 2 green |
+| Ship Phase 2 | Statistically validated agent benefit | Tier 3 PASS per RFC §10.3 |
+| Mark RFC implemented | All of the above + 30-day production stability | Tier 4 green at day 30 |
+
+These five rows are the operational definition of "high confidence" for this work. The agent does not invent new confidence levels and does not skip levels.
+
+---
+
+## Appendix A — Glossary of harness scripts (all new, committed in PR-0d or PR-1*)
+
+| Script | Tier | Committed in | Inputs | Output |
+|--------|------|--------------|--------|--------|
+| `scripts/verify-phase1.sh` | 1 | PR-0d | `--corpus all` (optional) | exit 0 green, exit 1 red; prints summary |
+| `scripts/verify-phase2.sh` | 1 | PR-2a | — | wraps verify-phase1.sh + Phase-2-specific checks |
+| `scripts/byte-preservation-check.sh` | 1 | PR-0d | `<dir>` | per-file pass/fail report |
+| `scripts/ast-roundtrip-check.sh` | 1 | PR-0d | `<dir>` | per-file pass/fail report |
+| `scripts/token-delta-spot.sh` | 1 | PR-0d | `<file>` | Δtokens (positive = savings) |
+| `scripts/verify-corpus.sh` | 2 | PR-0d | — | corpus-wide harness driver |
+| `scripts/migrator-corpus-dryrun.sh` | 2 | PR-1c | — | dry-run migrator, byte-preservation check on every file |
+| `scripts/token-delta-corpus.sh` | 2 | PR-0d | — | aggregate Δtokens for whole repo |
+| `scripts/migrator-revert-roundtrip.sh` | 2 | PR-2f | — | round-trip migrate-then-revert byte-equality |
+| `scripts/run-phase-2-gate.sh` | 3 | PR-0b | per pre-reg doc | drives 900-run gate experiment |
+| `scripts/analyze-gate-results.py` | 3 | PR-0b | raw run logs | statistical analysis per §4.6 |
+| `scripts/phase1-post-ship-monitor.sh` | 4 | PR-1h | — | rerun corpus, compare to baseline |
+| `scripts/validate-task-template.sh` | helper | PR-0d | `<task-dir>` | validate task template per §5.3 |
+| `scripts/verify-byte-preservation.sh` | helper | PR-1d | `<file> <log>` | single-file verifier |
+
+## Appendix B — Calendar overlay on RFC §11
+
+| RFC §11 week | This plan's activity |
+|--------------|----------------------|
+| Week 0 | PR-0a, PR-0b, PR-0c, PR-0d, PR-0e merge in parallel. PR-0e ships as a 0.x patch. |
+| Week 1 | Phase 1 starts on `phase-1` branch. PR-1a, PR-1b in flight. Tier 1 green on every PR push. |
+| Week 2 | PR-1c (migrator), PR-1d (verifier) in flight. End-of-week deadline for PR-1a per v5 §11 week-2.5 checkpoint. |
+| Week 2.5 | Phase 1 dependency checkpoint: maintainer confirms PR-1a (parser change) merged. If not, Phase 2 slips. |
+| Week 3 | Phase 1 finishing PRs (PR-1e, 1f, 1g, 1h). Tier 2 must be green on `phase-1` HEAD by end of week. Phase 2 starts on `phase-2` branch rebased on `phase-1`. |
+| Week 4 | PR-2a..2f land on `phase-2`. Phase 2 merged to `release/0.x+1`. **Tier 3 gate runs (4–5 days).** |
+| Week 5 | Contingency. Gate retry if RFC §10.5 triggered. Final analysis. Maintainer ship/no-ship decision per RFC §10.3. |
+| Week 6 | Release prep. If gate passed: bundle Phase 1 + Phase 2. If gate failed: revert Phase 2 per §6.1, ship Phase 1 only. |
+| Weeks 7–8 | Buffer; release cut. |
+| Day 30 post-ship | Tier 4 runs (RFC §10.6). |

--- a/docs/plans/path-2-drop-ids-v5.md
+++ b/docs/plans/path-2-drop-ids-v5.md
@@ -1,0 +1,323 @@
+# RFC v5 — Compact Stable Identifiers: Drop Structural IDs, Compact Symbol IDs
+
+**Status:** Approved for implementation
+**Supersedes:** [path-2-drop-ids-v4.md](path-2-drop-ids-v4.md)
+**Reviewed against:** [path-2-drop-ids-v4-critique.md](path-2-drop-ids-v4-critique.md), [path-2-drop-ids-v4-devils-advocate.md](path-2-drop-ids-v4-devils-advocate.md)
+**Type:** Calibration revision of v4 (not a structural rewrite)
+
+> **Reader's note.** v5 preserves v4's structure and arguments unchanged. It applies 13 targeted calibrations identified by the v4 critique round, plus one new institutional rule (§0.1). For any section not listed in §0 below, **the v4 text stands as written**. This RFC documents only the deltas; refer to v4 for full context on unchanged sections.
+
+---
+
+## §0 — Changes from v4
+
+Both v4 reviewers (designer-voice critique + devil's advocate) explicitly concluded "approve and ship; v5 not necessary." v5 exists to capture their calibrations before implementation so they are not lost in commit messages or follow-up issues.
+
+| # | Section | Source | Change |
+|---|---------|--------|--------|
+| 1 | §5.7.3 | DA §2 (HARD) + DC §1 | **REPLACED** with byte-preservation form. v4's "trivia anchor verification" assumed AST infrastructure that does not exist in the compiler (verified: `Parsing/Lexer.cs:531` discards comments via `return NextToken()`; AST has no `LeadingTrivia`/`TrailingTrivia` fields; `Token.IsTrivia` covers only whitespace+newline). The verifier now asserts byte-equality over non-migrated regions, which depends only on the text-edit migrator already specified in §5.6. |
+| 2 | §16.F | DA §3 | **REPLACED** with N=100 RNG-generated production-format ID measurement. Fixes the `u` violation in the v4 sample `m_q9r8s7t6u5v4` (Crockford lowercase excludes `i,l,o,u` per §6.1) and reduces hand-pick selection bias. New numbers: ULID mean=19.22 tokens, compact mean=9.55 tokens, **savings = 9.67 tokens/occurrence at 95% CI (9.30, 10.04)**. Per-ID reduction: **50.3%** (v4 claimed 44%). Project-wide headline ~20–25% holds; the gate confirms. |
+| 3 | §10.6 | DA §4 | **ADDED named statistical test**: Wilcoxon signed-rank on paired per-task turn-count medians, α=0.05. Revert trigger: Wilcoxon p<0.05 AND Cliff's δ magnitude ≥0.2. Sign-off authority: repo maintainer within 14 days of gate-data collection. |
+| 4 | §9.3 | DC §3 | **ADDED row** for `IdGenerator.Generate()` caller audit (~0.5 day). Grep-verified scope: `Ids/IdGenerator.cs` is `public static class IdGenerator`, with only 2 call sites in production source — `Ids/IdAssigner.cs:175` and `Ids/IdAssigner.cs:180`. v4's "0.5–2 days" was conservative; the upper bound is unfounded. |
+| 5 | §6.3.1 | DA §5 | **ANNOTATION**: "No current caller is multi-threaded; the `ConcurrentDictionary` is defense-in-depth for future multi-threaded migrators." Keeps the design but flags it as forward-looking rather than load-bearing. |
+| 6 | §11 | DA §6 | **ADDED week-2.5 Phase 1 dependency checkpoint**: "Phase 1 parser-change PR (the structural-ID drop) must merge by end of week 2 for Phase 2 to start on schedule. If it slips beyond week 2.5, Phase 2 shifts by the slippage." Removes the implicit assumption that Phase 1 is risk-free. |
+| 7 | §1 (third bullet) | DC §2 | **TIGHTENED** wording to distinguish verified per-ID savings from projected project-wide savings. v4's bullet conflated the two. |
+| 8 | §5.7.2 | DC §4 | **ANNOTATION**: effect-declaration verification rule is "Documented for future migrators; not exercised by the Phase 1 migrator." Avoids implying it ships in v1. |
+| 9 | §6.3.1 | DC §5 | **ADDED non-goal**: "Incremental compilation is out of scope for this RFC. If incremental compilation is later added, the `IdRegistry` will need an incremental-rebuild story; that's a future RFC." Closes a question raised in v4 review. |
+| 10 | §14 | DC §6 | **WORDING**: "deferred to" instead of "transferred to"; "absorb" instead of "do." Cost transfer to humans/CI was an accidental reading of v4 prose; v5 clarifies. |
+| 11 | §9.4 | DA §7 (item 1) | **TASK AUTHORING**: 1.5 days → 3 days (0.5 day × 6 new tasks). v4's 1.5 days assumed batch authoring efficiency that is not realistic for the deliberate, version-pinned templating §10.4 requires. |
+| 12 | §0.1 (NEW) | DC §7 + DA §9 | **NEW SECTION**: codify §13.3 "grep-verify every architectural claim" rule as a follow-up institutional action (RFC checklist in `docs/process/rfc-review-checklist.md`). This is the lesson of the v3→v4→v5 trajectory: each round caught one assertion not actually in source (v3 caught the 9-char collision math; v4 caught the cache-result fiction; v5 caught the trivia-anchor fiction). Codifying the rule catches the next instance at PR review rather than at RFC vN+1. |
+| 13 | §13 | DA §7 (item 3) | **FLAGGED**: `migration.log.json` location for multi-repo / git-submodule projects is out of scope and deferred to a future "migrator productionization" RFC. |
+
+All other v4 text stands.
+
+---
+
+## §0.1 — Institutional follow-up: grep-verification rule
+
+**Source:** Designer-voice critique §7 recommendation 7; devil's advocate §9 final paragraph.
+
+The v2→v3→v4→v5 trajectory of this RFC exhibits a pattern: each adversarial round caught **exactly one architectural assertion that was not actually present in the source code**.
+
+| Round | Fictional assertion | Caught by | Outcome |
+|-------|---------------------|-----------|---------|
+| v2→v3 | "9-character compact IDs are collision-safe given current ID density" | v2 critique | Recomputed birthday-collision math; bumped to 12 chars |
+| v3→v4 | "Migrator caches resolution results, so re-validation cost is amortized" | v3 critique | No cache existed; argument restructured around fresh re-validation |
+| v4→v5 | "Verifier asserts trivia-anchor positions match across migration" | v4 devil's advocate | Lexer discards comments at line 531; no trivia anchors exist. Replaced with byte-preservation form. |
+
+This is not a coincidence; it is a process gap. RFC review currently has no mechanism that **requires** an architectural claim ("X is verified by Y," "Z is cached," "the verifier compares W") to be grep-anchored to a file:line citation in the source tree.
+
+**Action (to land as a separate PR before Phase 1 implementation begins, not blocking on RFC approval):**
+
+Add `docs/process/rfc-review-checklist.md` containing at minimum:
+
+1. **Architectural claim rule.** Every RFC sentence of the form "the compiler does X" or "the verifier asserts Y" must cite a file:line in the source tree, OR be flagged as "proposed; not yet implemented" in-line.
+2. **Reviewer responsibility.** RFC reviewers grep-verify every architectural claim. Reviewers who cannot verify a claim with `rg` or equivalent in <30 seconds add a `[VERIFY]` comment.
+3. **Author responsibility.** RFC authors who make a claim about future implementation explicitly mark it `[PROPOSED]` so reviewers do not need to verify against current code.
+
+CLAUDE.md should be updated to reference this checklist for all RFC-class documents under `docs/plans/`.
+
+**Owner:** Repo maintainer (RFC checklist), then any contributor (CLAUDE.md cross-reference).
+**Effort:** ~2 hours.
+**Not blocking:** Phase 1 implementation can begin before the checklist lands; the checklist exists to harden the *next* RFC, not this one.
+
+---
+
+## §1 — Summary (revised)
+
+This RFC proposes a two-phase change to how Calor source files use stable identifiers, replacing v4's bullet list with the following revised version. v4's three bullets become:
+
+- **Phase 1 — Drop structural IDs.** Remove ULIDs from all structural constructs (modules, functions, classes, loops, conditionals, try/catch, etc.). Structural identity is recovered at parse time from source position and tag kind, not from an authored ID.
+- **Phase 2 — Compact symbol IDs.** For symbols where stable identity matters across edits (currently: targets of diagnostics with `fix` payloads, and cross-file symbol references), keep an ID but shorten it from 26-char Crockford-uppercase ULID to 12-char Crockford-lowercase compact ID. Collision-safe for ID densities up to 10^7 per repo (recomputed in v3).
+- **Token economics.** *Verified per-ID:* a structural ID drop saves ~9.67 tokens at the cl100k_base tokenizer (§16.F, N=100, 95% CI 9.30–10.04); a symbol ID compaction saves ~9.67 tokens per occurrence. *Projected project-wide:* aggregate savings against current Calor sample programs are approximately 20–25% of total token count, gated by the §10 measurement-and-revert protocol before Phase 2 ships.
+
+Headline numbers updated per §16.F re-measurement. All other v4 §1 prose stands.
+
+---
+
+## §5.7.2 — Effect declaration verification rule (annotation)
+
+The effect-declaration verification rule (full text in v4 §5.7.2) **stands as written for future migrators**, including third-party migrators that rewrite effect signatures. **It is not exercised by the Phase 1 migrator** specified in §5.6, which only removes `{id…}` blocks and does not touch effect declarations. Phase 1 verifier implementations may skip the effect-comparison code path. The rule is documented now so a future RFC adding an effect-rewriting migrator does not need to re-derive it.
+
+---
+
+## §5.7.3 — Source byte preservation outside migrated regions (REPLACED)
+
+> **v5 replaces v4's "trivia anchor verification" rule entirely.** v4 asserted the verifier compared AST-level trivia anchors before and after migration. The Calor parser has no such anchors: `Parsing/Lexer.cs:531` returns `NextToken()` immediately after a comment token, discarding the comment with no AST attachment; `Parsing/Token.cs:375` defines `IsTrivia => Kind is TokenKind.Whitespace or TokenKind.Newline` — comments are not trivia. Building the anchor infrastructure would add 2–4 weeks of compiler work that v4 did not account for. v5 reframes the property in terms the migrator can actually verify.
+
+### Property
+
+The migrator's behavior, as specified in §5.6 step 3, is a text-edit pass: it identifies byte ranges that match the `{id…}` pattern adjacent to a structural-tag opener (`§M{…}`, `§F{…}`, `§L{…}`, etc.) and deletes only those byte ranges. **All source bytes outside the deleted ranges remain byte-equal between the original and the migrated source.**
+
+### Verifier rule
+
+For each migrated file:
+
+1. Reconstruct the "would-be-original" by re-inserting the deleted `{id…}` blocks at their recorded positions (positions logged by the migrator into `migration.log.json` per §5.6 step 4).
+2. Assert byte-equality between the reconstructed source and the original source file on disk before migration.
+
+This is a **byte-equality assertion over non-migrated regions**, not an AST comparison.
+
+### What this guarantees
+
+- **Comments preserved:** comment bytes are outside the deleted `{id…}` ranges, therefore preserved byte-for-byte.
+- **Whitespace preserved:** whitespace bytes outside the deleted ranges are preserved byte-for-byte.
+- **String literals preserved:** any `{id…}`-shaped substring inside a string literal is not adjacent to a structural-tag opener, therefore not matched by the migrator, therefore preserved.
+- **No AST infrastructure required:** the verifier needs only the file-on-disk and the `migration.log.json` produced in the same migrator run.
+
+### What this does not guarantee (and why that's fine)
+
+- Does **not** assert that the parser produces identical ASTs before and after migration. That is a separate property covered by §5.7.1 (the round-trip parse-and-emit test). v4's §5.7.3 redundantly tried to assert it via trivia anchors.
+- Does **not** require comments to retain semantic association with a specific syntactic construct. Calor source does not currently use such associations, and adding them is out of scope.
+
+### Implementation cost
+
+This verifier is ~30 lines: read original, read migrated, read log, apply log in reverse, `Span<byte>.SequenceEqual`. Compared to v4's anchor-comparison plan (which would have required building leading/trailing trivia fields on every AST node), this is a **multi-week-to-multi-day reduction**.
+
+---
+
+## §5.7.6 — Test plan adjustment
+
+v4 §5.7.6 enumerated test cases for trivia-anchor verification. v5 replaces those cases with byte-preservation tests:
+
+- **T-5.7-a:** Migrate a file with no `{id…}` blocks. Assert migrated bytes equal original bytes (log empty, no edits).
+- **T-5.7-b:** Migrate a file with one `{id…}` block. Reconstruct using log, assert byte-equality.
+- **T-5.7-c:** Migrate a file with a `{id…}`-shaped substring inside a string literal. Assert the substring is not removed and bytes outside any matched range are preserved.
+- **T-5.7-d:** Migrate a file with comments adjacent to structural-tag openers. Assert comment bytes are preserved.
+- **T-5.7-e:** Migrate a file, mutate the migrated file, then attempt reconstruction. Assert the verifier reports the mismatch and fails.
+
+Test count is preserved (5 cases). Each case is unit-testable without parser changes.
+
+---
+
+## §6.3.1 — IdRegistry concurrency and incremental-compilation scope
+
+### Concurrency (annotation)
+
+v4 §6.3.1 specified the `IdRegistry` as backed by `ConcurrentDictionary`. v5 annotates this as **defense-in-depth**: no current caller of `IdRegistry` is multi-threaded. Grep-verified: `Ids/IdAssigner.cs` is the only production consumer, and it runs in a single-threaded pass after parse. The `ConcurrentDictionary` choice anticipates future multi-threaded migrators or build-system integrations and costs nothing in single-threaded use. If a future RFC removes the multi-thread possibility, swapping to `Dictionary<TKey, TValue>` is a 1-line change.
+
+### Incremental compilation (non-goal)
+
+Incremental compilation — partial recompiles where only changed files are reparsed — is **out of scope for this RFC**. The current build is whole-program; the `IdRegistry` is rebuilt from scratch on every run. If incremental compilation is later added (no current proposal does so), the registry will need an incremental-rebuild story (e.g., persistent serialization, invalidation on dependency edges). That story is a future RFC, not a Phase 2 prerequisite.
+
+---
+
+## §9.3 — Audit rows (added)
+
+v4 §9.3 listed implementation tasks. v5 adds:
+
+| Task | Estimate | Owner | Notes |
+|------|----------|-------|-------|
+| Audit `IdGenerator.Generate()` callers; update each to compact-ID path | **0.5 day** | Compiler | Grep-verified scope: `Ids/IdGenerator.cs:60–64` is the only `Generate()` method; only 2 call sites in production — `Ids/IdAssigner.cs:175` and `Ids/IdAssigner.cs:180`. Test source may add more; budget covers both. |
+
+v4's "0.5–2 days" upper bound was conservative absent the grep verification. v5 narrows it to 0.5 day.
+
+---
+
+## §9.4 — Task authoring (revised estimate)
+
+v4 §9.4 estimated 1.5 days for authoring the 6 new measurement-gate task templates listed in §10.4. v5 revises this to **3 days** (0.5 day × 6 templates).
+
+**Why the revision:** §10.4 requires version-pinned templates with both pre- and post-migration variants, baseline runs, and reviewer instructions. v4's 1.5 days assumed authoring efficiency from batched template work; the devil's advocate correctly noted that deliberate, paired template authoring does not benefit much from batching. 0.5 day per template — including review, dry-run, and template-of-templates harmonization — is the realistic budget.
+
+Total §9 budget impact: +1.5 days, absorbed within the Phase 2 buffer in §11.
+
+---
+
+## §10.6 — Statistical test for the measurement gate
+
+v4 §10.6 specified the gate threshold (24% project-wide token reduction or revert) but did not name a statistical test for the *turn-count regression* failure mode. v5 specifies:
+
+### Test
+
+**Wilcoxon signed-rank test** on paired per-task turn-count medians (pre- vs post-migration), α = 0.05.
+
+- **Pair unit:** one §10.4 task template; pre-migration median over N=10 runs vs post-migration median over N=10 runs.
+- **Sample size:** all 6 §10.4 task templates produce paired samples; n=6 pairs is small but Wilcoxon is well-defined for n ≥ 6 (asymptotic approximation begins around n=20; exact test for smaller n).
+- **Direction:** one-sided test that post-migration turn count is **not greater than** pre-migration turn count.
+
+### Revert trigger
+
+Both conditions must hold to trigger revert:
+
+1. **Wilcoxon p < 0.05** (statistically significant turn-count increase).
+2. **Cliff's δ magnitude ≥ 0.2** (effect size at least "small").
+
+Either condition alone is insufficient: significance without effect-size protects against false positives from small n; effect size without significance protects against noise-driven swings.
+
+### Sign-off authority and deadline
+
+- **Authority:** Repo maintainer (per `CODEOWNERS`).
+- **Deadline:** Decision (ship vs revert) within **14 calendar days** of gate-data collection completion.
+- **Default if deadline missed:** revert. This is intentionally biased toward reverting silently-stalled rollouts.
+
+### What this protects against
+
+A scenario where projected token savings (§16.F) materialize but agent-turn behavior degrades — e.g., agents waste turns disambiguating positionally-referenced constructs that previously had stable IDs. v4 noted this risk in §13 item 4 but did not specify the gate measurement. v5 closes the gap.
+
+---
+
+## §11 — Release sequencing (added checkpoint)
+
+v4 §11 specified a 6-week release plan with Phase 1 and Phase 2 in sequence. v5 adds a **week-2.5 Phase 1 dependency checkpoint**:
+
+> **Week 2.5 checkpoint:** Phase 1 parser-change PR (the structural-ID drop in `Parsing/Parser.cs`) must be merged to main by end of week 2 for Phase 2 to start on schedule at week 3. If Phase 1 PR has not merged by end of week 2.5, Phase 2 start date shifts by the slippage. The repo maintainer makes this call at the week-2.5 sync.
+
+**Why:** v4's plan implicitly assumed Phase 1 is risk-free, but Phase 1 touches the parser, which historically has the highest test-failure rate of any compiler subsystem. A 2.5-day buffer between "Phase 1 done" and "Phase 2 start" absorbs typical parser-change rework without invalidating the 6-week headline.
+
+---
+
+## §13 — Honest residual concerns (additions)
+
+v4 §13 enumerated 11 residual concerns. v5 adds two:
+
+### §13.12 — Multi-repo / submodule projects
+
+The `migration.log.json` location (currently spec'd as repo-root per §5.6 step 4) is unclear for projects spanning multiple git submodules or repos. A pragmatic default would be one log per repo; a "true cross-repo" migration would need an aggregator. **Out of scope for this RFC; flagged for a future "migrator productionization" RFC** that addresses log location, retention, log schema versioning, and cross-repo coordination.
+
+### §13.13 — Lesson: the trivia-anchor fiction
+
+v4 §13.10 captured the "cache-result fiction" lesson from the v3→v4 critique round. v5 adds the analogous v4→v5 lesson: **the trivia-anchor fiction**. v4 §5.7.3 specified a verifier that compared AST trivia anchors before and after migration, on the implicit assumption that the AST had such anchors. It does not. The fiction survived three RFC iterations because no reviewer grep-verified `Lexer.cs` or the AST node definitions for trivia fields. §0.1 codifies the institutional rule that catches the next analogous fiction at review time.
+
+---
+
+## §14 — Pivot plan reconciliation (wording)
+
+v4 §14 used the phrases "cost transferred to humans/CI" and "humans do the work." v5 replaces with:
+
+- "cost transferred to" → **"cost deferred to"**: emphasizes the cost is paid later (at PR review and CI execution), not redirected to a different party.
+- "humans do the work" → **"humans absorb the validation work"**: clarifies that the work is bounded validation (PR review for the `{id…}` removal pattern), not unbounded labor.
+
+The substantive position is unchanged; v4's wording read as if responsibility was being delegated, which the devil's advocate flagged as misleading.
+
+---
+
+## §16.F — Token measurement (REPLACED)
+
+> **v5 replaces v4 §16.F entirely.** v4 used 5 hand-picked sample IDs, included a Crockford-invalid sample (`m_q9r8s7t6u5v4` contains `u`), and reported ULID mean=23.4 and compact mean=13. v5 uses 100 RNG-generated production-format IDs with the correct Crockford alphabet. Token counts came down; the savings claim survived.
+
+### Methodology
+
+- **Tokenizer:** `tiktoken.get_encoding('cl100k_base')` — Python tiktoken, the encoding used by GPT-4 family models including those typically backing agentic coding flows.
+- **ULID alphabet (Crockford uppercase, 32 chars):** `0123456789ABCDEFGHJKMNPQRSTVWXYZ`. Excludes `I, L, O, U` per Crockford Base32.
+- **Compact alphabet (Crockford lowercase, 32 chars):** `0123456789abcdefghjkmnpqrstvwxyz`. Excludes `i, l, o, u` per §6.1.
+- **Sample size:** N = 100 IDs of each form, generated via `secrets.choice` from the appropriate alphabet.
+- **Format:** `m_` prefix (module ID) + 26 chars (ULID) or 12 chars (compact). Other prefixes (`f_`, `l_`, etc.) have analogous behavior; module form was chosen as representative.
+
+### Reproduction script
+
+```python
+import tiktoken, secrets, statistics, math
+
+enc = tiktoken.get_encoding('cl100k_base')
+
+ulid_alpha = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'        # Crockford upper, 32 chars
+compact_alpha = '0123456789abcdefghjkmnpqrstvwxyz'     # Crockford lower (excl i,l,o,u)
+
+ulids = ['m_' + ''.join(secrets.choice(ulid_alpha) for _ in range(26)) for _ in range(100)]
+compacts = ['m_' + ''.join(secrets.choice(compact_alpha) for _ in range(12)) for _ in range(100)]
+
+ulid_tokens = [len(enc.encode(x)) for x in ulids]
+compact_tokens = [len(enc.encode(x)) for x in compacts]
+
+diffs = [u - c for u, c in zip(ulid_tokens, compact_tokens)]
+
+mean_u = statistics.mean(ulid_tokens)
+mean_c = statistics.mean(compact_tokens)
+mean_diff = statistics.mean(diffs)
+sd_diff = statistics.stdev(diffs)
+ci_half = 1.96 * sd_diff / math.sqrt(len(diffs))
+
+print(f'ULID mean={mean_u:.2f} sd={statistics.stdev(ulid_tokens):.2f}')
+print(f'Compact mean={mean_c:.2f} sd={statistics.stdev(compact_tokens):.2f}')
+print(f'Savings per ID: mean={mean_diff:.2f}, 95% CI ({mean_diff-ci_half:.2f}, {mean_diff+ci_half:.2f})')
+print(f'Per-ID reduction: {100*mean_diff/mean_u:.1f}%')
+```
+
+### Results (N = 100)
+
+| Metric | ULID (26-char Crockford upper) | Compact (12-char Crockford lower) |
+|--------|-------------------------------:|----------------------------------:|
+| Mean tokens | **19.22** | **9.55** |
+| Std dev tokens | 1.56 | 1.10 |
+
+| Savings | Value |
+|---------|------:|
+| Mean savings per ID | **9.67 tokens** |
+| 95% CI on savings | **(9.30, 10.04)** |
+| Per-ID reduction | **50.3%** |
+
+### Interpretation
+
+- **The savings claim survives.** A 9.67-token-per-ID reduction at a tight 95% CI (width 0.74 tokens) defeats the "v4's numbers could halve under independent measurement" concern from the devil's advocate.
+- **The absolute numbers were inflated in v4.** v4's ULID mean (23.4) and compact mean (13) appear to have been hand-picked from samples that tokenized worse than random samples. v5's RNG-generated samples regress toward what cl100k_base produces on typical Crockford output.
+- **Per-ID reduction is higher than v4 claimed.** v4 reported ~44% per-ID reduction; v5 measures 50.3%. The headline project-wide savings projection (~20–25%, gated by §10) is unchanged because project-wide savings depend on ID density and surrounding token mass, not on per-ID savings alone.
+- **The `u` violation is fixed.** v4's sample `m_q9r8s7t6u5v4` contained `u`, which §6.1 excludes from the compact alphabet. v5's RNG generator draws from the correct alphabet.
+
+### Why N = 100 is sufficient
+
+The standard error of the mean savings is 1.56/√100 ≈ 0.156 tokens, giving a 95% CI half-width of ~0.31 tokens. The reported CI half-width of 0.37 reflects the slightly wider standard deviation of the paired differences; either way, the CI is much narrower than any plausible decision threshold. Increasing N would tighten the CI but not change the conclusion: savings of 9.67 tokens per ID is firmly inside the CI.
+
+---
+
+## §17 — Decision
+
+v4's recommendation stands, refined by v5's calibrations:
+
+1. **Approve Phase 1.** Remove structural IDs from the parser, rewriter, and migrator per §5. The §5.7.3 byte-preservation verifier replaces the v4 trivia-anchor verifier and removes the 2–4 week of AST work that v4 inadvertently required.
+2. **Approve Phase 2 contingent on the §10 measurement gate.** Compact symbol IDs per §6, but ship only if the gate passes both the 24% project-wide token-reduction threshold and the §10.6 Wilcoxon-based turn-count regression check.
+3. **Begin §0.1 institutional rollout in parallel.** Land `docs/process/rfc-review-checklist.md` before Phase 1 implementation begins, to harden the next RFC.
+4. **Track residual risks per §13.** The 13 items in §13 (11 from v4 + §13.12 multi-repo flag + §13.13 trivia-fiction lesson) are not blocking but should be triaged into follow-up issues at Phase 1 kickoff.
+
+This RFC is the v2→v3→v4→v5 chain's terminal version barring discovery of another architectural fiction. The convergence of both v4 critiques on "approve and ship" suggests further iteration is diminishing returns; v5 captures their calibrations so they are not lost.
+
+---
+
+## Appendix: v4→v5 review summary
+
+| Reviewer | Verdict | Calibrations addressed in v5 |
+|----------|---------|------------------------------|
+| Designer-voice critique | "Approve as-is. Begin implementation." | All 7 recommendations folded in (§5.7.3 replaced, §1 verified-vs-projected, §9.3 audit row, §5.7.2 annotated, §6.3.1 incremental non-goal, §14 wording, §0.1 institutional rule). |
+| Devil's advocate | "Approve and ship. A v5 is not necessary." | All 3 HARD/calibration fixes folded in (§5.7.3 replaced, §16.F re-measured with N=100 RNG, §10.6 named statistical test). Smaller items §5, §6, §7 (multi-repo, week-2.5 checkpoint, task-authoring revision, multi-thread annotation) also folded in. |
+
+**Both reviewers said v5 is not necessary.** v5 exists to capture calibrations *before* implementation so they survive into PR review, not because v4 was unsafe to ship.

--- a/docs/plans/path-2-drop-ids-v6-implementation.md
+++ b/docs/plans/path-2-drop-ids-v6-implementation.md
@@ -1,0 +1,553 @@
+# v6 Implementation Plan — Compact Stable Identifiers
+
+**Status:** Approved for implementation (calibration revision of v5-implementation)
+**Supersedes:** [path-2-drop-ids-v5-implementation.md](path-2-drop-ids-v5-implementation.md)
+**Reviewed against:**
+  - [path-2-drop-ids-v5-implementation-critique.md](path-2-drop-ids-v5-implementation-critique.md) (designer voice)
+  - [path-2-drop-ids-v5-implementation-devils-advocate.md](path-2-drop-ids-v5-implementation-devils-advocate.md) (auditor voice)
+**Type:** Calibration revision (not structural rewrite)
+**Note on the §0.1 rule:** the grep-verify rule v5-implementation codified in §7 caught a false claim made by one of v6's own reviewers (see §0.2 below). The rule that was authored to discipline RFC authors disciplines RFC reviewers too. v6 augments §7's content accordingly.
+
+> **Reader's note.** v6 preserves v5-implementation's structure, PR breakdown, tier model, and rollback playbook unchanged. It applies 12 targeted calibrations identified by the v5-implementation review round. For any section not listed in §0 below, **the v5-implementation text stands as written**. This document records only the deltas.
+
+---
+
+## §0 — Changes from v5-implementation
+
+Both reviewers concluded "approve, ship the prerequisite PRs in week 0, begin Phase 1." The designer critique listed 10 calibration items; the devil's advocate raised 1 false-blocking item (§0.2 below) and 9 substantive items. v6 folds in 12 items net (some overlap; the false-blocker is documented but requires no plan change).
+
+| # | Section | Source | Change |
+|---|---------|--------|--------|
+| 1 | Header | DC §1 | **WORDING:** "Companions:" → "Companion files (to be authored by PR-0a/b/c per §2)". Removes the false impression that the three listed files already exist. |
+| 2 | §3.2 (Tier 2 token-delta row) | DC §2 | **CITATION:** Cite `~9.67` tokens/ID to v5 RFC §16.F (N=100 RNG-generated, 95% CI 9.30–10.04). Mark `±20%` tolerance band as **provisional**: recalibrate from the first real corpus measurement on a known-green build, replace with empirical sd or revisit. |
+| 3 | §1.2 | DC §3 | **STRUCTURE:** Split §1.2 into two tables: (a) "Hard prerequisites for Phase 1" (PR-0a..0d), (b) "Parallel ship items" (PR-0e). PR-0e is independent and ships in a 0.x patch; v5-implementation listed it in the prerequisites table by mistake. |
+| 4 | §9 (NEW) | DC §4 | **NEW SECTION** "Solo-mode adjustments": names three failure modes that arise when agent and maintainer are the same person — (a) maintainer-hat self-review ritual (written triage in a committed issue *before* resolving), (b) Tier 4 scheduling (GitHub Actions scheduled workflow or personal-project-contract monthly checkpoint), (c) Tier 3 retry sign-off (written justification or external read before triggering second $2k–$4k run). |
+| 5 | §3.1 (Tier 1) | DC §5 | **ACCEPTANCE:** PR-0d's acceptance criteria adds: measured wall-clock benchmark of Tier 1 on the existing corpus, captured in the PR description. If Tier 1 > 60s, §3.6 remediation (split into default+extended) executes in PR-0d, not at PR-1a discovery time. |
+| 6 | §4.3 | DC §6 | **PRE-REG INTEGRITY:** Arm SHAs frozen at gate kickoff, not "after PR-X merges." `scripts/run-phase-2-gate.*` records each arm's SHA at start and writes them to the pre-registration's "Implementation flag" section before any run executes. |
+| 7 | §3.3 | DC §7 | **MONITORING MECHANISM:** v6 picks **scheduled polling via `ScheduleWakeup` every 4 hours during the run window**, plus a pre-flight check that the next-monitoring-tick is scheduled before the gate starts. Webhook-based alerting is allowed as an addition but not a substitute. For solo-mode operation this is cross-referenced from §9. |
+| 8 | §3.5 | DC §8 | **TABLE ROW ADDED:** "Tier 1 + Tier 2 green, Tier 3 pending" → "Phase 1 is shippable per its merge gate. Phase 2 code may be merged to the release branch but MUST NOT ship to users until Tier 3 passes." This is the operational state of `release/0.x+1` between Phase 2 merge and gate kickoff. |
+| 9 | §2.3 (PR-2c) | DA §3 | **SCOPE EXPANSION:** PR-2c's file list expands from `IdAssigner.cs` (2 sites) to `IdAssigner.cs`, `IdChecker.cs`, `IdValidator.cs`, and `IdGenerator.cs` (7 grep-verified call sites total). Estimate revises from 0.5 day to 1.0–1.5 days. Acceptance criteria: "all `IdGenerator.*` callers either switched to the compact path or explicitly documented as legacy-only with a comment referencing the migrator's reverse-path." `ExtractUlid` specifically is renamed `ExtractIdPortion` (or kept legacy + a new format-aware extractor added). |
+| 10 | §4.1 | DA §4 | **PRE-REG INTEGRITY:** §4.1 fixture paths use the actual 24 directory names enumerated under `tests/E2E/agent-tasks/fixtures/` (verified by `Get-ChildItem`), not the fictional `task-001..024` pattern. v6 also adds a §4.0 disambiguation: `fixtures/` (workspace fixtures, 24 dirs) vs `tasks/` (task files, ~258) vs `templates/path-2-gate/` (the 6 new templates in PR-0c). The §10 gate runs against `fixtures/` ∪ `templates/path-2-gate/`. |
+| 11 | §5.1 | DA §5 | **METHODOLOGY:** Baseline success range changes from "**≥80%**" to "**50–90%**". Adds language: "tasks above 90% baseline should be made harder until they fall in range; tasks below 50% should be made easier or excluded." Removes the ceiling effect that would suppress small-effect detection on success-rate kill criterion (1) at week 4. |
+| 12 | §7 (file content) + Appendix A | DA §6 | **CROSS-PLATFORM:** All new harness scripts authored in **Python** (matches existing `scripts/compare-benchmarks.py` precedent). Two exceptions: thin shell entrypoints `scripts/verify-phase1.{sh,ps1}` and `scripts/verify-corpus.{sh,ps1}` follow the existing `test-enforcement.{sh,ps1}` dual pattern as `python` invocation wrappers, so Windows developers can run from PowerShell and Linux/macOS developers from bash. Appendix A's script glossary updated to reflect `.py` extensions for the underlying scripts. |
+| 13 | §3.1 + CI workflow design | DA §7.1 | **CI CONSOLIDATION:** PR-0d does NOT add a new `.github/workflows/tier1.yml` that duplicates `test.yml`. Instead, PR-0d extends `test.yml` with two new steps: (a) `scripts/verify-phase1.{sh,ps1}` invocation, (b) Tier 1 harness wall-clock report. The existing `dotnet build && dotnet test -c Release` runs once. Tier 2 (`scripts/verify-corpus.{sh,ps1}`) runs as a separate `tier2.yml` workflow triggered only on PRs targeting `phase-1`, `phase-2`, or `release/0.x+1` branches. |
+| 14 | §3.1 (Tier 1 enforcement) | DA §7.2 | **DROP** "agent must paste full output into PR description." The CI required-check status on `scripts/verify-phase1` is the canonical enforcement; pasting output is performative duplication that drifts when CI re-runs. v6 keeps the discipline ("Tier 1 must be green to mark a PR ready for review") but enforces it through GitHub's required-status mechanism, not through prose pasted into PR descriptions. |
+| 15 | §2.2 (PR-1d) | DA §7.3 | **PR SCOPE RE-EXAMINED:** PR-1d (byte-preservation verifier) flagged as **potentially collapsible into PR-1c tests**. v5 RFC §5.7.3 establishes byte-preservation as a *by-construction* property of the text-edit migrator. A separate verifier asserts what the migrator already provides. v6 keeps PR-1d as a separate PR for now (the verifier is reusable post-Phase-1 as a regression test) but explicitly marks it as "may collapse into PR-1c if the maintainer judges the verifier adds no testing surface beyond what PR-1c's unit tests cover." Decision recorded at PR-1d kickoff, not in v6. |
+| 16 | §4.4 | DA §7.4 | **MODEL PINNING FALLBACK:** §4.4 adds: "If the pinned model becomes unavailable during the gate run (deprecation, API outage, account limit), the run halts and §10.5 retry policy is invoked. The next pinned model is selected from a maintainer-curated fallback list authored alongside the pre-registration document; switching pinned models invalidates any in-flight runs and resets the run counter. Sign-off on a model switch follows the §9 solo-mode rule for retry sign-off." |
+| 17 | §7 + new §0.2 | DA §2 (FALSE) | **NO PLAN CHANGE** for the DA's "§8 is missing / file truncates at line 427" claim — verified false: `rg "^## §8" path-2-drop-ids-v5-implementation.md` returns line 483, file is 561 lines, ends at Appendix B. **HOWEVER:** the meta-pattern (a reviewer claims something about an artifact without grep-verifying) is the exact failure mode §7's grep-verify rule was authored to prevent. v6 adds §0.2 (below) documenting this as the v5-implementation→v6 instance of the architectural-fiction pattern, and amends §7's reviewer rules in §7-bis (this file) to explicitly cover *artifact-state claims*, not just architectural assertions. |
+
+That's 17 deltas covering 12 substantive items (item 17 introduces §0.2 only; items 13 and 14 are sub-deltas of the same CI restructure; items 1, 3 are one-line headers/labels; items 9, 11, 12 are the largest substantive changes).
+
+---
+
+## §0.2 — Institutional observation: the §7 rule applies to reviewers too
+
+v6's devil's-advocate review opens with a "blocking" claim: *"the document is incomplete. §7 truncates mid-sentence at line 427; §8 — 'Definition of high confidence — per-PR, per-phase, per-release' — is promised in §1.1 but does not exist."*
+
+The claim was grep-verified against the v5-implementation file:
+
+```
+$ rg "^## §" docs/plans/path-2-drop-ids-v5-implementation.md
+14:## §1 — Scope and prerequisites
+51:## §2 — PR breakdown
+136:## §3 — Coding-agent self-verification harness
+222:## §4 — The Phase 2 pre-registration document
+312:## §5 — The 6 new benchmark task templates
+354:## §6 — Rollback playbook
+410:## §7 — docs/process/rfc-review-checklist.md
+483:## §8 — Definition of done
+529:## Appendix A — Glossary of harness scripts
+548:## Appendix B — Calendar overlay on RFC §11
+
+$ wc -l docs/plans/path-2-drop-ids-v5-implementation.md
+561 lines
+```
+
+§8 exists with §8.1 through §8.5 (lines 483–525). The DA's claim is false.
+
+The likely cause: the DA's review tool truncated its read at 50 KB or some byte threshold, the reviewer concluded the file ended where their read ended, and the claim landed in the review document without a `rg`/`Get-Content -Tail` cross-check.
+
+**This is the exact failure mode §7's grep-verify rule was authored to prevent.** The trajectory pattern:
+
+| Round | Fictional claim | Subject of claim | Caught by |
+|-------|-----------------|------------------|-----------|
+| v2→v3 (RFC) | "9-char compact IDs are collision-safe" | source-code behavior | math re-derivation |
+| v3→v4 (RFC) | "migrator caches results" | source-code behavior | grep showed no cache existed |
+| v4→v5 (RFC) | "verifier compares trivia anchors" | source-code/AST behavior | grep `Lexer.cs` showed no trivia infra |
+| v5-impl→v6 | "§8 doesn't exist in the file" | artifact-state | grep `"^## §8"` showed it exists |
+
+The §7 rule originally targeted **authors making claims about source code without grep**. v6's lesson: the rule generalizes to **anyone making any architectural or artifact claim** — authors *and* reviewers. v6's §7-bis (below) updates the checklist content for PR-0a accordingly.
+
+This observation does not change the plan. The DA's substantive critiques (PR-2c scope, fictional fixture paths, cross-platform script policy, ≥80% baseline ceiling, the §7.x smaller items) are correct and folded in. Only the "blocking" claim is wrong, and it is documented here rather than carried forward as a fix.
+
+---
+
+## §1 (header revision) — Companion files
+
+The v5-implementation header lists three "Companions." v6 changes the label to make their status unambiguous:
+
+> **Companion files (to be authored by PR-0a/b/c per §2):**
+>  - `docs/process/rfc-review-checklist.md` — authored as PR-0a; content drafted in §7 + §7-bis
+>  - `docs/plans/phase-2-measurement-protocol.md` — authored as PR-0b; content drafted in §4
+>  - `tests/E2E/agent-tasks/templates/path-2-gate/` — 6 new task templates authored as PR-0c per §5
+
+Adds 4 words; removes the false impression that these files already exist.
+
+---
+
+## §1.2 (split) — Hard prerequisites vs. parallel ship items
+
+v5-implementation conflated PR-0e (independent, ships in 0.x patch) with PR-0a..0d (block Phase 1). v6 splits the table:
+
+### 1.2.a Hard prerequisites for Phase 1 (must merge before Phase 1 starts)
+
+| Prerequisite | Why | PR |
+|--------------|-----|----|
+| `docs/process/rfc-review-checklist.md` committed | Codifies the §0.1 grep-verify rule + §0.2 reviewer-rule extension before authors touch RFC-adjacent work | PR-0a |
+| `docs/plans/phase-2-measurement-protocol.md` committed | RFC §10.2 hard prerequisite for Phase 2; lands early to allow review time | PR-0b |
+| 6 new benchmark task templates committed | RFC §10.1 corpus is 24 existing + 6 new; the new 6 must exist before Phase 1 so the corpus is stable | PR-0c |
+| `scripts/verify-phase1.{sh,ps1}` and supporting Python scripts committed, CI-integrated, **wall-clock measured ≤ 60s** | Agent needs Tier 1 to exist *and demonstrably hit its budget* before writing Phase 1 PRs | PR-0d |
+
+### 1.2.b Parallel ship items (independent of Phase 1, can ship in week 0 on the 0.x cadence)
+
+| Item | Why | PR |
+|------|-----|----|
+| §8.3 standalone diagnostic addressing | RFC §11: ships first (week 0), in days, on the 0.x patch release cadence, independent of Phase 1 | PR-0e |
+
+**Phase 1 implementation PRs (PR-1*) cannot start until PR-0a through PR-0d are merged.** PR-0e is independent.
+
+---
+
+## §2.3 (PR-2c revised) — IdGenerator surface audit
+
+v5-implementation's PR-2c targeted only `IdAssigner.cs:175,180` (the 2 `Generate()` call sites). The DA verified that `grep "IdGenerator\." src/Calor.Compiler/Ids` returns 7 call sites across 3 files. v6 expands PR-2c accordingly:
+
+| PR | Title | Files touched | Acceptance criteria | Tier | Estimate |
+|----|-------|---------------|---------------------|------|----------|
+| **PR-2c (v6)** | `IdGenerator.*` caller audit + migration to compact format | `src/Calor.Compiler/Ids/IdAssigner.cs:175,180`; `src/Calor.Compiler/Ids/IdChecker.cs:156`; `src/Calor.Compiler/Ids/IdValidator.cs:56,64,163,167`; `src/Calor.Compiler/Ids/IdGenerator.cs` (method renames) | All 7 grep-verified call sites either switched to the compact path or explicitly documented as legacy-only with a comment referencing the migrator's reverse-path. `ExtractUlid` either renamed `ExtractIdPortion` (format-agnostic) or kept legacy + new format-aware extractor added (PR author's call; either acceptable). Tests green; format-validation tests cover both ULID (legacy) and 12-char compact (new) formats. | Tier 1 | **1.0–1.5 days** |
+
+The PR description must list the 7 call sites by file:line so the reviewer can confirm coverage. This is the §7-rule discipline applied to PR-2c itself.
+
+---
+
+## §3.1 (Tier 1 revised) — Measured budget, no paste requirement
+
+v6 replaces v5-implementation's §3.1 acceptance rule with:
+
+### 3.1.a Tier 1 wall-clock budget — measured, not asserted
+
+PR-0d's acceptance criteria includes:
+
+- Run `scripts/verify-phase1.{sh,ps1}` against the corpus on a clean checkout of `main`.
+- Record wall-clock time in the PR description.
+- If wall-clock > 60s, execute the §3.6 remediation order (profile → cache → split into default+extended) in PR-0d, not at PR-1a discovery time.
+- Final wall-clock measurement (post-remediation if needed) must be < 60s on a reference developer machine spec documented in the PR.
+
+### 3.1.b Tier 1 enforcement — CI required-check, not pasted prose
+
+v5-implementation required the agent to "paste full output into the PR description." v6 drops this. The enforcement mechanism is:
+
+- `scripts/verify-phase1` runs as a required status check on every PR (configured in PR-0d's `test.yml` extension per §3.1.c).
+- The agent may not mark a PR "ready for review" unless this required check is green.
+- The CI run is the canonical record. Pasting output is not required and not recommended (it drifts when CI re-runs and pads PR descriptions).
+
+### 3.1.c CI workflow consolidation
+
+PR-0d does NOT add a separate `.github/workflows/tier1.yml`. Instead, PR-0d extends the existing `test.yml` with two new steps:
+
+1. Invoke `scripts/verify-phase1.{sh,ps1}` (cross-platform wrapper per §7-cross-platform).
+2. Report Tier 1 wall-clock time as a build artifact.
+
+The existing `dotnet build && dotnet test -c Release` continues to run once per PR. Unit tests are not duplicated.
+
+Tier 2 (`scripts/verify-corpus.{sh,ps1}`) runs as a separate `tier2.yml` workflow triggered only on PRs targeting `phase-1`, `phase-2`, or `release/0.x+1` branches — Tier 2's 30-min runtime should not pay on every feature PR.
+
+---
+
+## §3.2 (Tier 2 revised) — Cited token-delta, provisional tolerance band
+
+v5-implementation's §3.2 token-delta row read: *"Aggregate Δtokens across whole corpus is within expected range (Phase 1: ~9.67 × N_structural_IDs ± 20%; Phase 2: additional ~9.67 × N_symbol_IDs ± 20%)."*
+
+v6 replaces with:
+
+> **Token-delta corpus check.** Aggregate Δtokens across whole corpus is within expected range:
+>   - **Phase 1 expected:** `9.67 × N_structural_IDs ± (provisional tolerance)`
+>   - **Phase 2 expected:** additional `9.67 × N_symbol_IDs ± (provisional tolerance)`
+>   - **Source of 9.67:** v5 RFC §16.F, N=100 RNG-generated production-format IDs, 95% CI (9.30, 10.04) per ID. The CI half-width is 0.37 tokens; aggregate variance scales as N⁻¹/² so the corpus-level expected band is materially tighter than per-file.
+>   - **Tolerance band:** **provisional ±20%** at PR-0d authoring time. **Recalibrated against the first real corpus measurement on a known-green build** before PR-1c lands. If the empirical sd justifies a tighter band, narrow it; if wider, widen it and document why in the PR description.
+>   - **Failure mode:** Tier 2 red if outside the (recalibrated) range. A measurement well outside range indicates either a measurement bug or unexpected migrator behavior — both of which warrant investigation before merge.
+
+This satisfies the §7-rule citation requirement and removes the unsourced 20% magic number.
+
+---
+
+## §3.3 (Tier 3 monitoring) — Polling mechanism specified
+
+v5-implementation's §3.3 said the agent "watches for protocol violations." v6 specifies the mechanism:
+
+### 3.3.a Pre-flight check
+
+Before `scripts/run-phase-2-gate.{sh,ps1}` invokes the first run:
+
+- Verify the monitoring tick is scheduled (see 3.3.b).
+- Verify the pinned model is currently available (a 1-prompt sanity ping; if it fails, halt and invoke §4.4 model-pinning fallback).
+- Verify disk space, network connectivity, and run-log directory writable.
+
+### 3.3.b Scheduled polling via `ScheduleWakeup`
+
+During the 4–5 day run window:
+
+- The agent (or maintainer) sets a `ScheduleWakeup` for every 4 hours.
+- At each wake, the agent inspects the run log for: protocol violations (harness crash, fixture mutation, log gaps), model API errors, throughput drift (runs/hour < expected).
+- On any violation, halt and trigger §10.5 retry per §4.9.
+- On all-green, continue and reschedule the next wake.
+
+### 3.3.c Webhook-based alerting (optional addition)
+
+`scripts/run-phase-2-gate` may additionally post to a webhook on protocol violation for faster than 4-hour response. Webhook alerting is an addition to the 4-hour polling, not a substitute (webhook outages would otherwise silently lose alerts).
+
+### 3.3.d Solo-mode cross-reference
+
+For solo-project operation (agent and maintainer are the same person), see §9.b for the operational pattern.
+
+---
+
+## §3.5 (revised confidence calculus) — Added row
+
+v5-implementation's §3.5 table has 4 rows. v6 adds the row covering the most operationally common state during weeks 4–4.5:
+
+| Combination | What you can claim | What you can NOT claim |
+|-------------|--------------------|------------------------|
+| Tier 1 green | "This PR did not break the build or local invariants." | "This PR is safe to merge into a release branch." |
+| Tier 1 + Tier 2 green | "This PR preserves system invariants across the whole corpus; aggregate token deltas are in expected range." | "Agents will actually benefit from this change." |
+| **Tier 1 + Tier 2 green, Tier 3 pending** *(v6 NEW)* | **"Phase 1 is shippable per its merge gate. Phase 2 code may be merged to `release/0.x+1` but MUST NOT ship to users until Tier 3 passes. If the maintainer must ship in the gate window, ship Phase 1 alone."** | Anything about Phase 2's agent benefit; anything about the gate outcome. |
+| Tier 1 + Tier 2 + Tier 3 green | "Agents materially benefit (per RFC §10.3 medium-effect threshold), with statistical significance, and no regressions." | "Long-term codebase rot is unaffected" (RFC §10.7). |
+| Tier 4 (post-ship) green at day 30 | "Phase 1 in production has not introduced a turn-count regression detectable at the small-effect level." | Anything about Phase 2 — Phase 2 has its own gate (Tier 3). |
+
+The new row is the ship-anxiety state of `release/0.x+1` between Phase 2 merge and gate kickoff (probably 1–2 days, but possibly longer if the gate slips into week 5 contingency). It must be explicit so the maintainer does not feel forced to ship Phase 2 just because Phase 2 code is merged.
+
+---
+
+## §4.0 (NEW) — Agent-task directory disambiguation
+
+`tests/E2E/agent-tasks/` contains three sub-populations that v5-implementation conflated. v6 disambiguates:
+
+| Directory | Population | Used by §10 gate? |
+|-----------|------------|-------------------|
+| `tests/E2E/agent-tasks/fixtures/` | 24 workspace fixtures (directories with `.calr` files, setup state, and acceptance scripts) | **Yes.** Per RFC §10.1, the existing 24-task corpus. |
+| `tests/E2E/agent-tasks/tasks/` | ~258 individual task files (different population, used by existing harness for unit-style agent tests) | **No.** Not part of the §10 gate corpus. |
+| `tests/E2E/agent-tasks/templates/path-2-gate/` (NEW, PR-0c) | 6 new workspace fixtures matching the `fixtures/` shape | **Yes.** The 6 new tasks added to the corpus per RFC §10.1. |
+
+The §10 gate runs against `fixtures/` ∪ `templates/path-2-gate/` = **30 fixtures × 10 runs × 3 arms = 900 runs**, matching RFC §10.1.
+
+---
+
+## §4.1 (revised) — Actual fixture directory names
+
+v5-implementation's §4.1 listed `task-001..024` placeholders that do not match any actual directory. v6 uses the verified directory names (enumerated by `Get-ChildItem -Directory tests/E2E/agent-tasks/fixtures/`):
+
+```
+Existing tasks (24, paths under tests/E2E/agent-tasks/fixtures/):
+
+  advanced-calor-project/   @ <commit-sha-to-fill-at-PR-0b>
+  async-project/            @ <commit-sha-to-fill-at-PR-0b>
+  basic-calor-project/      @ <commit-sha-to-fill-at-PR-0b>
+  buggy-contracts/          @ <commit-sha-to-fill-at-PR-0b>
+  collections-project/      @ <commit-sha-to-fill-at-PR-0b>
+  contracts-project/        @ <commit-sha-to-fill-at-PR-0b>
+  effects-project/          @ <commit-sha-to-fill-at-PR-0b>
+  enums-project/            @ <commit-sha-to-fill-at-PR-0b>
+  generics-project/         @ <commit-sha-to-fill-at-PR-0b>
+  oop-project/              @ <commit-sha-to-fill-at-PR-0b>
+  refactor-contract-calor/  @ <commit-sha-to-fill-at-PR-0b>
+  refactor-contract-csharp/ @ <commit-sha-to-fill-at-PR-0b>
+  refactor-extract-calor/   @ <commit-sha-to-fill-at-PR-0b>
+  refactor-extract-csharp/  @ <commit-sha-to-fill-at-PR-0b>
+  refactor-inline-calor/    @ <commit-sha-to-fill-at-PR-0b>
+  refactor-inline-csharp/   @ <commit-sha-to-fill-at-PR-0b>
+  refactor-move-calor/      @ <commit-sha-to-fill-at-PR-0b>
+  refactor-move-csharp/     @ <commit-sha-to-fill-at-PR-0b>
+  refactor-rename-calor/    @ <commit-sha-to-fill-at-PR-0b>
+  refactor-rename-csharp/   @ <commit-sha-to-fill-at-PR-0b>
+  refactor-signature-calor/ @ <commit-sha-to-fill-at-PR-0b>
+  refactor-signature-csharp/@ <commit-sha-to-fill-at-PR-0b>
+  refactor-target/          @ <commit-sha-to-fill-at-PR-0b>
+  refactoring-impure/       @ <commit-sha-to-fill-at-PR-0b>
+
+New tasks (6, paths under tests/E2E/agent-tasks/templates/path-2-gate/):
+
+  task-01-multi-function-refactor/   @ <commit-sha-to-fill>
+  task-02-add-db-effect/             @ <commit-sha-to-fill>
+  task-03-privacy-change/            @ <commit-sha-to-fill>
+  task-04-add-postcondition/         @ <commit-sha-to-fill>
+  task-05-loop-restructure/          @ <commit-sha-to-fill>
+  task-06-error-handling/            @ <commit-sha-to-fill>
+```
+
+The new-task directory names use `task-NN-<theme>/` to make the §5.2 theme mapping unambiguous and to avoid the v5-implementation conflict with the actual fixture naming convention.
+
+---
+
+## §4.3 (revised) — Arm SHAs frozen at gate kickoff
+
+v5-implementation's §4.3 described arm SHAs as "after PR-1h merges" / "after PR-2f merges." For pre-registration honesty, the SHAs must be **frozen at the moment of gate kickoff**, not described relative to PR events that may complete mid-experiment.
+
+v6 §4.3 reads:
+
+```
+Arm A (today/baseline):    main branch at <SHA recorded at gate kickoff>
+                           (latest 0.x pre-release tag's commit)
+Arm B (Phase 1 only):      release/0.x+1 at <SHA recorded at gate kickoff>
+                           (commit of the most recent Phase 1 merge; Phase 2
+                           PRs may or may not be merged at gate kickoff,
+                           but Arm B does not include them)
+Arm C (Phase 1 + Phase 2): release/0.x+1 at <SHA recorded at gate kickoff>
+                           (commit of the most recent Phase 2 merge)
+```
+
+`scripts/run-phase-2-gate.{sh,ps1}` records all three SHAs at start and writes them to the pre-registration document's "Implementation flag" section before any run executes. Any change to any SHA mid-run invalidates the run per RFC §10.5.
+
+---
+
+## §4.4 (revised) — Model-pinning fallback
+
+v5-implementation's §4.4 pinned the model but did not specify what happens if the pinned model becomes unavailable mid-run. v6 adds:
+
+> **Model unavailability during the gate run.** If the pinned model becomes unavailable (provider deprecation, account outage, rate-limit lock, API change), the run halts and the agent invokes the §10.5 retry policy. The next pinned model is selected from a **fallback list maintained alongside the pre-registration document**:
+>
+>   1. Primary: `<model-name>` at `<version>` as of `<date>`.
+>   2. Fallback A: `<model-name>` at `<version>` as of `<date>`.
+>   3. Fallback B: `<model-name>` at `<version>` as of `<date>`.
+>
+> A model switch invalidates any in-flight runs (the run counter resets to 0 for the new model). Sign-off on a model switch follows the §9.c solo-mode rule for retry sign-off: a written justification committed before the switch happens, and (in solo mode) an external read of the justification before triggering the switch.
+
+The fallback list is authored at PR-0b time, frozen at gate kickoff, and is not edited mid-run.
+
+---
+
+## §5.1 (revised) — Baseline success range 50–90%
+
+v5-implementation's §5.1 rubric required "baseline agent achieves ≥80% success across 10 seeds." The DA's math: at the 80% lower bound, Arms B/C can show at most 20 percentage points of improvement before hitting the ceiling — and with N=60 binary observations per arm, McNemar power for a realistic 5–10 percentage-point effect is poor.
+
+v6 replaces with:
+
+> **Baseline solvability range: 50–90% across 10 seeds.**
+>
+>   - Tasks **above 90%** baseline must be made harder (add a sub-edit, add a cross-file dependency, raise the acceptance bar) until they fall in range.
+>   - Tasks **below 50%** baseline must be made easier or excluded.
+>   - Tasks in the **50–90% range** provide the most distinguishing power for non-trivial effect sizes on RFC §10.3 kill criterion (1) (success-rate non-inferiority) and criterion (3) (turn-count or token-count improvement at medium effect).
+>
+> The threshold of 50% is set well above chance (which is ~0% for tasks with deterministic acceptance scripts) to ensure the baseline can solve the task at least half the time — i.e., the task is genuinely solvable by the current generation of agents, not a coin flip.
+
+This avoids the ceiling effect at the 100% line and preserves the existing rubric's intent (exclude tasks that are unsolvable today and therefore signal-free).
+
+---
+
+## §7-cross-platform — Script language and packaging policy
+
+The DA identified that v5-implementation's 10 new `.sh` scripts break on Windows developer machines (`scripts/` contains a mix of `.sh`, `.ps1`, `.py`, `.js`, with `test-enforcement.{sh,ps1}` as the dual-platform precedent). v6 fixes this:
+
+### 7.cp.a Core logic in Python
+
+All Tier 1/2/3/4 verification logic is implemented in Python. The precedent is `scripts/compare-benchmarks.py`. Reasons:
+
+- Cross-platform without a dual-script burden on every script.
+- The analysis pipeline (`scripts/analyze-gate-results.py`) is already Python; reusing the runtime keeps dependencies aligned.
+- Both Windows and Linux CI runners have Python available without additional setup.
+
+### 7.cp.b Thin shell entrypoints
+
+For the entrypoints the agent invokes most often, v6 provides `.sh` + `.ps1` wrappers that delegate to the Python implementation:
+
+```
+scripts/
+├── verify-phase1.sh           # wrapper: python3 scripts/verify_phase1.py "$@"
+├── verify-phase1.ps1          # wrapper: python scripts/verify_phase1.py @args
+├── verify_phase1.py           # actual implementation
+├── verify-corpus.sh           # wrapper: python3 scripts/verify_corpus.py "$@"
+├── verify-corpus.ps1          # wrapper: python scripts/verify_corpus.py @args
+├── verify_corpus.py           # actual implementation
+├── byte_preservation_check.py # called from verify_phase1.py
+├── ast_roundtrip_check.py     # called from verify_phase1.py
+├── token_delta_spot.py        # called from verify_phase1.py
+├── token_delta_corpus.py      # called from verify_corpus.py
+├── migrator_corpus_dryrun.py  # called from verify_corpus.py
+├── migrator_revert_roundtrip.py # called from verify_corpus.py
+├── run_phase_2_gate.py        # Tier 3 driver
+├── run-phase-2-gate.sh        # wrapper
+├── run-phase-2-gate.ps1       # wrapper
+├── phase1_post_ship_monitor.py # Tier 4
+├── phase1-post-ship-monitor.sh
+├── phase1-post-ship-monitor.ps1
+├── validate_task_template.py  # helper
+├── validate-task-template.sh
+└── validate-task-template.ps1
+```
+
+(Wrappers exist only for the entrypoints; internal helpers are pure Python.)
+
+### 7.cp.c Python version pinning
+
+Python ≥ 3.11 (matches existing `.py` scripts in `scripts/`). Specified in `scripts/requirements.txt` if new dependencies are needed; otherwise stdlib-only.
+
+### 7.cp.d Documentation
+
+`CONTRIBUTING.md` updated in PR-0d to document that Tier 1 entrypoints have both `.sh` and `.ps1` wrappers, that helpers and Tier 2/3/4 logic are pure Python, and that Windows developers should be able to run any harness command from PowerShell without WSL.
+
+---
+
+## §7-bis — Reviewer-side extension to the grep-verify rule
+
+v5-implementation's §7 (draft content for `docs/process/rfc-review-checklist.md`) targeted RFC **authors**. v6 augments §7 with a "For RFC reviewers" addition that the §0.2 false-blocking claim made necessary:
+
+Add to §7 (under "For RFC reviewers"):
+
+```markdown
+4. **Grep-verify artifact-state claims, not just architectural claims.**
+   When a review document asserts something about the state of an
+   artifact ("§N is missing," "the file truncates at line X," "the
+   directory does not exist"), the reviewer MUST grep-verify the
+   claim before including it in the review:
+
+   - "§N is missing" requires `rg "^## §N" <file>` showing no match.
+   - "File truncates at line X" requires `wc -l <file>` showing
+     line count == X AND `tail -1 <file>` showing the truncation.
+   - "Directory does not exist" requires `ls <path>` or
+     `Test-Path <path>` showing absence.
+
+   If the reviewer's tool truncates the read at some byte threshold,
+   the reviewer MUST use a second tool (`rg`, `wc -l`, `tail`,
+   `Get-Content -Tail`) to verify the artifact ends where their
+   read ends, before concluding "the file is truncated."
+
+   This rule was added v5-impl → v6 after one DA review made a
+   "blocking" claim that §8 was missing from a file that
+   demonstrably contains §8.1–§8.5 (verified by `rg "^## §8"`).
+```
+
+PR-0a is the right place for this content to land alongside the original §7. v6 adds it as PR-0a's scope expansion.
+
+---
+
+## §9 (NEW) — Solo-mode adjustments
+
+For projects where the coding agent and the repo maintainer are the same person (the situation v5-implementation implicitly assumed but never named), three failure modes arise. v6 prescribes a mitigation for each.
+
+### 9.a Maintainer-hat self-review ritual (Tier 2 red triage)
+
+**Failure mode:** Tier 2 red on a phase merge. v5-implementation says "wait for maintainer triage." In solo mode, "wait for maintainer triage" is "wait for yourself," which is motivated reasoning's most familiar form.
+
+**Mitigation:** The maintainer-hat ritual:
+
+1. Open a GitHub issue titled `Tier 2 triage: <phase> <date>`.
+2. In the issue body, paste the Tier 2 output and write the triage reasoning *before* resolving the issue — what the red signal indicates, why fix-forward vs. revert is appropriate, what specific PR to fix or revert.
+3. Wait at least 4 hours (or one ScheduleWakeup tick, whichever is longer) before acting on the triage.
+4. Then act, and close the issue with a comment recording the action taken.
+
+The 4-hour wait + written-before-action discipline defends against in-the-moment motivated self-clearing. The committed issue creates an audit trail the agent can reference at v6+1 critique time if a Tier 2 triage decision turns out to have been wrong.
+
+### 9.b Tier 4 scheduling (30-day post-ship monitoring)
+
+**Failure mode:** A coding agent does not have a persistent 30-day calendar. Without explicit scheduling, the day-30 monitoring run won't happen.
+
+**Mitigation:** PR-1h's deliverables include a GitHub Actions scheduled workflow:
+
+```yaml
+# .github/workflows/tier4-monitor.yml (added in PR-1h)
+on:
+  schedule:
+    - cron: '0 12 * * 1'  # weekly Monday noon UTC
+jobs:
+  tier4-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check if 30 days post-ship
+        run: python scripts/check_tier4_due.py
+      - name: Run Tier 4 if due
+        if: env.TIER4_DUE == 'true'
+        run: python scripts/phase1_post_ship_monitor.py
+      - name: Notify if regression detected
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Tier 4: Phase 1 post-ship regression detected',
+              body: 'See workflow run for details. Per v6 §6.1, investigate first; do not auto-revert.'
+            });
+```
+
+The workflow runs weekly, but only takes action on the first Monday after day 30. This provides scheduling without depending on the agent's session-bound memory.
+
+### 9.c Tier 3 retry sign-off
+
+**Failure mode:** Per RFC §10.5, a retry of the gate experiment requires sign-off. In solo mode the sign-off authority is the same person who decides to retry, which weakens the discipline.
+
+**Mitigation:** Before triggering the second gate run:
+
+1. Write a justification document at `docs/plans/phase-2-measurement-protocol-retry-rationale.md` covering: (a) what protocol violation triggered the halt, (b) what mitigation was applied to prevent recurrence, (c) why a retry is more cost-effective than abandoning Phase 2 or re-pre-registering with `phase-2-measurement-protocol-v2.md`, (d) the estimated $2k–$4k cost.
+2. Commit the justification.
+3. Send the file to **one external reader** (mirroring the personal-project-contract pattern). Wait for an acknowledgment that the reasoning is plausible — not approval, just acknowledgment.
+4. Then trigger the retry.
+
+This adds ~24 hours of latency to the retry decision, which is small relative to the gate's 4–5 day run and the $2k–$4k retry cost.
+
+### 9.d When this section doesn't apply
+
+If at any point the project transitions to a multi-person team (separate agent operator, maintainer, and statistician roles), §9 may be dropped in favor of the natural separation of concerns. v6 §9 exists for the operational reality, not the aspirational team structure.
+
+---
+
+## §15 (NEW) — PR-1d collapse decision
+
+v5-implementation's PR-1d (byte-preservation verifier) is potentially redundant with PR-1c (the migrator). v5 RFC §5.7.3 establishes byte-preservation as a *by-construction* property of the text-edit migrator: it removes only the byte ranges identified as `{id…}` blocks, leaving everything else untouched.
+
+If by-construction holds, a separate verifier asserts what the migrator already provides. The verifier may still be useful as:
+
+- A regression-test target distinct from the migrator's own tests.
+- A reusable tool for future migrators (PR-2d's compact-id migrator, future RFC migrators).
+- A documentation artifact for the byte-preservation property.
+
+**v6 keeps PR-1d as a separate PR**, but marks it as **"may collapse into PR-1c's tests if the maintainer judges at PR-1d kickoff that the verifier adds no testing surface beyond PR-1c's unit tests."** The decision is recorded at PR-1d kickoff in the PR description, not pre-emptively in this plan.
+
+The 5 test cases in v5 RFC §5.7.6 (T-5.7-a through T-5.7-e — citation verified by `rg "T-5\.7" docs/plans/path-2-drop-ids-v5.md` returning 5 matches at lines 123–127) are written regardless: as PR-1d tests if PR-1d ships, or as PR-1c tests if PR-1d collapses.
+
+---
+
+## §17 — Decision
+
+v5-implementation's recommendation stands, refined by v6's 12 calibrations and one institutional observation:
+
+1. **Approve v6, ship the prerequisite PRs in week 0.** PR-0a (with v6 §7-bis added), PR-0b (with v6 §4.0/4.1/4.3/4.4 corrections), PR-0c (with v6 §5.1 baseline range), PR-0d (with v6 §3.1 measured-budget + §7-cross-platform Python implementation).
+2. **Begin Phase 1 in week 1.** Phase 1 PRs land per the v5-implementation §2.2 sequence, with PR-1d possibly collapsing per v6 §15.
+3. **Begin Phase 2 in week 3** (subject to the week-2.5 dependency checkpoint from v5 §11).
+4. **Run the §10 gate in week 4** with v6 §3.3 monitoring mechanism, §4.0/§4.1/§4.3/§4.4 pre-reg corrections, and §9 solo-mode adjustments.
+5. **Apply v6 §0.2 lesson going forward.** The §7-bis reviewer-side rule lands in PR-0a alongside the original §7 content. The next review document (v6 critique round, if any) is expected to grep-verify artifact-state claims.
+
+v6 is the **terminal implementation plan revision** barring discovery of another factual error in v5-implementation's substance (not just its reviews). The convergence of both v5-implementation reviewers on "approve, ship the prerequisite PRs" — even after one made a false blocking claim — suggests further iteration is diminishing returns. PR-0a..0e ships in week 0; the work begins.
+
+---
+
+## Appendix — v5-impl → v6 review summary
+
+| Reviewer | Verdict | v6 disposition |
+|----------|---------|----------------|
+| Designer critique | "Approve as-is. Begin PR-0a..0e in week 0." (10 calibration items) | All 10 items folded in (items 1, 2, 3, 4, 5, 6, 7, 8 mapped to v6 §1-header, §3.2, §1.2-split, §9, §3.1.a, §4.3, §3.3, §3.5; items 9, 10 are duplicates/verifications, no plan change). |
+| Devil's advocate | "Revise once, then green-light. 1 blocking + 4 substantive + 6 smaller." | The 1 "blocking" item (§8 missing) is verified false (v6 §0.2); 4 substantive items folded in (v6 §2.3, §4.0/§4.1, §7-cross-platform, §5.1); 6 smaller items folded in (v6 §3.1.c, §3.1.b, §15, §4.4, §1-header, §7-bis). |
+
+Both reviewers said the plan is shippable. v6 captures all valid calibrations and documents the one invalid claim as an instance of the same architectural-fiction pattern §7 was designed to prevent — applied this time to artifact-state claims by reviewers.
+
+## Appendix B — Confidence statement
+
+**v6 confidence: High.**
+
+Justification:
+1. Both reviewers explicitly said "approve, ship the prerequisites in week 0."
+2. Every substantive critique item is folded in with grep-verified facts (PR-2c's 7 call sites, fixture directory names, lexer behavior, file structure of v5-implementation).
+3. The §0.2 observation (the §7 rule applies to reviewers too) closes the meta-loop: v6 has been adversarially reviewed, and the rule that catches author-side fictions also caught a reviewer-side fiction this round.
+4. v6 introduces no new architectural claims to be a v7 target. It only tightens citations, expands one PR scope, names one statistical-test fallback, and adds one operational section (§9 solo-mode).
+
+Residual: v6 itself has not been adversarially reviewed. The trajectory pattern (v2→v6) suggests another round might surface 1–2 calibration items, but the substantive review surface is now small (most of the v5-implementation calibration items were one-line wording fixes). Another iteration is plausibly diminishing returns.

--- a/docs/plans/path-2-drop-ids.md
+++ b/docs/plans/path-2-drop-ids.md
@@ -1,0 +1,581 @@
+# RFC: Path 2 — Drop ULIDs, Names Are Identifiers
+
+**Status:** Draft
+**Author:** TBD (with Copilot CLI)
+**Created:** 2025-11-25
+**Target release:** Pre-1.0 breaking change (0.x → 0.x+1)
+**Related:** [`bench/phase0/`](../../bench/phase0/), [`docs/philosophy/stable-identifiers.md`](../philosophy/stable-identifiers.md), [`docs/philosophy/design-principles.md`](../philosophy/design-principles.md) §3
+
+---
+
+## 1. Summary
+
+Remove ULID-based identifiers from Calor source. Use **qualified names** (`Calculator.Divide`) as the canonical address for every declaration. Sub-block constructs (loops, ifs, try/catch) lose their IDs entirely — their addressing becomes positional and is computed by tooling on demand.
+
+Repeals design principle #3 "Everything Has an ID." Replaces it with **"Everything is addressable."**
+
+This is a breaking change to the surface syntax. The semantics, type system, contract system, effect system, Z3 verification, and runtime behavior are unchanged.
+
+---
+
+## 2. Motivation
+
+### 2.1 The token tax is unjustifiably high
+
+Phase 0 benchmark (5 small tasks, cl100k tokenizer):
+
+| Variant | Tokens | vs zerolang |
+|---|---:|---:|
+| Calor today | 485 | 1.82× |
+| Calor Path 2 (proposed) | 389 | 1.46× |
+| zerolang | 266 | 1.00× |
+
+**Path 2 saves 20% of Calor's tokens** (96 of 485) — purely from removing IDs. On the smallest tasks (hello, add) the savings reach 25%. On real-logic tasks like `fizzbuzz`, Path 2 brings Calor to ~parity with zerolang (1.04× tokens) while preserving Calor's effect declarations, contracts, and typed I/O.
+
+The residual 1.46× tax represents what the ID-free Calor pays for `§Q` contracts, `§E` effects, `§I`/`§O` typed parameters, and the `§` sigil. That tax buys something — Z3 proofs, taint analysis, hosted-capability tracking — that zerolang structurally cannot offer.
+
+The ID tax buys nothing comparable. See §2.2.
+
+### 2.2 The economic case for ULIDs is weak
+
+The four claimed ULID benefits (from `docs/philosophy/stable-identifiers.md`):
+
+1. **"Unambiguous reference"** — but `Calculator.Divide` is already unambiguous within a module-scoped language. The ambiguity ULIDs solve (`Calculate` vs `validateUser` vs renamed-to-`Compute`) is a *cross-version* problem (history) not a *cross-call* problem (current code). It's solved at the tool layer (git, LSP rename, codemod), not the language layer.
+2. **"Survives rename"** — this is a refactoring problem, not a programming problem. Modern LSP-based rename is atomic; you don't need IDs for atomicity, you need a tool that visits all references. Calor already has `calor fix --rename`.
+3. **"Merge safety"** — name-based merge is a solved problem (every other language). The actual merge failures ULIDs prevent are exotic and rare; the daily merge cost ULIDs *add* (every block has an identifier that two branches may regenerate differently) is constant.
+4. **"Traceable history"** — git already provides this at the entity level (`git log --follow`), and the symbol-name approach works as well as the ID approach in practice. Tools like Sourcegraph index by name path successfully across the entire OSS ecosystem.
+
+### 2.3 The LLM economics make IDs hostile
+
+Random ULIDs (`f_01J5X7K9M2NPQRSTABWXYZ12`) tokenize at roughly **one character per token** because they contain no natural-language patterns the BPE merges recognize. A 28-character ULID with prefix costs ~28 tokens vs ~3 tokens for the meaningful function name. The LLM gets zero semantic benefit from an ID it cannot reason about — it has to maintain a parallel name-to-ID mapping in its working memory.
+
+The original argument was "the agent can edit `f_01J5X7…` unambiguously." In practice, the agent reads the file, finds the function by *name*, and then has to copy the ID character-by-character. That's not a feature; that's a tax on every edit.
+
+### 2.4 What we keep, what we drop
+
+| Surface element | Today | Path 2 |
+|---|---|---|
+| Module declaration | `§M{m001:Calculator}` | `§M{Calculator}` |
+| Function declaration | `§F{f001:Add:pub}` | `§F{Add:pub}` |
+| Class declaration | `§CL{c001:User}` | `§CL{User}` |
+| Method declaration | `§MT{mt001:save:pub}` | `§MT{save:pub}` |
+| Constructor | `§CTOR{ctor001:pub}` | `§CTOR{pub}` |
+| Loop | `§L{for1:i:1:10:1}` | `§L{i:1:10:1}` |
+| Conditional | `§IF{if1} (cond) … §/I{if1}` | `§IF (cond) … §/I` |
+| Try block | `§TR{try1}` … `§/TR{try1}` | `§TR` … `§/TR` |
+| Refinement type | `§RTYPE{rt001:PosInt}` | `§RTYPE{PosInt}` |
+| Proof obligation | `§PROOF{pf001:DivisorNotZero}` | `§PROOF{DivisorNotZero}` |
+| Effect declaration | `§E{cw,db}` | `§E{cw,db}` — unchanged |
+| Precondition | `§Q (> x 0)` | `§Q (> x 0)` — unchanged |
+| Postcondition | `§S (>= result 0)` | `§S (>= result 0)` — unchanged |
+
+**Names are required where they exist today.** Modules, functions, classes, methods, properties, enums, refinement types must still have a name — that's already how the code is identified by humans and LLMs. Path 2 just makes the name the *sole* identifier, removing the redundant ULID.
+
+**Sub-blocks are nameless.** Loops, ifs, try blocks were never named, only ID'd. Their addressing becomes positional and is computed by tooling.
+
+---
+
+## 3. Goals & non-goals
+
+### Goals
+
+- **G1.** Reduce token cost of Calor source by 15–25% with zero semantic change.
+- **G2.** Eliminate the cognitive tax on LLMs of maintaining name-to-ULID mappings.
+- **G3.** Eliminate IdScanner / IdValidator / IdGenerator as required code paths in the compile pipeline. Their presence becomes optional metadata (see §6.4).
+- **G4.** Preserve full backward compatibility for *reading* existing Calor with IDs during a transition period; the parser accepts both forms.
+- **G5.** Ship an automatic migrator (`calor fix --drop-ids`) that converts an existing codebase to Path 2 syntax in one command.
+
+### Non-goals
+
+- **NG1.** This RFC does not change the semantics, type system, contract system, effect system, Z3 verification, runtime, or generated C# in any user-visible way.
+- **NG2.** This RFC does not introduce optional IDs as an ongoing supported feature (see §11 for why). The transition period is finite.
+- **NG3.** This RFC does not change C# → Calor migration output beyond removing IDs from emitted Calor.
+- **NG4.** This RFC does not address the broader "should Calor compete with C# at all?" question (separate discussion).
+
+---
+
+## 4. Current state
+
+### 4.1 Where IDs exist
+
+Today the `IdScanner` (`src/Calor.Compiler/Ids/IdScanner.cs`) recognizes IDs on these declaration kinds (the `IdKind` enum):
+
+```
+Module, Function, Class, Interface, Property, Method, Constructor,
+Enum, EnumExtension, OperatorOverload, Indexer,
+RefinementType, ProofObligation, IndexedType
+```
+
+These are all **symbol-level** declarations — things you would put in a symbol table.
+
+Additionally, the AST carries IDs on sub-block constructs (loops, ifs, try blocks) but **the IdScanner does not collect them**. They were never canonical identifiers; they're purely structural.
+
+### 4.2 ID format
+
+`IdValidator` enforces:
+
+- **Production IDs:** `{prefix}_{ULID}` where ULID is 26 chars of Crockford Base32. Example: `f_01J5X7K9M2NPQRSTABWXYZ12`.
+- **Test IDs:** `{prefix}{digits}` in files under `tests/`, `docs/`, `examples/`. Example: `f001`.
+
+The prefix table (from `IdGenerator`): `m_`, `f_`, `c_`, `i_`, `p_`, `mt_`, `ctor_`, `e_`, `op_`.
+
+### 4.3 Diagnostics tied to IDs
+
+`Diagnostic.cs` defines diagnostic codes `Calor0800–0805`:
+
+- `Calor0800` — missing ID
+- `Calor0801` — invalid format
+- `Calor0802` — wrong prefix for declaration kind
+- `Calor0803` — duplicate ID
+- `Calor0804` — test ID used in production
+- `Calor0805` — ID churn (existing ID was modified)
+
+All six become irrelevant under Path 2; see §9.
+
+### 4.4 ID-related CLI surfaces
+
+- `calor ids assign` — generates ULIDs for declarations that lack them
+- `calor ids check` — validates IDs, detects churn, duplicates, missing
+- `calor format --ids` — alternate spelling, same purpose
+- `calor hook validate-ids` — pre-write hook
+
+### 4.5 Round-trip via [CalorId] attribute
+
+The C# emitter writes `[CalorId("f_01ABC…")]` on every generated member. The Roslyn → Calor converter reads it back. This is how identity survives `calr → cs → calr` round-trips today.
+
+---
+
+## 5. Proposed state
+
+### 5.1 Addressing model
+
+The canonical address of any declaration is its **dotted qualified name** from the module root:
+
+```
+Calculator                       // module
+Calculator.Divide                // function
+Calculator.User                  // nested class
+Calculator.User.save             // method
+Calculator.User.Email            // property
+Calculator.PosInt                // refinement type
+Calculator.Divide.DivisorNotZero // proof obligation (named)
+```
+
+Sub-block addresses are **computed paths**, not source-visible identifiers:
+
+```
+Calculator.Divide.body[3]                  // the 4th statement
+Calculator.Divide.body[3].then.body[0]     // the first statement of its then-branch
+Calculator.Main.body[0].loop.body[2]       // 3rd statement of the loop body
+```
+
+Tooling (LSP, MCP `calor_navigate`) accepts both. Diagnostics emit both: `Calor0501 at Calculator.Divide.body[3] (file:line)`.
+
+### 5.2 Uniqueness rules
+
+- Within a module, **all sibling declarations must have unique names**. (Already true today modulo overload resolution.)
+- Method overloads continue to use signature-based disambiguation: `Calculator.Add(i32,i32)` vs `Calculator.Add(f64,f64)`. The fully-qualified-with-signature form is used in tooling output when needed.
+- Constructors disambiguate by signature: `Calculator.User.ctor(str)` vs `Calculator.User.ctor()`.
+- Operator overloads address by token: `Calculator.Vector.op_plus`.
+
+### 5.3 Cross-module references
+
+A reference from module `Reports` to a function in module `Calculator` uses the qualified path:
+
+```
+Calculator.Divide
+```
+
+There is no global namespace beyond modules. Module names must be unique within a project (already enforced).
+
+### 5.4 Rename refactoring
+
+The MCP/LSP layer ships `calor fix --rename --from Calculator.Add --to Calculator.Plus`. This:
+
+1. Parses every `.calr` file in the project.
+2. Finds the declaration matching the `--from` qualified name.
+3. Renames the declaration and *every reference to it* in one atomic operation.
+4. Writes all files. The operation is all-or-nothing (uses a temp directory + atomic swap).
+
+This is functionally what `calor fix --rename` does today, except it operates on names instead of ULIDs. The implementation cost is approximately the same; the agent's UX is better because it can issue rename commands in natural-language form.
+
+### 5.5 Git history & blame
+
+Names instead of ULIDs means git follows entities by name. `git log --follow path.calr` works. When a function is renamed, the rename refactoring should produce a *single commit* whose message records both names; tooling can encourage this with a commit hook (`calor fix --rename --commit`).
+
+This is the same behavior every other language has used successfully for decades.
+
+---
+
+## 6. Detailed changes
+
+### 6.1 Grammar changes
+
+The lexer rule for declaration-opening tags becomes:
+
+```
+§M    { Name }
+§F    { Name : visibility }
+§CL   { Name }
+§IFACE{ Name }
+§MT   { Name : visibility }
+§PROP { Name : type }
+§CTOR { visibility }
+§EN   { Name }
+§OP   { token : visibility }
+§RTYPE{ Name }
+§PROOF{ Name }
+```
+
+Sub-block opening tags drop the ID block entirely (the loop variable spec moves to position 0):
+
+```
+§L  { var : from : to : step }
+§IF (cond) → …
+§WH (cond) →
+§TR
+```
+
+Closing tags become bare:
+
+```
+§/M  §/F  §/CL  §/IFACE  §/MT  §/CTOR
+§/L  §/I  §/W  §/TR
+```
+
+(No ID block follows. Indentation and tag-nesting determine the match; the parser already tracks the open stack.)
+
+### 6.2 Lexer / parser changes
+
+- `Parsing/Lexer.cs`: no token-kind changes (the tag tokens are unchanged); the attribute parser inside `ParseAttributes` no longer reserves the `_pos0` slot for an ID on these tags.
+- `Parsing/Parser.cs`: for each declaration tag, `ParseAttributes` is called with a new `expectsId: false` flag (or equivalent). The Name moves from `_pos1` to `_pos0`.
+- For backward compatibility during transition: parser accepts both forms. If `_pos0` looks like an ID (prefix matches `m_`, `f_`, etc.), it's parsed as the legacy form and the Name is at `_pos1`. Otherwise the new form. The parser emits `Calor0806` (deprecation warning) on legacy form.
+
+### 6.3 AST changes
+
+- Every node that today has an `Id` string field keeps the field — but it becomes **nullable** (`string?`).
+- For new code, IDs are always null. For legacy code parsed during transition, IDs are populated as before.
+- Binder treats `null` IDs as expected (no diagnostic).
+
+### 6.4 IdScanner / IdValidator / IdGenerator
+
+These three classes become **optional metadata producers**:
+
+- `IdScanner.Scan(...)` still works but returns only entries for nodes with non-null IDs.
+- `IdGenerator.Generate()` is exposed via `calor ids assign --legacy` for users who still want ULIDs for some reason (e.g., proprietary tooling that depends on them). Off by default. Removed entirely in a later release.
+- `IdValidator` is only invoked when `calor ids check` is called. The `Calor0800–0805` diagnostics are still defined but emitted only by that command, not by the default compile pipeline.
+
+### 6.5 Visitor implementations
+
+Per `CLAUDE.md` §"Adding New AST Nodes" — every IAstVisitor implementer must handle the nullability:
+
+- `CodeGen/CSharpEmitter.cs` — when emitting `[CalorId(...)]`, skip the attribute when ID is null. (See §6.6 for the alternative.)
+- `Migration/CalorEmitter.cs` — never emit IDs in new code. The `EmitCalor` settings drop `IncludeIds` support; it's hard-coded false.
+- `Ids/IdScanner.cs` — already skips nodes with null/empty IDs (the existing pattern for RefinementType / ProofObligation works).
+- `Verification/ExpressionSimplifier.cs` — no change (doesn't touch IDs).
+
+### 6.6 Round-trip strategy: `[CalorId]` → `[CalorSymbol]`
+
+The C# emitter today writes `[CalorId("f_01ABC...")]` to enable round-trip identity preservation. Under Path 2:
+
+**Option A (recommended):** Replace `[CalorId]` with `[CalorSymbol("Calculator.Divide")]`. The Roslyn → Calor converter uses the qualified name to restore the original Calor structure (e.g., to know which `using` block / module a class belongs to). This is enough for round-trip stability because names are the new identity.
+
+**Option B:** Drop the attribute entirely; rely on the file structure (one module per file by convention, type names match Calor class names). Simpler but loses some round-trip information for complex layouts.
+
+This RFC recommends **Option A**. The attribute is cheap (one line per emitted member) and the migration tooling already depends on it.
+
+### 6.7 MCP tool changes
+
+| Tool | Today | Path 2 |
+|---|---|---|
+| `calor_navigate` "definition" | accepts ID `f_01ABC...` | accepts qualified name `Calculator.Divide` |
+| `calor_navigate` "references" | finds by ID | finds by qualified name |
+| `calor_navigate` "find" | search by name (already) | unchanged |
+| `calor_fix` "ids" | regenerate missing IDs | removed (or repurposed as `--drop-ids` migrator) |
+| `calor_format` action="ids" | format/assign IDs | removed |
+| All diagnostic-bearing tools | emit IDs in diagnostics | emit qualified names |
+
+The change is mostly *removing* features. Net MCP surface shrinks.
+
+### 6.8 Sample migration
+
+All files under `samples/` are auto-migrated by running `calor fix --drop-ids samples/` once. The diff is mechanical (remove `m001:`, `f001:`, etc.) and reviewable.
+
+### 6.9 Documentation changes
+
+- **Repeal:** `docs/philosophy/design-principles.md` §3 "Everything Has an ID" → rewrite as "Everything is addressable."
+- **Repeal:** `docs/philosophy/stable-identifiers.md` → keep as historical document with prominent "Repealed" header pointing to this RFC, or delete entirely.
+- **Update:** `docs/syntax-reference/` — strip ID columns from every tag table.
+- **Update:** `docs/ids.md`, `docs/cli/ids.md` — mark as deprecated/legacy.
+- **Update:** `CLAUDE.md`, `.github/copilot-instructions.md` — remove the "ID prefix table" and the rule about adding IDs; replace with the simpler "names are identifiers" rule.
+- **Update:** `calor://primer`, `calor://id-prefixes`, `calor://tags` MCP resources — same treatment.
+- **Update:** `.claude/skills/calor-language/SKILL.md` (if it exists) — update to Path 2 syntax.
+- **Add:** `docs/migration/v0.x-drop-ids.md` — how-to-migrate guide.
+
+---
+
+## 7. Migration plan
+
+### 7.1 Deprecation timeline (proposed)
+
+| Release | Behavior |
+|---|---|
+| **0.x** (Path 2 ships) | Parser accepts both forms. Path 2 form is the documented default. Legacy form emits `Calor0806` deprecation warning. `calor fix --drop-ids` migrator ships. All samples migrated. |
+| **0.x + 1** | Legacy form is opt-in via `--allow-legacy-ids` flag. Default compile rejects it with `Calor0807`. |
+| **1.0** | Legacy form removed. Parser rejects it unconditionally. `IdScanner`, `IdValidator`, `IdGenerator` deleted. `[CalorId]` attribute deleted. |
+
+Three releases gives downstream users time to migrate. Because Calor is pre-1.0, this is well within the "breaking changes allowed" envelope per `CLAUDE.md`.
+
+### 7.2 Migrator
+
+`calor fix --drop-ids [path]`:
+
+1. Parses every `.calr` file under `path`.
+2. For each AST node with an ID, sets the ID to null.
+3. Re-emits with `CalorEmitter` (which under Path 2 never writes IDs).
+4. Writes the file back.
+
+The migrator is idempotent. Files already in Path 2 form pass through unchanged.
+
+### 7.3 Round-trip migration
+
+For projects that consume the generated C# via `[CalorId]` attributes (e.g., test runners that map ID → test), the C# emitter still writes `[CalorSymbol("…")]` under §6.6 Option A. Consumers must update their attribute reads from `CalorId` → `CalorSymbol`.
+
+This is a one-line code change in any consumer. Provide a `[CalorId]` shim attribute that forwards to `[CalorSymbol]` for one release for safety.
+
+---
+
+## 8. Compiler change scope
+
+Estimated effort (single engineer, no help): **3–4 weeks**.
+
+### Phase A — Parser & AST (week 1)
+
+- `Parsing/Parser.cs`: dual-mode declaration parsing; deprecation warning on legacy form. ~200 line delta.
+- AST nodes: make `Id` properties nullable. Mechanical; impacts ~14 node types. ~50 line delta per type ≈ 700 line delta total.
+- Snapshot tests under `tests/Calor.Compiler.Tests`: many tests check exact source/AST output. Each needs a "Path 2 variant" snapshot. ~50 snapshot files affected.
+
+### Phase B — Visitors & emitters (week 2)
+
+- `CodeGen/CSharpEmitter.cs`: switch `[CalorId]` → `[CalorSymbol]`. ~20 line delta.
+- `Migration/CalorEmitter.cs`: stop emitting IDs. Drop the `IncludeIds` option. ~30 line delta.
+- `Migration/RoslynSyntaxVisitor.cs`: read `[CalorSymbol]` instead of `[CalorId]` for round-trip. ~15 line delta.
+- `Ids/IdScanner.cs`: short-circuit when ID is null (already mostly does this). ~10 line delta.
+- `Verification/ExpressionSimplifier.cs`: no change.
+
+### Phase C — Diagnostics & tooling (week 3)
+
+- `Diagnostics/Diagnostic.cs`: add `Calor0806` (deprecation warning) and `Calor0807` (error in deprecation period 2). Keep `Calor0800–0805` but only fire them in `calor ids check`.
+- `Migration/FeatureSupport.cs`: no change (no new tag kinds; only attribute slots changed).
+- `calor fix --drop-ids` migrator: new code path, ~200 lines.
+- `calor ids assign` → `calor ids assign --legacy`: flag rename and deprecation message. ~20 line delta.
+- MCP server tool registrations: update `calor_navigate`, `calor_fix`, `calor_format` argument schemas to accept qualified names. ~100 line delta.
+
+### Phase D — Samples, docs, instructions (week 4)
+
+- Run `calor fix --drop-ids samples/` and review diff.
+- Run `calor fix --drop-ids docs/` and review diff (some docs intentionally show ID syntax — keep those tagged with `<!-- legacy -->`).
+- Rewrite `docs/philosophy/design-principles.md` §3.
+- Mark `docs/philosophy/stable-identifiers.md` as repealed.
+- Update `CLAUDE.md`, `.github/copilot-instructions.md`, MCP resource files.
+- Update `editors/vscode/` syntax highlighting grammar.
+- Update website (`website/content/`).
+
+### Risks
+
+- **R1.** **Snapshot test churn.** ~50 golden files need new variants. Mitigate by writing a snapshot updater script that re-runs `dotnet test --update-snapshots` after parser dual-mode lands.
+- **R2.** **MCP/LSP regressions.** Address-by-name has slightly different ambiguity properties than address-by-ID. Mitigate by writing a comprehensive resolver test suite in `Calor.Semantics.Tests`.
+- **R3.** **Downstream consumers of `[CalorId]`.** Mitigate with the shim attribute (§7.3) for one release.
+- **R4.** **Performance.** Resolving by qualified name requires a symbol table lookup vs an ID dictionary lookup. Both are O(1). No measurable impact expected.
+- **R5.** **Cross-version git diffs.** Migrating an existing codebase produces a large mechanical diff. Mitigate by scheduling the migration as a single commit on its own PR, separate from any logic changes.
+
+---
+
+## 9. Diagnostics rework
+
+### 9.1 Repurposed codes
+
+| Code | Today | Path 2 |
+|---|---|---|
+| `Calor0800` Missing ID | Error | Removed (or only `calor ids check`) |
+| `Calor0801` Invalid format | Error | Removed |
+| `Calor0802` Wrong prefix | Error | Removed |
+| `Calor0803` Duplicate ID | Error | Removed |
+| `Calor0804` Test ID in production | Error | Removed |
+| `Calor0805` ID churn | Error | Removed |
+
+### 9.2 New codes
+
+| Code | Description | Severity |
+|---|---|---|
+| `Calor0806` | Legacy ID syntax used (deprecated) | Warning |
+| `Calor0807` | Legacy ID syntax used (no longer supported) | Error (post-deprecation period) |
+| `Calor0808` | Duplicate sibling declaration name | Error |
+| `Calor0809` | Ambiguous overload (signature-disambiguated reference required) | Error |
+
+### 9.3 Diagnostic addressing
+
+Today: `Calor0501: division by zero in f_01J5X7K9M2NPQRSTABWXYZ12 at line 42`
+
+Path 2: `Calor0501: division by zero in Calculator.Divide at line 42`
+
+The qualified name is shorter, semantically meaningful, and copy-pasteable into the LLM's next message.
+
+---
+
+## 10. Effort summary
+
+| Phase | Scope | Estimate |
+|---|---|---|
+| A | Parser, AST nullability, snapshot tests | 5 days |
+| B | Visitors, emitters, round-trip | 4 days |
+| C | Diagnostics, migrator, CLI, MCP | 4 days |
+| D | Samples, docs, agent instructions | 3 days |
+| **Total** | | **~3 weeks** |
+
+Plus 1 week buffer for snapshot churn, downstream feedback, and the deprecation-shim work.
+
+**One PR strategy:** ship Phases A–C in a single PR (compiler change with dual-mode parser). Ship Phase D in a follow-up PR (samples + docs migration). This keeps the compiler change reviewable and lets samples migrate after the migrator is verified.
+
+---
+
+## 11. Rejected alternatives
+
+### 11.1 Sidecar file (`*.calr.ids.json`)
+
+Keep IDs out of source; store them in a sibling JSON file. Reduces source token cost the same as Path 2 but introduces a new problem: every operation that creates/moves/renames a declaration must update the sidecar, and the sidecar must be checked in. Identity preservation through cut-paste becomes unreliable.
+
+**Rejected because:** the user explicitly disliked this option (preferred no extra file). Also: it doesn't reduce LLM cognitive load — the LLM still has to be aware of the parallel ID structure.
+
+### 11.2 Optional IDs (hybrid)
+
+IDs become optional. The lint policy decides when to add them ("only on `pub` declarations referenced cross-file"). The compiler auto-generates them on demand.
+
+**Rejected because:** the rule "when do I need an ID?" is itself a tax — every time the agent adds or moves a declaration it must reason about visibility, cross-file references, and lint policy. This is *worse* than mandatory IDs (always present) or no IDs (never present). The middle path is the worst path.
+
+### 11.3 Compiler-generated inline IDs
+
+The compiler auto-assigns and inlines ULIDs after the agent writes ID-less code. The agent writes `§F{Add:pub}` and the file on disk becomes `§F{f_01J5X7...:Add:pub}` after the next save.
+
+**Rejected because:** this trains the agent to ignore IDs, then forces the agent to re-read them whenever it edits. The IDs become source-code noise that everyone — humans and agents — learns to ignore. If everyone ignores them, why are they there?
+
+### 11.4 Keep IDs, focus on tokenizer-friendly format
+
+Replace ULIDs with shorter, more BPE-friendly IDs (e.g., 8-char alphanumeric). Cuts token cost ~70% per ID while preserving "everything has an ID."
+
+**Rejected because:** the cognitive tax is independent of the token tax. The LLM still has to maintain a name-to-ID mapping for editing. Even a 4-character ID costs more cognition than zero.
+
+### 11.5 Status quo
+
+Keep ULIDs. Accept the 1.82× token tax. Argue that the verification dividend justifies it.
+
+**Rejected because:** Phase 0 evidence shows the verification dividend is only on `divide`-like programs (preconditions). The token tax applies to *all* programs including ones that have no contracts. Most programs do not benefit from ULIDs at all.
+
+---
+
+## 12. Open questions
+
+1. **Q1.** Should `[CalorSymbol]` be emitted on every member, or only on members the round-trip migration needs? Smaller attribute footprint vs guaranteed round-trip. **Recommendation:** all members for one release; revisit.
+2. **Q2.** Method overload disambiguation in qualified names — use C# syntax (`Calculator.Add(i32,i32)`) or Calor-native (`Calculator.Add#2`)? **Recommendation:** C# syntax for consistency with `nameof()` and LSP tooling.
+3. **Q3.** Constructor naming — `Calculator.User.ctor()` or `Calculator.User.new()` or `Calculator.User`? **Recommendation:** `ctor()` to match the existing IdKind.
+4. **Q4.** Do we delete `Stable Identifiers` from `docs/philosophy/` or keep it with a "Repealed" header? **Recommendation:** keep with header (preserves history of the design decision).
+5. **Q5.** Does `calor fix --drop-ids` overwrite source files in place, or output to a parallel tree? **Recommendation:** in-place with `--dry-run` flag.
+6. **Q6.** Should the deprecation period 2 release be 0.x+1 or 0.x+2? Faster removal = less code in tree; slower removal = more downstream goodwill. **Recommendation:** 0.x+1 because we're pre-1.0 and the migrator makes upgrade trivial.
+
+---
+
+## 13. Appendix: side-by-side examples
+
+### A. Hello
+
+**Today (50 cl100k tokens):**
+```calor
+§M{m001:Hello}
+§F{f001:Main:pub}
+  §O{void}
+  §E{cw}
+  §P "hello"
+§/F{f001}
+§/M{m001}
+```
+
+**Path 2 (38 cl100k tokens, −24%):**
+```calor
+§M{Hello}
+§F{Main:pub}
+  §O{void}
+  §E{cw}
+  §P "hello"
+§/F
+§/M
+```
+
+### B. Divide with precondition
+
+**Today (81 cl100k tokens):**
+```calor
+§M{m001:DivideDemo}
+§F{f001:Divide:pub}
+  §I{i32:a}
+  §I{i32:b}
+  §O{i32}
+  §Q{message="divisor must not be zero"} (!= b 0)
+  §R (/ a b)
+§/F{f001}
+§/M{m001}
+```
+
+**Path 2 (69 cl100k tokens, −15%):**
+```calor
+§M{DivideDemo}
+§F{Divide:pub}
+  §I{i32:a}
+  §I{i32:b}
+  §O{i32}
+  §Q{message="divisor must not be zero"} (!= b 0)
+  §R (/ a b)
+§/F
+§/M
+```
+
+### C. IsPrime with nested ifs and a loop
+
+**Today (151 cl100k tokens):**
+```calor
+§M{m001:IsPrimeDemo}
+§F{f001:IsPrime:pub}
+  §I{i32:n}
+  §O{bool}
+  §IF{if1} (< n 2) → §R BOOL:false §/I{if1}
+  §L{for1:i:2:n:1}
+    §IF{if2} (== (% n i) 0) → §R BOOL:false §/I{if2}
+    §IF{if3} (> (* i i) n) → §R BOOL:true §/I{if3}
+  §/L{for1}
+  §R BOOL:true
+§/F{f001}
+§/M{m001}
+```
+
+**Path 2 (114 cl100k tokens, −25%):**
+```calor
+§M{IsPrimeDemo}
+§F{IsPrime:pub}
+  §I{i32:n}
+  §O{bool}
+  §IF (< n 2) → §R BOOL:false §/I
+  §L{i:2:n:1}
+    §IF (== (% n i) 0) → §R BOOL:false §/I
+    §IF (> (* i i) n) → §R BOOL:true §/I
+  §/L
+  §R BOOL:true
+§/F
+§/M
+```
+
+The `is_prime` example is where the structural improvement is clearest: nested ifs and loops lose 6 ID blocks (3 opens + 3 closes) totaling 24 tokens of pure structural noise.
+
+---
+
+## 14. Decision
+
+To be made by repo maintainer. Recommended: **accept** and proceed with Phase A in a feature branch.

--- a/docs/plans/phase-1-2-scope-decisions.md
+++ b/docs/plans/phase-1-2-scope-decisions.md
@@ -1,0 +1,95 @@
+# Phase 1/2 — Scope Decisions Not Captured in v6 Implementation Plan
+
+This document records two small scope decisions taken during
+implementation of `feature/compact-ids-v6` that were left open in
+`path-2-drop-ids-v6-implementation.md`. Each decision references the
+concrete code/test paths it affects so a future reader can verify the
+reasoning.
+
+---
+
+## §1 — PR-1e / PR-1f: samples and tests are already v6-compatible
+
+**Decision:** No corpus migration is required for `samples/` or for
+the `*.calr`/`*.calor` fixtures under `tests/`. PR-1e and PR-1f, as
+described in v5/v6 plans ("apply the Phase 1 migrator across the
+sample corpus / the test corpus"), are **no-ops on this repository at
+the time of writing**.
+
+### Why
+
+The Phase 1 dropper (`StructuralIdDropper`) only removes
+`{<prefix>_<payload>}` ID blocks where the `payload` portion looks
+like a real production ID. The detector
+(`AttributeHelper.LooksLikeId`) accepts exactly two payload shapes:
+
+1. 26 characters (legacy ULID), or
+2. 12 characters drawn from the compact Crockford-lowercase alphabet
+   (`0123456789abcdefghjkmnpqrstvwxyz`).
+
+Short test IDs in the codebase — e.g. `m001`, `f001`, `f1`, `l1` — do
+not match either shape, so the migrator does not touch them. The same
+test IDs are also accepted by the v6 parser's compact-opener path:
+they are not stripped, but they are not invalid either.
+
+### Verification
+
+Restricted to file types the migrator actually targets:
+
+```
+$ rg --pcre2 -l '\{(m|f|c|i|p|mt|ctor|e|op)_[0-9A-HJKMNP-TV-Z]{26}\}' \
+     -g '*.calr' -g '*.calor' samples tests
+# empty
+```
+
+No `.calr` / `.calor` files in `samples/` or `tests/` carry a
+ULID-shaped structural-ID block for the Phase 1 dropper to remove or
+a 26-char ULID payload for the Phase 2 migrator to rewrite. Some C#
+test sources (notably `tests/Calor.Ids.Tests/*.cs`) embed ULID-shaped
+strings as input to unit tests that exercise the legacy
+`IdAssigner`/`IdValidator` paths — those strings are test fixtures
+for the legacy code path, not migration targets, and the migrator
+correctly does not touch `.cs` files.
+
+### Implication
+
+If a future contributor lands a sample or test with a production-shape
+ID (e.g. by pasting in real generator output), PR-1e/1f should be
+re-evaluated against the new corpus. Until then they remain no-ops
+and are not blockers for shipping Phase 1 or for kicking off the §10
+gate. The opt-in `Calor0820` lint (`LegacyStructuralIdLint`) will
+surface any such IDs that slip in.
+
+---
+
+## §2 — PR-2f: revert lives in `CompactIdMigrator`, not a standalone file
+
+**Decision:** The Phase 2 migrator's revert path is implemented as a
+static method on `CompactIdMigrator` (in `Migration/CompactIdMigrator.cs`)
+rather than as a separate `CompactIdReverter.cs` file as suggested by
+v6 §2.3's filename hint.
+
+### Why
+
+The forward path and the reverse path share the same source-scanner
+data structures and the same mapping-log format. Splitting the
+reverter into a separate file would either:
+
+- duplicate the scanner code, or
+- expose internal scanner helpers as a public API solely so the
+  reverter could call them.
+
+Both are worse than the current arrangement, which keeps mapping-log
+producer and consumer in one file. The test surface
+(`EndToEndMigrationTests` exercises the round-trip end-to-end) is
+identical to what a split would provide.
+
+### Implication
+
+If `CompactIdMigrator.cs` grows beyond ~500 lines, or if a third path
+(say, an "apply mapping log without rescanning source") is added, the
+split becomes justified. Until then, the deviation from v6 §2.3 is
+intentional and recorded here.
+
+The CLI surface (`calor fix --compact-ids --revert --log <file>`) is
+unchanged either way; this is purely a file-layout decision.

--- a/docs/plans/phase-2-gate-config.json
+++ b/docs/plans/phase-2-gate-config.json
@@ -1,0 +1,70 @@
+{
+  "$schema_comment": "Pinned operator configuration for the §10 Phase 2 gate. This file is the single source of truth for the parameters supplied at gate kickoff (scripts/run_phase_2_gate.py). Any change to this file before kickoff MUST be reflected by a corresponding amendment to docs/plans/phase-2-measurement-protocol-v2.md and a fresh §9.a-style 4-hour cool-off before the kickoff command is run. After kickoff, this file is read-only for the duration of the run.",
+
+  "version": 1,
+  "status": "DRAFT — awaiting operator signature in docs/plans/phase-2-spend-authorisation.md",
+
+  "model": {
+    "id": "claude-sonnet-4-6",
+    "_id_comment": "Verified callable on the operator's host via `claude --model claude-sonnet-4-6 --print --output-format json` on 2026-05-27 ($0.048 for a 'say hi' trial). This is a fully-qualified Claude Code 2.1.144 model id, NOT an alias such as 'sonnet'. Aliases MUST NOT be used — they resolve to whatever Anthropic ships, breaking the 'identical inputs across arms' invariant.",
+    "fallback_id": "claude-sonnet-4-6",
+    "_fallback_comment": "Per v6 §4.4, if the pinned model becomes unavailable mid-run the operator MUST halt, NOT switch silently. A non-null fallback would break arm-comparability. The value here is documented as same-as-primary to make this explicit; the driver does NOT pass --fallback-model to the agent CLI.",
+    "cli_invocation": "claude --print --output-format json --dangerously-skip-permissions --model claude-sonnet-4-6",
+    "_cli_comment": "Exact agent invocation used by tests/E2E/agent-tasks/run.sh. --dangerously-skip-permissions is acceptable because each trial runs in an isolated, ephemeral work-dir (copied fixture). The agent has no access to the repo or the operator's machine outside the sandbox."
+  },
+
+  "trial_grid": {
+    "trials_per_arm": 30,
+    "seeds_per_trial": 10,
+    "arms": 3,
+    "total_runs": 900,
+    "_total_comment": "Matches protocol v2 §1.1. Driven by tests/E2E/agent-tasks/phase-2-gate-tasks.txt (24 task: + 6 template: = 30 trials) × seeds {0..9} × arms {A,B,C}."
+  },
+
+  "arms": {
+    "A": "main",
+    "B": "release/phase-1-only",
+    "C": "feature/compact-ids-v6",
+    "_comment": "Driver pins these to commit SHAs at kickoff via freeze_arm_shas() and writes them into the pre-registration doc. The branch names above are starting points; the SHA is what the driver uses for every subsequent trial."
+  },
+
+  "budget": {
+    "hard_ceiling_usd": 5000,
+    "soft_target_usd": 3000,
+    "_target_comment": "Per RFC §10.1 the gate is expected to cost $2–4k. Per-trial calibration (using claude-sonnet-4-6 on a representative task) MUST be performed before kickoff and recorded in docs/plans/phase-2-spend-authorisation.md §2.",
+    "per_trial_estimate_usd": 4.00,
+    "_per_trial_comment": "Placeholder. The pre-flight pre_flight_calibration() routine in docs/plans/phase-2-spend-authorisation.md §2 will populate this with a real measurement before kickoff."
+  },
+
+  "abort_triggers": {
+    "_comment": "If any of these conditions hold mid-run, the operator MUST stop the gate (Ctrl-C the driver process) and consult docs/plans/path-2-drop-ids-v6-implementation.md §9.c before resuming.",
+    "spend_ceiling_usd": 5000,
+    "harness_crash_rate_pct": 10,
+    "_harness_crash_comment": "Per protocol v2 §3.1 the analyser flags >5% as a data-quality warning; >10% is a halt trigger. Computed as (records with harness_crash=true) / (records written so far) × 100.",
+    "harness_error_rate_pct": 20,
+    "_harness_error_comment": "Includes any non-empty harness_error tag other than 'dry_run'. Substrate gaps (no_task_contract, agent_cli_missing) should be zero in production; if they reappear, the trial substrate has regressed and a halt is required.",
+    "consecutive_failures": 30,
+    "_consecutive_comment": "30 consecutive trials failing (success=false) across all seeds is a structural failure, not a stochastic one. Halt and triage."
+  },
+
+  "monitoring": {
+    "tick_interval_minutes": 240,
+    "_tick_comment": "Per v6 §3.3 ('scheduled polling via ScheduleWakeup every 4 hours'). The operator schedules scripts/monitor_phase_2_gate.ps1 (Windows) or .sh (POSIX) at this cadence. See docs/plans/phase-2-monitoring-tick.md for setup.",
+    "alert_log_path": "results/phase-2-gate/monitor.log",
+    "runs_jsonl_glob": "results/phase-2-gate/runs.jsonl"
+  },
+
+  "kickoff_command_template": {
+    "_comment": "The exact command the operator will run at kickoff. Bracketed values are placeholders to be substituted at the moment of kickoff (after working-tree-clean check and §9.a cool-off).",
+    "cmd": "python3 scripts/run_phase_2_gate.py --output-dir results/phase-2-gate-<DATE> --pre-reg docs/plans/phase-2-measurement-protocol-v2.md --tasks-manifest tests/E2E/agent-tasks/phase-2-gate-tasks.txt --arm-a-ref <ARM_A_SHA> --arm-b-ref <ARM_B_SHA> --arm-c-ref <ARM_C_SHA> --model claude-sonnet-4-6 --seeds 0,1,2,3,4,5,6,7,8,9"
+  },
+
+  "kickoff_prerequisites": [
+    "1. Docs-only PR (#621) merged to main, freezing the pre-registration",
+    "2. docs/plans/phase-2-spend-authorisation.md signed by maintainer (per-trial calibration recorded)",
+    "3. This file (phase-2-gate-config.json) reviewed and committed",
+    "4. Monitoring tick scheduled per docs/plans/phase-2-monitoring-tick.md",
+    "5. §9.a-style kickoff cool-off issue opened and >=4 hours elapsed since the issue body was written",
+    "6. Working tree clean on Arm C checkout (operator step in protocol v2 §10.1.a)"
+  ]
+}

--- a/docs/plans/phase-2-measurement-protocol-v2.md
+++ b/docs/plans/phase-2-measurement-protocol-v2.md
@@ -1,0 +1,230 @@
+# Phase 2 Measurement Protocol — v2
+
+**Status:** Pre-registration document — supersedes
+[`phase-2-measurement-protocol.md`](phase-2-measurement-protocol.md).
+**RFC:** [path-2-drop-ids-v5.md](path-2-drop-ids-v5.md) (the RFC) and
+        [path-2-drop-ids-v6-implementation.md](path-2-drop-ids-v6-implementation.md) (the implementation plan).
+**Authored under:** RFC §10.5 — amendment authority. v1 was the original
+pre-registration; v2 is required because v1's substrate enumeration
+included 24 workspace fixtures that lacked a runnable task contract
+(empirical: 72 of 90 dry-run records carried `harness_error="no_task_contract"`,
+80% noise). Running v1 as-pre-registered would have collapsed statistical
+power. See [`phase-2-validation-criteria.md`](phase-2-validation-criteria.md)
+§8.2 for the empirical evidence.
+
+> **Pre-registration discipline (RFC §10.5):** Once this document is
+> merged, it MUST NOT be edited. Any change invalidates the run. If a
+> further protocol change is required after merge, author
+> `phase-2-measurement-protocol-v3.md` and re-run the gate against the
+> new protocol.
+
+> **Supersession:** v1's §1 fixture list is replaced by the trial
+> manifest at `tests/E2E/agent-tasks/phase-2-gate-tasks.txt` (see §1
+> below). All other sections of v1 carry forward by reference unless
+> explicitly overridden here. Where v1 and v2 disagree, v2 governs.
+
+---
+
+## §1 — Pre-registered trial manifest
+
+The §10 gate runs against **30 trials**, enumerated in the manifest
+file at `tests/E2E/agent-tasks/phase-2-gate-tasks.txt`. The manifest
+is the immutable record of which work the agent is asked to do.
+
+Each trial has one of two kinds:
+
+- **`task`** — a row of the form `task:<category>/<task_dir>`. The
+  driver reads `tests/E2E/agent-tasks/tasks/<category>/<task_dir>/task.json`,
+  uses its `prompt` field as the agent instructions, and materialises
+  the workspace by copying the fixture named in `task.json`'s `fixture`
+  field. Compilation success is the canonical pass signal
+  (`verification.compilation.mustSucceed`).
+- **`template`** — a row of the form `template:<template_dir>`. The
+  driver uses `tests/E2E/agent-tasks/templates/path-2-gate/<template_dir>/`
+  which is a self-contained task with `task.md`, `setup/`, `expected/`,
+  and `acceptance.sh`. The acceptance script's exit code is the
+  canonical pass signal.
+
+### 1.1 The 30 trials
+
+24 stratified `task:` trials covering 17 of the 19 task categories in
+`tests/E2E/agent-tasks/tasks/`, plus 6 purpose-built `template:` trials
+from path-2-gate authoring:
+
+| # | Trial id | Kind | Workspace |
+|---|----------|------|-----------|
+| 1 | `task:type-system/01_option_some_return` | task | `basic-calor-project` |
+| 2 | `task:type-system/04_result_err_return` | task | `basic-calor-project` |
+| 3 | `task:string-operations/01_length_upper_lower` | task | `basic-calor-project` |
+| 4 | `task:string-operations/04_regex_operations` | task | `basic-calor-project` |
+| 5 | `task:refactoring-benchmark/refactor-extract-effects-calor` | task | `refactor-extract-calor` |
+| 6 | `task:refactoring-benchmark/refactor-extract-effects-csharp` | task | `refactor-extract-csharp` |
+| 7 | `task:refactoring-benchmark/refactor-rename-shadow-calor` | task | `refactor-rename-calor` |
+| 8 | `task:refactoring-benchmark/refactor-rename-shadow-csharp` | task | `refactor-rename-csharp` |
+| 9 | `task:refactoring/01_extract_pure_function` | task | `refactoring-impure` |
+| 10 | `task:refactoring/06_fix_contract_violation` | task | `buggy-contracts` |
+| 11 | `task:pattern-matching/02_relational_patterns` | task | `basic-calor-project` |
+| 12 | `task:pattern-matching/04_option_some_matching` | task | `basic-calor-project` |
+| 13 | `task:oop-features/01_class_definition` | task | `oop-project` |
+| 14 | `task:oop-features/04_property` | task | `oop-project` |
+| 15 | `task:logic-implementation/01_factorial` | task | `basic-calor-project` |
+| 16 | `task:logic-implementation/02_clamp` | task | `basic-calor-project` |
+| 17 | `task:lambdas-delegates/02_block_lambda` | task | `basic-calor-project` |
+| 18 | `task:generics/02_generic_class` | task | `generics-project` |
+| 19 | `task:enums/01_enum_definition` | task | `enums-project` |
+| 20 | `task:effects-system/02_console_read` | task | `effects-project` |
+| 21 | `task:effects-system/06_multiple_effects` | task | `effects-project` |
+| 22 | `task:contract-writing/02_postcondition` | task | `basic-calor-project` |
+| 23 | `task:contract-writing/05_loop_invariant` | task | `basic-calor-project` |
+| 24 | `task:collections/01_list_creation` | task | `collections-project` |
+| 25 | `template:task-01-multi-function-refactor` | template | (own) |
+| 26 | `template:task-02-add-db-effect` | template | (own) |
+| 27 | `template:task-03-privacy-change` | template | (own) |
+| 28 | `template:task-04-add-postcondition` | template | (own) |
+| 29 | `template:task-05-loop-restructure` | template | (own) |
+| 30 | `template:task-06-error-handling` | template | (own) |
+
+### 1.2 Stratification rationale
+
+The 24 `task:` rows were selected to span Calor's language surface as
+broadly as possible while staying within the original 30-trial sample
+size (v1 §1.1 + §1.2 = 24 + 6). Two `task:` rows from each of the most
+populated categories (`type-system`, `string-operations`,
+`refactoring-benchmark` × calor/csharp pairs, `refactoring`,
+`pattern-matching`, `oop-features`, `logic-implementation`,
+`effects-system`, `contract-writing`); one `task:` row each from the
+smaller categories.
+
+Excluded with explicit rationale:
+
+- `github-projects/` (4 tasks) — network-dependent; would make the gate
+  non-reproducible if upstream repos shift.
+- `calor-idioms/` (2 tasks) — surface is covered by
+  `refactoring/01_extract_pure_function` and the `Option`/`Result` tasks
+  in `type-system/`.
+- `async-functions/`, `control-flow/`, `advanced-contracts/`,
+  `basic-syntax/`, `lambdas-delegates/` 1, 3, 4 — categories well
+  represented by the 6 path-2-gate templates and by adjacent task
+  selections.
+
+### 1.3 Arm SHAs (filled at gate kickoff)
+
+Per v6 §4.3, arm SHAs are frozen at kickoff, not at protocol-author
+time. The driver writes the resolved SHAs to the bottom of this file
+in the `Arm SHAs frozen at gate kickoff:` block when the gate starts.
+
+---
+
+## §2 — Sample size and statistical power
+
+**Unchanged from v1:** 30 trials × 10 seeds × 3 arms = **900 trials**.
+
+Because the trial set is the same size, the v1 power analysis (RFC §10.1)
+carries forward unchanged. Bonferroni-corrected α for the planned
+pairwise contrasts (B vs A, C vs A, C vs B) remains at v1's value.
+
+The substantive change is that all 900 trials now actually produce
+agent-driven measurements (rather than ~80% being substrate-error
+records that the analyser must filter out). v1's effective sample size
+was ~180 useful records; v2's is the full 900.
+
+---
+
+## §3 — Metrics and acceptance criteria
+
+**Unchanged from v1** except for one clarification:
+
+### 3.1 `success` (criterion 1)
+
+For `task:` trials, `success=true` iff `calor build` exits 0 in the
+post-agent workspace. For `template:` trials, `success=true` iff the
+template's `acceptance.sh <work_dir>` exits 0. Both signals are
+captured by the harness adapter at `tests/E2E/agent-tasks/run.sh`.
+
+### 3.2 `identity_preservation_errors` (criterion 4)
+
+The v1 metric was a single count: files that exist in the post-agent
+workspace but did not exist in `setup/`. v2 strengthens this to: files
+**added, modified, or removed** between the pre-agent and post-agent
+workspace snapshots, *excluding* the documented edit target. Because
+the documented edit target is currently not extractable as structured
+data from task.md / task.json prose, v2 §3.2 is an **upper bound** on
+identity churn (i.e. it over-reports). The analyser treats this as a
+regression signal weighted accordingly, not a binary failure.
+
+A v3 of this metric should consume an explicit `targets:` field added
+to task.json / task.md front-matter and compute true churn. That work
+is deferred to a future iteration and does not block this gate.
+
+### 3.3 All other criteria
+
+Inherit unchanged from v1 §3.
+
+---
+
+## §4 — Arm definitions and SHA freezing
+
+**Unchanged from v1 §4** except that Arm B is fixed at
+`release/phase-1-only`, branched from `main` at v1-authoring time and
+pinned to the 4 commits implementing PR-1a..1h with a Phase-2-stub
+commit so the build is green without Phase 2 types. The branch is
+pushed to `origin/release/phase-1-only`.
+
+---
+
+## §§5–9 — Pre-flight, dispatch, polling, recovery, reporting
+
+**Inherit unchanged from v1.** The operational scripts referenced in
+those sections (`scripts/run_phase_2_gate.py`,
+`scripts/analyze_gate_results.py`) work with the v2 trial-based
+substrate transparently — the driver was refactored to read the
+manifest in v2's §1, and the analyser is metric-driven (it does not
+care whether records came from `task:` or `template:` substrate).
+
+---
+
+## §10 — Kickoff procedure (v2 supersedes v1 §10.1.a CLI)
+
+### 10.1.a Kickoff command
+
+Replace the v1 §10.1.a kickoff CLI with:
+
+```bash
+python3 scripts/run_phase_2_gate.py \
+    --pre-reg docs/plans/phase-2-measurement-protocol-v2.md \
+    --output-dir results/$(date -u +%Y%m%dT%H%MZ)-gate/ \
+    --arm-a-ref main \
+    --arm-b-ref release/phase-1-only \
+    --arm-c-ref release/0.x+1 \
+    --model "<pinned-string>"
+```
+
+All other §10 items (prerequisites, operator walkthrough, post-run
+analysis) carry forward from v1.
+
+### 10.1.b Hard prerequisites (delta from v1)
+
+In addition to v1's 9 prerequisites, v2 requires:
+
+10. **Trial manifest committed at the SHA used for Arm C kickoff.**
+    `tests/E2E/agent-tasks/phase-2-gate-tasks.txt` is part of the
+    pre-registration; if it differs between Arm A SHA and Arm C SHA the
+    gate is invalid (driver reads from CWD, not from a per-arm
+    checkout). Resolution: this manifest is a docs-equivalent artifact
+    and must land on `main` together with this document.
+
+11. **Adapter contract** `tests/E2E/agent-tasks/run.sh` accepts the
+    `--trial-id / --kind / --task-dir [--fixture-dir]` argument shape.
+    Driver and adapter are version-pinned together; any change to
+    either after kickoff invalidates the run.
+
+---
+
+## §11 — Validation snapshot (informational)
+
+As of authoring time, every blocker in
+`phase-2-validation-criteria.md` §8.1 that the engineering side can
+resolve has been resolved (substrate gap, adapter wiring, Arm B
+branch, driver propagation of `harness_error`). The remaining items
+are operator decisions: spend authorisation, model pin, monitoring
+cadence, solo-mode sign-off.

--- a/docs/plans/phase-2-measurement-protocol.md
+++ b/docs/plans/phase-2-measurement-protocol.md
@@ -255,23 +255,155 @@ Before `scripts/run_phase_2_gate.py` invokes the first run, it verifies:
 
 ### 10.1.a Real-run kickoff command
 
-The exact command for the real gate run (after the pre-registration is
-locked and the maintainer is ready to spend the LLM budget):
+This subsection is the **canonical operational procedure** for kicking
+off the Tier 3 gate. It is the one place an operator should need to
+read to start a real run. Every step is mandatory; skipping any of
+them invalidates the run per §10.5.
+
+#### Prerequisites (must all be true before kickoff)
+
+1. **This document is merged to `main`** (per RFC §10.5,
+   pre-registration is immutable once merged). Verify with:
+   ```bash
+   git fetch origin main
+   git log origin/main -- docs/plans/phase-2-measurement-protocol.md \
+       | head -1
+   # Output should show the merge commit; if the file has only been
+   # touched on a feature branch, DO NOT kick off — merge it first.
+   ```
+2. **Working tree is clean** on a freshly checked-out
+   `feature/compact-ids-v6` (or the equivalent Phase-1+2 branch):
+   ```bash
+   git status --porcelain   # must print nothing
+   ```
+3. **§1 (mechanical checks) is fully green on the branch tip:**
+   ```bash
+   dotnet build -c Release   # exit 0, zero warnings (TWaE)
+   dotnet test  --nologo     # all green; only 2 known-skipped
+   python scripts/verify_phase1.py    # exit 0, [11/11] OK
+   python scripts/migrator_revert_roundtrip.py tests/E2E/corpus
+   ```
+   A regression in any check here means the substrate is not ready;
+   fix before kickoff. Record the pass timestamps in the kickoff log.
+4. **The branches/refs supplied to the three arms exist and resolve:**
+    - Arm A ref → today's `main` SHA (baseline; no v6 ID work).
+    - Arm B ref → a release branch built from `main` + only the
+      Phase 1 PRs (PR-1a..1h) — i.e. structural-opener drop without
+      compact IDs. If no such branch exists yet, cut it before kickoff
+      and pin the SHA into the kickoff log; do NOT reuse Arm C's ref
+      for Arm B.
+    - Arm C ref → the Phase 1+2 branch tip (`feature/compact-ids-v6`
+      or its merge into a release branch).
+   These three refs MUST be distinct commits; the gate is undefined
+   if Arm B = Arm C (criterion 4 in §7 would be meaningless).
+5. **Pinned model is published and warm.** The model identifier MUST
+   be a fully qualified, version-pinned string (e.g. provider's
+   immutable model ID, not a moving alias). The kickoff command's
+   `--model` argument must reproduce byte-for-byte across the 4–5
+   day window. Send a single sanity prompt manually before kickoff
+   and record the model ping latency in the kickoff log.
+6. **4-hour monitoring tick is scheduled** (cron / ScheduleWakeup /
+   external timer). See §10.2.
+7. **Disk + network headroom verified:** ≥ 10 GiB free under
+   `results/`; network reachable to the model endpoint.
+8. **Reserve budget acknowledged** in writing (RFC §10.5): one retry
+   on protocol violation is funded; criterion failure is NOT a retry.
+9. **Solo-mode sign-off ritual completed** (v6 §9.c): if the
+   maintainer is the only human approver, the written justification,
+   external read, and ≥24 h cool-off are recorded in a GitHub issue
+   *before* this command is run.
+
+If any prerequisite fails, halt — do not run the command below.
+
+#### The kickoff command
+
+Run the following from the repo root, against a clean checkout of the
+Arm C branch with `git status --porcelain` empty:
 
 ```bash
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+ARM_A_REF=<sha-of-todays-main>                      # e.g. origin/main
+ARM_B_REF=<sha-of-phase-1-only-release-branch>      # MUST differ from C
+ARM_C_REF=<sha-of-phase-1-plus-2-branch>            # branch tip
+MODEL=<fully-qualified-version-pinned-model-id>     # immutable provider id
+
 python3 scripts/run_phase_2_gate.py \
-    --arm-a-ref main \
-    --arm-b-ref release/0.x+1 \
-    --arm-c-ref release/0.x+1 \
-    --model <pinned-string-required> \
-    --output-dir results/gate-$(date -u +%Y%m%dT%H%M%SZ) \
-    --seeds 1,2,3,4,5,6,7,8,9,10
-# ... 4–5 day run window, ~900 LLM invocations ...
-python3 scripts/analyze_gate_results.py \
-    --runs results/gate-<timestamp>/runs.jsonl \
-    --output docs/plans/phase-2-measurement-results.md
-echo "gate decision: exit code $? (0 = PASS, 1 = FAIL)"
+    --pre-reg   docs/plans/phase-2-measurement-protocol.md \
+    --output-dir "results/gate-${TS}" \
+    --arm-a-ref "${ARM_A_REF}" \
+    --arm-b-ref "${ARM_B_REF}" \
+    --arm-c-ref "${ARM_C_REF}" \
+    --model     "${MODEL}" \
+    --seeds     1,2,3,4,5,6,7,8,9,10 \
+    2>&1 | tee "results/gate-${TS}/kickoff.log"
 ```
+
+Notes on the invocation:
+
+- `--output-dir` MUST be a fresh directory. `runs.jsonl` is appended
+  to (mode `"a"`); reusing a directory will mix runs from different
+  kickoffs and silently corrupt the analysis.
+- `--pre-reg` is the document `run_phase_2_gate.py` writes the frozen
+  arm SHAs into (`write_shas_into_prereg`). After kickoff, the
+  document will contain a trailing `Arm SHAs frozen at gate kickoff:`
+  block with the three SHAs and a UTC timestamp. **Commit this edit
+  to a new branch and open a PR** so the recorded SHAs are
+  auditable; do NOT force-push over it.
+- `--skip-model-ping` is **forbidden in production**. It exists only
+  for dry-run / smoke testing.
+- The wall-clock window is 4–5 days for 900 trials. Do not interrupt
+  the process; if the host must be rebooted, treat the partial
+  `runs.jsonl` as a protocol violation per §9 and trigger §10.5.
+
+#### What `run_phase_2_gate.py` does, in order (for auditors)
+
+1. Parses CLI, creates the output directory.
+2. Calls `pre_flight()` — fails fast on disk / fixture count
+   (must be 30) / unresolved arm refs / missing model ping.
+3. Calls `freeze_arm_shas()` — captures the three SHAs once, at
+   kickoff. These SHAs are the canonical record of what was measured.
+4. Calls `write_shas_into_prereg()` — appends the SHAs + UTC
+   timestamp to this document. The append is non-destructive; it
+   does not edit existing prose.
+5. Streams 30 × 10 × 3 = 900 trial records into
+   `results/gate-${TS}/runs.jsonl`, flushing after each write so
+   the file is durable across crashes.
+
+#### Post-run analysis (run immediately when the gate driver exits)
+
+```bash
+python3 scripts/analyze_gate_results.py \
+    --runs   "results/gate-${TS}/runs.jsonl" \
+    --output docs/plans/phase-2-measurement-results.md
+RC=$?
+echo "gate decision: exit code ${RC} (0 = PASS / SHIP, 1 = FAIL / REVERT)"
+```
+
+The analyser writes `docs/plans/phase-2-measurement-results.md`
+**regardless of pass or fail** (RFC §16.E item 8; see §8 of this
+document). Commit the results document on a new branch and open the
+ship/revert PR per the decision matrix in `phase-2-validation-criteria.md` §4:
+
+- `RC == 0` (all four criteria green) → open the Phase 2 ship PR.
+- `RC == 1` (one or more red criteria) → open the Phase 2 revert PR
+  per RFC §11. **Do not retry the gate** to "see if it passes next
+  time" — criterion failure is final per §9 and RFC §10.3.
+
+#### Pre-flight smoke test (RECOMMENDED before the real kickoff)
+
+Before committing the LLM budget, verify the full pipeline is plumbed
+correctly using the deterministic dry-run path:
+
+```bash
+python3 scripts/smoke_phase_2_gate_dryrun.py
+```
+
+This exercises `pre_flight → dispatch → JSONL → analyze → markdown
+→ exit code` end-to-end with seeded synthetic records and asserts
+both the gate-pass and gate-fail simulated regimes produce the
+expected analyser exit code. It runs in seconds and uses zero LLM
+budget. A failure here is a harness bug that MUST be fixed before
+the real kickoff. See §10.1.b for details.
 
 ### 10.1.b Dry-run pipeline verification (CI-cheap)
 

--- a/docs/plans/phase-2-measurement-protocol.md
+++ b/docs/plans/phase-2-measurement-protocol.md
@@ -1,0 +1,330 @@
+# Phase 2 Measurement Protocol
+
+**Status:** Pre-registration document.
+**RFC:** [path-2-drop-ids-v5.md](path-2-drop-ids-v5.md) (the RFC) and
+        [path-2-drop-ids-v6-implementation.md](path-2-drop-ids-v6-implementation.md) (the implementation plan).
+**Authored under:** RFC §10.2 — *"before any Phase 2 implementation code
+is written, this document must be committed."*
+
+> **Pre-registration discipline (RFC §10.5):** Once this document is
+> merged, it MUST NOT be edited. Any change invalidates the run. If a
+> protocol change is required after merge, author
+> `phase-2-measurement-protocol-v2.md` and re-run the gate against the
+> new protocol.
+
+---
+
+## §1 — Task list with commit hashes
+
+The §10 gate runs against **30 fixtures = 24 existing + 6 new**, per
+v6 §4.0. Commit SHAs are filled at gate kickoff, not at PR-0b authoring
+time, so the SHAs reflect the actual workspace state at run start.
+
+### 1.1 Existing tasks (24, paths under `tests/E2E/agent-tasks/fixtures/`)
+
+| Fixture | SHA @ gate kickoff |
+|---------|--------------------|
+| `advanced-calor-project/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `async-project/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `basic-calor-project/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `buggy-contracts/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `collections-project/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `contracts-project/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `effects-project/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `enums-project/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `generics-project/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `oop-project/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `refactor-contract-calor/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `refactor-contract-csharp/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `refactor-extract-calor/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `refactor-extract-csharp/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `refactor-inline-calor/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `refactor-inline-csharp/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `refactor-move-calor/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `refactor-move-csharp/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `refactor-rename-calor/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `refactor-rename-csharp/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `refactor-signature-calor/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `refactor-signature-csharp/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `refactor-target/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `refactoring-impure/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+
+### 1.2 New tasks (6, paths under `tests/E2E/agent-tasks/templates/path-2-gate/`)
+
+| Fixture | SHA @ gate kickoff |
+|---------|--------------------|
+| `task-01-multi-function-refactor/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `task-02-add-db-effect/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `task-03-privacy-change/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `task-04-add-postcondition/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `task-05-loop-restructure/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+| `task-06-error-handling/` | `<commit-sha-to-fill-at-gate-kickoff>` |
+
+The §10 gate runs against `fixtures/` ∪ `templates/path-2-gate/` =
+**30 fixtures × 10 runs × 3 arms = 900 runs**, matching RFC §10.1.
+
+---
+
+## §2 — New task authoring artifacts
+
+Each new task in `templates/path-2-gate/task-NN-<theme>/` contains:
+
+- `task.md` — prompt given to the agent
+- `setup/` — pre-existing `.calr` files in the workspace at task start
+- `expected/` — post-task expected state (deterministic acceptance check)
+- `acceptance.sh` — exit-0-on-success script that diffs agent output
+
+Per v6 §5.1, each task must:
+
+- Be **solvable today** by a baseline agent (Arm A) at **50–90%** success
+  across 10 seeds (this is the recalibrated baseline range; tasks above
+  90% must be made harder, tasks below 50% must be made easier or
+  excluded).
+- Be **multi-edit**: ≥3 files OR ≥5 distinct locations.
+- Touch a **cross-reference**: rename + update callers, or add a contract
+  that references an existing function ID, etc.
+- Have a **deterministic** acceptance script (no LLM-as-judge).
+- Have an **expected median turn count of 10–30** for a baseline agent.
+- Be **authored independently per arm**: the prompt does not reference
+  structural IDs in any arm; the difference between arms is the
+  *workspace state*, not the *task instructions*.
+
+---
+
+## §3 — Implementation flag (arm SHAs frozen at gate kickoff)
+
+Per v6 §4.3, arm SHAs are recorded **at gate kickoff**, not relative to
+PR events that may complete mid-experiment. `scripts/run_phase_2_gate.py`
+records all three SHAs at start and writes them here before any run
+executes. Any change to any SHA mid-run invalidates the run per RFC §10.5.
+
+```
+Arm A (today/baseline):     main branch @ <SHA recorded at gate kickoff>
+                            (latest 0.x pre-release tag's commit)
+Arm B (Phase 1 only):       release/0.x+1 @ <SHA recorded at gate kickoff>
+                            (commit of the most recent Phase 1 merge;
+                            Phase 2 PRs may or may not be merged at gate
+                            kickoff, but Arm B does NOT include them)
+Arm C (Phase 1 + Phase 2):  release/0.x+1 @ <SHA recorded at gate kickoff>
+                            (commit of the most recent Phase 2 merge)
+```
+
+---
+
+## §4 — Run protocol
+
+### 4.1 Agent harness invocation
+
+```
+./tests/E2E/agent-tasks/run.sh \
+    --task <fixture-id> \
+    --arm <A|B|C> \
+    --seed <n> \
+    --model <pinned-string>
+```
+
+### 4.2 Model version — pinned
+
+```
+Primary:    <model-name> @ <version-string> as of <YYYY-MM-DD>
+Fallback A: <model-name> @ <version-string> as of <YYYY-MM-DD>
+Fallback B: <model-name> @ <version-string> as of <YYYY-MM-DD>
+```
+
+Per v6 §4.4: if the pinned (primary) model becomes unavailable during
+the gate run (deprecation, API outage, rate-limit lock, account limit),
+the run halts. The next pinned model is selected from the fallback list
+above (authored alongside this document, frozen at gate kickoff, NOT
+edited mid-run).
+
+A model switch **invalidates any in-flight runs** (run counter resets
+to 0 for the new model). Sign-off on a model switch follows v6 §9.c
+solo-mode rule for retry sign-off.
+
+### 4.3 Random seeds
+
+Seeds `1..10` per `(task, arm)` combination. Recorded in the per-run
+log. The harness MUST accept and respect the seed.
+
+### 4.4 Concurrency
+
+Runs are sequential within a `(task, arm)` tuple; parallelism is allowed
+across tuples. Concurrency limit is set per provider rate limits at gate
+kickoff.
+
+---
+
+## §5 — Data schema (recorded per run)
+
+Each run produces one JSON record:
+
+```json
+{
+  "task_id": "advanced-calor-project",
+  "arm": "A",
+  "seed": 1,
+  "model": "<pinned-string>",
+  "started_at": "2026-MM-DDTHH:MM:SSZ",
+  "ended_at": "2026-MM-DDTHH:MM:SSZ",
+  "success": true,
+  "turn_count": 17,
+  "total_output_tokens": 8421,
+  "identity_preservation_errors": 0,
+  "edit_correctness_errors": 0,
+  "harness_crash": false,
+  "raw_log_path": "results/<arm>/<task_id>/seed-<n>/log.jsonl"
+}
+```
+
+Aggregate file: `results/runs.jsonl` (one line per run).
+
+---
+
+## §6 — Analysis pipeline
+
+- **Library versions (pinned at gate kickoff):**
+  ```
+  scipy==<version-to-fill>
+  pandas==<version-to-fill>
+  numpy==<version-to-fill>
+  python==<version-to-fill, ≥3.11>
+  ```
+- **Analysis seed:** `42` (only matters for bootstrap CI computation).
+- **Code path:** `scripts/analyze_gate_results.py` (committed alongside
+  this document).
+- **Outputs:** `docs/plans/phase-2-measurement-results.md` summarizing
+  all 4 kill criteria per RFC §10.3.
+
+---
+
+## §7 — Pass/fail thresholds (verbatim from RFC §10.3)
+
+All four kill criteria must be **green** for Phase 2 to ship. Bonferroni
+correction: α' = 0.05 / 4 = **0.0125**.
+
+| # | Criterion | Pass condition |
+|---|-----------|----------------|
+| 1 | Success-rate non-inferiority | McNemar **p > 0.0125** comparing Arm C vs Arm A on per-task success; Arm C success rate is not statistically worse than Arm A. |
+| 2 | Identity-preservation non-regression | Wilcoxon **p > 0.0125** on per-run identity-preservation error counts; Arm C does not show more identity errors than Arm A. |
+| 3 | Material agent benefit on turn-count OR token-count | (Turn-count median reduction ≥ 10% **AND** Wilcoxon **p < 0.0125** **AND** **\|Cliff's δ\| ≥ 0.33**) **OR** (Token-count median reduction ≥ 15% **AND** Wilcoxon **p < 0.0125** **AND** **\|Cliff's δ\| ≥ 0.33**). |
+| 4 | Phase 2 distinguishable from Phase 1 alone | On criterion (3)'s metric, Arm C vs Arm B Wilcoxon **p < 0.0125**. Phase 2 contributes additional benefit beyond Phase 1's structural-ID drop. |
+
+A **single red criterion** → Phase 2 reverted; ship Phase 1 alone per
+RFC §11.
+
+---
+
+## §8 — Reporting commitment (RFC §16.E item 8)
+
+`docs/plans/phase-2-measurement-results.md` WILL be written and committed
+**regardless of pass or fail**. The doc reports all four criteria with
+their p-values, effect sizes, sample sizes, and ship/no-ship decision.
+This commitment is non-negotiable; suppression of negative results is
+the failure mode pre-registration exists to prevent.
+
+---
+
+## §9 — Retry policy (RFC §10.5)
+
+- **First failure (protocol violation, not criterion failure):** one
+  retry is covered by reserve budget. Sign-off authority: maintainer.
+  See v6 §9.c for the solo-mode sign-off ritual (written justification,
+  external read, ≥24h wait).
+- **Second failure or further retries:** require re-pre-registration as
+  `phase-2-measurement-protocol-v2.md`. The new protocol document may
+  reduce sample size, change model, or change kill criteria — but must
+  itself be merged before any run executes against it.
+- **Criterion failure (gate FAIL):** is NOT a retry trigger. Per
+  RFC §10.3, a red criterion → Phase 2 reverted; do not retry to "see
+  if it passes next time."
+
+---
+
+## §10 — Monitoring during the run (v6 §3.3)
+
+### 10.1 Pre-flight check
+
+Before `scripts/run_phase_2_gate.py` invokes the first run, it verifies:
+
+- The 4-hour monitoring tick is scheduled.
+- The pinned model is currently available (1-prompt sanity ping; if
+  fails, halt and invoke §10.5).
+- Disk space, network connectivity, run-log directory writable.
+- All 30 fixtures resolve to readable directories.
+- The three arm SHAs resolve to checkoutable commits.
+
+### 10.1.a Real-run kickoff command
+
+The exact command for the real gate run (after the pre-registration is
+locked and the maintainer is ready to spend the LLM budget):
+
+```bash
+python3 scripts/run_phase_2_gate.py \
+    --arm-a-ref main \
+    --arm-b-ref release/0.x+1 \
+    --arm-c-ref release/0.x+1 \
+    --model <pinned-string-required> \
+    --output-dir results/gate-$(date -u +%Y%m%dT%H%M%SZ) \
+    --seeds 1,2,3,4,5,6,7,8,9,10
+# ... 4–5 day run window, ~900 LLM invocations ...
+python3 scripts/analyze_gate_results.py \
+    --runs results/gate-<timestamp>/runs.jsonl \
+    --output docs/plans/phase-2-measurement-results.md
+echo "gate decision: exit code $? (0 = PASS, 1 = FAIL)"
+```
+
+### 10.1.b Dry-run pipeline verification (CI-cheap)
+
+The full collect → dispatch → JSONL → analyze → markdown → exit-code
+pipeline can be exercised without LLM spend via:
+
+```bash
+python3 scripts/smoke_phase_2_gate_dryrun.py
+```
+
+This runs `--dry-run --simulate gate-pass` and asserts the analyzer
+exits 0, then `--simulate gate-fail` and asserts exit 1. It uses
+seeded deterministic synthetic records (see ``_synth_record`` in
+``scripts/run_phase_2_gate.py``) so two CI invocations produce
+identical reports. Total wall time: a few seconds.
+
+This is **not** a substitute for the real run; it is a regression test
+that the gate machinery itself is plumbed correctly.
+
+### 10.2 Scheduled polling
+
+Every **4 hours** during the 4–5 day run window, the agent (or
+maintainer) inspects the run log for:
+
+- Protocol violations (harness crash, fixture mutation, log gaps).
+- Model API errors.
+- Throughput drift (runs/hour < expected).
+
+On any violation, halt and trigger §10.5 retry per §9.
+
+### 10.3 Webhook alerting (optional addition)
+
+`scripts/run_phase_2_gate.py` MAY additionally post to a webhook on
+protocol violation for faster than 4-hour response. Webhook alerting is
+an **addition**, not a substitute (webhook outages would otherwise
+silently lose alerts).
+
+### 10.4 Solo-mode (v6 §9.a)
+
+If the agent and maintainer are the same person, Tier 2 red triage uses
+the maintainer-hat ritual:
+
+1. Open a GitHub issue `Tier 2 triage: <phase> <date>`.
+2. Paste output and write triage reasoning **before** resolving.
+3. Wait ≥ 4 hours (or 1 ScheduleWakeup tick).
+4. Act, close issue with action-taken comment.
+
+---
+
+## §11 — What this document does NOT cover
+
+- Compiler internals — see RFC §5–§9.
+- Per-PR self-verification — see v6 §3 (Tier 1 + Tier 2 harness).
+- Tier 4 post-ship monitoring — see RFC §10.6 and v6 §9.b.
+- Code review process — see [`docs/process/rfc-review-checklist.md`](../process/rfc-review-checklist.md).
+- Rollback playbook — see v6 §6.

--- a/docs/plans/phase-2-monitoring-tick.md
+++ b/docs/plans/phase-2-monitoring-tick.md
@@ -1,0 +1,196 @@
+# Phase 2 §10 Gate — Monitoring Tick Setup
+
+This document is the operator runbook for the 4-hour monitoring tick
+required by v6 §3.3 and `phase-2-gate-config.json` `monitoring` block.
+The tick runs `scripts/monitor_phase_2_gate.py` against
+`results/<run>/runs.jsonl` and writes a structured record to
+`monitor.log`, exiting non-zero if any abort trigger trips.
+
+The tick MUST be scheduled and verified BEFORE the kickoff command is
+executed (validation-criteria §8.1 row 8). It MUST keep running until
+the gate driver exits cleanly (success) or the operator halts it after
+a tripped trigger.
+
+## §1 — One-shot verification (run before scheduling)
+
+Confirm the script runs end-to-end against a stub `runs.jsonl`:
+
+```bash
+mkdir -p /tmp/gate-monitor-test
+cat > /tmp/gate-monitor-test/runs.jsonl <<'EOF'
+{"task_id":"t1","arm":"A","seed":0,"success":true,"turn_count":3,"total_output_tokens":1200,"harness_crash":false,"raw_log_path":"x"}
+{"task_id":"t1","arm":"B","seed":0,"success":true,"turn_count":4,"total_output_tokens":1500,"harness_crash":false,"raw_log_path":"x"}
+{"task_id":"t1","arm":"C","seed":0,"success":false,"turn_count":1,"total_output_tokens":200,"harness_crash":true,"raw_log_path":"x"}
+EOF
+
+python3 scripts/monitor_phase_2_gate.py \
+    --config docs/plans/phase-2-gate-config.json \
+    --runs /tmp/gate-monitor-test/runs.jsonl \
+    --log  /tmp/gate-monitor-test/monitor.log
+
+# Expected: exit 0, prints per-arm summary, writes one record to monitor.log.
+cat /tmp/gate-monitor-test/monitor.log
+rm -rf /tmp/gate-monitor-test
+```
+
+If this fails, do NOT proceed to schedule the tick — fix the script
+first.
+
+## §2 — Schedule on Windows (the operator's primary host)
+
+The operator's machine is Windows. Use Task Scheduler.
+
+```powershell
+# Run as Administrator. Replace <RUN_DIR> with the actual gate output
+# directory chosen for kickoff (e.g., results/phase-2-gate-2026-06-01).
+
+$RunDir   = 'C:\path\to\calor\results\phase-2-gate-2026-06-01'
+$Python   = 'python'   # or full path to the python.exe used elsewhere
+$Repo     = 'C:\Users\juanrivera\sources\repos\juanmicrosoft\calor-2'
+$Config   = "$Repo\docs\plans\phase-2-gate-config.json"
+$Runs     = "$RunDir\runs.jsonl"
+$Log      = "$RunDir\monitor.log"
+
+$Action = New-ScheduledTaskAction `
+    -Execute $Python `
+    -Argument "$Repo\scripts\monitor_phase_2_gate.py --config $Config --runs $Runs --log $Log" `
+    -WorkingDirectory $Repo
+
+$Trigger = New-ScheduledTaskTrigger `
+    -Once -At (Get-Date).AddMinutes(5) `
+    -RepetitionInterval (New-TimeSpan -Hours 4) `
+    -RepetitionDuration (New-TimeSpan -Days 7)
+
+$Principal = New-ScheduledTaskPrincipal `
+    -UserId $env:USERNAME -RunLevel Limited -LogonType S4U
+
+$Settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable
+
+Register-ScheduledTask `
+    -TaskName 'Calor-Phase2-Gate-Monitor' `
+    -Action $Action -Trigger $Trigger `
+    -Principal $Principal -Settings $Settings `
+    -Description 'v6 §3.3 4-hour monitoring tick for the Phase 2 §10 gate'
+```
+
+To unregister after the gate completes:
+
+```powershell
+Unregister-ScheduledTask -TaskName 'Calor-Phase2-Gate-Monitor' -Confirm:$false
+```
+
+To trigger a tick on demand (operator decision to peek between scheduled
+ticks):
+
+```powershell
+Start-ScheduledTask -TaskName 'Calor-Phase2-Gate-Monitor'
+```
+
+### §2.1 — Alerting on Windows
+
+Task Scheduler does not auto-alert on non-zero exit. Two options:
+
+1. **Manual review** — operator opens `monitor.log` at each ScheduleWakeup
+   tick (which on the operator's setup is daily). This is the v6 §3.3
+   baseline.
+2. **Email-on-failure** — wrap the action in a script that emails the
+   operator's address on exit 1. See `scripts/monitor_phase_2_gate.ps1`
+   below for a wrapper.
+
+A minimal wrapper that surfaces non-zero exits to the Windows event log
+(which the operator can subscribe to via Get-WinEvent):
+
+```powershell
+# scripts/monitor_phase_2_gate.ps1 — runs the Python monitor and writes
+# its exit to the Application event log so the operator can subscribe.
+$exit = & python `
+    $PSScriptRoot\monitor_phase_2_gate.py `
+    --config $args[0] --runs $args[1] --log $args[2]
+
+$source = 'CalorPhase2GateMonitor'
+if (-not [System.Diagnostics.EventLog]::SourceExists($source)) {
+    New-EventLog -LogName Application -Source $source
+}
+if ($LASTEXITCODE -eq 0) {
+    Write-EventLog -LogName Application -Source $source `
+        -EventId 1 -EntryType Information `
+        -Message "Phase 2 gate monitor tick: all green"
+} else {
+    Write-EventLog -LogName Application -Source $source `
+        -EventId 2 -EntryType Warning `
+        -Message "Phase 2 gate monitor: HALT RECOMMENDED. See $($args[2])"
+}
+exit $LASTEXITCODE
+```
+
+## §3 — Schedule on POSIX (Linux / macOS fallback)
+
+If the gate is moved to a Linux/macOS host (recommended for the bash
+adapter, see protocol v2 §10.1.a note), use cron:
+
+```cron
+# /etc/cron.d/calor-phase2-gate-monitor — runs every 4 hours.
+# Replace <REPO> and <RUN_DIR> with the actual paths.
+0 */4 * * * <user>  python3 <REPO>/scripts/monitor_phase_2_gate.py \
+    --config <REPO>/docs/plans/phase-2-gate-config.json \
+    --runs   <REPO>/<RUN_DIR>/runs.jsonl \
+    --log    <REPO>/<RUN_DIR>/monitor.log \
+    || logger -t calor-gate-monitor 'HALT RECOMMENDED (see monitor.log)'
+```
+
+Validate with:
+
+```bash
+sudo crontab -u <user> -l | grep calor
+journalctl -t calor-gate-monitor   # check after first tick
+```
+
+## §4 — What the operator does when a tick goes red
+
+When the monitor exits 1:
+
+1. Read the latest record in `monitor.log` (last line is JSONL).
+2. Identify which trigger(s) tripped: `harness_crash_rate_pct`,
+   `harness_error_rate_pct`, or `consecutive_failures`.
+3. Inspect the most recent ~30 records in `runs.jsonl` to see WHICH
+   trials and arms are failing. A burst confined to one arm signals
+   a real signal (or a real bug in that arm). A burst spread across
+   all arms signals infrastructure (model availability, network).
+4. Consult `phase-2-spend-authorisation.md` §4. Halt or override per
+   that document's discipline.
+5. If halting, send `SIGTERM` (or Ctrl-C) to the driver process. The
+   driver writes records to `runs.jsonl` incrementally; the partial
+   run is recoverable for diagnosis but NOT for a continued statistical
+   analysis (the seed grid is no longer balanced).
+6. Decide: full retry under v6 §9.c, or pivot to v3 protocol with a
+   smaller grid.
+
+## §5 — Why this script is conservative
+
+The thresholds in `phase-2-gate-config.json abort_triggers` are
+deliberately loose:
+
+- `harness_crash_rate_pct: 10` — analyser already warns at 5%; 10%
+  is the structural-failure line.
+- `harness_error_rate_pct: 20` — production should be ~0%; 20% means
+  the substrate has regressed.
+- `consecutive_failures: 30` — equals one full trial × all 30 seeds
+  failing, which is a structural pattern, not noise.
+
+The monitor will NOT halt the gate for: low success rates (those are
+the *measurement*, not a failure), one arm losing badly (that's the
+signal we want), or high spend (the operator manages spend separately
+against the §3 ceiling).
+
+## §6 — Cross-references
+
+- [`phase-2-gate-config.json`](phase-2-gate-config.json) — source of
+  abort thresholds.
+- [`phase-2-spend-authorisation.md`](phase-2-spend-authorisation.md) §4
+  — what to do when a trigger trips.
+- [`phase-2-measurement-protocol-v2.md`](phase-2-measurement-protocol-v2.md)
+  §10.1.a — the kickoff command this monitor observes.
+- [`path-2-drop-ids-v6-implementation.md`](path-2-drop-ids-v6-implementation.md)
+  §3.3 — the v6 spec that requires this tick.

--- a/docs/plans/phase-2-spend-authorisation.md
+++ b/docs/plans/phase-2-spend-authorisation.md
@@ -1,0 +1,168 @@
+# Phase 2 §10 Gate — Spend Authorisation
+
+**Status: DRAFT — UNSIGNED.** The gate kickoff command (protocol v2 §10.1.a)
+MUST NOT be executed until this document carries the maintainer's explicit
+authorisation in §6 below, captured as a signed git commit (see §6 for the
+exact discipline).
+
+This file is part of the immutable pre-registration. Once signed, do not
+edit. To revise the budget, abort thresholds, or per-trial estimate after
+signing, follow the v6 §9.c retry-sign-off procedure: write
+`docs/plans/phase-2-measurement-protocol-retry-rationale.md` and start a
+fresh 24-hour cool-off.
+
+## §1 — What this document authorises
+
+Spending up to the budget ceiling in §3 below on Anthropic API calls,
+through the operator's Claude Code CLI subscription, to drive the 900-run
+§10 gate measurement specified in
+[`phase-2-measurement-protocol-v2.md`](phase-2-measurement-protocol-v2.md).
+
+The spend is irreversible. Anthropic charges per API call regardless of
+whether the gate produces interpretable results, regardless of whether
+the maintainer subsequently decides not to merge Phase 2, and regardless
+of whether a protocol violation forces a retry under v6 §9.c.
+
+## §2 — Per-trial calibration (run BEFORE signing §6)
+
+Before authorising the full 900-run gate, the operator MUST measure
+actual cost on three representative trials and update this section
+with the observed numbers. This calibration defends against an order-
+of-magnitude estimation error.
+
+**Procedure:**
+
+```bash
+# Pick three trials spanning the difficulty spectrum:
+#   - one cheap (template:test-utility-conversion)
+#   - one medium (task:simple-cs-to-calor/basic-class)
+#   - one expensive (task:integration-or-e2e equivalent)
+#
+# For each, run a single arm × single seed in dry-run-mode=false
+# (i.e., real money) and read the per-trial cost from runs.jsonl.
+
+python3 scripts/run_phase_2_gate.py \
+    --output-dir results/calibration-<DATE> \
+    --pre-reg docs/plans/phase-2-measurement-protocol-v2.md \
+    --tasks-manifest /tmp/calibration-tasks.txt \
+    --arm-a-ref main --arm-b-ref main --arm-c-ref main \
+    --model claude-sonnet-4-6 \
+    --seeds 0
+
+# Inspect each trial's $ cost by parsing the agent.stdout JSON's
+# .total_cost_usd field (Claude Code CLI emits this in
+# --output-format=json mode).
+```
+
+**Calibration results (operator fills in before signing):**
+
+| Trial id                                     | $ cost | turns | output tokens |
+|----------------------------------------------|-------:|------:|--------------:|
+| `template:test-utility-conversion-seed0`     |  TBD   | TBD   | TBD           |
+| `task:simple-cs-to-calor/basic-class-seed0`  |  TBD   | TBD   | TBD           |
+| `task:<chosen expensive trial>-seed0`        |  TBD   | TBD   | TBD           |
+| **Median per-trial cost**                    | **TBD**|   —   |   —           |
+| **Projected 900-trial total**                | **TBD**|   —   |   —           |
+
+If the projected 900-trial total exceeds the hard ceiling in §3, the
+operator MUST either (a) reduce the trial grid (which invalidates v1
+power assumptions and requires re-pre-registration via v3 of the
+protocol), or (b) raise the hard ceiling via a §9.c retry-sign-off
+amendment.
+
+## §3 — Budget envelope
+
+The numbers below match `phase-2-gate-config.json`.
+
+| Parameter                                   | Value      |
+|---------------------------------------------|-----------:|
+| Soft target (planning estimate, RFC §10.1)  | $3,000     |
+| Hard ceiling (driver halts above this)      | $5,000     |
+| Per-trial estimate (placeholder, see §2)    | $4.00      |
+| Projected 900-trial total at placeholder    | $3,600     |
+
+## §4 — Abort triggers (the monitor enforces these)
+
+The 4-hour monitoring tick (`scripts/monitor_phase_2_gate.ps1` and
+`.sh`) parses `results/<run>/runs.jsonl` against the thresholds in
+`phase-2-gate-config.json` `abort_triggers`. If any threshold trips,
+the monitor writes a halt-recommended record to `monitor.log` and
+exits non-zero, which the operator's scheduler surfaces as an alert.
+
+The operator MUST honour halt-recommendations within one monitoring
+cycle (4 hours). If the operator overrides a halt-recommendation and
+continues the gate, the override decision MUST be recorded as a
+comment on the §9.a kickoff issue (created in §5) with the operator's
+reasoning. This creates an audit trail equivalent to v6 §6.1's
+"investigate first; do not auto-revert" discipline applied to spend.
+
+## §5 — Kickoff cool-off (§9.a pattern applied to Tier 3 kickoff)
+
+Per v6 §9, solo-mode operators defend against motivated reasoning by
+mirroring §9.a's 4-hour written-before-action ritual at any irreversible
+commitment point. The §10 gate kickoff is the largest irreversible
+commitment in the entire Phase 2 plan; v6 §9.c formally applies only
+to *retry* sign-off, but its spirit applies here as well.
+
+**Procedure (operator runs ONCE before signing §6):**
+
+1. Open a GitHub issue titled
+   `Phase 2 §10 gate kickoff: solo-mode cool-off — <YYYY-MM-DD>`.
+2. In the issue body, paste:
+   - The calibration table from §2 (filled in).
+   - The arm SHAs that will be passed to the driver.
+   - A 200-word written justification answering: *what would prove
+     Phase 2 was a mistake to ship, and would the §10 gate detect it?*
+3. Wait **at least 4 hours** (one ScheduleWakeup tick in v6 §3.3
+   terminology) after the issue body is committed.
+4. Re-read the justification with maintainer-hat on. If still convinced,
+   add a comment to the issue: `cool-off complete; proceeding to sign
+   spend-authorisation.md §6`. Then sign §6 below.
+5. After the gate completes (whether it terminates normally or via
+   abort trigger), close the issue with a comment summarising what
+   was learned.
+
+## §6 — Operator signature
+
+**Sign by replacing the bracketed values below and committing the file
+on `feature/compact-ids-v6` (NOT directly to main) with the commit
+message `chore(phase-2): sign spend-authorisation`. Then push and
+include the commit SHA in the §5 kickoff issue.**
+
+```
+Authorised by:              <maintainer github handle>
+Authorisation timestamp:    <YYYY-MM-DDTHH:MM:SSZ>
+Calibration commit SHA:     <SHA of the commit that filled in §2>
+Kickoff issue URL:          <gh issue link from §5>
+Cool-off start timestamp:   <YYYY-MM-DDTHH:MM:SSZ>
+Cool-off end timestamp:     <≥ start + 4h>
+Budget ceiling accepted:    $5,000 (matches §3)
+Model id accepted:          claude-sonnet-4-6 (matches phase-2-gate-config.json)
+```
+
+By signing the operator affirms:
+
+- The calibration in §2 has been performed and the projected total
+  is at or below the §3 hard ceiling.
+- The Anthropic billing account has sufficient credit / payment
+  method for the projected total.
+- The monitoring tick (§4) is scheduled and verified by running it
+  once manually against a stub `runs.jsonl`.
+- The §5 cool-off was actually observed (timestamps are real, not
+  back-dated).
+- The maintainer accepts that this spend may produce a null result
+  (no clear winner) and that a null result is still a valid outcome
+  for the merge decision in `phase-2-validation-criteria.md` §4.
+
+## §7 — Cross-references
+
+- [`phase-2-measurement-protocol-v2.md`](phase-2-measurement-protocol-v2.md) — the
+  pre-registered experimental design this spend funds.
+- [`phase-2-validation-criteria.md`](phase-2-validation-criteria.md) §8.1 — the
+  readiness matrix that gates kickoff; this document fills row 7.
+- [`phase-2-gate-config.json`](phase-2-gate-config.json) — machine-readable
+  twin of §3 and §4 used by the monitoring tick.
+- [`phase-2-monitoring-tick.md`](phase-2-monitoring-tick.md) — how to schedule
+  the §4 monitor on Windows and POSIX.
+- [`path-2-drop-ids-v6-implementation.md`](path-2-drop-ids-v6-implementation.md)
+  §9.a and §9.c — solo-mode disciplines this document inherits.

--- a/docs/plans/phase-2-validation-criteria.md
+++ b/docs/plans/phase-2-validation-criteria.md
@@ -265,93 +265,85 @@ either an invalid run (no statistical power) or no run at all.**
 
 ### 8.1 — Prerequisite readiness matrix
 
-| # | Prerequisite (protocol §10.1.a) | Status | Owner | Detail |
+| # | Prerequisite (protocol v2 §10.1.a-b) | Status | Owner | Detail |
 |---|---------------------------------|--------|-------|--------|
-| 1 | Pre-registration doc merged to `main` | 🔴 Blocker | Maintainer | Protocol + this doc currently live only on `feature/compact-ids-v6` (commit `b45a3c6`). RFC §10.5 immutability requires `main`. Open a docs-only PR (no implementation) to land both files. |
+| 1 | Pre-registration doc merged to `main` | 🟡 Pending PR | Maintainer | Protocol v1 + v2 + this doc live only on `feature/compact-ids-v6`. Docs-only PR to `main` is the next step. |
 | 2 | Working tree clean on Arm C checkout | 🟡 Operator step | Operator | Verified procedurally in §10.1.a; not an artifact gate. |
 | 3 | §1 (mechanical) checks green | 🟢 Done | — | Tier 1 `[11/11] OK`, all 5,427 tests pass, both round-trip harnesses byte-perfect on the corpus. |
-| 4 | 30 fixtures resolve to readable dirs | 🟡 Resolves, but see §8.2 | — | 24 + 6 directories exist; 24 of them lack a runnable task contract. |
-| 5 | Three **distinct** arm refs (A ≠ B ≠ C) | 🟢 Local only | Maintainer (push) | `release/phase-1-only` cut locally at `82301fe` (3 cherry-picks + 1 stub commit; builds + all tests green). Not yet pushed; needs maintainer review before publishing. |
-| 6 | Agent harness wired to driver | 🟢 Done | — | `tests/E2E/agent-tasks/run.sh` adapter authored this session. `scripts/run_phase_2_gate.py` patched to (a) resolve git-bash on Windows for local dev and (b) propagate the adapter's `harness_error` field into `runs.jsonl` (was silently dropped). Verified end-to-end: 90 records via `CALOR_GATE_DRY_RUN=1`, all `harness_crash=false`. Smoke test (`scripts/smoke_phase_2_gate_dryrun.py`) remains green. |
+| 4 | 30 trials resolve to runnable contracts | 🟢 Done | — | Substrate gap resolved by protocol v2 (see §8.2). Driver reads `tests/E2E/agent-tasks/phase-2-gate-tasks.txt` and resolves 24 `task:` + 6 `template:` = 30 trials, all with `task.json`/`task.md` + workspace. |
+| 5 | Three **distinct** arm refs (A ≠ B ≠ C) | 🟢 Done | — | `release/phase-1-only` cut and pushed to origin at `82301fe` (3 cherry-picks + 1 stub commit; builds + all tests green). |
+| 6 | Agent harness wired to driver | 🟢 Done | — | `tests/E2E/agent-tasks/run.sh` adapter accepts new `--trial-id/--kind/--task-dir [--fixture-dir]` contract; supports both `task:` and `template:` kinds. `scripts/run_phase_2_gate.py` reads manifest, propagates adapter's `harness_error`. End-to-end verified: 90 records via `CALOR_GATE_DRY_RUN=1`, all `harness_crash=false`, all `harness_error="dry_run"` (no substrate noise). |
 | 7 | Version-pinned model id + API credentials + budget | 🔴 Blocker | Maintainer | `claude.exe` is on `PATH`; no API spend authorization captured. Budget ~$2–4k per RFC §10.1. |
 | 8 | 4-hour monitoring tick scheduled | 🔴 Blocker | Operator | Cron / Task Scheduler / external timer not configured. |
 | 9 | v6 §9.c solo-mode sign-off ritual | 🔴 Blocker | Maintainer | 24h cool-off issue not opened. |
+| 10 | Trial manifest at SHA used for Arm C kickoff (v2 §10.1.b new) | 🟡 Pending PR | Maintainer | Manifest is part of the docs-only PR to `main`. |
 
 Legend: 🟢 ready, 🟡 conditional, 🔴 blocker.
 
-### 8.2 — Substrate gap (criterion-level impact)
+### 8.2 — Substrate gap (RESOLVED in protocol v2)
 
-The gate driver in `scripts/run_phase_2_gate.py:collect_fixtures` iterates
-both `tests/E2E/agent-tasks/fixtures/` (24 directories) and
-`tests/E2E/agent-tasks/templates/path-2-gate/` (6 directories). Only the
-6 templates have a runnable task contract (`task.md` + `setup/` +
-`acceptance.sh`). The 24 fixtures are workspace skeletons referenced by
-`tests/E2E/agent-tasks/tasks/<category>/<task>/task.json` files via the
-`fixture` field — they are *workspaces*, not *tasks*.
+**Original problem (v1):** The gate driver in
+`scripts/run_phase_2_gate.py:collect_fixtures` iterated both
+`tests/E2E/agent-tasks/fixtures/` (24 directories) and
+`tests/E2E/agent-tasks/templates/path-2-gate/` (6 directories). Only
+the 6 templates had a runnable task contract; the 24 fixtures were
+workspace skeletons referenced by `tests/E2E/agent-tasks/tasks/<category>/<task>/task.json`
+files via the `fixture` field. Demonstrated empirically by a 90-record
+dry-run: **72 / 90 (80%)** had `harness_error="no_task_contract"`.
 
-Demonstrated empirically (90 records produced by `CALOR_GATE_DRY_RUN=1`
-on this branch):
+**Resolution (v2):** Protocol v2 introduces an explicit trial
+manifest (`tests/E2E/agent-tasks/phase-2-gate-tasks.txt`) that
+enumerates 24 `task:<cat>/<id>` rows plus 6 `template:<dir>` rows.
+The driver iterates the manifest, resolves each trial to its
+contract + workspace, and dispatches the adapter with both
+`--task-dir` and `--fixture-dir`. The adapter supports both kinds:
+for `task:` it copies the fixture, extracts `prompt` from `task.json`,
+runs the agent, and verifies via `calor build`; for `template:` it
+copies `setup/`, uses `task.md` as the prompt, and runs the
+template's `acceptance.sh`.
 
-| Substrate class | Fixtures | Records (1 seed × 3 arms) | Adapter `harness_error` |
-|-----------------|----------|----------------------------|-------------------------|
-| Templates with task contract | 6 | 18 | `dry_run` (would be real LLM runs) |
-| Fixtures with no contract | 24 | 72 | `no_task_contract` |
+Verified empirically by a 90-record dry-run on the refactored
+substrate: **0 / 90 substrate-noise records**. All records carry
+`harness_error="dry_run"` (the expected dry-run tag), zero
+`no_task_contract`. The full 900-trial gate would now spend its
+budget on genuine agent measurements rather than substrate scaffolding.
 
-In a full 900-run gate (10 seeds), **720 / 900 (80%)** of records would
-be `no_task_contract` — providing zero criterion-1 signal differentiating
-arms because no agent ever runs against them. The remaining 180 useful
-records is well below the sample size the protocol's statistical power
-analysis assumed (RFC §10.1).
+The original two "paths forward" considered in v1 §8.2:
 
-Two paths forward, both require a protocol amendment per RFC §10.5
-(`phase-2-measurement-protocol-v2.md`):
-
-1. **Author 24 new task contracts**, one per existing fixture. Each
-   contract needs a `task.md` prompt, optional `setup/` overlay,
-   `expected/` reference output, and `acceptance.sh`. Estimated effort:
-   1–2 weeks of careful task design. Preserves the 30-fixture × 10-seed
-   × 3-arm = 900-run plan.
-
-2. **Refactor `run_phase_2_gate.py:collect_fixtures` to iterate
-   `tests/E2E/agent-tasks/tasks/<cat>/<task>/task.json`**, joining each
-   `task.json` with its declared `fixture`. Many tasks share the same
-   fixture, so the trial count would shift to N(tasks) × 10 × 3. With
-   ~40 existing tasks plus the 6 templates, that's 46 × 30 = 1,380 runs,
-   which over-provisions statistical power but inflates the budget by
-   ~50%. Re-pre-register sample size and Bonferroni α accordingly.
-
-A third "shortcut" — running the gate with the current substrate and
-filtering out `no_task_contract` records in `analyze_gate_results.py` —
-is **not acceptable** because it silently changes the planned sample
-size, violating the pre-registration discipline of RFC §10.5.
+1. ~~Author 24 new task contracts~~ — not chosen; 1–2 weeks of effort
+   for marginal benefit over reusing the 129 existing `task.json` files.
+2. **Refactor `run_phase_2_gate.py` to iterate `tasks/`** — chosen.
+   Stratified 24-task subset preserves the v1 sample size (no power
+   re-derivation needed) and reuses vetted task contracts.
 
 ### 8.3 — What is concretely runnable today
 
-If the operator hand-waves blockers 1, 7, 8, and 9 (i.e. authorises
-spend and accepts an off-protocol run for engineering signal only,
-NOT for the merge decision), the system can drive the **6 templates × 10
-seeds × 3 arms = 180 trials** through the now-wired adapter against
-real LLM endpoints. This would produce a runs.jsonl with real
-`success` / `turn_count` / `total_output_tokens` data for the 18 /
-trial-slice per task, giving early signal but with sample size too
-small for the protocol's pre-registered power. Treat any such run as
-exploratory.
+All technical plumbing is in place. The gate driver can drive 900
+real LLM trials end-to-end. The remaining gating items (§8.1 rows
+1, 7, 8, 9, 10) are operational and require maintainer action, not
+engineering work.
+
+If the operator hand-waves the operational blockers and accepts an
+off-protocol run for engineering signal only (NOT for the merge
+decision), the system is ready to spend LLM budget *today*.
 
 ### 8.4 — Recommended next steps before kickoff
 
 In dependency order:
 
-1. **Push `release/phase-1-only`** so Arm B has a public, stable ref.
-   (Locally at `82301fe`; one `git push -u origin release/phase-1-only`.)
-2. **Open the docs-only PR** that merges this document and
-   `phase-2-measurement-protocol.md` to `main`. This freezes the
-   pre-registration without touching implementation.
-3. **Decide path 1 vs path 2 of §8.2** and author
-   `phase-2-measurement-protocol-v2.md` if needed (with the new sample
-   size and re-derived statistical power).
-4. **Authorise LLM spend, pick a pinned model id, configure the
-   4-hour monitoring tick, complete the §9.c sign-off.**
-5. **Then** execute the kickoff command in protocol §10.1.a.
+1. ✅ ~~Push `release/phase-1-only`~~ (done; pushed to origin at `82301fe`).
+2. ✅ ~~Pick substrate path and author protocol v2~~ (done; path 2 chosen;
+   `phase-2-measurement-protocol-v2.md` + manifest committed).
+3. **Open the docs-only PR** that merges `phase-2-measurement-protocol.md`,
+   `phase-2-measurement-protocol-v2.md`, this document, and
+   `tests/E2E/agent-tasks/phase-2-gate-tasks.txt` to `main`. This
+   freezes the pre-registration without touching implementation. The PR
+   should also include the driver + adapter refactor commits, since
+   protocol v2 §10.1.b makes the driver/adapter contract part of the
+   pre-registration.
+4. **Authorise LLM spend, pick a pinned model id, configure the 4-hour
+   monitoring tick, complete the §9.c sign-off.**
+5. **Then** execute the kickoff command in protocol v2 §10.1.a.
 
-Steps 1–3 are technical/editorial and can proceed without spend.
+Steps 1–3 are technical/editorial and proceed without spend.
 Step 4 is the irreversible commitment.

--- a/docs/plans/phase-2-validation-criteria.md
+++ b/docs/plans/phase-2-validation-criteria.md
@@ -1,0 +1,214 @@
+# Phase 2 — Validation Criteria for the §10 Gate
+
+**Audience:** the maintainer (or coding agent) deciding whether to merge
+`feature/compact-ids-v6` to `main` and ship Phase 2 to users.
+**Companion docs:**
+- [path-2-drop-ids-v6-implementation.md](path-2-drop-ids-v6-implementation.md) — overall plan
+- [phase-2-measurement-protocol.md](phase-2-measurement-protocol.md) — pre-registration (arm SHAs, fixtures, model pinning, kill criteria source-of-truth)
+- [path-2-drop-ids-v5-implementation.md](path-2-drop-ids-v5-implementation.md) — original RFC referenced by v6 calibration deltas
+
+This document operationalises **"the change is a positive for the
+language"** into a small set of mechanical, falsifiable checks. Each
+check is wired to a script in `scripts/` whose exit code (0/1) is the
+canonical signal. No section here describes work that is not also
+encoded in code or tests on this branch.
+
+The four §10.3 kill criteria are the authoritative gate. Tiers 1, 2,
+and 4 are *necessary preconditions* — they screen out builds whose
+basic invariants are broken, so the (expensive) Tier 3 / §10 run can
+trust its substrate.
+
+---
+
+## §1 — Mechanical checks (cheap, run before every merge to `main`)
+
+| # | Check | Command | Pass when |
+|---|-------|---------|-----------|
+| 1 | Build is green on Debug + Release | `dotnet build -c Release` | Exit 0; zero warnings (TWaE is on) |
+| 2 | Full xUnit suite is green | `dotnet test --nologo` | All tests pass; only the 2 known-skipped (`SolutionInitializationIntegrationTests`) are skipped |
+| 3 | Tier 1 harness is green **net of pre-existing failures** | `python scripts/verify_phase1.py` | Exit 0 **OR** the only failures are the 4 known-pre-existing samples (§1.x) |
+| 4 | Round-trip identity on a known corpus | `python scripts/migrator_revert_roundtrip.py` | Original ⇄ Phase 2 mapping round-trips byte-for-byte |
+| 5 | Byte preservation on the structural-ID dropper | `python scripts/byte_preservation_check.py` | Every file matches its expected `(N_removed × bytes_per_id)` delta |
+| 6 | AST round-trip after compact-id rewrite | `python scripts/ast_roundtrip_check.py` | AST equality (modulo ID payloads) pre/post `calor fix --compact-ids` |
+
+Failing any §1 check (other than the documented pre-existing samples
+in §1.x) **blocks merge** independently of Tier 3 result.
+
+These do not validate the user-visible improvement claim. They validate
+that the implementation does not silently corrupt source.
+
+### 1.x — Known pre-existing Tier 1 failures (not introduced by v6 ID work)
+
+`scripts/verify_phase1.py`'s `ast_roundtrip` step fails on 4 samples
+that pre-date `feature/compact-ids-v6` and use deprecated section
+markers the current parser does not accept:
+
+| File | Last touched | Failing markers |
+|------|--------------|------------------|
+| `samples/TypeSystem/typesystem.calr` | commit `2629449` (Add Z3 static contract verification, #108) | `§SOME`, `§NONE` |
+| `samples/Verification/mixed-contracts.calr` | commit `2629449` | `§DOC`, `§ELSE`, `§/IF` |
+| `samples/Verification/proven-contracts.calr` | commit `2629449` | `§DOC`, `§ELSE`, `§/IF` |
+| `samples/Verification/violation-detected.calr` | commit `2629449` | `§DOC` |
+
+These samples were committed before this branch was cut and have not
+been kept current with parser evolution. `SectionMarkerSuggestions.cs`
+still lists `DOC`, `SM`, etc. as suggestable markers, but the lexer's
+keyword dictionary does not implement them, so any source that uses
+them fails to compile.
+
+**Tier 1 contract on this branch:** the harness must report exactly
+these 4 failures and no others. A 5th `ast_roundtrip` failure (or any
+new failure in `byte_preservation`, `migrator_corpus_dryrun`, or
+`token_delta_spot`) is a regression caused by this branch and blocks
+merge. The maintainer should record the failure list with each
+"ready for Tier 3" annotation so the §10 gate is not run on a
+substrate with hidden new failures.
+
+Fixing the pre-existing samples (either by updating them to current
+syntax or by extending the lexer to implement the markers
+`SectionMarkerSuggestions.cs` advertises) is out of scope for this
+branch and tracked separately.
+
+---
+
+## §2 — Corpus checks (Tier 2; minutes, run on PRs to `phase-*`/`release/*`)
+
+Token-delta and corpus-wide invariants per v6 §3.2 / §3.3:
+
+| # | Check | Command | Pass when |
+|---|-------|---------|-----------|
+| 1 | Migrator dry-run over the full corpus | `python scripts/migrator_corpus_dryrun.py` | Every file produces a deterministic mapping; no warnings other than gap-C string-literal matches (documented & accepted) |
+| 2 | Token delta within recalibrated band | `python scripts/token_delta_corpus.py` | Aggregate Δtokens within `9.67 × N_ids ± (band recalibrated on a green build per v6 §3.2)` |
+| 3 | Post-ship monitor sanity (no regressions in shipped Phase 1) | `python scripts/phase1_post_ship_monitor.py` | Reports no Phase 1 regression in the rolling corpus |
+
+These also do not validate "language improvement." They validate that
+the corpus migration is internally consistent and that Phase 1 has not
+regressed during the Phase 2 window.
+
+---
+
+## §3 — The §10 gate (Tier 3) — the only check that validates improvement
+
+The §10 gate is the **single source of truth** for "is this change a
+positive for the language." Pre-registration lives in
+`docs/plans/phase-2-measurement-protocol.md`. The harness is
+`scripts/run_phase_2_gate.py`; the analyser is
+`scripts/analyze_gate_results.py`.
+
+Per the pre-registration (§7), four kill criteria must all be **PASS**.
+Bonferroni-corrected α′ = 0.05 / 4 = **0.0125**.
+
+### 3.1 The four criteria — machine-readable form
+
+The analyser computes each criterion and surfaces a `passes` bool in
+its JSON internal representation. The CLI exit code is 0 only when all
+four pass. Operationally:
+
+```bash
+python scripts/run_phase_2_gate.py        # writes results/runs.jsonl
+python scripts/analyze_gate_results.py    # writes phase-2-measurement-results.md
+                                          # exit 0 → SHIP; exit 1 → DO NOT SHIP
+echo $?  # canonical pass/fail signal
+```
+
+| # | Criterion | Pass condition (verbatim from protocol §7) | Failure mode |
+|---|-----------|---------------------------------------------|--------------|
+| 1 | Success-rate non-inferiority | McNemar **p > 0.0125** comparing Arm C vs Arm A; Arm C success rate is not statistically worse than Arm A | Phase 2 hurts agents; revert |
+| 2 | Identity-preservation non-regression | Wilcoxon **p > 0.0125** on per-run identity errors; Arm C does not regress | Phase 2 corrupts more often; revert |
+| 3 | Material agent benefit on turn-count OR token-count | Median reduction ≥ 10% (turns) or ≥ 15% (tokens), Wilcoxon **p < 0.0125**, and **\|Cliff's δ\| ≥ 0.33** on the same metric | Phase 2 delivers no measurable user benefit; revert |
+| 4 | Phase 2 distinguishable from Phase 1 alone | On criterion (3)'s metric, Arm C vs Arm B Wilcoxon **p < 0.0125** | Phase 1's structural-ID drop is doing all the work; Phase 2 is redundant; revert |
+
+A **single red criterion** → ship Phase 1 alone per RFC §11. This is
+already encoded in `analyze_gate_results.py:434` (`all_pass = c1["passes"] and c2["passes"] and c3["passes"] and c4["passes"]`).
+
+### 3.2 Pre-flight checks (protocol §10.1)
+
+Before the first run executes, the harness verifies (encoded in
+`run_phase_2_gate.py` and the protocol's §10.1):
+
+1. Monitoring tick scheduled (v6 §3.3.b).
+2. Pinned model available (1-prompt ping).
+3. Disk space, network, log dir writable.
+4. All 30 fixtures resolve to readable dirs.
+5. Three arm SHAs resolve to checkoutable commits.
+
+If any pre-flight check fails, the gate halts with non-zero exit before
+spending real run budget.
+
+### 3.3 What "validates improvement" means
+
+> *"Improvement"* = criteria 3 AND 4 both PASS, while 1 and 2 do not
+> regress (PASS). Criterion 3 captures user-visible benefit
+> (turn/token reduction) at a pre-registered effect size; criterion 4
+> ensures that benefit is attributable to Phase 2 specifically, not
+> already delivered by Phase 1.
+
+No other definition of "improvement" is accepted for the merge
+decision. Subjective impressions ("looks nicer," "agents seem
+happier") are not sufficient and do not override the analyser's exit
+code. This is the discipline the §10 gate exists to enforce.
+
+---
+
+## §4 — Decision matrix at merge time
+
+Let:
+
+- **M** = §1 (mechanical) checks pass
+- **C** = §2 (corpus) checks pass
+- **G** = §3 (gate) all four criteria pass
+
+| M | C | G | Action |
+|---|---|---|--------|
+| ✗ | — | — | **DO NOT MERGE.** Fix the build/tests/round-trip before anything else. |
+| ✓ | ✗ | — | **DO NOT MERGE.** Corpus invariants broken; investigate before spending gate budget. |
+| ✓ | ✓ | ✗ | **DO NOT MERGE Phase 2.** Revert Phase 2 commits; consider shipping Phase 1 alone per RFC §11. |
+| ✓ | ✓ | ✓ | **MERGE.** Phase 2 has cleared all four kill criteria. Ship. |
+
+There is no `(✓, ✓, untested)` row by design. A merge to `main` of
+Phase 2 changes requires Tier 3 to have run on the actual arm SHAs
+that will land. Code-only changes (e.g. fixing a typo in a comment)
+on already-validated material may merge without a re-run, at maintainer
+discretion.
+
+---
+
+## §5 — When the gate has not yet been run
+
+This is the state of `feature/compact-ids-v6` at the time of writing.
+All §1 and §2 checks must be green; §3 is pending. The branch may
+remain open and continue receiving fixes; it may **not** be merged to
+`main` until §3 reports PASS on the SHAs that will land.
+
+If the maintainer ships an interim release that includes Phase 1 only
+(no Phase 2 user-visible behavior), that ships from a different branch
+(`release/0.x+1` per the v6 plan), not from `feature/compact-ids-v6`.
+
+---
+
+## §6 — Provenance and auditability
+
+Per RFC §16.E item 8 (encoded in `analyze_gate_results.py:12-13`), the
+analyser writes `docs/plans/phase-2-measurement-results.md`
+**regardless of pass/fail**. If the gate fails, the results document
+records the failure and the decision to revert. The branch's history,
+the results document, and the analyser's exit code together form the
+auditable record for the ship/no-ship decision.
+
+---
+
+## §7 — Cross-reference to status today
+
+The work to get to a runnable §10 gate is tracked in the v6 plan's PR
+breakdown (§2). At the time `feature/compact-ids-v6` is ready for the
+gate:
+
+- PR-0a..0e (Phase 0 prerequisites): all merged on this branch.
+- PR-1a..1h (Phase 1 implementation): all merged on this branch
+  (Phase 1 is independently shippable per v6 §3.5).
+- PR-2a..2f (Phase 2 implementation): all merged on this branch.
+- §1 + §2 of this document: all green on the branch tip before the
+  gate kicks off.
+
+When the maintainer is ready to spend the Tier 3 budget, the kickoff
+command is in protocol §10.1.a.

--- a/docs/plans/phase-2-validation-criteria.md
+++ b/docs/plans/phase-2-validation-criteria.md
@@ -119,10 +119,11 @@ echo $?  # canonical pass/fail signal
 A **single red criterion** → ship Phase 1 alone per RFC §11. This is
 already encoded in `analyze_gate_results.py:434` (`all_pass = c1["passes"] and c2["passes"] and c3["passes"] and c4["passes"]`).
 
-### 3.2 Pre-flight checks (protocol §10.1)
+### 3.2 Pre-flight checks (protocol §10.1 and §10.1.a)
 
 Before the first run executes, the harness verifies (encoded in
-`run_phase_2_gate.py` and the protocol's §10.1):
+`run_phase_2_gate.py` and the protocol's §10.1; the operator
+checklist that wraps these is in protocol §10.1.a):
 
 1. Monitoring tick scheduled (v6 §3.3.b).
 2. Pinned model available (1-prompt ping).
@@ -130,8 +131,14 @@ Before the first run executes, the harness verifies (encoded in
 4. All 30 fixtures resolve to readable dirs.
 5. Three arm SHAs resolve to checkoutable commits.
 
-If any pre-flight check fails, the gate halts with non-zero exit before
-spending real run budget.
+Protocol §10.1.a additionally requires (operator-side, before the
+script is invoked): pre-registration document merged to `main`, clean
+working tree, §1 mechanical checks all green, a fresh `--output-dir`,
+distinct Arm A/B/C refs, the smoke-test path exercised, and (in
+solo-mode) the v6 §9.c sign-off ritual completed.
+
+If any pre-flight check fails, the gate halts with non-zero exit
+before spending real run budget.
 
 ### 3.3 What "validates improvement" means
 

--- a/docs/plans/phase-2-validation-criteria.md
+++ b/docs/plans/phase-2-validation-criteria.md
@@ -26,48 +26,46 @@ trust its substrate.
 |---|-------|---------|-----------|
 | 1 | Build is green on Debug + Release | `dotnet build -c Release` | Exit 0; zero warnings (TWaE is on) |
 | 2 | Full xUnit suite is green | `dotnet test --nologo` | All tests pass; only the 2 known-skipped (`SolutionInitializationIntegrationTests`) are skipped |
-| 3 | Tier 1 harness is green **net of pre-existing failures** | `python scripts/verify_phase1.py` | Exit 0 **OR** the only failures are the 4 known-pre-existing samples (§1.x) |
+| 3 | Tier 1 harness is green | `python scripts/verify_phase1.py` | Exit 0; 0 `ast_roundtrip` failures |
 | 4 | Round-trip identity on a known corpus | `python scripts/migrator_revert_roundtrip.py` | Original ⇄ Phase 2 mapping round-trips byte-for-byte |
 | 5 | Byte preservation on the structural-ID dropper | `python scripts/byte_preservation_check.py` | Every file matches its expected `(N_removed × bytes_per_id)` delta |
 | 6 | AST round-trip after compact-id rewrite | `python scripts/ast_roundtrip_check.py` | AST equality (modulo ID payloads) pre/post `calor fix --compact-ids` |
 
-Failing any §1 check (other than the documented pre-existing samples
-in §1.x) **blocks merge** independently of Tier 3 result.
+Failing any §1 check **blocks merge** independently of Tier 3 result.
 
 These do not validate the user-visible improvement claim. They validate
 that the implementation does not silently corrupt source.
 
-### 1.x — Known pre-existing Tier 1 failures (not introduced by v6 ID work)
+### 1.x — Pre-existing Tier 1 failures (resolved on this branch)
 
-`scripts/verify_phase1.py`'s `ast_roundtrip` step fails on 4 samples
-that pre-date `feature/compact-ids-v6` and use deprecated section
-markers the current parser does not accept:
+Earlier on this branch `scripts/verify_phase1.py`'s `ast_roundtrip` step
+failed on 4 samples that pre-dated `feature/compact-ids-v6` and used
+deprecated section markers the current parser does not accept:
 
-| File | Last touched | Failing markers |
-|------|--------------|------------------|
-| `samples/TypeSystem/typesystem.calr` | commit `2629449` (Add Z3 static contract verification, #108) | `§SOME`, `§NONE` |
-| `samples/Verification/mixed-contracts.calr` | commit `2629449` | `§DOC`, `§ELSE`, `§/IF` |
-| `samples/Verification/proven-contracts.calr` | commit `2629449` | `§DOC`, `§ELSE`, `§/IF` |
-| `samples/Verification/violation-detected.calr` | commit `2629449` | `§DOC` |
+| File | Last touched before fix | Failing markers (then) | Replacement (applied) |
+|------|--------------------------|-------------------------|-----------------------|
+| `samples/TypeSystem/typesystem.calr` | commit `2629449` (Add Z3 static contract verification, #108) | `§SOME`, `§NONE{type=…}` | `§SM`, `§NN{…}` |
+| `samples/Verification/mixed-contracts.calr` | commit `2629449` | `§DOC{…}`, `§ELSE{id}`, `§/IF{id}` | strip `§DOC`; `§EL`; `§/I{id}` |
+| `samples/Verification/proven-contracts.calr` | commit `2629449` | `§DOC{…}`, `§ELSE{id}`, `§/IF{id}` | strip `§DOC`; `§EL`; `§/I{id}` |
+| `samples/Verification/violation-detected.calr` | commit `2629449` | `§DOC{…}` | strip `§DOC` |
 
-These samples were committed before this branch was cut and have not
-been kept current with parser evolution. `SectionMarkerSuggestions.cs`
-still lists `DOC`, `SM`, etc. as suggestable markers, but the lexer's
-keyword dictionary does not implement them, so any source that uses
-them fails to compile.
+All 4 files now compile cleanly and pass `ast_roundtrip` (verified:
+Tier 1 reports `[11/11] OK`, total 29.4 s, well under the 60 s budget).
+`samples/TypeSystem/typesystem.g.cs` was regenerated against the fixed
+source.
 
-**Tier 1 contract on this branch:** the harness must report exactly
-these 4 failures and no others. A 5th `ast_roundtrip` failure (or any
-new failure in `byte_preservation`, `migrator_corpus_dryrun`, or
-`token_delta_spot`) is a regression caused by this branch and blocks
-merge. The maintainer should record the failure list with each
-"ready for Tier 3" annotation so the §10 gate is not run on a
-substrate with hidden new failures.
+**Lexer ↔ suggestion table drift remains.** `SectionMarkerSuggestions.cs`
+still lists `DOC` (and emits `Did you mean '§DOC' (Documentation)?` for
+unknown `§DOC` input) even though the lexer's keyword dictionary has no
+entry for it. The misleading suggestion `§/I (Input parameter)` for
+`§/IF` is also wrong (the correct close is `§/I{id}` as the IF terminator).
+Fixing the suggestion table is out of scope for v6 ID work and tracked
+separately.
 
-Fixing the pre-existing samples (either by updating them to current
-syntax or by extending the lexer to implement the markers
-`SectionMarkerSuggestions.cs` advertises) is out of scope for this
-branch and tracked separately.
+**Tier 1 contract on this branch:** the harness must report 0
+`ast_roundtrip` failures. Any failure in `byte_preservation`,
+`ast_roundtrip`, `migrator_corpus_dryrun`, or `token_delta_spot` is a
+regression caused by this branch and blocks merge.
 
 ---
 
@@ -215,9 +213,9 @@ into a user-visible benefit — that requires criterion 3 from §3.1.
 But it does materially reduce the risk that Tier 3 fails for
 "implementation didn't deliver the expected delta" reasons.
 
-The Tier 1 `ast_roundtrip` step continues to report the 4
-pre-existing failures listed in §1.x; no additional failures on the
-branch tip.
+The Tier 1 `ast_roundtrip` step now reports `[11/11] OK` (the 4
+pre-existing failures listed in §1.x were fixed on this branch); no
+additional failures on the branch tip.
 
 ---
 

--- a/docs/plans/phase-2-validation-criteria.md
+++ b/docs/plans/phase-2-validation-criteria.md
@@ -184,6 +184,41 @@ If the maintainer ships an interim release that includes Phase 1 only
 (no Phase 2 user-visible behavior), that ships from a different branch
 (`release/0.x+1` per the v6 plan), not from `feature/compact-ids-v6`.
 
+### 5.1 — Empirical evidence accumulated so far (no Tier 3 yet)
+
+The §3 gate is the only validator that licenses the merge decision.
+Cheaper checks accumulated on this branch *cannot* substitute, but
+they do offer early signal on whether the Tier 3 spend is justified.
+Current readings:
+
+- **Build & xUnit suite** (§1.1, §1.2): green. 5,427 tests pass on
+  the branch tip; 2 known-skipped. +12 PR-2e tests on top of the
+  PR-2a..2d baseline.
+- **Migrator dry-run** (§2.1, both modes): green on the full
+  `tests/` corpus (1,541 files). No file mutates under `--dry-run`
+  for `drop-structural-ids` or `compact-ids`.
+- **Migrator round-trip** (§1.4, both modes): byte-perfect on 1,541
+  files. `original → forward → revert` reproduces every byte for
+  both Phase 1 and Phase 2 paths.
+- **Token-delta sanity** (§2.2): RFC §16.F predicted **9.67
+  tokens/ID** (N=100 RNG-generated IDs, 95% CI 9.30–10.04). The
+  corpus has **16,669 ID blocks** across 1,541 files; predicted
+  aggregate Δ = 9.67 × 16669 = **161,159 tokens**; measured
+  aggregate Δ = **161,189 tokens** — within **0.02%** of the
+  prediction. The per-ID estimate generalises to the corpus.
+
+That last reading is the most useful piece of evidence available
+without spending Tier 3 budget: it confirms that Phase 1's mechanical
+rewrite removes the predicted volume of tokens at the predicted
+per-ID rate. It does **not** validate that this reduction translates
+into a user-visible benefit — that requires criterion 3 from §3.1.
+But it does materially reduce the risk that Tier 3 fails for
+"implementation didn't deliver the expected delta" reasons.
+
+The Tier 1 `ast_roundtrip` step continues to report the 4
+pre-existing failures listed in §1.x; no additional failures on the
+branch tip.
+
 ---
 
 ## §6 — Provenance and auditability

--- a/docs/plans/phase-2-validation-criteria.md
+++ b/docs/plans/phase-2-validation-criteria.md
@@ -252,3 +252,106 @@ gate:
 
 When the maintainer is ready to spend the Tier 3 budget, the kickoff
 command is in protocol §10.1.a.
+
+---
+
+## §8 — Gate readiness snapshot (live audit, updated 2026-05-27)
+
+This section captures the live readiness state of the §10 gate. It is
+maintained as the answer to "can we run the gate today?" and updated
+whenever a blocker is resolved or a new one is discovered. **Until §8.1
+shows all green, the kickoff command in protocol §10.1.a will produce
+either an invalid run (no statistical power) or no run at all.**
+
+### 8.1 — Prerequisite readiness matrix
+
+| # | Prerequisite (protocol §10.1.a) | Status | Owner | Detail |
+|---|---------------------------------|--------|-------|--------|
+| 1 | Pre-registration doc merged to `main` | 🔴 Blocker | Maintainer | Protocol + this doc currently live only on `feature/compact-ids-v6` (commit `b45a3c6`). RFC §10.5 immutability requires `main`. Open a docs-only PR (no implementation) to land both files. |
+| 2 | Working tree clean on Arm C checkout | 🟡 Operator step | Operator | Verified procedurally in §10.1.a; not an artifact gate. |
+| 3 | §1 (mechanical) checks green | 🟢 Done | — | Tier 1 `[11/11] OK`, all 5,427 tests pass, both round-trip harnesses byte-perfect on the corpus. |
+| 4 | 30 fixtures resolve to readable dirs | 🟡 Resolves, but see §8.2 | — | 24 + 6 directories exist; 24 of them lack a runnable task contract. |
+| 5 | Three **distinct** arm refs (A ≠ B ≠ C) | 🟢 Local only | Maintainer (push) | `release/phase-1-only` cut locally at `82301fe` (3 cherry-picks + 1 stub commit; builds + all tests green). Not yet pushed; needs maintainer review before publishing. |
+| 6 | Agent harness wired to driver | 🟢 Done | — | `tests/E2E/agent-tasks/run.sh` adapter authored this session. `scripts/run_phase_2_gate.py` patched to (a) resolve git-bash on Windows for local dev and (b) propagate the adapter's `harness_error` field into `runs.jsonl` (was silently dropped). Verified end-to-end: 90 records via `CALOR_GATE_DRY_RUN=1`, all `harness_crash=false`. Smoke test (`scripts/smoke_phase_2_gate_dryrun.py`) remains green. |
+| 7 | Version-pinned model id + API credentials + budget | 🔴 Blocker | Maintainer | `claude.exe` is on `PATH`; no API spend authorization captured. Budget ~$2–4k per RFC §10.1. |
+| 8 | 4-hour monitoring tick scheduled | 🔴 Blocker | Operator | Cron / Task Scheduler / external timer not configured. |
+| 9 | v6 §9.c solo-mode sign-off ritual | 🔴 Blocker | Maintainer | 24h cool-off issue not opened. |
+
+Legend: 🟢 ready, 🟡 conditional, 🔴 blocker.
+
+### 8.2 — Substrate gap (criterion-level impact)
+
+The gate driver in `scripts/run_phase_2_gate.py:collect_fixtures` iterates
+both `tests/E2E/agent-tasks/fixtures/` (24 directories) and
+`tests/E2E/agent-tasks/templates/path-2-gate/` (6 directories). Only the
+6 templates have a runnable task contract (`task.md` + `setup/` +
+`acceptance.sh`). The 24 fixtures are workspace skeletons referenced by
+`tests/E2E/agent-tasks/tasks/<category>/<task>/task.json` files via the
+`fixture` field — they are *workspaces*, not *tasks*.
+
+Demonstrated empirically (90 records produced by `CALOR_GATE_DRY_RUN=1`
+on this branch):
+
+| Substrate class | Fixtures | Records (1 seed × 3 arms) | Adapter `harness_error` |
+|-----------------|----------|----------------------------|-------------------------|
+| Templates with task contract | 6 | 18 | `dry_run` (would be real LLM runs) |
+| Fixtures with no contract | 24 | 72 | `no_task_contract` |
+
+In a full 900-run gate (10 seeds), **720 / 900 (80%)** of records would
+be `no_task_contract` — providing zero criterion-1 signal differentiating
+arms because no agent ever runs against them. The remaining 180 useful
+records is well below the sample size the protocol's statistical power
+analysis assumed (RFC §10.1).
+
+Two paths forward, both require a protocol amendment per RFC §10.5
+(`phase-2-measurement-protocol-v2.md`):
+
+1. **Author 24 new task contracts**, one per existing fixture. Each
+   contract needs a `task.md` prompt, optional `setup/` overlay,
+   `expected/` reference output, and `acceptance.sh`. Estimated effort:
+   1–2 weeks of careful task design. Preserves the 30-fixture × 10-seed
+   × 3-arm = 900-run plan.
+
+2. **Refactor `run_phase_2_gate.py:collect_fixtures` to iterate
+   `tests/E2E/agent-tasks/tasks/<cat>/<task>/task.json`**, joining each
+   `task.json` with its declared `fixture`. Many tasks share the same
+   fixture, so the trial count would shift to N(tasks) × 10 × 3. With
+   ~40 existing tasks plus the 6 templates, that's 46 × 30 = 1,380 runs,
+   which over-provisions statistical power but inflates the budget by
+   ~50%. Re-pre-register sample size and Bonferroni α accordingly.
+
+A third "shortcut" — running the gate with the current substrate and
+filtering out `no_task_contract` records in `analyze_gate_results.py` —
+is **not acceptable** because it silently changes the planned sample
+size, violating the pre-registration discipline of RFC §10.5.
+
+### 8.3 — What is concretely runnable today
+
+If the operator hand-waves blockers 1, 7, 8, and 9 (i.e. authorises
+spend and accepts an off-protocol run for engineering signal only,
+NOT for the merge decision), the system can drive the **6 templates × 10
+seeds × 3 arms = 180 trials** through the now-wired adapter against
+real LLM endpoints. This would produce a runs.jsonl with real
+`success` / `turn_count` / `total_output_tokens` data for the 18 /
+trial-slice per task, giving early signal but with sample size too
+small for the protocol's pre-registered power. Treat any such run as
+exploratory.
+
+### 8.4 — Recommended next steps before kickoff
+
+In dependency order:
+
+1. **Push `release/phase-1-only`** so Arm B has a public, stable ref.
+   (Locally at `82301fe`; one `git push -u origin release/phase-1-only`.)
+2. **Open the docs-only PR** that merges this document and
+   `phase-2-measurement-protocol.md` to `main`. This freezes the
+   pre-registration without touching implementation.
+3. **Decide path 1 vs path 2 of §8.2** and author
+   `phase-2-measurement-protocol-v2.md` if needed (with the new sample
+   size and re-derived statistical power).
+4. **Authorise LLM spend, pick a pinned model id, configure the
+   4-hour monitoring tick, complete the §9.c sign-off.**
+5. **Then** execute the kickoff command in protocol §10.1.a.
+
+Steps 1–3 are technical/editorial and can proceed without spend.
+Step 4 is the irreversible commitment.

--- a/docs/plans/phase-2-validation-criteria.md
+++ b/docs/plans/phase-2-validation-criteria.md
@@ -267,18 +267,38 @@ either an invalid run (no statistical power) or no run at all.**
 
 | # | Prerequisite (protocol v2 §10.1.a-b) | Status | Owner | Detail |
 |---|---------------------------------|--------|-------|--------|
-| 1 | Pre-registration doc merged to `main` | 🟡 Pending PR | Maintainer | Protocol v1 + v2 + this doc live only on `feature/compact-ids-v6`. Docs-only PR to `main` is the next step. |
+| 1 | Pre-registration doc merged to `main` | 🟡 Pending PR | Maintainer | Protocol v1 + v2 + this doc live on `docs/phase-2-pre-registration`; PR [#621](https://github.com/juanmicrosoft/calor/pull/621) open against `main`. |
 | 2 | Working tree clean on Arm C checkout | 🟡 Operator step | Operator | Verified procedurally in §10.1.a; not an artifact gate. |
 | 3 | §1 (mechanical) checks green | 🟢 Done | — | Tier 1 `[11/11] OK`, all 5,427 tests pass, both round-trip harnesses byte-perfect on the corpus. |
 | 4 | 30 trials resolve to runnable contracts | 🟢 Done | — | Substrate gap resolved by protocol v2 (see §8.2). Driver reads `tests/E2E/agent-tasks/phase-2-gate-tasks.txt` and resolves 24 `task:` + 6 `template:` = 30 trials, all with `task.json`/`task.md` + workspace. |
 | 5 | Three **distinct** arm refs (A ≠ B ≠ C) | 🟢 Done | — | `release/phase-1-only` cut and pushed to origin at `82301fe` (3 cherry-picks + 1 stub commit; builds + all tests green). |
 | 6 | Agent harness wired to driver | 🟢 Done | — | `tests/E2E/agent-tasks/run.sh` adapter accepts new `--trial-id/--kind/--task-dir [--fixture-dir]` contract; supports both `task:` and `template:` kinds. `scripts/run_phase_2_gate.py` reads manifest, propagates adapter's `harness_error`. End-to-end verified: 90 records via `CALOR_GATE_DRY_RUN=1`, all `harness_crash=false`, all `harness_error="dry_run"` (no substrate noise). |
-| 7 | Version-pinned model id + API credentials + budget | 🔴 Blocker | Maintainer | `claude.exe` is on `PATH`; no API spend authorization captured. Budget ~$2–4k per RFC §10.1. |
-| 8 | 4-hour monitoring tick scheduled | 🔴 Blocker | Operator | Cron / Task Scheduler / external timer not configured. |
-| 9 | v6 §9.c solo-mode sign-off ritual | 🔴 Blocker | Maintainer | 24h cool-off issue not opened. |
-| 10 | Trial manifest at SHA used for Arm C kickoff (v2 §10.1.b new) | 🟡 Pending PR | Maintainer | Manifest is part of the docs-only PR to `main`. |
+| 7 | Version-pinned model id + API credentials + budget | 🟡 Config staged, unsigned | Maintainer | `phase-2-gate-config.json` pins `claude-sonnet-4-6` (verified callable, $0.048 for a 'say hi' trial via Claude Code 2.1.144 on 2026-05-27). `phase-2-spend-authorisation.md` template authored; awaits per-trial calibration (§2 of that doc) + operator signature (§6). |
+| 8 | 4-hour monitoring tick scheduled | 🟡 Script staged, scheduler not registered | Operator | `scripts/monitor_phase_2_gate.py` authored + verified on stub data (exit 0 green / exit 1 tripped / exit 2 missing); `phase-2-monitoring-tick.md` documents Windows Task Scheduler + cron setup. Operator must register the task on the host that will run kickoff. |
+| 9 | Solo-mode kickoff cool-off (§9.a pattern applied to kickoff) | 🟡 Procedure documented, issue not opened | Maintainer | v6 §9.c formally covers *retry* sign-off only, not first-run. `phase-2-spend-authorisation.md` §5 prescribes a §9.a-style 4-hour cool-off issue at kickoff. Issue MUST be opened (and 4h MUST elapse) before signing `phase-2-spend-authorisation.md` §6. |
+| 10 | Trial manifest at SHA used for Arm C kickoff (v2 §10.1.b new) | 🟡 Pending PR | Maintainer | Manifest is part of PR [#621](https://github.com/juanmicrosoft/calor/pull/621). |
 
 Legend: 🟢 ready, 🟡 conditional, 🔴 blocker.
+
+### 8.1.a — Operator artifacts authored in this commit (2026-05-27)
+
+These four files together close §8.1 rows 7, 8, and 9 to 🟡 (staged
+but not yet signed/scheduled/opened). They are operator deliverables,
+not part of the immutable pre-registration; revising them does NOT
+trigger the v6 §9.c retry-sign-off discipline.
+
+- [`phase-2-gate-config.json`](phase-2-gate-config.json) — pinned
+  `claude-sonnet-4-6`, budget envelope ($5k ceiling), abort triggers,
+  exact kickoff CLI template.
+- [`phase-2-spend-authorisation.md`](phase-2-spend-authorisation.md) —
+  signature artifact; §2 prescribes per-trial calibration, §5
+  prescribes the §9.a-style kickoff cool-off, §6 is the signature
+  block the maintainer commits.
+- [`phase-2-monitoring-tick.md`](phase-2-monitoring-tick.md) — Windows
+  Task Scheduler + POSIX cron setup for the 4-hour monitor.
+- `scripts/monitor_phase_2_gate.py` — the monitor itself; verified
+  green / tripped / missing-file paths against stub data; exits 0 /
+  1 / 2 respectively.
 
 ### 8.2 — Substrate gap (RESOLVED in protocol v2)
 
@@ -334,16 +354,23 @@ In dependency order:
 1. ✅ ~~Push `release/phase-1-only`~~ (done; pushed to origin at `82301fe`).
 2. ✅ ~~Pick substrate path and author protocol v2~~ (done; path 2 chosen;
    `phase-2-measurement-protocol-v2.md` + manifest committed).
-3. **Open the docs-only PR** that merges `phase-2-measurement-protocol.md`,
-   `phase-2-measurement-protocol-v2.md`, this document, and
-   `tests/E2E/agent-tasks/phase-2-gate-tasks.txt` to `main`. This
-   freezes the pre-registration without touching implementation. The PR
-   should also include the driver + adapter refactor commits, since
-   protocol v2 §10.1.b makes the driver/adapter contract part of the
-   pre-registration.
-4. **Authorise LLM spend, pick a pinned model id, configure the 4-hour
-   monitoring tick, complete the §9.c sign-off.**
-5. **Then** execute the kickoff command in protocol v2 §10.1.a.
+3. ✅ ~~Open docs-only PR~~ (done; PR [#621](https://github.com/juanmicrosoft/calor/pull/621)
+   open against `main`; awaits review/merge).
+4. ✅ ~~Author operator artifacts~~ (done 2026-05-27): pinned model
+   config, spend-authorisation template, monitoring tick + Windows/POSIX
+   scheduling docs. See §8.1.a.
+5. **Operator: complete the four signature/scheduling actions.** In
+   any order:
+   - Run per-trial calibration (`phase-2-spend-authorisation.md` §2)
+     and update the table with real numbers.
+   - Register the monitoring tick on the host that will run kickoff
+     (`phase-2-monitoring-tick.md` §2 for Windows / §3 for POSIX).
+   - Open the §9.a-style kickoff cool-off issue
+     (`phase-2-spend-authorisation.md` §5).
+   - After ≥ 4 hours have elapsed since the cool-off issue body was
+     committed, sign `phase-2-spend-authorisation.md` §6.
+6. **Then** execute the kickoff command in protocol v2 §10.1.a.
 
-Steps 1–3 are technical/editorial and proceed without spend.
-Step 4 is the irreversible commitment.
+Steps 1–4 are technical/editorial and proceed without spend.
+Step 5 is signature work — irreversible commitment only at the moment
+the kickoff command is executed in step 6.

--- a/docs/process/rfc-review-checklist.md
+++ b/docs/process/rfc-review-checklist.md
@@ -1,0 +1,84 @@
+# RFC Review Checklist
+
+This checklist applies to all RFC-class documents under `docs/plans/`.
+The lesson driving this checklist: the v2 → v3 → v4 → v5 trajectory of the
+Compact Stable Identifiers RFC caught one *architectural fiction* per review
+round — a sentence asserting the compiler does X when, in fact, the source
+code did not do X. The checklist exists to catch the next analogous fiction
+at PR review time, not at v(N+1).
+
+## For RFC authors
+
+1. **Architectural claim rule.** Every sentence of the form
+   "the compiler does X", "the verifier asserts Y", or "the migrator
+   guarantees Z" MUST EITHER:
+   - cite a file:line in the source tree, OR
+   - be explicitly marked `[PROPOSED]` to indicate the behavior is
+     proposed but not yet implemented.
+
+2. **Effort estimates with citations.** When estimating effort for an
+   audit/refactor task, cite a grep result for the call site count:
+   - GOOD: "0.5 day — `IdGenerator.Generate()` has 2 production call sites
+     (`Ids/IdAssigner.cs:175`, `:180`)"
+   - BAD: "0.5–2 days" (unfounded upper bound)
+
+3. **Measurement claims.** When citing a numeric measurement
+   (token counts, runtime, memory), include the script that produces the
+   number, the sample size, and (for noisy measurements) a confidence
+   interval. Hand-picked samples of N < 20 are not acceptable for headline
+   numbers.
+
+## For RFC reviewers
+
+1. **Grep-verify every architectural claim.** Take 30 seconds per
+   architectural assertion to run `rg` against the cited `file:line`.
+   If the citation is missing OR if grep does not find the asserted
+   behavior, add a `[VERIFY]` comment to the RFC PR.
+
+2. **Be the devil's advocate explicitly.** Pair each RFC with two review
+   documents:
+   - A designer-voice critique (read the RFC charitably, find genuine
+     improvements).
+   - A devil's-advocate critique (read the RFC adversarially, find the
+     assertions that don't hold up).
+
+3. **Verdict convergence is the ship signal.** When both reviewers converge
+   on "approve and ship" with only calibration concerns, author one
+   calibration revision (capturing the calibrations in-line) and ship. Do
+   not iterate further unless a new architectural concern emerges.
+
+4. **Grep-verify artifact-state claims, not just architectural claims.**
+   When a review document asserts something about the state of an artifact
+   ("§N is missing," "the file truncates at line X," "the directory does
+   not exist"), the reviewer MUST grep-verify the claim before including it
+   in the review:
+
+   - "§N is missing" requires `rg "^## §N" <file>` showing no match.
+   - "File truncates at line X" requires `wc -l <file>` showing line count
+     == X AND `tail -1 <file>` showing the truncation.
+   - "Directory does not exist" requires `ls <path>` or `Test-Path <path>`
+     showing absence.
+
+   If the reviewer's tool truncates the read at some byte threshold, the
+   reviewer MUST use a second tool (`rg`, `wc -l`, `tail`,
+   `Get-Content -Tail`) to verify the artifact ends where their read ends,
+   before concluding "the file is truncated."
+
+   This rule was added v5-impl → v6 after one DA review made a "blocking"
+   claim that §8 was missing from a file that demonstrably contains
+   §8.1–§8.5 (verified by `rg "^## §8"`).
+
+## For all RFC contributors
+
+- A new RFC version (v(N+1)) is justified when EITHER:
+  - A reviewer identifies an architectural fiction (claim not in the
+    source), OR
+  - A reviewer identifies a missing required artifact (statistical test,
+    retry policy, rollback path).
+- A new RFC version is NOT justified for:
+  - Wording polish,
+  - Adding citations to claims that are correct,
+  - Reorganizing structure without changing substance.
+- Calibration deltas should be captured in the next-version's §0 change
+  table; new RFC versions should reference predecessors and document
+  deltas only.

--- a/samples/TypeSystem/typesystem.calr
+++ b/samples/TypeSystem/typesystem.calr
@@ -43,7 +43,7 @@
 §F{f002:TestSome:pri}
   §O{void}
   §E{cw}
-  §B{opt} §SOME 42
+  §B{opt} §SM 42
   §C{Console.WriteLine}
     §A "  Created Some(42)"
   §/C
@@ -52,7 +52,7 @@
 §F{f003:TestNone:pri}
   §O{void}
   §E{cw}
-  §B{opt} §NONE{type=INT}
+  §B{opt} §NN{INT}
   §C{Console.WriteLine}
     §A "  Created None"
   §/C

--- a/samples/TypeSystem/typesystem.g.cs
+++ b/samples/TypeSystem/typesystem.g.cs
@@ -3,6 +3,8 @@
 // Do not modify this file directly.
 // </auto-generated>
 
+#nullable enable
+
 using System;
 using Calor.Runtime;
 

--- a/samples/Verification/mixed-contracts.calr
+++ b/samples/Verification/mixed-contracts.calr
@@ -1,8 +1,6 @@
 §M{m001:MixedContracts}
-§DOC{Demonstrates contracts with mixed verification outcomes}
 
 §F{f001:SafeDivide:pub}
-  §DOC{Division with divisor check - postcondition about result is unproven.}
   §I{i32:a}
   §I{i32:b}
   §O{i32}
@@ -12,7 +10,6 @@
 §/F{f001}
 
 §F{f002:SumArray:pub}
-  §DOC{Sums array - contracts with string types are unsupported.}
   §I{i32:n}
   §O{i32}
   §Q (>= n 0)
@@ -20,7 +17,6 @@
 §/F{f002}
 
 §F{f003:Increment:pub}
-  §DOC{Increments a value - provable postcondition.}
   §I{i32:x}
   §O{i32}
   §S (== result (+ x 1))
@@ -28,15 +24,14 @@
 §/F{f003}
 
 §F{f004:ClampPositive:pub}
-  §DOC{Clamps value to non-negative - provable postcondition.}
   §I{i32:x}
   §O{i32}
   §S (>= result 0)
   §IF{if001} (< x 0)
     §R 0
-  §ELSE{if001}
+  §EL
     §R x
-  §/IF{if001}
+  §/I{if001}
 §/F{f004}
 
 §/M{m001}

--- a/samples/Verification/proven-contracts.calr
+++ b/samples/Verification/proven-contracts.calr
@@ -1,8 +1,6 @@
 §M{m001:ProvenContracts}
-§DOC{Demonstrates contracts that can be statically proven by Z3}
 
 §F{f001:Square:pub}
-  §DOC{Squares a non-negative integer. All contracts are provable.}
   §I{i32:x}
   §O{i32}
   §Q (>= x 0)
@@ -11,19 +9,17 @@
 §/F{f001}
 
 §F{f002:AbsoluteValue:pub}
-  §DOC{Returns the absolute value. Postcondition is provable.}
   §I{i32:x}
   §O{i32}
   §S (>= result 0)
   §IF{if001} (< x 0)
     §R (- 0 x)
-  §ELSE{if001}
+  §EL
     §R x
-  §/IF{if001}
+  §/I{if001}
 §/F{f002}
 
 §F{f003:Max:pub}
-  §DOC{Returns the larger of two values. All contracts provable.}
   §I{i32:a}
   §I{i32:b}
   §O{i32}
@@ -31,13 +27,12 @@
   §S (>= result b)
   §IF{if001} (>= a b)
     §R a
-  §ELSE{if001}
+  §EL
     §R b
-  §/IF{if001}
+  §/I{if001}
 §/F{f003}
 
 §F{f004:AddPositive:pub}
-  §DOC{Adds two positive numbers. Result is greater than both inputs.}
   §I{i32:a}
   §I{i32:b}
   §O{i32}
@@ -49,7 +44,6 @@
 §/F{f004}
 
 §F{f005:Identity:pub}
-  §DOC{Identity function - trivially provable postcondition.}
   §I{i32:x}
   §O{i32}
   §S (== result x)

--- a/samples/Verification/violation-detected.calr
+++ b/samples/Verification/violation-detected.calr
@@ -1,9 +1,6 @@
 §M{m001:ViolationDetected}
-§DOC{Demonstrates contracts that Z3 can prove are violated}
 
 §F{f001:BadPostcondition:pub}
-  §DOC{This function has a postcondition that Z3 will prove is violated.}
-  §DOC{Postcondition claims result > x, but we return x unchanged.}
   §I{i32:x}
   §O{i32}
   §S (> result x)
@@ -11,7 +8,6 @@
 §/F{f001}
 
 §F{f002:ImpossibleContract:pub}
-  §DOC{Postcondition claims x + 1 > x + 2, which is impossible.}
   §I{i32:x}
   §O{i32}
   §S (> (+ x 1) (+ x 2))
@@ -19,7 +15,6 @@
 §/F{f002}
 
 §F{f003:DivisionBug:pub}
-  §DOC{Claims a/b > a, which is false for many inputs (e.g., a=0, b=1).}
   §I{i32:a}
   §I{i32:b}
   §O{i32}

--- a/scripts/analyze_gate_results.py
+++ b/scripts/analyze_gate_results.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+"""
+analyze_gate_results.py — Tier 3 / §10 gate analysis pipeline.
+
+Reads per-run JSONL output from scripts/run_phase_2_gate.py
+(default: results/runs.jsonl) and produces
+docs/plans/phase-2-measurement-results.md with the four RFC §10.3 kill
+criteria computed.
+
+Pinned analysis seed: 42. Bonferroni correction: alpha' = 0.0125.
+
+Per RFC §16.E item 8, this script writes the results document
+regardless of pass/fail.
+
+Usage:
+    python3 scripts/analyze_gate_results.py \\
+        --runs results/runs.jsonl \\
+        --output docs/plans/phase-2-measurement-results.md \\
+        [--seed 42] [--alpha 0.0125]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+# ---------------------------------------------------------------------------
+# Per-RFC §10.3
+ALPHA_BONFERRONI = 0.0125  # 0.05 / 4 criteria
+CLIFFS_DELTA_MEDIUM = 0.33  # medium effect threshold
+TURN_COUNT_REDUCTION_THRESHOLD = 0.10  # 10%
+TOKEN_COUNT_REDUCTION_THRESHOLD = 0.15  # 15%
+DEFAULT_SEED = 42
+
+# ---------------------------------------------------------------------------
+# Lightweight stats — avoid hard scipy dependency at import time so the
+# script can at least produce a partial report when scipy is not installed.
+try:
+    from scipy import stats as _scipy_stats  # type: ignore
+
+    _SCIPY = True
+except Exception:  # pragma: no cover - environmental
+    _scipy_stats = None  # type: ignore
+    _SCIPY = False
+
+
+@dataclass(frozen=True)
+class RunRecord:
+    task_id: str
+    arm: str  # 'A' | 'B' | 'C'
+    seed: int
+    model: str
+    success: bool
+    turn_count: int
+    total_output_tokens: int
+    identity_preservation_errors: int
+    edit_correctness_errors: int
+    harness_crash: bool
+
+
+# ---------------------------------------------------------------------------
+
+
+def load_runs(path: Path) -> list[RunRecord]:
+    records: list[RunRecord] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line_no, raw in enumerate(fh, start=1):
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                obj = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise SystemExit(
+                    f"analyze_gate_results: malformed JSON at "
+                    f"{path}:{line_no}: {exc}"
+                )
+            records.append(
+                RunRecord(
+                    task_id=str(obj["task_id"]),
+                    arm=str(obj["arm"]),
+                    seed=int(obj["seed"]),
+                    model=str(obj.get("model", "<unknown>")),
+                    success=bool(obj["success"]),
+                    turn_count=int(obj["turn_count"]),
+                    total_output_tokens=int(obj["total_output_tokens"]),
+                    identity_preservation_errors=int(
+                        obj.get("identity_preservation_errors", 0)
+                    ),
+                    edit_correctness_errors=int(
+                        obj.get("edit_correctness_errors", 0)
+                    ),
+                    harness_crash=bool(obj.get("harness_crash", False)),
+                )
+            )
+    return records
+
+
+def group_by(
+    runs: Iterable[RunRecord], key: str
+) -> dict[tuple, list[RunRecord]]:
+    grouped: dict[tuple, list[RunRecord]] = defaultdict(list)
+    for r in runs:
+        if key == "arm":
+            grouped[(r.arm,)].append(r)
+        elif key == "task_arm":
+            grouped[(r.task_id, r.arm)].append(r)
+        else:
+            raise ValueError(f"unknown grouping key: {key}")
+    return dict(grouped)
+
+
+# ---------------------------------------------------------------------------
+# Criterion 1 — McNemar success-rate non-inferiority (Arm C vs Arm A)
+# Paired by (task_id, seed): a "discordant pair" is when one arm succeeded
+# and the other did not.
+
+
+def mcnemar_pvalue(b: int, c: int) -> float:
+    """Two-sided McNemar (exact binomial when b+c is small, else chi-square)."""
+    n = b + c
+    if n == 0:
+        return 1.0
+    if n < 25:
+        # Exact two-sided binomial test, P = 0.5.
+        k = min(b, c)
+        # Sum binomial probabilities for tails.
+        cum = 0.0
+        for i in range(0, k + 1):
+            cum += math.comb(n, i) * (0.5**n)
+        return min(1.0, 2.0 * cum)
+    # Chi-square with continuity correction.
+    chi = ((abs(b - c) - 1) ** 2) / (b + c)
+    # Survival function of chi-square with 1 df: erfc(sqrt(chi/2)).
+    return math.erfc(math.sqrt(chi / 2.0))
+
+
+def criterion_1(runs: list[RunRecord]) -> dict:
+    by_pair: dict[tuple[str, int], dict[str, bool]] = defaultdict(dict)
+    for r in runs:
+        if r.arm in ("A", "C"):
+            by_pair[(r.task_id, r.seed)][r.arm] = r.success
+    b = c = 0  # b = A succ, C fail; c = A fail, C succ.
+    n_pairs = 0
+    for arms in by_pair.values():
+        if "A" not in arms or "C" not in arms:
+            continue
+        n_pairs += 1
+        if arms["A"] and not arms["C"]:
+            b += 1
+        elif not arms["A"] and arms["C"]:
+            c += 1
+    p = mcnemar_pvalue(b, c)
+    a_succ_rate = sum(1 for r in runs if r.arm == "A" and r.success) / max(
+        1, sum(1 for r in runs if r.arm == "A")
+    )
+    c_succ_rate = sum(1 for r in runs if r.arm == "C" and r.success) / max(
+        1, sum(1 for r in runs if r.arm == "C")
+    )
+    passes = p > ALPHA_BONFERRONI
+    return {
+        "name": "Criterion 1: Success-rate non-inferiority (Arm C vs Arm A)",
+        "n_pairs": n_pairs,
+        "discordant_b_A_only": b,
+        "discordant_c_C_only": c,
+        "p_value": p,
+        "arm_A_success_rate": a_succ_rate,
+        "arm_C_success_rate": c_succ_rate,
+        "pass_condition": f"McNemar p > {ALPHA_BONFERRONI} (non-inferiority)",
+        "passes": passes,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Wilcoxon signed-rank (paired) — fallback to scipy if available.
+
+
+def wilcoxon_signed_rank(x: list[float], y: list[float]) -> float:
+    if len(x) != len(y) or len(x) == 0:
+        return 1.0
+    if _SCIPY:
+        try:
+            stat = _scipy_stats.wilcoxon(x, y, alternative="two-sided")  # type: ignore
+            return float(stat.pvalue)
+        except ValueError:
+            return 1.0  # all-zero differences
+    # Fallback: normal approximation, two-sided.
+    diffs = [(xi - yi) for xi, yi in zip(x, y) if (xi - yi) != 0]
+    n = len(diffs)
+    if n == 0:
+        return 1.0
+    abs_ranks = sorted(((abs(d), i) for i, d in enumerate(diffs)))
+    ranks: dict[int, float] = {}
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and abs_ranks[j + 1][0] == abs_ranks[i][0]:
+            j += 1
+        avg_rank = (i + j) / 2.0 + 1.0
+        for k in range(i, j + 1):
+            ranks[abs_ranks[k][1]] = avg_rank
+        i = j + 1
+    w_plus = sum(ranks[i] for i, d in enumerate(diffs) if d > 0)
+    mean_w = n * (n + 1) / 4.0
+    var_w = n * (n + 1) * (2 * n + 1) / 24.0
+    if var_w == 0:
+        return 1.0
+    z = (w_plus - mean_w) / math.sqrt(var_w)
+    # Two-sided p from normal CDF.
+    p = math.erfc(abs(z) / math.sqrt(2.0))
+    return min(1.0, max(0.0, p))
+
+
+def cliffs_delta(x: list[float], y: list[float]) -> float:
+    """|delta| = |#(x>y) - #(x<y)| / (n*m). Sign: positive when x > y."""
+    nx, ny = len(x), len(y)
+    if nx == 0 or ny == 0:
+        return 0.0
+    gt = lt = 0
+    for xi in x:
+        for yi in y:
+            if xi > yi:
+                gt += 1
+            elif xi < yi:
+                lt += 1
+    return (gt - lt) / (nx * ny)
+
+
+# ---------------------------------------------------------------------------
+# Criterion 2 — Identity-preservation non-regression (Arm C vs Arm A)
+
+
+def criterion_2(runs: list[RunRecord]) -> dict:
+    paired = _pair_metric(runs, "A", "C", lambda r: r.identity_preservation_errors)
+    a_vals = [p[0] for p in paired]
+    c_vals = [p[1] for p in paired]
+    p = wilcoxon_signed_rank(a_vals, c_vals)
+    passes = p > ALPHA_BONFERRONI or (sum(c_vals) <= sum(a_vals))
+    return {
+        "name": (
+            "Criterion 2: Identity-preservation non-regression "
+            "(Arm C vs Arm A)"
+        ),
+        "n_pairs": len(paired),
+        "arm_A_errors_total": sum(a_vals),
+        "arm_C_errors_total": sum(c_vals),
+        "wilcoxon_p_value": p,
+        "pass_condition": (
+            f"Wilcoxon p > {ALPHA_BONFERRONI} (non-regression) "
+            "OR Arm C errors <= Arm A errors"
+        ),
+        "passes": passes,
+    }
+
+
+def _pair_metric(
+    runs: list[RunRecord],
+    arm_a: str,
+    arm_b: str,
+    metric_fn,
+) -> list[tuple[float, float]]:
+    a_map: dict[tuple[str, int], float] = {}
+    b_map: dict[tuple[str, int], float] = {}
+    for r in runs:
+        key = (r.task_id, r.seed)
+        if r.arm == arm_a:
+            a_map[key] = float(metric_fn(r))
+        elif r.arm == arm_b:
+            b_map[key] = float(metric_fn(r))
+    paired = []
+    for key, av in a_map.items():
+        if key in b_map:
+            paired.append((av, b_map[key]))
+    return paired
+
+
+# ---------------------------------------------------------------------------
+# Criterion 3 — Material agent benefit on turn-count OR token-count
+# (Arm C vs Arm A).
+
+
+def _eval_metric_benefit(
+    runs: list[RunRecord],
+    metric_fn,
+    reduction_threshold: float,
+    label: str,
+) -> dict:
+    paired = _pair_metric(runs, "A", "C", metric_fn)
+    a_vals = [p[0] for p in paired]
+    c_vals = [p[1] for p in paired]
+    if not a_vals:
+        return {
+            "metric": label,
+            "median_A": float("nan"),
+            "median_C": float("nan"),
+            "median_reduction": 0.0,
+            "wilcoxon_p_value": 1.0,
+            "cliffs_delta": 0.0,
+            "passes": False,
+            "n_pairs": 0,
+        }
+    median_a = statistics.median(a_vals)
+    median_c = statistics.median(c_vals)
+    reduction = (median_a - median_c) / median_a if median_a else 0.0
+    p = wilcoxon_signed_rank(a_vals, c_vals)
+    delta = cliffs_delta(a_vals, c_vals)
+    passes = (
+        reduction >= reduction_threshold
+        and p < ALPHA_BONFERRONI
+        and abs(delta) >= CLIFFS_DELTA_MEDIUM
+    )
+    return {
+        "metric": label,
+        "n_pairs": len(paired),
+        "median_A": median_a,
+        "median_C": median_c,
+        "median_reduction": reduction,
+        "wilcoxon_p_value": p,
+        "cliffs_delta": delta,
+        "passes": passes,
+    }
+
+
+def criterion_3(runs: list[RunRecord]) -> dict:
+    turn = _eval_metric_benefit(
+        runs, lambda r: r.turn_count, TURN_COUNT_REDUCTION_THRESHOLD, "turn_count"
+    )
+    tok = _eval_metric_benefit(
+        runs,
+        lambda r: r.total_output_tokens,
+        TOKEN_COUNT_REDUCTION_THRESHOLD,
+        "total_output_tokens",
+    )
+    return {
+        "name": (
+            "Criterion 3: Material agent benefit on turn-count OR "
+            "token-count (Arm C vs Arm A)"
+        ),
+        "turn_count_branch": turn,
+        "token_count_branch": tok,
+        "passes": turn["passes"] or tok["passes"],
+        "winning_branch": (
+            "turn_count" if turn["passes"] else
+            ("total_output_tokens" if tok["passes"] else None)
+        ),
+        "pass_condition": (
+            f"(turn_count median reduction >= {TURN_COUNT_REDUCTION_THRESHOLD:.0%} "
+            f"AND Wilcoxon p < {ALPHA_BONFERRONI} AND |Cliff's δ| >= "
+            f"{CLIFFS_DELTA_MEDIUM}) OR (total_output_tokens median reduction "
+            f">= {TOKEN_COUNT_REDUCTION_THRESHOLD:.0%} AND Wilcoxon p < "
+            f"{ALPHA_BONFERRONI} AND |Cliff's δ| >= {CLIFFS_DELTA_MEDIUM})"
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Criterion 4 — Phase 2 distinguishable from Phase 1 (Arm C vs Arm B)
+# on criterion (3)'s winning metric.
+
+
+def criterion_4(runs: list[RunRecord], c3: dict) -> dict:
+    metric_name = c3["winning_branch"]
+    if metric_name is None:
+        # Criterion 3 did not pass, so criterion 4 is moot. Per RFC §10.3
+        # a single red criterion fails the gate; we still compute c4
+        # for both metrics to leave a record in the report.
+        turn_p = _arm_vs_arm_wilcoxon(runs, "B", "C", lambda r: r.turn_count)
+        tok_p = _arm_vs_arm_wilcoxon(
+            runs, "B", "C", lambda r: r.total_output_tokens
+        )
+        return {
+            "name": (
+                "Criterion 4: Phase 2 distinguishable from Phase 1 "
+                "(Arm C vs Arm B) on criterion 3's winning metric"
+            ),
+            "note": "Criterion 3 did not pass; reporting both metrics.",
+            "turn_count_wilcoxon_p_value": turn_p,
+            "token_count_wilcoxon_p_value": tok_p,
+            "passes": False,
+        }
+    metric_fn = (
+        (lambda r: r.turn_count)
+        if metric_name == "turn_count"
+        else (lambda r: r.total_output_tokens)
+    )
+    p = _arm_vs_arm_wilcoxon(runs, "B", "C", metric_fn)
+    passes = p < ALPHA_BONFERRONI
+    return {
+        "name": (
+            "Criterion 4: Phase 2 distinguishable from Phase 1 "
+            "(Arm C vs Arm B) on criterion 3's winning metric"
+        ),
+        "metric": metric_name,
+        "wilcoxon_p_value": p,
+        "pass_condition": f"Wilcoxon p < {ALPHA_BONFERRONI}",
+        "passes": passes,
+    }
+
+
+def _arm_vs_arm_wilcoxon(
+    runs: list[RunRecord], arm_a: str, arm_b: str, metric_fn
+) -> float:
+    paired = _pair_metric(runs, arm_a, arm_b, metric_fn)
+    if not paired:
+        return 1.0
+    a_vals = [p[0] for p in paired]
+    b_vals = [p[1] for p in paired]
+    return wilcoxon_signed_rank(a_vals, b_vals)
+
+
+# ---------------------------------------------------------------------------
+
+
+def render_report(
+    runs: list[RunRecord],
+    c1: dict,
+    c2: dict,
+    c3: dict,
+    c4: dict,
+    seed: int,
+) -> str:
+    n_total = len(runs)
+    arms = sorted(set(r.arm for r in runs))
+    tasks = sorted(set(r.task_id for r in runs))
+    models = sorted(set(r.model for r in runs))
+    all_pass = (
+        c1["passes"] and c2["passes"] and c3["passes"] and c4["passes"]
+    )
+    decision = "SHIP Phase 2" if all_pass else "DO NOT SHIP Phase 2 — revert per RFC §11"
+
+    now_utc = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    lines = [
+        "# Phase 2 Measurement Results",
+        "",
+        f"**Generated:** {now_utc}",
+        f"**Analysis seed:** {seed}",
+        f"**Total runs:** {n_total}",
+        f"**Arms present:** {', '.join(arms) or '<none>'}",
+        f"**Tasks present:** {len(tasks)}",
+        f"**Models present:** {', '.join(models) or '<none>'}",
+        f"**Bonferroni-corrected alpha':** {ALPHA_BONFERRONI}",
+        "",
+        f"## Ship/no-ship decision: **{decision}**",
+        "",
+        "Decision rule: all four RFC §10.3 kill criteria must be PASS.",
+        "",
+        "---",
+        "",
+        "## Criterion 1",
+        f"**{c1['name']}**",
+        "",
+        f"- Pairs (task × seed): {c1['n_pairs']}",
+        f"- Discordant pairs (A succ / C fail): {c1['discordant_b_A_only']}",
+        f"- Discordant pairs (A fail / C succ): {c1['discordant_c_C_only']}",
+        f"- Arm A success rate: {c1['arm_A_success_rate']:.3f}",
+        f"- Arm C success rate: {c1['arm_C_success_rate']:.3f}",
+        f"- McNemar p-value: {c1['p_value']:.6f}",
+        f"- Pass condition: {c1['pass_condition']}",
+        f"- **Result: {'PASS' if c1['passes'] else 'FAIL'}**",
+        "",
+        "## Criterion 2",
+        f"**{c2['name']}**",
+        "",
+        f"- Pairs (task × seed): {c2['n_pairs']}",
+        f"- Arm A identity-preservation errors: {c2['arm_A_errors_total']}",
+        f"- Arm C identity-preservation errors: {c2['arm_C_errors_total']}",
+        f"- Wilcoxon p-value: {c2['wilcoxon_p_value']:.6f}",
+        f"- Pass condition: {c2['pass_condition']}",
+        f"- **Result: {'PASS' if c2['passes'] else 'FAIL'}**",
+        "",
+        "## Criterion 3",
+        f"**{c3['name']}**",
+        "",
+    ]
+    for branch_key in ("turn_count_branch", "token_count_branch"):
+        b = c3[branch_key]
+        lines += [
+            f"### Branch: {b['metric']}",
+            f"- Pairs: {b['n_pairs']}",
+            f"- Median Arm A: {b['median_A']:.3f}",
+            f"- Median Arm C: {b['median_C']:.3f}",
+            f"- Median reduction: {b['median_reduction']*100:.2f}%",
+            f"- Wilcoxon p-value: {b['wilcoxon_p_value']:.6f}",
+            f"- |Cliff's δ|: {abs(b['cliffs_delta']):.4f} (sign: "
+            f"{'A>C' if b['cliffs_delta']>0 else 'A<C'})",
+            f"- Branch result: {'PASS' if b['passes'] else 'FAIL'}",
+            "",
+        ]
+    lines += [
+        f"- Pass condition: {c3['pass_condition']}",
+        f"- Winning branch: {c3['winning_branch'] or '<none>'}",
+        f"- **Result: {'PASS' if c3['passes'] else 'FAIL'}**",
+        "",
+        "## Criterion 4",
+        f"**{c4['name']}**",
+        "",
+    ]
+    if c4.get("note"):
+        lines += [
+            f"- Note: {c4['note']}",
+            f"- Turn-count Wilcoxon p-value: "
+            f"{c4['turn_count_wilcoxon_p_value']:.6f}",
+            f"- Token-count Wilcoxon p-value: "
+            f"{c4['token_count_wilcoxon_p_value']:.6f}",
+        ]
+    else:
+        lines += [
+            f"- Metric: {c4['metric']}",
+            f"- Wilcoxon p-value: {c4['wilcoxon_p_value']:.6f}",
+            f"- Pass condition: {c4['pass_condition']}",
+        ]
+    lines += [
+        f"- **Result: {'PASS' if c4['passes'] else 'FAIL'}**",
+        "",
+        "---",
+        "",
+        "## Summary table",
+        "",
+        "| # | Criterion | Result |",
+        "|---|-----------|--------|",
+        f"| 1 | Success-rate non-inferiority | {'PASS' if c1['passes'] else 'FAIL'} |",
+        f"| 2 | Identity-preservation non-regression | {'PASS' if c2['passes'] else 'FAIL'} |",
+        f"| 3 | Material agent benefit (turn or token) | {'PASS' if c3['passes'] else 'FAIL'} |",
+        f"| 4 | Phase 2 distinguishable from Phase 1 | {'PASS' if c4['passes'] else 'FAIL'} |",
+        "",
+        f"**Decision: {decision}**",
+        "",
+        "Per RFC §16.E item 8, this document is committed regardless of",
+        "pass/fail.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--runs", default="results/runs.jsonl",
+                   help="Path to JSONL run records.")
+    p.add_argument("--output", default="docs/plans/phase-2-measurement-results.md",
+                   help="Output Markdown path.")
+    p.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    args = p.parse_args(argv)
+
+    runs_path = Path(args.runs)
+    if not runs_path.exists():
+        print(f"analyze_gate_results: --runs file not found: {runs_path}",
+              file=sys.stderr)
+        return 2
+    runs = load_runs(runs_path)
+    if not runs:
+        print("analyze_gate_results: no runs in JSONL", file=sys.stderr)
+        return 2
+
+    c1 = criterion_1(runs)
+    c2 = criterion_2(runs)
+    c3 = criterion_3(runs)
+    c4 = criterion_4(runs, c3)
+
+    md = render_report(runs, c1, c2, c3, c4, args.seed)
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(md, encoding="utf-8")
+    print(f"analyze_gate_results: wrote {out}")
+    all_pass = c1["passes"] and c2["passes"] and c3["passes"] and c4["passes"]
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ast_roundtrip_check.py
+++ b/scripts/ast_roundtrip_check.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+ast_roundtrip_check.py — Per-PR AST round-trip check.
+
+For each `.calr` fixture in a directory, invoke the `calor` compiler to
+parse → emit → parse. Compilation success is the Phase-0 proxy for
+AST-equality (a richer AST-diff would require a new compiler CLI
+command that is not in scope for PR-0d).
+
+Exit codes:
+    0  all fixtures round-trip cleanly
+    1  one or more fixtures failed to round-trip
+    2  bad arguments / dir missing
+
+Usage:
+    python3 scripts/ast_roundtrip_check.py <dir>
+    python3 scripts/ast_roundtrip_check.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CALOR_PROJECT = REPO_ROOT / "src" / "Calor.Compiler"
+
+
+def calor_command() -> list[str]:
+    """Resolve `calor` invocation. Prefer the global tool when available,
+    fall back to `dotnet run --project src/Calor.Compiler --`."""
+    # Check the installed global tool first.
+    from shutil import which
+    if which("calor"):
+        return ["calor"]
+    return [
+        "dotnet", "run", "--project", str(CALOR_PROJECT), "-c", "Release",
+        "--no-build", "--",
+    ]
+
+
+def compile_one(calor_cmd: list[str], src: Path, out_dir: Path) -> tuple[int, str]:
+    out_cs = out_dir / (src.stem + ".g.cs")
+    cmd = calor_cmd + ["--input", str(src), "--output", str(out_cs)]
+    cp = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO_ROOT)
+    return cp.returncode, (cp.stdout + cp.stderr)[-2000:]
+
+
+def check_dir(directory: Path) -> int:
+    if not directory.is_dir():
+        print(f"ast_roundtrip: not a directory: {directory}", file=sys.stderr)
+        return 2
+
+    calor_cmd = calor_command()
+    fixtures = sorted(directory.rglob("*.calr"))
+    if not fixtures:
+        print(f"ast_roundtrip: no .calr files under {directory}")
+        return 0
+
+    print(f"ast_roundtrip: checking {len(fixtures)} fixture(s) under "
+          f"{directory}")
+    failures: list[tuple[Path, str]] = []
+    with tempfile.TemporaryDirectory() as td:
+        out_dir = Path(td)
+        for i, src in enumerate(fixtures, 1):
+            rc, log_tail = compile_one(calor_cmd, src, out_dir)
+            if rc != 0:
+                failures.append((src, log_tail))
+                print(f"  [{i}/{len(fixtures)}] FAIL {src}")
+            else:
+                if i % 50 == 0 or i == len(fixtures):
+                    print(f"  [{i}/{len(fixtures)}] OK so far")
+
+    if failures:
+        print(f"\nast_roundtrip: {len(failures)} failure(s):", file=sys.stderr)
+        for src, log in failures[:10]:
+            print(f"  - {src}", file=sys.stderr)
+            for line in log.splitlines()[-5:]:
+                print(f"      {line}", file=sys.stderr)
+        if len(failures) > 10:
+            print(f"  ... and {len(failures) - 10} more", file=sys.stderr)
+        return 1
+    print("ast_roundtrip: all fixtures OK")
+    return 0
+
+
+def self_test() -> int:
+    """Compile a synthetic positive fixture and a synthetic negative one."""
+    failures = 0
+    with tempfile.TemporaryDirectory() as td:
+        td_path = Path(td)
+        calor_cmd = calor_command()
+
+        positive = td_path / "positive.calr"
+        positive.write_text(
+            "§M{m_pos:Pos}\n\n"
+            "§F{f_pos1:Echo:pub}\n"
+            "  §I{i32:x}\n"
+            "  §O{i32}\n"
+            "  §R x\n"
+            "§/F{f_pos1}\n\n"
+            "§/M{m_pos}\n",
+            encoding="utf-8",
+        )
+        rc, log = compile_one(calor_cmd, positive, td_path)
+        if rc != 0:
+            print("ast_roundtrip self-test: positive case FAIL", file=sys.stderr)
+            print(log, file=sys.stderr)
+            failures += 1
+        else:
+            print("ast_roundtrip self-test: positive PASS")
+
+        negative = td_path / "negative.calr"
+        # Intentionally malformed.
+        negative.write_text("§M{m_neg:Neg}\n§Q (unterminated\n", encoding="utf-8")
+        rc, log = compile_one(calor_cmd, negative, td_path)
+        if rc == 0:
+            print("ast_roundtrip self-test: negative case unexpectedly "
+                  "succeeded", file=sys.stderr)
+            failures += 1
+        else:
+            print("ast_roundtrip self-test: negative PASS (rejected as "
+                  "expected)")
+    return 0 if failures == 0 else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("directory", nargs="?", help="Directory to scan.")
+    p.add_argument("--self-test", action="store_true")
+    args = p.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+    if not args.directory:
+        p.error("directory is required (or use --self-test)")
+    return check_dir(Path(args.directory))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/byte_preservation_check.py
+++ b/scripts/byte_preservation_check.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""
+byte_preservation_check.py — RFC §5.7.3 byte-preservation verifier.
+
+Given an original `.calr` file and a `migration.log.json` produced by
+the migrator, this script verifies the migrator only removed the byte
+ranges recorded in the log — everything outside those ranges is
+byte-identical to the original.
+
+Without a log (Phase 0 self-test), the script verifies the trivial
+identity: file == file.
+
+Exit codes:
+    0  byte-preservation holds
+    1  byte-preservation violated
+    2  bad arguments / file missing
+
+Usage:
+    python3 scripts/byte_preservation_check.py \\
+        <original.calr> <migrated.calr> [--log <log.json>]
+    python3 scripts/byte_preservation_check.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def reconstruct_from_log(
+    migrated_bytes: bytes,
+    log: list[dict],
+) -> bytes:
+    """Reverse the migrator: re-insert each removed byte range.
+
+    Log schema (per RFC §5.7):
+        [
+          {
+            "file": "<rel path>",
+            "removed_offset": <int byte offset in ORIGINAL>,
+            "removed_length": <int bytes removed>,
+            "removed_bytes_base64": "<base64 of removed bytes>"
+          },
+          ...
+        ]
+    Entries MUST be sorted by removed_offset ASCENDING.
+    """
+    import base64
+
+    out = bytearray()
+    pos_in_migrated = 0
+    last_orig_offset = 0
+    for entry in log:
+        offset = int(entry["removed_offset"])
+        length = int(entry["removed_length"])
+        removed = base64.b64decode(entry["removed_bytes_base64"])
+        assert len(removed) == length, f"log entry length mismatch: {entry}"
+        chunk_len = offset - last_orig_offset
+        # Copy the surviving bytes from migrated.
+        out += migrated_bytes[pos_in_migrated:pos_in_migrated + chunk_len]
+        pos_in_migrated += chunk_len
+        out += removed
+        last_orig_offset = offset + length
+    # Trailing bytes.
+    out += migrated_bytes[pos_in_migrated:]
+    return bytes(out)
+
+
+def check_pair(
+    original_path: Path,
+    migrated_path: Path,
+    log_path: Path | None,
+) -> int:
+    if not original_path.is_file():
+        print(f"byte_preservation: original missing: {original_path}",
+              file=sys.stderr)
+        return 2
+    if not migrated_path.is_file():
+        print(f"byte_preservation: migrated missing: {migrated_path}",
+              file=sys.stderr)
+        return 2
+
+    original = original_path.read_bytes()
+    migrated = migrated_path.read_bytes()
+
+    if log_path is None:
+        if original != migrated:
+            print(
+                f"byte_preservation FAIL (no log given, but files differ): "
+                f"{original_path}",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"byte_preservation OK (identity): {original_path}")
+        return 0
+
+    if not log_path.is_file():
+        print(f"byte_preservation: log missing: {log_path}", file=sys.stderr)
+        return 2
+
+    log_data = json.loads(log_path.read_text(encoding="utf-8"))
+    entries = log_data.get("entries", log_data) if isinstance(log_data, dict) else log_data
+    # Filter to the entries pertaining to this file.
+    rel = str(original_path)
+    matching = [
+        e for e in entries
+        if Path(str(e.get("file", ""))).name == original_path.name
+        or str(e.get("file", "")) == rel
+    ]
+    matching.sort(key=lambda e: int(e["removed_offset"]))
+    reconstructed = reconstruct_from_log(migrated, matching)
+    if reconstructed != original:
+        print(
+            f"byte_preservation FAIL: reconstruction != original for "
+            f"{original_path} (got {len(reconstructed)} bytes, expected "
+            f"{len(original)} bytes)",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"byte_preservation OK: {original_path}")
+    return 0
+
+
+def self_test() -> int:
+    """T-5.7-a..e from RFC §5.7.6 — synthetic positive/negative cases."""
+    import base64
+    import tempfile
+
+    failures = 0
+
+    with tempfile.TemporaryDirectory() as td:
+        td_path = Path(td)
+        # T-5.7-a: trivial identity (no migration applied).
+        orig_a = td_path / "a.calr"
+        orig_a.write_bytes(b"\xc2\xa7M{m_abc:Foo}\nbody\n\xc2\xa7/M{m_abc}\n")
+        if check_pair(orig_a, orig_a, None) != 0:
+            print("T-5.7-a FAIL", file=sys.stderr)
+            failures += 1
+        else:
+            print("T-5.7-a PASS (identity)")
+
+        # T-5.7-b: a single removed range, faithfully reconstructible.
+        orig_b = td_path / "b.calr"
+        orig_b.write_bytes(b"\xc2\xa7M{m_xyz:Foo}\nbody\n\xc2\xa7/M{m_xyz}\n")
+        migrated_b = td_path / "b.migrated.calr"
+        # Remove the "{m_xyz:Foo}" block. § is 2 UTF-8 bytes (\xc2\xa7) +
+        # 'M' = 3 bytes prefix, so the {...} block starts at offset 3 and
+        # is 12 bytes long ("{m_xyz:Foo}").
+        orig_bytes = orig_b.read_bytes()
+        block_start = orig_bytes.index(b"{m_xyz:Foo}")
+        block_len = len(b"{m_xyz:Foo}")
+        removed = orig_bytes[block_start:block_start + block_len]
+        migrated_b.write_bytes(
+            orig_bytes[:block_start] + orig_bytes[block_start + block_len:]
+        )
+        log_b = td_path / "b.log.json"
+        log_b.write_text(json.dumps({
+            "entries": [{
+                "file": "b.calr",
+                "removed_offset": block_start,
+                "removed_length": block_len,
+                "removed_bytes_base64": base64.b64encode(removed).decode(),
+            }],
+        }), encoding="utf-8")
+        if check_pair(orig_b, migrated_b, log_b) != 0:
+            print("T-5.7-b FAIL", file=sys.stderr)
+            failures += 1
+        else:
+            print("T-5.7-b PASS (single range)")
+
+        # T-5.7-c: multiple disjoint ranges.
+        orig_c = td_path / "c.calr"
+        orig_c.write_bytes(
+            b"\xc2\xa7F{f1:Foo:pub}\n  body\n\xc2\xa7/F{f1}\n"
+            b"\xc2\xa7F{f2:Bar:pub}\n  body2\n\xc2\xa7/F{f2}\n"
+        )
+        migrated_c = td_path / "c.migrated.calr"
+        ob = orig_c.read_bytes()
+        # Two removed ranges: {f1:Foo:pub} (offset 2..14, len 12), {f1} (offset
+        # of "{f1}" inside §/F{f1}), {f2:Bar:pub}, {f2}. Compute by find().
+        ranges = []
+        for marker in [b"{f1:Foo:pub}", b"{f1}", b"{f2:Bar:pub}", b"{f2}"]:
+            off = ob.find(marker)
+            ranges.append((off, len(marker)))
+        ranges.sort()
+        # Build migrated (in reverse to preserve offsets while editing).
+        migrated_bytes = ob
+        for off, length in reversed(ranges):
+            migrated_bytes = migrated_bytes[:off] + migrated_bytes[off + length:]
+        migrated_c.write_bytes(migrated_bytes)
+        log_c = td_path / "c.log.json"
+        log_c.write_text(json.dumps({
+            "entries": [
+                {
+                    "file": "c.calr",
+                    "removed_offset": off,
+                    "removed_length": length,
+                    "removed_bytes_base64": base64.b64encode(
+                        ob[off:off + length]
+                    ).decode(),
+                }
+                for off, length in ranges
+            ],
+        }), encoding="utf-8")
+        if check_pair(orig_c, migrated_c, log_c) != 0:
+            print("T-5.7-c FAIL", file=sys.stderr)
+            failures += 1
+        else:
+            print("T-5.7-c PASS (multiple ranges)")
+
+        # T-5.7-d: NEGATIVE — migrated file differs OUTSIDE the recorded ranges.
+        # Reuse case b's setup but corrupt the migrated file post-hoc.
+        migrated_d = td_path / "d.migrated.calr"
+        migrated_d.write_bytes(migrated_b.read_bytes() + b"EXTRA\n")
+        rc = check_pair(orig_b, migrated_d, log_b)
+        if rc == 0:
+            print("T-5.7-d FAIL — corruption not detected", file=sys.stderr)
+            failures += 1
+        else:
+            print("T-5.7-d PASS (corruption detected)")
+
+        # T-5.7-e: NEGATIVE — log claims a wrong byte range.
+        log_e = td_path / "e.log.json"
+        log_e.write_text(json.dumps({
+            "entries": [{
+                "file": "b.calr",
+                "removed_offset": block_start,
+                "removed_length": block_len,
+                "removed_bytes_base64": base64.b64encode(b"X" * block_len).decode(),
+            }],
+        }), encoding="utf-8")
+        rc = check_pair(orig_b, migrated_b, log_e)
+        if rc == 0:
+            print("T-5.7-e FAIL — wrong-bytes log not detected",
+                  file=sys.stderr)
+            failures += 1
+        else:
+            print("T-5.7-e PASS (wrong-bytes log detected)")
+
+    if failures:
+        print(f"\nbyte_preservation self-test: {failures} failure(s)",
+              file=sys.stderr)
+        return 1
+    print("\nbyte_preservation self-test: all 5 cases PASS")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("original", nargs="?", help="Original .calr path.")
+    p.add_argument("migrated", nargs="?", help="Migrated .calr path.")
+    p.add_argument("--log", default=None,
+                   help="Path to migration.log.json (optional).")
+    p.add_argument("--self-test", action="store_true",
+                   help="Run T-5.7-a..e synthetic checks.")
+    args = p.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+    if not args.original or not args.migrated:
+        p.error("original and migrated are required (or use --self-test)")
+    return check_pair(
+        Path(args.original),
+        Path(args.migrated),
+        Path(args.log) if args.log else None,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrator_corpus_dryrun.py
+++ b/scripts/migrator_corpus_dryrun.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+migrator_corpus_dryrun.py — Tier 2 migrator dry-run over the corpus.
+
+Walks every `.calr` file under a directory tree and invokes the
+migrator in `--dry-run` mode. Asserts the migrator does not modify
+the file on disk and that the byte-preservation invariant holds for
+the proposed migration.
+
+In Phase 0 (no migrator yet), this script reports the count of `.calr`
+files that WOULD be migrated and exits 0 — the actual migrator hooks
+in at PR-1c.
+
+Usage:
+    python3 scripts/migrator_corpus_dryrun.py <root-dir> \\
+        [--mode drop-structural-ids|compact-ids]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CALOR_PROJECT = REPO_ROOT / "src" / "Calor.Compiler"
+
+ID_BLOCK_RE = re.compile(r"§[A-Z]+\{[^}]*\}")
+
+
+def calor_command() -> list[str]:
+    from shutil import which
+    if which("calor"):
+        return ["calor"]
+    return [
+        "dotnet", "run", "--project", str(CALOR_PROJECT), "-c", "Release",
+        "--no-build", "--",
+    ]
+
+
+def file_sha1(p: Path) -> str:
+    return hashlib.sha1(p.read_bytes()).hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("root", help="Root directory.")
+    p.add_argument("--mode", default="drop-structural-ids",
+                   choices=("drop-structural-ids", "compact-ids"))
+    args = p.parse_args(argv)
+
+    root = Path(args.root)
+    if not root.is_dir():
+        print(f"migrator_corpus_dryrun: not a directory: {root}",
+              file=sys.stderr)
+        return 2
+
+    calor_cmd = calor_command()
+    files = sorted(root.rglob("*.calr"))
+    print(f"migrator_corpus_dryrun: {len(files)} file(s) in scope "
+          f"(mode={args.mode})")
+
+    # Probe whether the migrator subcommand exists.
+    probe = subprocess.run(
+        calor_cmd + ["fix", "--help"], capture_output=True, text=True
+    )
+    migrator_present = (
+        probe.returncode == 0 and args.mode in (probe.stdout + probe.stderr)
+    )
+    if not migrator_present:
+        print("migrator_corpus_dryrun: migrator subcommand not yet "
+              "available; reporting candidate count (Phase 0).")
+        n_candidates = sum(
+            1 for f in files
+            if ID_BLOCK_RE.search(f.read_text(encoding="utf-8", errors="ignore"))
+        )
+        print(f"  files_with_id_blocks: {n_candidates}")
+        return 0
+
+    failures = 0
+    for f in files:
+        h_before = file_sha1(f)
+        cmd = calor_cmd + [
+            "fix", f"--{args.mode}", "--dry-run", "--input", str(f),
+        ]
+        cp = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO_ROOT)
+        if cp.returncode != 0:
+            print(f"  FAIL {f}: migrator exit {cp.returncode}", file=sys.stderr)
+            print(f"    {cp.stderr.strip()[-500:]}", file=sys.stderr)
+            failures += 1
+            continue
+        h_after = file_sha1(f)
+        if h_before != h_after:
+            print(f"  FAIL {f}: file changed despite --dry-run",
+                  file=sys.stderr)
+            failures += 1
+
+    if failures:
+        print(f"\nmigrator_corpus_dryrun: {failures} failure(s)",
+              file=sys.stderr)
+        return 1
+    print(f"migrator_corpus_dryrun: OK ({len(files)} files)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrator_corpus_dryrun.py
+++ b/scripts/migrator_corpus_dryrun.py
@@ -81,19 +81,23 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     failures = 0
+    # `calor fix` takes a positional <root> directory and walks it
+    # recursively for .calr files; it does not accept --input. For
+    # Tier 2 corpus coverage we invoke fix once over the whole root
+    # and rely on `--dry-run` to ensure no file changes.
+    hashes_before = {f: file_sha1(f) for f in files}
+    cmd = calor_cmd + [
+        "fix", str(root), f"--{args.mode}", "--dry-run",
+    ]
+    cp = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO_ROOT)
+    if cp.returncode != 0:
+        print(f"  FAIL: migrator exit {cp.returncode}", file=sys.stderr)
+        print(f"    {cp.stderr.strip()[-1000:]}", file=sys.stderr)
+        return 1
+    # Verify no file was actually modified by dry-run.
     for f in files:
-        h_before = file_sha1(f)
-        cmd = calor_cmd + [
-            "fix", f"--{args.mode}", "--dry-run", "--input", str(f),
-        ]
-        cp = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO_ROOT)
-        if cp.returncode != 0:
-            print(f"  FAIL {f}: migrator exit {cp.returncode}", file=sys.stderr)
-            print(f"    {cp.stderr.strip()[-500:]}", file=sys.stderr)
-            failures += 1
-            continue
         h_after = file_sha1(f)
-        if h_before != h_after:
+        if h_after != hashes_before.get(f):
             print(f"  FAIL {f}: file changed despite --dry-run",
                   file=sys.stderr)
             failures += 1

--- a/scripts/migrator_revert_roundtrip.py
+++ b/scripts/migrator_revert_roundtrip.py
@@ -61,13 +61,13 @@ def main(argv: list[str] | None = None) -> int:
         calor_cmd + ["fix", "--help"], capture_output=True, text=True
     )
     forward_flag = f"--{args.mode}"
-    revert_flag = (
-        "--revert-drop-structural-ids"
-        if args.mode == "drop-structural-ids"
-        else "--revert-compact-ids"
-    )
     text = probe.stdout + probe.stderr
-    if probe.returncode != 0 or forward_flag not in text or revert_flag not in text:
+    if (
+        probe.returncode != 0
+        or forward_flag not in text
+        or "--revert" not in text
+        or "--log" not in text
+    ):
         print(f"migrator_revert_roundtrip: required flags not present in "
               f"`calor fix --help`; Phase 0 stub run.")
         return 0
@@ -79,9 +79,11 @@ def main(argv: list[str] | None = None) -> int:
         work_root = Path(td) / "work"
         log_path = Path(td) / "migration.log.json"
         shutil.copytree(root, work_root)
-        # Forward migration on the temp tree.
+        # Forward migration on the temp tree. `calor fix` takes the
+        # root directory as a positional argument; the forward run
+        # writes the migration log to --log.
         fwd = subprocess.run(
-            calor_cmd + ["fix", forward_flag, "--root", str(work_root),
+            calor_cmd + ["fix", str(work_root), forward_flag,
                          "--log", str(log_path)],
             capture_output=True, text=True, cwd=REPO_ROOT,
         )
@@ -90,10 +92,11 @@ def main(argv: list[str] | None = None) -> int:
                   file=sys.stderr)
             print(fwd.stderr[-1000:], file=sys.stderr)
             return 1
-        # Revert.
+        # Revert: same subcommand with --revert reads the same log to
+        # reverse the rewrite.
         rev = subprocess.run(
-            calor_cmd + ["fix", revert_flag, "--root", str(work_root),
-                         "--log", str(log_path)],
+            calor_cmd + ["fix", str(work_root), forward_flag,
+                         "--revert", "--log", str(log_path)],
             capture_output=True, text=True, cwd=REPO_ROOT,
         )
         if rev.returncode != 0:

--- a/scripts/migrator_revert_roundtrip.py
+++ b/scripts/migrator_revert_roundtrip.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+migrator_revert_roundtrip.py — Tier 2 round-trip migrate/revert check.
+
+For each `.calr` file under a directory tree, perform:
+    original → migrate → revert → byte-equal to original
+
+This script delegates the migrate/revert steps to the `calor fix`
+subcommand. In Phase 0 (no migrator yet) it reports that the subcommand
+is not present and exits 0; the check becomes substantive at PR-1c
+(drop-structural-ids) and again at PR-2f (compact-ids).
+
+Usage:
+    python3 scripts/migrator_revert_roundtrip.py <root-dir> \\
+        [--mode drop-structural-ids|compact-ids]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CALOR_PROJECT = REPO_ROOT / "src" / "Calor.Compiler"
+
+
+def calor_command() -> list[str]:
+    from shutil import which
+    if which("calor"):
+        return ["calor"]
+    return [
+        "dotnet", "run", "--project", str(CALOR_PROJECT), "-c", "Release",
+        "--no-build", "--",
+    ]
+
+
+def file_sha1(p: Path) -> str:
+    return hashlib.sha1(p.read_bytes()).hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("root", help="Root directory.")
+    p.add_argument("--mode", default="drop-structural-ids",
+                   choices=("drop-structural-ids", "compact-ids"))
+    args = p.parse_args(argv)
+
+    root = Path(args.root)
+    if not root.is_dir():
+        print(f"migrator_revert_roundtrip: not a directory: {root}",
+              file=sys.stderr)
+        return 2
+
+    calor_cmd = calor_command()
+    probe = subprocess.run(
+        calor_cmd + ["fix", "--help"], capture_output=True, text=True
+    )
+    forward_flag = f"--{args.mode}"
+    revert_flag = (
+        "--revert-drop-structural-ids"
+        if args.mode == "drop-structural-ids"
+        else "--revert-compact-ids"
+    )
+    text = probe.stdout + probe.stderr
+    if probe.returncode != 0 or forward_flag not in text or revert_flag not in text:
+        print(f"migrator_revert_roundtrip: required flags not present in "
+              f"`calor fix --help`; Phase 0 stub run.")
+        return 0
+
+    failures = 0
+    files = sorted(root.rglob("*.calr"))
+    print(f"migrator_revert_roundtrip: {len(files)} file(s) (mode={args.mode})")
+    with tempfile.TemporaryDirectory() as td:
+        work_root = Path(td) / "work"
+        log_path = Path(td) / "migration.log.json"
+        shutil.copytree(root, work_root)
+        # Forward migration on the temp tree.
+        fwd = subprocess.run(
+            calor_cmd + ["fix", forward_flag, "--root", str(work_root),
+                         "--log", str(log_path)],
+            capture_output=True, text=True, cwd=REPO_ROOT,
+        )
+        if fwd.returncode != 0:
+            print("migrator_revert_roundtrip: forward FAIL",
+                  file=sys.stderr)
+            print(fwd.stderr[-1000:], file=sys.stderr)
+            return 1
+        # Revert.
+        rev = subprocess.run(
+            calor_cmd + ["fix", revert_flag, "--root", str(work_root),
+                         "--log", str(log_path)],
+            capture_output=True, text=True, cwd=REPO_ROOT,
+        )
+        if rev.returncode != 0:
+            print("migrator_revert_roundtrip: revert FAIL",
+                  file=sys.stderr)
+            print(rev.stderr[-1000:], file=sys.stderr)
+            return 1
+        # Compare.
+        for f in files:
+            rel = f.relative_to(root)
+            after = work_root / rel
+            if not after.is_file():
+                print(f"  missing post-revert: {rel}", file=sys.stderr)
+                failures += 1
+                continue
+            if file_sha1(f) != file_sha1(after):
+                print(f"  byte-mismatch post-revert: {rel}", file=sys.stderr)
+                failures += 1
+
+    if failures:
+        print(f"\nmigrator_revert_roundtrip: {failures} failure(s)",
+              file=sys.stderr)
+        return 1
+    print("migrator_revert_roundtrip: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/monitor_phase_2_gate.py
+++ b/scripts/monitor_phase_2_gate.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""4-hour monitoring tick for the §10 Phase 2 gate.
+
+Per v6 §3.3 the operator schedules this script to run every 4 hours
+during the gate's 4–5 day execution window. It is the *only* automated
+observer between the operator's eyes and the gate's $2–4k spend.
+
+What it does:
+    1. Reads `phase-2-gate-config.json` for the abort thresholds.
+    2. Parses `results/<run>/runs.jsonl` (the driver's output).
+    3. Computes: total records, harness_crash rate, harness_error
+       breakdown, consecutive-failure run, and per-arm summary
+       (mean turn_count, mean output_tokens, success rate).
+    4. Compares against `abort_triggers` in the config.
+    5. Writes a structured record to `monitor.log` (JSONL).
+    6. Exits 0 if all green, 1 if any threshold tripped (so the
+       scheduler surfaces an alert).
+
+Usage:
+    python3 scripts/monitor_phase_2_gate.py \
+        --config docs/plans/phase-2-gate-config.json \
+        --runs results/phase-2-gate-<DATE>/runs.jsonl \
+        --log  results/phase-2-gate-<DATE>/monitor.log
+
+Exit codes:
+    0 — all thresholds within bounds; gate may continue
+    1 — at least one abort_trigger tripped; operator review required
+    2 — runs.jsonl missing or unparseable; the gate may not have
+        started, or it crashed catastrophically
+
+This script never modifies the gate run. It only observes.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+def parse_runs(runs_path: Path) -> list[dict[str, Any]]:
+    """Read runs.jsonl. Tolerant of partial lines (driver still writing)."""
+    if not runs_path.is_file():
+        raise FileNotFoundError(f"runs.jsonl not found at {runs_path}")
+    out: list[dict[str, Any]] = []
+    with runs_path.open("r", encoding="utf-8") as f:
+        for line_no, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                # last line might be partial — driver still writing
+                if line_no == sum(1 for _ in runs_path.open()):
+                    continue
+                # otherwise data corruption: report but keep going
+                print(
+                    f"warn: line {line_no} of runs.jsonl is not valid JSON; skipping",
+                    file=sys.stderr,
+                )
+    return out
+
+
+def compute_metrics(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute the metrics referenced by abort_triggers."""
+    n = len(records)
+    if n == 0:
+        return {
+            "n_records": 0,
+            "harness_crash_pct": 0.0,
+            "harness_error_pct": 0.0,
+            "consecutive_failures": 0,
+            "harness_error_breakdown": {},
+            "per_arm": {},
+        }
+
+    n_crash = sum(1 for r in records if r.get("harness_crash"))
+    n_err = sum(
+        1
+        for r in records
+        if r.get("harness_error") and r["harness_error"] != "dry_run"
+    )
+
+    # Consecutive failures, looking from the most recent record backwards.
+    consec = 0
+    for r in reversed(records):
+        if not r.get("success", False):
+            consec += 1
+        else:
+            break
+
+    err_breakdown = Counter(
+        r["harness_error"] for r in records if r.get("harness_error")
+    )
+
+    per_arm: dict[str, dict[str, float]] = {}
+    arm_buckets: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for r in records:
+        arm_buckets[str(r.get("arm", "?"))].append(r)
+    for arm, recs in sorted(arm_buckets.items()):
+        m = len(recs)
+        per_arm[arm] = {
+            "n": m,
+            "success_rate_pct": (
+                100.0 * sum(1 for r in recs if r.get("success")) / m if m else 0.0
+            ),
+            "mean_turns": (
+                sum(int(r.get("turn_count", 0)) for r in recs) / m if m else 0.0
+            ),
+            "mean_output_tokens": (
+                sum(int(r.get("total_output_tokens", 0)) for r in recs) / m
+                if m
+                else 0.0
+            ),
+        }
+
+    return {
+        "n_records": n,
+        "harness_crash_pct": 100.0 * n_crash / n,
+        "harness_error_pct": 100.0 * n_err / n,
+        "consecutive_failures": consec,
+        "harness_error_breakdown": dict(err_breakdown),
+        "per_arm": per_arm,
+    }
+
+
+def check_triggers(
+    metrics: dict[str, Any], triggers: dict[str, Any]
+) -> list[str]:
+    """Return list of tripped trigger names; empty list = all green."""
+    tripped: list[str] = []
+    if metrics["harness_crash_pct"] > float(triggers.get("harness_crash_rate_pct", 100)):
+        tripped.append(
+            f"harness_crash_rate_pct: {metrics['harness_crash_pct']:.2f}% "
+            f"> {triggers['harness_crash_rate_pct']}%"
+        )
+    if metrics["harness_error_pct"] > float(triggers.get("harness_error_rate_pct", 100)):
+        tripped.append(
+            f"harness_error_rate_pct: {metrics['harness_error_pct']:.2f}% "
+            f"> {triggers['harness_error_rate_pct']}%"
+        )
+    if metrics["consecutive_failures"] >= int(triggers.get("consecutive_failures", 1_000_000)):
+        tripped.append(
+            f"consecutive_failures: {metrics['consecutive_failures']} "
+            f">= {triggers['consecutive_failures']}"
+        )
+    return tripped
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--config", required=True, type=Path)
+    p.add_argument("--runs", required=True, type=Path)
+    p.add_argument("--log", required=True, type=Path)
+    args = p.parse_args()
+
+    cfg = json.loads(args.config.read_text(encoding="utf-8"))
+    triggers = cfg.get("abort_triggers", {})
+
+    try:
+        records = parse_runs(args.runs)
+    except FileNotFoundError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    metrics = compute_metrics(records)
+    tripped = check_triggers(metrics, triggers)
+
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    log_record = {
+        "tick_at": now,
+        "runs_path": str(args.runs),
+        "metrics": metrics,
+        "tripped": tripped,
+        "halt_recommended": bool(tripped),
+    }
+
+    args.log.parent.mkdir(parents=True, exist_ok=True)
+    with args.log.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(log_record) + "\n")
+
+    # Operator-readable summary on stdout.
+    print(f"=== Phase 2 gate monitor — {now} ===")
+    print(f"records: {metrics['n_records']}")
+    print(f"harness_crash: {metrics['harness_crash_pct']:.2f}%")
+    print(
+        f"harness_error: {metrics['harness_error_pct']:.2f}% "
+        f"({dict(metrics['harness_error_breakdown'])})"
+    )
+    print(f"consecutive failures: {metrics['consecutive_failures']}")
+    for arm, m in metrics["per_arm"].items():
+        print(
+            f"  arm {arm}: n={m['n']:>3} "
+            f"success={m['success_rate_pct']:>5.1f}% "
+            f"mean_turns={m['mean_turns']:>5.1f} "
+            f"mean_out_tok={m['mean_output_tokens']:>7.0f}"
+        )
+    if tripped:
+        print("\n!!! HALT RECOMMENDED !!!")
+        for t in tripped:
+            print(f"  - {t}")
+        print(
+            f"\nReview {args.log} and consult "
+            "docs/plans/phase-2-spend-authorisation.md §4 "
+            "before deciding whether to override."
+        )
+        return 1
+    print("\nall thresholds within bounds; gate may continue")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/phase1_post_ship_monitor.py
+++ b/scripts/phase1_post_ship_monitor.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Phase 1 post-ship monitor.
+
+Tier 4 of the v6 measurement plan (RFC §10.4): a low-cost, scheduled
+job that watches the live ecosystem for regressions after the
+structural-ID optionalisation lands.
+
+Signals tracked:
+  * Count of legacy `{id:…}` blocks remaining in the public corpus
+    (samples/ and tests/E2E/ fixtures shipped with the repo).
+  * Newly-introduced legacy blocks in the most recent commit window.
+  * Compiler diagnostics that fire as a result of the new permissive
+    parser path (proxy: `dotnet build` exit code + warning count).
+
+The script is intentionally additive — failure does not block CI, but
+the workflow uses an "issue on regression" pattern so spikes are
+surfaced for human triage.
+
+Usage:
+    python scripts/phase1_post_ship_monitor.py \
+        --root . \
+        --window 7 \
+        --output phase1-monitor.json
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+SECTION_RE = re.compile(
+    r"\xc2\xa7(/?[A-Za-z]+)\{([^}]*)\}", re.MULTILINE)
+
+# Same shape rule as AttributeHelper.LooksLikeId in the C# code.
+ID_RE = re.compile(r"^[a-z]+_[A-Za-z0-9]{12}$|^[a-z]+_[A-Za-z0-9]{26}$")
+
+
+def count_legacy_ids(root: Path) -> tuple[int, int]:
+    """Return (file_count_with_legacy, total_legacy_blocks)."""
+    files = 0
+    total = 0
+    for calr in root.rglob("*.calr"):
+        if any(seg in {"bin", "obj"} for seg in calr.parts):
+            continue
+        try:
+            data = calr.read_bytes()
+        except OSError:
+            continue
+        local = 0
+        for m in SECTION_RE.finditer(data.decode("utf-8", errors="replace")):
+            inner = m.group(2)
+            first = inner.split(":", 1)[0]
+            if ID_RE.match(first):
+                local += 1
+        if local:
+            files += 1
+            total += local
+    return files, total
+
+
+def recent_introductions(root: Path, days: int) -> int:
+    """Best-effort: ask git for additions in `.calr` files over the window
+    that match the legacy `{id:…}` shape. Returns -1 if git unavailable."""
+    since = f"--since=\"{days} days ago\""
+    cmd = ["git", "-C", str(root), "log", since, "--diff-filter=A",
+           "--unified=0", "-p", "--", "*.calr"]
+    try:
+        out = subprocess.run(
+            cmd, capture_output=True, text=True, check=False, timeout=60)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return -1
+    additions = 0
+    for line in out.stdout.splitlines():
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        for m in SECTION_RE.finditer(line[1:]):
+            inner = m.group(2)
+            first = inner.split(":", 1)[0]
+            if ID_RE.match(first):
+                additions += 1
+    return additions
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--root", default=".", help="Repo root")
+    p.add_argument("--window", type=int, default=7,
+                   help="Days of git history to inspect for new legacy IDs")
+    p.add_argument("--output", default="phase1-monitor.json",
+                   help="JSON output path")
+    p.add_argument("--fail-on-increase-over", type=int, default=-1,
+                   help="Exit 1 if total legacy blocks exceeds this baseline")
+    args = p.parse_args()
+
+    root = Path(args.root).resolve()
+    files, total = count_legacy_ids(root)
+    recent = recent_introductions(root, args.window)
+
+    report: dict[str, Any] = {
+        "ts": int(time.time()),
+        "root": str(root),
+        "legacy_block_count": total,
+        "files_with_legacy": files,
+        "recent_additions_window_days": args.window,
+        "recent_additions": recent,
+    }
+    Path(args.output).write_text(
+        json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    print(f"phase1-monitor: legacy_blocks={total} files={files} "
+          f"recent_additions={recent}")
+
+    if args.fail_on_increase_over >= 0 and total > args.fail_on_increase_over:
+        print(
+            f"::error::legacy block count {total} exceeds baseline "
+            f"{args.fail_on_increase_over}",
+            file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run-phase-2-gate.ps1
+++ b/scripts/run-phase-2-gate.ps1
@@ -1,0 +1,5 @@
+# Thin wrapper for scripts/run_phase_2_gate.py.
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+python "$here/run_phase_2_gate.py" @args
+exit $LASTEXITCODE

--- a/scripts/run-phase-2-gate.sh
+++ b/scripts/run-phase-2-gate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Thin wrapper for scripts/run_phase_2_gate.py.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "${HERE}/run_phase_2_gate.py" "$@"

--- a/scripts/run_phase_2_gate.py
+++ b/scripts/run_phase_2_gate.py
@@ -34,13 +34,54 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-FIXTURE_DIR = REPO_ROOT / "tests" / "E2E" / "agent-tasks" / "fixtures"
-TEMPLATE_DIR = (
-    REPO_ROOT / "tests" / "E2E" / "agent-tasks" / "templates" / "path-2-gate"
-)
+AGENT_TASKS_DIR = REPO_ROOT / "tests" / "E2E" / "agent-tasks"
+TASKS_DIR = AGENT_TASKS_DIR / "tasks"
+FIXTURE_DIR = AGENT_TASKS_DIR / "fixtures"
+TEMPLATE_DIR = AGENT_TASKS_DIR / "templates" / "path-2-gate"
+TASK_MANIFEST = AGENT_TASKS_DIR / "phase-2-gate-tasks.txt"
 DEFAULT_SEEDS = list(range(1, 11))  # seeds 1..10
 ARMS = ("A", "B", "C")
 PRE_FLIGHT_DISK_BYTES = 10 * 1024 * 1024 * 1024  # 10 GiB
+EXPECTED_TRIAL_COUNT = 30
+
+
+class Trial:
+    """One row of the pre-registered task manifest.
+
+    ``trial_id`` is the stable identifier the analyser sees on each
+    record. ``kind`` is either ``"task"`` (driven by a
+    ``tasks/<cat>/<task>/task.json`` paired with a workspace fixture)
+    or ``"template"`` (a self-contained path-2-gate template with its
+    own task.md/setup/expected/acceptance.sh).
+
+    For ``task`` trials, ``task_dir`` is the directory containing
+    ``task.json`` and ``fixture_dir`` is the resolved workspace
+    template referenced by the task's ``fixture`` field.
+
+    For ``template`` trials, ``task_dir`` is the template directory
+    itself and ``fixture_dir`` is ``None`` (the template owns its
+    workspace).
+    """
+
+    __slots__ = ("trial_id", "kind", "task_dir", "fixture_dir")
+
+    def __init__(
+        self,
+        trial_id: str,
+        kind: str,
+        task_dir: Path,
+        fixture_dir: Path | None,
+    ) -> None:
+        self.trial_id = trial_id
+        self.kind = kind
+        self.task_dir = task_dir
+        self.fixture_dir = fixture_dir
+
+    def __repr__(self) -> str:  # pragma: no cover — debug aid only
+        return (
+            f"Trial(id={self.trial_id!r}, kind={self.kind!r}, "
+            f"task_dir={self.task_dir}, fixture_dir={self.fixture_dir})"
+        )
 
 
 def utcnow_iso() -> str:
@@ -101,6 +142,10 @@ def git_head_sha(branch: str) -> str:
 
 
 def collect_fixtures() -> list[Path]:
+    """Legacy v1 substrate enumeration. Kept for backwards-compat with
+    callers that haven't migrated to ``collect_trials``. Do not use in
+    new code — it returns workspace fixtures, most of which lack a
+    runnable task contract (see protocol v2 §1 substrate-gap notes)."""
     existing = sorted(p for p in FIXTURE_DIR.iterdir() if p.is_dir())
     new = (
         sorted(p for p in TEMPLATE_DIR.iterdir() if p.is_dir())
@@ -110,7 +155,76 @@ def collect_fixtures() -> list[Path]:
     return existing + new
 
 
-def pre_flight(args, fixtures: list[Path]) -> None:
+def collect_trials(manifest_path: Path = TASK_MANIFEST) -> list[Trial]:
+    """Read the pre-registered task manifest and resolve each line to a
+    fully populated :class:`Trial`.
+
+    Raises ``RuntimeError`` on the first malformed entry — the
+    pre-registration discipline (RFC §10.5) treats a broken manifest as
+    a kickoff-blocking error rather than something to paper over with
+    placeholder records. The dry-run pipeline reuses this so smoke
+    tests catch protocol drift early.
+    """
+    if not manifest_path.exists():
+        raise RuntimeError(f"trial manifest not found: {manifest_path}")
+    trials: list[Trial] = []
+    for line_no, raw in enumerate(
+        manifest_path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" not in line:
+            raise RuntimeError(
+                f"{manifest_path}:{line_no}: missing 'kind:' prefix in "
+                f"{line!r}"
+            )
+        kind, _, body = line.partition(":")
+        kind = kind.strip()
+        body = body.strip()
+        if kind == "task":
+            task_dir = TASKS_DIR / body
+            task_json_path = task_dir / "task.json"
+            if not task_json_path.exists():
+                raise RuntimeError(
+                    f"{manifest_path}:{line_no}: task.json not found at "
+                    f"{task_json_path}"
+                )
+            data = json.loads(task_json_path.read_text(encoding="utf-8"))
+            fixture_name = data.get("fixture")
+            if not fixture_name:
+                raise RuntimeError(
+                    f"{manifest_path}:{line_no}: task {body!r} has no "
+                    f"'fixture' field in task.json (github-sourced tasks "
+                    f"are not eligible for the gate; remove from manifest)"
+                )
+            fixture_dir = FIXTURE_DIR / fixture_name
+            if not fixture_dir.is_dir():
+                raise RuntimeError(
+                    f"{manifest_path}:{line_no}: task {body!r} references "
+                    f"missing fixture workspace {fixture_dir}"
+                )
+            trial_id = f"task:{body}"
+        elif kind == "template":
+            tpl_dir = TEMPLATE_DIR / body
+            if not tpl_dir.is_dir():
+                raise RuntimeError(
+                    f"{manifest_path}:{line_no}: template dir not found "
+                    f"at {tpl_dir}"
+                )
+            task_dir = tpl_dir
+            fixture_dir = None
+            trial_id = f"template:{body}"
+        else:
+            raise RuntimeError(
+                f"{manifest_path}:{line_no}: unknown kind {kind!r}; "
+                f"expected 'task' or 'template'"
+            )
+        trials.append(Trial(trial_id, kind, task_dir, fixture_dir))
+    return trials
+
+
+def pre_flight(args, trials: list[Trial]) -> None:
     issues: list[str] = []
     # Disk space — skip for dry-run since we write tiny placeholders.
     if not args.dry_run and hasattr(os, "statvfs"):
@@ -118,14 +232,20 @@ def pre_flight(args, fixtures: list[Path]) -> None:
         free = st.f_bavail * st.f_frsize
         if free < PRE_FLIGHT_DISK_BYTES:
             issues.append(f"disk: {free} bytes free < {PRE_FLIGHT_DISK_BYTES}")
-    # Fixtures.
-    if not args.dry_run and len(fixtures) != 30:
+    # Trials: the manifest is the contract; require the pre-registered count.
+    if not args.dry_run and len(trials) != EXPECTED_TRIAL_COUNT:
         issues.append(
-            f"fixtures: expected 30 (24 + 6 new), found {len(fixtures)}"
+            f"trials: expected {EXPECTED_TRIAL_COUNT} from manifest, "
+            f"found {len(trials)}"
         )
-    for f in fixtures:
-        if not f.is_dir():
-            issues.append(f"fixture not a dir: {f}")
+    for t in trials:
+        if not t.task_dir.is_dir():
+            issues.append(f"trial {t.trial_id}: task_dir missing: {t.task_dir}")
+        if t.kind == "task" and (t.fixture_dir is None or not t.fixture_dir.is_dir()):
+            issues.append(
+                f"trial {t.trial_id}: fixture workspace missing: "
+                f"{t.fixture_dir}"
+            )
     # Arm SHAs resolvable.
     if not args.dry_run:
         for arm, branch in (
@@ -193,7 +313,7 @@ def write_shas_into_prereg(pre_reg_path: Path, shas: dict[str, str], dry_run: bo
 
 
 def dispatch_run(
-    fixture: Path,
+    trial: Trial,
     arm: str,
     seed: int,
     model: str,
@@ -203,19 +323,21 @@ def dispatch_run(
     sim_seed: int = 42,
 ) -> dict:
     started = utcnow_iso()
-    raw_log = output_dir / arm / fixture.name / f"seed-{seed}" / "log.jsonl"
+    # Use a filesystem-safe slug for the per-trial log subtree.
+    slug = trial.trial_id.replace(":", "__").replace("/", "_")
+    raw_log = output_dir / arm / slug / f"seed-{seed}" / "log.jsonl"
     raw_log.parent.mkdir(parents=True, exist_ok=True)
 
     if dry_run:
         record = _synth_record(
-            fixture, arm, seed, model, started, raw_log, simulate, sim_seed)
+            trial, arm, seed, model, started, raw_log, simulate, sim_seed)
         return record
 
     # Real invocation — delegate to the existing harness if present.
     harness_sh = REPO_ROOT / "tests" / "E2E" / "agent-tasks" / "run.sh"
     if not harness_sh.exists():
         return {
-            "task_id": fixture.name,
+            "task_id": trial.trial_id,
             "arm": arm,
             "seed": seed,
             "model": model,
@@ -233,8 +355,16 @@ def dispatch_run(
     cmd = [
         _resolve_bash(),
         str(harness_sh),
-        "--task",
-        fixture.name,
+        "--trial-id",
+        trial.trial_id,
+        "--kind",
+        trial.kind,
+        "--task-dir",
+        str(trial.task_dir),
+    ]
+    if trial.fixture_dir is not None:
+        cmd.extend(["--fixture-dir", str(trial.fixture_dir)])
+    cmd.extend([
         "--arm",
         arm,
         "--seed",
@@ -243,12 +373,12 @@ def dispatch_run(
         model,
         "--log",
         str(raw_log),
-    ]
+    ])
     cp = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO_ROOT)
     ended = utcnow_iso()
     if cp.returncode != 0:
         return {
-            "task_id": fixture.name,
+            "task_id": trial.trial_id,
             "arm": arm,
             "seed": seed,
             "model": model,
@@ -275,7 +405,7 @@ def dispatch_run(
         except json.JSONDecodeError:
             continue
     record = {
-        "task_id": fixture.name,
+        "task_id": trial.trial_id,
         "arm": arm,
         "seed": seed,
         "model": model,
@@ -303,7 +433,7 @@ def dispatch_run(
 
 
 def _synth_record(
-    fixture: Path,
+    trial: Trial,
     arm: str,
     seed: int,
     model: str,
@@ -314,7 +444,7 @@ def _synth_record(
 ) -> dict:
     """Generate a deterministic plausible-looking dry-run record.
 
-    `simulate` selects the regime:
+    ``simulate`` selects the regime:
       * ``trivial``   — all-zero placeholder (back-compat default).
       * ``gate-pass`` — Arms B and C show 15% turn / 20% token reduction
         over Arm A with ≥95% success and ≤1% identity errors.
@@ -328,13 +458,13 @@ def _synth_record(
     import hashlib
     import random
 
-    base = f"{sim_seed}|{simulate}|{arm}|{fixture.name}|{seed}"
+    base = f"{sim_seed}|{simulate}|{arm}|{trial.trial_id}|{seed}"
     digest = hashlib.sha256(base.encode("utf-8")).digest()
     rng = random.Random(int.from_bytes(digest[:8], "big"))
 
     if simulate == "trivial":
         return {
-            "task_id": fixture.name,
+            "task_id": trial.trial_id,
             "arm": arm,
             "seed": seed,
             "model": model,
@@ -385,7 +515,7 @@ def _synth_record(
     edit_correctness_errors = 0 if success else 1
 
     return {
-        "task_id": fixture.name,
+        "task_id": trial.trial_id,
         "arm": arm,
         "seed": seed,
         "model": model,
@@ -446,27 +576,30 @@ def main(argv: list[str] | None = None) -> int:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     seeds = [int(s) for s in args.seeds.split(",") if s.strip()]
-    fixtures = collect_fixtures()
-    print(f"discovered {len(fixtures)} fixtures")
+    trials = collect_trials()
+    print(
+        f"discovered {len(trials)} trials from manifest "
+        f"({TASK_MANIFEST.relative_to(REPO_ROOT)})"
+    )
 
-    pre_flight(args, fixtures)
+    pre_flight(args, trials)
     shas = freeze_arm_shas(args)
     write_shas_into_prereg(Path(args.pre_reg), shas, dry_run=args.dry_run)
 
     runs_jsonl = output_dir / "runs.jsonl"
-    n_total = len(fixtures) * len(seeds) * len(ARMS)
+    n_total = len(trials) * len(seeds) * len(ARMS)
     print(
-        f"starting {n_total} runs ({len(fixtures)} fixtures × "
+        f"starting {n_total} runs ({len(trials)} trials × "
         f"{len(seeds)} seeds × {len(ARMS)} arms)"
     )
     with runs_jsonl.open("a", encoding="utf-8") as out:
         i = 0
-        for fixture in fixtures:
+        for trial in trials:
             for arm in ARMS:
                 for seed in seeds:
                     i += 1
                     rec = dispatch_run(
-                        fixture=fixture,
+                        trial=trial,
                         arm=arm,
                         seed=seed,
                         model=args.model,
@@ -478,7 +611,7 @@ def main(argv: list[str] | None = None) -> int:
                     out.write(json.dumps(rec) + "\n")
                     out.flush()
                     print(
-                        f"  [{i}/{n_total}] {fixture.name} arm={arm} "
+                        f"  [{i}/{n_total}] {trial.trial_id} arm={arm} "
                         f"seed={seed} success={rec.get('success')}"
                     )
     print(f"wrote {n_total} run records to {runs_jsonl}")

--- a/scripts/run_phase_2_gate.py
+++ b/scripts/run_phase_2_gate.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""
+run_phase_2_gate.py — Tier 3 statistical gate driver (RFC §10).
+
+Drives the 30 tasks × 10 seeds × 3 arms = 900 agent runs over a 4–5 day
+window. Records arm SHAs at start, writes them into the pre-registration
+document, runs pre-flight checks, and dispatches the agent harness.
+
+PER v6 §4.3 — Arm SHAs are frozen at gate kickoff, not at PR merge.
+PER v6 §4.4 — Pinned model with fallback list.
+PER v6 §3.3 — Pre-flight + 4-hour scheduled polling.
+
+This driver is NOT a statistical analysis. It produces:
+    results/runs.jsonl — per-run JSON records consumed by
+                          scripts/analyze_gate_results.py
+
+Usage:
+    python3 scripts/run_phase_2_gate.py \\
+        --pre-reg docs/plans/phase-2-measurement-protocol.md \\
+        --output-dir results/ \\
+        [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE_DIR = REPO_ROOT / "tests" / "E2E" / "agent-tasks" / "fixtures"
+TEMPLATE_DIR = (
+    REPO_ROOT / "tests" / "E2E" / "agent-tasks" / "templates" / "path-2-gate"
+)
+DEFAULT_SEEDS = list(range(1, 11))  # seeds 1..10
+ARMS = ("A", "B", "C")
+PRE_FLIGHT_DISK_BYTES = 10 * 1024 * 1024 * 1024  # 10 GiB
+
+
+def utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _rel_to_repo(p: Path) -> str:
+    """Return ``p`` relative to the repo root when possible; otherwise the
+    absolute path. ``Path.relative_to`` raises when ``p`` is outside the
+    repo (e.g. an output-dir under ``$TMPDIR``); fall back to the
+    absolute path so dry-run smoke tests work cross-platform.
+    """
+    try:
+        return str(p.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(p.resolve())
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+
+
+def git_head_sha(branch: str) -> str:
+    cp = run(["git", "rev-parse", branch], cwd=REPO_ROOT)
+    if cp.returncode != 0:
+        raise RuntimeError(
+            f"git rev-parse {branch} failed: {cp.stderr.strip()}"
+        )
+    return cp.stdout.strip()
+
+
+def collect_fixtures() -> list[Path]:
+    existing = sorted(p for p in FIXTURE_DIR.iterdir() if p.is_dir())
+    new = (
+        sorted(p for p in TEMPLATE_DIR.iterdir() if p.is_dir())
+        if TEMPLATE_DIR.exists()
+        else []
+    )
+    return existing + new
+
+
+def pre_flight(args, fixtures: list[Path]) -> None:
+    issues: list[str] = []
+    # Disk space — skip for dry-run since we write tiny placeholders.
+    if not args.dry_run and hasattr(os, "statvfs"):
+        st = os.statvfs(args.output_dir)
+        free = st.f_bavail * st.f_frsize
+        if free < PRE_FLIGHT_DISK_BYTES:
+            issues.append(f"disk: {free} bytes free < {PRE_FLIGHT_DISK_BYTES}")
+    # Fixtures.
+    if not args.dry_run and len(fixtures) != 30:
+        issues.append(
+            f"fixtures: expected 30 (24 + 6 new), found {len(fixtures)}"
+        )
+    for f in fixtures:
+        if not f.is_dir():
+            issues.append(f"fixture not a dir: {f}")
+    # Arm SHAs resolvable.
+    if not args.dry_run:
+        for arm, branch in (
+            ("A", args.arm_a_ref),
+            ("B", args.arm_b_ref),
+            ("C", args.arm_c_ref),
+        ):
+            try:
+                git_head_sha(branch)
+            except RuntimeError as exc:
+                issues.append(f"arm {arm}: {exc}")
+    # Model sanity ping is provider-specific; placeholder.
+    if not args.skip_model_ping and not args.dry_run:
+        issues.append(
+            "model sanity ping not implemented; supply --skip-model-ping "
+            "to bypass after manually verifying availability"
+        )
+    if issues:
+        print("pre-flight FAILED:", file=sys.stderr)
+        for i in issues:
+            print(f"  - {i}", file=sys.stderr)
+        sys.exit(2)
+    print("pre-flight OK")
+
+
+def freeze_arm_shas(args) -> dict[str, str]:
+    if args.dry_run:
+        # Synthesise stable, recognisable placeholders.
+        return {
+            "A": "0" * 40,
+            "B": "1" * 40,
+            "C": "2" * 40,
+        }
+    shas = {
+        "A": git_head_sha(args.arm_a_ref),
+        "B": git_head_sha(args.arm_b_ref),
+        "C": git_head_sha(args.arm_c_ref),
+    }
+    print(f"arm SHAs frozen at gate kickoff:")
+    for arm, sha in shas.items():
+        print(f"  Arm {arm} ({getattr(args, f'arm_{arm.lower()}_ref')}): {sha}")
+    return shas
+
+
+def write_shas_into_prereg(pre_reg_path: Path, shas: dict[str, str], dry_run: bool = False) -> None:
+    if dry_run:
+        # Don't pollute the pre-reg document with synthetic SHAs.
+        return
+    if not pre_reg_path.exists():
+        print(f"warning: pre-reg path not found: {pre_reg_path}",
+              file=sys.stderr)
+        return
+    text = pre_reg_path.read_text(encoding="utf-8")
+    marker = "Arm SHAs frozen at gate kickoff:\n"
+    block = (
+        marker
+        + f"  Arm A: {shas['A']}\n"
+        + f"  Arm B: {shas['B']}\n"
+        + f"  Arm C: {shas['C']}\n"
+        + f"  Recorded: {utcnow_iso()}\n"
+    )
+    # Append at end, do not edit existing prose.
+    pre_reg_path.write_text(text + "\n" + block, encoding="utf-8")
+    print(f"appended arm SHAs to {pre_reg_path}")
+
+
+def dispatch_run(
+    fixture: Path,
+    arm: str,
+    seed: int,
+    model: str,
+    output_dir: Path,
+    dry_run: bool,
+    simulate: str = "trivial",
+    sim_seed: int = 42,
+) -> dict:
+    started = utcnow_iso()
+    raw_log = output_dir / arm / fixture.name / f"seed-{seed}" / "log.jsonl"
+    raw_log.parent.mkdir(parents=True, exist_ok=True)
+
+    if dry_run:
+        record = _synth_record(
+            fixture, arm, seed, model, started, raw_log, simulate, sim_seed)
+        return record
+
+    # Real invocation — delegate to the existing harness if present.
+    harness_sh = REPO_ROOT / "tests" / "E2E" / "agent-tasks" / "run.sh"
+    if not harness_sh.exists():
+        return {
+            "task_id": fixture.name,
+            "arm": arm,
+            "seed": seed,
+            "model": model,
+            "started_at": started,
+            "ended_at": utcnow_iso(),
+            "success": False,
+            "turn_count": 0,
+            "total_output_tokens": 0,
+            "identity_preservation_errors": 0,
+            "edit_correctness_errors": 0,
+            "harness_crash": True,
+            "raw_log_path": _rel_to_repo(raw_log),
+            "harness_error": "run.sh missing",
+        }
+    cmd = [
+        "bash",
+        str(harness_sh),
+        "--task",
+        fixture.name,
+        "--arm",
+        arm,
+        "--seed",
+        str(seed),
+        "--model",
+        model,
+        "--log",
+        str(raw_log),
+    ]
+    cp = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO_ROOT)
+    ended = utcnow_iso()
+    if cp.returncode != 0:
+        return {
+            "task_id": fixture.name,
+            "arm": arm,
+            "seed": seed,
+            "model": model,
+            "started_at": started,
+            "ended_at": ended,
+            "success": False,
+            "turn_count": 0,
+            "total_output_tokens": 0,
+            "identity_preservation_errors": 0,
+            "edit_correctness_errors": 0,
+            "harness_crash": True,
+            "raw_log_path": _rel_to_repo(raw_log),
+            "harness_stderr": cp.stderr[-2000:],
+        }
+    # Expect the harness to write a one-line summary as its stdout final line.
+    summary = {}
+    for line in reversed(cp.stdout.splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            summary = json.loads(line)
+            break
+        except json.JSONDecodeError:
+            continue
+    return {
+        "task_id": fixture.name,
+        "arm": arm,
+        "seed": seed,
+        "model": model,
+        "started_at": started,
+        "ended_at": ended,
+        "success": bool(summary.get("success", False)),
+        "turn_count": int(summary.get("turn_count", 0)),
+        "total_output_tokens": int(summary.get("total_output_tokens", 0)),
+        "identity_preservation_errors": int(
+            summary.get("identity_preservation_errors", 0)
+        ),
+        "edit_correctness_errors": int(
+            summary.get("edit_correctness_errors", 0)
+        ),
+        "harness_crash": False,
+        "raw_log_path": _rel_to_repo(raw_log),
+    }
+
+
+def _synth_record(
+    fixture: Path,
+    arm: str,
+    seed: int,
+    model: str,
+    started: str,
+    raw_log: Path,
+    simulate: str,
+    sim_seed: int,
+) -> dict:
+    """Generate a deterministic plausible-looking dry-run record.
+
+    `simulate` selects the regime:
+      * ``trivial``   — all-zero placeholder (back-compat default).
+      * ``gate-pass`` — Arms B and C show 15% turn / 20% token reduction
+        over Arm A with ≥95% success and ≤1% identity errors.
+      * ``gate-fail`` — no improvement and elevated identity errors so
+        the analyzer reports a failed gate.
+
+    The RNG seed combines ``sim_seed``, the per-run ``seed``, and the
+    arm/task identifiers, so two invocations with the same arguments
+    produce identical records — useful for CI reproducibility.
+    """
+    import hashlib
+    import random
+
+    base = f"{sim_seed}|{simulate}|{arm}|{fixture.name}|{seed}"
+    digest = hashlib.sha256(base.encode("utf-8")).digest()
+    rng = random.Random(int.from_bytes(digest[:8], "big"))
+
+    if simulate == "trivial":
+        return {
+            "task_id": fixture.name,
+            "arm": arm,
+            "seed": seed,
+            "model": model,
+            "started_at": started,
+            "ended_at": utcnow_iso(),
+            "success": False,
+            "turn_count": 0,
+            "total_output_tokens": 0,
+            "identity_preservation_errors": 0,
+            "edit_correctness_errors": 0,
+            "harness_crash": False,
+            "raw_log_path": _rel_to_repo(raw_log),
+            "dry_run": True,
+        }
+
+    # Arm A is the baseline; Arms B and C improve under gate-pass and
+    # match-or-regress under gate-fail.
+    if simulate == "gate-pass":
+        a_turns_mean = 12
+        b_turns_mean = 10  # ~17% reduction
+        c_turns_mean = 9   # ~25% reduction
+        a_tokens_mean = 6000
+        b_tokens_mean = 5000  # ~17% reduction
+        c_tokens_mean = 4500  # ~25% reduction
+        success_rate = 0.97
+        id_err_rate = 0.005
+    elif simulate == "gate-fail":
+        a_turns_mean = 12
+        b_turns_mean = 13
+        c_turns_mean = 13
+        a_tokens_mean = 6000
+        b_tokens_mean = 6200
+        c_tokens_mean = 6100
+        success_rate = 0.70
+        id_err_rate = 0.05
+    else:
+        raise ValueError(f"unknown --simulate mode: {simulate!r}")
+
+    turns = {"A": a_turns_mean, "B": b_turns_mean, "C": c_turns_mean}[arm]
+    tokens = {"A": a_tokens_mean, "B": b_tokens_mean, "C": c_tokens_mean}[arm]
+
+    # Add a touch of per-run noise so the analyzer's stats are non-trivial.
+    turn_count = max(1, int(round(rng.gauss(turns, max(1.0, turns * 0.10)))))
+    total_output_tokens = max(
+        100, int(round(rng.gauss(tokens, max(50.0, tokens * 0.08)))))
+    success = rng.random() < success_rate
+    identity_preservation_errors = 1 if rng.random() < id_err_rate else 0
+    edit_correctness_errors = 0 if success else 1
+
+    return {
+        "task_id": fixture.name,
+        "arm": arm,
+        "seed": seed,
+        "model": model,
+        "started_at": started,
+        "ended_at": utcnow_iso(),
+        "success": success,
+        "turn_count": turn_count,
+        "total_output_tokens": total_output_tokens,
+        "identity_preservation_errors": identity_preservation_errors,
+        "edit_correctness_errors": edit_correctness_errors,
+        "harness_crash": False,
+        "raw_log_path": _rel_to_repo(raw_log),
+        "dry_run": True,
+        "simulate_mode": simulate,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--pre-reg",
+        default="docs/plans/phase-2-measurement-protocol.md",
+        help="Path to the pre-registration document.",
+    )
+    p.add_argument("--output-dir", default="results", help="Output directory.")
+    p.add_argument(
+        "--arm-a-ref", default="main",
+        help="Git ref for Arm A (today/baseline).",
+    )
+    p.add_argument(
+        "--arm-b-ref", default="release/0.x+1",
+        help="Git ref for Arm B (Phase 1 only).",
+    )
+    p.add_argument(
+        "--arm-c-ref", default="release/0.x+1",
+        help="Git ref for Arm C (Phase 1 + Phase 2).",
+    )
+    p.add_argument("--model", default="<pinned-string-required>")
+    p.add_argument("--seeds", default=",".join(str(s) for s in DEFAULT_SEEDS),
+                   help="Comma-separated seed list.")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Skip real agent invocations; emit placeholder records.")
+    p.add_argument(
+        "--simulate",
+        choices=("trivial", "gate-pass", "gate-fail"),
+        default="trivial",
+        help=("With --dry-run, the regime to simulate: trivial = zeros, "
+              "gate-pass = seeded plausible records that pass the gate, "
+              "gate-fail = seeded records that fail it."),
+    )
+    p.add_argument("--simulate-seed", type=int, default=42,
+                   help="Seed for the dry-run record generator.")
+    p.add_argument("--skip-model-ping", action="store_true",
+                   help="Skip the pre-flight model availability check.")
+    args = p.parse_args(argv)
+
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    seeds = [int(s) for s in args.seeds.split(",") if s.strip()]
+    fixtures = collect_fixtures()
+    print(f"discovered {len(fixtures)} fixtures")
+
+    pre_flight(args, fixtures)
+    shas = freeze_arm_shas(args)
+    write_shas_into_prereg(Path(args.pre_reg), shas, dry_run=args.dry_run)
+
+    runs_jsonl = output_dir / "runs.jsonl"
+    n_total = len(fixtures) * len(seeds) * len(ARMS)
+    print(
+        f"starting {n_total} runs ({len(fixtures)} fixtures × "
+        f"{len(seeds)} seeds × {len(ARMS)} arms)"
+    )
+    with runs_jsonl.open("a", encoding="utf-8") as out:
+        i = 0
+        for fixture in fixtures:
+            for arm in ARMS:
+                for seed in seeds:
+                    i += 1
+                    rec = dispatch_run(
+                        fixture=fixture,
+                        arm=arm,
+                        seed=seed,
+                        model=args.model,
+                        output_dir=output_dir,
+                        dry_run=args.dry_run,
+                        simulate=args.simulate,
+                        sim_seed=args.simulate_seed,
+                    )
+                    out.write(json.dumps(rec) + "\n")
+                    out.flush()
+                    print(
+                        f"  [{i}/{n_total}] {fixture.name} arm={arm} "
+                        f"seed={seed} success={rec.get('success')}"
+                    )
+    print(f"wrote {n_total} run records to {runs_jsonl}")
+    print("next: python3 scripts/analyze_gate_results.py "
+          f"--runs {runs_jsonl}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_phase_2_gate.py
+++ b/scripts/run_phase_2_gate.py
@@ -63,6 +63,34 @@ def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, capture_output=True, text=True, **kwargs)
 
 
+def _resolve_bash() -> str:
+    """Return the path to a working bash interpreter.
+
+    On Linux/macOS this is just ``bash`` (resolved from PATH). On Windows
+    the first ``bash.exe`` on PATH is typically the WSL bridge
+    (``C:\\Windows\\system32\\bash.exe``), which fails if no WSL distro is
+    installed — turning every gate trial into a phantom ``harness_crash``.
+    Prefer the Git for Windows shell when present, falling back to PATH
+    if not.
+
+    Operators running the real gate should run it from Linux or macOS;
+    the Windows-aware fallback exists to support local plumbing tests
+    (``--dry-run``) on developer laptops.
+    """
+    override = os.environ.get("CALOR_GATE_BASH")
+    if override:
+        return override
+    if os.name == "nt":
+        for candidate in (
+            r"C:\Program Files\Git\bin\bash.exe",
+            r"C:\Program Files\Git\usr\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\bin\bash.exe",
+        ):
+            if Path(candidate).exists():
+                return candidate
+    return "bash"
+
+
 def git_head_sha(branch: str) -> str:
     cp = run(["git", "rev-parse", branch], cwd=REPO_ROOT)
     if cp.returncode != 0:
@@ -203,7 +231,7 @@ def dispatch_run(
             "harness_error": "run.sh missing",
         }
     cmd = [
-        "bash",
+        _resolve_bash(),
         str(harness_sh),
         "--task",
         fixture.name,
@@ -246,7 +274,7 @@ def dispatch_run(
             break
         except json.JSONDecodeError:
             continue
-    return {
+    record = {
         "task_id": fixture.name,
         "arm": arm,
         "seed": seed,
@@ -265,6 +293,13 @@ def dispatch_run(
         "harness_crash": False,
         "raw_log_path": _rel_to_repo(raw_log),
     }
+    # Propagate any harness_error tag the adapter emitted (e.g.
+    # "no_task_contract", "dry_run", "agent_cli_missing"). The analyser
+    # relies on this to distinguish task-substrate gaps from genuine
+    # agent failures; dropping it silently would corrupt criterion 1.
+    if "harness_error" in summary:
+        record["harness_error"] = str(summary["harness_error"])
+    return record
 
 
 def _synth_record(

--- a/scripts/run_phase_2_gate.py
+++ b/scripts/run_phase_2_gate.py
@@ -570,16 +570,28 @@ def main(argv: list[str] | None = None) -> int:
                    help="Seed for the dry-run record generator.")
     p.add_argument("--skip-model-ping", action="store_true",
                    help="Skip the pre-flight model availability check.")
+    p.add_argument(
+        "--tasks-manifest",
+        default=str(TASK_MANIFEST),
+        help=(
+            "Path to the trial manifest (one `kind:value` per line). "
+            "v2 §10.1.b makes this part of the pre-registration: "
+            "specify it explicitly at kickoff so the chosen manifest is "
+            "recorded in shell history and CI logs even though it has a "
+            "sensible default."
+        ),
+    )
     args = p.parse_args(argv)
 
     output_dir = Path(args.output_dir).resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
     seeds = [int(s) for s in args.seeds.split(",") if s.strip()]
-    trials = collect_trials()
+    manifest_path = Path(args.tasks_manifest).resolve()
+    trials = collect_trials(manifest_path)
     print(
         f"discovered {len(trials)} trials from manifest "
-        f"({TASK_MANIFEST.relative_to(REPO_ROOT)})"
+        f"({manifest_path.relative_to(REPO_ROOT) if manifest_path.is_relative_to(REPO_ROOT) else manifest_path})"
     )
 
     pre_flight(args, trials)

--- a/scripts/smoke_phase_2_gate_dryrun.py
+++ b/scripts/smoke_phase_2_gate_dryrun.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+smoke_phase_2_gate_dryrun.py — Exercise the Tier 3 gate end-to-end
+without spending LLM budget.
+
+Runs ``run_phase_2_gate.py --dry-run --simulate gate-pass`` and asserts
+that ``analyze_gate_results.py`` returns exit 0 (gate passes), then runs
+``--simulate gate-fail`` and asserts exit 1 (gate fails). This proves
+the whole pipeline (collect → dispatch → JSONL → analyze → markdown
+report → pass/fail) wires up correctly.
+
+Exits 0 on success, 1 on any unexpected outcome.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GATE = REPO_ROOT / "scripts" / "run_phase_2_gate.py"
+ANALYZE = REPO_ROOT / "scripts" / "analyze_gate_results.py"
+
+
+def _run(cmd: list[str]) -> int:
+    print(f"+ {' '.join(cmd)}")
+    return subprocess.call(cmd, cwd=str(REPO_ROOT))
+
+
+def _exercise(simulate: str, expected_exit: int, tmp: Path) -> bool:
+    out_dir = tmp / f"dryrun-{simulate}"
+    rc = _run([
+        sys.executable, str(GATE),
+        "--dry-run", "--simulate", simulate,
+        "--output-dir", str(out_dir),
+        "--skip-model-ping",
+        "--seeds", "1,2,3",
+    ])
+    if rc != 0:
+        print(f"smoke: run_phase_2_gate.py exited {rc} for {simulate}",
+              file=sys.stderr)
+        return False
+    rc = _run([
+        sys.executable, str(ANALYZE),
+        "--runs", str(out_dir / "runs.jsonl"),
+        "--output", str(out_dir / "report.md"),
+    ])
+    if rc != expected_exit:
+        print(
+            f"smoke: analyze_gate_results.py exited {rc}; expected "
+            f"{expected_exit} for simulate={simulate}",
+            file=sys.stderr,
+        )
+        return False
+    print(f"smoke: simulate={simulate} -> exit {rc} (expected {expected_exit}) OK")
+    return True
+
+
+def main() -> int:
+    tmp = Path(tempfile.mkdtemp(prefix="calor-gate-dryrun-"))
+    try:
+        ok = (
+            _exercise("gate-pass", 0, tmp)
+            and _exercise("gate-fail", 1, tmp)
+        )
+        if not ok:
+            return 1
+        print("smoke: phase-2 gate dry-run pipeline OK")
+        return 0
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/token_delta_corpus.py
+++ b/scripts/token_delta_corpus.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+token_delta_corpus.py — Tier 2 aggregate token-delta check.
+
+Walks every `.calr` file under a directory tree and either:
+- Reports the aggregate counterfactual delta (Phase 0: no migrator yet),
+  or
+- If `--logs-dir` is supplied, reports the actual delta between original
+  files and their migrated counterparts under that directory.
+
+Compares aggregate delta to RFC v5 §16.F expected value
+(9.67 × N_ids ± 20% provisional tolerance band per v6 §3.2).
+
+Exit codes:
+    0  aggregate delta within band
+    1  aggregate delta out of band
+    2  bad arguments / dir missing
+
+Usage:
+    python3 scripts/token_delta_corpus.py <root-dir> \\
+        [--migrated-dir <root-dir-with-migrated-files>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Delegate token-counting to token_delta_spot's helpers.
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+from token_delta_spot import count_id_blocks, count_tokens, TOKENS_PER_ID_MEAN  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("root", help="Root directory to walk.")
+    p.add_argument("--migrated-dir", default=None,
+                   help="Parallel directory of migrated files (optional).")
+    p.add_argument("--tolerance", type=float, default=0.20,
+                   help="Provisional tolerance band (default 0.20).")
+    args = p.parse_args(argv)
+
+    root = Path(args.root)
+    if not root.is_dir():
+        print(f"token_delta_corpus: not a directory: {root}", file=sys.stderr)
+        return 2
+    migrated_root = Path(args.migrated_dir) if args.migrated_dir else None
+
+    total_pre = 0
+    total_post = 0
+    total_ids = 0
+    n_files = 0
+
+    for f in sorted(root.rglob("*.calr")):
+        n_files += 1
+        pre_text = f.read_text(encoding="utf-8")
+        total_pre += count_tokens(pre_text)
+        total_ids += count_id_blocks(pre_text)
+        if migrated_root:
+            rel = f.relative_to(root)
+            m = migrated_root / rel
+            if m.is_file():
+                total_post += count_tokens(m.read_text(encoding="utf-8"))
+            else:
+                total_post += count_tokens(pre_text)  # not migrated.
+
+    expected = int(round(total_ids * TOKENS_PER_ID_MEAN))
+    print(f"files_scanned:       {n_files}")
+    print(f"total_id_blocks:     {total_ids}")
+    print(f"aggregate_pre_tok:   {total_pre}")
+
+    if migrated_root:
+        delta = total_pre - total_post
+        ratio = delta / expected if expected else 0.0
+        in_band = (
+            (1.0 - args.tolerance) <= ratio <= (1.0 + args.tolerance)
+            if expected > 0 else delta == 0
+        )
+        print(f"aggregate_post_tok:  {total_post}")
+        print(f"aggregate_delta:     {delta}")
+        print(f"expected_delta:      {expected}")
+        print(f"ratio:               {ratio:.3f}")
+        print(f"tolerance_band:      ±{args.tolerance*100:.0f}%")
+        print(f"in_band:             {in_band}")
+        return 0 if in_band else 1
+
+    print(f"counterfactual_delta: {expected}")
+    print(f"counterfactual_post:  {total_pre - expected}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/token_delta_spot.py
+++ b/scripts/token_delta_spot.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+token_delta_spot.py — Single-file token-delta spot check.
+
+Reports the token-count delta (post-migration - pre-migration) for a
+single `.calr` file. In Phase 0 (no migrator yet), reports the current
+token count and the COUNTERFACTUAL delta that would result from
+dropping all `{id...}` blocks at the per-RFC v5 §16.F rate of
+~9.67 tokens per ID.
+
+Token counting uses tiktoken with the `cl100k_base` encoding if
+available; otherwise falls back to a whitespace word-count
+approximation with a documented inflation factor of ~1.3.
+
+Exit codes:
+    0  reported successfully
+    2  bad arguments / file missing
+
+Usage:
+    python3 scripts/token_delta_spot.py <file.calr> \\
+        [--migrated <migrated.calr>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# RFC v5 §16.F: mean 9.67 tokens per ID, 95% CI (9.30, 10.04), N=100.
+TOKENS_PER_ID_MEAN = 9.67
+
+# Matches §X{id-block}. Captures the id-block (with curly braces) so we
+# can count its length.
+ID_BLOCK_RE = re.compile(r"§[A-Z]+(\{[^}]*\})", re.UNICODE)
+
+
+def count_tokens(text: str) -> int:
+    try:
+        import tiktoken  # type: ignore
+
+        enc = tiktoken.get_encoding("cl100k_base")
+        return len(enc.encode(text))
+    except Exception:
+        # Fallback: whitespace tokens × 1.3.
+        return int(len(text.split()) * 1.3)
+
+
+def count_id_blocks(text: str) -> int:
+    return sum(1 for _ in ID_BLOCK_RE.finditer(text))
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("file", help="Input .calr file.")
+    p.add_argument("--migrated", default=None,
+                   help="Path to the migrated counterpart (optional).")
+    args = p.parse_args(argv)
+
+    f = Path(args.file)
+    if not f.is_file():
+        print(f"token_delta_spot: file missing: {f}", file=sys.stderr)
+        return 2
+
+    pre_text = f.read_text(encoding="utf-8")
+    pre_tokens = count_tokens(pre_text)
+    n_ids = count_id_blocks(pre_text)
+
+    if args.migrated:
+        m = Path(args.migrated)
+        if not m.is_file():
+            print(f"token_delta_spot: migrated missing: {m}", file=sys.stderr)
+            return 2
+        post_tokens = count_tokens(m.read_text(encoding="utf-8"))
+        delta = pre_tokens - post_tokens
+        expected = int(round(n_ids * TOKENS_PER_ID_MEAN))
+        print(f"file:            {f}")
+        print(f"migrated:        {m}")
+        print(f"pre_tokens:      {pre_tokens}")
+        print(f"post_tokens:     {post_tokens}")
+        print(f"delta_actual:    {delta}")
+        print(f"delta_expected:  {expected} (n_ids={n_ids} × "
+              f"{TOKENS_PER_ID_MEAN})")
+        # Within +/-20% tolerance band (provisional per v6 §3.2).
+        if expected == 0:
+            ratio = float("inf") if delta != 0 else 1.0
+        else:
+            ratio = delta / expected
+        in_band = 0.80 <= ratio <= 1.20 if expected > 0 else delta == 0
+        print(f"in_provisional_20pct_band: {in_band}")
+        return 0
+
+    expected = int(round(n_ids * TOKENS_PER_ID_MEAN))
+    print(f"file:                            {f}")
+    print(f"current_tokens:                  {pre_tokens}")
+    print(f"id_blocks_found:                 {n_ids}")
+    print(f"counterfactual_drop_delta:       {expected} tokens")
+    print(f"counterfactual_post_tokens:      {pre_tokens - expected}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate-task-template.ps1
+++ b/scripts/validate-task-template.ps1
@@ -1,0 +1,4 @@
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+python "$here/validate_task_template.py" @args
+exit $LASTEXITCODE

--- a/scripts/validate-task-template.sh
+++ b/scripts/validate-task-template.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "${HERE}/validate_task_template.py" "$@"

--- a/scripts/validate_task_template.py
+++ b/scripts/validate_task_template.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+validate_task_template.py — §5.3 task template validator.
+
+Checks:
+    1. `task.md` exists and is non-empty.
+    2. `setup/` contains at least one `.calr` file.
+    3. `expected/` contains at least one file consumed by `acceptance.sh`.
+    4. `acceptance.sh` is executable and exits 0 when invoked against
+       `expected/`.
+    5. `acceptance.sh` exits non-zero when invoked against `setup/`
+       (the task is non-trivial).
+
+Usage:
+    python3 scripts/validate_task_template.py <task-dir>
+    python3 scripts/validate_task_template.py --all <templates-root>
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def _find_bash() -> str | None:
+    """Locate a usable bash. On Windows, prefer Git Bash over the WSL
+    shim (`C:\\Windows\\System32\\bash.exe`), which fails when WSL is not
+    installed.
+    """
+    candidates: list[str] = []
+    if os.name == "nt":
+        candidates.extend([
+            r"C:\Program Files\Git\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\bin\bash.exe",
+        ])
+    found = shutil.which("bash")
+    if found:
+        # Skip the WSL shim under System32 if Git Bash is available.
+        if os.name == "nt" and "system32" in found.lower():
+            for c in candidates:
+                if Path(c).is_file():
+                    return c
+        candidates.append(found)
+    for c in candidates:
+        if Path(c).is_file():
+            return c
+    return None
+
+
+def validate_one(task_dir: Path) -> list[str]:
+    errors: list[str] = []
+    if not task_dir.is_dir():
+        return [f"not a directory: {task_dir}"]
+
+    task_md = task_dir / "task.md"
+    setup = task_dir / "setup"
+    expected = task_dir / "expected"
+    acceptance = task_dir / "acceptance.sh"
+
+    if not task_md.is_file() or task_md.stat().st_size == 0:
+        errors.append(f"task.md missing or empty: {task_md}")
+    if not setup.is_dir() or not any(setup.rglob("*.calr")):
+        errors.append(f"setup/ missing or has no .calr files: {setup}")
+    if not expected.is_dir() or not any(expected.iterdir()):
+        errors.append(f"expected/ missing or empty: {expected}")
+    if not acceptance.is_file():
+        errors.append(f"acceptance.sh missing: {acceptance}")
+        return errors
+
+    # bash must be available. On Windows, `bash.exe` is the WSL shim;
+    # prefer Git Bash when WSL is not installed.
+    bash_path = _find_bash()
+    if not bash_path:
+        errors.append("bash not on PATH; cannot validate acceptance script")
+        return errors
+
+    # Make a working copy of expected/ so the script can't accidentally
+    # mutate templates. Pass the script as a relative path (basename) and
+    # the work dir via Path.as_posix() so Git Bash on Windows can locate
+    # them (Git Bash does not understand Windows backslashed paths from
+    # the `bash <path>` argv).
+    with tempfile.TemporaryDirectory() as td:
+        work_expected = Path(td) / "work_expected"
+        shutil.copytree(expected, work_expected)
+        cp = subprocess.run(
+            [bash_path, acceptance.name, work_expected.as_posix()],
+            capture_output=True, text=True, cwd=str(task_dir),
+        )
+        if cp.returncode != 0:
+            errors.append(
+                f"acceptance.sh expected/ FAIL (exit={cp.returncode}):\n"
+                f"  stdout: {cp.stdout.strip()[-500:]}\n"
+                f"  stderr: {cp.stderr.strip()[-500:]}"
+            )
+        # Now: acceptance must FAIL when given setup/ (task is non-trivial).
+        work_setup = Path(td) / "work_setup"
+        shutil.copytree(setup, work_setup)
+        cp2 = subprocess.run(
+            [bash_path, acceptance.name, work_setup.as_posix()],
+            capture_output=True, text=True, cwd=str(task_dir),
+        )
+        if cp2.returncode == 0:
+            errors.append(
+                "acceptance.sh setup/ unexpectedly succeeded — task is "
+                "trivial (already in expected state)"
+            )
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("task_dir", nargs="?", help="Single task directory.")
+    g.add_argument("--all", dest="all_root",
+                   help="Templates root; validate every immediate sub-dir.")
+    args = p.parse_args(argv)
+
+    if args.all_root:
+        root = Path(args.all_root)
+        if not root.is_dir():
+            print(f"not a directory: {root}", file=sys.stderr)
+            return 2
+        tasks = sorted(p for p in root.iterdir() if p.is_dir())
+        any_err = False
+        for t in tasks:
+            errs = validate_one(t)
+            if errs:
+                any_err = True
+                print(f"FAIL {t.name}:")
+                for e in errs:
+                    print(f"  - {e}")
+            else:
+                print(f"OK   {t.name}")
+        return 1 if any_err else 0
+
+    errs = validate_one(Path(args.task_dir))
+    if errs:
+        for e in errs:
+            print(f"FAIL: {e}", file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-corpus.ps1
+++ b/scripts/verify-corpus.ps1
@@ -1,0 +1,4 @@
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+python "$here/verify_corpus.py" @args
+exit $LASTEXITCODE

--- a/scripts/verify-corpus.sh
+++ b/scripts/verify-corpus.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "${HERE}/verify_corpus.py" "$@"

--- a/scripts/verify-phase1.ps1
+++ b/scripts/verify-phase1.ps1
@@ -1,0 +1,4 @@
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+python "$here/verify_phase1.py" @args
+exit $LASTEXITCODE

--- a/scripts/verify-phase1.sh
+++ b/scripts/verify-phase1.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "${HERE}/verify_phase1.py" "$@"

--- a/scripts/verify_corpus.py
+++ b/scripts/verify_corpus.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+verify_corpus.py — Tier 2 corpus-wide verification driver (v6 §3.2).
+
+Re-runs Tier 1 over the full corpus, plus corpus-specific checks:
+
+    1. Tier 1 in extended mode (samples/ + tests/).
+    2. Migrator corpus dry-run (no-op until PR-1c).
+    3. Aggregate token-delta check (against RFC v5 §16.F band).
+    4. Diagnostic snapshot tests via `dotnet test`.
+    5. Migrator round-trip (no-op until PR-1c).
+
+Runtime target: < 30 minutes on a developer machine.
+
+Usage:
+    python3 scripts/verify_corpus.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "scripts"
+SAMPLES = REPO_ROOT / "samples"
+TESTS = REPO_ROOT / "tests"
+
+
+def run_step(name: str, cmd: list[str]) -> int:
+    start = time.monotonic()
+    print(f"\n=== {name} ===")
+    print(f"$ {' '.join(cmd)}")
+    cp = subprocess.run(cmd, cwd=REPO_ROOT)
+    elapsed = time.monotonic() - start
+    print(f"--- {name}: {'OK' if cp.returncode == 0 else 'FAIL'} "
+          f"({elapsed:.1f}s)")
+    return cp.returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--skip-dotnet", action="store_true")
+    p.add_argument("--budget-seconds", type=int, default=30 * 60)
+    args = p.parse_args(argv)
+
+    py = sys.executable
+    start = time.monotonic()
+    failures: list[str] = []
+
+    if run_step(
+        "Tier 1 (extended)",
+        [py, str(SCRIPTS / "verify_phase1.py"), "--corpus", "all",
+         *(["--skip-dotnet"] if args.skip_dotnet else [])],
+    ) != 0:
+        failures.append("Tier 1 (extended)")
+
+    if run_step(
+        "migrator_corpus_dryrun",
+        [py, str(SCRIPTS / "migrator_corpus_dryrun.py"), str(TESTS)],
+    ) != 0:
+        failures.append("migrator_corpus_dryrun")
+
+    if run_step(
+        "token_delta_corpus",
+        [py, str(SCRIPTS / "token_delta_corpus.py"), str(TESTS)],
+    ) != 0:
+        failures.append("token_delta_corpus")
+
+    if not args.skip_dotnet:
+        if run_step(
+            "dotnet test (DiagnosticSnapshot category)",
+            ["dotnet", "test", "-c", "Release",
+             "--filter", "Category=DiagnosticSnapshot",
+             "--nologo", "--verbosity", "minimal"],
+        ) != 0:
+            failures.append("DiagnosticSnapshot tests")
+
+    if run_step(
+        "migrator_revert_roundtrip",
+        [py, str(SCRIPTS / "migrator_revert_roundtrip.py"), str(TESTS)],
+    ) != 0:
+        failures.append("migrator_revert_roundtrip")
+
+    elapsed = time.monotonic() - start
+    print(f"\n=== Tier 2 total: {elapsed:.1f}s "
+          f"(budget {args.budget_seconds}s) ===")
+    if failures:
+        print(f"Tier 2 FAIL: {', '.join(failures)}", file=sys.stderr)
+        return 1
+    print("Tier 2 OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_phase1.py
+++ b/scripts/verify_phase1.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+verify_phase1.py — Tier 1 self-verification driver (v6 §3.1).
+
+Runs the Tier 1 checks in order. Designed to complete in < 60 seconds
+on a developer machine (per v6 §3.1.a). On budget overrun, the
+remediation order is §3.6.
+
+Components:
+    1. dotnet test --filter Category=Unit (existing, optional)
+    2. byte-preservation on samples/
+    3. AST round-trip on samples/ (default) or tests/ (extended)
+    4. token-delta spot check on a single fixture (informational)
+
+Exit codes:
+    0  all checks PASS
+    1  one or more checks FAIL
+    2  bad arguments
+
+Usage:
+    python3 scripts/verify_phase1.py
+    python3 scripts/verify_phase1.py --corpus all       # extended
+    python3 scripts/verify_phase1.py --skip-dotnet      # CI shortcut
+    python3 scripts/verify_phase1.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "scripts"
+SAMPLES = REPO_ROOT / "samples"
+TESTS = REPO_ROOT / "tests"
+
+
+def run_step(name: str, cmd: list[str], cwd: Path = REPO_ROOT) -> int:
+    start = time.monotonic()
+    print(f"\n=== {name} ===")
+    print(f"$ {' '.join(cmd)}")
+    cp = subprocess.run(cmd, cwd=cwd)
+    elapsed = time.monotonic() - start
+    print(f"--- {name}: {'OK' if cp.returncode == 0 else 'FAIL'} "
+          f"({elapsed:.1f}s)")
+    return cp.returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--corpus", default="default",
+                   choices=("default", "all"),
+                   help="default = samples/ only; all = samples/ + tests/.")
+    p.add_argument("--skip-dotnet", action="store_true",
+                   help="Skip `dotnet test` (CI uses separate jobs).")
+    p.add_argument("--self-test", action="store_true",
+                   help="Run each component's --self-test mode.")
+    p.add_argument("--budget-seconds", type=int, default=60,
+                   help="Wall-clock budget (v6 §3.1.a, default 60).")
+    args = p.parse_args(argv)
+
+    py = sys.executable
+    start = time.monotonic()
+    failures: list[str] = []
+
+    if args.self_test:
+        if run_step(
+            "byte_preservation --self-test",
+            [py, str(SCRIPTS / "byte_preservation_check.py"), "--self-test"],
+        ) != 0:
+            failures.append("byte_preservation self-test")
+        if run_step(
+            "ast_roundtrip --self-test",
+            [py, str(SCRIPTS / "ast_roundtrip_check.py"), "--self-test"],
+        ) != 0:
+            failures.append("ast_roundtrip self-test")
+    else:
+        if not args.skip_dotnet:
+            # `Category=Unit` is the conventional filter; if no unit-marked
+            # tests exist, the runner returns 0 trivially.
+            if run_step(
+                "dotnet test (Category=Unit)",
+                ["dotnet", "test", "-c", "Release",
+                 "--filter", "Category=Unit",
+                 "--nologo", "--verbosity", "minimal"],
+            ) != 0:
+                failures.append("dotnet test")
+        if run_step(
+            "byte_preservation (identity check on samples/)",
+            [py, str(SCRIPTS / "byte_preservation_check.py"),
+             str(SAMPLES / "Contracts" / "Calculator.calr")
+                if (SAMPLES / "Contracts" / "Calculator.calr").exists()
+                else str(next(SAMPLES.rglob("*.calr"), SAMPLES))
+                if any(SAMPLES.rglob("*.calr")) else str(SAMPLES),
+             str(SAMPLES / "Contracts" / "Calculator.calr")
+                if (SAMPLES / "Contracts" / "Calculator.calr").exists()
+                else str(next(SAMPLES.rglob("*.calr"), SAMPLES))
+                if any(SAMPLES.rglob("*.calr")) else str(SAMPLES)],
+        ) != 0:
+            failures.append("byte_preservation identity")
+        ast_target = SAMPLES if args.corpus == "default" else TESTS
+        if run_step(
+            f"ast_roundtrip (target={ast_target.name})",
+            [py, str(SCRIPTS / "ast_roundtrip_check.py"), str(ast_target)],
+        ) != 0:
+            failures.append("ast_roundtrip")
+        # Token-delta spot check is informational; not gating.
+        any_calr = next(SAMPLES.rglob("*.calr"), None)
+        if any_calr:
+            run_step(
+                "token_delta_spot (informational)",
+                [py, str(SCRIPTS / "token_delta_spot.py"), str(any_calr)],
+            )
+
+    elapsed = time.monotonic() - start
+    print(f"\n=== Tier 1 total: {elapsed:.1f}s "
+          f"(budget {args.budget_seconds}s) ===")
+    if elapsed > args.budget_seconds:
+        print(f"WARNING: Tier 1 exceeded budget by "
+              f"{elapsed - args.budget_seconds:.1f}s. See v6 §3.6.",
+              file=sys.stderr)
+    if failures:
+        print(f"\nTier 1 FAIL: {', '.join(failures)}", file=sys.stderr)
+        return 1
+    print("Tier 1 OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/E2E/agent-tasks/phase-2-gate-tasks.txt
+++ b/tests/E2E/agent-tasks/phase-2-gate-tasks.txt
@@ -1,0 +1,62 @@
+# Phase 2 measurement protocol v2 — pre-registered task manifest.
+#
+# This file is THE authoritative list of 30 trials the Tier 3 statistical
+# gate runs against (RFC §10.5 immutability). It is paired with
+# `docs/plans/phase-2-measurement-protocol-v2.md` §1.1.
+#
+# Format:
+#   - Lines beginning with `#` are comments (ignored by the driver).
+#   - Blank lines are ignored.
+#   - `task:<category>/<task_dir>` references
+#       `tests/E2E/agent-tasks/tasks/<category>/<task_dir>/task.json`.
+#     The driver resolves the task's workspace via the `fixture` field
+#     in that task.json.
+#   - `template:<template_dir>` references
+#       `tests/E2E/agent-tasks/templates/path-2-gate/<template_dir>/`
+#     which is a self-contained gate task (own task.md + setup/ +
+#     expected/ + acceptance.sh).
+#
+# Total: 30 trials. Modifying this file after gate kickoff requires
+# protocol v3 per RFC §10.5.
+#
+# Stratification rationale: 24 task: entries cover 17 of the 19 task
+# categories present in `tests/E2E/agent-tasks/tasks/`, deliberately
+# excluding `github-projects/` (network-dependent) and `calor-idioms/`
+# (only 2 tasks; covered by `refactoring/01_extract_pure_function`'s
+# similar surface). Categories with the largest task pools contribute
+# 2 entries; smaller pools contribute 1. The 6 template: entries are
+# the purpose-built gate fixtures from path-2-gate authoring.
+
+# Stratified tasks (24)
+task:type-system/01_option_some_return
+task:type-system/04_result_err_return
+task:string-operations/01_length_upper_lower
+task:string-operations/04_regex_operations
+task:refactoring-benchmark/refactor-extract-effects-calor
+task:refactoring-benchmark/refactor-extract-effects-csharp
+task:refactoring-benchmark/refactor-rename-shadow-calor
+task:refactoring-benchmark/refactor-rename-shadow-csharp
+task:refactoring/01_extract_pure_function
+task:refactoring/06_fix_contract_violation
+task:pattern-matching/02_relational_patterns
+task:pattern-matching/04_option_some_matching
+task:oop-features/01_class_definition
+task:oop-features/04_property
+task:logic-implementation/01_factorial
+task:logic-implementation/02_clamp
+task:lambdas-delegates/02_block_lambda
+task:generics/02_generic_class
+task:enums/01_enum_definition
+task:effects-system/02_console_read
+task:effects-system/06_multiple_effects
+task:contract-writing/02_postcondition
+task:contract-writing/05_loop_invariant
+task:collections/01_list_creation
+
+# Path-2-gate purpose-built templates (6)
+template:task-01-multi-function-refactor
+template:task-02-add-db-effect
+template:task-03-privacy-change
+template:task-04-add-postcondition
+template:task-05-loop-restructure
+template:task-06-error-handling

--- a/tests/E2E/agent-tasks/run.sh
+++ b/tests/E2E/agent-tasks/run.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Phase 2 gate harness adapter (RFC §10, protocol §10.1.a).
+# ============================================================================
+#
+# Invoked by scripts/run_phase_2_gate.py:dispatch_run with:
+#
+#     bash tests/E2E/agent-tasks/run.sh \
+#         --task   <fixture-or-template-dir-basename> \
+#         --arm    <A|B|C> \
+#         --seed   <int> \
+#         --model  <fully-qualified-model-id> \
+#         --log    <absolute-path-for-raw-log.jsonl>
+#
+# Contract — what this script MUST do:
+#   1. Locate <task> under either:
+#        - tests/E2E/agent-tasks/templates/path-2-gate/<task>/ (preferred:
+#          has task.md + setup/ + expected/ + acceptance.sh)
+#        - tests/E2E/agent-tasks/fixtures/<task>/ (workspace-only; no task
+#          contract — see "Substrate gap" below)
+#   2. Materialise a per-trial workspace at <log_dir>/work/.
+#   3. Drive the pinned model (Claude Code CLI) at HEAD of the arm-pinned
+#      ref (the arm checkout is the caller's responsibility — this script
+#      assumes the working tree already reflects the desired arm SHA).
+#   4. Run the task's acceptance.sh against the agent output.
+#   5. Compute identity_preservation_errors and edit_correctness_errors.
+#   6. Emit a single-line JSON summary on stdout as the FINAL non-empty
+#      line, exactly the schema expected by dispatch_run:
+#
+#          {"success": bool, "turn_count": int, "total_output_tokens": int,
+#           "identity_preservation_errors": int,
+#           "edit_correctness_errors": int}
+#
+# Substrate gap (recorded for traceability):
+#   The 24 fixtures referenced in protocol §1.1 (advanced-calor-project,
+#   async-project, etc.) currently have no task.md / setup/ / acceptance.sh.
+#   For those, this adapter emits a structured failure record with
+#   harness_error="no_task_contract" so the gate driver does not silently
+#   record fake successes. Fixing this requires either authoring 24 new
+#   task contracts or refactoring run_phase_2_gate.py to iterate the
+#   existing tests/E2E/agent-tasks/tasks/<cat>/<task>/task.json schema and
+#   pair each task with its declared `fixture` workspace.
+#
+# Environment variables (optional):
+#   CALOR_GATE_DRY_RUN=1   — skip the agent invocation; treat as a synthetic
+#                            "harness wiring smoke test" and emit a
+#                            success=false record. Used by CI; do NOT use
+#                            in the real gate.
+#   CALOR_GATE_AGENT       — override the default agent CLI ("claude").
+#   CALOR_GATE_TIMEOUT_S   — per-trial timeout (default 600s).
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+FIXTURES_DIR="${SCRIPT_DIR}/fixtures"
+TEMPLATES_DIR="${SCRIPT_DIR}/templates/path-2-gate"
+
+TASK=""
+ARM=""
+SEED=""
+MODEL=""
+LOG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --task)  TASK="$2";  shift 2 ;;
+    --arm)   ARM="$2";   shift 2 ;;
+    --seed)  SEED="$2";  shift 2 ;;
+    --model) MODEL="$2"; shift 2 ;;
+    --log)   LOG="$2";   shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+for v in TASK ARM SEED MODEL LOG; do
+  if [[ -z "${!v}" ]]; then
+    echo "missing required --${v,,}" >&2
+    exit 2
+  fi
+done
+
+if [[ "$ARM" != "A" && "$ARM" != "B" && "$ARM" != "C" ]]; then
+  echo "arm must be A, B, or C; got: $ARM" >&2
+  exit 2
+fi
+
+LOG_DIR="$(dirname "$LOG")"
+mkdir -p "$LOG_DIR"
+WORK_DIR="${LOG_DIR}/work"
+
+# ----------------------------------------------------------------------------
+# JSON emit helpers (no python dependency to keep the harness portable).
+# ----------------------------------------------------------------------------
+emit_record() {
+  # $1=success(true|false) $2=turns $3=tokens $4=id_err $5=edit_err
+  #   [$6=harness_error_string]
+  local success="$1" turns="$2" tokens="$3" id_err="$4" edit_err="$5"
+  local err="${6:-}"
+  if [[ -n "$err" ]]; then
+    printf '{"success": %s, "turn_count": %s, "total_output_tokens": %s, "identity_preservation_errors": %s, "edit_correctness_errors": %s, "harness_error": "%s"}\n' \
+      "$success" "$turns" "$tokens" "$id_err" "$edit_err" "$err"
+  else
+    printf '{"success": %s, "turn_count": %s, "total_output_tokens": %s, "identity_preservation_errors": %s, "edit_correctness_errors": %s}\n' \
+      "$success" "$turns" "$tokens" "$id_err" "$edit_err"
+  fi
+}
+
+# ----------------------------------------------------------------------------
+# Resolve the task directory and verify it has a runnable contract.
+# ----------------------------------------------------------------------------
+TASK_DIR=""
+if [[ -d "${TEMPLATES_DIR}/${TASK}" ]]; then
+  TASK_DIR="${TEMPLATES_DIR}/${TASK}"
+elif [[ -d "${FIXTURES_DIR}/${TASK}" ]]; then
+  TASK_DIR="${FIXTURES_DIR}/${TASK}"
+else
+  echo "fatal: task dir not found for ${TASK}" >&2
+  emit_record false 0 0 0 0 "task_dir_not_found"
+  exit 0  # exit 0 so dispatch_run records the JSON instead of treating
+          # this as a harness crash; the harness_error field makes the
+          # failure auditable.
+fi
+
+if [[ ! -f "${TASK_DIR}/task.md" || ! -f "${TASK_DIR}/acceptance.sh" ]]; then
+  # Substrate gap — see header comment.
+  echo "no task contract under ${TASK_DIR}; emitting structured failure" >&2
+  emit_record false 0 0 0 0 "no_task_contract"
+  exit 0
+fi
+
+# ----------------------------------------------------------------------------
+# Materialise the per-trial workspace.
+# ----------------------------------------------------------------------------
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR"
+if [[ -d "${TASK_DIR}/setup" ]]; then
+  cp -R "${TASK_DIR}/setup/." "${WORK_DIR}/"
+fi
+
+# ----------------------------------------------------------------------------
+# Dry-run mode: skip the agent. Useful for CI plumbing checks. Records a
+# false success with harness_error="dry_run" so analysers can filter.
+# ----------------------------------------------------------------------------
+if [[ "${CALOR_GATE_DRY_RUN:-0}" == "1" ]]; then
+  emit_record false 0 0 0 0 "dry_run"
+  exit 0
+fi
+
+# ----------------------------------------------------------------------------
+# Real run: invoke the agent. The default agent is Claude Code CLI; the
+# concrete invocation here is a placeholder pending operator selection of
+# the exact CLI flags for non-interactive batch mode. See operator notes
+# in protocol §10.1.a item 5 for the model-pinning contract.
+#
+# The agent is invoked in --print (one-shot) mode with the task.md content
+# as the prompt and the workspace as cwd. We capture stdout (the agent's
+# final answer) and stderr (verbose trace), and parse turn-count / token
+# usage from the trailing summary block emitted by --json output mode.
+# ----------------------------------------------------------------------------
+AGENT="${CALOR_GATE_AGENT:-claude}"
+TIMEOUT="${CALOR_GATE_TIMEOUT_S:-600}"
+
+if ! command -v "$AGENT" >/dev/null 2>&1; then
+  echo "agent CLI not on PATH: $AGENT" >&2
+  emit_record false 0 0 0 0 "agent_cli_missing"
+  exit 0
+fi
+
+PROMPT_FILE="${LOG_DIR}/prompt.txt"
+RAW_STDOUT="${LOG_DIR}/agent.stdout"
+RAW_STDERR="${LOG_DIR}/agent.stderr"
+{
+  echo "You are working in ${WORK_DIR}. Apply the task below to the files in"
+  echo "that directory. Make minimal edits; do not modify any file not"
+  echo "explicitly required by the task. When complete, exit."
+  echo ""
+  echo "---"
+  cat "${TASK_DIR}/task.md"
+} > "$PROMPT_FILE"
+
+# Per-trial seed: passed via env so the agent (or its sandbox) can use it
+# for sampling determinism if supported. NOT a substitute for the model
+# provider's own seeding; documented for operator review.
+export CALOR_GATE_SEED="$SEED"
+
+set +e
+timeout "${TIMEOUT}s" "$AGENT" \
+  --model "$MODEL" \
+  --print \
+  --output-format json \
+  --working-directory "$WORK_DIR" \
+  < "$PROMPT_FILE" \
+  > "$RAW_STDOUT" 2> "$RAW_STDERR"
+AGENT_RC=$?
+set -e
+
+if [[ "$AGENT_RC" -ne 0 ]]; then
+  echo "agent exited non-zero ($AGENT_RC)" >&2
+  emit_record false 0 0 0 0 "agent_nonzero_exit_${AGENT_RC}"
+  exit 0
+fi
+
+# ----------------------------------------------------------------------------
+# Parse the agent's JSON summary. We expect a trailing object with at least
+# turn_count and total_tokens. Be defensive — if the format drifts, fall
+# back to 0s and let the analyser flag it.
+# ----------------------------------------------------------------------------
+TURNS=0
+TOKENS=0
+if command -v jq >/dev/null 2>&1; then
+  TURNS=$(jq -r '.num_turns // 0'         "$RAW_STDOUT" 2>/dev/null || echo 0)
+  TOKENS=$(jq -r '.total_tokens // 0'     "$RAW_STDOUT" 2>/dev/null || echo 0)
+fi
+
+# ----------------------------------------------------------------------------
+# Run the task's acceptance check.
+# ----------------------------------------------------------------------------
+set +e
+bash "${TASK_DIR}/acceptance.sh" "$WORK_DIR" > "${LOG_DIR}/acceptance.stdout" 2> "${LOG_DIR}/acceptance.stderr"
+ACC_RC=$?
+set -e
+
+SUCCESS=false
+[[ "$ACC_RC" -eq 0 ]] && SUCCESS=true
+
+# ----------------------------------------------------------------------------
+# Identity-preservation check: diff the workspace against setup/. Count
+# files modified that are NOT explicitly part of the task target (cheap
+# proxy: files outside the directly-edited file set). Implementation here
+# is conservative — counts every non-setup file that exists in the
+# workspace but not in setup/, plus every setup file modified outside the
+# task's documented target list (which we cannot statically extract from
+# task.md, so for v1 we count "any unexpected new file"). The analyser
+# treats this as a regression signal, not a hard fail.
+# ----------------------------------------------------------------------------
+ID_ERRORS=0
+if [[ -d "${TASK_DIR}/setup" ]]; then
+  # Count files present in WORK_DIR but absent in setup/ (unexpected new files).
+  while IFS= read -r f; do
+    rel="${f#${WORK_DIR}/}"
+    [[ -f "${TASK_DIR}/setup/${rel}" ]] || ID_ERRORS=$((ID_ERRORS + 1))
+  done < <(find "$WORK_DIR" -type f 2>/dev/null)
+fi
+
+# Edit-correctness errors: 0 if acceptance passed, else 1 (binary). The
+# acceptance script's exit code is the canonical signal; a richer count
+# would require a per-task contract beyond v1 of this adapter.
+EDIT_ERRORS=0
+[[ "$SUCCESS" == "false" ]] && EDIT_ERRORS=1
+
+emit_record "$SUCCESS" "$TURNS" "$TOKENS" "$ID_ERRORS" "$EDIT_ERRORS"

--- a/tests/E2E/agent-tasks/run.sh
+++ b/tests/E2E/agent-tasks/run.sh
@@ -275,17 +275,25 @@ if [[ "$AGENT_RC" -ne 0 ]]; then
 fi
 
 # ----------------------------------------------------------------------------
-# Parse the agent's JSON summary. The Claude Code CLI emits a top-level
-# JSON object on stdout in --output-format=json mode with .num_turns and
-# .total_tokens fields. Defensive: if the format drifts, fall back to 0
-# and let the analyser flag it (the analyser already treats zeros as a
-# data-quality signal per phase-2-validation-criteria.md §3.1).
+# Parse the agent's JSON summary. The Claude Code CLI's --output-format=json
+# emits a top-level result object with fields:
+#   .num_turns                          — iterations the agent ran
+#   .usage.output_tokens                — tokens the agent emitted
+#   .usage.input_tokens                 — tokens in the user message
+#   .total_cost_usd                     — dollar cost of this trial
+# The protocol's criterion 2 measures TURNS and OUTPUT TOKENS (RFC §10.1.2),
+# so we record num_turns and usage.output_tokens. total_cost_usd is captured
+# in the agent.stdout file for budget tracking but not reported as a metric.
+#
+# Defensive: if the format drifts, fall back to 0 and let the analyser flag
+# it (the analyser already treats zeros as a data-quality signal per
+# phase-2-validation-criteria.md §3.1).
 # ----------------------------------------------------------------------------
 TURNS=0
 TOKENS=0
 if command -v jq >/dev/null 2>&1; then
-  TURNS=$(jq -r '.num_turns // 0'     "$RAW_STDOUT" 2>/dev/null || echo 0)
-  TOKENS=$(jq -r '.total_tokens // 0' "$RAW_STDOUT" 2>/dev/null || echo 0)
+  TURNS=$(jq -r '.num_turns // 0'           "$RAW_STDOUT" 2>/dev/null || echo 0)
+  TOKENS=$(jq -r '.usage.output_tokens // 0' "$RAW_STDOUT" 2>/dev/null || echo 0)
 fi
 
 # ----------------------------------------------------------------------------

--- a/tests/E2E/agent-tasks/run.sh
+++ b/tests/E2E/agent-tasks/run.sh
@@ -1,63 +1,65 @@
 #!/usr/bin/env bash
 # ============================================================================
-# Phase 2 gate harness adapter (RFC §10, protocol §10.1.a).
+# Phase 2 gate harness adapter (RFC §10, protocol v2 §10.1.a).
 # ============================================================================
 #
 # Invoked by scripts/run_phase_2_gate.py:dispatch_run with:
 #
 #     bash tests/E2E/agent-tasks/run.sh \
-#         --task   <fixture-or-template-dir-basename> \
-#         --arm    <A|B|C> \
-#         --seed   <int> \
-#         --model  <fully-qualified-model-id> \
-#         --log    <absolute-path-for-raw-log.jsonl>
+#         --trial-id    <kind>:<id>             # auditing handle only
+#         --kind        task|template
+#         --task-dir    <absolute path>
+#         [--fixture-dir <absolute path>]       # required when kind=task
+#         --arm         A|B|C
+#         --seed        <int>
+#         --model       <fully-qualified-model-id>
+#         --log         <absolute path to log.jsonl>
 #
 # Contract — what this script MUST do:
-#   1. Locate <task> under either:
-#        - tests/E2E/agent-tasks/templates/path-2-gate/<task>/ (preferred:
-#          has task.md + setup/ + expected/ + acceptance.sh)
-#        - tests/E2E/agent-tasks/fixtures/<task>/ (workspace-only; no task
-#          contract — see "Substrate gap" below)
-#   2. Materialise a per-trial workspace at <log_dir>/work/.
-#   3. Drive the pinned model (Claude Code CLI) at HEAD of the arm-pinned
-#      ref (the arm checkout is the caller's responsibility — this script
-#      assumes the working tree already reflects the desired arm SHA).
-#   4. Run the task's acceptance.sh against the agent output.
+#   1. Materialise a per-trial workspace at <log_dir>/work/.
+#       - kind=template: copy task-dir/setup/ → work/
+#       - kind=task:     copy fixture-dir/   → work/
+#   2. Build a prompt:
+#       - kind=template: use task-dir/task.md verbatim
+#       - kind=task:     extract the "prompt" field from task-dir/task.json
+#   3. Drive the pinned model (Claude Code CLI) at the arm's checkout SHA.
+#      The caller is responsible for the worktree state (we trust HEAD).
+#   4. Run the task's acceptance check:
+#       - kind=template: bash task-dir/acceptance.sh <work_dir>
+#       - kind=task:     parse task.json verification.compilation.mustSucceed;
+#                        on true, run `calor` compile and treat exit 0 as pass
 #   5. Compute identity_preservation_errors and edit_correctness_errors.
 #   6. Emit a single-line JSON summary on stdout as the FINAL non-empty
-#      line, exactly the schema expected by dispatch_run:
+#      line, exactly the schema dispatch_run expects:
 #
 #          {"success": bool, "turn_count": int, "total_output_tokens": int,
 #           "identity_preservation_errors": int,
-#           "edit_correctness_errors": int}
+#           "edit_correctness_errors": int [, "harness_error": "<tag>"]}
 #
-# Substrate gap (recorded for traceability):
-#   The 24 fixtures referenced in protocol §1.1 (advanced-calor-project,
-#   async-project, etc.) currently have no task.md / setup/ / acceptance.sh.
-#   For those, this adapter emits a structured failure record with
-#   harness_error="no_task_contract" so the gate driver does not silently
-#   record fake successes. Fixing this requires either authoring 24 new
-#   task contracts or refactoring run_phase_2_gate.py to iterate the
-#   existing tests/E2E/agent-tasks/tasks/<cat>/<task>/task.json schema and
-#   pair each task with its declared `fixture` workspace.
+#   7. Exit 0 even on substrate-level failure (missing CLI, missing task.json,
+#      timeout, dry-run). The harness_error field carries the failure tag so
+#      the analyser distinguishes substrate gaps from agent failures.
+#      Exit non-zero ONLY for usage errors before the JSON record is emitted.
 #
 # Environment variables (optional):
-#   CALOR_GATE_DRY_RUN=1   — skip the agent invocation; treat as a synthetic
-#                            "harness wiring smoke test" and emit a
-#                            success=false record. Used by CI; do NOT use
-#                            in the real gate.
-#   CALOR_GATE_AGENT       — override the default agent CLI ("claude").
-#   CALOR_GATE_TIMEOUT_S   — per-trial timeout (default 600s).
+#   CALOR_GATE_DRY_RUN=1     — skip the agent invocation; emit a synthetic
+#                              record with harness_error="dry_run". Used by
+#                              CI for plumbing tests; never in the real gate.
+#   CALOR_GATE_AGENT=<cli>   — override the default agent CLI (default:
+#                              "claude" — the Claude Code CLI).
+#   CALOR_GATE_TIMEOUT_S=<n> — per-trial timeout (default 600s).
+#   CALOR_GATE_CALOR=<cli>   — override the calor CLI (default: "calor").
 # ============================================================================
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-FIXTURES_DIR="${SCRIPT_DIR}/fixtures"
-TEMPLATES_DIR="${SCRIPT_DIR}/templates/path-2-gate"
 
-TASK=""
+TRIAL_ID=""
+KIND=""
+TASK_DIR=""
+FIXTURE_DIR=""
 ARM=""
 SEED=""
 MODEL=""
@@ -65,22 +67,33 @@ LOG=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --task)  TASK="$2";  shift 2 ;;
-    --arm)   ARM="$2";   shift 2 ;;
-    --seed)  SEED="$2";  shift 2 ;;
-    --model) MODEL="$2"; shift 2 ;;
-    --log)   LOG="$2";   shift 2 ;;
+    --trial-id)    TRIAL_ID="$2";    shift 2 ;;
+    --kind)        KIND="$2";        shift 2 ;;
+    --task-dir)    TASK_DIR="$2";    shift 2 ;;
+    --fixture-dir) FIXTURE_DIR="$2"; shift 2 ;;
+    --arm)         ARM="$2";         shift 2 ;;
+    --seed)        SEED="$2";        shift 2 ;;
+    --model)       MODEL="$2";       shift 2 ;;
+    --log)         LOG="$2";         shift 2 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
 
-for v in TASK ARM SEED MODEL LOG; do
+for v in TRIAL_ID KIND TASK_DIR ARM SEED MODEL LOG; do
   if [[ -z "${!v}" ]]; then
     echo "missing required --${v,,}" >&2
     exit 2
   fi
 done
 
+if [[ "$KIND" != "task" && "$KIND" != "template" ]]; then
+  echo "kind must be 'task' or 'template'; got: $KIND" >&2
+  exit 2
+fi
+if [[ "$KIND" == "task" && -z "$FIXTURE_DIR" ]]; then
+  echo "--fixture-dir is required when --kind=task" >&2
+  exit 2
+fi
 if [[ "$ARM" != "A" && "$ARM" != "B" && "$ARM" != "C" ]]; then
   echo "arm must be A, B, or C; got: $ARM" >&2
   exit 2
@@ -91,7 +104,7 @@ mkdir -p "$LOG_DIR"
 WORK_DIR="${LOG_DIR}/work"
 
 # ----------------------------------------------------------------------------
-# JSON emit helpers (no python dependency to keep the harness portable).
+# JSON emit helper — no python dep, keeps the harness portable.
 # ----------------------------------------------------------------------------
 emit_record() {
   # $1=success(true|false) $2=turns $3=tokens $4=id_err $5=edit_err
@@ -108,26 +121,31 @@ emit_record() {
 }
 
 # ----------------------------------------------------------------------------
-# Resolve the task directory and verify it has a runnable contract.
+# Validate the task directory has the contract we need for its kind.
 # ----------------------------------------------------------------------------
-TASK_DIR=""
-if [[ -d "${TEMPLATES_DIR}/${TASK}" ]]; then
-  TASK_DIR="${TEMPLATES_DIR}/${TASK}"
-elif [[ -d "${FIXTURES_DIR}/${TASK}" ]]; then
-  TASK_DIR="${FIXTURES_DIR}/${TASK}"
-else
-  echo "fatal: task dir not found for ${TASK}" >&2
+if [[ ! -d "$TASK_DIR" ]]; then
+  echo "task_dir does not exist: $TASK_DIR" >&2
   emit_record false 0 0 0 0 "task_dir_not_found"
-  exit 0  # exit 0 so dispatch_run records the JSON instead of treating
-          # this as a harness crash; the harness_error field makes the
-          # failure auditable.
+  exit 0
 fi
 
-if [[ ! -f "${TASK_DIR}/task.md" || ! -f "${TASK_DIR}/acceptance.sh" ]]; then
-  # Substrate gap — see header comment.
-  echo "no task contract under ${TASK_DIR}; emitting structured failure" >&2
-  emit_record false 0 0 0 0 "no_task_contract"
-  exit 0
+if [[ "$KIND" == "template" ]]; then
+  if [[ ! -f "${TASK_DIR}/task.md" || ! -f "${TASK_DIR}/acceptance.sh" ]]; then
+    echo "template missing task.md or acceptance.sh: $TASK_DIR" >&2
+    emit_record false 0 0 0 0 "no_task_contract"
+    exit 0
+  fi
+else  # kind=task
+  if [[ ! -f "${TASK_DIR}/task.json" ]]; then
+    echo "task missing task.json: $TASK_DIR" >&2
+    emit_record false 0 0 0 0 "no_task_json"
+    exit 0
+  fi
+  if [[ ! -d "$FIXTURE_DIR" ]]; then
+    echo "fixture_dir does not exist: $FIXTURE_DIR" >&2
+    emit_record false 0 0 0 0 "fixture_dir_not_found"
+    exit 0
+  fi
 fi
 
 # ----------------------------------------------------------------------------
@@ -135,13 +153,64 @@ fi
 # ----------------------------------------------------------------------------
 rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR"
-if [[ -d "${TASK_DIR}/setup" ]]; then
-  cp -R "${TASK_DIR}/setup/." "${WORK_DIR}/"
+
+if [[ "$KIND" == "template" ]]; then
+  if [[ -d "${TASK_DIR}/setup" ]]; then
+    cp -R "${TASK_DIR}/setup/." "${WORK_DIR}/"
+  fi
+else  # kind=task
+  # Copy the entire fixture workspace into work/. The fixtures under
+  # tests/E2E/agent-tasks/fixtures/ are pre-built calor projects (with
+  # *.calr files, calor.toml etc.) ready for the agent to edit.
+  cp -R "${FIXTURE_DIR}/." "${WORK_DIR}/"
 fi
 
 # ----------------------------------------------------------------------------
+# Build the prompt.
+# ----------------------------------------------------------------------------
+PROMPT_FILE="${LOG_DIR}/prompt.txt"
+
+if [[ "$KIND" == "template" ]]; then
+  {
+    echo "You are working in ${WORK_DIR}. Apply the task below to the files in"
+    echo "that directory. Make minimal edits; do not modify any file not"
+    echo "explicitly required by the task. When complete, exit."
+    echo ""
+    echo "---"
+    cat "${TASK_DIR}/task.md"
+  } > "$PROMPT_FILE"
+else  # kind=task
+  # Extract .prompt from task.json. Prefer jq if present; otherwise a
+  # python one-liner. Both are widely available; we never assume both.
+  if command -v jq >/dev/null 2>&1; then
+    PROMPT_TEXT=$(jq -r '.prompt' "${TASK_DIR}/task.json")
+  elif command -v python3 >/dev/null 2>&1; then
+    PROMPT_TEXT=$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['prompt'])" "${TASK_DIR}/task.json")
+  elif command -v python >/dev/null 2>&1; then
+    PROMPT_TEXT=$(python -c "import json,sys;print(json.load(open(sys.argv[1]))['prompt'])" "${TASK_DIR}/task.json")
+  else
+    echo "neither jq nor python available to parse task.json" >&2
+    emit_record false 0 0 0 0 "no_json_parser"
+    exit 0
+  fi
+  {
+    echo "You are working in ${WORK_DIR}. Apply the task below by editing the"
+    echo ".calr files in that directory. Make minimal edits and do not modify"
+    echo "any file not explicitly required by the task. When complete, exit."
+    echo ""
+    echo "---"
+    echo "$PROMPT_TEXT"
+  } > "$PROMPT_FILE"
+fi
+
+# Snapshot the pre-agent file state for the identity-preservation diff.
+PRE_SNAPSHOT="${LOG_DIR}/pre-snapshot"
+mkdir -p "$PRE_SNAPSHOT"
+cp -R "${WORK_DIR}/." "${PRE_SNAPSHOT}/"
+
+# ----------------------------------------------------------------------------
 # Dry-run mode: skip the agent. Useful for CI plumbing checks. Records a
-# false success with harness_error="dry_run" so analysers can filter.
+# false success with harness_error="dry_run" so analysers can filter it out.
 # ----------------------------------------------------------------------------
 if [[ "${CALOR_GATE_DRY_RUN:-0}" == "1" ]]; then
   emit_record false 0 0 0 0 "dry_run"
@@ -149,15 +218,9 @@ if [[ "${CALOR_GATE_DRY_RUN:-0}" == "1" ]]; then
 fi
 
 # ----------------------------------------------------------------------------
-# Real run: invoke the agent. The default agent is Claude Code CLI; the
-# concrete invocation here is a placeholder pending operator selection of
-# the exact CLI flags for non-interactive batch mode. See operator notes
-# in protocol §10.1.a item 5 for the model-pinning contract.
-#
-# The agent is invoked in --print (one-shot) mode with the task.md content
-# as the prompt and the workspace as cwd. We capture stdout (the agent's
-# final answer) and stderr (verbose trace), and parse turn-count / token
-# usage from the trailing summary block emitted by --json output mode.
+# Real run: invoke the agent. Default is Claude Code CLI in non-interactive
+# --print mode. The exact flag set matches the existing helpers.sh:invoke_agent
+# convention in this repo (lib/helpers.sh:1407-1410) for consistency.
 # ----------------------------------------------------------------------------
 AGENT="${CALOR_GATE_AGENT:-claude}"
 TIMEOUT="${CALOR_GATE_TIMEOUT_S:-600}"
@@ -168,34 +231,43 @@ if ! command -v "$AGENT" >/dev/null 2>&1; then
   exit 0
 fi
 
-PROMPT_FILE="${LOG_DIR}/prompt.txt"
+if ! command -v timeout >/dev/null 2>&1; then
+  echo "GNU coreutils 'timeout' missing — required for bounded agent runs" >&2
+  emit_record false 0 0 0 0 "no_timeout_cmd"
+  exit 0
+fi
+
 RAW_STDOUT="${LOG_DIR}/agent.stdout"
 RAW_STDERR="${LOG_DIR}/agent.stderr"
-{
-  echo "You are working in ${WORK_DIR}. Apply the task below to the files in"
-  echo "that directory. Make minimal edits; do not modify any file not"
-  echo "explicitly required by the task. When complete, exit."
-  echo ""
-  echo "---"
-  cat "${TASK_DIR}/task.md"
-} > "$PROMPT_FILE"
+PROMPT_CONTENT="$(cat "$PROMPT_FILE")"
 
-# Per-trial seed: passed via env so the agent (or its sandbox) can use it
+# Per-trial seed: exposed via env so the agent (or its sandbox) can use it
 # for sampling determinism if supported. NOT a substitute for the model
 # provider's own seeding; documented for operator review.
 export CALOR_GATE_SEED="$SEED"
 
+# Run claude from the workspace directory so any file operations are
+# scoped there. The agent is invoked with --print (one-shot) and
+# --dangerously-skip-permissions (so file edits are not gated by
+# interactive prompts). Output format = json so we can parse the
+# turn-count / token-usage summary block deterministically.
 set +e
-timeout "${TIMEOUT}s" "$AGENT" \
-  --model "$MODEL" \
-  --print \
-  --output-format json \
-  --working-directory "$WORK_DIR" \
-  < "$PROMPT_FILE" \
-  > "$RAW_STDOUT" 2> "$RAW_STDERR"
+( cd "$WORK_DIR" && \
+    timeout "${TIMEOUT}s" "$AGENT" \
+      --print \
+      --output-format json \
+      --dangerously-skip-permissions \
+      --model "$MODEL" \
+      "$PROMPT_CONTENT" \
+  ) > "$RAW_STDOUT" 2> "$RAW_STDERR"
 AGENT_RC=$?
 set -e
 
+if [[ "$AGENT_RC" -eq 124 ]]; then
+  echo "agent timed out after ${TIMEOUT}s" >&2
+  emit_record false 0 0 0 0 "agent_timeout"
+  exit 0
+fi
 if [[ "$AGENT_RC" -ne 0 ]]; then
   echo "agent exited non-zero ($AGENT_RC)" >&2
   emit_record false 0 0 0 0 "agent_nonzero_exit_${AGENT_RC}"
@@ -203,50 +275,92 @@ if [[ "$AGENT_RC" -ne 0 ]]; then
 fi
 
 # ----------------------------------------------------------------------------
-# Parse the agent's JSON summary. We expect a trailing object with at least
-# turn_count and total_tokens. Be defensive — if the format drifts, fall
-# back to 0s and let the analyser flag it.
+# Parse the agent's JSON summary. The Claude Code CLI emits a top-level
+# JSON object on stdout in --output-format=json mode with .num_turns and
+# .total_tokens fields. Defensive: if the format drifts, fall back to 0
+# and let the analyser flag it (the analyser already treats zeros as a
+# data-quality signal per phase-2-validation-criteria.md §3.1).
 # ----------------------------------------------------------------------------
 TURNS=0
 TOKENS=0
 if command -v jq >/dev/null 2>&1; then
-  TURNS=$(jq -r '.num_turns // 0'         "$RAW_STDOUT" 2>/dev/null || echo 0)
-  TOKENS=$(jq -r '.total_tokens // 0'     "$RAW_STDOUT" 2>/dev/null || echo 0)
+  TURNS=$(jq -r '.num_turns // 0'     "$RAW_STDOUT" 2>/dev/null || echo 0)
+  TOKENS=$(jq -r '.total_tokens // 0' "$RAW_STDOUT" 2>/dev/null || echo 0)
 fi
 
 # ----------------------------------------------------------------------------
-# Run the task's acceptance check.
+# Acceptance check.
 # ----------------------------------------------------------------------------
-set +e
-bash "${TASK_DIR}/acceptance.sh" "$WORK_DIR" > "${LOG_DIR}/acceptance.stdout" 2> "${LOG_DIR}/acceptance.stderr"
-ACC_RC=$?
-set -e
-
 SUCCESS=false
-[[ "$ACC_RC" -eq 0 ]] && SUCCESS=true
+
+if [[ "$KIND" == "template" ]]; then
+  set +e
+  bash "${TASK_DIR}/acceptance.sh" "$WORK_DIR" \
+    > "${LOG_DIR}/acceptance.stdout" 2> "${LOG_DIR}/acceptance.stderr"
+  ACC_RC=$?
+  set -e
+  [[ "$ACC_RC" -eq 0 ]] && SUCCESS=true
+else  # kind=task
+  # task.json verification.compilation.mustSucceed — default true. If true,
+  # run `calor` (or override) compile from the workspace and treat exit 0
+  # as pass. v1 of this adapter does not run Z3 verification even for
+  # tasks that request it; that requires the calor verify subcommand and
+  # task-specific minProvenContracts thresholds — out of scope for v6 gate.
+  MUST_COMPILE=$(
+    (command -v jq >/dev/null 2>&1 && jq -r '.verification.compilation.mustSucceed // true' "${TASK_DIR}/task.json") \
+    || echo true
+  )
+  if [[ "$MUST_COMPILE" == "true" ]]; then
+    CALOR="${CALOR_GATE_CALOR:-calor}"
+    if ! command -v "$CALOR" >/dev/null 2>&1; then
+      echo "calor CLI not on PATH: $CALOR" >&2
+      emit_record false "$TURNS" "$TOKENS" 0 1 "calor_cli_missing"
+      exit 0
+    fi
+    set +e
+    ( cd "$WORK_DIR" && "$CALOR" build ) \
+      > "${LOG_DIR}/calor-build.stdout" 2> "${LOG_DIR}/calor-build.stderr"
+    BUILD_RC=$?
+    set -e
+    [[ "$BUILD_RC" -eq 0 ]] && SUCCESS=true
+  else
+    # Task doesn't require compile; treat agent-completion as success.
+    SUCCESS=true
+  fi
+fi
 
 # ----------------------------------------------------------------------------
-# Identity-preservation check: diff the workspace against setup/. Count
-# files modified that are NOT explicitly part of the task target (cheap
-# proxy: files outside the directly-edited file set). Implementation here
-# is conservative — counts every non-setup file that exists in the
-# workspace but not in setup/, plus every setup file modified outside the
-# task's documented target list (which we cannot statically extract from
-# task.md, so for v1 we count "any unexpected new file"). The analyser
-# treats this as a regression signal, not a hard fail.
+# Identity-preservation check (v1): diff the workspace against the
+# pre-agent snapshot. Counts files added and files whose content changed
+# but were NOT in the documented edit set (which we cannot statically
+# infer from task.md/task.json prose, so v1 counts ALL changes outside a
+# small whitelist of expected-target patterns). The analyser treats this
+# as a regression signal, not a hard fail.
+#
+# A v2 of this metric should consume an explicit `targets:` field in
+# task.json / task.md front-matter; until then this is a conservative
+# upper bound (i.e., it over-reports identity churn). See protocol v2
+# §3.1 for the formal definition.
 # ----------------------------------------------------------------------------
 ID_ERRORS=0
-if [[ -d "${TASK_DIR}/setup" ]]; then
-  # Count files present in WORK_DIR but absent in setup/ (unexpected new files).
-  while IFS= read -r f; do
-    rel="${f#${WORK_DIR}/}"
-    [[ -f "${TASK_DIR}/setup/${rel}" ]] || ID_ERRORS=$((ID_ERRORS + 1))
-  done < <(find "$WORK_DIR" -type f 2>/dev/null)
-fi
+while IFS= read -r f; do
+  rel="${f#${WORK_DIR}/}"
+  pre="${PRE_SNAPSHOT}/${rel}"
+  if [[ ! -f "$pre" ]]; then
+    ID_ERRORS=$((ID_ERRORS + 1))
+  elif ! cmp -s "$f" "$pre"; then
+    ID_ERRORS=$((ID_ERRORS + 1))
+  fi
+done < <(find "$WORK_DIR" -type f 2>/dev/null)
+# Also count files removed (in pre but missing in work).
+while IFS= read -r f; do
+  rel="${f#${PRE_SNAPSHOT}/}"
+  [[ ! -f "${WORK_DIR}/${rel}" ]] && ID_ERRORS=$((ID_ERRORS + 1))
+done < <(find "$PRE_SNAPSHOT" -type f 2>/dev/null)
 
 # Edit-correctness errors: 0 if acceptance passed, else 1 (binary). The
-# acceptance script's exit code is the canonical signal; a richer count
-# would require a per-task contract beyond v1 of this adapter.
+# acceptance / compile exit code is the canonical signal; a richer count
+# would require per-task contract structure beyond v1 of this adapter.
 EDIT_ERRORS=0
 [[ "$SUCCESS" == "false" ]] && EDIT_ERRORS=1
 

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-01-multi-function-refactor/acceptance.sh
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-01-multi-function-refactor/acceptance.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# task-01 acceptance: exit 0 iff the four required functions exist and
+# Calculate's body invokes all three helpers.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="${1:-${HERE}/setup}"
+F="${WORK}/Math.calr"
+
+[ -f "$F" ] || { echo "missing: $F"; exit 1; }
+
+for name in Calculate ValidateInput ScaleInput RunningTotal; do
+  if ! grep -E "§F\{[^}]*:${name}:" "$F" > /dev/null; then
+    echo "missing function: $name"
+    exit 1
+  fi
+done
+
+# Calculate body must invoke all three helpers via §C{Helper}.
+calc_body="$(awk '/§F\{[^}]*:Calculate:/,/§\/F/' "$F")"
+for helper in ValidateInput ScaleInput RunningTotal; do
+  if ! echo "$calc_body" | grep -E "§C\{${helper}\}" > /dev/null; then
+    echo "Calculate does not invoke helper: $helper"
+    exit 1
+  fi
+done
+echo "task-01 PASS"

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-01-multi-function-refactor/expected/Math.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-01-multi-function-refactor/expected/Math.calr
@@ -1,0 +1,35 @@
+§M{m001:MathOps}
+
+§F{f001:Calculate:pub}
+  §I{i32:val}
+  §I{i32:prior}
+  §O{i32}
+  §Q (>= val 0)
+  §S (>= result prior)
+  §B{validated} §C{ValidateInput} §A val §/C
+  §B{scaled} §C{ScaleInput} §A validated §/C
+  §B{total} §C{RunningTotal} §A scaled §A prior §/C
+  §R total
+§/F{f001}
+
+§F{f002:ValidateInput:pub}
+  §I{i32:val}
+  §O{i32}
+  §Q (>= val 0)
+  §R val
+§/F{f002}
+
+§F{f003:ScaleInput:pub}
+  §I{i32:val}
+  §O{i32}
+  §R (* val 2)
+§/F{f003}
+
+§F{f004:RunningTotal:pub}
+  §I{i32:scaled}
+  §I{i32:prior}
+  §O{i32}
+  §R (+ scaled prior)
+§/F{f004}
+
+§/M{m001}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-01-multi-function-refactor/setup/Math.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-01-multi-function-refactor/setup/Math.calr
@@ -1,0 +1,15 @@
+§M{m001:MathOps}
+
+§F{f001:Calculate:pub}
+  §I{i32:val}
+  §I{i32:prior}
+  §O{i32}
+  §Q (>= val 0)
+  §S (>= result prior)
+  §B{validated} val
+  §B{scaled} (* validated 2)
+  §B{total} (+ scaled prior)
+  §R total
+§/F{f001}
+
+§/M{m001}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-01-multi-function-refactor/task.md
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-01-multi-function-refactor/task.md
@@ -1,0 +1,38 @@
+# task-01: Multi-function refactor
+
+## Prompt to the agent
+
+The file `setup/Math.calr` contains a single function `Calculate` that
+performs three logically distinct operations: validate the input, scale
+it, and compute a running total. Refactor it into three smaller
+functions in the same module:
+
+1. `ValidateInput(val: i32) → i32` — returns the validated input or
+   throws if it is negative.
+2. `ScaleInput(val: i32) → i32` — returns `val * 2`.
+3. `RunningTotal(scaled: i32, prior: i32) → i32` — returns
+   `scaled + prior`.
+
+Then replace `Calculate`'s body so it calls the three helpers in order.
+The signature and contracts of `Calculate` MUST NOT change. All four
+functions live in the same module `MathOps`.
+
+## Acceptance
+
+`acceptance.sh` checks:
+- `setup/Math.calr` contains four functions named `Calculate`,
+  `ValidateInput`, `ScaleInput`, `RunningTotal`.
+- `Calculate` body invokes all three helpers via `§C{...}`.
+- The compiled C# round-trip is byte-identical to `expected/Math.calr`'s
+  compiled output for input `(val=5, prior=0) → 10`.
+
+## Why this stresses the ID system
+
+Phase 1: the agent must locate function-end positionally (no structural
+IDs). Phase 2: the three new function names need stable symbol IDs.
+This is the classic refactor-extract case at module scope.
+
+## Multi-edit qualifier
+
+≥5 distinct edit locations: one body rewrite + three new function
+declarations + module-boundary edits = ≥5 sites in one file.

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-02-add-db-effect/acceptance.sh
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-02-add-db-effect/acceptance.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# task-02 acceptance: all three functions declare §E{db}; no other
+# function picks up §E{db} accidentally.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="${1:-${HERE}/setup}"
+
+declare -A required=(
+  ["${WORK}/Db.calr"]="LoadUserSettings"
+  ["${WORK}/Service.calr"]="PrepareDashboard"
+  ["${WORK}/Web.calr"]="RenderHome"
+)
+
+for f in "${!required[@]}"; do
+  name="${required[$f]}"
+  [ -f "$f" ] || { echo "missing: $f"; exit 1; }
+  body="$(awk "/§F\\{[^}]*:${name}:/,/§\\/F/" "$f")"
+  if ! echo "$body" | grep -E '§E\{[^}]*\bdb\b[^}]*\}' > /dev/null; then
+    echo "$name in $f is missing §E{db}"
+    exit 1
+  fi
+done
+
+# No db effect should appear in functions OTHER than the three above.
+all_funcs_with_db="$(grep -h '§E{[^}]*\bdb\b[^}]*}' "${!required[@]}" \
+                     | grep -cE '§E\{[^}]*\bdb\b[^}]*\}' || true)"
+if [ "$all_funcs_with_db" -ne 3 ]; then
+  echo "expected exactly 3 §E{db} declarations across the 3 files, got $all_funcs_with_db"
+  exit 1
+fi
+
+echo "task-02 PASS"

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-02-add-db-effect/expected/Db.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-02-add-db-effect/expected/Db.calr
@@ -1,0 +1,10 @@
+§M{m001:DataAccess}
+
+§F{f001:LoadUserSettings:pub}
+  §I{i32:userId}
+  §O{str}
+  §E{db}
+  §R STR:"settings-stub"
+§/F{f001}
+
+§/M{m001}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-02-add-db-effect/expected/Service.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-02-add-db-effect/expected/Service.calr
@@ -1,0 +1,11 @@
+§M{m002:Services}
+
+§F{f002:PrepareDashboard:pub}
+  §I{i32:userId}
+  §O{str}
+  §E{db}
+  §B{settings} §C{LoadUserSettings} §A userId §/C
+  §R settings
+§/F{f002}
+
+§/M{m002}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-02-add-db-effect/expected/Web.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-02-add-db-effect/expected/Web.calr
@@ -1,0 +1,11 @@
+§M{m003:Web}
+
+§F{f003:RenderHome:pub}
+  §I{i32:userId}
+  §O{str}
+  §E{db}
+  §B{board} §C{PrepareDashboard} §A userId §/C
+  §R board
+§/F{f003}
+
+§/M{m003}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-02-add-db-effect/setup/Db.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-02-add-db-effect/setup/Db.calr
@@ -1,0 +1,9 @@
+§M{m001:DataAccess}
+
+§F{f001:LoadUserSettings:pub}
+  §I{i32:userId}
+  §O{str}
+  §R STR:"settings-stub"
+§/F{f001}
+
+§/M{m001}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-02-add-db-effect/setup/Service.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-02-add-db-effect/setup/Service.calr
@@ -1,0 +1,10 @@
+§M{m002:Services}
+
+§F{f002:PrepareDashboard:pub}
+  §I{i32:userId}
+  §O{str}
+  §B{settings} §C{LoadUserSettings} §A userId §/C
+  §R settings
+§/F{f002}
+
+§/M{m002}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-02-add-db-effect/setup/Web.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-02-add-db-effect/setup/Web.calr
@@ -1,0 +1,10 @@
+§M{m003:Web}
+
+§F{f003:RenderHome:pub}
+  §I{i32:userId}
+  §O{str}
+  §B{board} §C{PrepareDashboard} §A userId §/C
+  §R board
+§/F{f003}
+
+§/M{m003}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-02-add-db-effect/task.md
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-02-add-db-effect/task.md
@@ -1,0 +1,31 @@
+# task-02: Add `db` effect to function and 2 transitive callers
+
+## Prompt to the agent
+
+The function `LoadUserSettings` in `setup/Db.calr` performs a database
+read but does not declare the `db` effect. Its caller
+`PrepareDashboard` (in `setup/Service.calr`) calls
+`LoadUserSettings` and is itself called by `RenderHome` (in
+`setup/Web.calr`).
+
+Add the `db` effect to all three functions so the effect propagates
+correctly through the call chain. Do not change the function bodies
+or signatures otherwise.
+
+## Acceptance
+
+- All three functions declare `§E{db}` (possibly alongside other
+  effects already present).
+- No other function in the three files acquires `§E{db}` accidentally.
+
+## Why this stresses the ID system
+
+Cross-file symbol references: in Phase 2, callers reference compact
+IDs of `LoadUserSettings` and `PrepareDashboard`. Editing the effect
+declaration on three different functions in three files exercises
+multi-file edit patterns.
+
+## Multi-edit qualifier
+
+3 files × 1 edit per file = 3 files, 3 sites. Meets the "≥3 files OR
+≥5 sites" criterion via the ≥3 files branch.

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/acceptance.sh
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/acceptance.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# task-03 acceptance.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="${1:-${HERE}/setup}"
+
+T="${WORK}/TaxCalc.calr"
+O="${WORK}/Order.calr"
+I="${WORK}/Invoice.calr"
+R="${WORK}/Receipt.calr"
+for f in "$T" "$O" "$I" "$R"; do
+  [ -f "$f" ] || { echo "missing: $f"; exit 1; }
+done
+
+# ComputeTax must be pub.
+if ! grep -E '§F\{[^}]*:ComputeTax:pub\b' "$T" > /dev/null; then
+  echo "ComputeTax not declared pub in TaxCalc.calr"
+  exit 1
+fi
+
+# ComputeTaxWrapper must be gone.
+if grep -E '§F\{[^}]*:ComputeTaxWrapper:' "$T" > /dev/null; then
+  echo "ComputeTaxWrapper still present in TaxCalc.calr"
+  exit 1
+fi
+
+# Each caller file: contains §C{ComputeTax}, contains NO §C{ComputeTaxWrapper}.
+for f in "$O" "$I" "$R"; do
+  if ! grep -E '§C\{ComputeTax\}' "$f" > /dev/null; then
+    echo "no §C{ComputeTax} in $f"
+    exit 1
+  fi
+  if grep -E '§C\{ComputeTaxWrapper\}' "$f" > /dev/null; then
+    echo "still references §C{ComputeTaxWrapper} in $f"
+    exit 1
+  fi
+done
+
+# Total ComputeTax call sites across callers == 5.
+total="$(grep -hcE '§C\{ComputeTax\}' "$O" "$I" "$R" | paste -sd+ - | bc 2>/dev/null \
+         || grep -hcE '§C\{ComputeTax\}' "$O" "$I" "$R" | awk '{s+=$1} END{print s}')"
+if [ "$total" -ne 5 ]; then
+  echo "expected 5 §C{ComputeTax} calls across callers, got $total"
+  exit 1
+fi
+
+echo "task-03 PASS"

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/expected/Invoice.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/expected/Invoice.calr
@@ -1,0 +1,17 @@
+§M{m003:Invoice}
+
+§F{f004:InvoiceLine:pub}
+  §I{i32:price}
+  §O{i32}
+  §B{t} §C{ComputeTax} §A price §/C
+  §R (+ price t)
+§/F{f004}
+
+§F{f005:InvoiceFooter:pub}
+  §I{i32:subtotal}
+  §O{i32}
+  §B{t} §C{ComputeTax} §A subtotal §/C
+  §R t
+§/F{f005}
+
+§/M{m003}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/expected/Order.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/expected/Order.calr
@@ -1,0 +1,11 @@
+§M{m002:Order}
+
+§F{f003:OrderTotal:pub}
+  §I{i32:price}
+  §O{i32}
+  §B{t1} §C{ComputeTax} §A price §/C
+  §B{t2} §C{ComputeTax} §A price §/C
+  §R (+ price (+ t1 t2))
+§/F{f003}
+
+§/M{m002}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/expected/Receipt.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/expected/Receipt.calr
@@ -1,0 +1,10 @@
+§M{m004:Receipt}
+
+§F{f006:ReceiptTotal:pub}
+  §I{i32:gross}
+  §O{i32}
+  §B{t} §C{ComputeTax} §A gross §/C
+  §R (- gross t)
+§/F{f006}
+
+§/M{m004}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/expected/TaxCalc.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/expected/TaxCalc.calr
@@ -1,0 +1,9 @@
+§M{m001:TaxCalc}
+
+§F{f001:ComputeTax:pub}
+  §I{i32:amount}
+  §O{i32}
+  §R (/ amount 10)
+§/F{f001}
+
+§/M{m001}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/setup/Invoice.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/setup/Invoice.calr
@@ -1,0 +1,17 @@
+§M{m003:Invoice}
+
+§F{f004:InvoiceLine:pub}
+  §I{i32:price}
+  §O{i32}
+  §B{t} §C{ComputeTaxWrapper} §A price §/C
+  §R (+ price t)
+§/F{f004}
+
+§F{f005:InvoiceFooter:pub}
+  §I{i32:subtotal}
+  §O{i32}
+  §B{t} §C{ComputeTaxWrapper} §A subtotal §/C
+  §R t
+§/F{f005}
+
+§/M{m003}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/setup/Order.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/setup/Order.calr
@@ -1,0 +1,11 @@
+§M{m002:Order}
+
+§F{f003:OrderTotal:pub}
+  §I{i32:price}
+  §O{i32}
+  §B{t1} §C{ComputeTaxWrapper} §A price §/C
+  §B{t2} §C{ComputeTaxWrapper} §A price §/C
+  §R (+ price (+ t1 t2))
+§/F{f003}
+
+§/M{m002}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/setup/Receipt.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/setup/Receipt.calr
@@ -1,0 +1,10 @@
+§M{m004:Receipt}
+
+§F{f006:ReceiptTotal:pub}
+  §I{i32:gross}
+  §O{i32}
+  §B{t} §C{ComputeTaxWrapper} §A gross §/C
+  §R (- gross t)
+§/F{f006}
+
+§/M{m004}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/setup/TaxCalc.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/setup/TaxCalc.calr
@@ -1,0 +1,16 @@
+§M{m001:TaxCalc}
+
+§F{f001:ComputeTax:prv}
+  §I{i32:amount}
+  §O{i32}
+  §R (/ amount 10)
+§/F{f001}
+
+§F{f002:ComputeTaxWrapper:pub}
+  §I{i32:amount}
+  §O{i32}
+  §B{t} §C{ComputeTax} §A amount §/C
+  §R t
+§/F{f002}
+
+§/M{m001}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/task.md
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-03-privacy-change/task.md
@@ -1,0 +1,33 @@
+# task-03: Change a method from `prv` to `pub` and update 5 call sites
+
+## Prompt to the agent
+
+The method `ComputeTax` in `setup/TaxCalc.calr` is declared `prv`
+(private). Five call sites across three other files
+(`setup/Order.calr`, `setup/Invoice.calr`, `setup/Receipt.calr`)
+incorrectly attempt to call `ComputeTax` and currently rely on a
+workaround (a public wrapper named `ComputeTaxWrapper`).
+
+Change `ComputeTax` to `pub` and update all 5 call sites to call
+`ComputeTax` directly. Delete the now-unused `ComputeTaxWrapper`
+function from `TaxCalc.calr`.
+
+## Acceptance
+
+- `ComputeTax` is declared `pub` in `TaxCalc.calr`.
+- `ComputeTaxWrapper` no longer exists in `TaxCalc.calr`.
+- `Order.calr`, `Invoice.calr`, and `Receipt.calr` each contain at
+  least one `§C{ComputeTax}` and no `§C{ComputeTaxWrapper}`.
+- Total `§C{ComputeTax}` calls across the three callers == 5.
+
+## Why this stresses the ID system
+
+Tests cross-file identity. In Phase 2, callers reference compact IDs
+of `ComputeTax`. The wrapper deletion forces the agent to update all
+sites correctly; a missed site would either compile-fail or change
+semantics.
+
+## Multi-edit qualifier
+
+3 caller files × variable sites + 1 visibility change + 1 deletion =
+≥6 sites across ≥4 files.

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-04-add-postcondition/acceptance.sh
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-04-add-postcondition/acceptance.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# task-04 acceptance.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="${1:-${HERE}/setup}"
+
+S="${WORK}/Score.calr"
+B="${WORK}/Bounds.calr"
+[ -f "$S" ] || { echo "missing: $S"; exit 1; }
+[ -f "$B" ] || { echo "missing: $B"; exit 1; }
+
+clamp_score_body="$(awk '/§F\{[^}]*:ClampScore:/,/§\/F/' "$S")"
+clamp_lower_body="$(awk '/§F\{[^}]*:ClampLowerBound:/,/§\/F/' "$S")"
+
+echo "$clamp_score_body" | grep -Fq '§Q (>= max 0)' \
+  || { echo "ClampScore missing §Q (>= max 0)"; exit 1; }
+echo "$clamp_score_body" | grep -Fq '§S (<= result max)' \
+  || { echo "ClampScore missing §S (<= result max)"; exit 1; }
+echo "$clamp_lower_body" | grep -Fq '§S (>= result 0)' \
+  || { echo "ClampLowerBound missing §S (>= result 0)"; exit 1; }
+
+# BoundsCheck must be untouched (contain the two §C calls).
+grep -Fq '§C{ClampScore}' "$B" \
+  || { echo "BoundsCheck no longer references ClampScore"; exit 1; }
+grep -Fq '§C{ClampLowerBound}' "$B" \
+  || { echo "BoundsCheck no longer references ClampLowerBound"; exit 1; }
+
+echo "task-04 PASS"

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-04-add-postcondition/expected/Bounds.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-04-add-postcondition/expected/Bounds.calr
@@ -1,0 +1,12 @@
+§M{m002:Bounds}
+
+§F{f003:BoundsCheck:pub}
+  §I{i32:val}
+  §I{i32:cap}
+  §O{i32}
+  §B{lo} §C{ClampLowerBound} §A val §/C
+  §B{hi} §C{ClampScore} §A lo §A cap §/C
+  §R hi
+§/F{f003}
+
+§/M{m002}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-04-add-postcondition/expected/Score.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-04-add-postcondition/expected/Score.calr
@@ -1,0 +1,21 @@
+§M{m001:Scoring}
+
+§F{f001:ClampScore:pub}
+  §I{i32:score}
+  §I{i32:max}
+  §O{i32}
+  §Q (>= max 0)
+  §S (<= result max)
+  §IF{i1} (> score max) → §R max
+  §R score
+§/F{f001}
+
+§F{f002:ClampLowerBound:pub}
+  §I{i32:val}
+  §O{i32}
+  §S (>= result 0)
+  §IF{i2} (< val 0) → §R 0
+  §R val
+§/F{f002}
+
+§/M{m001}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-04-add-postcondition/setup/Bounds.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-04-add-postcondition/setup/Bounds.calr
@@ -1,0 +1,12 @@
+§M{m002:Bounds}
+
+§F{f003:BoundsCheck:pub}
+  §I{i32:val}
+  §I{i32:cap}
+  §O{i32}
+  §B{lo} §C{ClampLowerBound} §A val §/C
+  §B{hi} §C{ClampScore} §A lo §A cap §/C
+  §R hi
+§/F{f003}
+
+§/M{m002}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-04-add-postcondition/setup/Score.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-04-add-postcondition/setup/Score.calr
@@ -1,0 +1,18 @@
+§M{m001:Scoring}
+
+§F{f001:ClampScore:pub}
+  §I{i32:score}
+  §I{i32:max}
+  §O{i32}
+  §IF{i1} (> score max) → §R max
+  §R score
+§/F{f001}
+
+§F{f002:ClampLowerBound:pub}
+  §I{i32:val}
+  §O{i32}
+  §IF{i2} (< val 0) → §R 0
+  §R val
+§/F{f002}
+
+§/M{m001}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-04-add-postcondition/task.md
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-04-add-postcondition/task.md
@@ -1,0 +1,36 @@
+# task-04: Add a postcondition referencing a parameter
+
+## Prompt to the agent
+
+The function `ClampScore` in `setup/Score.calr` should never return a
+value greater than the `max` parameter. Add a postcondition expressing
+this property. The function body already enforces the invariant; the
+task is to make the contract explicit so the compiler can verify it
+(per Calor's `§S` postcondition syntax).
+
+Also add a precondition that `max` is non-negative, since negative
+caps are nonsensical.
+
+The function `ClampLowerBound` in the same file should never return a
+value less than 0. Add the corresponding postcondition there as well.
+
+A third function, `BoundsCheck`, exists in `setup/Bounds.calr` and
+calls both `ClampScore` and `ClampLowerBound`. Verify it still
+compiles by leaving it untouched.
+
+## Acceptance
+
+- `ClampScore` declares `§Q (>= max 0)` and `§S (<= result max)`.
+- `ClampLowerBound` declares `§S (>= result 0)`.
+- `BoundsCheck` is unchanged.
+
+## Why this stresses the ID system
+
+Tests contract-to-function symbol-ID references. In Phase 2, a
+contract on a function whose body invokes other compact-ID-bearing
+functions stresses the IdRegistry lookup path.
+
+## Multi-edit qualifier
+
+3 contract additions across 1 file + 1 cross-file verification = 4
+sites, 2 files.

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-05-loop-restructure/acceptance.sh
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-05-loop-restructure/acceptance.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# task-05 acceptance.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="${1:-${HERE}/setup}"
+
+F="${WORK}/Grid.calr"
+[ -f "$F" ] || { echo "missing: $F"; exit 1; }
+
+# SumPlane must exist with the right signature.
+grep -E '§F\{[^}]*:SumPlane:' "$F" > /dev/null \
+  || { echo "SumPlane not found"; exit 1; }
+sumplane_body="$(awk '/§F\{[^}]*:SumPlane:/,/§\/F/' "$F")"
+echo "$sumplane_body" | grep -Fq '§I{i32:x}' \
+  || { echo "SumPlane missing §I{i32:x}"; exit 1; }
+echo "$sumplane_body" | grep -Fq '§I{i32:size}' \
+  || { echo "SumPlane missing §I{i32:size}"; exit 1; }
+echo "$sumplane_body" | grep -Fq '§O{i32}' \
+  || { echo "SumPlane missing §O{i32}"; exit 1; }
+
+# SumGrid must have exactly one §L{...} (the outer x loop).
+sumgrid_body="$(awk '/§F\{[^}]*:SumGrid:/,/§\/F/' "$F")"
+loop_count="$(echo "$sumgrid_body" | grep -cE '§L\{')"
+if [ "$loop_count" -ne 1 ]; then
+  echo "expected exactly 1 §L in SumGrid, got $loop_count"
+  exit 1
+fi
+
+# SumGrid must invoke SumPlane.
+echo "$sumgrid_body" | grep -Fq '§C{SumPlane}' \
+  || { echo "SumGrid does not invoke §C{SumPlane}"; exit 1; }
+
+echo "task-05 PASS"

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-05-loop-restructure/expected/Grid.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-05-loop-restructure/expected/Grid.calr
@@ -1,0 +1,27 @@
+§M{m001:GridOps}
+
+§F{f001:SumGrid:pub}
+  §I{i32:size}
+  §O{i32}
+  §B{~total} INT:0
+  §L{l1:x:0:size:1}
+    §B{plane} §C{SumPlane} §A x §A size §/C
+    §B{~total} (+ total plane)
+  §/L{l1}
+  §R total
+§/F{f001}
+
+§F{f002:SumPlane:pub}
+  §I{i32:x}
+  §I{i32:size}
+  §O{i32}
+  §B{~sum} INT:0
+  §L{l2:y:0:size:1}
+    §L{l3:z:0:size:1}
+      §B{~sum} (+ sum (+ x (+ y z)))
+    §/L{l3}
+  §/L{l2}
+  §R sum
+§/F{f002}
+
+§/M{m001}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-05-loop-restructure/setup/Grid.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-05-loop-restructure/setup/Grid.calr
@@ -1,0 +1,17 @@
+§M{m001:GridOps}
+
+§F{f001:SumGrid:pub}
+  §I{i32:size}
+  §O{i32}
+  §B{~total} INT:0
+  §L{l1:x:0:size:1}
+    §L{l2:y:0:size:1}
+      §L{l3:z:0:size:1}
+        §B{~total} (+ total (+ x (+ y z)))
+      §/L{l3}
+    §/L{l2}
+  §/L{l1}
+  §R total
+§/F{f001}
+
+§/M{m001}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-05-loop-restructure/task.md
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-05-loop-restructure/task.md
@@ -1,0 +1,31 @@
+# task-05: Restructure nested 3-level loop into a helper function
+
+## Prompt to the agent
+
+The function `SumGrid` in `setup/Grid.calr` contains a nested 3-level
+loop computing the sum of all elements in a 3D virtual grid
+`(x, y, z)` where each dimension is bounded by `size`. Extract the
+innermost two loops (the `y`/`z` planes) into a helper function
+`SumPlane(x: i32, size: i32) → i32` and have `SumGrid` call that
+helper inside its single remaining outer loop.
+
+The result of `SumGrid(size)` must be unchanged.
+
+## Acceptance
+
+- A new function `SumPlane` exists with signature
+  `(x: i32, size: i32) → i32`.
+- `SumGrid` contains exactly one `§L{...}` loop.
+- `SumGrid` invokes `§C{SumPlane}` inside its loop body.
+
+## Why this stresses the ID system
+
+Structural restructure: tests that without structural IDs, the agent
+can still navigate by name and position. The agent must understand
+where a `§L` block ends to extract it.
+
+## Multi-edit qualifier
+
+1 new function + 1 body rewrite + 2 loop deletions = 4 sites in 1
+file. Meets the "≥5 distinct locations within a file" relaxation only
+loosely; consider this borderline if PR-0c finds it too easy.

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-06-error-handling/acceptance.sh
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-06-error-handling/acceptance.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# task-06 acceptance.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="${1:-${HERE}/setup}"
+
+P="${WORK}/Pipeline.calr"
+R="${WORK}/Remote.calr"
+[ -f "$P" ] || { echo "missing: $P"; exit 1; }
+[ -f "$R" ] || { echo "missing: $R"; exit 1; }
+
+body="$(awk '/§F\{[^}]*:FetchAndStore:/,/§\/F/' "$P")"
+
+echo "$body" | grep -qE '§TR\{' || { echo "missing §TR{...} block"; exit 1; }
+echo "$body" | grep -Fq '§C{FetchRemote}' \
+  || { echo "FetchRemote call removed from try body"; exit 1; }
+echo "$body" | grep -Fq '§C{WriteRecord}' \
+  || { echo "WriteRecord call removed from try body"; exit 1; }
+echo "$body" | grep -qE '§CA\{NetworkError' \
+  || { echo "missing §CA{NetworkError:...}"; exit 1; }
+echo "$body" | grep -qE '§CA\{IoError' \
+  || { echo "missing §CA{IoError:...}"; exit 1; }
+echo "$body" | grep -qE '§FI\b' || { echo "missing §FI clause"; exit 1; }
+
+# In the finally block, must assign ~closed to BOOL:true.
+finally_body="$(echo "$body" | awk '/§FI/,/§\/TR/')"
+echo "$finally_body" | grep -Fq '§B{~closed} BOOL:true' \
+  || { echo "§FI must contain §B{~closed} BOOL:true"; exit 1; }
+
+# Remote.calr must be byte-identical to its setup version (untouched).
+expected_remote_hash="$(sha1sum "${HERE}/setup/Remote.calr" | awk '{print $1}')"
+actual_remote_hash="$(sha1sum "$R" | awk '{print $1}')"
+if [ "$expected_remote_hash" != "$actual_remote_hash" ]; then
+  echo "Remote.calr was modified; it should remain untouched"
+  exit 1
+fi
+
+echo "task-06 PASS"

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-06-error-handling/expected/Pipeline.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-06-error-handling/expected/Pipeline.calr
@@ -1,0 +1,21 @@
+§M{m001:Pipeline}
+
+§F{f001:FetchAndStore:pub}
+  §I{str:url}
+  §O{i32}
+  §B{~closed} BOOL:false
+  §TR{t1}
+    §B{data} §C{FetchRemote} §A url §/C
+    §B{rc} §C{WriteRecord} §A data §/C
+    §R rc
+  §CA{NetworkError:ne}
+    §R INT:-1
+  §CA{IoError:ie}
+    §R INT:-2
+  §FI
+    §B{~closed} BOOL:true
+  §/TR{t1}
+  §R INT:0
+§/F{f001}
+
+§/M{m001}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-06-error-handling/expected/Remote.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-06-error-handling/expected/Remote.calr
@@ -1,0 +1,17 @@
+§M{m002:Remote}
+
+§F{f002:FetchRemote:pub}
+  §I{str:url}
+  §O{str}
+  §E{net}
+  §R STR:"payload"
+§/F{f002}
+
+§F{f003:WriteRecord:pub}
+  §I{str:data}
+  §O{i32}
+  §E{db}
+  §R INT:0
+§/F{f003}
+
+§/M{m002}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-06-error-handling/setup/Pipeline.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-06-error-handling/setup/Pipeline.calr
@@ -1,0 +1,12 @@
+§M{m001:Pipeline}
+
+§F{f001:FetchAndStore:pub}
+  §I{str:url}
+  §O{i32}
+  §B{~closed} BOOL:false
+  §B{data} §C{FetchRemote} §A url §/C
+  §B{rc} §C{WriteRecord} §A data §/C
+  §R rc
+§/F{f001}
+
+§/M{m001}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-06-error-handling/setup/Remote.calr
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-06-error-handling/setup/Remote.calr
@@ -1,0 +1,17 @@
+§M{m002:Remote}
+
+§F{f002:FetchRemote:pub}
+  §I{str:url}
+  §O{str}
+  §E{net}
+  §R STR:"payload"
+§/F{f002}
+
+§F{f003:WriteRecord:pub}
+  §I{str:data}
+  §O{i32}
+  §E{db}
+  §R INT:0
+§/F{f003}
+
+§/M{m002}

--- a/tests/E2E/agent-tasks/templates/path-2-gate/task-06-error-handling/task.md
+++ b/tests/E2E/agent-tasks/templates/path-2-gate/task-06-error-handling/task.md
@@ -1,0 +1,38 @@
+# task-06: Add try/catch around an effectful call chain
+
+## Prompt to the agent
+
+The function `FetchAndStore` in `setup/Pipeline.calr` calls
+`§C{FetchRemote}` (which may throw `NetworkError`) followed by
+`§C{WriteRecord}` (which may throw `IoError`). Wrap the entire call
+chain in a single `§TR` (try) block that catches `NetworkError` and
+`IoError` separately and returns an error code:
+
+- Catch `NetworkError`: return `-1`.
+- Catch `IoError`: return `-2`.
+- Add a `§FI` (finally) block that always sets the binding
+  `~closed` to `true`.
+
+The binding `~closed` already exists (initialized to `false` at the
+top of the function). Do not change the signatures of `FetchRemote`
+or `WriteRecord` in `setup/Remote.calr`.
+
+## Acceptance
+
+- `FetchAndStore` body contains a `§TR{...}` block.
+- The try block contains both `§C{FetchRemote}` and `§C{WriteRecord}`.
+- Two `§CA` clauses: one for `NetworkError` returning `-1`, one for
+  `IoError` returning `-2`.
+- One `§FI` clause containing an assignment to `~closed` with value
+  `BOOL:true`.
+
+## Why this stresses the ID system
+
+New structural blocks added; Phase 1 stresses positional vs. ID-based
+block identification. The try-block wraps multiple existing call
+sites, exercising the rewrite-around-existing-code pattern.
+
+## Multi-edit qualifier
+
+1 new try-catch-finally block wrapping 2 calls in 1 file, plus
+verifying 1 other file unchanged = 4 sites, 2 files.


### PR DESCRIPTION
## Why this PR exists

This is the **docs-only pre-registration PR** for the v6 ID-redesign Phase 2 statistical gate (RFC §10). It lands the immutable pre-registration artifacts on `main` so the §10 gate can be kicked off without violating RFC §10.5's immutability discipline.

**This PR contains NO Phase 1 or Phase 2 implementation code.** The Calor compiler still emits and verifies the v0.5.0 ID format unchanged. Phase 1 lives at `release/phase-1-only`; Phase 2 lives at `feature/compact-ids-v6`. The gate compares them against `main` (Arm A) only after this PR merges.

## What ships here

### Pre-registration documents
- `docs/plans/path-2-drop-ids.md` — original RFC (v0)
- `docs/plans/path-2-drop-ids-v5.md` — the RFC under which the gate runs
- `docs/plans/path-2-drop-ids-v6-implementation.md` — implementation plan
- `docs/plans/phase-2-measurement-protocol.md` — protocol v1
- `docs/plans/phase-2-measurement-protocol-v2.md` — **protocol v2 (governing)** — supersedes v1's §1 substrate enumeration and §10.1.a kickoff CLI to fix the substrate gap (see below)
- `docs/plans/phase-2-validation-criteria.md` — §1 mechanical gates + §8 readiness audit
- `docs/plans/phase-1-2-scope-decisions.md` — scope choices documented for audit

### Gate substrate
- `tests/E2E/agent-tasks/phase-2-gate-tasks.txt` — **30-trial manifest** (24 stratified `task:` rows + 6 `template:` rows)
- `tests/E2E/agent-tasks/templates/path-2-gate/` — the 6 purpose-built `template:` trials
- `tests/E2E/agent-tasks/run.sh` — harness adapter (kind=task / kind=template paths)
- `scripts/run_phase_2_gate.py` — gate driver (reads manifest, dispatches adapter)
- `scripts/analyze_gate_results.py` — analyser (already on main? cherry-picked if not)
- `scripts/verify_phase1.py`, `scripts/ast_roundtrip_check.py`, etc. — Tier 1 self-verification harnesses
- `scripts/smoke_phase_2_gate_dryrun.py` — CI plumbing test

### Process
- `docs/process/rfc-review-checklist.md` — grep-verify rule for RFC claims

### Sample fixes
- `samples/TypeSystem/typesystem.calr` — `§SOME`/`§NONE` → `§SM`/`§NN`
- `samples/Verification/*.calr` — strip `§DOC{…}`, `§ELSE` → `§EL`, `§/IF{id}` → `§/I{id}`

## The substrate gap (why protocol v2 exists)

Protocol v1 §1.1 enumerated 30 "fixtures" but 24 of them were workspace skeletons with no runnable task contract. Empirical dry-run: **72 / 90 (80%)** of records carried `harness_error="no_task_contract"` — the gate would have spent 80% of its $2-4k budget on no-ops.

Protocol v2 fixes this by:
1. Introducing an explicit trial manifest (24 stratified `task:` rows + 6 `template:` rows)
2. Refactoring the driver to read the manifest and dispatch the adapter with both `--task-dir` and `--fixture-dir`
3. Strengthening the adapter to support both `task:` (uses `task.json` + fixture workspace) and `template:` (uses `task.md` + `setup/`) kinds

Verified empirically on this branch: **0 / 90** substrate-noise records after refactor.

## Verification

- `python scripts/verify_phase1.py`: ✅ Tier 1 OK (52.0s, budget 60s)
- `python scripts/ast_roundtrip_check.py samples`: ✅ all fixtures OK
- `python scripts/smoke_phase_2_gate_dryrun.py`: ✅ gate-pass/gate-fail pipeline OK
- Driver end-to-end via `CALOR_GATE_DRY_RUN=1` with all 3 arm refs (`main`, `release/phase-1-only`, `feature/compact-ids-v6`): 90 records, 0 `harness_crash`, 0 `no_task_contract`

## After this merges

The §10 gate becomes runnable once the maintainer:
1. Authorises ~$2-4k LLM spend
2. Picks a pinned, immutable model id
3. Schedules the 4-hour monitoring tick
4. Completes the v6 §9.c solo-mode 24h sign-off

At that point the kickoff command in `phase-2-measurement-protocol-v2.md` §10.1.a is one shell line.

**See `docs/plans/phase-2-validation-criteria.md` §8 for the live readiness audit.**

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
