### PR TITLE
Ship Phase 1: optional closing-tag IDs + calor fix migration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,13 +71,13 @@ All paths relative to `src/Calor.Compiler/`.
 ## Calor Syntax Quick Reference
 
 ```
-§M{id:Name}              Module (close: §/M{id})
-§F{id:name:retType:vis}   Function (close: §/F{id})
+§M{id:Name}              Module (close: §/M)
+§F{id:name:retType:vis}   Function (close: §/F)
 §B{name:type}             Immutable binding
 §B{~name:type}            Mutable binding
-§L{id:var:from:to:step}   For loop (close: §/L{id})
+§L{id:var:from:to:step}   For loop (close: §/L)
 §IF{id} (cond) → §R expr  Inline if-return
-§IF{id} (cond) ... §/I{id} Block if (close: §/I NOT §/IF)
+§IF{id} (cond) ... §/I    Block if (close: §/I NOT §/IF)
 §EI (cond)                 ElseIf
 §EL                        Else
 §C{object.method} §A arg §/C  Method call with argument
@@ -88,7 +88,11 @@ All paths relative to `src/Calor.Compiler/`.
 
 **Typed literals:** `INT:42`, `STR:"hello"`, `BOOL:true`, `FLOAT:3.14`
 
-**Critical:** Closing tags use abbreviated forms — `§/I` (not `§/IF`), `§/M`, `§/F`, `§/L`.
+**Closing tags:**
+- Abbreviated form: `§/I` (not `§/IF`), `§/M`, `§/F`, `§/L`.
+- IDs on closing tags are **optional**. `§/M` and `§/M{m001}` both parse; the parser
+  pairs closers by structural nesting. Drop legacy IDs in bulk with
+  `calor fix --drop-structural-ids <root>`. Legacy closers lint as `Calor0820`.
 
 ## Adding New AST Nodes — Checklist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Optional closing-tag IDs** — Structural closing tags (`§/M`, `§/F`, `§/AF`, `§/L`, `§/I`, `§/TR`, `§/CL`, `§/IN`, `§/PR`, `§/MT`) may now omit the trailing `{id}` block. Both forms are accepted side-by-side; the parser pairs closers with their nearest matching opener by structural nesting. Openers continue to carry IDs as before.
+- **`calor fix --drop-structural-ids <root>`** — Bulk, mechanical, byte-reversible source rewriter that strips `{id}` from structural closing tags (and the leading `{id:…}` from openers when the rest can be preserved). Records every removal in a `migration.log.json` and supports `--revert --log <file>` to restore the original bytes exactly. Only touches values that look like production IDs (`prefix_payload` with a 12-char compact or 26-char ULID payload); short test IDs like `m001` are left alone. See [`docs/cli/fix.md`](docs/cli/fix.md).
+- **`Calor0820 LegacyStructuralId`** — Opt-in lint that flags closing tags still carrying a production-ID payload, with a `fix` patch that points at `calor fix --drop-structural-ids`.
+- **`BytePreservationVerifier`** — Migration utility that verifies a rewrite plus its revert reproduces the original file byte-for-byte. Used by the integration tests for `calor fix`.
+
+### Documentation
+- New: `docs/cli/fix.md`.
+- Updated: `docs/syntax-reference/structure-tags.md`, `docs/syntax-reference/index.md`, `docs/ids.md`, `docs/cli/index.md` reflect the optional closing-tag ID and the new `calor fix` command.
+
 ## [0.5.0] - 2026-04-22
 
 ### Benchmark Results (Statistical: 30 runs)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,13 +71,13 @@ All paths relative to `src/Calor.Compiler/`.
 ## Calor Syntax Quick Reference
 
 ```
-§M{id:Name}              Module (close: §/M{id})
-§F{id:name:retType:vis}   Function (close: §/F{id})
+§M{id:Name}              Module (close: §/M)
+§F{id:name:retType:vis}   Function (close: §/F)
 §B{name:type}             Immutable binding
 §B{~name:type}            Mutable binding
-§L{id:var:from:to:step}   For loop (close: §/L{id})
+§L{id:var:from:to:step}   For loop (close: §/L)
 §IF{id} (cond) → §R expr  Inline if-return
-§IF{id} (cond) ... §/I{id} Block if (close: §/I NOT §/IF)
+§IF{id} (cond) ... §/I    Block if (close: §/I NOT §/IF)
 §EI (cond)                 ElseIf
 §EL                        Else
 §C{object.method} §A arg §/C  Method call with argument
@@ -88,7 +88,11 @@ All paths relative to `src/Calor.Compiler/`.
 
 **Typed literals:** `INT:42`, `STR:"hello"`, `BOOL:true`, `FLOAT:3.14`
 
-**Critical:** Closing tags use abbreviated forms — `§/I` (not `§/IF`), `§/M`, `§/F`, `§/L`.
+**Closing tags:**
+- Abbreviated form: `§/I` (not `§/IF`), `§/M`, `§/F`, `§/L`.
+- IDs on closing tags are **optional**. `§/M` and `§/M{m001}` both parse; the parser
+  pairs closers by structural nesting. Drop legacy IDs in bulk with
+  `calor fix --drop-structural-ids <root>`. Legacy closers lint as `Calor0820`.
 
 ## Adding New AST Nodes — Checklist
 

--- a/docs/cli/fix.md
+++ b/docs/cli/fix.md
@@ -1,0 +1,94 @@
+---
+layout: default
+title: calor fix
+parent: CLI Reference
+nav_order: 11
+---
+
+# calor fix
+
+`calor fix` applies **bulk, mechanically safe, byte-reversible** rewrites
+across every `.calr` file under a root directory.
+
+Each operation writes a `migration.log.json` that records the exact
+bytes it removed. Passing the log back with `--revert` restores the
+original file contents byte-for-byte.
+
+---
+
+## Subcommands
+
+| Flag | What it does |
+|:-----|:-------------|
+| `--drop-structural-ids` | Strip the `{id}` block from structural closing tags (`§/M{…}` → `§/M`, etc.). |
+| `--revert` | Reverse a prior `--drop-structural-ids` operation using `--log`. |
+| `--log <file>` | Write (without `--revert`) or read (with `--revert`) the migration log. |
+| `--dry-run`, `-n` | Report what would change without writing files. |
+
+---
+
+## `--drop-structural-ids`
+
+Structural closing-tag IDs (`§/M{m001}`, `§/F{f001}`, `§/L{for1}`,
+`§/I{if1}`, …) have been **optional** since v6+. Source written before
+that release still carries them. This subcommand removes them in bulk,
+leaving the openers (where IDs continue to live) untouched.
+
+```bash
+calor fix --drop-structural-ids src/                # rewrite in place
+calor fix --drop-structural-ids src/ --dry-run      # report only
+calor fix --drop-structural-ids src/ \
+    --log .calor/migration.log.json                 # also write a log
+```
+
+### What it rewrites
+
+The migrator targets only the recognized closing-tag shape and only
+when the contents inside `{…}` are an ID-shaped token (ULID-style,
+short test ID like `f001`, or compact). It leaves everything else
+alone — closing tags without an ID block are skipped (idempotent), and
+opening tags are never touched.
+
+### Output
+
+```
+drop-structural-ids: files_changed=42 removals=178
+wrote .calor/migration.log.json
+```
+
+Exit codes: `0` on success, `2` on usage error.
+
+---
+
+## Reverting
+
+```bash
+calor fix --drop-structural-ids src/ \
+    --revert --log .calor/migration.log.json
+```
+
+The revert re-inserts the removed byte ranges at their original
+offsets. The result is **byte-identical** to the pre-rewrite source —
+the `BytePreservationVerifier` covering the migrator's tests asserts
+exactly this property on every change.
+
+---
+
+## Why use it
+
+The closing-tag ID was redundant: the parser already knows which
+opener the closer is paired with via structural nesting. Dropping it
+shrinks files, removes a class of "I changed the opener ID but forgot
+the closer" bugs, and makes diffs smaller when IDs do change.
+
+If a closing-tag ID is left in source, the opt-in lint
+[`Calor0820 LegacyStructuralId`](/calor/ids/#9-diagnostics) flags it
+and emits a `fix` patch that points back at this command.
+
+---
+
+## See also
+
+- [ID Specification](/calor/ids/) — full rules for opener IDs.
+- [`calor ids`](/calor/cli/ids/) — check, assign, and re-index opener IDs.
+- [`calor format`](/calor/cli/format/) — canonicalize whitespace, attribute order, etc.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -41,6 +41,7 @@ dotnet tool update -g calor
 | [`calor ids`](/calor/cli/ids/) | Manage unique identifiers (check, assign, index) |
 | [`calor benchmark`](/calor/cli/benchmark/) | Compare Calor vs C# across evaluation metrics |
 | [`calor format`](/calor/cli/format/) | Format Calor source files to canonical style |
+| [`calor fix`](/calor/cli/fix/) | Bulk, reversible source rewrites (e.g. drop legacy closing-tag IDs) |
 | [`calor diagnose`](/calor/cli/diagnose/) | Output machine-readable diagnostics for tooling |
 | [`calor mcp`](/calor/cli/mcp/) | Start MCP server for AI agent tool integration |
 | `calor lsp` | Start Language Server Protocol server for IDE features |

--- a/docs/ids.md
+++ b/docs/ids.md
@@ -53,6 +53,34 @@ Some elements use local scope identifiers rather than global IDs:
 - If blocks (`§IF{if1}`) - scope-local
 - Call targets (`§C{target}`) - reference, not declaration
 
+### 2.2 Structural IDs Are Optional in v6+ (Phase 1)
+
+As of the v6 release, structural openers (`§M`, `§F`, `§AF`, `§L`,
+`§IF`, `§TR`, `§CL`, `§IN`, `§PR`, `§MT`) accept a **compact form**
+that omits the leading `{id:…}` block. The compiler infers an ID
+automatically. Both forms are accepted side-by-side; the legacy form
+remains valid.
+
+```calor
+§M{Calculator}              # compact form (v6+, recommended)
+§/M
+
+§M{m_01J5X7K9M2NPQRSTABWXYZ12:Calculator}   # legacy form (still valid)
+§/M{m_01J5X7K9M2NPQRSTABWXYZ12}
+```
+
+Existing repositories can migrate mechanically with:
+
+```bash
+calor fix --drop-structural-ids <root> --log migration.log.json
+```
+
+The migrator records every removed byte range in `migration.log.json`
+and can be reverted with `calor fix --drop-structural-ids --revert`.
+The opt-in lint **Calor0820** (`LegacyStructuralId`) flags any
+remaining legacy blocks. Phase 2 will introduce 12-char compact IDs
+(diagnostics **Calor0821** and **Calor0822**).
+
 ---
 
 ## 3. Canonical ID Format

--- a/docs/ids.md
+++ b/docs/ids.md
@@ -53,33 +53,45 @@ Some elements use local scope identifiers rather than global IDs:
 - If blocks (`§IF{if1}`) - scope-local
 - Call targets (`§C{target}`) - reference, not declaration
 
-### 2.2 Structural IDs Are Optional in v6+ (Phase 1)
+### 2.2 Structural IDs Are Optional in v6+
 
-As of the v6 release, structural openers (`§M`, `§F`, `§AF`, `§L`,
-`§IF`, `§TR`, `§CL`, `§IN`, `§PR`, `§MT`) accept a **compact form**
-that omits the leading `{id:…}` block. The compiler infers an ID
-automatically. Both forms are accepted side-by-side; the legacy form
-remains valid.
+As of v6, structural openers (`§M`, `§F`, `§AF`, `§L`,
+`§IF`, `§TR`, `§CL`, `§IFACE`, `§MT`, `§CTOR`, `§EN`)
+accept a **compact form** that omits the leading `{id:…}` block. The
+compiler auto-assigns an ID of the shape `<prefix>_auto<N>`.
+
+When the opener uses the compact form, the matching closing tag
+(`§/M`, `§/F`, `§/AF`, `§/L`, `§/I`, `§/TR`, `§/CL`, `§/IFACE`,
+`§/MT`, `§/CTOR`, `§/EN`) may also omit `{id}`. **The two sides are
+linked**: if the opener carries an explicit `{id:…}`, the closer must
+still carry the matching `{id}` (diagnostic `Calor0101` if they
+diverge). Both forms parse and are valid side-by-side:
 
 ```calor
-§M{Calculator}              # compact form (v6+, recommended)
+# Compact (recommended for new code)
+§M{Calculator}
 §/M
 
-§M{m_01J5X7K9M2NPQRSTABWXYZ12:Calculator}   # legacy form (still valid)
-§/M{m_01J5X7K9M2NPQRSTABWXYZ12}
+# Legacy (still accepted)
+§M{m_01j5x7k9m2npqrstabwxyz12:Calculator}
+§/M{m_01j5x7k9m2npqrstabwxyz12}
 ```
 
-Existing repositories can migrate mechanically with:
+Existing repositories can migrate mechanically with the
+[`calor fix --drop-structural-ids`](/calor/cli/fix/) command, which
+rewrites opener and closer together (and only touches values that
+look like production IDs — short test IDs like `m001` are left alone):
 
 ```bash
-calor fix --drop-structural-ids <root> --log migration.log.json
+calor fix --drop-structural-ids . --log migration.log.json
 ```
 
 The migrator records every removed byte range in `migration.log.json`
-and can be reverted with `calor fix --drop-structural-ids --revert`.
+and can be reverted byte-exactly with
+`calor fix --drop-structural-ids --revert --log migration.log.json .`.
 The opt-in lint **Calor0820** (`LegacyStructuralId`) flags any
-remaining legacy blocks. Phase 2 will introduce 12-char compact IDs
-(diagnostics **Calor0821** and **Calor0822**).
+remaining legacy closing-tag IDs and emits a `fix` patch that
+points at the `calor fix` command.
 
 ---
 
@@ -371,6 +383,7 @@ calor ids check .
 | Calor0802 | WrongIdPrefix | Error | ID prefix doesn't match kind |
 | Calor0803 | DuplicateId | Error | ID used for multiple declarations |
 | Calor0804 | TestIdInProduction | Error | Test ID (f001) in production code |
+| Calor0820 | LegacyStructuralId | Info (opt-in lint) | Closing tag still carries a `{id}` payload; suggests `calor fix --drop-structural-ids` |
 
 ---
 

--- a/docs/syntax-reference/index.md
+++ b/docs/syntax-reference/index.md
@@ -43,7 +43,7 @@ Complete reference for Calor syntax. Calor uses Lisp-style expressions for all o
 | Return | `§R expr` | `§R (+ a b)` |
 | Binding | `§B{name} expr` | `§B{x} (+ 1 2)` |
 | Operations | `(op args...)` | `(+ a b)`, `(== x 0)` |
-| Close tag | `§/X{id}` | `§/F{f001}` |
+| Close tag | `§/X` or `§/X{id}` | `§/F` (preferred), `§/F{f001}` |
 | List | `§LIST{id:type}` | `§LIST{nums:i32}` |
 | Dictionary | `§DICT{id:kType:vType}` | `§DICT{ages:str:i32}` |
 | HashSet | `§HSET{id:type}` | `§HSET{tags:str}` |
@@ -136,11 +136,14 @@ All operators use Lisp-style prefix notation: `(+ a b)`, `(&& x y)`, `(upper s)`
     §EI (== (% i 3) 0) → §P "Fizz"
     §EI (== (% i 5) 0) → §P "Buzz"
     §EL → §P i
-    §/I{if1}
-  §/L{for1}
-§/F{f001}
-§/M{m001}
+    §/I
+  §/L
+§/F
+§/M
 ```
+
+> Closing-tag IDs are optional for structural closers — see
+> [Structure Tags](/calor/syntax-reference/structure-tags/) for the rule.
 
 ---
 

--- a/docs/syntax-reference/structure-tags.md
+++ b/docs/syntax-reference/structure-tags.md
@@ -9,6 +9,17 @@ nav_order: 1
 
 Structure tags define the organization of Calor code: modules, functions, and their boundaries.
 
+> **Closing-tag IDs are optional when the opener omits its ID.** Since
+> v6+, the structural opener forms `§M{Name}`, `§F{Name:vis}`,
+> `§L{var:from:to}`, `§IF`, `§CL{Name}`, `§MT{Name:vis}`, etc. drop the
+> `id:` prefix and the parser auto-assigns an ID. Their closing tags
+> (`§/M`, `§/F`, `§/L`, `§/I`, `§/CL`, `§/MT`, …) may then also omit
+> `{id}`. If the opener carries an explicit `{id:…}`, the closer must
+> still match it (`§F{f001:Add:pub}` pairs with `§/F{f001}`). The
+> examples below use the compact form; bulk-migrate production code
+> with [`calor fix --drop-structural-ids`](/calor/cli/fix/), which
+> rewrites opener and closer together.
+
 ---
 
 ## Modules
@@ -18,24 +29,26 @@ Modules are like C# namespaces. They group related functions.
 ### Syntax
 
 ```
-§M{id:name}
+§M{name}
   // contents
-§/M{id}
+§/M
 ```
 
 ### Example
 
 ```
-§M{m001:Calculator}
+§M{Calculator}
   // functions go here
-§/M{m001}
+§/M
 ```
 
 ### Rules
 
-- `id` must be unique within the file
 - `name` becomes the C# namespace
-- Every `§M` must have a matching `§/M` with the same ID
+- Every `§M` must have a matching `§/M`
+- A `§M{id:name}` opener (legacy form) must be paired with `§/M{id}`. The
+  compact form (`§M{name}` / `§/M`) is recommended for new code; bulk-migrate
+  existing files with [`calor fix --drop-structural-ids`](/calor/cli/fix/).
 
 ---
 
@@ -46,14 +59,14 @@ Functions are the primary code containers.
 ### Syntax
 
 ```
-§F{id:name:visibility}
+§F{name:visibility}
   §I{type:param}       // inputs (0 or more)
   §O{type}             // output (required)
   §E{effects}          // effects (optional)
   §Q condition         // preconditions (0 or more)
   §S condition         // postconditions (0 or more)
   // body
-§/F{id}
+§/F
 ```
 
 ### Visibility
@@ -67,34 +80,34 @@ Functions are the primary code containers.
 
 **Simple function:**
 ```
-§F{f001:Add:pub}
+§F{Add:pub}
   §I{i32:a}
   §I{i32:b}
   §O{i32}
   §R (+ a b)
-§/F{f001}
+§/F
 ```
 
 **Function with effects:**
 ```
-§F{f001:PrintSum:pub}
+§F{PrintSum:pub}
   §I{i32:a}
   §I{i32:b}
   §O{void}
   §E{cw}
   §P (+ a b)
-§/F{f001}
+§/F
 ```
 
 **Function with contracts:**
 ```
-§F{f001:Divide:pub}
+§F{Divide:pub}
   §I{i32:a}
   §I{i32:b}
   §O{i32}
   §Q (!= b 0)
   §R (/ a b)
-§/F{f001}
+§/F
 ```
 
 ---
@@ -106,23 +119,23 @@ Async functions use `§AF` instead of `§F` and automatically wrap return types 
 ### Syntax
 
 ```
-§AF{id:name:visibility}
+§AF{name:visibility}
   §I{type:param}       // inputs (0 or more)
   §O{type}             // output (auto-wrapped to Task<T>)
   // body with §AWAIT expressions
-§/AF{id}
+§/AF
 ```
 
 ### Examples
 
 **Simple async function:**
 ```
-§AF{f001:FetchDataAsync:pub}
+§AF{FetchDataAsync:pub}
   §I{str:url}
   §O{str}
   §B{result} §AWAIT §C{httpClient.GetStringAsync} §A url §/C
   §R result
-§/AF{f001}
+§/AF
 ```
 
 Emits C#:
@@ -136,10 +149,10 @@ public static async Task<string> FetchDataAsync(string url)
 
 **Async void function (returns Task):**
 ```
-§AF{f001:ProcessAsync:pub}
+§AF{ProcessAsync:pub}
   §O{void}
   §AWAIT §C{Task.Delay} §A 1000 §/C
-§/AF{f001}
+§/AF
 ```
 
 ### Automatic Task Wrapping
@@ -713,20 +726,26 @@ Every structural element must be closed with a matching tag.
 
 ## Tag Reference
 
+The `id` in closing tags is **optional** for structural closers (`§/M`,
+`§/F`, `§/AF`, `§/L`, `§/I`, `§/CL`, `§/MT`, `§/AMT`, `§/IFACE`,
+`§/PROP`, `§/TR`). The compact form (no `{id}`) is recommended; the
+parser pairs each closer with its nearest matching opener by
+structural nesting.
+
 | Opening | Closing | Purpose |
 |:--------|:--------|:--------|
-| `§M{id:name}` | `§/M{id}` | Module |
-| `§F{id:name:vis}` | `§/F{id}` | Function |
-| `§AF{id:name:vis}` | `§/AF{id}` | Async function |
-| `§MT{id:name:vis}` | `§/MT{id}` | Method |
-| `§AMT{id:name:vis}` | `§/AMT{id}` | Async method |
+| `§M{id:name}` | `§/M` | Module |
+| `§F{id:name:vis}` | `§/F` | Function |
+| `§AF{id:name:vis}` | `§/AF` | Async function |
+| `§MT{id:name:vis}` | `§/MT` | Method |
+| `§AMT{id:name:vis}` | `§/AMT` | Async method |
 | `§DEL{id:name}` | `§/DEL{id}` | Delegate definition |
 | `§LAM{id:params}` | `§/LAM{id}` | Lambda (block body) |
 | `§EVT{id:name:vis:type}` | - | Event definition |
-| `§L{id:var:from:to:step}` | `§/L{id}` | For loop |
+| `§L{id:var:from:to:step}` | `§/L` | For loop |
 | `§WH{id} cond` | `§/WH{id}` | While loop |
 | `§DO{id}` | `§/DO{id} cond` | Do-while loop |
-| `§IF{id} cond` | `§/I{id}` | Conditional |
+| `§IF{id} cond` | `§/I` | Conditional |
 | `§C{target}` | `§/C` | Call (no ID needed) |
 
 ---

--- a/src/Calor.Compiler/Analysis/LegacyStructuralIdLint.cs
+++ b/src/Calor.Compiler/Analysis/LegacyStructuralIdLint.cs
@@ -1,0 +1,138 @@
+using Calor.Compiler.Migration;
+using Calor.Compiler.Parsing;
+
+namespace Calor.Compiler.Analysis;
+
+/// <summary>
+/// Opt-in lint (Calor0820): flag legacy <c>{id:…}</c> blocks on
+/// structural openers that the Phase 1 migrator can safely strip.
+///
+/// This is a SOURCE-level scanner (not AST) — it intentionally matches
+/// exactly what <see cref="StructuralIdDropper"/> would rewrite, so a
+/// developer can run the diagnostic to discover migration opportunities
+/// and then apply <c>calor fix --drop-structural-ids</c> for the
+/// machine-applicable fix.
+///
+/// Wiring into the standard <c>calor lint</c> pipeline is intentionally
+/// gated: the lint surfaces only when callers ask for it. This avoids
+/// noisy warnings in repositories that have not yet adopted v6 syntax.
+/// </summary>
+public static class LegacyStructuralIdLint
+{
+    /// <summary>
+    /// One finding. Coordinates are 1-based line/column at the opening
+    /// section marker (<c>§</c>) so they line up with the diagnostic
+    /// addresses described in RFC §8.3.
+    /// </summary>
+    public sealed record Finding(
+        string File,
+        int Line,
+        int Column,
+        string Keyword,
+        string IdValue,
+        int RemovedOffset,
+        int RemovedLength);
+
+    /// <summary>
+    /// Scan source text for legacy structural-ID blocks. Returns one
+    /// finding per occurrence in source order.
+    /// </summary>
+    public static IReadOnlyList<Finding> Scan(string source, string filePath)
+    {
+        var dropper = new StructuralIdDropper();
+        var (_, removals) = dropper.Process(source, filePath);
+        if (removals.Count == 0)
+        {
+            return Array.Empty<Finding>();
+        }
+
+        // Compute byte→(line,col) using the original source.
+        var bytes = System.Text.Encoding.UTF8.GetBytes(source);
+        var findings = new List<Finding>(removals.Count);
+        foreach (var entry in removals)
+        {
+            var (line, col) = ByteOffsetToLineCol(bytes, entry.RemovedOffset);
+            // Walk back to the nearest preceding § to find the keyword.
+            var (kw, kwOffset) = FindOpenerBefore(source, entry.RemovedOffset);
+            findings.Add(new Finding(
+                File: filePath,
+                Line: line,
+                Column: col,
+                Keyword: kw,
+                IdValue: DecodeRemoved(entry.RemovedBytesBase64, entry.RemovedLength),
+                RemovedOffset: entry.RemovedOffset,
+                RemovedLength: entry.RemovedLength));
+        }
+        return findings;
+    }
+
+    private static (int Line, int Column) ByteOffsetToLineCol(byte[] bytes, int offset)
+    {
+        int line = 1, col = 1;
+        for (int i = 0; i < offset && i < bytes.Length; i++)
+        {
+            if (bytes[i] == (byte)'\n')
+            {
+                line++;
+                col = 1;
+            }
+            else if ((bytes[i] & 0xC0) != 0x80)
+            {
+                // Count one column per leading byte of a UTF-8 sequence.
+                col++;
+            }
+        }
+        return (line, col);
+    }
+
+    private static (string Keyword, int Offset) FindOpenerBefore(string source, int byteOffset)
+    {
+        // We have the byte offset of the removal, not the char offset.
+        // Walk character-wise from the start, tracking byte cursor, to
+        // find the §Keyword{ preceding it.
+        int cursor = 0;
+        int lastSectionOffset = -1;
+        string lastKw = "";
+        for (int i = 0; i < source.Length; i++)
+        {
+            int b = Utf8Len(source[i]);
+            if (cursor + b > byteOffset) break;
+            if (source[i] == '\u00a7')
+            {
+                int kwStart = i + 1;
+                int kwEnd = kwStart;
+                if (kwEnd < source.Length && source[kwEnd] == '/') kwEnd++;
+                while (kwEnd < source.Length && (char.IsLetter(source[kwEnd]) || char.IsDigit(source[kwEnd])))
+                {
+                    kwEnd++;
+                }
+                lastSectionOffset = cursor;
+                lastKw = source.Substring(kwStart, kwEnd - kwStart);
+            }
+            cursor += b;
+        }
+        return (lastKw, lastSectionOffset);
+    }
+
+    private static string DecodeRemoved(string base64, int expectedLen)
+    {
+        try
+        {
+            var raw = Convert.FromBase64String(base64);
+            return System.Text.Encoding.UTF8.GetString(raw);
+        }
+        catch
+        {
+            return $"<{expectedLen} bytes>";
+        }
+    }
+
+    private static int Utf8Len(char ch)
+    {
+        if (ch < 0x0080) return 1;
+        if (ch < 0x0800) return 2;
+        if (char.IsHighSurrogate(ch)) return 4;
+        if (char.IsLowSurrogate(ch)) return 0;
+        return 3;
+    }
+}

--- a/src/Calor.Compiler/Commands/FixCommand.cs
+++ b/src/Calor.Compiler/Commands/FixCommand.cs
@@ -1,0 +1,311 @@
+using System.CommandLine;
+using System.Text;
+using System.Text.Json;
+using Calor.Compiler.Migration;
+
+namespace Calor.Compiler.Commands;
+
+/// <summary>
+/// <c>calor fix</c> — bulk source rewrites that are mechanically safe
+/// and reversible (each operation records a <c>migration.log.json</c>).
+///
+/// Subcommands implemented for the v6 plan:
+/// <list type="bullet">
+///   <item><description><c>--drop-structural-ids</c>: Phase 1 (PR-1c)
+///   — strips the leading <c>{id…}</c> blocks from structural openers
+///   and closers. Run repeatedly: each invocation drops only IDs that
+///   match the recognized shape.</description></item>
+///   <item><description><c>--compact-ids</c>: Phase 2 (PR-2d) — rewrites
+///   ULID payloads to 12-char Crockford-lowercase compact IDs.
+///   Implemented in a later PR; the flag is wired here as a stub to
+///   keep CLI surface stable.</description></item>
+/// </list>
+/// </summary>
+public static class FixCommand
+{
+    public static Command Create()
+    {
+        var rootArgument = new Argument<DirectoryInfo>(
+            name: "root",
+            description: "Root directory to walk recursively for .calr files")
+        {
+            Arity = ArgumentArity.ExactlyOne
+        };
+
+        var dropStructuralIdsOption = new Option<bool>(
+            aliases: ["--drop-structural-ids"],
+            description: "Phase 1: drop {id...} blocks from structural openers/closers");
+
+        var compactIdsOption = new Option<bool>(
+            aliases: ["--compact-ids"],
+            description: "Phase 2: rewrite ULID payloads to 12-char compact IDs");
+
+        var revertOption = new Option<bool>(
+            aliases: ["--revert"],
+            description: "Reverse the operation using --log");
+
+        var logOption = new Option<FileInfo?>(
+            aliases: ["--log"],
+            description: "Path to write (or read, with --revert) migration.log.json");
+
+        var dryRunOption = new Option<bool>(
+            aliases: ["--dry-run", "-n"],
+            description: "Report what would change without writing files");
+
+        var command = new Command("fix", "Apply mechanical, reversible source rewrites")
+        {
+            rootArgument,
+            dropStructuralIdsOption,
+            compactIdsOption,
+            revertOption,
+            logOption,
+            dryRunOption,
+        };
+
+        command.SetHandler(
+            ExecuteAsync,
+            rootArgument, dropStructuralIdsOption, compactIdsOption,
+            revertOption, logOption, dryRunOption);
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        DirectoryInfo root,
+        bool dropStructuralIds,
+        bool compactIds,
+        bool revert,
+        FileInfo? log,
+        bool dryRun)
+    {
+        if (!root.Exists)
+        {
+            Console.Error.WriteLine($"root directory not found: {root.FullName}");
+            return 2;
+        }
+        if (!(dropStructuralIds || compactIds))
+        {
+            Console.Error.WriteLine("specify --drop-structural-ids or --compact-ids");
+            return 2;
+        }
+        if (dropStructuralIds && compactIds)
+        {
+            Console.Error.WriteLine("--drop-structural-ids and --compact-ids are mutually exclusive");
+            return 2;
+        }
+
+        if (compactIds)
+        {
+            if (revert)
+            {
+                return await RevertCompactIdsAsync(root, log, dryRun);
+            }
+            return await CompactIdsAsync(root, log, dryRun);
+        }
+
+        if (revert)
+        {
+            return await RevertStructuralIdsAsync(root, log, dryRun);
+        }
+        return await DropStructuralIdsAsync(root, log, dryRun);
+    }
+
+    private static async Task<int> DropStructuralIdsAsync(
+        DirectoryInfo root, FileInfo? logFile, bool dryRun)
+    {
+        var dropper = new StructuralIdDropper();
+        var migrationLog = new StructuralIdDropper.MigrationLog();
+        int filesChanged = 0;
+        int totalRemovals = 0;
+
+        foreach (var path in EnumerateCalrFiles(root))
+        {
+            var rel = MakeRelativePosix(root, path);
+            var original = await File.ReadAllTextAsync(path, Encoding.UTF8);
+            var (migrated, removals) = dropper.Process(original, rel);
+            if (removals.Count == 0)
+            {
+                continue;
+            }
+            migrationLog.Entries.AddRange(removals);
+            totalRemovals += removals.Count;
+            filesChanged++;
+
+            if (!dryRun)
+            {
+                await File.WriteAllTextAsync(path, migrated, new UTF8Encoding(false));
+            }
+        }
+
+        Console.WriteLine(
+            $"drop-structural-ids: {(dryRun ? "[dry-run] " : "")}files_changed={filesChanged} removals={totalRemovals}");
+
+        if (logFile != null)
+        {
+            var json = StructuralIdDropper.SerializeLog(migrationLog);
+            await File.WriteAllTextAsync(logFile.FullName, json, new UTF8Encoding(false));
+            Console.WriteLine($"wrote {logFile.FullName}");
+        }
+
+        return 0;
+    }
+
+    private static async Task<int> RevertStructuralIdsAsync(
+        DirectoryInfo root, FileInfo? logFile, bool dryRun)
+    {
+        if (logFile == null || !logFile.Exists)
+        {
+            Console.Error.WriteLine("--revert requires --log <existing migration.log.json>");
+            return 2;
+        }
+        var json = await File.ReadAllTextAsync(logFile.FullName, Encoding.UTF8);
+        var migrationLog = StructuralIdDropper.DeserializeLog(json);
+
+        int filesRestored = 0;
+        foreach (var group in migrationLog.Entries.GroupBy(e => e.File))
+        {
+            var migPath = Path.Combine(root.FullName, group.Key.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(migPath))
+            {
+                Console.Error.WriteLine($"skip missing file: {migPath}");
+                continue;
+            }
+            var migrated = await File.ReadAllBytesAsync(migPath);
+            var restored = ReinsertRemovals(migrated, group);
+            if (!dryRun)
+            {
+                await File.WriteAllBytesAsync(migPath, restored);
+            }
+            filesRestored++;
+        }
+        Console.WriteLine(
+            $"revert: {(dryRun ? "[dry-run] " : "")}files_restored={filesRestored}");
+        return 0;
+    }
+
+    private static byte[] ReinsertRemovals(
+        ReadOnlySpan<byte> migrated,
+        IEnumerable<StructuralIdDropper.LogEntry> entries)
+    {
+        var sorted = entries.OrderBy(e => e.RemovedOffset).ToList();
+        int totalLen = migrated.Length + sorted.Sum(e => e.RemovedLength);
+        var result = new byte[totalLen];
+
+        int srcIdx = 0;
+        int dstIdx = 0;
+        foreach (var entry in sorted)
+        {
+            int preLen = entry.RemovedOffset - dstIdx;
+            if (preLen > 0)
+            {
+                migrated.Slice(srcIdx, preLen).CopyTo(result.AsSpan(dstIdx, preLen));
+                srcIdx += preLen;
+                dstIdx += preLen;
+            }
+            var removed = Convert.FromBase64String(entry.RemovedBytesBase64);
+            removed.CopyTo(result.AsSpan(dstIdx));
+            dstIdx += removed.Length;
+        }
+        int tail = migrated.Length - srcIdx;
+        if (tail > 0)
+        {
+            migrated.Slice(srcIdx, tail).CopyTo(result.AsSpan(dstIdx, tail));
+        }
+        return result;
+    }
+
+    private static IEnumerable<string> EnumerateCalrFiles(DirectoryInfo root)
+    {
+        return Directory.EnumerateFiles(root.FullName, "*.calr", SearchOption.AllDirectories)
+            .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                     && !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+    }
+
+    private static string MakeRelativePosix(DirectoryInfo root, string fullPath)
+    {
+        var rel = Path.GetRelativePath(root.FullName, fullPath);
+        return rel.Replace('\\', '/');
+    }
+
+    private static async Task<int> CompactIdsAsync(
+        DirectoryInfo root, FileInfo? logFile, bool dryRun)
+    {
+        var migrator = new CompactIdMigrator();
+        var mappingLog = new CompactIdMigrator.MappingLog();
+        int filesChanged = 0;
+        int totalRewrites = 0;
+
+        foreach (var path in EnumerateCalrFiles(root))
+        {
+            var rel = MakeRelativePosix(root, path);
+            var original = await File.ReadAllTextAsync(path, Encoding.UTF8);
+            var (migrated, newEntries) = migrator.Process(original, rel);
+            if (newEntries.Count == 0) continue;
+
+            mappingLog.Entries.AddRange(newEntries);
+            totalRewrites += newEntries.Sum(e => e.OccurrenceCount);
+            filesChanged++;
+
+            if (!dryRun)
+            {
+                await File.WriteAllTextAsync(path, migrated, new UTF8Encoding(false));
+            }
+        }
+
+        Console.WriteLine(
+            $"compact-ids: {(dryRun ? "[dry-run] " : "")}files_changed={filesChanged} rewrites={totalRewrites}");
+
+        if (logFile != null)
+        {
+            var json = System.Text.Json.JsonSerializer.Serialize(mappingLog,
+                new System.Text.Json.JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.SnakeCaseLower,
+                });
+            await File.WriteAllTextAsync(logFile.FullName, json, new UTF8Encoding(false));
+            Console.WriteLine($"wrote {logFile.FullName}");
+        }
+        return 0;
+    }
+
+    private static async Task<int> RevertCompactIdsAsync(
+        DirectoryInfo root, FileInfo? logFile, bool dryRun)
+    {
+        if (logFile == null || !logFile.Exists)
+        {
+            Console.Error.WriteLine("--revert requires --log <existing compact-id mapping.json>");
+            return 2;
+        }
+        var json = await File.ReadAllTextAsync(logFile.FullName, Encoding.UTF8);
+        var mappingLog = System.Text.Json.JsonSerializer.Deserialize<CompactIdMigrator.MappingLog>(
+            json,
+            new System.Text.Json.JsonSerializerOptions
+            {
+                PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.SnakeCaseLower,
+                PropertyNameCaseInsensitive = true,
+            }) ?? new CompactIdMigrator.MappingLog();
+
+        int filesRestored = 0;
+        var entriesByFile = mappingLog.Entries.GroupBy(e => e.File);
+        foreach (var group in entriesByFile)
+        {
+            var migPath = Path.Combine(root.FullName, group.Key.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(migPath))
+            {
+                Console.Error.WriteLine($"skip missing file: {migPath}");
+                continue;
+            }
+            var migrated = await File.ReadAllTextAsync(migPath, Encoding.UTF8);
+            var restored = CompactIdMigrator.Revert(migrated, group);
+            if (!dryRun)
+            {
+                await File.WriteAllTextAsync(migPath, restored, new UTF8Encoding(false));
+            }
+            filesRestored++;
+        }
+        Console.WriteLine(
+            $"compact-ids revert: {(dryRun ? "[dry-run] " : "")}files_restored={filesRestored}");
+        return 0;
+    }
+}

--- a/src/Calor.Compiler/Commands/FixCommand.cs
+++ b/src/Calor.Compiler/Commands/FixCommand.cs
@@ -1,6 +1,5 @@
 using System.CommandLine;
 using System.Text;
-using System.Text.Json;
 using Calor.Compiler.Migration;
 
 namespace Calor.Compiler.Commands;
@@ -9,16 +8,13 @@ namespace Calor.Compiler.Commands;
 /// <c>calor fix</c> — bulk source rewrites that are mechanically safe
 /// and reversible (each operation records a <c>migration.log.json</c>).
 ///
-/// Subcommands implemented for the v6 plan:
+/// Subcommands:
 /// <list type="bullet">
-///   <item><description><c>--drop-structural-ids</c>: Phase 1 (PR-1c)
-///   — strips the leading <c>{id…}</c> blocks from structural openers
-///   and closers. Run repeatedly: each invocation drops only IDs that
-///   match the recognized shape.</description></item>
-///   <item><description><c>--compact-ids</c>: Phase 2 (PR-2d) — rewrites
-///   ULID payloads to 12-char Crockford-lowercase compact IDs.
-///   Implemented in a later PR; the flag is wired here as a stub to
-///   keep CLI surface stable.</description></item>
+///   <item><description><c>--drop-structural-ids</c>: strips the leading
+///   <c>{id…}</c> blocks from structural closing tags
+///   (<c>§/M{id}</c> → <c>§/M</c>, etc.). Closing-tag IDs are optional
+///   since v0.5.x — the lexer accepts both forms. Run repeatedly: each
+///   invocation drops only IDs that match the recognized shape.</description></item>
 /// </list>
 /// </summary>
 public static class FixCommand
@@ -34,11 +30,7 @@ public static class FixCommand
 
         var dropStructuralIdsOption = new Option<bool>(
             aliases: ["--drop-structural-ids"],
-            description: "Phase 1: drop {id...} blocks from structural openers/closers");
-
-        var compactIdsOption = new Option<bool>(
-            aliases: ["--compact-ids"],
-            description: "Phase 2: rewrite ULID payloads to 12-char compact IDs");
+            description: "Drop {id...} blocks from structural closing tags");
 
         var revertOption = new Option<bool>(
             aliases: ["--revert"],
@@ -56,7 +48,6 @@ public static class FixCommand
         {
             rootArgument,
             dropStructuralIdsOption,
-            compactIdsOption,
             revertOption,
             logOption,
             dryRunOption,
@@ -64,7 +55,7 @@ public static class FixCommand
 
         command.SetHandler(
             ExecuteAsync,
-            rootArgument, dropStructuralIdsOption, compactIdsOption,
+            rootArgument, dropStructuralIdsOption,
             revertOption, logOption, dryRunOption);
 
         return command;
@@ -73,7 +64,6 @@ public static class FixCommand
     private static async Task<int> ExecuteAsync(
         DirectoryInfo root,
         bool dropStructuralIds,
-        bool compactIds,
         bool revert,
         FileInfo? log,
         bool dryRun)
@@ -83,24 +73,10 @@ public static class FixCommand
             Console.Error.WriteLine($"root directory not found: {root.FullName}");
             return 2;
         }
-        if (!(dropStructuralIds || compactIds))
+        if (!dropStructuralIds)
         {
-            Console.Error.WriteLine("specify --drop-structural-ids or --compact-ids");
+            Console.Error.WriteLine("specify --drop-structural-ids");
             return 2;
-        }
-        if (dropStructuralIds && compactIds)
-        {
-            Console.Error.WriteLine("--drop-structural-ids and --compact-ids are mutually exclusive");
-            return 2;
-        }
-
-        if (compactIds)
-        {
-            if (revert)
-            {
-                return await RevertCompactIdsAsync(root, log, dryRun);
-            }
-            return await CompactIdsAsync(root, log, dryRun);
         }
 
         if (revert)
@@ -225,87 +201,5 @@ public static class FixCommand
     {
         var rel = Path.GetRelativePath(root.FullName, fullPath);
         return rel.Replace('\\', '/');
-    }
-
-    private static async Task<int> CompactIdsAsync(
-        DirectoryInfo root, FileInfo? logFile, bool dryRun)
-    {
-        var migrator = new CompactIdMigrator();
-        var mappingLog = new CompactIdMigrator.MappingLog();
-        int filesChanged = 0;
-        int totalRewrites = 0;
-
-        foreach (var path in EnumerateCalrFiles(root))
-        {
-            var rel = MakeRelativePosix(root, path);
-            var original = await File.ReadAllTextAsync(path, Encoding.UTF8);
-            var (migrated, newEntries) = migrator.Process(original, rel);
-            if (newEntries.Count == 0) continue;
-
-            mappingLog.Entries.AddRange(newEntries);
-            totalRewrites += newEntries.Sum(e => e.OccurrenceCount);
-            filesChanged++;
-
-            if (!dryRun)
-            {
-                await File.WriteAllTextAsync(path, migrated, new UTF8Encoding(false));
-            }
-        }
-
-        Console.WriteLine(
-            $"compact-ids: {(dryRun ? "[dry-run] " : "")}files_changed={filesChanged} rewrites={totalRewrites}");
-
-        if (logFile != null)
-        {
-            var json = System.Text.Json.JsonSerializer.Serialize(mappingLog,
-                new System.Text.Json.JsonSerializerOptions
-                {
-                    WriteIndented = true,
-                    PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.SnakeCaseLower,
-                });
-            await File.WriteAllTextAsync(logFile.FullName, json, new UTF8Encoding(false));
-            Console.WriteLine($"wrote {logFile.FullName}");
-        }
-        return 0;
-    }
-
-    private static async Task<int> RevertCompactIdsAsync(
-        DirectoryInfo root, FileInfo? logFile, bool dryRun)
-    {
-        if (logFile == null || !logFile.Exists)
-        {
-            Console.Error.WriteLine("--revert requires --log <existing compact-id mapping.json>");
-            return 2;
-        }
-        var json = await File.ReadAllTextAsync(logFile.FullName, Encoding.UTF8);
-        var mappingLog = System.Text.Json.JsonSerializer.Deserialize<CompactIdMigrator.MappingLog>(
-            json,
-            new System.Text.Json.JsonSerializerOptions
-            {
-                PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.SnakeCaseLower,
-                PropertyNameCaseInsensitive = true,
-            }) ?? new CompactIdMigrator.MappingLog();
-
-        int filesRestored = 0;
-        var entriesByFile = mappingLog.Entries.GroupBy(e => e.File);
-        foreach (var group in entriesByFile)
-        {
-            var migPath = Path.Combine(root.FullName, group.Key.Replace('/', Path.DirectorySeparatorChar));
-            if (!File.Exists(migPath))
-            {
-                Console.Error.WriteLine($"skip missing file: {migPath}");
-                continue;
-            }
-            var migrated = await File.ReadAllTextAsync(migPath, Encoding.UTF8);
-            var restored = CompactIdMigrator.Revert(migrated, group);
-            if (!dryRun)
-            {
-                await File.WriteAllTextAsync(migPath, restored, new UTF8Encoding(false));
-            }
-            filesRestored++;
-        }
-        Console.WriteLine(
-            $"compact-ids revert: {(dryRun ? "[dry-run] " : "")}files_restored={filesRestored}");
-        return 0;
     }
 }

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -209,6 +209,34 @@ public static class DiagnosticCode
     /// </summary>
     public const string Z3UnavailableForInheritance = "Calor0817";
 
+    // Legacy structural-ID lint (Calor0820-0822) — Phase 1/2 v6 plan
+    // (drop structural IDs, then introduce compact 12-char IDs).
+
+    /// <summary>
+    /// Info (opt-in lint): a structural opener still carries a legacy
+    /// <c>{id:…}</c> block that the Phase 1 migrator (<c>calor fix
+    /// --drop-structural-ids</c>) can safely remove.
+    ///
+    /// Per RFC §5.7 the diagnostic is informational and must include a
+    /// machine-applicable suggested fix (the byte range to delete).
+    /// </summary>
+    public const string LegacyStructuralId = "Calor0820";
+
+    /// <summary>
+    /// Info (opt-in lint, Phase 2): a Calor declaration uses a 26-char
+    /// ULID payload that the compact migrator (<c>calor fix
+    /// --compact-ids</c>) can rewrite to a 12-char Crockford-lowercase
+    /// compact ID.
+    /// </summary>
+    public const string LegacyUlidPayload = "Calor0821";
+
+    /// <summary>
+    /// Warning (Phase 2): two declarations in the compile unit produced
+    /// the same compact ID. Indicates a generator collision and is
+    /// surfaced as a hard error in the registry path.
+    /// </summary>
+    public const string CompactIdCollision = "Calor0822";
+
     // Contract simplification (Calor0330-0339)
 
     /// <summary>

--- a/src/Calor.Compiler/Migration/BytePreservationVerifier.cs
+++ b/src/Calor.Compiler/Migration/BytePreservationVerifier.cs
@@ -1,0 +1,140 @@
+using System.Text;
+using Calor.Compiler.Migration;
+
+namespace Calor.Compiler.Migration;
+
+/// <summary>
+/// Replays a <see cref="StructuralIdDropper.MigrationLog"/> against the
+/// migrated files and asserts that every byte outside the recorded
+/// removal ranges matches the original. This is the in-process
+/// equivalent of the Python <c>byte_preservation_check.py</c> harness
+/// from PR-0d.
+///
+/// The verifier reconstructs the original by splicing the recorded
+/// <c>removed_bytes_base64</c> chunks back into the migrated file. If
+/// the reconstruction matches the on-disk pre-migration backup (or
+/// equals what was recorded as the original), the migration is
+/// declared byte-preserving.
+/// </summary>
+public sealed class BytePreservationVerifier
+{
+    public sealed record FileResult(string File, bool Ok, string? Reason);
+
+    /// <summary>
+    /// Verify that <paramref name="migrated"/> + recorded removals
+    /// reconstructs <paramref name="original"/> exactly. Returns
+    /// <c>true</c> when every byte not covered by a recorded entry is
+    /// identical, and the removed ranges replay byte-for-byte.
+    /// </summary>
+    public static bool Verify(
+        ReadOnlySpan<byte> original,
+        ReadOnlySpan<byte> migrated,
+        IEnumerable<StructuralIdDropper.LogEntry> entries,
+        out string? reason)
+    {
+        var sorted = entries
+            .OrderBy(e => e.RemovedOffset)
+            .ToList();
+
+        long expectedLen = (long)migrated.Length + sorted.Sum(e => (long)e.RemovedLength);
+        if (expectedLen != original.Length)
+        {
+            reason = $"length mismatch: original={original.Length} expected={expectedLen}";
+            return false;
+        }
+
+        int origIdx = 0;
+        int migIdx = 0;
+        foreach (var entry in sorted)
+        {
+            int preLen = entry.RemovedOffset - origIdx;
+            if (preLen < 0)
+            {
+                reason = $"overlapping or out-of-order removal at offset {entry.RemovedOffset}";
+                return false;
+            }
+            if (preLen > 0)
+            {
+                if (!original.Slice(origIdx, preLen).SequenceEqual(migrated.Slice(migIdx, preLen)))
+                {
+                    reason = $"byte mismatch in preserved range [{origIdx},{origIdx + preLen})";
+                    return false;
+                }
+                origIdx += preLen;
+                migIdx += preLen;
+            }
+
+            var removed = Convert.FromBase64String(entry.RemovedBytesBase64);
+            if (removed.Length != entry.RemovedLength)
+            {
+                reason = $"removed_bytes_base64 length {removed.Length} != removed_length {entry.RemovedLength} at offset {entry.RemovedOffset}";
+                return false;
+            }
+            if (!original.Slice(origIdx, entry.RemovedLength).SequenceEqual(removed))
+            {
+                reason = $"recorded removed bytes do not match original at offset {entry.RemovedOffset}";
+                return false;
+            }
+            origIdx += entry.RemovedLength;
+        }
+
+        // Tail.
+        int tail = original.Length - origIdx;
+        if (tail != migrated.Length - migIdx)
+        {
+            reason = $"trailing length mismatch: origTail={tail} migTail={migrated.Length - migIdx}";
+            return false;
+        }
+        if (tail > 0 && !original.Slice(origIdx, tail).SequenceEqual(migrated.Slice(migIdx, tail)))
+        {
+            reason = $"byte mismatch in trailing preserved range [{origIdx},{origIdx + tail})";
+            return false;
+        }
+
+        reason = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Verify a whole migration log against pairs of original/migrated
+    /// files on disk. <paramref name="originalProvider"/> returns the
+    /// pre-migration bytes for a given relative file path; tests pass
+    /// in-memory snapshots and the CLI passes a <c>.bak</c>-suffixed
+    /// reader.
+    /// </summary>
+    public static IReadOnlyList<FileResult> VerifyLog(
+        StructuralIdDropper.MigrationLog log,
+        string migratedRoot,
+        Func<string, ReadOnlyMemory<byte>> originalProvider)
+    {
+        var byFile = log.Entries
+            .GroupBy(e => e.File)
+            .ToList();
+
+        var results = new List<FileResult>();
+        foreach (var group in byFile)
+        {
+            var rel = group.Key;
+            var migPath = Path.Combine(migratedRoot, rel.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(migPath))
+            {
+                results.Add(new FileResult(rel, false, $"migrated file not found: {migPath}"));
+                continue;
+            }
+            ReadOnlyMemory<byte> original;
+            try
+            {
+                original = originalProvider(rel);
+            }
+            catch (Exception ex)
+            {
+                results.Add(new FileResult(rel, false, $"original provider failed: {ex.Message}"));
+                continue;
+            }
+            var migrated = File.ReadAllBytes(migPath);
+            var ok = Verify(original.Span, migrated, group, out var reason);
+            results.Add(new FileResult(rel, ok, reason));
+        }
+        return results;
+    }
+}

--- a/src/Calor.Compiler/Migration/StructuralIdDropper.cs
+++ b/src/Calor.Compiler/Migration/StructuralIdDropper.cs
@@ -1,0 +1,266 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Calor.Compiler.Parsing;
+
+namespace Calor.Compiler.Migration;
+
+/// <summary>
+/// Removes the leading <c>{id…}</c> block from each structural opener
+/// (<c>§M</c>, <c>§F</c>, <c>§AF</c>, <c>§L</c>, <c>§IF</c>, <c>§TR</c>,
+/// …) and the trailing <c>{id}</c> from each matching closer, when the
+/// first positional value matches the ID shape recognised by
+/// <see cref="AttributeHelper.LooksLikeId"/>.
+///
+/// Implements Phase 1 of the v6 plan (RFC §5.7). Removed byte ranges are
+/// recorded in <see cref="MigrationLog"/> so that
+/// <see cref="BytePreservationVerifier"/> can confirm byte-equality of
+/// non-removed regions, and a reverse migrator can restore the file
+/// exactly.
+///
+/// The dropper is conservative:
+/// <list type="bullet">
+///   <item><description>It only fires on the structural-opener prefixes
+///   listed in <see cref="StructuralOpeners"/>.</description></item>
+///   <item><description>If the first positional value does not look
+///   like an ID, the block is left untouched (so user-authored
+///   <c>§M{Calculator}</c> is preserved verbatim).</description></item>
+///   <item><description>It does not touch any expression-level
+///   <c>{...}</c> blocks: it only matches blocks immediately following
+///   a section marker.</description></item>
+/// </list>
+/// </summary>
+public sealed class StructuralIdDropper
+{
+    /// <summary>
+    /// Section-marker keywords on which a leading <c>{id:…}</c> block
+    /// is droppable. Closing forms (<c>/M</c>, <c>/F</c>, etc.) are
+    /// included because the closing tag's sole positional is the ID.
+    /// </summary>
+    private static readonly HashSet<string> StructuralOpeners = new(StringComparer.Ordinal)
+    {
+        // Opens
+        "M", "F", "AF", "L", "IF", "TR", "CL", "IN", "PR", "MT",
+        // Closes
+        "/M", "/F", "/AF", "/L", "/I", "/TR", "/CL", "/IN", "/PR", "/MT",
+    };
+
+    /// <summary>
+    /// Section-marker keywords whose first positional is treated as the
+    /// ID and whose payload may include further values that must be
+    /// retained (e.g. the name on <c>§M{id:Name}</c>). For these
+    /// openers the dropper rewrites <c>{id:rest}</c> as <c>{rest}</c>
+    /// rather than removing the whole block.
+    /// </summary>
+    private static readonly HashSet<string> OpenersWithExtraPositionals = new(StringComparer.Ordinal)
+    {
+        "M", "F", "AF", "L", "IF", "TR", "CL", "IN", "PR", "MT",
+    };
+
+    /// <summary>
+    /// In-memory representation of <c>migration.log.json</c>.
+    /// Schema is fixed and consumed by
+    /// <see cref="BytePreservationVerifier"/> and the Python
+    /// <c>byte_preservation_check.py</c> harness.
+    /// </summary>
+    public sealed class MigrationLog
+    {
+        public List<LogEntry> Entries { get; init; } = new();
+    }
+
+    /// <summary>
+    /// One removal record. <see cref="RemovedBytesBase64"/> is the
+    /// base64-encoded UTF-8 bytes that were removed; the verifier and
+    /// reverter use this to reconstruct the original.
+    /// </summary>
+    public sealed class LogEntry
+    {
+        public required string File { get; init; }
+        public required int RemovedOffset { get; init; }
+        public required int RemovedLength { get; init; }
+        public required string RemovedBytesBase64 { get; init; }
+    }
+
+    /// <summary>
+    /// Drops structural IDs from <paramref name="source"/>. Returns the
+    /// rewritten source and a list of removals (offsets are in terms
+    /// of the ORIGINAL source's UTF-8 byte layout).
+    /// </summary>
+    /// <param name="source">The original source as a string. The
+    /// dropper operates on UTF-8 byte ranges so callers can losslessly
+    /// reconstruct the file.</param>
+    /// <param name="relativeFilePath">Path stored in the log entries.
+    /// Use a forward-slashed path relative to the migration root so
+    /// logs are platform-portable.</param>
+    public (string Migrated, List<LogEntry> Removals) Process(
+        string source, string relativeFilePath)
+    {
+        var originalBytes = Encoding.UTF8.GetBytes(source);
+        var removals = new List<LogEntry>();
+        var sb = new StringBuilder(source.Length);
+
+        int i = 0;
+        int byteCursor = 0;
+        while (i < source.Length)
+        {
+            var ch = source[i];
+            if (ch != '\u00a7')
+            {
+                sb.Append(ch);
+                byteCursor += Utf8ByteCount(ch);
+                i++;
+                continue;
+            }
+
+            // Scan the section keyword (letters and a possible leading slash).
+            var kwStart = i + 1;
+            var kwEnd = kwStart;
+            if (kwEnd < source.Length && source[kwEnd] == '/')
+            {
+                kwEnd++;
+            }
+            while (kwEnd < source.Length &&
+                   (char.IsLetter(source[kwEnd]) || char.IsDigit(source[kwEnd])))
+            {
+                kwEnd++;
+            }
+            var keyword = source.Substring(kwStart, kwEnd - kwStart);
+
+            // Copy the "§Keyword" portion verbatim.
+            for (int j = i; j < kwEnd; j++)
+            {
+                sb.Append(source[j]);
+            }
+            var sectionByteLen = Utf8ByteCount(source, i, kwEnd);
+            byteCursor += sectionByteLen;
+            i = kwEnd;
+
+            if (!StructuralOpeners.Contains(keyword) || i >= source.Length || source[i] != '{')
+            {
+                // Not a candidate, or no attribute block follows. Move on.
+                continue;
+            }
+
+            // Find the matching close brace (no nesting allowed in our
+            // attribute grammar).
+            int braceStart = i;
+            int braceEnd = source.IndexOf('}', braceStart + 1);
+            if (braceEnd < 0)
+            {
+                // Malformed source — leave it for the parser to diagnose.
+                continue;
+            }
+            var inner = source.Substring(braceStart + 1, braceEnd - braceStart - 1);
+            var firstColon = inner.IndexOf(':');
+            var firstPositional = firstColon < 0 ? inner : inner.Substring(0, firstColon);
+
+            if (!AttributeHelper.LooksLikeId(firstPositional))
+            {
+                // First value isn't an ID-shaped token. Pass through.
+                CopyRange(source, braceStart, braceEnd + 1, sb);
+                byteCursor += Utf8ByteCount(source, braceStart, braceEnd + 1);
+                i = braceEnd + 1;
+                continue;
+            }
+
+            // We are going to remove the ID. Two cases:
+            //   (a) Closing tags (`/M`, `/F`, …) or any tag whose only
+            //       positional is the ID — drop the whole `{id}` block,
+            //       including the braces themselves.
+            //   (b) Openers with extra positionals (`M`, `F`, `L`, …) —
+            //       drop `id:` and keep `{rest}`.
+            bool wholeBlock = !OpenersWithExtraPositionals.Contains(keyword) || firstColon < 0;
+            int removedStartChar, removedEndChar;
+            if (wholeBlock)
+            {
+                removedStartChar = braceStart;
+                removedEndChar = braceEnd + 1;
+            }
+            else
+            {
+                // Drop "id:" — that's the chars from braceStart+1
+                // through firstColon (inclusive of the colon).
+                removedStartChar = braceStart + 1;
+                removedEndChar = braceStart + 1 + firstColon + 1;
+            }
+
+            int removedByteStart = byteCursor + Utf8ByteCount(source, braceStart, removedStartChar);
+            int removedByteLen = Utf8ByteCount(source, removedStartChar, removedEndChar);
+            var removedBytes = new byte[removedByteLen];
+            Array.Copy(originalBytes, removedByteStart, removedBytes, 0, removedByteLen);
+
+            removals.Add(new LogEntry
+            {
+                File = relativeFilePath,
+                RemovedOffset = removedByteStart,
+                RemovedLength = removedByteLen,
+                RemovedBytesBase64 = Convert.ToBase64String(removedBytes),
+            });
+
+            // Emit the preserved chars (those before the removal).
+            CopyRange(source, braceStart, removedStartChar, sb);
+            // Emit the chars after the removal up to and including '}'.
+            CopyRange(source, removedEndChar, braceEnd + 1, sb);
+
+            byteCursor += Utf8ByteCount(source, braceStart, braceEnd + 1);
+            i = braceEnd + 1;
+        }
+
+        return (sb.ToString(), removals);
+    }
+
+    /// <summary>
+    /// Convenience: serialise a <see cref="MigrationLog"/> to JSON in
+    /// the schema consumed by the Python and C# verifiers.
+    /// </summary>
+    public static string SerializeLog(MigrationLog log)
+    {
+        return JsonSerializer.Serialize(log, new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        });
+    }
+
+    /// <summary>
+    /// Convenience: deserialise a previously-written log.
+    /// </summary>
+    public static MigrationLog DeserializeLog(string json)
+    {
+        return JsonSerializer.Deserialize<MigrationLog>(json, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            PropertyNameCaseInsensitive = true,
+        }) ?? new MigrationLog();
+    }
+
+    private static void CopyRange(string source, int startInclusive, int endExclusive, StringBuilder sink)
+    {
+        for (int j = startInclusive; j < endExclusive; j++)
+        {
+            sink.Append(source[j]);
+        }
+    }
+
+    private static int Utf8ByteCount(char ch)
+    {
+        if (ch < 0x0080) return 1;
+        if (ch < 0x0800) return 2;
+        if (char.IsHighSurrogate(ch)) return 4; // one half of a surrogate pair
+        if (char.IsLowSurrogate(ch)) return 0;  // accounted for by high surrogate
+        return 3;
+    }
+
+    private static int Utf8ByteCount(string source, int startInclusive, int endExclusive)
+    {
+        int total = 0;
+        for (int j = startInclusive; j < endExclusive; j++)
+        {
+            total += Utf8ByteCount(source[j]);
+        }
+        return total;
+    }
+
+    // Unused but available for callers who need a culture-explicit int parse.
+    private static int ParseInt(string s) => int.Parse(s, CultureInfo.InvariantCulture);
+}

--- a/src/Calor.Compiler/Parsing/AttributeHelper.cs
+++ b/src/Calor.Compiler/Parsing/AttributeHelper.cs
@@ -8,7 +8,60 @@ namespace Calor.Compiler.Parsing;
 public static class AttributeHelper
 {
     /// <summary>
-    /// Interprets attributes for MODULE/§M: {id:name}
+    /// Heuristic shape check: returns true when <paramref name="value"/>
+    /// looks like a structural ID emitted by the compiler — i.e. a
+    /// lowercase prefix, an underscore, and an alphanumeric payload.
+    ///
+    /// Used by the structural-opener interpreters (Module, Func, Loop,
+    /// …) to distinguish the legacy form <c>§F{id:Name}</c> from the
+    /// new form <c>§F{Name}</c> introduced by RFC §1 Phase 1. Both
+    /// ULID-shaped IDs (<c>f_01J5X7K9M2NPQRSTABWXYZ12AB</c>) and the
+    /// compact form (<c>f_abc123def456</c>) match.
+    ///
+    /// User-supplied names like <c>Calculator</c>, <c>do_thing</c>,
+    /// or <c>Foo_bar</c> are deliberately rejected: real Calor names
+    /// follow PascalCase or contain uppercase letters, while IDs are
+    /// strictly lowercase digits-and-letters with one separating
+    /// underscore.
+    /// </summary>
+    public static bool LooksLikeId(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return false;
+        var underscoreIx = value.IndexOf('_');
+        if (underscoreIx <= 0 || underscoreIx >= value.Length - 1)
+        {
+            return false;
+        }
+        // Prefix must be all-lowercase letters.
+        for (int i = 0; i < underscoreIx; i++)
+        {
+            if (!char.IsLower(value[i])) return false;
+        }
+        // Payload must be all lowercase letters or digits (Crockford
+        // base32 lowercase or uppercase digits/letters as emitted by
+        // either generator). No underscores, no uppercase, no
+        // punctuation.
+        for (int i = underscoreIx + 1; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (!(char.IsDigit(c) || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')))
+            {
+                return false;
+            }
+        }
+        // Plausible payload lengths: 12 (compact) or 26 (ULID). Any
+        // smaller would be a typo; any larger is too speculative.
+        var payloadLen = value.Length - underscoreIx - 1;
+        return payloadLen == 12 || payloadLen == 26;
+    }
+
+    /// <summary>
+    /// Interprets attributes for MODULE/§M: <c>{id:name}</c>.
+    ///
+    /// Returns raw positional values. Form-disambiguation (legacy
+    /// <c>{id:Name}</c> vs new <c>{Name}</c>) is performed by the
+    /// Parser at the call site so the auto-id assignment can share its
+    /// counter with other compact-syntax shifts.
     /// </summary>
     public static (string Id, string Name) InterpretModuleAttributes(AttributeCollection attrs)
     {
@@ -24,7 +77,11 @@ public static class AttributeHelper
     }
 
     /// <summary>
-    /// Interprets attributes for FUNC/§F: {id:name:visibility}
+    /// Interprets attributes for FUNC/§F: <c>{id:name:visibility}</c>.
+    ///
+    /// Returns raw positional values. Form-disambiguation (legacy 3-arg
+    /// vs new 2-arg) is performed by the Parser; see
+    /// <c>ParseFunction</c> in <c>Parser.cs</c>.
     /// </summary>
     public static (string Id, string Name, string Visibility) InterpretFuncAttributes(AttributeCollection attrs)
     {
@@ -48,6 +105,13 @@ public static class AttributeHelper
 
         return (attrs["_pos0"] ?? "", attrs["_pos1"] ?? "", visibility);
     }
+
+    /// <summary>
+    /// Visibility tokens recognised by the Parser when disambiguating
+    /// the compact <c>§F{Name:vis}</c> form.
+    /// </summary>
+    public static bool IsVisibilityToken(string value) => value is
+        "pub" or "pri" or "int" or "public" or "private" or "internal";
 
     /// <summary>
     /// Interprets attributes for END_FUNC/§/F: {id}
@@ -206,7 +270,11 @@ public static class AttributeHelper
     }
 
     /// <summary>
-    /// Interprets attributes for FOR/§L (loop): {id:var:from:to:step}
+    /// Interprets attributes for FOR/§L (loop):
+    /// <c>{id:var:from:to:step}</c>.
+    ///
+    /// Returns raw positional values. Form-disambiguation (legacy 5-arg
+    /// vs new 4-arg) is performed by the Parser at <c>ParseFor</c>.
     /// </summary>
     public static (string Id, string Var, string From, string To, string Step) InterpretForAttributes(AttributeCollection attrs)
     {

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -75,6 +75,18 @@ public sealed class Parser
         var attrs = ParseAttributes();
 
         var (id, moduleName) = AttributeHelper.InterpretModuleAttributes(attrs);
+
+        // --- Compact syntax: optional ID (RFC §1 Phase 1) ---
+        // §M{Calculator} or §M Calculator (1 positional, name only)
+        // is accepted in addition to the legacy §M{m001:Calculator}.
+        var modPosCount = int.TryParse(attrs["_posCount"], out var mpc) ? mpc : 0;
+        if (modPosCount < 2 && !IsIdPattern(id) && !string.IsNullOrEmpty(id))
+        {
+            // Shift: id was actually name.
+            moduleName = id;
+            id = GenerateParserAutoId("m");
+        }
+
         if (string.IsNullOrEmpty(id))
         {
             _diagnostics.ReportMissingRequiredAttribute(startToken.Span, "MODULE", "id");
@@ -3710,6 +3722,25 @@ public sealed class Parser
 
         // Interpret loop attributes
         var (id, varName, fromStr, toStr, stepStr) = AttributeHelper.InterpretForAttributes(attrs);
+
+        // --- Compact syntax: optional ID (RFC §1 Phase 1) ---
+        // §L{var:from:to[:step]} is accepted alongside the legacy
+        // §L{id:var:from:to[:step]}. Disambiguation: when _pos0 does
+        // not match the id pattern, treat the values as shifted left.
+        var forPosCount = int.TryParse(attrs["_posCount"], out var fpc) ? fpc : 0;
+        if (forPosCount < 5 && !IsIdPattern(id) && !string.IsNullOrEmpty(id))
+        {
+            varName = id;
+            fromStr = attrs["_pos1"] ?? "";
+            toStr = attrs["_pos2"] ?? "";
+            stepStr = attrs["_pos3"] ?? "";
+            if (string.IsNullOrEmpty(stepStr))
+            {
+                stepStr = "1";
+            }
+            id = GenerateParserAutoId("l");
+        }
+
         if (string.IsNullOrEmpty(id))
         {
             _diagnostics.ReportMissingRequiredAttribute(startToken.Span, "FOR", "id");

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -210,6 +210,7 @@ public class Program
         rootCommand.AddCommand(AnalyzeConvertibilityCommand.Create());
         rootCommand.AddCommand(HookCommand.Create());
         rootCommand.AddCommand(IdsCommand.Create());
+        rootCommand.AddCommand(FixCommand.Create());
         rootCommand.AddCommand(EffectsCommand.Create());
         rootCommand.AddCommand(VerifyCommand.Create());
         rootCommand.AddCommand(LspCommand.Create());

--- a/tests/Calor.Compiler.Tests/Analysis/LegacyStructuralIdLintTests.cs
+++ b/tests/Calor.Compiler.Tests/Analysis/LegacyStructuralIdLintTests.cs
@@ -1,0 +1,42 @@
+using Calor.Compiler.Analysis;
+using Calor.Compiler.Diagnostics;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Unit tests for the opt-in Calor0820 lint
+/// (<see cref="LegacyStructuralIdLint"/>).
+/// </summary>
+public class LegacyStructuralIdLintTests
+{
+    [Fact]
+    public void FlagsLegacyModuleId()
+    {
+        const string src = "§M{m_01j5x7abcdef01j5x7abcdef01:Calc}\n";
+        var findings = LegacyStructuralIdLint.Scan(src, "a.calr");
+
+        var f = Assert.Single(findings);
+        Assert.Equal("a.calr", f.File);
+        Assert.Equal("M", f.Keyword);
+        Assert.Equal(1, f.Line);
+        Assert.Contains("m_01j5x7abcdef01j5x7abcdef01", f.IdValue);
+    }
+
+    [Fact]
+    public void NoFindingsOnCompactForm()
+    {
+        const string src = "§M{Calc}\n§/M\n";
+        var findings = LegacyStructuralIdLint.Scan(src, "b.calr");
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void DiagnosticCodeIsRegistered()
+    {
+        Assert.Equal("Calor0820", DiagnosticCode.LegacyStructuralId);
+        Assert.Equal("Calor0821", DiagnosticCode.LegacyUlidPayload);
+        Assert.Equal("Calor0822", DiagnosticCode.CompactIdCollision);
+    }
+}

--- a/tests/Calor.Compiler.Tests/Migration/StructuralIdDropperTests.cs
+++ b/tests/Calor.Compiler.Tests/Migration/StructuralIdDropperTests.cs
@@ -1,0 +1,199 @@
+using System.Text;
+using Calor.Compiler.Migration;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="StructuralIdDropper"/> and
+/// <see cref="BytePreservationVerifier"/> (PR-1c, PR-1d).
+///
+/// These tests guard the invariants the v6 RFC §5 relies on:
+///   T-5.7-a  drop on §M{id:Name}
+///   T-5.7-b  drop on §F{id:name:vis} with extra positionals
+///   T-5.7-c  drop on closing §/M{id}, §/F{id}
+///   T-5.7-d  no-op when first positional is not ID-shaped
+///   T-5.7-e  round-trip (drop → verify → revert) is byte-equal
+/// </summary>
+public class StructuralIdDropperTests
+{
+    private static readonly StructuralIdDropper Sut = new();
+    private static readonly UTF8Encoding Utf8 = new(false);
+
+    [Fact]
+    public void T_5_7_a_DropsModuleId()
+    {
+        const string src = "§M{m_01j5x7abcdef01j5x7abcdef01:Calc}\n§/M{m_01j5x7abcdef01j5x7abcdef01}";
+        var (out_, removals) = Sut.Process(src, "a.calr");
+
+        Assert.Equal("§M{Calc}\n§/M", out_);
+        Assert.Equal(2, removals.Count);
+        Assert.All(removals, r => Assert.Equal("a.calr", r.File));
+    }
+
+    [Fact]
+    public void T_5_7_b_DropsFunctionIdKeepsNameAndVis()
+    {
+        const string src = "§F{f_01j5x7abcdef01j5x7abcdef01:divide:i32:public}";
+        var (out_, removals) = Sut.Process(src, "f.calr");
+
+        Assert.Equal("§F{divide:i32:public}", out_);
+        Assert.Single(removals);
+    }
+
+    [Fact]
+    public void T_5_7_c_DropsClosingTagWholeBlock()
+    {
+        // Closing tag carries only an ID; the whole {…} should disappear.
+        const string src = "§/F{f_01j5x7abcdef01j5x7abcdef01}";
+        var (out_, removals) = Sut.Process(src, "c.calr");
+
+        Assert.Equal("§/F", out_);
+        Assert.Single(removals);
+    }
+
+    [Fact]
+    public void T_5_7_d_LeavesNonIdFirstPositionalUntouched()
+    {
+        // First positional `Calc` is a bare name — already compact form.
+        const string src = "§M{Calc}\n§/M";
+        var (out_, removals) = Sut.Process(src, "n.calr");
+
+        Assert.Equal(src, out_);
+        Assert.Empty(removals);
+    }
+
+    [Fact]
+    public void T_5_7_e_RoundTripIsByteEqual()
+    {
+        const string src = "§M{m_01j5x7abcdef01j5x7abcdef01:Calc}\n§F{f_01j5x7abcdef01j5x7abcdef01:add:i32:public}\n§/F{f_01j5x7abcdef01j5x7abcdef01}\n§/M{m_01j5x7abcdef01j5x7abcdef01}\n";
+        var (migrated, removals) = Sut.Process(src, "rt.calr");
+
+        var originalBytes = Utf8.GetBytes(src);
+        var migratedBytes = Utf8.GetBytes(migrated);
+
+        var ok = BytePreservationVerifier.Verify(
+            originalBytes, migratedBytes, removals, out var reason);
+        Assert.True(ok, reason);
+    }
+
+    [Fact]
+    public void DoesNotTouchExpressionBraces()
+    {
+        // Braces that aren't part of a structural opener must be left alone.
+        const string src = "§P {not_an_attr_block}";
+        var (out_, removals) = Sut.Process(src, "x.calr");
+
+        Assert.Equal(src, out_);
+        Assert.Empty(removals);
+    }
+
+    [Fact]
+    public void CompactIdIsAlsoRecognised()
+    {
+        // 12-char Crockford lowercase compact ID.
+        const string src = "§M{m_0123456789ab:Calc}";
+        var (out_, removals) = Sut.Process(src, "compact.calr");
+
+        Assert.Equal("§M{Calc}", out_);
+        Assert.Single(removals);
+    }
+
+    [Fact]
+    public void HandlesMultipleSectionsOnSameLine()
+    {
+        const string src = "§M{m_01j5x7abcdef01j5x7abcdef01:X} §F{f_01j5x7abcdef01j5x7abcdef01:y:i32:public}";
+        var (out_, removals) = Sut.Process(src, "m.calr");
+
+        Assert.Equal("§M{X} §F{y:i32:public}", out_);
+        Assert.Equal(2, removals.Count);
+    }
+
+    [Fact]
+    public void RevertingViaReinsertRestoresExactBytes()
+    {
+        // We need to exercise the full drop → reinsert pipeline. The
+        // reinsert logic lives in FixCommand.ReinsertRemovals so we
+        // re-implement the inverse here using the recorded bytes.
+        const string src = "§M{m_01j5x7abcdef01j5x7abcdef01:Calc}\n§/M{m_01j5x7abcdef01j5x7abcdef01}";
+        var (migrated, removals) = Sut.Process(src, "r.calr");
+
+        var migratedBytes = Utf8.GetBytes(migrated);
+        var rebuilt = Reinsert(migratedBytes, removals);
+
+        Assert.Equal(Utf8.GetBytes(src), rebuilt);
+    }
+
+    [Fact]
+    public void LogSerialisesToSnakeCase()
+    {
+        var log = new StructuralIdDropper.MigrationLog();
+        log.Entries.Add(new StructuralIdDropper.LogEntry
+        {
+            File = "a.calr",
+            RemovedOffset = 5,
+            RemovedLength = 7,
+            RemovedBytesBase64 = "QUJDREVGRw==",
+        });
+        var json = StructuralIdDropper.SerializeLog(log);
+
+        Assert.Contains("\"entries\"", json);
+        Assert.Contains("\"file\"", json);
+        Assert.Contains("\"removed_offset\"", json);
+        Assert.Contains("\"removed_length\"", json);
+        Assert.Contains("\"removed_bytes_base64\"", json);
+
+        // Round-trip
+        var parsed = StructuralIdDropper.DeserializeLog(json);
+        Assert.Single(parsed.Entries);
+        Assert.Equal("a.calr", parsed.Entries[0].File);
+        Assert.Equal(5, parsed.Entries[0].RemovedOffset);
+        Assert.Equal(7, parsed.Entries[0].RemovedLength);
+    }
+
+    [Fact]
+    public void VerifierDetectsCorruption()
+    {
+        const string src = "§M{m_01j5x7abcdef01j5x7abcdef01:Calc}";
+        var (migrated, removals) = Sut.Process(src, "v.calr");
+
+        var originalBytes = Utf8.GetBytes(src);
+        var corruptedMigrated = Utf8.GetBytes(migrated.Replace("Calc", "CalX"));
+
+        var ok = BytePreservationVerifier.Verify(
+            originalBytes, corruptedMigrated, removals, out var reason);
+        Assert.False(ok);
+        Assert.NotNull(reason);
+    }
+
+    private static byte[] Reinsert(
+        ReadOnlySpan<byte> migrated,
+        IEnumerable<StructuralIdDropper.LogEntry> entries)
+    {
+        var sorted = entries.OrderBy(e => e.RemovedOffset).ToList();
+        int totalLen = migrated.Length + sorted.Sum(e => e.RemovedLength);
+        var result = new byte[totalLen];
+
+        int srcIdx = 0;
+        int dstIdx = 0;
+        foreach (var entry in sorted)
+        {
+            int preLen = entry.RemovedOffset - dstIdx;
+            if (preLen > 0)
+            {
+                migrated.Slice(srcIdx, preLen).CopyTo(result.AsSpan(dstIdx, preLen));
+                srcIdx += preLen;
+                dstIdx += preLen;
+            }
+            var removed = Convert.FromBase64String(entry.RemovedBytesBase64);
+            removed.CopyTo(result.AsSpan(dstIdx));
+            dstIdx += removed.Length;
+        }
+        int tail = migrated.Length - srcIdx;
+        if (tail > 0)
+        {
+            migrated.Slice(srcIdx, tail).CopyTo(result.AsSpan(dstIdx, tail));
+        }
+        return result;
+    }
+}

--- a/tests/Calor.Compiler.Tests/StructuralIdOptionalTests.cs
+++ b/tests/Calor.Compiler.Tests/StructuralIdOptionalTests.cs
@@ -1,0 +1,129 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for RFC §1 Phase 1: structural openers accept the bare-name form
+/// (no surrounding ID block) in addition to the legacy
+/// <c>§M{id:Name}</c> / <c>§F{id:Name:vis}</c> / <c>§L{id:var:from:to}</c>
+/// forms.
+/// </summary>
+public class StructuralIdOptionalTests
+{
+    private static ModuleNode Parse(string source, out DiagnosticBag diagnostics)
+    {
+        diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAll();
+        var parser = new Parser(tokens, diagnostics);
+        return parser.Parse();
+    }
+
+    [Fact]
+    public void OptionalId_Module_BareName_Parses()
+    {
+        var source = """
+            §M{Calculator}
+            §F{Main:pub}
+            §O{void}
+            §R
+            §/F
+            §/M
+            """;
+
+        var module = Parse(source, out var diagnostics);
+        Assert.False(diagnostics.HasErrors,
+            string.Join("\n", diagnostics.Select(d => d.Message)));
+        Assert.Equal("Calculator", module.Name);
+        Assert.Contains("_auto", module.Id);
+    }
+
+    [Fact]
+    public void OptionalId_Module_LegacyForm_StillParses()
+    {
+        var source = """
+            §M{m001:Calculator}
+            §F{Main:pub}
+            §O{void}
+            §R
+            §/F
+            §/M{m001}
+            """;
+
+        var module = Parse(source, out var diagnostics);
+        Assert.False(diagnostics.HasErrors,
+            string.Join("\n", diagnostics.Select(d => d.Message)));
+        Assert.Equal("Calculator", module.Name);
+        Assert.Equal("m001", module.Id);
+    }
+
+    [Fact]
+    public void OptionalId_Loop_BareForm_Parses()
+    {
+        // §L{var:from:to} — no leading id; bare numeric bounds so the
+        // colon-based attribute splitter doesn't split typed literals.
+        var source = """
+            §M{Loops}
+            §F{Sum:pub}
+            §O{void}
+            §B{~total:i32} INT:0
+            §L{i:0:10}
+              §B{~total:i32} (+ total i)
+            §/L
+            §R
+            §/F
+            §/M
+            """;
+
+        var module = Parse(source, out var diagnostics);
+        Assert.False(diagnostics.HasErrors,
+            string.Join("\n", diagnostics.Select(d => d.Message)));
+        var fn = Assert.Single(module.Functions);
+        var loop = Assert.Single(fn.Body.OfType<ForStatementNode>());
+        Assert.Equal("i", loop.VariableName);
+        Assert.Contains("_auto", loop.Id);
+    }
+
+    [Fact]
+    public void OptionalId_Loop_LegacyForm_StillParses()
+    {
+        var source = """
+            §M{m001:Loops}
+            §F{f001:Sum:pub}
+            §O{void}
+            §B{~total:i32} INT:0
+            §L{l001:i:0:10}
+              §B{~total:i32} (+ total i)
+            §/L{l001}
+            §R
+            §/F{f001}
+            §/M{m001}
+            """;
+
+        var module = Parse(source, out var diagnostics);
+        Assert.False(diagnostics.HasErrors,
+            string.Join("\n", diagnostics.Select(d => d.Message)));
+        var fn = Assert.Single(module.Functions);
+        var loop = Assert.Single(fn.Body.OfType<ForStatementNode>());
+        Assert.Equal("l001", loop.Id);
+        Assert.Equal("i", loop.VariableName);
+    }
+
+    [Theory]
+    [InlineData("m_01J5X7K9M2NPQRSTABWXYZ12AB", true)]     // ULID-shaped
+    [InlineData("f_abc123def456", true)]                    // compact (12)
+    [InlineData("ctor_01J5X7K9M2NPQRSTABWXYZ12AB", true)]   // ctor prefix
+    [InlineData("Calculator", false)]                       // PascalCase name
+    [InlineData("do_thing", false)]                         // user snake_case
+    [InlineData("Foo_bar", false)]                          // mixed case
+    [InlineData("", false)]
+    [InlineData("f001", false)]                             // legacy short
+    [InlineData("f_short", false)]                          // wrong payload len
+    public void LooksLikeId_ClassifiesValuesCorrectly(string value, bool expected)
+    {
+        Assert.Equal(expected, AttributeHelper.LooksLikeId(value));
+    }
+}


### PR DESCRIPTION
## Ship Phase 1: optional closing-tag IDs + `calor fix` migration

Ships the **Phase 1** subset of the v6 "compact stable identifiers" work after the §10 measurement gate.

### What changed

- **Parser**: structural openers (`§M`, `§F`, `§AF`, `§L`, `§IF`, `§TR`, `§CL`, `§IN`, `§PR`, `§MT`, `§CTOR`, `§EN`) accept a *compact* form where the ID is auto-generated and the matching closing tag may omit the ID. The all-or-nothing pairing rule (compact opener ↔ bare closer; explicit opener ↔ explicit closer) is enforced; mixed forms continue to raise `Calor0101`.
- **Migration**: new `calor fix --drop-structural-ids` rewrites closing-tag IDs out of existing source byte-for-byte, with `--revert --log <file>` round-trip. A `BytePreservationVerifier` cross-checks the result.
- **Diagnostic**: `Calor0820 LegacyStructuralId` (lint) flags closing tags that still carry an ID so they show up in IDE squiggles and can be opt-in cleaned up.
- **Docs**: syntax reference, ID spec, CLI reference, agent instructions (`CLAUDE.md`, `.github/copilot-instructions.md`), and CHANGELOG updated. New `docs/cli/fix.md`.

### Why ship this and not Phase 2

The full v6 work was measured by the §10 gate (900 trials, three arms). Results live on `feature/compact-ids-v6` at `docs/plans/phase-2-measurement-results.md`. Verdict:

- **Phase 2 (compact ULIDs)**: REJECTED on Criteria 3 + 4 (no material benefit; Cliff's δ ≈ 0).
- **Phase 1 (optional closing IDs)**: directionally better than baseline (Arm B 85.7% vs Arm A 84.0%). Cheap, locally scoped, fully reversible.

So Phase 1 ships; Phase 2 (`--compact-ids`) is **not** in this PR — its stub surface from the gate-time Arm B build was removed (commit `e392b98`).

### Validation

- `dotnet build`: 0 errors, 0 warnings.
- Targeted Phase 1 tests (`StructuralIdOptional`, `StructuralIdDropper`, `LegacyStructuralIdLint`, `FixCommand`): 27/27 green.
- Full `Calor.Compiler.Tests`: 5,376 passed, 2 skipped (pre-existing).
- Full solution test suite: 7,091 passed, 4 skipped, 0 failed across 11 test projects.
- Manual smoke: compact-form sample compiles cleanly to C#.

### Out of scope (follow-ups)

- Migrating `samples/` to the compact form (orthogonal; `calor fix --drop-structural-ids` is reversible).
- Phase 3 "Python-style indentation" RFC (planned next, separate doc + measurement plan).

### Commits

1. `ac9bfe4` feat(parser): accept compact form for structural openers (PR-1a + PR-1b)
2. `3b58296` feat(migrate): calor fix --drop-structural-ids + byte-preservation (PR-1c + PR-1d)
3. `59b61e8` feat(diag): Calor0820 LegacyStructuralId lint + docs (PR-1g + PR-1h)
4. `e392b98` fix(commands): remove Phase 2 compact-ids surface from calor fix
5. `94667c8` docs: document Phase 1 optional closing-tag IDs and calor fix

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
