### PR TITLE
cleanup: Phase 4d follow-ups (docs second sweep + VSCode + parser rename)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,10 @@ calor --input program.calr --output program.g.cs
 
 ```
 §M{m001:Hello}
-§F{f001:Main:pub}
-  §O{void}
-  §E{cw}
-  §P "Hello from Calor!"
-§/F{f001}
-§/M{m001}
+  §F{f001:Main:pub}
+    §O{void}
+    §E{cw}
+    §P "Hello from Calor!"
 ```
 
 Save as `hello.calr`, then:

--- a/docs/agent-skill-audit.md
+++ b/docs/agent-skill-audit.md
@@ -65,14 +65,12 @@ All documented syntax was tested against `Parser.cs` to confirm full parser supp
   §O{str}
   §B{str:result} §AWAIT §C{GetStringAsync}§/C
   §R result
-§/AF{1}
 
 # Try/Catch - PASSES
 §TR{t1}
   §R (/ a b)
 §CA{DivideByZeroException:ex}
   §R 0
-§/TR{t1}
 
 # Collections - PASSES
 §LIST{items:i32}
@@ -108,7 +106,7 @@ The following features were **fully documented** in this update:
 - Full template with working syntax in `calor.md`
 
 ### ✅ Exception Handling - NOW DOCUMENTED
-- `§TR{id}...§CA{Type:var}...§FI...§/TR{id}`
+- `§TR{id}` with indented body, `§CA{Type:var}`, and optional `§FI` clauses
 - `§TH "message"` - Throw
 - `§RT` - Rethrow
 - `§WHEN condition` - Exception filter
@@ -116,7 +114,7 @@ The following features were **fully documented** in this update:
 
 ### ✅ Lambdas & Delegates - NOW DOCUMENTED
 - `§LAM{id:param:type}...§/LAM{id}` - Lambda expressions
-- `§DEL{id:Name:vis}...§/DEL{id}` - Delegate definitions
+- `§DEL{id:Name:vis}` - Delegate definitions (body indents below)
 - Inline lambda syntax: `(x:i32) → (+ x 1)`
 - Full template with working syntax in `calor.md`
 

--- a/docs/benchmarking/metrics/generation-accuracy.md
+++ b/docs/benchmarking/metrics/generation-accuracy.md
@@ -105,8 +105,8 @@ C# errors often have clear fixes:
 - Wrong type → cast or convert
 
 Calor errors may be less familiar:
-- Missing `§/F{id}` → requires understanding closing tag rules
-- Wrong ID in closing tag → requires ID matching understanding
+- Misindented block body → requires understanding indent-only scope
+- Wrong block nesting → requires indentation-level understanding
 
 ---
 
@@ -142,13 +142,13 @@ public static int Add(int a, int b)
 **Calor generation (common error):**
 ```
 §F{f001:Add:pub}
-  §I{i32:a}
-  §I{i32:b}
-  §O{i32}
-  §R (+ a b)
+§I{i32:a}
+§I{i32:b}
+§O{i32}
+§R (+ a b)
 ```
 - Compiles: No
-- Error: Mismatched closing tag
+- Error: Function body is not indented
 - Score: 0.0
 
 ---
@@ -159,10 +159,10 @@ public static int Add(int a, int b)
 
 | Error | Cause | Example |
 |:------|:------|:--------|
-| Mismatched IDs | Wrong ID in closing tag | `§F{f001}...§/F{f002}` |
-| Missing closing tag | Forgot to close structure | `§L{for1}...` (no `§/L`) |
-| Wrong tag type | Confused closing tag | `§F{f001}...§/M{f001}` |
-| Missing module wrapper | No `§M{}...§/M{}` | Function outside module |
+| Misindented body | Body not indented under opener | `§F{f001}` followed by unindented statements |
+| Missing block body | Forgot statements inside a block | `§L{for1}` with no indented body |
+| Wrong nesting | Dedented or indented at the wrong level | `§IF{if1}` body aligned with parent |
+| Missing module wrapper | No enclosing `§M{}` block | Function outside module |
 
 ### Common C# Errors
 
@@ -180,7 +180,7 @@ public static int Add(int a, int b)
 ### For Calor
 
 1. **Template-based generation:** Start with valid templates
-2. **ID tracking:** Maintain list of open IDs, ensure matching closes
+2. **Indentation tracking:** Maintain consistent block levels
 3. **Validation pass:** Check structure before outputting
 
 ### For C#

--- a/docs/benchmarking/metrics/token-economics.md
+++ b/docs/benchmarking/metrics/token-economics.md
@@ -181,7 +181,7 @@ public static int Divide(int a, int b)
 | Effect declaration | 3-5 | 0 (implicit) |
 | Contract | 4-6 | 5-10 |
 | Return statement | 4+ | 3+ |
-| Closing tags | 2-4 | 1 |
+| Block indentation | 0 lexical tokens | 0 lexical tokens |
 
 ---
 
@@ -204,13 +204,14 @@ namespace Name   // Just keyword + name
 // C#: No equivalent - effects are implicit
 ```
 
-### 3. Closing Tags
+### 3. Block Indentation
 
-Every structure requires explicit closing:
+Nested structures use indentation instead of structural closers:
 ```
-§F{f001}...§/F{f001}
-  §L{for1}...§/L{for1}
-    §IF{if1}...§/I{if1}
+§F{f001}
+  §L{for1}
+    §IF{if1}
+      §P i
 ```
 
 ### 4. Contract Syntax

--- a/docs/cli/convert.md
+++ b/docs/cli/convert.md
@@ -94,7 +94,7 @@ When converting C# to Calor, the converter:
 | `method` | `§F{id:Name:vis}` function |
 | `property` | `§PROP{id:Name:vis:type}` property |
 | `field` | `§FLD{id:type:name}` field |
-| `if/else if/else` | `§IF{id}...§EI...§EL...§/I{id}` |
+| `if/else if/else` | `§IF{id}` / `§EI` / `§EL` branches (end at dedent) |
 | `for` loop | `§L{id:var:from:to:step}` |
 | `while` loop | `§WH{id}` |
 | `try/catch` | Converted to `Result<T,E>` pattern |

--- a/docs/cli/fix.md
+++ b/docs/cli/fix.md
@@ -20,7 +20,7 @@ original file contents byte-for-byte.
 
 | Flag | What it does |
 |:-----|:-------------|
-| `--drop-structural-ids` | Strip the `{id}` block from structural closing tags (`§/M{…}` → `§/M`, etc.). |
+| `--drop-structural-ids` | Legacy pre-Phase-4d migration: strip `{id}` from structural closing tags (removed in Phase 4d). |
 | `--revert` | Reverse a prior `--drop-structural-ids` operation using `--log`. |
 | `--log <file>` | Write (without `--revert`) or read (with `--revert`) the migration log. |
 | `--dry-run`, `-n` | Report what would change without writing files. |
@@ -29,10 +29,10 @@ original file contents byte-for-byte.
 
 ## `--drop-structural-ids`
 
-Structural closing-tag IDs (`§/M{m001}`, `§/F{f001}`, `§/L{for1}`,
-`§/I{if1}`, …) have been **optional** since v6+. Source written before
-that release still carries them. This subcommand removes them in bulk,
-leaving the openers (where IDs continue to live) untouched.
+Legacy structural closing-tag IDs (`§/M{m001}`, `§/F{f001}`, `§/L{for1}`,
+`§/I{if1}`, …) were an intermediate pre-Phase-4d form (removed in Phase 4d).
+This subcommand removes those IDs in older source as a historical migration
+step; modern Calor uses indentation and has no structural closing tags.
 
 ```bash
 calor fix --drop-structural-ids src/                # rewrite in place
@@ -46,8 +46,8 @@ calor fix --drop-structural-ids src/ \
 The migrator targets only the recognized closing-tag shape and only
 when the contents inside `{…}` are an ID-shaped token (ULID-style,
 short test ID like `f001`, or compact). It leaves everything else
-alone — closing tags without an ID block are skipped (idempotent), and
-opening tags are never touched.
+alone — legacy closing tags without an ID block are skipped (idempotent),
+and opening tags are never touched.
 
 ### Output
 
@@ -76,12 +76,12 @@ exactly this property on every change.
 
 ## Why use it
 
-The closing-tag ID was redundant: the parser already knows which
-opener the closer is paired with via structural nesting. Dropping it
-shrinks files, removes a class of "I changed the opener ID but forgot
-the closer" bugs, and makes diffs smaller when IDs do change.
+Before Phase 4d, the legacy closing-tag ID was redundant: the parser
+already knew which opener it paired with via structural nesting. Dropping
+it shrank files, removed a class of "I changed the opener ID but forgot
+the closer" bugs, and made diffs smaller when IDs changed.
 
-If a closing-tag ID is left in source, the opt-in lint
+In legacy source, if a closing-tag ID is left behind, the opt-in lint
 [`Calor0820 LegacyStructuralId`](/calor/ids/#9-diagnostics) flags it
 and emits a `fix` patch that points back at this command.
 

--- a/docs/dependent-types-m4-backlog.md
+++ b/docs/dependent-types-m4-backlog.md
@@ -11,8 +11,7 @@ Deferred items from M2 gap analysis. These are known limitations, not bugs.
 §IF{if1} (< i n)
   §R §IDX items i       // guard holds — should discharge
 §EL
-§R §IDX items i       // guard does NOT hold — should fail
-§/I{if1}
+  §R §IDX items i       // guard does NOT hold — should fail
 ```
 
 Currently both branches would be discharged because `(< i n)` is asserted globally.

--- a/docs/getting-started/claude-integration.md
+++ b/docs/getting-started/claude-integration.md
@@ -206,15 +206,15 @@ If you're using Claude outside of Claude Code, you can teach it Calor by includi
 I'm working with Calor, a language for AI agents that compiles to C#.
 
 Key syntax:
-- §M{id:Name} / §/M{id} - Module
-- §F{id:Name:vis} / §/F{id} - Function (pub/pri)
+- §M{id:Name} - Module; body indents below
+- §F{id:Name:vis} - Function (pub/pri); body indents below
 - §I{type:name} - Input parameter
 - §O{type} - Output type
 - §E{cw,fs:r,net:rw} - Effects (console write, file read, network)
 - §Q condition - Requires (precondition)
 - §S condition - Ensures (postcondition)
-- §L{id:var:from:to:step} / §/L{id} - Loop
-- §IF{id} cond → action §EI cond → action §EL → action §/I{id} - Conditional
+- §L{id:var:from:to:step} - Loop; body indents below
+- §IF{id} cond → action; §EI/§EL branches align with §IF
 - §P expr - Print
 - §R expr - Return
 - (+ a b), (* a b), (== a b) - Lisp-style expressions

--- a/docs/philosophy/design-principles.md
+++ b/docs/philosophy/design-principles.md
@@ -155,10 +155,9 @@ at the next line that dedents back to the parent column.
 
 ### Legacy Closer Tags
 
-Pre-Phase-3 Calor used explicit closer tags such as `§/M{m001}` and
-`§/F{f001}`. These are **still accepted** by the lexer during the
-transition window but are no longer recommended. Bulk-migrate older
-sources with [`calor format`](/calor/cli/format/).
+Pre-Phase-4d Calor used explicit closer tags such as `§/M{m001}` and
+`§/F{f001}` (removed in Phase 4d). Modern Calor is indent-only; bulk-migrate
+older sources with [`calor format`](/calor/cli/format/).
 
 ---
 

--- a/docs/philosophy/tradeoffs.md
+++ b/docs/philosophy/tradeoffs.md
@@ -156,7 +156,7 @@ Calor's syntax is optimized for machine parsing:
 if (x > 0) return x;
 
 // Less familiar
-§IF{if1} (> x 0) → §R x §/I{if1}
+§IF{if1} (> x 0) → §R x
 ```
 
 ### 3. You Need Library Ecosystem

--- a/docs/syntax-reference/control-flow.md
+++ b/docs/syntax-reference/control-flow.md
@@ -233,7 +233,6 @@ For complex branches:
 
 ```
 §IF{if1} (> x 0) → §P "positive"
-§/I{if1}
 ```
 
 ### If-Else
@@ -332,16 +331,16 @@ Pattern matching provides concise multi-way branching with C# switch expression 
 
 ```
 §W{id} expression
-§K pattern1 → result1
-§K pattern2 → result2
-§K _ → default
+  §K pattern1 → result1
+  §K pattern2 → result2
+  §K _ → default
 ```
 
 | Part | Description |
 |:-----|:------------|
 | `§W expr` | Switch expression (cases indent below) |
 | `expression` | Value to match against |
-| `§K` | Case keyword (at same column as `§W`) |
+| `§K` | Case keyword (indented under `§W`) |
 | `pattern` | Pattern to match |
 | `→` | Arrow to result (single expression) |
 | `_` | Wildcard (matches anything) |
@@ -353,11 +352,10 @@ Match exact values:
 
 ```
 §B{day} §W{sw1} dayNum
-§K 0 → "Sunday"
-§K 1 → "Monday"
-§K 2 → "Tuesday"
-§K _ → "Other"
-§/W{sw1}
+  §K 0 → "Sunday"
+  §K 1 → "Monday"
+  §K 2 → "Tuesday"
+  §K _ → "Other"
 ```
 
 ### Relational Patterns (`§PREL`)
@@ -374,12 +372,11 @@ Match value ranges using relational operators:
 **Example - Grade calculation:**
 ```
 §B{grade} §W{sw1} score
-§K §PREL{gte} 90 → "A"
-§K §PREL{gte} 80 → "B"
-§K §PREL{gte} 70 → "C"
-§K §PREL{gte} 60 → "D"
-§K _ → "F"
-§/W{sw1}
+  §K §PREL{gte} 90 → "A"
+  §K §PREL{gte} 80 → "B"
+  §K §PREL{gte} 70 → "C"
+  §K §PREL{gte} 60 → "D"
+  §K _ → "F"
 ```
 
 ### Variable Patterns with Guards (`§VAR`, `§WHEN`)
@@ -388,12 +385,11 @@ Capture the matched value and add conditions:
 
 ```
 §B{desc} §W{sw1} value
-§K §VAR{n} §WHEN (> n 100) → "large positive"
-§K §VAR{n} §WHEN (> n 0) → "small positive"
-§K 0 → "zero"
-§K §VAR{n} §WHEN (> n -100) → "small negative"
-§K _ → "large negative"
-§/W{sw1}
+  §K §VAR{n} §WHEN (> n 100) → "large positive"
+  §K §VAR{n} §WHEN (> n 0) → "small positive"
+  §K 0 → "zero"
+  §K §VAR{n} §WHEN (> n -100) → "small negative"
+  §K _ → "large negative"
 ```
 
 | Part | Description |
@@ -407,9 +403,8 @@ Match Option types:
 
 ```
 §R §W{sw1} maybeValue
-§K §SM §VAR{v} → v        // Some(v) - extract value
-§K §NN → 0                 // None - default
-§/W{sw1}
+  §K §SM §VAR{v} → v        // Some(v) - extract value
+  §K §NN → 0                 // None - default
 ```
 
 ### Result Patterns (`§OK`, `§ERR`)
@@ -418,9 +413,8 @@ Match Result types:
 
 ```
 §R §W{sw1} result
-§K §OK §VAR{v} → (+ "Success: " v)
-§K §ERR §VAR{e} → (+ "Error: " e)
-§/W{sw1}
+  §K §OK §VAR{v} → (+ "Success: " v)
+  §K §ERR §VAR{e} → (+ "Error: " e)
 ```
 
 ### Block Syntax (`§/K`)
@@ -429,12 +423,12 @@ For cases with multiple statements, use block syntax:
 
 ```
 §W{sw1} x
-§K 1 → "one"              // Arrow syntax (single expression)
-§K 2
-  §P "matched two"         // Block syntax (multiple statements)
-  §R "two"
-  §/K
-§K _ → "other"
+  §K 1 → "one"              // Arrow syntax (single expression)
+  §K 2
+    §P "matched two"         // Block syntax (multiple statements)
+    §R "two"
+    §/K
+  §K _ → "other"
 ```
 
 ### Complete Example
@@ -445,13 +439,12 @@ For cases with multiple statements, use block syntax:
     §I{i32:code}
     §O{str}
     §R §W{sw1} code
-§K 200 → "OK"
-§K 201 → "Created"
-§K 400 → "Bad Request"
-§K 404 → "Not Found"
-§K 500 → "Server Error"
-§K _ → "Unknown Status"
-    §/W{sw1}
+      §K 200 → "OK"
+      §K 201 → "Created"
+      §K 400 → "Bad Request"
+      §K 404 → "Not Found"
+      §K 500 → "Server Error"
+      §K _ → "Unknown Status"
 ```
 
 ---
@@ -459,7 +452,7 @@ For cases with multiple statements, use block syntax:
 ## Why Explicit Loop IDs?
 
 1. **Precise targeting** - "Modify loop for1" is unambiguous
-2. **Verification** - Compiler checks matching `§L` and `§/L`
+2. **Verification** - Compiler uses indentation to determine loop boundaries
 3. **Agent-friendly** - Easy to identify loop boundaries
 4. **Refactoring safe** - IDs survive code movement
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -6,16 +6,16 @@ Syntax highlighting for the [Calor programming language](https://github.com/juan
 
 - Syntax highlighting for `.calr` files
 - Bracket matching and auto-closing
-- Code folding for modules, functions, loops, and conditionals
+- Indentation-based code folding for modules, functions, loops, and conditionals
 - Comment toggling with `//`
 
 ## Supported Syntax Elements
 
 ### Control Structures
-- Module declarations: `§M{id:name}`, `§/M{id}`
-- Function declarations: `§F{id:name:visibility}`, `§/F{id}`
-- Loops: `§L{id:var:from:to:step}`, `§/L{id}`
-- Conditionals: `§IF{id}`, `§EI`, `§EL`, `§/I{id}`
+- Module declarations: `§M{id:name}` with an indented body
+- Function declarations: `§F{id:name:visibility}` with an indented body
+- Loops: `§L{id:var:from:to:step}` with an indented body
+- Conditionals: `§IF{id}`, `§EI`, `§EL` with indented bodies
 - Function calls: `§C{target}`, `§/C`
 
 ### Type System
@@ -45,18 +45,14 @@ Syntax highlighting for the [Calor programming language](https://github.com/juan
 
 ```calor
 §M{m001:FizzBuzz}
-§F{f001:Main:pub}
-  §O{void}
-  §E{cw}
-  §L{for1:i:1:100:1}
-    §IF{if1} (== (% i 15) 0) → §P "FizzBuzz"
-    §EI (== (% i 3) 0) → §P "Fizz"
-    §EI (== (% i 5) 0) → §P "Buzz"
-    §EL → §P i
-    §/I{if1}
-  §/L{for1}
-§/F{f001}
-§/M{m001}
+  §F{f001:Main:pub}
+    §O{void}
+    §E{cw}
+    §L{for1:i:1:100:1}
+      §IF{if1} (== (% i 15) 0) → §P "FizzBuzz"
+      §EI (== (% i 3) 0) → §P "Fizz"
+      §EI (== (% i 5) 0) → §P "Buzz"
+      §EL → §P i
 ```
 
 ## Installation

--- a/editors/vscode/language-configuration.json
+++ b/editors/vscode/language-configuration.json
@@ -18,11 +18,5 @@
     { "open": "[", "close": "]" },
     { "open": "(", "close": ")" },
     { "open": "\"", "close": "\"" }
-  ],
-  "folding": {
-    "markers": {
-      "start": "^\u00a7(M|F|L|IF|C)\\{",
-      "end": "^\u00a7/(M|F|L|I|C)"
-    }
-  }
+  ]
 }

--- a/editors/vscode/syntaxes/calor.tmLanguage.json
+++ b/editors/vscode/syntaxes/calor.tmLanguage.json
@@ -32,59 +32,19 @@
     "closing-tags": {
       "patterns": [
         {
-          "comment": "Module/Function closing tags",
+          "comment": "Valid do-while, preprocessor, and match-case closing delimiters",
           "name": "keyword.control.close.calor",
-          "match": "§/(M|F|AF)\\{[^}]*\\}"
+          "match": "§/(?:(?:DO|PP)(?:\\{[^}]*\\})?|K)(?![a-zA-Z0-9_])"
         },
         {
-          "comment": "Class/Interface/Enum closing tags",
-          "name": "storage.type.close.calor",
-          "match": "§/(CL|IFACE|EN|ENUM|EXT)\\{[^}]*\\}"
+          "comment": "Valid inline expression closing tags",
+          "name": "keyword.control.inline.close.calor",
+          "match": "§/(C|T|NEW|A|LIST|DICT|HSET|ARR|LAM|THIS|BASE|INIT)(?![a-zA-Z0-9_])"
         },
         {
-          "comment": "Method/Property/Constructor closing tags",
-          "name": "entity.name.function.close.calor",
-          "match": "§/(MT|AMT|PROP|CTOR|GET|SET)\\{[^}]*\\}"
-        },
-        {
-          "comment": "Control flow closing tags",
-          "name": "keyword.control.close.calor",
-          "match": "§/(I|L|WH|DO|W|K|TR|WITH)\\{[^}]*\\}"
-        },
-        {
-          "comment": "Collection closing tags",
-          "name": "storage.type.collection.close.calor",
-          "match": "§/(ARR|LIST|DICT|HSET|EACH|EACHKV)\\{[^}]*\\}"
-        },
-        {
-          "comment": "Type/Record closing tags",
-          "name": "storage.type.close.calor",
-          "match": "§/(T|D)\\{[^}]*\\}"
-        },
-        {
-          "comment": "Lambda/Delegate closing tags",
-          "name": "entity.name.function.close.calor",
-          "match": "§/(LAM|DEL)\\{[^}]*\\}"
-        },
-        {
-          "comment": "Metadata closing tags",
-          "name": "comment.block.documentation.close.calor",
-          "match": "§/(US|UB|DC|CT|VS|HD)\\{[^}]*\\}"
-        },
-        {
-          "comment": "Interpolation closing tag",
-          "name": "string.interpolated.close.calor",
-          "match": "§/INTERP\\{[^}]*\\}"
-        },
-        {
-          "comment": "Call closing tag (no braces)",
-          "name": "keyword.control.call.close.calor",
-          "match": "§/C(?![a-zA-Z0-9_])"
-        },
-        {
-          "comment": "This/Base closing tags (no braces)",
-          "name": "variable.language.close.calor",
-          "match": "§/(THIS|BASE)(?![a-zA-Z0-9_])"
+          "comment": "Removed structural closing tags (invalid in indent-only Calor)",
+          "name": "invalid.deprecated.structural-close.calor",
+          "match": "§/(F|M|I|L|CL|IFACE|MT|CTOR|PROP|EN|AF|AMT|IXER|OP|TR|EACH|EACHKV|UNSAFE|SYNC|FIXED|EVT|EADD|EREM|EEXT|DEL|USE|W|WH|SW)(?:\\{[^}]*\\})?(?![a-zA-Z0-9_])"
         }
       ]
     },

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -15,11 +15,10 @@ public sealed class Parser
     private bool _insideRefinementPredicate;
 
     /// <summary>
-    /// Phase 4c — TokenKinds whose textual form is a legacy structural
+    /// Phase 4d — TokenKinds whose textual form is a legacy structural
     /// closing tag (<c>§/M</c>, <c>§/F</c>, <c>§/CL</c>, …) that indent
-    /// form has replaced. Encountering any of these in the token stream
-    /// produces a <c>Calor0830 LegacyCloserForm</c> error rather than
-    /// silently consuming them.
+    /// form has fully replaced. Encountering any of these in the token
+    /// stream produces a <c>Calor0830 LegacyCloserForm</c> error.
     ///
     /// Closers that still carry payload — <see cref="TokenKind.EndDo"/>
     /// (carries the do-while condition), <see cref="TokenKind.EndCase"/>
@@ -158,7 +157,7 @@ public sealed class Parser
     {
         if (Check(explicitCloser))
         {
-            ReportLegacyCloserIfStrict(Current);
+            ReportLegacyCloser(Current);
             return Advance();
         }
         if (Check(TokenKind.Dedent))
@@ -170,7 +169,7 @@ public sealed class Parser
             {
                 // Closer-form: consume all dedents, then the closer.
                 while (Check(TokenKind.Dedent)) Advance();
-                ReportLegacyCloserIfStrict(Current);
+                ReportLegacyCloser(Current);
                 return Advance();
             }
             // Indent-only: consume the single Dedent that ends this block.
@@ -187,14 +186,16 @@ public sealed class Parser
     }
 
     /// <summary>
-    /// Phase 4c — emit a <c>Calor0830</c> error whenever the parser is
-    /// about to consume a structural legacy closer token. The
-    /// diagnostic is reported once per occurrence; the parser still
-    /// consumes the token so downstream productions see the structure
-    /// they expect (parsing recovers, then the bag reports the error
-    /// to the caller).
+    /// Phase 4d — emit <c>Calor0830</c> unconditionally whenever the
+    /// parser is about to consume a structural legacy closer token.
+    /// Closer form was removed from the language in Phase 4d, so any
+    /// occurrence of one of the <see cref="StructuralLegacyClosers"/>
+    /// tokens is an error. The parser still consumes the token (the
+    /// closer-form code paths above remain in place so downstream
+    /// productions see the structure they expect) and reports the
+    /// diagnostic via the bag.
     /// </summary>
-    private void ReportLegacyCloserIfStrict(Token closerToken)
+    private void ReportLegacyCloser(Token closerToken)
     {
         if (!StructuralLegacyClosers.Contains(closerToken.Kind)) return;
 

--- a/website/content/benchmarking/metrics/generation-accuracy.mdx
+++ b/website/content/benchmarking/metrics/generation-accuracy.mdx
@@ -103,8 +103,8 @@ C# errors often have clear fixes:
 - Wrong type → cast or convert
 
 Calor errors may be less familiar:
-- Missing `§/F{id}` → requires understanding closing tag rules
-- Wrong ID in closing tag → requires ID matching understanding
+- Misindented block body → requires understanding indent-only scope
+- Wrong block nesting → requires indentation-level understanding
 
 ---
 
@@ -140,13 +140,13 @@ public static int Add(int a, int b)
 **Calor generation (common error):**
 ```
 §F{f001:Add:pub}
-  §I{i32:a}
-  §I{i32:b}
-  §O{i32}
-  §R (+ a b)
+§I{i32:a}
+§I{i32:b}
+§O{i32}
+§R (+ a b)
 ```
 - Compiles: No
-- Error: Mismatched closing tag
+- Error: Function body is not indented
 - Score: 0.0
 
 ---
@@ -157,10 +157,10 @@ public static int Add(int a, int b)
 
 | Error | Cause | Example |
 |:------|:------|:--------|
-| Mismatched IDs | Wrong ID in closing tag | `§F{f001}...§/F{f002}` |
-| Missing closing tag | Forgot to close structure | `§L{for1}...` (no `§/L`) |
-| Wrong tag type | Confused closing tag | `§F{f001}...§/M{f001}` |
-| Missing module wrapper | No `§M{}...§/M{}` | Function outside module |
+| Misindented body | Body not indented under opener | `§F{f001}` followed by unindented statements |
+| Missing block body | Forgot statements inside a block | `§L{for1}` with no indented body |
+| Wrong nesting | Dedented or indented at the wrong level | `§IF{if1}` body aligned with parent |
+| Missing module wrapper | No enclosing `§M{}` block | Function outside module |
 
 ### Common C# Errors
 
@@ -178,7 +178,7 @@ public static int Add(int a, int b)
 ### For Calor
 
 1. **Template-based generation:** Start with valid templates
-2. **ID tracking:** Maintain list of open IDs, ensure matching closes
+2. **Indentation tracking:** Maintain consistent block levels
 3. **Validation pass:** Check structure before outputting
 
 ### For C#

--- a/website/content/benchmarking/metrics/token-economics.mdx
+++ b/website/content/benchmarking/metrics/token-economics.mdx
@@ -179,7 +179,7 @@ public static int Divide(int a, int b)
 | Effect declaration | 3-5 | 0 (implicit) |
 | Contract | 4-6 | 5-10 |
 | Return statement | 4+ | 3+ |
-| Closing tags | 2-4 | 1 |
+| Block indentation | 0 lexical tokens | 0 lexical tokens |
 
 ---
 
@@ -202,13 +202,14 @@ namespace Name   // Just keyword + name
 // C#: No equivalent - effects are implicit
 ```
 
-### 3. Closing Tags
+### 3. Block Indentation
 
-Every structure requires explicit closing:
+Nested structures use indentation instead of structural closers:
 ```
-§F{f001}...§/F{f001}
-  §L{for1}...§/L{for1}
-    §IF{if1}...§/I{if1}
+§F{f001}
+  §L{for1}
+    §IF{if1}
+      §P i
 ```
 
 ### 4. Contract Syntax

--- a/website/content/cli/convert.mdx
+++ b/website/content/cli/convert.mdx
@@ -72,7 +72,7 @@ If `--output` is not specified:
 | `method` | `§F{id:Name:vis}` function |
 | `property` | `§PROP{id:Name:vis:type}` property |
 | `field` | `§FLD{id:type:name}` field |
-| `if/else if/else` | `§IF{id}...§EI...§EL...§/I{id}` |
+| `if/else if/else` | `§IF{id}` / `§EI` / `§EL` branches (end at dedent) |
 | `for` loop | `§L{id:var:from:to:step}` |
 | `while` loop | `§WH{id}` |
 

--- a/website/content/cli/lint.mdx
+++ b/website/content/cli/lint.mdx
@@ -51,7 +51,7 @@ The Calor linter is designed specifically for **agent-optimized code**, not huma
 
 | Aspect | Traditional Linters | Calor Linter |
 |--------|---------------------|--------------|
-| **Indentation** | Enforce consistent indentation | Remove all indentation |
+| **Indentation** | Enforce style indentation | Preserve meaningful block indentation |
 | **Whitespace** | Format for readability | Eliminate unnecessary whitespace |
 | **Identifiers** | Descriptive names encouraged | Abbreviated IDs (`m1`, `f1`, `l1`) |
 | **Blank lines** | Separate logical sections | Remove all blank lines |
@@ -63,11 +63,11 @@ The Calor linter is designed specifically for **agent-optimized code**, not huma
 AI coding agents process code as tokens. Every character costs tokens and processing time. The Calor linter optimizes for:
 
 1. **Minimal token count** - Fewer tokens = faster processing, lower cost
-2. **Unambiguous structure** - Tags and IDs replace indentation for structure
+2. **Unambiguous structure** - Indentation defines blocks; tags and IDs identify elements
 3. **Consistent format** - No style variations that add noise to agent context
 4. **Semantic density** - Maximum information per token
 
-### Key Principle: Structure Through Tags, Not Whitespace
+### Key Principle: Structure Through Indentation
 
 Traditional code uses indentation to show structure:
 
@@ -82,7 +82,7 @@ public void Main() {
 }
 ```
 
-Calor uses explicit tags with IDs:
+Calor uses indent-only blocks with explicit tags and IDs:
 
 ```calor
 §F{f1:Main:pub}
@@ -92,7 +92,7 @@ Calor uses explicit tags with IDs:
       §P i
 ```
 
-The structure is explicit in the tags (`§L{l1}...§/L{l1}`), making indentation redundant noise.
+The structure is explicit in indentation; IDs like `l1` identify blocks without requiring closing tags.
 
 ## Lint Rules
 
@@ -110,11 +110,11 @@ Identifiers should use the shortest unambiguous form.
 
 ### Whitespace
 
-No indentation or trailing whitespace should exist.
+Use two spaces per block level. Avoid trailing whitespace and unnecessary blank lines.
 
 | Issue | Example |
 |-------|---------|
-| Leading spaces | `  §P "text"` (2 leading spaces) |
+| Wrong indent width | `    §P "text"` (4 spaces where 2 expected) |
 | Leading tabs | `\t§P "text"` (leading tab) |
 | Trailing whitespace | `§M{m1:Name}  ` (trailing spaces) |
 | Blank lines | Empty lines between statements |

--- a/website/content/cli/mcp.mdx
+++ b/website/content/cli/mcp.mdx
@@ -231,7 +231,7 @@ Verify function contracts using Z3 SMT solver.
 **Input:**
 ```json
 {
-  "source": "§M{m001:Test}\n§F{f001:Div:pub}\n§I{i32:a}\n§I{i32:b}\n§O{i32}\n§Q (!= b 0)\n§R (/ a b)\n§/F{f001}\n§/M{m001}",
+  "source": "§M{m001:Test}\n  §F{f001:Div:pub}\n    §I{i32:a}\n    §I{i32:b}\n    §O{i32}\n    §Q (!= b 0)\n    §R (/ a b)",
   "timeout": 5000
 }
 ```

--- a/website/content/getting-started/hello-world.mdx
+++ b/website/content/getting-started/hello-world.mdx
@@ -61,7 +61,7 @@ You don't need to understand every detail of this syntax - the AI handles it. Bu
 | `§O{void}` | The function returns nothing |
 | `§E{cw}` | The function writes to console (`cw` = console write) |
 | `§P "Hello..."` | Prints the message |
-| `§/F{f001}` `§/M{m001}` | Close the function and module |
+| Dedent | Ends the function and module blocks (no closing tags) |
 
 ---
 

--- a/website/content/philosophy/design-principles.mdx
+++ b/website/content/philosophy/design-principles.mdx
@@ -144,10 +144,9 @@ at the next line that dedents back to the parent column.
 
 ### Legacy Closer Tags
 
-Pre-Phase-3 Calor used explicit closer tags such as `§/M{m001}` and
-`§/F{f001}`. These are **still accepted** by the lexer during the
-transition window but are no longer recommended. Bulk-migrate older
-sources with [`calor format`](/cli/format/).
+Pre-Phase-4d Calor used explicit closer tags such as `§/M{m001}` and
+`§/F{f001}` (removed in Phase 4d). Modern Calor is indent-only; bulk-migrate
+older sources with [`calor format`](/cli/format/).
 
 ---
 

--- a/website/content/philosophy/tradeoffs.mdx
+++ b/website/content/philosophy/tradeoffs.mdx
@@ -134,7 +134,7 @@ Calor's syntax is optimized for machine parsing:
 if (x > 0) return x;
 
 // Less familiar
-§IF{if1} (> x 0) → §R x §/I{if1}
+§IF{if1} (> x 0) → §R x
 ```
 
 ### 3. You Need Library Ecosystem

--- a/website/content/syntax-reference/control-flow.mdx
+++ b/website/content/syntax-reference/control-flow.mdx
@@ -231,7 +231,6 @@ For complex branches:
 
 ```
 §IF{if1} (> x 0) → §P "positive"
-§/I{if1}
 ```
 
 ### If-Else
@@ -330,16 +329,16 @@ Pattern matching provides concise multi-way branching with C# switch expression 
 
 ```
 §W{id} expression
-§K pattern1 → result1
-§K pattern2 → result2
-§K _ → default
+  §K pattern1 → result1
+  §K pattern2 → result2
+  §K _ → default
 ```
 
 | Part | Description |
 |:-----|:------------|
 | `§W expr` | Switch expression (cases indent below) |
 | `expression` | Value to match against |
-| `§K` | Case keyword (at same column as `§W`) |
+| `§K` | Case keyword (indented under `§W`) |
 | `pattern` | Pattern to match |
 | `→` | Arrow to result (single expression) |
 | `_` | Wildcard (matches anything) |
@@ -351,11 +350,10 @@ Match exact values:
 
 ```
 §B{day} §W{sw1} dayNum
-§K 0 → "Sunday"
-§K 1 → "Monday"
-§K 2 → "Tuesday"
-§K _ → "Other"
-§/W{sw1}
+  §K 0 → "Sunday"
+  §K 1 → "Monday"
+  §K 2 → "Tuesday"
+  §K _ → "Other"
 ```
 
 ### Relational Patterns (`§PREL`)
@@ -372,12 +370,11 @@ Match value ranges using relational operators:
 **Example - Grade calculation:**
 ```
 §B{grade} §W{sw1} score
-§K §PREL{gte} 90 → "A"
-§K §PREL{gte} 80 → "B"
-§K §PREL{gte} 70 → "C"
-§K §PREL{gte} 60 → "D"
-§K _ → "F"
-§/W{sw1}
+  §K §PREL{gte} 90 → "A"
+  §K §PREL{gte} 80 → "B"
+  §K §PREL{gte} 70 → "C"
+  §K §PREL{gte} 60 → "D"
+  §K _ → "F"
 ```
 
 ### Variable Patterns with Guards (`§VAR`, `§WHEN`)
@@ -386,12 +383,11 @@ Capture the matched value and add conditions:
 
 ```
 §B{desc} §W{sw1} value
-§K §VAR{n} §WHEN (> n 100) → "large positive"
-§K §VAR{n} §WHEN (> n 0) → "small positive"
-§K 0 → "zero"
-§K §VAR{n} §WHEN (> n -100) → "small negative"
-§K _ → "large negative"
-§/W{sw1}
+  §K §VAR{n} §WHEN (> n 100) → "large positive"
+  §K §VAR{n} §WHEN (> n 0) → "small positive"
+  §K 0 → "zero"
+  §K §VAR{n} §WHEN (> n -100) → "small negative"
+  §K _ → "large negative"
 ```
 
 | Part | Description |
@@ -405,9 +401,8 @@ Match Option types:
 
 ```
 §R §W{sw1} maybeValue
-§K §SM §VAR{v} → v        // Some(v) - extract value
-§K §NN → 0                 // None - default
-§/W{sw1}
+  §K §SM §VAR{v} → v        // Some(v) - extract value
+  §K §NN → 0                 // None - default
 ```
 
 ### Result Patterns (`§OK`, `§ERR`)
@@ -416,9 +411,8 @@ Match Result types:
 
 ```
 §R §W{sw1} result
-§K §OK §VAR{v} → (+ "Success: " v)
-§K §ERR §VAR{e} → (+ "Error: " e)
-§/W{sw1}
+  §K §OK §VAR{v} → (+ "Success: " v)
+  §K §ERR §VAR{e} → (+ "Error: " e)
 ```
 
 ### Block Syntax (`§/K`)
@@ -427,12 +421,12 @@ For cases with multiple statements, use block syntax:
 
 ```
 §W{sw1} x
-§K 1 → "one"              // Arrow syntax (single expression)
-§K 2
-  §P "matched two"         // Block syntax (multiple statements)
-  §R "two"
-  §/K
-§K _ → "other"
+  §K 1 → "one"              // Arrow syntax (single expression)
+  §K 2
+    §P "matched two"         // Block syntax (multiple statements)
+    §R "two"
+    §/K
+  §K _ → "other"
 ```
 
 ### Complete Example
@@ -443,13 +437,12 @@ For cases with multiple statements, use block syntax:
     §I{i32:code}
     §O{str}
     §R §W{sw1} code
-§K 200 → "OK"
-§K 201 → "Created"
-§K 400 → "Bad Request"
-§K 404 → "Not Found"
-§K 500 → "Server Error"
-§K _ → "Unknown Status"
-    §/W{sw1}
+      §K 200 → "OK"
+      §K 201 → "Created"
+      §K 400 → "Bad Request"
+      §K 404 → "Not Found"
+      §K 500 → "Server Error"
+      §K _ → "Unknown Status"
 ```
 
 ---
@@ -457,7 +450,7 @@ For cases with multiple statements, use block syntax:
 ## Why Explicit Loop IDs?
 
 1. **Precise targeting** - "Modify loop for1" is unambiguous
-2. **Verification** - Compiler checks matching `§L` and `§/L`
+2. **Verification** - Compiler uses indentation to determine loop boundaries
 3. **Agent-friendly** - Easy to identify loop boundaries
 4. **Refactoring safe** - IDs survive code movement
 


### PR DESCRIPTION
## Phase 4d follow-up cleanup

Three independent cleanups that fell out of Phase 4d (PR #635). No
behavioral changes; no test count changes.

### 1. Parser.cs internal rename

`ReportLegacyCloserIfStrict` → `ReportLegacyCloser`. The `_IfStrict` suffix
referred to a strict/lax distinction that Phase 4d removed — there is no
opt-out anymore, so the helper always reports. XML doc-comment updated
from "Phase 4c" to "Phase 4d" to match what shipped.

### 2. User-facing docs second sweep

Phase 5 did the bulk doc migration; this catches what remained:

- **README.md** — "Your First Calor Program" example rewritten in indent form
- **19 files** under `docs/` and `website/content/`: fenced code blocks,
  Quick Reference tables, and prose updated to teach indent form. Closer
  rows in tables removed; "Functions close with `§/F{id}`" prose rewritten
  as "Functions end at dedent".
- **Historical record preserved**: `docs/plans/*` (design-phase snapshots)
  and `CHANGELOG.md` deliberately untouched.
- **Legitimate "removed in Phase 4d" callouts retained** in
  `docs/cli/fix.md`, `docs/philosophy/design-principles.md`, and the
  `.mdx` website counterpart.

### 3. VSCode extension audit

- `editors/vscode/README.md`: indent-form example
- `editors/vscode/language-configuration.json`: removed closer-dependent
  folding markers (indent is now the only folding signal)
- `editors/vscode/syntaxes/calor.tmLanguage.json`: structural closers
  re-classified as `invalid.deprecated` (they'll render in red) so users
  see the error visually. Still-valid closers (`§/DO`, `§/PP`, `§/K`,
  inline expression closers) keep their existing scopes.
- No `snippets/` dir present; no version bump.

### Verification

- `dotnet build src/Calor.Compiler` succeeds (0 warnings)
- `dotnet test Calor.Compiler.Tests`: 5402/0/7 (identical to pre-cleanup)
- `editors/vscode/*.json` validated as parseable JSON

### Files touched
24 files, +186 / -254
