### PR TITLE
fix(website): update landing snippets to v0.5.1 indent-only syntax

### DIFF
--- a/website/src/components/landing/CatchBugs.tsx
+++ b/website/src/components/landing/CatchBugs.tsx
@@ -7,14 +7,11 @@ export function CatchBugs() {
   const codeRef = useScrollReveal<HTMLDivElement>({ direction: 'left' });
   const errorRef = useScrollReveal<HTMLDivElement>({ direction: 'right' });
 
-  const calorCode = `§F[f_01A8X:ProcessOrder:pub]
-  §I[Order:order]
-  §O[bool]
-  §E[db]
-
-  §C[SaveOrder] order
-  §C[NotifyCustomer] order
-§/F[f_01A8X]`;
+  const calorCode = `§M{m1:Orders}
+  §F{f_01A8X:ProcessOrder:pub} (Order:order) -> bool
+    §E{db}
+    §C{SaveOrder} §A order §/C
+    §C{NotifyCustomer} §A order §/C`;
 
   const errorOutput = `error CALOR0410: Function 'ProcessOrder' uses effect 'net'
                    but does not declare it
@@ -22,11 +19,11 @@ export function CatchBugs() {
   Call chain: ProcessOrder → NotifyCustomer → SendEmail
               → HttpClient.PostAsync
 
-  Declared effects: §E[db]
-  Required effects: §E[db,net]
+  Declared effects: §E{db}
+  Required effects: §E{db,net}
 
   Fix: Add 'net' to the effect declaration:
-       §E[db,net]`;
+       §E{db,net}`;
 
   return (
     <section className="relative py-24 overflow-hidden">

--- a/website/src/components/landing/CodeComparison.tsx
+++ b/website/src/components/landing/CodeComparison.tsx
@@ -5,13 +5,11 @@ import { cn } from '@/lib/utils';
 import { trackCodeComparisonTab } from '@/lib/analytics';
 import { useScrollReveal } from '@/hooks/useScrollReveal';
 
-const calorCode = `§F{f_01J5X7K9M2:Square:pub}
-  §I{i32:x}
-  §O{i32}
-  §Q (>= x 0)
-  §S (>= result 0)
-  §R (* x x)
-§/F{f_01J5X7K9M2}`;
+const calorCode = `§M{m1:Math}
+  §F{f_01J5X7K9M2:Square:pub} (i32:x) -> i32
+    §Q (>= x 0)
+    §S (>= result 0)
+    §R (* x x)`;
 
 const csharpCode = `public static int Square(int x)
 {
@@ -24,10 +22,10 @@ const csharpCode = `public static int Square(int x)
 }`;
 
 const calorAnnotations = [
-  { line: 0, text: 'Permanent ID means AI can find this function even after you rename it' },
-  { line: 3, text: 'Rule: input must be >= 0. Compiler enforces this automatically.' },
-  { line: 4, text: 'Rule: output must be >= 0. No way to return invalid results.' },
-  { line: 5, text: 'No database or network calls—guaranteed by the compiler.' },
+  { line: 1, text: 'Permanent ID means AI can find this function even after you rename it' },
+  { line: 2, text: 'Rule: input must be >= 0. Compiler enforces this automatically.' },
+  { line: 3, text: 'Rule: output must be >= 0. No way to return invalid results.' },
+  { line: 4, text: 'No database or network calls—guaranteed by the compiler.' },
 ];
 
 const csharpAnnotations = [

--- a/website/src/components/landing/FeatureGrid.tsx
+++ b/website/src/components/landing/FeatureGrid.tsx
@@ -31,11 +31,11 @@ const features = [
     href: '/docs/philosophy/stable-identifiers/',
   },
   {
-    name: 'No More Missing Braces',
+    name: 'Structure AI Can Navigate',
     description:
-      'Explicit start/end tags mean AI can\'t generate malformed code. No more "unexpected token" from bad indentation.',
+      'Every block opens with a §-prefixed tag. AI tools find any function, module, or loop at a glance—indentation defines scope, just like Python.',
     icon: Layers,
-    code: '§M{m_01J5X7K9M2:App}\n  ...\n§/M{m_01J5X7K9M2}',
+    code: '§M{m_01J5X7K9M2:App}\n  §F{f1:Main:pub} () -> void\n    §P "hello"',
     href: '/docs/syntax-reference/',
   },
 ];


### PR DESCRIPTION
## Summary
Audit and fix of the three landing-page React components that still embedded **pre-v0.5.1 (pre-Phase-4d) Calor syntax**. Spotted by the user: the snippet in `CatchBugs.tsx` uses a square-bracket pseudo-syntax that the real parser has never accepted (`§F[...]`, `§I[...]`, `§E[...]`, `§/F[...]`), and a follow-up audit found two more landing components with stale closer-form (`§/F{id}`, `§/M{id}`) that was removed in Phase 4d.

## Audit scope and result
Searched `website/src/` and `website/content/` for:
- Square-bracket attribute form `§X[...]` → **1 file** (`CatchBugs.tsx`, fixed)
- Structural closer-form `§/F{id}`, `§/M{id}`, `§/L{id}`, etc. → **2 files in landing** (`CodeComparison.tsx`, `FeatureGrid.tsx`, both fixed)
- MDX docs in `website/content/` still mentioning closer-form → only the legacy callouts in `design-principles.mdx` and the `changelog.mdx` entry I just wrote, both intentional (Phase 5 doc migration already swept the rest).
- `WhatsNewBanner.tsx` mentions `§/F, §/M, §/I` in prose explaining the removal — intentional, left alone.

## Changes per file

### `website/src/components/landing/CatchBugs.tsx`
- Replaced `calorCode` snippet: now uses indent-form wrapped in a `§M{m1:Orders}` module, parameters inline in `(Order:order) -> bool`, inline calls as `§C{name} §A arg §/C`. Removed the `§/F[f_01A8X]` closer.
- Fixed the `errorOutput` compiler-message text: `§E[db]` → `§E{db}`, `§E[db,net]` → `§E{db,net}`.

### `website/src/components/landing/CodeComparison.tsx`
- Wrapped the `Square` function in a `§M{m1:Math}` module.
- Removed the `§/F{f_01J5X7K9M2}` closer (block ends are pure dedent post-Phase 4d).
- Folded `§I{i32:x}` / `§O{i32}` into the canonical signature line `(i32:x) -> i32`, matching `samples/Contracts/contracts.calr`.
- Shifted annotation `line:` indices by +1 to account for the new module wrapper line.

### `website/src/components/landing/FeatureGrid.tsx`
- Card #4's code snippet used `§M{m_...:App}\n  ...\n§/M{m_...}` — replaced with an indent-form example showing `§M` containing `§F` containing `§P`.
- Reframed the card title and description. The original ("No More Missing Braces" / *"explicit start/end tags mean AI can't generate malformed code. No more 'unexpected token' from bad indentation."*) became **self-contradictory** post-Phase 4d, because indentation IS now load-bearing. New framing emphasises the real value prop: tagged structural markers + indent-defined scope.

## Verification
All three new snippets compile cleanly through the locally-built v0.5.1 `calor` CLI (`dotnet run --project src/Calor.Compiler -- --input probe.calr --output probe.cs`).