### PR TITLE
feat(bind-inference): Calor0251-0253 strict bind-inference diagnostics

### DIFF
--- a/docs/syntax-reference/binding.md
+++ b/docs/syntax-reference/binding.md
@@ -171,20 +171,29 @@ case, producing wrong-typed code with no diagnostic. The diagnostic
 was added in v0.6 and is enforced through the main `calor compile`
 pipeline by `BindValidationPass`.
 
-### Reserved (future)
+### Strict-mode diagnostics (`--strict-bind-inference`)
 
-These codes are reserved in the `Calor0250-0259` range for the
-optional strict-mode inference checks described in the RFC. They are
-not yet active.
+The following diagnostics are reserved in the `Calor0250-0259` range
+and are enforced **only** when the `--strict-bind-inference` flag is
+passed to `calor compile`. They are scheduled to become default-on in
+v0.7 (see RFC §6).
 
 | Code | Title | Fires on |
 |:-----|:------|:---------|
-| `Calor0251` | `BindCannotInferNullLiteral` | `§B{x} none` |
-| `Calor0252` | `BindCannotInferGenericReturn` | `§B{x} §C{Vec.empty}` (generic return) |
-| `Calor0253` | `BindAmbiguousNumeric` | `§B{x} (+ INT:0 FLOAT:0.0)` |
+| `Calor0251` | `BindCannotInferNullLiteral` | `§B{x} §NN` (untyped None) or `§B{x} null` |
+| `Calor0252` | `BindCannotInferGenericReturn` | `§B{x} §C{Vec.empty} §/C` and other well-known generic factory targets (`Vec.empty`, `List.empty`, `Array.empty`, `Set.empty`, `Map.empty`, …) |
+| `Calor0253` | `BindAmbiguousNumeric` | `§B{x} (+ INT:0 FLOAT:0.0)` — a binary op mixing integer and floating-point literal operands |
 
-Each will ship with an LSP quick-fix that inserts the recommended
-explicit annotation. Tracked in
+Each fires only when the binding lacks an explicit `:type` annotation;
+adding the annotation always silences the diagnostic.
+
+```
+§B{x:Option<i32>} §NN              // silences Calor0251
+§B{x:Vec<i32>} §C{Vec.empty} §/C   // silences Calor0252
+§B{x:f64} (+ INT:0 FLOAT:0.0)      // silences Calor0253
+```
+
+LSP quick-fixes that insert the recommended annotation are tracked in
 [#644](https://github.com/juanmicrosoft/calor/issues/644).
 
 ---

--- a/src/Calor.Compiler/Analysis/BindValidationPass.cs
+++ b/src/Calor.Compiler/Analysis/BindValidationPass.cs
@@ -7,23 +7,61 @@ namespace Calor.Compiler.Analysis;
 /// Validates <c>§B</c> binding declarations against the rules in
 /// <c>docs/syntax-reference/binding.md</c>.
 ///
-/// Currently enforces a single rule: a binding must carry either a
-/// <c>:type</c> annotation or an initializer expression. The other
-/// inference-related checks (<c>Calor0251</c>–<c>Calor0253</c>) are
-/// reserved for a future strict-inference pass.
+/// <para>Always-on checks (the bug-fix baseline):</para>
+/// <list type="bullet">
+///   <item><c>Calor0250 BindRequiresTypeOrInitializer</c> —
+///   a binding must carry either a <c>:type</c> annotation or
+///   an initializer expression.</item>
+/// </list>
 ///
-/// This pass walks the parsed AST directly and does not depend on the
+/// <para>Strict-mode checks (enabled by <c>--strict-bind-inference</c>):</para>
+/// <list type="bullet">
+///   <item><c>Calor0251 BindCannotInferNullLiteral</c> —
+///   <c>§B{x} none</c> / <c>§B{x} null</c> with no <c>:type</c> annotation.</item>
+///   <item><c>Calor0252 BindCannotInferGenericReturn</c> —
+///   <c>§B{x} §C{Vec.empty}</c> and similar well-known generic
+///   factory calls without a <c>:type</c> annotation.</item>
+///   <item><c>Calor0253 BindAmbiguousNumeric</c> —
+///   <c>§B{x} (+ INT:0 FLOAT:0.0)</c> mixing integer and floating-point
+///   literal operands without a <c>:type</c> annotation.</item>
+/// </list>
+///
+/// <para>This pass walks the parsed AST directly and does not depend on the
 /// <c>Binder</c>. The <c>Binder</c> still contains a defensive copy of
-/// the check (used by <c>VerificationAnalysisPass</c> and unit tests)
-/// so that direct binder invocations still surface the diagnostic.
+/// the <c>Calor0250</c> check (used by <c>VerificationAnalysisPass</c>
+/// and unit tests) so that direct binder invocations still surface
+/// the diagnostic.</para>
 /// </summary>
 public sealed class BindValidationPass
 {
     private readonly DiagnosticBag _diagnostics;
+    private readonly bool _strictInference;
 
-    public BindValidationPass(DiagnosticBag diagnostics)
+    /// <summary>
+    /// Well-known generic factory calls whose return type cannot be inferred
+    /// without an explicit type argument. Matched on the call's target
+    /// string ending — so <c>Vec.empty</c>, <c>Vec&lt;T&gt;.empty</c>, and
+    /// <c>some.module.Vec.empty</c> all match <c>Vec.empty</c>.
+    /// </summary>
+    private static readonly string[] GenericFactoryTargets =
+    [
+        "Vec.empty",
+        "Vec.create",
+        "List.empty",
+        "List.create",
+        "Array.empty",
+        "Set.empty",
+        "Map.empty",
+        "Dictionary.empty",
+        "Dict.empty",
+        "Queue.empty",
+        "Stack.empty",
+    ];
+
+    public BindValidationPass(DiagnosticBag diagnostics, bool strictInference = false)
     {
         _diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
+        _strictInference = strictInference;
     }
 
     public void Check(ModuleNode module)
@@ -159,12 +197,95 @@ public sealed class BindValidationPass
 
     private void CheckBind(BindStatementNode bind)
     {
+        // Calor0250 — always-on baseline.
         if (bind.TypeName == null && bind.Initializer == null)
         {
             _diagnostics.ReportError(bind.Span, DiagnosticCode.BindRequiresTypeOrInitializer,
                 $"Binding '{bind.Name}' has no type annotation and no initializer. " +
                 "Add either ':type' (e.g. '§B{" + bind.Name + ":i32}') " +
                 "or an initializer expression so the binder can infer the type.");
+            return;
+        }
+
+        // Strict-mode checks (Calor0251-0253) — only when --strict-bind-inference is set
+        // and the binding has no explicit type annotation. An explicit :type always wins.
+        if (!_strictInference || bind.TypeName != null || bind.Initializer == null)
+        {
+            return;
+        }
+
+        CheckStrictInitializer(bind, bind.Initializer);
+    }
+
+    private void CheckStrictInitializer(BindStatementNode bind, ExpressionNode init)
+    {
+        // Calor0251 — bare none/null cannot infer a type.
+        if (init is NoneExpressionNode none && none.TypeName == null)
+        {
+            _diagnostics.ReportError(bind.Span, DiagnosticCode.BindCannotInferNullLiteral,
+                $"Binding '{bind.Name}' uses 'none' without a type. " +
+                "Inference cannot pick a concrete element type. " +
+                "Add ':Option<T>' (e.g. '§B{" + bind.Name + ":Option<i32>} none') " +
+                "or use a typed §NN{type=...} form.");
+            return;
+        }
+
+        if (init is ReferenceNode refNode && refNode.Name == "null")
+        {
+            _diagnostics.ReportError(bind.Span, DiagnosticCode.BindCannotInferNullLiteral,
+                $"Binding '{bind.Name}' is initialised to 'null' with no declared type. " +
+                "Inference cannot pick a concrete type. " +
+                "Add ':T?' or use an Option type (e.g. '§B{" + bind.Name + ":Option<T>} none').");
+            return;
+        }
+
+        // Calor0252 — well-known generic factory call without explicit type.
+        if (init is CallExpressionNode call && IsGenericFactoryTarget(call.Target))
+        {
+            _diagnostics.ReportError(bind.Span, DiagnosticCode.BindCannotInferGenericReturn,
+                $"Binding '{bind.Name}' is initialised from '{call.Target}' whose return type " +
+                "is generic and has no resolved type argument. " +
+                "Add an explicit type annotation, e.g. '§B{" + bind.Name + ":Vec<i32>} §C{Vec<i32>.empty} §/C'.");
+            return;
+        }
+
+        // Calor0253 — binary op mixing integer and float literal operands.
+        if (init is BinaryOperationNode bin && IsAmbiguousNumeric(bin))
+        {
+            _diagnostics.ReportError(bind.Span, DiagnosticCode.BindAmbiguousNumeric,
+                $"Binding '{bind.Name}' is initialised from a numeric expression that mixes " +
+                "integer and floating-point literals; widening could pick more than one type. " +
+                "Add an explicit numeric annotation, e.g. '§B{" + bind.Name + ":f64} ...' " +
+                "or '§B{" + bind.Name + ":i32} ...'.");
+            return;
         }
     }
+
+    private static bool IsGenericFactoryTarget(string target)
+    {
+        if (string.IsNullOrEmpty(target))
+        {
+            return false;
+        }
+        // Match either an exact target, or any target whose tail is a known
+        // factory (so e.g. "my.module.Vec.empty" still matches "Vec.empty").
+        foreach (var known in GenericFactoryTargets)
+        {
+            if (target == known || target.EndsWith("." + known, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool IsAmbiguousNumeric(BinaryOperationNode bin)
+    {
+        return IsIntegerLiteral(bin.Left) && IsFloatLiteral(bin.Right)
+            || IsFloatLiteral(bin.Left) && IsIntegerLiteral(bin.Right);
+    }
+
+    private static bool IsIntegerLiteral(ExpressionNode e) => e is IntLiteralNode;
+
+    private static bool IsFloatLiteral(ExpressionNode e) => e is FloatLiteralNode or DecimalLiteralNode;
 }

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -68,6 +68,36 @@ public static class DiagnosticCode
     /// </summary>
     public const string BindRequiresTypeOrInitializer = "Calor0250";
 
+    /// <summary>
+    /// Error: <c>§B{name} none</c> / <c>§B{name} null</c> cannot infer a
+    /// type — the right-hand side carries no concrete element type. The
+    /// fix is to give the binding an explicit option type, e.g.
+    /// <c>§B{name:Option&lt;T&gt;} none</c>.
+    /// Fires only under <c>--strict-bind-inference</c> in v0.6; default-on
+    /// in v0.7. See RFC v0.6 bind-inference-formalization §3.2.
+    /// </summary>
+    public const string BindCannotInferNullLiteral = "Calor0251";
+
+    /// <summary>
+    /// Error: <c>§B{name} §C{Foo.bar}</c> cannot infer a type when
+    /// <c>Foo.bar</c> returns a generic with an unresolved type
+    /// parameter (e.g. <c>Vec&lt;T&gt;.empty</c>). The fix is to give
+    /// the binding an explicit type argument.
+    /// Fires only under <c>--strict-bind-inference</c> in v0.6; default-on
+    /// in v0.7. See RFC v0.6 bind-inference-formalization §3.2.
+    /// </summary>
+    public const string BindCannotInferGenericReturn = "Calor0252";
+
+    /// <summary>
+    /// Error: <c>§B{name} (+ INT:0 FLOAT:0.0)</c> — the initializer mixes
+    /// numeric types and widening could pick more than one bound type.
+    /// The fix is to give the binding an explicit numeric annotation
+    /// (<c>:i32</c>, <c>:f64</c>, …).
+    /// Fires only under <c>--strict-bind-inference</c> in v0.6; default-on
+    /// in v0.7. See RFC v0.6 bind-inference-formalization §3.2.
+    /// </summary>
+    public const string BindAmbiguousNumeric = "Calor0253";
+
     // Contract errors (Calor0300-0399)
     public const string InvalidPrecondition = "Calor0300";
     public const string InvalidPostcondition = "Calor0301";

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -101,6 +101,11 @@ public class Program
             aliases: ["--all-findings"],
             description: "Report all analysis findings including inconclusive and low-confidence results (default: only report verified findings)");
 
+        var strictBindInferenceOption = new Option<bool>(
+            aliases: ["--strict-bind-inference"],
+            description: "Enable strict bind-inference diagnostics Calor0251-0253 (null/none, generic factory, ambiguous-numeric). Default-on in v0.7.",
+            getDefaultValue: () => false);
+
         var experimentalOption = new Option<string[]>(
             aliases: ["--experimental"],
             description: "Enable an experimental feature flag (repeatable). Flag names are defined in docs/experiments/registry.json. Unknown flags are accepted silently.")
@@ -124,6 +129,7 @@ public class Program
             noTelemetryOption,
             analyzeOption,
             allFindingsOption,
+            strictBindInferenceOption,
             experimentalOption
         };
 
@@ -156,6 +162,7 @@ public class Program
             var verificationTimeout = ctx.ParseResult.GetValueForOption(verificationTimeoutOption);
             var analyze = ctx.ParseResult.GetValueForOption(analyzeOption);
             var allFindings = ctx.ParseResult.GetValueForOption(allFindingsOption);
+            var strictBindInference = ctx.ParseResult.GetValueForOption(strictBindInferenceOption);
             var experimental = ctx.ParseResult.GetValueForOption(experimentalOption) ?? Array.Empty<string>();
 
             telemetry?.TrackEvent("CompileOptions", new Dictionary<string, string>
@@ -170,12 +177,13 @@ public class Program
                 ["noCache"] = noCache.ToString(),
                 ["verificationTimeout"] = verificationTimeout.ToString(),
                 ["analyze"] = analyze.ToString(),
+                ["strictBindInference"] = strictBindInference.ToString(),
                 ["experimentalFlagCount"] = experimental.Length.ToString()
             });
 
             try
             {
-                ctx.ExitCode = await CompileAsync(input, output, verbose, strictApi, requireDocs, enforceEffects, strictEffects, permissiveEffects, contractMode, verify, noCache, clearCache, verificationTimeout, analyze, allFindings, experimental);
+                ctx.ExitCode = await CompileAsync(input, output, verbose, strictApi, requireDocs, enforceEffects, strictEffects, permissiveEffects, contractMode, verify, noCache, clearCache, verificationTimeout, analyze, allFindings, experimental, strictBindInference);
             }
             catch (Exception ex)
             {
@@ -243,7 +251,7 @@ public class Program
         return result;
     }
 
-    private static async Task<int> CompileAsync(FileInfo[]? input, FileInfo? output, bool verbose, bool strictApi, bool requireDocs, bool enforceEffects, bool strictEffects, bool permissiveEffects, string contractMode, bool verify, bool noCache, bool clearCache, int verificationTimeout, bool analyze, bool allFindings = false, string[]? experimentalFlags = null)
+    private static async Task<int> CompileAsync(FileInfo[]? input, FileInfo? output, bool verbose, bool strictApi, bool requireDocs, bool enforceEffects, bool strictEffects, bool permissiveEffects, string contractMode, bool verify, bool noCache, bool clearCache, int verificationTimeout, bool analyze, bool allFindings = false, string[]? experimentalFlags = null, bool strictBindInference = false)
     {
         try
         {
@@ -348,7 +356,8 @@ public class Program
                     } : null,
                     ExperimentalFlags = experimentalFlags != null && experimentalFlags.Length > 0
                         ? new ExperimentalFlags(experimentalFlags)
-                        : ExperimentalFlags.None
+                        : ExperimentalFlags.None,
+                    StrictBindInference = strictBindInference
                 };
                 var result = Compile(source, file.FullName, options);
 
@@ -530,7 +539,7 @@ public class Program
 
         // Bind validation (Calor0250: §B requires type or initializer)
         phaseSw.Restart();
-        var bindValidator = new BindValidationPass(diagnostics);
+        var bindValidator = new BindValidationPass(diagnostics, options.StrictBindInference);
         bindValidator.Check(ast);
         phaseSw.Stop();
         telemetry?.TrackPhase("BindValidation", phaseSw.ElapsedMilliseconds, !diagnostics.HasErrors);
@@ -954,6 +963,14 @@ public sealed class CompilationOptions
     /// Enable type checking phase.
     /// </summary>
     public bool EnableTypeChecking { get; init; }
+
+    /// <summary>
+    /// Enable strict bind-inference diagnostics (Calor0251-0253). When false,
+    /// only Calor0250 (BindRequiresTypeOrInitializer) is enforced. Designed
+    /// to ship behind a flag for one release per RFC v0.6 bind-inference-formalization §6.
+    /// Default-on in v0.7.
+    /// </summary>
+    public bool StrictBindInference { get; init; }
 
     /// <summary>
     /// Cancellation token for aborting long-running operations (e.g., Z3 verification).

--- a/tests/Calor.Compiler.Tests/CompilerBugFixTests.cs
+++ b/tests/Calor.Compiler.Tests/CompilerBugFixTests.cs
@@ -702,5 +702,148 @@ public class CompilerBugFixTests
             d => d.Code == DiagnosticCode.BindRequiresTypeOrInitializer);
     }
 
+    [Fact]
+    public void StrictBindInference_NoneInitializer_ReportsCalor0251()
+    {
+        // §B{x} §NN with --strict-bind-inference must fail with Calor0251.
+        var source = """
+            §M{m001:Test}
+              §F{f001:Foo:pub}
+                  §O{void}
+                  §B{x} §NN
+            """;
+
+        var result = Program.Compile(source, "test.calr",
+            new CompilationOptions { StrictBindInference = true });
+
+        Assert.True(result.HasErrors);
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.BindCannotInferNullLiteral);
+    }
+
+    [Fact]
+    public void StrictBindInference_NoneInitializer_NoStrict_Compiles()
+    {
+        // Without --strict-bind-inference, §B{x} §NN must compile cleanly.
+        var source = """
+            §M{m001:Test}
+              §F{f001:Foo:pub}
+                  §O{void}
+                  §B{x} §NN
+            """;
+
+        var result = Program.Compile(source);
+
+        Assert.False(result.HasErrors,
+            "Without --strict-bind-inference, §B{x} §NN must not fire Calor0251.");
+    }
+
+    [Fact]
+    public void StrictBindInference_TypedNone_DoesNotReportCalor0251()
+    {
+        // §B{x:Option<i32>} §NN bypasses the inference path entirely.
+        var source = """
+            §M{m001:Test}
+              §F{f001:Foo:pub}
+                  §O{void}
+                  §B{x:Option<i32>} §NN
+            """;
+
+        var result = Program.Compile(source, "test.calr",
+            new CompilationOptions { StrictBindInference = true });
+
+        Assert.DoesNotContain(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.BindCannotInferNullLiteral);
+    }
+
+    [Fact]
+    public void StrictBindInference_GenericFactoryCall_ReportsCalor0252()
+    {
+        // §B{x} §C{Vec.empty} §/C is a known generic factory; strict mode flags it.
+        var source = """
+            §M{m001:Test}
+              §F{f001:Foo:pub}
+                  §O{void}
+                  §B{x} §C{Vec.empty} §/C
+            """;
+
+        var result = Program.Compile(source, "test.calr",
+            new CompilationOptions { StrictBindInference = true });
+
+        Assert.True(result.HasErrors);
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.BindCannotInferGenericReturn);
+    }
+
+    [Fact]
+    public void StrictBindInference_GenericFactoryCall_NoStrict_Compiles()
+    {
+        var source = """
+            §M{m001:Test}
+              §F{f001:Foo:pub}
+                  §O{void}
+                  §B{x} §C{Vec.empty} §/C
+            """;
+
+        var result = Program.Compile(source, "test.calr",
+            new CompilationOptions { EnforceEffects = false });
+
+        Assert.DoesNotContain(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.BindCannotInferGenericReturn);
+    }
+
+    [Fact]
+    public void StrictBindInference_AmbiguousNumeric_ReportsCalor0253()
+    {
+        // (+ INT:0 FLOAT:0.0) mixes integer and float literals: ambiguous widening.
+        var source = """
+            §M{m001:Test}
+              §F{f001:Foo:pub}
+                  §O{void}
+                  §B{x} (+ INT:0 FLOAT:0.0)
+            """;
+
+        var result = Program.Compile(source, "test.calr",
+            new CompilationOptions { StrictBindInference = true });
+
+        Assert.True(result.HasErrors);
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.BindAmbiguousNumeric);
+    }
+
+    [Fact]
+    public void StrictBindInference_AmbiguousNumeric_NoStrict_Compiles()
+    {
+        var source = """
+            §M{m001:Test}
+              §F{f001:Foo:pub}
+                  §O{void}
+                  §B{x} (+ INT:0 FLOAT:0.0)
+            """;
+
+        var result = Program.Compile(source);
+
+        Assert.False(result.HasErrors,
+            "Without --strict-bind-inference, mixed INT+FLOAT must not fire Calor0253.");
+    }
+
+    [Fact]
+    public void StrictBindInference_HomogeneousNumeric_DoesNotReportCalor0253()
+    {
+        // Same-type operands: no ambiguity, no diagnostic.
+        var source = """
+            §M{m001:Test}
+              §F{f001:Foo:pub}
+                  §O{void}
+                  §B{x} (+ INT:1 INT:2)
+            """;
+
+        var result = Program.Compile(source, "test.calr",
+            new CompilationOptions { StrictBindInference = true });
+
+        Assert.DoesNotContain(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.BindAmbiguousNumeric);
+    }
+
     #endregion
 }


### PR DESCRIPTION
## Summary

Implements **issue #644** — the deferred Phase 3 of RFC v0.6 bind-inference-formalization.

Ships three new strict-mode bind-inference diagnostics behind a new `--strict-bind-inference` flag in v0.6.1; default-on in v0.7 per RFC §6.

### New diagnostics

Each fires only when the binding lacks an explicit `:type` annotation; adding the annotation always silences the diagnostic.

| Code | Title | Fires on |
|:-----|:------|:---------|
| `Calor0251` | `BindCannotInferNullLiteral` | `§B{x} §NN` (untyped None) or `§B{x} null` |
| `Calor0252` | `BindCannotInferGenericReturn` | `§B{x} §C{Vec.empty} §/C` and other well-known generic factory targets (`Vec.empty`, `List.empty`, `Array.empty`, `Set.empty`, `Map.empty`, `Dict.empty`, `Queue.empty`, `Stack.empty`, plus `.create` variants where defined). Match is on the dotted target tail so fully-qualified names like `my.module.Vec.empty` also fire. |
| `Calor0253` | `BindAmbiguousNumeric` | `§B{x} (+ INT:0 FLOAT:0.0)` — a binary op mixing integer and floating-point literal operands. |

### Implementation

- Diagnostic constants registered in `src/Calor.Compiler/Diagnostics/Diagnostic.cs` (codes `Calor0251-0253` in the already-reserved `Calor0250-0259` range that PR #642 set aside).
- Detection logic added to `BindValidationPass` (PR #646), gated by a new constructor flag `strictInference`. The pass already walks every binding in functions, methods, constructors, property accessors, operator overloads, indexer accessors, and nested `§IF`/`§L`/`§W`/`§MATCH`/`§TRY` bodies — so the new diagnostics get full coverage for free.
- `CompilationOptions.StrictBindInference` (defaults `false`) plumbed through from a new `--strict-bind-inference` CLI option in `Program.cs`.

### Tests

Nine new tests in `CompilerBugFixTests`:
- Three positive tests: each diagnostic fires under `--strict-bind-inference`.
- Three negative tests: each diagnostic does **not** fire without the flag.
- Three bypass/safety tests:
  - `§B{x:Option<i32>} §NN` (typed None) skips Calor0251
  - `§B{x} (+ INT:1 INT:2)` (homogeneous numeric) skips Calor0253
  - and the existing baseline `§B{x} INT:42` regression test.

Full suite: 7,373 tests, 0 failures.

### Out of scope / follow-up

LSP code action quick-fixes are **not** included in this PR. RFC §6 explicitly allows deferring the strict-mode set to v0.7 if quick-fixes are not ready. The diagnostics today already carry suggested-fix text in the message body (e.g. `Add ':Option<T>' (e.g. '§B{x:Option<i32>} none')`). A follow-up issue should track wiring these through `DiagnosticBag.ReportErrorWithFix` so they appear as one-click code actions in VS Code.

### Manual verification

\\\
\$ calor compile --strict-bind-inference -i bare-none.calr -o out.cs
error Calor0251: Binding 'x' uses 'none' without a type. ...

\$ calor compile --strict-bind-inference -i vec-empty.calr -o out.cs
error Calor0252: Binding 'x' is initialised from 'Vec.empty' whose return type is generic ...

\$ calor compile --strict-bind-inference -i ambiguous.calr -o out.cs
error Calor0253: Binding 'x' is initialised from a numeric expression that mixes integer and floating-point literals ...
\\\

Each case compiles cleanly without the flag, as expected.

Closes #644.