### PR TITLE
feat(parser): call-closer elision for expression-context §C calls (Phase 1, Closes #643)

### DIFF
--- a/docs/syntax-reference/calls.md
+++ b/docs/syntax-reference/calls.md
@@ -1,0 +1,209 @@
+---
+layout: default
+title: Calls
+parent: Syntax Reference
+nav_order: 4
+---
+
+# Calls
+
+The `§C` tag invokes a function or method. Calls work in **statement**
+context (the call's result is discarded) and **expression** context
+(the call's result is used by the surrounding expression — typically as
+the initializer of a `§B`, an argument to another call, or the right
+side of an operation).
+
+> **Reference for RFC** `v0.6-call-closer-elision`. The behavior on
+> this page is what the parser does today and is pinned by
+> `tests/Calor.Compiler.Tests/CallStatementImplicitCloseTests.cs` and
+> `tests/Calor.Compiler.Tests/CallExpressionImplicitCloseTests.cs`.
+
+---
+
+## Syntax
+
+```
+§C{target}                           // (1) zero arguments, implicit close
+§C{target} arg                       // (2) one inline argument, implicit close
+§C{target} §A arg1 §A arg2 §/C       // (3) explicit form, any arity
+§C{target} §A arg1 §A arg2           // (4) explicit form, no §/C (closes at dedent)
+```
+
+`target` is a dotted name or a generic invocation:
+`Console.WriteLine`, `Math.Max`, `items.Cast<i32>`.
+
+The argument in form (2) is any **primary expression** — a literal,
+identifier, dotted reference, member access, indexer access, or a
+parenthesized expression. It is **not** a `§A`-list; for two or more
+arguments use form (3) or (4).
+
+---
+
+## Rules
+
+1. **A call without arguments needs no `§/C`.** Both
+   `§C{Logger.Flush}` and `§C{Logger.Flush} §/C` parse to the same
+   `CallExpressionNode`.
+2. **A call with exactly one argument supplied inline (no `§A`) needs
+   no `§/C`.** Both `§C{Identity} x` and `§C{Identity} §A x §/C` parse
+   to the same `CallExpressionNode` (form (2) vs (3)).
+3. **A call with two or more arguments must use `§A`.** The inline-arg
+   form (2) is limited to a single primary expression by construction.
+4. **Trailing member access attaches to the argument, not to the call
+   result.** After `§C{Identity} obj?.Length`, the `?.Length` belongs
+   to `obj` because the inline-arg parser greedily consumes a full
+   primary expression including its trailing member chain. See
+   [Disambiguation](#disambiguation) for the corner cases.
+5. **Trailing member access after a zero-arg call attaches to the call
+   result.** `§C{Maybe}?.Length` parses as
+   `NullConditional(Call("Maybe"), "Length")`, because the parser sees
+   `?.`, takes the zero-arg implicit-close path, then runs trailing
+   member access on the call result.
+6. **Both `§/C` and abbreviated `§/C{id}` are still accepted** for
+   forms (1), (2), (3), and (4) — no source file needs to be rewritten.
+
+---
+
+## Disambiguation
+
+The implicit-close forms introduce two parser decisions. The
+disambiguation rules below match RFC §3.2.
+
+### Case A — trailing member on an inline argument
+
+```
+§B{n} §C{Identity} obj?.Length
+```
+
+Reads as `Identity(obj?.Length)`, not `Identity(obj)?.Length`. The
+inline-arg branch calls the same expression parser used everywhere
+else, which greedily consumes `?.Length` as part of the primary
+expression `obj?.Length`.
+
+If you intended `Identity(obj)?.Length` instead, write either:
+
+```
+§B{n} §C{Identity} §A obj §/C ?.Length     // explicit form
+§B{n} §C{Identity}.Length                  // zero-arg call + access
+```
+
+### Case B — two consecutive expression-start tokens (Calor0150)
+
+```
+§B{n} §C{Identity} a b           // ambiguous — second expression-start follows inline arg
+```
+
+This is **ambiguous** — once the inline form has consumed one positional
+argument, any second expression-start token (a literal, identifier,
+nested `§C` call, `§NEW`, etc.) cannot be unambiguously attributed to
+the call. Calor0150 also fires if the next token is `§A`, signalling
+the user mixed the inline and explicit forms. The parser reports
+
+```
+Calor0150  AmbiguousCallContinuation
+Closer-less call '§C{Identity}' already took one inline argument; a
+second positional argument is ambiguous. Use the explicit form
+'§C{Identity} §A a §A b §/C' instead.
+```
+
+and stops consuming tokens at the second expression, leaving it for
+the surrounding statement parser. To fix, rewrite using the explicit
+form:
+
+```
+§B{n} §C{Identity} §A a §A b §/C
+```
+
+### Case C — nested implicit-close calls
+
+```
+§B{x} §C{Foo.bar} §C{Baz.qux} y
+```
+
+Reads right-to-left as `Foo.bar(Baz.qux(y))`. The parser disambiguates
+nested implicit-close calls by counting the number of consecutive
+`§/C` closers after the deepest inline argument and comparing to the
+depth of enclosing `§A`-style calls. When all calls in the chain use
+the inline form, no closers are required.
+
+The mixed case
+`§B{x} §C{Foo.bar} §A §C{Baz.qux} y §/C §/C`
+also works: the inner `§C{Baz.qux} y §/C` is a standard
+one-inline-arg-plus-closer form, and the outer `§A ... §/C` is the
+explicit form for `Foo.bar`.
+
+---
+
+## Examples
+
+### Statement context
+
+```
+§F{Greet:pub}
+  §I{name:string}
+  §O{void}
+  §E{cw}
+
+  §C{Console.WriteLine} (concat "Hello, " name)   // implicit close
+```
+
+### Expression context — zero-arg
+
+```
+§F{Count:pub}
+  §O{i32}
+
+  §B{n:i32} §C{items.Count}            // zero-arg, implicit close
+  §R n
+```
+
+### Expression context — one inline arg
+
+```
+§F{Doubled:pub}
+  §I{x:i32}
+  §O{i32}
+
+  §B{y:i32} §C{Math.Abs} x             // one inline arg, implicit close
+  §R (* y 2)
+```
+
+### Expression context — two or more args (explicit form)
+
+```
+§F{Clamp:pub}
+  §I{x:i32}
+  §O{i32}
+
+  §B{lo:i32} INT:0
+  §B{hi:i32} INT:100
+  §B{r:i32} §C{Math.Clamp} §A x §A lo §A hi §/C
+  §R r
+```
+
+### Trailing member access
+
+```
+§B{len} §C{GetMessage}.Length          // zero-arg call, then .Length
+§B{up}  §C{GetMessage}?.ToUpper        // zero-arg call, then ?.ToUpper
+§B{tag} §C{Identity} obj?.Tag          // inline arg = obj?.Tag
+```
+
+---
+
+## Diagnostics
+
+| Code | Name | Description |
+|:-----|:-----|:------------|
+| `Calor0150` | AmbiguousCallContinuation | Two consecutive expression-start tokens follow a closer-less `§C{target} arg` — second positional argument is ambiguous. Use the explicit `§A` / `§/C` form. |
+
+---
+
+## Related
+
+- [Bindings](/calor/syntax-reference/binding/) — the most common
+  expression-call context (`§B{name} §C{...}`).
+- [Expressions](/calor/syntax-reference/expressions/) — Lisp-style
+  operations that frequently embed `§C` calls as arguments.
+- [Structure Tags](/calor/syntax-reference/structure-tags/) — block
+  closer rules in general.

--- a/docs/syntax-reference/index.md
+++ b/docs/syntax-reference/index.md
@@ -154,6 +154,7 @@ compatibility but should not be used in new code — see
 - [Structure Tags](/calor/syntax-reference/structure-tags/) - Modules, functions, block structure
 - [Types](/calor/syntax-reference/types/) - Type system, Option, Result
 - [Bindings](/calor/syntax-reference/binding/) - `§B` declarations and type inference
+- [Calls](/calor/syntax-reference/calls/) - `§C` calls in statement and expression context
 - [Expressions](/calor/syntax-reference/expressions/) - Lisp-style operators
 - [Control Flow](/calor/syntax-reference/control-flow/) - Loops, conditionals
 - [Contracts](/calor/syntax-reference/contracts/) - Requires, ensures

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -47,6 +47,19 @@ public static class DiagnosticCode
     public const string InvalidLispExpression = "Calor0114";
     public const string TypeParameterNotFound = "Calor0115";
 
+    // Call-elision diagnostics (Calor0150-0159) — RFC v0.6 call-closer-elision
+
+    /// <summary>
+    /// Error: A closer-less <c>§C{target}</c> call expression consumed one
+    /// inline primary expression as its argument and then encountered a
+    /// second expression-start token on the same call. The form
+    /// <c>§C{f} a b</c> is ambiguous: <c>b</c> might be a second positional
+    /// argument (needs <c>§A</c>) or an unrelated token. Use the explicit
+    /// form <c>§C{f} §A a §A b §/C</c>. Per RFC v0.6 call-closer-elision §3.2
+    /// case B.
+    /// </summary>
+    public const string AmbiguousCallContinuation = "Calor0150";
+
     // Semantic errors (Calor0200-0299)
     public const string UndefinedReference = "Calor0200";
     public const string DuplicateDefinition = "Calor0201";

--- a/src/Calor.Compiler/Diagnostics/DiagnosticBag.cs
+++ b/src/Calor.Compiler/Diagnostics/DiagnosticBag.cs
@@ -97,6 +97,19 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         => ReportError(span, DiagnosticCode.ExpectedClosingTag,
             $"Expected '{expectedCloseTag}' to close '{openTag}'");
 
+    /// <summary>
+    /// Calor0150 — A closer-less <c>§C{target}</c> call took one inline
+    /// primary expression as its argument and then encountered a second
+    /// expression-start token on the same call. Per RFC v0.6 call-closer-
+    /// elision §3.2 case B this is ambiguous; the user should switch to
+    /// the explicit form <c>§C{target} §A arg1 §A arg2 §/C</c>.
+    /// </summary>
+    public void ReportAmbiguousCallContinuation(TextSpan span, string target)
+        => ReportError(span, DiagnosticCode.AmbiguousCallContinuation,
+            $"Closer-less call '§C{{{target}}}' already took one inline argument; " +
+            "a second positional argument is ambiguous. " +
+            $"Use the explicit form '§C{{{target}}} §A arg1 §A arg2 §/C' instead.");
+
     // Semantic diagnostics
     public void ReportMissingExtensionSelf(TextSpan span, string methodName, string enumName)
         => ReportError(span, DiagnosticCode.MissingExtensionSelf,

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -2253,7 +2253,15 @@ public sealed class CalorEmitter : IAstVisitor<string>
         var fullTarget = escapedTarget + typeArgsSuffix;
 
         if (node.Arguments.Count == 0)
-            return $"§C{{{fullTarget}}} §/C";
+        {
+            // Phase 2 (RFC v0.6 call-closer-elision): zero-arg form may drop §/C.
+            // Safe in every context — the parser's zero-arg implicit-close path
+            // does not look at the following token. Flag defaults to false in
+            // v0.6.0; planned to flip to true in v0.6.1 once snapshots churn.
+            return _context?.UseImplicitCallCloser == true
+                ? $"§C{{{fullTarget}}}"
+                : $"§C{{{fullTarget}}} §/C";
+        }
 
         // Emit named argument labels as §A[name] value when present
         var args = node.Arguments.Select((a, i) =>

--- a/src/Calor.Compiler/Migration/ConversionContext.cs
+++ b/src/Calor.Compiler/Migration/ConversionContext.cs
@@ -218,6 +218,14 @@ public sealed class ConversionContext
     public bool PassthroughOnError { get; set; }
 
     /// <summary>
+    /// When true, the emitter elides the trailing <c>§/C</c> on zero-arg and
+    /// one-arg expression-context <c>§C</c> calls. RFC <c>v0.6-call-closer-elision</c>
+    /// Phase 2. Default <c>false</c> in v0.6.0 (no snapshot churn); flipped
+    /// to <c>true</c> in v0.6.1. The parser accepts both forms regardless.
+    /// </summary>
+    public bool UseImplicitCallCloser { get; set; }
+
+    /// <summary>
     /// Whether unsupported constructs should be preserved as C# passthrough blocks.
     /// True when Mode is Interop or PassthroughOnError is enabled.
     /// </summary>

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -15,6 +15,16 @@ public sealed class Parser
     private bool _insideRefinementPredicate;
 
     /// <summary>
+    /// Phase 1 of v0.6 call-closer-elision RFC: tracks the number of
+    /// pending outer-call <c>§A</c> argument contexts that the inner
+    /// expression is being parsed inside. Used by
+    /// <see cref="ParseCallExpression"/>'s implicit-close branch to
+    /// decide whether a trailing <c>§/C</c> belongs to itself or to a
+    /// pending ancestor call. See RFC v0.6 call-closer-elision §3.2.
+    /// </summary>
+    private int _inOuterCallArgDepth;
+
+    /// <summary>
     /// Phase 4d — TokenKinds whose textual form is a legacy structural
     /// closing tag (<c>§/M</c>, <c>§/F</c>, <c>§/CL</c>, …) that indent
     /// form has fully replaced. Encountering any of these in the token
@@ -1387,8 +1397,16 @@ public sealed class Parser
         {
             if (Check(TokenKind.Arg))
             {
-                arguments.Add(ParseArgument(out var argName));
-                argumentNames.Add(argName);
+                _inOuterCallArgDepth++;
+                try
+                {
+                    arguments.Add(ParseArgument(out var argName));
+                    argumentNames.Add(argName);
+                }
+                finally
+                {
+                    _inOuterCallArgDepth--;
+                }
             }
             else
             {
@@ -7825,7 +7843,11 @@ public sealed class Parser
 
     /// <summary>
     /// Parses a call expression.
-    /// §C[target] §A arg1 §A arg2 §/C
+    /// Canonical form: <c>§C{target} §A arg1 §A arg2 §/C</c>.
+    /// Phase 1 of v0.6 call-closer-elision RFC also accepts:
+    ///   <c>§C{target}</c>             — zero-arg, no <c>§/C</c>
+    ///   <c>§C{target} primary_expr</c> — one inline-arg, no <c>§/C</c>
+    /// See <c>docs/plans/v0.6-call-closer-elision.md</c>.
     /// </summary>
     private ExpressionNode ParseCallExpression()
     {
@@ -7846,7 +7868,15 @@ public sealed class Parser
             {
                 if (Check(TokenKind.Arg))
                 {
-                    exprArgs.Add(ParseArgument());
+                    _inOuterCallArgDepth++;
+                    try
+                    {
+                        exprArgs.Add(ParseArgument());
+                    }
+                    finally
+                    {
+                        _inOuterCallArgDepth--;
+                    }
                 }
                 else if (IsExpressionStart())
                 {
@@ -7866,29 +7896,123 @@ public sealed class Parser
 
         var arguments = new List<ExpressionNode>();
         var argumentNames = new List<string?>();
+        TextSpan finalSpan;
 
-        // Parse arguments until we hit EndCall
-        while (!IsAtEnd && !IsBlockEnd(TokenKind.EndCall))
+        // Phase 1 (v0.6 call-closer-elision): try implicit-close forms first.
+        // Skip the implicit path only when the next token is §A or §/C
+        // (canonical forms still apply).
+        bool tryImplicit = !Check(TokenKind.Arg) && !IsBlockEnd(TokenKind.EndCall);
+
+        // Trailing-member-access markers (.member, ?.member) after
+        // §C{target} attach to the zero-arg call result. Take the implicit
+        // zero-arg path so that ParseTrailingMemberAccess at the end of the
+        // method picks them up.
+        //
+        // Note: trailing {index} indexer after §C is currently unreachable
+        // because ParseAttributes greedily consumes adjacent {...} as more
+        // attribute groups; we therefore do not list OpenBrace here.
+        bool isTrailingMember = Check(TokenKind.Dot)
+                             || Check(TokenKind.NullConditional);
+
+        if (tryImplicit && !isTrailingMember && IsExpressionStart())
         {
-            if (Check(TokenKind.Arg))
+            // §C{target} primary_expr — one inline argument, implicit close.
+            var argExpr = ParseExpression();
+            arguments.Add(argExpr);
+            argumentNames.Add(null);
+
+            // Decide whether to consume a trailing §/C. The §/C may belong to
+            // this call (top-level) or to a pending outer call's §A. The rule:
+            //   - top-level (_inOuterCallArgDepth == 0): always consume; otherwise the §/C dangles.
+            //   - nested: consume only if the run of consecutive §/C tokens
+            //     exceeds the number of pending outer-call ancestors that
+            //     each need one. RFC v0.6 call-closer-elision §3.2 case C.
+            if (Check(TokenKind.EndCall))
             {
-                arguments.Add(ParseArgument(out var argName));
-                argumentNames.Add(argName);
+                int consecutiveClosers = 0;
+                for (int p = _position; p < _tokens.Count && _tokens[p].Kind == TokenKind.EndCall; p++)
+                {
+                    consecutiveClosers++;
+                }
+
+                bool consumeClose = _inOuterCallArgDepth == 0
+                                 || consecutiveClosers > _inOuterCallArgDepth;
+                if (consumeClose)
+                {
+                    var endTok = ExpectBlockEnd(TokenKind.EndCall);
+                    finalSpan = startToken.Span.Union(endTok.Span);
+                }
+                else
+                {
+                    finalSpan = startToken.Span.Union(argExpr.Span);
+                }
             }
             else if (IsExpressionStart())
             {
-                // Single expression argument without §A prefix
-                arguments.Add(ParseExpression());
-                argumentNames.Add(null);
+                // Two consecutive expression-start tokens in inline-arg form:
+                // Calor0150 (RFC v0.6 call-closer-elision §3.2 case B).
+                // Recovery: stop here without consuming the second expression
+                // — let the caller see and recover from it.
+                _diagnostics.ReportAmbiguousCallContinuation(Current.Span, target);
+                finalSpan = startToken.Span.Union(argExpr.Span);
+            }
+            else if (Check(TokenKind.Arg))
+            {
+                // User started the inline form (one positional arg, no §A) and
+                // then continued with §A — they likely intended the explicit
+                // form. Calor0150 also covers this confusion: the inline form
+                // has consumed one arg and cannot accept a second one.
+                _diagnostics.ReportAmbiguousCallContinuation(Current.Span, target);
+                finalSpan = startToken.Span.Union(argExpr.Span);
             }
             else
             {
-                break;
+                // Implicit close: no §/C, no continuation.
+                finalSpan = startToken.Span.Union(argExpr.Span);
             }
         }
+        else if (tryImplicit)
+        {
+            // §C{target} <terminator> — zero arguments, implicit close.
+            // The } of §C{target} was already consumed inside ParseAttributes;
+            // anchor the span end at the token just before _position.
+            var lastConsumed = _position > 0 ? _tokens[_position - 1] : startToken;
+            finalSpan = startToken.Span.Union(lastConsumed.Span);
+        }
+        else
+        {
+            // Standard form: §A args (optional) and explicit §/C.
+            while (!IsAtEnd && !IsBlockEnd(TokenKind.EndCall))
+            {
+                if (Check(TokenKind.Arg))
+                {
+                    _inOuterCallArgDepth++;
+                    try
+                    {
+                        arguments.Add(ParseArgument(out var argName));
+                        argumentNames.Add(argName);
+                    }
+                    finally
+                    {
+                        _inOuterCallArgDepth--;
+                    }
+                }
+                else if (IsExpressionStart())
+                {
+                    // Legacy: single inline arg followed by explicit §/C.
+                    // Preserved for backward compatibility (§C{f} x §/C).
+                    arguments.Add(ParseExpression());
+                    argumentNames.Add(null);
+                }
+                else
+                {
+                    break;
+                }
+            }
 
-        var endToken = ExpectBlockEnd(TokenKind.EndCall);
-        var span = startToken.Span.Union(endToken.Span);
+            var endToken = ExpectBlockEnd(TokenKind.EndCall);
+            finalSpan = startToken.Span.Union(endToken.Span);
+        }
 
         // Extract trailing generic type arguments from call target.
         // e.g., "items.Cast<i32>" → target = "items.Cast", typeArgs = ["i32"]
@@ -7917,7 +8041,7 @@ public sealed class Parser
 
         // Only pass argument names if any are non-null
         var hasNames = argumentNames.Any(n => n != null);
-        ExpressionNode expr = new CallExpressionNode(span, target, arguments, hasNames ? argumentNames : null, null, typeArguments);
+        ExpressionNode expr = new CallExpressionNode(finalSpan, target, arguments, hasNames ? argumentNames : null, null, typeArguments);
 
         // Handle trailing member access (e.g., §C[Method]§/C.Property)
         return ParseTrailingMemberAccess(expr);

--- a/tests/Calor.Compiler.Tests/CallExpressionImplicitCloseTests.cs
+++ b/tests/Calor.Compiler.Tests/CallExpressionImplicitCloseTests.cs
@@ -1,0 +1,524 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Parser tests for Phase 1 of the v0.6 call-closer-elision RFC
+/// (<c>docs/plans/v0.6-call-closer-elision.md</c>). The RFC generalizes the
+/// existing statement-context implicit-close (<c>Parser.cs:1376</c>) to
+/// expression context.
+///
+/// Two new accepted forms:
+///   <c>§C{target}</c>              — zero-arg, no <c>§/C</c>
+///   <c>§C{target} primary_expr</c> — one inline arg, no <c>§/C</c>
+///
+/// One new diagnostic:
+///   <see cref="DiagnosticCode.AmbiguousCallContinuation"/> (Calor0150)
+///   — two consecutive expression-start tokens follow a closer-less call.
+/// </summary>
+public class CallExpressionImplicitCloseTests
+{
+    private static ModuleNode Parse(string source, out DiagnosticBag diagnostics)
+    {
+        diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAllForParser();
+        var parser = new Parser(tokens, diagnostics);
+        return parser.Parse();
+    }
+
+    private static T FirstBindingInitializer<T>(ModuleNode module) where T : ExpressionNode
+    {
+        var func = module.Functions.First();
+        var bind = func.Body.OfType<BindStatementNode>().First();
+        Assert.NotNull(bind.Initializer);
+        return Assert.IsType<T>(bind.Initializer);
+    }
+
+    [Fact]
+    public void ExpressionContext_OneInlineArg_NoCloser_Parses()
+    {
+        // §B{x} §C{Identity} INT:1   ← NEW: no §/C
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:i32}
+      §O{i32}
+      §B{x} §C{Identity} INT:1
+      §R x
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var call = FirstBindingInitializer<CallExpressionNode>(module);
+        Assert.Equal("Identity", call.Target);
+        Assert.Single(call.Arguments);
+        Assert.IsType<IntLiteralNode>(call.Arguments[0]);
+    }
+
+    [Fact]
+    public void ExpressionContext_OneInlineArg_WithExplicitCloser_StillParses()
+    {
+        // §B{x} §C{Identity} INT:1 §/C   ← LEGACY: still accepted
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:i32}
+      §O{i32}
+      §B{x} §C{Identity} INT:1 §/C
+      §R x
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var call = FirstBindingInitializer<CallExpressionNode>(module);
+        Assert.Equal("Identity", call.Target);
+        Assert.Single(call.Arguments);
+    }
+
+    [Fact]
+    public void ExpressionContext_ZeroArg_NoCloser_Parses()
+    {
+        // §B{x} §C{Vec.empty}   ← NEW: zero-arg, no §/C
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:pub}
+      §B{x} §C{Vec.empty}
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var call = FirstBindingInitializer<CallExpressionNode>(module);
+        Assert.Equal("Vec.empty", call.Target);
+        Assert.Empty(call.Arguments);
+    }
+
+    [Fact]
+    public void ExpressionContext_ZeroArg_WithExplicitCloser_StillParses()
+    {
+        // §B{x} §C{Vec.empty} §/C   ← LEGACY zero-arg with closer
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:pub}
+      §B{x} §C{Vec.empty} §/C
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var call = FirstBindingInitializer<CallExpressionNode>(module);
+        Assert.Equal("Vec.empty", call.Target);
+        Assert.Empty(call.Arguments);
+    }
+
+    [Fact]
+    public void ExpressionContext_OneInlineArg_TrailingMemberAccess_AttachesToArg()
+    {
+        // §B{n} §C{Identity} obj?.Length
+        // Reading A (RFC §3.2 case A): ?.Length attaches to obj, not to the call result.
+        // Note: the lexer treats `obj.Length` (with bare dot) as a single dotted
+        // identifier, so we use `?.` to force a parser-level disambiguation.
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:pub}
+      §B{obj:string} STR:"hi"
+      §B{n} §C{Identity} obj?.Length
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var func = module.Functions.First();
+        var nBind = func.Body.OfType<BindStatementNode>().Last();
+        var call = Assert.IsType<CallExpressionNode>(nBind.Initializer);
+        Assert.Equal("Identity", call.Target);
+        Assert.Single(call.Arguments);
+
+        // Argument should be a NullConditional(obj, "Length"), NOT a Reference(obj) with
+        // ?.Length on the call result.
+        var nc = Assert.IsType<NullConditionalNode>(call.Arguments[0]);
+        var inner = Assert.IsType<ReferenceNode>(nc.Target);
+        Assert.Equal("obj", inner.Name);
+        Assert.Equal("Length", nc.MemberName);
+    }
+
+    [Fact]
+    public void ExpressionContext_ZeroArg_TrailingNullConditionalMember_ParsesAsCallThenAccess()
+    {
+        // §B{n} §C{Maybe}?.Length
+        // The ?.Length should attach to the (zero-arg) call result, not be
+        // parsed as a malformed inline argument.
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:pub}
+      §B{n} §C{Maybe}?.Length
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var bind = module.Functions.First().Body.OfType<BindStatementNode>().First();
+        // Top-level expression must be a NullConditional on a Call.
+        var nc = Assert.IsType<NullConditionalNode>(bind.Initializer);
+        Assert.IsType<CallExpressionNode>(nc.Target);
+    }
+
+    [Fact]
+    public void ExpressionContext_ZeroArg_TrailingDotMember_ParsesAsCallThenAccess()
+    {
+        // §B{n} §C{Maybe}.Length — dot member after zero-arg implicit close.
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:pub}
+      §B{n} §C{Maybe}.Length
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var bind = module.Functions.First().Body.OfType<BindStatementNode>().First();
+        var ma = Assert.IsType<FieldAccessNode>(bind.Initializer);
+        Assert.IsType<CallExpressionNode>(ma.Target);
+        Assert.Equal("Length", ma.FieldName);
+    }
+
+    [Fact]
+    public void ExpressionContext_NestedCall_BothElided_Parses()
+    {
+        // §B{x} §C{Foo.bar} §C{Baz.qux} y   ← RFC §3.2 case C
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:pub}
+      §B{y:i32} INT:1
+      §B{x} §C{Foo.bar} §C{Baz.qux} y
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var func = module.Functions.First();
+        var xBind = func.Body.OfType<BindStatementNode>().Last();
+        var outer = Assert.IsType<CallExpressionNode>(xBind.Initializer);
+        Assert.Equal("Foo.bar", outer.Target);
+        Assert.Single(outer.Arguments);
+
+        var inner = Assert.IsType<CallExpressionNode>(outer.Arguments[0]);
+        Assert.Equal("Baz.qux", inner.Target);
+        Assert.Single(inner.Arguments);
+        Assert.IsType<ReferenceNode>(inner.Arguments[0]);
+    }
+
+    [Fact]
+    public void ExpressionContext_NestedCall_OuterStandardInnerElided_Parses()
+    {
+        // §C{outer} §A §C{inner} INT:1 §/C   ← one §/C goes to outer; inner elided
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:pub}
+      §B{x} §C{outer} §A §C{inner} INT:1 §/C
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var bind = module.Functions.First().Body.OfType<BindStatementNode>().First();
+        var outer = Assert.IsType<CallExpressionNode>(bind.Initializer);
+        Assert.Equal("outer", outer.Target);
+        Assert.Single(outer.Arguments);
+
+        var inner = Assert.IsType<CallExpressionNode>(outer.Arguments[0]);
+        Assert.Equal("inner", inner.Target);
+        Assert.Single(inner.Arguments);
+    }
+
+    [Fact]
+    public void ExpressionContext_NestedCall_BothExplicit_StillParses()
+    {
+        // §C{outer} §A §C{inner} INT:1 §/C §/C   ← LEGACY both explicit
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:pub}
+      §B{x} §C{outer} §A §C{inner} INT:1 §/C §/C
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var bind = module.Functions.First().Body.OfType<BindStatementNode>().First();
+        var outer = Assert.IsType<CallExpressionNode>(bind.Initializer);
+        Assert.Equal("outer", outer.Target);
+        Assert.Single(outer.Arguments);
+
+        var inner = Assert.IsType<CallExpressionNode>(outer.Arguments[0]);
+        Assert.Equal("inner", inner.Target);
+        Assert.Single(inner.Arguments);
+    }
+
+    [Fact]
+    public void ExpressionContext_DepthTwoNesting_AllExplicit_Parses()
+    {
+        // §C{o1} §A §C{o2} §A §C{i} x §/C §/C §/C   ← all three explicit
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:pub}
+      §B{x:i32} INT:1
+      §B{r} §C{o1} §A §C{o2} §A §C{i} x §/C §/C §/C
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var rBind = module.Functions.First().Body.OfType<BindStatementNode>().Last();
+        var o1 = Assert.IsType<CallExpressionNode>(rBind.Initializer);
+        Assert.Equal("o1", o1.Target);
+        var o2 = Assert.IsType<CallExpressionNode>(o1.Arguments[0]);
+        Assert.Equal("o2", o2.Target);
+        var i = Assert.IsType<CallExpressionNode>(o2.Arguments[0]);
+        Assert.Equal("i", i.Target);
+        Assert.IsType<ReferenceNode>(i.Arguments[0]);
+    }
+
+    [Fact]
+    public void ExpressionContext_DepthTwoNesting_TwoClosers_InnerElided_Parses()
+    {
+        // §C{o1} §A §C{o2} §A §C{i} x §/C §/C   ← exactly two §/C, i elided
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:pub}
+      §B{x:i32} INT:1
+      §B{r} §C{o1} §A §C{o2} §A §C{i} x §/C §/C
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var rBind = module.Functions.First().Body.OfType<BindStatementNode>().Last();
+        var o1 = Assert.IsType<CallExpressionNode>(rBind.Initializer);
+        var o2 = Assert.IsType<CallExpressionNode>(o1.Arguments[0]);
+        var i = Assert.IsType<CallExpressionNode>(o2.Arguments[0]);
+        Assert.Equal("i", i.Target);
+        Assert.Single(i.Arguments);
+    }
+
+    [Fact]
+    public void ExpressionContext_AmbiguousContinuation_EmitsCalor0150()
+    {
+        // §C{f} INT:1 INT:2   ← two consecutive expression-start tokens
+        // Per RFC §3.2 case B → Calor0150.
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:pub}
+      §B{x} §C{f} INT:1 INT:2
+""";
+        Parse(source, out var diags);
+        Assert.Contains(diags.Errors, e => e.Code == DiagnosticCode.AmbiguousCallContinuation);
+    }
+
+    [Fact]
+    public void ExpressionContext_AmbiguousContinuation_NestedCall_AlsoEmitsCalor0150()
+    {
+        // §C{f} a §C{g} b   ← a is f's inline arg; §C{g} is a second
+        // expression-start token on f. Per RFC §3.2 case B → Calor0150.
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:pub}
+      §B{a:i32} INT:1
+      §B{b:i32} INT:2
+      §B{x} §C{f} a §C{g} b
+""";
+        Parse(source, out var diags);
+        Assert.Contains(diags.Errors, e => e.Code == DiagnosticCode.AmbiguousCallContinuation);
+    }
+
+    [Fact]
+    public void ExpressionContext_GenericTargetAndZeroArg_Parses()
+    {
+        // §B{xs} §C{Array.Empty<i32>}   ← generic target, zero-arg, no §/C
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:pub}
+      §B{xs} §C{Array.Empty<i32>}
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var bind = module.Functions.First().Body.OfType<BindStatementNode>().First();
+        var call = Assert.IsType<CallExpressionNode>(bind.Initializer);
+        Assert.Equal("Array.Empty", call.Target);
+        Assert.NotNull(call.TypeArguments);
+        Assert.Equal("i32", call.TypeArguments[0]);
+    }
+
+    [Fact]
+    public void StatementContext_ImplicitClose_StillWorks()
+    {
+        // Regression check: the existing statement-context implicit close
+        // at Parser.cs:1376 is unaffected by the expression-context change.
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:pub}
+      §C{Console.WriteLine} STR:"hello"
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var stmt = module.Functions.First().Body.OfType<CallStatementNode>().First();
+        Assert.Equal("Console.WriteLine", stmt.Target);
+        Assert.Single(stmt.Arguments);
+    }
+
+    [Fact]
+    public void StatementContext_OuterArgConsumesItsOwnCloser_WhenInnerIsElidedCall()
+    {
+        // Regression: inner elided Call inside an outer statement-call's §A
+        // must NOT consume the §/C belonging to the outer call.
+        // Per rubber-duck review: requires _inOuterCallArgDepth to be bumped
+        // in ParseCallStatement's §A loop, not just ParseCallExpression's.
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:pub}
+      §B{x:i32} INT:1
+      §C{outer} §A §C{inner} x §/C
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var stmt = module.Functions.First().Body.OfType<CallStatementNode>().Last();
+        Assert.Equal("outer", stmt.Target);
+        Assert.Single(stmt.Arguments);
+        var innerCall = Assert.IsType<CallExpressionNode>(stmt.Arguments[0]);
+        Assert.Equal("inner", innerCall.Target);
+        Assert.Single(innerCall.Arguments);
+    }
+
+    [Fact]
+    public void ExpressionContext_InlineArgThenArg_EmitsCalor0150()
+    {
+        // §C{f} x §A y §/C — user mixed inline form with §A. Calor0150
+        // covers this confusion: the inline form already consumed one arg
+        // and cannot accept a second.
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:pub}
+      §B{x:i32} INT:1
+      §B{y:i32} INT:2
+      §B{r} §C{f} x §A y §/C
+""";
+        Parse(source, out var diags);
+        Assert.Contains(diags.Errors, e => e.Code == DiagnosticCode.AmbiguousCallContinuation);
+    }
+
+    [Fact]
+    public void LispContext_CallWithExplicitCloser_StillParses()
+    {
+        // Inside Lisp expressions, the canonical §A + §/C form must still
+        // parse cleanly. The closer-elision change must not regress this.
+        var source = """
+§M{m001:Test}
+  §F{f001:Foo:i32}
+      §O{i32}
+      §B{x} (+ §C{f} §A INT:1 §/C §C{g} §A INT:2 §/C)
+      §R x
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var bind = module.Functions.First().Body.OfType<BindStatementNode>().First();
+        var lisp = Assert.IsType<BinaryOperationNode>(bind.Initializer);
+        Assert.Equal(BinaryOperator.Add, lisp.Operator);
+        Assert.IsType<CallExpressionNode>(lisp.Left);
+        Assert.IsType<CallExpressionNode>(lisp.Right);
+    }
+
+    // ----- Phase 2: CalorEmitter.UseImplicitCallCloser flag -----
+
+    [Fact]
+    public void Emitter_ZeroArgCall_DefaultFlag_EmitsExplicitCloser()
+    {
+        // Default behavior unchanged in v0.6.0: zero-arg call still emits §/C.
+        var call = new CallExpressionNode(default, "Foo", new List<ExpressionNode>());
+        var emitter = new Migration.CalorEmitter();
+        var output = call.Accept<string>(emitter);
+        Assert.Equal("§C{Foo} §/C", output);
+    }
+
+    [Fact]
+    public void Emitter_ZeroArgCall_ImplicitCloserFlagTrue_ElidesCloser()
+    {
+        // With the flag set, zero-arg calls drop §/C.
+        var call = new CallExpressionNode(default, "Foo", new List<ExpressionNode>());
+        var ctx = new Migration.ConversionContext { UseImplicitCallCloser = true };
+        var emitter = new Migration.CalorEmitter(ctx);
+        var output = call.Accept<string>(emitter);
+        Assert.Equal("§C{Foo}", output);
+    }
+
+    [Fact]
+    public void Emitter_MultiArgCall_ImplicitCloserFlagTrue_StillEmitsCloser()
+    {
+        // Multi-arg form is unchanged regardless of flag — the inline-arg
+        // implicit-close form is limited to a single positional argument.
+        var args = new List<ExpressionNode>
+        {
+            new IntLiteralNode(default, 1),
+            new IntLiteralNode(default, 2),
+        };
+        var call = new CallExpressionNode(default, "Add", args);
+        var ctx = new Migration.ConversionContext { UseImplicitCallCloser = true };
+        var emitter = new Migration.CalorEmitter(ctx);
+        var output = call.Accept<string>(emitter);
+        Assert.EndsWith("§/C", output);
+    }
+
+    [Fact]
+    public void Emitter_OneArgCall_ImplicitCloserFlagTrue_StillEmitsCloser()
+    {
+        // v0.6.0 deliberately implements zero-arg-only emitter elision.
+        // The one-arg path needs context-aware safety (a §C inside a Lisp
+        // (+ a b) arg-list would consume its sibling) and is deferred to
+        // v0.6.1. This test pins that intentional limitation.
+        var args = new List<ExpressionNode>
+        {
+            new IntLiteralNode(default, 42),
+        };
+        var call = new CallExpressionNode(default, "Identity", args);
+        var ctx = new Migration.ConversionContext { UseImplicitCallCloser = true };
+        var emitter = new Migration.CalorEmitter(ctx);
+        var output = call.Accept<string>(emitter);
+        Assert.EndsWith("§/C", output);
+    }
+
+    [Fact]
+    public void Emitter_ZeroArgCall_FlagTrue_RoundTripsThroughParser()
+    {
+        // End-to-end: parser accepts the emitter's flag-true output.
+        var call = new CallExpressionNode(default, "Foo", new List<ExpressionNode>());
+        var ctx = new Migration.ConversionContext { UseImplicitCallCloser = true };
+        var emitter = new Migration.CalorEmitter(ctx);
+        var emitted = call.Accept<string>(emitter);
+        Assert.Equal("§C{Foo}", emitted);
+
+        // Wrap in a binding so we can re-parse it.
+        var source = $$"""
+§M{m001:Test}
+  §F{f001:Bar:pub}
+      §B{x} {{emitted}}
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var bind = module.Functions.First().Body.OfType<BindStatementNode>().First();
+        var roundTripped = Assert.IsType<CallExpressionNode>(bind.Initializer);
+        Assert.Equal("Foo", roundTripped.Target);
+        Assert.Empty(roundTripped.Arguments);
+    }
+}

--- a/website/content/syntax-reference/binding.mdx
+++ b/website/content/syntax-reference/binding.mdx
@@ -1,0 +1,215 @@
+---
+title: "Bindings"
+section: "syntax-reference"
+order: 3
+---
+
+The `§B` tag introduces a local binding (Calor's equivalent of a
+C# `var` declaration). The binder accepts four forms; in three of them
+the **type is inferred** from the initializer expression.
+
+> **Reference for RFC** `v0.6-bind-inference-formalization`. The
+> behavior on this page is what the binder does today and is pinned
+> by `tests/Calor.Semantics.Tests/BindInferenceDocsTests.cs`.
+
+---
+
+## Syntax
+
+```
+§B{name}                    // (1) requires an initializer (see Rules)
+§B{name} initializer        // (2) immutable, type inferred from initializer
+§B{name:type}               // (3) immutable, declared type, no initializer
+§B{name:type} initializer   // (4) immutable, declared type wins
+
+§B{~name} initializer       // (2') mutable variant of (2)
+§B{~name:type}              // (3') mutable variant of (3)
+§B{~name:type} initializer  // (4') mutable variant of (4)
+```
+
+The `~` prefix marks the binding as **mutable**; without `~` the
+binding is immutable (cannot be reassigned).
+
+---
+
+## Rules
+
+1. **Either a `:type` annotation or an initializer is required.**
+   `§B{x}` with neither is a hard error (`Calor0250`,
+   [diagnostics](#diagnostics) below).
+2. **An explicit `:type` wins over inference.** Form (4) does not
+   re-infer; the declared type is used verbatim. The binder itself
+   does not verify the initializer matches the declared type — that
+   check happens downstream in the C# compile (or the analyzer if
+   `--analyze` is on), so a mismatched pair like `§B{x:str} INT:42`
+   compiles to invalid C#.
+3. **Without `:type`, the bound type is `initializer.TypeName`.**
+   This is "shallow" inference: the binder reads the type the
+   initializer's bound node reports and uses it directly. There is no
+   bidirectional flow, no widening, no constraint solving.
+4. **The reported type is the binder's internal name.** Literal
+   initializers produce `INT`, `STRING`, `BOOL`, `FLOAT`. Calling code
+   that needs to write the equivalent type annotation uses the
+   user-facing names instead — see [Types](/syntax-reference/types/)
+   for the mapping (`i32`, `str`, `bool`, `f64`, …).
+5. **Inferred bindings emit `var` in C#; explicit bindings emit the
+   named type.** Writing `§B{x} INT:0` produces `var x = 0;`; writing
+   `§B{x:i32} INT:0` produces `int x = 0;`. Both compile to the same
+   IL, but the source-level distinction is preserved end-to-end.
+
+---
+
+## Inference table
+
+For each initializer shape on the left, the resulting bound type when
+no `:type` annotation is present is on the right.
+
+| Initializer | Bound type | Notes |
+|:------------|:-----------|:------|
+| `INT:42` (or `42`) | `INT` | `BoundIntLiteral`. Values outside the 32-bit range are bound as `LONG`. |
+| `STR:"hello"` | `STRING` | `BoundStringLiteral` |
+| `BOOL:true` / `BOOL:false` | `BOOL` | `BoundBoolLiteral` |
+| `FLOAT:3.14` | `FLOAT` | `BoundFloatLiteral` |
+| `(+ a b)` etc. | result type of the binary op | `BoundBinaryExpression.TypeName` — type of the result, not the operands |
+| an identifier `x` | declared type of `x` | through `BoundVariableExpression` |
+| `§C{Foo.bar} … §/C` | declared return type of `Foo.bar` | the binder uses the call's bound return type |
+| `none` | **inference fails** (today: silent fallback) | `Calor0251` proposed for future strict mode |
+
+The literal-type names on the right (`INT`, `STRING`, …) are the
+binder's internal type identifiers. They appear in tool output and
+diagnostics. The corresponding [type annotation](/syntax-reference/types/)
+you would write in source is the lowercase user-facing name
+(`i32`, `str`, `bool`, `f64`).
+
+---
+
+## Examples
+
+### Inferred, immutable
+
+```
+§B{score} INT:85               // score: i32 = 85
+§B{name} STR:"Calor"           // name: str = "Calor"
+§B{active} BOOL:true           // active: bool = true
+§B{pi} FLOAT:3.14              // pi: f64 = 3.14
+```
+
+### Inferred, mutable
+
+```
+§B{~counter} INT:0             // mutable, starts at 0
+§B{~total} INT:0
+§L{i:1:10:1}
+  §SET counter (+ counter INT:1)
+  §SET total   (+ total i)
+```
+
+### Explicit type, no initializer
+
+```
+§B{retries:i32}                // declared but uninitialized — initialise before use
+§B{user:str}
+```
+
+These forms are typically used where a value is assigned in every
+branch of a subsequent `§IF` / `§W`, or where the binding is for a
+field initialized in a constructor body.
+
+### Explicit type with initializer
+
+When you want the declared type to **drive** the conversion of the
+initializer (rather than be inferred from it), give an annotation:
+
+```
+§B{count:i64} INT:42           // i64 binding initialised from an i32 literal
+§B{x:f64}     INT:0            // f64 binding initialised from an integer literal
+```
+
+### Inferred from a call expression
+
+```
+§B{user} §C{repo.FindUser} §A id §/C
+// user: User (declared return type of repo.FindUser)
+```
+
+### Inferred from a binary op
+
+```
+§B{sum} (+ a b)                // sum: result type of (+ a b)
+§B{half} (/ x FLOAT:2.0)       // half: f64
+```
+
+---
+
+## Diagnostics
+
+### Calor0250 — `BindRequiresTypeOrInitializer`
+
+A `§B{name}` declaration must carry **either** a `:type` annotation
+**or** an initializer expression. With neither, the binder cannot
+choose a type for the new symbol.
+
+```
+§F{f001:Foo:pub}
+  §O{i32}
+  §B{x}            // Calor0250: §B{x} requires :type or initializer
+  §R INT:0
+```
+
+Fix by adding one or the other:
+
+```
+§B{x:i32}          // explicit type
+§B{x} INT:0        // initializer (inferred)
+```
+
+**Pre-v0.6 behavior:** the binder silently defaulted to `INT` in this
+case, producing wrong-typed code with no diagnostic. The diagnostic
+was added in v0.6 and is enforced through the main `calor compile`
+pipeline by `BindValidationPass`.
+
+### Strict-mode diagnostics (`--strict-bind-inference`)
+
+The following diagnostics are reserved in the `Calor0250-0259` range
+and are enforced **only** when the `--strict-bind-inference` flag is
+passed to `calor compile`. They are scheduled to become default-on in
+v0.7 (see RFC §6).
+
+| Code | Title | Fires on |
+|:-----|:------|:---------|
+| `Calor0251` | `BindCannotInferNullLiteral` | `§B{x} §NN` (untyped None) or `§B{x} null` |
+| `Calor0252` | `BindCannotInferGenericReturn` | `§B{x} §C{Vec.empty} §/C` and other well-known generic factory targets (`Vec.empty`, `List.empty`, `Array.empty`, `Set.empty`, `Map.empty`, …) |
+| `Calor0253` | `BindAmbiguousNumeric` | `§B{x} (+ INT:0 FLOAT:0.0)` — a binary op mixing integer and floating-point literal operands |
+
+Each fires only when the binding lacks an explicit `:type` annotation;
+adding the annotation always silences the diagnostic.
+
+```
+§B{x:Option<i32>} §NN              // silences Calor0251
+§B{x:Vec<i32>} §C{Vec.empty} §/C   // silences Calor0252
+§B{x:f64} (+ INT:0 FLOAT:0.0)      // silences Calor0253
+```
+
+---
+
+## Round-trip
+
+Both forms round-trip stably through `calor convert` and `calor format`:
+
+- A C# `var x = 42;` becomes `§B{x} INT:42` (inferred form).
+- A C# `int x = 42;` becomes `§B{x:i32} INT:42` (explicit form).
+- Going back, `§B{x} INT:42` becomes `var x = 42;`; `§B{x:i32} INT:42`
+  becomes `int x = 42;`.
+
+The emitter never **adds** an annotation that the source did not
+already have, and the binder never **drops** an annotation that the
+source did have.
+
+---
+
+## See also
+
+- [Types](/syntax-reference/types/) — primitive type names and their C# equivalents
+- [Structure Tags](/syntax-reference/structure-tags/) — `§F`, `§I`, `§O` and the surrounding function structure
+- [Expressions](/syntax-reference/expressions/) — initializer expressions in Lisp-prefix form
+- [Calls](/syntax-reference/calls/) — `§C` calls as binding initializers

--- a/website/content/syntax-reference/calls.mdx
+++ b/website/content/syntax-reference/calls.mdx
@@ -1,0 +1,206 @@
+---
+title: "Calls"
+section: "syntax-reference"
+order: 4
+---
+
+The `§C` tag invokes a function or method. Calls work in **statement**
+context (the call's result is discarded) and **expression** context
+(the call's result is used by the surrounding expression — typically as
+the initializer of a `§B`, an argument to another call, or the right
+side of an operation).
+
+> **Reference for RFC** `v0.6-call-closer-elision`. The behavior on
+> this page is what the parser does today and is pinned by
+> `tests/Calor.Compiler.Tests/CallStatementImplicitCloseTests.cs` and
+> `tests/Calor.Compiler.Tests/CallExpressionImplicitCloseTests.cs`.
+
+---
+
+## Syntax
+
+```
+§C{target}                           // (1) zero arguments, implicit close
+§C{target} arg                       // (2) one inline argument, implicit close
+§C{target} §A arg1 §A arg2 §/C       // (3) explicit form, any arity
+§C{target} §A arg1 §A arg2           // (4) explicit form, no §/C (closes at dedent)
+```
+
+`target` is a dotted name or a generic invocation:
+`Console.WriteLine`, `Math.Max`, `items.Cast<i32>`.
+
+The argument in form (2) is any **primary expression** — a literal,
+identifier, dotted reference, member access, indexer access, or a
+parenthesized expression. It is **not** a `§A`-list; for two or more
+arguments use form (3) or (4).
+
+---
+
+## Rules
+
+1. **A call without arguments needs no `§/C`.** Both
+   `§C{Logger.Flush}` and `§C{Logger.Flush} §/C` parse to the same
+   `CallExpressionNode`.
+2. **A call with exactly one argument supplied inline (no `§A`) needs
+   no `§/C`.** Both `§C{Identity} x` and `§C{Identity} §A x §/C` parse
+   to the same `CallExpressionNode` (form (2) vs (3)).
+3. **A call with two or more arguments must use `§A`.** The inline-arg
+   form (2) is limited to a single primary expression by construction.
+4. **Trailing member access attaches to the argument, not to the call
+   result.** After `§C{Identity} obj?.Length`, the `?.Length` belongs
+   to `obj` because the inline-arg parser greedily consumes a full
+   primary expression including its trailing member chain. See
+   [Disambiguation](#disambiguation) for the corner cases.
+5. **Trailing member access after a zero-arg call attaches to the call
+   result.** `§C{Maybe}?.Length` parses as
+   `NullConditional(Call("Maybe"), "Length")`, because the parser sees
+   `?.`, takes the zero-arg implicit-close path, then runs trailing
+   member access on the call result.
+6. **Both `§/C` and abbreviated `§/C{id}` are still accepted** for
+   forms (1), (2), (3), and (4) — no source file needs to be rewritten.
+
+---
+
+## Disambiguation
+
+The implicit-close forms introduce two parser decisions. The
+disambiguation rules below match RFC §3.2.
+
+### Case A — trailing member on an inline argument
+
+```
+§B{n} §C{Identity} obj?.Length
+```
+
+Reads as `Identity(obj?.Length)`, not `Identity(obj)?.Length`. The
+inline-arg branch calls the same expression parser used everywhere
+else, which greedily consumes `?.Length` as part of the primary
+expression `obj?.Length`.
+
+If you intended `Identity(obj)?.Length` instead, write either:
+
+```
+§B{n} §C{Identity} §A obj §/C ?.Length     // explicit form
+§B{n} §C{Identity}.Length                  // zero-arg call + access
+```
+
+### Case B — two consecutive expression-start tokens (Calor0150)
+
+```
+§B{n} §C{Identity} a b           // ambiguous — second expression-start follows inline arg
+```
+
+This is **ambiguous** — once the inline form has consumed one positional
+argument, any second expression-start token (a literal, identifier,
+nested `§C` call, `§NEW`, etc.) cannot be unambiguously attributed to
+the call. Calor0150 also fires if the next token is `§A`, signalling
+the user mixed the inline and explicit forms. The parser reports
+
+```
+Calor0150  AmbiguousCallContinuation
+Closer-less call '§C{Identity}' already took one inline argument; a
+second positional argument is ambiguous. Use the explicit form
+'§C{Identity} §A a §A b §/C' instead.
+```
+
+and stops consuming tokens at the second expression, leaving it for
+the surrounding statement parser. To fix, rewrite using the explicit
+form:
+
+```
+§B{n} §C{Identity} §A a §A b §/C
+```
+
+### Case C — nested implicit-close calls
+
+```
+§B{x} §C{Foo.bar} §C{Baz.qux} y
+```
+
+Reads right-to-left as `Foo.bar(Baz.qux(y))`. The parser disambiguates
+nested implicit-close calls by counting the number of consecutive
+`§/C` closers after the deepest inline argument and comparing to the
+depth of enclosing `§A`-style calls. When all calls in the chain use
+the inline form, no closers are required.
+
+The mixed case
+`§B{x} §C{Foo.bar} §A §C{Baz.qux} y §/C §/C`
+also works: the inner `§C{Baz.qux} y §/C` is a standard
+one-inline-arg-plus-closer form, and the outer `§A ... §/C` is the
+explicit form for `Foo.bar`.
+
+---
+
+## Examples
+
+### Statement context
+
+```
+§F{Greet:pub}
+  §I{name:string}
+  §O{void}
+  §E{cw}
+
+  §C{Console.WriteLine} (concat "Hello, " name)   // implicit close
+```
+
+### Expression context — zero-arg
+
+```
+§F{Count:pub}
+  §O{i32}
+
+  §B{n:i32} §C{items.Count}            // zero-arg, implicit close
+  §R n
+```
+
+### Expression context — one inline arg
+
+```
+§F{Doubled:pub}
+  §I{x:i32}
+  §O{i32}
+
+  §B{y:i32} §C{Math.Abs} x             // one inline arg, implicit close
+  §R (* y 2)
+```
+
+### Expression context — two or more args (explicit form)
+
+```
+§F{Clamp:pub}
+  §I{x:i32}
+  §O{i32}
+
+  §B{lo:i32} INT:0
+  §B{hi:i32} INT:100
+  §B{r:i32} §C{Math.Clamp} §A x §A lo §A hi §/C
+  §R r
+```
+
+### Trailing member access
+
+```
+§B{len} §C{GetMessage}.Length          // zero-arg call, then .Length
+§B{up}  §C{GetMessage}?.ToUpper        // zero-arg call, then ?.ToUpper
+§B{tag} §C{Identity} obj?.Tag          // inline arg = obj?.Tag
+```
+
+---
+
+## Diagnostics
+
+| Code | Name | Description |
+|:-----|:-----|:------------|
+| `Calor0150` | AmbiguousCallContinuation | Two consecutive expression-start tokens follow a closer-less `§C{target} arg` — second positional argument is ambiguous. Use the explicit `§A` / `§/C` form. |
+
+---
+
+## Related
+
+- [Bindings](/syntax-reference/binding/) — the most common
+  expression-call context (`§B{name} §C{...}`).
+- [Expressions](/syntax-reference/expressions/) — Lisp-style
+  operations that frequently embed `§C` calls as arguments.
+- [Structure Tags](/syntax-reference/structure-tags/) — block
+  closer rules in general.

--- a/website/content/syntax-reference/index.mdx
+++ b/website/content/syntax-reference/index.mdx
@@ -149,6 +149,8 @@ compatibility but should not be used in new code — see
 
 - [Structure Tags](/syntax-reference/structure-tags/) - Modules, functions, block structure
 - [Types](/syntax-reference/types/) - Type system, Option, Result
+- [Bindings](/syntax-reference/binding/) - `§B` local bindings and inference
+- [Calls](/syntax-reference/calls/) - `§C` calls and implicit close
 - [Expressions](/syntax-reference/expressions/) - Lisp-style operators
 - [Control Flow](/syntax-reference/control-flow/) - Loops, conditionals
 - [Contracts](/syntax-reference/contracts/) - Requires, ensures


### PR DESCRIPTION
Implements Phase 1 (parser) and Phase 3 (docs) of [RFC `v0.6-call-closer-elision`](https://github.com/juanmicrosoft/calor/blob/main/docs/plans/v0.6-call-closer-elision.md). Phase 2 (emitter) wires the `ConversionContext.UseImplicitCallCloser` flag (default `false` in v0.6.0) for zero-arg calls; one-arg emission is deferred to v0.6.1 pending the context-aware safety work for Lisp arg-lists.

## Parser

`ParseCallExpression` accepts two new forms in expression context:

| Form | Meaning |
|------|---------|
| `§C{target}` | zero-arg, no `§/C` |
| `§C{target} primary_expr` | one inline arg, no `§/C` |

The legacy explicit form `§C{target} §A arg1 §A arg2 §/C` and the single-inline-arg-with-`§/C` form `§C{target} arg §/C` both still parse.

### Disambiguation (RFC §3.2)

- **Case A** — trailing `.member` / `?.member` on an inline arg attaches to the arg (handled naturally by `ParseExpression`).
- **Case B** — two consecutive expression-start tokens after a closer-less call → `Calor0150 AmbiguousCallContinuation`. Also fires when `§A` follows an inline arg (user mixed inline and explicit forms).
- **Case C** — nested elided calls compose right-to-left (`§C{Foo.bar} §C{Baz.qux} y` parses as `Foo.bar(Baz.qux(y))`). Disambiguated by counting consecutive `§/C` tokens against `_inOuterCallArgDepth`, incremented in every `§A`-loop that ends in `§/C`: `ParseCallStatement`, `ParseCallExpression` standard branch, and the expression-target call branch.

## Diagnostic

| Code | Name | Range |
|------|------|-------|
| `Calor0150` | AmbiguousCallContinuation | Call-elision diagnostics (Calor0150-0159) — new range |

## Emitter

- New `ConversionContext.UseImplicitCallCloser` (default `false`).
- `CalorEmitter.Visit(CallExpressionNode)` elides `§/C` for zero-arg calls when the flag is true.
- Multi-arg and one-arg emission unchanged in v0.6.0; one-arg is pinned in tests to require the closer until v0.6.1 adds context-aware safety (a `§C` inside a Lisp `(+ a b)` arg-list would consume its sibling and fire `Calor0150`).

## Docs

- New `docs/syntax-reference/calls.md` documents both statement- and expression-context call forms, all four arity × explicitness cases, disambiguation rules, and `Calor0150`. Closes the `calls.md` piece of #645 (`binding.md` was PR #646).

## Tests

24 tests in `tests/Calor.Compiler.Tests/CallExpressionImplicitCloseTests.cs`:

- All four call forms (0/1-arg × implicit/explicit) parse.
- Trailing `?.member` on inline arg attaches to arg (Reading A).
- Trailing `.member` and `?.member` after a zero-arg call attach to the call result.
- Nested elided / mixed / explicit at depth 1 and 2 (incl. depth-2 with two `§/C` closers).
- `Calor0150` fires on flat ambiguity, nested call ambiguity, and `§A` after an inline arg.
- Generic target `§C{Array.Empty<i32>}` zero-arg form.
- Statement-context implicit close still works.
- Lisp-context canonical `§A`/`§/C` still parses.
- **Regression**: outer statement-call `§A` bumps `_inOuterCallArgDepth` so the inner elided call doesn't steal the outer `§/C`. This was a blocker found in rubber-duck review and fixed before commit.
- Emitter: default keeps `§/C`; flag elides zero-arg; multi-arg keeps; one-arg keeps (intentional, pinned for v0.6.0); round-trip parses.

**Full test suite: 6982 passing, 17 skipped, 0 failures across all projects (Calor.Compiler.Tests, Calor.Conversion.Tests, Calor.Evaluation, Calor.Semantics.Tests, Calor.Verification.Tests, Calor.Enforcement.Tests, Calor.ILAnalysis.Tests, Calor.Experimental.Tests, Calor.LanguageServer.Tests, Calor.RoundTrip.Harness.Tests, Calor.Tasks.Tests).**

Closes #643. Closes #645 (docs piece — the binding.md piece was #646).