### PR TITLE
Release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-09
+
+### Benchmark Results (Statistical: 30 runs)
+- **Overall Advantage**: 1.29x (Calor leads)
+- **Metrics**: Calor wins 7, C# wins 1
+- **Highlights**:
+  - Comprehension: 1.85x ± 0.00 (Calor wins, large effect d=1.84)
+  - ErrorDetection: 1.52x ± 0.00 (Calor wins, large effect d=1.26)
+  - RefactoringStability: 1.38x ± 0.00 (Calor wins, large effect d=7.10)
+  - EditPrecision: 1.36x ± 0.00 (Calor wins, large effect d=4.83)
+  - Correctness: 1.31x ± 0.00 (Calor wins, large effect d=1.40)
+- **Programs Tested**: 207
+
 ### Changed
 - **`ConversionContext.UseImplicitCallCloser` now defaults to `true`** (was `false` in v0.6.0). The C# → Calor converter (`CalorEmitter.Visit(CallExpressionNode)`) now elides `§/C` for zero-argument calls by default, producing more idiomatic Calor output. The opt-out (`UseImplicitCallCloser = false`) is preserved and tested (`CallExpressionImplicitCloseTests.Emitter_ZeroArgCall_ImplicitCloserFlagFalse_PinsExplicitCloser`). One-argument elision remains intentionally deferred — see `docs/plans/v0.6-call-closer-elision.md` §2.2.
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.6.0</Version>
+    <Version>0.6.1</Version>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "calor",
   "displayName": "Calor Language",
   "description": "Language support for the Calor programming language",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publisher": "calor-dev",
   "license": "Apache-2.0",
   "icon": "icons/calor-icon.png",

--- a/website/content/changelog.mdx
+++ b/website/content/changelog.mdx
@@ -10,6 +10,8 @@ All notable changes to Calor, organized by release.
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-09
+
 ### Changed
 - **`ConversionContext.UseImplicitCallCloser` now defaults to `true`** (was `false` in v0.6.0). The C# → Calor converter now elides `§/C` for zero-argument calls by default, producing more idiomatic Calor output. The opt-out (`UseImplicitCallCloser = false`) is preserved.
 

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calor-website",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/website/public/data/benchmark-results.json
+++ b/website/public/data/benchmark-results.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
-  "timestamp": "2026-06-04T23:58:12.9639916Z",
-  "commit": "eacb5697",
+  "timestamp": "2026-06-09T15:24:11.3402872Z",
+  "commit": "b2bbec53",
   "frameworkVersion": "1.0.0",
   "summary": {
     "overallAdvantage": 1.29,

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -15,9 +15,9 @@ export function WhatsNewBanner() {
         <div className="flex items-center justify-center gap-3 text-sm">
           <Sparkles className="h-4 w-4 text-calor-cerulean flex-shrink-0" />
           <p className="text-center">
-            <span className="font-semibold text-calor-cerulean">v0.6.0</span>
+            <span className="font-semibold text-calor-cerulean">v0.6.1</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">Token-economics release: §C call-closer elision (zero/one-arg), formalized §B inference, and four new diagnostics (Calor0150, Calor0250–0253).</span>
+            <span className="text-foreground">Implicit `§/C` for zero-arg `§C` calls is now the default — more idiomatic Calor by default; opt-out via `--explicit-call-closers`.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"


### PR DESCRIPTION
## Summary
- Bump version to 0.6.1
- Update CHANGELOG.md with release date and benchmark results
- Update website changelog and WhatsNewBanner
- Update benchmark results JSON for website dashboard

## Benchmark Results (Statistical: 30 runs)
- **Overall Advantage**: 1.29x (Calor leads)
- **Metrics**: Calor wins 7, C# wins 1
- **Highlights**:
  - Comprehension: 1.85x (Calor wins, large effect d=1.84)
  - ErrorDetection: 1.52x (Calor wins, large effect d=1.26)
  - RefactoringStability: 1.38x (Calor wins, large effect d=7.10)
  - EditPrecision: 1.36x (Calor wins, large effect d=4.83)
  - Correctness: 1.31x (Calor wins, large effect d=1.40)
- **Programs Tested**: 207

## Release highlights
This is a token-economics-quality release built on the v0.6.0 parser:

- `ConversionContext.UseImplicitCallCloser` now defaults to `true` — the C# → Calor converter emits more idiomatic zero-arg `§C` calls without trailing `§/C`.
- Four parser bug-fixes uncovered while flipping the default (Dedent swallowing, same-column sibling absorption, statement-form zero-arg implicit close, expression-form same-line `§A` discipline).
- Emitter now tracks an inline-sibling context counter so zero-arg `§/C` elision never corrupts the AST when a call is emitted inside another call's argument list, an array initializer, a `§KV`, a `§PUT`/`§SETIDX`/`§INS`/`§IDX`, a Lisp binary op, null-coalesce, conditional, or forall/exists/implication body.
- Opt-out is reachable from CLI (`--explicit-call-closers`), MCP (`calor_convert` + `calor_migrate`), SDK (`ConversionOptions`), and the public `Converter.ConvertFileAsync`/`Converter.ConvertCSharpToCalorAsync` facade overloads.

## Checklist
- [x] Version updated in Directory.Build.props
- [x] Version updated in editors/vscode/package.json
- [x] Version updated in website/package.json
- [x] CHANGELOG.md updated with version, date, and benchmark summary
- [x] website/content/changelog.mdx updated with version and changes (no benchmark stats)
- [x] website/src/components/landing/WhatsNewBanner.tsx updated with version and headline
- [x] website/public/data/benchmark-results.json updated with latest results
