### PR TITLE
Release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,33 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-06-10
+
+### Benchmark Results (Statistical: 30 runs)
+- **Overall Advantage**: 1.29x (Calor leads)
+- **Metrics**: Calor wins 7, C# wins 1
+- **Highlights**:
+  - Comprehension: 1.86x ± 0.00 (Calor wins, large effect d=1.84)
+  - ErrorDetection: 1.51x ± 0.00 (Calor wins, large effect d=1.25)
+  - RefactoringStability: 1.38x ± 0.00 (Calor wins, large effect d=7.10)
+  - EditPrecision: 1.36x ± 0.00 (Calor wins, large effect d=4.85)
+  - Correctness: 1.30x ± 0.00 (Calor wins, large effect d=1.37)
+  - TokenEconomics: 1.12x ± 0.00 (Calor wins)
+  - GenerationAccuracy: 1.02x ± 0.00 (Calor wins, marginal)
+  - InformationDensity: 0.99x ± 0.00 (C# wins, small effect d=-0.47)
+- **Programs Tested**: 210 (was 207 in v0.6.1 — three new TokenEconomics fixtures exercising statement-context call elision: `VoidSequence`, `LogPipeline`, `PairLogger`)
+
+### Added
+- **Elision-aware TokenEconomics benchmark fixtures.** Three new programs (`VoidSequence`, `LogPipeline`, `PairLogger`) added to `tests/TestData/Benchmarks/TokenEconomics/` to exercise the new statement-context `§/C` elision path. Two are favorable to Calor (zero-arg and one-arg call sequences); `PairLogger` is a neutral control using multi-arg calls where elision does not apply. See PR #653 for the bias analysis.
+
+### Changed
+- **Statement-context `§C` calls now elide `§/C` by default (when safe).** `CalorEmitter.Visit(CallStatementNode)` rewrites zero-argument calls as `§C{target}` and one-argument unnamed calls (with safe-prefix arguments) as `§C{target} arg`, matching the v0.6.1 behavior for expression-context calls. Elision is gated by `UseImplicitCallCloser` and is suppressed inside inline-sibling contexts (e.g. short lambda bodies) to avoid AST corruption. RFC: `docs/plans/v0.6-call-closer-elision.md` §3.2/§4. See PR #652.
+
 ### Removed
 - **`calor diagnose` CLI command removed.** The command was deprecated in v0.5.x (PR #609) with a removal target of v0.6.0; this release completes that deprecation. For machine-readable diagnostics use the `calor_check` MCP tool with `action: "diagnose"` (or `calor_compile` with automatic fix application). Documentation pages and cross-links have been removed.
+
+### Fixed
+- **Contract verifier: class methods, user-defined types, and visibility preservation.** `ContractSimplificationPass` now preserves the `Visibility` of class methods so the contract verifier can be reached for `§MT` members. `ContractVerificationPass` extended to walk class-method bodies. The Z3 contract translator gained support for user-defined types and dot-path field access (`a.b.c`). PR #618.
 
 ## [0.6.1] - 2026-06-09
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.6.1</Version>
+    <Version>0.6.2</Version>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "calor",
   "displayName": "Calor Language",
   "description": "Language support for the Calor programming language",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "publisher": "calor-dev",
   "license": "Apache-2.0",
   "icon": "icons/calor-icon.png",

--- a/website/content/changelog.mdx
+++ b/website/content/changelog.mdx
@@ -10,6 +10,20 @@ All notable changes to Calor, organized by release.
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-06-10
+
+### Added
+- **Elision-aware TokenEconomics benchmark fixtures** (`VoidSequence`, `LogPipeline`, `PairLogger`) exercise the new statement-context `§/C` elision path. Corpus is now 210 programs.
+
+### Changed
+- **Statement-context `§C` calls now elide `§/C` by default (when safe).** `CalorEmitter.Visit(CallStatementNode)` rewrites zero-argument calls as `§C{target}` and one-argument unnamed calls (with safe-prefix arguments) as `§C{target} arg`. Mirrors the v0.6.1 behavior for expression-context calls. Elision is gated by `UseImplicitCallCloser` and suppressed in inline-sibling contexts.
+
+### Removed
+- **`calor diagnose` CLI command removed.** Deprecated in v0.5.x with a stated removal target of v0.6.0; v0.6.2 completes that deprecation. For machine-readable diagnostics use the `calor_check` MCP tool with `action: "diagnose"` (or `calor_compile` with automatic fix application).
+
+### Fixed
+- **Contract verifier: class methods, user-defined types, and visibility preservation.** `ContractSimplificationPass` now preserves `Visibility` so the verifier reaches `§MT` members. `ContractVerificationPass` walks class-method bodies. Z3 translator gained support for user-defined types and dot-path field access (`a.b.c`).
+
 ## [0.6.1] - 2026-06-09
 
 ### Changed

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calor-website",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/website/public/data/benchmark-results.json
+++ b/website/public/data/benchmark-results.json
@@ -1,11 +1,11 @@
 {
   "version": "1.0",
-  "timestamp": "2026-06-09T15:24:11.3402872Z",
-  "commit": "b2bbec53",
+  "timestamp": "2026-06-10T15:49:25.8303576Z",
+  "commit": "3a2f9549",
   "frameworkVersion": "1.0.0",
   "summary": {
     "overallAdvantage": 1.29,
-    "programCount": 207,
+    "programCount": 210,
     "metricCount": 8,
     "calorWins": 7,
     "cSharpWins": 1,
@@ -16,12 +16,12 @@
       "ratio": 1.12,
       "winner": "calor",
       "ci95": [
-        1.122,
-        1.122
+        1.116,
+        1.116
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": -0.125,
+      "effectSize": -0.12,
       "effectInterpretation": "negligible"
     },
     "GenerationAccuracy": {
@@ -33,19 +33,19 @@
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": 0.344,
+      "effectSize": 0.341,
       "effectInterpretation": "small"
     },
     "Comprehension": {
-      "ratio": 1.85,
+      "ratio": 1.86,
       "winner": "calor",
       "ci95": [
-        1.855,
-        1.855
+        1.857,
+        1.857
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": 1.841,
+      "effectSize": 1.837,
       "effectInterpretation": "large"
     },
     "EditPrecision": {
@@ -57,55 +57,55 @@
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": 4.829,
+      "effectSize": 4.854,
       "effectInterpretation": "large"
     },
     "ErrorDetection": {
-      "ratio": 1.52,
+      "ratio": 1.51,
       "winner": "calor",
       "ci95": [
-        1.515,
-        1.515
+        1.508,
+        1.508
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": 1.263,
+      "effectSize": 1.245,
       "effectInterpretation": "large"
     },
     "InformationDensity": {
       "ratio": 0.99,
       "winner": "csharp",
       "ci95": [
-        0.994,
-        0.994
+        0.988,
+        0.988
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": -0.436,
+      "effectSize": -0.466,
       "effectInterpretation": "small"
     },
     "RefactoringStability": {
       "ratio": 1.38,
       "winner": "calor",
       "ci95": [
-        1.376,
-        1.376
+        1.377,
+        1.377
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": 7.097,
+      "effectSize": 7.098,
       "effectInterpretation": "large"
     },
     "Correctness": {
-      "ratio": 1.31,
+      "ratio": 1.3,
       "winner": "calor",
       "ci95": [
-        1.308,
-        1.308
+        1.303,
+        1.303
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": 1.397,
+      "effectSize": 1.371,
       "effectInterpretation": "large"
     }
   },
@@ -2714,6 +2714,83 @@
       }
     },
     {
+      "id": "050",
+      "name": "VoidSequence",
+      "level": 2,
+      "features": [
+        "module",
+        "function",
+        "void_return",
+        "call_statement",
+        "zero_arg_call",
+        "v0_6_2_elision"
+      ],
+      "calorSuccess": true,
+      "cSharpSuccess": true,
+      "advantage": 1.266,
+      "metrics": {
+        "TokenEconomics": 0.679,
+        "GenerationAccuracy": 1,
+        "Comprehension": 3.028,
+        "EditPrecision": 1.351,
+        "ErrorDetection": 1,
+        "InformationDensity": 0.601,
+        "RefactoringStability": 1.471,
+        "Correctness": 1
+      }
+    },
+    {
+      "id": "051",
+      "name": "LogPipeline",
+      "level": 2,
+      "features": [
+        "module",
+        "function",
+        "void_return",
+        "call_statement",
+        "one_arg_call",
+        "v0_6_2_elision"
+      ],
+      "calorSuccess": true,
+      "cSharpSuccess": true,
+      "advantage": 1.077,
+      "metrics": {
+        "TokenEconomics": 0.783,
+        "GenerationAccuracy": 1,
+        "Comprehension": 1.578,
+        "EditPrecision": 1.314,
+        "ErrorDetection": 1,
+        "InformationDensity": 0.53,
+        "RefactoringStability": 1.415,
+        "Correctness": 1
+      }
+    },
+    {
+      "id": "052",
+      "name": "PairLogger",
+      "level": 2,
+      "features": [
+        "module",
+        "function",
+        "void_return",
+        "call_statement",
+        "multi_arg_call"
+      ],
+      "calorSuccess": true,
+      "cSharpSuccess": true,
+      "advantage": 1.038,
+      "metrics": {
+        "TokenEconomics": 0.678,
+        "GenerationAccuracy": 1,
+        "Comprehension": 1.421,
+        "EditPrecision": 1.314,
+        "ErrorDetection": 1,
+        "InformationDensity": 0.473,
+        "RefactoringStability": 1.415,
+        "Correctness": 1
+      }
+    },
+    {
       "id": "async001",
       "name": "SimpleAsync",
       "level": 3,
@@ -5076,11 +5153,11 @@
     ],
     "categoryDetails": {
       "TokenEconomics": {
-        "mean": 1.122,
-        "stdDev": 16.542,
-        "ci95Lower": 1.11,
-        "ci95Upper": 1.134,
-        "cohensD": -0.125,
+        "mean": 1.116,
+        "stdDev": 16.589,
+        "ci95Lower": 1.104,
+        "ci95Upper": 1.128,
+        "cohensD": -0.12,
         "pValue": 0.0001,
         "significant": true
       },
@@ -5088,62 +5165,62 @@
         "mean": 1.017,
         "stdDev": 0.039,
         "ci95Lower": 1.016,
-        "ci95Upper": 1.019,
-        "cohensD": 0.344,
+        "ci95Upper": 1.018,
+        "cohensD": 0.341,
         "pValue": 0.0001,
         "significant": true
       },
       "Comprehension": {
-        "mean": 1.855,
+        "mean": 1.857,
         "stdDev": 0.032,
-        "ci95Lower": 1.841,
-        "ci95Upper": 1.868,
-        "cohensD": 1.841,
+        "ci95Lower": 1.843,
+        "ci95Upper": 1.871,
+        "cohensD": 1.837,
         "pValue": 0.0001,
         "significant": true
       },
       "EditPrecision": {
         "mean": 1.36,
         "stdDev": 0.008,
-        "ci95Lower": 1.358,
-        "ci95Upper": 1.363,
-        "cohensD": 4.829,
+        "ci95Lower": 1.357,
+        "ci95Upper": 1.362,
+        "cohensD": 4.854,
         "pValue": 0.0001,
         "significant": true
       },
       "ErrorDetection": {
-        "mean": 1.515,
+        "mean": 1.508,
         "stdDev": 0.105,
-        "ci95Lower": 1.502,
-        "ci95Upper": 1.529,
-        "cohensD": 1.263,
+        "ci95Lower": 1.494,
+        "ci95Upper": 1.522,
+        "cohensD": 1.245,
         "pValue": 0.0001,
         "significant": true
       },
       "InformationDensity": {
-        "mean": 0.994,
+        "mean": 0.988,
         "stdDev": 0.024,
-        "ci95Lower": 0.984,
-        "ci95Upper": 1.004,
-        "cohensD": -0.436,
+        "ci95Lower": 0.978,
+        "ci95Upper": 0.998,
+        "cohensD": -0.466,
         "pValue": 0.0001,
         "significant": true
       },
       "RefactoringStability": {
-        "mean": 1.376,
+        "mean": 1.377,
         "stdDev": 0.01,
         "ci95Lower": 1.374,
-        "ci95Upper": 1.379,
-        "cohensD": 7.097,
+        "ci95Upper": 1.38,
+        "cohensD": 7.098,
         "pValue": 0.0001,
         "significant": true
       },
       "Correctness": {
-        "mean": 1.308,
-        "stdDev": 0.054,
-        "ci95Lower": 1.3,
-        "ci95Upper": 1.315,
-        "cohensD": 1.397,
+        "mean": 1.303,
+        "stdDev": 0.055,
+        "ci95Lower": 1.296,
+        "ci95Upper": 1.311,
+        "cohensD": 1.371,
         "pValue": 0.0001,
         "significant": true
       }

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -15,9 +15,9 @@ export function WhatsNewBanner() {
         <div className="flex items-center justify-center gap-3 text-sm">
           <Sparkles className="h-4 w-4 text-calor-cerulean flex-shrink-0" />
           <p className="text-center">
-            <span className="font-semibold text-calor-cerulean">v0.6.1</span>
+            <span className="font-semibold text-calor-cerulean">v0.6.2</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">Implicit `§/C` for zero-arg `§C` calls is now the default — more idiomatic Calor by default; opt-out via `--explicit-call-closers`.</span>
+            <span className="text-foreground">Statement-context `§C` calls now elide `§/C` by default, the deprecated `calor diagnose` command was removed, and the benchmark corpus grew to 210 programs.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"


### PR DESCRIPTION
## Summary

Release **v0.6.2** — version bump and changelog updates.

This release ships the following PRs that landed on `main` since v0.6.1:

- **PR #618** — Contract verifier fixes: class-method verification (`§MT`), user-defined types and dot-path field access in the Z3 translator, and visibility preservation through `ContractSimplificationPass`.
- **PR #652** — Statement-context `§C` calls now elide `§/C` by default (zero-arg + one-arg unnamed, safe-prefix gated, suppressed in inline-sibling contexts).
- **PR #653** — Three new TokenEconomics benchmark fixtures (`VoidSequence`, `LogPipeline`, `PairLogger`) exercising the new statement-context elision path. Corpus 207 -> 210.
- **PR #654** — Removed deprecated `calor diagnose` CLI command (deprecation completed from v0.5.x `TODO(v0.6.0)` target).

## Benchmark Results (Statistical: 30 runs)

- **Overall Advantage**: 1.29x (Calor leads)
- **Programs Tested**: 210 (was 207 in v0.6.1)
- **Calor wins**: 7 / **C# wins**: 1
- **Highlights**:
  - Comprehension: **1.86x** (large effect d=1.84)
  - ErrorDetection: **1.51x** (large effect d=1.25)
  - RefactoringStability: **1.38x** (large effect d=7.10)
  - EditPrecision: **1.36x** (large effect d=4.85)
  - Correctness: **1.30x** (large effect d=1.37)
  - TokenEconomics: **1.12x** (Calor wins)
  - GenerationAccuracy: 1.02x (marginal)
  - InformationDensity: 0.99x (C# wins, small d=-0.47)
- **Compilation**: Calor 210/210, C# 209/210

## Checklist

- [x] Bump `Directory.Build.props` -> 0.6.2
- [x] Bump `editors/vscode/package.json` -> 0.6.2
- [x] Bump `website/package.json` -> 0.6.2
- [x] Update `CHANGELOG.md` with v0.6.2 section + benchmark stats
- [x] Update `website/content/changelog.mdx` with v0.6.2 section
- [x] Update `WhatsNewBanner.tsx` headline
- [x] Refresh `website/public/data/benchmark-results.json` (30 runs)
- [x] Local build green
- [ ] CI green (pending)
- [ ] GitHub Release published with `--prerelease`
- [ ] Website deploy triggered

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
