### PR TITLE
feat(emitter): elide §/C on one-arg expression-context calls (v0.6.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Expression-context `§C` calls now elide `§/C` by default for one-argument forms.** `CalorEmitter.Visit(CallExpressionNode)` extends the v0.6.1 zero-arg elision and the v0.6.2 stmt-context one-arg elision to expression context: `§C{target} arg` (no `§A`, no `§/C`) when the argument is unnamed, the rendered first token is in the `StartsWithExpressionStarter` whitelist, and we are not inside an inline-sibling context. Conversion scorecard: 96/100 → 99/100 round-trip pass (+3 net, 0 regressions). RFC: `docs/plans/v0.6-call-closer-elision.md` §2.1/§2.2/§8.1.
+
+### Fixed
+- **Parser: `Calor0150` no longer fires across sibling-statement boundaries.** When the next expression-start token after a one-arg elided call is on a different line, it is a sibling statement, not an ambiguous second positional arg. Previously the parser misclassified patterns like `§B{p} §C{f} §IDX{a} i` followed on the next line by `§IF p ...` as a second arg, raising a spurious Calor0150. Now gated by a same-line check at `Parser.cs ~7992`. Regression test: `ExpressionContext_OneArgFollowedBySiblingStatement_NoCalor0150`.
+- **Emitter: `§LAM` body, `§WITH` target, and `§LIST`/`§HSET` element emit sites now use `AcceptInInlineSibling`.** These same-line sibling positions previously used raw `node.X.Accept(this)`, which could silently corrupt the AST after the one-arg expression-context elision landed. Guarded by the existing `CalorEmitter_HasNoRawAcceptInSpaceSeparatedSiblingPosition` static test.
+
+### Internal
+- Closed stale PRs #559, #619, #625 (superseded by later work).
+- Updated four conversion snapshots (`tests/Calor.Conversion.Tests/Snapshots/{05-01,05-02,05-03,12-02}.approved.calr`) for the mechanical `§A arg §/C` → `arg` shape change.
+
 ## [0.6.2] - 2026-06-10
 
 ### Benchmark Results (Statistical: 30 runs)

--- a/docs/plans/v0.6-call-closer-elision.md
+++ b/docs/plans/v0.6-call-closer-elision.md
@@ -214,8 +214,11 @@ call_expression
 
 The migration emitter (C# → Calor) emits the elided form for zero-argument
 calls when the call site is at a "leaf" position (binding initializer, return
-value, statement standalone, etc.). One-argument elision in the emitter remains
-deferred to a future release — see §8 Status table.
+value, statement standalone, etc.). **One-argument elision in the emitter
+shipped in v0.6.3** for both statement context (PR #652, v0.6.2) and
+expression context (PR-elision-expr, v0.6.3), gated by the same
+`_inInlineSiblingContext` and `StartsWithExpressionStarter` discipline as
+the zero-arg path.
 
 `CSharpEmitter` is unaffected — it consumes the bound tree.
 
@@ -407,7 +410,23 @@ is reduced from "all four required" to "criteria 1-3 required; criterion
 
 **Verdict:** Criteria 1-3 hard-met; criterion 4 explicitly reclassified as a v0.7 follow-up. v0.6.1 ships.
 
-### 8.1 Migration / compatibility footprint
+### 8.1 v0.6.3 expansion — emitter one-arg expression-context elision
+
+v0.6.3 finishes the emitter side of §2.2 by extending one-arg elision from
+statement context (v0.6.2, PR #652) to expression context. The same gates
+apply: `UseImplicitCallCloser != false`, `_inInlineSiblingContext == 0`,
+and `StartsWithExpressionStarter` on the rendered argument. A latent
+parser bug surfaced and was fixed in the same release: `Calor0150` no
+longer fires when the next expression-start token after a one-arg elided
+call is on a **different** line — that case is a sibling statement, not
+an ambiguous second positional arg (cf. `Parser.cs ~7992`, regression
+test `ExpressionContext_OneArgFollowedBySiblingStatement_NoCalor0150`).
+
+Conversion-scorecard delta (round-trip pass): 96/100 → 99/100 with zero
+regressions; four snapshots updated for the mechanical `§A arg §/C` → `arg`
+shape change (`tests/Calor.Conversion.Tests/Snapshots/{05-01,05-02,05-03,12-02}`).
+
+### 8.2 Migration / compatibility footprint
 
 - **Default change** affects every C# → Calor conversion path (`calor convert`, `calor migrate`, MCP `calor_convert` / `calor_migrate`, public `Converter.ConvertFileAsync(..., ConversionOptions?)` / `Converter.ConvertCSharpToCalorAsync(..., ConversionOptions?)` overloads, and direct `CSharpToCalorConverter` construction with `ConversionOptions`).
 - **Opt-out** is available at every entry point: `--explicit-call-closers` CLI flag (convert & migrate), `"explicitCallClosers": true` MCP arg, `UseImplicitCallCloser = false` SDK / `ConversionOptions` / `MigrationPlanOptions` property. The opt-out reproduces byte-identical v0.6.0 converter behavior.

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -1299,12 +1299,16 @@ public sealed class CalorEmitter : IAstVisitor<string>
         if (ContainsSectionMarker(variableName))
             variableName = $"_hoist{_hoistCounter++:D3}";
 
-        // Pre-evaluate all elements to collect hoisted bindings before the list block
+        // Pre-evaluate all elements to collect hoisted bindings before the list block.
+        // AcceptInInlineSibling: each element line is parsed as a sibling expression
+        // and a one-arg closer-less §C inside an element would absorb the next
+        // sibling (or §/LIST) as its inline argument (v0.6.3 RFC §3.2 case B).
+        // Mirrors §DICT entries, §HSET elements, and §ARR inline elements.
         var evaluatedElements = new List<string>();
         var allHoisted = new List<string>();
         foreach (var element in node.Elements)
         {
-            var val = element.Accept(this);
+            var val = AcceptInInlineSibling(element);
             if (_pendingHoistedLines.Count > 0)
             {
                 allHoisted.AddRange(_pendingHoistedLines);
@@ -1373,12 +1377,35 @@ public sealed class CalorEmitter : IAstVisitor<string>
     {
         var elementType = TypeMapper.CSharpToCalor(node.ElementType);
 
+        // AcceptInInlineSibling: each §HSET element is emitted on its own line,
+        // but the parser treats elements as sibling expressions and a one-arg
+        // closer-less §C inside an element would absorb the next §C / §/HSET
+        // as its inline argument (v0.6.3 RFC §3.2 case B). Mirrors §DICT entries
+        // (line ~1346) and §ROW elements (line ~1474). Pre-evaluate to flush
+        // any hoisted bindings BEFORE the §HSET opener so they sit at the parent
+        // scope, not inside the set body.
+        var evalElements = new List<string>();
+        var allHoisted = new List<string>();
+        foreach (var element in node.Elements)
+        {
+            var val = AcceptInInlineSibling(element);
+            if (_pendingHoistedLines.Count > 0)
+            {
+                allHoisted.AddRange(_pendingHoistedLines);
+                _pendingHoistedLines.Clear();
+            }
+            evalElements.Add(val);
+        }
+
+        foreach (var hoisted in allHoisted)
+            AppendLine(hoisted);
+
         AppendLine($"§HSET{{{variableName}:{elementType}}}");
         Indent();
 
-        foreach (var element in node.Elements)
+        foreach (var val in evalElements)
         {
-            AppendLine(element.Accept(this));
+            AppendLine(val);
         }
 
         Dedent();
@@ -1714,12 +1741,14 @@ public sealed class CalorEmitter : IAstVisitor<string>
     {
         var elementType = TypeMapper.CSharpToCalor(node.ElementType);
 
-        // Evaluate all elements first, collecting any hoisted bindings before the list
+        // Evaluate all elements first, collecting any hoisted bindings before the list.
+        // AcceptInInlineSibling: each element line is parsed as a sibling expression
+        // and a one-arg closer-less §C would absorb the next sibling (v0.6.3 RFC §3.2 B).
         var evaluatedElements = new List<string>();
         var allHoisted = new List<string>();
         foreach (var element in node.Elements)
         {
-            var val = element.Accept(this);
+            var val = AcceptInInlineSibling(element);
             // Collect any hoisted lines generated during element evaluation
             if (_pendingHoistedLines.Count > 0)
             {
@@ -1802,12 +1831,14 @@ public sealed class CalorEmitter : IAstVisitor<string>
     {
         var elementType = TypeMapper.CSharpToCalor(node.ElementType);
 
-        // Pre-evaluate elements to flush hoisted bindings before the §HSET block
+        // Pre-evaluate elements to flush hoisted bindings before the §HSET block.
+        // AcceptInInlineSibling: each element line is parsed as a sibling expression
+        // and a one-arg closer-less §C would absorb the next sibling (v0.6.3 RFC §3.2 B).
         var evaluatedElements = new List<string>();
         var allHoisted = new List<string>();
         foreach (var element in node.Elements)
         {
-            var val = element.Accept(this);
+            var val = AcceptInInlineSibling(element);
             if (_pendingHoistedLines.Count > 0)
             {
                 allHoisted.AddRange(_pendingHoistedLines);
@@ -2398,11 +2429,38 @@ public sealed class CalorEmitter : IAstVisitor<string>
         var args = node.Arguments.Select((a, i) =>
         {
             var argValue = AcceptInInlineSibling(a);
-            if (node.ArgumentNames != null && i < node.ArgumentNames.Count && node.ArgumentNames[i] != null)
-                return $"§A[{node.ArgumentNames[i]!.TrimStart('@')}] {argValue}";
-            return $"§A {argValue}";
-        });
-        return $"§C{{{fullTarget}}} {string.Join(" ", args)} §/C";
+            bool named = node.ArgumentNames != null
+                      && i < node.ArgumentNames.Count
+                      && node.ArgumentNames[i] != null;
+            var wrapped = named
+                ? $"§A[{node.ArgumentNames![i]!.TrimStart('@')}] {argValue}"
+                : $"§A {argValue}";
+            return (named, wrapped, argValue);
+        }).ToList();
+
+        // RFC v0.6 call-closer-elision §2.1 / §2.2 — expression-context
+        // one-arg elision. Mirrors the stmt-context path at Visit(CallStatementNode).
+        // Parser side: Parser.cs `ParseCallExpression` accepts `§C{target} primary_expr`
+        // (no §A, no §/C) when followed by a syntactic terminator (RFC §2).
+        // Held back inside _inInlineSiblingContext (§A chain / §ARR / §ROW / §SALLOC
+        // initializer / §NEW arg) — there a same-line sibling would be absorbed as
+        // this call's inline argument and silently corrupt the AST (e.g.
+        // `§ARR{...} §C{f} x §C{g} y §/ARR` would re-parse as one element `f(x, g(y))`
+        // instead of two elements `f(x), g(y)`). Trailing-postfix safety (RFC §3.2
+        // case A: `§C{Box.unwrap} y.Length`) is handled by FieldAccessNode and
+        // peers detecting section markers in the inner emission and hoisting via
+        // HoistToTempVar — the same mechanism that protects zero-arg elision.
+        // Named args, multi-arg, or args whose first token is not in
+        // IsExpressionStart() keep the standard §A ... §/C form.
+        if (args.Count == 1 && !args[0].named)
+        {
+            bool canElide = _context?.UseImplicitCallCloser != false
+                         && _inInlineSiblingContext == 0
+                         && StartsWithExpressionStarter(args[0].argValue);
+            if (canElide)
+                return $"§C{{{fullTarget}}} {args[0].argValue}";
+        }
+        return $"§C{{{fullTarget}}} {string.Join(" ", args.Select(a => a.wrapped))} §/C";
     }
 
     /// <summary>
@@ -2670,7 +2728,12 @@ public sealed class CalorEmitter : IAstVisitor<string>
 
         if (node.IsExpressionLambda && node.ExpressionBody != null)
         {
-            var body = node.ExpressionBody.Accept(this);
+            // Inline-sibling context: the body is space-joined between §LAM{...}
+            // and §/LAM{...} on a single emitted line, so any one-arg §C{...} arg
+            // inside the body (v0.6.3 RFC §2.1) would absorb the §/LAM as its
+            // inline argument and corrupt the AST. Mirrors the v0.6.1 zero-arg
+            // discipline at all other sibling-context sites.
+            var body = AcceptInInlineSibling(node.ExpressionBody);
             return $"§LAM{{{header}}} {body} §/LAM{{{node.Id}}}";
         }
         else if (node.StatementBody != null && node.StatementBody.Count > 0)
@@ -3215,7 +3278,11 @@ public sealed class CalorEmitter : IAstVisitor<string>
 
     public string Visit(WithExpressionNode node)
     {
-        var target = node.Target.Accept(this);
+        // Inline-sibling context for the target: §WITH target ... §/WITH is
+        // emitted on a single line, so an elided one-arg §C{f} target form
+        // (v0.6.3 RFC §2.1) would absorb the following §SET / §/WITH as its
+        // inline argument.
+        var target = AcceptInInlineSibling(node.Target);
         var assignments = string.Join(" ", node.Assignments.Select(a => AcceptInInlineSibling(a)));
         if (assignments.Length > 0)
             return $"§WITH {target} {assignments} §/WITH";

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -7989,12 +7989,21 @@ public sealed class Parser
                     finalSpan = startToken.Span.Union(argExpr.Span);
                 }
             }
-            else if (IsExpressionStart())
+            else if (IsExpressionStart() && Current.Span.Line == _tokens[_position - 1].Span.Line)
             {
-                // Two consecutive expression-start tokens in inline-arg form:
-                // Calor0150 (RFC v0.6 call-closer-elision §3.2 case B).
-                // Recovery: stop here without consuming the second expression
-                // — let the caller see and recover from it.
+                // Two consecutive expression-start tokens on the SAME line in
+                // inline-arg form: Calor0150 (RFC v0.6 call-closer-elision §3.2
+                // case B). Recovery: stop here without consuming the second
+                // expression — let the caller see and recover from it.
+                //
+                // If the next expression-start is on a NEW line it is the start
+                // of a sibling statement (e.g. `§B{p} §C{f} §IDX{a} i\n§IF ...`),
+                // not a continuation — take the implicit-close path silently.
+                // The expr-context one-arg elision (v0.6.3) relies on this:
+                // emitted args like `§IDX{a} i` parse correctly because §IDX's
+                // own ParseExpression() consumes the trailing index, but the
+                // outer call must not then mistake the next-line statement
+                // opener for a second positional arg.
                 _diagnostics.ReportAmbiguousCallContinuation(Current.Span, target);
                 finalSpan = startToken.Span.Union(argExpr.Span);
             }

--- a/tests/Calor.Compiler.Tests/CallExpressionImplicitCloseTests.cs
+++ b/tests/Calor.Compiler.Tests/CallExpressionImplicitCloseTests.cs
@@ -335,6 +335,29 @@ public class CallExpressionImplicitCloseTests
     }
 
     [Fact]
+    public void ExpressionContext_OneArgFollowedBySiblingStatement_NoCalor0150()
+    {
+        // v0.6.3 — sibling-statement-on-next-line must NOT trigger Calor0150.
+        // Without the same-line guard at Parser.cs ~7992, the §IF on the
+        // next line would be misclassified as a second positional arg of
+        // §C{pred}. Mirrors the conversion-scorecard test 093 (Delegates):
+        // `§B{_pre} §C{pred} §IDX{numbers} i / §IF _pre ...`.
+        var source = """
+§M{m001:Test}
+  §F{f001:Filter:pub} (i32[]:numbers, F:pred) -> i32
+      §B{~count:i32} 0
+      §L{for010:i:0:(- (len numbers) 1):1}
+          §B{_pre} §C{pred} §IDX{numbers} i
+          §IF{if011} _pre
+              §ASSIGN count (+ count 1)
+      §R count
+""";
+        Parse(source, out var diags);
+        Assert.DoesNotContain(diags.Errors,
+            e => e.Code == DiagnosticCode.AmbiguousCallContinuation);
+    }
+
+    [Fact]
     public void ExpressionContext_GenericTargetAndZeroArg_Parses()
     {
         // §B{xs} §C{Array.Empty<i32>}   ← generic target, zero-arg, no §/C
@@ -608,14 +631,13 @@ public class CallExpressionImplicitCloseTests
     }
 
     [Fact]
-    public void Emitter_OneArgCall_ImplicitCloserFlagTrue_StillEmitsCloser()
+    public void Emitter_OneArgCall_ImplicitCloserFlagTrue_ElidesCloser()
     {
-        // v0.6.1 ships zero-arg-only emitter elision (RFC §6). The one-arg
-        // path needs context-aware safety (a §C inside a Lisp `(+ a b)`
-        // arg-list would consume its sibling) — that work tracks separately
-        // in CHANGELOG.md under "Out of scope for v0.6.1". This test pins
-        // the intentional zero-arg-only limitation so it can't silently
-        // expand without a deliberate decision.
+        // v0.6.3 (RFC v0.6 call-closer-elision §2.1/§2.2): one-arg expression-context
+        // calls now elide §/C by default — mirroring the stmt-context behavior
+        // shipped in v0.6.2 (PR #652). Trailing-postfix safety (RFC §3.2 case A)
+        // is handled by FieldAccessNode hoisting on section-marker detection;
+        // sibling-absorption safety is handled by _inInlineSiblingContext.
         var args = new List<ExpressionNode>
         {
             new IntLiteralNode(default, 42),
@@ -624,7 +646,88 @@ public class CallExpressionImplicitCloseTests
         var ctx = new Migration.ConversionContext { UseImplicitCallCloser = true };
         var emitter = new Migration.CalorEmitter(ctx);
         var output = call.Accept<string>(emitter);
+        Assert.Equal("§C{Identity} 42", output);
+    }
+
+    [Fact]
+    public void Emitter_OneArgCall_ImplicitCloserFlagFalse_PinsExplicitCloser()
+    {
+        // Opt-out path mirror for one-arg: UseImplicitCallCloser=false restores
+        // the explicit §A ... §/C form. Pins the opt-out so it can't silently
+        // regress alongside the v0.6.3 default flip.
+        var args = new List<ExpressionNode>
+        {
+            new IntLiteralNode(default, 42),
+        };
+        var call = new CallExpressionNode(default, "Identity", args);
+        var ctx = new Migration.ConversionContext { UseImplicitCallCloser = false };
+        var emitter = new Migration.CalorEmitter(ctx);
+        var output = call.Accept<string>(emitter);
+        Assert.Equal("§C{Identity} §A 42 §/C", output);
+    }
+
+    [Fact]
+    public void Emitter_OneArgCall_NamedArg_KeepsExplicitCloser()
+    {
+        // Named arguments cannot use the inline-arg form (the parser's one-arg
+        // implicit-close path at Parser.cs:1398 only accepts a primary_expr,
+        // not §A[name] value). Must keep §A[name] ... §/C even at leaf positions.
+        var args = new List<ExpressionNode> { new IntLiteralNode(default, 42) };
+        var argNames = new List<string?> { "value" };
+        var call = new CallExpressionNode(default, "Configure", args, argNames);
+        var emitter = new Migration.CalorEmitter();
+        var output = call.Accept<string>(emitter);
+        Assert.Equal("§C{Configure} §A[value] 42 §/C", output);
+    }
+
+    [Fact]
+    public void Emitter_OneArgCallInsideOuterCallArgs_KeepsExplicitCloser()
+    {
+        // BLOCKER mirror for one-arg: a one-arg call as one of several §A
+        // arguments to an outer call MUST keep its explicit §/C. Otherwise
+        // `§C{M} §A §C{A} x §A 2 §/C` would re-parse as `M(A(x, 2))` instead
+        // of `M(A(x), 2)`. _inInlineSiblingContext suppresses the elision.
+        var args = new List<ExpressionNode>
+        {
+            new CallExpressionNode(default, "A", new List<ExpressionNode>
+            {
+                new ReferenceNode(default, "x"),
+            }),
+            new IntLiteralNode(default, 2),
+        };
+        var outer = new CallExpressionNode(default, "M", args);
+        var emitter = new Migration.CalorEmitter();
+        var output = outer.Accept<string>(emitter);
+        // Inner one-arg A(x) must keep its §/C inside the outer §A chain.
+        Assert.Contains("§C{A} §A x §/C", output);
         Assert.EndsWith("§/C", output);
+    }
+
+    [Fact]
+    public void Emitter_OneArgCall_FlagTrue_RoundTripsThroughParser()
+    {
+        // End-to-end: the parser accepts the emitter's flag-true one-arg output.
+        var call = new CallExpressionNode(default, "Identity", new List<ExpressionNode>
+        {
+            new IntLiteralNode(default, 1),
+        });
+        var emitted = EmitWithImplicitCloser(call);
+        Assert.Equal("§C{Identity} 1", emitted);
+
+        var source = $$"""
+§M{m001:Test}
+  §F{f001:Bar:pub}
+      §B{x} {{emitted}}
+""";
+        var module = Parse(source, out var diags);
+        Assert.False(diags.HasErrors,
+            $"Errors: {string.Join("; ", diags.Errors.Select(e => e.Message))}");
+
+        var bind = module.Functions.First().Body.OfType<BindStatementNode>().First();
+        var rt = Assert.IsType<CallExpressionNode>(bind.Initializer);
+        Assert.Equal("Identity", rt.Target);
+        Assert.Single(rt.Arguments);
+        Assert.IsType<IntLiteralNode>(rt.Arguments[0]);
     }
 
     [Fact]

--- a/tests/Calor.Conversion.Tests/Snapshots/05-01.approved.calr
+++ b/tests/Calor.Conversion.Tests/Snapshots/05-01.approved.calr
@@ -3,7 +3,7 @@
 
   §CL{c001:DataService:pub}
     §AMT{m002:FetchDataAsync:pub} () -> str
-      §B{_} §AWAIT §C{Task.Delay} §A 100 §/C
+      §B{_} §AWAIT §C{Task.Delay} 100
       §R "data"
 
 

--- a/tests/Calor.Conversion.Tests/Snapshots/05-02.approved.calr
+++ b/tests/Calor.Conversion.Tests/Snapshots/05-02.approved.calr
@@ -5,7 +5,7 @@
   §CL{c001:Filter:pub}
     §MT{m002:GetPositive:pub} (List<i32>:items) -> List<i32>
       §B{_lamWhere004} §LAM{lam003:x:i32} (> x 0) §/LAM{lam003}
-      §B{_chainWhere005} §C{items.Where} §A _lamWhere004 §/C
+      §B{_chainWhere005} §C{items.Where} _lamWhere004
       §R §C{_chainWhere005.ToList}
 
 

--- a/tests/Calor.Conversion.Tests/Snapshots/05-03.approved.calr
+++ b/tests/Calor.Conversion.Tests/Snapshots/05-03.approved.calr
@@ -7,9 +7,9 @@
       §B{_lamOrderBy004} §LAM{lam003:s:str} s §/LAM{lam003}
       §B{_lamSelect006} §LAM{lam005:s:str} (upper s) §/LAM{lam005}
       §B{_lamWhere008} §LAM{lam007:s:str} (> (len s) 0) §/LAM{lam007}
-      §B{_chainWhere009} §C{items.Where} §A _lamWhere008 §/C
-      §B{_chainSelect010} §C{_chainWhere009.Select} §A _lamSelect006 §/C
-      §B{_chainOrderBy011} §C{_chainSelect010.OrderBy} §A _lamOrderBy004 §/C
+      §B{_chainWhere009} §C{items.Where} _lamWhere008
+      §B{_chainSelect010} §C{_chainWhere009.Select} _lamSelect006
+      §B{_chainOrderBy011} §C{_chainSelect010.OrderBy} _lamOrderBy004
       §R §C{_chainOrderBy011.ToList}
 
 

--- a/tests/Calor.Conversion.Tests/Snapshots/12-02.approved.calr
+++ b/tests/Calor.Conversion.Tests/Snapshots/12-02.approved.calr
@@ -4,7 +4,7 @@
       §ASSIGN result 0
       §IF{if003} (isempty input)
         §R false
-      §ASSIGN result §C{int.Parse} §A input §/C
+      §ASSIGN result §C{int.Parse} input
       §R true
 
     §MT{m004:Increment:pub} (i32:value:ref)


### PR DESCRIPTION
## Summary

Completes RFC §2.2 by extending one-arg §/C elision from statement context (v0.6.2, PR #652) to expression context. Calls like binding initializers, return values, and call arguments now emit `§C{target} arg` instead of `§C{target} §A arg §/C` when safe.

## Emitter change

`CalorEmitter.Visit(CallExpressionNode)` mirrors the v0.6.2 stmt-context template at `Visit(CallStatementNode)`:

- Eligibility: `args.Count == 1 && !args[0].named`
- Gates: `UseImplicitCallCloser != false`, `_inInlineSiblingContext == 0`, `StartsWithExpressionStarter(argValue)`
- Trailing-postfix protection inherits from existing `HoistToTempVar` discipline in `FieldAccessNode` / `BinaryOperationNode` / etc.

## Parser fix (Calor0150 across sibling-statement boundaries)

Surfaced by the round-trip of conversion test 093 Delegates. Patterns like:

`
§B{p} §C{f} §IDX{a} i
§IF{...} p
`

were misclassified as a second positional arg of `§C{f}` because the next-line `§IF` is `IsExpressionStart()`. The fix at `Parser.cs ~7992` adds a same-line guard mirroring the entry-side `inlineArgOnSameLine` check at line 7957. Regression test: `ExpressionContext_OneArgFollowedBySiblingStatement_NoCalor0150`.

## Emitter collateral (newly-risky same-line sibling-emit sites)

These previously used raw `node.X.Accept(this)` in same-line sibling positions and were caught by the static guard `CalorEmitter_HasNoRawAcceptInSpaceSeparatedSiblingPosition` immediately after the one-arg path landed:

- `Visit(LambdaExpressionNode)` body
- `Visit(WithExpressionNode)` target
- `EmitListCreationWithName` / `EmitSetCreationWithName` element emit
- `Visit(ListCreationNode)` / `Visit(SetCreationNode)` element emit

All four now use `AcceptInInlineSibling` per established discipline.

## Test results

- Full suite: **7,007 passed, 17 skipped, 0 failed**
- Elision pinned tests: **48/48** (1 new regression test added)
- Conversion scorecard: **96/100 → 99/100** round-trip pass, **0 regressions**, **+3 improvements** (059, 095, 099 + 093 once parser fix landed)

## Snapshot updates

Four mechanical `§A arg §/C` → `arg` rewrites:

- `tests/Calor.Conversion.Tests/Snapshots/05-01.approved.calr`
- `tests/Calor.Conversion.Tests/Snapshots/05-02.approved.calr`
- `tests/Calor.Conversion.Tests/Snapshots/05-03.approved.calr`
- `tests/Calor.Conversion.Tests/Snapshots/12-02.approved.calr`

## Benchmark expectation

TokenEconomics will move modestly upward (~+0.4-0.9 % per RFC §4) once benchmarks run on green CI — the conversion corpus emits many one-arg call patterns (`§AWAIT §C{Task.Delay} 100`, LINQ `.Where` / `.Select` chains, etc.) that previously contributed three tokens each (`§A` + value + `§/C`) and now contribute one.

## RFC

`docs/plans/v0.6-call-closer-elision.md` §2.2 promoted from "deferred" to shipped in v0.6.3; new §8.1 status section added.

## CHANGELOG

`CHANGELOG.md` `[Unreleased]` section updated.
