### PR TITLE
Release v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-06-13
+
+### Benchmark Results (Statistical: 30 runs)
+- **Overall Advantage**: 1.29x (Calor leads)
+- **Metrics**: Calor wins 7, C# wins 1
+- **Highlights**:
+  - Comprehension: 1.86x ± 0.00 (Calor wins, large effect d=1.84)
+  - ErrorDetection: 1.51x ± 0.00 (Calor wins, large effect d=1.25)
+  - RefactoringStability: 1.38x ± 0.00 (Calor wins, large effect d=7.10)
+  - EditPrecision: 1.36x ± 0.00 (Calor wins, large effect d=4.85)
+  - Correctness: 1.30x ± 0.00 (Calor wins, large effect d=1.37)
+  - TokenEconomics: 1.12x ± 0.00 (Calor wins)
+  - GenerationAccuracy: 1.02x ± 0.00 (Calor wins, marginal)
+  - InformationDensity: 0.99x ± 0.00 (C# wins, small effect d=-0.47)
+- **Programs Tested**: 210
+
 ### Added
 - **`calor fix --elide-call-closers` bulk migrator (CLI + SDK).** New `calor fix` subcommand that rewrites existing `.calr` source trees to the v0.6.x call-closer-elided form: zero-arg `§C{X} §/C` → `§C{X}` and same-line one-arg `§C{X} §A arg §/C` → `§C{X} arg`. Multi-line forms, named-arg (`§A[name] x`), multi-arg, and `ref`/`out`/`in` arg modifiers are left untouched. Computes token-precise byte spans on the original source and records them as `{file, byte_offset, byte_length, removed_bytes_base64}` entries (shape shared with `StructuralIdDropper.LogEntry`) so `--revert --log <file>` restores byte-for-byte. Includes a canonical-emit safety net (re-parse the migrated source, re-emit both ASTs through `CalorEmitter`, drop the file's edits on any divergence) that catches semantics-changing edits (e.g. a trailing `§+ y` sibling that would be absorbed into the call's arg expression). Mutually exclusive with `--drop-structural-ids` and `--compact-ids`; supports `--dry-run` and `--log`. Implementation: `src/Calor.Compiler/Migration/CallCloserElider.cs`. Tests: 12 cases in `tests/Calor.Compiler.Tests/Migration/CallCloserEliderTests.cs` (zero-/one-/multi-arg, named args, nested, multi-line skip, round-trip byte equality, idempotence, lex-error skip). Closes the v0.6.3 item from `docs/plans/v0.6-call-closer-elision.md` §2.3 ("No new migrator (yet)").
 - **LSP quick-fixes for strict bind-inference diagnostics `Calor0251`/`Calor0252`/`Calor0253`.** Each diagnostic now ships a `SuggestedFix` that inserts the recommended `:type` annotation right before the closing `}` of the bind's attribute block. Concrete templates: `:Option<object>` (for `§NN`), `:object?` (for `null`), `:Vec<object>` / `:Map<object, object>` / etc. arity-aware per the matched generic factory, and `:f64` (for ambiguous numeric). Surfaces in any IDE talking to `calor-lsp` via the existing `CodeActionHandler` and in the CLI's existing fix-application paths. Closes #644. Only fires on canonical bind shapes (`§B{name}` / `§B{~name}`) so the edit placement is provably correct.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "calor",
   "displayName": "Calor Language",
   "description": "Language support for the Calor programming language",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "publisher": "calor-dev",
   "license": "Apache-2.0",
   "icon": "icons/calor-icon.png",

--- a/website/content/changelog.mdx
+++ b/website/content/changelog.mdx
@@ -10,6 +10,21 @@ All notable changes to Calor, organized by release.
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-06-13
+
+### Added
+- **`calor fix --elide-call-closers` bulk migrator.** New `calor fix` subcommand that rewrites existing `.calr` source trees to the v0.6.x call-closer-elided form: zero-arg `§C{X} §/C` → `§C{X}` and same-line one-arg `§C{X} §A arg §/C` → `§C{X} arg`. Multi-line forms, named-arg (`§A[name] x`), multi-arg, and `ref`/`out`/`in` arg modifiers are left untouched. Includes a canonical-emit safety net (re-parse the migrated source, re-emit both ASTs, drop the file's edits on any divergence) and `--revert --log <file>` for byte-for-byte round-trip. Mutually exclusive with `--drop-structural-ids` and `--compact-ids`; supports `--dry-run`.
+- **LSP quick-fixes for strict bind-inference diagnostics `Calor0251`/`Calor0252`/`Calor0253`.** Each diagnostic now ships a `SuggestedFix` that inserts the recommended `:type` annotation right before the closing `}` of the bind's attribute block. Templates: `:Option<object>` (for `§NN`), `:object?` (for `null`), `:Vec<object>` / `:Map<object, object>` / etc. arity-aware per the matched generic factory, and `:f64` (for ambiguous numeric).
+- **`Calor.LanguageServer.DocumentState.Reanalyze` now runs `BindValidationPass`** so strict-bind diagnostics (and their quick-fixes) surface in editors; previously the LSP only ran the lexer/parser/binder and these diagnostics were CLI-only.
+
+### Changed
+- **Expression-context `§C` calls now elide `§/C` by default for one-argument forms.** `CalorEmitter.Visit(CallExpressionNode)` extends the v0.6.1 zero-arg elision and the v0.6.2 stmt-context one-arg elision to expression context: `§C{target} arg` (no `§A`, no `§/C`) when the argument is unnamed, the rendered first token is in the `StartsWithExpressionStarter` whitelist, and we are not inside an inline-sibling context.
+- **Strict bind-inference diagnostics `Calor0251`/`Calor0252`/`Calor0253` are now default-on.** These flag bindings that cannot infer a concrete type without an explicit `:type` annotation: untyped `§NN`/`null`, well-known generic factory calls (`Vec.empty`, `List.empty`, etc.), and binary ops mixing integer and floating-point literals. Opt out for one release with `--no-strict-bind-inference` (CLI) or `CompilationOptions.StrictBindInference = false` (SDK).
+
+### Fixed
+- **Parser: `Calor0150` no longer fires across sibling-statement boundaries.** When the next expression-start token after a one-arg elided call is on a different line, it is a sibling statement, not an ambiguous second positional arg.
+- **Emitter: `§LAM` body, `§WITH` target, and `§LIST`/`§HSET` element emit sites now use `AcceptInInlineSibling`.** These same-line sibling positions previously used raw `node.X.Accept(this)`, which could silently corrupt the AST after the one-arg expression-context elision landed.
+
 ## [0.6.2] - 2026-06-10
 
 ### Added

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calor-website",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/website/public/data/benchmark-results.json
+++ b/website/public/data/benchmark-results.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
-  "timestamp": "2026-06-10T15:49:25.8303576Z",
-  "commit": "3a2f9549",
+  "timestamp": "2026-06-13T14:26:50.5239206Z",
+  "commit": "8672612d",
   "frameworkVersion": "1.0.0",
   "summary": {
     "overallAdvantage": 1.29,
@@ -16,12 +16,12 @@
       "ratio": 1.12,
       "winner": "calor",
       "ci95": [
-        1.116,
-        1.116
+        1.118,
+        1.118
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": -0.12,
+      "effectSize": -0.128,
       "effectInterpretation": "negligible"
     },
     "GenerationAccuracy": {
@@ -76,8 +76,8 @@
       "ratio": 0.99,
       "winner": "csharp",
       "ci95": [
-        0.988,
-        0.988
+        0.987,
+        0.987
       ],
       "significant": true,
       "pValue": 0.0001,
@@ -1076,14 +1076,14 @@
       ],
       "calorSuccess": true,
       "cSharpSuccess": true,
-      "advantage": 1.5,
+      "advantage": 1.503,
       "metrics": {
-        "TokenEconomics": 0.312,
+        "TokenEconomics": 0.335,
         "GenerationAccuracy": 1,
         "Comprehension": 2.637,
         "EditPrecision": 1.314,
         "ErrorDetection": 2.5,
-        "InformationDensity": 0.896,
+        "InformationDensity": 0.904,
         "RefactoringStability": 1.439,
         "Correctness": 1.9
       }
@@ -1100,14 +1100,14 @@
       ],
       "calorSuccess": true,
       "cSharpSuccess": true,
-      "advantage": 1.526,
+      "advantage": 1.53,
       "metrics": {
-        "TokenEconomics": 0.245,
+        "TokenEconomics": 0.266,
         "GenerationAccuracy": 1,
         "Comprehension": 2.87,
         "EditPrecision": 1.314,
         "ErrorDetection": 2.5,
-        "InformationDensity": 0.94,
+        "InformationDensity": 0.949,
         "RefactoringStability": 1.439,
         "Correctness": 1.9
       }
@@ -1537,14 +1537,14 @@
       ],
       "calorSuccess": true,
       "cSharpSuccess": true,
-      "advantage": 1.486,
+      "advantage": 1.491,
       "metrics": {
-        "TokenEconomics": 0.448,
+        "TokenEconomics": 0.481,
         "GenerationAccuracy": 1,
         "Comprehension": 2.706,
         "EditPrecision": 1.314,
         "ErrorDetection": 2.5,
-        "InformationDensity": 0.68,
+        "InformationDensity": 0.687,
         "RefactoringStability": 1.439,
         "Correctness": 1.8
       }
@@ -3767,14 +3767,14 @@
       ],
       "calorSuccess": true,
       "cSharpSuccess": true,
-      "advantage": 1.001,
+      "advantage": 1.004,
       "metrics": {
-        "TokenEconomics": 1.131,
+        "TokenEconomics": 1.199,
         "GenerationAccuracy": 0.76,
         "Comprehension": 0.417,
         "EditPrecision": 0.98,
         "ErrorDetection": 1,
-        "InformationDensity": 0.591,
+        "InformationDensity": 0.549,
         "RefactoringStability": 2.128,
         "Correctness": 1
       }
@@ -3791,14 +3791,14 @@
       ],
       "calorSuccess": true,
       "cSharpSuccess": true,
-      "advantage": 0.957,
+      "advantage": 0.959,
       "metrics": {
-        "TokenEconomics": 1.028,
+        "TokenEconomics": 1.073,
         "GenerationAccuracy": 0.76,
         "Comprehension": 0.369,
         "EditPrecision": 0.944,
         "ErrorDetection": 0.857,
-        "InformationDensity": 0.77,
+        "InformationDensity": 0.735,
         "RefactoringStability": 1.831,
         "Correctness": 1.1
       }
@@ -4090,14 +4090,14 @@
       ],
       "calorSuccess": true,
       "cSharpSuccess": true,
-      "advantage": 1.451,
+      "advantage": 1.46,
       "metrics": {
-        "TokenEconomics": 1.746,
+        "TokenEconomics": 1.823,
         "GenerationAccuracy": 1.136,
         "Comprehension": 1.889,
         "EditPrecision": 1.431,
         "ErrorDetection": 1.143,
-        "InformationDensity": 1.661,
+        "InformationDensity": 1.654,
         "RefactoringStability": 1.6,
         "Correctness": 1
       }
@@ -5153,11 +5153,11 @@
     ],
     "categoryDetails": {
       "TokenEconomics": {
-        "mean": 1.116,
-        "stdDev": 16.589,
-        "ci95Lower": 1.104,
-        "ci95Upper": 1.128,
-        "cohensD": -0.12,
+        "mean": 1.118,
+        "stdDev": 18.629,
+        "ci95Lower": 1.105,
+        "ci95Upper": 1.13,
+        "cohensD": -0.128,
         "pValue": 0.0001,
         "significant": true
       },
@@ -5198,10 +5198,10 @@
         "significant": true
       },
       "InformationDensity": {
-        "mean": 0.988,
+        "mean": 0.987,
         "stdDev": 0.024,
-        "ci95Lower": 0.978,
-        "ci95Upper": 0.998,
+        "ci95Lower": 0.977,
+        "ci95Upper": 0.997,
         "cohensD": -0.466,
         "pValue": 0.0001,
         "significant": true

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -15,9 +15,9 @@ export function WhatsNewBanner() {
         <div className="flex items-center justify-center gap-3 text-sm">
           <Sparkles className="h-4 w-4 text-calor-cerulean flex-shrink-0" />
           <p className="text-center">
-            <span className="font-semibold text-calor-cerulean">v0.6.2</span>
+            <span className="font-semibold text-calor-cerulean">v0.6.3</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">Statement-context `§C` calls now elide `§/C` by default, the deprecated `calor diagnose` command was removed, and the benchmark corpus grew to 210 programs.</span>
+            <span className="text-foreground">Expression-context one-arg `§C` calls now elide `§/C`, strict bind-inference (Calor0251–0253) is default-on with LSP quick-fixes, and the new `calor fix --elide-call-closers` bulk migrator rewrites existing `.calr` trees to the elided form.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"


### PR DESCRIPTION
## Summary
- Bump version to 0.6.3
- Update CHANGELOG.md with release date and benchmark results
- Update website changelog and WhatsNewBanner
- Update benchmark results JSON for website dashboard

## v0.6.3 contents
| PR | Title |
|---:|---|
| #656 | feat(emitter): elide `§/C` on one-arg expression-context calls |
| #657 | feat: promote Calor0251–0253 strict bind-inference to default-on |
| #658 | feat(lsp): quick-fixes for strict bind-inference diagnostics |
| #659 | feat: bulk migrator `calor fix --elide-call-closers` |

Closes the v0.6.3 plan item in `docs/plans/v0.6-call-closer-elision.md` §2.3.

## Benchmark Results (Statistical: 30 runs, 210 programs)

| Metric | Ratio | Winner |
|---|---:|---|
| Comprehension | 1.86x | 🟢 Calor (d=1.84, large) |
| ErrorDetection | 1.51x | 🟢 Calor (d=1.25, large) |
| RefactoringStability | 1.38x | 🟢 Calor (d=7.10, large) |
| EditPrecision | 1.36x | 🟢 Calor (d=4.85, large) |
| Correctness | 1.30x | 🟢 Calor (d=1.37, large) |
| TokenEconomics | 1.12x | 🟢 Calor |
| GenerationAccuracy | 1.02x | 🟢 Calor (marginal) |
| InformationDensity | 0.99x | 🟡 C# (d=-0.47, small) |

**Overall: 1.29x (Calor leads), 7/8 wins.**

## Checklist
- [x] Version updated in `Directory.Build.props`
- [x] Version updated in `editors/vscode/package.json`
- [x] Version updated in `website/package.json`
- [x] `CHANGELOG.md` updated with version, date, and benchmark summary
- [x] `website/content/changelog.mdx` updated with version and changes (no benchmark stats)
- [x] `website/src/components/landing/WhatsNewBanner.tsx` updated with version and headline
- [x] `website/public/data/benchmark-results.json` updated with latest results