### PR TITLE
Release v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-06-16
+
+### Benchmark Results (Statistical: 30 runs)
+- **Overall Advantage**: 1.28x (Calor leads)
+- **Metrics**: Calor wins 7, C# wins 1
+- **Highlights**:
+  - Comprehension: 1.84x ± 0.00 (Calor wins, large effect d=1.80)
+  - ErrorDetection: 1.49x ± 0.00 (Calor wins, large effect d=1.21)
+  - RefactoringStability: 1.38x ± 0.00 (Calor wins, large effect d=7.09)
+  - EditPrecision: 1.36x ± 0.00 (Calor wins, large effect d=4.90)
+  - Correctness: 1.29x ± 0.00 (Calor wins, large effect d=1.31)
+  - TokenEconomics: 1.11x ± 0.00 (Calor wins, negligible effect d=-0.12)
+  - GenerationAccuracy: 1.02x ± 0.00 (Calor wins, small effect d=0.34)
+  - InformationDensity: 0.98x ± 0.00 (C# wins, medium effect d=-0.52)
+- **Programs Tested**: 217
+
 ### Fixed
 - **Parser: elided-call statement no longer steals the parent block's terminating Dedent.** `ParseCallStatement` previously called `ExpectBlockEnd(EndCall)` unconditionally after a `§A`-argument list (and excluded `Dedent`/`Eof` from the zero-arg implicit-close branch), which consumed the enclosing function/if/loop body's terminator when no `§/C` was actually present. The bug manifested whenever an elided call (`§C{X}` or `§C{X} §A arg`) was the last statement of a function body that was followed by a sibling top-level declaration (e.g. another `§F`) — the parser then tried to parse `§F` as a statement and reported `Calor0100: Expected statement but found Func`. Discovered while modernizing `samples/TypeSystem/typesystem.calr` for v0.6.4 item C. Fix at `src/Calor.Compiler/Parsing/Parser.cs ParseCallStatement` + new `DedentRunEndsAtEndCall` helper. Regression coverage: 4 new tests in `CallStatementImplicitCloseTests` (`V064_ZeroArgStmt_LastInBody_BeforeSiblingFunc_Parses`, `V064_OneArgStmtViaA_LastInBody_BeforeSiblingFunc_Parses`, `V064_OneArgStmtInline_LastInBody_BeforeSiblingFunc_Parses`, `V064_LegacyMultiLineCall_StillParses`).
 
@@ -17,7 +33,7 @@ All notable changes to this project will be documented in this file.
 - **`BindCorpusCleanTests.Corpus_HasZeroBindInferenceFirings`** — permanent CI-enforced pin that runs `BindValidationPass` (strict inference on) against every `.calr` file under `samples/` and `tests/TestData/Benchmarks/` and asserts zero firings of `Calor0250`/`Calor0251`/`Calor0252`/`Calor0253`. Lex/parse failures are skipped (some corpus files use experimental shapes outside this audit's scope); only the well-parsed subset is audited. Any future regression in the corpus or a tightening of the bind-inference checks will now block merge with the offending file + diagnostic in the failure message.
 
 ### Added
-- **7 new TokenEconomics benchmark fixtures** (ids 053–059, `tests/TestData/Benchmarks/TokenEconomics/`) exercising v0.6.3 expression-context call elision and v0.6 bind-inference, with two neutral controls. Closes the v0.6 call-closer-elision RFC §8.1 criterion 4 ("Expected `TokenEconomics` lower-95%-CI > 1.122") and the v0.6.4 roadmap item A:
+- **7 new TokenEconomics benchmark fixtures** (ids 053–059, `tests/TestData/Benchmarks/TokenEconomics/`) exercising v0.6.3 expression-context call elision and v0.6 bind-inference, with two neutral controls. These broaden corpus coverage of elision/bind-inference patterns (parser, formatter, delegation, aggregation shapes):
 
   | ID | Name | Pattern | Composite ratio |
   |---|---|---|---|
@@ -29,7 +45,7 @@ All notable changes to this project will be documented in this file.
   | 058 | ThreeWayMerge | three-arg expr-context call (NEUTRAL control — no elision) | 1.34x |
   | 059 | NamedConfig | named-arg expr-context call (NEUTRAL control — `§A[name]` excluded from elision) | 1.32x |
 
-  Honest measurement: composite ratios are inflated by the line-count component (small focused programs structurally favor Calor's lower namespace/class boilerplate overhead). The elision-favorable fixtures average 0.80 on pure token ratio vs the existing 45-fixture corpus average of 0.81, so the *token-level* elision savings are real but small. The two neutral controls (with composite ratios in the same band as PR #653's `PairLogger` neutral, 1.22x) document the floor under the same structural conditions.
+  **Correction / honest measurement:** these fixtures were originally added (v0.6.4 roadmap item A) to push the `TokenEconomics` 30-run lower-95%-CI past the v0.7 gate of 1.122. They do **not** achieve that. The `TokenEconomics` category measures **raw token count only** — `TokenEconomicsCalculator` computes a token×char×line composite (the ratios in the table above) but discards it and reports `calorTokenCount`/`csharpTokenCount`. On small focused programs Calor's `§`-sigil punctuation costs *more* tokens than the equivalent C#, so the new fixtures' token ratios average ~0.80 (C# leaner) and nudged the category from 1.12x (v0.6.3) down to **1.11x**. They are retained because they are representative, honest programs — the benchmark deliberately includes cases C# wins (e.g. InformationDensity 0.98x). The v0.7 `TokenEconomics` gate remains **open**, now correctly understood to require token-favorable (high-C#-ceremony) programs rather than composite-favorable ones; the discarded-composite in the calculator is flagged as a latent bug for v0.7 review.
 
 ## [0.6.3] - 2026-06-13
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.6.3</Version>
+    <Version>0.6.4</Version>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "calor",
   "displayName": "Calor Language",
   "description": "Language support for the Calor programming language",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "publisher": "calor-dev",
   "license": "Apache-2.0",
   "icon": "icons/calor-icon.png",

--- a/website/content/changelog.mdx
+++ b/website/content/changelog.mdx
@@ -10,6 +10,20 @@ All notable changes to Calor, organized by release.
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-06-16
+
+### Fixed
+- **Parser: an elided `§C` call no longer steals the parent block's terminating `Dedent`.** An elided `§C{X}` / `§C{X} §A arg` call that was the last statement of a function body followed by a sibling declaration (e.g. another `§F`) previously failed with `Calor0100: Expected statement but found Func`. Discovered while modernizing the TypeSystem sample for this release.
+
+### Added
+- **7 new TokenEconomics benchmark fixtures** broadening corpus coverage of v0.6.3 expression-context call elision and v0.6 bind-inference (parser, formatter, delegation, and aggregation shapes), plus two neutral controls. Honest note: the `TokenEconomics` category scores raw token count only, and Calor's `§`-sigils cost more tokens than the equivalent C# on small programs, so these representative fixtures left the category at 1.11x — the v0.7 `TokenEconomics` gate remains open.
+
+### Internal
+- **The TypeSystem sample and the `04_option_result` E2E scenario were modernized to canonical v0.6.3 syntax** — a legacy triply-nested `§OK{§ARR…}` array form (an artifact of mass C# → Calor conversion) was replaced with the canonical `§OK value` / `§ERR "msg"` short form, fixing the generated C# from `Result.Ok<object, string>(new object[]{…})` to `Result.Ok<int, string>(100)`.
+
+### Documentation
+- **v0.6 bind-inference RFC §7 — the `Calor0250` open question is resolved.** The diagnostic has always shipped as a hard error; the "promote warning→error in v0.7?" bullet was a stale carry-over and is now marked resolved, backed by a permanent corpus-clean test pinning zero bind-inference firings across the sample and benchmark corpus.
+
 ## [0.6.3] - 2026-06-13
 
 ### Added

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calor-website",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/website/public/data/benchmark-results.json
+++ b/website/public/data/benchmark-results.json
@@ -1,11 +1,11 @@
 {
   "version": "1.0",
-  "timestamp": "2026-06-13T14:26:50.5239206Z",
-  "commit": "8672612d",
+  "timestamp": "2026-06-16T18:39:43.5059996Z",
+  "commit": "0335c912",
   "frameworkVersion": "1.0.0",
   "summary": {
-    "overallAdvantage": 1.29,
-    "programCount": 210,
+    "overallAdvantage": 1.28,
+    "programCount": 217,
     "metricCount": 8,
     "calorWins": 7,
     "cSharpWins": 1,
@@ -13,15 +13,15 @@
   },
   "metrics": {
     "TokenEconomics": {
-      "ratio": 1.12,
+      "ratio": 1.11,
       "winner": "calor",
       "ci95": [
-        1.118,
-        1.118
+        1.107,
+        1.107
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": -0.128,
+      "effectSize": -0.119,
       "effectInterpretation": "negligible"
     },
     "GenerationAccuracy": {
@@ -33,79 +33,79 @@
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": 0.341,
+      "effectSize": 0.335,
       "effectInterpretation": "small"
     },
     "Comprehension": {
-      "ratio": 1.86,
+      "ratio": 1.84,
       "winner": "calor",
       "ci95": [
-        1.857,
-        1.857
+        1.836,
+        1.836
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": 1.837,
+      "effectSize": 1.796,
       "effectInterpretation": "large"
     },
     "EditPrecision": {
       "ratio": 1.36,
       "winner": "calor",
       "ci95": [
-        1.36,
-        1.36
+        1.358,
+        1.358
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": 4.854,
+      "effectSize": 4.903,
       "effectInterpretation": "large"
     },
     "ErrorDetection": {
-      "ratio": 1.51,
+      "ratio": 1.49,
       "winner": "calor",
       "ci95": [
-        1.508,
-        1.508
+        1.492,
+        1.492
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": 1.245,
+      "effectSize": 1.206,
       "effectInterpretation": "large"
     },
     "InformationDensity": {
-      "ratio": 0.99,
+      "ratio": 0.98,
       "winner": "csharp",
       "ci95": [
-        0.987,
-        0.987
+        0.976,
+        0.976
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": -0.466,
-      "effectInterpretation": "small"
+      "effectSize": -0.516,
+      "effectInterpretation": "medium"
     },
     "RefactoringStability": {
       "ratio": 1.38,
       "winner": "calor",
       "ci95": [
-        1.377,
-        1.377
+        1.378,
+        1.378
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": 7.098,
+      "effectSize": 7.089,
       "effectInterpretation": "large"
     },
     "Correctness": {
-      "ratio": 1.3,
+      "ratio": 1.29,
       "winner": "calor",
       "ci95": [
-        1.303,
-        1.303
+        1.294,
+        1.294
       ],
       "significant": true,
       "pValue": 0.0001,
-      "effectSize": 1.371,
+      "effectSize": 1.315,
       "effectInterpretation": "large"
     }
   },
@@ -2791,6 +2791,188 @@
       }
     },
     {
+      "id": "053",
+      "name": "ParseAndDouble",
+      "level": 2,
+      "features": [
+        "module",
+        "function",
+        "bind",
+        "bind_inference",
+        "one_arg_call",
+        "expression_context_call",
+        "v0_6_3_elision"
+      ],
+      "calorSuccess": true,
+      "cSharpSuccess": true,
+      "advantage": 1.061,
+      "metrics": {
+        "TokenEconomics": 0.79,
+        "GenerationAccuracy": 1,
+        "Comprehension": 1.289,
+        "EditPrecision": 1.314,
+        "ErrorDetection": 1,
+        "InformationDensity": 0.656,
+        "RefactoringStability": 1.439,
+        "Correctness": 1
+      }
+    },
+    {
+      "id": "054",
+      "name": "FormatHeader",
+      "level": 2,
+      "features": [
+        "module",
+        "function",
+        "string_return",
+        "bind",
+        "bind_inference",
+        "one_arg_call",
+        "expression_context_call",
+        "v0_6_3_elision"
+      ],
+      "calorSuccess": true,
+      "cSharpSuccess": true,
+      "advantage": 1.064,
+      "metrics": {
+        "TokenEconomics": 0.81,
+        "GenerationAccuracy": 1,
+        "Comprehension": 1.289,
+        "EditPrecision": 1.314,
+        "ErrorDetection": 1,
+        "InformationDensity": 0.663,
+        "RefactoringStability": 1.439,
+        "Correctness": 1
+      }
+    },
+    {
+      "id": "055",
+      "name": "ReturnMapped",
+      "level": 2,
+      "features": [
+        "module",
+        "function",
+        "one_arg_call",
+        "expression_context_call",
+        "return_expression",
+        "v0_6_3_elision"
+      ],
+      "calorSuccess": true,
+      "cSharpSuccess": true,
+      "advantage": 1.051,
+      "metrics": {
+        "TokenEconomics": 0.786,
+        "GenerationAccuracy": 1,
+        "Comprehension": 1.253,
+        "EditPrecision": 1.314,
+        "ErrorDetection": 1,
+        "InformationDensity": 0.642,
+        "RefactoringStability": 1.415,
+        "Correctness": 1
+      }
+    },
+    {
+      "id": "056",
+      "name": "AggregateStats",
+      "level": 2,
+      "features": [
+        "module",
+        "function",
+        "bind",
+        "bind_inference",
+        "arithmetic",
+        "v0_6_bind_inference"
+      ],
+      "calorSuccess": true,
+      "cSharpSuccess": true,
+      "advantage": 1.02,
+      "metrics": {
+        "TokenEconomics": 0.811,
+        "GenerationAccuracy": 1,
+        "Comprehension": 1.091,
+        "EditPrecision": 1.314,
+        "ErrorDetection": 1,
+        "InformationDensity": 0.626,
+        "RefactoringStability": 1.319,
+        "Correctness": 1
+      }
+    },
+    {
+      "id": "057",
+      "name": "TemperatureRange",
+      "level": 2,
+      "features": [
+        "module",
+        "function",
+        "bind",
+        "bind_inference",
+        "arithmetic",
+        "float_arithmetic",
+        "v0_6_bind_inference"
+      ],
+      "calorSuccess": true,
+      "cSharpSuccess": true,
+      "advantage": 1.037,
+      "metrics": {
+        "TokenEconomics": 0.831,
+        "GenerationAccuracy": 1,
+        "Comprehension": 1.137,
+        "EditPrecision": 1.314,
+        "ErrorDetection": 1,
+        "InformationDensity": 0.691,
+        "RefactoringStability": 1.319,
+        "Correctness": 1
+      }
+    },
+    {
+      "id": "058",
+      "name": "ThreeWayMerge",
+      "level": 2,
+      "features": [
+        "module",
+        "function",
+        "multi_arg_call",
+        "expression_context_call"
+      ],
+      "calorSuccess": true,
+      "cSharpSuccess": true,
+      "advantage": 1.014,
+      "metrics": {
+        "TokenEconomics": 0.713,
+        "GenerationAccuracy": 1,
+        "Comprehension": 1.148,
+        "EditPrecision": 1.314,
+        "ErrorDetection": 1,
+        "InformationDensity": 0.521,
+        "RefactoringStability": 1.415,
+        "Correctness": 1
+      }
+    },
+    {
+      "id": "059",
+      "name": "NamedConfig",
+      "level": 2,
+      "features": [
+        "module",
+        "function",
+        "named_arg_call",
+        "expression_context_call"
+      ],
+      "calorSuccess": true,
+      "cSharpSuccess": true,
+      "advantage": 1.038,
+      "metrics": {
+        "TokenEconomics": 0.699,
+        "GenerationAccuracy": 1,
+        "Comprehension": 1.253,
+        "EditPrecision": 1.314,
+        "ErrorDetection": 1,
+        "InformationDensity": 0.623,
+        "RefactoringStability": 1.415,
+        "Correctness": 1
+      }
+    },
+    {
       "id": "async001",
       "name": "SimpleAsync",
       "level": 3,
@@ -5153,74 +5335,74 @@
     ],
     "categoryDetails": {
       "TokenEconomics": {
-        "mean": 1.118,
-        "stdDev": 18.629,
-        "ci95Lower": 1.105,
-        "ci95Upper": 1.13,
-        "cohensD": -0.128,
+        "mean": 1.107,
+        "stdDev": 18.582,
+        "ci95Lower": 1.095,
+        "ci95Upper": 1.118,
+        "cohensD": -0.119,
         "pValue": 0.0001,
         "significant": true
       },
       "GenerationAccuracy": {
         "mean": 1.017,
-        "stdDev": 0.039,
-        "ci95Lower": 1.016,
+        "stdDev": 0.038,
+        "ci95Lower": 1.015,
         "ci95Upper": 1.018,
-        "cohensD": 0.341,
+        "cohensD": 0.335,
         "pValue": 0.0001,
         "significant": true
       },
       "Comprehension": {
-        "mean": 1.857,
-        "stdDev": 0.032,
-        "ci95Lower": 1.843,
-        "ci95Upper": 1.871,
-        "cohensD": 1.837,
+        "mean": 1.836,
+        "stdDev": 0.033,
+        "ci95Lower": 1.822,
+        "ci95Upper": 1.85,
+        "cohensD": 1.796,
         "pValue": 0.0001,
         "significant": true
       },
       "EditPrecision": {
-        "mean": 1.36,
-        "stdDev": 0.008,
-        "ci95Lower": 1.357,
-        "ci95Upper": 1.362,
-        "cohensD": 4.854,
+        "mean": 1.358,
+        "stdDev": 0.007,
+        "ci95Lower": 1.356,
+        "ci95Upper": 1.361,
+        "cohensD": 4.903,
         "pValue": 0.0001,
         "significant": true
       },
       "ErrorDetection": {
-        "mean": 1.508,
-        "stdDev": 0.105,
-        "ci95Lower": 1.494,
-        "ci95Upper": 1.522,
-        "cohensD": 1.245,
+        "mean": 1.492,
+        "stdDev": 0.106,
+        "ci95Lower": 1.478,
+        "ci95Upper": 1.505,
+        "cohensD": 1.206,
         "pValue": 0.0001,
         "significant": true
       },
       "InformationDensity": {
-        "mean": 0.987,
-        "stdDev": 0.024,
-        "ci95Lower": 0.977,
-        "ci95Upper": 0.997,
-        "cohensD": -0.466,
+        "mean": 0.976,
+        "stdDev": 0.025,
+        "ci95Lower": 0.966,
+        "ci95Upper": 0.986,
+        "cohensD": -0.516,
         "pValue": 0.0001,
         "significant": true
       },
       "RefactoringStability": {
-        "mean": 1.377,
-        "stdDev": 0.01,
-        "ci95Lower": 1.374,
-        "ci95Upper": 1.38,
-        "cohensD": 7.098,
+        "mean": 1.378,
+        "stdDev": 0.009,
+        "ci95Lower": 1.375,
+        "ci95Upper": 1.381,
+        "cohensD": 7.089,
         "pValue": 0.0001,
         "significant": true
       },
       "Correctness": {
-        "mean": 1.303,
-        "stdDev": 0.055,
-        "ci95Lower": 1.296,
-        "ci95Upper": 1.311,
-        "cohensD": 1.371,
+        "mean": 1.294,
+        "stdDev": 0.057,
+        "ci95Lower": 1.286,
+        "ci95Upper": 1.301,
+        "cohensD": 1.315,
         "pValue": 0.0001,
         "significant": true
       }

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -15,9 +15,9 @@ export function WhatsNewBanner() {
         <div className="flex items-center justify-center gap-3 text-sm">
           <Sparkles className="h-4 w-4 text-calor-cerulean flex-shrink-0" />
           <p className="text-center">
-            <span className="font-semibold text-calor-cerulean">v0.6.3</span>
+            <span className="font-semibold text-calor-cerulean">v0.6.4</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">Expression-context one-arg `§C` calls now elide `§/C`, strict bind-inference (Calor0251–0253) is default-on with LSP quick-fixes, and the new `calor fix --elide-call-closers` bulk migrator rewrites existing `.calr` trees to the elided form.</span>
+            <span className="text-foreground">A parser fix lets an elided `§C` call sit safely as the last statement before a sibling declaration, the TypeSystem sample is modernized to canonical `§OK`/`§ERR` syntax, and the benchmark corpus grows with new elision-aware TokenEconomics fixtures.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"


### PR DESCRIPTION
## Summary
- Bump version to **0.6.4** (Directory.Build.props, vscode + website package.json)
- Update CHANGELOG.md with release date + 30-run statistical benchmark summary
- Update website changelog.mdx and WhatsNewBanner
- Refresh website benchmark-results.json dashboard data

This release ships the merged v0.6.4 scope **A + B + C**:
- **Item C** (#663) — parser fix: an elided `§C` call no longer steals the parent block's terminating `Dedent`; TypeSystem sample + `04_option_result` E2E modernized to canonical `§OK`/`§ERR` syntax.
- **Item B** (#664) — v0.6 bind-inference RFC §7 `Calor0250` open question resolved (always a hard error); permanent corpus-clean test pins zero firings.
- **Item A** (#665) — 7 new TokenEconomics fixtures broadening elision/bind-inference coverage + 2 neutral controls.

## ⚠️ Honest correction (item A did not meet its stated goal)
Item A was scoped to push the `TokenEconomics` 30-run lower-95%-CI past the **v0.7 gate of 1.122**. It does **not**. The `TokenEconomics` category scores **raw token count only** — `TokenEconomicsCalculator` computes a token×char×line composite then **discards it** and reports `calorTokenCount`/`csharpTokenCount`. Calor's `§`-sigils cost more tokens than equivalent C# on small programs, so the new fixtures (token ratio ~0.80) nudged the category **1.12x → 1.11x**. The fixtures are retained as representative honest programs (the benchmark deliberately includes cases C# wins, e.g. InformationDensity 0.98x). The v0.7 `TokenEconomics` gate **remains open**, now correctly understood to require token-favorable (high-C#-ceremony) programs; the discarded-composite is flagged as a latent calculator bug for v0.7. Full disclosure is in CHANGELOG.md.

## Benchmark Results (Statistical: 30 runs)
- **Overall Advantage**: 1.28x (Calor leads)
- **Metrics**: Calor wins 7, C# wins 1
- TokenEconomics: 1.11x | Comprehension: 1.84x | ErrorDetection: 1.49x | RefactoringStability: 1.38x | EditPrecision: 1.36x | Correctness: 1.29x | GenerationAccuracy: 1.02x | InformationDensity: 0.98x (C#)
- **Programs Tested**: 217

## Checklist
- [x] Version updated in Directory.Build.props
- [x] Version updated in editors/vscode/package.json
- [x] Version updated in website/package.json
- [x] CHANGELOG.md updated with version, date, and benchmark summary
- [x] website/content/changelog.mdx updated (no benchmark stats)
- [x] website/src/components/landing/WhatsNewBanner.tsx updated
- [x] website/public/data/benchmark-results.json updated
