### PR TITLE
Release v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.5] - 2026-06-30
+
+### Benchmark Results (Statistical: 30 runs)
+- **Overall Advantage**: 1.32x (Calor leads)
+- **Metrics**: Calor wins 7, C# wins 1
+- **Highlights**:
+  - Comprehension: 1.84x ± 0.00 (Calor wins, large effect d=1.80)
+  - ErrorDetection: 1.49x ± 0.00 (Calor wins, large effect d=1.21)
+  - TokenEconomics: 1.42x ± 0.00 (Calor wins, composite metric — see Fixed)
+  - RefactoringStability: 1.38x ± 0.00 (Calor wins, large effect d=7.09)
+  - EditPrecision: 1.36x ± 0.00 (Calor wins, large effect d=4.90)
+  - Correctness: 1.29x ± 0.00 (Calor wins, large effect d=1.31)
+  - GenerationAccuracy: 1.02x ± 0.00 (Calor wins, small effect d=0.34)
+  - InformationDensity: 0.98x ± 0.00 (C# wins, medium effect d=-0.52)
+- **Programs Tested**: 217
+
+> **Note:** the overall and TokenEconomics figures rose vs v0.6.4 (1.28x → 1.32x; 1.11x → 1.42x) as a **measurement correction**, not a Calor improvement — the TokenEconomics metric now reports the composite it always computed (see Fixed). Calor still uses more *raw tokens* than C# on small programs.
+
 ### Fixed
 - **`TokenEconomics` benchmark metric now reports the composite it computes (the discarded-composite bug, #668).** `TokenEconomicsCalculator.CalculateAsync` computed a composite advantage — the geometric mean of the token, character, and line ratios — and then **discarded it**, reporting the raw token-count ratio only despite the metric being named `CompositeTokenEconomics`. The category now reports the composite. The metric is deterministic (pure token/char/line counting, no LLM sampling), so its 95% CI equals its point estimate. **This raises the headline numbers — TokenEconomics from `1.11×` (token-only) to `1.42×` (composite), and overall from `1.28×` to `1.32×` — purely as a measurement correction; it is not a Calor improvement.** The honest caveat is documented: Calor still uses *more raw tokens* than C# on small programs (the `§`-sigil premium), but is more compact once character and line counts are included. Fix applied to both calculator copies (`tests/Calor.Evaluation/Metrics/TokenEconomicsCalculator.cs`, `src/Calor.Compiler/Evaluation/Metrics/TokenEconomicsCalculator.cs`); the misleading "Token savings: … fewer tokens" report line was corrected to "Compactness: … more compact (composite)". Regression coverage: `MetricCalculatorTests.TokenEconomicsCalculator_ReportsCompositeAdvantage_NotRawTokenRatioOnly` pins that the reported advantage equals the geometric mean of the three ratios (not the token ratio alone).
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.6.4</Version>
+    <Version>0.6.5</Version>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "calor",
   "displayName": "Calor Language",
   "description": "Language support for the Calor programming language",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "publisher": "calor-dev",
   "license": "Apache-2.0",
   "icon": "icons/calor-icon.png",

--- a/website/content/changelog.mdx
+++ b/website/content/changelog.mdx
@@ -10,6 +10,14 @@ All notable changes to Calor, organized by release.
 
 ## [Unreleased]
 
+## [0.6.5] - 2026-06-30
+
+### Fixed
+- **The `TokenEconomics` benchmark metric now reports the composite it computes (the discarded-composite bug, [#668](https://github.com/juanmicrosoft/calor/issues/668)).** The calculator computed a composite advantage — the geometric mean of the token, character, and line ratios — and then *discarded it*, reporting the raw token-count ratio only despite the metric being named `CompositeTokenEconomics`. The category now reports the composite. The metric is deterministic, so its 95% CI equals its point estimate. This lifts the headline numbers — TokenEconomics from `1.11×` (token-only) to `1.42×` (composite) and overall from `1.28×` to `1.32×` — purely as a **measurement correction, not a Calor improvement**. The honest caveat stands: Calor still uses *more raw tokens* than C# on small programs (the `§`-sigil premium), but is more compact once character and line counts are included.
+
+### Changed
+- **The deferred v0.7 `TokenEconomics` gate was recalibrated against the corrected metric.** The old token-only target (`lower-95%-CI > 1.122`) is superseded by a composite gate of **≥ 1.40×**, anchored to the measured 1.42× baseline. The public [Token Economics metric page](/benchmarking/metrics/token-economics/) was corrected — it had previously and incorrectly reported the category as "C# wins".
+
 ## [0.6.4] - 2026-06-16
 
 ### Fixed

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calor-website",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/website/public/data/benchmark-results.json
+++ b/website/public/data/benchmark-results.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
-  "timestamp": "2026-06-30T16:09:04.9794708Z",
-  "commit": "44bcc3ab",
+  "timestamp": "2026-06-30T16:44:04.1783653Z",
+  "commit": "8e9b8b01",
   "frameworkVersion": "1.0.0",
   "summary": {
     "overallAdvantage": 1.32,

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -15,9 +15,9 @@ export function WhatsNewBanner() {
         <div className="flex items-center justify-center gap-3 text-sm">
           <Sparkles className="h-4 w-4 text-calor-cerulean flex-shrink-0" />
           <p className="text-center">
-            <span className="font-semibold text-calor-cerulean">v0.6.4</span>
+            <span className="font-semibold text-calor-cerulean">v0.6.5</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">A parser fix lets an elided `§C` call sit safely as the last statement before a sibling declaration, the TypeSystem sample is modernized to canonical `§OK`/`§ERR` syntax, and the benchmark corpus grows with new elision-aware TokenEconomics fixtures.</span>
+            <span className="text-foreground">The TokenEconomics benchmark now reports the composite compactness score it always computed instead of raw token count alone &mdash; an honest measurement fix that lifts the category to 1.42&times; and the overall advantage to 1.32&times;, with the v0.7 gate recalibrated against the corrected metric.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"


### PR DESCRIPTION
## Summary
- Bump version to 0.6.5
- Update CHANGELOG.md with release date and benchmark results
- Update website changelog and WhatsNewBanner (TokenEconomics composite-metric correction)
- Update benchmark results JSON for website dashboard

## Headline
v0.6.5 ships the **#668 TokenEconomics metric fix**: the benchmark now reports the *composite* compactness score (geomean of token/char/line ratios) it always computed instead of raw token count alone. This is an **honest measurement correction, not a Calor improvement** — TokenEconomics moves 1.11x → 1.42x and overall 1.28x → 1.32x. The deferred v0.7 gate was recalibrated from the token-only `>1.122` to a composite `≥1.40x`.

## Benchmark Results (Statistical: 30 runs)
- **Overall Advantage**: 1.32x (Calor leads)
- **Metrics**: Calor wins 7, C# wins 1
- **Highlights**:
  - Comprehension: 1.84x (Calor)
  - ErrorDetection: 1.49x (Calor)
  - TokenEconomics: 1.42x (Calor, composite)
  - RefactoringStability: 1.38x (Calor)
  - EditPrecision: 1.36x (Calor)
  - InformationDensity: 0.98x (C#)
- **Programs Tested**: 217

## Checklist
- [x] Version updated in Directory.Build.props
- [x] Version updated in editors/vscode/package.json
- [x] Version updated in website/package.json
- [x] CHANGELOG.md updated with version, date, and benchmark summary
- [x] website/content/changelog.mdx updated with version and changes (no benchmark stats)
- [x] website/src/components/landing/WhatsNewBanner.tsx updated with version and headline
- [x] website/public/data/benchmark-results.json updated with latest results