### PR TITLE
docs: v0.7 MCP agent-loop plan (5-loop reviewed)

### DIFF
--- a/docs/plans/v0.7-mcp-agent-loop.md
+++ b/docs/plans/v0.7-mcp-agent-loop.md
@@ -395,6 +395,13 @@ document `missing` as **pre-autofix** state. `callChains` via `FindCallChain`
 
 ### F. Runtime contract validation on `tools/call` — **0.7.0 (after B+C), M effort**
 
+> **A+probe reallocation (2026-06-30):** under the adopted A+probe decision, F's
+> budget is redirected into the **bounded ecosystem probe** (wire the existing
+> `Effects/IL/ILEffectAnalyzer` into the MCP/effects path for Definitive concrete-call
+> cases). F itself is **deferred to v0.8** alongside full ecosystem coverage; the
+> nested-schema hardening below stays a small Track 2 hygiene task. The runtime
+> key-validation rationale is preserved here for when F is picked up.
+
 **Why moved to Track 2 (loop-4 BLOCKER fix):** F validates `arguments` against
 each tool's schema and rejects unknown/mis-nested keys. If F shipped in 0.6.6, it
 would **reject the very calls 0.6.6's own docs still advertise** —
@@ -567,11 +574,19 @@ ecosystem resolution is explicitly the v0.8 spine, not a vague backlog item.
 
 ---
 
-## Strategic decision pending — scaffold-first vs ecosystem-first *(codebase evidence, 2026-06-30)*
+## Strategic decision — ADOPTED: A+probe *(scaffold-first spine + bounded ecosystem probe; maintainer-approved 2026-06-30)*
+
+> **Resolution (2026-06-30):** the maintainer chose **A+probe**. The proven minimal
+> `calor_scaffold` remains the 0.7.0 spine; **Item F's budget is reallocated into a
+> bounded ecosystem probe** that wires the *existing* IL analyzer into the MCP/effects
+> path for the "Definitive" concrete-call cases (`File`/`HttpClient`/`DbCommand`/
+> `JsonSerializer`), with interface-heavy frameworks explicitly deferred to v0.8.
+> The probe makes the v0.8 ecosystem-spine decision evidence-based rather than a bet.
+> Track 1 (0.6.6 docs-correctness) proceeds first and is fork-independent.
 
 Before committing 0.7.0's spine, the load-bearing assumption — *"ecosystem effect
 resolution is a new v0.8 subsystem"* — was checked against the actual code. It is
-**only partly true**, which sharpens (but does not settle) the call.
+**only partly true**, which sharpened the call.
 
 **What already exists (ecosystem resolution is NOT greenfield):**
 - `src/Calor.Compiler/Effects/IL/` is a real ~80KB IL-analysis subsystem
@@ -613,8 +628,9 @@ returning `Unknown`/over-approximated on exactly the calls users care about.
   repo?) at a fraction of B's risk, and makes the v0.8 spine decision evidence-based
   instead of a bet, while keeping a crisp, shippable 0.7.0.
 
-**Status:** decision is the maintainer's to make; recorded here for review. Track 1
-(0.6.6 docs-correctness) is fork-independent and can proceed under any option.
+**Status:** decision **ADOPTED — A+probe** (maintainer-approved 2026-06-30). Item F's
+budget is reallocated into the bounded ecosystem probe (see resolution callout above).
+Track 1 (0.6.6 docs-correctness) is fork-independent and proceeds first.
 
 ---
 

--- a/docs/plans/v0.7-mcp-agent-loop.md
+++ b/docs/plans/v0.7-mcp-agent-loop.md
@@ -1,5 +1,5 @@
 ---
-status: DRAFT — for review (proposed 2026-06-30; revised 5× after 3-persona review loops 1–5)
+status: DRAFT — for review (proposed 2026-06-30; revised 5× after review loops 1–5, then v7 empirically validated)
 opened: 2026-06-30
 owner: @juanmicrosoft
 supersedes: none
@@ -10,7 +10,8 @@ review-history: |
   loop 3 — competitive-designer 55%, devils-advocate 68%, mcp-engineer 84%
   loop 4 — competitive-designer 56%, devils-advocate 61%, mcp-engineer 73% (v4 reshape introduced an F-ordering blocker; an empirical compiler build surfaced the closer-form lie below)
   loop 5 — competitive-designer 62%, devils-advocate 63%, mcp-engineer 78% (avg ~68%; 5-loop cap reached, 95% not met). Consensus, empirically reproduced by 2 reviewers building the compiler: (a) empty §R emits `return;` not `return default;` (CSharpEmitter.cs:599, NOT :3076 which is the postcondition-only branch) → value-returning scaffold fails csc CS0126 — fixed in v6 (emit typed default literals); (b) D2 semantic guard false-fails on the current primer because CORRECT examples are fragments (Calor0100/0102) and the primer also teaches intentional WRONG examples that must error — fixed in v6 (D1 rewrites CORRECT examples as complete modules / wraps fragments via CheckTool context, and asserts WRONG examples error). Competitive designer's lead ask — a Calor0830 SuggestedFix to auto-heal closers — promoted into Track 1 (D1b).
-  (all load-bearing claims re-verified against source after each loop; loops 4–5 mcp-engineer + devils-advocate built the compiler and compiled scaffold/primer snippets)
+  v7 — EMPIRICAL VALIDATION run against the built compiler (0.6.5): premise CONFIRMED (8/8 primer examples fail to compile as taught); D1 fix CONFIRMED (indent-only complete modules compile green); scaffold spine CONFIRMED (v6 typed-default §R is Calor-green AND csc-buildable; old empty-§R fails csc CS0126); D1b CONFIRMED-STRONGER (no tool repairs closers — calor format/lint --fix both fail — and the Calor0830 message advertises a broken remediation). Two NEW doc bugs surfaced that 5 review loops missed: §RESULT is an unknown marker (Calor0006; use lowercase `result`) and the broken `calor format` remediation. Both folded into D1/D1b.
+  (all load-bearing claims re-verified against source after each loop; loops 4–5 + v7 built the compiler and compiled scaffold/primer snippets directly)
 ---
 
 # v0.7 — MCP Agent Loop: a contract that's true, *compile-tested*, and one real new capability
@@ -109,9 +110,35 @@ can't rescue it. **An agent that follows the primer writes non-compiling Calor.*
 | **#Gap 3 closer-form** | **hard `Calor0830` compile error, no autofix** (`Parser.cs:224–234`) | **worst: agent-authored code fails to compile** |
 
 The "why now" is **correctness + agent-trust**: the contract doesn't just dangle
-symbols, it *teaches code that won't compile.* (Note: the parser message itself
-says *"Run `calor format` to rewrite…"* — a formatter can strip closers, but the
-**docs** must stop teaching them.)
+symbols, it *teaches code that won't compile.* (The parser message says *"Run
+`calor format` to rewrite…"*, but **experiment shows `calor format` and `calor lint
+--fix` both fail on closer-form** and leave the file unchanged — so today there is
+no working automated repair. D1b fixes that; the **docs** must also stop teaching
+closers.)
+
+> **Empirical validation (run against the built compiler, 0.6.5).** The premise and
+> the proposed fixes were *measured*, not just asserted:
+> - **Premise — every primer example fails.** Compiling the 8 Calor examples the
+>   primer teaches, exactly as written: **8/8 fail.** The 3 complete examples fail
+>   `Calor0830` (closers); the 5 fragments fail `Calor0100/0102` (no module
+>   wrapper); the contracts example *additionally* fails `Calor0006` because the
+>   primer teaches `§RESULT`, an unknown marker (→ D1's new `§RESULT`→`result` fix).
+> - **D1 fix works.** The same examples rewritten indent-only as complete modules
+>   all compile **green (zero diagnostics).**
+> - **Scaffold spine works *and* is csc-buildable.** The v6 scaffold output
+>   (typed-default `§R`) compiles green **and** builds clean under csc; the *old*
+>   empty-`§R` form is Calor-green but **fails csc `CS0126`** — validating the v6
+>   typed-default correction. The 4-field `§F` header **silently** emits
+>   `private static void` (drops return type + visibility, zero diagnostics);
+>   call-less `§E` over-declaration is clean under `--enforce-effects` while a
+>   non-BCL `§C`+`§E` raises `Calor0410/0411`.
+> - **No automated closer repair exists today** (`calor format`/`lint --fix` both
+>   fail; `calor fix` has no closer-stripping mode) — strengthening D1b.
+>
+> Net: the release's two load-bearing claims (the docs are broken; the scaffold
+> compiles) are confirmed by direct compilation, and two *new* doc bugs (`§RESULT`,
+> the broken `calor format` remediation) were surfaced that the 5 review loops
+> missed because no one compiled the examples.
 
 ---
 
@@ -179,20 +206,35 @@ completion D2b).
   (it would otherwise flip `EnforceEffects=false`, `ConvertTool.cs:521`).
 - Retask the 4 `calor_generate_ids` refs to `calor_scaffold` (or drop the step).
 - Reconcile `calor://types` (RFC §0.7) vs shipped `calor://type-mappings`.
+- **(new, found by experiment) Fix the `§RESULT` contract bug.** The primer's
+  *"CORRECT"* contract examples teach `§S (>= §RESULT FLOAT:0.0)` / `§S (== §RESULT a)`
+  (`:519,587`), but `§RESULT` is an **unknown section marker** — it compiles to
+  **`Calor0006` "Unknown section marker '§RESULT'. Did you mean '§REST'?"**. The
+  valid postcondition return-value reference is lowercase **`result`** (no sigil),
+  which compiles green. Rewrite every `§RESULT` → `result` (the primer even claims
+  both forms work at `:585` — only `result` does).
 
 **D1b — make `Calor0830` self-healing (loop-5 competitive ask; cheap, high-leverage).**
 Removing closer-form from the docs makes Calor correct *only for agents that read
 and perfectly internalize the primer*. Untrained agents carry C#/Java/XML priors
 where closing a construct is normal, so they will still emit `§/F`/`§/M` from
-prior pressure. Today that is a **dead end**: `Calor0830` is a `ReportError` with
-**no `SuggestedFix`** (`Parser.cs:224–234`), so even `autoFix:true` can't rescue
-it. Attach a `SuggestedFix` that **deletes the closer-line span** (the `TextEdit`/
-autofix machinery already ships — e.g. `Calor0410` carries a fix surfaced even on
-`autoFix:false`, `EffectEnforcementPass.cs:201–216`). This converts the single
-most-likely agent syntax error from "hard-fails, unrepairable" into "auto-heals,"
-and it is a *runtime correctness* fix, not a doc change — so it ships in **Track 1
-(0.6.6)** alongside D1, with a unit test asserting `§/F`/`§/M` now carry a fix that
-strips the closer and recompiles clean.
+prior pressure. Today that is a **dead end** — and *experiment confirms it is worse
+than "no autofix"*: `Calor0830` is a `ReportError` with **no `SuggestedFix`**
+(`Parser.cs:224–234`), **and the remediation the error message itself advertises is
+broken.** The message says *"Run `calor format` to rewrite this file in canonical
+indent form"*, but `calor format` and `calor lint --fix` **both fail on closer-form
+with the same `Calor0830` and leave the file unchanged** (the parser rejects the
+input before either tool can strip the closers); `calor fix` has no closer-stripping
+mode. So there is currently **no working automated path** to repair closer-form.
+Fix this in two parts: **(1)** attach a `SuggestedFix` that **deletes the closer-line
+span** (the `TextEdit`/autofix machinery already ships — e.g. `Calor0410` carries a
+fix surfaced even on `autoFix:false`, `EffectEnforcementPass.cs:201–216`), so MCP
+`autoFix` auto-heals; and **(2)** either make `calor format`/`lint --fix` tolerant
+enough to strip closers, **or** correct the misleading `Calor0830` message. This
+converts the single most-likely agent syntax error from "hard-fails, unrepairable,
+points at a broken fix" into "auto-heals." It is a *runtime correctness* fix, not a
+doc change — so it ships in **Track 1 (0.6.6)** alongside D1, with a unit test
+asserting `§/F`/`§/M` now carry a fix that strips the closer and recompiles clean.
 
 
 `Calor.Compiler.Tests` driving **`resources/list` + `resources/read` through the

--- a/docs/plans/v0.7-mcp-agent-loop.md
+++ b/docs/plans/v0.7-mcp-agent-loop.md
@@ -1,0 +1,534 @@
+---
+status: DRAFT — for review (proposed 2026-06-30; revised 5× after 3-persona review loops 1–5)
+opened: 2026-06-30
+owner: @juanmicrosoft
+supersedes: none
+implements: docs/plans/mcp-improvements.md (Phase 0 follow-through + Phases 1–3 slice)
+review-history: |
+  loop 1 — devils-advocate 38%, competitive-designer 38%, mcp-engineer 45%
+  loop 2 — competitive-designer 58%, devils-advocate 63%, mcp-engineer 72%
+  loop 3 — competitive-designer 55%, devils-advocate 68%, mcp-engineer 84%
+  loop 4 — competitive-designer 56%, devils-advocate 61%, mcp-engineer 73% (v4 reshape introduced an F-ordering blocker; an empirical compiler build surfaced the closer-form lie below)
+  loop 5 — competitive-designer 62%, devils-advocate 63%, mcp-engineer 78% (avg ~68%; 5-loop cap reached, 95% not met). Consensus, empirically reproduced by 2 reviewers building the compiler: (a) empty §R emits `return;` not `return default;` (CSharpEmitter.cs:599, NOT :3076 which is the postcondition-only branch) → value-returning scaffold fails csc CS0126 — fixed in v6 (emit typed default literals); (b) D2 semantic guard false-fails on the current primer because CORRECT examples are fragments (Calor0100/0102) and the primer also teaches intentional WRONG examples that must error — fixed in v6 (D1 rewrites CORRECT examples as complete modules / wraps fragments via CheckTool context, and asserts WRONG examples error). Competitive designer's lead ask — a Calor0830 SuggestedFix to auto-heal closers — promoted into Track 1 (D1b).
+  (all load-bearing claims re-verified against source after each loop; loops 4–5 mcp-engineer + devils-advocate built the compiler and compiled scaffold/primer snippets)
+---
+
+# v0.7 — MCP Agent Loop: a contract that's true, *compile-tested*, and one real new capability
+
+> One-line theme: **Calor's MCP resources advertise — and *teach* — an agent-facing
+> contract the compiler rejects. Worst of all, the primer teaches removed
+> closer-form syntax that hard-errors (Calor0830). v0.7 (a) makes the docs
+> *compile* and guards them with a semantic snippet test, as a 0.6.6 correctness
+> patch, and (b) ships one genuine new capability — a `calor_scaffold` that emits
+> a Calor module that passes the full compiler pipeline in one call — as the
+> 0.7.0 feature spine.**
+
+This is the shippable execution slice of the design RFC
+`docs/plans/mcp-improvements.md` (v3, 2026-04-21). Much of that RFC has shipped
+(the `calor://primer`, `calor://effects`, `calor://tags`, `calor://id-prefixes`,
+`calor://workflows` resources; `autoFix` on `calor_compile`; the `bench/mcp/`
+harness). This plan closes the highest-signal gap the RFC's own resources opened,
+then takes the smallest real step toward the RFC's `scaffold`.
+
+> **Honest framing (rewritten after loop 4).** Four review loops, the last
+> backed by an empirical compiler build, reshaped this plan twice:
+> 1. **The biggest lie is a hard compile error, not a cosmetic one.** The primer
+>    and `tags` resources teach **closer-form syntax** (`§/F`, `§/M`, `§/I`, …)
+>    throughout (`McpMessageHandler.cs:487,498–602,646–671,858–862`). That syntax
+>    was **removed** (indent-only language); the parser now rejects every closer
+>    with **`Calor0830 LegacyCloserForm`**, a hard error with **no `SuggestedFix`**
+>    so `autoFix` cannot repair it (`Parser.cs:224–234`). An untrained agent that
+>    writes Calor exactly as the primer teaches produces code that **does not
+>    compile**. Meanwhile the ULID example IDs the earlier drafts obsessed over
+>    actually *parse clean*. So the headline correctness work is **making the
+>    docs compile**, guarded by a test that **actually compiles the doc snippets** —
+>    not string-matching symbols.
+> 2. **The "moat piece" already ships.** The `§E{…}` fix-carrying effect
+>    diagnostic (former Item E) already exists for `Calor0410`
+>    (`EffectEnforcementPass.cs:201–216`; surfaced even on `autoFix:false`,
+>    `CompileTool.cs:198,235–271`; `EnforceEffects` defaults `true`,
+>    `Program.cs:894`). Former Item E is **deleted**; its one new part (a
+>    structured `missing` field) folds into Item C.
+>
+> So **Track 1 ships as a 0.6.6 patch** (doc-truth + the compile guard — pure
+> correctness, *no runtime behaviour change*). The **0.7.0 minor bump is earned
+> by one capability a rival would fear**: `calor_scaffold` (minimal). Everything
+> else is correctness paving the road for it — and we measure whether the road
+> mattered (item T).
+
+---
+
+## The core finding (why now)
+
+Calor exists to be *"a DSL designed for AI agents."* The MCP resources are the
+agent's Rosetta Stone — an untrained agent reads `calor://primer` /
+`calor://workflows` at session start and does exactly what they say. **Today they
+say things the compiler rejects, in three escalating ways.**
+
+### Gap 1 — Dangling symbols (referenced, never implemented)
+
+| # | Resource advertises | Reality | Citation |
+|---|---|---|---|
+| 1 | `calor_generate_ids` tool (**4 refs**) | **No such tool registered.** 15 tools exist; not this. | advertised: `McpMessageHandler.cs:609,686,693,712`; tools: `:42–72` |
+| 2 | `calor_help action=effects_for` (2 refs) | **No such action.** Valid: `syntax, features, error, example`. | advertised: `:694,701`; actions: `HelpTool.cs:49,88–95` |
+| 3 | `calor_compile … includeEffectSummary:true` | **No such option** (no `effectSummary` in any response). | advertised: `:708,714`; options: `CompileTool.cs:48–78` |
+| 4 | `calor_convert … includeEffects:true` | **No such option** (`additionalProperties:false`, no such key). | advertised: `:704`; schema: `ConvertTool.cs:40–108` |
+
+The `calor_generate_ids` count is **4, not 3** — the fourth (`:686`) is embedded
+**inside a JSON string value**, so a naive line audit misses it. Under this plan,
+`calor_generate_ids` is **retired into `calor_scaffold`** (§Scope).
+
+### Gap 2 — Mis-nested options that silently no-op
+
+`calor_compile` reads its flags from a **nested `options` object**
+(`CompileTool.cs:157–164`) and declares `additionalProperties:false` **only at
+the top level** (`:101`; the nested `options` object at `:48–78` is **not**
+closed). Yet every workflow advertises these flags **flat**
+(`McpMessageHandler.cs:696,699,705,708,714`). With no server-side validation
+(`HandleToolsCallAsync` checks only the tool name, `:246–278`), a flat option is
+**silently ignored**. `autoFix` "works" only because its default is already
+`true`; a flat `autoFix:false` is a no-op. (This motivates **Item F**.)
+
+### Gap 3 — The docs teach removed syntax that hard-errors *(the worst lie; found by an empirical build in loop 4)*
+
+The primer teaches **closer-form** structural syntax throughout — e.g. an
+explicit "Closing tags" line (`McpMessageHandler.cs:487`), example closers
+`§/F`/`§/M`/`§/I`/`§/L`/`§/MT` (`:498,500,510,521,534,540,551,566,574`), a
+"CLOSING TAGS" reference block (`:600–602`), the `tags` resource's per-construct
+`"close":"§/X{id}"` fields and a `closingTagRules` string (`:646–671`), and the
+manifest help (`:858–862`). **That syntax was removed — Calor is indent-only.**
+The parser rejects every closer with **`Calor0830 LegacyCloserForm`**, a hard
+`ReportError` with **no `SuggestedFix`** (`Parser.cs:224–234`), so even `autoFix`
+can't rescue it. **An agent that follows the primer writes non-compiling Calor.**
+
+| Gap | Client-visible behavior | Severity |
+|---|---|---|
+| #1 unknown tool | `tools/call` → `-32602 Invalid params` (`McpMessageHandler.cs:276`→`McpProtocol.cs:81`) | 1 wasted round-trip |
+| #2 unknown action | success `tools/call` w/ `isError:true` result (`HelpTool.cs:94–95`) | 1 soft-error round-trip |
+| #3/#4 flat/unknown option | **silently ignored** | *worse:* agent believes it worked |
+| **#Gap 3 closer-form** | **hard `Calor0830` compile error, no autofix** (`Parser.cs:224–234`) | **worst: agent-authored code fails to compile** |
+
+The "why now" is **correctness + agent-trust**: the contract doesn't just dangle
+symbols, it *teaches code that won't compile.* (Note: the parser message itself
+says *"Run `calor format` to rewrite…"* — a formatter can strip closers, but the
+**docs** must stop teaching them.)
+
+---
+
+## State entering v0.7 (verified)
+
+| Signal | Value | Source |
+|---|---|---|
+| Current version | **0.6.5** | `Directory.Build.props` |
+| Open issues / PRs | 0 issues; 1 stale bot PR #670 (close it) | `gh issue/pr list` |
+| MCP tools | 15 (all declare **top-level** `additionalProperties:false`; several have **unclosed nested objects** — see F) | `McpMessageHandler.cs:42–72` |
+| MCP resources | 8 (2 embedded files + 6 inline-built) | `:76–131` |
+| `McpResourceValidator` exposure | only 4 of 8 | `McpResourceValidator.cs:8–11` |
+| Closer-form in docs | **taught throughout** primer + tags + manifest; rejected by `Calor0830`, no fix | `:487,498–602,646–671,858–862`; `Parser.cs:224–234` |
+| Effect fix-in-error (Calor0410) | **already ships**, surfaced even on `autoFix:false` | `EffectEnforcementPass.cs:201–216`, `CompileTool.cs:198,235–271`, `Program.cs:894` |
+| `bench/mcp/` harness | compiles directly via `Program.Compile`; no agent/MCP layer; skips greenfield/conversion; no token metric | `bench/mcp/harness/Program.cs:14–16,56–82,171–238` |
+| Codegen reality | `Program.Compile` emits a **C# string** and never invokes Roslyn/csc on it (`Program.cs:779`); "zero diagnostics" = **Calor-level**, not csc | verified loop 4 |
+
+---
+
+## Measurement reality (committed, with a binding direction)
+
+Earlier drafts cited unmeasurable round-trip/byte deltas (the harness calls
+`Program.Compile` directly, counts autofix passes as round-trips, skips
+greenfield/conversion). A **thin agent-trajectory runner (item T)** is now a
+**committed Track-2 deliverable** that drives the public `HandleRequestAsync`
+(`McpMessageHandler.cs:176`), counts tool round-trips + response bytes, and runs
+greenfield tasks **plus ≥1 real OSS NuGet-heavy C# repo** (to make the BCL-only
+ceiling visible in our own numbers). Its first job: measure `calor_scaffold`'s
+delta vs the "generate→stub→compile→fix" baseline.
+
+- **Numeric thresholds stay non-gating** (we don't pre-commit a magnitude we
+  can't justify), **but two things ARE gating:** (a) T must *produce and publish*
+  a baseline + delta (existence-gated), and (b) one **directional** assertion —
+  *scaffold must show a net round-trip reduction vs the baseline on greenfield
+  tasks, or it does not ship as the 0.7.0 spine.* Direction is defensible even
+  when magnitude isn't.
+
+---
+
+## Scope
+
+**Track 1 = 0.6.6 correctness** (D1 + D1b + D2a — doc-truth + a self-healing
+`Calor0830` autofix + compile guard; **no *breaking* runtime change** — D1b is a
+strictly additive bug fix: a diagnostic that should always have carried a fix now
+does, patch-appropriate under SemVer). **Track 2 = 0.7.0 feature** (scaffold spine
+S; supporting B + C; runtime hardening F **after** B/C; trajectory runner T; guard
+completion D2b).
+
+### D. Make the docs compile + a semantic CI guard — **0.6.6 keystone, M effort**
+
+**D1 — make the resources true and *compilable*.** In `McpMessageHandler.cs`:
+- **(headline) Remove all closer-form syntax** from the primer, `tags`, and
+  manifest help (`:487,498–602,646–671,858–862`): rewrite every example into
+  indent-only form, delete the "Closing tags" guidance, and **remove the `tags`
+  resource's per-construct `"close"` fields + `closingTagRules`** (there are no
+  closing tags). This is the fix that makes agent-authored code compile.
+- Rewrite **every** `_01J…`-shaped ULID example to a valid 12-char compact
+  payload, and every stale-ID **prose** site: `:122` (the `resources/list`
+  Description), `:486`, `:608`, `:686` (`"ULID-based (26-character Crockford
+  Base32)"`). (Cosmetic but in-scope; the bare word "ULID" in workflow `why`
+  strings `:693,712` is handled by the generate_ids→scaffold retask.)
+- Fix the **flat↔nested** option invocations to match how tools read args (and,
+  where C makes `includeEffectSummary` top-level, ensure resource = schema).
+- Repoint the `calor_convert includeEffects` step (`:704`) — **rewrite the step**
+  (it would otherwise flip `EnforceEffects=false`, `ConvertTool.cs:521`).
+- Retask the 4 `calor_generate_ids` refs to `calor_scaffold` (or drop the step).
+- Reconcile `calor://types` (RFC §0.7) vs shipped `calor://type-mappings`.
+
+**D1b — make `Calor0830` self-healing (loop-5 competitive ask; cheap, high-leverage).**
+Removing closer-form from the docs makes Calor correct *only for agents that read
+and perfectly internalize the primer*. Untrained agents carry C#/Java/XML priors
+where closing a construct is normal, so they will still emit `§/F`/`§/M` from
+prior pressure. Today that is a **dead end**: `Calor0830` is a `ReportError` with
+**no `SuggestedFix`** (`Parser.cs:224–234`), so even `autoFix:true` can't rescue
+it. Attach a `SuggestedFix` that **deletes the closer-line span** (the `TextEdit`/
+autofix machinery already ships — e.g. `Calor0410` carries a fix surfaced even on
+`autoFix:false`, `EffectEnforcementPass.cs:201–216`). This converts the single
+most-likely agent syntax error from "hard-fails, unrepairable" into "auto-heals,"
+and it is a *runtime correctness* fix, not a doc change — so it ships in **Track 1
+(0.6.6)** alongside D1, with a unit test asserting `§/F`/`§/M` now carry a fix that
+strips the closer and recompiles clean.
+
+
+`Calor.Compiler.Tests` driving **`resources/list` + `resources/read` through the
+public `HandleRequestAsync`** (`:176`) for all 8 resources incl. the 2 embedded
+(`LoadResourceContent` is `private static` at `:400`; the public path needs **no
+visibility change**). Three checks, strongest first:
+
+1. **Semantic snippet compilation (new, the keystone):** extract the Calor code
+   snippets the primer (and any Calor-bearing resource) teaches and **compile
+   them, asserting the *expected* diagnostic outcome.** This catches `Calor0830`
+   closer-form *and any future syntax drift* — it is the one check that would
+   have caught Gap 3, which every string/symbol guard misses. **Two empirical
+   constraints (loop 5, verified by building the compiler):**
+   - The primer's CORRECT examples today are **fragments**, not whole modules —
+     bare bindings/if/for/expressions compile to `Calor0100 "Expected Module"` /
+     `Calor0102` standalone (`McpMessageHandler.cs:525–540,594–596`). So D1 must
+     **either** rewrite each CORRECT example as a *complete, self-contained
+     module* (declare the params/bindings it references) **or** the guard must
+     wrap fragments using `calor_check`'s existing context mechanism
+     (`CheckTool.cs:62–93`, `location: expression|statement|function_body|module_body`).
+     The guard asserts **zero diagnostics** on these.
+   - The primer **intentionally teaches WRONG examples** (`§K`, `§ELSE`,
+     `§Q{x >= 0}`, malformed `§IF`; `McpMessageHandler.cs:576–580,588`) that
+     *must* error. D1 **explicitly tags** each example CORRECT vs WRONG (a
+     deterministic fenced marker); the guard asserts CORRECT⇒zero-diagnostics and
+     **WRONG⇒errors** (so a "compile everything, assert green" rule can't
+     false-fail on them). The whole-primer-blob fallback is **rejected** — it
+     mixes CORRECT, WRONG, and fragments and cannot be asserted cleanly.
+2. **Structural symbol check (`calor://workflows` only):** every `"tool"` ∈
+   registered tools; the **action discriminator `args.action`** (grandchild of a
+   `"tool":"calor_help"` step, `:694,701`) ∈ `calor_help`'s enum (ignore free-text
+   step-level `action`, `:695,700`); **arg keys validated PATH-AWARE** against
+   each tool's schema (valid dotted paths e.g. top-level `includeEffectSummary`,
+   nested `options.autoFix`) — **never resolve-anywhere** (that would accept flat
+   `autoFix` and false-negative Gap 2). Plus a `calor_[a-z_]+` token check over
+   the other 7 resources' **rendered text** and the `resources/list` descriptions
+   (catches tokens embedded in JSON strings, `:686`).
+3. **ULID denylist (= D1's rewrite set):** `"26-character"`, `"ULID-based"`,
+   `"Crockford Base32"`, `_01J…` absent from the target resources and the
+   `resources/list` descriptions (not a blanket ULID regex — legacy `GenerateUlid`
+   still exists, `IdGenerator.cs:100`).
+4. **Cross-check for Gap 2/F (new):** assert **no resource advertises an argument
+   key that Item F would reject** (every advertised arg path is valid for some
+   shipped tool's schema *at the version that resource ships in*). This is the
+   guard that prevents the F-ordering hazard below.
+
+**D2a / D2b split — keep `main` green at every merge:**
+- **D2a (Track 1 / 0.6.6, green right after D1):** semantic snippet compilation +
+  ULID denylist + **path-nesting of keys that exist in some schema** (flat
+  `autoFix` → `options.autoFix`) + prose. D2a **skips** symbol-existence of
+  not-yet-built tools/actions/options (deferred to D2b).
+- **D2b (Track 2, introduced already-green with the final feature PR):**
+  existence of **every** symbol — workflow `"tool"`, the token check, the
+  `action` enum, scaffold/`includeEffectSummary` paths — plus the Gap-2/F
+  cross-check (#4). Never red on `main`.
+
+> **Scope honesty:** 0.6.6 makes the docs **compile** and fixes IDs/nesting/prose;
+> a few symbols still legitimately dangle in 0.6.6 docs until Track 2 ships them
+> (D1 retasks generate_ids; B/C/scaffold close the rest in 0.7.0). 0.6.6 release
+> notes must say so — "the docs now compile and stop teaching dead syntax;
+> remaining symbol-truth lands in 0.7.0."
+
+### S. `calor_scaffold` (minimal) — **0.7.0 SPINE, M–L effort** *(the one new capability)*
+
+**Why the spine:** with former Item E conceded as already-shipped, a release of
+only D+F advances zero differentiators. The smallest thing a rival fears is
+one-shot greenfield correctness. `calor_scaffold` composes the feasible pieces
+(compact-ID minting + effect declaration) into one call.
+
+**What "green" means (honest, per loop-4 empirical build):** the emitted module
+**passes the full Calor pipeline** (lex→parse→bind→analyze→emit) via
+`calor_compile` with **zero diagnostics and no autofix pass**. It is **not**
+claimed to be csc-buildable in general — the emitted C# is a *skeleton* that may
+reference types the agent will define. (`Program.Compile` never runs csc;
+`Program.cs:779`. **Loop-5 correction:** an *empty* `§R` emits **`return;`** via
+the canonical `Visit(ReturnStatementNode)` path (`CSharpEmitter.cs:599`) — **not**
+`return default;` (the `?? "default"` at `:3076` is the *postcondition-only*
+branch, which scaffold functions don't have). A bare-identifier `§R default`
+instead emits `@default`, also wrong. Since `return;` in a value-returning method
+is invalid C# (CS0126), **scaffold must emit a type-appropriate default literal
+for value returns** — `§R BOOL:false`, `§R INT:0`, `§R STR:""`, etc. → valid
+`return false;`/`return 0;`/`return "";` — and **omit `§R` for void**.) A
+**stretch acceptance** compiles a **self-contained** fixture (only built-in types)
+under csc to prove the skeleton is real; with typed-default returns this is
+achievable for value-returning functions too.
+
+**Construction (corrected after loop 4):**
+- Header is **indent-only**: `§F{id:name:vis} (params) -> retType` (the earlier
+  4-field `§F{id:name:retType:vis}` is mis-parsed — `_pos2` is read as visibility,
+  dropping the return type and silently making it `private`, `AttributeHelper.cs:88,106`).
+- Mint compact IDs via `IdGenerator.Generate(IdKind)` (`:86`; label→kind map,
+  `operator`→`OperatorOverload`, `:132`).
+- **Effect stubs are call-less (loop-4 finding).** Emitting a non-BCL `§C{…}` call
+  with `§E{}` triggers `Calor0410`+`Calor0411` and breaks green; **over-declaring
+  an effect with no call body is clean** (`computed ⊆ declared`,
+  `EffectEnforcementPass.cs:162`). So scaffold emits **`§E{…}` effect
+  declarations without `§C{…}` bodies** (the agent fills bodies later). For each
+  requested `calls` entry, resolve via `EffectResolver` (BCL-only) and emit the
+  matching `§E{…}`; unknown calls emit `§E{}` + a TODO comment, not a call.
+- Value-returning functions get a **typed default `§R`** — `§R BOOL:false`,
+  `§R INT:0`, `§R STR:""` (→ valid `return false;`/`return 0;`/`return "";`); void
+  functions omit `§R`. (An *empty* `§R` would emit `return;` → CS0126 in a
+  value-returning method, `CSharpEmitter.cs:599`.)
+
+**Moat-relevant acceptance (loop-4 — so "green" isn't vanity):** on a **BCL
+fixture**, the `§E{…}` scaffold declares for a given `calls` set must **equal**
+the effects `EffectResolver` resolves for those calls. (Green-compile is the
+floor; effect-correctness is the point.)
+
+**`ids-only` mode (loop-4 — don't lose the incremental-edit primitive):** retiring
+`generate_ids` removes the only lightweight ID path for "add one method/property
+to an existing class" (needs an `mt_`/`p_` ID, not a whole module). `calor_scaffold`
+gains an `ids-only` mode that returns IDs for `{kind,count}` **without** a module
+wrapper — covering that case with one tool instead of reviving the dangling one.
+
+**Bound:** "minimal" = one module + N functions, call-less effect declarations,
+typed-default `§R` bodies. Full scaffold (multi-module, contracts, real bodies,
+`ops` edits) is v0.8. The value is the *passes-the-compiler* guarantee + correct
+BCL effect declarations, not breadth.
+
+**I/O (corrected):**
+```jsonc
+{"module":"Orders","functions":[
+   {"name":"PlaceOrder","returns":"bool","calls":["File.WriteAllText"]},
+   {"name":"Tally","returns":"i32"}]}
+// →
+{"calor":"§M{m_3k7p2q9w4x1z:Orders}\n  §F{f_8a2b5c1d9e0f:PlaceOrder:pub} () -> bool\n    §E{fs:w}\n    §R BOOL:false\n  §F{f_7d1e9c0a2b5f:Tally:pub} () -> i32\n    §R INT:0\n",
+ "ids":{"module":"m_3k7p2q9w4x1z","functions":{"PlaceOrder":"f_8a2b5c1d9e0f","Tally":"f_7d1e9c0a2b5f"}}}
+```
+
+### B. `calor_help action=effects_for` — **0.7.0, M effort (supporting + feeds scaffold)**
+
+**Closes:** dangling refs `:694,701`. Add `effects_for` to the `action` enum
+(`HelpTool.cs:49`) **and** a `calls` array property to the schema
+(`additionalProperties:false`, `:80`). Parse dotted calls via
+`EffectEnforcementPass.ParseCallTargetForChain` + `MapShortTypeNameToFullName`
+(`:276,297`) — **promote `ParseCallTargetForChain` `private`→`internal static`**.
+Map effects via `ToSurfaceCode` (`:968`); `source` from `EffectResolution.Source`
+(`EffectResolver.cs:412`). Status discriminator must cover all three
+`EffectResolutionStatus` values incl. **`PureExplicit`** (`:427`). **BCL-only
+limitation** stands — `unknown` + a fill template for NuGet calls; real
+resolution is the named v0.8 #1.
+
+### C. `includeEffectSummary` on `calor_compile` — **0.7.0, M effort (absorbs former E's `missing`)**
+
+**Closes:** dangling refs `:708,714`. **Top-level**, read via
+`GetBool(arguments, "includeEffectSummary")` mirroring `checkCompat` (`:309`) —
+**not** under `options`. Surfaces `_computedEffects` (`EffectEnforcementPass.cs:25,101`).
+**Capture pre-fix:** `Program.Compile` early-returns on enforcement errors
+(`Program.cs:603–607`, error ctor `:606`); `enforcementPass` is scoped inside
+`if(EnforceEffects)` (`:582,587`). **Hoist an `EffectSummary?` above `:582`**,
+populate before `:603`, set it on **every** post-enforcement exit (`:606`,
+contract-inheritance `:624–627`, success `:820`) via an optional settable
+property. In `CompileTool`, read it off the **first** `Program.Compile`
+(`CompileTool.cs:193`) **before** the autoFix loop overwrites `result` (`:224`);
+document `missing` as **pre-autofix** state. `callChains` via `FindCallChain`
+(`:385`); cross-module deferred. Default `false`.
+
+### F. Runtime contract validation on `tools/call` — **0.7.0 (after B+C), M effort**
+
+**Why moved to Track 2 (loop-4 BLOCKER fix):** F validates `arguments` against
+each tool's schema and rejects unknown/mis-nested keys. If F shipped in 0.6.6, it
+would **reject the very calls 0.6.6's own docs still advertise** —
+`calor_help{action:effects_for,calls:[…]}` (`:694`) and
+`calor_compile{includeEffectSummary:true}` (`:708,714`) — because those schema
+keys don't exist until B/C. So **F ships in Track 2, sequenced *after* B and C**,
+once every advertised key exists; D2's cross-check #4 enforces this invariant.
+
+**What:** in the `tools/call` dispatch (`HandleToolsCallAsync:246–278`), walk the
+parsed schema (`IMcpTool.GetInputSchema()`→`JsonElement`, `IMcpTool.cs:57`;
+`Arguments` is `JsonElement?`, `McpProtocol.cs:225`) — **no JSON-Schema library
+needed**. On an unknown/mis-nested key, return an **`isError:true` tool result**
+(many agent runtimes hide raw JSON-RPC errors from the model) carrying the key
+and the correct nesting (*"unknown key `autoFix`; did you mean `options.autoFix`?"*),
+plus `-32602` as the protocol fallback.
+
+**Prerequisite — close the nested objects (loop-4):** several tools have a nested
+`type:object` with **no** `additionalProperties:false` — `CompileTool.cs:48–78`,
+`AnalyzeTool.cs:41,68`, `CheckTool.cs:63,79`, `ConvertTool.cs:86`,
+`FormatTool.cs:44`. F must close each before it can reject a nested typo
+(`options:{autoFx:true}`); closing each risks rejecting previously-silently-ignored
+nested keys, so audit existing tests + workflows. D1 (already landed) guarantees
+Calor's own advertised calls are well-shaped before F starts rejecting.
+
+### T. Thin agent-trajectory runner — **0.7.0, committed (existence + direction gating)**
+
+Drives the public `HandleRequestAsync` (`:176`) as an agent would; counts tool
+round-trips + response bytes; runs greenfield tasks the current harness skips
+(`harness/Program.cs:56–82`) **and ≥1 real OSS NuGet-heavy repo**. Gating per
+§Measurement: must publish baseline + delta, and scaffold must show a net
+round-trip reduction vs the generate→stub→fix baseline or it doesn't ship as the
+spine. Numeric magnitude non-gating.
+
+---
+
+## Out of scope for v0.7 (with rationale)
+
+| Item | Why deferred | Higher-leverage? |
+|---|---|---|
+| **Full** `calor_scaffold` (multi-module, contracts, real bodies, `ops`) | Large; minimal passes-the-compiler version ships now. | Breadth is v0.8; the compile guarantee + BCL effect-correctness is the v0.7 win. |
+| **Effect-manifest ECOSYSTEM coverage** (NuGet/Roslyn-metadata) | New analysis subsystem. | **Yes — #1 v0.8 differentiator** (reviewers' top "what we'd fear"): makes `effects_for`/scaffold *resolve* third-party calls instead of stubbing `unknown`. The cart (scaffold) is shipped minimal *now* partly to de-risk and measure; the horse (ecosystem resolution) is the v0.8 spine. |
+| §-sigil raw-token reduction | Emitter/tokenizer risk. | **Yes** — Calor's only losing axis; this cycle slightly *widens* it (new payloads), accepted for one cycle but paired with a compactness commitment (below). |
+| Structured edit `ops` (RFC §4.2) | Needs real trajectories — item T first. | Later (enabled by T). |
+| Session cache / `project/index` (RFC §5–6); `finalize` (RFC §4.1) | Heavy / no new capability. | Later / No. |
+
+**Compactness commitment (loop-4):** new payloads (`effectSummary`, `perCall`,
+scaffold output) default to **terse shapes with opt-in verbosity**, so the
+raw-token gap is held flat this cycle rather than widened release-over-release.
+
+---
+
+## Ship sequence & versioning
+
+**Track 1 — correctness, 0.6.6 (patch; only additive bug fixes):**
+```
+PR 1  fix(mcp): remove closer-form syntax from primer/tags/manifest (Calor0830)
+      + rewrite CORRECT examples as complete modules / tag WRONG examples
+      + content-based ULID→compact rewrite (incl. list description :122)
+      + flat↔nested option fixes + repoint convert step + retask generate_ids   (D1)
+PR 2  fix(parser): Calor0830 LegacyCloserForm carries a SuggestedFix that strips
+      the closer span so autoFix auto-heals closer-form input                    (D1b)
+PR 3  test(mcp): contract guard D2a — SEMANTIC snippet compilation (CORRECT⇒0
+      diags, WRONG⇒errors) + ULID denylist + existing-key path-nesting + prose   (D2a)
+PR 4  chore: bump version to 0.6.6   (via create-release skill)
+```
+
+**Track 2 — capability + feature, 0.7.0 (minor, <1.0.0 ⇒ --prerelease):**
+```
+PR 5  feat(mcp): calor_help action=effects_for (enum+calls schema,
+      ParseCallTargetForChain→internal, PureExplicit status)                     (B)
+PR 6  feat(mcp): includeEffectSummary on calor_compile (top-level, hoisted
+      EffectSummary?, pre-fix capture, structured `missing`)                     (C)
+PR 7  feat(mcp): calor_scaffold (minimal) — passes-the-compiler module + ids-only
+      mode; call-less §E{} stubs; typed-default §R; subsumes generate_ids        (S)
+PR 8  feat(mcp): close nested option sub-schemas + runtime path-aware key
+      validation on tools/call (isError result + -32602)  — AFTER B/C            (F)
+PR 9  test(mcp): agent-trajectory runner + real-repo fixture; publish scaffold
+      round-trip/byte delta (existence + directional gating)                     (T)
+PR 10 test(mcp): contract guard D2b (symbol existence + Gap-2/F cross-check),
+      introduced green                                                           (D2b)
+PR 11 chore: bump version to 0.7.0   (via create-release skill)
+```
+
+`main` is green after every merge: D2a/F red only on their own branches; D2b
+introduced already-green at PR 10; F lands after B/C so it never rejects a
+shipped-doc call.
+
+---
+
+## Acceptance criteria
+
+1. **Docs compile (D2, semantic):** every Calor snippet the primer/resources
+   teach passes `calor_compile` with **zero diagnostics** — in particular no
+   `Calor0830`. D2a green after D1; D2b introduced green at PR 10; `main` green
+   after every merge.
+2. **Referential integrity (D2):** every advertised `tool`/`action`/option key
+   (path-aware) resolves to a real implementation; **no resource advertises a key
+   F would reject** (cross-check #4).
+3. **Scaffold passes the compiler on first call (S):** representative
+   `calor_scaffold` output passes `calor_compile` with zero diagnostics and no
+   autofix; the **self-contained** stretch fixture additionally builds under csc;
+   the emitted signature's **return type + visibility match the request** (guards
+   the dropped-return-type trap); and on a **BCL fixture the declared `§E{…}`
+   equals `EffectResolver`'s resolved effects** for the requested calls.
+4. **No silent no-ops (F):** a flat/unknown top-level key is rejected with an
+   `isError` result (+`-32602`) naming the correct nesting; once nested sub-schemas
+   are closed, an unknown nested key is rejected too; a regression test asserts the
+   previously-silent flat `autoFix`/`includeEffectSummary` now errors.
+5. **Doc truth:** no closer-form syntax remains in any resource; ID docs describe
+   compact IDs; no `"26-character"`/`"ULID-based"`/`"Crockford Base32"`/`_01J…`
+   remains (incl. `resources/list` descriptions); workflow option invocations
+   match how tools read them.
+6. **No regressions:** `TreatWarningsAsErrors` clean; all test projects green;
+   opt-in flags default to prior behavior; **no correctly-shaped call that
+   previously had its intended effect is rejected by F** (only previously-silent
+   mis-shaped calls now error).
+7. **Premise measured (T):** baseline + scaffold delta published (existence-gated);
+   scaffold shows a net round-trip reduction vs baseline or doesn't ship as spine.
+   Numeric magnitude non-gating.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| **Semantic snippet test mishandles fragments / WRONG examples** | D1 restructures each CORRECT primer example as a complete module **or** the guard wraps fragments via `calor_check` context (`CheckTool.cs:62–93`); WRONG examples are tagged and asserted to **error**. Whole-primer-blob compilation is rejected (mixes CORRECT + WRONG + fragments). |
+| **Scaffold "passes the compiler" slips to vanity** (green but useless) | "Green" defined as Calor-pipeline-level + a csc stretch fixture; the **BCL effect-equality** bar makes correctness, not just compilation, the test; minimal scope keeps it mechanical. If unmet, ship Track 1 (0.6.6) only — do **not** ship a non-compiling scaffold. |
+| Scaffold/effects only correct on BCL | Honestly bounded; non-BCL calls get `§E{}`+TODO (no call body); ecosystem resolution is the named v0.8 #1; T's real-repo fixture makes the ceiling visible. |
+| **F rejects 0.6.6-advertised calls** | F moved to Track 2 after B/C; D2 cross-check #4 forbids advertising a key F would reject; nested sub-schemas closed first; audited vs tests + workflows. |
+| Item C plumbing touches many exits | Hoisted `EffectSummary?` above `:582`, captured pre-fix at `CompileTool.cs:193` before `:224`, optional property set at **every** post-enforcement exit (`:606,:624–627,:820`). |
+| D2 false pos/neg | Semantic-first (compile snippets); structural only for workflows; path-aware (no resolve-anywhere); token regex over rendered text + list descriptions; all 8 URIs via `HandleRequestAsync`. |
+| green-main | Precise D2a/D2b seam; F after B/C; D2b introduced green. |
+| raw-token axis widens | Compactness commitment (terse default shapes, opt-in verbosity). |
+
+---
+
+## Strategic positioning (revised after loop 5)
+
+A competitor is relieved by a cycle spent on hygiene. Loops 4–5 sharpened the
+response into two honest moves: **bank the correctness work as 0.6.6** (now with
+real teeth — the docs *compile*, guarded by a semantic test that would have
+caught the closer-form lie no string guard could, **and** `Calor0830` now
+auto-heals so an agent's reflexive closer is repaired rather than dead-ended),
+and **spend the 0.7.0 minor bump on the one thing a rival fears** — `calor_scaffold`
+that passes the compiler on first call with correct BCL effect declarations. The
+cart (minimal scaffold) ships now partly to **de-risk and measure** (item T) the
+bigger bet; the horse is named, ranked v0.8 #1:
+
+1. **Effect-manifest ECOSYSTEM coverage** — resolve third-party (NuGet) effects
+   via Roslyn metadata. Turns Calor's effect/ErrorDetection moat from a BCL trophy
+   into a production asset. *(Reviewers' top "what we'd fear"; the strongest
+   argument for sequencing this as the v0.8 spine.)*
+2. **Full `calor_scaffold`** — multi-module, contracts, real bodies, `ops` edits
+   (enabled by T).
+3. **Self-describing errors everywhere** — extend the `Calor0410`/`Calor0830` fix
+   pattern (the latter now ships in 0.6.6 as D1b) to the remaining ID/structural
+   diagnostics, so `autoFix` repairs the common agent mistakes class-wide.
+4. **§-sigil raw-token reduction** — attack Calor's only losing metric.
+
+**Per-symbol disposition:** `generate_ids` → **retired into `calor_scaffold`**
+(incl. `ids-only` mode); `effects_for` → **implement (B)**; `includeEffectSummary`
+→ **implement top-level (C)**; `includeEffects` (convert) → **retract/repoint**.
+
+**Acknowledged tradeoff (loop-4 competitive challenge):** shipping minimal
+scaffold before ecosystem effect resolution is "cart before horse." We accept it
+deliberately: minimal scaffold is cheap, de-risks the full version, gives T a
+subject to measure, and the **BCL effect-equality** bar keeps it honest — while
+ecosystem resolution is explicitly the v0.8 spine, not a vague backlog item.
+
+---
+
+## Relationship to `mcp-improvements.md`
+
+This executes that RFC's Phase 0 follow-through (doc truth + guard — now a
+*compile* guard), its Gap-2 runtime-validation implication (F), and the smallest
+real slice of its `scaffold` (RFC §3.1) — a minimal module that passes the
+compiler — while measuring the premise (T) so v0.8's ecosystem/`ops`/full-scaffold
+bets are evidence-driven.

--- a/docs/plans/v0.7-mcp-agent-loop.md
+++ b/docs/plans/v0.7-mcp-agent-loop.md
@@ -567,6 +567,57 @@ ecosystem resolution is explicitly the v0.8 spine, not a vague backlog item.
 
 ---
 
+## Strategic decision pending — scaffold-first vs ecosystem-first *(codebase evidence, 2026-06-30)*
+
+Before committing 0.7.0's spine, the load-bearing assumption — *"ecosystem effect
+resolution is a new v0.8 subsystem"* — was checked against the actual code. It is
+**only partly true**, which sharpens (but does not settle) the call.
+
+**What already exists (ecosystem resolution is NOT greenfield):**
+- `src/Calor.Compiler/Effects/IL/` is a real ~80KB IL-analysis subsystem
+  (`AssemblyIndex`, `ILCallGraphBuilder`, `ILEffectAnalyzer`, `TransitiveEffectPropagator`,
+  `StateMachineResolver`, `MethodKey`, `ILAnalysisOptions`).
+- `EffectResolver` already calls it as a fallback ("after all manifest layers,
+  before Unknown") for methods, properties, and ctors (`TryILAnalysis`).
+- `Effects/Manifests/` has a priority-ordered `ManifestLoader`; there is a tracked
+  `InteropEffectCoverage` metric.
+- Two mature plan docs already exist: `dotnet-ecosystem-effect-manifests.md` (v4,
+  4 critique rounds) and `effects-suggest-command.md`.
+- **But:** the IL analyzer is currently constructed only in the **MSBuild task**
+  (`Calor.Tasks/CompileCalor.cs`), **not** in the CLI or MCP path the agent loop uses.
+
+**The honest ceiling (from the v4 plan, corroborated):** IL analysis resolves only
+**~5–25%** for interface-heavy frameworks and **over-approximates the high-value
+cases** (`ILogger`, `DbContext.SaveChanges`, `IMediator.Send`) to results that are
+"sound but useless." The fix — curated interface-level manifests — is an ongoing
+operational burden (the rejected manifest-everything approach was costed at
+~0.5 FTE). So ecosystem-first as a *spine* risks spending the cycle and still
+returning `Unknown`/over-approximated on exactly the calls users care about.
+
+**The options (evidence-weighted):**
+- **A — scaffold-first (plan as written).** Low risk: empirically proven this
+  session (typed-default scaffold compiles green + is csc-buildable). Modest reward;
+  de-risks the layer that was never risky (JSON in → Calor out). Ecosystem = v0.8.
+- **B — ecosystem-first (competitive designer).** High reward *if it lands* (attacks
+  the real adoption blocker, moves a tracked metric, reinforces the effect/
+  ErrorDetection moat) but **high risk + open-ended "done"** because the high-value
+  interface-heavy cases hit the over-approximation ceiling the team's own 4-round
+  plan could not close.
+- **A+probe — RECOMMENDED.** Keep the proven scaffold as the 0.7.0 spine, and
+  **reallocate Item F's budget into a bounded ecosystem probe** (the competitive
+  designer's actual loop-5 ask): wire the *existing* IL analyzer into the MCP/effects
+  path and ship resolution for the **"Definitive" concrete-call cases only**
+  (`File`/`HttpClient`/`DbCommand`/`JsonSerializer`), explicitly deferring
+  interface-heavy frameworks to curated manifests in v0.8. This captures most of B's
+  *learning* (does ecosystem resolution actually move the metric on a real NuGet
+  repo?) at a fraction of B's risk, and makes the v0.8 spine decision evidence-based
+  instead of a bet, while keeping a crisp, shippable 0.7.0.
+
+**Status:** decision is the maintainer's to make; recorded here for review. Track 1
+(0.6.6 docs-correctness) is fork-independent and can proceed under any option.
+
+---
+
 ## Relationship to `mcp-improvements.md`
 
 This executes that RFC's Phase 0 follow-through (doc truth + guard — now a


### PR DESCRIPTION
## Summary
Adds `docs/plans/v0.7-mcp-agent-loop.md` — the v0.7 execution plan, finalized after a **5-loop multi-persona review** (devil's-advocate / competitive-designer / mcp-engineer, all opus-4.8).

Confidence trajectory (3-reviewer avg): **40% → 64% → 69% → 63% → 68%**. The 5-loop cap was reached; the residual ceiling is a *strategic* disagreement (scaffold-first vs ecosystem-first), not a fixable defect.

## Headline finding
The shipped MCP server's `primer`/`tags`/`manifest` resources **teach removed closer-form syntax** (`§/F`, `§/M`, `§/I`) that hard-errors with **`Calor0830`** (no `SuggestedFix`, so `autoFix` can't repair it). An agent following Calor's own docs writes **non-compiling Calor** — acutely corrosive for "a DSL designed for AI agents." Found by an empirical compiler build during review.

## Plan shape
- **Track 1 — 0.6.6 (patch):** make the docs compile (D1) + a `Calor0830` auto-heal `SuggestedFix` (D1b) + a **semantic snippet-compilation guard** (D2a) so the docs can never silently teach non-compiling syntax again. *Unanimous high-confidence slice.*
- **Track 2 — 0.7.0 (minor):** minimal `calor_scaffold` spine (S) that passes the compiler on first call + `effects_for` (B) + `includeEffectSummary` (C) + runtime key validation after B/C (F) + trajectory runner (T) + guard completion (D2b).
- **v0.8 #1 spine:** ecosystem (NuGet/Roslyn) effect resolution.

## Status
**DRAFT for review.** This PR is the plan itself; implementation lands as the PR sequence described inside (Track 1 PRs 1–4, Track 2 PRs 5–11).

## Note
The plan documents two empirically-reproduced corrections from loop 5: scaffold must emit typed-default `§R` (an empty `§R` emits `return;` → CS0126), and the semantic guard must handle primer *fragments* + *intentional WRONG examples*.