### PR TITLE
docs: purge removed closer-form from teaching/reference docs (Calor0830)

### DIFF
--- a/docs/ids.md
+++ b/docs/ids.md
@@ -66,12 +66,12 @@ As of v6, structural openers (`§M`, `§F`, `§AF`, `§L`,
 accept a **compact form** that omits the leading `{id:…}` block. The
 compiler auto-assigns an ID of the shape `<prefix>_auto<N>`.
 
-When the opener uses the compact form, the matching closing tag
-(`§/M`, `§/F`, `§/AF`, `§/L`, `§/I`, `§/TR`, `§/CL`, `§/IFACE`,
-`§/MT`, `§/CTOR`, `§/EN`) may also omit `{id}`. **The two sides are
-linked**: if the opener carries an explicit `{id:…}`, the closer must
-still carry the matching `{id}` (diagnostic `Calor0101` if they
-diverge). Both forms parse and are valid side-by-side:
+Indent-only Calor has no closing tags at all — a block ends at its
+dedent — so an opener's `{id:…}` is the only place a structural ID
+appears. (Pre-Phase-4d Calor paired each opener with a `§/…` closer that
+repeated the ID; closer tags were removed in Phase 4d and an explicit
+closer now raises `Calor0830`.) Both opener forms parse and are valid
+side-by-side:
 
 ```calor
 # Compact (recommended for new code)

--- a/docs/semantics/core.md
+++ b/docs/semantics/core.md
@@ -362,11 +362,10 @@ Match expressions MUST be exhaustive. The compiler emits `Calor0500: NonExhausti
 ### 8.2 Evaluation
 
 ```calor
-§MATCH{m1} expr
-§CASE pattern1 guard1 => body1
-§CASE pattern2 => body2
-§CASE _ => default
-§/MATCH{m1}
+§W{sw1:expr} n
+  §K §VAR{x} §WHEN (> x 100) → "large"
+  §K 0 → "zero"
+  §K _ → "other"
 ```
 
 **Semantics:**
@@ -387,13 +386,12 @@ Patterns are tried in **declaration order**. First matching pattern wins.
 ### 9.1 Try/Catch/Finally
 
 ```calor
-§TRY{try1}
-body
-§CATCH{ExceptionType:var}
-handler
-§FINALLY
-cleanup
-§/TRY{try1}
+§TR{tr1}
+  body
+§CA{ExceptionType:var}
+  handler
+§FI
+  cleanup
 ```
 
 **Semantics:**

--- a/docs/semantics/dotnet-backend.md
+++ b/docs/semantics/dotnet-backend.md
@@ -319,18 +319,19 @@ namespace Calor.Runtime
 
 **Calor:**
 ```calor
-§MATCH{m1} §REF{name=opt}
-§CASE §SOME{x} => §R §REF{name=x}
-§CASE §NONE => §R INT:0
-§/MATCH{m1}
+§W{sw1:expr} code
+  §K 200 → "OK"
+  §K 404 → "Not Found"
+  §K _ → "Unknown"
 ```
 
 **C#:**
 ```csharp
-opt switch
+code switch
 {
-    Option<int>.Some(var x) => x,
-    Option<int>.None => 0,
+    200 => "OK",
+    404 => "Not Found",
+    _ => "Unknown",
 }
 ```
 
@@ -436,14 +437,12 @@ await expr.ConfigureAwait(false)
 
 **Calor:**
 ```calor
-§CLASS{c1:Circle:seal}
-§EXT{Shape}
-§IMPL{IDrawable}
-§FLD{f64:Radius:pri}
-§METHOD{m1:Area:pub:over} §O{f64} §E{}
-§R §OP{kind=MUL} 3.14159 §OP{kind=MUL} §REF{name=Radius} §REF{name=Radius}
-§/METHOD{m1}
-§/CLASS{c1}
+§CL{c1:Circle:pub:seal}
+  §EXT{Shape}
+  §IMPL{IDrawable}
+  §FLD{f64:Radius:priv}
+  §MT{mt1:Area:pub:over} () -> f64
+    §R (* 3.14159 (* this.Radius this.Radius))
 ```
 
 **C#:**

--- a/docs/semantics/inventory.md
+++ b/docs/semantics/inventory.md
@@ -68,36 +68,29 @@ Defined in `ExpressionNodes.cs:141-146`:
 | ElseIf Clause | `ElseIfClauseNode` | `ControlFlowNodes.cs:140-157` |
 
 ```calor
-§IF{id001}
-  §COND §OP{kind=GT} §REF{name=x} 0
-  §THEN
-  §R INT:1
-  §ELSEIF
-  §COND §OP{kind=LT} §REF{name=x} 0
-  §THEN
-  §R INT:-1
-  §ELSE
-  §R INT:0
+§IF{if1} (> x 0)
+  §R 1
+§EI (< x 0)
+  §R -1
+§EL
+  §R 0
 ```
 
 ### 3.2 Loops
 
 | Construct | Node Type | Syntax | File Reference |
 |-----------|-----------|--------|----------------|
-| For Loop | `ForStatementNode` | `§FOR{id}{var}{from}{to}{step}` | `ControlFlowNodes.cs:9-41` |
-| While Loop | `WhileStatementNode` | `§WHILE{id}` | `ControlFlowNodes.cs:47-70` |
+| For Loop | `ForStatementNode` | `§L{id:var:from:to:step}` | `ControlFlowNodes.cs:9-41` |
+| While Loop | `WhileStatementNode` | `§WH{id} (cond)` | `ControlFlowNodes.cs:47-70` |
 | Do-While Loop | `DoWhileStatementNode` | `§DO{id}...§/DO` | `ControlFlowNodes.cs:76-99` |
 | Foreach Loop | `ForeachStatementNode` | `§EACH{id:var:type}` | `ArrayNodes.cs:115-164` |
 
 ```calor
-§FOR{for1}{var=i}{from=0}{to=10}{step=1}
-§PRINT §REF{name=i}
-§/FOR{for1}
+§L{l1:i:0:10:1}
+  §P i
 
-§WHILE{while1}
-§COND §OP{kind=LT} §REF{name=i} 100
-...
-§/WHILE{while1}
+§WH{w1} (< i 100)
+  §P i
 ```
 
 ### 3.3 Loop Control
@@ -120,14 +113,10 @@ Defined in `ExpressionNodes.cs:141-146`:
 | Match Case | `MatchCaseNode` | `PatternNodes.cs:59-75` |
 
 ```calor
-§MATCH{m001} §REF{name=shape}
-§CASE §PATTERN{Some} §VAR{s}
-§BODY §R §REF{name=s}
-§/CASE
-§CASE §PATTERN{None}
-§BODY §R STR:"none"
-§/CASE
-§/MATCH{m001}
+§W{sw1:expr} code
+  §K 200 → "OK"
+  §K 404 → "Not Found"
+  §K _ → "Unknown"
 ```
 
 ### 4.2 Pattern Types
@@ -249,21 +238,20 @@ Defined in `ExpressionNodes.cs:141-146`:
 
 | Construct | Node Type | Syntax | File Reference |
 |-----------|-----------|--------|----------------|
-| Try Statement | `TryStatementNode` | `§TRY{id}...§/TRY` | `ExceptionNodes.cs:17-43` |
-| Catch Clause | `CatchClauseNode` | `§CATCH{Type:var}` | `ExceptionNodes.cs:50-92` |
-| Throw | `ThrowStatementNode` | `§THROW expr` | `ExceptionNodes.cs:98-113` |
-| Rethrow | `RethrowStatementNode` | `§RETHROW` | `ExceptionNodes.cs:119-125` |
+| Try Statement | `TryStatementNode` | `§TR{id} ... §CA ... §FI` | `ExceptionNodes.cs:17-43` |
+| Catch Clause | `CatchClauseNode` | `§CA{Type:var}` | `ExceptionNodes.cs:50-92` |
+| Throw | `ThrowStatementNode` | `§TH expr` | `ExceptionNodes.cs:98-113` |
+| Rethrow | `RethrowStatementNode` | `§RT` | `ExceptionNodes.cs:119-125` |
 
 ```calor
-§TRY{try1}
-§C{RiskyOperation} §/C
+§TR{tr1}
+  §C{RiskyOperation} §/C
 §CA{IOException:ex}
-§PRINT §REF{name=ex}
-§CA
-§RETHROW
+  §P ex
+§CA{Exception:ex}
+  §RT
 §FI
-§C{Cleanup} §/C
-§/TRY{try1}
+  §C{Cleanup} §/C
 ```
 
 ---

--- a/docs/semantics/normal-form.md
+++ b/docs/semantics/normal-form.md
@@ -384,10 +384,10 @@ end_block:
 
 **Source:**
 ```calor
-§IF{if1}
-  §COND condition
-  §THEN then_body
-  §ELSE else_body
+§IF{if1} (condition)
+  then_body
+§EL
+  else_body
 ```
 
 **CNF:**
@@ -406,10 +406,8 @@ end_label:
 
 **Source:**
 ```calor
-§WHILE{w1}
-§COND condition
-body
-§/WHILE{w1}
+§WH{w1} (condition)
+  body
 ```
 
 **CNF:**
@@ -426,9 +424,8 @@ loop_exit:
 
 **Source:**
 ```calor
-§FOR{for1}{var=i}{from=0}{to=10}{step=1}
-body
-§/FOR{for1}
+§L{for1:i:0:10:1}
+  body
 ```
 
 **CNF:**
@@ -448,11 +445,10 @@ loop_exit:
 
 **Source:**
 ```calor
-§MATCH{m1} target
-§CASE pattern1 => body1
-§CASE pattern2 => body2
-§CASE _ => default
-§/MATCH{m1}
+§W{sw1:expr} target
+  §K pattern1 → body1
+  §K pattern2 → body2
+  §K _ → default
 ```
 
 **CNF:**

--- a/docs/syntax-reference/index.md
+++ b/docs/syntax-reference/index.md
@@ -143,8 +143,8 @@ to reference the element from external tooling (e.g. `calor navigate`).
 ```
 
 Blocks are delimited by **indentation** (default 2 spaces per nesting
-level). Legacy `§/X` closers are still accepted for transition
-compatibility but should not be used in new code — see
+level). There are no closer tags — an explicit `§/X` was removed in
+Phase 4d and now raises `Calor0830`. See
 [Structure Tags](/calor/syntax-reference/structure-tags/) for details.
 
 ---

--- a/docs/syntax-reference/structure-tags.md
+++ b/docs/syntax-reference/structure-tags.md
@@ -14,10 +14,11 @@ Structure tags define the organization of Calor code: modules, functions, and th
 > ends at the first line that **dedents** back to the parent column. No
 > closing tags are required. The compiler default is `2` spaces per
 > nesting level (mixing tabs and spaces is rejected). Legacy closer tags
-> (`§/M`, `§/F`, `§/L`, `§/I`, …) are still accepted during the
-> transition window, but all examples below use the indent-only form;
-> bulk-migrate older corpora with
-> [`calor format`](/calor/cli/format/).
+> (`§/M`, `§/F`, `§/L`, `§/I`, …) were **removed** in Phase 4d: an explicit
+> closer now raises `Calor0830`. A block is terminated by indentation
+> alone, so all examples below use the indent-only form. To migrate an
+> older corpus that still has closer lines, delete those lines — the
+> indentation already marks where each block ends.
 
 ---
 
@@ -44,8 +45,8 @@ Modules are like C# namespaces. They group related functions.
 - `name` becomes the C# namespace
 - The module block extends until the next line that dedents back to
   column 0 (or end of file)
-- Legacy `§/M` closers are still accepted but discouraged; migrate
-  with [`calor format`](/calor/cli/format/)
+- Legacy `§/M` closers were removed in Phase 4d; an explicit closer now
+  raises `Calor0830`. The module ends at the next dedent to column 0
 
 ---
 
@@ -669,25 +670,24 @@ dedents back to (or past) the parent column.
 3. Chain continuations (`§EI`, `§EL`, `§K`, `§WHEN`, `§CA`, `§FI`)
    sit at the **same** column as their parent (`§IF`, `§W`, `§TR`),
    not indented inside it
-4. Legacy `§/X` closers are still accepted and ignored
+4. Closer tags were removed in Phase 4d — an explicit `§/X` raises `Calor0830`
 
 ### Example
 
 ```
-§M{Example}
-  §F{Main:pub}
-    §O{void}
+§M{m1:Example}
+  §F{f1:Main:pub} () -> void
     §E{cw}
-    §L{i:1:10:1}
-      §IF (> i 5)
+    §L{l1:i:1:10:1}
+      §IF{if1} (> i 5)
         §P i
       §EL
         §P "small"
 ```
 
-The `§/I`, `§/L`, `§/F`, `§/M` closers are inferred from the dedents.
-If you write them explicitly, the lexer drops them silently — but
-calorfmt will strip them in a future release.
+Each block above (`§IF`, `§L`, `§F`, `§M`) ends purely at its dedent —
+there are no closer tags. Writing an explicit `§/I`, `§/L`, `§/F`, or
+`§/M` now raises `Calor0830`.
 
 ### Tag Reference
 


### PR DESCRIPTION
## Summary

Track 1 / 0.6.6 item **D1 (markdown docs sweep)** — the follow-up to the MCP primer fix (#674). Phase 4d removed structural closer tags (`§/M`, `§/F`, `§/I`, `§/L`, …); they now **hard-error `Calor0830`**. The Markdown docs still (a) claimed closers were "still accepted" and (b) showed closer-form / stale pseudo-syntax in code examples — so an agent following Calor's own docs would write non-compiling Calor.

## What changed

**Canonical syntax reference (agent-facing) — corrected false claims:**
- `syntax-reference/structure-tags.md` — the intro callout, the Modules rule, the indentation rule (#4), and the closing note all said closers were "still accepted / inferred from dedents." Now state they were removed in Phase 4d and raise `Calor0830`. Also fixed the adjacent loop example, which **didn't compile** (`§IF` needs an id — `Calor0102`; old `§F{Main:pub}`+`§O{void}` header).
- `syntax-reference/index.md` — "Legacy `§/X` closers are still accepted" → removed/`Calor0830`.
- `ids.md` §2.2 — removed the stale "the matching closing tag may also omit `{id}` … both forms parse and are valid" paragraph (it implied closers still parse).

**Semantics specs — modernized stale code blocks to verified current syntax:**
- `semantics/core.md`, `dotnet-backend.md`, `inventory.md`, `normal-form.md` — rewrote the **if / loop / match / class / try-catch** examples from removed closer-form + obsolete AST pseudo-notation (`§MATCH/§CASE/§/MATCH`, `§FOR{}{}{}`, `§CLASS/§METHOD`, `§COND/§THEN`, `§REF/§OP`, `INT:` literals) to current indent-only syntax (`§W`/`§K`/`→`, `§L`, `§WH`, `§CL`/`§MT`, `§TR`/`§CA`/`§FI`).

## Verification

Every **concrete** example I wrote was compiled with `calor` and succeeds (match, value-match, if/elseif/else, class with `§EXT`+`§IMPL`+`override`, try/catch/finally + rethrow, the structure-tags loop module). `normal-form.md` blocks remain intentional placeholder *shapes* (paired with abstract CNF), now in correct current notation. Final scan confirms **no removed structural closers remain** in teaching docs outside accurate prose.

Findings worth noting:
- `§I{}`/`§O{}` input/output param markers **still compile** — old style, not breakage — so they're left as-is (high-churn cosmetic modernization deferred).
- No `§RESULT` and no 26-char ULID IDs exist in teaching docs.

## Follow-up (out of scope — needs syntax investigation)

The 4 semantics specs still contain stale blocks for features whose current surface syntax isn't covered by the compiling corpus and that I won't invent in docs: **records (§11), with-expressions (§11.2), property patterns (§7.2)**, plus the residual `§REF/§OP/INT:` AST-notation in untouched blocks. These warrant a dedicated semantics-doc modernization pass.

Relates to #673.
