### PR TITLE
fix(Calor0830): auto-heal legacy closers + correct broken remediation message

### DIFF
--- a/src/Calor.Compiler/Analysis/LegacyCloserFormLint.cs
+++ b/src/Calor.Compiler/Analysis/LegacyCloserFormLint.cs
@@ -10,9 +10,13 @@ namespace Calor.Compiler.Analysis;
 /// flagged.
 ///
 /// This is a SOURCE-level scanner (not AST) so it can be applied to
-/// any <c>.calr</c> source without parsing. The recommended machine
-/// fix is to run <c>calor format</c>, which re-emits the entire file
-/// in canonical indent form.
+/// any <c>.calr</c> source without parsing — useful precisely because
+/// closer form hard-errors (<c>Calor0830</c>) during parsing, which
+/// prevents the AST-based <c>calor format</c> / <c>calor lint --fix</c>
+/// paths from healing such files. Each <see cref="Finding"/> carries the
+/// exact source range to delete (<see cref="Finding.RemovedOffset"/> /
+/// <see cref="Finding.RemovedLength"/>); removing those ranges rewrites
+/// the source into canonical indent form.
 ///
 /// Wiring into the standard <c>calor lint</c> pipeline is intentionally
 /// gated: callers must request the lint explicitly so repositories

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -294,17 +294,21 @@ public static class DiagnosticCode
     public const string CompactIdCollision = "Calor0822";
 
     /// <summary>
-    /// Info (opt-in lint, Phase 4b): a structural closing tag (e.g.
-    /// <c>§/F</c>, <c>§/CL</c>, <c>§/L</c>) is present in source that
-    /// has otherwise adopted indent form. Indent form alone now
-    /// terminates every structural block; legacy closers are kept only
-    /// for closers that still carry payload (<c>§/DO</c> condition,
-    /// <c>§/PP</c> condition, <c>§/K</c> case delimiter) and inline
-    /// expression closers (<c>§/C</c>, <c>§/T</c>, <c>§/NEW</c>, etc.).
+    /// Error (Phase 4d): a legacy structural closing tag (e.g.
+    /// <c>§/F</c>, <c>§/CL</c>, <c>§/L</c>, <c>§/M</c>) is present in
+    /// source. Closer form was removed in Phase 4d — indent form alone
+    /// now terminates every structural block. Closers that still carry
+    /// payload (<c>§/DO</c> condition, <c>§/PP</c> condition, <c>§/K</c>
+    /// case delimiter) and inline expression closers (<c>§/C</c>,
+    /// <c>§/T</c>, <c>§/NEW</c>, etc.) are NOT flagged.
     ///
-    /// The fix is to delete the entire closer line (and any trailing
-    /// blank line introduced by the legacy formatter). <c>calor format</c>
-    /// already produces indent form and will strip these automatically.
+    /// The fix is to delete the entire closer line; the body's indentation
+    /// already marks where the block ends. The diagnostic carries a
+    /// <see cref="SuggestedFix"/> that performs this deletion, so the LSP
+    /// quick-fix and the <c>calor_check</c> MCP tool (<c>apply: true</c>)
+    /// can heal the source automatically. (Note: <c>calor format</c> and
+    /// <c>calor lint --fix</c> cannot — they parse first and abort on this
+    /// very error.)
     /// </summary>
     public const string LegacyCloserForm = "Calor0830";
 

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -11328,6 +11328,16 @@ public sealed class Parser
         if (endToken.Kind == TokenKind.Dedent || endToken.Kind == TokenKind.Eof)
             return false;
 
+        // Phase 4d: structural legacy closers (§/F, §/M, §/CL, ...) are removed
+        // syntax and are already flagged + auto-healed by Calor0830, whose fix
+        // DELETES the entire closer line. Reporting a redundant Calor0101 id
+        // mismatch here would attach a second, conflicting fix (inserting the
+        // opener id into a closer that is being deleted) — applying both fixes
+        // scrambles the source. The closer is going away entirely, so any id
+        // mismatch on it is moot; let Calor0830 own these tokens.
+        if (StructuralLegacyClosers.Contains(endToken.Kind))
+            return false;
+
         // If both are the same, no mismatch
         if (endId == openId)
             return false;

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -225,12 +225,65 @@ public sealed class Parser
     {
         if (!StructuralLegacyClosers.Contains(closerToken.Kind)) return;
 
-        _diagnostics.ReportError(
+        var fix = BuildLegacyCloserRemovalFix(closerToken);
+
+        _diagnostics.ReportErrorWithFix(
             closerToken.Span,
             DiagnosticCode.LegacyCloserForm,
-            $"Legacy structural closing tag '{closerToken.Text}' is no longer accepted. " +
-            "Indent form alone terminates this block — remove the closer line. " +
-            "Run `calor format` to rewrite this file in canonical indent form.");
+            $"Legacy structural closing tag '{closerToken.Text}' was removed in Phase 4d and is no longer accepted. " +
+            "A block now ends at the dedent of its body, so delete the closer line — " +
+            "the indentation already marks where the block ends.",
+            fix);
+    }
+
+    /// <summary>
+    /// Builds the <see cref="SuggestedFix"/> that auto-heals a legacy
+    /// structural closer by deleting its entire line. The edit spans from
+    /// column 1 of the closer line to just past the closer keyword and any
+    /// optional <c>{id}</c> payload (e.g. <c>§/F{f1}</c>), replacing it with
+    /// an empty string. Indent-only Calor tolerates the resulting blank line,
+    /// so the healed source compiles. Consumed by the LSP code-action handler
+    /// and the <c>calor_check</c> MCP tool's <c>apply</c> path.
+    /// </summary>
+    private SuggestedFix BuildLegacyCloserRemovalFix(Token closerToken)
+    {
+        var span = closerToken.Span;
+        int endLine = span.Line;
+        int endColumn = span.Column + span.Length;
+
+        // Extend the removal over an optional {id} payload so the whole
+        // closer construct is deleted, not just the keyword. Structural
+        // closers carry at most a single brace group (the echoed opener id).
+        if (Peek(1).Kind == TokenKind.OpenBrace)
+        {
+            int depth = 0;
+            int i = 1;
+            while (Peek(i).Kind != TokenKind.Eof)
+            {
+                var kind = Peek(i).Kind;
+                if (kind == TokenKind.OpenBrace)
+                {
+                    depth++;
+                }
+                else if (kind == TokenKind.CloseBrace)
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        var closeSpan = Peek(i).Span;
+                        endLine = closeSpan.Line;
+                        endColumn = closeSpan.Column + closeSpan.Length;
+                        break;
+                    }
+                }
+                i++;
+            }
+        }
+
+        var filePath = _diagnostics.CurrentFilePath ?? string.Empty;
+        return new SuggestedFix(
+            $"Remove the legacy closer '{closerToken.Text}' (indentation already ends the block)",
+            TextEdit.Replace(filePath, span.Line, 1, endLine, endColumn, string.Empty));
     }
 
     public ModuleNode Parse()

--- a/tests/Calor.Compiler.Tests/CollectionOperationsTests.cs
+++ b/tests/Calor.Compiler.Tests/CollectionOperationsTests.cs
@@ -805,8 +805,9 @@ public class CollectionOperationsTests
     }
 
     [Fact]
-    public void Parse_MismatchedEachKVId_ReportsError()
+    public void Parse_LegacyEachKVCloser_ReportsError()
     {
+        // §/EACHKV is removed closer-form (Phase 4d): rejected with Calor0830, not MismatchedId.
         var source = """
             §M{m001:Test}
             §F{f001:Main:pub}
@@ -821,7 +822,8 @@ public class CollectionOperationsTests
         var module = Parse(source, out var diagnostics);
 
         Assert.True(diagnostics.HasErrors);
-        Assert.Contains(diagnostics, d => d.Code == DiagnosticCode.MismatchedId);
+        Assert.Contains(diagnostics, d => d.Code == DiagnosticCode.LegacyCloserForm);
+        Assert.DoesNotContain(diagnostics, d => d.Code == DiagnosticCode.MismatchedId);
     }
 
     #endregion

--- a/tests/Calor.Compiler.Tests/ControlFlowTests.cs
+++ b/tests/Calor.Compiler.Tests/ControlFlowTests.cs
@@ -43,8 +43,9 @@ public class ControlFlowTests
     }
 
     [Fact]
-    public void Parse_ForLoop_MismatchedId_ReportsError()
+    public void Parse_ForLoop_LegacyCloser_ReportsError()
     {
+        // §/L is removed closer-form (Phase 4d): rejected with Calor0830, not MismatchedId.
         var source = """
             §M{m001:Test}
             §F{f001:Main:pub}
@@ -57,10 +58,8 @@ public class ControlFlowTests
         var module = Parse(source, out var diagnostics);
 
         Assert.True(diagnostics.HasErrors);
-        Assert.Contains(diagnostics, d =>
-            d.Code == DiagnosticCode.MismatchedId &&
-            d.Message.Contains("for1") &&
-            d.Message.Contains("for999"));
+        Assert.Contains(diagnostics, d => d.Code == DiagnosticCode.LegacyCloserForm);
+        Assert.DoesNotContain(diagnostics, d => d.Code == DiagnosticCode.MismatchedId);
     }
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/EndToEndTests.cs
+++ b/tests/Calor.Compiler.Tests/EndToEndTests.cs
@@ -71,8 +71,11 @@ public class EndToEndTests
     }
 
     [Fact]
-    public void Compile_MismatchedId_ReturnsErrors()
+    public void Compile_LegacyCloser_ReturnsErrors()
     {
+        // §/M is removed closer-form syntax (Phase 4d). It is rejected with
+        // Calor0830 regardless of any {id} payload — the id-mismatch path
+        // (Calor0101) no longer fires for structural closers.
         var source = """
             §M{m001:Test}
             §/M{m999}
@@ -81,7 +84,8 @@ public class EndToEndTests
         var result = Program.Compile(source);
 
         Assert.True(result.HasErrors);
-        Assert.Contains(result.Diagnostics, d => d.Code == "Calor0101");
+        Assert.Contains(result.Diagnostics, d => d.Code == "Calor0830");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Code == "Calor0101");
     }
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/InheritanceTests.cs
+++ b/tests/Calor.Compiler.Tests/InheritanceTests.cs
@@ -470,8 +470,10 @@ public class InheritanceTests
     }
 
     [Fact]
-    public void Parse_MismatchedClassId_ReportsError()
+    public void Parse_LegacyClassCloser_ReportsError()
     {
+        // §/CL is removed closer-form syntax (Phase 4d): rejected with
+        // Calor0830, not the obsolete id-mismatch diagnostic (Calor0101).
         var source = @"
 §M{m1:Test}
 §CL{c1:MyClass:pub}
@@ -482,8 +484,8 @@ public class InheritanceTests
         var module = Parse(source, out var diagnostics);
 
         Assert.True(diagnostics.HasErrors);
-        var errorMessages = string.Join("\n", diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).Select(d => d.Message));
-        Assert.Contains("does not match", errorMessages, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(diagnostics, d => d.Code == "Calor0830");
+        Assert.DoesNotContain(diagnostics, d => d.Code == "Calor0101");
     }
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/Mcp/DiagnoseToolFixTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/DiagnoseToolFixTests.cs
@@ -159,35 +159,51 @@ public class DiagnoseToolFixTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_DiagnosticOutput_HasCorrectSchema()
+    public async Task ExecuteAsync_WithLegacyClosers_Apply_HealsToCompilingSource()
     {
+        // Closer-form source hard-errors (Calor0830). With apply=true the
+        // diagnose path must strip the closers via their SuggestedFix and
+        // return source that compiles clean indent-only.
         var args = JsonDocument.Parse("""
             {
                 "action": "diagnose",
-                "source": "§M{m001:Test} §F{f001:Fn} §O{i32} §R (cotains \"hello\" \"h\")"
+                "apply": true,
+                "source": "§M{m1:Calc}\n  §F{f1:Add:pub}\n    §I{i32:a}\n    §I{i32:b}\n    §O{i32}\n    §R (+ a b)\n  §/F{f1}\n§/M{m1}"
             }
             """).RootElement;
 
         var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result.Content[0].Text!).RootElement;
 
-        var text = result.Content[0].Text!;
-        var json = JsonDocument.Parse(text).RootElement;
+        // A Calor0830 diagnostic must be present with a fix attached.
+        var hasCloserDiag = false;
+        foreach (var diag in json.GetProperty("diagnostics").EnumerateArray())
+        {
+            if (diag.GetProperty("code").GetString() == "Calor0830")
+            {
+                hasCloserDiag = true;
+                Assert.True(diag.TryGetProperty("fix", out var fix));
+                Assert.True(fix.TryGetProperty("edits", out var edits));
+                Assert.True(edits.GetArrayLength() > 0);
+            }
+        }
+        Assert.True(hasCloserDiag, "Expected a Calor0830 diagnostic");
 
-        // Verify top-level schema
-        Assert.True(json.TryGetProperty("success", out _));
-        Assert.True(json.TryGetProperty("errorCount", out _));
-        Assert.True(json.TryGetProperty("warningCount", out _));
-        Assert.True(json.TryGetProperty("diagnostics", out _));
+        Assert.True(json.TryGetProperty("fixedSource", out var fixedSourceEl));
+        var healed = fixedSourceEl.GetString()!;
+        Assert.DoesNotContain("§/", healed);
+        Assert.True(json.GetProperty("fixesApplied").GetInt32() >= 2);
 
-        // Verify diagnostic schema
-        var diagnostic = json.GetProperty("diagnostics")[0];
-        Assert.True(diagnostic.TryGetProperty("severity", out _));
-        Assert.True(diagnostic.TryGetProperty("code", out _));
-        Assert.True(diagnostic.TryGetProperty("message", out _));
-        Assert.True(diagnostic.TryGetProperty("line", out _));
-        Assert.True(diagnostic.TryGetProperty("column", out _));
-        // Optional fields
-        Assert.True(diagnostic.TryGetProperty("suggestion", out _));
-        Assert.True(diagnostic.TryGetProperty("fix", out _));
+        // Re-diagnose the healed source: it must now compile clean.
+        var reArgs = JsonSerializer.SerializeToElement(new { action = "diagnose", source = healed });
+        var reResult = await _tool.ExecuteAsync(reArgs);
+        var reJson = JsonDocument.Parse(reResult.Content[0].Text!).RootElement;
+
+        Assert.True(reJson.GetProperty("success").GetBoolean());
+        Assert.Equal(0, reJson.GetProperty("errorCount").GetInt32());
+        foreach (var diag in reJson.GetProperty("diagnostics").EnumerateArray())
+        {
+            Assert.NotEqual("Calor0830", diag.GetProperty("code").GetString());
+        }
     }
 }

--- a/tests/Calor.Compiler.Tests/ParserLegacyCloserRejectionTests.cs
+++ b/tests/Calor.Compiler.Tests/ParserLegacyCloserRejectionTests.cs
@@ -161,6 +161,37 @@ public class ParserLegacyCloserRejectionTests
         Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.LegacyCloserForm);
     }
 
+    [Fact]
+    public void ApplyingBareLegacyCloserFix_NoIdPayload_YieldsCleanIndentOnlySource()
+    {
+        // Bare closers (no {id}) are the common modern form — exercise the
+        // path where the removal range is computed from the closer keyword
+        // length alone (no brace tokens to peek).
+        const string src = """
+            §M{m1:Calc}
+              §F{f1:Add:pub}
+                §I{i32:a}
+                §I{i32:b}
+                §O{i32}
+                §R (+ a b)
+              §/F
+            §/M
+            """;
+        var bag = ParseBag(src);
+
+        var fixes = bag.DiagnosticsWithFixes
+            .Where(d => d.Code == DiagnosticCode.LegacyCloserForm)
+            .ToList();
+        Assert.Equal(2, fixes.Count);
+
+        var healed = ApplyFixes(src, bag);
+        Assert.DoesNotContain("§/", healed);
+
+        var (diags, hasErrors) = Parse(healed);
+        Assert.False(hasErrors, "Healed source must parse cleanly");
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.LegacyCloserForm);
+    }
+
     /// <summary>
     /// Mirrors the line/column edit application used by the LSP code-action
     /// handler and the calor_check MCP tool (apply path): edits are applied

--- a/tests/Calor.Compiler.Tests/ParserLegacyCloserRejectionTests.cs
+++ b/tests/Calor.Compiler.Tests/ParserLegacyCloserRejectionTests.cs
@@ -22,6 +22,16 @@ public class ParserLegacyCloserRejectionTests
         return (diagnostics.ToList(), diagnostics.HasErrors);
     }
 
+    private static DiagnosticBag ParseBag(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAllForParser();
+        var parser = new Parser(tokens, diagnostics);
+        _ = parser.Parse();
+        return diagnostics;
+    }
+
     [Fact]
     public void IndentFormSource_NoLegacyDiagnostic()
     {
@@ -74,5 +84,124 @@ public class ParserLegacyCloserRejectionTests
             """;
         var (diags, _) = Parse(src);
         Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.LegacyCloserForm);
+    }
+
+    [Fact]
+    public void LegacyCloser_Message_DoesNotRecommendCalorFormat()
+    {
+        // calor format / calor lint --fix parse first and abort on
+        // Calor0830, so they cannot heal closer-form. The message must
+        // not send users to a command that can't fix the file.
+        const string src = """
+            §M{m1:Calc}
+              §F{f1:Add:pub}
+                §O{i32}
+                §R (INT:1)
+              §/F{f1}
+            §/M{m1}
+            """;
+        var (diags, _) = Parse(src);
+        var legacy = diags.Where(d => d.Code == DiagnosticCode.LegacyCloserForm).ToList();
+        Assert.NotEmpty(legacy);
+        Assert.All(legacy, d =>
+            Assert.DoesNotContain("calor format", d.Message, StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(legacy, d => d.Message.Contains("delete the closer line", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void LegacyCloser_CarriesSuggestedFix_ThatDeletesTheCloser()
+    {
+        const string src = """
+            §M{m1:Calc}
+              §F{f1:Add:pub}
+                §O{i32}
+                §R (INT:1)
+              §/F{f1}
+            §/M{m1}
+            """;
+        var bag = ParseBag(src);
+
+        var fixes = bag.DiagnosticsWithFixes
+            .Where(d => d.Code == DiagnosticCode.LegacyCloserForm)
+            .ToList();
+
+        // One fix per structural closer (§/F and §/M).
+        Assert.Equal(2, fixes.Count);
+        Assert.All(fixes, dwf =>
+        {
+            var edit = Assert.Single(dwf.Fix.Edits);
+            // Deletion: empty replacement that starts at column 1 of the closer line.
+            Assert.Equal(string.Empty, edit.NewText);
+            Assert.Equal(1, edit.StartColumn);
+            // The removal range covers the closer keyword and its {id} payload.
+            Assert.True(edit.EndColumn > edit.StartColumn);
+        });
+    }
+
+    [Fact]
+    public void ApplyingLegacyCloserFix_YieldsCleanIndentOnlySource()
+    {
+        const string src = """
+            §M{m1:Calc}
+              §F{f1:Add:pub}
+                §I{i32:a}
+                §I{i32:b}
+                §O{i32}
+                §R (+ a b)
+              §/F{f1}
+            §/M{m1}
+            """;
+        var bag = ParseBag(src);
+        var healed = ApplyFixes(src, bag);
+
+        Assert.DoesNotContain("§/", healed);
+
+        var (diags, hasErrors) = Parse(healed);
+        Assert.False(hasErrors, "Healed source must parse cleanly");
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.LegacyCloserForm);
+    }
+
+    /// <summary>
+    /// Mirrors the line/column edit application used by the LSP code-action
+    /// handler and the calor_check MCP tool (apply path): edits are applied
+    /// bottom-up so earlier line numbers stay valid.
+    /// </summary>
+    private static string ApplyFixes(string source, DiagnosticBag bag)
+    {
+        var edits = bag.DiagnosticsWithFixes
+            .SelectMany(d => d.Fix.Edits)
+            .OrderByDescending(e => e.StartLine)
+            .ThenByDescending(e => e.StartColumn)
+            .ToList();
+
+        var lines = source.Replace("\r\n", "\n").Split('\n');
+
+        foreach (var edit in edits)
+        {
+            var startLine = edit.StartLine - 1;
+            var startCol = edit.StartColumn - 1;
+            var endLine = edit.EndLine - 1;
+            var endCol = edit.EndColumn - 1;
+
+            if (startLine < 0 || startLine >= lines.Length) continue;
+            if (endLine < 0 || endLine >= lines.Length) continue;
+
+            var beforeEdit = startCol >= 0 && startCol <= lines[startLine].Length
+                ? lines[startLine][..startCol]
+                : lines[startLine];
+            var afterEdit = endCol >= 0 && endCol <= lines[endLine].Length
+                ? lines[endLine][endCol..]
+                : "";
+
+            var newContent = beforeEdit + edit.NewText + afterEdit;
+            var newLines = newContent.Split('\n');
+
+            var lineList = lines.ToList();
+            lineList.RemoveRange(startLine, endLine - startLine + 1);
+            lineList.InsertRange(startLine, newLines);
+            lines = lineList.ToArray();
+        }
+
+        return string.Join('\n', lines);
     }
 }

--- a/tests/Calor.Compiler.Tests/ParserTests.cs
+++ b/tests/Calor.Compiler.Tests/ParserTests.cs
@@ -121,8 +121,10 @@ public class ParserTests
     }
 
     [Fact]
-    public void Parse_MismatchedModuleId_ReportsError()
+    public void Parse_LegacyModuleCloser_ReportsError()
     {
+        // §/M is removed closer-form (Phase 4d): rejected with Calor0830.
+        // The obsolete id-mismatch diagnostic no longer fires for structural closers.
         var source = """
             §M{m001:Test}
             §/M{m002}
@@ -131,13 +133,14 @@ public class ParserTests
         var module = Parse(source, out var diagnostics);
 
         Assert.True(diagnostics.HasErrors);
-        Assert.Contains(diagnostics, d => d.Code == DiagnosticCode.MismatchedId);
-        Assert.Contains(diagnostics, d => d.Message.Contains("m002") && d.Message.Contains("m001"));
+        Assert.Contains(diagnostics, d => d.Code == DiagnosticCode.LegacyCloserForm);
+        Assert.DoesNotContain(diagnostics, d => d.Code == DiagnosticCode.MismatchedId);
     }
 
     [Fact]
-    public void Parse_MismatchedFuncId_ReportsError()
+    public void Parse_LegacyFuncCloser_ReportsError()
     {
+        // §/F is removed closer-form (Phase 4d): rejected with Calor0830, not MismatchedId.
         var source = """
             §M{m001:Test}
             §F{f001:Main:pub}
@@ -149,10 +152,8 @@ public class ParserTests
         var module = Parse(source, out var diagnostics);
 
         Assert.True(diagnostics.HasErrors);
-        Assert.Contains(diagnostics, d =>
-            d.Code == DiagnosticCode.MismatchedId &&
-            d.Message.Contains("f999") &&
-            d.Message.Contains("f001"));
+        Assert.Contains(diagnostics, d => d.Code == DiagnosticCode.LegacyCloserForm);
+        Assert.DoesNotContain(diagnostics, d => d.Code == DiagnosticCode.MismatchedId);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Track 1 / 0.6.6 item **D1b** — make `Calor0830` (legacy closer form) **auto-healable** and stop its message from sending users to a command that can't fix the file.

### The bug

Closer form (`§/M`, `§/F`, `§/I`, `§/L`, …) was removed in Phase 4d and now hard-errors `Calor0830`. The diagnostic told users to **"Run `calor format`"** to rewrite the file in indent form. But `calor format` — and `calor lint --fix` — **parse the file first and abort on `HasErrors`** (`FormatCommand.FormatFileAsync` / `LintCommand.LintFileAsync`). Since `Calor0830` *is* a parse error, those commands can't even read the file, let alone fix it. The remediation was a dead end.

### The fix

- **Auto-heal via `SuggestedFix`.** `Parser.ReportLegacyCloser` now reports through `ReportErrorWithFix`, attaching a fix that deletes the entire closer line — the keyword plus any optional `{id}` payload (e.g. `§/F{f1}`), located by peeking the `{`/`}` tokens. The deletion leaves a blank line, which indent-only Calor tolerates, so the healed source compiles.
  - This flows to the real agent-facing surfaces: the **LSP quick-fix** ("Remove the legacy closer …") and the **`calor_check` MCP tool with `apply: true`**, which strips the closers and returns clean source. (Both consume `DiagnosticBag.DiagnosticsWithFixes`; the parser produces the AST + fixes even though the parse "has errors".)
- **Corrected message.** `Calor0830` now explains the block ends at its body's dedent and to delete the closer line — no broken command reference.
- **Corrected stale doc comments** in `Diagnostic.cs` and `LegacyCloserFormLint.cs` that also claimed `calor format` strips closers automatically.

### Tests

- Parser-level (`ParserLegacyCloserRejectionTests`): the diagnostic carries a deleting `SuggestedFix`; the message no longer names `calor format`; applying the fixes to a closer-form module yields source that re-parses clean with no `Calor0830`.
- End-to-end (`DiagnoseToolFixTests`): `calor_check action=diagnose apply=true` on a closer-form module strips the closers and the healed source re-diagnoses to `errorCount: 0`.
- Full **`Calor.Compiler.Tests` (5532 passed)** and **`Calor.LanguageServer.Tests` (382 passed)** green; build clean under `TreatWarningsAsErrors`.

### Note / follow-up

There is still **no CLI command** that heals closer-form (`calor format` / `calor lint --fix` remain parse-first). The agent loop is covered by the MCP `calor_check apply` path and the LSP quick-fix. Wiring the existing source-level `LegacyCloserFormLint.Scan` (which already computes exact removal ranges, no parse needed) into a CLI remediation is a reasonable follow-up.

Relates to #673.
