### PR TITLE
Release v0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.6] - 2026-07-01
+
+### Benchmark Results (Statistical: 30 runs)
+- **Overall Advantage**: 1.32x (Calor leads)
+- **Metrics**: Calor wins 7, C# wins 1
+- **Highlights**:
+  - Comprehension: 1.84x ± 0.00 (Calor wins, large effect d=1.80)
+  - ErrorDetection: 1.49x ± 0.00 (Calor wins, large effect d=1.21)
+  - TokenEconomics: 1.42x ± 0.00 (Calor wins, composite metric)
+  - RefactoringStability: 1.38x ± 0.00 (Calor wins, large effect d=7.09)
+  - EditPrecision: 1.36x ± 0.00 (Calor wins, large effect d=4.90)
+  - Correctness: 1.29x ± 0.00 (Calor wins, large effect d=1.31)
+  - GenerationAccuracy: 1.02x ± 0.00 (Calor wins, small effect d=0.34)
+  - InformationDensity: 0.98x ± 0.00 (C# wins, medium effect d=-0.52)
+- **Programs Tested**: 217
+
+> **Note:** this release is docs / tooling / test correctness only (primer + reference-doc fixes, `Calor0830` auto-heal, and two compile-time primer guards); it contains no benchmark-affecting code changes, so the profile is unchanged from v0.6.5.
+
+### Fixed
+- **`calor://primer` MCP resource now compiles (Track 1 / D1, #674).** The agent primer served at `calor://primer` (`McpMessageHandler.GetPrimerContent`) taught syntax the compiler rejects today — closer-form tags (`§/F`, `§/M`, `§/I`, `§/L`), ULID IDs, `§RESULT`, `§I`/`§O` markers, and empty `§R` — so an agent onboarded from the primer at session start wrote non-compiling Calor (`Calor0830`/`Calor0006`/…). The primer was rewritten to be fully indent-only and empirically compilable: 3-field `§F` headers with arrow signatures (`(i32:a, i32:b) -> i32`), lowercase `result` in postconditions, BCL-only effectful calls with declared `§E{cw}`, no structural closers, plus a "Common mistakes" section and a quick reference. Exposed to tests via `McpResourceValidator.GetPrimer()`.
+- **`Calor0830` (legacy closer form) is now auto-healable, and its remediation no longer points to a dead end (Track 1 / D1b, #676).** The diagnostic told users to run `calor format`, but `calor format` and `calor lint --fix` parse the file first and abort on `HasErrors` — and `Calor0830` *is* a parse error, so those commands could never read, let alone fix, the file. `Parser.ReportLegacyCloser` now reports through `ReportErrorWithFix`, attaching a `SuggestedFix` that deletes the entire closer line (keyword + any optional `{id}` payload). This flows to the LSP quick-fix and the `calor_check apply:true` MCP tool, and the healed source compiles. The message now explains the block ends at its body's dedent; stale doc comments in `Diagnostic.cs` and `LegacyCloserFormLint.cs` that also referenced `calor format` were corrected. (No CLI heal command yet — parse-first `calor format`/`lint --fix` remain; wiring `LegacyCloserFormLint.Scan` into a CLI remediation is a tracked follow-up.)
+
+### Documentation
+- **Purged removed closer-form from teaching/reference docs (Track 1 / D1, #675).** Phase 4d removed structural closer tags (`§/M`, `§/F`, `§/I`, `§/L`, …), which now hard-error `Calor0830`, but the Markdown docs still claimed closers were "still accepted" and showed closer-form / stale pseudo-syntax — so an agent following Calor's own docs wrote non-compiling Calor. Corrected the false "still accepted" claims in `syntax-reference/structure-tags.md`, `syntax-reference/index.md`, and `ids.md` §2.2; modernized stale if / loop / match / class / try-catch code blocks in `semantics/core.md`, `dotnet-backend.md`, `inventory.md`, and `normal-form.md` from removed closer-form + obsolete AST pseudo-notation to current indent-only syntax. Every concrete example rewritten was compiled with `calor` and succeeds. (Records, with-expressions, and property patterns remain a deferred semantics-doc modernization pass.)
+
+### Tests
+- **`PrimerCompilesTests` — the semantic guard that every correct module the primer teaches compiles (#674).** Extracts every complete `§M` module from `calor://primer` and compiles it via `Program.Compile` under the same options `calor_compile` uses by default, asserting zero errors, plus a guard that all taught modules are discovered. This is the guard that would have caught the closer-form/`§RESULT` lies that 5 review loops and every string-based test missed.
+- **`PrimerMistakesRejectedTests` — the dual guard: every "Common mistakes (these do NOT compile)" example genuinely fails to compile (Track 1 / D2a, #677).** Each curated fragment is rewritten into the smallest complete module where it would naturally appear and asserted to fail at **either** the Calor layer (`HasErrors`) or the generated-C# layer (Roslyn). The 4-field `§F{f1:Add:i32:pub}` header is caught only at the C# layer (**CS0127** — Calor accepts it but emits `void Add() { return 0; }`; a Calor-level "value returned from void function" check is the deferred "F-prerequisite invariant" follow-up). Drift guards (`Primer_ListsEachCuratedMistake`, `Primer_MistakeCount_MatchesCuratedSet`, `CorrectModule_CompilesAtBothLayers`) keep the curated set and the primer in sync.
+
 ## [0.6.5] - 2026-06-30
 
 ### Benchmark Results (Statistical: 30 runs)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.6.5</Version>
+    <Version>0.6.6</Version>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "calor",
   "displayName": "Calor Language",
   "description": "Language support for the Calor programming language",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "publisher": "calor-dev",
   "license": "Apache-2.0",
   "icon": "icons/calor-icon.png",

--- a/website/content/changelog.mdx
+++ b/website/content/changelog.mdx
@@ -10,6 +10,18 @@ All notable changes to Calor, organized by release.
 
 ## [Unreleased]
 
+## [0.6.6] - 2026-07-01
+
+### Fixed
+- **The `calor://primer` MCP resource now compiles.** The agent primer served at `calor://primer` taught syntax the compiler rejects today — closer-form tags (`§/F`, `§/M`, `§/I`, `§/L`), ULID IDs, `§RESULT`, and empty `§R` — so an agent onboarded from it at session start wrote non-compiling Calor. It was rewritten to be fully indent-only and empirically compilable, with 3-field `§F` headers, arrow signatures, BCL-only effectful calls, a "Common mistakes" section, and a quick reference.
+- **`Calor0830` (legacy closer form) is now auto-healable.** Its remediation previously told users to run `calor format`, which parses the file first and aborts on the very error it was meant to fix — a dead end. The diagnostic now attaches a quick-fix that deletes the closer line, surfaced through the LSP quick-fix and the `calor_check apply` MCP tool, and the message explains the block ends at its body's dedent.
+
+### Documentation
+- **Teaching and reference docs no longer show removed closer-form syntax.** The Markdown docs still claimed closers were "still accepted" and showed closer-form / stale pseudo-syntax, so an agent following Calor's own docs wrote non-compiling Calor. The false claims were corrected and the stale if / loop / match / class / try-catch examples were modernized to current indent-only syntax — each verified to compile.
+
+### Tests
+- **Compile-time guards keep the primer honest in both directions.** `PrimerCompilesTests` proves every correct module the primer teaches compiles under the same options `calor_compile` uses by default; `PrimerMistakesRejectedTests` proves every example in the primer's "these do NOT compile" section genuinely fails to compile — so Calor's own onboarding materials can't drift into teaching non-compiling code. Drift guards keep the curated mistake set in sync with the primer.
+
 ## [0.6.5] - 2026-06-30
 
 ### Fixed

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calor-website",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/website/public/data/benchmark-results.json
+++ b/website/public/data/benchmark-results.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
-  "timestamp": "2026-06-30T16:44:04.1783653Z",
-  "commit": "8e9b8b01",
+  "timestamp": "2026-07-01T13:48:37.7298675Z",
+  "commit": "ed41abc5",
   "frameworkVersion": "1.0.0",
   "summary": {
     "overallAdvantage": 1.32,

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -15,9 +15,9 @@ export function WhatsNewBanner() {
         <div className="flex items-center justify-center gap-3 text-sm">
           <Sparkles className="h-4 w-4 text-calor-cerulean flex-shrink-0" />
           <p className="text-center">
-            <span className="font-semibold text-calor-cerulean">v0.6.5</span>
+            <span className="font-semibold text-calor-cerulean">v0.6.6</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">The TokenEconomics benchmark now reports the composite compactness score it always computed instead of raw token count alone &mdash; an honest measurement fix that lifts the category to 1.42&times; and the overall advantage to 1.32&times;, with the v0.7 gate recalibrated against the corrected metric.</span>
+            <span className="text-foreground">Calor&apos;s own onboarding materials now compile: the <code>calor://primer</code> MCP resource and the teaching docs no longer teach removed closer-form syntax, and compile-time guards keep the primer honest in both directions &mdash; every &ldquo;correct&rdquo; example compiles and every &ldquo;common mistake&rdquo; genuinely fails. Legacy <code>Calor0830</code> closers now auto-heal via the LSP and MCP quick-fix.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"


### PR DESCRIPTION
## Summary
- Bump version to 0.6.6 across `Directory.Build.props`, `editors/vscode/package.json`, `website/package.json`
- Update `CHANGELOG.md` with release date, benchmark results, and the 0.6.6 changes
- Update `website/content/changelog.mdx` and `WhatsNewBanner.tsx`
- Refresh `website/public/data/benchmark-results.json` (30-run statistical)

This is the **Track 1 / 0.6.6 docs-correctness** release, shipping the four already-merged PRs:
- #674 — `calor://primer` MCP resource rewritten to be fully indent-only + compilable (D1) + `PrimerCompilesTests`
- #675 — teaching/reference docs purged of removed closer-form syntax (D1)
- #676 — `Calor0830` legacy closers now auto-heal via LSP/MCP quick-fix; broken remediation message corrected (D1b)
- #677 — `PrimerMistakesRejectedTests`: every "common mistake" example is proven to genuinely not compile (D2a)

## Benchmark Results (Statistical: 30 runs)
- **Overall Advantage**: 1.32x (Calor leads); Calor wins 7, C# wins 1; 217 programs
- Docs/tooling/test-only release — **no benchmark-affecting code changes**, profile unchanged vs v0.6.5

## Checklist
- [x] Version updated in Directory.Build.props
- [x] Version updated in editors/vscode/package.json
- [x] Version updated in website/package.json
- [x] CHANGELOG.md updated with version, date, and benchmark summary
- [x] website/content/changelog.mdx updated with version and changes (no benchmark stats)
- [x] website/src/components/landing/WhatsNewBanner.tsx updated with version and headline
- [x] website/public/data/benchmark-results.json updated with latest results