### PR TITLE
docs(agent): sweep all agent-readable docs to indent-only syntax (v0.6.7 Item 0)

### DIFF
--- a/src/Calor.Compiler/Mcp/McpMessageHandler.cs
+++ b/src/Calor.Compiler/Mcp/McpMessageHandler.cs
@@ -623,32 +623,32 @@ public sealed class McpMessageHandler
     internal static string GetTagCatalogJsonPublic() => GetTagCatalogJson();
     private static string GetTagCatalogJson() => """
         {"tags":[
-          {"open":"§M{id:Name}","close":"§/M{id}","description":"Module","idPrefix":"m_"},
-          {"open":"§F{id:Name:vis}","close":"§/F{id}","description":"Function","idPrefix":"f_"},
-          {"open":"§AF{id:Name:vis}","close":"§/AF{id}","description":"Async function","idPrefix":"f_"},
-          {"open":"§CL{id:Name:vis}","close":"§/CL{id}","description":"Class","idPrefix":"c_"},
-          {"open":"§IF{id}","close":"§/I{id}","description":"If block (NOTE: close is §/I not §/IF)"},
-          {"open":"§EI","close":"(none)","description":"Else-if branch"},
+          {"open":"§M{id:Name}","close":"(none — indent-only)","description":"Module (body indented)","idPrefix":"m_"},
+          {"open":"§F{id:name:vis} (type:name, ...) -> retType","close":"(none — indent-only)","description":"Function (body indented)","idPrefix":"f_"},
+          {"open":"§AF{id:name:vis} (type:name, ...) -> retType","close":"(none — indent-only)","description":"Async function (body indented)","idPrefix":"f_"},
+          {"open":"§CL{id:Name:vis}","close":"(none — indent-only)","description":"Class (body indented)","idPrefix":"c_"},
+          {"open":"§IF{id} (cond)","close":"(none — indent-only)","description":"If block (bodies indented; §EI/§EL for elseif/else)"},
+          {"open":"§EI (cond)","close":"(none)","description":"Else-if branch"},
           {"open":"§EL","close":"(none)","description":"Else branch"},
-          {"open":"§L{id:var:from:to:step}","close":"§/L{id}","description":"For loop"},
-          {"open":"§C{target}","close":"§/C","description":"Method call"},
+          {"open":"§L{id:var:from:to:step}","close":"(none — indent-only)","description":"For loop (body indented)"},
+          {"open":"§C{target}","close":"§/C","description":"Method call (§/C optional, closes inline)"},
           {"open":"§A","close":"(inline)","description":"Argument to call"},
           {"open":"§R","close":"(inline)","description":"Return expression"},
-          {"open":"§B{name:type}","close":"(inline)","description":"Immutable binding"},
-          {"open":"§B{~name:type}","close":"(inline)","description":"Mutable binding (~ prefix)"},
-          {"open":"§I{type:name}","close":"(inline)","description":"Function input parameter"},
-          {"open":"§O{type}","close":"(inline)","description":"Function output type"},
+          {"open":"§B{name}","close":"(inline)","description":"Immutable binding (§B{name} expr)"},
+          {"open":"§B{~name}","close":"(inline)","description":"Mutable binding (~ prefix)"},
+          {"open":"§I{type:name}","close":"(inline)","description":"Function input parameter (explicit form)"},
+          {"open":"§O{type}","close":"(inline)","description":"Function output type (explicit form)"},
           {"open":"§E{effects}","close":"(inline)","description":"Effect declaration (comma-separated codes)"},
           {"open":"§Q (expr)","close":"(inline)","description":"Precondition contract"},
           {"open":"§S (expr)","close":"(inline)","description":"Postcondition contract"},
-          {"open":"§MT{id:Name:vis}","close":"§/MT{id}","description":"Method (inside class)","idPrefix":"mt_"},
-          {"open":"§AMT{id:Name:vis}","close":"§/AMT{id}","description":"Async method","idPrefix":"mt_"},
-          {"open":"§CT{id:vis}","close":"§/CT{id}","description":"Constructor","idPrefix":"ctor_"},
-          {"open":"§P{id:Name:type:vis}","close":"§/P{id}","description":"Property","idPrefix":"p_"},
-          {"open":"§IN{id:Name}","close":"§/IN{id}","description":"Interface","idPrefix":"i_"},
-          {"open":"§EN{id:Name:vis}","close":"§/EN{id}","description":"Enum","idPrefix":"e_"},
-          {"open":"§OP{id:operator:vis}","close":"§/OP{id}","description":"Operator overload","idPrefix":"op_"}
-        ],"closingTagRules":"Closing tags use ABBREVIATED forms: §/F (not §/IF), §/M, §/CL, §/I (for if blocks), §/L, §/MT, §/CT, §/P, §/IN, §/EN, §/OP. The most common error is using §/IF instead of §/I for if-blocks."}
+          {"open":"§MT{id:name:vis} (type:name, ...) -> retType","close":"(none — indent-only)","description":"Method (inside class, body indented)","idPrefix":"mt_"},
+          {"open":"§AMT{id:name:vis} (type:name, ...) -> retType","close":"(none — indent-only)","description":"Async method (body indented)","idPrefix":"mt_"},
+          {"open":"§CTOR{id:vis}","close":"(none — indent-only)","description":"Constructor (body indented)","idPrefix":"ctor_"},
+          {"open":"§PROP{id:Name:type:vis}","close":"(none — indent-only)","description":"Property (body indented)","idPrefix":"p_"},
+          {"open":"§IFACE{id:Name}","close":"(none — indent-only)","description":"Interface (body indented)","idPrefix":"i_"},
+          {"open":"§EN{id:Name:vis}","close":"(none — indent-only)","description":"Enum (body indented)","idPrefix":"e_"},
+          {"open":"§OP{id:operator:vis}","close":"(none — indent-only)","description":"Operator overload (body indented)","idPrefix":"op_"}
+        ],"closingTagRules":"Calor is INDENT-ONLY: a block's body is indented (2 spaces per level) under its opener and ends at the next dedent. There are NO structural closing tags — never write §/M, §/F, §/CL, §/I, §/L, §/MT, §/CTOR, §/PROP, §/IFACE, §/EN, §/OP. The only closers that remain are inline/optional: §/C closes a call, and §RAW…§/RAW, §CSHARP{…}§/CSHARP, §PP…§/PP keep their delimiters."}
         """;
 
     internal static string GetIdPrefixCatalogJsonPublic() => GetIdPrefixCatalogJson();
@@ -834,12 +834,13 @@ public sealed class McpMessageHandler
         3. After writing any .calr code, compile with calor_compile (autoFix is on by default).
         4. Never edit .g.cs files — they are auto-generated from .calr sources.
 
-        SYNTAX ESSENTIALS:
-        - Module: §M{id:Name} ... §/M{id}
-        - Function: §F{id:Name:vis} ... §/F{id}
-        - Binding: §B{name:type} expr (immutable), §B{~name:type} expr (mutable)
-        - Loop: §L{id:var:from:to:step} ... §/L{id}
-        - Conditional: §IF{id} (cond) ... §/I{id} (NOTE: close with §/I, not §/IF)
+        SYNTAX ESSENTIALS (Calor is INDENT-ONLY: bodies are indented, no closing tags):
+        - Module: §M{id:Name} (body indented)
+        - Function: §F{id:name:vis} (type:name, ...) -> retType (body indented)
+        - Binding: §B{name} expr (immutable), §B{~name} expr (mutable)
+        - Loop: §L{id:var:from:to:step} (body indented)
+        - Conditional: §IF{id} (cond) with §EI (cond) / §EL; inline §IF{id} (cond) → §R expr
+        - NO structural closing tags — never write §/M, §/F, §/L, §/I; a block ends at the next dedent
         - Typed literals: INT:42, STR:"hello", BOOL:true, FLOAT:3.14
         - Expressions use prefix notation: (+ a b), (== x 0), (% i 15)
         - Types: i32, i64, str, bool, f64, void, ?i32 (option), i32!str (result)

--- a/src/Calor.Compiler/Mcp/Tools/HelpTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/HelpTool.cs
@@ -425,31 +425,37 @@ public sealed class HelpTool : McpToolBase
 
                 Calor is a DSL that compiles to C# on .NET 10. All constructs use section markers (§).
 
+                Calor is **indent-only**: a block's body is indented (2 spaces per level) under its
+                opener and ends at the next dedent. There are **NO structural closing tags** — never
+                write §/M, §/F, §/L, §/I, §/CL, §/MT, §/TR, etc. (The inline call closer §/C is still
+                valid and optional; §RAW…§/RAW, §CSHARP{…}§/CSHARP and §PP…§/PP keep their delimiters.)
+
                 ### Core Tags
                 ```
-                §M{id:Name}              Module (close: §/M{id})
-                §F{id:name:vis}           Function (close: §/F{id})
-                §B{name:type}             Immutable binding
-                §B{~name:type}            Mutable binding
-                §I{type:name}             Parameter
+                §M{id:Name}              Module (body indented)
+                §F{id:name:vis} (type:name, ...) -> retType   Function (body indented)
+                §B{name}                 Immutable binding (§B{name} expr)
+                §B{~name}                Mutable binding (§B{~name} expr)
+                §I{type:name}             Parameter (explicit form; alt. to the (…) signature)
                 §I{type:name:this}        Extension method parameter (C# 'this' modifier)
                 §I{type:name:ref}         Ref parameter
                 §I{type:name:out}         Out parameter
                 §I{type:name:in}          In (readonly ref) parameter
                 §I{type:name:params}      Params array parameter
                 §I{type:name}=expr        Parameter with default value
-                §O{type}                  Return type
+                §O{type}                  Return type (explicit form; alt. to -> retType)
                 §R expr                   Return statement
                 §C{obj.Method} §A arg §/C Method call with argument
                 ```
 
                 ### Control Flow
                 ```
-                §IF{id} (cond) ... §EI (cond2) ... §EL ... §/I{id}   If/ElseIf/Else
-                §L{id:var:from:to:step} ... §/L{id}                  For loop
-                §L{id:item:collection} ... §/L{id}                   Foreach loop
-                §WH{id} (cond) ... §/WH{id}                          While loop
-                §W{expr} §K{pattern} result §/W                      Match/Switch
+                §IF{id} (cond)  /  §EI (cond2)  /  §EL      If/ElseIf/Else (bodies indented)
+                §IF{id} (cond) → §R expr                    Inline if (single statement)
+                §L{id:var:from:to:step}                     For loop (body indented)
+                §EACH{var:collection}                       Foreach loop (body indented)
+                §WH{id} (cond)                              While loop (body indented)
+                §W{expr}  then  §K{pattern} → result        Match/Switch (arms indented)
                 §GOTO{label}                                          Goto label
                 §GOTO{CASE:expr}                                      Goto case expr
                 §GOTO{DEFAULT}                                        Goto default
@@ -457,22 +463,22 @@ public sealed class HelpTool : McpToolBase
 
                 ### Types and Classes
                 ```
-                §CL{id:Name:vis}          Class (close: §/CL{id})
+                §CL{id:Name:vis}          Class (body indented)
                 §CL{id:Name:vis:stat}     Static class
-                §IFACE{id:Name}           Interface (close: §/IFACE{id})
-                §ST{id:Name:vis}          Struct (close: §/ST{id})
-                §MT{id:name:vis}          Method (close: §/MT{id})
-                §CTOR{id:vis}             Constructor (close: §/CTOR{id})
+                §CL{id:Name:vis:struct}   Struct
+                §IFACE{id:Name}           Interface (body indented)
+                §MT{id:name:vis} (type:name, ...) -> retType   Method (body indented)
+                §CTOR{id:vis}             Constructor (body indented)
                 §BASE arg1 arg2           Constructor chaining to base class
                 §THIS arg1 arg2           Constructor chaining to another constructor
-                §PROP{id:Name:type:vis}   Property (close: §/PROP{id})
-                §IXER{id:type:vis}        Indexer (close: §/IXER{id})
+                §PROP{id:Name:type:vis}   Property (body indented)
+                §IXER{id:type:vis}        Indexer (body indented)
                 §FLD{type:name:vis}       Field
                 §FLD{type:name:vis:volatile} Volatile field
                 §EXT{BaseClass}           Extends
                 §IMPL{Interface}          Implements
-                §EN{id:Name}              Enum (close: §/EN{id})
-                §SYNC{id} expr ... §/SYNC{id}  Lock/synchronization block
+                §EN{id:Name}              Enum (body indented)
+                §SYNC{id}                 Lock/synchronization block (body indented)
                 ```
 
                 ### Properties and Indexers (compact forms)
@@ -492,12 +498,12 @@ public sealed class HelpTool : McpToolBase
 
                 ### Async, Exceptions, and Resources
                 ```
-                §AF{id:name:vis}          Async function
-                §AMT{id:name:vis}         Async method
-                §AWAIT expr §/AWAIT       Await expression
-                §TR{id} ... §CA{Type:var} ... §FI{} ... §/TR{id}   Try/Catch/Finally
+                §AF{id:name:vis} (type:name, ...) -> retType   Async function (body indented)
+                §AMT{id:name:vis} (type:name, ...) -> retType  Async method (body indented)
+                §AWAIT expr               Await expression
+                §TR{id}  /  §CA{Type:var}  /  §FI    Try/Catch/Finally (bodies indented; §CA{Type:var} WHEN (cond) for filters)
                 §TH expr                  Throw
-                §USE{var}=expr ... §/USE  Using statement
+                §USE{var} expr            Using statement (body indented)
                 §YIELD expr               Yield return
                 §YBRK                     Yield break
                 ```
@@ -537,7 +543,7 @@ public sealed class HelpTool : McpToolBase
                 §PP{CONDITION} ... §PPE ... §/PP{CONDITION}   #if/#else/#endif
                 §CSHARP{code}§/CSHARP                         Raw C# passthrough (member-level)
                 §RAW ... §/RAW                                Raw C# block
-                §UNSAFE{id} ... §/UNSAFE{id}                  Unsafe block
+                §UNSAFE{id}                                   Unsafe block (body indented)
                 ```
 
                 ### Typed Literals

--- a/src/Calor.Compiler/Mcp/Tools/InteropHintAnalyzer.cs
+++ b/src/Calor.Compiler/Mcp/Tools/InteropHintAnalyzer.cs
@@ -38,8 +38,8 @@ internal static class InteropHintAnalyzer
             "yield return/break is supported via §YIELD and §YBRK — consider converting iterator methods"),
 
         (new Regex(@"\busing\s*\(", RegexOptions.Compiled),
-            "using-statement", "§USE{var}=expr",
-            "using statements are supported via §USE{var}=expr ... §/USE — consider converting resource management blocks"),
+            "using-statement", "§USE{var} expr",
+            "using statements are supported via §USE{var} expr with an indented body — consider converting resource management blocks"),
 
         (new Regex(@"\bdelegate\s+", RegexOptions.Compiled),
             "delegate", "§DEL{id:name:vis}",

--- a/src/Calor.Compiler/README.nuget.md
+++ b/src/Calor.Compiler/README.nuget.md
@@ -15,7 +15,7 @@ Calor makes these things explicit:
 | Side effects | `§E{cw,fr,net}` | Know effects without reading implementation |
 | Contracts | `§Q` (requires), `§S` (ensures) | Generate tests, verify correctness |
 | Unique IDs | `§F{f001:Main}` | Precise references that survive refactoring |
-| Clear structure | `§F{...}...§/F{...}` | Unambiguous scope boundaries |
+| Clear structure | Indentation-based nesting (no closing tags) | Unambiguous scope boundaries |
 
 ## Quick Start
 
@@ -34,12 +34,9 @@ calor --input program.calr --output program.g.cs
 
 ```
 §M{m001:Hello}
-§F{f001:Main:pub}
-  §O{void}
-  §E{cw}
-  §P "Hello from Calor!"
-§/F{f001}
-§/M{m001}
+  §F{f001:Main:pub} () -> void
+    §E{cw}
+    §P "Hello from Calor!"
 ```
 
 ## Documentation

--- a/src/Calor.Compiler/Resources/Templates/AGENTS.md.template
+++ b/src/Calor.Compiler/Resources/Templates/AGENTS.md.template
@@ -86,17 +86,18 @@ calor convert file.calr              # Convert Calor to C#
 
 #### Calor v2+ Syntax Reference
 
+Calor is **indent-only**: a block's body is indented under its opener and ends at
+the next dedent. There are **no closing tags** — never write `§/`-prefixed closers.
+
 | Structure | Syntax |
 |-----------|--------|
-| Module | `§M{id:Name}` ... `§/M{id}` |
-| Function | `§F{id:Name:vis}` ... `§/F{id}` |
-| Async Func | `§AF{id:Name:vis}` ... `§/AF{id}` |
-| Input | `§I{type:name}` |
-| Output | `§O{type}` |
+| Module | `§M{id:Name}` (body indented) |
+| Function | `§F{id:name:vis} (type:name, ...) -> retType` |
+| Async Func | `§AF{id:name:vis} (type:name, ...) -> retType` |
 | Effects | `§E{cw,db,net}` |
-| Loop | `§L{id:var:from:to:step}` ... `§/L{id}` |
-| Conditional | `§IF{id} condition → action` |
-| Try/Catch | `§TR{id}` ... `§CA{Type:var}` ... `§FI` ... `§/TR{id}` |
+| Loop | `§L{id:var:from:to:step}` (body indented) |
+| Conditional | `§IF{id} (cond)` + `§EI (cond)` / `§EL`; inline `→ §R expr` |
+| Try/Catch | `§TR{id}` ... `§CA{Type:var}` ... `§FI` (indent-only) |
 | Preprocessor | `§PP{CONDITION}` ... `§PPE` ... `§/PP{CONDITION}` |
 
 **Expressions (Lisp-style):** `(+ a b)`, `(== x 0)`, `(% i 15)`
@@ -109,10 +110,10 @@ calor convert file.calr              # Convert Calor to C#
 
 **Contracts:** `§Q (> x 0)` (precondition), `§S (>= result 0)` (postcondition)
 
-**Collections:**
-- List: `§LIST{name:type}` ... `§/LIST{name}`, `§PUSH{name} value`
-- Dict: `§DICT{name:key:val}` ... `§KV key val` ... `§/DICT{name}`
-- HashSet: `§HSET{name:type}` ... `§/HSET{name}`
+**Collections (indent-only; items indented under the opener):**
+- List: `§LIST{name:type}` then indented values; append with `§PUSH{name} value`
+- Dict: `§DICT{name:key:val}` then indented `§KV key value`; set with `§PUT{name} key value`
+- HashSet: `§HSET{name:type}` then indented values
 
 #### Type Mappings
 | C# | Calor |

--- a/src/Calor.Compiler/Resources/Templates/CLAUDE.md.template
+++ b/src/Calor.Compiler/Resources/Templates/CLAUDE.md.template
@@ -117,17 +117,18 @@ calor convert file.calr              # Convert Calor to C#
 
 #### Calor v2+ Syntax Reference
 
+Calor is **indent-only**: a block's body is indented under its opener and ends at
+the next dedent. There are **no closing tags** — never write `§/`-prefixed closers.
+
 | Structure | Syntax |
 |-----------|--------|
-| Module | `§M{id:Name}` ... `§/M{id}` |
-| Function | `§F{id:Name:vis}` ... `§/F{id}` |
-| Async Func | `§AF{id:Name:vis}` ... `§/AF{id}` |
-| Input | `§I{type:name}` |
-| Output | `§O{type}` |
+| Module | `§M{id:Name}` (body indented) |
+| Function | `§F{id:name:vis} (type:name, ...) -> retType` |
+| Async Func | `§AF{id:name:vis} (type:name, ...) -> retType` |
 | Effects | `§E{cw,db,net}` |
-| Loop | `§L{id:var:from:to:step}` ... `§/L{id}` |
-| Conditional | `§IF{id} condition → action` |
-| Try/Catch | `§TR{id}` ... `§CA{Type:var}` ... `§FI` ... `§/TR{id}` |
+| Loop | `§L{id:var:from:to:step}` (body indented) |
+| Conditional | `§IF{id} (cond)` + `§EI (cond)` / `§EL`; inline `→ §R expr` |
+| Try/Catch | `§TR{id}` ... `§CA{Type:var}` ... `§FI` (indent-only) |
 
 **Expressions (Lisp-style):** `(+ a b)`, `(== x 0)`, `(% i 15)`
 
@@ -139,10 +140,10 @@ calor convert file.calr              # Convert Calor to C#
 
 **Contracts:** `§Q (> x 0)` (precondition), `§S (>= result 0)` (postcondition)
 
-**Collections:**
-- List: `§LIST{name:type}` ... `§/LIST{name}`, `§PUSH{name} value`
-- Dict: `§DICT{name:key:val}` ... `§KV key val` ... `§/DICT{name}`
-- HashSet: `§HSET{name:type}` ... `§/HSET{name}`
+**Collections (indent-only; items indented under the opener):**
+- List: `§LIST{name:type}` then indented values; append with `§PUSH{name} value`
+- Dict: `§DICT{name:key:val}` then indented `§KV key value`; set with `§PUT{name} key value`
+- HashSet: `§HSET{name:type}` then indented values
 
 #### Type Mappings
 | C# | Calor |

--- a/src/Calor.Compiler/Resources/Templates/GEMINI.md.template
+++ b/src/Calor.Compiler/Resources/Templates/GEMINI.md.template
@@ -81,17 +81,18 @@ calor convert file.calr              # Convert Calor to C#
 
 #### Calor v2+ Syntax Reference
 
+Calor is **indent-only**: a block's body is indented under its opener and ends at
+the next dedent. There are **no closing tags** — never write `§/`-prefixed closers.
+
 | Structure | Syntax |
 |-----------|--------|
-| Module | `§M{id:Name}` ... `§/M{id}` |
-| Function | `§F{id:Name:vis}` ... `§/F{id}` |
-| Async Func | `§AF{id:Name:vis}` ... `§/AF{id}` |
-| Input | `§I{type:name}` |
-| Output | `§O{type}` |
+| Module | `§M{id:Name}` (body indented) |
+| Function | `§F{id:name:vis} (type:name, ...) -> retType` |
+| Async Func | `§AF{id:name:vis} (type:name, ...) -> retType` |
 | Effects | `§E{cw,db,net}` |
-| Loop | `§L{id:var:from:to:step}` ... `§/L{id}` |
-| Conditional | `§IF{id} condition → action` |
-| Try/Catch | `§TR{id}` ... `§CA{Type:var}` ... `§FI` ... `§/TR{id}` |
+| Loop | `§L{id:var:from:to:step}` (body indented) |
+| Conditional | `§IF{id} (cond)` + `§EI (cond)` / `§EL`; inline `→ §R expr` |
+| Try/Catch | `§TR{id}` ... `§CA{Type:var}` ... `§FI` (indent-only) |
 
 **Expressions (Lisp-style):** `(+ a b)`, `(== x 0)`, `(% i 15)`
 
@@ -103,10 +104,10 @@ calor convert file.calr              # Convert Calor to C#
 
 **Contracts:** `§Q (> x 0)` (precondition), `§S (>= result 0)` (postcondition)
 
-**Collections:**
-- List: `§LIST{name:type}` ... `§/LIST{name}`, `§PUSH{name} value`
-- Dict: `§DICT{name:key:val}` ... `§KV key val` ... `§/DICT{name}`
-- HashSet: `§HSET{name:type}` ... `§/HSET{name}`
+**Collections (indent-only; items indented under the opener):**
+- List: `§LIST{name:type}` then indented values; append with `§PUSH{name} value`
+- Dict: `§DICT{name:key:val}` then indented `§KV key value`; set with `§PUT{name} key value`
+- HashSet: `§HSET{name:type}` then indented values
 
 #### Type Mappings
 | C# | Calor |

--- a/src/Calor.Compiler/Resources/Templates/copilot-instructions.md.template
+++ b/src/Calor.Compiler/Resources/Templates/copilot-instructions.md.template
@@ -39,13 +39,16 @@ Use `calor_help` with action=features to check specific features, or `calor_batc
 
 ### Quick Syntax Reference
 
+Calor is **indent-only**: a block's body is indented under its opener and ends at
+the next dedent. There are **no closing tags** — never write `§/`-prefixed closers.
+
 | Structure | Calor Syntax |
 |-----------|-------------|
-| Module | `§M{id:Name}` ... `§/M{id}` |
-| Function | `§F{id:name:returnType:vis}` ... `§/F{id}` |
-| Binding | `§B{name:type} expr` (immutable), `§B{~name:type}` (mutable) |
-| Loop | `§L{id:var:from:to:step}` ... `§/L{id}` |
-| Conditional | `§IF{id} (cond) → §R expr` |
+| Module | `§M{id:Name}` (body indented) |
+| Function | `§F{id:name:vis} (type:name, ...) -> retType` (body indented) |
+| Binding | `§B{name} expr` (immutable), `§B{~name} expr` (mutable) |
+| Loop | `§L{id:var:from:to:step}` (body indented) |
+| Conditional | `§IF{id} (cond)` + `§EI (cond)` / `§EL`; inline `§IF{id} (cond) → §R expr` |
 | Contracts | `§Q (precondition)`, `§S (postcondition)` |
 | Types | `i32`, `i64`, `str`, `bool`, `f64`, `void`, `?i32` (option), `i32!str` (result) |
 | Expressions | Prefix notation: `(+ a b)`, `(== x 0)`, `(% i 15)` |

--- a/src/Calor.Compiler/Resources/calor-syntax-documentation.json
+++ b/src/Calor.Compiler/Resources/calor-syntax-documentation.json
@@ -5,20 +5,20 @@
       "id": "object_instantiation",
       "csharpConstruct": "object instantiation",
       "keywords": ["new", "object", "instantiation", "create", "constructor", "instance", "instantiate"],
-      "calorSyntax": "§NEW{ClassName}(arg1, arg2)",
-      "description": "Creates a new instance of a class. The class name goes in braces, constructor arguments in parentheses.",
+      "calorSyntax": "§NEW{ClassName} §A arg1 §A arg2 §/NEW",
+      "description": "Creates a new instance of a class. The class name goes in braces; constructor arguments use §A. Use §NEW{ClassName} §/NEW for zero-argument constructors.",
       "examples": [
         {
           "csharp": "var user = new User(\"John\", 25);",
-          "calor": "§B{user}=§NEW{User}(\"John\", 25)§/B"
+          "calor": "§B{user} §NEW{User} §A \"John\" §A 25 §/NEW"
         },
         {
           "csharp": "var list = new List<int>();",
-          "calor": "§B{list}=§NEW{List<i32>}()§/B"
+          "calor": "§B{list} §NEW{List<i32>} §/NEW"
         },
         {
           "csharp": "return new Result(value);",
-          "calor": "§R §NEW{Result}(value) §/R"
+          "calor": "§R §NEW{Result} §A value §/NEW"
         }
       ]
     },
@@ -26,20 +26,20 @@
       "id": "variable_declaration",
       "csharpConstruct": "variable declaration",
       "keywords": ["var", "variable", "declare", "declaration", "let", "binding", "assign"],
-      "calorSyntax": "§B{name}=value§/B or §B{~name}=value§/B (mutable)",
+      "calorSyntax": "§B{name} value or §B{~name} value (mutable)",
       "description": "Declares a variable binding. Use ~ prefix for mutable variables. Immutable by default.",
       "examples": [
         {
           "csharp": "var count = 0;",
-          "calor": "§B{count}=0§/B"
+          "calor": "§B{count} 0"
         },
         {
           "csharp": "int mutableCount = 0; // needs to be modified later",
-          "calor": "§B{~mutableCount}=0§/B"
+          "calor": "§B{~mutableCount} 0"
         },
         {
           "csharp": "string name = \"John\";",
-          "calor": "§B{name}=\"John\"§/B"
+          "calor": "§B{name} \"John\""
         }
       ]
     },
@@ -47,20 +47,20 @@
       "id": "method_definition",
       "csharpConstruct": "method definition",
       "keywords": ["method", "function", "def", "define", "void", "return type", "class method", "member method"],
-      "calorSyntax": "§MT{id:name:visibility:modifiers} §I{type:param}... §O{returnType} body §/MT",
-      "description": "Defines a method within a class. Supports visibility (pub/priv/prot), virtual (vr), override (ov), abstract (ab), and static (st) modifiers.",
+      "calorSyntax": "§MT{id:name:vis[:modifiers]} (type:param, ...) -> returnType",
+      "description": "Defines a method within a class. Supports visibility (pub/priv/prot) and modifiers such as virt/vr, over/ov, abs, stat/st, and seal.",
       "examples": [
         {
           "csharp": "public void Process(int value) { ... }",
-          "calor": "§MT{1:Process:pub}\n  §I{i32:value}\n  §O{void}\n  ...\n§/MT"
+          "calor": "§MT{m001:Process:pub} (i32:value) -> void\n  ..."
         },
         {
           "csharp": "public virtual string GetName() { return _name; }",
-          "calor": "§MT{1:GetName:pub:vr}\n  §O{str}\n  §R _name §/R\n§/MT"
+          "calor": "§MT{m002:GetName:pub:virt} () -> str\n  §R _name"
         },
         {
           "csharp": "public override int Calculate(int x) { ... }",
-          "calor": "§MT{1:Calculate:pub:ov}\n  §I{i32:x}\n  §O{i32}\n  ...\n§/MT"
+          "calor": "§MT{m003:Calculate:pub:over} (i32:x) -> i32\n  ..."
         }
       ]
     },
@@ -68,16 +68,16 @@
       "id": "function_definition",
       "csharpConstruct": "function definition",
       "keywords": ["function", "func", "method", "standalone", "static method", "top-level"],
-      "calorSyntax": "§F{id:name:visibility} §I{type:param}... §O{returnType} body §/F",
+      "calorSyntax": "§F{id:name:vis} (type:param, ...) -> returnType",
       "description": "Defines a standalone function (not a class member). Use for top-level functions or static utility methods.",
       "examples": [
         {
           "csharp": "public static int Add(int a, int b) { return a + b; }",
-          "calor": "§F{1:Add:pub}\n  §I{i32:a}\n  §I{i32:b}\n  §O{i32}\n  §R a + b §/R\n§/F"
+          "calor": "§F{f001:Add:pub} (i32:a, i32:b) -> i32\n  §R (+ a b)"
         },
         {
           "csharp": "private void Log(string message) { Console.WriteLine(message); }",
-          "calor": "§F{1:Log:priv}\n  §I{str:message}\n  §O{void}\n  §E{cw}\n  §!{Console.WriteLine}(message)§/!\n§/F"
+          "calor": "§F{f002:Log:priv} (str:message) -> void\n  §E{cw}\n  §C{Console.WriteLine} message"
         }
       ]
     },
@@ -85,20 +85,20 @@
       "id": "lambda_expression",
       "csharpConstruct": "lambda expression",
       "keywords": ["lambda", "arrow", "=>", "anonymous", "closure", "delegate", "action", "func"],
-      "calorSyntax": "§LAM{id:param1:type1:param2:type2} body §/LAM{id}",
-      "description": "Creates an anonymous function/lambda expression. The id is required. Parameters are positional pairs (name:type) after the id. Can capture variables from enclosing scope.",
+      "calorSyntax": "§LAM{id:param:type...} expression §/LAM{id}",
+      "description": "Creates an anonymous function/lambda expression. The id is required. Lambda parameters are name:type pairs after the id. Can capture variables from enclosing scope.",
       "examples": [
         {
           "csharp": "x => x * 2",
-          "calor": "§LAM{lam1:x:i32}\n  x * 2\n§/LAM{lam1}"
+          "calor": "§LAM{lam1:x:i32} (* x 2) §/LAM{lam1}"
         },
         {
           "csharp": "(a, b) => a + b",
-          "calor": "§LAM{lam1:a:i32:b:i32}\n  a + b\n§/LAM{lam1}"
+          "calor": "§LAM{lam1:a:i32:b:i32} (+ a b) §/LAM{lam1}"
         },
         {
           "csharp": "items.Where(x => x > 5)",
-          "calor": "§C{items.Where} §A §LAM{lam1:x:i32} x > 5 §/LAM{lam1} §/C"
+          "calor": "§C{items.Where} §A §LAM{lam1:x:i32} (> x 5) §/LAM{lam1} §/C"
         }
       ]
     },
@@ -106,20 +106,20 @@
       "id": "property_definition",
       "csharpConstruct": "property definition",
       "keywords": ["property", "get", "set", "getter", "setter", "accessor", "prop"],
-      "calorSyntax": "§PROP{id:name:type:visibility:modifiers} §GET body §/GET §SET body §/SET §/PROP",
-      "description": "Defines a property with optional getter and setter. Auto-properties use shorthand syntax. The optional 5th positional arg is modifiers (e.g., 'stat' for static).",
+      "calorSyntax": "§PROP{id:name:type:vis[:modifiers...:accessors]} [= default]",
+      "description": "Defines a property with optional getter and setter. Auto-properties use accessor shorthand such as get,set, get,priset, or get,init. Full properties use indented §GET and §SET bodies.",
       "examples": [
         {
           "csharp": "public string Name { get; set; }",
-          "calor": "§PROP{1:Name:str:pub}§/PROP"
+          "calor": "§PROP{p001:Name:str:pub:get,set}"
         },
         {
           "csharp": "public int Count { get; private set; }",
-          "calor": "§PROP{1:Count:i32:pub}\n  §GET §/GET\n  §SET:priv §/SET\n§/PROP"
+          "calor": "§PROP{p002:Count:i32:pub:get,priset}"
         },
         {
           "csharp": "public int Value { get { return _value; } set { _value = value; } }",
-          "calor": "§PROP{1:Value:i32:pub}\n  §GET §R _value §/R §/GET\n  §SET _value = value §/SET\n§/PROP"
+          "calor": "§PROP{p003:Value:i32:pub}\n  §GET\n    §R _value\n  §SET\n    §ASSIGN _value value"
         }
       ]
     },
@@ -127,8 +127,8 @@
       "id": "indexer_definition",
       "csharpConstruct": "indexer definition",
       "keywords": ["indexer", "this[]", "this[int", "this[string", "bracket", "index", "§IXER"],
-      "calorSyntax": "§IXER{id:returnType:visibility[:modifiers[:accessors]]} (type:param) or full form with §GET/§SET",
-      "description": "Defines an indexer (this[]) on a class or interface. Compact auto-property form puts accessors and parameters inline. Full form uses §I for parameters and §GET/§SET/§INIT accessor blocks, closed with §/IXER{id}.",
+      "calorSyntax": "§IXER{id:returnType:vis[:modifiers[:accessors]]} (type:param, ...)",
+      "description": "Defines an indexer (this[]) on a class or interface. Compact auto-property form puts accessors and parameters inline. Full form uses indented §GET/§SET/§INIT accessor blocks.",
       "examples": [
         {
           "csharp": "public int this[int index] { get; set; }",
@@ -144,7 +144,7 @@
         },
         {
           "csharp": "public int this[int i] { get { return _data[i]; } set { _data[i] = value; } }",
-          "calor": "§IXER{ix1:i32:pub}\n  §I{i32:i}\n  §GET\n    §R §IDX _data i\n  §/GET\n  §SET\n    §SETIDX _data i value\n  §/SET\n§/IXER{ix1}"
+          "calor": "§IXER{ix1:i32:pub} (i32:i)\n  §GET\n    §R §IDX _data i\n  §SET\n    §SETIDX _data i value"
         }
       ]
     },
@@ -152,8 +152,8 @@
       "id": "property_access_vs_method_call",
       "csharpConstruct": "property access vs method call",
       "keywords": ["property access", "member access", "method call", "call", "parentheses", "getter"],
-      "calorSyntax": "Property: use bare member expression (e.g., obj.Property). Method: use §C{obj.Method} §/C.",
-      "description": "§C{...}§/C always emits parentheses, making it a method call. For property or field access (no parentheses), use a bare dotted expression in a binding (§B{var} obj.Property) or directly as an expression. Do NOT use §C for property access — it will emit obj.Property() with unwanted parens.",
+      "calorSyntax": "Property: use bare member expression (e.g., obj.Property). Method: use §C{obj.Method} args.",
+      "description": "§C{...} emits parentheses, making it a method call. For property or field access (no parentheses), use a bare dotted expression in a binding (§B{var} obj.Property) or directly as an expression. Do NOT use §C for property access — it will emit obj.Property() with unwanted parens.",
       "examples": [
         {
           "csharp": "var items = Data.Products;",
@@ -161,7 +161,7 @@
         },
         {
           "csharp": "var items = Data.GetProducts();",
-          "calor": "§B{~items} §C{Data.GetProducts} §/C"
+          "calor": "§B{~items} §C{Data.GetProducts}"
         }
       ]
     },
@@ -169,20 +169,20 @@
       "id": "for_loop",
       "csharpConstruct": "for loop",
       "keywords": ["for", "loop", "iterate", "iteration", "counter", "index", "range"],
-      "calorSyntax": "§L{var:start..end} body §/L or §L{var:start..end..step} body §/L",
-      "description": "For loop with range. Use .. for exclusive end, ..= for inclusive. Optional step value.",
+      "calorSyntax": "§L{id:var:from:to:step}",
+      "description": "For loop with an inclusive integer range. The body is indented under the loop header.",
       "examples": [
         {
           "csharp": "for (int i = 0; i < 10; i++) { ... }",
-          "calor": "§L{i:0..10}\n  ...\n§/L"
+          "calor": "§L{l1:i:0:9:1}\n  ..."
         },
         {
           "csharp": "for (int i = 0; i <= 10; i++) { ... }",
-          "calor": "§L{i:0..=10}\n  ...\n§/L"
+          "calor": "§L{l2:i:0:10:1}\n  ..."
         },
         {
           "csharp": "for (int i = 0; i < 100; i += 2) { ... }",
-          "calor": "§L{i:0..100..2}\n  ...\n§/L"
+          "calor": "§L{l3:i:0:98:2}\n  ..."
         }
       ]
     },
@@ -190,16 +190,16 @@
       "id": "foreach_loop",
       "csharpConstruct": "foreach loop",
       "keywords": ["foreach", "for each", "iterate", "collection", "enumerable", "items", "elements"],
-      "calorSyntax": "§L{item:collection} body §/L",
+      "calorSyntax": "§EACH{var:collection}",
       "description": "Iterates over each element in a collection.",
       "examples": [
         {
           "csharp": "foreach (var item in items) { ... }",
-          "calor": "§L{item:items}\n  ...\n§/L"
+          "calor": "§EACH{item:items}\n  ..."
         },
         {
           "csharp": "foreach (var (key, value) in dictionary) { ... }",
-          "calor": "§L{(key, value):dictionary}\n  ...\n§/L"
+          "calor": "§EACHKV{key:value:dictionary}\n  ..."
         }
       ]
     },
@@ -207,16 +207,16 @@
       "id": "while_loop",
       "csharpConstruct": "while loop",
       "keywords": ["while", "loop", "condition", "repeat", "until"],
-      "calorSyntax": "§WH{condition} body §/WH",
+      "calorSyntax": "§WH{id} (condition)",
       "description": "Executes body while condition is true.",
       "examples": [
         {
           "csharp": "while (count > 0) { count--; }",
-          "calor": "§WH{count > 0}\n  count--\n§/WH"
+          "calor": "§WH{w1} (> count 0)\n  §ASSIGN count (- count 1)"
         },
         {
           "csharp": "while (true) { if (done) break; }",
-          "calor": "§WH{true}\n  §IF{done} §BK §/IF\n§/WH"
+          "calor": "§WH{w2} true\n  §IF{i1} done\n    §BK"
         }
       ]
     },
@@ -224,20 +224,20 @@
       "id": "if_statement",
       "csharpConstruct": "if statement",
       "keywords": ["if", "else", "conditional", "branch", "condition", "then", "elseif", "else if"],
-      "calorSyntax": "§IF{condition} body §EI{condition} body §EL body §/IF",
+      "calorSyntax": "§IF{id} (condition) body §EI (condition) body §EL body",
       "description": "Conditional branching. §EI for else-if, §EL for else. Both are optional.",
       "examples": [
         {
           "csharp": "if (x > 0) { return true; }",
-          "calor": "§IF{x > 0}\n  §R true §/R\n§/IF"
+          "calor": "§IF{i1} (> x 0)\n  §R true"
         },
         {
           "csharp": "if (x > 0) { a(); } else { b(); }",
-          "calor": "§IF{x > 0}\n  a()\n§EL\n  b()\n§/IF"
+          "calor": "§IF{i1} (> x 0)\n  §C{a}\n§EL\n  §C{b}"
         },
         {
           "csharp": "if (x > 0) { } else if (x < 0) { } else { }",
-          "calor": "§IF{x > 0}\n  ...\n§EI{x < 0}\n  ...\n§EL\n  ...\n§/IF"
+          "calor": "§IF{i1} (> x 0)\n  ...\n§EI (< x 0)\n  ...\n§EL\n  ..."
         }
       ]
     },
@@ -266,20 +266,20 @@
       "id": "return_statement",
       "csharpConstruct": "return statement",
       "keywords": ["return", "result", "output", "yield", "value"],
-      "calorSyntax": "§R expression §/R or §R§/R (void)",
-      "description": "Returns a value from a function or method. Use empty §R§/R for void returns.",
+      "calorSyntax": "§R expression or §R (void)",
+      "description": "Returns a value from a function or method. Use bare §R for void returns.",
       "examples": [
         {
           "csharp": "return 42;",
-          "calor": "§R 42 §/R"
+          "calor": "§R 42"
         },
         {
           "csharp": "return user.Name;",
-          "calor": "§R user.Name §/R"
+          "calor": "§R user.Name"
         },
         {
           "csharp": "return;",
-          "calor": "§R§/R"
+          "calor": "§R"
         }
       ]
     },
@@ -287,20 +287,20 @@
       "id": "class_definition",
       "csharpConstruct": "class definition",
       "keywords": ["class", "type", "object", "inheritance", "extends", "implements", "abstract", "sealed"],
-      "calorSyntax": "§CL{id:name:visibility:modifiers} §EXT{base} §IMPL{interface} members... §/CL",
-      "description": "Defines a class. Supports abstract (abs), sealed, partial modifiers. Use §EXT for base class, §IMPL for interfaces.",
+      "calorSyntax": "§CL{id:Name:vis[:modifiers]}",
+      "description": "Defines a class. Supports modifiers such as abs, seal, partial, stat, struct, and readonly. Use §EXT for base class and §IMPL for interfaces.",
       "examples": [
         {
           "csharp": "public class User { }",
-          "calor": "§CL{1:User:pub}\n§/CL"
+          "calor": "§CL{c001:User:pub}"
         },
         {
           "csharp": "public class Admin : User, IAdmin { }",
-          "calor": "§CL{1:Admin:pub}\n  §EXT{User}\n  §IMPL{IAdmin}\n§/CL"
+          "calor": "§CL{c001:Admin:pub}\n  §EXT{User}\n  §IMPL{IAdmin}"
         },
         {
           "csharp": "public abstract class BaseEntity { }",
-          "calor": "§CL{1:BaseEntity:pub:abs}\n§/CL"
+          "calor": "§CL{c001:BaseEntity:pub:abs}"
         }
       ]
     },
@@ -308,16 +308,16 @@
       "id": "async_method",
       "csharpConstruct": "async method",
       "keywords": ["async", "await", "task", "asynchronous", "async/await", "promise", "future"],
-      "calorSyntax": "§AF{id:name} or §AMT{id:name} for async methods",
+      "calorSyntax": "§AF{id:name:vis} (type:param, ...) -> returnType or §AMT{id:name:vis} (type:param, ...) -> returnType",
       "description": "Defines an async function. Use §AF for standalone async functions, §AMT for async class methods.",
       "examples": [
         {
           "csharp": "public async Task<string> FetchDataAsync() { ... }",
-          "calor": "§AF{1:FetchDataAsync:pub}\n  §O{str}\n  ...\n§/AF"
+          "calor": "§AF{f001:FetchDataAsync:pub} () -> str\n  ..."
         },
         {
           "csharp": "public async Task ProcessAsync() { await DoWork(); }",
-          "calor": "§AMT{1:ProcessAsync:pub}\n  §O{void}\n  §AWAIT §!{DoWork}()§/! §/AWAIT\n§/AMT"
+          "calor": "§AMT{m001:ProcessAsync:pub} () -> void\n  §AWAIT §C{DoWork}"
         }
       ]
     },
@@ -325,16 +325,16 @@
       "id": "await_expression",
       "csharpConstruct": "await expression",
       "keywords": ["await", "async", "wait", "asynchronous", "task"],
-      "calorSyntax": "§AWAIT expression §/AWAIT",
+      "calorSyntax": "§AWAIT expression",
       "description": "Awaits an asynchronous operation.",
       "examples": [
         {
           "csharp": "var result = await FetchAsync();",
-          "calor": "§B{result}=§AWAIT §!{FetchAsync}()§/! §/AWAIT§/B"
+          "calor": "§B{result} §AWAIT §C{FetchAsync}"
         },
         {
           "csharp": "await Task.Delay(1000);",
-          "calor": "§AWAIT §!{Task.Delay}(1000)§/! §/AWAIT"
+          "calor": "§B{_} §AWAIT §C{Task.Delay} 1000"
         }
       ]
     },
@@ -342,20 +342,20 @@
       "id": "try_catch",
       "csharpConstruct": "try catch",
       "keywords": ["try", "catch", "finally", "exception", "error", "throw", "handle"],
-      "calorSyntax": "§TR{} body §CA{ExceptionType:varName} handler §FI{} cleanup §/TR",
+      "calorSyntax": "§TR{id} body §CA{ExceptionType:varName} handler §FI cleanup",
       "description": "Exception handling. §TR for try block, §CA for catch (with optional type and variable), §FI for finally.",
       "examples": [
         {
           "csharp": "try { x(); } catch { y(); }",
-          "calor": "§TR{}\n  x()\n§CA{}\n  y()\n§/TR"
+          "calor": "§TR{t1}\n  §C{x}\n§CA{Exception}\n  §C{y}"
         },
         {
           "csharp": "try { } catch (Exception ex) { Log(ex); }",
-          "calor": "§TR{}\n  ...\n§CA{Exception:ex}\n  §!{Log}(ex)§/!\n§/TR"
+          "calor": "§TR{t1}\n  ...\n§CA{Exception:ex}\n  §C{Log} ex"
         },
         {
           "csharp": "try { } finally { Cleanup(); }",
-          "calor": "§TR{}\n  ...\n§FI{}\n  §!{Cleanup}()§/!\n§/TR"
+          "calor": "§TR{t1}\n  ...\n§FI\n  §C{Cleanup}"
         }
       ]
     },
@@ -363,16 +363,16 @@
       "id": "throw_statement",
       "csharpConstruct": "throw statement",
       "keywords": ["throw", "exception", "error", "raise"],
-      "calorSyntax": "§TH expression §/TH or §TH§/TH (rethrow)",
-      "description": "Throws an exception. Use empty §TH§/TH to rethrow in a catch block.",
+      "calorSyntax": "§TH expression or §RT (rethrow)",
+      "description": "Throws an exception. Use §RT to rethrow in a catch block.",
       "examples": [
         {
           "csharp": "throw new ArgumentException(\"Invalid\");",
-          "calor": "§TH §NEW{ArgumentException}(\"Invalid\") §/TH"
+          "calor": "§TH §NEW{ArgumentException} §A \"Invalid\" §/NEW"
         },
         {
           "csharp": "throw;",
-          "calor": "§TH§/TH"
+          "calor": "§RT"
         }
       ]
     },
@@ -381,19 +381,19 @@
       "csharpConstruct": "side effects",
       "keywords": ["effects", "side effect", "pure", "impure", "io", "console", "file", "network", "database"],
       "calorSyntax": "§E{effect1,effect2,...}",
-      "description": "Declares side effects a function may have. Common effects: cw (console write), cr (console read), fs:r (file read), fs:w (file write), net (network), db (database), mem (memory allocation).",
+      "description": "Declares side effects a function may have. Common effects: cw (console write), db (database), net (network), fs (file system), rnd (random), time, and env.",
       "examples": [
         {
           "csharp": "// Method that writes to console",
-          "calor": "§F{1:Print:pub}\n  §E{cw}\n  ...\n§/F"
+          "calor": "§F{f001:Print:pub} () -> void\n  §E{cw}\n  ..."
         },
         {
           "csharp": "// Method that reads file and writes console",
-          "calor": "§F{1:ProcessFile:pub}\n  §E{fs:r,cw}\n  ...\n§/F"
+          "calor": "§F{f002:ProcessFile:pub} () -> void\n  §E{fs,cw}\n  ..."
         },
         {
           "csharp": "// Pure function (no effects)",
-          "calor": "§F{1:Calculate:pub}\n  §O{i32}\n  §R a + b §/R\n§/F"
+          "calor": "§F{f003:Calculate:pub} (i32:a, i32:b) -> i32\n  §R (+ a b)"
         }
       ]
     },
@@ -401,16 +401,16 @@
       "id": "precondition",
       "csharpConstruct": "precondition",
       "keywords": ["precondition", "requires", "require", "contract", "guard", "validate", "check", "assert"],
-      "calorSyntax": "§Q (condition) or §Q (condition, \"message\")",
+      "calorSyntax": "§Q (condition) or §Q{\"message\"} (condition)",
       "description": "Declares a precondition that must be true when the function is called. Part of Design by Contract.",
       "examples": [
         {
           "csharp": "// Contract.Requires(value >= 0)",
-          "calor": "§F{1:Process:pub}\n  §I{i32:value}\n  §Q (value >= 0)\n  ...\n§/F"
+          "calor": "§F{f001:Process:pub} (i32:value) -> void\n  §Q (>= value 0)\n  ..."
         },
         {
           "csharp": "// Guard.Against.Null(input)",
-          "calor": "§F{1:Process:pub}\n  §I{str:input}\n  §Q (input != null, \"input cannot be null\")\n  ...\n§/F"
+          "calor": "§F{f001:Process:pub} (str:input) -> void\n  §Q{\"input cannot be null\"} (!= input null)\n  ..."
         }
       ]
     },
@@ -418,16 +418,16 @@
       "id": "postcondition",
       "csharpConstruct": "postcondition",
       "keywords": ["postcondition", "ensures", "ensure", "contract", "result", "guarantee"],
-      "calorSyntax": "§S (condition) or §S (condition, \"message\")",
-      "description": "Declares a postcondition that will be true when the function returns. Use $result to refer to return value.",
+      "calorSyntax": "§S (condition) or §S{\"message\"} (condition)",
+      "description": "Declares a postcondition that will be true when the function returns. Use result to refer to the return value.",
       "examples": [
         {
           "csharp": "// Contract.Ensures(result >= 0)",
-          "calor": "§F{1:Abs:pub}\n  §I{i32:x}\n  §O{i32}\n  §S ($result >= 0)\n  ...\n§/F"
+          "calor": "§F{f001:Abs:pub} (i32:x) -> i32\n  §S (>= result 0)\n  ..."
         },
         {
           "csharp": "// Ensures non-empty result",
-          "calor": "§F{1:GetItems:pub}\n  §O{List<Item>}\n  §S ($result.Count > 0, \"must return at least one item\")\n  ...\n§/F"
+          "calor": "§F{f002:GetItems:pub} () -> List<Item>\n  §S{\"must return at least one item\"} (> result.Count 0)\n  ..."
         }
       ]
     },
@@ -440,7 +440,7 @@
       "examples": [
         {
           "csharp": "// [ContractInvariantMethod] void Invariants() { Contract.Invariant(_count >= 0); }",
-          "calor": "§CL{1:Counter:pub}\n  §INV (_count >= 0)\n  §FLD{i32:_count:priv}\n§/CL"
+          "calor": "§CL{c001:Counter:pub}\n  §INV (>= _count 0)\n  §FLD{i32:_count:priv}"
         }
       ]
     },
@@ -448,20 +448,20 @@
       "id": "method_call",
       "csharpConstruct": "method call",
       "keywords": ["call", "invoke", "method", "function call", "execute"],
-      "calorSyntax": "§!{method}(args)§/! or just method(args) for internal calls",
-      "description": "Calls a method or function. Use §!{...}§/! for external/effectful calls.",
+      "calorSyntax": "§C{method} arg1 arg2",
+      "description": "Calls a method or function. Use §C{target} followed by arguments; §A and §/C may be used to close inline nested calls where needed.",
       "examples": [
         {
           "csharp": "Console.WriteLine(\"Hello\");",
-          "calor": "§!{Console.WriteLine}(\"Hello\")§/!"
+          "calor": "§C{Console.WriteLine} \"Hello\""
         },
         {
           "csharp": "user.Save();",
-          "calor": "§!{user.Save}()§/!"
+          "calor": "§C{user.Save}"
         },
         {
           "csharp": "Calculate(x, y) // internal pure call",
-          "calor": "Calculate(x, y)"
+          "calor": "§C{Calculate} x y"
         }
       ]
     },
@@ -478,7 +478,7 @@
         },
         {
           "csharp": "private readonly int _id;",
-          "calor": "§FLD{i32:_id:priv:ro}"
+          "calor": "§FLD{i32:_id:priv:readonly}"
         }
       ]
     },
@@ -486,12 +486,12 @@
       "id": "interface_definition",
       "csharpConstruct": "interface definition",
       "keywords": ["interface", "contract", "abstraction", "implement"],
-      "calorSyntax": "§IFACE{id:name:visibility} signatures... §/IFACE",
+      "calorSyntax": "§IFACE{id:Name:vis}",
       "description": "Defines an interface with method signatures.",
       "examples": [
         {
           "csharp": "public interface IRepository { void Save(Entity e); }",
-          "calor": "§IFACE{1:IRepository:pub}\n  §MT{1:Save}\n    §I{Entity:e}\n    §O{void}\n  §/MT\n§/IFACE"
+          "calor": "§IFACE{i001:IRepository:pub}\n  §MT{m001:Save} (Entity:e) -> void"
         }
       ]
     },
@@ -499,16 +499,16 @@
       "id": "enum_definition",
       "csharpConstruct": "enum definition",
       "keywords": ["enum", "enumeration", "values", "constants"],
-      "calorSyntax": "§EN{id:name:visibility:underlyingType} §EV{name:value} §/EN",
-      "description": "Defines an enumeration. §EV for each enum value.",
+      "calorSyntax": "§EN{id:Name:vis[:underlyingType]} values...",
+      "description": "Defines an enumeration. Enum values are indented under §EN and may use = for explicit values.",
       "examples": [
         {
           "csharp": "public enum Status { Active, Inactive, Pending }",
-          "calor": "§EN{1:Status:pub}\n  §EV{Active}\n  §EV{Inactive}\n  §EV{Pending}\n§/EN"
+          "calor": "§EN{e001:Status:pub}\n  Active\n  Inactive\n  Pending"
         },
         {
           "csharp": "public enum Priority : byte { Low = 0, High = 1 }",
-          "calor": "§EN{1:Priority:pub:byte}\n  §EV{Low:0}\n  §EV{High:1}\n§/EN"
+          "calor": "§EN{e001:Priority:pub:byte}\n  Low = 0\n  High = 1"
         }
       ]
     },
@@ -516,16 +516,16 @@
       "id": "constructor",
       "csharpConstruct": "constructor",
       "keywords": ["constructor", "ctor", "initialize", "new", "construct"],
-      "calorSyntax": "§CTOR{visibility} §I{type:param}... body §/CTOR",
-      "description": "Defines a class constructor. Use §BASE(...) to call base constructor, §THIS(...) to chain constructors.",
+      "calorSyntax": "§CTOR{id:vis} (type:param, ...)",
+      "description": "Defines a class constructor. Use §BASE with §A arguments to call a base constructor, or §THIS to chain constructors.",
       "examples": [
         {
           "csharp": "public User(string name) { _name = name; }",
-          "calor": "§CTOR{pub}\n  §I{str:name}\n  _name = name\n§/CTOR"
+          "calor": "§CTOR{ctor001:pub} (str:name)\n  §ASSIGN _name name"
         },
         {
           "csharp": "public Admin(string name) : base(name) { }",
-          "calor": "§CTOR{pub}\n  §I{str:name}\n  §BASE(name)\n§/CTOR"
+          "calor": "§CTOR{ctor001:pub} (str:name)\n  §BASE §A name"
         }
       ]
     },
@@ -533,16 +533,16 @@
       "id": "switch_expression",
       "csharpConstruct": "switch expression",
       "keywords": ["switch", "match", "pattern", "case", "when"],
-      "calorSyntax": "§W{expression} §K{pattern} result §K{_} default §/W",
-      "description": "Pattern matching switch expression. §K for each case/pattern. Use _ for default.",
+      "calorSyntax": "§W{id:expr} expression with indented §K pattern → result cases",
+      "description": "Pattern matching switch expression. §K introduces each case/pattern. Use _ for default.",
       "examples": [
         {
           "csharp": "x switch { 1 => \"one\", 2 => \"two\", _ => \"other\" }",
-          "calor": "§W{x}\n  §K{1} \"one\"\n  §K{2} \"two\"\n  §K{_} \"other\"\n§/W"
+          "calor": "§W{sw1:expr} x\n  §K 1 → \"one\"\n  §K 2 → \"two\"\n  §K _ → \"other\""
         },
         {
           "csharp": "shape switch { Circle c => c.Area(), Rectangle r => r.Width * r.Height }",
-          "calor": "§W{shape}\n  §K{Circle c} c.Area()\n  §K{Rectangle r} r.Width * r.Height\n§/W"
+          "calor": "§W{sw1:expr} shape\n  §K Circle c → §C{c.Area}\n  §K Rectangle r → (* r.Width r.Height)"
         }
       ]
     },
@@ -563,7 +563,7 @@
         },
         {
           "csharp": "GetValue() ?? fallback",
-          "calor": "(?? §C{GetValue}§/C fallback)"
+          "calor": "(?? §C{GetValue} fallback)"
         }
       ]
     },
@@ -571,16 +571,16 @@
       "id": "using_statement",
       "csharpConstruct": "using statement",
       "keywords": ["using", "dispose", "resource", "cleanup", "idisposable"],
-      "calorSyntax": "§USE{var}=expression body §/USE",
+      "calorSyntax": "§USE{id:var:type} resourceExpression",
       "description": "Resource management with automatic disposal.",
       "examples": [
         {
           "csharp": "using (var stream = File.OpenRead(path)) { ... }",
-          "calor": "§USE{stream}=§!{File.OpenRead}(path)§/!\n  ...\n§/USE"
+          "calor": "§USE{u1:stream:Stream} §C{File.OpenRead} path\n  ..."
         },
         {
           "csharp": "using var connection = new SqlConnection(connStr);",
-          "calor": "§USE{connection}=§NEW{SqlConnection}(connStr)\n  ...\n§/USE"
+          "calor": "§USE{u1:connection:SqlConnection} §NEW{SqlConnection} §A connStr §/NEW\n  ..."
         }
       ]
     },
@@ -588,16 +588,16 @@
       "id": "generic_type",
       "csharpConstruct": "generic type",
       "keywords": ["generic", "template", "<T>", "type parameter", "constraint", "where"],
-      "calorSyntax": "§G{T} for type parameter, §WHERE{T:constraint} for constraints",
+      "calorSyntax": "Use type parameters in names, e.g. §CL{c001:Repository<T>:pub}; constraints use §WHERE T : class",
       "description": "Generic type parameters and constraints.",
       "examples": [
         {
           "csharp": "public class Repository<T> where T : class { }",
-          "calor": "§CL{1:Repository:pub}\n  §G{T}\n  §WHERE{T:class}\n§/CL"
+          "calor": "§CL{c001:Repository<T>:pub}\n  §WHERE T : class"
         },
         {
           "csharp": "public T Get<T>(int id) where T : new() { }",
-          "calor": "§F{1:Get:pub}\n  §G{T}\n  §WHERE{T:new()}\n  §I{i32:id}\n  §O{T}\n  ...\n§/F"
+          "calor": "§F{f001:Get<T>:pub} (i32:id) -> T\n  §WHERE T : new()\n  ..."
         }
       ]
     },
@@ -605,16 +605,16 @@
       "id": "linq_query",
       "csharpConstruct": "LINQ query",
       "keywords": ["linq", "query", "where", "select", "orderby", "from"],
-      "calorSyntax": "Use method syntax with lambdas: §C{collection.Method} §A §LAM{id:param:type} body §/LAM{id} §/C",
-      "description": "LINQ queries use method-chain syntax with §C (call) and §LAM (lambda) in Calor. Each LINQ operator becomes a §C call with a lambda argument.",
+      "calorSyntax": "Use method syntax with lambdas: §C{collection.Where} lambdaValue",
+      "description": "LINQ queries use method-chain syntax with §C (call) and §LAM (lambda) in Calor. Complex chains are commonly hoisted into bindings before the final call.",
       "examples": [
         {
           "csharp": "items.Where(x => x > 5).Select(x => x * 2)",
-          "calor": "§C{§C{items.Where} §A §LAM{lam1:x:i32} x > 5 §/LAM{lam1} §/C.Select} §A §LAM{lam2:x:i32} x * 2 §/LAM{lam2} §/C"
+          "calor": "§B{_lamWhere} §LAM{lam1:x:i32} (> x 5) §/LAM{lam1}\n§B{_chainWhere} §C{items.Where} _lamWhere\n§B{_lamSelect} §LAM{lam2:x:i32} (* x 2) §/LAM{lam2}\n§C{_chainWhere.Select} _lamSelect"
         },
         {
           "csharp": "from item in items where item.Active select item.Name",
-          "calor": "§C{§C{items.Where} §A §LAM{lam1:item:Item} item.Active §/LAM{lam1} §/C.Select} §A §LAM{lam2:item:Item} item.Name §/LAM{lam2} §/C"
+          "calor": "§B{_lamWhere} §LAM{lam1:item:Item} item.Active §/LAM{lam1}\n§B{_chainWhere} §C{items.Where} _lamWhere\n§B{_lamSelect} §LAM{lam2:item:Item} item.Name §/LAM{lam2}\n§C{_chainWhere.Select} _lamSelect"
         }
       ]
     },
@@ -622,20 +622,20 @@
       "id": "string_interpolation",
       "csharpConstruct": "string interpolation",
       "keywords": ["interpolation", "format", "$\"", "string format", "template string"],
-      "calorSyntax": "Inline: STR:\"text ${expression} text\" or Block: §INTERP \"text\" §EXP expression \"text\" §/INTERP",
-      "description": "String interpolation with embedded expressions. Two forms: (1) inline ${} within string literals for simple cases, (2) §INTERP/§/INTERP block form with §EXP markers for complex cases. Note: ${0}, ${1} etc. are treated as format placeholders, not interpolation.",
+      "calorSyntax": "Inline: \"text ${expression} text\"",
+      "description": "String interpolation uses ${} inside ordinary string literals. Note: ${0}, ${1} etc. are treated as format placeholders, not interpolation.",
       "examples": [
         {
           "csharp": "$\"Hello, {name}!\"",
-          "calor": "STR:\"Hello ${name}!\""
+          "calor": "\"Hello ${name}!\""
         },
         {
           "csharp": "$\"Total: {price:C2}\"",
-          "calor": "§INTERP \"Total: \" §EXP (fmt \"{0:C2}\" price) §/INTERP"
+          "calor": "\"Total: ${(fmt \"{0:C2}\" price)}\""
         },
         {
           "csharp": "$\"{firstName} {lastName}\"",
-          "calor": "STR:\"${firstName} ${lastName}\""
+          "calor": "\"${firstName} ${lastName}\""
         },
         {
           "csharp": "$\"Result: {Calculate(x, y)} units\"",
@@ -652,11 +652,11 @@
       "examples": [
         {
           "csharp": "if (done) break;",
-          "calor": "§IF{done} §BK §/IF"
+          "calor": "§IF{i1} done\n  §BK"
         },
         {
           "csharp": "if (skip) continue;",
-          "calor": "§IF{skip} §CN §/IF"
+          "calor": "§IF{i1} skip\n  §CN"
         }
       ]
     },
@@ -664,12 +664,12 @@
       "id": "record_type",
       "csharpConstruct": "record type",
       "keywords": ["record", "data", "immutable", "value object"],
-      "calorSyntax": "§D{id:name:visibility} §FLD{type:name}... §/D",
+      "calorSyntax": "§D{Name} (type:field, ...)",
       "description": "Defines an immutable data record.",
       "examples": [
         {
           "csharp": "public record Person(string Name, int Age);",
-          "calor": "§D{1:Person:pub}\n  §FLD{str:Name:pub}\n  §FLD{i32:Age:pub}\n§/D"
+          "calor": "§D{Person} (str:Name, i32:Age)"
         }
       ]
     },
@@ -698,12 +698,12 @@
       "id": "static_class",
       "csharpConstruct": "static class",
       "keywords": ["static", "static class", "utility", "helper"],
-      "calorSyntax": "§CL{id:name:pub:stat} ... §/CL",
+      "calorSyntax": "§CL{id:Name:pub:stat}",
       "description": "Defines a static class (utility class). Use 'stat' modifier.",
       "examples": [
         {
           "csharp": "public static class StringHelper { }",
-          "calor": "§CL{1:StringHelper:pub:stat}\n  ...\n§/CL"
+          "calor": "§CL{c001:StringHelper:pub:stat}\n  ..."
         }
       ]
     },
@@ -711,16 +711,16 @@
       "id": "virtual_method",
       "csharpConstruct": "virtual method",
       "keywords": ["virtual", "override", "polymorphism", "inheritance", "overridable"],
-      "calorSyntax": "§MT{id:name:visibility:vr} body §/MT",
-      "description": "Defines a virtual method that can be overridden in derived classes. Use 'vr' modifier.",
+      "calorSyntax": "§MT{id:name:vis:virt} (type:param, ...) -> returnType",
+      "description": "Defines a virtual method that can be overridden in derived classes. Use the 'virt' modifier (the compiler also accepts 'vr').",
       "examples": [
         {
           "csharp": "public virtual string GetName() { return _name; }",
-          "calor": "§MT{1:GetName:pub:vr}\n  §O{str}\n  §R _name §/R\n§/MT"
+          "calor": "§MT{m001:GetName:pub:virt} () -> str\n  §R _name"
         },
         {
           "csharp": "protected virtual void OnChanged() { }",
-          "calor": "§MT{1:OnChanged:prot:vr}\n  §O{void}\n§/MT"
+          "calor": "§MT{m002:OnChanged:prot:virt} () -> void"
         }
       ]
     },
@@ -728,16 +728,16 @@
       "id": "override_method",
       "csharpConstruct": "override method",
       "keywords": ["override", "overriding", "polymorphism", "derived", "subclass"],
-      "calorSyntax": "§MT{id:name:visibility:ov} body §/MT",
-      "description": "Overrides a virtual method from a base class. Use 'ov' modifier.",
+      "calorSyntax": "§MT{id:name:vis:over} (type:param, ...) -> returnType",
+      "description": "Overrides a virtual method from a base class. Use the 'over' modifier (the compiler also accepts 'ov').",
       "examples": [
         {
           "csharp": "public override string ToString() { return _name; }",
-          "calor": "§MT{1:ToString:pub:ov}\n  §O{str}\n  §R _name §/R\n§/MT"
+          "calor": "§MT{m001:ToString:pub:over} () -> str\n  §R _name"
         },
         {
           "csharp": "public override int GetHashCode() { return _id; }",
-          "calor": "§MT{1:GetHashCode:pub:ov}\n  §O{i32}\n  §R _id §/R\n§/MT"
+          "calor": "§MT{m002:GetHashCode:pub:over} () -> i32\n  §R _id"
         }
       ]
     },
@@ -745,12 +745,12 @@
       "id": "abstract_class",
       "csharpConstruct": "abstract class",
       "keywords": ["abstract", "base class", "inheritance", "cannot instantiate"],
-      "calorSyntax": "§CL{id:name:visibility:ab} body §/CL",
-      "description": "Defines an abstract class that cannot be instantiated directly. Use 'ab' modifier.",
+      "calorSyntax": "§CL{id:Name:vis:abs}",
+      "description": "Defines an abstract class that cannot be instantiated directly. Use 'abs' modifier.",
       "examples": [
         {
           "csharp": "public abstract class Shape { }",
-          "calor": "§CL{1:Shape:pub:ab}\n  ...\n§/CL"
+          "calor": "§CL{c001:Shape:pub:abs}\n  ..."
         }
       ]
     },
@@ -758,12 +758,12 @@
       "id": "abstract_method",
       "csharpConstruct": "abstract method",
       "keywords": ["abstract", "no body", "must override", "pure virtual"],
-      "calorSyntax": "§MT{id:name:visibility:ab} §I{...} §O{type} §/MT",
-      "description": "Defines an abstract method with no body that must be overridden. Use 'ab' modifier.",
+      "calorSyntax": "§MT{id:name:vis:abs} (type:param, ...) -> returnType",
+      "description": "Defines an abstract method with no body that must be overridden. Use 'abs' modifier.",
       "examples": [
         {
           "csharp": "public abstract double GetArea();",
-          "calor": "§MT{1:GetArea:pub:ab}\n  §O{f64}\n§/MT"
+          "calor": "§MT{m001:GetArea:pub:abs} () -> f64"
         }
       ]
     },
@@ -771,12 +771,12 @@
       "id": "sealed_class",
       "csharpConstruct": "sealed class",
       "keywords": ["sealed", "final", "no inheritance", "cannot derive"],
-      "calorSyntax": "§CL{id:name:visibility:seal} body §/CL",
+      "calorSyntax": "§CL{id:Name:vis:seal}",
       "description": "Defines a sealed class that cannot be inherited from. Use 'seal' modifier.",
       "examples": [
         {
           "csharp": "public sealed class FinalClass { }",
-          "calor": "§CL{1:FinalClass:pub:seal}\n  ...\n§/CL"
+          "calor": "§CL{c001:FinalClass:pub:seal}\n  ..."
         }
       ]
     },
@@ -784,12 +784,12 @@
       "id": "lock_statement",
       "csharpConstruct": "lock statement",
       "keywords": ["lock", "thread", "synchronization", "mutex", "critical section", "thread-safe"],
-      "calorSyntax": "§LK{object} body §/LK",
+      "calorSyntax": "§LK{object}",
       "description": "Acquires an exclusive lock on an object for thread-safe access.",
       "examples": [
         {
           "csharp": "lock (_sync) { _count++; }",
-          "calor": "§LK{_sync}\n  §B{_count}=_count + 1§/B\n§/LK"
+          "calor": "§LK{_sync}\n  §ASSIGN _count (+ _count 1)"
         }
       ]
     },
@@ -853,7 +853,7 @@
       "examples": [
         {
           "csharp": "public void Method() { }",
-          "calor": "§MT{1:Method:pub}\n  §O{void}\n§/MT"
+          "calor": "§MT{m001:Method:pub} () -> void"
         },
         {
           "csharp": "private int _field;",
@@ -861,7 +861,7 @@
         },
         {
           "csharp": "protected virtual void OnChange() { }",
-          "calor": "§MT{1:OnChange:prot:vr}\n  §O{void}\n§/MT"
+          "calor": "§MT{m002:OnChange:prot:virt} () -> void"
         }
       ]
     },
@@ -869,8 +869,8 @@
       "id": "event_definition",
       "csharpConstruct": "event definition",
       "keywords": ["event", "delegate", "handler", "subscribe", "publish", "raise", "eventhandler", "add", "remove", "accessor", "§EADD", "§EREM"],
-      "calorSyntax": "§EVT{id:name:visibility:delegateType} ... §/EVT{id}",
-      "description": "Defines an event. Simple form has no body. For custom add/remove accessors, use §EADD/§EREM blocks inside the event body, closed with §/EVT{id}.",
+      "calorSyntax": "§EVT{id:name:vis:delegateType}",
+      "description": "Defines an event. Simple form has no body. For custom add/remove accessors, use indented §EADD and §EREM blocks inside the event body.",
       "examples": [
         {
           "csharp": "public event EventHandler OnChanged;",
@@ -882,7 +882,7 @@
         },
         {
           "csharp": "public event EventHandler Click { add { _click += value; } remove { _click -= value; } }",
-          "calor": "§EVT{e1:Click:pub:EventHandler}\n  §EADD\n    §ASSIGN _click (+ _click value)\n  §/EADD\n  §EREM\n    §ASSIGN _click (- _click value)\n  §/EREM\n§/EVT{e1}"
+          "calor": "§EVT{e1:Click:pub:EventHandler}\n  §EADD\n    §ASSIGN _click (+ _click value)\n  §EREM\n    §ASSIGN _click (- _click value)"
         }
       ]
     },
@@ -890,24 +890,24 @@
       "id": "operator_overload",
       "csharpConstruct": "operator overload",
       "keywords": ["operator", "overload", "+", "-", "==", "!=", "implicit", "explicit", "conversion"],
-      "calorSyntax": "§OP{id:operator:visibility} §I{type:param}... §O{returnType} body §/OP{id}",
+      "calorSyntax": "§OP{id:operator:vis} (type:param, ...) -> returnType",
       "description": "Defines an operator overload for a class or struct. Supports binary operators (+, -, *, /, ==, etc.), unary operators (-, !, ~, ++, --), and conversion operators (implicit, explicit).",
       "examples": [
         {
           "csharp": "public static MyType operator+(MyType left, MyType right) { return new MyType(left.Value + right.Value); }",
-          "calor": "§OP{1:+:pub}\n  §I{MyType:left}\n  §I{MyType:right}\n  §O{MyType}\n  §R §NEW{MyType}((+ (. left Value) (. right Value)))§/NEW\n§/OP{1}"
+          "calor": "§OP{op001:+:pub} (MyType:left, MyType:right) -> MyType\n  §R §NEW{MyType} §A (+ left.Value right.Value) §/NEW"
         },
         {
           "csharp": "public static MyType operator-(MyType value) { return new MyType(-value.Value); }",
-          "calor": "§OP{1:-:pub}\n  §I{MyType:value}\n  §O{MyType}\n  §R §NEW{MyType}((- (. value Value)))§/NEW\n§/OP{1}"
+          "calor": "§OP{op001:-:pub} (MyType:value) -> MyType\n  §R §NEW{MyType} §A (- value.Value) §/NEW"
         },
         {
           "csharp": "public static implicit operator int(MyType value) { return value.Value; }",
-          "calor": "§OP{1:implicit:pub}\n  §I{MyType:value}\n  §O{i32}\n  §R (. value Value)\n§/OP{1}"
+          "calor": "§OP{op001:implicit:pub} (MyType:value) -> i32\n  §R value.Value"
         },
         {
           "csharp": "public static explicit operator MyType(int value) { return new MyType(value); }",
-          "calor": "§OP{1:explicit:pub}\n  §I{i32:value}\n  §O{MyType}\n  §R §NEW{MyType}(value)§/NEW\n§/OP{1}"
+          "calor": "§OP{op001:explicit:pub} (i32:value) -> MyType\n  §R §NEW{MyType} §A value §/NEW"
         }
       ]
     },
@@ -958,7 +958,7 @@
         },
         {
           "csharp": "public IEnumerable<int> GetNumbers() { for (int i = 0; i < 10; i++) yield return i; }",
-          "calor": "§MT{1:GetNumbers:pub}\n  §O{IEnumerable<i32>}\n  §L{i:0..10}\n    §YIELD i\n  §/L\n§/MT"
+          "calor": "§MT{m001:GetNumbers:pub} () -> IEnumerable<i32>\n  §L{l1:i:0:9:1}\n    §YIELD i"
         }
       ]
     },
@@ -966,20 +966,20 @@
       "id": "delegate_definition",
       "csharpConstruct": "delegate definition",
       "keywords": ["delegate", "callback", "function pointer", "multicast", "action", "func", "predicate", "nested delegate"],
-      "calorSyntax": "§DEL{id:name:visibility} §I{type:param}... §O{returnType} §/DEL",
+      "calorSyntax": "§DEL{id:name} with indented §I parameters and optional §O return type",
       "description": "Defines a delegate type (function signature). Use for callbacks, event handlers, and function references. §DEL can appear at the top level or nested inside §CL class bodies.",
       "examples": [
         {
           "csharp": "public delegate void EventCallback(string message);",
-          "calor": "§DEL{1:EventCallback:pub}\n  §I{str:message}\n  §O{void}\n§/DEL"
+          "calor": "§DEL{del001:EventCallback}\n  §I{str:message}"
         },
         {
           "csharp": "public delegate int Transformer(int value);",
-          "calor": "§DEL{1:Transformer:pub}\n  §I{i32:value}\n  §O{i32}\n§/DEL"
+          "calor": "§DEL{del001:Transformer}\n  §I{i32:value}\n  §O{i32}"
         },
         {
           "csharp": "public class MyClass { public delegate void Handler(int x); }",
-          "calor": "§CL{1:MyClass:pub}\n  §DEL{d1:Handler:pub}\n    §I{i32:x}\n    §O{void}\n  §/DEL\n§/CL"
+          "calor": "§CL{c001:MyClass:pub}\n  §DEL{del001:Handler}\n    §I{i32:x}"
         }
       ]
     },
@@ -992,11 +992,11 @@
       "examples": [
         {
           "csharp": "#if DEBUG\n    Console.WriteLine(\"Debug mode\");\n#endif",
-          "calor": "§PP{DEBUG}\n  §!{Console.WriteLine}(\"Debug mode\")§/!\n§/PP{DEBUG}"
+          "calor": "§PP{DEBUG}\n  §C{Console.WriteLine} \"Debug mode\"\n§/PP{DEBUG}"
         },
         {
           "csharp": "#if NET8_0_OR_GREATER\n    UseNewApi();\n#else\n    UseLegacyApi();\n#endif",
-          "calor": "§PP{NET8_0_OR_GREATER}\n  §!{UseNewApi}()§/!\n§PPE\n  §!{UseLegacyApi}()§/!\n§/PP{NET8_0_OR_GREATER}"
+          "calor": "§PP{NET8_0_OR_GREATER}\n  §C{UseNewApi}\n§PPE\n  §C{UseLegacyApi}\n§/PP{NET8_0_OR_GREATER}"
         }
       ]
     },
@@ -1004,16 +1004,16 @@
       "id": "struct_definition",
       "csharpConstruct": "struct definition",
       "keywords": ["struct", "value type", "stack allocated", "readonly struct"],
-      "calorSyntax": "§CL{id:name:visibility:struct} members... §/CL",
-      "description": "Defines a value type (struct). Uses the 'struct' modifier on §CL. Supports readonly structs with additional 'ro' modifier.",
+      "calorSyntax": "§CL{id:Name:vis:struct}",
+      "description": "Defines a value type (struct). Uses the 'struct' modifier on §CL. Supports readonly structs with the 'readonly' modifier.",
       "examples": [
         {
           "csharp": "public struct Point { public int X; public int Y; }",
-          "calor": "§CL{1:Point:pub:struct}\n  §FLD{i32:X:pub}\n  §FLD{i32:Y:pub}\n§/CL"
+          "calor": "§CL{s001:Point:pub:struct}\n  §FLD{i32:X:pub}\n  §FLD{i32:Y:pub}"
         },
         {
           "csharp": "public readonly struct Vector2D { public readonly double X; public readonly double Y; }",
-          "calor": "§CL{1:Vector2D:pub:ro:struct}\n  §FLD{f64:X:pub:ro}\n  §FLD{f64:Y:pub:ro}\n§/CL"
+          "calor": "§CL{s001:Vector2D:pub:readonly,struct}\n  §FLD{f64:X:pub:readonly}\n  §FLD{f64:Y:pub:readonly}"
         }
       ]
     },
@@ -1021,20 +1021,20 @@
       "id": "generic_constraint",
       "csharpConstruct": "generic type constraint",
       "keywords": ["where", "constraint", "generic constraint", "type constraint", "class constraint", "new()", "struct constraint"],
-      "calorSyntax": "§G{T} for type parameter, §WHERE{T:constraint} for constraints",
+      "calorSyntax": "§WHERE T : constraint for generic constraints",
       "description": "Constrains generic type parameters. Supports class, struct, new(), interface, and base class constraints.",
       "examples": [
         {
           "csharp": "public class Repository<T> where T : class, IEntity { }",
-          "calor": "§CL{1:Repository:pub}\n  §G{T}\n  §WHERE{T:class,IEntity}\n§/CL"
+          "calor": "§CL{c001:Repository<T>:pub}\n  §WHERE T : class, IEntity"
         },
         {
           "csharp": "public T Create<T>() where T : new() { return new T(); }",
-          "calor": "§MT{1:Create:pub}\n  §G{T}\n  §WHERE{T:new()}\n  §O{T}\n  §R §NEW{T}() §/R\n§/MT"
+          "calor": "§MT{m001:Create<T>:pub} () -> T\n  §WHERE T : new()\n  §R §NEW{T} §/NEW"
         },
         {
           "csharp": "public void Process<T>(T item) where T : struct { }",
-          "calor": "§MT{1:Process:pub}\n  §G{T}\n  §WHERE{T:struct}\n  §I{T:item}\n  §O{void}\n§/MT"
+          "calor": "§MT{m002:Process<T>:pub} (T:item) -> void\n  §WHERE T : struct"
         }
       ]
     },
@@ -1042,12 +1042,12 @@
       "id": "do_while_loop",
       "csharpConstruct": "do-while loop",
       "keywords": ["do", "do while", "do-while", "loop", "repeat until", "at least once"],
-      "calorSyntax": "§DO{id} body §/DO{id} condition",
-      "description": "Executes the body at least once, then continues while condition is true. The condition expression follows the closing tag.",
+      "calorSyntax": "§DO{id} (condition)",
+      "description": "Executes the body at least once, then continues while condition is true. The body is indented under the §DO header.",
       "examples": [
         {
           "csharp": "do { Process(); } while (HasMore());",
-          "calor": "§DO{d1}\n  §!{Process}()§/!\n§/DO{d1} §!{HasMore}()§/!"
+          "calor": "§DO{d1} (§C{HasMore})\n  §C{Process}"
         }
       ]
     },
@@ -1055,12 +1055,12 @@
       "id": "partial_class",
       "csharpConstruct": "partial class",
       "keywords": ["partial", "partial class", "split", "multiple files"],
-      "calorSyntax": "§CL{id:name:visibility:partial} members... §/CL",
+      "calorSyntax": "§CL{id:Name:vis:partial}",
       "description": "Defines part of a class that can be split across multiple files. Uses the 'partial' modifier.",
       "examples": [
         {
           "csharp": "public partial class UserService { public void Save() { } }",
-          "calor": "§CL{1:UserService:pub:partial}\n  §MT{1:Save:pub}\n    §O{void}\n  §/MT\n§/CL"
+          "calor": "§CL{c001:UserService:pub:partial}\n  §MT{m001:Save:pub} () -> void"
         }
       ]
     },
@@ -1068,12 +1068,12 @@
       "id": "unsafe_block",
       "csharpConstruct": "unsafe block",
       "keywords": ["unsafe", "pointer", "fixed", "stackalloc", "unmanaged"],
-      "calorSyntax": "§UNSAFE{id} body §/UNSAFE{id}",
+      "calorSyntax": "§UNSAFE{id}",
       "description": "Marks a block for unsafe pointer operations. Required for pointer arithmetic, fixed statements, and stackalloc.",
       "examples": [
         {
           "csharp": "unsafe { int* ptr = &value; *ptr = 42; }",
-          "calor": "§UNSAFE{u1}\n  §B{~ptr:i32*} §ADDR value\n  §DEREF ptr = 42\n§/UNSAFE{u1}"
+          "calor": "§UNSAFE{u1}\n  §B{~ptr:i32*} §ADDR value\n  §ASSIGN (§DEREF ptr) 42"
         }
       ]
     },
@@ -1081,16 +1081,16 @@
       "id": "null_coalescing_assignment",
       "csharpConstruct": "null-coalescing assignment",
       "keywords": ["??=", "null coalescing assignment", "null-coalescing assignment", "null assign"],
-      "calorSyntax": "§IF{id} (== x null) §ASSIGN x default §/IF",
+      "calorSyntax": "§IF{id} (== x null) with indented §ASSIGN x default",
       "description": "C#'s ??= operator has no direct Calor equivalent. Use an §IF null check with §ASSIGN as a workaround.",
       "examples": [
         {
           "csharp": "x ??= GetDefault();",
-          "calor": "§IF{id} (== x null)\n  §ASSIGN x §C{GetDefault}§/C\n§/IF"
+          "calor": "§IF{i1} (== x null)\n  §ASSIGN x §C{GetDefault}"
         },
         {
           "csharp": "_cache ??= new Dictionary<string, int>();",
-          "calor": "§IF{id} (== _cache null)\n  §ASSIGN _cache §NEW{Dictionary<str, i32>}()\n§/IF"
+          "calor": "§IF{i1} (== _cache null)\n  §ASSIGN _cache §NEW{Dictionary<str, i32>} §/NEW"
         }
       ]
     },
@@ -1103,11 +1103,11 @@
       "examples": [
         {
           "csharp": "[Serializable]\npublic class Data { }",
-          "calor": "[@Serializable]\n§CL{1:Data:pub}\n§/CL"
+          "calor": "[@Serializable]\n§CL{c001:Data:pub}"
         },
         {
           "csharp": "[Obsolete(\"Use NewMethod\")]\npublic void OldMethod() { }",
-          "calor": "[@Obsolete(\"Use NewMethod\")]\n§MT{1:OldMethod:pub}\n  §O{void}\n§/MT"
+          "calor": "[@Obsolete(\"Use NewMethod\")]\n§MT{m001:OldMethod:pub} () -> void"
         }
       ]
     },
@@ -1162,11 +1162,11 @@
       "examples": [
         {
           "csharp": "(hour, minute) switch { (0, 0) => \"midnight\" }",
-          "calor": "§IF{id} (&& (== hour 0) (== minute 0))\n  §R STR:\"midnight\"\n§/IF"
+          "calor": "§IF{i1} (&& (== hour 0) (== minute 0))\n  §R \"midnight\""
         },
         {
           "csharp": "obj switch { { Length: > 0 } => true }",
-          "calor": "§IF{id} (> obj.Length 0)\n  §R BOOL:true\n§/IF"
+          "calor": "§IF{i1} (> obj.Length 0)\n  §R true"
         }
       ]
     },
@@ -1275,101 +1275,101 @@
   "tags": {
     "§NEW": {
       "name": "New Instance",
-      "syntax": "§NEW{ClassName}(args)",
+      "syntax": "§NEW{ClassName} §A arg1 §A arg2 §/NEW",
       "description": "Creates a new instance of a class using its constructor.",
       "csharpEquivalent": "new ClassName(args)"
     },
     "§B": {
       "name": "Binding",
-      "syntax": "§B{name}=value§/B or §B{~name}=value§/B",
+      "syntax": "§B{name} value or §B{~name} value",
       "description": "Variable binding. Immutable by default, use ~ prefix for mutable variables.",
       "csharpEquivalent": "var name = value; or int name = value; (mutable)"
     },
     "§V": {
       "name": "Binding (Alias)",
-      "syntax": "§V{name}=value§/V",
-      "description": "Alternative syntax for variable binding. Identical to §B.",
+      "syntax": "§V{name} value",
+      "description": "Alternative syntax for variable binding. Identical to §B{name} value.",
       "csharpEquivalent": "var name = value;"
     },
     "§F": {
       "name": "Function",
-      "syntax": "§F{id:name:visibility} body §/F",
+      "syntax": "§F{id:name:vis} (type:param, ...) -> returnType",
       "description": "Defines a standalone function. Not a class member.",
       "csharpEquivalent": "public static ReturnType Name(params) { body }"
     },
     "§AF": {
       "name": "Async Function",
-      "syntax": "§AF{id:name:visibility} body §/AF",
+      "syntax": "§AF{id:name:vis} (type:param, ...) -> returnType",
       "description": "Defines an async standalone function.",
       "csharpEquivalent": "public static async Task<T> Name(params) { body }"
     },
     "§M": {
       "name": "Function (Alias)",
-      "syntax": "§M{id:name:visibility} body §/M",
+      "syntax": "§F{id:name:vis} (type:param, ...) -> returnType",
       "description": "Alternative syntax for function definition. Identical to §F.",
       "csharpEquivalent": "public static ReturnType Name(params) { body }"
     },
     "§MT": {
       "name": "Method",
-      "syntax": "§MT{id:name:visibility:modifiers} body §/MT",
-      "description": "Defines a class method. Modifiers: vr (virtual), ov (override), ab (abstract), st (static).",
+      "syntax": "§MT{id:name:vis[:modifiers]} (type:param, ...) -> returnType",
+      "description": "Defines a class method. Modifiers include virt/vr, over/ov, abs, stat/st, and seal.",
       "csharpEquivalent": "public ReturnType Name(params) { body }"
     },
     "§AMT": {
       "name": "Async Method",
-      "syntax": "§AMT{id:name:visibility} body §/AMT",
+      "syntax": "§AMT{id:name:vis[:modifiers]} (type:param, ...) -> returnType",
       "description": "Defines an async class method.",
       "csharpEquivalent": "public async Task<T> Name(params) { body }"
     },
     "§I": {
       "name": "Input Parameter",
-      "syntax": "§I{type:name} or §I{type:name:modifier} or §I{type:name}=defaultExpr",
-      "description": "Defines an input parameter. Modifiers: 'this' (extension method), 'ref', 'out', 'in', 'params'. Default values use =expr after the closing brace.",
+      "syntax": "(type:name) or (type:name:modifier) or (type:name = defaultExpr) in a header signature",
+      "description": "Header parameter syntax. Modifiers: 'this' (extension method), 'ref', 'out', 'in', 'params'. Default values use =expr in the signature.",
       "csharpEquivalent": "Type name, this Type name, ref Type name, params Type[] name, Type name = default",
       "examples": [
         {
           "name": "Extension Method Parameter",
-          "calor": "§I{str:value:this}",
+          "calor": "str:value:this",
           "description": "Marks this as an extension method parameter (C# 'this' modifier)"
         },
         {
           "name": "Params Array",
-          "calor": "§I{object[]:args:params}",
+          "calor": "object[]:args:params",
           "description": "Params array parameter (C# 'params' keyword)"
         },
         {
           "name": "Default Value",
-          "calor": "§I{i32:count}=INT:0",
+          "calor": "i32:count = 0",
           "description": "Parameter with default value"
         },
         {
           "name": "Ref Parameter",
-          "calor": "§I{i32:value:ref}",
+          "calor": "i32:value:ref",
           "description": "Ref parameter (C# 'ref' keyword)"
         },
         {
           "name": "Out Parameter",
-          "calor": "§I{i32:result:out}",
+          "calor": "i32:result:out",
           "description": "Out parameter (C# 'out' keyword)"
         }
       ]
     },
     "§O": {
       "name": "Output Type",
-      "syntax": "§O{type}",
-      "description": "Declares the return type of a function or method.",
+      "syntax": "-> type in a header signature",
+      "description": "Declares the return type of a function or method via the header arrow.",
       "csharpEquivalent": "Return type declaration"
     },
     "§R": {
       "name": "Return",
-      "syntax": "§R expression §/R or §R§/R",
+      "syntax": "§R expression or §R",
       "description": "Returns a value from a function. Empty for void returns.",
       "csharpEquivalent": "return expression; or return;"
     },
     "§CL": {
       "name": "Class",
-      "syntax": "§CL{id:name:visibility:modifiers} body §/CL",
-      "description": "Defines a class. Modifiers: abs (abstract), sealed, partial, st (static).",
+      "syntax": "§CL{id:Name:vis[:modifiers]}",
+      "description": "Defines a class. Modifiers include abs, seal, partial, stat, struct, and readonly.",
       "csharpEquivalent": "public class Name { body }"
     },
     "§EXT": {
@@ -1386,80 +1386,80 @@
     },
     "§IFACE": {
       "name": "Interface",
-      "syntax": "§IFACE{id:name:visibility} body §/IFACE",
+      "syntax": "§IFACE{id:Name:vis}",
       "description": "Defines an interface.",
       "csharpEquivalent": "public interface IName { body }"
     },
     "§L": {
       "name": "Loop",
-      "syntax": "§L{var:range} body §/L or §L{item:collection} body §/L",
-      "description": "For loop or foreach loop. Range syntax: start..end (exclusive), start..=end (inclusive).",
+      "syntax": "§L{id:var:from:to:step}",
+      "description": "For loop over an inclusive integer range. Use §EACH for foreach loops.",
       "csharpEquivalent": "for (var i = start; i < end; i++) or foreach (var item in collection)"
     },
     "§WH": {
       "name": "While Loop",
-      "syntax": "§WH{condition} body §/WH",
+      "syntax": "§WH{id} (condition)",
       "description": "While loop that continues while condition is true.",
       "csharpEquivalent": "while (condition) { body }"
     },
     "§DO": {
       "name": "Do-While Loop",
-      "syntax": "§DO{} body §WH{condition}§/DO",
+      "syntax": "§DO{id} (condition)",
       "description": "Do-while loop that executes at least once.",
       "csharpEquivalent": "do { body } while (condition);"
     },
     "§IF": {
       "name": "If Statement",
-      "syntax": "§IF{condition} body §/IF",
+      "syntax": "§IF{id} (condition)",
       "description": "Conditional execution. Can include §EI (else-if) and §EL (else).",
       "csharpEquivalent": "if (condition) { body }"
     },
     "§EI": {
       "name": "Else If",
-      "syntax": "§EI{condition} body",
+      "syntax": "§EI (condition)",
       "description": "Else-if branch in a conditional.",
       "csharpEquivalent": "else if (condition) { body }"
     },
     "§EL": {
       "name": "Else",
-      "syntax": "§EL body",
+      "syntax": "§EL",
       "description": "Else branch in a conditional.",
       "csharpEquivalent": "else { body }"
     },
     "§ASYNC": {
       "name": "Async Block",
-      "syntax": "§ASYNC{} body §/ASYNC",
+      "syntax": "Use §AF or §AMT async headers",
       "description": "Marks a block as async.",
       "csharpEquivalent": "async context"
     },
     "§AWAIT": {
       "name": "Await",
-      "syntax": "§AWAIT expression §/AWAIT",
+      "syntax": "§AWAIT expression",
       "description": "Awaits an asynchronous operation.",
       "csharpEquivalent": "await expression"
     },
     "§TR": {
       "name": "Try Block",
-      "syntax": "§TR{} body §CA{Type:var} handler §FI{} cleanup §/TR",
+      "syntax": "§TR{id} body §CA{Type:var} handler §FI cleanup",
       "description": "Exception handling with try, catch, and optional finally.",
       "csharpEquivalent": "try { body } catch (Type var) { handler } finally { cleanup }"
     },
     "§CA": {
       "name": "Catch Block",
-      "syntax": "§CA{ExceptionType:varName} body or §CA{} body",
+      "syntax": "§CA{ExceptionType:varName} or §CA{Exception}",
       "description": "Catches exceptions. Type and variable name are optional.",
       "csharpEquivalent": "catch (ExceptionType varName) { body }"
     },
     "§FI": {
       "name": "Finally Block",
-      "syntax": "§FI{} body",
+      "syntax": "§FI",
       "description": "Finally block that always executes.",
       "csharpEquivalent": "finally { body }"
     },
     "§TH": {
       "name": "Throw",
-      "syntax": "§TH expression §/TH or §TH§/TH",
-      "description": "Throws an exception. Empty form rethrows current exception.",
+      "syntax": "§TH expression or §RT",
+      "description": "Throws an exception. Use §RT to rethrow the current exception.",
       "csharpEquivalent": "throw expression; or throw;"
     },
     "§GOTO": {
@@ -1483,7 +1483,7 @@
     "§S": {
       "name": "Postcondition",
       "syntax": "§S (condition) or §S (condition, \"message\")",
-      "description": "Declares a postcondition that will be true when function returns. Use $result for return value.",
+      "description": "Declares a postcondition that will be true when function returns. Use result for return value.",
       "csharpEquivalent": "Contract.Ensures(condition)"
     },
     "§PRE": {
@@ -1506,19 +1506,19 @@
     },
     "§PROP": {
       "name": "Property",
-      "syntax": "§PROP{id:name:type:visibility:modifiers} body §/PROP",
-      "description": "Defines a property with optional getter and setter. Positional args: id, name, type, visibility (pub/pri/pro/int), optional modifiers (e.g., stat for static). Example: §PROP{p001:Count:i32:pub:stat} for a public static int property.",
+      "syntax": "§PROP{id:name:type:vis[:modifiers...:accessors]} [= default]",
+      "description": "Defines a property. Positional args: id, name, type, visibility, optional modifiers/accessors. Example: §PROP{p001:Count:i32:pub:stat:get,set} for a public static int property.",
       "csharpEquivalent": "public Type Name { get; set; }"
     },
     "§GET": {
       "name": "Getter",
-      "syntax": "§GET body §/GET",
+      "syntax": "§GET",
       "description": "Property getter.",
       "csharpEquivalent": "get { body }"
     },
     "§SET": {
       "name": "Setter",
-      "syntax": "§SET body §/SET or §SET:visibility body §/SET",
+      "syntax": "§SET or §SET{visibility}",
       "description": "Property setter with optional visibility modifier.",
       "csharpEquivalent": "set { body } or private set { body }"
     },
@@ -1530,25 +1530,25 @@
     },
     "§CTOR": {
       "name": "Constructor",
-      "syntax": "§CTOR{visibility} body §/CTOR",
+      "syntax": "§CTOR{id:vis} (type:param, ...)",
       "description": "Defines a class constructor.",
       "csharpEquivalent": "public ClassName(params) { body }"
     },
     "§BASE": {
       "name": "Base Constructor",
-      "syntax": "§BASE(args)",
+      "syntax": "§BASE §A arg1 §A arg2",
       "description": "Calls the base class constructor.",
       "csharpEquivalent": ": base(args)"
     },
     "§THIS": {
       "name": "This Constructor",
-      "syntax": "§THIS(args)",
+      "syntax": "§THIS §A arg1 §A arg2",
       "description": "Chains to another constructor in the same class.",
       "csharpEquivalent": ": this(args)"
     },
     "§EN": {
       "name": "Enum",
-      "syntax": "§EN{id:name:visibility:underlyingType} body §/EN",
+      "syntax": "§EN{id:Name:vis[:underlyingType]}",
       "description": "Defines an enumeration.",
       "csharpEquivalent": "public enum Name { ... }"
     },
@@ -1560,31 +1560,31 @@
     },
     "§EVT": {
       "name": "Event",
-      "syntax": "§EVT{id:name:visibility:delegateType} [§EADD...§/EADD §EREM...§/EREM] §/EVT{id}",
-      "description": "Defines an event. Positional attributes: id, name, visibility, delegateType. Simple form (no body) for field-like events. With §EADD/§EREM accessor blocks for custom add/remove logic.",
+      "syntax": "§EVT{id:name:vis:delegateType}",
+      "description": "Defines an event. Positional attributes: id, name, visibility, delegateType. Simple form for field-like events; use indented §EADD/§EREM blocks for custom add/remove logic.",
       "csharpEquivalent": "public event DelegateType Name; or event with add/remove accessors"
     },
     "§EADD": {
       "name": "Event Add Accessor",
-      "syntax": "§EADD body §/EADD",
+      "syntax": "§EADD",
       "description": "Custom add accessor body inside an event definition (§EVT). Contains statements executed when a handler is subscribed.",
       "csharpEquivalent": "add { body }"
     },
     "§EREM": {
       "name": "Event Remove Accessor",
-      "syntax": "§EREM body §/EREM",
+      "syntax": "§EREM",
       "description": "Custom remove accessor body inside an event definition (§EVT). Contains statements executed when a handler is unsubscribed.",
       "csharpEquivalent": "remove { body }"
     },
     "§LAM": {
       "name": "Lambda",
-      "syntax": "§LAM{id} body §/LAM  —or—  (param) → expr",
+      "syntax": "§LAM{id:param:type...} expression §/LAM{id}",
       "description": "Anonymous function/lambda expression. Inline arrow form preferred for simple expressions.",
       "csharpEquivalent": "(params) => expression or (params) => { body }"
     },
     "§W": {
       "name": "Switch/Match",
-      "syntax": "§W{expression} §K{pattern} result ... §/W",
+      "syntax": "§W{id:expr} expression with indented §K pattern → result cases",
       "description": "Pattern matching switch expression.",
       "csharpEquivalent": "expression switch { pattern => result, ... }"
     },
@@ -1608,13 +1608,13 @@
     },
     "§!": {
       "name": "External Call",
-      "syntax": "§!{method}(args)§/!",
-      "description": "Calls an external or effectful method.",
+      "syntax": "§C{method} arg1 arg2",
+      "description": "Calls a method or function.",
       "csharpEquivalent": "method(args)"
     },
     "§USE": {
       "name": "Using/Resource",
-      "syntax": "§USE{var}=expression body §/USE",
+      "syntax": "§USE{id:var:type} resourceExpression",
       "description": "Resource management with automatic disposal.",
       "csharpEquivalent": "using (var name = expression) { body }"
     },
@@ -1632,7 +1632,7 @@
     },
     "§?": {
       "name": "Null-Conditional (Legacy)",
-      "syntax": "§?{expression}§/?",
+      "syntax": "(?. target Member)",
       "description": "Legacy null-conditional syntax. Prefer Lisp-style (?. target Member) for null-conditional access.",
       "csharpEquivalent": "expression?."
     },
@@ -1650,19 +1650,19 @@
     },
     "§D": {
       "name": "Data/Record",
-      "syntax": "§D{id:name:visibility} body §/D",
+      "syntax": "§D{Name} (type:field, ...)",
       "description": "Defines an immutable data record.",
       "csharpEquivalent": "public record Name { ... }"
     },
     "§STR": {
       "name": "String Interpolation (NOT IMPLEMENTED)",
       "syntax": "NOT VALID — use inline ${} or §INTERP instead",
-      "description": "§STR is not a valid section marker. For string interpolation, use: (1) inline ${} within string literals, e.g., STR:\"Hello ${name}\", or (2) §INTERP \"text\" §EXP expr §/INTERP block form. See §INTERP.",
+      "description": "§STR is not a valid section marker. For string interpolation, use inline ${} within ordinary string literals, e.g., \"Hello ${name}\".",
       "csharpEquivalent": "$\"text {expression} text\""
     },
     "§INTERP": {
       "name": "String Interpolation",
-      "syntax": "§INTERP \"literal\" §EXP expr \"literal\" §/INTERP",
+      "syntax": "Prefer inline string interpolation: \"literal ${expr} literal\"",
       "description": "Builds an interpolated string from literal parts and §EXP expression parts. Strings are opaque — expressions cannot be embedded inside quotes. Use separate \"literal\" and §EXP expr parts.",
       "csharpEquivalent": "$\"literal{expr}literal\""
     },
@@ -1674,7 +1674,7 @@
     },
     "§M": {
       "name": "Module",
-      "syntax": "§M{id:name} body §/M",
+      "syntax": "§M{id:Name}",
       "description": "Defines a module (namespace/compilation unit). All code must be inside a module.",
       "csharpEquivalent": "namespace Name { ... }"
     },
@@ -1687,7 +1687,7 @@
     "§U": {
       "name": "Using Import",
       "syntax": "§U{namespace} or §U{alias:namespace}",
-      "description": "Imports a namespace or creates an alias. Must appear inside a module (§M) block.",
+      "description": "Imports a namespace or creates an alias. Must appear inside a module (§M{id:Name}) block.",
       "csharpEquivalent": "using Namespace; or using Alias = Namespace;"
     },
     "§SM": {
@@ -1716,19 +1716,19 @@
     },
     "§ARR": {
       "name": "Array",
-      "syntax": "§ARR{elementType} size or §ARR{elementType} [elements]",
+      "syntax": "§ARR{id:type} elements §/ARR{id} or §ARR{type:name:size}",
       "description": "Creates a fixed-size array.",
       "csharpEquivalent": "new Type[size] or new[] { elements }"
     },
     "§LIST": {
       "name": "List",
-      "syntax": "§LIST{elementType} or §LIST{elementType} [elements]",
+      "syntax": "§LIST{name:type} with indented values",
       "description": "Creates a dynamic list.",
       "csharpEquivalent": "new List<Type>() or new List<Type> { elements }"
     },
     "§DICT": {
       "name": "Dictionary",
-      "syntax": "§DICT{keyType:valueType}",
+      "syntax": "§DICT{name:keyType:valueType} with indented §KV key value entries",
       "description": "Creates a dictionary/map.",
       "csharpEquivalent": "new Dictionary<TKey, TValue>()"
     },
@@ -1740,7 +1740,7 @@
     },
     "§EACH": {
       "name": "Foreach",
-      "syntax": "§EACH{id:var} collection body §/EACH{id}",
+      "syntax": "§EACH{var:collection}",
       "description": "Iterates over each element in a collection. Type is inferred automatically. Use three-field form §EACH{id:var:type} for explicit typing.",
       "csharpEquivalent": "foreach (var item in collection) { body }"
     },
@@ -1752,7 +1752,7 @@
     },
     "§SIG": {
       "name": "Signature",
-      "syntax": "§SIG{id:name} (params) → returnType",
+      "syntax": "§MT{id:name} (type:param, ...) -> returnType",
       "description": "Declares a method signature in an interface.",
       "csharpEquivalent": "ReturnType Name(params);"
     },
@@ -1776,43 +1776,43 @@
     },
     "§A": {
       "name": "Argument",
-      "syntax": "§A{type:name}",
-      "description": "Defines an argument (alternative to §I for input parameters).",
+      "syntax": "§A expression",
+      "description": "Marks an argument in inline calls or constructors.",
       "csharpEquivalent": "Type name"
     },
     "§VR": {
       "name": "Virtual Modifier",
-      "syntax": "§MT{id:name:pub:vr}",
+      "syntax": "§MT{id:name:pub:virt} () -> returnType",
       "description": "Marks a method as virtual, allowing it to be overridden in derived classes.",
       "csharpEquivalent": "public virtual ReturnType Name()"
     },
     "§OV": {
       "name": "Override Modifier",
-      "syntax": "§MT{id:name:pub:ov}",
+      "syntax": "§MT{id:name:pub:over} () -> returnType",
       "description": "Marks a method as overriding a virtual method from a base class.",
       "csharpEquivalent": "public override ReturnType Name()"
     },
     "§AB": {
       "name": "Abstract Modifier",
-      "syntax": "§MT{id:name:pub:ab} or §CL{id:name:pub:ab}",
+      "syntax": "§MT{id:name:pub:abs} () -> returnType or §CL{id:Name:pub:abs}",
       "description": "Marks a method or class as abstract. Abstract methods have no body.",
       "csharpEquivalent": "public abstract ReturnType Name(); or public abstract class Name"
     },
     "§SD": {
       "name": "Sealed Modifier",
-      "syntax": "§CL{id:name:pub:sd}",
+      "syntax": "§CL{id:Name:pub:seal}",
       "description": "Marks a class as sealed, preventing inheritance.",
       "csharpEquivalent": "public sealed class Name"
     },
     "§SW": {
       "name": "Switch/Match",
-      "syntax": "§SW{expression} cases §/SW",
-      "description": "Pattern matching switch expression. Alternative syntax for §K (match).",
+      "syntax": "§W{id:expr} expression with indented §K cases",
+      "description": "Pattern matching switch expression. Prefer §W with indented §K cases.",
       "csharpEquivalent": "expression switch { patterns }"
     },
     "§BODY": {
       "name": "Body Start",
-      "syntax": "§BODY content §/BODY",
+      "syntax": "Indent the body under the header",
       "description": "Explicitly marks the start of a function or method body. Optional in most cases.",
       "csharpEquivalent": "{ body }"
     },
@@ -1836,7 +1836,7 @@
     },
     "§EX": {
       "name": "Example",
-      "syntax": "§EX{description} code §/EX",
+      "syntax": "§EX{description} code",
       "description": "Inline example or test code in documentation.",
       "csharpEquivalent": "// Example: description"
     },
@@ -1872,7 +1872,7 @@
     },
     "§DC": {
       "name": "Decision",
-      "syntax": "§DC{id:title} alternatives §/DC",
+      "syntax": "§DC{id:title} alternatives",
       "description": "Documents an architectural or design decision with alternatives considered.",
       "csharpEquivalent": "// DECISION: title"
     },
@@ -1884,25 +1884,25 @@
     },
     "§CT": {
       "name": "Context",
-      "syntax": "§CT{description} §/CT",
+      "syntax": "§CT{description}",
       "description": "Documents the context or background for a decision or feature.",
       "csharpEquivalent": "// CONTEXT: description"
     },
     "§VS": {
       "name": "Visible Section",
-      "syntax": "§VS content §/VS",
+      "syntax": "§VS content",
       "description": "Marks a section as visible (not hidden).",
       "csharpEquivalent": "#region Visible"
     },
     "§HD": {
       "name": "Hidden Section",
-      "syntax": "§HD content §/HD",
+      "syntax": "§HD content",
       "description": "Marks a section as hidden from normal view.",
       "csharpEquivalent": "#region Hidden"
     },
     "§FC": {
       "name": "Focus",
-      "syntax": "§FC content §/FC",
+      "syntax": "§FC content",
       "description": "Marks a section as the current focus area for editing.",
       "csharpEquivalent": "// FOCUS"
     },
@@ -1920,26 +1920,26 @@
     },
     "§UB": {
       "name": "Used By",
-      "syntax": "§UB{function_or_class} §/UB",
+      "syntax": "§UB{function_or_class}",
       "description": "Documents what uses this code (reverse dependency).",
       "csharpEquivalent": "// Used by: function_or_class"
     },
     "§LK": {
       "name": "Lock",
-      "syntax": "§LK{object} body §/LK",
+      "syntax": "§LK{object}",
       "description": "Acquires a lock on an object for thread-safe access.",
       "csharpEquivalent": "lock (object) { body }"
     },
     "§SYNC": {
       "name": "Synchronization Block",
-      "syntax": "§SYNC{id} lockExpr body §/SYNC{id}",
+      "syntax": "§SYNC{id} lockExpr",
       "description": "Lock/synchronization block. Preferred over §LK for converter output. Compiles to C# lock statement.",
       "csharpEquivalent": "lock (lockExpr) { body }",
       "tags": ["§SYNC", "lock", "synchronization", "thread-safety"]
     },
     "§PT": {
       "name": "Property Test",
-      "syntax": "§PT{property} body §/PT",
+      "syntax": "§PT{property}",
       "description": "Defines a property-based test.",
       "csharpEquivalent": "[Property] public bool TestName() { ... }"
     },
@@ -1969,7 +1969,7 @@
     },
     "§US": {
       "name": "Uses",
-      "syntax": "§US dependencies §/US",
+      "syntax": "§US dependencies",
       "description": "Declares dependencies or imports used by the code.",
       "csharpEquivalent": "using Namespace;"
     },
@@ -1987,13 +1987,13 @@
     },
     "§ENUM": {
       "name": "Enum (Legacy)",
-      "syntax": "§ENUM{id:name} members §/ENUM",
+      "syntax": "§EN{id:Name:vis[:underlyingType]}",
       "description": "Legacy syntax for enum definition. Prefer §EN.",
       "csharpEquivalent": "public enum Name { members }"
     },
     "§EEXT": {
       "name": "Enum Extension",
-      "syntax": "§EEXT{EnumName} extensions §/EEXT",
+      "syntax": "§EEXT{EnumName} extensions",
       "description": "Defines extension methods for an enum type.",
       "csharpEquivalent": "public static class EnumExtensions { ... }"
     },

--- a/src/Calor.Compiler/Resources/error-suggestions.json
+++ b/src/Calor.Compiler/Resources/error-suggestions.json
@@ -37,10 +37,10 @@
       "title": "Variable Redeclaration",
       "matchPatterns": ["already defined", "already declared", "redeclar", "already exists"],
       "matchCodes": ["Calor0201"],
-      "description": "Use §B to declare a new variable and §ASSIGN to update an existing one.",
+      "description": "Declare a variable once with §B. Use §B{~name} for a mutable binding, then reassign it later with §ASSIGN name value — do not declare the same name twice.",
       "wrongExample": "§B{k} (% rng n)    // First use: declares k\n§B{k} (+ k 1)      // ERROR - 'k' already defined",
-      "correctExample": "§B{k} (% rng n)    // Declare k\n§ASSIGN k (+ k 1)   // Update k",
-      "explanation": "§B declares a new binding. Once declared, use §ASSIGN to update the variable's value. This applies inside conditionals too."
+      "correctExample": "§B{~k} (% rng n)   // Declare k once (mutable)\n§ASSIGN k (+ k 1)  // Reassign k — no re-declaration",
+      "explanation": "§B declares a NEW binding, so using it twice for the same name is a redeclaration. Declare once with §B{~name} for a value that changes, then update it with §ASSIGN name value (a second §B{~name} would re-declare, not update)."
     },
     {
       "id": "char-literals",
@@ -58,8 +58,8 @@
       "matchPatterns": ["i32[]", "string[]", "wrong type syntax", "array type"],
       "matchCodes": ["Calor0113"],
       "description": "Array type brackets go BEFORE the type name in Calor, not after.",
-      "wrongExample": "§I{i32[]:items}     // ERROR - wrong type syntax",
-      "correctExample": "§I{[i32]:items}     // Array of i32",
+      "wrongExample": "§F{f1:UseItems:pub} (i32[]:items) -> i32     // ERROR - wrong array type syntax",
+      "correctExample": "§F{f1:UseItems:pub} ([i32]:items) -> i32\n  §R (len items)",
       "explanation": "In Calor, array types use [T] syntax with brackets before the type name: [i32], [str], [f64]."
     },
     {
@@ -68,8 +68,8 @@
       "matchPatterns": ["get arr", "at arr", "arr[", "element access", "§IDX inside", "tag inside Lisp"],
       "matchCodes": ["Calor0106", "Calor0104"],
       "description": "Use §IDX for array element access. Cannot nest §IDX inside Lisp expressions.",
-      "wrongExample": "§B{x} (get arr i)      // ERROR - 'get' doesn't exist\n§B{x} arr[i]           // ERROR - no C# indexer\n§ASSIGN sum (+ sum §IDX data i)  // ERROR - tag inside Lisp expr",
-      "correctExample": "§B{x} §IDX arr i       // arr[i]\n§SETIDX{arr} i value   // arr[i] = value\n\n// For use in expressions, extract to binding first:\n§B{val} §IDX data i\n§ASSIGN sum (+ sum val)",
+      "wrongExample": "§B{x} (get arr i)      // ERROR - 'get' doesn't exist\n§B{x} arr[i]           // ERROR - no C# indexer\n§B{~sum} (+ sum §IDX data i)  // ERROR - tag inside Lisp expr",
+      "correctExample": "§B{x} §IDX arr i       // arr[i]\n§SETIDX{arr} i value   // arr[i] = value\n\n// For use in expressions, extract to binding first:\n§B{val} §IDX data i\n§B{~sum} (+ sum val)",
       "explanation": "Use §IDX for reading (no braces), §SETIDX{arr} for writing. §IDX cannot be nested inside Lisp expressions — extract to a binding first."
     },
     {
@@ -87,10 +87,10 @@
       "title": "Missing Built-in Operators",
       "matchPatterns": ["(abs ", "(max ", "(min ", "(sqrt ", "(pow ", "undefined function"],
       "matchCodes": ["Calor0200"],
-      "description": "abs, max, min, sqrt, pow are not built-in. Use IF expressions instead.",
+      "description": "abs, max, min, sqrt, pow are not built-in. Use IF branches instead.",
       "wrongExample": "§R (abs x)     // ERROR - abs doesn't exist\n§R (max a b)   // ERROR - max doesn't exist",
-      "correctExample": "§B{absX} §IF{if1} (< x 0) → (- 0 x) §EL → x §/I{if1}\n§B{maxVal} §IF{if1} (> a b) → a §EL → b §/I{if1}",
-      "explanation": "Calor doesn't have abs, max, min, sqrt, pow as built-in functions. Use IF expressions (ternary) to implement them inline."
+      "correctExample": "§IF{if1} (< x 0) → §R (- 0 x)\n§R x\n\n§IF{if2} (> a b) → §R a\n§R b",
+      "explanation": "Calor doesn't have abs, max, min, sqrt, pow as built-in functions. Use §IF with a single return or an indented block to implement branch logic."
     },
     {
       "id": "control-flow-arrow",
@@ -99,8 +99,8 @@
       "matchCodes": ["Calor0100", "Calor0104"],
       "description": "Arrow syntax (→) is for single statements only. Use block syntax for multiple statements.",
       "wrongExample": "§IF{if1} (condition) → §B{x} 1 → §R x   // ERROR",
-      "correctExample": "§IF{if1} (condition)\n  §B{x} 1\n  §R x\n§/I{if1}",
-      "explanation": "The arrow (→) can only be followed by a single statement. For multiple statements, use the block form with §/I{id} closing tag."
+      "correctExample": "§IF{if1} (condition)\n  §B{x} 1\n  §R x",
+      "explanation": "The arrow (→) can only be followed by a single statement. For multiple statements, put an indented block under the §IF opener; the block ends at dedent."
     },
     {
       "id": "new-object-placeholder",
@@ -109,7 +109,7 @@
       "matchCodes": ["Calor0106", "Calor0200"],
       "description": "The converter generates §NEW{object} when it can't resolve the target type of a C# target-typed 'new()'. Replace 'object' with the actual type.",
       "wrongExample": "§TH §NEW{object} §A \"Invalid input\" §/NEW   // 'object' is a placeholder",
-      "correctExample": "§TH §NEW{ArgumentException} §A \"Invalid input\" §/NEW",
+      "correctExample": "§TH §NEW{ArgumentException}(\"Invalid input\")",
       "explanation": "Look at the context — throw statements usually need an Exception type, assignments need the variable's declared type, method returns need the return type. Replace §NEW{object} with the correct concrete type."
     },
     {
@@ -119,7 +119,7 @@
       "matchCodes": ["Calor0112", "Calor0113"],
       "description": "Large integer literals may overflow i32 range. Calor now supports i64 natively — values outside int range are handled automatically.",
       "wrongExample": "§C{Method} §A -1486618624   // This was 1000000000000 truncated to i32!",
-      "correctExample": "§C{Method} §A 1000000000000   // Now correctly stored as i64",
+      "correctExample": "§C{Method} §A 1000000000000 §/C   // Now correctly stored as i64",
       "explanation": "If you see suspiciously negative numbers where large positive values are expected, the original C# likely used long/Int64 literals. Re-convert the file to pick up the i64 fix."
     },
     {
@@ -129,58 +129,58 @@
       "matchCodes": ["Calor0106", "Calor0104"],
       "description": "Generic type arguments like <T> in call expressions are not yet fully supported in expression contexts.",
       "wrongExample": "§C{EnumCache<T>.GetInfo} §/C   // Parser rejects <T> in expressions",
-      "correctExample": "§B{~info} §C{EnumCache}.GetInfo §/C   // Use without type param, let C# infer",
+      "correctExample": "§B{~info} §C{EnumCache.GetInfo} §/C   // Use without type param, let C# infer",
       "explanation": "When converting generic method calls, remove the type arguments from the call expression if C# type inference can resolve them. For explicit type args, use a §CSHARP interop block."
     },
     {
       "id": "if-id-mismatch",
-      "title": "IF Block ID Mismatch",
+      "title": "Legacy IF Closing Tag",
       "matchPatterns": ["does not match IF id", "END_IF id", "mismatch"],
       "matchCodes": ["Calor0100", "Calor0102"],
-      "description": "Nested IF blocks have mismatched opening/closing IDs, usually caused by converter bug with continue/break inside nested conditionals.",
-      "wrongExample": "§IF{if016} (condition)\n  §/I{if017}   // ID mismatch!",
-      "correctExample": "§IF{if016} (condition)\n  §/I{if016}   // IDs must match",
-      "explanation": "Manually fix the closing ID to match the opening ID. Count the nesting levels to identify which §/I belongs to which §IF."
+      "description": "Current Calor IF blocks are indentation-delimited. Do not add legacy IF closing tags or try to match IF IDs.",
+      "wrongExample": "§IF{if016} (condition)\n  §R 1\n§/I{if017}   // ERROR: legacy structural closing tag",
+      "correctExample": "§IF{if016} (condition)\n  §R 1",
+      "explanation": "Indent the IF body under §IF. The block ends at dedent, so there is no IF closing tag or closing ID to match."
     },
     {
       "id": "invalid-lisp-expression",
       "title": "Invalid Lisp Expression",
       "matchPatterns": ["Unexpected token in expression", "invalid expression argument", "invalid lisp"],
       "matchCodes": ["Calor0114"],
-      "description": "The parser encountered an unexpected token inside a Lisp-style expression (parenthesized prefix notation). Common causes: nullable type in cast position (?T), unsupported operator, or malformed nested expression.",
-      "wrongExample": "(cast ?T value)          // ?T not recognized as type\n(+ a §IDX arr i)         // Can't nest § tags in Lisp expressions",
-      "correctExample": "(cast T? value)          // Use postfix nullable\n§B{_tmp} §IDX arr i      // Extract to binding first\n(+ a _tmp)",
-      "explanation": "Lisp expressions use prefix notation: (operator arg1 arg2). Types must be valid identifiers — use T? postfix notation for nullable types. Section markers (§) cannot appear inside parenthesized expressions."
+      "description": "The parser encountered an unexpected token inside a Lisp-style expression (parenthesized prefix notation). Common causes: postfix nullable type syntax (T?), unsupported operator, or malformed nested expression.",
+      "wrongExample": "(cast T? value)          // Use prefix ?T for option/nullable types\n(+ a §IDX arr i)         // Can't nest § tags in Lisp expressions",
+      "correctExample": "(cast ?T value)          // Prefix option/nullable type\n§B{_tmp} §IDX arr i      // Extract to binding first\n(+ a _tmp)",
+      "explanation": "Lisp expressions use prefix notation: (operator arg1 arg2). Types must use Calor type forms such as ?T for option/nullable values. Section markers (§) cannot appear inside parenthesized expressions."
     },
     {
       "id": "mismatched-id",
-      "title": "Mismatched Block ID",
+      "title": "Legacy Block Closing ID",
       "matchPatterns": ["mismatched id", "does not match", "closing tag id", "opening id"],
       "matchCodes": ["Calor0101"],
-      "description": "A closing tag's ID does not match the corresponding opening tag. This commonly happens with nested IF, LOOP, TRY, or MATCH blocks where copy-paste or converter output has incorrect IDs.",
-      "wrongExample": "§LOOP{loop1} (range 0 n)\n  §IF{if1} (condition)\n  §/I{if1}\n§/L{loop2}   // ERROR: loop2 != loop1",
-      "correctExample": "§LOOP{loop1} (range 0 n)\n  §IF{if1} (condition)\n  §/I{if1}\n§/L{loop1}   // IDs must match",
-      "explanation": "Every opening tag (§IF{id}, §LOOP{id}, §TRY{id}, §MATCH{id}) must have a closing tag with the same ID. Check nesting carefully — mismatched IDs usually indicate a copy-paste error or incorrect nesting."
+      "description": "Current Calor blocks are indentation-delimited; legacy closing-tag IDs for IF, LOOP, TRY, or MATCH are obsolete. Similar parser errors usually mean an unwanted closing tag or bad indentation.",
+      "wrongExample": "§L{loop1:i:0:n:1}\n  §IF{if1} (condition)\n    §R i\n§/L{loop2}   // ERROR: legacy structural closing tag",
+      "correctExample": "§L{loop1:i:0:n:1}\n  §IF{if1} (condition)\n    §R i",
+      "explanation": "Remove legacy closing tags and indent nested bodies. Blocks end at the next dedent; there are no structural IDs to match."
     },
     {
       "id": "expected-keyword",
       "title": "Expected Keyword",
       "matchPatterns": ["expected keyword", "expected 'module'", "expected 'fn'", "expected 'type'"],
       "matchCodes": ["Calor0103"],
-      "description": "The parser expected a specific keyword (module, fn, type, etc.) but found something else. This usually means a structural syntax error.",
-      "wrongExample": "mymodule MyApp         // Missing 'module' keyword\n  function Add(a b)    // 'function' is not a Calor keyword",
-      "correctExample": "module MyApp\n  fn Add(a:i32 b:i32) -> i32",
-      "explanation": "Calor requires specific keywords: 'module' for module declarations, 'fn' for functions, 'type' for type definitions. Check spelling and ensure you're using Calor keywords, not C# keywords."
+      "description": "The parser expected a Calor section marker such as §M or §F but found something else. This usually means obsolete keyword syntax or a malformed declaration.",
+      "wrongExample": "module MyApp         // Obsolete keyword syntax\n  function Add(a b)    // 'function' is not a Calor marker",
+      "correctExample": "§M{m1:MyApp}\n  §F{f1:Add:pub} (i32:a, i32:b) -> i32\n    §R (+ a b)",
+      "explanation": "Use current Calor section markers: §M{id:Name} for modules and §F{id:name:vis} (type:name, ...) -> retType for functions. Do not use C# or legacy keyword forms."
     },
     {
       "id": "expected-closing-tag",
-      "title": "Expected Closing Tag",
+      "title": "Expected Indented Block",
       "matchPatterns": ["expected closing tag", "unterminated block", "missing §/", "unclosed"],
       "matchCodes": ["Calor0105"],
-      "description": "A block was opened with a section marker but never properly closed. Every §IF, §LOOP, §TRY, §MATCH, §NEW, §FOREACH must have a matching closing tag.",
-      "wrongExample": "§IF{if1} (> x 0)\n  §R x\n// Missing §/I{if1}",
-      "correctExample": "§IF{if1} (> x 0)\n  §R x\n§/I{if1}",
-      "explanation": "Block tags must be closed: §IF→§/I, §LOOP→§/L, §TRY→§/T, §MATCH→§/M, §NEW→§/NEW, §FOREACH→§/FE. The closing tag must include the same ID as the opening tag."
+      "description": "A legacy diagnostic may mention closing tags, but current Calor blocks are indentation-delimited. This usually means a block body is missing or incorrectly indented.",
+      "wrongExample": "§IF{if1} (> x 0)\n§R x   // ERROR: body must be indented under §IF",
+      "correctExample": "§IF{if1} (> x 0)\n  §R x",
+      "explanation": "Do not add structural closing tags. Indent the block body under the opener; the block ends when indentation returns to the parent level."
     },
     {
       "id": "invalid-modifier",
@@ -188,9 +188,9 @@
       "matchPatterns": ["invalid modifier", "unexpected modifier", "modifier not allowed"],
       "matchCodes": ["Calor0107"],
       "description": "A modifier keyword was used in an invalid position or an unrecognized modifier was applied to a declaration.",
-      "wrongExample": "static fn Helper() -> i32   // 'static' may not be valid here\npublic private fn Bad()     // Conflicting modifiers",
-      "correctExample": "fn Helper() -> i32\npub fn Good() -> i32",
-      "explanation": "Calor uses its own modifier keywords (pub, mut, etc.). C# modifiers like static, private, protected are not directly supported. Check the Calor language reference for valid modifiers."
+      "wrongExample": "static §F{f1:Helper:pub} () -> i32   // C# modifier before Calor marker\n§F{f2:Bad:public} () -> i32           // Use pub/priv, not public/private",
+      "correctExample": "§F{f1:Helper:pub} () -> i32\n  §R 0\n§F{f2:Good:priv} () -> i32\n  §R 1",
+      "explanation": "Calor stores visibility and modifiers inside declaration markers (for example pub or priv). C# modifier keywords like public, private, protected, and static are not written before §F."
     },
     {
       "id": "type-parameter-not-found",
@@ -198,9 +198,9 @@
       "matchPatterns": ["type parameter not found", "unknown type parameter", "undefined type param"],
       "matchCodes": ["Calor0115"],
       "description": "A reference to a generic type parameter (like T, K, V) was used but the parameter is not declared in the current scope.",
-      "wrongExample": "fn Identity(x:T) -> T      // T not declared as type param",
-      "correctExample": "fn Identity<T>(x:T) -> T   // T declared in angle brackets",
-      "explanation": "Generic type parameters must be declared in the function or type signature using angle brackets. Ensure the type parameter name matches exactly (case-sensitive)."
+      "wrongExample": "§F{f1:Identity:pub} (T:x) -> T      // T not declared as type param",
+      "correctExample": "§F{f1:Identity<T>:pub} (T:x) -> T\n  §R x",
+      "explanation": "Generic type parameters must be declared in the function or type name field using angle brackets. Ensure the type parameter name matches exactly (case-sensitive)."
     },
     {
       "id": "invalid-reference",
@@ -218,8 +218,8 @@
       "matchPatterns": ["missing extension self", "extension method", "first parameter must be self"],
       "matchCodes": ["Calor0204"],
       "description": "An extension function is missing the required 'self' first parameter. Extension functions in Calor must declare the receiver type as the first parameter.",
-      "wrongExample": "ext fn ToUpper() -> str     // Missing self parameter",
-      "correctExample": "ext fn ToUpper(self:str) -> str",
+      "wrongExample": "§F{f1:ToUpper:pub} () -> str     // Missing self parameter",
+      "correctExample": "§F{f1:ToUpper:pub} (str:self) -> str\n  §R (upper self)",
       "explanation": "Extension functions require a 'self' parameter as the first argument to specify the type being extended. This is equivalent to the 'this' parameter in C# extension methods."
     },
     {
@@ -228,9 +228,9 @@
       "matchPatterns": ["§NEW{object}", "NEW{object}"],
       "matchCodes": ["Calor0106", "Calor0200"],
       "description": "The converter generated §NEW{object} where a concrete type is needed. Use calor_fix with error code 'new_object' to auto-replace from context (binding type, field type, throw → Exception, return type).",
-      "wrongExample": "§B{b1:result:List<int>} §NEW{object}§/NEW",
-      "correctExample": "§B{b1:result:List<int>} §NEW{List<int>}§/NEW",
-      "explanation": "The calor_fix tool infers the correct type from surrounding context: §B binding types, §FLD field types, §TH throw (→ Exception), or §O return types."
+      "wrongExample": "§F{f1:Make:pub} () -> List<i32>\n  §R §NEW{object}()",
+      "correctExample": "§F{f1:Make:pub} () -> List<i32>\n  §R §NEW{List<i32>}()",
+      "explanation": "The calor_fix tool infers the correct type from surrounding context: binding values, field/property types, throw statements (→ Exception), or function/method return types."
     },
     {
       "id": "arrow-multi-statement-autofix",
@@ -239,8 +239,8 @@
       "matchCodes": ["Calor0106"],
       "description": "Arrow syntax (→) only supports a single statement. Use calor_fix with error code 'arrow_multi_statement' to convert to block form automatically.",
       "wrongExample": "§IF{if1} (condition) → §B{x} 1 §R x",
-      "correctExample": "§IF{if1} (condition)\n  §B{x} 1\n  §R x\n§/I{if1}",
-      "explanation": "The calor_fix tool detects arrow bodies with multiple §-tagged statements and rewrites them as block bodies with proper closing tags."
+      "correctExample": "§IF{if1} (condition)\n  §B{x} 1\n  §R x",
+      "explanation": "The calor_fix tool detects arrow bodies with multiple §-tagged statements and rewrites them as indented block bodies."
     },
     {
       "id": "id-conflicts-autofix",
@@ -248,9 +248,9 @@
       "matchPatterns": ["duplicate id", "id conflict", "already defined"],
       "matchCodes": ["Calor0301", "Calor0302"],
       "description": "Duplicate declaration IDs (e.g., two §F{f1:...}) cause compilation errors. Use calor_fix with error code 'id_conflicts' to renumber duplicates automatically.",
-      "wrongExample": "§F{f1:Foo:pub} ... §/F{f1}\n§F{f1:Bar:pub} ... §/F{f1}",
-      "correctExample": "§F{f1:Foo:pub} ... §/F{f1}\n§F{f2:Bar:pub} ... §/F{f2}",
-      "explanation": "The calor_fix tool scans for duplicate IDs and renumbers the second (and subsequent) occurrences while updating both opening and closing tags."
+      "wrongExample": "§F{f1:Foo:pub} () -> void\n  §R\n§F{f1:Bar:pub} () -> void\n  §R",
+      "correctExample": "§F{f1:Foo:pub} () -> void\n  §R\n§F{f2:Bar:pub} () -> void\n  §R",
+      "explanation": "The calor_fix tool scans for duplicate IDs and renumbers the second and subsequent occurrences. Blocks are indentation-delimited, so only declaration IDs need updating."
     }
   ]
 }

--- a/tests/Calor.Compiler.Tests/Mcp/AgentDocsSyntaxGuardTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/AgentDocsSyntaxGuardTests.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Calor.Compiler;
+using Calor.Compiler.Analysis;
+using Calor.Compiler.Effects;
+using Xunit;
+
+namespace Calor.Compiler.Tests.Mcp;
+
+/// <summary>
+/// Guard for EVERY agent-readable documentation surface (v0.6.7 plan, Item 0).
+/// Calor is indent-only: structural closing tags (§/F, §/M, §/L, …) hard-error at
+/// compile time (Calor0830), and the old 4-field §F/§AF header and §B{name}=value
+/// binding form are obsolete. Agent docs that teach any of these make an agent that
+/// follows Calor's own documentation write non-compiling Calor.
+///
+/// This test scans the positive-teaching text of each agent-doc surface for the
+/// forbidden forms and compiles every complete §M module it can find. The forbidden
+/// structural-closer set is the compiler's own <see cref="LegacyCloserFormLint"/>
+/// scanner (which mirrors the parser's StructuralLegacyClosers hard-error set), so the
+/// guard can never drift from the language.
+///
+/// Negative examples (JSON <c>wrongExample</c> fields, the MCP primer's "Common
+/// mistakes" section) intentionally contain closer-form and are excluded: JSON surfaces
+/// scan only designated correct-syntax fields, and the primer is guarded separately by
+/// <see cref="PrimerCompilesTests"/> / PrimerMistakesRejectedTests.
+/// </summary>
+public class AgentDocsSyntaxGuardTests
+{
+    private static readonly Regex FourFieldHeader =
+        new(@"§A?F\{[^}]*:[^}]*:[^}]*:[^}]*\}", RegexOptions.Compiled);
+
+    private static readonly Regex BindEquals =
+        new(@"§B\{[^}]*\}\s*=", RegexOptions.Compiled);
+
+    // A real module header is the marker alone on its line. Cheat-sheet / reference
+    // blocks write "§M{id:Name}   <prose describing the tag>", which must NOT be
+    // treated as compilable code.
+    private static readonly Regex ModuleHeaderLine =
+        new(@"^§M\{[^}]*\}\s*$", RegexOptions.Compiled);
+
+    // JSON property names whose string values are CORRECT Calor examples that agents are
+    // taught to imitate. Everything else (csharp, wrongExample, description, prose, …) is
+    // skipped so illustrative "don't do this" snippets are not flagged.
+    private static readonly HashSet<string> CorrectCalorJsonFields = new(StringComparer.Ordinal)
+    {
+        "calorSyntax", "calor", "syntax", "correctExample",
+    };
+
+    // ----------------------------------------------------------------------------------
+    // Surface discovery
+    // ----------------------------------------------------------------------------------
+
+    private sealed record Surface(string Name, string PositiveText);
+
+    private static readonly Lazy<IReadOnlyList<Surface>> Surfaces = new(LoadSurfaces);
+
+    private static IReadOnlyList<Surface> LoadSurfaces()
+    {
+        var root = FindRepoRoot()
+            ?? throw new InvalidOperationException("Could not locate repository root from test assembly location.");
+
+        var list = new List<Surface>();
+
+        // Whole-file positive-teaching surfaces (markdown / templates).
+        foreach (var rel in new[]
+        {
+            @"src\Calor.Compiler\Resources\Templates\copilot-instructions.md.template",
+            @"src\Calor.Compiler\Resources\Templates\AGENTS.md.template",
+            @"src\Calor.Compiler\Resources\Templates\CLAUDE.md.template",
+            @"src\Calor.Compiler\Resources\Templates\GEMINI.md.template",
+            @"src\Calor.Compiler\README.nuget.md",
+            @"tests\Calor.Evaluation\Skills\calor-language-skills.md",
+        })
+        {
+            var path = Path.Combine(root, rel);
+            list.Add(new Surface(rel, File.ReadAllText(path)));
+        }
+
+        // JSON surfaces: only the correct-Calor fields are positive teaching.
+        foreach (var rel in new[]
+        {
+            @"src\Calor.Compiler\Resources\calor-syntax-documentation.json",
+            @"src\Calor.Compiler\Resources\error-suggestions.json",
+        })
+        {
+            var path = Path.Combine(root, rel);
+            var correct = CollectCorrectCalorStrings(File.ReadAllText(path));
+            list.Add(new Surface(rel, string.Join("\n\n", correct)));
+        }
+
+        return list;
+    }
+
+    private static List<string> CollectCorrectCalorStrings(string json)
+    {
+        var result = new List<string>();
+        using var doc = JsonDocument.Parse(json);
+        Walk(doc.RootElement, propertyName: null);
+        return result;
+
+        void Walk(JsonElement el, string? propertyName)
+        {
+            switch (el.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    foreach (var prop in el.EnumerateObject())
+                    {
+                        Walk(prop.Value, prop.Name);
+                    }
+                    break;
+                case JsonValueKind.Array:
+                    foreach (var item in el.EnumerateArray())
+                    {
+                        Walk(item, propertyName);
+                    }
+                    break;
+                case JsonValueKind.String:
+                    if (propertyName != null && CorrectCalorJsonFields.Contains(propertyName))
+                    {
+                        result.Add(el.GetString()!);
+                    }
+                    break;
+            }
+        }
+    }
+
+    // ----------------------------------------------------------------------------------
+    // Structural / obsolete-form scans
+    // ----------------------------------------------------------------------------------
+
+    public static IEnumerable<object[]> AllSurfaces()
+        => Surfaces.Value.Select(s => new object[] { s.Name, s.PositiveText });
+
+    [Theory]
+    [MemberData(nameof(AllSurfaces))]
+    public void Surface_TeachesNoStructuralClosers(string name, string positiveText)
+    {
+        var findings = LegacyCloserFormLint.Scan(positiveText, name);
+        Assert.True(
+            findings.Count == 0,
+            $"Agent-doc surface '{name}' teaches {findings.Count} legacy structural closer(s) that " +
+            $"hard-error (Calor0830). Calor is indent-only; delete the closer(s):\n" +
+            string.Join("\n", findings.Select(f => $"  §/{f.Keyword} at L{f.Line}:{f.Column}")));
+    }
+
+    [Theory]
+    [MemberData(nameof(AllSurfaces))]
+    public void Surface_TeachesNoFourFieldFunctionHeaders(string name, string positiveText)
+    {
+        var matches = FourFieldHeader.Matches(positiveText);
+        Assert.True(
+            matches.Count == 0,
+            $"Agent-doc surface '{name}' teaches {matches.Count} obsolete 4-field §F/§AF header(s) " +
+            $"(§F{{id:name:returnType:vis}}). Use the 3-field header + signature: " +
+            $"§F{{id:name:vis}} (type:name) -> retType. Offenders:\n" +
+            string.Join("\n", matches.Select(m => "  " + m.Value)));
+    }
+
+    [Theory]
+    [MemberData(nameof(AllSurfaces))]
+    public void Surface_TeachesNoBindEqualsForm(string name, string positiveText)
+    {
+        var matches = BindEquals.Matches(positiveText);
+        Assert.True(
+            matches.Count == 0,
+            $"Agent-doc surface '{name}' teaches {matches.Count} obsolete §B{{name}}=value binding(s). " +
+            $"Use §B{{name}} expr (no '='). Offenders:\n" +
+            string.Join("\n", matches.Select(m => "  " + m.Value)));
+    }
+
+    [Fact]
+    public void Guard_CoversEveryKnownSurface()
+    {
+        // Drift guard: if a surface is removed/renamed this fails loudly rather than
+        // silently scanning fewer files. 6 markdown/template + 2 JSON surfaces.
+        Assert.Equal(8, Surfaces.Value.Count);
+    }
+
+    // ----------------------------------------------------------------------------------
+    // Complete-module compile check
+    // ----------------------------------------------------------------------------------
+
+    public static IEnumerable<object[]> CompleteModules()
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var surface in Surfaces.Value)
+        {
+            foreach (var module in ExtractCompleteModules(surface.PositiveText))
+            {
+                if (seen.Add(module))
+                {
+                    var header = module.Split('\n')[0].Trim();
+                    yield return new object[] { surface.Name, header, module };
+                }
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(CompleteModules))]
+    public void CompleteModule_Compiles(string surface, string header, string source)
+    {
+        // Illustrative doc snippets may call external methods and omit effect
+        // declarations for brevity; disable unknown-call and effect enforcement so this
+        // check fails only on real parse/bind/emit breakage (closer-form is a parse
+        // error regardless of effect policy) — the syntax correctness the sweep is about.
+        var options = new CompilationOptions
+        {
+            ContractMode = ContractMode.Debug,
+            UnknownCallPolicy = UnknownCallPolicy.Warn,
+            EnforceEffects = false,
+            StrictEffects = false,
+            VerifyContracts = false,
+        };
+
+        var result = Program.Compile(source, "agent-doc-example.calr", options);
+        var errors = result.Diagnostics.Where(d => d.IsError).ToList();
+
+        Assert.True(
+            errors.Count == 0,
+            $"Agent-doc module '{header}' from '{surface}' must compile but produced {errors.Count} error(s):\n" +
+            string.Join("\n", errors.Select(e => $"  [{e.Code}] L{e.Span.Line}:{e.Span.Column} {e.Message}")) +
+            $"\n--- source ---\n{source}");
+    }
+
+    /// <summary>
+    /// Extracts every complete module from arbitrary text: a module begins at a
+    /// column-0 <c>§M{</c> line and includes every following blank or indented line,
+    /// ending at the next column-0 non-blank line. Fenced markdown code blocks keep the
+    /// module at column 0, so this works for both markdown and raw JSON-field snippets.
+    /// </summary>
+    private static IEnumerable<string> ExtractCompleteModules(string text)
+    {
+        var lines = text.Replace("\r\n", "\n").Split('\n');
+        var i = 0;
+        while (i < lines.Length)
+        {
+            if (!ModuleHeaderLine.IsMatch(lines[i]))
+            {
+                i++;
+                continue;
+            }
+
+            var start = i;
+            i++;
+            while (i < lines.Length && (lines[i].Length == 0 || char.IsWhiteSpace(lines[i][0])))
+            {
+                i++;
+            }
+
+            var end = i;
+            while (end > start + 1 && lines[end - 1].Trim().Length == 0)
+            {
+                end--;
+            }
+
+            yield return string.Join("\n", lines[start..end]) + "\n";
+        }
+    }
+
+    // ----------------------------------------------------------------------------------
+    // Repo-root discovery (mirrors BindCorpusCleanTests)
+    // ----------------------------------------------------------------------------------
+
+    private static string? FindRepoRoot()
+    {
+        var assemblyDir = Path.GetDirectoryName(typeof(AgentDocsSyntaxGuardTests).Assembly.Location);
+        var dir = assemblyDir != null ? new DirectoryInfo(assemblyDir) : null;
+        while (dir != null)
+        {
+            var sln = Path.Combine(dir.FullName, "Calor.sln");
+            var templates = Path.Combine(dir.FullName, "src", "Calor.Compiler", "Resources", "Templates");
+            if (File.Exists(sln) && Directory.Exists(templates))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}

--- a/tests/Calor.Compiler.Tests/Mcp/AgentDocsSyntaxGuardTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/AgentDocsSyntaxGuardTests.cs
@@ -77,7 +77,7 @@ public class AgentDocsSyntaxGuardTests
             @"tests\Calor.Evaluation\Skills\calor-language-skills.md",
         })
         {
-            var path = Path.Combine(root, rel);
+            var path = Path.Combine(root, ToPlatformRelative(rel));
             list.Add(new Surface(rel, File.ReadAllText(path)));
         }
 
@@ -88,13 +88,20 @@ public class AgentDocsSyntaxGuardTests
             @"src\Calor.Compiler\Resources\error-suggestions.json",
         })
         {
-            var path = Path.Combine(root, rel);
+            var path = Path.Combine(root, ToPlatformRelative(rel));
             var correct = CollectCorrectCalorStrings(File.ReadAllText(path));
             list.Add(new Surface(rel, string.Join("\n\n", correct)));
         }
 
         return list;
     }
+
+    // The surface paths above are written with Windows-style '\' separators for
+    // readability; normalize them to the running platform's separator so the
+    // guard reads the files on Linux/macOS CI as well as on Windows.
+    private static string ToPlatformRelative(string rel) =>
+        rel.Replace('\\', Path.DirectorySeparatorChar)
+           .Replace('/', Path.DirectorySeparatorChar);
 
     private static List<string> CollectCorrectCalorStrings(string json)
     {

--- a/tests/Calor.Evaluation/Skills/calor-language-skills.md
+++ b/tests/Calor.Evaluation/Skills/calor-language-skills.md
@@ -30,14 +30,14 @@ Calor natively supports far more C# constructs than you might expect. Before usi
 |-------------|-------------|--------|
 | foreach loop | `§L{item:collection}` | Full |
 | for loop | `§L{var:start..end}` | Full |
-| while loop | `§WH{condition}` | Full |
+| while loop | `§WH{id} (cond)` with an indented body | Full |
 | do-while loop | `§DO{id} ... §/DO{id} condition` | Full |
-| switch/match | `§W{expr} §K{pattern} result §/W` | Full |
-| if/else | `§IF{condition} ... §EI ... §EL ... §/IF` | Full |
-| async/await | `§AF{id:name}` / `§AMT{id:name}` / `§AWAIT expr §/AWAIT` | Full |
+| switch/match | `§W{expr}` with indented `§K{pattern}` cases | Full |
+| if/else | `§IF{id} (cond)` / `§EI (cond)` / `§EL` with indented bodies | Full |
+| async/await | `§AF{id:name:vis} (params) -> ret` / `§AMT{id:name:vis} (params) -> ret` / `§AWAIT expr` | Full |
 | yield return | `§YIELD expr` / `§YBRK` | Full |
-| try/catch/finally | `§TR{} ... §CA{Type:var} ... §FI{} ... §/TR` | Full |
-| using statement | `§USE{var}=expr ... §/USE` | Full |
+| try/catch/finally | `§TR{id}` / `§CA{Type:var}` / `§FI` with indented bodies | Full |
+| using statement | `§USE{var} expr` with an indented body | Full |
 | struct types | `§CL{id:Name:vis:struct}` | Full |
 | generic constraints | `§G{T}` / `§WHERE{T:constraint}` | Full |
 | delegates | `§DEL{id:Name:vis}` | Full |
@@ -56,7 +56,7 @@ Calor natively supports far more C# constructs than you might expect. Before usi
 | attributes | `[@AttributeName]` or `[@Attr(args)]` | Full |
 | LINQ (method syntax) | `§C{coll.Where} §A §LAM{...} ... §/C` | Full |
 | indexers (this[]) | `§IXER{id:type:vis:get,set} (type:param)` | Full |
-| unsafe code | `§UNSAFE{id} ... §/UNSAFE{id}` | Full |
+| unsafe code | `§UNSAFE{id}` with an indented body | Full |
 | is pattern combinators | `(&& (> x 0) (< x 100))` / `(|| ...)` | Full |
 | range expression (0..5) | `§RANGE start end` | Full |
 | index from end (^1) | `§^ n` | Full |
@@ -90,14 +90,11 @@ The contracts become your specification. **If you can't satisfy a postcondition,
 
 ```calor
 // FIRST: Write the contracts
-§F{f001:MyFunction:pub}
-  §I{i32:n}
-  §O{i32}
+§F{f001:MyFunction:pub} (i32:n) -> i32
   §Q (> n 0)           // Input constraint from requirement
   §S (>= result 0)     // Output guarantee from requirement
   // THEN: Implement logic that satisfies the contracts
   §R ...
-§/F{f001}
 ```
 
 ## Why Contracts Give You an Advantage
@@ -174,9 +171,7 @@ The `(len arr)` operation will throw `NullReferenceException` if `arr` is null. 
 
 **Example - Array Max function:**
 ```calor
-§F{f001:Max:pub}
-  §I{[i32]:arr}
-  §O{i32}
+§F{f001:Max:pub} ([i32]:arr) -> i32
   §Q (!= arr null)              // First: array must not be null
   §Q (> (len arr) 0)            // Then: array must have elements
   §B{max} §IDX arr 0
@@ -185,11 +180,10 @@ The `(len arr)` operation will throw `NullReferenceException` if `arr` is null. 
     §B{current} §IDX arr i
     §IF{if1} (> current max)
       §ASSIGN max current
-    §/I{if1}
+
     §ASSIGN i (+ i 1)
-  §/WH{wh1}
+
   §R max
-§/F{f001}
 ```
 
 **Why this matters:** Without the null check, passing `null` causes a runtime crash (`NullReferenceException`) instead of a clean contract violation (`ContractViolationException`). The null check ensures invalid inputs are rejected with a proper error message.
@@ -202,12 +196,11 @@ The `(len arr)` operation will throw `NullReferenceException` if `arr` is null. 
 §M{id:Name}           Module (namespace) — dotted names supported for nested namespaces
                       e.g. §M{m001:Calor.Runtime} → namespace Calor.Runtime { ... }
                       e.g. §M{m001:MyApp.Services} → namespace MyApp.Services { ... }
-§F{id:Name:vis}       Function (pub|pri)
-§I{type:name}         Input parameter
-§O{type}              Output/return type
+§F{id:Name:vis} (type:name, ...) -> returnType
+                      Function (pub|pri) with parameters and return type
 §E{effects}           Side effects: cw,cr,fs:r,fs:w,net:rw,db:rw
 §U{namespace}         Using directive
-§/M{id} §/F{id}       Close tags (ID must match)
+Indentation delimits modules/functions; do not write structural close tags
 ```
 
 ### Types
@@ -285,13 +278,13 @@ INT:2147483647     // int.MaxValue (2^31 - 1)
 **Use IF expressions to implement these:**
 ```calor
 // Absolute value - NO (abs x) operator!
-§B{absVal} §IF{if1} (< x 0) → (- 0 x) §EL → x §/I{if1}
+§B{absVal} §IF{if1} (< x 0) → (- 0 x) §EL → x
 
 // Maximum - NO (max a b) operator!
-§B{maxVal} §IF{if1} (> a b) → a §EL → b §/I{if1}
+§B{maxVal} §IF{if1} (> a b) → a §EL → b
 
 // Minimum - NO (min a b) operator!
-§B{minVal} §IF{if1} (< a b) → a §EL → b §/I{if1}
+§B{minVal} §IF{if1} (< a b) → a §EL → b
 ```
 
 ### String Operations
@@ -405,16 +398,16 @@ INT:2147483647     // int.MaxValue (2^31 - 1)
 **Array Creation:**
 ```calor
 // Sized array with literal
-§B{[i32]:arr} §ARR{a001:i32:5}              // Create int[5]
+§B{arr} §ARR{a001:i32:5}                    // Create int[5]
 
 // Sized array with variable
-§B{[i32]:arr} §ARR{a001:i32:n}              // Create int[n]
+§B{arr} §ARR{a001:i32:n}                    // Create int[n]
 
 // Sized array with expression
-§B{[i32]:result} §ARR{a001:i32:(len data)}  // Create int[data.Length]
+§B{result} §ARR{a001:i32:(len data)}        // Create int[data.Length]
 
 // Initialized array
-§B{[i32]:arr} §ARR{a001:i32} 1 2 3 §/ARR{a001}  // Create [1, 2, 3]
+§B{arr} §ARR{a001:i32} 1 2 3 §/ARR{a001}       // Create [1, 2, 3]
 ```
 
 **Array Element Access:**
@@ -452,9 +445,7 @@ INT:2147483647     // int.MaxValue (2^31 - 1)
 
 **Complete Array Example:**
 ```calor
-§F{f001:SumArray:pub}
-  §I{[i32]:nums}
-  §O{i32}
+§F{f001:SumArray:pub} ([i32]:nums) -> i32
   §B{sum} 0
   §B{i} 0
   §WH{wh1} (< i (len nums))
@@ -462,9 +453,8 @@ INT:2147483647     // int.MaxValue (2^31 - 1)
     §B{val} §IDX nums i
     §ASSIGN sum (+ sum val)
     §ASSIGN i (+ i 1)
-  §/WH{wh1}
+
   §R sum
-§/F{f001}
 ```
 
 **CRITICAL: Don't mix tag-style (§IDX) inside Lisp expressions or contracts:**
@@ -494,11 +484,10 @@ Calor has two styles for if statements. Choosing the wrong one causes compilatio
 §IF{id} (condition) → §R value1
 §EI (condition2) → §R value2
 §EL → §R value3
-§/I{id}
 ```
 - Use ONLY when each branch has exactly ONE statement
 - The statement must immediately follow the arrow
-- Always end with `§/I{id}`
+- End the if by dedenting; do not write a structural close tag
 
 **Block syntax - MULTIPLE STATEMENTS:**
 ```calor
@@ -508,7 +497,6 @@ Calor has two styles for if statements. Choosing the wrong one causes compilatio
   // multiple statements allowed here
   §B{x} 5
   §R x
-§/I{id}
 ```
 - Use when ANY branch needs more than one statement
 - No arrow after the condition
@@ -519,12 +507,12 @@ Calor has two styles for if statements. Choosing the wrong one causes compilatio
 §IF can be used as an expression to return a value (like C#'s ternary `?:`):
 
 ```calor
-// Syntax: §IF{id} condition → thenValue §EL → elseValue §/I{id}
-§B{x} §IF{if1} (< n 0) → (- 0 n) §EL → n §/I{if1}
+// Syntax: §IF{id} (condition) → thenValue §EL → elseValue
+§B{x} §IF{if1} (< n 0) → (- 0 n) §EL → n
 // Compiles to: var x = (n < 0) ? (0 - n) : n;
 
 // Conditional assignment - minimum of two values
-§B{minLen} §IF{if1} (<= lenA lenB) → lenA §EL → lenB §/I{if1}
+§B{minLen} §IF{if1} (<= lenA lenB) → lenA §EL → lenB
 // Compiles to: var minLen = (lenA <= lenB) ? lenA : lenB;
 ```
 
@@ -534,15 +522,14 @@ Calor has two styles for if statements. Choosing the wrong one causes compilatio
 ```calor
 // WRONG - arrow syntax cannot have statements after it on separate lines
 §IF{if1} (== x 0) → §R false
-§ASSIGN y (+ y 1)    // ERROR: parser expects §/I or §EI here
-§/I{if1}
+§ASSIGN y (+ y 1)    // ERROR: arrow syntax accepts only the branch statement here
 ```
 
 **CORRECT - use block syntax when you need multiple statements:**
 ```calor
 §IF{if1} (== x 0)
   §R false
-§/I{if1}
+
 §ASSIGN y (+ y 1)    // Now this is outside the if, which is correct
 ```
 
@@ -550,14 +537,12 @@ Calor has two styles for if statements. Choosing the wrong one causes compilatio
 ```calor
 §L{id:var:start:end:step}
   // body (var goes from start to end inclusive)
-§/L{id}
 ```
 
 **While Loop:**
 ```calor
 §WH{id} (condition)
   // body - use block-style ifs inside loops
-§/WH{id}
 ```
 
 **Do-While Loop:**
@@ -579,16 +564,15 @@ When you have a loop with conditional logic inside, use block-style for inner if
 §WH{wh1} (condition)
   §IF{if1} (check)
     §R result
-  §/I{if1}
+
   §ASSIGN i (+ i 1)
-§/WH{wh1}
 ```
 
 ### Bindings and Assignment
 
 ```calor
 §B{varName} expression    // Create binding: varName = expression
-§B{type:varName} expr     // Create binding with explicit type
+§B{~varName} expression   // Create mutable binding
 §ASSIGN varName expr      // Update existing binding
 ```
 
@@ -619,101 +603,73 @@ When you have a loop with conditional logic inside, use block-style for inner if
 
 ### Simple Function (no constraints)
 ```calor
-§F{f001:Square:pub}
-  §I{i32:n}
-  §O{i32}
+§F{f001:Square:pub} (i32:n) -> i32
   §R (* n n)
-§/F{f001}
 ```
 
 ### Function with Precondition
 ```calor
-§F{f001:SafeDivide:pub}
-  §I{i32:a}
-  §I{i32:b}
-  §O{i32}
+§F{f001:SafeDivide:pub} (i32:a, i32:b) -> i32
   §Q (!= b 0)
   §R (/ a b)
-§/F{f001}
 ```
 
 ### Function with Postcondition
 ```calor
-§F{f001:Abs:pub}
-  §I{i32:n}
-  §O{i32}
+§F{f001:Abs:pub} (i32:n) -> i32
   §S (>= result 0)
   §IF{if1} (< n 0) → §R (- 0 n)
   §EL → §R n
-  §/I{if1}
-§/F{f001}
 ```
 
 ### Function with Both Pre and Postconditions
 ```calor
-§F{f001:Clamp:pub}
-  §I{i32:value}
-  §I{i32:min}
-  §I{i32:max}
-  §O{i32}
+§F{f001:Clamp:pub} (i32:value, i32:min, i32:max) -> i32
   §Q (<= min max)
   §S (>= result min)
   §S (<= result max)
   §IF{if1} (< value min) → §R min
   §EI (> value max) → §R max
   §EL → §R value
-  §/I{if1}
-§/F{f001}
 ```
 
 ### Recursive Function
 ```calor
-§F{f001:Factorial:pub}
-  §I{i32:n}
-  §O{i32}
+§F{f001:Factorial:pub} (i32:n) -> i32
   §Q (>= n 0)
   §S (>= result 1)
   §IF{if1} (<= n 1) → §R 1
   §EL → §R (* n §C{Factorial} §A (- n 1) §/C)
-  §/I{if1}
-§/F{f001}
 ```
 
 ### Loop-based Function
 ```calor
-§F{f001:Power:pub}
-  §I{i32:base}
-  §I{i32:exp}
-  §O{i32}
+§F{f001:Power:pub} (i32:base, i32:exp) -> i32
   §Q (>= exp 0)
   §B{result} 1
   §L{for1:i:1:exp:1}
     §ASSIGN result (* result base)
-  §/L{for1}
+
   §R result
-§/F{f001}
 ```
 
 ### Loop with Conditional (Block-Style)
 When a loop contains an if statement, always use block-style for the inner if:
 ```calor
-§F{f001:IsPrime:pub}
-  §I{i32:n}
-  §O{bool}
+§F{f001:IsPrime:pub} (i32:n) -> bool
   §Q (> n 0)
   §IF{if1} (<= n 1) → §R false
   §EI (== n 2) → §R true
   §EI (== (% n 2) 0) → §R false
-  §/I{if1}
+
   §B{i} 3
   §WH{wh1} (<= (* i i) n)
     §IF{if2} (== (% n i) 0)
       §R false
-    §/I{if2}
+
     §ASSIGN i (+ i 2)
-  §/WH{wh1}
+
   §R true
-§/F{f001}
 ```
 
 ## Complex Composed Examples
@@ -724,42 +680,24 @@ These examples demonstrate real-world patterns that combine multiple Calor featu
 // C# patterns: class, fields, constructor, ==, !=, Equals, operator overloads
 ```calor
 §M{m001:PointModule}
-§CL{cl01:Point:pub}
-  §FLD{i32:_x:pri}
-  §FLD{i32:_y:pri}
+  §CL{cl01:Point:pub}
+    §FLD{i32:_x:pri}
+    §FLD{i32:_y:pri}
 
-  §CTOR{ct01:pub}
-    §I{i32:x}
-    §I{i32:y}
-    §ASSIGN §THIS._x x
-    §ASSIGN §THIS._y y
-  §/CTOR{ct01}
+    §CTOR{ct01:pub} (i32:x, i32:y)
+      §ASSIGN §THIS._x x
+      §ASSIGN §THIS._y y
 
-  §MT{mt01:Equals:pub}
-    §I{Point:other}
-    §O{bool}
-    §IF{if1} (== other null) → §R false
-    §EL → §R true
-    §/I{if1}
-  §/MT{mt01}
+    §MT{mt01:Equals:pub} (Point:other) -> bool
+      §IF{if1} (== other null) → §R false
+      §EL → §R true
 
-  §OP{op01:==:pub}
-    §I{Point:left}
-    §I{Point:right}
-    §O{bool}
-    §IF{if1} (== left null) → §R (== right null)
-    §EL → §R §C{left.Equals} §A right §/C
-    §/I{if1}
-  §/OP{op01}
+    §OP{op01:==:pub} (Point:left, Point:right) -> bool
+      §IF{if1} (== left null) → §R (== right null)
+      §EL → §R §C{left.Equals} §A right §/C
 
-  §OP{op02:!=:pub}
-    §I{Point:left}
-    §I{Point:right}
-    §O{bool}
-    §R (not (== left right))
-  §/OP{op02}
-§/CL{cl01}
-§/M{m001}
+    §OP{op02:!=:pub} (Point:left, Point:right) -> bool
+      §R (not (== left right))
 ```
 
 ### Async Method with Try/Catch
@@ -777,12 +715,6 @@ These examples demonstrate real-world patterns that combine multiple Calor featu
         §R (+ "data from " url)
       §CA{Exception:ex}
         §R (+ "error: " ex.Message)
-      §/TR{try003}
-    §/AMT{m002}
-
-  §/CL{c001}
-
-§/M{m001}
 ```
 
 ### Enum with Switch/Match
@@ -795,7 +727,6 @@ These examples demonstrate real-world patterns that combine multiple Calor featu
     Active
     Suspended
     Closed
-  §/EN{e001}
 
   §CL{c002:StatusHelper:pub}
     §MT{m003:GetLabel:pub:stat} (Status:s) -> str
@@ -805,12 +736,6 @@ These examples demonstrate real-world patterns that combine multiple Calor featu
         §K Status.Suspended → "Temporarily Suspended"
         §K Status.Closed → "Closed"
         §K _ → "Unknown"
-      §/W{match004}
-    §/MT{m003}
-
-  §/CL{c002}
-
-§/M{m001}
 ```
 
 ### Yield Iterator
@@ -824,47 +749,34 @@ These examples demonstrate real-world patterns that combine multiple Calor featu
     §MT{m002:GetEvens:pub} (i32:max) -> Seq<i32>
       §L{for003:i:0:max:2}
         §YIELD i
-      §/L{for003}
-    §/MT{m002}
-
-  §/CL{c001}
-
-§/M{m001}
 ```
 
 ### Hybrid Native + §CSHARP Interop
 // C# patterns: native Calor class with one method using raw C# via §CSHARP block
 ```calor
 §M{m001:HybridModule}
-§CL{cl01:DataProcessor:pub}
-  §FLD{str:_connStr:pri}
+  §CL{cl01:DataProcessor:pub}
+    §FLD{str:_connStr:pri}
 
-  §CTOR{ct01:pub}
-    §I{str:connStr}
-    §ASSIGN §THIS._connStr connStr
-  §/CTOR{ct01}
+    §CTOR{ct01:pub} (str:connStr)
+      §ASSIGN §THIS._connStr connStr
 
-  §MT{mt01:GetCount:pub}
-    §I{str:table}
-    §O{i32}
-    §B{query} (concat "SELECT COUNT(*) FROM " table)
-    §R §C{Execute} §A _connStr §A query §/C
-  §/MT{mt01}
+    §MT{mt01:GetCount:pub} (str:table) -> i32
+      §B{query} (concat "SELECT COUNT(*) FROM " table)
+      §R §C{Execute} §A _connStr §A query §/C
 
-  §CSHARP{
-    public System.Data.DataTable RunQuery(string sql)
-    {
-        using var conn = new System.Data.SqlClient.SqlConnection(_connStr);
-        conn.Open();
-        using var cmd = new System.Data.SqlClient.SqlCommand(sql, conn);
-        var adapter = new System.Data.SqlClient.SqlDataAdapter(cmd);
-        var table = new System.Data.DataTable();
-        adapter.Fill(table);
-        return table;
-    }
-  }§/CSHARP
-§/CL{cl01}
-§/M{m001}
+    §CSHARP{
+      public System.Data.DataTable RunQuery(string sql)
+      {
+          using var conn = new System.Data.SqlClient.SqlConnection(_connStr);
+          conn.Open();
+          using var cmd = new System.Data.SqlClient.SqlCommand(sql, conn);
+          var adapter = new System.Data.SqlClient.SqlDataAdapter(cmd);
+          var table = new System.Data.DataTable();
+          adapter.Fill(table);
+          return table;
+      }
+    }§/CSHARP
 ```
 
 ## String Operation Examples
@@ -877,13 +789,8 @@ Task: Return `"{type}:{id}"`
 
 ```calor
 §M{m001:CacheModule}
-§F{f001:BuildCacheKey:pub}
-  §I{str:type}
-  §I{i32:id}
-  §O{str}
-  §R (concat type ":" (str id))
-§/F{f001}
-§/M{m001}
+  §F{f001:BuildCacheKey:pub} (str:type, i32:id) -> str
+    §R (concat type ":" (str id))
 ```
 
 ### Generating Formatted Tokens
@@ -892,13 +799,8 @@ Task: Return `"TOKEN-{userId}-{sequence}"`
 
 ```calor
 §M{m001:TokenModule}
-§F{f001:GenerateToken:pub}
-  §I{i32:userId}
-  §I{i32:sequence}
-  §O{str}
-  §R (fmt "TOKEN-{0}-{1}" userId sequence)
-§/F{f001}
-§/M{m001}
+  §F{f001:GenerateToken:pub} (i32:userId, i32:sequence) -> str
+    §R (fmt "TOKEN-{0}-{1}" userId sequence)
 ```
 
 ### Zero-Padded IDs
@@ -907,13 +809,8 @@ Task: Return `"{prefix}-{sequence:D6}"` (6-digit zero-padded)
 
 ```calor
 §M{m001:IdModule}
-§F{f001:GenerateId:pub}
-  §I{str:prefix}
-  §I{i32:sequence}
-  §O{str}
-  §R (fmt "{0}-{1:D6}" prefix sequence)
-§/F{f001}
-§/M{m001}
+  §F{f001:GenerateId:pub} (str:prefix, i32:sequence) -> str
+    §R (fmt "{0}-{1:D6}" prefix sequence)
 ```
 
 ## Collections
@@ -924,7 +821,6 @@ Task: Return `"{prefix}-{sequence:D6}"` (6-digit zero-padded)
 §LIST{name:elementType}   // Create and initialize a list
   value1
   value2
-§/LIST{name}
 
 §PUSH{listName} value     // Add to end of list
 §INS{listName} index val  // Insert at index
@@ -941,7 +837,6 @@ Task: Return `"{prefix}-{sequence:D6}"` (6-digit zero-padded)
 §DICT{name:keyType:valType}  // Create dictionary
   §KV key1 value1
   §KV key2 value2
-§/DICT{name}
 
 §PUT{dictName} key value     // Add or update entry
 §REM{dictName} key           // Remove by key
@@ -955,7 +850,6 @@ Task: Return `"{prefix}-{sequence:D6}"` (6-digit zero-padded)
 §HSET{name:elementType}   // Create hash set
   value1
   value2
-§/HSET{name}
 
 §PUSH{setName} value      // Add to set
 §REM{setName} value       // Remove from set
@@ -969,11 +863,9 @@ Task: Return `"{prefix}-{sequence:D6}"` (6-digit zero-padded)
 §EACH{id:var} collection      // Foreach (type inferred)
 §EACH{id:var:type} collection  // Foreach (explicit type)
   ...body...
-§/EACH{id}
 
 §EACHKV{id:k:v} dict      // Foreach over dictionary key-values
   ...body...
-§/EACHKV{id}
 ```
 
 ## Async/Await
@@ -981,10 +873,8 @@ Task: Return `"{prefix}-{sequence:D6}"` (6-digit zero-padded)
 Async functions and methods use `§AF` and `§AMT` tags:
 
 ```calor
-§AF{id:Name:vis}          // Async function (returns Task<T>)
-§/AF{id}                  // End async function
-§AMT{id:Name:vis}         // Async method (returns Task<T>)
-§/AMT{id}                 // End async method
+§AF{id:Name:vis} (params) -> ret   // Async function (returns Task<T>)
+§AMT{id:Name:vis} (params) -> ret  // Async method (returns Task<T>)
 §AWAIT expr               // Await an async operation
 §AWAIT{false} expr        // Await with ConfigureAwait(false)
 ```
@@ -993,13 +883,9 @@ Async functions and methods use `§AF` and `§AMT` tags:
 
 ```calor
 §M{m001:AsyncDemo}
-§AF{f001:FetchDataAsync:pub}
-  §I{str:url}
-  §O{str}
-  §B{str:result} §AWAIT §C{client.GetStringAsync} §A url §/C
-  §R result
-§/AF{f001}
-§/M{m001}
+  §AF{f001:FetchDataAsync:pub} (str:url) -> str
+    §B{result} §AWAIT §C{client.GetStringAsync} §A url §/C
+    §R result
 ```
 
 ## Exception Handling
@@ -1013,8 +899,6 @@ Async functions and methods use `§AF` and `§AMT` tags:
   ...catch body...
 §FI                       // Finally block
   ...finally body...
-§/TR{id}                  // End try block
-
 §TH "message"             // Throw new Exception
 §TH expr                  // Throw expression
 §RT                       // Rethrow (inside catch)
@@ -1026,20 +910,14 @@ Async functions and methods use `§AF` and `§AMT` tags:
 
 ```calor
 §M{m001:ErrorHandling}
-§F{f001:SafeDivide:pub}
-  §I{i32:a}
-  §I{i32:b}
-  §O{i32}
-  §TR{t1}
-    §R (/ a b)
-  §CA{DivideByZeroException:ex}
-    §P "Division by zero!"
-    §R 0
-  §FI
-    §P "Cleanup complete"
-  §/TR{t1}
-§/F{f001}
-§/M{m001}
+  §F{f001:SafeDivide:pub} (i32:a, i32:b) -> i32
+    §TR{t1}
+      §R (/ a b)
+    §CA{DivideByZeroException:ex}
+      §P "Division by zero!"
+      §R 0
+    §FI
+      §P "Cleanup complete"
 ```
 
 ## Generics
@@ -1070,26 +948,18 @@ Type parameters use `<T>` suffix syntax after tag attributes:
 
 ```calor
 §M{m001:GenericDemo}
-§CL{c001:Repository:pub}<T>
-  §WHERE T : class
-  §FLD{List<T>:_items:pri}
+  §CL{c001:Repository:pub}<T>
+    §WHERE T : class
+    §FLD{List<T>:_items:pri}
 
-  §CTOR{ct001:pub}
-    §ASSIGN _items §NEW{List<T>}
-  §/CTOR{ct001}
+    §CTOR{ct001:pub} ()
+      §ASSIGN _items §NEW{List<T>}
 
-  §MT{m001:Add:pub}
-    §I{T:item}
-    §O{void}
-    §C{_items.Add} §A item §/C
-  §/MT{m001}
+    §MT{m001:Add:pub} (T:item) -> void
+      §C{_items.Add} §A item §/C
 
-  §MT{m002:GetAll:pub}
-    §O{IReadOnlyList<T>}
-    §R _items
-  §/MT{m002}
-§/CL{c001}
-§/M{m001}
+    §MT{m002:GetAll:pub} () -> IReadOnlyList<T>
+      §R _items
 ```
 
 ## Classes and Interfaces
@@ -1107,11 +977,7 @@ Type parameters use `<T>` suffix syntax after tag attributes:
 
 ```calor
 §IFACE{id:Name}           // Interface definition
-  §MT{id:MethodName}      // Method signature
-    §I{type:param}        // Parameters
-    §O{returnType}        // Return type
-  §/MT{id}
-§/IFACE{id}
+  §MT{id:MethodName} (type:param) -> returnType
 ```
 
 ### Method Modifiers
@@ -1127,57 +993,40 @@ Type parameters use `<T>` suffix syntax after tag attributes:
 
 ```calor
 §M{m001:Shapes}
-§CL{c001:Shape:pub abs}
-  §MT{mt001:Area:pub:abs}
-    §O{f64}
-  §/MT{mt001}
-§/CL{c001}
+  §CL{c001:Shape:pub abs}
+    §MT{mt001:Area:pub:abs} () -> f64
 
-§CL{c002:Circle:pub}
-  §EXT{Shape}
-  §FLD{f64:radius:pri}
-  §MT{mt001:Area:pub:over}
-    §O{f64}
-    §R (* 3.14159 (* radius radius))
-  §/MT{mt001}
-§/CL{c002}
-§/M{m001}
+  §CL{c002:Circle:pub}
+    §EXT{Shape}
+    §FLD{f64:radius:pri}
+    §MT{mt001:Area:pub:over} () -> f64
+      §R (* 3.14159 (* radius radius))
 ```
 
 ## Constructors
 
 ```calor
-§CTOR{id:visibility}      // Constructor
-  §I{type:param}          // Parameters
+§CTOR{id:visibility} (type:param)
   §BASE §A arg §/BASE     // Call base constructor
   §THIS §A arg §/THIS     // Call this constructor
   §ASSIGN target value    // Field assignment
-§/CTOR{id}
 ```
 
 ### Template: Constructor with Base Call
 
 ```calor
 §M{m001:Animals}
-§CL{c001:Animal:pub}
-  §FLD{str:_name:pro}
-  §CTOR{ctor001:pub}
-    §I{str:name}
-    §ASSIGN §THIS._name name
-  §/CTOR{ctor001}
-§/CL{c001}
+  §CL{c001:Animal:pub}
+    §FLD{str:_name:pro}
+    §CTOR{ctor001:pub} (str:name)
+      §ASSIGN §THIS._name name
 
-§CL{c002:Dog:pub}
-  §EXT{Animal}
-  §FLD{str:_breed:pri}
-  §CTOR{ctor001:pub}
-    §I{str:name}
-    §I{str:breed}
-    §BASE §A name §/BASE
-    §ASSIGN §THIS._breed breed
-  §/CTOR{ctor001}
-§/CL{c002}
-§/M{m001}
+  §CL{c002:Dog:pub}
+    §EXT{Animal}
+    §FLD{str:_breed:pri}
+    §CTOR{ctor001:pub} (str:name, str:breed)
+      §BASE §A name §/BASE
+      §ASSIGN §THIS._breed breed
 ```
 
 ## Switch/Match Expressions
@@ -1187,26 +1036,21 @@ Type parameters use `<T>` suffix syntax after tag attributes:
 §K pattern → expr         // Case with arrow syntax
 §K pattern                // Case with block body
   ...body...
-§/K                       // End case
-§/W{id}                   // End match
+§/K                       // End case (valid case delimiter)
+                          // Match ends at the next dedent
 ```
 
 ### Template: Switch Expression
 
 ```calor
 §M{m001:Grades}
-§F{f001:GetGrade:pub}
-  §I{i32:score}
-  §O{str}
-  §R §W{sw1} score
-    §K §PREL{gte} 90 → "A"
-    §K §PREL{gte} 80 → "B"
-    §K §PREL{gte} 70 → "C"
-    §K §PREL{gte} 60 → "D"
-    §K _ → "F"
-  §/W{sw1}
-§/F{f001}
-§/M{m001}
+  §F{f001:GetGrade:pub} (i32:score) -> str
+    §R §W{sw1} score
+      §K §PREL{gte} 90 → "A"
+      §K §PREL{gte} 80 → "B"
+      §K §PREL{gte} 70 → "C"
+      §K §PREL{gte} 60 → "D"
+      §K _ → "F"
 ```
 
 ### Guard Clauses with WHEN
@@ -1217,7 +1061,6 @@ Type parameters use `<T>` suffix syntax after tag attributes:
   §K §VAR{n} §WHEN (< n 0) → "negative"
   §K 0 → "zero"
   §K _ → "normal"
-§/W{sw1}
 ```
 
 ## Enums
@@ -1227,13 +1070,11 @@ Type parameters use `<T>` suffix syntax after tag attributes:
   Red
   Green
   Blue
-§/EN{id}
 
 §EN{id:Name:underlyingType}  // Enum with underlying type
   Ok = 200
   NotFound = 404
   Error = 500
-§/EN{id}
 ```
 
 ## Guidelines for Writing Calor
@@ -1259,7 +1100,7 @@ Type parameters use `<T>` suffix syntax after tag attributes:
    - Inside loops, prefer block-style for inner if statements
    - When in doubt, use block syntax - it always works
 
-7. **Close all structures**: Every `§IF{id}` needs `§/I{id}`, every `§WH{id}` needs `§/WH{id}`, etc. The closing ID must match the opening ID.
+7. **Use indentation to delimit structures**: Blocks end at the next dedent. Do not write structural close tags; they are compile-time errors.
 
 8. **Use contracts to verify your work**: If a postcondition fails at runtime, your implementation is incorrect. Contracts are your self-checking mechanism.
 
@@ -1272,24 +1113,18 @@ Type parameters use `<T>` suffix syntax after tag attributes:
 **WRONG - Checking length without null check first:**
 ```calor
 // WRONG: If arr is null, this throws NullReferenceException, not ContractViolationException
-§F{f001:Max:pub}
-  §I{[i32]:arr}
-  §O{i32}
+§F{f001:Max:pub} ([i32]:arr) -> i32
   §Q (> (len arr) 0)            // ❌ Crashes if arr is null!
   // ...
-§/F{f001}
 ```
 
 **CORRECT - Always check null BEFORE length:**
 ```calor
 // CORRECT: Null check first, then length check
-§F{f001:Max:pub}
-  §I{[i32]:arr}
-  §O{i32}
+§F{f001:Max:pub} ([i32]:arr) -> i32
   §Q (!= arr null)              // ✓ First: reject null
   §Q (> (len arr) 0)            // ✓ Then: check length (safe now)
   // ...
-§/F{f001}
 ```
 
 **Why this matters:** Contracts are evaluated in order. If you call `(len arr)` when `arr` is null, you get a crash instead of a proper contract violation. Always guard reference types with `(!= x null)` before accessing their properties.
@@ -1346,7 +1181,6 @@ Type parameters use `<T>` suffix syntax after tag attributes:
 §B{result} 0
 §IF{if1} (< n 0)
   §B{result} (- 0 n)            // ❌ ERROR - 'result' already exists
-§/I{if1}
 ```
 
 **CORRECT - Use §ASSIGN to update existing variables:**
@@ -1359,7 +1193,6 @@ Type parameters use `<T>` suffix syntax after tag attributes:
 §B{result} 0
 §IF{if1} (< n 0)
   §ASSIGN result (- 0 n)        // ✓ Update existing result
-§/I{if1}
 ```
 
 ### Character Literal Mistakes
@@ -1398,7 +1231,7 @@ Type parameters use `<T>` suffix syntax after tag attributes:
 **WRONG - C#-style array syntax:**
 ```calor
 // WRONG: Type with brackets after
-§I{i32[]:items}                 // ❌ ERROR - wrong type syntax
+§F{f001:UseItems:pub} (i32[]:items) -> i32  // ❌ ERROR - wrong type syntax
 
 // WRONG: C#-style element access
 §B{x} (get arr i)               // ❌ ERROR - 'get' doesn't exist
@@ -1415,7 +1248,7 @@ Type parameters use `<T>` suffix syntax after tag attributes:
 **CORRECT - Calor array syntax:**
 ```calor
 // CORRECT: Type with brackets before
-§I{[i32]:items}                 // ✓ Array of i32
+§F{f001:UseItems:pub} ([i32]:items) -> i32  // ✓ Array of i32
 
 // CORRECT: Element access with §IDX (both forms valid)
 §B{x} §IDX arr i                // ✓ arr[i]
@@ -1453,11 +1286,11 @@ Type parameters use `<T>` suffix syntax after tag attributes:
 **§IF as Expression - NOW SUPPORTED:**
 ```calor
 // IF expression for conditional values (compiles to C# ternary)
-§B{absX} §IF{if1} (< x 0) → (- 0 x) §EL → x §/I{if1}
+§B{absX} §IF{if1} (< x 0) → (- 0 x) §EL → x
 // Compiles to: var absX = (x < 0) ? (0 - x) : x;
 
 // IF expression in return
-§R §IF{if1} (< a b) → (- 0 1) §EL → 1 §/I{if1}
+§R §IF{if1} (< a b) → (- 0 1) §EL → 1
 // Compiles to: return (a < b) ? (0 - 1) : 1;
 ```
 
@@ -1473,7 +1306,6 @@ Type parameters use `<T>` suffix syntax after tag attributes:
 **CORRECT - Use string operations or character codes:**
 ```calor
 §IF{if1} (equals a b) → §R 0
-§/I{if1}
 ```
 
 For lexicographic comparison, compare character by character using `(char-at)` and `(char-code)`.
@@ -1505,12 +1337,9 @@ For lexicographic comparison, compare character by character using `(char-at)` a
 §PROP{id:Name:type:vis}   Property definition
   §GET{vis}               Getter
     §R expression
-  §/GET
   §SET                    Setter
     §ASSIGN _field value
-  §/SET
   §INIT                   Init-only setter (C# 9+)
-§/PROP{id}
 
 §FLD{type:name:vis}       Field definition
 §DEFAULT                  Default value expression
@@ -1522,15 +1351,11 @@ For lexicographic comparison, compare character by character using `(char-at)` a
 §IXER{id:type:vis:get,set} (type:param)     Compact auto-indexer (single line)
 §IXER{id:type:vis:get,set} (t1:p1, t2:p2)   Multi-parameter indexer
 
-§IXER{id:type:vis}        Full indexer definition
-  §I{type:param}           Parameter
+§IXER{id:type:vis} (type:param)  Full indexer definition
   §GET                     Getter body
     §R expression
-  §/GET
   §SET                     Setter body
     ...
-  §/SET
-§/IXER{id}
 ```
 
 C# `this[string key] { get; set; }` becomes `§IXER{ix1:str:pub:get,set} (str:key)`.
@@ -1543,7 +1368,7 @@ C# `this[string key] { get; set; }` becomes `§IXER{ix1:str:pub:get,set} (str:ke
 §DEL{id:Name:vis}         Delegate type declaration
   §I{type:param}
   §O{returnType}
-§/DEL{id}
+  // Delegate body ends at the next dedent
 ```
 
 ### Lambda Expressions
@@ -1605,7 +1430,7 @@ Alternative alias `§SW` is available for `§W`:
 
 ```
 §SW{id} target            Same as §W{id} target
-§/SW{id}                  Same as §/W{id}
+  Cases are indented under `§SW`; the match ends at the next dedent
 ```
 
 ## Pattern Matching Enhancements
@@ -1681,14 +1506,11 @@ No special tags needed — works in `§IF`, contracts (`§Q`/`§S`), bindings, a
 
 ```
 §ENUM{id:Name}            Enum (legacy alias for §EN)
-§/ENUM{id}                End enum (legacy)
+  Enum members are indented; the enum ends at the next dedent
 
 §EEXT{id:EnumName}        Extension methods for enum
-  §F{f001:MethodName:pub}
-    §I{EnumType:self}     First param becomes 'this'
-    §O{returnType}
-  §/F{f001}
-§/EEXT{id}
+  §F{f001:MethodName:pub} (EnumType:self) -> returnType
+    // First param becomes 'this'; extension block ends at the next dedent
 ```
 
 ## Extended Features: Metadata
@@ -2003,14 +1825,12 @@ Lock statements are converted to `§SYNC` blocks with full round-trip semantics.
 ```calor
 §SYNC{id} (lockExpression)
   ... body statements ...
-§/SYNC{id}
 ```
 
 ### Example
 ```calor
 §SYNC{s1} (_syncRoot)
-  §B{~count:i32} = (+ count INT:1)
-§/SYNC{s1}
+  §ASSIGN count (+ count INT:1)
 ```
 
 Compiles to:

--- a/tests/Calor.LanguageServer.Tests/Documentation/TagDocumentationProviderTests.cs
+++ b/tests/Calor.LanguageServer.Tests/Documentation/TagDocumentationProviderTests.cs
@@ -410,7 +410,7 @@ public class TagDocumentationProviderTests
         var doc = provider.GetTagDocumentation("§VR");
 
         Assert.NotNull(doc);
-        Assert.Contains("vr", doc.Syntax.ToLower());
+        Assert.Contains("virt", doc.Syntax.ToLower());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Every agent-readable documentation surface in the compiler taught **removed closer-form syntax** (structural closers that now hard-error `Calor0830`), **4-field `§F`/`§AF` headers**, and other constructs that fail to compile. An AI agent following Calor's own docs would emit non-compiling Calor. This PR (Item 0 of the v0.6.7 plan) rewrites every such surface to canonical **indent-only** Calor and adds a guard test so the docs can never silently regress.

## Surfaces rewritten
- Init templates: `copilot-instructions.md.template`, `AGENTS.md.template`, `CLAUDE.md.template`, `GEMINI.md.template`
- MCP `HelpTool` cheat-sheet; `McpMessageHandler` tag-catalog / server-instructions
- `InteropHintAnalyzer` `§USE` hint
- `README.nuget.md` example + table cell
- `Resources/calor-syntax-documentation.json` (correct-Calor fields rewritten)
- `Resources/error-suggestions.json` (incl. `variable-redeclaration`: declare once, then reassign with `§ASSIGN` — the old "correct" example re-declared a mutable binding, which is itself the error)
- `Skills/calor-language-skills.md` (full rewrite, ~123 closers removed)

## New guard test — `AgentDocsSyntaxGuardTests`
For every correct-Calor doc surface, scans for structural closers, 4-field headers, and `§B{...}=` assignments, and **compiles** each complete taught `§M` module. Locks the docs to compiling indent-only syntax.

## Test-pin update
`TagDocumentationProviderTests.GetTagDocumentation_VirtualModifier_HasCorrectSyntax` now asserts the canonical `virt` modifier (what `CalorEmitter` emits) instead of the `vr` alias, matching the corrected `§VR` doc entry.

## Verification
- Full solution build clean (`TreatWarningsAsErrors`, 0/0).
- Full solution test suite green (Compiler 5592, LanguageServer 382, Conversion 280, Evaluation 199, Tasks 48, Enforcement 249, Verification 253, Semantics 37, ILAnalysis 28, Experimental 21, RoundTrip 22 — 0 failures).
- All doc files line-ending-normalized to match each file's original (no spurious CRLF churn).

Part of the v0.6.7 plan (Item 0 / PR-0). PR-1a (parser arity diagnostic) and PR-1b (always-on `Calor0205` return-validation pass) follow.
