### PR TITLE
feat(parser): flag malformed four-field function headers (Calor0116)

### DIFF
--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -47,6 +47,19 @@ public static class DiagnosticCode
     public const string InvalidLispExpression = "Calor0114";
     public const string TypeParameterNotFound = "Calor0115";
 
+    /// <summary>
+    /// Error: A <c>§F</c>/<c>§AF</c> function header carries four positional
+    /// fields (<c>{id:name:type:vis}</c>) where the third is a return type and
+    /// the fourth a visibility. Function headers take at most
+    /// <c>{id:name:visibility}</c>; the return type belongs in the signature
+    /// (<c>(...) -&gt; type</c>). Left unflagged, the extra field is silently
+    /// dropped — the parser reads the type as the visibility and discards the
+    /// real visibility — emitting a void method (e.g. <c>void Add() { return 0; }</c>,
+    /// CS0127). Only <c>§F</c>/<c>§AF</c> are affected; <c>§MT</c>/<c>§AMT</c>
+    /// legitimately take a fourth modifier field.
+    /// </summary>
+    public const string MalformedFunctionHeader = "Calor0116";
+
     // Call-elision diagnostics (Calor0150-0159) — RFC v0.6 call-closer-elision
 
     /// <summary>

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -286,6 +286,84 @@ public sealed class Parser
             TextEdit.Replace(filePath, span.Line, 1, endLine, endColumn, string.Empty));
     }
 
+    /// <summary>
+    /// Detects the malformed four-field function header
+    /// <c>§F{id:name:type:vis}</c> / <c>§AF{id:name:type:vis}</c> and reports
+    /// <see cref="DiagnosticCode.MalformedFunctionHeader"/> (Calor0116). Only
+    /// <c>§F</c>/<c>§AF</c> are checked — <c>§MT</c>/<c>§AMT</c> legitimately
+    /// take a fourth modifier field. The detection is deliberately narrow:
+    /// exactly four positional fields whose fourth is a visibility token, which
+    /// uniquely identifies the "return type placed in the header" mistake. Left
+    /// unflagged the parser reads the type as the visibility and silently drops
+    /// the real visibility, emitting a void method (CS0127).
+    ///
+    /// The attached <see cref="SuggestedFix"/> is safe to auto-apply: it drops
+    /// the type from the header (<c>{id:name:vis}</c>) and, when no inline
+    /// signature or type-parameter list follows on the header line, appends
+    /// <c>() -&gt; type</c> so the healed function keeps the intended return
+    /// type instead of becoming void.
+    /// </summary>
+    private void CheckMalformedFunctionHeader(Token startToken, AttributeCollection attrs, Token headerOpen, Token headerClose)
+    {
+        var posCount = int.TryParse(attrs["_posCount"], out var pc) ? pc : 0;
+        if (posCount != 4)
+        {
+            return;
+        }
+
+        var visRaw = attrs["_pos3"] ?? string.Empty;
+        if (!AttributeHelper.IsVisibilityToken(visRaw))
+        {
+            return;
+        }
+
+        // The header block must be a well-formed {...} we can rewrite.
+        if (headerOpen.Kind != TokenKind.OpenBrace || headerClose.Kind != TokenKind.CloseBrace)
+        {
+            return;
+        }
+
+        var id = attrs["_pos0"] ?? string.Empty;
+        var name = attrs["_pos1"] ?? string.Empty;
+        var type = attrs["_pos2"] ?? string.Empty;
+
+        var filePath = _diagnostics.CurrentFilePath ?? string.Empty;
+        var headerEndLine = headerClose.Span.Line;
+        var headerEndColumn = headerClose.Span.Column + headerClose.Span.Length;
+
+        var edits = new List<TextEdit>
+        {
+            TextEdit.Replace(
+                filePath,
+                headerOpen.Span.Line,
+                headerOpen.Span.Column,
+                headerEndLine,
+                headerEndColumn,
+                $"{{{id}:{name}:{visRaw}}}"),
+        };
+
+        // Only inject a signature when nothing already follows the header on
+        // this line — an inline signature `(...)` or a type-parameter list
+        // `<...>` means we must not append a second one.
+        var followsSignatureOrTypeParams = Check(TokenKind.OpenParen) || Check(TokenKind.Less);
+        if (!followsSignatureOrTypeParams)
+        {
+            edits.Add(TextEdit.Insert(filePath, headerEndLine, headerEndColumn, $" () -> {type}"));
+        }
+
+        var fix = new SuggestedFix(
+            $"Move the return type '{type}' out of the header: use {{{id}:{name}:{visRaw}}} and declare the return type in the signature",
+            edits);
+
+        _diagnostics.ReportErrorWithFix(
+            startToken.Span.Union(headerClose.Span),
+            DiagnosticCode.MalformedFunctionHeader,
+            $"'{startToken.Text}' header has four fields ({{{id}:{name}:{type}:{visRaw}}}), but §F/§AF headers take at most {{id:name:visibility}}. " +
+            $"The third field '{type}' is a return type — declare it in the signature as '(...) -> {type}', not in the header. " +
+            "A four-field header silently drops the return type and emits a void method.",
+            fix);
+    }
+
     public ModuleNode Parse()
     {
         return ParseModule();
@@ -587,7 +665,9 @@ public sealed class Parser
     private FunctionNode ParseFunction()
     {
         var startToken = Expect(TokenKind.Func);
+        var headerOpen = Current;
         var attrs = ParseAttributes();
+        CheckMalformedFunctionHeader(startToken, attrs, headerOpen, Peek(-1));
 
         var (id, funcName, visibilityStr) = AttributeHelper.InterpretFuncAttributes(attrs);
 
@@ -779,7 +859,9 @@ public sealed class Parser
     private FunctionNode ParseAsyncFunction()
     {
         var startToken = Expect(TokenKind.AsyncFunc);
+        var headerOpen = Current;
         var attrs = ParseAttributes();
+        CheckMalformedFunctionHeader(startToken, attrs, headerOpen, Peek(-1));
 
         var (id, funcName, visibilityStr) = AttributeHelper.InterpretFuncAttributes(attrs);
 

--- a/tests/Calor.Compiler.Tests/MalformedFunctionHeaderTests.cs
+++ b/tests/Calor.Compiler.Tests/MalformedFunctionHeaderTests.cs
@@ -1,0 +1,389 @@
+using Calor.Compiler;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Effects;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// v0.6.7 Item 1a — the parser flags a malformed four-field function header
+/// <c>§F{id:name:type:vis}</c> / <c>§AF{id:name:type:vis}</c> with
+/// <c>Calor0116 MalformedFunctionHeader</c> and an auto-applicable
+/// <see cref="SuggestedFix"/>.
+///
+/// <para>
+/// Canonical function headers are three-field (<c>§F{id:name:vis}</c>) with the
+/// return type declared in the signature (<c>(...) -&gt; type</c>). A four-field
+/// header silently misreads the return type as the visibility, drops the real
+/// visibility, and emits a <c>void</c> method that returns a value — a CS0127 in
+/// the generated C# with no Calor-level explanation. This diagnostic closes that
+/// gap. It is deliberately narrow: it fires ONLY when the fourth field is a
+/// visibility token, and it is wired ONLY into <c>§F</c>/<c>§AF</c> — never into
+/// <c>§MT</c>/<c>§AMT</c>, whose fourth field is a legitimate modifier.
+/// </para>
+/// </summary>
+public class MalformedFunctionHeaderTests
+{
+    private static (IList<Diagnostic> Diagnostics, bool HasErrors) Parse(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAllForParser();
+        var parser = new Parser(tokens, diagnostics);
+        _ = parser.Parse();
+        return (diagnostics.ToList(), diagnostics.HasErrors);
+    }
+
+    private static DiagnosticBag ParseBag(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAllForParser();
+        var parser = new Parser(tokens, diagnostics);
+        _ = parser.Parse();
+        return diagnostics;
+    }
+
+    // ---------------------------------------------------------------------
+    // Positive — fires on malformed four-field §F / §AF headers.
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Function_FourFieldHeader_EmitsCalor0116()
+    {
+        const string src = """
+            §M{m1:Calc}
+              §F{f1:Add:i32:pub}
+                §R (+ 1 2)
+            """;
+        var (diags, _) = Parse(src);
+
+        var malformed = diags.Where(d => d.Code == DiagnosticCode.MalformedFunctionHeader).ToList();
+        Assert.Single(malformed);
+        Assert.Contains("four fields", malformed[0].Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("i32", malformed[0].Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AsyncFunction_FourFieldHeader_EmitsCalor0116()
+    {
+        const string src = """
+            §M{m1:Calc}
+              §AF{f1:FetchAsync:i32:pub}
+                §R (+ 1 2)
+            """;
+        var (diags, _) = Parse(src);
+
+        var malformed = diags.Where(d => d.Code == DiagnosticCode.MalformedFunctionHeader).ToList();
+        Assert.Single(malformed);
+        Assert.Contains("four fields", malformed[0].Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ---------------------------------------------------------------------
+    // Negative — valid forms must NOT fire.
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Function_ThreeFieldHeader_NoCalor0116()
+    {
+        const string src = """
+            §M{m1:Calc}
+              §F{f1:Add:pub} (i32:a, i32:b) -> i32
+                §R (+ a b)
+            """;
+        var (diags, hasErrors) = Parse(src);
+
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.MalformedFunctionHeader);
+        Assert.False(hasErrors, "Canonical three-field header must parse cleanly");
+    }
+
+    [Fact]
+    public void Method_FourFieldModifier_NoCalor0116()
+    {
+        // §MT's fourth field is a legitimate modifier (virt) — never Calor0116.
+        const string src = """
+            §M{m1:Calc}
+              §CL{c1:Greeter:pub}
+                §MT{mt1:Name:pub:virt} () -> str
+                  §R STR:"x"
+            """;
+        var (diags, _) = Parse(src);
+
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.MalformedFunctionHeader);
+    }
+
+    [Fact]
+    public void AsyncMethod_FourFieldModifier_NoCalor0116()
+    {
+        // §AMT's fourth field is a legitimate modifier (virt) — never Calor0116.
+        const string src = """
+            §M{m1:Calc}
+              §CL{c1:Svc:pub}
+                §AMT{mt1:GetAsync:pub:virt} () -> i32
+                  §R (+ 1 2)
+            """;
+        var (diags, _) = Parse(src);
+
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.MalformedFunctionHeader);
+    }
+
+    [Fact]
+    public void Function_FourFieldHeader_NonVisibilityFourthField_NoCalor0116()
+    {
+        // Narrowness guard: the diagnostic requires the FOURTH field to be a
+        // visibility token. A non-visibility fourth field is some other shape
+        // and must not be misattributed to the malformed-header pattern.
+        const string src = """
+            §M{m1:Calc}
+              §F{f1:Add:i32:frobnicate}
+                §R (+ 1 2)
+            """;
+        var (diags, _) = Parse(src);
+
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.MalformedFunctionHeader);
+    }
+
+    // ---------------------------------------------------------------------
+    // Fix — structure and healing behaviour.
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Fix_HeaderOnly_CarriesReplaceAndSignatureInsert()
+    {
+        const string src = """
+            §M{m1:Calc}
+              §F{f1:Add:i32:pub}
+                §R (+ 1 2)
+            """;
+        var bag = ParseBag(src);
+
+        var dwf = Assert.Single(
+            bag.DiagnosticsWithFixes.Where(d => d.Code == DiagnosticCode.MalformedFunctionHeader));
+
+        // Two edits: rewrite the header to three fields, then append a signature
+        // so the healed function keeps its return type instead of becoming void.
+        Assert.Equal(2, dwf.Fix.Edits.Count);
+        Assert.Contains(dwf.Fix.Edits, e => e.NewText == "{f1:Add:pub}");
+        Assert.Contains(dwf.Fix.Edits, e => e.NewText == " () -> i32");
+    }
+
+    [Fact]
+    public void ApplyingFix_HeaderOnly_HealsToReturningFunction()
+    {
+        const string src = """
+            §M{m1:Calc}
+              §F{f1:Add:i32:pub}
+                §R (+ 1 2)
+            """;
+        var bag = ParseBag(src);
+        var healed = ApplyFixes(src, bag);
+
+        Assert.Contains("§F{f1:Add:pub} () -> i32", healed);
+        Assert.DoesNotContain("i32:pub", healed);
+
+        // Healed source parses cleanly (no residual Calor0116).
+        var (diags, hasErrors) = Parse(healed);
+        Assert.False(hasErrors, "Healed source must parse cleanly");
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.MalformedFunctionHeader);
+
+        // And it compiles to a value-returning method, not a void one.
+        var result = Compile(healed);
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        Assert.Contains("int Add(", result.GeneratedCode);
+        Assert.DoesNotContain("void Add(", result.GeneratedCode);
+    }
+
+    [Fact]
+    public void ApplyingFix_WithInlineSignature_DropsHeaderTypeOnly()
+    {
+        // When an inline signature already follows the header, the fix must drop
+        // ONLY the header type — it must not append a second signature.
+        const string src = """
+            §M{m1:Calc}
+              §F{f1:Add:i32:pub} (i32:a) -> i32
+                §R a
+            """;
+        var bag = ParseBag(src);
+
+        var dwf = Assert.Single(
+            bag.DiagnosticsWithFixes.Where(d => d.Code == DiagnosticCode.MalformedFunctionHeader));
+        var edit = Assert.Single(dwf.Fix.Edits);
+        Assert.Equal("{f1:Add:pub}", edit.NewText);
+
+        var healed = ApplyFixes(src, bag);
+        Assert.Contains("§F{f1:Add:pub} (i32:a) -> i32", healed);
+        // Exactly one signature arrow — no duplicated "() -> i32" tail.
+        Assert.Equal(1, CountOccurrences(healed, "-> i32"));
+
+        var (diags, hasErrors) = Parse(healed);
+        Assert.False(hasErrors, "Healed source must parse cleanly");
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.MalformedFunctionHeader);
+    }
+
+    // ---------------------------------------------------------------------
+    // Corpus pin — the in-repo corpus contains zero malformed four-field
+    // §F/§AF headers, so Calor0116 must never fire across it. This also
+    // guards the never-touch invariant: the §MT-rich benchmark corpus
+    // (DesignPatterns etc.) uses many valid four-field modifier headers.
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Corpus_HasZeroMalformedFunctionHeaderFirings()
+    {
+        var roots = ResolveCorpusRoots();
+        Assert.NotEmpty(roots);
+
+        var calrFiles = roots
+            .SelectMany(r => Directory.EnumerateFiles(r, "*.calr", SearchOption.AllDirectories))
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.NotEmpty(calrFiles);
+
+        var failures = new List<string>();
+
+        foreach (var file in calrFiles)
+        {
+            var source = File.ReadAllText(file);
+            var diagnostics = new DiagnosticBag();
+
+            var lexer = new Lexer(source, diagnostics);
+            var tokens = lexer.TokenizeAllForParser();
+
+            try
+            {
+                var parser = new Parser(tokens, diagnostics);
+                _ = parser.Parse();
+            }
+            catch
+            {
+                // Corpus contains some intentionally broken / migration-pending
+                // fixtures; a parser throw is unrelated to this audit.
+                continue;
+            }
+
+            foreach (var d in diagnostics)
+            {
+                if (d.Code == DiagnosticCode.MalformedFunctionHeader)
+                {
+                    failures.Add($"{file}: {d.Message}");
+                }
+            }
+        }
+
+        Assert.True(
+            failures.Count == 0,
+            $"Malformed-function-header corpus audit failed: expected zero firings of Calor0116 " +
+            $"across {calrFiles.Count} .calr files, found {failures.Count}:\n  " +
+            string.Join("\n  ", failures));
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers.
+    // ---------------------------------------------------------------------
+
+    private static CompilationResult Compile(string source)
+    {
+        var options = new CompilationOptions
+        {
+            ContractMode = ContractMode.Debug,
+            UnknownCallPolicy = UnknownCallPolicy.Strict,
+            StrictEffects = false,
+            VerifyContracts = false,
+        };
+        return Program.Compile(source, "malformed-header.calr", options);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+
+    /// <summary>
+    /// Mirrors the line/column edit application used by the LSP code-action
+    /// handler and the calor_check MCP tool (apply path): edits are applied
+    /// bottom-up (and right-to-left within a line) so earlier positions stay
+    /// valid.
+    /// </summary>
+    private static string ApplyFixes(string source, DiagnosticBag bag)
+    {
+        var edits = bag.DiagnosticsWithFixes
+            .SelectMany(d => d.Fix.Edits)
+            .OrderByDescending(e => e.StartLine)
+            .ThenByDescending(e => e.StartColumn)
+            .ToList();
+
+        var lines = source.Replace("\r\n", "\n").Split('\n');
+
+        foreach (var edit in edits)
+        {
+            var startLine = edit.StartLine - 1;
+            var startCol = edit.StartColumn - 1;
+            var endLine = edit.EndLine - 1;
+            var endCol = edit.EndColumn - 1;
+
+            if (startLine < 0 || startLine >= lines.Length) continue;
+            if (endLine < 0 || endLine >= lines.Length) continue;
+
+            var beforeEdit = startCol >= 0 && startCol <= lines[startLine].Length
+                ? lines[startLine][..startCol]
+                : lines[startLine];
+            var afterEdit = endCol >= 0 && endCol <= lines[endLine].Length
+                ? lines[endLine][endCol..]
+                : "";
+
+            var newContent = beforeEdit + edit.NewText + afterEdit;
+            var newLines = newContent.Split('\n');
+
+            var lineList = lines.ToList();
+            lineList.RemoveRange(startLine, endLine - startLine + 1);
+            lineList.InsertRange(startLine, newLines);
+            lines = lineList.ToArray();
+        }
+
+        return string.Join('\n', lines);
+    }
+
+    private static IReadOnlyList<string> ResolveCorpusRoots()
+    {
+        var repoRoot = FindRepoRoot();
+        if (repoRoot == null) return Array.Empty<string>();
+
+        var roots = new List<string>();
+        foreach (var rel in new[]
+        {
+            Path.Combine("samples"),
+            Path.Combine("tests", "TestData", "Benchmarks"),
+        })
+        {
+            var full = Path.Combine(repoRoot, rel);
+            if (Directory.Exists(full)) roots.Add(full);
+        }
+        return roots;
+    }
+
+    private static string? FindRepoRoot()
+    {
+        var assemblyDir = Path.GetDirectoryName(typeof(MalformedFunctionHeaderTests).Assembly.Location);
+        var dir = assemblyDir != null ? new DirectoryInfo(assemblyDir) : null;
+        while (dir != null)
+        {
+            var samples = Path.Combine(dir.FullName, "samples");
+            var benchmarks = Path.Combine(dir.FullName, "tests", "TestData", "Benchmarks");
+            if (Directory.Exists(samples) && Directory.Exists(benchmarks))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}

--- a/tests/Calor.Compiler.Tests/Mcp/DiagnoseToolFixTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/DiagnoseToolFixTests.cs
@@ -136,6 +136,57 @@ public class DiagnoseToolFixTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WithFourFieldHeader_Apply_HealsToReturningSource()
+    {
+        // A four-field §F header hard-errors (Calor0116). With apply=true the
+        // diagnose path must rewrite it to a three-field header plus a signature
+        // via its SuggestedFix and return source that compiles clean — and, in
+        // particular, keeps the return type instead of silently becoming void.
+        var args = JsonDocument.Parse("""
+            {
+                "action": "diagnose",
+                "apply": true,
+                "source": "§M{m1:Calc}\n  §F{f1:Add:i32:pub}\n    §R (+ 1 2)"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result.Content[0].Text!).RootElement;
+
+        // A Calor0116 diagnostic must be present with a fix attached.
+        var hasHeaderDiag = false;
+        foreach (var diag in json.GetProperty("diagnostics").EnumerateArray())
+        {
+            if (diag.GetProperty("code").GetString() == "Calor0116")
+            {
+                hasHeaderDiag = true;
+                Assert.True(diag.TryGetProperty("fix", out var fix));
+                Assert.True(fix.TryGetProperty("edits", out var edits));
+                Assert.True(edits.GetArrayLength() > 0);
+            }
+        }
+        Assert.True(hasHeaderDiag, "Expected a Calor0116 diagnostic");
+
+        Assert.True(json.TryGetProperty("fixedSource", out var fixedSourceEl));
+        var healed = fixedSourceEl.GetString()!;
+        Assert.Contains("§F{f1:Add:pub} () -> i32", healed);
+        Assert.DoesNotContain("i32:pub", healed);
+        Assert.True(json.GetProperty("fixesApplied").GetInt32() >= 1);
+
+        // Re-diagnose the healed source: it must now compile clean.
+        var reArgs = JsonSerializer.SerializeToElement(new { action = "diagnose", source = healed });
+        var reResult = await _tool.ExecuteAsync(reArgs);
+        var reJson = JsonDocument.Parse(reResult.Content[0].Text!).RootElement;
+
+        Assert.True(reJson.GetProperty("success").GetBoolean());
+        Assert.Equal(0, reJson.GetProperty("errorCount").GetInt32());
+        foreach (var diag in reJson.GetProperty("diagnostics").EnumerateArray())
+        {
+            Assert.NotEqual("Calor0116", diag.GetProperty("code").GetString());
+        }
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WithUnknownSectionMarker_IncludesHelpfulMessage()
     {
         var args = JsonDocument.Parse("""

--- a/tests/Calor.Compiler.Tests/Migration/CallCloserEliderTests.cs
+++ b/tests/Calor.Compiler.Tests/Migration/CallCloserEliderTests.cs
@@ -36,7 +36,7 @@ public class CallCloserEliderTests
     public void T_elide_a_ZeroArgStmt_ElidesEndC()
     {
         var src = Module
-            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:void:public}\n"
+            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:public}\n"
             + "  §C{Doit} §/C\n";
         var result = Sut.Process(src, "a.calr");
 
@@ -50,7 +50,7 @@ public class CallCloserEliderTests
     public void T_elide_b_OneArgStmt_SameLine_ElidesBoth()
     {
         var src = Module
-            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:void:public}\n"
+            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:public}\n"
             + "  §C{Doit} §A x §/C\n";
         var result = Sut.Process(src, "b.calr");
 
@@ -69,7 +69,7 @@ public class CallCloserEliderTests
         // (Calor bindings place the initializer expression directly after
         // §B{name:type} — there is no '§=' token.)
         var src = Module
-            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:void:public}\n"
+            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:public}\n"
             + "  §B{r:i32} §C{Add} §A 1 §/C\n";
         var result = Sut.Process(src, "c.calr");
 
@@ -83,7 +83,7 @@ public class CallCloserEliderTests
     {
         // §A is on a different line from §C — must NOT elide.
         var src = Module
-            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:void:public}\n"
+            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:public}\n"
             + "  §C{Doit}\n"
             + "    §A x\n"
             + "  §/C\n";
@@ -99,7 +99,7 @@ public class CallCloserEliderTests
     public void T_elide_e_NamedArg_NotElided()
     {
         var src = Module
-            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:void:public}\n"
+            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:public}\n"
             + "  §C{Doit} §A[name] x §/C\n";
         var result = Sut.Process(src, "e.calr");
 
@@ -112,7 +112,7 @@ public class CallCloserEliderTests
     public void T_elide_f_TwoArgs_NotElided()
     {
         var src = Module
-            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:void:public}\n"
+            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:public}\n"
             + "  §C{Add} §A 1 §A 2 §/C\n";
         var result = Sut.Process(src, "f.calr");
 
@@ -126,7 +126,7 @@ public class CallCloserEliderTests
     {
         // Nested call: outer arg is itself a call expression.
         var src = Module
-            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:void:public}\n"
+            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:public}\n"
             + "  §C{Outer} §A §C{Inner} §A x §/C §/C\n";
         var result = Sut.Process(src, "g.calr");
 
@@ -154,7 +154,7 @@ public class CallCloserEliderTests
     public void T_elide_i_RoundTrip_ByteEqual()
     {
         var src = Module
-            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:void:public}\n"
+            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:public}\n"
             + "  §C{Doit} §A x §/C\n"
             + "  §C{Another} §/C\n";
         var result = Sut.Process(src, "i.calr");
@@ -175,7 +175,7 @@ public class CallCloserEliderTests
     public void T_elide_j_Idempotent()
     {
         var src = Module
-            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:void:public}\n"
+            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:public}\n"
             + "  §C{Doit} §A x §/C\n";
         var first = Sut.Process(src, "j.calr");
         Assert.False(first.Skipped, first.SkipReason);
@@ -191,7 +191,7 @@ public class CallCloserEliderTests
     {
         // No §/C at all — nothing to elide.
         var src = Module
-            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:void:public}\n"
+            + "§F{f_01j5x7abcdef01j5x7abcdef01:run:public}\n"
             + "  §C{Doit} x\n";
         var result = Sut.Process(src, "k.calr");
 

--- a/tests/Calor.Compiler.Tests/Migration/CompactIdMigratorTests.cs
+++ b/tests/Calor.Compiler.Tests/Migration/CompactIdMigratorTests.cs
@@ -223,9 +223,7 @@ public class CompactIdMigratorTests
         // matching closer ID to exercise the closer-rewrite path.
         var src =
             $"§M{{m_{Ulid1}:Calc}}\n" +
-            $"  §F{{f_{Ulid2}:divide:i32:public}}\n" +
-            $"    §I{{i32:a}}\n" +
-            $"    §I{{i32:b}}\n" +
+            $"  §F{{f_{Ulid2}:divide:public}} (i32:a, i32:b) -> i32\n" +
             $"    §R (/ a b)\n";
 
         // Baseline: source pre-migration must parse cleanly so the test

--- a/tests/Calor.Compiler.Tests/SyntaxTests.cs
+++ b/tests/Calor.Compiler.Tests/SyntaxTests.cs
@@ -978,7 +978,7 @@ public class SyntaxTests
         var diagnostics = new DiagnosticBag();
         var source = @"
 §M{m001:Test}
-  §F{f001:Calc:i32:pub}
+  §F{f001:Calc:pub} () -> i32
         §R (+ §THIS.Value INT:1)";
         var lexer = new Lexer(source, diagnostics);
         var tokens = lexer.TokenizeAllForParser();
@@ -1005,7 +1005,7 @@ public class SyntaxTests
         var diagnostics = new DiagnosticBag();
         var source = @"
 §M{m001:Test}
-  §F{f001:Calc:i32:pub}
+  §F{f001:Calc:pub} () -> i32
         §R (+ §BASE.Value INT:1)";
         var lexer = new Lexer(source, diagnostics);
         var tokens = lexer.TokenizeAllForParser();


### PR DESCRIPTION
## v0.6.7 — PR-1a: Malformed four-field function-header diagnostic (Calor0116)

Second PR of the finalized v0.6.7 plan (independent of PR-0 #679).

### Problem
A four-field function header — `§F{id:name:type:vis}` / `§AF{id:name:type:vis}` — is a legacy shape that **silently misreads the return type as the visibility** and drops the real visibility. `AttributeHelper.InterpretFuncAttributes` reads `_pos2` as visibility, so `§F{f1:Add:i32:pub}` becomes a private `void Add()` whose body returns a value — a **CS0127 in the generated C# with no Calor-level explanation**.

### Fix
New parser diagnostic **`Calor0116 MalformedFunctionHeader`** with an auto-applicable `SuggestedFix`:
- **Edit 1** rewrites the header to three fields: `{id:name:vis}`.
- **Edit 2** appends ` () -> type` so the healed function **keeps its return type** instead of becoming void — but only when no inline signature / type-parameter list already follows.

`§F{f1:Add:i32:pub}` → `§F{f1:Add:pub} () -> i32`.

### Deliberately narrow (never touches §MT/§AMT)
- Fires **only** when the fourth field is a visibility token (`pub`/`pri`/`int`/…), uniquely identifying the "type-inserted-before-vis" mistake.
- Wired **only** into `ParseFunction` / `ParseAsyncFunction` — **never** the method parsers, whose four-field header (`§MT{...:pub:virt}`) carries a legitimate modifier. A corpus pin asserts **zero** firings across `samples/` + `tests/TestData/Benchmarks/` (which use many valid four-field modifier headers).

### Flows everywhere for free
It's a parser diagnostic on `DiagnosticsWithFixes`, so it surfaces in CLI compile, `calor_check` MCP (with `apply:true` auto-heal), and the LSP quick-fix path — no extra wiring. An end-to-end MCP apply test confirms the two-edit fix heals to compiling source.

### Tests
- New `MalformedFunctionHeaderTests` (10): fires on 4-field `§F`/`§AF`; does **not** fire on canonical 3-field, on `§MT`/`§AMT`, or on a non-visibility 4th field (narrowness); fix structure + healing (header-only and with an existing inline signature); **corpus pin** (zero Calor0116 across the in-repo corpus).
- `DiagnoseToolFixTests` (+1): `calor_check apply:true` heals a 4-field header end-to-end and re-diagnoses clean.
- Modernized three legacy `§I`/`§O`-era fixtures (CallCloserElider, CompactIdMigrator, SyntaxTests) that used the now-flagged form.

### Verification
Full solution green: **Compiler 5560**, LanguageServer 382, Conversion 280, Evaluation 199, Enforcement 249, Verification 253, Semantics 37, Tasks 48, ILAnalysis 28, Experimental 21, RoundTrip 22 — **0 failures**. Clean build (`TreatWarningsAsErrors`).

Part of the v0.6.7 correctness sweep. **DO NOT MERGE** until reviewed (user owns merges).