### PR TITLE
feat(analysis): Calor0205 value-returned-from-void-owner (v0.6.7 Item 1b)

### DIFF
--- a/src/Calor.Compiler/Analysis/RecursiveAstWalker.cs
+++ b/src/Calor.Compiler/Analysis/RecursiveAstWalker.cs
@@ -1,0 +1,140 @@
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Reflection;
+using Calor.Compiler.Ast;
+
+namespace Calor.Compiler.Analysis;
+
+/// <summary>
+/// Reflection-based structural walker that enumerates the child
+/// <see cref="AstNode"/>s of a node via its public properties — including
+/// statement bodies and nested member/clause nodes — but EXCLUDING any child
+/// whose (static or runtime) type is an <see cref="ExpressionNode"/>.
+///
+/// <para>Skipping expression subtrees is deliberate. It keeps consumers such as
+/// <see cref="ReturnValidationPass"/> from descending into lambda bodies
+/// (<see cref="LambdaExpressionNode"/>) and match-expression arms
+/// (<see cref="MatchExpressionNode"/>), where a <c>§R</c> is a value rather than
+/// a statement-position member return.</para>
+///
+/// <para>Because coverage of statement bodies is by <em>construction</em> — any
+/// property typed <c>StatementNode</c> or <c>IEnumerable&lt;StatementNode&gt;</c>
+/// is traversed — adding a new statement-bearing AST node is covered
+/// automatically without editing this walker. The completeness meta-test
+/// (<c>ReturnValidationCompletenessTests</c>) enforces that guarantee.</para>
+/// </summary>
+public static class RecursiveAstWalker
+{
+    private static readonly ConcurrentDictionary<Type, PropertyInfo[]> Cache = new();
+
+    /// <summary>
+    /// Enumerates the direct child <see cref="AstNode"/>s of
+    /// <paramref name="node"/> that are not expressions, in a deterministic
+    /// order (declaration order, then property name).
+    /// </summary>
+    public static IEnumerable<AstNode> GetChildren(AstNode node)
+    {
+        if (node is null)
+        {
+            yield break;
+        }
+
+        foreach (var prop in GetChildProperties(node.GetType()))
+        {
+            object? value;
+            try
+            {
+                value = prop.GetValue(node);
+            }
+            catch
+            {
+                // A property getter should never throw on a parsed AST, but be
+                // defensive so an unexpected node can't crash compilation.
+                continue;
+            }
+
+            if (value is null)
+            {
+                continue;
+            }
+
+            if (value is AstNode single)
+            {
+                if (single is not ExpressionNode)
+                {
+                    yield return single;
+                }
+            }
+            else if (value is IEnumerable seq)
+            {
+                foreach (var item in seq)
+                {
+                    if (item is AstNode child and not ExpressionNode)
+                    {
+                        yield return child;
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the cached set of properties on <paramref name="type"/> that can
+    /// hold non-expression child <see cref="AstNode"/>s (single or enumerable),
+    /// in a deterministic order.
+    /// </summary>
+    public static PropertyInfo[] GetChildProperties(Type type) =>
+        Cache.GetOrAdd(type, static t =>
+            t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.GetIndexParameters().Length == 0 && CanHoldChildAstNode(p.PropertyType))
+                .OrderBy(p => p.MetadataToken)
+                .ThenBy(p => p.Name, StringComparer.Ordinal)
+                .ToArray());
+
+    private static bool CanHoldChildAstNode(Type propertyType)
+    {
+        if (typeof(AstNode).IsAssignableFrom(propertyType))
+        {
+            // A property statically typed as an expression subtree is skipped
+            // wholesale. Base-typed AstNode properties are still visited; the
+            // runtime `is not ExpressionNode` filter in GetChildren guards them.
+            return !typeof(ExpressionNode).IsAssignableFrom(propertyType);
+        }
+
+        var element = GetEnumerableElementType(propertyType);
+        if (element is null || !typeof(AstNode).IsAssignableFrom(element))
+        {
+            return false;
+        }
+
+        return !typeof(ExpressionNode).IsAssignableFrom(element);
+    }
+
+    private static Type? GetEnumerableElementType(Type type)
+    {
+        if (type == typeof(string))
+        {
+            return null;
+        }
+
+        foreach (var candidate in Prepend(type, type.GetInterfaces()))
+        {
+            if (candidate.IsGenericType &&
+                candidate.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            {
+                return candidate.GetGenericArguments()[0];
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<Type> Prepend(Type first, Type[] rest)
+    {
+        yield return first;
+        foreach (var t in rest)
+        {
+            yield return t;
+        }
+    }
+}

--- a/src/Calor.Compiler/Analysis/ReturnValidationPass.cs
+++ b/src/Calor.Compiler/Analysis/ReturnValidationPass.cs
@@ -1,0 +1,290 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+
+namespace Calor.Compiler.Analysis;
+
+/// <summary>
+/// Always-on semantic pass that emits <c>Calor0205</c> when a value-returning
+/// <c>§R expr</c> appears in the body of an owner that returns no value:
+///
+/// <list type="bullet">
+///   <item>a <c>void</c> function/method (no <c>§O</c> / no header return type);</item>
+///   <item>an <c>async</c> function/method with no return type (compiles to <c>Task</c>);</item>
+///   <item>an iterator (its body uses <c>§YIELD</c>/<c>§YBRK</c>);</item>
+///   <item>a constructor;</item>
+///   <item>a property/indexer <c>set</c>/<c>init</c> accessor;</item>
+///   <item>an event <c>add</c>/<c>remove</c> accessor.</item>
+/// </list>
+///
+/// <para>Without this pass the generated C# silently fails to compile
+/// (CS0127 "since it returns void" / CS1622 for iterators). The classic case:
+/// an agent writes a correct 3-field <c>void</c> header but then <c>§R INT:0</c>
+/// in the body — nothing flagged it before Calor0205.</para>
+///
+/// <para><b>False-positive safety.</b> The pass is always-on and reports a hard
+/// error, so it must never fire on legal code. The C#→Calor migration lowers a
+/// void expression-bodied member such as <c>void F() =&gt; VoidCall();</c> into
+/// <c>§R &lt;call&gt;</c>, which is legal. To stay sound the pass only flags a
+/// return whose expression is <em>definitely</em> a non-void value that can
+/// never be a valid C# statement-expression — literals, arithmetic/logical
+/// operations, plain references, ternaries, and a handful of clearly-value
+/// forms (see <see cref="IsDefinitelyValue"/>). Calls, object creation,
+/// <c>await</c>, and increment/decrement are deliberately left unflagged
+/// because they can be void-typed or valid void statement-expressions. The
+/// corpus-clean pin (<c>ReturnValidationCorpusCleanTests</c>) gates this.</para>
+/// </summary>
+public sealed class ReturnValidationPass
+{
+    private readonly DiagnosticBag _diagnostics;
+
+    private enum OwnerKind
+    {
+        /// <summary>Not inside a return-bearing owner (e.g. module/class scope).</summary>
+        None,
+
+        /// <summary>Value-returning owner — a value <c>§R</c> is expected.</summary>
+        Value,
+
+        /// <summary>Non-async member with no return type (compiles to <c>void</c>).</summary>
+        Void,
+
+        /// <summary>Async member with no return type (compiles to <c>Task</c>).</summary>
+        AsyncVoid,
+
+        /// <summary>Iterator member (its body yields).</summary>
+        Iterator,
+
+        /// <summary>Property/indexer <c>set</c> or <c>init</c> accessor.</summary>
+        Setter,
+
+        /// <summary>Constructor.</summary>
+        Constructor,
+
+        /// <summary>Event <c>add</c>/<c>remove</c> accessor.</summary>
+        EventAccessor,
+    }
+
+    public ReturnValidationPass(DiagnosticBag diagnostics)
+    {
+        _diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
+    }
+
+    public void Check(ModuleNode module)
+    {
+        if (module is null)
+        {
+            return;
+        }
+
+        Walk(module, OwnerKind.None);
+    }
+
+    private void Walk(AstNode node, OwnerKind context)
+    {
+        // The context that applies to this node's *children*. Owner nodes open a
+        // fresh context (their own return classification); everything else — in
+        // particular control-flow bodies — inherits the enclosing context.
+        var childContext = context;
+
+        switch (node)
+        {
+            case FunctionNode f:
+                childContext = ClassifyCallable(f.Output, f.IsAsync, f);
+                break;
+            case MethodNode m:
+                childContext = ClassifyCallable(m.Output, m.IsAsync, m);
+                break;
+            case OperatorOverloadNode op:
+                childContext = ClassifyCallable(op.Output, isAsync: false, op);
+                break;
+            case ConstructorNode:
+                childContext = OwnerKind.Constructor;
+                break;
+            case PropertyAccessorNode accessor:
+                childContext = ClassifyAccessor(accessor);
+                break;
+            case EventDefinitionNode:
+                childContext = OwnerKind.EventAccessor;
+                break;
+            case ReturnStatementNode ret:
+                CheckReturn(ret, context);
+                break;
+        }
+
+        foreach (var child in RecursiveAstWalker.GetChildren(node))
+        {
+            Walk(child, childContext);
+        }
+    }
+
+    private OwnerKind ClassifyCallable(OutputNode? output, bool isAsync, AstNode owner)
+    {
+        if (IsIterator(owner))
+        {
+            return OwnerKind.Iterator;
+        }
+
+        var noValue = output is null || IsVoidType(output.TypeName);
+        if (noValue)
+        {
+            return isAsync ? OwnerKind.AsyncVoid : OwnerKind.Void;
+        }
+
+        return OwnerKind.Value;
+    }
+
+    private OwnerKind ClassifyAccessor(PropertyAccessorNode accessor)
+    {
+        if (accessor.Kind == PropertyAccessorNode.AccessorKind.Get)
+        {
+            // A getter returns the property value, so a value §R is expected —
+            // unless the getter is itself an iterator.
+            return IsIterator(accessor) ? OwnerKind.Iterator : OwnerKind.Value;
+        }
+
+        // set / init accessors never return a value.
+        return OwnerKind.Setter;
+    }
+
+    private void CheckReturn(ReturnStatementNode ret, OwnerKind context)
+    {
+        if (!IsNoValueOwner(context))
+        {
+            return;
+        }
+
+        var expr = ret.Expression;
+        if (expr is null)
+        {
+            // Bare §R (return;) is valid in every no-value owner.
+            return;
+        }
+
+        if (!IsDefinitelyValue(expr))
+        {
+            // Conservative: the expression could be void-typed (e.g. a call) or
+            // a valid void statement-expression (e.g. new / ++). Do not flag.
+            return;
+        }
+
+        _diagnostics.ReportError(ret.Span, DiagnosticCode.ReturnValueInVoidOwner, MessageFor(context));
+    }
+
+    private static bool IsNoValueOwner(OwnerKind kind) => kind switch
+    {
+        OwnerKind.Void or OwnerKind.AsyncVoid or OwnerKind.Iterator
+            or OwnerKind.Setter or OwnerKind.Constructor or OwnerKind.EventAccessor => true,
+        _ => false,
+    };
+
+    private static string MessageFor(OwnerKind kind) => kind switch
+    {
+        OwnerKind.Void =>
+            "'§R' returns a value, but the enclosing function/method declares no return type and " +
+            "compiles to 'void', which cannot return a value. Add a return type ('§O{type}' or a " +
+            "return type in the header), or drop the value and use a bare '§R' to return early.",
+        OwnerKind.AsyncVoid =>
+            "'§R' returns a value, but the enclosing async function/method declares no return type and " +
+            "compiles to 'Task', which cannot return a value. Add a return type ('§O{type}', emitted as " +
+            "'Task<type>'), or drop the value and use a bare '§R'.",
+        OwnerKind.Iterator =>
+            "'§R' returns a value, but the enclosing member is an iterator (its body uses '§YIELD'/'§YBRK') " +
+            "and cannot 'return' a value. Use '§YIELD expr' to produce a value, or a bare '§R' to stop iteration.",
+        OwnerKind.Setter =>
+            "'§R' returns a value, but a property/indexer 'set' or 'init' accessor cannot return a value. " +
+            "Use a bare '§R' to return early.",
+        OwnerKind.Constructor =>
+            "'§R' returns a value, but a constructor cannot return a value. Use a bare '§R' to return early.",
+        OwnerKind.EventAccessor =>
+            "'§R' returns a value, but an event 'add'/'remove' accessor cannot return a value. " +
+            "Use a bare '§R' to return early.",
+        _ => "'§R' returns a value in a member that has no return value.",
+    };
+
+    private static bool IsVoidType(string typeName)
+    {
+        var t = typeName.Trim();
+        // Only "void" is treated as no-value, matching the C# emitter's own rule
+        // (CSharpEmitter uses returnType != "void"). Keeping the set this narrow
+        // avoids diverging from codegen and thus avoids false positives.
+        return t.Equals("void", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private bool IsIterator(AstNode owner)
+    {
+        foreach (var child in RecursiveAstWalker.GetChildren(owner))
+        {
+            if (ContainsYield(child))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsYield(AstNode node)
+    {
+        if (node is YieldReturnStatementNode or YieldBreakStatementNode)
+        {
+            return true;
+        }
+
+        // Do not cross into a nested owner boundary (defensive — statement bodies
+        // do not currently contain nested owners, and lambdas are expressions
+        // that RecursiveAstWalker already skips).
+        if (IsOwner(node))
+        {
+            return false;
+        }
+
+        foreach (var child in RecursiveAstWalker.GetChildren(node))
+        {
+            if (ContainsYield(child))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsOwner(AstNode node) => node is
+        FunctionNode or MethodNode or OperatorOverloadNode or
+        ConstructorNode or PropertyAccessorNode or EventDefinitionNode;
+
+    /// <summary>
+    /// True only for expressions that are <em>definitely</em> a non-void value
+    /// AND can never be a valid C# statement-expression. This is a deliberate
+    /// default-deny allow-list: anything not listed (calls, object creation,
+    /// await, increment/decrement, match-expressions, member access, casts, …)
+    /// is left unflagged because it could legitimately appear as
+    /// <c>§R &lt;expr&gt;</c> from a migrated void expression-bodied member.
+    /// </summary>
+    private static bool IsDefinitelyValue(ExpressionNode expr) => expr switch
+    {
+        IntLiteralNode => true,
+        FloatLiteralNode => true,
+        DecimalLiteralNode => true,
+        StringLiteralNode => true,
+        BoolLiteralNode => true,
+        BinaryOperationNode => true,
+        ConditionalExpressionNode => true,
+        ReferenceNode => true,
+        ThisExpressionNode => true,
+        BaseExpressionNode => true,
+        TupleLiteralNode => true,
+        InterpolatedStringNode => true,
+        RangeExpressionNode => true,
+        IndexFromEndNode => true,
+        TypeOfExpressionNode => true,
+        NameOfExpressionNode => true,
+        SizeOfNode => true,
+        // Prefix/postfix ++/-- ARE valid void statement-expressions, so exclude
+        // them; other unary operations (-, !, ~) are always values.
+        UnaryOperationNode u => u.Operator is not (
+            UnaryOperator.PreIncrement or UnaryOperator.PostIncrement or
+            UnaryOperator.PreDecrement or UnaryOperator.PostDecrement),
+        _ => false,
+    };
+}

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -71,6 +71,17 @@ public static class DiagnosticCode
     /// </summary>
     public const string MissingExtensionSelf = "Calor0204";
 
+    /// <summary>
+    /// Error: a value-returning <c>§R expr</c> appears in the body of an owner
+    /// that returns no value — a <c>void</c>/<c>Task</c> function or method, an
+    /// iterator (its body yields), a constructor, a property/indexer setter or
+    /// init accessor, or an event add/remove accessor. The generated C# would
+    /// fail to compile (CS0127 "since it returns void" / CS1622 for iterators).
+    /// The fix is either to declare a return type (<c>§O{type}</c> / a 3-field
+    /// header return type) or to drop the value and use a bare <c>§R</c>.
+    /// </summary>
+    public const string ReturnValueInVoidOwner = "Calor0205";
+
     // Bind inference diagnostics (Calor0250-0259) — RFC v0.6 bind-inference-formalization
 
     /// <summary>

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -552,6 +552,15 @@ public class Program
         phaseSw.Stop();
         telemetry?.TrackPhase("BindValidation", phaseSw.ElapsedMilliseconds, !diagnostics.HasErrors);
 
+        // Return validation (Calor0205: value returned from a no-value owner).
+        // Always-on hard error — runs regardless of EnableTypeChecking so the
+        // generated C# never silently fails with CS0127/CS1622.
+        phaseSw.Restart();
+        var returnValidator = new ReturnValidationPass(diagnostics);
+        returnValidator.Check(ast);
+        phaseSw.Stop();
+        telemetry?.TrackPhase("ReturnValidation", phaseSw.ElapsedMilliseconds, !diagnostics.HasErrors);
+
         if (diagnostics.HasErrors)
         {
             TrackDiagnostics(telemetry, diagnostics);

--- a/src/Calor.LanguageServer/State/DocumentState.cs
+++ b/src/Calor.LanguageServer/State/DocumentState.cs
@@ -128,6 +128,21 @@ public sealed class DocumentState
                 }
             }
 
+            // Phase 5: Return validation (Calor0205). Always runs when an AST is
+            // available so the IDE surfaces value-returned-from-void-owner errors.
+            if (Ast != null)
+            {
+                try
+                {
+                    var returnValidator = new ReturnValidationPass(Diagnostics);
+                    returnValidator.Check(Ast);
+                }
+                catch (Exception)
+                {
+                    // Validation should never throw on a parsed AST, but be defensive.
+                }
+            }
+
             // Populate DiagnosticsWithFixes from DiagnosticBag
             DiagnosticsWithFixes.AddRange(Diagnostics.DiagnosticsWithFixes);
         }

--- a/tests/Calor.Compiler.Tests/Analysis/ReturnValidationCompletenessTests.cs
+++ b/tests/Calor.Compiler.Tests/Analysis/ReturnValidationCompletenessTests.cs
@@ -1,0 +1,134 @@
+using System.Collections;
+using System.Reflection;
+using Calor.Compiler.Analysis;
+using Calor.Compiler.Ast;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Completeness guarantee for <see cref="ReturnValidationPass"/>: it must be
+/// impossible for a value <c>§R</c> to hide, unchecked, inside a no-value owner.
+///
+/// <para>The pass relies on <see cref="RecursiveAstWalker"/> traversing every
+/// statement-bearing property of every AST node. This meta-test enforces that BY
+/// CONSTRUCTION: for each concrete <see cref="AstNode"/> type, every property that
+/// can hold a <see cref="StatementNode"/> (directly or via an enumerable) must be
+/// visited by the walker — UNLESS the declaring node is itself an
+/// <see cref="ExpressionNode"/>, in which case the whole subtree is deliberately
+/// skipped (a <c>§R</c> there is a value, e.g. a lambda body or match arm).</para>
+///
+/// <para>Adding a new statement-bearing node with a public statement property will
+/// pass automatically; adding one whose statement property is somehow NOT visited
+/// (e.g. non-public) fails here, flagging the coverage hole before it can ship.</para>
+/// </summary>
+public class ReturnValidationCompletenessTests
+{
+    /// <summary>
+    /// ExpressionNode subtypes whose statement-bearing subtrees are intentionally
+    /// NOT walked (a return inside them is a value expression, not a member
+    /// return). Documented here so the exemption is explicit and reviewable.
+    /// </summary>
+    private static readonly HashSet<string> DocumentedExpressionExemptions = new(StringComparer.Ordinal)
+    {
+        nameof(LambdaExpressionNode),
+        nameof(MatchExpressionNode),
+    };
+
+    [Fact]
+    public void EveryStatementBearingProperty_IsWalked_OrIsAnExpressionSubtree()
+    {
+        var assembly = typeof(AstNode).Assembly;
+        var astTypes = assembly.GetTypes()
+            .Where(t => typeof(AstNode).IsAssignableFrom(t) && !t.IsAbstract && !t.IsInterface)
+            .OrderBy(t => t.FullName, StringComparer.Ordinal);
+
+        var holes = new List<string>();
+        var exemptedExpressionTypes = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var type in astTypes)
+        {
+            var isExpression = typeof(ExpressionNode).IsAssignableFrom(type);
+            var walkedProperties = RecursiveAstWalker.GetChildProperties(type)
+                .Select(p => p.Name)
+                .ToHashSet(StringComparer.Ordinal);
+
+            foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (prop.GetIndexParameters().Length != 0)
+                {
+                    continue;
+                }
+
+                if (!CanHoldStatement(prop.PropertyType))
+                {
+                    continue;
+                }
+
+                if (isExpression)
+                {
+                    // The whole expression subtree is skipped by design; record it
+                    // so we can assert the exemption set stays documented.
+                    exemptedExpressionTypes.Add(type.Name);
+                    continue;
+                }
+
+                if (!walkedProperties.Contains(prop.Name))
+                {
+                    holes.Add($"{type.FullName}.{prop.Name} ({prop.PropertyType.Name})");
+                }
+            }
+        }
+
+        Assert.True(
+            holes.Count == 0,
+            "Statement-bearing properties NOT visited by RecursiveAstWalker (a §R could " +
+            "hide unchecked here):\n  " + string.Join("\n  ", holes));
+
+        // Any ExpressionNode type that carries statements must be a documented
+        // exemption — otherwise we've silently grown a new unchecked hiding place.
+        var undocumented = exemptedExpressionTypes
+            .Where(name => !DocumentedExpressionExemptions.Contains(name))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            undocumented.Count == 0,
+            "Undocumented ExpressionNode subtypes carrying statement subtrees " +
+            "(add to DocumentedExpressionExemptions after confirming a §R there is a " +
+            "value, not a member return):\n  " + string.Join("\n  ", undocumented));
+    }
+
+    private static bool CanHoldStatement(Type propertyType)
+    {
+        if (typeof(AstNode).IsAssignableFrom(propertyType))
+        {
+            return typeof(StatementNode).IsAssignableFrom(propertyType);
+        }
+
+        var element = GetEnumerableElementType(propertyType);
+        return element is not null && typeof(StatementNode).IsAssignableFrom(element);
+    }
+
+    private static Type? GetEnumerableElementType(Type type)
+    {
+        if (type == typeof(string))
+        {
+            return null;
+        }
+
+        var candidates = new List<Type> { type };
+        candidates.AddRange(type.GetInterfaces());
+
+        foreach (var candidate in candidates)
+        {
+            if (candidate.IsGenericType &&
+                candidate.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            {
+                return candidate.GetGenericArguments()[0];
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Calor.Compiler.Tests/Analysis/ReturnValidationCorpusCleanTests.cs
+++ b/tests/Calor.Compiler.Tests/Analysis/ReturnValidationCorpusCleanTests.cs
@@ -1,0 +1,121 @@
+// migrate_inline_calor: skip
+using Calor.Compiler.Analysis;
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Pins the corpus-clean result for <c>Calor0205 ReturnValueInVoidOwner</c>.
+///
+/// <para><see cref="ReturnValidationPass"/> is always-on and reports a hard
+/// error, so the single most important guarantee is that it never fires on
+/// legal in-repo code. This test runs the pass against every <c>.calr</c> file
+/// under <c>samples/</c> and <c>tests/TestData/Benchmarks/</c> and asserts zero
+/// firings. If a corpus file would emit a <c>Calor0205</c>, the test fails with
+/// the file path and message so the regression is immediately attributable.</para>
+///
+/// <para>Lexer/parser failures are tolerated (some corpus files use
+/// experimental or migration-pending shapes unrelated to return validation);
+/// only the well-parsed subset is audited.</para>
+/// </summary>
+public class ReturnValidationCorpusCleanTests
+{
+    [Fact]
+    public void Corpus_HasZeroReturnValidationFirings()
+    {
+        var roots = ResolveCorpusRoots();
+        Assert.NotEmpty(roots);
+
+        var calrFiles = roots
+            .SelectMany(r => Directory.EnumerateFiles(r, "*.calr", SearchOption.AllDirectories))
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.NotEmpty(calrFiles);
+
+        var failures = new List<string>();
+
+        foreach (var file in calrFiles)
+        {
+            var source = File.ReadAllText(file);
+            var diagnostics = new DiagnosticBag();
+
+            var lexer = new Lexer(source, diagnostics);
+            var tokens = lexer.TokenizeAllForParser();
+
+            // Skip files with lex errors — not in scope for this audit.
+            if (diagnostics.HasErrors) continue;
+
+            var parser = new Parser(tokens, diagnostics);
+            ModuleNode module;
+            try
+            {
+                module = parser.Parse();
+            }
+            catch
+            {
+                continue;
+            }
+
+            // Skip parse failures (corpus contains intentionally broken fixtures
+            // + migration-pending shapes outside our scope).
+            if (diagnostics.HasErrors) continue;
+
+            var passDiagnostics = new DiagnosticBag();
+            var pass = new ReturnValidationPass(passDiagnostics);
+            pass.Check(module);
+
+            foreach (var d in passDiagnostics)
+            {
+                if (d.Code == DiagnosticCode.ReturnValueInVoidOwner)
+                {
+                    failures.Add($"{file}: {d.Code} — {d.Message}");
+                }
+            }
+        }
+
+        Assert.True(
+            failures.Count == 0,
+            $"Return-validation corpus audit failed: expected zero firings of Calor0205 across " +
+            $"{calrFiles.Count} .calr files, found {failures.Count}:\n  " +
+            string.Join("\n  ", failures));
+    }
+
+    private static IReadOnlyList<string> ResolveCorpusRoots()
+    {
+        var repoRoot = FindRepoRoot();
+        if (repoRoot == null) return Array.Empty<string>();
+
+        var roots = new List<string>();
+        foreach (var rel in new[]
+        {
+            Path.Combine("samples"),
+            Path.Combine("tests", "TestData", "Benchmarks"),
+        })
+        {
+            var full = Path.Combine(repoRoot, rel);
+            if (Directory.Exists(full)) roots.Add(full);
+        }
+        return roots;
+    }
+
+    private static string? FindRepoRoot()
+    {
+        var assemblyDir = Path.GetDirectoryName(typeof(ReturnValidationCorpusCleanTests).Assembly.Location);
+        var dir = assemblyDir != null ? new DirectoryInfo(assemblyDir) : null;
+        while (dir != null)
+        {
+            var samples = Path.Combine(dir.FullName, "samples");
+            var benchmarks = Path.Combine(dir.FullName, "tests", "TestData", "Benchmarks");
+            if (Directory.Exists(samples) && Directory.Exists(benchmarks))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}

--- a/tests/Calor.Compiler.Tests/Analysis/ReturnValidationPassTests.cs
+++ b/tests/Calor.Compiler.Tests/Analysis/ReturnValidationPassTests.cs
@@ -1,0 +1,347 @@
+using Calor.Compiler;
+using Calor.Compiler.Analysis;
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Behavioral tests for <see cref="ReturnValidationPass"/> (Calor0205 —
+/// value returned from a no-value owner). Positives assert the pass fires on a
+/// value <c>§R expr</c> in a void/async-void/iterator/constructor/setter/event
+/// owner (including when nested inside control flow); negatives assert it stays
+/// silent on value-returning owners, bare <c>§R</c>, and expressions that might
+/// legitimately be void-typed (calls) or valid void statement-expressions.
+/// </summary>
+public class ReturnValidationPassTests
+{
+    private static IReadOnlyList<Diagnostic> Run(string source)
+    {
+        var parseDiagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, parseDiagnostics);
+        var tokens = lexer.TokenizeAllForParser();
+        var parser = new Parser(tokens, parseDiagnostics);
+        var module = parser.Parse();
+
+        Assert.False(
+            parseDiagnostics.HasErrors,
+            "Test source failed to parse:\n  " +
+            string.Join("\n  ", parseDiagnostics.Select(d => $"{d.Code}: {d.Message}")));
+
+        var passDiagnostics = new DiagnosticBag();
+        new ReturnValidationPass(passDiagnostics).Check(module);
+        return passDiagnostics
+            .Where(d => d.Code == DiagnosticCode.ReturnValueInVoidOwner)
+            .ToList();
+    }
+
+    private static void AssertFires(string source) => Assert.Single(Run(source));
+
+    private static void AssertSilent(string source) => Assert.Empty(Run(source));
+
+    // ---------------------------------------------------------------- Positives
+
+    [Fact]
+    public void VoidFunction_InlineHeader_ReturnsValue_Fires()
+    {
+        AssertFires(@"
+§M{m1:T}
+  §F{f1:Do:pub} () -> void
+    §R INT:0
+");
+    }
+
+    [Fact]
+    public void VoidFunction_OmittedReturnType_ReturnsValue_Fires()
+    {
+        AssertFires(@"
+§M{m1:T}
+  §F{f1:Do:pub}
+    §R INT:0
+");
+    }
+
+    [Fact]
+    public void VoidFunction_OutputVoidMarker_ReturnsValue_Fires()
+    {
+        AssertFires(@"
+§M{m1:T}
+  §F{f1:Do:pub}
+    §O{void}
+    §R INT:0
+");
+    }
+
+    [Fact]
+    public void AsyncVoidFunction_ReturnsValue_Fires()
+    {
+        AssertFires(@"
+§M{m1:T}
+  §AF{f1:DoAsync:pub}
+    §R INT:0
+");
+    }
+
+    [Fact]
+    public void Iterator_ReturnsValue_Fires()
+    {
+        AssertFires(@"
+§M{m1:T}
+  §F{f1:Nums:pub}
+    §O{i32}
+    §YIELD 42
+    §R INT:0
+");
+    }
+
+    [Fact]
+    public void VoidMethod_ReturnsValue_Fires()
+    {
+        AssertFires(@"
+§M{m1:T}
+  §CL{c1:C:pub}
+    §MT{mt1:Do:pub} () -> void
+      §R INT:0
+");
+    }
+
+    [Fact]
+    public void Constructor_ReturnsValue_Fires()
+    {
+        AssertFires(@"
+§M{m1:T}
+  §CL{c1:C:pub}
+    §CTOR{ctor1:pub} ()
+      §R INT:0
+");
+    }
+
+    [Fact]
+    public void Setter_ReturnsValue_Fires_ButGetterDoesNot()
+    {
+        AssertFires(@"
+§M{m1:T}
+  §CL{c1:C:pub}
+    §PROP{p1:Name:str:pub}
+      §GET
+        §R ""x""
+      §/GET
+      §SET
+        §R INT:0
+      §/SET
+    §/PROP{p1}
+");
+    }
+
+    [Fact]
+    public void EventAddAccessor_ReturnsValue_Fires()
+    {
+        AssertFires(@"
+§M{m1:T}
+  §CL{c1:C:pub}
+    §EVT{e1:Click:pub:EventHandler}
+    §EADD
+    §R INT:0
+    §/EADD
+    §/EVT{e1}
+");
+    }
+
+    [Fact]
+    public void EnumExtensionVoidMethod_ReturnsValue_Fires()
+    {
+        AssertFires(@"
+§M{m1:T}
+  §EEXT{ext1:Color}
+    §F{f1:Describe:pub}
+      §I{Color:self}
+      §R INT:0
+  §/EEXT{ext1}
+");
+    }
+
+    [Fact]
+    public void NestedInIf_ReturnsValue_Fires()
+    {
+        AssertFires(@"
+§M{m1:T}
+  §F{f1:Do:pub} () -> void
+    §IF{if1} BOOL:true
+      §R INT:0
+");
+    }
+
+    [Fact]
+    public void NestedInForLoop_ReturnsValue_Fires()
+    {
+        AssertFires(@"
+§M{m1:T}
+  §F{f1:Do:pub} () -> void
+    §L{for1:i:1:10:1}
+      §R INT:0
+");
+    }
+
+    [Fact]
+    public void NestedInWhile_ReturnsValue_Fires()
+    {
+        AssertFires(@"
+§M{m1:T}
+  §F{f1:Do:pub} () -> void
+    §WH{w1} BOOL:true
+      §R INT:0
+");
+    }
+
+    [Fact]
+    public void NestedInTryBody_ReturnsValue_Fires()
+    {
+        AssertFires(@"
+§M{m1:T}
+  §F{f1:Do:pub} () -> void
+    §TR{t1}
+    §R INT:0
+    §CA{Exception:e}
+    §P ""x""
+    §/TR{t1}
+");
+    }
+
+    [Theory]
+    [InlineData("INT:0")]
+    [InlineData("BOOL:true")]
+    [InlineData("STR:\"hello\"")]
+    [InlineData("(* INT:2 INT:3)")]
+    [InlineData("(> INT:1 INT:0)")]
+    public void VoidFunction_DefiniteValueForms_Fire(string valueExpr)
+    {
+        AssertFires($@"
+§M{{m1:T}}
+  §F{{f1:Do:pub}} () -> void
+    §R {valueExpr}
+");
+    }
+
+    [Fact]
+    public void VoidFunction_ReturnsReference_Fires()
+    {
+        AssertFires(@"
+§M{m1:T}
+  §F{f1:Do:pub}
+    §I{i32:x}
+    §O{void}
+    §R x
+");
+    }
+
+    // ---------------------------------------------------------------- Negatives
+
+    [Fact]
+    public void NonVoidFunction_ReturnsValue_Silent()
+    {
+        AssertSilent(@"
+§M{m1:T}
+  §F{f1:Do:pub} () -> i32
+    §R INT:0
+");
+    }
+
+    [Fact]
+    public void VoidFunction_BareReturn_Silent()
+    {
+        AssertSilent(@"
+§M{m1:T}
+  §F{f1:Do:pub} () -> void
+    §R
+");
+    }
+
+    [Fact]
+    public void AsyncFunctionWithReturnType_ReturnsValue_Silent()
+    {
+        AssertSilent(@"
+§M{m1:T}
+  §AF{f1:GetAsync:pub}
+    §O{str}
+    §R ""data""
+");
+    }
+
+    [Fact]
+    public void VoidFunction_ReturnsCall_Silent()
+    {
+        // A call can be void-typed (a migrated `void F() => VoidCall();` lowers to
+        // `§R <call>`), so the pass conservatively does not flag it.
+        AssertSilent(@"
+§M{m1:T}
+  §F{f1:Do:pub} () -> void
+    §R §C{Helper.Run} INT:1
+");
+    }
+
+    [Fact]
+    public void Getter_ReturnsValue_Silent()
+    {
+        AssertSilent(@"
+§M{m1:T}
+  §CL{c1:C:pub}
+    §PROP{p1:Name:str:pub}
+      §GET
+        §R ""x""
+      §/GET
+    §/PROP{p1}
+");
+    }
+
+    [Fact]
+    public void AbstractMethod_NoBody_Silent()
+    {
+        AssertSilent(@"
+§M{m1:T}
+  §CL{c1:C:int:abs}
+    §MT{mt1:Do:pub:abs} () -> void
+");
+    }
+
+    [Fact]
+    public void VoidMethodWithModifier_BareReturn_Silent()
+    {
+        AssertSilent(@"
+§M{m1:T}
+  §CL{c1:C:pub}
+    §MT{mt1:Do:pub:stat} () -> void
+      §R
+");
+    }
+
+    // ------------------------------------------------------- End-to-end (always-on)
+
+    [Fact]
+    public void Compile_VoidFunctionReturningValue_EmitsCalor0205_WithoutTypeChecking()
+    {
+        var source = @"
+§M{m1:T}
+  §F{f1:Do:pub} () -> void
+    §R INT:0
+";
+        var result = Program.Compile(source, filePath: null, new CompilationOptions { EnableTypeChecking = false });
+
+        Assert.True(result.HasErrors);
+        Assert.Contains(result.Diagnostics, d => d.Code == DiagnosticCode.ReturnValueInVoidOwner);
+    }
+
+    [Fact]
+    public void Compile_CleanVoidFunction_NoCalor0205()
+    {
+        var source = @"
+§M{m1:T}
+  §F{f1:Do:pub} () -> void
+    §R
+";
+        var result = Program.Compile(source, filePath: null, new CompilationOptions { EnableTypeChecking = false });
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Code == DiagnosticCode.ReturnValueInVoidOwner);
+    }
+}

--- a/tests/Calor.LanguageServer.Tests/Handlers/CodeActionHandlerTests.cs
+++ b/tests/Calor.LanguageServer.Tests/Handlers/CodeActionHandlerTests.cs
@@ -81,7 +81,7 @@ public class CodeActionHandlerTests
     {
         var source = """
             §M{m001:TestModule}
-              §F{f001:Test}
+              §F{f001:Test:pub} () -> i32
                 §R 0
             """;
 
@@ -95,7 +95,7 @@ public class CodeActionHandlerTests
     {
         var source = """
             §M{m001:TestModule}
-            §F{f001:Test}
+            §F{f001:Test:pub} () -> i32
             §R 0
             """;
 

--- a/tests/Calor.LanguageServer.Tests/State/DocumentStateTests.cs
+++ b/tests/Calor.LanguageServer.Tests/State/DocumentStateTests.cs
@@ -24,7 +24,7 @@ public class DocumentStateTests
     {
         var source = """
             §M{m001:TestModule}
-              §F{f001:Test}
+              §F{f001:Test:pub} () -> i32
                 §R 0
             """;
 


### PR DESCRIPTION
## v0.6.7 — Item 1b: `Calor0205` value-returned-from-void-owner (diagnostic-only subset)

Third PR in the v0.6.7 sequence (after #679 agent-docs sweep and #680 malformed four-field header `Calor0116`). **Independent of both** — different files/diagnostic ranges — so it can merge in any order.

### What & why
Adds an **always-on** `Analysis/ReturnValidationPass` that emits a new **`Calor0205`** hard error when a value-returning `§R expr` appears in the body of an owner that returns no value:

- a `void` / async-`void` function or method,
- an iterator (its body uses `§YIELD`/`§YBRK`),
- a constructor,
- a property/indexer `set`/`init` accessor,
- an event `add`/`remove` accessor.

Without this the generated C# silently failed to compile (**CS0127** "since it returns void" / **CS1622** for iterators). The classic case: an agent writes a correct `void` header, then `§R INT:0` in the body — nothing flagged it.

### Zero-false-positive design (the load-bearing constraint)
Always-on hard error ⇒ it must never fire on legal code. Two guards:

1. **Default-deny allow-list** (`IsDefinitelyValue`): only flags returns whose expression is *definitely* a non-void value that can **never** be a valid C# statement-expression — literals, arithmetic/logical ops, plain references, ternaries, tuple/interpolated/range/`typeof`/`nameof`/`sizeof`. **Calls, `new`, `await`, and `++`/`--` are left unflagged** because they can be void-typed or valid void statement-expressions. This is exactly what keeps the C#→Calor migration lowering of `void F() => VoidCall();` (which becomes `§R <call>`) from tripping the error.
2. **Corpus-clean pin**: `ReturnValidationCorpusCleanTests` asserts **zero** `Calor0205` firings across all `samples/` + `benchmarks/` — an empirical false-positive gate.

### Completeness by construction
`RecursiveAstWalker` is a reflection-based structural walker that traverses every statement-bearing property of every node while **skipping `ExpressionNode` subtrees** (so `§R` inside a lambda body or match arm is correctly a *value*, not a member return). `ReturnValidationCompletenessTests` reflects over all AST nodes and fails if any statement-bearing property could be silently missed.

### Wiring
- `Program.Compile` — runs after bind validation, **regardless of `EnableTypeChecking`** (which defaults off), before the `HasErrors` gate.
- LSP `DocumentState` — Phase 5, so the IDE surfaces it too.

### Tests
- **ReturnValidationPassTests** — behavioral positives (all owner kinds incl. enum-extension methods; nested in `§IF`/`§L`/`§WH`/`§TR`; value forms via `[Theory]`) + negatives (non-void owners, bare `§R`, calls, getter, abstract/no-body, modifier headers) + two end-to-end `Program.Compile` assertions.
- **ReturnValidationCompletenessTests** — reflection guarantee.
- **ReturnValidationCorpusCleanTests** — samples + benchmarks pin (PASS, 0 firings).
- Modernized 3 pre-existing LSP fixtures that returned a value from a `void` function (they were technically invalid Calor).

### Verification
Full solution green — **0 failures**: Compiler 5581, LSP 382, Conversion 280, Evaluation 199, Enforcement 249, Verification 253, Semantics 37, Tasks 48, ILAnalysis 28, Experimental 21, RoundTrip 22. Build clean (`TreatWarningsAsErrors`).

### Scope note (honest)
This is the **diagnostic-only subset** of plan Item 1b. The shared emitter `ReturnShape` refactor + pre-refactor golden tests are **deferred** (the codegen already handles these owners; the gap was the *missing diagnostic*, which this closes).
