### PR TITLE
Release v0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.7] - 2026-07-01
+
+### Benchmark Results (Statistical: 30 runs)
+- **Overall Advantage**: 1.32x (Calor leads)
+- **Metrics**: Calor wins 7, C# wins 1
+- **Highlights**:
+  - Comprehension: 1.84x ± 0.00 (Calor wins, large effect d=1.80)
+  - ErrorDetection: 1.49x ± 0.00 (Calor wins, large effect d=1.21)
+  - TokenEconomics: 1.42x ± 0.00 (Calor wins, composite metric)
+  - RefactoringStability: 1.38x ± 0.00 (Calor wins, large effect d=7.09)
+  - EditPrecision: 1.36x ± 0.00 (Calor wins, large effect d=4.90)
+  - Correctness: 1.29x ± 0.00 (Calor wins, large effect d=1.31)
+  - GenerationAccuracy: 1.02x ± 0.00 (Calor wins, small effect d=0.34)
+  - InformationDensity: 0.98x ± 0.00 (C# wins, medium effect d=-0.52)
+- **Programs Tested**: 217
+
+> **Note:** this release is compile-time-diagnostic, docs, and test-correctness only — two new hard-error diagnostics that reject non-compiling Calor *earlier* (closing the deferred "F-prerequisite invariant" gap from v0.6.6), plus an agent-docs sweep to indent-only syntax. It contains no benchmark-affecting code changes, so the profile is unchanged from v0.6.6.
+
+### Added
+- **`Calor0116` — malformed four-field `§F`/`§AF` function headers are now a parse error (#680).** A header like `§F{f1:Add:i32:pub}` looks reasonable but is silently wrong: function headers take at most `{id:name:visibility}`, and the return type belongs in the signature (`(...) -> type`). Left unflagged, the parser read the extra field's type as the visibility and *discarded the real visibility*, emitting a void method (e.g. `void Add() { return 0; }`, then **CS0127** in the generated C#). The parser now reports `Calor0116` with the correct 3-field-plus-arrow form. Only `§F`/`§AF` are affected; `§MT`/`§AMT` legitimately take a fourth *modifier* field, so they are untouched.
+- **`Calor0205` — a value returned from a no-value owner is now a hard error (#681).** An always-on `ReturnValidationPass` flags a value-returning `§R expr` in the body of an owner that returns no value: a `void`/async-`void` function or method, an iterator (its body uses `§YIELD`/`§YBRK`), a constructor, a property/indexer `set`/`init` accessor, or an event `add`/`remove` accessor. Previously this silently produced non-compiling C# (**CS0127** / **CS1622**) — the classic case being a correct `void` header followed by `§R INT:0`. Because the check is always-on and reports a hard error, the design is conservative to guarantee **zero false positives**: it flags only expressions that are *definitely* a non-void value and can never be a valid C# statement-expression (literals, arithmetic/logical ops, references, ternaries, tuples, interpolated strings, ranges, `typeof`/`nameof`/`sizeof`); calls, `new`, `await`, and `++`/`--` are left unflagged because they can be void-typed or valid void statement-expressions (which is what keeps the C#→Calor migration lowering of `void F() => VoidCall();` safe). Completeness is enforced by construction via a reflection-based structural walker plus a completeness meta-test, and a corpus-clean pin asserts zero firings across all samples and benchmarks. Together with `Calor0116`, this closes the deferred "value returned from void function" / F-prerequisite follow-up noted in v0.6.6. (Scoped as diagnostic-only; a shared emitter `ReturnShape` refactor remains a tracked follow-up.)
+
+### Documentation
+- **Swept every agent-readable surface to indent-only syntax (v0.6.7 Item 0, #679).** The MCP primer surfaces, the `copilot-instructions`/`AGENTS`/`CLAUDE`/`GEMINI` templates, `README.nuget.md`, the evaluation skills doc, and the correct-Calor fields of the JSON resources were audited and corrected so no agent-facing teaching material still shows removed closer-form tags, four-field headers, or other syntax the compiler rejects. A new `AgentDocsSyntaxGuardTests` compiles/scans every surface and fails if any teaches non-compiling forms (four-field headers, `§B =` bind-equals, structural closers), keeping the guarantee from drifting.
+
+### Fixed
+- **`AgentDocsSyntaxGuardTests` surface paths are now cross-platform (#679).** The guard's doc-surface relative paths were written with Windows `\` separators and passed straight to `Path.Combine`, so on the Linux CI runner they resolved to a single literal filename segment and threw `FileNotFoundException` — failing every case on CI while passing locally on Windows. Each relative path's separators are now normalized to `Path.DirectorySeparatorChar` before combining.
+
 ## [0.6.6] - 2026-07-01
 
 ### Benchmark Results (Statistical: 30 runs)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.6.6</Version>
+    <Version>0.6.7</Version>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "calor",
   "displayName": "Calor Language",
   "description": "Language support for the Calor programming language",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "publisher": "calor-dev",
   "license": "Apache-2.0",
   "icon": "icons/calor-icon.png",

--- a/website/content/changelog.mdx
+++ b/website/content/changelog.mdx
@@ -10,6 +10,15 @@ All notable changes to Calor, organized by release.
 
 ## [Unreleased]
 
+## [0.6.7] - 2026-07-01
+
+### Added
+- **`Calor0116` — malformed four-field `§F`/`§AF` function headers are now a parse error.** A header like `§F{f1:Add:i32:pub}` looks reasonable but is silently wrong: function headers take at most `{id:name:visibility}`, and the return type belongs in the signature (`(...) -> type`). Left unflagged, the parser read the extra field's type as the visibility and *discarded the real visibility*, emitting a void method (e.g. `void Add() { return 0; }`, then a CS0127 in the generated C#). The parser now reports it up front. Only `§F`/`§AF` are affected — `§MT`/`§AMT` legitimately take a fourth *modifier* field.
+- **`Calor0205` — a value returned from a no-value owner is now a hard error.** An always-on pass flags a value-returning `§R expr` in a `void`/async-`void` function or method, an iterator, a constructor, a property/indexer `set`/`init` accessor, or an event `add`/`remove` accessor — cases that previously produced non-compiling C# (CS0127 / CS1622), the classic one being a correct `void` header followed by `§R INT:0`. Being always-on, it is deliberately conservative for **zero false positives**: it flags only expressions that are definitely a value and never a valid void statement-expression, leaving calls, `new`, `await`, and `++`/`--` untouched. Together with `Calor0116`, this closes the deferred "value returned from void function" gap from v0.6.6.
+
+### Documentation
+- **Every agent-readable surface was swept to indent-only syntax.** The MCP primer, the editor/agent instruction templates, `README.nuget`, the evaluation skills doc, and the correct-Calor fields of the JSON resources were corrected so no agent-facing material still shows removed closer-form tags, four-field headers, or other syntax the compiler rejects — with a new compile-time guard that fails if any surface drifts back to teaching non-compiling forms.
+
 ## [0.6.6] - 2026-07-01
 
 ### Fixed

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calor-website",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/website/public/data/benchmark-results.json
+++ b/website/public/data/benchmark-results.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
-  "timestamp": "2026-07-01T13:48:37.7298675Z",
-  "commit": "ed41abc5",
+  "timestamp": "2026-07-01T21:13:21.6316074Z",
+  "commit": "dc83d7c9",
   "frameworkVersion": "1.0.0",
   "summary": {
     "overallAdvantage": 1.32,

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -15,9 +15,9 @@ export function WhatsNewBanner() {
         <div className="flex items-center justify-center gap-3 text-sm">
           <Sparkles className="h-4 w-4 text-calor-cerulean flex-shrink-0" />
           <p className="text-center">
-            <span className="font-semibold text-calor-cerulean">v0.6.6</span>
+            <span className="font-semibold text-calor-cerulean">v0.6.7</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">Calor&apos;s own onboarding materials now compile: the <code>calor://primer</code> MCP resource and the teaching docs no longer teach removed closer-form syntax, and compile-time guards keep the primer honest in both directions &mdash; every &ldquo;correct&rdquo; example compiles and every &ldquo;common mistake&rdquo; genuinely fails. Legacy <code>Calor0830</code> closers now auto-heal via the LSP and MCP quick-fix.</span>
+            <span className="text-foreground">Two new compile-time diagnostics catch non-compiling Calor earlier: <code>Calor0116</code> rejects malformed four-field function headers, and <code>Calor0205</code> flags a value returned from a <code>void</code>, iterator, constructor, setter, or event accessor &mdash; together closing the &ldquo;value returned from void&rdquo; gap. Every agent-readable doc surface was also swept to indent-only syntax, guarded by a compile-time test.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"


### PR DESCRIPTION
## Summary
- Bump version to 0.6.7
- Update CHANGELOG.md with release date and benchmark results
- Update website changelog and WhatsNewBanner
- Update benchmark results JSON for website dashboard

Ships v0.6.7 = three merged PRs: #679 (agent-docs sweep to indent-only), #680 (`Calor0116` malformed four-field function headers), #681 (`Calor0205` value-returned-from-void-owner). Correctness-only; no benchmark-affecting code changes.

## Benchmark Results (Statistical: 30 runs)
- Overall Advantage: **1.32x** (Calor leads); Calor wins 7 metrics, C# wins 1
- Programs tested: 217 (Calor compiled 217, C# 216)
- Unchanged vs v0.6.6 (this release contains no benchmark-affecting code changes)

## Checklist
- [x] Version updated in Directory.Build.props
- [x] Version updated in editors/vscode/package.json
- [x] Version updated in website/package.json
- [x] CHANGELOG.md updated with version, date, and benchmark summary
- [x] website/content/changelog.mdx updated with version and changes (no benchmark stats)
- [x] website/src/components/landing/WhatsNewBanner.tsx updated with version and headline
- [x] website/public/data/benchmark-results.json updated with latest results
