### PR TITLE
feat: calor fix --heal-closers CLI (v0.6.8 A2)

### DIFF
--- a/src/Calor.Compiler/Analysis/LegacyCloserFormLint.cs
+++ b/src/Calor.Compiler/Analysis/LegacyCloserFormLint.cs
@@ -1,3 +1,6 @@
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+
 namespace Calor.Compiler.Analysis;
 
 /// <summary>
@@ -125,5 +128,65 @@ public static class LegacyCloserFormLint
         }
 
         return findings;
+    }
+
+    /// <summary>
+    /// Like <see cref="Scan"/>, but returns ONLY the findings that are safe to
+    /// delete from a <c>.calr</c> source file (used by <c>calor fix
+    /// --heal-closers</c>). A raw <see cref="Scan"/> matches the literal text
+    /// <c>§/…</c> anywhere — including inside a string literal (e.g.
+    /// <c>§P "see §/F"</c>) or a <c>//</c> comment — so a bulk rewriter driven
+    /// by raw findings would corrupt such content. The parser/LSP/MCP auto-heal
+    /// never has this problem because it operates on the token/AST level.
+    ///
+    /// <para>This method restores that safety at the source level by tokenizing
+    /// with the real <see cref="Lexer"/> and keeping only findings whose offset
+    /// coincides with a genuine closer TOKEN. Closer text that lands inside a
+    /// string/char literal is part of a <c>StrLiteral</c> token, and text inside
+    /// a <c>//</c> comment is skipped entirely, so neither produces a closer
+    /// token — such findings are dropped and the content is left untouched. If
+    /// the source cannot be tokenized at all, no findings are returned (heal
+    /// nothing rather than risk corruption).</para>
+    /// </summary>
+    public static IReadOnlyList<Finding> ScanForHeal(string source, string filePath)
+    {
+        var raw = Scan(source, filePath);
+        if (raw.Count == 0)
+        {
+            return raw;
+        }
+
+        HashSet<int> closerTokenOffsets;
+        try
+        {
+            var lexer = new Lexer(source, new DiagnosticBag());
+            closerTokenOffsets = new HashSet<int>();
+            foreach (var token in lexer.TokenizeAll())
+            {
+                // A genuine closer token's text is the source slice starting at
+                // the '§' (e.g. "§/F"); its span start is that '§' offset, which
+                // is exactly Finding.RemovedOffset.
+                if (token.Text.StartsWith("\u00A7/", StringComparison.Ordinal))
+                {
+                    closerTokenOffsets.Add(token.Span.Start);
+                }
+            }
+        }
+        catch
+        {
+            // Untokenizable source — be conservative and heal nothing.
+            return Array.Empty<Finding>();
+        }
+
+        var safe = new List<Finding>();
+        foreach (var finding in raw)
+        {
+            if (closerTokenOffsets.Contains(finding.RemovedOffset))
+            {
+                safe.Add(finding);
+            }
+        }
+
+        return safe;
     }
 }

--- a/src/Calor.Compiler/Commands/FixCommand.cs
+++ b/src/Calor.Compiler/Commands/FixCommand.cs
@@ -19,6 +19,13 @@ namespace Calor.Compiler.Commands;
 ///   Crockford-lowercase compact form (saves ~9.7 tokens per ID).
 ///   The mapping is collision-detected across all files in
 ///   <c>root</c>.</description></item>
+///   <item><description><c>--elide-call-closers</c>: elides <c>§/C</c> on
+///   zero-arg and one-arg same-line calls.</description></item>
+///   <item><description><c>--heal-closers</c>: deletes legacy structural
+///   closing tags (<c>§/F</c>, <c>§/M</c>, <c>§/L</c>, …) to rewrite a file
+///   into canonical indent-only form. Safe against closer text embedded in
+///   string literals or comments (see
+///   <see cref="Analysis.LegacyCloserFormLint.ScanForHeal"/>).</description></item>
 /// </list>
 /// </summary>
 public static class FixCommand
@@ -44,6 +51,10 @@ public static class FixCommand
             aliases: ["--elide-call-closers"],
             description: "Elide §/C on zero-arg + one-arg same-line calls (v0.6.x)");
 
+        var healClosersOption = new Option<bool>(
+            aliases: ["--heal-closers"],
+            description: "Delete legacy structural closers (§/F, §/M, …) -> indent-only form");
+
         var revertOption = new Option<bool>(
             aliases: ["--revert"],
             description: "Reverse the operation using --log");
@@ -62,6 +73,7 @@ public static class FixCommand
             dropStructuralIdsOption,
             compactIdsOption,
             elideCallClosersOption,
+            healClosersOption,
             revertOption,
             logOption,
             dryRunOption,
@@ -70,7 +82,7 @@ public static class FixCommand
         command.SetHandler(
             ExecuteAsync,
             rootArgument, dropStructuralIdsOption, compactIdsOption,
-            elideCallClosersOption, revertOption, logOption, dryRunOption);
+            elideCallClosersOption, healClosersOption, revertOption, logOption, dryRunOption);
 
         return command;
     }
@@ -80,6 +92,7 @@ public static class FixCommand
         bool dropStructuralIds,
         bool compactIds,
         bool elideCallClosers,
+        bool healClosers,
         bool revert,
         FileInfo? log,
         bool dryRun)
@@ -91,15 +104,16 @@ public static class FixCommand
         }
         var selectedCount = (dropStructuralIds ? 1 : 0)
                           + (compactIds ? 1 : 0)
-                          + (elideCallClosers ? 1 : 0);
+                          + (elideCallClosers ? 1 : 0)
+                          + (healClosers ? 1 : 0);
         if (selectedCount == 0)
         {
-            Console.Error.WriteLine("specify --drop-structural-ids, --compact-ids, or --elide-call-closers");
+            Console.Error.WriteLine("specify --drop-structural-ids, --compact-ids, --elide-call-closers, or --heal-closers");
             return 2;
         }
         if (selectedCount > 1)
         {
-            Console.Error.WriteLine("--drop-structural-ids, --compact-ids, and --elide-call-closers are mutually exclusive; run them separately");
+            Console.Error.WriteLine("--drop-structural-ids, --compact-ids, --elide-call-closers, and --heal-closers are mutually exclusive; run them separately");
             return 2;
         }
 
@@ -114,6 +128,12 @@ public static class FixCommand
             return revert
                 ? await RevertElideCallClosersAsync(root, log, dryRun)
                 : await ElideCallClosersAsync(root, log, dryRun);
+        }
+        if (healClosers)
+        {
+            return revert
+                ? await RevertHealClosersAsync(root, log, dryRun)
+                : await HealClosersAsync(root, log, dryRun);
         }
         // compactIds
         return revert
@@ -338,6 +358,79 @@ public static class FixCommand
         }
         var json = await File.ReadAllTextAsync(logFile.FullName, Encoding.UTF8);
         var migrationLog = CallCloserElider.DeserializeLog(json);
+
+        int filesRestored = 0;
+        foreach (var group in migrationLog.Entries.GroupBy(e => e.File))
+        {
+            var migPath = Path.Combine(root.FullName, group.Key.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(migPath))
+            {
+                Console.Error.WriteLine($"skip missing file: {migPath}");
+                continue;
+            }
+            var migrated = await File.ReadAllBytesAsync(migPath);
+            var restored = ReinsertRemovals(migrated, group);
+            if (!dryRun)
+            {
+                await File.WriteAllBytesAsync(migPath, restored);
+            }
+            filesRestored++;
+        }
+        Console.WriteLine(
+            $"revert: {(dryRun ? "[dry-run] " : "")}files_restored={filesRestored}");
+        return 0;
+    }
+
+    private static async Task<int> HealClosersAsync(
+        DirectoryInfo root, FileInfo? logFile, bool dryRun)
+    {
+        var migrator = new CloserHealMigrator();
+        var migrationLog = new StructuralIdDropper.MigrationLog();
+        int filesChanged = 0;
+        int totalRemovals = 0;
+
+        foreach (var path in EnumerateCalrFiles(root))
+        {
+            var rel = MakeRelativePosix(root, path);
+            var original = await File.ReadAllTextAsync(path, Encoding.UTF8);
+            var (migrated, removals) = migrator.Process(original, rel);
+            if (removals.Count == 0)
+            {
+                continue;
+            }
+            migrationLog.Entries.AddRange(removals);
+            totalRemovals += removals.Count;
+            filesChanged++;
+
+            if (!dryRun)
+            {
+                await File.WriteAllTextAsync(path, migrated, new UTF8Encoding(false));
+            }
+        }
+
+        Console.WriteLine(
+            $"heal-closers: {(dryRun ? "[dry-run] " : "")}files_changed={filesChanged} removals={totalRemovals}");
+
+        if (logFile != null)
+        {
+            var json = CloserHealMigrator.SerializeLog(migrationLog);
+            await File.WriteAllTextAsync(logFile.FullName, json, new UTF8Encoding(false));
+            Console.WriteLine($"wrote {logFile.FullName}");
+        }
+
+        return 0;
+    }
+
+    private static async Task<int> RevertHealClosersAsync(
+        DirectoryInfo root, FileInfo? logFile, bool dryRun)
+    {
+        if (logFile == null || !logFile.Exists)
+        {
+            Console.Error.WriteLine("--revert requires --log <existing migration.log.json>");
+            return 2;
+        }
+        var json = await File.ReadAllTextAsync(logFile.FullName, Encoding.UTF8);
+        var migrationLog = CloserHealMigrator.DeserializeLog(json);
 
         int filesRestored = 0;
         foreach (var group in migrationLog.Entries.GroupBy(e => e.File))

--- a/src/Calor.Compiler/Migration/CloserHealMigrator.cs
+++ b/src/Calor.Compiler/Migration/CloserHealMigrator.cs
@@ -1,0 +1,83 @@
+using System.Text;
+using Calor.Compiler.Analysis;
+
+namespace Calor.Compiler.Migration;
+
+/// <summary>
+/// <c>calor fix --heal-closers</c> — deletes legacy structural closing tags
+/// (<c>§/F</c>, <c>§/M</c>, <c>§/L</c>, …) from a <c>.calr</c> source, rewriting
+/// it into canonical indent-only form. Closer form hard-errors at parse time
+/// (<c>Calor0830</c>), so the AST-based <c>calor format</c> / <c>calor lint
+/// --fix</c> paths cannot heal such a file — this migrator works at the source
+/// level via <see cref="LegacyCloserFormLint.ScanForHeal"/>.
+///
+/// <para>Removals are recorded as UTF-8 <em>byte</em> ranges plus the removed
+/// bytes (base64) using the shared <see cref="StructuralIdDropper.LogEntry"/>
+/// schema, so a <c>migration.log.json</c> can byte-exactly revert the change via
+/// the same <c>ReinsertRemovals</c> path the other <c>fix</c> subcommands use.
+/// <see cref="LegacyCloserFormLint.ScanForHeal"/> returns offsets in CHARACTER
+/// units; because <c>§</c> is a two-byte UTF-8 code point, this migrator converts
+/// each removal to a byte offset/length for the log (a char offset would corrupt
+/// revert whenever any non-ASCII precedes the removal).</para>
+/// </summary>
+public sealed class CloserHealMigrator
+{
+    /// <summary>
+    /// Heal one file. Returns the rewritten source and the byte-accurate
+    /// removal records (empty when there is nothing to heal).
+    /// </summary>
+    public (string Migrated, List<StructuralIdDropper.LogEntry> Removals) Process(
+        string source, string relativeFilePath)
+    {
+        var removals = new List<StructuralIdDropper.LogEntry>();
+        var findings = LegacyCloserFormLint.ScanForHeal(source, relativeFilePath);
+        if (findings.Count == 0)
+        {
+            return (source, removals);
+        }
+
+        var ordered = findings.OrderBy(f => f.RemovedOffset).ToList();
+        var sb = new StringBuilder(source.Length);
+        int cursor = 0; // char cursor into source
+
+        foreach (var finding in ordered)
+        {
+            int startChar = finding.RemovedOffset;
+            int endChar = finding.RemovedOffset + finding.RemovedLength;
+
+            // Defensive: skip a finding that overlaps one already applied.
+            if (startChar < cursor || endChar > source.Length)
+            {
+                continue;
+            }
+
+            // Preserve the gap before this removal.
+            sb.Append(source, cursor, startChar - cursor);
+
+            // Record the removal in ORIGINAL-source UTF-8 byte coordinates so the
+            // shared byte-based revert can reconstruct the file exactly.
+            int removedByteStart = Encoding.UTF8.GetByteCount(source.AsSpan(0, startChar));
+            var removedBytes = Encoding.UTF8.GetBytes(source.Substring(startChar, endChar - startChar));
+            removals.Add(new StructuralIdDropper.LogEntry
+            {
+                File = relativeFilePath,
+                RemovedOffset = removedByteStart,
+                RemovedLength = removedBytes.Length,
+                RemovedBytesBase64 = Convert.ToBase64String(removedBytes),
+            });
+
+            cursor = endChar;
+        }
+
+        sb.Append(source, cursor, source.Length - cursor);
+        return (sb.ToString(), removals);
+    }
+
+    /// <summary>Serialise a heal log (delegates to the shared schema).</summary>
+    public static string SerializeLog(StructuralIdDropper.MigrationLog log)
+        => StructuralIdDropper.SerializeLog(log);
+
+    /// <summary>Deserialise a heal log (delegates to the shared schema).</summary>
+    public static StructuralIdDropper.MigrationLog DeserializeLog(string json)
+        => StructuralIdDropper.DeserializeLog(json);
+}

--- a/tests/Calor.Compiler.Tests/Migration/CloserHealMigratorTests.cs
+++ b/tests/Calor.Compiler.Tests/Migration/CloserHealMigratorTests.cs
@@ -1,0 +1,222 @@
+using System.Text;
+using Calor.Compiler.Analysis;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Migration;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="CloserHealMigrator"/> and the lexer-backed
+/// <see cref="LegacyCloserFormLint.ScanForHeal"/> it relies on (v0.6.8, the CLI
+/// <c>calor fix --heal-closers</c> backend).
+///
+/// Invariants:
+///   T-heal-a  bare structural closers (§/F, §/M) are removed
+///   T-heal-b  id-bearing closers (§/F{f1}, §/M{m1}) removed incl. payload
+///   T-heal-c  non-structural inline closer (§/C) is NOT removed
+///   T-heal-d  a §/F inside a STRING literal is NOT removed (safety)
+///   T-heal-e  a §/F inside a // COMMENT is NOT removed (safety)
+///   T-heal-f  mixed genuine + string-embedded closers: heals only genuine
+///   T-heal-g  round-trip (heal → revert via byte log) is byte-equal
+///   T-heal-h  round-trip is byte-equal with Unicode-before + CRLF
+///   T-heal-i  no closers → no edits, no log entries
+///   T-heal-j  healed source re-parses with no Calor0830 and no errors
+///   T-heal-k  idempotent: healing twice = healing once
+/// </summary>
+public class CloserHealMigratorTests
+{
+    private static readonly CloserHealMigrator Sut = new();
+
+    private const string CloserModule =
+        "§M{m1:Calc}\n" +
+        "  §F{f1:Add:pub}\n" +
+        "    §I{i32:a}\n" +
+        "    §I{i32:b}\n" +
+        "    §O{i32}\n" +
+        "    §R (+ a b)\n" +
+        "  §/F{f1}\n" +
+        "§/M{m1}\n";
+
+    [Fact]
+    public void T_heal_a_RemovesBareStructuralClosers()
+    {
+        const string src = "§M{Calc}\n  §F{add}\n    §R INT:0\n  §/F\n§/M\n";
+        var (migrated, removals) = Sut.Process(src, "a.calr");
+
+        Assert.Equal(2, removals.Count);
+        Assert.DoesNotContain("§/F", migrated);
+        Assert.DoesNotContain("§/M", migrated);
+        Assert.Contains("§F{add}", migrated);
+    }
+
+    [Fact]
+    public void T_heal_b_RemovesIdBearingClosersWithPayload()
+    {
+        var (migrated, removals) = Sut.Process(CloserModule, "b.calr");
+
+        Assert.Equal(2, removals.Count);
+        Assert.DoesNotContain("§/F", migrated);
+        Assert.DoesNotContain("§/M", migrated);
+        // Payload braces went with the closer.
+        Assert.DoesNotContain("{f1}\n", migrated.Replace("§F{f1", ""));
+    }
+
+    [Fact]
+    public void T_heal_c_LeavesNonStructuralInlineCloser()
+    {
+        // §/C (call closer) is inline, not structural — must stay.
+        const string src = "§M{Calc}\n  §F{run}\n    §C{Math.Abs} §A INT:-5 §/C\n  §/F\n";
+        var (migrated, removals) = Sut.Process(src, "c.calr");
+
+        Assert.Single(removals); // only §/F
+        Assert.Contains("§/C", migrated);
+        Assert.DoesNotContain("§/F", migrated);
+    }
+
+    [Fact]
+    public void T_heal_d_DoesNotTouchCloserInsideStringLiteral()
+    {
+        const string src = "§M{Calc}\n  §F{run:pub}\n    §P \"see §/F in docs\"\n";
+        // Raw scan (unsafe) WOULD flag the embedded §/F...
+        Assert.NotEmpty(LegacyCloserFormLint.Scan(src, "d.calr"));
+        // ...but the safe heal scan must not, so nothing is removed.
+        var (migrated, removals) = Sut.Process(src, "d.calr");
+        Assert.Empty(removals);
+        Assert.Equal(src, migrated);
+    }
+
+    [Fact]
+    public void T_heal_e_DoesNotTouchCloserInsideLineComment()
+    {
+        const string src = "§M{Calc}\n  §F{run:pub}\n    §R INT:0 // note about §/F here\n";
+        Assert.NotEmpty(LegacyCloserFormLint.Scan(src, "e.calr"));
+        var (migrated, removals) = Sut.Process(src, "e.calr");
+        Assert.Empty(removals);
+        Assert.Equal(src, migrated);
+    }
+
+    [Fact]
+    public void T_heal_f_MixedStringAndGenuine_HealsOnlyGenuine()
+    {
+        const string src =
+            "§M{m1:Calc}\n" +
+            "  §F{f1:run:pub}\n" +
+            "    §P \"literal §/F stays\"\n" +
+            "    §R INT:0\n" +
+            "  §/F{f1}\n" +
+            "§/M{m1}\n";
+
+        // Raw scan sees 3 (string §/F + two genuine); safe scan sees 2.
+        Assert.Equal(3, LegacyCloserFormLint.Scan(src, "f.calr").Count);
+        Assert.Equal(2, LegacyCloserFormLint.ScanForHeal(src, "f.calr").Count);
+
+        var (migrated, removals) = Sut.Process(src, "f.calr");
+        Assert.Equal(2, removals.Count);
+        Assert.Contains("literal §/F stays", migrated);
+    }
+
+    [Fact]
+    public void T_heal_g_RoundTrip_ByteEqual()
+    {
+        var (migrated, removals) = Sut.Process(CloserModule, "g.calr");
+        Assert.NotEmpty(removals);
+
+        var restored = Encoding.UTF8.GetString(
+            ReinsertRemovals(Encoding.UTF8.GetBytes(migrated), removals));
+        Assert.Equal(CloserModule, restored);
+    }
+
+    [Fact]
+    public void T_heal_h_RoundTrip_ByteEqual_UnicodeAndCrlf()
+    {
+        // Unicode before the closer (é, 世) exercises the char→byte offset
+        // conversion; CRLF line endings exercise \r handling.
+        var src =
+            "§M{m1:Café}\r\n" +
+            "  §F{f1:世界:pub}\r\n" +
+            "    §R INT:0\r\n" +
+            "  §/F{f1}\r\n" +
+            "§/M{m1}\r\n";
+        var (migrated, removals) = Sut.Process(src, "h.calr");
+        Assert.Equal(2, removals.Count);
+
+        var restored = Encoding.UTF8.GetString(
+            ReinsertRemovals(Encoding.UTF8.GetBytes(migrated), removals));
+        Assert.Equal(src, restored);
+    }
+
+    [Fact]
+    public void T_heal_i_NoClosers_NoOp()
+    {
+        const string src = "§M{Calc}\n  §F{run:pub}\n    §R INT:0\n";
+        var (migrated, removals) = Sut.Process(src, "i.calr");
+        Assert.Empty(removals);
+        Assert.Equal(src, migrated);
+    }
+
+    [Fact]
+    public void T_heal_j_HealedSourceReparsesCleanly()
+    {
+        var (migrated, _) = Sut.Process(CloserModule, "j.calr");
+        var (diags, hasErrors) = Parse(migrated);
+
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.LegacyCloserForm);
+        Assert.False(hasErrors, "Healed source must parse without errors");
+    }
+
+    [Fact]
+    public void T_heal_k_Idempotent()
+    {
+        var (first, _) = Sut.Process(CloserModule, "k.calr");
+        var (second, removals2) = Sut.Process(first, "k.calr");
+
+        Assert.Empty(removals2);
+        Assert.Equal(first, second);
+    }
+
+    // ---- helpers ----------------------------------------------------------
+
+    private static (IList<Diagnostic> Diagnostics, bool HasErrors) Parse(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAllForParser();
+        var parser = new Parser(tokens, diagnostics);
+        _ = parser.Parse();
+        return (diagnostics.ToList(), diagnostics.HasErrors);
+    }
+
+    // Mirror of FixCommand.ReinsertRemovals (byte-based revert).
+    private static byte[] ReinsertRemovals(
+        byte[] migrated,
+        IEnumerable<StructuralIdDropper.LogEntry> entries)
+    {
+        var sorted = entries.OrderBy(e => e.RemovedOffset).ToList();
+        var totalLen = migrated.Length + sorted.Sum(e => e.RemovedLength);
+        var result = new byte[totalLen];
+
+        var srcIdx = 0;
+        var dstIdx = 0;
+        foreach (var entry in sorted)
+        {
+            var preLen = entry.RemovedOffset - dstIdx;
+            if (preLen > 0)
+            {
+                Array.Copy(migrated, srcIdx, result, dstIdx, preLen);
+                srcIdx += preLen;
+                dstIdx += preLen;
+            }
+            var removed = Convert.FromBase64String(entry.RemovedBytesBase64);
+            Array.Copy(removed, 0, result, dstIdx, removed.Length);
+            dstIdx += removed.Length;
+        }
+        var tail = migrated.Length - srcIdx;
+        if (tail > 0)
+        {
+            Array.Copy(migrated, srcIdx, result, dstIdx, tail);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary (v0.6.8 — PR-A2 of the "retire deferred debt" patch track)

Adds `calor fix --heal-closers`, the CLI that finishes the **Calor0830 auto-heal** story. Closer-form syntax (`§/F`, `§/M`, `§/L`, …) was removed in Phase 4d and now hard-errors at parse time, so the AST-based `calor format` / `calor lint --fix` paths **cannot** heal such a file (the error *is* a parse error). This works at the **source level** instead.

## What it does
`calor fix --heal-closers <root> [--log <file>] [--revert] [--dry-run]` walks `.calr` files and deletes legacy structural closers, rewriting them into canonical indent-only form. `--revert --log` restores byte-exactly.

## Key correctness properties (both were review blockers, folded in with tests)
1. **Byte-vs-char offsets** — `LegacyCloserFormLint.Scan` returns CHAR offsets, but the reversible `StructuralIdDropper.LogEntry` schema is UTF-8 **byte**-based (and `§` = 2 bytes). `CloserHealMigrator` removes by char range but records **byte** offsets + base64, so `--revert` is byte-exact even with non-ASCII before a closer.
2. **String/comment safety** — raw `Scan` is a char scan; `§/F` inside a string literal or `//` comment would be deleted. New `LegacyCloserFormLint.ScanForHeal` tokenizes with the real `Lexer` and keeps only findings that coincide with a genuine closer **token**. `Scan` is unchanged (still used as a detector by the agent-docs guard).

## Tests
`CloserHealMigratorTests` (11): bare + id-bearing closers healed, non-structural `§/C` kept, closers inside string literals / `//` comments left untouched, **byte-exact round-trip incl. Unicode + CRLF**, no-op, idempotence, healed source re-parses with no `Calor0830` and no errors.

Full `Calor.Compiler.Tests`: **5645 pass / 0 fail**. Build clean (`TreatWarningsAsErrors`).

## Scope / risk
Correctness/tooling only — no emitted-C# or benchmark movement. Disjoint from PR-A1 (shared `ReturnShape` classifier), which follows. Part of the v0.6.8 plan.

DO NOT MERGE without your review — you own merges.
