### PR TITLE
refactor: shared Analysis/ReturnShape classifier (v0.6.8 A1)

### DIFF
--- a/src/Calor.Compiler/Analysis/ReturnShape.cs
+++ b/src/Calor.Compiler/Analysis/ReturnShape.cs
@@ -1,0 +1,172 @@
+using Calor.Compiler.Ast;
+
+namespace Calor.Compiler.Analysis;
+
+/// <summary>
+/// Single source of truth for the "return shape" of an owner — a
+/// function/method/operator, constructor, property/indexer accessor, or event
+/// accessor — i.e. whether a value <c>§R</c> is expected and, if not, why.
+///
+/// <para>This classification used to be duplicated: <see cref="ReturnValidationPass"/>
+/// carried a private <c>OwnerKind</c> enum with <c>ClassifyCallable</c>/
+/// <c>ClassifyAccessor</c>/iterator-detection, and
+/// <see cref="Verification.ContractVerifier"/> re-derived "does this function
+/// declare a value output" inline. Both now defer here so the two consumers can
+/// never drift.</para>
+///
+/// <para>Note the distinction between two related questions:
+/// <list type="bullet">
+///   <item><see cref="Classify"/> answers the runtime question ("does control
+///   leave this owner carrying a value") and therefore folds in async/iterator
+///   lowering — an iterator that declares <c>IEnumerable&lt;T&gt;</c> is
+///   <see cref="Kind.Iterator"/>, not <see cref="Kind.Value"/>.</item>
+///   <item><see cref="DeclaresValueOutput"/> answers the narrower header question
+///   ("did the signature declare a non-void return type"), which is what the
+///   contract verifier needs for <c>result</c> referenceability and which must
+///   NOT fold in iterator lowering.</item>
+/// </list></para>
+/// </summary>
+public static class ReturnShape
+{
+    /// <summary>The classified return shape of an owner.</summary>
+    public enum Kind
+    {
+        /// <summary>Not a return-bearing owner (e.g. module/class scope).</summary>
+        None,
+
+        /// <summary>Value-returning owner — a value <c>§R</c> is expected.</summary>
+        Value,
+
+        /// <summary>Non-async owner with no return type (compiles to <c>void</c>).</summary>
+        Void,
+
+        /// <summary>Async owner with no return type (compiles to <c>Task</c>).</summary>
+        AsyncVoid,
+
+        /// <summary>Iterator owner (its body yields).</summary>
+        Iterator,
+
+        /// <summary>Property/indexer <c>set</c> or <c>init</c> accessor.</summary>
+        Setter,
+
+        /// <summary>Constructor.</summary>
+        Constructor,
+
+        /// <summary>Event <c>add</c>/<c>remove</c> accessor.</summary>
+        EventAccessor,
+    }
+
+    /// <summary>
+    /// Classify an owner node. Non-owner nodes classify as <see cref="Kind.None"/>.
+    /// </summary>
+    public static Kind Classify(AstNode owner) => owner switch
+    {
+        FunctionNode f => ClassifyCallable(f.Output, f.IsAsync, f),
+        MethodNode m => ClassifyCallable(m.Output, m.IsAsync, m),
+        OperatorOverloadNode op => ClassifyCallable(op.Output, isAsync: false, op),
+        ConstructorNode => Kind.Constructor,
+        PropertyAccessorNode accessor => ClassifyAccessor(accessor),
+        EventDefinitionNode => Kind.EventAccessor,
+        _ => Kind.None,
+    };
+
+    /// <summary>
+    /// True when the owner produces no value at its return site, so a value
+    /// <c>§R</c> is illegal there (void/async-void/iterator/setter/constructor/
+    /// event accessor).
+    /// </summary>
+    public static bool IsNoValueOwner(Kind shape) => shape switch
+    {
+        Kind.Void or Kind.AsyncVoid or Kind.Iterator
+            or Kind.Setter or Kind.Constructor or Kind.EventAccessor => true,
+        _ => false,
+    };
+
+    /// <summary>
+    /// Whether an <see cref="OutputNode"/> declares a non-void return type — the
+    /// narrow header predicate (does NOT fold in async/iterator lowering). Used by
+    /// the contract verifier to decide whether <c>result</c> is referenceable.
+    /// </summary>
+    public static bool DeclaresValueOutput(OutputNode? output)
+        => output is not null && !IsVoidType(output.TypeName);
+
+    /// <summary>
+    /// The void-name test shared by every consumer. Only <c>void</c> (case-
+    /// insensitive) is treated as no-value, matching the C# emitter's own rule
+    /// (<c>returnType != "void"</c>); keeping the set this narrow avoids diverging
+    /// from codegen and thus avoids false positives.
+    /// </summary>
+    public static bool IsVoidType(string typeName)
+        => typeName.Trim().Equals("void", StringComparison.OrdinalIgnoreCase);
+
+    private static Kind ClassifyCallable(OutputNode? output, bool isAsync, AstNode owner)
+    {
+        if (IsIterator(owner))
+        {
+            return Kind.Iterator;
+        }
+
+        if (!DeclaresValueOutput(output))
+        {
+            return isAsync ? Kind.AsyncVoid : Kind.Void;
+        }
+
+        return Kind.Value;
+    }
+
+    private static Kind ClassifyAccessor(PropertyAccessorNode accessor)
+    {
+        if (accessor.Kind == PropertyAccessorNode.AccessorKind.Get)
+        {
+            // A getter returns the property value, so a value §R is expected —
+            // unless the getter is itself an iterator.
+            return IsIterator(accessor) ? Kind.Iterator : Kind.Value;
+        }
+
+        // set / init accessors never return a value.
+        return Kind.Setter;
+    }
+
+    private static bool IsIterator(AstNode owner)
+    {
+        foreach (var child in RecursiveAstWalker.GetChildren(owner))
+        {
+            if (ContainsYield(child))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsYield(AstNode node)
+    {
+        if (node is YieldReturnStatementNode or YieldBreakStatementNode)
+        {
+            return true;
+        }
+
+        // Do not cross into a nested owner boundary (defensive — statement bodies
+        // do not currently contain nested owners, and lambdas are expressions
+        // that RecursiveAstWalker already skips).
+        if (IsOwner(node))
+        {
+            return false;
+        }
+
+        foreach (var child in RecursiveAstWalker.GetChildren(node))
+        {
+            if (ContainsYield(child))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsOwner(AstNode node) => node is
+        FunctionNode or MethodNode or OperatorOverloadNode or
+        ConstructorNode or PropertyAccessorNode or EventDefinitionNode;
+}

--- a/src/Calor.Compiler/Analysis/ReturnValidationPass.cs
+++ b/src/Calor.Compiler/Analysis/ReturnValidationPass.cs
@@ -37,33 +37,6 @@ public sealed class ReturnValidationPass
 {
     private readonly DiagnosticBag _diagnostics;
 
-    private enum OwnerKind
-    {
-        /// <summary>Not inside a return-bearing owner (e.g. module/class scope).</summary>
-        None,
-
-        /// <summary>Value-returning owner — a value <c>§R</c> is expected.</summary>
-        Value,
-
-        /// <summary>Non-async member with no return type (compiles to <c>void</c>).</summary>
-        Void,
-
-        /// <summary>Async member with no return type (compiles to <c>Task</c>).</summary>
-        AsyncVoid,
-
-        /// <summary>Iterator member (its body yields).</summary>
-        Iterator,
-
-        /// <summary>Property/indexer <c>set</c> or <c>init</c> accessor.</summary>
-        Setter,
-
-        /// <summary>Constructor.</summary>
-        Constructor,
-
-        /// <summary>Event <c>add</c>/<c>remove</c> accessor.</summary>
-        EventAccessor,
-    }
-
     public ReturnValidationPass(DiagnosticBag diagnostics)
     {
         _diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
@@ -76,10 +49,10 @@ public sealed class ReturnValidationPass
             return;
         }
 
-        Walk(module, OwnerKind.None);
+        Walk(module, ReturnShape.Kind.None);
     }
 
-    private void Walk(AstNode node, OwnerKind context)
+    private void Walk(AstNode node, ReturnShape.Kind context)
     {
         // The context that applies to this node's *children*. Owner nodes open a
         // fresh context (their own return classification); everything else — in
@@ -88,23 +61,9 @@ public sealed class ReturnValidationPass
 
         switch (node)
         {
-            case FunctionNode f:
-                childContext = ClassifyCallable(f.Output, f.IsAsync, f);
-                break;
-            case MethodNode m:
-                childContext = ClassifyCallable(m.Output, m.IsAsync, m);
-                break;
-            case OperatorOverloadNode op:
-                childContext = ClassifyCallable(op.Output, isAsync: false, op);
-                break;
-            case ConstructorNode:
-                childContext = OwnerKind.Constructor;
-                break;
-            case PropertyAccessorNode accessor:
-                childContext = ClassifyAccessor(accessor);
-                break;
-            case EventDefinitionNode:
-                childContext = OwnerKind.EventAccessor;
+            case FunctionNode or MethodNode or OperatorOverloadNode
+                or ConstructorNode or PropertyAccessorNode or EventDefinitionNode:
+                childContext = ReturnShape.Classify(node);
                 break;
             case ReturnStatementNode ret:
                 CheckReturn(ret, context);
@@ -117,38 +76,9 @@ public sealed class ReturnValidationPass
         }
     }
 
-    private OwnerKind ClassifyCallable(OutputNode? output, bool isAsync, AstNode owner)
+    private void CheckReturn(ReturnStatementNode ret, ReturnShape.Kind context)
     {
-        if (IsIterator(owner))
-        {
-            return OwnerKind.Iterator;
-        }
-
-        var noValue = output is null || IsVoidType(output.TypeName);
-        if (noValue)
-        {
-            return isAsync ? OwnerKind.AsyncVoid : OwnerKind.Void;
-        }
-
-        return OwnerKind.Value;
-    }
-
-    private OwnerKind ClassifyAccessor(PropertyAccessorNode accessor)
-    {
-        if (accessor.Kind == PropertyAccessorNode.AccessorKind.Get)
-        {
-            // A getter returns the property value, so a value §R is expected —
-            // unless the getter is itself an iterator.
-            return IsIterator(accessor) ? OwnerKind.Iterator : OwnerKind.Value;
-        }
-
-        // set / init accessors never return a value.
-        return OwnerKind.Setter;
-    }
-
-    private void CheckReturn(ReturnStatementNode ret, OwnerKind context)
-    {
-        if (!IsNoValueOwner(context))
+        if (!ReturnShape.IsNoValueOwner(context))
         {
             return;
         }
@@ -170,88 +100,29 @@ public sealed class ReturnValidationPass
         _diagnostics.ReportError(ret.Span, DiagnosticCode.ReturnValueInVoidOwner, MessageFor(context));
     }
 
-    private static bool IsNoValueOwner(OwnerKind kind) => kind switch
+    private static string MessageFor(ReturnShape.Kind kind) => kind switch
     {
-        OwnerKind.Void or OwnerKind.AsyncVoid or OwnerKind.Iterator
-            or OwnerKind.Setter or OwnerKind.Constructor or OwnerKind.EventAccessor => true,
-        _ => false,
-    };
-
-    private static string MessageFor(OwnerKind kind) => kind switch
-    {
-        OwnerKind.Void =>
+        ReturnShape.Kind.Void =>
             "'§R' returns a value, but the enclosing function/method declares no return type and " +
             "compiles to 'void', which cannot return a value. Add a return type ('§O{type}' or a " +
             "return type in the header), or drop the value and use a bare '§R' to return early.",
-        OwnerKind.AsyncVoid =>
+        ReturnShape.Kind.AsyncVoid =>
             "'§R' returns a value, but the enclosing async function/method declares no return type and " +
             "compiles to 'Task', which cannot return a value. Add a return type ('§O{type}', emitted as " +
             "'Task<type>'), or drop the value and use a bare '§R'.",
-        OwnerKind.Iterator =>
+        ReturnShape.Kind.Iterator =>
             "'§R' returns a value, but the enclosing member is an iterator (its body uses '§YIELD'/'§YBRK') " +
             "and cannot 'return' a value. Use '§YIELD expr' to produce a value, or a bare '§R' to stop iteration.",
-        OwnerKind.Setter =>
+        ReturnShape.Kind.Setter =>
             "'§R' returns a value, but a property/indexer 'set' or 'init' accessor cannot return a value. " +
             "Use a bare '§R' to return early.",
-        OwnerKind.Constructor =>
+        ReturnShape.Kind.Constructor =>
             "'§R' returns a value, but a constructor cannot return a value. Use a bare '§R' to return early.",
-        OwnerKind.EventAccessor =>
+        ReturnShape.Kind.EventAccessor =>
             "'§R' returns a value, but an event 'add'/'remove' accessor cannot return a value. " +
             "Use a bare '§R' to return early.",
         _ => "'§R' returns a value in a member that has no return value.",
     };
-
-    private static bool IsVoidType(string typeName)
-    {
-        var t = typeName.Trim();
-        // Only "void" is treated as no-value, matching the C# emitter's own rule
-        // (CSharpEmitter uses returnType != "void"). Keeping the set this narrow
-        // avoids diverging from codegen and thus avoids false positives.
-        return t.Equals("void", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private bool IsIterator(AstNode owner)
-    {
-        foreach (var child in RecursiveAstWalker.GetChildren(owner))
-        {
-            if (ContainsYield(child))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static bool ContainsYield(AstNode node)
-    {
-        if (node is YieldReturnStatementNode or YieldBreakStatementNode)
-        {
-            return true;
-        }
-
-        // Do not cross into a nested owner boundary (defensive — statement bodies
-        // do not currently contain nested owners, and lambdas are expressions
-        // that RecursiveAstWalker already skips).
-        if (IsOwner(node))
-        {
-            return false;
-        }
-
-        foreach (var child in RecursiveAstWalker.GetChildren(node))
-        {
-            if (ContainsYield(child))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static bool IsOwner(AstNode node) => node is
-        FunctionNode or MethodNode or OperatorOverloadNode or
-        ConstructorNode or PropertyAccessorNode or EventDefinitionNode;
 
     /// <summary>
     /// True only for expressions that are <em>definitely</em> a non-void value

--- a/src/Calor.Compiler/Verification/ContractVerifier.cs
+++ b/src/Calor.Compiler/Verification/ContractVerifier.cs
@@ -1,3 +1,4 @@
+using Calor.Compiler.Analysis;
 using Calor.Compiler.Ast;
 using Calor.Compiler.Diagnostics;
 using Calor.Compiler.Parsing;
@@ -110,8 +111,7 @@ public sealed class ContractVerifier
         var validNames = function.Parameters.Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
         validNames.Add("result"); // Special identifier for return value
 
-        var hasReturnValue = function.Output != null &&
-                             !function.Output.TypeName.Equals("VOID", StringComparison.OrdinalIgnoreCase);
+        var hasReturnValue = ReturnShape.DeclaresValueOutput(function.Output);
 
         foreach (var name in referencedNames)
         {

--- a/tests/Calor.Compiler.Tests/Analysis/ReturnShapeTests.cs
+++ b/tests/Calor.Compiler.Tests/Analysis/ReturnShapeTests.cs
@@ -1,0 +1,238 @@
+using Calor.Compiler.Analysis;
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Unit table for <see cref="ReturnShape"/> — the shared classifier that
+/// <see cref="ReturnValidationPass"/> (Calor0205) and
+/// <see cref="Calor.Compiler.Verification.ContractVerifier"/> (<c>result</c>
+/// referenceability) both defer to. Verifies each owner construct maps to the
+/// expected <see cref="ReturnShape.Kind"/>, the no-value predicate, and — the
+/// case the two consumers must NOT confuse — the divergence between the runtime
+/// classification (<see cref="ReturnShape.Classify"/>) and the header predicate
+/// (<see cref="ReturnShape.DeclaresValueOutput"/>) for an iterator.
+/// </summary>
+public class ReturnShapeTests
+{
+    // ------------------------------------------------------------- Classify()
+
+    [Fact]
+    public void ValueFunction_ClassifiesAsValue()
+        => Assert.Equal(ReturnShape.Kind.Value, ClassifyFirst<FunctionNode>(@"
+§M{m1:T}
+  §F{f1:Get:pub}
+    §O{i32}
+    §R INT:0
+"));
+
+    [Fact]
+    public void VoidFunction_ClassifiesAsVoid()
+        => Assert.Equal(ReturnShape.Kind.Void, ClassifyFirst<FunctionNode>(@"
+§M{m1:T}
+  §F{f1:Do:pub}
+    §P ""x""
+"));
+
+    [Fact]
+    public void AsyncVoidFunction_ClassifiesAsAsyncVoid()
+        => Assert.Equal(ReturnShape.Kind.AsyncVoid, ClassifyFirst<FunctionNode>(@"
+§M{m1:T}
+  §AF{f1:DoAsync:pub}
+    §P ""x""
+"));
+
+    [Fact]
+    public void IteratorFunction_ClassifiesAsIterator()
+        => Assert.Equal(ReturnShape.Kind.Iterator, ClassifyFirst<FunctionNode>(@"
+§M{m1:T}
+  §F{f1:Nums:pub}
+    §O{i32}
+    §YIELD 42
+"));
+
+    [Fact]
+    public void ValueMethod_ClassifiesAsValue()
+        => Assert.Equal(ReturnShape.Kind.Value, ClassifyFirst<MethodNode>(@"
+§M{m1:T}
+  §CL{c1:C:pub}
+    §MT{mt1:Get:pub} () -> i32
+      §R INT:0
+"));
+
+    [Fact]
+    public void VoidMethod_ClassifiesAsVoid()
+        => Assert.Equal(ReturnShape.Kind.Void, ClassifyFirst<MethodNode>(@"
+§M{m1:T}
+  §CL{c1:C:pub}
+    §MT{mt1:Do:pub} () -> void
+      §P ""x""
+"));
+
+    [Fact]
+    public void ValueOperator_ClassifiesAsValue()
+        => Assert.Equal(ReturnShape.Kind.Value, ClassifyFirst<OperatorOverloadNode>(@"
+§M{m1:T}
+  §CL{c1:Vector:pub}
+    §OP{op1:+:pub} (Vector:a, Vector:b) -> Vector
+      §R a
+"));
+
+    [Fact]
+    public void Constructor_ClassifiesAsConstructor()
+        => Assert.Equal(ReturnShape.Kind.Constructor, ClassifyFirst<ConstructorNode>(@"
+§M{m1:T}
+  §CL{c1:C:pub}
+    §CTOR{ctor1:pub} ()
+      §P ""x""
+"));
+
+    [Fact]
+    public void Event_ClassifiesAsEventAccessor()
+        => Assert.Equal(ReturnShape.Kind.EventAccessor, ClassifyFirst<EventDefinitionNode>(@"
+§M{m1:T}
+  §CL{c1:C:pub}
+    §EVT{e1:Click:pub:EventHandler}
+    §EADD
+    §P ""x""
+    §/EADD
+    §/EVT{e1}
+"));
+
+    [Fact]
+    public void PropertyGetter_ClassifiesAsValue_AndSetterAsSetter()
+    {
+        const string src = @"
+§M{m1:T}
+  §CL{c1:C:pub}
+    §PROP{p1:Name:str:pub}
+      §GET
+        §R ""x""
+      §/GET
+      §SET
+        §P ""x""
+      §/SET
+    §/PROP{p1}
+";
+        var accessors = FindAll<PropertyAccessorNode>(Parse(src));
+        var getter = accessors.Single(a => a.Kind == PropertyAccessorNode.AccessorKind.Get);
+        var setter = accessors.Single(a => a.Kind != PropertyAccessorNode.AccessorKind.Get);
+
+        Assert.Equal(ReturnShape.Kind.Value, ReturnShape.Classify(getter));
+        Assert.Equal(ReturnShape.Kind.Setter, ReturnShape.Classify(setter));
+    }
+
+    [Fact]
+    public void NonOwnerNode_ClassifiesAsNone()
+        => Assert.Equal(ReturnShape.Kind.None, ReturnShape.Classify(Parse(@"
+§M{m1:T}
+  §F{f1:Do:pub}
+    §P ""x""
+")));
+
+    // ------------------------------------------- Iterator divergence (the trap)
+
+    /// <summary>
+    /// An iterator DECLARES a value output (e.g. <c>IEnumerable&lt;T&gt;</c>), so the
+    /// header predicate <see cref="ReturnShape.DeclaresValueOutput"/> is true and the
+    /// contract verifier still allows <c>result</c> — but the runtime
+    /// <see cref="ReturnShape.Classify"/> is <see cref="ReturnShape.Kind.Iterator"/>,
+    /// not <see cref="ReturnShape.Kind.Value"/>, so the return-value pass treats a
+    /// value <c>§R</c> as illegal. The two answers legitimately diverge; this test
+    /// pins that so the two consumers can't be accidentally collapsed.
+    /// </summary>
+    [Fact]
+    public void Iterator_DeclaresValueOutput_ButClassifiesAsIterator()
+    {
+        var fn = FindAll<FunctionNode>(Parse(@"
+§M{m1:T}
+  §F{f1:Nums:pub}
+    §O{i32}
+    §YIELD 42
+")).Single();
+
+        Assert.True(ReturnShape.DeclaresValueOutput(fn.Output));
+        Assert.Equal(ReturnShape.Kind.Iterator, ReturnShape.Classify(fn));
+    }
+
+    // ------------------------------------------------ DeclaresValueOutput / void
+
+    [Fact]
+    public void DeclaresValueOutput_NullOutput_IsFalse()
+        => Assert.False(ReturnShape.DeclaresValueOutput(null));
+
+    [Theory]
+    [InlineData("void", false)]
+    [InlineData("VOID", false)]
+    [InlineData("Void", false)]
+    [InlineData(" void ", false)]
+    [InlineData("i32", true)]
+    [InlineData("string", true)]
+    public void DeclaresValueOutput_MatchesVoidNameCaseInsensitively(string typeName, bool expected)
+        => Assert.Equal(expected, ReturnShape.DeclaresValueOutput(new OutputNode(default, typeName)));
+
+    [Theory]
+    [InlineData("void", true)]
+    [InlineData("VOID", true)]
+    [InlineData(" void ", true)]
+    [InlineData("i32", false)]
+    public void IsVoidType_MatchesVoidNameCaseInsensitively(string typeName, bool expected)
+        => Assert.Equal(expected, ReturnShape.IsVoidType(typeName));
+
+    // ---------------------------------------------------------- IsNoValueOwner
+
+    [Theory]
+    [InlineData(ReturnShape.Kind.Void)]
+    [InlineData(ReturnShape.Kind.AsyncVoid)]
+    [InlineData(ReturnShape.Kind.Iterator)]
+    [InlineData(ReturnShape.Kind.Setter)]
+    [InlineData(ReturnShape.Kind.Constructor)]
+    [InlineData(ReturnShape.Kind.EventAccessor)]
+    public void IsNoValueOwner_TrueForEveryNoValueShape(ReturnShape.Kind kind)
+        => Assert.True(ReturnShape.IsNoValueOwner(kind));
+
+    [Theory]
+    [InlineData(ReturnShape.Kind.None)]
+    [InlineData(ReturnShape.Kind.Value)]
+    public void IsNoValueOwner_FalseForValueBearingShapes(ReturnShape.Kind kind)
+        => Assert.False(ReturnShape.IsNoValueOwner(kind));
+
+    // ---------------------------------------------------------------- helpers
+
+    private static ModuleNode Parse(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        var tokens = new Lexer(source, diagnostics).TokenizeAllForParser();
+        var module = new Parser(tokens, diagnostics).Parse();
+        Assert.False(
+            diagnostics.HasErrors,
+            "Test source failed to parse:\n  " +
+            string.Join("\n  ", diagnostics.Select(d => $"{d.Code}: {d.Message}")));
+        return module;
+    }
+
+    private static ReturnShape.Kind ClassifyFirst<T>(string source) where T : AstNode
+        => ReturnShape.Classify(FindAll<T>(Parse(source)).First());
+
+    private static List<T> FindAll<T>(AstNode root) where T : AstNode
+    {
+        var found = new List<T>();
+        Collect(root, found);
+        return found;
+
+        static void Collect(AstNode node, List<T> acc)
+        {
+            if (node is T t)
+            {
+                acc.Add(t);
+            }
+            foreach (var child in RecursiveAstWalker.GetChildren(node))
+            {
+                Collect(child, acc);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary (v0.6.8 — PR-A1 of the "retire deferred debt" patch track)

Single-sources the "does this owner return a value" classification that was **duplicated** across the analysis layer, into a new `Analysis/ReturnShape`. This retires the honest-scope debt left by v0.6.7's Calor0205 work.

## The duplication (before)
- `ReturnValidationPass` carried a private `OwnerKind` enum + `ClassifyCallable`/`ClassifyAccessor` + iterator detection.
- `ContractVerifier` re-derived `hasReturnValue` inline (`Output != null && != "VOID"`).

Two independent copies of the same idea → drift risk between the value-return diagnostic (Calor0205) and `result` referenceability in postconditions.

## After
New `Analysis/ReturnShape` exposes:
- **`Classify(owner)`** → `ReturnShape.Kind` (Value/Void/AsyncVoid/Iterator/Setter/Constructor/EventAccessor/None) — the *runtime* shape, folding in async/iterator lowering.
- **`DeclaresValueOutput(output)`** — the *narrow header* predicate the contract verifier needs. It deliberately does **NOT** fold in iterator lowering (an iterator still declares `IEnumerable<T>`), so `result` stays referenceable in an iterator's postcondition.
- `IsNoValueOwner` / `IsVoidType` helpers.

`ReturnValidationPass` and `ContractVerifier` now both defer here. Both refactors are **behavior-preserving** (same predicates; `MessageFor`/`IsDefinitelyValue` stay in the pass as diagnostic-specific logic).

## The iterator trap (pinned by a test)
`Classify` and `DeclaresValueOutput` legitimately **diverge** for iterators: an iterator DECLARES a value output (so the verifier still allows `result`) but its runtime shape is `Iterator` (so the return-value pass rejects a value `§R`). `ReturnShapeTests.Iterator_DeclaresValueOutput_ButClassifiesAsIterator` pins this so the two can't be accidentally collapsed.

## Scope
Analysis consumers only. **Emitter signature codegen / `WrapInTask` are OUT of scope** (unchanged) — so no emitted-C# or benchmark movement. Disjoint from PR-A2 (#683, `--heal-closers`).

## Tests
`ReturnShapeTests` (31 cases): every owner shape → expected `Kind`, the iterator divergence pin, and `DeclaresValueOutput`/`IsVoidType`/`IsNoValueOwner` truth tables. Existing `ReturnValidationPassTests` / `ReturnValidationCompletenessTests` / `ReturnValidationCorpusCleanTests` stay green.

Full solution: **Calor.Compiler.Tests 5676, Calor.Verification.Tests 253, Calor.LanguageServer.Tests 382, Calor.Conversion.Tests 280 — 0 fail.** Build clean (`TreatWarningsAsErrors`).

DO NOT MERGE without your review — you own merges.
