### PR TITLE
Release v0.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.8] - 2026-07-01
+
+### Benchmark Results (Statistical: 30 runs)
+- **Overall Advantage**: 1.32x (Calor leads)
+- **Metrics**: Calor wins 7, C# wins 1
+- **Highlights**:
+  - Comprehension: 1.84x ± 0.00 (Calor wins, large effect d=1.80)
+  - ErrorDetection: 1.49x ± 0.00 (Calor wins, large effect d=1.21)
+  - TokenEconomics: 1.42x ± 0.00 (Calor wins, composite metric)
+  - RefactoringStability: 1.38x ± 0.00 (Calor wins, large effect d=7.09)
+  - EditPrecision: 1.36x ± 0.00 (Calor wins, large effect d=4.90)
+  - Correctness: 1.29x ± 0.00 (Calor wins, large effect d=1.31)
+  - GenerationAccuracy: 1.02x ± 0.00 (Calor wins, small effect d=0.34)
+  - InformationDensity: 0.98x ± 0.00 (C# wins, medium effect d=-0.52)
+- **Programs Tested**: 217
+
+> **Note:** this release is CLI tooling and an internal refactor only — a source-level `calor fix --heal-closers` migrator and a shared return-classification helper. It contains no benchmark-affecting code changes, so the profile is unchanged from v0.6.7.
+
+### Added
+- **`calor fix --heal-closers` — a source-level CLI that finishes the `Calor0830` auto-heal story (#683).** Closer-form syntax (`§/F`, `§/M`, `§/L`, …) hard-errors at parse time, so the AST-based `calor format` / `calor lint --fix` paths cannot heal such a file — the error *is* a parse error, so those commands abort before they can read it. The new `calor fix --heal-closers <root> [--log <file>] [--revert] [--dry-run]` deletes legacy structural closers at the source level, rewriting a file into canonical indent-only form, and `--revert --log` restores it byte-exactly. A lexer-backed `LegacyCloserFormLint.ScanForHeal` keeps only closers that are genuine tokens, so a `§/F` embedded in a string literal or a `//` comment is left untouched (a raw text scan would corrupt it); removals are recorded as UTF-8 **byte** ranges (the `§` code point is two bytes) via the shared reversible migration-log schema, so revert is byte-exact even across non-ASCII content and CRLF line endings. This delivers the CLI heal command deferred in v0.6.6.
+
+### Changed
+- **Single-sourced return-value classification in a shared `Analysis/ReturnShape` (#684).** The void / async-void / iterator / accessor "does this owner return a value" classification was duplicated between `ReturnValidationPass` (which drives `Calor0205`) and `ContractVerifier` (which decides whether `result` is referenceable in a postcondition), risking drift between the two. Both now defer to a single `Analysis/ReturnShape` classifier, which deliberately distinguishes the *runtime* shape (`Classify`, folding in async/iterator lowering) from the narrow *header* predicate (`DeclaresValueOutput`, which does not — an iterator still *declares* `IEnumerable<T>`, so `result` stays referenceable in its postcondition). The refactor is behavior-preserving and the emitter's own signature / `WrapInTask` codegen is intentionally left untouched; a 31-case unit table pins every owner shape including the iterator divergence. This retires the "shared emitter `ReturnShape` refactor" follow-up noted in v0.6.7.
+
 ## [0.6.7] - 2026-07-01
 
 ### Benchmark Results (Statistical: 30 runs)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.6.7</Version>
+    <Version>0.6.8</Version>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "calor",
   "displayName": "Calor Language",
   "description": "Language support for the Calor programming language",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "publisher": "calor-dev",
   "license": "Apache-2.0",
   "icon": "icons/calor-icon.png",

--- a/website/content/changelog.mdx
+++ b/website/content/changelog.mdx
@@ -10,6 +10,14 @@ All notable changes to Calor, organized by release.
 
 ## [Unreleased]
 
+## [0.6.8] - 2026-07-01
+
+### Added
+- **`calor fix --heal-closers` — a source-level CLI that finishes the `Calor0830` auto-heal story.** Closer-form syntax (`§/F`, `§/M`, `§/L`, …) hard-errors at parse time, so `calor format` / `calor lint --fix` — which parse the file first — can never read, let alone heal, it. The new `calor fix --heal-closers <root> [--log <file>] [--revert] [--dry-run]` deletes legacy structural closers at the source level, rewriting a file into canonical indent-only form, and `--revert --log` restores it byte-exactly. It is lexer-backed, so a `§/F` embedded in a string literal or a `//` comment is left untouched, and removals are recorded as UTF-8 byte ranges so revert is exact even across non-ASCII text and CRLF endings. This delivers the CLI heal command deferred in v0.6.6.
+
+### Changed
+- **Single-sourced return-value classification in a shared `Analysis/ReturnShape`.** The "does this owner return a value" classification — for `void`/async-`void` functions and methods, iterators, constructors, setters, and event accessors — was duplicated between the `Calor0205` pass and the contract verifier's `result` check. Both now defer to one classifier, which distinguishes the *runtime* shape (folding in async/iterator lowering) from the narrow *header* predicate (which keeps `result` referenceable in an iterator's postcondition, since an iterator still declares `IEnumerable<T>`). The refactor is behavior-preserving and leaves codegen untouched, retiring the shared-`ReturnShape` follow-up noted in v0.6.7.
+
 ## [0.6.7] - 2026-07-01
 
 ### Added

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calor-website",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/website/public/data/benchmark-results.json
+++ b/website/public/data/benchmark-results.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
-  "timestamp": "2026-07-01T21:13:21.6316074Z",
-  "commit": "dc83d7c9",
+  "timestamp": "2026-07-02T00:01:48.5166796Z",
+  "commit": "cb31d9fd",
   "frameworkVersion": "1.0.0",
   "summary": {
     "overallAdvantage": 1.32,

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -15,9 +15,9 @@ export function WhatsNewBanner() {
         <div className="flex items-center justify-center gap-3 text-sm">
           <Sparkles className="h-4 w-4 text-calor-cerulean flex-shrink-0" />
           <p className="text-center">
-            <span className="font-semibold text-calor-cerulean">v0.6.7</span>
+            <span className="font-semibold text-calor-cerulean">v0.6.8</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">Two new compile-time diagnostics catch non-compiling Calor earlier: <code>Calor0116</code> rejects malformed four-field function headers, and <code>Calor0205</code> flags a value returned from a <code>void</code>, iterator, constructor, setter, or event accessor &mdash; together closing the &ldquo;value returned from void&rdquo; gap. Every agent-readable doc surface was also swept to indent-only syntax, guarded by a compile-time test.</span>
+            <span className="text-foreground">New <code>calor fix --heal-closers</code> CLI rewrites legacy closer-form source (<code>§/F</code>, <code>§/M</code>, …) into canonical indent-only form &mdash; reversibly and byte-exactly &mdash; finishing the <code>Calor0830</code> auto-heal story. Internally, return-value classification is now single-sourced in a shared <code>ReturnShape</code> helper. A tooling-and-refactor release with no benchmark-affecting changes.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"


### PR DESCRIPTION
## Summary
- Bump version to 0.6.8
- Update CHANGELOG.md with release date and statistical benchmark results
- Update website changelog (changelog.mdx) and WhatsNewBanner
- Update benchmark results JSON for the website dashboard

## What''s in 0.6.8 (tooling + internal refactor only)
- **`calor fix --heal-closers` (#683)** — source-level CLI that rewrites legacy closer-form (`§/F`, `§/M`, …) to canonical indent-only form, reversibly and byte-exactly, finishing the `Calor0830` auto-heal story. Lexer-backed (closers inside string literals / comments left untouched).
- **Shared `Analysis/ReturnShape` (#684)** — single-sources return-value classification across `ReturnValidationPass` and `ContractVerifier`; behavior-preserving, codegen untouched.

## Benchmark Results (Statistical: 30 runs)
- **Overall Advantage**: 1.32x (Calor leads) — unchanged from v0.6.7 (no benchmark-affecting code)
- **Metrics**: Calor wins 7, C# wins 1
- **Programs Tested**: 217 (Calor 217 pass / C# 216 pass)

## Checklist
- [x] Version updated in Directory.Build.props
- [x] Version updated in editors/vscode/package.json
- [x] Version updated in website/package.json
- [x] CHANGELOG.md updated with version, date, and benchmark summary
- [x] website/content/changelog.mdx updated with version and changes (no benchmark stats)
- [x] website/src/components/landing/WhatsNewBanner.tsx updated with version and headline
- [x] website/public/data/benchmark-results.json updated with latest results
