### PR TITLE
Agent-native strategy: RFC v4.1, verification soundness fixes, Phase 0 prerequisites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Calor Compiler
 
-Calor is a DSL designed for AI agents that compiles to C# on .NET 10. The compiler lives in `src/Calor.Compiler/` and is packaged as the `calor` global tool. Version is tracked in `Directory.Build.props` (currently 0.3.5).
+Calor is a DSL designed for AI agents that compiles to C# on .NET 10. The compiler lives in `src/Calor.Compiler/` and is packaged as the `calor` global tool. Version is tracked in `Directory.Build.props` (check there for the current version; do not trust a number written in docs).
 
 ## Build & Test
 
@@ -70,29 +70,45 @@ All paths relative to `src/Calor.Compiler/`.
 
 ## Calor Syntax Quick Reference
 
+Block structure is **indentation-only** (2 spaces per level, Python-style). **Never
+write structural closer tags** — the main block closers (`§/M`, `§/F`, `§/L`, `§/I`,
+`§/W`, `§/WH`, `§/CL`, `§/MT`, `§/IFACE`, and others) raise a hard error (`Calor0830`);
+a few remaining closer forms are still tolerated by the parser but always optional.
+The only closers you should ever write are `§/C` (call argument lists) and `§/LAM`
+(block lambdas).
+
 ```
-§M{id:Name}              Module (close: §/M)
-§F{id:name:retType:vis}   Function (close: §/F)
-§B{name:type}             Immutable binding
-§B{~name:type}            Mutable binding
-§L{id:var:from:to:step}   For loop (close: §/L)
-§IF{id} (cond) → §R expr  Inline if-return
-§IF{id} (cond) ... §/I    Block if (close: §/I NOT §/IF)
-§EI (cond)                 ElseIf
-§EL                        Else
+§M{id:Name}                Module
+§F{id:name:vis} (T:x) -> R  Function with inline signature
+§B{name:type}              Immutable binding
+§B{~name:type}             Mutable binding
+§L{id:var:from:to:step}    For loop
+§IF{id} (cond)             If (body indented)
+§EI (cond)                  ElseIf (at parent column)
+§EL                         Else (at parent column)
 §C{object.method} §A arg §/C  Method call with argument
+§E{codes}                  Effects (§E{} = pure)
 §Q (expr)                  Precondition
 §S (expr)                  Postcondition
 §INV                       Invariant
 ```
 
-**Typed literals:** `INT:42`, `STR:"hello"`, `BOOL:true`, `FLOAT:3.14`
+Example (current syntax — see `samples/FizzBuzz/fizzbuzz.calr`):
 
-**Closing tags:**
-- Abbreviated form: `§/I` (not `§/IF`), `§/M`, `§/F`, `§/L`.
-- IDs on closing tags are **optional**. `§/M` and `§/M{m001}` both parse; the parser
-  pairs closers by structural nesting. Drop legacy IDs in bulk with
-  `calor fix --drop-structural-ids <root>`. Legacy closers lint as `Calor0820`.
+```
+§M{m001:FizzBuzz}
+  §F{f001:Main:pub} () -> void
+    §E{cw}
+    §L{for1:i:1:100:1}
+      §IF{if1} (== (% i 15) 0)
+        §P "FizzBuzz"
+      §EI (== (% i 3) 0)
+        §P "Fizz"
+      §EL
+        §P i
+```
+
+**Typed literals:** `INT:42`, `STR:"hello"`, `BOOL:true`, `FLOAT:3.14`
 
 ## Adding New AST Nodes — Checklist
 

--- a/bench/phase0-agent-native/README.md
+++ b/bench/phase0-agent-native/README.md
@@ -1,0 +1,44 @@
+# Phase 0 — Agent-Native Benchmark Suite
+
+**Parent docs:** [`docs/plans/agent-native-strategy.md`](../../docs/plans/agent-native-strategy.md) (v4.1, §4 Phase 0) and [`docs/plans/agent-native-gates.md`](../../docs/plans/agent-native-gates.md) (thresholds, freeze rules).
+**Status:** Scaffold. The suite is **not frozen**; nothing here is gate evidence yet.
+
+This suite measures the strategy's narrow bet: *machine-checked proofs and enforced effect discipline vs agent-generated evidence in C#* — same tasks, two arms, arm-shared held-out tests, pinned models, adversarially pre-registered categories.
+
+## Layout
+
+```
+categories.json          Pre-registered category registry (machine-readable; freezes with the suite)
+task-spec-schema.json    Schema every pair manifest must validate against
+templates/calor-arm/     Execution-path template for the Calor arm (Calor.Sdk csproj + test project)
+pairs/<ID>/              One directory per fixture pair:
+  pair.json              Pair manifest (schema above)
+  spec.md                Behavioral specification (arm-neutral; the ONLY task statement)
+  tests/                 Arm-shared held-out tests (black-box, run via dotnet test in either arm)
+  csharp/                Idiomatic C# starting fixture
+  calor/                 Idiomatic Calor starting fixture
+epochs/<epoch-id>/       Per-epoch pins.json + raw results (created by runs, never edited)
+```
+
+## Construction rules (from the gates doc — enforced, not aspirational)
+
+1. **Spec first.** `spec.md` and `tests/` are written before either fixture. Fixtures are authored independently, idiomatically per language, from the spec alone.
+2. **Tests are arm-shared and black-box.** One suite, two runners. Per-arm test authorship is prohibited (it would make the escaped-bugs metric incomparable).
+3. **Structural parity at authoring:** declaration count and cyclomatic-complexity sum within ±30% across arms; recorded in `pair.json`.
+4. **Wedge pairs (W1–W3) are authored against** [`docs/verification-modeled-forms.md`](../../docs/verification-modeled-forms.md): intended contracts must fall inside the modeled-forms whitelist, and W3 effect boundaries must be manifest-covered (BCL manifests + `calor-runtime.calor-effects.json`). A wedge pair whose contracts fall outside the whitelist is invalid at authoring time.
+5. **Calor-arm config is pinned** (gates doc §1): SDK path, enforcement on, permissive off, contract mode debug, Z3 present. Runs violating the pin are invalid by automated check.
+
+## Runner
+
+Extends `tests/E2E/agent-tasks/run-agent-tests.sh` (live-agent harness, majority voting). Additions needed (tracked below): pair-manifest support, two-arm dispatch, held-out test execution via the calor-arm template, transcript capture for the `.g.cs` dead-end metric, per-epoch pins.
+
+## Status / what remains before the baseline
+
+- [x] Category registry pre-registered (`categories.json`)
+- [x] Pair schema + calor-arm execution template
+- [x] Seed pair W3-001 (demonstrates the format; NOT yet difficulty-validated)
+- [ ] Gates doc feasibility calculation (dry run ≥3 runs/arm on ≥5 pairs) → freeze N and thresholds
+- [ ] Author remaining pairs to the §5 proportions (W1–W3 ≥4 each, N1 ≥8, C1–C3 ≥2 each)
+- [ ] Two-arm runner extension of `run-agent-tests.sh`
+- [ ] Difficulty-equivalence pass (gates doc §3) → re-author/drop out-of-band pairs
+- [ ] **Freeze** (suite + gates doc together) → record baseline epoch → publish including the losses

--- a/bench/phase0-agent-native/categories.json
+++ b/bench/phase0-agent-native/categories.json
@@ -2,7 +2,7 @@
   "version": "1.0-draft",
   "frozen": false,
   "description": "Pre-registered category registry for the agent-native Phase 0 suite. Freezes with the suite; no categories may be added, merged, or excluded after freeze (gates doc §0.3, §5).",
-  "gateRule": "Phase 2a gate uses the pooled result of all gate-bearing wedge categories (W1+W2+W3). Per-category results are reported but not individually gated.",
+  "gateRule": "Phase 2a gate uses the pooled result of all gate-bearing wedge categories (W1+W2+W3), with no single category contributing more than 40% of pooled pairs (gates doc §4). Exact per-category pair counts freeze here at suite freeze. Per-category results are reported but not individually gated.",
   "categories": [
     {
       "id": "W1",

--- a/bench/phase0-agent-native/categories.json
+++ b/bench/phase0-agent-native/categories.json
@@ -1,0 +1,92 @@
+{
+  "version": "1.0-draft",
+  "frozen": false,
+  "description": "Pre-registered category registry for the agent-native Phase 0 suite. Freezes with the suite; no categories may be added, merged, or excluded after freeze (gates doc §0.3, §5).",
+  "gateRule": "Phase 2a gate uses the pooled result of all gate-bearing wedge categories (W1+W2+W3). Per-category results are reported but not individually gated.",
+  "categories": [
+    {
+      "id": "W1",
+      "name": "contract-preserving-refactors",
+      "kind": "wedge",
+      "gateBearing": true,
+      "minPairs": 4,
+      "expectedWinner": "calor",
+      "description": "Refactor existing code without violating declared §Q/§S contracts; held-out tests probe contract-relevant behavior."
+    },
+    {
+      "id": "W2",
+      "name": "contract-dense-algorithmic",
+      "kind": "wedge",
+      "gateBearing": true,
+      "minPairs": 4,
+      "expectedWinner": "calor",
+      "description": "Implement or modify pure/contract-dense algorithmic code (Option/Result style) with contracts inside the modeled-forms whitelist."
+    },
+    {
+      "id": "W3",
+      "name": "first-order-effects",
+      "kind": "wedge",
+      "gateBearing": true,
+      "minPairs": 4,
+      "expectedWinner": "calor",
+      "description": "Changes crossing manifest-checked BCL effect boundaries (fs/net/db/console), first-order code only, no delegates. Calor's compile-error effect enforcement is sound here today."
+    },
+    {
+      "id": "W4",
+      "name": "effect-safe-db-writes",
+      "kind": "wedge-deferred",
+      "gateBearing": false,
+      "gateEligibleAfter": "strategy 2a item 4 (delegate/override/interop closure) + 2b item 1 (frames)",
+      "minPairs": 0,
+      "expectedWinner": "calor",
+      "description": "Deferred-eligibility wedge; pre-registered now so it cannot be invented post-hoc."
+    },
+    {
+      "id": "W5",
+      "name": "security-boundary-edits",
+      "kind": "wedge-deferred",
+      "gateBearing": false,
+      "gateEligibleAfter": "strategy 2a item 4 + 2b item 1",
+      "minPairs": 0,
+      "expectedWinner": "calor",
+      "description": "Taint/effect-derived sink boundaries. Deferred-eligibility wedge."
+    },
+    {
+      "id": "C1",
+      "name": "heavy-bcl-ecosystem",
+      "kind": "context",
+      "gateBearing": false,
+      "minPairs": 2,
+      "expectedWinner": "csharp",
+      "description": "Tasks C# should dominate: dense ecosystem/library integration."
+    },
+    {
+      "id": "C2",
+      "name": "performance-work",
+      "kind": "context",
+      "gateBearing": false,
+      "minPairs": 2,
+      "expectedWinner": "csharp",
+      "description": "Perf-sensitive changes; profiling-adjacent work."
+    },
+    {
+      "id": "C3",
+      "name": "debugger-dependent",
+      "kind": "context",
+      "gateBearing": false,
+      "minPairs": 2,
+      "expectedWinner": "csharp",
+      "description": "Diagnosis tasks that benefit from stepping through execution."
+    },
+    {
+      "id": "N1",
+      "name": "neutral-bread-and-butter",
+      "kind": "neutral",
+      "gateBearing": true,
+      "gateRole": "regression-tolerance only (gates doc §4), never a Calor-advantage claim",
+      "minPairs": 8,
+      "expectedWinner": "none",
+      "description": "Ordinary bug fixes, small features, test writing. Guards against the wedge being purchased with general usability."
+    }
+  ]
+}

--- a/bench/phase0-agent-native/pairs/W3-001-audit-log/calor/AuditLog.calr
+++ b/bench/phase0-agent-native/pairs/W3-001-audit-log/calor/AuditLog.calr
@@ -1,0 +1,4 @@
+§M{m001:AuditLog}
+  §F{f001:Append:pub} (str:path, str:entry) -> void
+    §E{fs:w}
+    §C{File.AppendAllText} §A path §A (+ entry "\n") §/C

--- a/bench/phase0-agent-native/pairs/W3-001-audit-log/csharp/AuditLog.cs
+++ b/bench/phase0-agent-native/pairs/W3-001-audit-log/csharp/AuditLog.cs
@@ -1,0 +1,9 @@
+namespace AuditLogLib;
+
+public static class AuditLog
+{
+    public static void Append(string path, string entry)
+    {
+        File.AppendAllText(path, entry + "\n");
+    }
+}

--- a/bench/phase0-agent-native/pairs/W3-001-audit-log/pair.json
+++ b/bench/phase0-agent-native/pairs/W3-001-audit-log/pair.json
@@ -1,0 +1,35 @@
+{
+  "id": "W3-001-audit-log",
+  "category": "W3",
+  "spec": "spec.md",
+  "tests": {
+    "path": "tests",
+    "runner": "dotnet-test",
+    "heldOut": true
+  },
+  "arms": {
+    "csharp": {
+      "fixture": "csharp",
+      "toolkit": "full"
+    },
+    "calor": {
+      "fixture": "calor",
+      "config": {
+        "enforceEffects": true,
+        "permissiveEffects": false,
+        "contractMode": "debug",
+        "z3Required": true
+      }
+    }
+  },
+  "parity": {
+    "csharpDeclCount": 2,
+    "calorDeclCount": 2,
+    "csharpComplexity": 2,
+    "calorComplexity": 2,
+    "notes": "Seed pair; parity trivially satisfied at this size. NOT yet difficulty-validated (gates doc §3.1) — do not use as gate evidence before the equivalence pass."
+  },
+  "wedgeWhitelistCheck": "No contracts in the starting fixtures; the task's effect boundaries (File.AppendAllText, File.ReadAllLines, File.Exists) are covered by bcl-io manifest entries. First-order code, no delegates.",
+  "iterationBudget": 10,
+  "timeoutSeconds": 600
+}

--- a/bench/phase0-agent-native/pairs/W3-001-audit-log/spec.md
+++ b/bench/phase0-agent-native/pairs/W3-001-audit-log/spec.md
@@ -1,0 +1,30 @@
+# W3-001 — Audit Log (behavioral specification)
+
+This is the only task statement either arm sees. It is arm-neutral: it specifies
+behavior and a public surface, never implementation language idioms.
+
+## Existing behavior (already implemented in the starting fixture)
+
+`Append(path, entry)` — appends `entry` followed by a single `\n` to the file at
+`path`, creating the file if it does not exist.
+
+## Task: implement the missing operations
+
+1. `CountEntries(path)` → integer — returns the number of appended entries
+   (lines) in the file at `path`. Returns `0` if the file does not exist.
+2. `LastEntry(path)` → string — returns the most recently appended entry
+   (without its trailing newline). Returns the empty string if the file does
+   not exist or has no entries.
+
+## Constraints
+
+- Reads and writes go through the real filesystem (no in-memory fakes).
+- All operations must correctly declare whatever your language requires for
+  filesystem access.
+- Do not change `Append`'s observable behavior.
+
+## Public surface (pinned; held-out tests bind to it via a fixed per-arm shim)
+
+Static functions `Append(string, string)`, `CountEntries(string) → int`,
+`LastEntry(string) → string`, reachable through the arm's `TestShim.cs`
+(provided by the harness; not editable by the agent).

--- a/bench/phase0-agent-native/pairs/W3-001-audit-log/tests/AuditLogHeldOutTests.cs
+++ b/bench/phase0-agent-native/pairs/W3-001-audit-log/tests/AuditLogHeldOutTests.cs
@@ -1,0 +1,63 @@
+// Arm-shared held-out tests (never shown to the agent under test).
+// Binds to the pinned public surface through the harness-provided TestShim
+// (per-arm, fixed, not agent-editable): Append / CountEntries / LastEntry.
+using Xunit;
+
+namespace AuditLog.HeldOut;
+
+public sealed class AuditLogHeldOutTests : IDisposable
+{
+    private readonly string _path = Path.Combine(
+        Path.GetTempPath(), $"audit-{Guid.NewGuid():N}.log");
+
+    public void Dispose()
+    {
+        if (File.Exists(_path)) File.Delete(_path);
+    }
+
+    [Fact]
+    public void Append_CreatesFileAndAddsLine()
+    {
+        TestShim.Append(_path, "first");
+        Assert.True(File.Exists(_path));
+        Assert.Equal("first\n", File.ReadAllText(_path));
+    }
+
+    [Fact]
+    public void CountEntries_MissingFile_ReturnsZero()
+    {
+        Assert.Equal(0, TestShim.CountEntries(_path));
+    }
+
+    [Fact]
+    public void CountEntries_CountsAppendedEntries()
+    {
+        TestShim.Append(_path, "a");
+        TestShim.Append(_path, "b");
+        TestShim.Append(_path, "c");
+        Assert.Equal(3, TestShim.CountEntries(_path));
+    }
+
+    [Fact]
+    public void LastEntry_MissingFile_ReturnsEmpty()
+    {
+        Assert.Equal(string.Empty, TestShim.LastEntry(_path));
+    }
+
+    [Fact]
+    public void LastEntry_ReturnsMostRecent_WithoutNewline()
+    {
+        TestShim.Append(_path, "older");
+        TestShim.Append(_path, "newest");
+        Assert.Equal("newest", TestShim.LastEntry(_path));
+    }
+
+    [Fact]
+    public void Append_DoesNotDisturbExistingEntries()
+    {
+        TestShim.Append(_path, "one");
+        TestShim.Append(_path, "two");
+        Assert.Equal(2, TestShim.CountEntries(_path));
+        Assert.Equal("one\ntwo\n", File.ReadAllText(_path));
+    }
+}

--- a/bench/phase0-agent-native/pairs/W3-001-audit-log/tests/shims/TestShim.calor.cs
+++ b/bench/phase0-agent-native/pairs/W3-001-audit-log/tests/shims/TestShim.calor.cs
@@ -1,0 +1,10 @@
+// Calor-arm shim (harness-provided, fixed, not agent-editable).
+// Calor module M emits namespace M / static class MModule.
+namespace AuditLog.HeldOut;
+
+internal static class TestShim
+{
+    public static void Append(string path, string entry) => global::AuditLog.AuditLogModule.Append(path, entry);
+    public static int CountEntries(string path) => global::AuditLog.AuditLogModule.CountEntries(path);
+    public static string LastEntry(string path) => global::AuditLog.AuditLogModule.LastEntry(path);
+}

--- a/bench/phase0-agent-native/pairs/W3-001-audit-log/tests/shims/TestShim.csharp.cs
+++ b/bench/phase0-agent-native/pairs/W3-001-audit-log/tests/shims/TestShim.csharp.cs
@@ -1,0 +1,9 @@
+// C#-arm shim (harness-provided, fixed, not agent-editable).
+namespace AuditLog.HeldOut;
+
+internal static class TestShim
+{
+    public static void Append(string path, string entry) => AuditLogLib.AuditLog.Append(path, entry);
+    public static int CountEntries(string path) => AuditLogLib.AuditLog.CountEntries(path);
+    public static string LastEntry(string path) => AuditLogLib.AuditLog.LastEntry(path);
+}

--- a/bench/phase0-agent-native/task-spec-schema.json
+++ b/bench/phase0-agent-native/task-spec-schema.json
@@ -68,7 +68,14 @@
       "type": "string",
       "description": "REQUIRED for W1-W5: statement that intended contracts fall inside docs/verification-modeled-forms.md, and (W3+) that effect boundaries are manifest-covered. Checked at authoring."
     },
-    "iterationBudget": { "type": "integer", "default": 10 },
-    "timeoutSeconds": { "type": "integer", "default": 600 }
+    "iterationBudget": {
+      "const": 10,
+      "description": "Pinned by the gates doc §2 — per-pair budget choice would move censoring points (a quiet knob). Any deviation must be pre-registered with rationale before the suite freeze, which requires changing this schema."
+    },
+    "timeoutSeconds": {
+      "type": "integer",
+      "default": 600,
+      "description": "Task-level timeout. A timeout mid-iteration fails that iteration (gates doc §2). Per-pair values must be set before freeze; not adjustable afterward."
+    }
   }
 }

--- a/bench/phase0-agent-native/task-spec-schema.json
+++ b/bench/phase0-agent-native/task-spec-schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agent-native Phase 0 pair manifest (pair.json)",
+  "type": "object",
+  "required": ["id", "category", "spec", "tests", "arms", "parity"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^(W[1-5]|C[1-3]|N1)-[0-9]{3}-[a-z0-9-]+$",
+      "description": "Category-prefixed pair id, e.g. W3-001-file-logger"
+    },
+    "category": { "type": "string", "enum": ["W1", "W2", "W3", "W4", "W5", "C1", "C2", "C3", "N1"] },
+    "spec": { "type": "string", "description": "Path to the arm-neutral behavioral spec (spec.md). The ONLY task statement either arm sees." },
+    "tests": {
+      "type": "object",
+      "required": ["path", "runner"],
+      "properties": {
+        "path": { "type": "string", "description": "Arm-shared held-out test directory. One suite, two runners; per-arm test authorship is prohibited." },
+        "runner": { "type": "string", "enum": ["dotnet-test"] },
+        "heldOut": { "type": "boolean", "default": true, "description": "Held-out tests are never shown to the agent under test." }
+      }
+    },
+    "arms": {
+      "type": "object",
+      "required": ["csharp", "calor"],
+      "properties": {
+        "csharp": {
+          "type": "object",
+          "required": ["fixture"],
+          "properties": {
+            "fixture": { "type": "string" },
+            "toolkit": { "type": "string", "default": "full", "description": "C# arm always gets Roslyn analyzers + NRT + freedom to generate its own evidence (gates doc §1)." }
+          }
+        },
+        "calor": {
+          "type": "object",
+          "required": ["fixture"],
+          "properties": {
+            "fixture": { "type": "string" },
+            "config": {
+              "type": "object",
+              "description": "Must match the gates-doc §1 pin; runs violating it are invalid.",
+              "properties": {
+                "enforceEffects": { "const": true },
+                "permissiveEffects": { "const": false },
+                "contractMode": { "const": "debug" },
+                "z3Required": { "const": true }
+              }
+            }
+          }
+        }
+      }
+    },
+    "parity": {
+      "type": "object",
+      "required": ["csharpDeclCount", "calorDeclCount", "csharpComplexity", "calorComplexity"],
+      "description": "Structural parity record (gates doc §3.3): decl count and cyclomatic-complexity sum within ±30% across arms.",
+      "properties": {
+        "csharpDeclCount": { "type": "integer", "minimum": 1 },
+        "calorDeclCount": { "type": "integer", "minimum": 1 },
+        "csharpComplexity": { "type": "integer", "minimum": 1 },
+        "calorComplexity": { "type": "integer", "minimum": 1 },
+        "notes": { "type": "string" }
+      }
+    },
+    "wedgeWhitelistCheck": {
+      "type": "string",
+      "description": "REQUIRED for W1-W5: statement that intended contracts fall inside docs/verification-modeled-forms.md, and (W3+) that effect boundaries are manifest-covered. Checked at authoring."
+    },
+    "iterationBudget": { "type": "integer", "default": 10 },
+    "timeoutSeconds": { "type": "integer", "default": 600 }
+  }
+}

--- a/bench/phase0-agent-native/templates/calor-arm/CalorArm.csproj.template
+++ b/bench/phase0-agent-native/templates/calor-arm/CalorArm.csproj.template
@@ -1,0 +1,33 @@
+<!--
+  Calor-arm execution template (gates doc §1 pin).
+  Instantiated by the runner per pair: __REPO_ROOT__ is substituted with the
+  repo root. Effects enforcement ON, permissive OFF, contract mode debug —
+  runs violating this pin are invalid by automated check.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <CalorTasksAssembly>__REPO_ROOT__/src/Calor.Tasks/bin/Release/net10.0/Calor.Tasks.dll</CalorTasksAssembly>
+    <CalorOutputDirectory>$(MSBuildThisFileDirectory)obj/calor/</CalorOutputDirectory>
+    <CalorEnforceEffects>true</CalorEnforceEffects>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="__REPO_ROOT__/src/Calor.Runtime/Calor.Runtime.csproj" />
+    <ProjectReference Include="__REPO_ROOT__/src/Calor.Tasks/Calor.Tasks.csproj"
+                      ReferenceOutputAssembly="false"
+                      Private="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <CalorCompile Include="**/*.calr" />
+  </ItemGroup>
+
+  <Import Project="__REPO_ROOT__/src/Calor.Sdk/Sdk/Sdk.targets" />
+
+</Project>

--- a/docs/plans/agent-native-gates.md
+++ b/docs/plans/agent-native-gates.md
@@ -1,0 +1,94 @@
+# Agent-Native Strategy — Gate Thresholds (Pre-Registration)
+
+**Status:** Draft v2 (v1 revised per adversarial review, 2026-07-02 — reviewer verdict on v1: 45%, "not fit to freeze"; all CRITICAL/MAJOR findings incorporated below, dispositions in §8). **Freezes at the Phase 0 suite freeze**, after the feasibility calculation (§6) is complete. Until frozen, values may change; after freezing, only the supersession rule (§7) permits change.
+**Parent:** [`agent-native-strategy.md`](agent-native-strategy.md) (v4.1). The planning envelopes in its §6 constrain every value here; a value outside its envelope requires a strategy-doc revision first.
+**Author:** Juan Rivera (with Claude Code)
+**Created:** 2026-07-02
+
+---
+
+## 0. Rules of interpretation
+
+1. Every gate decision uses **pinned-model, simultaneous, arm-vs-arm** comparisons within one epoch. An **epoch** is one gate's complete paired run (both arms, same pinned model set, same suite version). **All gate metrics are collected every epoch on all categories** (so cross-epoch deltas always have a Δ₁). Cross-epoch difference-in-differences is permitted in exactly two places: the parity-kill clause (§4) and nowhere else — the neutral-regression gate is within-epoch by construction (§4).
+2. A Calor-arm run with Z3 unavailable, effects enforcement off, or permissive mode on is **invalid** — detected by automated config check before results are examined. **Invalid, crashed (agent or harness), or API-errored runs are re-run with a fresh seed until N valid runs exist, capped at 2 re-attempts per slot; a slot still invalid after the cap counts as task failure for that arm.** Held-out tests must be deterministic, verified at authoring by 5 consecutive green runs against the reference solution; flakiness discovered after freeze is a §7 protocol defect.
+3. Metrics are computed per pre-registered category, then aggregated per gate as specified. No post-hoc category creation, merging, or exclusion (quarantine under §3.4 is rule-driven and one-sided).
+4. "Significant" always means the decision rule in **§6.1** — never eyeballing.
+
+## 1. Harness configuration (pinned)
+
+| Setting | Calor arm | C# arm |
+|---|---|---|
+| Compilation surface | `Calor.Sdk` MSBuild path (template `.csproj`), not bare CLI | standard `dotnet build` |
+| Effects enforcement | **on** (`EnforceEffects=true`) | n/a |
+| Permissive effects | **off** | n/a |
+| Contract mode | `debug` (all checks) | n/a |
+| Z3 | present, required | n/a |
+| `.g.cs` policy | **writes blocked** (hook), reads permitted but logged | n/a |
+| Analyzers | Calor defaults | **Roslyn analyzers + NRT enabled + full agent-generated evidence permitted** (tests, property-based tests, asserts, analyzer configs) |
+| Agent | same agent product, same model pin, same iteration budget both arms | same |
+| Held-out tests | arm-shared, black-box, **run silently by the harness after every iteration** (never surfaced to the agent) | same suite, same runner |
+
+Model pins recorded per epoch in `bench/phase0-agent-native/epochs/<epoch-id>/pins.json` (model IDs, agent-tool version, compiler commit, suite version).
+
+## 2. Metric definitions (machine-adjudicable)
+
+- **Iteration:** one harness-observed build-or-test invocation following ≥1 workspace edit. A build with no preceding edit does not count. A task-level timeout mid-iteration fails that iteration; the task continues or censors per remaining budget.
+- **Declared-done:** the agent's first terminal non-edit action (stops, asks a question, refuses) or budget/timeout exhaustion. A non-compiling final state counts as **all held-out tests failing**.
+- **Task success:** all arm-shared held-out tests pass within the iteration budget (**10 iterations, fixed; the pair schema pins it as a constant — per-pair deviations require pre-freeze registration with rationale**).
+- **Escaped bugs:** held-out test failures at declared-done. **Unit of analysis: the per-pair mean over runs, then the per-pair arm delta** (never per-category sums, which weight pairs by test count).
+- **Iterations-to-green:** iterations until held-out tests first all pass (harness-observed, silent); never-green tasks count at budget+1 (censored). **Censored fraction is reported per arm; a gate is invalid if either arm exceeds 40% censored on neutral tasks** (a ratio of mutual failure is not a pass).
+- **Median ratio:** the **median of paired per-pair ratios** (each pair's per-arm mean first, then the ratio) — not a ratio of arm medians.
+- **Tokens:** total input+output per task, both arms — **recorded, not gated**.
+- **`.g.cs` dead-end rate (Phase 1 only):** fraction of Calor-arm runs where either (a) the agent attempts a blocked `.g.cs` write, or (b) ≥1 wasted iteration occurs on a `.g.cs`-located error — *wasted* = two consecutive compiles with identical errors (identity = error code + message normalized by stripping paths/line numbers) and no `.calr` edit between; for runtime errors, (b) additionally requires the agent's subsequent action to reference the `.g.cs` frame (a stack trace merely containing generated frames is not by itself a dead-end).
+- **Retained-check overhead (recorded, not gated):** wall-clock delta of the held-out suite under contract mode `debug` vs `off`, Calor arm only.
+
+## 3. Phase 0 — fairness gates (suite construction)
+
+3.1 **Difficulty-equivalence band (C# arm):** a pair is out-of-band only if its C#-arm success rate's **90% CI lies wholly outside ±20pp ⚠ of the leave-one-out category mean** (point-estimate banding at feasible N flags pairs on binomial noise alone; the band value freezes from §6 dry-run variance). Out-of-band pairs are re-authored (max **M = 2** rounds) or dropped.
+3.2 **Kill threshold:** if strictly more than **N = 25%** of pairs in any gate-bearing category remain out-of-band after M rounds (at minPairs=4: ≥ 2 pairs), the Phase 0 kill row fires (publish and stop).
+3.3 **Calor-side symmetry (authoring-time):** each pair authored from the same behavioral spec; declaration count and cyclomatic-complexity sum within ±30% across arms; no Calor fixture may omit spec-required functionality. Recorded in `pair.json`.
+3.4 **Calor-side symmetry (measured):** at every epoch where a category's Calor-arm success is non-degenerate (≥ 30% category success — the check applies per category, only where that category itself is non-degenerate), run the band check on the Calor arm. **Only high-side (Calor-easy) outliers are quarantined from advantage evidence; low-side outliers stay in.** Pooled gate results are reported with and without quarantine. (One-sided by design: symmetric quarantine would remove Calor failures from gate evidence — selection in Calor's favor.)
+3.5 **Wedge fixtures** are authored against [`../verification-modeled-forms.md`](../verification-modeled-forms.md); a wedge fixture whose intended contracts fall outside the whitelist is invalid at authoring time.
+
+## 4. Phase gate thresholds
+
+Envelope references are to strategy §6. Values marked ⚠ are provisional pending §6 and freeze with it.
+
+| Gate | Metric | Threshold | Envelope |
+|---|---|---|---|
+| **Phase 1** | `.g.cs` dead-end rate | ≤ **5%** of Calor-arm runs | 0–10% |
+| **Phase 1** | Neutral iterations-to-green | Calor ≤ **125%** of C# arm (median ratio, §2) | 115–140% |
+| **Phase 1** | Neutral task success (non-inferiority companion) | Calor within **15pp ⚠** of C# arm | — (guards the degenerate both-arms-censored pass) |
+| **Phase 2a** | Escaped bugs, pooled wedge (W1+W2+W3) | ≥ **30%** relative reduction ⚠, per §6.1 decision rule | 20–40% |
+| **Phase 2a** | Iterations-to-green, pooled wedge | Calor ≤ **120%** of C# arm (appeasement allowance — bounded cost, not an advantage requirement) | 110–125% |
+| **Phase 2a** | Neutral regression (within-epoch) | 2a-epoch neutral median ratio ≤ **137.5%** (= Phase 1 threshold 125% × 1.10 tolerance) | tolerance 5–15% |
+| **Phase 2b** | Same as 2a, on 2b-exercising categories | same values | same |
+
+**Pooling constraint:** the gate pool is W1+W2+W3 with **no category contributing more than 40% of pooled pairs**; exact per-category pair counts freeze in `categories.json` at suite freeze. Per-category results are reported; the gate is the pooled result.
+
+**Parity-kill clause (the only cross-epoch rule):** sign convention — a positive delta means Calor better. Kill the current phase iff **(a)** the pooled-wedge escaped-bugs point estimate Δ₂ ≤ Δ₁ across two consecutive epochs, **and (b)** Δ₂'s one-sided 80% upper confidence bound is below the frozen 2a threshold. (Condition (a) alone is a hair-trigger at feasible N; condition (b) alone is a dead letter; the conjunction means "not improving and not plausibly near passing.")
+
+**Adopter gate (parallel with Phase 1):** named adopter with ≥1 non-maintainer reviewer, agreed in writing, by the Phase 1 gate date. Failure routes to the 2a kill *action* with conclusion "demand unproven."
+
+## 5. Category registry (pre-registered)
+
+Defined in [`../../bench/phase0-agent-native/categories.json`](../../bench/phase0-agent-native/categories.json): gate-bearing wedge **W1** contract-preserving refactors, **W2** contract-dense algorithmic, **W3** first-order effects; deferred-eligibility **W4/W5** (post 2a-item-4 + 2b-item-1); context **C1–C3** (C#-favored); neutral **N1**. Proportions: W1–W3 ≥ 4 pairs each (≤ 40% pool share each), N1 ≥ 8, C1–C3 ≥ 2 each. No new categories after freeze.
+
+## 6. Feasibility (power) requirement
+
+Before freezing, a dry run (≥ 3 runs per arm on ≥ 5 pairs — a floor; the power calculation must use the **upper confidence bound of the estimated variance**, not the point estimate) determines the frozen N (runs per task per arm per epoch). N must give ≥ 80% power under the §6.1 decision rule for the frozen escaped-bugs threshold within the epoch API budget ceiling of **$1,500 ⚠**. If the numbers don't close, reduce category count or raise the threshold *before* freezing — never after.
+
+### 6.1 Decision rule (gate-time)
+
+- **Unit of analysis:** the per-pair arm delta (per-pair means over runs first).
+- **Test:** cluster bootstrap over pairs (runs nested within pairs), **one-sided** — every gate is directional, so two-sided α would be miscalibrated. α = 0.05.
+- **Pass rule, stated in full:** a threshold gate passes iff the point estimate meets the threshold **and** the one-sided 95% CI excludes zero effect. (Point-passes-but-not-significant = gate fails; significant-but-below-threshold = gate fails. No third outcome.)
+- Ratio gates (iterations, neutral regression) use the same bootstrap on paired per-pair ratios against their threshold constant.
+
+## 7. Supersession rule
+
+After freezing, this document may be superseded only for a **documented empirical defect in the measurement protocol itself** (metric shown to be noise, harness bug invalidating runs) — the `phase-2-measurement-protocol` v1→v2 standard. A successor must contain a written defect analysis. **Threshold changes after seeing arm results are never a valid supersession.** Residual: at bus factor 1 the defect judgment is self-made; the written-analysis requirement and the envelopes are the constraint. Disclosed, not solvable by a document.
+
+## 8. Revision log
+
+**v1 → v2 (2026-07-02, adversarial review: 45% as written → est. 85% after fixes).** All findings accepted: §6.1 decision rule added (C1); equivalence band made interval-based with leave-one-out mean (C2); neutral-regression gate made within-epoch, resolving the §0.1 self-contradiction (C3); parity-kill made decidable via the two-condition conjunction, with all-metrics-every-epoch collection and sign convention (C4); median-ratio defined as paired per-pair ratios + non-inferiority companion + censoring cap (M5); quarantine made one-sided high-only, reported with/without, every epoch (M6); 40% pool-share cap (M7); iteration budget pinned as schema constant, timeout rule added (M8); invalid/crash/flake handling added (M9); `.g.cs` metric operationalized — write-block pinned in §1, error-identity normalization, runtime-frame condition (M10); iteration/declared-done/silent-test-execution defined (M11); integer arithmetic stated (m12); non-degeneracy scoped per-category (m13); variance upper-bound rule (m14); tokens marked recorded-not-gated (m15).

--- a/docs/plans/agent-native-strategy.md
+++ b/docs/plans/agent-native-strategy.md
@@ -1,0 +1,349 @@
+# Agent-Native Strategy: Making Calor Worth Leaving C# For
+
+**Status:** Draft v4.1 (v4 + round-4 verification patch) — **final paper revision; next artifacts are the gates doc and Phase 0 fixtures**
+**Author:** Juan Rivera (with Claude Code)
+**Created:** 2026-07-01
+**Revised:** 2026-07-01 (rounds 1–4 of adversarial review — see §8 revision log)
+**Reviewed against:** independent devil's-advocate critique (ChatGPT, §3); round-1 panel (DA 35%, PL 55%); round-2 panel (DA 55%, PL 72%); round-3 panel (DA 62%, PL 78%); round-4 verification panel (DA 78%, PL 81% — dispositions verified 6/6 substantive; **both ruling a fifth revision round would destroy value**); dispositions in §8
+**Related:** [`../design/calor-direction.md`](../design/calor-direction.md) (including the 2026-04-22 postscript), [`path-2-drop-ids-v6-implementation.md`](./path-2-drop-ids-v6-implementation.md), [`mcp-improvements.md`](./mcp-improvements.md), [`phase-2-measurement-protocol-v2.md`](./phase-2-measurement-protocol-v2.md), [`../dependent-types-m4-backlog.md`](../dependent-types-m4-backlog.md)
+
+---
+
+## 0. The claim this document defends
+
+> **Agents can make changes in Calor that humans would not trust them to make in C# — and the system shows exactly why those changes are safe, and exactly what remains unproven.**
+
+Stated in its **narrow, honest form**: the competitor is not C#-the-language, it is **agent-generated evidence in C#** — agents saturating C# with NRT annotations, generated test suites, property-based tests, mutation testing, and analyzer configs. Agents zero annotation cost for C# too. The bet is specifically:
+
+> **Machine-checked proofs and enforced effect discipline produce more trustworthy change, per unit of agent and human effort, than very good agent-generated tests.**
+
+The C# arm gets its full toolkit, explicitly.
+
+The moat decomposes into four testable sub-claims:
+
+1. Calor lets agents make changes with **fewer escaped bugs**.
+2. Calor lets agents make **bigger changes safely**.
+3. Calor lets humans **trust agent-generated changes faster**.
+4. Calor **reduces review burden** enough to justify per-module adoption cost.
+
+Sub-claims 1–2 are machine-adjudicable and anchor all phase gates. Sub-claims 3–4 involve human behavior; they are tracked as **qualitative observations and design targets, not gate criteria**, and any qualitative reading requires at least one **non-maintainer** reviewer (§4 Phase 2a entry conditions).
+
+---
+
+## 1. Audit: where Calor stands today (2026-07-01, v0.6.7)
+
+Fact-checked across three adversarial review rounds; where reality is worse than earlier drafts claimed, the worse version is stated. A process note the panel earned: **rounds 1–3 each found a verified factual error in this section's predecessor** (dead `DiagnosticFormatter`; silent-by-default delegate hole; split-brain enforcement default). That is evidence about audit drift at bus factor 1; the single-sourcing work (Phase 1 item 6) is the systemic fix, and claims below marked *(verified rN)* carry the round that checked them.
+
+### 1.1 Genuinely ahead of C# — with the enforcement caveats stated
+
+- **Effects are compile errors for first-order code — on enforcement-enabled paths.** Interprocedural, SCC-based enforcement (`src/Calor.Compiler/Effects/EffectEnforcementPass.cs`): undeclared effects fail the build with a full call chain (Calor0410) and a machine-applicable fix; BCL/ecosystem coverage via JSON manifests plus IL fallback. Three caveats, each verified:
+  - **Split-brain default** *(r3)*: the CLI's `--enforce-effects` defaults **false** (`Program.cs:47–50`, pass gated at `:591`), while `CompilationOptions.EnforceEffects` defaults **true** (`Program.cs:903`) — so the SDK/MSBuild per-module path enforces by default and `calor --input` does not. The Phase 0 gates doc pins the harness surface and flags (§4); the CLI default flip is scheduled with the other strictness changes in 2a item 4.
+  - **Delegate hole** *(r2)*: invocation of a delegate-typed value is **silently assumed pure by default**; an advisory exists only under opt-in `--strict-effects` (`EffectEnforcementPass.cs:636–652`). Narrowing fact: lambda *bodies* are charged to the enclosing function at definition site (`InferFromLambda`, `:919`).
+  - **Dispatch hole** *(r3)*: there is **no effect-variance rule on overrides** — `ContractInheritanceChecker` covers contracts only; an override with broader effects than its base launders them through dynamic dispatch exactly as a delegate does. Late binding is late binding. Fixed in 2a item 4 (it is a cheap declaration-local subset check), because "the hole is specifically delegate-typed values" was false as previously stated.
+  - Standing audit obligation *(r3)*: effect inference's expression switch ends `_ => EffectSet.Empty` (`EffectEnforcementPass.cs:~874`) — any future effectful expression form silently defaults to pure. First-order soundness depends on that switch staying exhaustive; noted here so it is a review-checklist item, not a rediscovery.
+- **Contracts are proven, not just checked — for scalar code.** Z3-backed `§Q`/`§S` with concrete counterexamples, quantifiers, refinement/dependent types, k-induction invariant synthesis, Liskov contract-inheritance proving. No heap model, no frames, no aliasing discipline, no termination measures, no vacuity detection (§4 Phase 2b, §5). `Proven` preconditions **already elide runtime checks today** (`CSharpEmitter.cs:~1657`), so §5's elision rule modifies existing behavior. Contracts mentioning **generic-typed values** (including `Option<T>`/`Result<T,E>`-typed ones) fall to `Unsupported` — this constrains Phase 0 fixture authoring and is named there *(r3)*.
+- **Taint sinks derive automatically from effect declarations** (`Analysis/Security/EffectSinkMapping.cs`).
+- **Match exhaustiveness is an error** (Calor0500); Option/Result are first-class; semantics are versioned (`§SEMVER`).
+- **Machine-readable diagnostics: aspiration, not fact** *(r2/r3)*. `Diagnostics/DiagnosticFormatter.cs` (JSON + SARIF) is referenced by nothing in production (test-only); `Commands/AssessCommand.cs:441–499` carries a second, private SARIF model; `verify`/`effects`/`benchmark` use ad-hoc JSON shapes. The MCP server (15 tool classes incl. self-healing `calor_check`) and `calor hook` enforcement are real.
+- **A live-agent E2E harness exists**: `tests/E2E/agent-tasks/run-agent-tests.sh`, Claude Code CLI, 2/3 majority voting, 19 task categories (incl. `lambdas-delegates` — priced in 2a item 4).
+
+### 1.2 Behind C# — dev-loop holes that undercut the pitch
+
+**While these hold, the "agent-first" claim is premature.**
+
+1. **No source mapping.** Zero `#line` directives in `CSharpEmitter.cs`; Roslyn errors, stack traces, and debugger sessions land in `.g.cs` files our own hooks forbid agents from editing.
+2. **No `calor run`, no `calor test`.** (Also blocks Phase 0 — see the execution prerequisite in §4.)
+3. **Structured output fragmented and partly dead code** (§1.1). No watch mode; CLI recompiles everything.
+4. **Verification cliffs are silent.** Float/call/string-op contracts degrade to `Unsupported` at scattered exception-fallback sites **across `Z3Verifier.cs` and `ContractTranslator.cs`** (a blacklist by accident); `VerificationResult.cs` documents "Keep runtime check **silently**"; Z3 `UNKNOWN` and timeout conflated (`Z3Verifier.cs:~117`); index-bounds models only the negative half; no `old()`, frames, purity rule, termination, or vacuity check.
+5. **Diagnostics are span-positional**, not declaration-anchored.
+6. **Immediate items — before any Phase 0 measurement:**
+   - `NullDereferenceChecker` precedence bug: **fixed 2026-07-01** (predicate made self-consistent with the safe-fallback list and order-independent; the bug-pattern test suites pass — `BugPatternTests` + `BugDetectionImprovementTests`). *Working-tree edit; commit pending.*
+   - `CLAUDE.md` staleness: **fixed 2026-07-01** (closer-tag teaching replaced with current indent-only guidance; hardcoded stale version removed; wrong lint code removed; round-4 accuracy correction applied — 13 closer kinds hard-error, others tolerated-but-optional). *Working-tree edit; commit pending.*
+   - **Obligations `FactCollector` flow-insensitivity** *(discovered r4 — pending)*: guard facts are collected flow-insensitively at function scope (`Verification/Obligations/FactCollector.cs:50–92`) and all asserted for every obligation (`ObligationSolver.cs:124–141`). Consequences: else-branch obligations discharged under then-guards; sibling `§EI` guards produce an UNSAT fact set that **vacuously discharges every obligation in the function**; facts survive assignments and loop exit. This is a third vacuity channel that neither the Phase 1 `§Q`-sat check nor 2b's consistency check covers. Contract-check *elision* is unaffected (it rides the body-blind `Z3Verifier`, not obligations), but the blast radius is refinement/index-bounds obligations — wedge-fixture terrain. **Minimum mitigation before Phase 0 fixtures:** fact-set SAT pre-check before trusting UNSAT discharge; proper fix (dominating-guards-only scoping + assignment kill) alongside. Supersedes the milder statement of this defect in [`dependent-types-m4-backlog.md`](../dependent-types-m4-backlog.md) item 1.
+7. **Agent-facing docs are not single-sourced** — the mechanism that produced item 6b. Phase 1 item 6.
+
+### 1.3 The migration answer already exists (and is under-communicated)
+
+Per-module adoption inside existing C# repos is the current architecture: `.calr` beside `.cs` via the MSBuild SDK; C#→Calor migration with `CSharpInteropBlockNode`; `calor assess`; the round-trip harness; effect manifests at the boundary.
+
+What coexistence does **not** dissolve: pre-1.0 instability, bus factor 1, no external users, `§`-syntax review burden, exit costs. Mitigations: (a) **"eject to C# losslessly at any time"** as a first-class tested feature (contracts/effects degrade to runtime checks and comments; the degradation is documented); (b) the adoption playbook (2a) written from the adopter's side.
+
+**The first-adopter condition, hardened:**
+- Search runs **in parallel with Phase 1**, deadline co-terminal with the Phase 1 gate. **No adopter by the deadline → the 2a kill *action* executes** (tooling-maintenance mode) — with its own conclusion wording: *demand unproven*, not "bet falsified"; adopter failure is a demand/BD result and produces no benchmark evidence either way *(r3)*.
+- "Adopter" requires **at least one non-maintainer reviewer**. The maintainer's own projects are pilot substrate only.
+- Candidates by evidential value: willing OSS project; internal Microsoft team; (pilot only) maintainer's own projects.
+
+---
+
+## 2. Thesis: why the moat is real — and what it is not
+
+Models are trained on billions of lines of C# and ~zero Calor; Calor cannot win on familiarity, ecosystem, or tokens. Roslyn can copy the *mechanics* of this plan (indexes, symbol edits, speculative apply, blast radius). It cannot copy the *semantic content* — effects, contracts, refinements are not in C#'s language. "Which proofs does this change invalidate?" is unanswerable in a language with no proofs.
+
+### 2.1 The history, both halves
+
+**Failure precedent (Spec#/Code Contracts), honestly.** Contracts on .NET died of several causes: annotation burden, a fragile IL rewriter, a slow noisy checker, no language integration, team dissolution. Agents eliminate annotation-*writing* cost; Calor's language integration eliminates the rewriter/integration causes. But agents **amplify prover-appeasement cost** — an agent facing `Unproven` will weaken the contract or contort code until the prover accepts. **We expect prover incompleteness, not annotation cost, to be the binding constraint**; iterations-to-green is a gate metric to surface exactly that. Spec# also sank on **framing and invariants over an aliased heap** — steered around by design in 2b, not by hope.
+
+**Success precedent (SPARK/Ada), both lessons.** SPARK succeeded on this plan's shape (per-unit adoption, modular verification, assumption tracking) *and* had two things Calor lacks: an **exogenous buyer** (certification credit) — hence the named-adopter condition — and **language restriction** (anti-aliasing, side-effect-free functions) rather than full-heap verification — hence the wedge targets the sound subset and 2b adopts a scoped aliasing restriction.
+
+> **Calor makes proof and effect discipline the default primitive of the language, not an IDE feature layered on top — and initially, only over the subset of the language where that discipline is sound.**
+
+The product is the workflow; the language is the enforcement substrate.
+
+---
+
+## 3. First external critique (ChatGPT): dispositions
+
+| # | Critique | Disposition |
+|---|----------|-------------|
+| 1 | Center on what Calor makes *impossible* | **Accepted** (§0). |
+| 2 | Agent-first claim premature | **Accepted** (§1.2). |
+| 3 | "C# can't copy this" overstated | **Half accepted** (§2). |
+| 4 | Migration gravity underestimated | **Accepted with evidence** (§1.3). |
+| 5 | "Verified nonsense" risk | **Accepted in full** (§5). |
+| 6 | Null elimination socially risky | **Accepted**; staged, rides an edition (Phase 3). |
+| 7 | One wedge; prove demand first | **Accepted** (2a). |
+| 8 | Evals first, frozen, adversarial | **Accepted in full** (Phase 0). |
+| 9 | Too compiler-centered | **Accepted for sequencing**; runtime-evidence deferred post-1.0. |
+| 10 | Moat is workflow, not language | **Accepted** (§2). |
+
+Panel dispositions: §8.
+
+---
+
+## 4. The plan
+
+Every phase has a calendar box, budget line, pre-registered gate thresholds, and a kill action (§6). Thresholds are frozen in `agent-native-gates.md` before Phase 0 measurement; §6 publishes the planning envelopes that constrain its author, the supersession rule that defines "frozen," and the **feasibility requirement**: the gates doc must include a power/detectability calculation showing each frozen threshold is decidable at the frozen API budget — otherwise the threshold or category count moves *before* freezing, never after *(r3)*.
+
+### Immediate items — **executed 2026-07-01** (see §1.2 item 6)
+
+### Phase 0 — Freeze the benchmark (calendar box: 4–6 weeks)
+
+Freeze an adversarial task suite before building anything else; record the baseline even though Calor will lose today.
+
+**Honest scoping.** Phase 0 contains real engineering:
+- **Execution prerequisite:** a minimal harness-internal execution path (template `.csproj` + `Calor.Sdk` + `dotnet test`, hand-wired once). Shipped CLI surface remains Phase 1.
+- **Starting asset:** extend `tests/E2E/agent-tasks/run-agent-tests.sh` (not `bench/mcp/harness/`, which skips agent tasks).
+- **Harness configuration is pinned in the gates doc** *(r3)*: effects enforcement **on**, permissive mode **off**, contract mode, Z3 present — because the CLI and SDK defaults disagree today (§1.1) and an unpinned surface would measure a language with no effect enforcement at all.
+
+**Fixture provenance — operationalized both ways.**
+- Each task ships as a **behavioral specification** (description + held-out tests), not source to convert. Each arm gets an idiomatic starting codebase authored independently.
+- **Held-out tests are arm-shared**: one black-box suite against the behavioral spec, two runners. Per-arm test authorship is prohibited (it would make escaped-bugs incomparable).
+- **Difficulty equivalence is measured on both arms** *(r3 — v3 measured only half)*: (i) at baseline, the *C# arm's* per-pair success rate must fall within a pre-registered band of its category mean; out-of-band pairs are re-authored or dropped (max M rounds; >N% failures fires the Phase 0 kill row). (ii) **Calor-side symmetry audit:** pre-registered structural parity constraints at authoring time (spec-derived scope; comparable declaration counts and branching), plus a re-run of the equivalence check on the *Calor arm* at the first epoch where its neutral-task success is non-degenerate; out-of-band pairs are quarantined from gate evidence. A maintainer authoring both sides must not be able to (even innocently) write smaller, cleaner Calor fixtures unchecked.
+- **Pre-registered categories** with selection rules (choosing among them later is permitted; inventing post-hoc ones is not): contract-preserving refactors / contract-dense algorithmic changes (the 2a wedge); **first-order effect-centric tasks** (manifest-checked BCL boundaries — Calor's most differentiated *sound* capability, so the moat is not tested only on property-based testing's home turf); effect-safe DB writes / security boundaries (gate-eligible only after 2a item 4 + 2b item 1); API changes with consumers; tasks C# should dominate; neutral tasks — at pre-registered proportions.
+- **Fixture-authoring constraint** *(r3, sequencing fixed r4)*: contracts mentioning generic-typed values are `Unsupported` today (§1.1); wedge-category fixtures are authored against the **modeled-forms whitelist**, which is therefore a **Phase 0 prerequisite** — the documentation-grade enumeration is cheap and must exist before fixtures are authored against it (v4 had it in Phase 1, which put fixture authoring ahead of the artifact it depends on; the whitelist's pricing/serialization work stays Phase 1, enforcement rearchitecture stays 2b). Likewise, the **`Calor.Runtime` combinator manifest entries** (see 2a item 4) **do not exist today** and must land before first-order effect-centric fixtures are authored — without them, `opt.Map(...)`-style code hits the unknown-call path and fails enforcement.
+
+**Baseline fairness.** The C# arm gets Roslyn analyzers, NRT, tests, and full freedom to generate its own evidence.
+
+**Measurement protocol.** Model pinning per epoch; both arms simultaneously on the same pinned model, compared arm-vs-arm (an **epoch** = one gate's complete paired run; arm-delta difference-in-differences across epochs is permitted evidence, raw longitudinal comparisons are not). Held-out split opened only at gates. Power analysis restored and joint-feasibility-checked against the budget (§6). Gate metrics: task success, escaped bugs (arm-shared tests), iterations-to-green, tokens. **Runtime overhead of retained contract checks recorded per-arm.** Review time: qualitative only. Z3-absent runs never count toward a gate.
+
+**Exit criterion:** suite frozen, gates doc frozen (with feasibility calc), baseline published including the losses.
+
+### Phase 1 — Cost of admission (calendar box: 8–10 weeks, hard, with shed order)
+
+**Gate-load-bearing (never shed):**
+1. **Source maps** (`#line` in `CSharpEmitter`; stack-trace remapping).
+2. **`calor run` / `calor test` CLI commands** (`calor test` wraps `dotnet test`; the `§TEST` *construct* is 2a — additive, non-breaking).
+3. **Structured-output plumbing sufficient for measurement** + taxonomy enum/serialization (§5) + **vacuity checks** (`§Q`-sat, plus the obligations fact-set SAT pre-check from the immediate items if not already landed) + **whitelist pricing/serialization** (the documentation-grade whitelist itself is a Phase 0 prerequisite *(r4)*; this item productizes it; enforcement rearchitecture stays 2b). Full unification honestly priced: pick one SARIF implementation (`DiagnosticFormatter` vs `Commands/AssessCommand.cs`'s private model), delete the other, wire the survivor, schema unvalidated until a command ships on it.
+
+**Sheddable to 2a in order:** 4. `calor watch` + CLI incrementality; 5. fault-tolerant parser mode (a parser-architecture feature) + canonical formatter as auto-heal; 6. single-sourcing *system* for the agent-facing spec (content already fixed).
+
+**Exit criterion (†):** pinned-model simultaneous arms — `.g.cs` dead-end rate below ceiling; neutral-task iterations-to-green within the pre-registered percentage of the C# arm.
+
+### Phase 2a — The wedge, sound subset first (calendar box: ~3 months, with shed order)
+
+*(v3 said ~2 months; round 3 correctly called that the same estimating sin v1/v2 were mocked for, given 2a also absorbs Phase 1 shed items.)*
+
+**Entry conditions:** Phase 1 gate passed; named adopter secured per §1.3.
+
+Scope: **pure/contract-dense modules plus first-order effect-checked code** inside an existing C# repo. And stated plainly *(r3)*: **enforced Calor is first-order by design until Phase 3** — a function that receives and invokes a function-typed parameter is an error under enforcement; `map`/`filter`-style callback APIs are out of the enforced wedge. This is a deliberate SPARK-style restriction (SPARK lived without function pointers for decades), not an oversight; definition-site lambda charging keeps the common inline-lambda idiom (`opt.Map(x → x+1)` where the callee is manifest-covered) working. The benchmark treats it honestly: neutral-task fixtures may use higher-order style only via interop/permissive paths, and the neutral tolerance absorbs a real expressiveness penalty — it is visible in the numbers, not hidden.
+
+```
+propose change (declaration-addressed edit)
+  → blast radius (callers, effect diffs, invalidated proofs, API surface)
+  → re-prove affected contracts (incremental, cached)
+  → run impacted tests
+  → emit review packet
+```
+
+**Never-shed core:** items 1–4. **Sheddable to 2b in order:** items 5→7.
+
+1. **Semantic index (subset):** call graph, effect summaries, contract results persisted to `obj/calor/` (SQLite); `calor query` + MCP tools.
+2. **Declaration-addressed edits** with signature-qualified addresses, positional lambda scheme, rename-aware remapping **plus load-time reconciliation** by (address, hash) for tool-bypassing text edits; `--check` speculative mode.
+3. **Review packet v1** over the §5 taxonomy, leading with the unproven remainder; includes **assumption-provenance tracking** in the verifier (priced as verifier work) and the packet's **interop/permissive-fraction line** (see item 4).
+4. **Close the effect holes — coherently, as one strictness batch** *(r3 restructure, r4 completion)*:
+   - **Delegate invocation:** unconditional **error** under enforcement. No annotation escape hatch in 2a (effect-annotated function types don't exist; that design goes to the Phase 3 TIER2D-vs-binder evaluation and the 2b design doc).
+   - **Override and interface-implementation effect-variance** *(r4 completed the spec)*: override effect set ⊆ base effect set, **and** implementation effect set ⊆ interface-declared effect set (interface dispatch launders identically) — declaration-local checks, JML/Eiffel behavioral-subtyping shape. The machinery exists (`MethodNode.IsVirtual/IsOverride`, `MethodSignatureNode.Effects`, `EffectSubtyping.Encompasses`), but `ContractInheritanceChecker` is interface-only today, so the base-chain traversal is new (small) work. **Priced separately** *(r4 — not declaration-local)*: call-site resolution — calls through base/interface-statically-typed receivers must charge the static type's declared `§E` (today they fall into the unknown-call chain and fail loud under strict policy, so there is no silent hole, but without this work OO dispatch stays outside usable enforcement). **External C# base classes/interfaces** carry no `§E` and route to the same Unknown/`Assumed` channel as interop.
+   - **Interop is effect-*unknown*, not effect-invisible** *(r3 — verified inversion: today interop blocks contribute `EffectSet.Empty`, i.e. the unanalyzed tier feeds *pure* summaries into the enforced tier)*: a function containing interop contributes an Unknown-effect marker that propagates as `Assumed` through the SCC pass, like manifest assumptions; the packet surfaces interop/permissive fraction per module.
+   - **`KnownPureMethodNames` mutator purge** *(r4)*: the bare-name purity fallback currently includes mutators (`Add`, `Remove`, `Clear`, `Sort`, `Insert`, delegate-taking `ForEach`, …) that are correctly `mut`-manifest-entered when the receiver type resolves — so the same call is `mut` or pure depending on whether type resolution succeeds. Purge mutators from the list; route the remainder through §5's `Assumed` provenance (already listed as an `Assumed` source; this schedules the operational half).
+   - **CLI enforcement default flipped to on** here, with the other strictness increases, priced together *(r3 N2)*.
+   - *Migration policy:* converted delegate-dense code → interop-wrap (now honest: `Assumed`, not silently pure) or `--permissive-effects` (which §5.2 names an explicit waiver). *In-repo cost:* `Calor.Enforcement.Tests`, the E2E `lambdas-delegates` category, round-trip flows. *Gate interaction:* strictness increases land before the 2a gate epoch; both gate arms measure the same post-change compiler.
+   - *Manifest convention* *(r3, tense corrected r4)*: `Calor.Runtime` combinators (`Map`, `AndThen`, `Match`, …) **will be** manifest-entered as **"pure modulo arguments, which are charged at the definition site."** **These entries do not exist today** (verified r4: `Manifests/` is BCL/ecosystem only) — they are a Phase 0 prerequisite (see Phase 0 fixture-authoring constraint), and the convention is written down now so it doesn't become a soundness dispute at the gate.
+5. **Contract purity rule:** contract-referenced functions must declare `§E{}`; the reads-half (no mutable-state reads) goes to the 2b design doc — `§E{}` alone is necessary, not sufficient, and content-hash proof caching is incorrect without the reads half (also 2b).
+6. **Review-packet trust sub-experiment** with the adopter's non-maintainer reviewers; if Assumed-heavy packets don't reduce review effort, the wedge stays proof-dense and the go-to-market says so.
+7. **`§TEST` construct** and the **adoption playbook** (tested eject story, bus-factor disclosure, syntax guide).
+
+**Cut from 2a:** runtime-evidence pipeline (post-1.0); API-diff engine beyond `ApiStrictnessChecker` (2b); counterexample→tests (2b).
+
+**Exit criterion (†):** on pre-registered wedge categories incl. first-order effects: **escaped-bugs advantage at or above threshold, with iterations-to-green within the §6 prover-appeasement allowance** *(r3 — v3's exit criterion demanded advantage on both metrics while §6 permitted Calor to be worse on iterations; reconciled: escaped bugs is the advantage metric, iterations is a bounded-cost metric)*; neutral-task regression within tolerance.
+
+### Phase 2b — Verification depth for the wedge (calendar box: ~3–4 months, entered only on a passed 2a gate)
+
+In dependency order:
+
+1. **Aliasing before frames before `old()`** — scoped honestly *(r3)*. The design doc opens with aliasing and confronts two facts: (i) the pairwise parameter rule ("no two mutable reference parameters alias") is **not** SPARK's full discipline — SPARK also had parameter–global anti-aliasing and no general access types; under reachability aliasing (`f(a, b)` where `b == a.Items`) the pairwise rule holds and frames still break. Therefore **2b frames are scoped to what the rule actually supports: scalars, arrays, and disjoint whole objects** — which is also what Z3's array theory models — with reachability-aliasing cases surfacing as named `Assumed` assumptions, not as proofs. (ii) **The C#-caller boundary:** exported Calor functions are callable from arbitrary C#; alias preconditions are compiler-checked at Calor call sites, enforced by **runtime `ReferenceEquals` entry checks** for the shallow pairwise case at exported boundaries, and `Assumed` for reachability. Ownership remains a 2b-blocking design constraint in exactly this restricted form; a full ownership system stays post-1.0. Then: extend `§E` to heap/parameter write-sets (may-upper-bounds under union-join; over-approximation havocs more, never less).
+2. **`old()`** re-priced as a heap-model project (field-map encoding in `ContractTranslator`), with specified runtime semantics (snapshot-at-entry, field-value capture, no deep copies).
+3. **Calls-in-contracts** with the full guard set: purity incl. reads; a **termination measure** (`§DEC` — additive construct; **note: §DEC on functions is not a termination story by itself** — contract-callable functions containing loops need loop variants, and k-induction synthesizes invariants, not termination; the SCC machinery from the effects pass is reusable for mutual recursion *(r3)*); assumption-set consistency sat-check.
+4. **Counterexamples → tests**; **API-diff engine** over the semantic index.
+5. **Closed-whitelist `Unsupported`:** rearchitect the exception-fallback sites **across `Z3Verifier` and `ContractTranslator`** into the positive whitelist (the documentation-grade list ships in Phase 1; this is the enforcement rearchitecture).
+6. **Exceptional postconditions — semantics stated now:** *`§S` holds only on normal return; exceptional paths are unverified and surface as an assumption.* JML `signals`-style specs go on the absent-list.
+7. **Known-limitation debt** from [`dependent-types-m4-backlog.md`](../dependent-types-m4-backlog.md).
+
+**Deliberately absent until evidence demands** (arrival is a plan change, not a surprise): ghost state/lemmas; object-invariant methodology (the hard Spec# problem); quantifier triggers (moves up if 2b proofs time out on quantified specs); JML-style exceptional specs; **async/concurrency** (effects across `await`, delegate hole × continuations, `old()` across suspension points); loop-variant syntax beyond §DEC if 2b's contract-callable functions turn out loop-light.
+
+**Exit criterion:** 2a gate metrics on 2b-exercising categories, same thresholds.
+
+### Phase 3 — Expand only what the benchmark justifies
+
+- **TIER2D (effect rows) vs .NET binder work** — the comparative evaluation the [`calor-direction.md`](../design/calor-direction.md) postscript demanded, with two new inputs: how often 2a's delegate/override errors bite in benchmark runs, and the **effect-annotated function-type design** as an explicit sub-question.
+- **Floats via Z3 FP theory**; narrow-type promotion fix.
+- **Real array bounds** (`BoundArrayAccessExpression`, both bounds, refinement-connected).
+- **Syntax editions before any further breaking change** (Rust-editions precedent; per-module). **The null ban rides an edition**, and its real design cost is named *(r3)*: a type-system default change needs an interop state at the edition boundary — C# NRT's "oblivious" and Kotlin's platform types are the precedents, and NRT is sitting in the target language.
+- **Staged null elimination:** visible → preferred (auto-fix) → banned at an edition boundary, with evidence.
+- **Declaration-anchored diagnostics**; persistent dispositions per §5's (address, hash) scheme.
+- **Provenance/intent metadata** (`§DOC`); broader `calor query`; `calor refactor change-signature` with checked rewrite + re-verification.
+
+### Deferred (post-1.0)
+
+Runtime-evidence loop; canonical non-file program store; full ownership/linear types (2b's restriction is the wedge-scoped subset).
+
+---
+
+## 5. Verification honesty (hard requirement, all phases)
+
+Agents overfit to the prover; a human who reads "Proven" and assumes safety when the proof was narrow is worse off than with no prover.
+
+### 5.1 Proof status (one axis) and disposition (an orthogonal axis)
+
+**Status** (produced by the verifier, on every surface):
+
+| Status | Meaning | Notes |
+|---|---|---|
+| `Proven` | Holds unconditionally under the modeled semantics | Only status permitted to elide runtime checks. Carries a **`vacuous` flag** when the precondition set is unsatisfiable — and a vacuous `§Q` additionally raises a **compiler diagnostic** (the function is uncallable: its retained runtime check throws on every call), not just packet metadata *(r3)*. Known-uncovered: implication-antecedent vacuity inside `§S` (named, deferred) |
+| `Disproven` | Concrete counterexample | Always included. No disposition may attach |
+| `Assumed` | Proof conditional on assumptions (callee summaries, effect manifests, `KnownPureMethodNames`, aliasing assumptions, **interop-unknown markers**) | Transitive; listed per-proof; never aggregates into `Proven`; never elides checks |
+| `Unknown` | Solver returned unknown, **with a reason field** (quantifier instantiation, nonlinear arithmetic, **solver error/crash**) *(r3 — solver exceptions previously had no home)* | Remediation: rewrite the spec (or report the crash) |
+| `Timeout` | Resource limit hit | **Derived from harness-side wall-clock/rlimit bookkeeping, not Z3 `ReasonUnknown` strings** |
+| `Unsupported` | Outside the **closed, enumerated whitelist** of modeled forms | Loud, never silent. Whitelist: documentation-grade list in Phase 1; enforcement rearchitecture in 2b |
+| `Unavailable` | Z3 not present | Never counts toward a gate |
+
+**Disposition** (recorded by a human, orthogonal): **`Justified(who, why, when)`**, valid on `Assumed`/`Unknown`/`Timeout`/`Unsupported`, structurally impossible on `Disproven`. **Keying, now defined** *(r3 — this definition is load-bearing)*:
+- Key = (signature-qualified declaration address, `H`) where `H` = hash of the **normalized contract-expression AST** (α-renamed, canonical operand order — surface-text hashing would churn on whitespace; unnormalized ASTs would churn on refactors) **+ the content-addressed assumption set**: each assumption is hashed by *content* (the callee's contract/effect signature, the manifest entry's body — not its name), canonically ordered. Content addressing is what makes editing callee `Foo`'s contract invalidate justifications that assumed it — name-addressed sets would resurrect the stale-justification bug one level down.
+- **No compiler-version salt**: semantic changes in how assumptions are *computed* surface as content changes in the assumption set itself; a compiler-version salt would invalidate every justification on every upgrade and produce SPARK-style justification fatigue (humans re-justifying by reflex), which defeats the mechanism. Two pins *(r4)*: (i) **Justified-eligible assumption sets contain declaration-sourced content only** (callee contracts, `§E` declarations, manifest entries) — *synthesized* artifacts (k-induction invariants, derived aliasing facts) are prover output that churns across upgrades with no source change, which would silently break the no-salt promise; residuals depending on synthesized assumptions are re-justified per epoch, disclosed as such. (ii) The principled middle ground if semantics shifts need capturing is a **`§SEMVER` semantics-version salt** (invalidates exactly when modeled semantics change, never otherwise) — recorded as the designated option for the 2a design, not decided here.
+- Invalidated on hash change; load-time reconciliation by (address, hash); re-listed (not re-litigated) in every packet touching the declaration; re-audited at release boundaries.
+
+### 5.2 Rules
+
+1. **Elision:** only unconditional, non-vacuous `Proven` elides runtime checks. This changes current behavior (`CSharpEmitter` already elides on `Proven`); the `vacuous` flag and assumption-provenance must be **plumbed to the emitter's elision branch** — named owner: 2a item 3 *(r3)*.
+2. **Explicit waivers, both of them** *(r3 — v3 caught contracts, missed effects)*: `--contract-mode off` strips all checks and **voids this section's contract guarantee**; `--permissive-effects` assumes unknown calls pure and **voids the effect guarantee**. Any review packet for a module compiled with either says so on its first line, and reports the interop/permissive fraction. `release` mode retains checks for all non-`Proven` statuses.
+3. **The packet leads with the unproven remainder** (everything not `Proven`; `Justified` items listed with dispositions).
+4. **Prover-model divergences from C# runtime semantics** are defects until fixed.
+5. **Anti-gaming:** escaped-bug measurement uses arm-shared held-out tests.
+6. **Pricing:** enum/serialization/vacuity/whitelist-doc — Phase 1 item 3. Assumption-provenance + emitter plumbing — 2a item 3. Whitelist enforcement rearchitecture — 2b item 5. `Justified` persistence/reconciliation — 2a items 2–3.
+
+---
+
+## 6. Budget, gates, and kill criteria
+
+Staffing: one maintainer plus agents; API spend dominates measurement cost.
+
+**Planning envelopes (constrain the gates doc; exact values † frozen there):**
+- Phase 1: `.g.cs` dead-end ceiling — envelope 0–10% of runs; neutral iterations-to-green within 15–40% of the C# arm.
+- Phase 2a: **escaped-bugs relative reduction ≥ 20–40% (the advantage metric)**; **iterations-to-green within 10–25% of the C# arm (the prover-appeasement allowance — a bounded cost, not an advantage requirement)** *(r3 reconciliation)*; neutral regression tolerance 5–15%.
+- Phase 0 fairness: equivalence band, M re-authoring rounds, N% pair-failure kill threshold, and the Calor-side symmetry constraints — set before any pair is authored.
+- **Joint feasibility:** the gates doc must show each frozen threshold is statistically decidable at the frozen API budget (power calculation); if not, threshold or category count moves before freezing. An undetectable gate is unfalsifiability wearing statistics *(r3)*.
+
+**Gates-doc supersession rule:** supersession only for a **documented empirical defect in the measurement protocol itself** (the `phase-2-measurement-protocol` v1→v2 standard), never threshold changes after seeing arm results; requires a written defect analysis in the successor. Residual honestly acknowledged *(r3)*: at bus factor 1, "empirical defect" is self-judged — the written-analysis requirement and published envelopes are the constraint, and this residual is of the same kind as bus factor 1 itself: disclosed, not solvable by a document.
+
+| Phase | Calendar box | Primary spend | Gate | Kill action if gate fails |
+|---|---|---|---|---|
+| 0 | 4–6 weeks | Harness eng.; API ceiling † | Suite + gates doc frozen (incl. feasibility calc); baseline published; ≤N% pairs out-of-band | >N% pairs fail equivalence after M rounds: publish the finding and stop — an unbuildable fair suite is itself a result |
+| 1 | 8–10 weeks, hard, shed order stated | Compiler eng. | Envelope thresholds, pinned-model simultaneous arms | Ship as tooling maintenance; do not enter 2a; re-evaluate |
+| — | (parallel with 1) | Adopter search | Named adopter with non-maintainer reviewer by the Phase 1 gate | No adopter → 2a kill *action* (maintenance mode), conclusion **"demand unproven"** — not benchmark falsification *(r3)* |
+| 2a | ~3 months, shed order stated | Compiler + index eng.; adopter time | Escaped-bugs advantage ≥ †; iterations within allowance †; neutral within tolerance † | **Named decision point:** maintenance mode; publish the negative result, scoped: *the bet is falsified for the tested wedge — pure/contract-dense + first-order effect-checked code — at current model capability*; nothing broader |
+| 2b | 3–4 months | Verification eng. (largest single bet) | 2a metrics on 2b-exercising categories | Freeze depth at 2a level; reassess at next model generation |
+| 3 | Per-item | Per-item | Per-item, evidence-gated | Item-level: don't build |
+
+Total calendar bet through 2b: **~10–13 months** (2a widened in v4).
+
+**Parity-kill clause:** an *epoch* is one gate's complete paired run. If across two consecutive epochs the arm delta (difference-in-differences, per metric) is flat or converging on the wedge categories, execute the current phase's kill action rather than extending the box.
+
+---
+
+## 7. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| C#+agent-generated-evidence closes the gap | Narrow bet tested head-on; full C#-arm toolkit; parity-kill clause. |
+| 2b verification underpriced | Aliasing→frames→`old()` order; frames scoped to scalars/arrays/disjoint objects; design doc opens with aliasing + the C#-boundary problem; absent-list explicit. |
+| Verifier gaming / false confidence | §5: elision rule with emitter plumbing owned, vacuity flag + uncallable-function diagnostic, transitive content-addressed assumptions, closed whitelist, arm-shared tests, both waivers surfaced. |
+| Effect-soundness regressions | All three holes (delegate, dispatch, interop-invisibility) closed together in 2a item 4; `InferFromExpression` catch-all named as a standing audit obligation. |
+| Prover appeasement dominates | Iterations-to-green is a bounded-cost gate metric with an explicit allowance; surfaced, not hidden. |
+| Runtime cost of retained checks | Measured per-arm from Phase 0. |
+| First-order restriction penalizes expressiveness | Owned in 2a scope statement; visible in neutral-task numbers; escape hatch design deferred to Phase 3 evaluation, not improvised. |
+| Wedge tested on weak terrain | First-order effect-centric category is gate-bearing; kill conclusions scoped to the tested wedge. |
+| Benchmark self-deception | Frozen suite; arm-shared tests; two-sided difficulty equivalence with kill threshold; held-out split; pinned simultaneous arms; supersession rule; joint feasibility; losses published. |
+| Adopter stall / self-satisfaction | Deadline routing to kill action with "demand unproven" wording; non-maintainer reviewer required. |
+| Humans find Calor unpleasant | Trust sub-experiment; tested eject story; null staging on editions; syntax guide. |
+| Bus factor 1 | Disclosed; single-sourced spec + gates doc reduce key-person knowledge; self-judged supersession residual acknowledged; not otherwise solvable by a document. |
+| Model drift | Arm-vs-arm on pinned models; defined arm-delta diffs only. |
+| Audit drift (3 rounds, 3 §1 errors) | Verified-round tags in §1; single-sourcing (Phase 1 item 6); the whitelist and gates doc convert prose claims into checkable artifacts. |
+
+---
+
+## 8. Revision log and panel dispositions
+
+### v1 → v2 (round 1: DA 35%, PL 55%) — summary
+Phase 0 re-scoped (execution prerequisite, correct starting asset); review-time demoted to qualitative; 2a/2b split with budget/kill table; TIER2D demoted per the direction-doc postscript; fixture-provenance rules; frames-before-`old()` with `§E` unification; purity/termination/consistency guards; taxonomy with `Assumed`/`Justified`/elision; editions-vs-`§SEMVER`; signature-qualified addressing. Full table in git history (v2).
+
+### v2 → v3 (round 2: DA 55%, PL 72%) — summary
+Delegate escape hatch removed (unconditional error + migration policy); adopter condition hardened; first-order effect category added; status/disposition orthogonality with hash-keyed `Justified`; aliasing promoted to 2b-blocking; vacuity detection; `ContractMode` precedence; planning envelopes + supersession rule; factual corrections (dead `DiagnosticFormatter`, silent-by-default delegate hole). Full table in git history (v3).
+
+### v3 → v4 (round 3: DA 62%, PL 78% — both declaring diminishing returns)
+
+| Finding (abridged) | Source | v4 disposition |
+|---|---|---|
+| §4 2a exit criterion contradicted §6's appeasement allowance (advantage on iterations vs up-to-25%-worse) | DA-N1 | Reconciled: escaped bugs = advantage metric; iterations = bounded-cost metric (§4, §6) |
+| "`--enforce-effects` (the default)" false; split-brain CLI-false/SDK-true; Phase 0 surface unpinned; default flip unscheduled | DA-N2, PL-7 | §1.1 corrected with the split-brain stated; Phase 0 pins harness flags; CLI default flip scheduled inside 2a item 4 |
+| 2a box (~2 months) not credible; no shed order; pressure-relief valve with no relief valve | DA-N3 | Widened to ~3 months; never-shed core (items 1–4) + shed-to-2b order; total bet restated 10–13 months |
+| Difficulty equivalence measured only on the C# arm; maintainer could author asymmetric fixtures unseen | DA-N4 | Two-sided: structural parity constraints at authoring + Calor-arm equivalence re-run at first non-degenerate epoch, quarantine rule |
+| Unconditional delegate error outlaws higher-order enforced Calor; cost framed as test chore | DA-N5 | Owned explicitly: "enforced Calor is first-order by design until Phase 3," SPARK precedent, benchmark treatment stated |
+| Adopter-failure kill wording over-concludes (demand failure ≠ bet falsification) | DA-N6 | Separate conclusion wording ("demand unproven") in §1.3 and §6 |
+| Envelopes published but detectability unconstrained — a frozen gate could be statistically undecidable | DA-N7 | Joint-feasibility requirement added to §6 |
+| "Content already fixed" was false; immediate items unexecuted | DA-N8 | **Executed 2026-07-01**: null-checker fix (78 tests pass) + CLAUDE.md fix; §1.2 item 6 updated truthfully |
+| `Unsupported` sites attributed to two different files in two sections | DA-N9 | "Across `Z3Verifier` and `ContractTranslator`" both places |
+| Vacuous-flag emitter plumbing unowned; supersession self-judged; `InferFromExpression` catch-all a standing risk | DA-N10 | Owner named (2a item 3); residual acknowledged (§6); audit obligation recorded (§1.1) |
+| `Justified` hash undefined (surface text? name-addressed assumptions? version salt?) | PL-1 | §5.1 keying defined: normalized-AST + content-addressed canonically-ordered assumption set; no version salt; rationale recorded |
+| Pairwise anti-aliasing ≠ SPARK's discipline; reachability aliasing breaks frames; C#-caller boundary unaddressed | PL-2 | 2b item 1 rescoped: frames limited to scalars/arrays/disjoint objects; reachability → `Assumed`; `ReferenceEquals` entry checks at exported boundaries |
+| Interop blocks are effect-*invisible* (contribute `EffectSet.Empty` into enforced summaries) — the cure relocated the hole | PL-3 | Interop → Unknown-effect marker propagating as `Assumed`; packet interop-fraction line; `--permissive-effects` named an explicit waiver (§5.2) |
+| Sound subset defined by an accidental blacklist until 2b — the gate bets on soundness the plan defines afterwards | PL-4 | Documentation-grade whitelist moved to Phase 1 item 3; fixtures authored against it; rearchitecture stays 2b |
+| Solver errors have no taxonomy home; vacuous `§Q` deserves a compiler diagnostic; antecedent vacuity uncovered | PL-5 | `Unknown` widened with reason field; uncallable-function diagnostic added; antecedent vacuity named known-uncovered |
+| Virtual dispatch is the delegate hole in OO clothing; no effect-variance on overrides; silence forbidden by the doc's own method | PL-6 | §1.1 corrected; override-subset rule ships in 2a item 4 |
+| §DEC alone isn't termination (loop variants); editions' real cost is the null-ban boundary semantics | PL-8 | Both noted in 2b item 3 / Phase 3 |
+| Generics×contracts unmentioned but constrains Phase 0; runtime combinator manifest semantics unstated | PL-9 | Phase 0 fixture-authoring constraint added; "pure modulo arguments" convention stated in 2a item 4 |
+
+**Rejected/limited from round 3:** nothing rejected.
+
+### v4 → v4.1 (round 4, verification: DA 78%, PL 81% — dispositions verified 6/6 substantive; both fixes verified real against source; **both ruling a fifth round would destroy value**)
+
+| Finding (abridged) | Source | v4.1 disposition |
+|---|---|---|
+| Whitelist sequencing inverted: fixtures authored in Phase 0 against a Phase 1 artifact | DA-MAJOR-1 | Documentation-grade whitelist made a Phase 0 prerequisite; pricing/serialization stays Phase 1; rearchitecture stays 2b |
+| CLAUDE.md closer sentence overclaimed ("only §/C and §/LAM remain"; 13 kinds hard-error, others tolerated) | DA-MINOR-1 | CLAUDE.md corrected to guidance form ("never write structural closers") with accurate mechanics |
+| "78 tests" not reproducible; fixes uncommitted | DA-MINOR-2/3 | Wording corrected (named suites); commit-pending status stated honestly |
+| **Obligations `FactCollector` flow-insensitive** — sibling-guard UNSAT vacuously discharges every obligation in a function; a third vacuity channel no planned check covered | PL-CRITICAL(repo) | Added to immediate items with the SAT-pre-check mitigation required before Phase 0 fixtures; supersedes the milder backlog statement |
+| Override rule half-specified: interface impls unstated; call-site static-type resolution not declaration-local and unpriced; external C# bases unrouted | PL-MAJOR | 2a item 4 completed: impl ⊆ interface rule; call-site resolution priced separately; external bases → Unknown/`Assumed` |
+| `Calor.Runtime` combinator manifests don't exist; doc's present tense was drift (4 rounds, 4 drift findings) | PL-MINOR | Tense corrected; entries made a Phase 0 prerequisite |
+| `KnownPureMethodNames` contains mutators (incl. delegate-taking `ForEach`); resolution-dependent purity | PL-MINOR | Mutator purge scheduled in 2a item 4's strictness batch |
+| Justified content-addressing ill-defined for synthesized assumptions; `§SEMVER` salt is the principled option | PL-MINOR | §5.1 pinned: declaration-sourced content only; `§SEMVER`-salt recorded as the designated design option |
+
+**Loop termination.** Four rounds: DA 35→55→62→78; PL 55→72→78→81. Round 4 was a verification round: all checked dispositions substantive, both executed fixes verified against source, the central closing claim ("remaining gap is empirical, not architectural") upheld by both panelists with one earned asterisk — a four-round streak of audit-drift findings, whose systemic fix (single-sourcing, whitelist and gates artifacts) this plan already schedules. Both panelists ruled a fifth revision round value-destroying. **The document stands at v4.1. The remaining confidence gap is closable only by data: build `agent-native-gates.md` (one adversarial review before freezing), fix the FactCollector defect, land the combinator manifests and whitelist, author the Phase 0 fixtures, and publish the baseline — including the losses.**

--- a/docs/verification-modeled-forms.md
+++ b/docs/verification-modeled-forms.md
@@ -1,0 +1,92 @@
+# Z3 Verification — Modeled-Forms Whitelist
+
+**Status:** Normative, documentation-grade (v1, 2026-07-02)
+**Role:** This is the enumerated definition of the *sound subset* — the expression forms the contract prover actually models. Phase 0 wedge fixtures are authored against this list; a contract using anything outside it receives `Unsupported` (runtime check retained). See [`plans/agent-native-strategy.md`](plans/agent-native-strategy.md) §4–§5 for the plan context; the enforcement rearchitecture (positive whitelist in code, replacing the exception-fallback sites across `Z3Verifier.cs` and `ContractTranslator.cs`) is Phase 2b item 5.
+**Source of truth:** `src/Calor.Compiler/Verification/Z3/ContractTranslator.cs` (primary translator, ~1,600 lines), `Verification/Z3/Z3Verifier.cs` (driver). Every claim below carries a file:line reference verified against v0.6.7. When code and this document disagree, the code is the bug or this document is stale — either way, file it.
+
+All arithmetic is modeled with Z3 **bit-vectors** (two's-complement, fixed-width), not unbounded integers (`ContractTranslator.cs:17–20`).
+
+---
+
+## 1. Types modeled as Z3 variables
+
+Names are case-insensitive and normalized (`NormalizeTypeName`, `:656–677`). Accepted forms and sorts:
+
+| Accepted names | Z3 sort | Width | Signed |
+|---|---|---|---|
+| `i8`, `sbyte`, `int8`, `System.SByte` | BitVec | 8 | yes |
+| `i16`, `short`, `int16`, `System.Int16` | BitVec | 16 | yes |
+| `i32`, `int`, `int32`, `System.Int32` | BitVec | 32 | yes |
+| `i64`, `long`, `int64`, `System.Int64` | BitVec | 64 | yes |
+| `u8`, `byte`, `uint8`, `System.Byte` | BitVec | 8 | no |
+| `u16`, `ushort`, `uint16`, `System.UInt16` | BitVec | 16 | no |
+| `u32`, `uint`, `uint32`, `System.UInt32` | BitVec | 32 | no |
+| `u64`, `ulong`, `uint64`, `System.UInt64` | BitVec | 64 | no |
+| `bool`, `boolean`, `System.Boolean` | Bool | — | — |
+| `string`, `str` | Z3 String (Seq) | — | — |
+| `T[]` where `T` is an integer type above | Array: BitVec64 → BitVec(width of T) | 64-bit index | element per T |
+| Any other non-empty name (user class; `?` suffix stripped) | Uninterpreted sort, one per name | — | — |
+
+- Every array variable auto-creates a companion `<name>$length` variable of type **u32** (`:647–650`).
+- **Not modelable as variables:** `f32`/`f64`/`float`/`double`/`single`/`decimal`; `object`/`dynamic`; `Func`/`Action`/delegate types; arrays of strings, bools, floats, or user types (`:606`, `:638–640`, `DiagnoseUnsupportedType :1597–1610`).
+
+## 2. Expression forms modeled
+
+**Literals:** integer (always emitted as signed 32-bit — see divergence D2), boolean, string. **Float literals are not modeled** (`:244`).
+
+**References:** simple variable references; dotted paths (`a.b.c`) resolve as chained uninterpreted field functions on user-type sorts (`ResolveDotPath :275–327`).
+
+**Binary operators** (operand widths normalized by sign/zero-extension, `:763–788`):
+`+  -  *  /  %  ==  !=  <  <=  >  >=  &&  ||  &  |  ^  <<  >>`
+Division, modulo, comparisons, and right-shift are signedness-aware (`ShouldUseUnsignedComparison :718–740`): both-unsigned → unsigned ops; mixed → unsigned only when the signed operand is a provably non-negative literal, else signed.
+
+**Unary operators:** `!` (bool), unary `-` (integer).
+
+**Conditional:** `(cond ? a : b)` → Z3 ITE (`:420–430`).
+
+**Quantifiers:** `forall` / `exists` with integer-typed bound variables; **implication** `(-> p q)` (`:454–524`).
+
+**Self-reference `#`** in refinement predicates (`:332–342`).
+
+**Arrays:** element access **only on a simple variable base** (no computed/nested/method-returned arrays, `:534`); array length (simple variable base only). An array first seen at an access site defaults to i32 elements (see divergence D6).
+
+**User-type fields:** `obj.Field` and dot-paths, modeled as uninterpreted functions; result sorts come from the user-type registry when supplied, else default to i32/BitVec32 (see divergence D7).
+
+**String operations (exhaustive):** `Length`, `Contains`, `StartsWith`, `EndsWith`, `Equals`, `IsNullOrEmpty`, `IndexOf` (2- and 3-arg), `Substring` (3-arg), `SubstringFrom`, `Concat`, `Replace` (first occurrence). Everything else is out (see §3).
+
+## 3. Explicitly NOT modeled (→ `Unsupported`, runtime check retained)
+
+1. **Function and method calls of any kind** in contracts (`CallExpressionNode → null`, `:245`). Calls-in-contracts via callee summaries is Phase 2b work and will carry `Assumed` status, never `Proven`.
+2. **All floating-point** types and literals.
+3. **String operations:** `ToUpper`, `ToLower`, `Trim`, `TrimStart`, `TrimEnd`, `PadLeft`, `PadRight`, `Split`, `Join`, `Format`, `ToString`, `IsNullOrWhiteSpace`, all Regex operations (`:1353–1362`).
+4. **`StringComparison` modes:** accepted syntactically, **ignored semantically** — verification is ordinal-only; non-ordinal modes add a warning but the proof proceeds (`:863–870`). Treat culture-sensitive string contracts as unverified.
+5. **Computed array bases** (method returns, nested accesses) for element access or length.
+6. **`object`/`dynamic`, delegate types** as variables.
+7. **Generic-typed values** (including `Option<T>`/`Result<T,E>`-typed ones) — they fall to uninterpreted sorts at best; contracts over their *contents* are not modeled. Constrains Phase 0 fixture authoring.
+8. Anything not listed in §2 (default case `:246`).
+
+## 4. Known semantic divergences from C# (tracked as defects per strategy §5.2 rule 4)
+
+| # | Divergence | Consequence |
+|---|---|---|
+| D1 | **No narrow-type promotion** (`:33–39`): `byte + byte` wraps at 8 bits; C# promotes to `int` (400 stays 400) | False positives *and* negatives on `byte`/`short` arithmetic contracts |
+| D2 | **Integer literals always signed 32-bit** (`:223`); out-of-range values truncate | Long-range contracts mis-modeled |
+| D3 | **Z3 strings cannot be null** (`:44–48`): `IsNullOrEmpty` tests length==0 only | Null-vs-empty indistinguishable |
+| D4 | **Ordinal-only string comparison** (§3 item 4) | Culture-sensitive contracts unverified without loud failure |
+| D5 | Contract `§S` holds **only on normal return**; exceptional paths unverified (strategy 2b item 6) | Exception-heavy code has weaker guarantees than the word "Proven" suggests |
+| D6 | Arrays first seen at an access site default to **i32 elements** (`:544–551`) | Element-width mismatch possible |
+| D7 | User-type fields default to **i32** without a registry (`:1185`) | Field-width/signedness mismatch possible |
+
+## 5. The second translator (bug-pattern checkers) — differences
+
+`BoundExpressionTranslator` (in `Analysis/BugPatterns/Patterns/DivisionByZeroChecker.cs:503–694`) backs the div-by-zero/overflow/index checkers. It is **narrower and signed-only**:
+
+- **Adds:** math functions via ITE — `abs`, `min`, `max`, `clamp`, `sign` (both `math.x` and bare names).
+- **Removes vs the primary:** strings, arrays, field access, quantifiers, implication, conditional, self-ref, bitwise/shift operators, all type aliases (`System.*`, `intNN`), width normalization.
+- **Signed-only everywhere** — unsigned types are mis-modeled by its comparisons and div/mod.
+
+Do not assume checker findings and contract proofs share a model; they don't.
+
+## 6. Maintenance rule
+
+Any change to `ContractTranslator`'s accepted forms MUST update this document in the same PR. When Phase 2b lands the positive-whitelist rearchitecture, this document becomes generated output and the hand-maintained version is retired.

--- a/src/Calor.Compiler/Analysis/BugPatterns/Patterns/NullDereferenceChecker.cs
+++ b/src/Calor.Compiler/Analysis/BugPatterns/Patterns/NullDereferenceChecker.cs
@@ -258,12 +258,14 @@ public sealed class NullDereferenceChecker : IBugPatternChecker
 
     private static bool IsUnsafeUnwrapCall(string target)
     {
-        // Detect unsafe unwrap patterns
+        // Detect unsafe unwrap patterns; the catch-all must exclude every
+        // safe fallback form so the predicate stays consistent with
+        // IsSafeUnwrapCall regardless of call order
         return target.EndsWith(".unwrap") ||
                target.EndsWith(".unwrap_unchecked") ||
                target.EndsWith(".expect") ||
-               target.EndsWith(".unwrap_or_else") == false && target.Contains("unwrap") ||
-               target.EndsWith(".get_unchecked");
+               target.EndsWith(".get_unchecked") ||
+               (!IsSafeUnwrapCall(target) && target.Contains("unwrap"));
     }
 
     private static bool IsSafeUnwrapCall(string target)

--- a/src/Calor.Compiler/Effects/EffectEnforcementPass.cs
+++ b/src/Calor.Compiler/Effects/EffectEnforcementPass.cs
@@ -294,8 +294,27 @@ public sealed class EffectEnforcementPass
     /// Maps common short type names to fully-qualified names for manifest resolution.
     /// Used by both ParseCallTarget (in EffectInferrer) and ParseCallTargetForChain.
     /// </summary>
-    internal static string MapShortTypeNameToFullName(string shortName) => shortName switch
+    internal static string MapShortTypeNameToFullName(string shortName)
     {
+        // Calor surface syntax for the runtime's Option/Result types:
+        // ?T is Option<T>; T!E is Result<T,E>. Their combinators are
+        // manifest-entered as pure-modulo-arguments (delegate arguments are
+        // charged at the lambda definition site by the effect pass).
+        if (shortName.StartsWith('?') || shortName.StartsWith("Option<"))
+            return "Calor.Runtime.Option`1";
+        if (shortName.StartsWith("Result<"))
+            return "Calor.Runtime.Result`2";
+        if (shortName.Contains('!') && !shortName.Contains('.') && !shortName.Contains('('))
+            return "Calor.Runtime.Result`2";
+
+        return MapKnownShortTypeName(shortName);
+    }
+
+    private static string MapKnownShortTypeName(string shortName) => shortName switch
+    {
+        // Calor runtime static helper classes
+        "Option" => "Calor.Runtime.Option",
+        "Result" => "Calor.Runtime.Result",
         // BCL types
         "Console" => "System.Console",
         "File" => "System.IO.File",

--- a/src/Calor.Compiler/Manifests/calor-runtime.calor-effects.json
+++ b/src/Calor.Compiler/Manifests/calor-runtime.calor-effects.json
@@ -1,0 +1,50 @@
+{
+  "version": "1.0",
+  "description": "Effect declarations for Calor.Runtime (Option, Result, Unit). Convention: pure modulo arguments — combinators that take delegates (Map, AndThen, Match, Filter, UnwrapOrElse, OrElse, MapErr, Try, ...) contribute no effects themselves; their delegate arguments are charged at the lambda definition site by the effect pass. Unwrap/UnwrapErr may throw on contract violation; per BCL manifest precedent (Int32.Parse), contract-violation throws are not modeled as effects.",
+  "library": "Calor.Runtime",
+  "mappings": [
+    {
+      "type": "Calor.Runtime.Option`1",
+      "defaultEffects": [],
+      "methods": {
+        "*": []
+      },
+      "getters": {
+        "IsSome": [],
+        "IsNone": []
+      }
+    },
+    {
+      "type": "Calor.Runtime.Option",
+      "defaultEffects": [],
+      "methods": {
+        "*": []
+      }
+    },
+    {
+      "type": "Calor.Runtime.Result`2",
+      "defaultEffects": [],
+      "methods": {
+        "*": []
+      },
+      "getters": {
+        "IsOk": [],
+        "IsErr": []
+      }
+    },
+    {
+      "type": "Calor.Runtime.Result",
+      "defaultEffects": [],
+      "methods": {
+        "*": []
+      }
+    },
+    {
+      "type": "Calor.Runtime.Unit",
+      "defaultEffects": [],
+      "methods": {
+        "*": []
+      }
+    }
+  ]
+}

--- a/src/Calor.Compiler/Verification/Obligations/FactCollector.cs
+++ b/src/Calor.Compiler/Verification/Obligations/FactCollector.cs
@@ -4,16 +4,49 @@ using Calor.Compiler.Parsing;
 namespace Calor.Compiler.Verification.Obligations;
 
 /// <summary>
+/// A fact together with the source range it governs. Guard facts (if/while
+/// conditions, loop bounds) only hold inside the body they guard, so the
+/// solver must not assert them for obligations outside that range.
+/// </summary>
+public sealed record ScopedFact(ExpressionNode Fact, int ScopeStart, int ScopeEnd)
+{
+    public static ScopedFact FunctionWide(ExpressionNode fact)
+        => new(fact, 0, int.MaxValue);
+
+    public bool AppliesTo(TextSpan span)
+        => span.Start >= ScopeStart && span.End <= ScopeEnd;
+}
+
+/// <summary>
 /// Collects flow-sensitive facts from the AST that can be used as Z3 assumptions
 /// when verifying obligations. Extracts loop bounds, if-guard conditions, and
 /// inline refinement predicates.
+///
+/// Facts are scoped to the statement range they dominate: an if-condition holds
+/// only inside the then-body, an elseif-condition only inside its own body, a
+/// while-condition only inside the loop body. Facts whose variables are rebound
+/// inside the governed range are dropped entirely (conservative assignment kill)
+/// because the guard may no longer hold at the obligation site.
 /// </summary>
 public sealed class FactCollector
 {
     /// <summary>
-    /// Collected facts as expression nodes suitable for Z3 translation.
+    /// Collected facts with the source ranges they govern.
     /// </summary>
-    public List<ExpressionNode> Facts { get; } = new();
+    public List<ScopedFact> ScopedFacts { get; } = new();
+
+    /// <summary>
+    /// Convenience view of the collected fact expressions (scope-erased).
+    /// </summary>
+    public IReadOnlyList<ExpressionNode> Facts
+        => ScopedFacts.Select(f => f.Fact).ToList();
+
+    /// <summary>
+    /// Adds a fact that holds for the whole function (e.g., an indexed-type
+    /// constraint), subject to no assignment kill.
+    /// </summary>
+    public void AddFunctionWideFact(ExpressionNode fact)
+        => ScopedFacts.Add(ScopedFact.FunctionWide(fact));
 
     /// <summary>
     /// Collects facts from a function's body and parameter refinements that are relevant
@@ -23,13 +56,16 @@ public sealed class FactCollector
     /// </summary>
     public void CollectFromFunction(FunctionNode func)
     {
-        // Collect parameter inline refinements as facts
-        // These serve as assumptions for IndexBounds and other obligations
+        // Parameter inline refinements hold on entry for the whole function —
+        // unless the body rebinds the parameter name, in which case the
+        // refinement may no longer describe the current value.
+        var bodyAssigned = CollectAssignedNames(func.Body);
         foreach (var param in func.Parameters)
         {
-            if (param.InlineRefinement != null)
+            if (param.InlineRefinement != null && !bodyAssigned.Contains(param.Name))
             {
-                Facts.Add(SubstituteSelfRef(param.InlineRefinement.Predicate, param.Name));
+                ScopedFacts.Add(ScopedFact.FunctionWide(
+                    SubstituteSelfRef(param.InlineRefinement.Predicate, param.Name)));
             }
         }
 
@@ -56,21 +92,19 @@ public sealed class FactCollector
                 break;
 
             case WhileStatementNode whileStmt:
-                // The while condition holds inside the loop body
-                Facts.Add(whileStmt.Condition);
+                // The while condition holds on entry to each iteration, but a
+                // body that reassigns its variables invalidates it mid-body.
+                AddGuardFact(whileStmt.Condition, whileStmt.Body);
                 CollectFromStatements(whileStmt.Body);
                 break;
 
             case IfStatementNode ifStmt:
-                // The if-condition is a fact within the then-body.
-                // We add it as a general assumption since obligations inside
-                // the then-body are only reachable when the condition holds.
-                Facts.Add(ifStmt.Condition);
+                // Each condition is a fact only within the body it guards.
+                AddGuardFact(ifStmt.Condition, ifStmt.ThenBody);
                 CollectFromStatements(ifStmt.ThenBody);
-                // ElseIf clauses have their own conditions
                 foreach (var elseIf in ifStmt.ElseIfClauses)
                 {
-                    Facts.Add(elseIf.Condition);
+                    AddGuardFact(elseIf.Condition, elseIf.Body);
                     CollectFromStatements(elseIf.Body);
                 }
                 if (ifStmt.ElseBody != null)
@@ -93,23 +127,102 @@ public sealed class FactCollector
 
     /// <summary>
     /// Extracts loop bounds from a for-loop.
-    /// §L{id:i:from:to:step} yields facts: i >= from AND i < to
+    /// §L{id:i:from:to:step} yields facts: i >= from AND i < to, scoped to the body.
     /// </summary>
     private void CollectFromForLoop(ForStatementNode forStmt)
     {
         var dummySpan = new TextSpan(0, 0, 1, 1);
         var loopVar = new ReferenceNode(dummySpan, forStmt.VariableName);
 
-        // Fact: loopVar >= from
         var geFrom = new BinaryOperationNode(dummySpan, BinaryOperator.GreaterOrEqual, loopVar, forStmt.From);
-        Facts.Add(geFrom);
+        AddGuardFact(geFrom, forStmt.Body);
 
-        // Fact: loopVar < to
         var ltTo = new BinaryOperationNode(dummySpan, BinaryOperator.LessThan, loopVar, forStmt.To);
-        Facts.Add(ltTo);
+        AddGuardFact(ltTo, forStmt.Body);
 
-        // Recurse into loop body
         CollectFromStatements(forStmt.Body);
+    }
+
+    /// <summary>
+    /// Records a guard fact scoped to the body it governs, unless the body
+    /// rebinds a variable the fact mentions (conservative assignment kill).
+    /// </summary>
+    private void AddGuardFact(ExpressionNode fact, IReadOnlyList<StatementNode> body)
+    {
+        if (body.Count == 0)
+            return;
+
+        var referenced = new HashSet<string>(StringComparer.Ordinal);
+        CollectReferencedNames(fact, referenced);
+
+        var assigned = CollectAssignedNames(body);
+        if (referenced.Overlaps(assigned))
+            return;
+
+        var scopeStart = body.Min(s => s.Span.Start);
+        var scopeEnd = body.Max(s => s.Span.End);
+        ScopedFacts.Add(new ScopedFact(fact, scopeStart, scopeEnd));
+    }
+
+    private static void CollectReferencedNames(ExpressionNode expr, HashSet<string> names)
+    {
+        switch (expr)
+        {
+            case ReferenceNode reference:
+                names.Add(reference.Name);
+                break;
+            case BinaryOperationNode binOp:
+                CollectReferencedNames(binOp.Left, names);
+                CollectReferencedNames(binOp.Right, names);
+                break;
+            case UnaryOperationNode unOp:
+                CollectReferencedNames(unOp.Operand, names);
+                break;
+        }
+    }
+
+    private static HashSet<string> CollectAssignedNames(IReadOnlyList<StatementNode> statements)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        CollectAssignedNames(statements, names);
+        return names;
+    }
+
+    private static void CollectAssignedNames(IReadOnlyList<StatementNode> statements, HashSet<string> names)
+    {
+        foreach (var stmt in statements)
+        {
+            switch (stmt)
+            {
+                case BindStatementNode bind:
+                    names.Add(bind.Name);
+                    break;
+                case ForStatementNode forStmt:
+                    names.Add(forStmt.VariableName);
+                    CollectAssignedNames(forStmt.Body, names);
+                    break;
+                case WhileStatementNode whileStmt:
+                    CollectAssignedNames(whileStmt.Body, names);
+                    break;
+                case DoWhileStatementNode doWhile:
+                    CollectAssignedNames(doWhile.Body, names);
+                    break;
+                case IfStatementNode ifStmt:
+                    CollectAssignedNames(ifStmt.ThenBody, names);
+                    foreach (var elseIf in ifStmt.ElseIfClauses)
+                        CollectAssignedNames(elseIf.Body, names);
+                    if (ifStmt.ElseBody != null)
+                        CollectAssignedNames(ifStmt.ElseBody, names);
+                    break;
+                case ForeachStatementNode foreach_:
+                    names.Add(foreach_.VariableName);
+                    CollectAssignedNames(foreach_.Body, names);
+                    break;
+                case TryStatementNode tryStmt:
+                    CollectAssignedNames(tryStmt.TryBody, names);
+                    break;
+            }
+        }
     }
 
     /// <summary>

--- a/src/Calor.Compiler/Verification/Obligations/ObligationSolver.cs
+++ b/src/Calor.Compiler/Verification/Obligations/ObligationSolver.cs
@@ -112,27 +112,58 @@ public sealed class ObligationSolver : IDisposable
             solver.Set("timeout", _timeoutMs);
 
             // ASSUME: Assert all translatable preconditions
+            var preconditionExprs = new List<BoolExpr>();
             foreach (var pre in info.Preconditions)
             {
                 var preExpr = translator.TranslateBoolExpr(pre.Condition);
                 if (preExpr != null)
                 {
+                    preconditionExprs.Add(preExpr);
                     solver.Assert(preExpr);
                 }
             }
 
-            // ASSUME: Assert collected flow-sensitive facts (loop bounds, parameter refinements, etc.)
-            // For RefinementEntry obligations, skip collected facts to avoid circular reasoning
-            // (the obligation IS the refinement, not an assumption for it).
+            // ASSUME: Assert collected flow-sensitive facts (loop bounds, parameter
+            // refinements, etc.) whose governed source range contains the obligation —
+            // a guard fact must not leak into sibling branches or past its body.
+            // For RefinementEntry obligations, skip collected facts to avoid circular
+            // reasoning (the obligation IS the refinement, not an assumption for it).
             if (obligation.Kind != ObligationKind.RefinementEntry)
             {
                 foreach (var fact in info.CollectedFacts)
                 {
-                    var factExpr = translator.TranslateBoolExpr(fact);
+                    if (!fact.AppliesTo(obligation.Span))
+                        continue;
+
+                    var factExpr = translator.TranslateBoolExpr(fact.Fact);
                     if (factExpr != null)
                     {
                         solver.Assert(factExpr);
                     }
+                }
+            }
+
+            // CONSISTENCY PRE-CHECK: an UNSAT assumption set would vacuously
+            // discharge every obligation ("assume False, prove anything"). If the
+            // assumptions are inconsistent, retry with preconditions only; if the
+            // preconditions themselves are inconsistent, refuse to discharge.
+            if (solver.Check() == Status.UNSATISFIABLE)
+            {
+                solver = _ctx.MkSolver();
+                solver.Set("timeout", _timeoutMs);
+                foreach (var preExpr in preconditionExprs)
+                {
+                    solver.Assert(preExpr);
+                }
+
+                if (solver.Check() == Status.UNSATISFIABLE)
+                {
+                    obligation.Status = ObligationStatus.Unsupported;
+                    obligation.CounterexampleDescription =
+                        "Assumption set is inconsistent (unsatisfiable preconditions); " +
+                        "vacuous discharge prevented";
+                    obligation.SolverDuration = sw.Elapsed;
+                    return;
                 }
             }
 
@@ -245,7 +276,7 @@ public sealed class ObligationSolver : IDisposable
                     // If the indexed type has a constraint, add it as a fact
                     if (itype.Constraint != null)
                     {
-                        factCollector.Facts.Add(
+                        factCollector.AddFunctionWideFact(
                             FactCollector.SubstituteSelfRefStatic(itype.Constraint, itype.SizeParam));
                     }
                 }
@@ -255,7 +286,7 @@ public sealed class ObligationSolver : IDisposable
                 parameters,
                 func.Preconditions,
                 func.Output?.TypeName,
-                factCollector.Facts,
+                factCollector.ScopedFacts,
                 extraVars);
         }
 
@@ -271,7 +302,7 @@ public sealed class ObligationSolver : IDisposable
                     parameters,
                     method.Preconditions,
                     method.Output?.TypeName,
-                    new List<ExpressionNode>(),
+                    new List<ScopedFact>(),
                     new List<(string, string)>());
             }
         }
@@ -283,7 +314,7 @@ public sealed class ObligationSolver : IDisposable
         List<(string Name, string TypeName)> Parameters,
         IReadOnlyList<RequiresNode> Preconditions,
         string? OutputType,
-        List<ExpressionNode> CollectedFacts,
+        List<ScopedFact> CollectedFacts,
         List<(string Name, string TypeName)> ExtraVariables);
 
     public void Dispose()

--- a/tests/Calor.Compiler.Tests/FactScopingTests.cs
+++ b/tests/Calor.Compiler.Tests/FactScopingTests.cs
@@ -1,0 +1,188 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Calor.Compiler.Verification.Obligations;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Regression tests for obligation fact scoping. Guard facts must be confined
+/// to the bodies they dominate: sibling branch guards must not combine into an
+/// inconsistent (UNSAT) assumption set that vacuously discharges every
+/// obligation in the function, and facts whose variables are rebound inside the
+/// governed body must be dropped.
+/// </summary>
+public sealed class FactScopingTests
+{
+    private static ModuleNode Parse(string source, out DiagnosticBag diagnostics)
+    {
+        diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAllForParser();
+        var parser = new Parser(tokens, diagnostics);
+        return parser.Parse();
+    }
+
+    [Fact]
+    public void SiblingGuards_HaveDisjointScopes()
+    {
+        var source = """
+            §M{m001:Test}
+              §F{f001:Branchy:priv}
+                  §I{i32:x}
+                  §O{i32}
+                  §IF{if1} (== x 1)
+                      §R INT:1
+                  §EI (== x 2)
+                      §R INT:2
+                  §R INT:0
+            """;
+
+        var module = Parse(source, out var diagnostics);
+        Assert.False(diagnostics.HasErrors,
+            $"Errors: {string.Join(", ", diagnostics.Select(d => d.Message))}");
+
+        var func = Assert.Single(module.Functions);
+        var collector = new FactCollector();
+        collector.CollectFromFunction(func);
+
+        // Both guard facts collected, but scoped to their own branches
+        Assert.Equal(2, collector.ScopedFacts.Count);
+
+        var first = collector.ScopedFacts[0];
+        var second = collector.ScopedFacts[1];
+
+        // No source position can be governed by both sibling guards
+        Assert.True(first.ScopeEnd <= second.ScopeStart || second.ScopeEnd <= first.ScopeStart,
+            $"Sibling guard scopes overlap: [{first.ScopeStart},{first.ScopeEnd}] vs [{second.ScopeStart},{second.ScopeEnd}]");
+    }
+
+    [Fact]
+    public void GuardFact_DoesNotApply_OutsideItsBranch()
+    {
+        var source = """
+            §M{m001:Test}
+              §F{f001:Guarded:priv}
+                  §I{i32:x}
+                  §O{i32}
+                  §IF{if1} (> x 0)
+                      §R INT:1
+                  §R INT:0
+            """;
+
+        var module = Parse(source, out var diagnostics);
+        Assert.False(diagnostics.HasErrors);
+
+        var func = Assert.Single(module.Functions);
+        var collector = new FactCollector();
+        collector.CollectFromFunction(func);
+
+        var guard = Assert.Single(collector.ScopedFacts);
+
+        // The trailing §R INT:0 sits after the then-body; the guard must not
+        // govern it
+        var trailingReturn = func.Body[^1];
+        Assert.False(guard.AppliesTo(trailingReturn.Span),
+            "Guard fact leaked past the body it dominates");
+    }
+
+    [Fact]
+    public void WhileCondition_Killed_WhenBodyRebindsItsVariable()
+    {
+        var source = """
+            §M{m001:Test}
+              §F{f001:Counter:priv}
+                  §I{i32:n}
+                  §O{i32}
+                  §B{~i:i32} INT:0
+                  §WH{w1} (< i n)
+                      §B{i:i32} (+ i INT:1)
+                  §R i
+            """;
+
+        var module = Parse(source, out var diagnostics);
+        Assert.False(diagnostics.HasErrors,
+            $"Errors: {string.Join(", ", diagnostics.Select(d => d.Message))}");
+
+        var func = Assert.Single(module.Functions);
+        var collector = new FactCollector();
+        collector.CollectFromFunction(func);
+
+        // The while condition (< i n) mentions i, and the body rebinds i, so the
+        // fact may not hold at obligation sites inside the body — it must be dropped
+        Assert.DoesNotContain(collector.ScopedFacts, f =>
+            f.Fact is BinaryOperationNode { Operator: BinaryOperator.LessThan });
+    }
+
+    [Fact]
+    public void ContradictorySiblingGuards_DoNotVacuouslyDischargeObligations()
+    {
+        // Before fact scoping, both sibling guards (x==1, x==2) were asserted
+        // together for every obligation in the function, making the assumption
+        // set UNSAT and vacuously discharging the unguarded index access.
+        var source = """
+            §M{m001:Test}
+              §ITYPE{it1:SizedList:IntArr:n}
+              §F{f001:Bad:priv}
+                  §I{SizedList:items}
+                  §I{i32:x}
+                  §O{i32}
+                  §IF{if1} (== x 1)
+                      §B{a:i32} INT:1
+                  §EI (== x 2)
+                      §B{b:i32} INT:2
+                  §R §IDX items x
+            """;
+
+        var options = new CompilationOptions
+        {
+            VerifyRefinements = true,
+            EnableTypeChecking = false,
+            EnforceEffects = false
+        };
+        var result = Program.Compile(source, "test.calr", options);
+
+        Assert.NotNull(options.ObligationResults);
+
+        var indexObl = options.ObligationResults.Obligations
+            .FirstOrDefault(o => o.Kind == ObligationKind.IndexBounds);
+        Assert.NotNull(indexObl);
+
+        // The unguarded access must not be proven safe
+        Assert.NotEqual(ObligationStatus.Discharged, indexObl.Status);
+    }
+
+    [Fact]
+    public void GuardedIndexAccess_InsideBranch_StillUsesGuardFact()
+    {
+        // The scoping change must not break the legitimate case: an index
+        // obligation inside the guarded body still sees the dominating guard.
+        var source = """
+            §M{m001:Test}
+              §ITYPE{it1:SizedList:IntArr:n}
+              §F{f001:SafeGet:priv}
+                  §I{SizedList:items}
+                  §I{i32:i} | (>= # INT:0)
+                  §O{i32}
+                  §IF{if1} (< i n)
+                      §R §IDX items i
+                  §R INT:0
+            """;
+
+        var options = new CompilationOptions
+        {
+            VerifyRefinements = true,
+            EnableTypeChecking = false,
+            EnforceEffects = false
+        };
+        var result = Program.Compile(source, "test.calr", options);
+
+        Assert.NotNull(options.ObligationResults);
+
+        var indexObl = options.ObligationResults.Obligations
+            .FirstOrDefault(o => o.Kind == ObligationKind.IndexBounds);
+        Assert.NotNull(indexObl);
+        Assert.Equal(ObligationStatus.Discharged, indexObl.Status);
+    }
+}

--- a/tests/Calor.Compiler.Tests/FactScopingTests.cs
+++ b/tests/Calor.Compiler.Tests/FactScopingTests.cs
@@ -115,9 +115,11 @@ public sealed class FactScopingTests
             f.Fact is BinaryOperationNode { Operator: BinaryOperator.LessThan });
     }
 
-    [Fact]
+    [SkippableFact]
     public void ContradictorySiblingGuards_DoNotVacuouslyDischargeObligations()
     {
+        Skip.IfNot(Verification.Z3.Z3ContextFactory.IsAvailable, "Z3 not available");
+
         // Before fact scoping, both sibling guards (x==1, x==2) were asserted
         // together for every obligation in the function, making the assumption
         // set UNSAT and vacuously discharging the unguarded index access.
@@ -153,9 +155,11 @@ public sealed class FactScopingTests
         Assert.NotEqual(ObligationStatus.Discharged, indexObl.Status);
     }
 
-    [Fact]
+    [SkippableFact]
     public void GuardedIndexAccess_InsideBranch_StillUsesGuardFact()
     {
+        Skip.IfNot(Verification.Z3.Z3ContextFactory.IsAvailable, "Z3 not available");
+
         // The scoping change must not break the legitimate case: an index
         // obligation inside the guarded body still sees the dominating guard.
         var source = """

--- a/tests/Calor.Enforcement.Tests/EffectResolverTests.cs
+++ b/tests/Calor.Enforcement.Tests/EffectResolverTests.cs
@@ -702,4 +702,45 @@ public class EffectResolverTests
         Assert.Equal(EffectResolutionStatus.Resolved, result.Status);
         Assert.Contains(result.Effects.Effects, e => e.Value == "intentional");
     }
+
+    // ───── Calor.Runtime combinators: pure modulo arguments ─────
+
+    [Theory]
+    [InlineData("Calor.Runtime.Option`1", "Map")]
+    [InlineData("Calor.Runtime.Option`1", "AndThen")]
+    [InlineData("Calor.Runtime.Option`1", "Match")]
+    [InlineData("Calor.Runtime.Option`1", "Filter")]
+    [InlineData("Calor.Runtime.Option`1", "Unwrap")]
+    [InlineData("Calor.Runtime.Option`1", "UnwrapOrElse")]
+    [InlineData("Calor.Runtime.Result`2", "Map")]
+    [InlineData("Calor.Runtime.Result`2", "MapErr")]
+    [InlineData("Calor.Runtime.Result`2", "AndThen")]
+    [InlineData("Calor.Runtime.Result`2", "OrElse")]
+    [InlineData("Calor.Runtime.Result`2", "Match")]
+    [InlineData("Calor.Runtime.Result", "Try")]
+    [InlineData("Calor.Runtime.Option", "Some")]
+    [InlineData("Calor.Runtime.Option", "FromNullable")]
+    public void CalorRuntime_Combinators_ArePure(string type, string method)
+    {
+        var resolver = new EffectResolver();
+        resolver.Initialize();
+        var result = resolver.Resolve(type, method);
+        Assert.True(result.Effects.IsEmpty,
+            $"{type}.{method} should be effect-free (pure modulo arguments), got: {result.Effects}");
+        Assert.NotEqual(EffectResolutionStatus.Unknown, result.Status);
+    }
+
+    [Theory]
+    [InlineData("?i32", "Calor.Runtime.Option`1")]
+    [InlineData("?str", "Calor.Runtime.Option`1")]
+    [InlineData("Option<i32>", "Calor.Runtime.Option`1")]
+    [InlineData("i32!str", "Calor.Runtime.Result`2")]
+    [InlineData("Result<i32,str>", "Calor.Runtime.Result`2")]
+    [InlineData("Option", "Calor.Runtime.Option")]
+    [InlineData("Result", "Calor.Runtime.Result")]
+    [InlineData("Console", "System.Console")]
+    public void MapShortTypeName_ResolvesCalorOptionResultSurfaceTypes(string surface, string expected)
+    {
+        Assert.Equal(expected, EffectEnforcementPass.MapShortTypeNameToFullName(surface));
+    }
 }


### PR DESCRIPTION
## Summary

Lands the agent-native strategy RFC (v4.1, four rounds of adversarial review) together with its first executable artifacts:

- **Strategy + gates**: `docs/plans/agent-native-strategy.md` (revision log and all panel dispositions in §8) and `docs/plans/agent-native-gates.md` v2 (pre-registered thresholds; revised after an adversarial measurement-protocol review — decision rule, interval banding, decidable parity-kill, one-sided quarantine).
- **Soundness fixes**:
  - `NullDereferenceChecker` precedence bug — `unwrap_or`/`unwrap_or_default` classification was order-dependent; predicate now delegates to the safe list.
  - `FactCollector`/`ObligationSolver` — guard facts were collected function-wide and asserted for every obligation, so contradictory sibling guards vacuously discharged everything; facts are now scoped to the range they dominate, killed on rebinding, and an UNSAT-assumption pre-check refuses vacuous discharge. Five regression tests.
- **Phase 0 prerequisites**:
  - `docs/verification-modeled-forms.md` — the enumerated sound subset of the Z3 contract translator (types, forms, rejections, C# divergences), line-referenced.
  - `src/Calor.Compiler/Manifests/calor-runtime.calor-effects.json` + surface-type mapping (`?T`, `T!E`, `Option<T>`, `Result<T,E>` → runtime manifest keys) so combinator calls resolve as pure-modulo-arguments instead of unknown calls. 22 new resolver tests.
  - `bench/phase0-agent-native/` — pre-registered category registry, pair-manifest schema (iteration budget pinned as a constant), Calor-arm execution template, and seed pair W3-001 (fixture verified to compile under effect enforcement; emitted surface matches the arm shim).
- **Doc integrity**: CLAUDE.md corrected (removed-closer teaching → indent-only guidance, stale version reference, wrong lint code).

## Test plan

- `Calor.Compiler.Tests`: 5,639 passed (incl. 5 new FactScoping regression tests)
- `Calor.Verification.Tests`: 253 passed
- `Calor.Enforcement.Tests`: 271 passed (incl. 22 new manifest/mapping tests)
- Seed fixture compiles with `--enforce-effects`; emitted `AuditLog.AuditLogModule` surface verified against the test shim

## Notes for review

- The benchmark suite is explicitly **not frozen**; gates-doc ⚠ values freeze only after the dry-run feasibility calculation (its §6).
- The FactCollector change makes obligation discharge strictly more conservative; previously-Discharged results that relied on leaked guards will now report honestly (Failed/Unsupported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
