### PR TITLE
Phase 0: two-arm benchmark runner and first-wave fixture pairs

### DIFF
--- a/bench/phase0-agent-native/pairs/N1-001-string-utils/calor/TextUtils.calr
+++ b/bench/phase0-agent-native/pairs/N1-001-string-utils/calor/TextUtils.calr
@@ -1,0 +1,5 @@
+§M{m001:TextUtils}
+  §F{f001:Slugify:pub} (str:s) -> str
+    §E{}
+    §B{lower:str} §C{s.ToLowerInvariant} §/C
+    §R §C{lower.Replace} §A " " §A "-" §/C

--- a/bench/phase0-agent-native/pairs/N1-001-string-utils/csharp/TextUtils.cs
+++ b/bench/phase0-agent-native/pairs/N1-001-string-utils/csharp/TextUtils.cs
@@ -1,0 +1,9 @@
+namespace TextUtilsLib;
+
+public static class TextUtils
+{
+    public static string Slugify(string s)
+    {
+        return s.ToLowerInvariant().Replace(' ', '-');
+    }
+}

--- a/bench/phase0-agent-native/pairs/N1-001-string-utils/pair.json
+++ b/bench/phase0-agent-native/pairs/N1-001-string-utils/pair.json
@@ -1,0 +1,35 @@
+{
+  "id": "N1-001-string-utils",
+  "category": "N1",
+  "spec": "spec.md",
+  "tests": {
+    "path": "tests",
+    "runner": "dotnet-test",
+    "heldOut": true
+  },
+  "arms": {
+    "csharp": {
+      "fixture": "csharp",
+      "toolkit": "full"
+    },
+    "calor": {
+      "fixture": "calor",
+      "config": {
+        "enforceEffects": true,
+        "permissiveEffects": false,
+        "contractMode": "debug",
+        "z3Required": true
+      }
+    }
+  },
+  "parity": {
+    "csharpDeclCount": 3,
+    "calorDeclCount": 3,
+    "csharpComplexity": 7,
+    "calorComplexity": 7,
+    "notes": "Reference solutions are structurally parallel: Slugify (1), Truncate (two guards, 3), WordCount (split + filter loop, 3). Calor normalizes tab/CR/LF to spaces before splitting (its Split call takes one separator); C# passes multiple separator chars to Split — same complexity count, both first-order. Complexity counted as 1 per function + 1 per branch/loop. NOT yet difficulty-validated (gates doc §3.1)."
+  },
+  "wedgeWhitelistCheck": "n/a (neutral category)",
+  "iterationBudget": 10,
+  "timeoutSeconds": 600
+}

--- a/bench/phase0-agent-native/pairs/N1-001-string-utils/reference/calor/TextUtils.calr
+++ b/bench/phase0-agent-native/pairs/N1-001-string-utils/reference/calor/TextUtils.calr
@@ -1,0 +1,25 @@
+§M{m001:TextUtils}
+  §F{f001:Slugify:pub} (str:s) -> str
+    §E{}
+    §B{lower:str} §C{s.ToLowerInvariant} §/C
+    §R §C{lower.Replace} §A " " §A "-" §/C
+
+  §F{f002:Truncate:pub} (str:s, i32:maxLen) -> str
+    §E{}
+    §IF{if1} (<= §LEN s maxLen)
+      §R s
+    §IF{if2} (<= maxLen INT:3)
+      §R §C{s.Substring} §A INT:0 §A maxLen §/C
+    §R (+ §C{s.Substring} §A INT:0 §A (- maxLen INT:3) §/C "...")
+
+  §F{f003:WordCount:pub} (str:s) -> i32
+    §E{}
+    §B{tabs:str} §C{s.Replace} §A "\t" §A " " §/C
+    §B{returns:str} §C{tabs.Replace} §A "\r" §A " " §/C
+    §B{norm:str} §C{returns.Replace} §A "\n" §A " " §/C
+    §B{parts:[str]} §C{norm.Split} §A ' ' §/C
+    §B{~count:i32} INT:0
+    §EACH{e1:part} parts
+      §IF{if3} (> §LEN part INT:0)
+        §ASSIGN count (+ count INT:1)
+    §R count

--- a/bench/phase0-agent-native/pairs/N1-001-string-utils/reference/csharp/TextUtils.cs
+++ b/bench/phase0-agent-native/pairs/N1-001-string-utils/reference/csharp/TextUtils.cs
@@ -1,0 +1,26 @@
+namespace TextUtilsLib;
+
+public static class TextUtils
+{
+    public static string Slugify(string s)
+    {
+        return s.ToLowerInvariant().Replace(' ', '-');
+    }
+
+    public static string Truncate(string s, int maxLen)
+    {
+        if (s.Length <= maxLen) return s;
+        if (maxLen <= 3) return s.Substring(0, maxLen);
+        return s.Substring(0, maxLen - 3) + "...";
+    }
+
+    public static int WordCount(string s)
+    {
+        var count = 0;
+        foreach (var part in s.Split(' ', '\t', '\r', '\n'))
+        {
+            if (part.Length > 0) count++;
+        }
+        return count;
+    }
+}

--- a/bench/phase0-agent-native/pairs/N1-001-string-utils/spec.md
+++ b/bench/phase0-agent-native/pairs/N1-001-string-utils/spec.md
@@ -1,0 +1,36 @@
+# N1-001 — String Utils (behavioral specification)
+
+This is the only task statement either arm sees. It is arm-neutral: it specifies
+behavior and a public surface, never implementation language idioms.
+
+## Existing behavior (already implemented in the starting fixture)
+
+`Slugify(s)` → string — lowercases `s` and replaces every space with a hyphen.
+
+## Task: implement the missing operations
+
+1. `Truncate(s, maxLen)` → string — shortens `s` to at most `maxLen`
+   characters:
+   - If `s` has `maxLen` or fewer characters, return `s` unchanged.
+   - Otherwise, if `maxLen > 3`, return the first `maxLen - 3` characters of
+     `s` followed by `"..."` (the result is exactly `maxLen` characters).
+   - Otherwise (`maxLen <= 3`, ellipsis does not fit), return the first
+     `maxLen` characters of `s` with no ellipsis. `maxLen` of `0` yields the
+     empty string. `maxLen` is never negative.
+2. `WordCount(s)` → integer — the number of words in `s`, where words are
+   maximal runs of non-whitespace characters separated by whitespace (spaces,
+   tabs, carriage returns, and/or newlines). The empty string and
+   whitespace-only strings contain `0` words. Leading/trailing whitespace and
+   repeated whitespace between words must not affect the count.
+
+## Constraints
+
+- Pure string computation only: no filesystem, network, console, or other
+  side effects. Declare whatever your language requires to express that.
+- Do not change `Slugify`'s observable behavior.
+
+## Public surface (pinned; held-out tests bind to it via a fixed per-arm shim)
+
+Static functions `Slugify(string) → string`, `Truncate(string, int) → string`,
+`WordCount(string) → int`, reachable through the arm's `TestShim.cs`
+(provided by the harness; not editable by the agent).

--- a/bench/phase0-agent-native/pairs/N1-001-string-utils/tests/TextUtilsHeldOutTests.cs
+++ b/bench/phase0-agent-native/pairs/N1-001-string-utils/tests/TextUtilsHeldOutTests.cs
@@ -1,0 +1,76 @@
+// Arm-shared held-out tests (never shown to the agent under test).
+// Binds to the pinned public surface through the harness-provided TestShim
+// (per-arm, fixed, not agent-editable): Slugify / Truncate / WordCount.
+using Xunit;
+
+namespace TextUtils.HeldOut;
+
+public sealed class TextUtilsHeldOutTests
+{
+    [Fact]
+    public void Slugify_LowercasesAndHyphenates()
+    {
+        Assert.Equal("hello-brave-world", TestShim.Slugify("Hello Brave World"));
+    }
+
+    [Fact]
+    public void Truncate_ShorterThanMax_Unchanged()
+    {
+        Assert.Equal("hi", TestShim.Truncate("hi", 10));
+    }
+
+    [Fact]
+    public void Truncate_ExactlyMax_Unchanged()
+    {
+        Assert.Equal("hello", TestShim.Truncate("hello", 5));
+    }
+
+    [Fact]
+    public void Truncate_Longer_AddsEllipsis_AtExactLength()
+    {
+        Assert.Equal("hello w...", TestShim.Truncate("hello world plus", 10));
+        Assert.Equal(10, TestShim.Truncate("hello world plus", 10).Length);
+    }
+
+    [Fact]
+    public void Truncate_MaxLenThree_NoEllipsis()
+    {
+        Assert.Equal("hel", TestShim.Truncate("hello", 3));
+    }
+
+    [Fact]
+    public void Truncate_MaxLenZero_ReturnsEmpty()
+    {
+        Assert.Equal(string.Empty, TestShim.Truncate("hello", 0));
+    }
+
+    [Fact]
+    public void WordCount_EmptyString_ReturnsZero()
+    {
+        Assert.Equal(0, TestShim.WordCount(""));
+    }
+
+    [Fact]
+    public void WordCount_WhitespaceOnly_ReturnsZero()
+    {
+        Assert.Equal(0, TestShim.WordCount("   \t \n "));
+    }
+
+    [Fact]
+    public void WordCount_SingleWord()
+    {
+        Assert.Equal(1, TestShim.WordCount("hello"));
+    }
+
+    [Fact]
+    public void WordCount_MultipleWords_SpacesTabsNewlines()
+    {
+        Assert.Equal(4, TestShim.WordCount("one two\tthree\nfour"));
+    }
+
+    [Fact]
+    public void WordCount_IgnoresLeadingTrailingAndRepeatedWhitespace()
+    {
+        Assert.Equal(2, TestShim.WordCount("  alpha \t\t beta \n"));
+    }
+}

--- a/bench/phase0-agent-native/pairs/N1-001-string-utils/tests/shims/TestShim.calor.cs
+++ b/bench/phase0-agent-native/pairs/N1-001-string-utils/tests/shims/TestShim.calor.cs
@@ -1,0 +1,10 @@
+// Calor-arm shim (harness-provided, fixed, not agent-editable).
+// Calor module M emits namespace M / static class MModule.
+namespace TextUtils.HeldOut;
+
+internal static class TestShim
+{
+    public static string Slugify(string s) => global::TextUtils.TextUtilsModule.Slugify(s);
+    public static string Truncate(string s, int maxLen) => global::TextUtils.TextUtilsModule.Truncate(s, maxLen);
+    public static int WordCount(string s) => global::TextUtils.TextUtilsModule.WordCount(s);
+}

--- a/bench/phase0-agent-native/pairs/N1-001-string-utils/tests/shims/TestShim.csharp.cs
+++ b/bench/phase0-agent-native/pairs/N1-001-string-utils/tests/shims/TestShim.csharp.cs
@@ -1,0 +1,9 @@
+// C#-arm shim (harness-provided, fixed, not agent-editable).
+namespace TextUtils.HeldOut;
+
+internal static class TestShim
+{
+    public static string Slugify(string s) => TextUtilsLib.TextUtils.Slugify(s);
+    public static string Truncate(string s, int maxLen) => TextUtilsLib.TextUtils.Truncate(s, maxLen);
+    public static int WordCount(string s) => TextUtilsLib.TextUtils.WordCount(s);
+}

--- a/bench/phase0-agent-native/pairs/N1-002-inventory/calor/Inventory.calr
+++ b/bench/phase0-agent-native/pairs/N1-002-inventory/calor/Inventory.calr
@@ -1,0 +1,7 @@
+§M{m001:Inventory}
+  §F{f001:AddItem:pub} (Dictionary<str, i32>:items, str:name, i32:qty) -> void
+    §E{mut}
+    §IF{if1} §HAS{items} §KEY name
+      §PUT{items} name (+ §IDX items name qty)
+    §EL
+      §PUT{items} name qty

--- a/bench/phase0-agent-native/pairs/N1-002-inventory/csharp/Inventory.cs
+++ b/bench/phase0-agent-native/pairs/N1-002-inventory/csharp/Inventory.cs
@@ -1,0 +1,16 @@
+namespace InventoryLib;
+
+public static class Inventory
+{
+    public static void AddItem(Dictionary<string, int> items, string name, int qty)
+    {
+        if (items.ContainsKey(name))
+        {
+            items[name] += qty;
+        }
+        else
+        {
+            items[name] = qty;
+        }
+    }
+}

--- a/bench/phase0-agent-native/pairs/N1-002-inventory/pair.json
+++ b/bench/phase0-agent-native/pairs/N1-002-inventory/pair.json
@@ -1,0 +1,35 @@
+{
+  "id": "N1-002-inventory",
+  "category": "N1",
+  "spec": "spec.md",
+  "tests": {
+    "path": "tests",
+    "runner": "dotnet-test",
+    "heldOut": true
+  },
+  "arms": {
+    "csharp": {
+      "fixture": "csharp",
+      "toolkit": "full"
+    },
+    "calor": {
+      "fixture": "calor",
+      "config": {
+        "enforceEffects": true,
+        "permissiveEffects": false,
+        "contractMode": "debug",
+        "z3Required": true
+      }
+    }
+  },
+  "parity": {
+    "csharpDeclCount": 3,
+    "calorDeclCount": 3,
+    "csharpComplexity": 8,
+    "calorComplexity": 8,
+    "notes": "Dictionary<string,int> domain kept (no simplification needed): Calor supports it natively via §HAS/§PUT/§IDX/§EACHKV and instance Remove; the compiler requires declaring the 'mut' effect on the mutating functions (per the bcl-system Dictionary manifest), which the fixture demonstrates on AddItem. Reference solutions are structurally identical: AddItem (if/else, 2), RemoveItem (guard + if/else, 3), TotalCount (loop, 2), +1 base each. NOT yet difficulty-validated (gates doc §3.1)."
+  },
+  "wedgeWhitelistCheck": "n/a (neutral category)",
+  "iterationBudget": 10,
+  "timeoutSeconds": 600
+}

--- a/bench/phase0-agent-native/pairs/N1-002-inventory/reference/calor/Inventory.calr
+++ b/bench/phase0-agent-native/pairs/N1-002-inventory/reference/calor/Inventory.calr
@@ -1,0 +1,24 @@
+§M{m001:Inventory}
+  §F{f001:AddItem:pub} (Dictionary<str, i32>:items, str:name, i32:qty) -> void
+    §E{mut}
+    §IF{if1} §HAS{items} §KEY name
+      §PUT{items} name (+ §IDX items name qty)
+    §EL
+      §PUT{items} name qty
+
+  §F{f002:RemoveItem:pub} (Dictionary<str, i32>:items, str:name, i32:qty) -> void
+    §E{mut}
+    §IF{if2} (! §HAS{items} §KEY name)
+      §R
+    §B{remaining:i32} (- §IDX items name qty)
+    §IF{if3} (<= remaining INT:0)
+      §C{items.Remove} §A name §/C
+    §EL
+      §PUT{items} name remaining
+
+  §F{f003:TotalCount:pub} (Dictionary<str, i32>:items) -> i32
+    §E{}
+    §B{~total:i32} INT:0
+    §EACHKV{e1:name:qty} items
+      §ASSIGN total (+ total qty)
+    §R total

--- a/bench/phase0-agent-native/pairs/N1-002-inventory/reference/csharp/Inventory.cs
+++ b/bench/phase0-agent-native/pairs/N1-002-inventory/reference/csharp/Inventory.cs
@@ -1,0 +1,43 @@
+namespace InventoryLib;
+
+public static class Inventory
+{
+    public static void AddItem(Dictionary<string, int> items, string name, int qty)
+    {
+        if (items.ContainsKey(name))
+        {
+            items[name] += qty;
+        }
+        else
+        {
+            items[name] = qty;
+        }
+    }
+
+    public static void RemoveItem(Dictionary<string, int> items, string name, int qty)
+    {
+        if (!items.ContainsKey(name))
+        {
+            return;
+        }
+        var remaining = items[name] - qty;
+        if (remaining <= 0)
+        {
+            items.Remove(name);
+        }
+        else
+        {
+            items[name] = remaining;
+        }
+    }
+
+    public static int TotalCount(Dictionary<string, int> items)
+    {
+        var total = 0;
+        foreach (var qty in items.Values)
+        {
+            total += qty;
+        }
+        return total;
+    }
+}

--- a/bench/phase0-agent-native/pairs/N1-002-inventory/spec.md
+++ b/bench/phase0-agent-native/pairs/N1-002-inventory/spec.md
@@ -1,0 +1,41 @@
+# N1-002 — Inventory (behavioral specification)
+
+This is the only task statement either arm sees. It is arm-neutral: it specifies
+behavior and a public surface, never implementation language idioms.
+
+## Data model
+
+An inventory is a mutable name → quantity map (`Dictionary<string, int>`)
+owned by the caller and passed to every operation. Quantities in the map are
+always positive: a name with quantity `0` is never stored — it is simply
+absent from the map.
+
+## Existing behavior (already implemented in the starting fixture)
+
+`AddItem(items, name, qty)` — adds `qty` units of `name` to `items`: if
+`name` is already present its quantity is increased by `qty`, otherwise a new
+entry with quantity `qty` is created.
+
+## Task: implement the missing operations
+
+1. `RemoveItem(items, name, qty)` — removes `qty` units of `name` from
+   `items`:
+   - If `name` is not present, do nothing (no error).
+   - If the remaining quantity would be `0` or negative, remove the entry
+     entirely (quantities never go to zero or below — see data model).
+   - Otherwise decrease the quantity by `qty`.
+2. `TotalCount(items)` → integer — the sum of all quantities in `items`.
+   Returns `0` for an empty inventory.
+
+## Constraints
+
+- Operations mutate the caller's map in place; no filesystem, network, or
+  console effects. Declare whatever your language requires to express that.
+- Do not change `AddItem`'s observable behavior.
+
+## Public surface (pinned; held-out tests bind to it via a fixed per-arm shim)
+
+Static functions `AddItem(Dictionary<string, int>, string, int)`,
+`RemoveItem(Dictionary<string, int>, string, int)`,
+`TotalCount(Dictionary<string, int>) → int`, reachable through the arm's
+`TestShim.cs` (provided by the harness; not editable by the agent).

--- a/bench/phase0-agent-native/pairs/N1-002-inventory/tests/InventoryHeldOutTests.cs
+++ b/bench/phase0-agent-native/pairs/N1-002-inventory/tests/InventoryHeldOutTests.cs
@@ -1,0 +1,91 @@
+// Arm-shared held-out tests (never shown to the agent under test).
+// Binds to the pinned public surface through the harness-provided TestShim
+// (per-arm, fixed, not agent-editable): AddItem / RemoveItem / TotalCount.
+using Xunit;
+
+namespace Inventory.HeldOut;
+
+public sealed class InventoryHeldOutTests
+{
+    [Fact]
+    public void AddItem_NewName_CreatesEntry()
+    {
+        var items = new Dictionary<string, int>();
+        TestShim.AddItem(items, "bolt", 5);
+        Assert.Equal(5, items["bolt"]);
+    }
+
+    [Fact]
+    public void AddItem_ExistingName_IncreasesQuantity()
+    {
+        var items = new Dictionary<string, int>();
+        TestShim.AddItem(items, "bolt", 5);
+        TestShim.AddItem(items, "bolt", 3);
+        Assert.Equal(8, items["bolt"]);
+    }
+
+    [Fact]
+    public void RemoveItem_PartialQuantity_Decrements()
+    {
+        var items = new Dictionary<string, int> { ["bolt"] = 5 };
+        TestShim.RemoveItem(items, "bolt", 2);
+        Assert.Equal(3, items["bolt"]);
+    }
+
+    [Fact]
+    public void RemoveItem_ExactQuantity_RemovesEntry()
+    {
+        var items = new Dictionary<string, int> { ["bolt"] = 5 };
+        TestShim.RemoveItem(items, "bolt", 5);
+        Assert.False(items.ContainsKey("bolt"));
+    }
+
+    [Fact]
+    public void RemoveItem_MoreThanHeld_RemovesEntry()
+    {
+        var items = new Dictionary<string, int> { ["bolt"] = 5 };
+        TestShim.RemoveItem(items, "bolt", 9);
+        Assert.False(items.ContainsKey("bolt"));
+    }
+
+    [Fact]
+    public void RemoveItem_MissingName_DoesNothing()
+    {
+        var items = new Dictionary<string, int> { ["nut"] = 2 };
+        TestShim.RemoveItem(items, "bolt", 1);
+        Assert.Single(items);
+        Assert.Equal(2, items["nut"]);
+    }
+
+    [Fact]
+    public void RemoveItem_DoesNotDisturbOtherEntries()
+    {
+        var items = new Dictionary<string, int> { ["nut"] = 2, ["bolt"] = 4 };
+        TestShim.RemoveItem(items, "bolt", 4);
+        Assert.Equal(2, items["nut"]);
+        Assert.False(items.ContainsKey("bolt"));
+    }
+
+    [Fact]
+    public void TotalCount_EmptyInventory_ReturnsZero()
+    {
+        Assert.Equal(0, TestShim.TotalCount(new Dictionary<string, int>()));
+    }
+
+    [Fact]
+    public void TotalCount_SumsAllQuantities()
+    {
+        var items = new Dictionary<string, int> { ["nut"] = 2, ["bolt"] = 4, ["washer"] = 10 };
+        Assert.Equal(16, TestShim.TotalCount(items));
+    }
+
+    [Fact]
+    public void AddThenRemove_EndToEnd()
+    {
+        var items = new Dictionary<string, int>();
+        TestShim.AddItem(items, "bolt", 5);
+        TestShim.AddItem(items, "nut", 7);
+        TestShim.RemoveItem(items, "bolt", 5);
+        Assert.Equal(7, TestShim.TotalCount(items));
+    }
+}

--- a/bench/phase0-agent-native/pairs/N1-002-inventory/tests/shims/TestShim.calor.cs
+++ b/bench/phase0-agent-native/pairs/N1-002-inventory/tests/shims/TestShim.calor.cs
@@ -1,0 +1,10 @@
+// Calor-arm shim (harness-provided, fixed, not agent-editable).
+// Calor module M emits namespace M / static class MModule.
+namespace Inventory.HeldOut;
+
+internal static class TestShim
+{
+    public static void AddItem(Dictionary<string, int> items, string name, int qty) => global::Inventory.InventoryModule.AddItem(items, name, qty);
+    public static void RemoveItem(Dictionary<string, int> items, string name, int qty) => global::Inventory.InventoryModule.RemoveItem(items, name, qty);
+    public static int TotalCount(Dictionary<string, int> items) => global::Inventory.InventoryModule.TotalCount(items);
+}

--- a/bench/phase0-agent-native/pairs/N1-002-inventory/tests/shims/TestShim.csharp.cs
+++ b/bench/phase0-agent-native/pairs/N1-002-inventory/tests/shims/TestShim.csharp.cs
@@ -1,0 +1,9 @@
+// C#-arm shim (harness-provided, fixed, not agent-editable).
+namespace Inventory.HeldOut;
+
+internal static class TestShim
+{
+    public static void AddItem(Dictionary<string, int> items, string name, int qty) => InventoryLib.Inventory.AddItem(items, name, qty);
+    public static void RemoveItem(Dictionary<string, int> items, string name, int qty) => InventoryLib.Inventory.RemoveItem(items, name, qty);
+    public static int TotalCount(Dictionary<string, int> items) => InventoryLib.Inventory.TotalCount(items);
+}

--- a/bench/phase0-agent-native/pairs/W1-001-temperature-converter/calor/TempConvert.calr
+++ b/bench/phase0-agent-native/pairs/W1-001-temperature-converter/calor/TempConvert.calr
@@ -1,0 +1,30 @@
+§M{m001:TempConvert}
+  §F{f001:CelsiusToFahrenheit:pub} (i32:celsius) -> i32
+    §E{}
+    §Q (>= celsius -273)
+    §S (>= result -459)
+    §S (<= result 9032)
+    §B{~c:i32} celsius
+    §IF{if1} (> c 5000)
+      §ASSIGN c 5000
+    §R (+ (/ (* c 9) 5) 32)
+
+  §F{f002:CelsiusToKelvin:pub} (i32:celsius) -> i32
+    §E{}
+    §Q (>= celsius -273)
+    §S (>= result 0)
+    §S (<= result 5273)
+    §B{~c:i32} celsius
+    §IF{if2} (> c 5000)
+      §ASSIGN c 5000
+    §R (+ c 273)
+
+  §F{f003:FahrenheitToCelsius:pub} (i32:fahrenheit) -> i32
+    §E{}
+    §Q (>= fahrenheit -459)
+    §S (>= result -273)
+    §S (<= result 5000)
+    §B{~f:i32} fahrenheit
+    §IF{if3} (> f 9032)
+      §ASSIGN f 9032
+    §R (/ (* (- f 32) 5) 9)

--- a/bench/phase0-agent-native/pairs/W1-001-temperature-converter/csharp/TempConvert.cs
+++ b/bench/phase0-agent-native/pairs/W1-001-temperature-converter/csharp/TempConvert.cs
@@ -1,0 +1,43 @@
+namespace TempConvertLib;
+
+/// <summary>
+/// Integer temperature conversions. All arithmetic is 32-bit integer
+/// arithmetic; division truncates toward zero. Inputs above each
+/// conversion's measurement ceiling are treated as the ceiling.
+/// Callers must not pass values below absolute zero.
+/// </summary>
+public static class TempConvert
+{
+    public static int CelsiusToFahrenheit(int celsius)
+    {
+        // Clamp to the supported measurement ceiling.
+        int c = celsius;
+        if (c > 5000)
+        {
+            c = 5000;
+        }
+        return c * 9 / 5 + 32;
+    }
+
+    public static int CelsiusToKelvin(int celsius)
+    {
+        // Clamp to the supported measurement ceiling.
+        int c = celsius;
+        if (c > 5000)
+        {
+            c = 5000;
+        }
+        return c + 273;
+    }
+
+    public static int FahrenheitToCelsius(int fahrenheit)
+    {
+        // Clamp to the supported measurement ceiling.
+        int f = fahrenheit;
+        if (f > 9032)
+        {
+            f = 9032;
+        }
+        return (f - 32) * 5 / 9;
+    }
+}

--- a/bench/phase0-agent-native/pairs/W1-001-temperature-converter/pair.json
+++ b/bench/phase0-agent-native/pairs/W1-001-temperature-converter/pair.json
@@ -1,0 +1,35 @@
+{
+  "id": "W1-001-temperature-converter",
+  "category": "W1",
+  "spec": "spec.md",
+  "tests": {
+    "path": "tests",
+    "runner": "dotnet-test",
+    "heldOut": true
+  },
+  "arms": {
+    "csharp": {
+      "fixture": "csharp",
+      "toolkit": "full"
+    },
+    "calor": {
+      "fixture": "calor",
+      "config": {
+        "enforceEffects": true,
+        "permissiveEffects": false,
+        "contractMode": "debug",
+        "z3Required": true
+      }
+    }
+  },
+  "parity": {
+    "csharpDeclCount": 4,
+    "calorDeclCount": 4,
+    "csharpComplexity": 6,
+    "calorComplexity": 6,
+    "notes": "Fixture per arm: 1 static class/module + 3 conversion functions, each base 1 + one clamp branch = 2. Structurally identical across arms. NOT yet difficulty-validated (gates doc §3.1) — do not use as gate evidence before the equivalence pass."
+  },
+  "wedgeWhitelistCheck": "All Calor-arm contracts are scalar i32 comparisons over a single parameter, `result`, and integer literals: (>= celsius -273), (>= fahrenheit -459), (>= kelvin 0), (<= result ceiling), and result-range bounds like (>= result -459)/(<= result 9032). These are binary comparison operators over BitVec32 variables and signed 32-bit literals — modeled-forms §1 (i32 variables) and §2 (binary comparison operators, integer literals). No function calls, no floats, no strings, no arrays, no generic-typed values appear in any contract. All functions are pure (§E{}), so no effect-manifest coverage is required.",
+  "iterationBudget": 10,
+  "timeoutSeconds": 600
+}

--- a/bench/phase0-agent-native/pairs/W1-001-temperature-converter/reference/calor/TempConvert.calr
+++ b/bench/phase0-agent-native/pairs/W1-001-temperature-converter/reference/calor/TempConvert.calr
@@ -1,0 +1,39 @@
+§M{m001:TempConvert}
+  §F{f005:ClampToCeiling:pri} (i32:value, i32:ceiling) -> i32
+    §E{}
+    §S (<= result ceiling)
+    §IF{if4} (> value ceiling)
+      §R ceiling
+    §R value
+
+  §F{f001:CelsiusToFahrenheit:pub} (i32:celsius) -> i32
+    §E{}
+    §Q (>= celsius -273)
+    §S (>= result -459)
+    §S (<= result 9032)
+    §B{c:i32} §C{ClampToCeiling} §A celsius §A 5000 §/C
+    §R (+ (/ (* c 9) 5) 32)
+
+  §F{f002:CelsiusToKelvin:pub} (i32:celsius) -> i32
+    §E{}
+    §Q (>= celsius -273)
+    §S (>= result 0)
+    §S (<= result 5273)
+    §B{c:i32} §C{ClampToCeiling} §A celsius §A 5000 §/C
+    §R (+ c 273)
+
+  §F{f003:FahrenheitToCelsius:pub} (i32:fahrenheit) -> i32
+    §E{}
+    §Q (>= fahrenheit -459)
+    §S (>= result -273)
+    §S (<= result 5000)
+    §B{f:i32} §C{ClampToCeiling} §A fahrenheit §A 9032 §/C
+    §R (/ (* (- f 32) 5) 9)
+
+  §F{f004:KelvinToCelsius:pub} (i32:kelvin) -> i32
+    §E{}
+    §Q (>= kelvin 0)
+    §S (>= result -273)
+    §S (<= result 5000)
+    §B{k:i32} §C{ClampToCeiling} §A kelvin §A 5273 §/C
+    §R (- k 273)

--- a/bench/phase0-agent-native/pairs/W1-001-temperature-converter/reference/csharp/TempConvert.cs
+++ b/bench/phase0-agent-native/pairs/W1-001-temperature-converter/reference/csharp/TempConvert.cs
@@ -1,0 +1,37 @@
+namespace TempConvertLib;
+
+/// <summary>
+/// Integer temperature conversions. All arithmetic is 32-bit integer
+/// arithmetic; division truncates toward zero. Inputs above each
+/// conversion's measurement ceiling are treated as the ceiling.
+/// Callers must not pass values below absolute zero.
+/// </summary>
+public static class TempConvert
+{
+    private static int ClampToCeiling(int value, int ceiling)
+        => value > ceiling ? ceiling : value;
+
+    public static int CelsiusToFahrenheit(int celsius)
+    {
+        int c = ClampToCeiling(celsius, 5000);
+        return c * 9 / 5 + 32;
+    }
+
+    public static int CelsiusToKelvin(int celsius)
+    {
+        int c = ClampToCeiling(celsius, 5000);
+        return c + 273;
+    }
+
+    public static int FahrenheitToCelsius(int fahrenheit)
+    {
+        int f = ClampToCeiling(fahrenheit, 9032);
+        return (f - 32) * 5 / 9;
+    }
+
+    public static int KelvinToCelsius(int kelvin)
+    {
+        int k = ClampToCeiling(kelvin, 5273);
+        return k - 273;
+    }
+}

--- a/bench/phase0-agent-native/pairs/W1-001-temperature-converter/spec.md
+++ b/bench/phase0-agent-native/pairs/W1-001-temperature-converter/spec.md
@@ -1,0 +1,52 @@
+# W1-001 — Temperature Converter (behavioral specification)
+
+This is the only task statement either arm sees. It is arm-neutral: it specifies
+behavior and a public surface, never implementation language idioms.
+
+## Existing behavior (already implemented in the starting fixture)
+
+Integer temperature conversions between degrees Celsius, degrees Fahrenheit,
+and kelvins. All arithmetic is 32-bit integer arithmetic; division truncates
+toward zero.
+
+Every conversion first clamps its input to a supported measurement ceiling
+(inputs above the ceiling are treated as the ceiling), then converts:
+
+1. `CelsiusToFahrenheit(c)` — clamps `c` to at most `5000`, returns
+   `c * 9 / 5 + 32`.
+2. `CelsiusToKelvin(c)` — clamps `c` to at most `5000`, returns `c + 273`.
+3. `FahrenheitToCelsius(f)` — clamps `f` to at most `9032`, returns
+   `(f - 32) * 5 / 9`.
+
+Valid input domain (callers must respect it; enforce it where your language
+can): `CelsiusToFahrenheit` / `CelsiusToKelvin` require `c >= -273`;
+`FahrenheitToCelsius` requires `f >= -459`. Behavior below absolute zero is
+outside the contract.
+
+Guaranteed output ranges (must be preserved; declare them where your language
+can): `CelsiusToFahrenheit` in `[-459, 9032]`; `CelsiusToKelvin` in
+`[0, 5273]`; `FahrenheitToCelsius` in `[-273, 5000]`.
+
+## Task
+
+1. **Refactor:** the input-ceiling clamping logic is duplicated in every
+   conversion function. Consolidate it into a single shared implementation.
+   All existing observable behavior — including every declared input-domain
+   and output-range guarantee — must be preserved exactly.
+2. **Add** `KelvinToCelsius(k)` — clamps `k` to at most `5273`, returns
+   `k - 273`. Valid input domain `k >= 0`; guaranteed output range
+   `[-273, 5000]`.
+
+## Constraints
+
+- Pure computation only: no I/O, no global state, no floating point.
+- Do not change any existing function's observable behavior.
+- Extend the same domain/range guarantees to the new function wherever your
+  language expresses them.
+
+## Public surface (pinned; held-out tests bind to it via a fixed per-arm shim)
+
+Static functions `CelsiusToFahrenheit(int) → int`,
+`CelsiusToKelvin(int) → int`, `FahrenheitToCelsius(int) → int`,
+`KelvinToCelsius(int) → int`, reachable through the arm's `TestShim.cs`
+(provided by the harness; not editable by the agent).

--- a/bench/phase0-agent-native/pairs/W1-001-temperature-converter/tests/TempConvertHeldOutTests.cs
+++ b/bench/phase0-agent-native/pairs/W1-001-temperature-converter/tests/TempConvertHeldOutTests.cs
@@ -1,0 +1,94 @@
+// Arm-shared held-out tests (never shown to the agent under test).
+// Binds to the pinned public surface through the harness-provided TestShim
+// (per-arm, fixed, not agent-editable): CelsiusToFahrenheit /
+// CelsiusToKelvin / FahrenheitToCelsius / KelvinToCelsius.
+using Xunit;
+
+namespace TempConvert.HeldOut;
+
+public sealed class TempConvertHeldOutTests
+{
+    // --- CelsiusToFahrenheit ---
+
+    [Theory]
+    [InlineData(-273, -459)] // absolute zero boundary
+    [InlineData(0, 32)]
+    [InlineData(37, 98)]     // truncating division: 333 / 5 = 66
+    [InlineData(100, 212)]
+    [InlineData(5000, 9032)] // ceiling boundary
+    public void CelsiusToFahrenheit_ConvertsCorrectly(int celsius, int expected)
+    {
+        Assert.Equal(expected, TestShim.CelsiusToFahrenheit(celsius));
+    }
+
+    [Fact]
+    public void CelsiusToFahrenheit_ClampsAboveCeiling()
+    {
+        Assert.Equal(9032, TestShim.CelsiusToFahrenheit(6000));
+    }
+
+    // --- CelsiusToKelvin ---
+
+    [Theory]
+    [InlineData(-273, 0)]    // absolute zero boundary
+    [InlineData(0, 273)]
+    [InlineData(5000, 5273)] // ceiling boundary
+    public void CelsiusToKelvin_ConvertsCorrectly(int celsius, int expected)
+    {
+        Assert.Equal(expected, TestShim.CelsiusToKelvin(celsius));
+    }
+
+    [Fact]
+    public void CelsiusToKelvin_ClampsAboveCeiling()
+    {
+        Assert.Equal(5273, TestShim.CelsiusToKelvin(9999));
+    }
+
+    // --- FahrenheitToCelsius ---
+
+    [Theory]
+    [InlineData(-459, -272)] // truncation toward zero: -2455 / 9 = -272
+    [InlineData(32, 0)]
+    [InlineData(98, 36)]     // truncating division: 330 / 9 = 36
+    [InlineData(212, 100)]
+    [InlineData(9032, 5000)] // ceiling boundary
+    public void FahrenheitToCelsius_ConvertsCorrectly(int fahrenheit, int expected)
+    {
+        Assert.Equal(expected, TestShim.FahrenheitToCelsius(fahrenheit));
+    }
+
+    [Fact]
+    public void FahrenheitToCelsius_ClampsAboveCeiling()
+    {
+        Assert.Equal(5000, TestShim.FahrenheitToCelsius(10000));
+    }
+
+    // --- KelvinToCelsius (new function) ---
+
+    [Theory]
+    [InlineData(0, -273)]    // absolute zero boundary
+    [InlineData(273, 0)]
+    [InlineData(310, 37)]
+    [InlineData(5273, 5000)] // ceiling boundary
+    public void KelvinToCelsius_ConvertsCorrectly(int kelvin, int expected)
+    {
+        Assert.Equal(expected, TestShim.KelvinToCelsius(kelvin));
+    }
+
+    [Fact]
+    public void KelvinToCelsius_ClampsAboveCeiling()
+    {
+        Assert.Equal(5000, TestShim.KelvinToCelsius(6000));
+    }
+
+    // --- Round trips inside the shared domain ---
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(100)]
+    [InlineData(4000)]
+    public void CelsiusKelvinRoundTrip_IsIdentity(int celsius)
+    {
+        Assert.Equal(celsius, TestShim.KelvinToCelsius(TestShim.CelsiusToKelvin(celsius)));
+    }
+}

--- a/bench/phase0-agent-native/pairs/W1-001-temperature-converter/tests/shims/TestShim.calor.cs
+++ b/bench/phase0-agent-native/pairs/W1-001-temperature-converter/tests/shims/TestShim.calor.cs
@@ -1,0 +1,11 @@
+// Calor-arm shim (harness-provided, fixed, not agent-editable).
+// Calor module M emits namespace M / static class MModule.
+namespace TempConvert.HeldOut;
+
+internal static class TestShim
+{
+    public static int CelsiusToFahrenheit(int celsius) => global::TempConvert.TempConvertModule.CelsiusToFahrenheit(celsius);
+    public static int CelsiusToKelvin(int celsius) => global::TempConvert.TempConvertModule.CelsiusToKelvin(celsius);
+    public static int FahrenheitToCelsius(int fahrenheit) => global::TempConvert.TempConvertModule.FahrenheitToCelsius(fahrenheit);
+    public static int KelvinToCelsius(int kelvin) => global::TempConvert.TempConvertModule.KelvinToCelsius(kelvin);
+}

--- a/bench/phase0-agent-native/pairs/W1-001-temperature-converter/tests/shims/TestShim.csharp.cs
+++ b/bench/phase0-agent-native/pairs/W1-001-temperature-converter/tests/shims/TestShim.csharp.cs
@@ -1,0 +1,10 @@
+// C#-arm shim (harness-provided, fixed, not agent-editable).
+namespace TempConvert.HeldOut;
+
+internal static class TestShim
+{
+    public static int CelsiusToFahrenheit(int celsius) => TempConvertLib.TempConvert.CelsiusToFahrenheit(celsius);
+    public static int CelsiusToKelvin(int celsius) => TempConvertLib.TempConvert.CelsiusToKelvin(celsius);
+    public static int FahrenheitToCelsius(int fahrenheit) => TempConvertLib.TempConvert.FahrenheitToCelsius(fahrenheit);
+    public static int KelvinToCelsius(int kelvin) => TempConvertLib.TempConvert.KelvinToCelsius(kelvin);
+}

--- a/bench/phase0-agent-native/pairs/W2-001-int-stats/calor/Stats.calr
+++ b/bench/phase0-agent-native/pairs/W2-001-int-stats/calor/Stats.calr
@@ -1,0 +1,24 @@
+§M{m001:Stats}
+  §F{f001:Min:pub} ([i32]:values) -> i32
+    §E{}
+    §Q (> §LEN values 0)
+    §B{~smallest:i32} §IDX values 0
+    §B{~i:i32} 1
+    §WH{wh1} (< i (len values))
+      §B{v:i32} §IDX values i
+      §IF{if1} (< v smallest)
+        §ASSIGN smallest v
+      §ASSIGN i (+ i 1)
+    §R smallest
+
+  §F{f002:Max:pub} ([i32]:values) -> i32
+    §E{}
+    §Q (> §LEN values 0)
+    §B{~largest:i32} §IDX values 0
+    §B{~i:i32} 1
+    §WH{wh2} (< i (len values))
+      §B{v:i32} §IDX values i
+      §IF{if2} (> v largest)
+        §ASSIGN largest v
+      §ASSIGN i (+ i 1)
+    §R largest

--- a/bench/phase0-agent-native/pairs/W2-001-int-stats/csharp/Stats.cs
+++ b/bench/phase0-agent-native/pairs/W2-001-int-stats/csharp/Stats.cs
@@ -1,0 +1,34 @@
+namespace StatsLib;
+
+/// <summary>
+/// Integer statistics over int arrays. All arithmetic is 32-bit;
+/// division truncates toward zero. Min and Max require a non-empty array.
+/// </summary>
+public static class Stats
+{
+    public static int Min(int[] values)
+    {
+        int min = values[0];
+        for (int i = 1; i < values.Length; i++)
+        {
+            if (values[i] < min)
+            {
+                min = values[i];
+            }
+        }
+        return min;
+    }
+
+    public static int Max(int[] values)
+    {
+        int max = values[0];
+        for (int i = 1; i < values.Length; i++)
+        {
+            if (values[i] > max)
+            {
+                max = values[i];
+            }
+        }
+        return max;
+    }
+}

--- a/bench/phase0-agent-native/pairs/W2-001-int-stats/pair.json
+++ b/bench/phase0-agent-native/pairs/W2-001-int-stats/pair.json
@@ -1,0 +1,35 @@
+{
+  "id": "W2-001-int-stats",
+  "category": "W2",
+  "spec": "spec.md",
+  "tests": {
+    "path": "tests",
+    "runner": "dotnet-test",
+    "heldOut": true
+  },
+  "arms": {
+    "csharp": {
+      "fixture": "csharp",
+      "toolkit": "full"
+    },
+    "calor": {
+      "fixture": "calor",
+      "config": {
+        "enforceEffects": true,
+        "permissiveEffects": false,
+        "contractMode": "debug",
+        "z3Required": true
+      }
+    }
+  },
+  "parity": {
+    "csharpDeclCount": 3,
+    "calorDeclCount": 3,
+    "csharpComplexity": 6,
+    "calorComplexity": 6,
+    "notes": "Fixture per arm: 1 static class/module + Min + Max; each function is base 1 + loop + comparison branch = 3. Structurally identical across arms. NOT yet difficulty-validated (gates doc §3.1) — do not use as gate evidence before the equivalence pass."
+  },
+  "wedgeWhitelistCheck": "Calor-arm contracts: (> §LEN values 0) on Min/Max/Mean — array length of a simple variable base, modeled per modeled-forms §2 ('array length (simple variable base only)', ArrayLengthNode -> u32 $length variable); (<= lo hi), (>= result lo), (<= result hi) on Clamp — binary comparisons over i32 parameters, result, and integer literals per §1/§2. No function calls, no floats, no strings, no computed array bases, no generic-typed values appear in any contract. All functions are pure (§E{}), so no effect-manifest coverage is required.",
+  "iterationBudget": 10,
+  "timeoutSeconds": 600
+}

--- a/bench/phase0-agent-native/pairs/W2-001-int-stats/reference/calor/Stats.calr
+++ b/bench/phase0-agent-native/pairs/W2-001-int-stats/reference/calor/Stats.calr
@@ -1,0 +1,52 @@
+§M{m001:Stats}
+  §F{f001:Min:pub} ([i32]:values) -> i32
+    §E{}
+    §Q (> §LEN values 0)
+    §B{~smallest:i32} §IDX values 0
+    §B{~i:i32} 1
+    §WH{wh1} (< i (len values))
+      §B{v:i32} §IDX values i
+      §IF{if1} (< v smallest)
+        §ASSIGN smallest v
+      §ASSIGN i (+ i 1)
+    §R smallest
+
+  §F{f002:Max:pub} ([i32]:values) -> i32
+    §E{}
+    §Q (> §LEN values 0)
+    §B{~largest:i32} §IDX values 0
+    §B{~i:i32} 1
+    §WH{wh2} (< i (len values))
+      §B{v:i32} §IDX values i
+      §IF{if2} (> v largest)
+        §ASSIGN largest v
+      §ASSIGN i (+ i 1)
+    §R largest
+
+  §F{f003:Sum:pub} ([i32]:values) -> i32
+    §E{}
+    §B{~total:i32} 0
+    §B{~i:i32} 0
+    §WH{wh3} (< i (len values))
+      §B{v:i32} §IDX values i
+      §ASSIGN total (+ total v)
+      §ASSIGN i (+ i 1)
+    §R total
+
+  §F{f004:Mean:pub} ([i32]:values) -> i32
+    §E{}
+    §Q (> §LEN values 0)
+    §B{total:i32} §C{Sum} §A values §/C
+    §B{n:i32} §LEN values
+    §R (/ total n)
+
+  §F{f005:Clamp:pub} (i32:value, i32:lo, i32:hi) -> i32
+    §E{}
+    §Q (<= lo hi)
+    §S (>= result lo)
+    §S (<= result hi)
+    §IF{if3} (< value lo)
+      §R lo
+    §IF{if4} (> value hi)
+      §R hi
+    §R value

--- a/bench/phase0-agent-native/pairs/W2-001-int-stats/reference/csharp/Stats.cs
+++ b/bench/phase0-agent-native/pairs/W2-001-int-stats/reference/csharp/Stats.cs
@@ -1,0 +1,63 @@
+namespace StatsLib;
+
+/// <summary>
+/// Integer statistics over int arrays. All arithmetic is 32-bit;
+/// division truncates toward zero. Min, Max, and Mean require a
+/// non-empty array.
+/// </summary>
+public static class Stats
+{
+    public static int Min(int[] values)
+    {
+        int min = values[0];
+        for (int i = 1; i < values.Length; i++)
+        {
+            if (values[i] < min)
+            {
+                min = values[i];
+            }
+        }
+        return min;
+    }
+
+    public static int Max(int[] values)
+    {
+        int max = values[0];
+        for (int i = 1; i < values.Length; i++)
+        {
+            if (values[i] > max)
+            {
+                max = values[i];
+            }
+        }
+        return max;
+    }
+
+    public static int Sum(int[] values)
+    {
+        int total = 0;
+        for (int i = 0; i < values.Length; i++)
+        {
+            total += values[i];
+        }
+        return total;
+    }
+
+    public static int Mean(int[] values)
+    {
+        return Sum(values) / values.Length;
+    }
+
+    public static int Clamp(int value, int lo, int hi)
+    {
+        if (value < lo)
+        {
+            return lo;
+        }
+        if (value > hi)
+        {
+            return hi;
+        }
+        return value;
+    }
+}

--- a/bench/phase0-agent-native/pairs/W2-001-int-stats/spec.md
+++ b/bench/phase0-agent-native/pairs/W2-001-int-stats/spec.md
@@ -1,0 +1,40 @@
+# W2-001 — Integer Statistics (behavioral specification)
+
+This is the only task statement either arm sees. It is arm-neutral: it specifies
+behavior and a public surface, never implementation language idioms.
+
+All arithmetic is 32-bit integer arithmetic; division truncates toward zero.
+
+## Existing behavior (already implemented in the starting fixture)
+
+1. `Min(values)` — returns the smallest element of the integer array `values`.
+2. `Max(values)` — returns the largest element of the integer array `values`.
+
+Both require a non-empty array (callers must respect this; it is enforced
+where your language can express it).
+
+## Task: implement the missing operations
+
+1. `Sum(values)` → integer — sum of all elements. **Edge case:** the sum of an
+   empty array is `0`. (Callers keep totals small enough that no 32-bit
+   overflow occurs; overflow behavior is outside the contract.)
+2. `Mean(values)` → integer — arithmetic mean, i.e. `Sum(values)` divided by
+   the number of elements using truncating integer division (toward zero;
+   e.g. the mean of `-3` and `-4` is `-3`). **Requires a non-empty array** —
+   declare this requirement where your language can express it; callers must
+   respect it.
+3. `Clamp(value, lo, hi)` → integer — `lo` if `value < lo`, `hi` if
+   `value > hi`, otherwise `value`. **Requires `lo <= hi`** (declare where
+   expressible). The result is guaranteed to lie in `[lo, hi]` — declare this
+   guarantee where your language can express it.
+
+## Constraints
+
+- Pure computation only: no I/O, no global state, no floating point.
+- Do not change `Min` or `Max`'s observable behavior.
+
+## Public surface (pinned; held-out tests bind to it via a fixed per-arm shim)
+
+Static functions `Min(int[]) → int`, `Max(int[]) → int`, `Sum(int[]) → int`,
+`Mean(int[]) → int`, `Clamp(int, int, int) → int`, reachable through the
+arm's `TestShim.cs` (provided by the harness; not editable by the agent).

--- a/bench/phase0-agent-native/pairs/W2-001-int-stats/tests/StatsHeldOutTests.cs
+++ b/bench/phase0-agent-native/pairs/W2-001-int-stats/tests/StatsHeldOutTests.cs
@@ -1,0 +1,73 @@
+// Arm-shared held-out tests (never shown to the agent under test).
+// Binds to the pinned public surface through the harness-provided TestShim
+// (per-arm, fixed, not agent-editable): Min / Max / Sum / Mean / Clamp.
+using Xunit;
+
+namespace Stats.HeldOut;
+
+public sealed class StatsHeldOutTests
+{
+    // --- Min / Max (pre-existing behavior must be preserved) ---
+
+    [Fact]
+    public void Min_FindsSmallestElement()
+    {
+        Assert.Equal(1, TestShim.Min(new[] { 3, 1, 2 }));
+        Assert.Equal(-8, TestShim.Min(new[] { 4, -8, 0, 7 }));
+        Assert.Equal(-5, TestShim.Min(new[] { -5 }));
+    }
+
+    [Fact]
+    public void Max_FindsLargestElement()
+    {
+        Assert.Equal(3, TestShim.Max(new[] { 3, 1, 2 }));
+        Assert.Equal(7, TestShim.Max(new[] { 4, -8, 0, 7 }));
+        Assert.Equal(-5, TestShim.Max(new[] { -5 }));
+    }
+
+    // --- Sum ---
+
+    [Fact]
+    public void Sum_EmptyArray_ReturnsZero()
+    {
+        Assert.Equal(0, TestShim.Sum(System.Array.Empty<int>()));
+    }
+
+    [Theory]
+    [InlineData(new[] { 1, 2, 3 }, 6)]
+    [InlineData(new[] { -2, 7, -5 }, 0)]
+    [InlineData(new[] { 42 }, 42)]
+    [InlineData(new[] { -1, -2, -3 }, -6)]
+    public void Sum_AddsAllElements(int[] values, int expected)
+    {
+        Assert.Equal(expected, TestShim.Sum(values));
+    }
+
+    // --- Mean (truncating integer division, toward zero) ---
+
+    [Theory]
+    [InlineData(new[] { 10 }, 10)]
+    [InlineData(new[] { 2, 3, 4 }, 3)]
+    [InlineData(new[] { 1, 2 }, 1)]      // 3 / 2 truncates to 1
+    [InlineData(new[] { -3, -4 }, -3)]   // -7 / 2 truncates toward zero to -3
+    [InlineData(new[] { -1, 1 }, 0)]
+    public void Mean_UsesTruncatingDivision(int[] values, int expected)
+    {
+        Assert.Equal(expected, TestShim.Mean(values));
+    }
+
+    // --- Clamp ---
+
+    [Theory]
+    [InlineData(5, 0, 10, 5)]    // inside range
+    [InlineData(-1, 0, 10, 0)]   // below lo
+    [InlineData(11, 0, 10, 10)]  // above hi
+    [InlineData(0, 0, 10, 0)]    // at lo boundary
+    [InlineData(10, 0, 10, 10)]  // at hi boundary
+    [InlineData(7, 7, 7, 7)]     // degenerate range lo == hi
+    [InlineData(-100, -50, -10, -50)]
+    public void Clamp_BoundsValueIntoRange(int value, int lo, int hi, int expected)
+    {
+        Assert.Equal(expected, TestShim.Clamp(value, lo, hi));
+    }
+}

--- a/bench/phase0-agent-native/pairs/W2-001-int-stats/tests/shims/TestShim.calor.cs
+++ b/bench/phase0-agent-native/pairs/W2-001-int-stats/tests/shims/TestShim.calor.cs
@@ -1,0 +1,12 @@
+// Calor-arm shim (harness-provided, fixed, not agent-editable).
+// Calor module M emits namespace M / static class MModule.
+namespace Stats.HeldOut;
+
+internal static class TestShim
+{
+    public static int Min(int[] values) => global::Stats.StatsModule.Min(values);
+    public static int Max(int[] values) => global::Stats.StatsModule.Max(values);
+    public static int Sum(int[] values) => global::Stats.StatsModule.Sum(values);
+    public static int Mean(int[] values) => global::Stats.StatsModule.Mean(values);
+    public static int Clamp(int value, int lo, int hi) => global::Stats.StatsModule.Clamp(value, lo, hi);
+}

--- a/bench/phase0-agent-native/pairs/W2-001-int-stats/tests/shims/TestShim.csharp.cs
+++ b/bench/phase0-agent-native/pairs/W2-001-int-stats/tests/shims/TestShim.csharp.cs
@@ -1,0 +1,11 @@
+// C#-arm shim (harness-provided, fixed, not agent-editable).
+namespace Stats.HeldOut;
+
+internal static class TestShim
+{
+    public static int Min(int[] values) => StatsLib.Stats.Min(values);
+    public static int Max(int[] values) => StatsLib.Stats.Max(values);
+    public static int Sum(int[] values) => StatsLib.Stats.Sum(values);
+    public static int Mean(int[] values) => StatsLib.Stats.Mean(values);
+    public static int Clamp(int value, int lo, int hi) => StatsLib.Stats.Clamp(value, lo, hi);
+}

--- a/bench/phase0-agent-native/pairs/W2-002-parity-encoder/calor/ParityEncoder.calr
+++ b/bench/phase0-agent-native/pairs/W2-002-parity-encoder/calor/ParityEncoder.calr
@@ -1,0 +1,12 @@
+§M{m001:ParityEncoder}
+  §F{f001:Encode:pub} ([i32]:values) -> i32
+    §E{}
+    §B{~odd:i32} 0
+    §B{~i:i32} 0
+    §WH{wh1} (< i (len values))
+      §B{v:i32} §IDX values i
+      §IF{if1} (!= (% v 2) 0)
+        §ASSIGN odd (+ odd 1)
+      §ASSIGN i (+ i 1)
+    §B{n:i32} §LEN values
+    §R (+ (* odd 65536) n)

--- a/bench/phase0-agent-native/pairs/W2-002-parity-encoder/csharp/ParityEncoder.cs
+++ b/bench/phase0-agent-native/pairs/W2-002-parity-encoder/csharp/ParityEncoder.cs
@@ -1,0 +1,23 @@
+namespace ParityEncoderLib;
+
+/// <summary>
+/// Encodes integer arrays into a parity checksum. An element is odd exactly
+/// when element % 2 != 0 under truncating remainder semantics (negative odd
+/// numbers count as odd). Supported domain: arrays with fewer than 65536
+/// elements.
+/// </summary>
+public static class ParityEncoder
+{
+    public static int Encode(int[] values)
+    {
+        int odd = 0;
+        for (int i = 0; i < values.Length; i++)
+        {
+            if (values[i] % 2 != 0)
+            {
+                odd++;
+            }
+        }
+        return odd * 65536 + values.Length;
+    }
+}

--- a/bench/phase0-agent-native/pairs/W2-002-parity-encoder/pair.json
+++ b/bench/phase0-agent-native/pairs/W2-002-parity-encoder/pair.json
@@ -1,0 +1,35 @@
+{
+  "id": "W2-002-parity-encoder",
+  "category": "W2",
+  "spec": "spec.md",
+  "tests": {
+    "path": "tests",
+    "runner": "dotnet-test",
+    "heldOut": true
+  },
+  "arms": {
+    "csharp": {
+      "fixture": "csharp",
+      "toolkit": "full"
+    },
+    "calor": {
+      "fixture": "calor",
+      "config": {
+        "enforceEffects": true,
+        "permissiveEffects": false,
+        "contractMode": "debug",
+        "z3Required": true
+      }
+    }
+  },
+  "parity": {
+    "csharpDeclCount": 2,
+    "calorDeclCount": 2,
+    "csharpComplexity": 3,
+    "calorComplexity": 3,
+    "notes": "Fixture per arm: 1 static class/module + Encode; Encode is base 1 + loop + parity branch = 3. Structurally identical across arms. NOT yet difficulty-validated (gates doc §3.1) — do not use as gate evidence before the equivalence pass."
+  },
+  "wedgeWhitelistCheck": "Calor-arm contracts: (>= expectedLength 0) on IsValidLength — binary comparison over an i32 parameter and an integer literal (modeled-forms §1/§2); (>= result 0) and (<= result §LEN values) on CountEven, (>= result -1) and (< result §LEN values) on IndexOfFirstOdd — comparisons over result, integer literals, and array length of a simple variable base (modeled-forms §2, 'array length (simple variable base only)'). No function calls, no floats, no strings, no computed array bases, no generic-typed values appear in any contract. All functions are pure (§E{}), so no effect-manifest coverage is required.",
+  "iterationBudget": 10,
+  "timeoutSeconds": 600
+}

--- a/bench/phase0-agent-native/pairs/W2-002-parity-encoder/reference/calor/ParityEncoder.calr
+++ b/bench/phase0-agent-native/pairs/W2-002-parity-encoder/reference/calor/ParityEncoder.calr
@@ -1,0 +1,43 @@
+§M{m001:ParityEncoder}
+  §F{f001:Encode:pub} ([i32]:values) -> i32
+    §E{}
+    §B{~odd:i32} 0
+    §B{~i:i32} 0
+    §WH{wh1} (< i (len values))
+      §B{v:i32} §IDX values i
+      §IF{if1} (!= (% v 2) 0)
+        §ASSIGN odd (+ odd 1)
+      §ASSIGN i (+ i 1)
+    §B{n:i32} §LEN values
+    §R (+ (* odd 65536) n)
+
+  §F{f002:IsValidLength:pub} ([i32]:values, i32:expectedLength) -> bool
+    §E{}
+    §Q (>= expectedLength 0)
+    §B{n:i32} §LEN values
+    §R (== n expectedLength)
+
+  §F{f003:CountEven:pub} ([i32]:values) -> i32
+    §E{}
+    §S (>= result 0)
+    §S (<= result §LEN values)
+    §B{~count:i32} 0
+    §B{~i:i32} 0
+    §WH{wh2} (< i (len values))
+      §B{v:i32} §IDX values i
+      §IF{if2} (== (% v 2) 0)
+        §ASSIGN count (+ count 1)
+      §ASSIGN i (+ i 1)
+    §R count
+
+  §F{f004:IndexOfFirstOdd:pub} ([i32]:values) -> i32
+    §E{}
+    §S (>= result -1)
+    §S (< result §LEN values)
+    §B{~i:i32} 0
+    §WH{wh3} (< i (len values))
+      §B{v:i32} §IDX values i
+      §IF{if3} (!= (% v 2) 0)
+        §R i
+      §ASSIGN i (+ i 1)
+    §R -1

--- a/bench/phase0-agent-native/pairs/W2-002-parity-encoder/reference/csharp/ParityEncoder.cs
+++ b/bench/phase0-agent-native/pairs/W2-002-parity-encoder/reference/csharp/ParityEncoder.cs
@@ -1,0 +1,53 @@
+namespace ParityEncoderLib;
+
+/// <summary>
+/// Encodes integer arrays into a parity checksum. An element is odd exactly
+/// when element % 2 != 0 under truncating remainder semantics (negative odd
+/// numbers count as odd). Supported domain: arrays with fewer than 65536
+/// elements.
+/// </summary>
+public static class ParityEncoder
+{
+    public static int Encode(int[] values)
+    {
+        int odd = 0;
+        for (int i = 0; i < values.Length; i++)
+        {
+            if (values[i] % 2 != 0)
+            {
+                odd++;
+            }
+        }
+        return odd * 65536 + values.Length;
+    }
+
+    public static bool IsValidLength(int[] values, int expectedLength)
+    {
+        return values.Length == expectedLength;
+    }
+
+    public static int CountEven(int[] values)
+    {
+        int count = 0;
+        for (int i = 0; i < values.Length; i++)
+        {
+            if (values[i] % 2 == 0)
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    public static int IndexOfFirstOdd(int[] values)
+    {
+        for (int i = 0; i < values.Length; i++)
+        {
+            if (values[i] % 2 != 0)
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/bench/phase0-agent-native/pairs/W2-002-parity-encoder/spec.md
+++ b/bench/phase0-agent-native/pairs/W2-002-parity-encoder/spec.md
@@ -1,0 +1,43 @@
+# W2-002 — Parity Encoder (behavioral specification)
+
+This is the only task statement either arm sees. It is arm-neutral: it specifies
+behavior and a public surface, never implementation language idioms.
+
+All arithmetic is 32-bit integer arithmetic. An element is **odd** exactly when
+`element % 2 != 0` under truncating remainder semantics (so negative odd
+numbers such as `-3` count as odd); it is **even** otherwise.
+
+## Existing behavior (already implemented in the starting fixture)
+
+`Encode(values)` → integer — encodes an integer array into a checksum:
+
+```
+Encode(values) = (number of odd elements) * 65536 + (number of elements)
+```
+
+The supported domain is arrays with fewer than 65536 elements.
+
+## Task: implement the missing validation operations
+
+1. `IsValidLength(values, expectedLength)` → boolean — `true` exactly when the
+   number of elements in `values` equals `expectedLength`. **Requires
+   `expectedLength >= 0`** (declare where your language can express it;
+   callers must respect it).
+2. `CountEven(values)` → integer — the number of even elements. The result is
+   guaranteed to lie in `[0, number of elements]` — declare this guarantee
+   where your language can express it. Returns `0` for an empty array.
+3. `IndexOfFirstOdd(values)` → integer — the zero-based index of the first odd
+   element, or `-1` if the array contains no odd element (including the empty
+   array). The result is guaranteed to be at least `-1` and strictly less than
+   the number of elements — declare where expressible.
+
+## Constraints
+
+- Pure computation only: no I/O, no global state, no floating point.
+- Do not change `Encode`'s observable behavior.
+
+## Public surface (pinned; held-out tests bind to it via a fixed per-arm shim)
+
+Static functions `Encode(int[]) → int`, `IsValidLength(int[], int) → bool`,
+`CountEven(int[]) → int`, `IndexOfFirstOdd(int[]) → int`, reachable through
+the arm's `TestShim.cs` (provided by the harness; not editable by the agent).

--- a/bench/phase0-agent-native/pairs/W2-002-parity-encoder/tests/ParityEncoderHeldOutTests.cs
+++ b/bench/phase0-agent-native/pairs/W2-002-parity-encoder/tests/ParityEncoderHeldOutTests.cs
@@ -1,0 +1,68 @@
+// Arm-shared held-out tests (never shown to the agent under test).
+// Binds to the pinned public surface through the harness-provided TestShim
+// (per-arm, fixed, not agent-editable): Encode / IsValidLength / CountEven /
+// IndexOfFirstOdd.
+using Xunit;
+
+namespace ParityEncoder.HeldOut;
+
+public sealed class ParityEncoderHeldOutTests
+{
+    // --- Encode (pre-existing behavior must be preserved) ---
+
+    [Fact]
+    public void Encode_EmptyArray_ReturnsZero()
+    {
+        Assert.Equal(0, TestShim.Encode(System.Array.Empty<int>()));
+    }
+
+    [Theory]
+    [InlineData(new[] { 2, 4 }, 2)]            // 0 odd * 65536 + 2
+    [InlineData(new[] { 1, 2, 3 }, 131075)]    // 2 odd * 65536 + 3
+    [InlineData(new[] { -3 }, 65537)]          // negative odd counts as odd
+    [InlineData(new[] { 0 }, 1)]               // zero is even
+    public void Encode_CombinesOddCountAndLength(int[] values, int expected)
+    {
+        Assert.Equal(expected, TestShim.Encode(values));
+    }
+
+    // --- IsValidLength ---
+
+    [Theory]
+    [InlineData(new int[0], 0, true)]
+    [InlineData(new[] { 1, 2 }, 2, true)]
+    [InlineData(new[] { 1 }, 3, false)]
+    [InlineData(new int[0], 1, false)]
+    public void IsValidLength_ComparesLengths(int[] values, int expected, bool valid)
+    {
+        Assert.Equal(valid, TestShim.IsValidLength(values, expected));
+    }
+
+    // --- CountEven ---
+
+    [Theory]
+    [InlineData(new int[0], 0)]
+    [InlineData(new[] { 1, 3, 5 }, 0)]
+    [InlineData(new[] { 2, 4 }, 2)]
+    [InlineData(new[] { 1, 2, 3, 4 }, 2)]
+    [InlineData(new[] { -4, -3 }, 1)]  // negative even counts as even
+    [InlineData(new[] { 0 }, 1)]       // zero is even
+    public void CountEven_CountsEvenElements(int[] values, int expected)
+    {
+        Assert.Equal(expected, TestShim.CountEven(values));
+    }
+
+    // --- IndexOfFirstOdd ---
+
+    [Theory]
+    [InlineData(new int[0], -1)]         // empty array has no odd element
+    [InlineData(new[] { 2, 4, 6 }, -1)]  // all even
+    [InlineData(new[] { 2, 3, 4 }, 1)]
+    [InlineData(new[] { 7 }, 0)]
+    [InlineData(new[] { -2, -7 }, 1)]    // negative odd counts as odd
+    [InlineData(new[] { 1, 3 }, 0)]      // first of several odds
+    public void IndexOfFirstOdd_FindsFirstOddIndex(int[] values, int expected)
+    {
+        Assert.Equal(expected, TestShim.IndexOfFirstOdd(values));
+    }
+}

--- a/bench/phase0-agent-native/pairs/W2-002-parity-encoder/tests/shims/TestShim.calor.cs
+++ b/bench/phase0-agent-native/pairs/W2-002-parity-encoder/tests/shims/TestShim.calor.cs
@@ -1,0 +1,11 @@
+// Calor-arm shim (harness-provided, fixed, not agent-editable).
+// Calor module M emits namespace M / static class MModule.
+namespace ParityEncoder.HeldOut;
+
+internal static class TestShim
+{
+    public static int Encode(int[] values) => global::ParityEncoder.ParityEncoderModule.Encode(values);
+    public static bool IsValidLength(int[] values, int expectedLength) => global::ParityEncoder.ParityEncoderModule.IsValidLength(values, expectedLength);
+    public static int CountEven(int[] values) => global::ParityEncoder.ParityEncoderModule.CountEven(values);
+    public static int IndexOfFirstOdd(int[] values) => global::ParityEncoder.ParityEncoderModule.IndexOfFirstOdd(values);
+}

--- a/bench/phase0-agent-native/pairs/W2-002-parity-encoder/tests/shims/TestShim.csharp.cs
+++ b/bench/phase0-agent-native/pairs/W2-002-parity-encoder/tests/shims/TestShim.csharp.cs
@@ -1,0 +1,10 @@
+// C#-arm shim (harness-provided, fixed, not agent-editable).
+namespace ParityEncoder.HeldOut;
+
+internal static class TestShim
+{
+    public static int Encode(int[] values) => ParityEncoderLib.ParityEncoder.Encode(values);
+    public static bool IsValidLength(int[] values, int expectedLength) => ParityEncoderLib.ParityEncoder.IsValidLength(values, expectedLength);
+    public static int CountEven(int[] values) => ParityEncoderLib.ParityEncoder.CountEven(values);
+    public static int IndexOfFirstOdd(int[] values) => ParityEncoderLib.ParityEncoder.IndexOfFirstOdd(values);
+}

--- a/bench/phase0-agent-native/pairs/W3-001-audit-log/reference/calor/AuditLog.calr
+++ b/bench/phase0-agent-native/pairs/W3-001-audit-log/reference/calor/AuditLog.calr
@@ -1,0 +1,22 @@
+§M{m001:AuditLog}
+  §F{f001:Append:pub} (str:path, str:entry) -> void
+    §E{fs:w}
+    §C{File.AppendAllText} §A path §A (+ entry "\n") §/C
+
+  §F{f002:CountEntries:pub} (str:path) -> i32
+    §E{fs:r}
+    §B{exists:bool} §C{File.Exists} §A path §/C
+    §IF{if1} (! exists)
+      §R INT:0
+    §B{lines:[str]} §C{File.ReadAllLines} §A path §/C
+    §R §LEN lines
+
+  §F{f003:LastEntry:pub} (str:path) -> str
+    §E{fs:r}
+    §B{exists:bool} §C{File.Exists} §A path §/C
+    §IF{if2} (! exists)
+      §R ""
+    §B{lines:[str]} §C{File.ReadAllLines} §A path §/C
+    §IF{if3} (== §LEN lines INT:0)
+      §R ""
+    §R §IDX lines (- §LEN lines INT:1)

--- a/bench/phase0-agent-native/pairs/W3-001-audit-log/reference/csharp/AuditLog.cs
+++ b/bench/phase0-agent-native/pairs/W3-001-audit-log/reference/csharp/AuditLog.cs
@@ -1,0 +1,22 @@
+namespace AuditLogLib;
+
+public static class AuditLog
+{
+    public static void Append(string path, string entry)
+    {
+        File.AppendAllText(path, entry + "\n");
+    }
+
+    public static int CountEntries(string path)
+    {
+        if (!File.Exists(path)) return 0;
+        return File.ReadAllLines(path).Length;
+    }
+
+    public static string LastEntry(string path)
+    {
+        if (!File.Exists(path)) return string.Empty;
+        var lines = File.ReadAllLines(path);
+        return lines.Length == 0 ? string.Empty : lines[^1];
+    }
+}

--- a/bench/phase0-agent-native/pairs/W3-002-config-store/calor/ConfigStore.calr
+++ b/bench/phase0-agent-native/pairs/W3-002-config-store/calor/ConfigStore.calr
@@ -1,0 +1,13 @@
+§M{m001:ConfigStore}
+  §F{f001:Get:pub} (str:path, str:key) -> str
+    §E{fs:r}
+    §B{exists:bool} §C{File.Exists} §A path §/C
+    §IF{if1} (! exists)
+      §R ""
+    §B{prefix:str} (+ key "=")
+    §B{lines:[str]} §C{File.ReadAllLines} §A path §/C
+    §EACH{e1:line} lines
+      §B{matches:bool} §C{line.StartsWith} §A prefix §/C
+      §IF{if2} matches
+        §R §C{line.Substring} §A §LEN prefix §/C
+    §R ""

--- a/bench/phase0-agent-native/pairs/W3-002-config-store/csharp/ConfigStore.cs
+++ b/bench/phase0-agent-native/pairs/W3-002-config-store/csharp/ConfigStore.cs
@@ -1,0 +1,18 @@
+namespace ConfigStoreLib;
+
+public static class ConfigStore
+{
+    public static string Get(string path, string key)
+    {
+        if (!File.Exists(path)) return string.Empty;
+        var prefix = key + "=";
+        foreach (var line in File.ReadAllLines(path))
+        {
+            if (line.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                return line.Substring(prefix.Length);
+            }
+        }
+        return string.Empty;
+    }
+}

--- a/bench/phase0-agent-native/pairs/W3-002-config-store/pair.json
+++ b/bench/phase0-agent-native/pairs/W3-002-config-store/pair.json
@@ -1,0 +1,35 @@
+{
+  "id": "W3-002-config-store",
+  "category": "W3",
+  "spec": "spec.md",
+  "tests": {
+    "path": "tests",
+    "runner": "dotnet-test",
+    "heldOut": true
+  },
+  "arms": {
+    "csharp": {
+      "fixture": "csharp",
+      "toolkit": "full"
+    },
+    "calor": {
+      "fixture": "calor",
+      "config": {
+        "enforceEffects": true,
+        "permissiveEffects": false,
+        "contractMode": "debug",
+        "z3Required": true
+      }
+    }
+  },
+  "parity": {
+    "csharpDeclCount": 3,
+    "calorDeclCount": 3,
+    "csharpComplexity": 14,
+    "calorComplexity": 14,
+    "notes": "Reference solutions are structurally identical (exists-guard + scan loop per operation; Set uses first-match-only replace with a found flag in both arms). Complexity counted as 1 per function + 1 per branch/loop/&&. NOT yet difficulty-validated (gates doc §3.1)."
+  },
+  "wedgeWhitelistCheck": "No contracts in the starting fixtures; the task's effect boundaries (File.Exists, File.ReadAllLines -> fs:r; File.WriteAllText -> fs:w) are covered by bcl-io manifest entries, and all string operations (StartsWith, Substring, concatenation) are effect-free under the bcl-system System.String mapping. First-order code, no delegates, no LINQ.",
+  "iterationBudget": 10,
+  "timeoutSeconds": 600
+}

--- a/bench/phase0-agent-native/pairs/W3-002-config-store/reference/calor/ConfigStore.calr
+++ b/bench/phase0-agent-native/pairs/W3-002-config-store/reference/calor/ConfigStore.calr
@@ -1,0 +1,45 @@
+§M{m001:ConfigStore}
+  §F{f001:Get:pub} (str:path, str:key) -> str
+    §E{fs:r}
+    §B{exists:bool} §C{File.Exists} §A path §/C
+    §IF{if1} (! exists)
+      §R ""
+    §B{prefix:str} (+ key "=")
+    §B{lines:[str]} §C{File.ReadAllLines} §A path §/C
+    §EACH{e1:line} lines
+      §B{matches:bool} §C{line.StartsWith} §A prefix §/C
+      §IF{if2} matches
+        §R §C{line.Substring} §A §LEN prefix §/C
+    §R ""
+
+  §F{f002:Set:pub} (str:path, str:key, str:value) -> void
+    §E{fs:rw}
+    §B{prefix:str} (+ key "=")
+    §B{~content:str} ""
+    §B{~found:bool} false
+    §B{exists:bool} §C{File.Exists} §A path §/C
+    §IF{if3} exists
+      §B{lines:[str]} §C{File.ReadAllLines} §A path §/C
+      §EACH{e2:line} lines
+        §B{matches:bool} §C{line.StartsWith} §A prefix §/C
+        §IF{if4} (&& (! found) matches)
+          §ASSIGN content (+ content (+ prefix (+ value "\n")))
+          §ASSIGN found true
+        §EL
+          §ASSIGN content (+ content (+ line "\n"))
+    §IF{if5} (! found)
+      §ASSIGN content (+ content (+ prefix (+ value "\n")))
+    §C{File.WriteAllText} §A path §A content §/C
+
+  §F{f003:Has:pub} (str:path, str:key) -> bool
+    §E{fs:r}
+    §B{exists:bool} §C{File.Exists} §A path §/C
+    §IF{if6} (! exists)
+      §R false
+    §B{prefix:str} (+ key "=")
+    §B{lines:[str]} §C{File.ReadAllLines} §A path §/C
+    §EACH{e3:line} lines
+      §B{matches:bool} §C{line.StartsWith} §A prefix §/C
+      §IF{if7} matches
+        §R true
+    §R false

--- a/bench/phase0-agent-native/pairs/W3-002-config-store/reference/csharp/ConfigStore.cs
+++ b/bench/phase0-agent-native/pairs/W3-002-config-store/reference/csharp/ConfigStore.cs
@@ -1,0 +1,59 @@
+namespace ConfigStoreLib;
+
+public static class ConfigStore
+{
+    public static string Get(string path, string key)
+    {
+        if (!File.Exists(path)) return string.Empty;
+        var prefix = key + "=";
+        foreach (var line in File.ReadAllLines(path))
+        {
+            if (line.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                return line.Substring(prefix.Length);
+            }
+        }
+        return string.Empty;
+    }
+
+    public static void Set(string path, string key, string value)
+    {
+        var prefix = key + "=";
+        var content = "";
+        var found = false;
+        if (File.Exists(path))
+        {
+            foreach (var line in File.ReadAllLines(path))
+            {
+                if (!found && line.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    content = content + prefix + value + "\n";
+                    found = true;
+                }
+                else
+                {
+                    content = content + line + "\n";
+                }
+            }
+        }
+        if (!found)
+        {
+            content = content + prefix + value + "\n";
+        }
+        File.WriteAllText(path, content);
+    }
+
+    public static bool Has(string path, string key)
+    {
+        if (!File.Exists(path)) return false;
+        var prefix = key + "=";
+        foreach (var line in File.ReadAllLines(path))
+        {
+            if (line.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/bench/phase0-agent-native/pairs/W3-002-config-store/spec.md
+++ b/bench/phase0-agent-native/pairs/W3-002-config-store/spec.md
@@ -1,0 +1,42 @@
+# W3-002 — Config Store (behavioral specification)
+
+This is the only task statement either arm sees. It is arm-neutral: it specifies
+behavior and a public surface, never implementation language idioms.
+
+## File format
+
+A config file is a plain-text file of `key=value` lines, one entry per line,
+each line terminated by a single `\n`. Keys never contain `=`; values may be
+empty. The first line whose key matches wins.
+
+## Existing behavior (already implemented in the starting fixture)
+
+`Get(path, key)` → string — returns the value of the first line whose key is
+`key` in the file at `path`. Returns the empty string if the file does not
+exist or no line matches.
+
+## Task: implement the missing operations
+
+1. `Set(path, key, value)` — writes `key=value` into the file at `path`:
+   - If the file does not exist, it is created containing that single entry.
+   - If a line with `key` already exists, that line is replaced in place
+     (same position); all other lines are preserved unchanged, in order.
+     Only the first matching line is replaced.
+   - Otherwise the entry is appended as a new last line.
+   - The resulting file consists of `\n`-terminated lines as described above.
+2. `Has(path, key)` → boolean — returns whether the file at `path` exists and
+   contains a line whose key is `key`. (Note: `Has` distinguishes a key with
+   an empty value from an absent key; `Get` alone cannot.)
+
+## Constraints
+
+- Reads and writes go through the real filesystem (no in-memory fakes).
+- All operations must correctly declare whatever your language requires for
+  filesystem access.
+- Do not change `Get`'s observable behavior.
+
+## Public surface (pinned; held-out tests bind to it via a fixed per-arm shim)
+
+Static functions `Get(string, string) → string`, `Set(string, string, string)`,
+`Has(string, string) → bool`, reachable through the arm's `TestShim.cs`
+(provided by the harness; not editable by the agent).

--- a/bench/phase0-agent-native/pairs/W3-002-config-store/tests/ConfigStoreHeldOutTests.cs
+++ b/bench/phase0-agent-native/pairs/W3-002-config-store/tests/ConfigStoreHeldOutTests.cs
@@ -1,0 +1,95 @@
+// Arm-shared held-out tests (never shown to the agent under test).
+// Binds to the pinned public surface through the harness-provided TestShim
+// (per-arm, fixed, not agent-editable): Get / Set / Has.
+using Xunit;
+
+namespace ConfigStore.HeldOut;
+
+public sealed class ConfigStoreHeldOutTests : IDisposable
+{
+    private readonly string _path = Path.Combine(
+        Path.GetTempPath(), $"config-{Guid.NewGuid():N}.conf");
+
+    public void Dispose()
+    {
+        if (File.Exists(_path)) File.Delete(_path);
+    }
+
+    [Fact]
+    public void Get_MissingFile_ReturnsEmpty()
+    {
+        Assert.Equal(string.Empty, TestShim.Get(_path, "host"));
+    }
+
+    [Fact]
+    public void Set_MissingFile_CreatesFileWithSingleEntry()
+    {
+        TestShim.Set(_path, "host", "localhost");
+        Assert.True(File.Exists(_path));
+        Assert.Equal("host=localhost\n", File.ReadAllText(_path));
+    }
+
+    [Fact]
+    public void Set_ThenGet_RoundTrips()
+    {
+        TestShim.Set(_path, "host", "localhost");
+        TestShim.Set(_path, "port", "8080");
+        Assert.Equal("localhost", TestShim.Get(_path, "host"));
+        Assert.Equal("8080", TestShim.Get(_path, "port"));
+    }
+
+    [Fact]
+    public void Set_ExistingKey_ReplacesInPlace_PreservingOrder()
+    {
+        TestShim.Set(_path, "a", "1");
+        TestShim.Set(_path, "b", "2");
+        TestShim.Set(_path, "c", "3");
+        TestShim.Set(_path, "b", "20");
+        Assert.Equal("a=1\nb=20\nc=3\n", File.ReadAllText(_path));
+    }
+
+    [Fact]
+    public void Set_NewKey_AppendsAsLastLine()
+    {
+        TestShim.Set(_path, "a", "1");
+        TestShim.Set(_path, "b", "2");
+        Assert.Equal("a=1\nb=2\n", File.ReadAllText(_path));
+    }
+
+    [Fact]
+    public void Set_EmptyValue_Persists()
+    {
+        TestShim.Set(_path, "flag", "");
+        Assert.Equal("flag=\n", File.ReadAllText(_path));
+        Assert.Equal(string.Empty, TestShim.Get(_path, "flag"));
+    }
+
+    [Fact]
+    public void Has_MissingFile_ReturnsFalse()
+    {
+        Assert.False(TestShim.Has(_path, "host"));
+    }
+
+    [Fact]
+    public void Has_PresentAndAbsentKeys()
+    {
+        TestShim.Set(_path, "host", "localhost");
+        Assert.True(TestShim.Has(_path, "host"));
+        Assert.False(TestShim.Has(_path, "port"));
+    }
+
+    [Fact]
+    public void Has_DistinguishesEmptyValueFromAbsentKey()
+    {
+        TestShim.Set(_path, "flag", "");
+        Assert.True(TestShim.Has(_path, "flag"));
+        Assert.False(TestShim.Has(_path, "other"));
+    }
+
+    [Fact]
+    public void Get_FirstMatchingLineWins()
+    {
+        File.WriteAllText(_path, "k=first\nk=second\n");
+        Assert.Equal("first", TestShim.Get(_path, "k"));
+    }
+}

--- a/bench/phase0-agent-native/pairs/W3-002-config-store/tests/shims/TestShim.calor.cs
+++ b/bench/phase0-agent-native/pairs/W3-002-config-store/tests/shims/TestShim.calor.cs
@@ -1,0 +1,10 @@
+// Calor-arm shim (harness-provided, fixed, not agent-editable).
+// Calor module M emits namespace M / static class MModule.
+namespace ConfigStore.HeldOut;
+
+internal static class TestShim
+{
+    public static string Get(string path, string key) => global::ConfigStore.ConfigStoreModule.Get(path, key);
+    public static void Set(string path, string key, string value) => global::ConfigStore.ConfigStoreModule.Set(path, key, value);
+    public static bool Has(string path, string key) => global::ConfigStore.ConfigStoreModule.Has(path, key);
+}

--- a/bench/phase0-agent-native/pairs/W3-002-config-store/tests/shims/TestShim.csharp.cs
+++ b/bench/phase0-agent-native/pairs/W3-002-config-store/tests/shims/TestShim.csharp.cs
@@ -1,0 +1,9 @@
+// C#-arm shim (harness-provided, fixed, not agent-editable).
+namespace ConfigStore.HeldOut;
+
+internal static class TestShim
+{
+    public static string Get(string path, string key) => ConfigStoreLib.ConfigStore.Get(path, key);
+    public static void Set(string path, string key, string value) => ConfigStoreLib.ConfigStore.Set(path, key, value);
+    public static bool Has(string path, string key) => ConfigStoreLib.ConfigStore.Has(path, key);
+}

--- a/bench/phase0-agent-native/run-epoch.sh
+++ b/bench/phase0-agent-native/run-epoch.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Phase 0 epoch orchestrator: all pairs x both arms x N runs, with pins.
+#
+# Usage:
+#   ./run-epoch.sh --epoch dry-run-001 --runs 3 [--null-agent] [--pairs "W3-001 N1-002"]
+#
+# An epoch is one gate's complete paired run (gates doc §0.1). pins.json
+# records model IDs, agent-tool version, compiler commit, and suite state.
+# Live (non-null) epochs consume agent API spend — get explicit authorization
+# before running one.
+# ============================================================================
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+EPOCH=""; RUNS=1; NULL_FLAG=""; PAIR_FILTER=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --epoch) EPOCH="$2"; shift 2 ;;
+        --runs) RUNS="$2"; shift 2 ;;
+        --null-agent) NULL_FLAG="--null-agent"; shift ;;
+        --pairs) PAIR_FILTER="$2"; shift 2 ;;
+        *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+[[ -n "$EPOCH" ]] || { echo "--epoch <id> required" >&2; exit 2; }
+
+OUT="$SCRIPT_DIR/epochs/$EPOCH"
+mkdir -p "$OUT"
+
+# Pins (gates doc §1)
+jq -n \
+    --arg compiler_commit "$(git -C "$REPO_ROOT" rev-parse HEAD)" \
+    --arg suite_dirty "$(git -C "$REPO_ROOT" status --porcelain "$SCRIPT_DIR" | wc -l | tr -d ' ')" \
+    --arg agent_version "$(claude --version 2>/dev/null || echo unavailable)" \
+    --arg model "${CLAUDE_MODEL:-default}" \
+    --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg null "${NULL_FLAG:-live}" \
+    '{compilerCommit:$compiler_commit, suiteDirtyFiles:($suite_dirty|tonumber),
+      agentVersion:$agent_version, modelPin:$model, startedAt:$date, mode:$null}' \
+    > "$OUT/pins.json"
+
+for pair_json in "$SCRIPT_DIR"/pairs/*/pair.json; do
+    pair_dir="$(dirname "$pair_json")"
+    pair_id="$(jq -r .id "$pair_json")"
+    if [[ -n "$PAIR_FILTER" ]] && ! grep -q "$(basename "$pair_dir" | cut -d- -f1-2)" <<< "$PAIR_FILTER"; then
+        continue
+    fi
+    for arm in csharp calor; do
+        echo "=== $pair_id / $arm ==="
+        "$SCRIPT_DIR/run-pair.sh" --pair "$pair_dir" --arm "$arm" --runs "$RUNS" \
+            $NULL_FLAG --out "$OUT" | jq -c '{pair,arm,run,taskSuccess,escapedBugs,iterationsToGreen,censored}'
+    done
+done
+
+# Roll-up
+find "$OUT" -name result.json -exec cat {} + | jq -s \
+    'group_by(.arm) | map({arm: .[0].arm,
+        runs: length,
+        successRate: (map(select(.taskSuccess)) | length) / length,
+        meanEscaped: (map(.escapedBugs) | add / length),
+        censoredFraction: (map(select(.censored)) | length) / length})' \
+    > "$OUT/rollup.json"
+echo "--- rollup ---"; cat "$OUT/rollup.json"

--- a/bench/phase0-agent-native/run-pair.sh
+++ b/bench/phase0-agent-native/run-pair.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Phase 0 two-arm pair runner (agent-native benchmark)
+# ============================================================================
+#
+# Runs ONE pair in ONE arm, N times, per the gates doc
+# (docs/plans/agent-native-gates.md). Produces per-run JSON results and a
+# journal of harness-observed iterations with silent held-out test outcomes.
+#
+# Usage:
+#   ./run-pair.sh --pair pairs/W3-001-audit-log --arm calor            # 1 run
+#   ./run-pair.sh --pair <dir> --arm csharp --runs 3                   # N runs
+#   ./run-pair.sh --pair <dir> --arm calor --null-agent                # plumbing
+#         validation: applies the reference solution instead of invoking the
+#         agent — zero API spend, exercises workspaces/shims/tests/metrics
+#   ./run-pair.sh ... --out epochs/dry-run-001                         # results dir
+#
+# Iteration definition (gates doc §2): one harness-observed build-or-test
+# invocation following >=1 workspace edit. Observed via a `dotnet` PATH shim
+# that journals invocations, hashes the src tree to detect edits, and silently
+# runs the held-out suite after each build/test.
+#
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PAIR_DIR=""
+ARM=""
+RUNS=1
+OUT_DIR="$SCRIPT_DIR/epochs/adhoc"
+NULL_AGENT=0
+ITERATION_BUDGET=10
+TIMEOUT_SECS=600
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pair) PAIR_DIR="$2"; shift 2 ;;
+        --arm) ARM="$2"; shift 2 ;;
+        --runs) RUNS="$2"; shift 2 ;;
+        --out) OUT_DIR="$2"; shift 2 ;;
+        --null-agent) NULL_AGENT=1; shift ;;
+        *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+[[ -n "$PAIR_DIR" && -n "$ARM" ]] || { echo "Usage: --pair <dir> --arm calor|csharp [--runs N] [--null-agent] [--out <dir>]" >&2; exit 2; }
+[[ "$ARM" == "calor" || "$ARM" == "csharp" ]] || { echo "--arm must be calor|csharp" >&2; exit 2; }
+PAIR_DIR="$(cd "$PAIR_DIR" && pwd)"
+PAIR_ID="$(jq -r .id "$PAIR_DIR/pair.json")"
+TIMEOUT_SECS="$(jq -r '.timeoutSeconds // 600' "$PAIR_DIR/pair.json")"
+mkdir -p "$OUT_DIR"
+OUT_DIR="$(cd "$OUT_DIR" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Config pin check (gates doc §0.2): calor arm must run enforced, strict,
+# contract-debug, Z3 present. Violations are invalid runs, detected up front.
+# ---------------------------------------------------------------------------
+check_pins() {
+    if [[ "$ARM" == "calor" ]]; then
+        local cfg
+        cfg="$(jq -r '.arms.calor.config | "\(.enforceEffects) \(.permissiveEffects) \(.contractMode) \(.z3Required)"' "$PAIR_DIR/pair.json")"
+        [[ "$cfg" == "true false debug true" ]] || { echo "INVALID: pair.json calor config violates gates-doc pin: $cfg" >&2; exit 3; }
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Workspace materialization. Layout:
+#   $ws/src/       agent-visible: fixture + spec.md + arm project file
+#   $ws_out/heldout/  harness-only: tests + shim + csproj referencing src
+# ---------------------------------------------------------------------------
+materialize() {
+    local ws="$1" ws_out="$2"
+    mkdir -p "$ws/src" "$ws_out/heldout"
+
+    cp -R "$PAIR_DIR/$ARM/." "$ws/src/"
+    cp "$PAIR_DIR/spec.md" "$ws/spec.md"
+
+    if [[ "$ARM" == "calor" ]]; then
+        sed "s|__REPO_ROOT__|$REPO_ROOT|g" \
+            "$SCRIPT_DIR/templates/calor-arm/CalorArm.csproj.template" > "$ws/src/Src.csproj"
+    else
+        cat > "$ws/src/Src.csproj" <<'EOF'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+</Project>
+EOF
+    fi
+
+    # Held-out project: tests + the arm's shim, outside the agent's workspace
+    cp "$PAIR_DIR"/tests/*.cs "$ws_out/heldout/" 2>/dev/null || true
+    cp "$PAIR_DIR/tests/shims/TestShim.$ARM.cs" "$ws_out/heldout/TestShim.cs"
+    cat > "$ws_out/heldout/HeldOut.csproj" <<EOF
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Reference the built assembly, not the project: keeps the held-out
+         build fully decoupled from the agent's workspace builds -->
+    <Reference Include="Src">
+      <HintPath>$ws/src/bin/Debug/net10.0/Src.dll</HintPath>
+    </Reference>
+    <Reference Include="Calor.Runtime" Condition="Exists('$ws/src/bin/Debug/net10.0/Calor.Runtime.dll')">
+      <HintPath>$ws/src/bin/Debug/net10.0/Calor.Runtime.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+</Project>
+EOF
+
+    # .g.cs write-block for the calor arm (gates doc §1) via Claude hook config
+    if [[ "$ARM" == "calor" && $NULL_AGENT -eq 0 ]]; then
+        mkdir -p "$ws/.claude"
+        cat > "$ws/.claude/settings.json" <<'EOF'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          { "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | grep -q '\\.g\\.cs$' && { echo 'BLOCKED: .g.cs files are generated; edit the .calr source' >&2; exit 2; } || exit 0" }
+        ]
+      }
+    ]
+  }
+}
+EOF
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# dotnet shim: journals build/test invocations, detects edits via src-tree
+# hash, and runs the held-out suite silently after each build/test.
+# ---------------------------------------------------------------------------
+write_shim() {
+    local ws="$1" ws_out="$2" shim_dir="$3"
+    local real_dotnet
+    real_dotnet="$(command -v dotnet)"
+    mkdir -p "$shim_dir"
+    cat > "$shim_dir/dotnet" <<EOF
+#!/usr/bin/env bash
+set -uo pipefail
+if [[ "\${CALOR_P0_SHIM_OFF:-0}" == "1" ]]; then exec "$real_dotnet" "\$@"; fi
+"$real_dotnet" "\$@"; rc=\$?
+case "\${1:-}" in
+  build|test|run)
+    hash=\$(find "$ws/src" -type f \\( -name '*.cs' -o -name '*.calr' \\) -exec shasum {} + 2>/dev/null | shasum | cut -d' ' -f1)
+    prev=\$(cat "$ws_out/.lasthash" 2>/dev/null || echo none)
+    edited=\$([[ "\$hash" != "\$prev" ]] && echo true || echo false)
+    echo "\$hash" > "$ws_out/.lasthash"
+    ho_pass=0; ho_fail=999
+    # Fresh, decoupled src build; only if it succeeds is the dll current and
+    # the held-out result meaningful (non-compiling state = all failing)
+    if CALOR_P0_SHIM_OFF=1 "$real_dotnet" build "$ws/src/Src.csproj" --nologo -v q > "$ws_out/.src_build.txt" 2>&1; then
+      if CALOR_P0_SHIM_OFF=1 "$real_dotnet" test "$ws_out/heldout/HeldOut.csproj" --nologo -v q > "$ws_out/.ho_last.txt" 2>&1; then
+        ho_fail=0
+        ho_pass=\$(grep -oE 'Passed:[[:space:]]+[0-9]+' "$ws_out/.ho_last.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
+      else
+        ho_fail=\$(grep -oE 'Failed:[[:space:]]+[0-9]+' "$ws_out/.ho_last.txt" | grep -oE '[0-9]+' | head -1 || echo 999)
+        ho_pass=\$(grep -oE 'Passed:[[:space:]]+[0-9]+' "$ws_out/.ho_last.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
+      fi
+    fi
+    printf '{"ts":"%s","cmd":"%s","exit":%d,"edited":%s,"heldout_pass":%s,"heldout_fail":%s}\n' \
+      "\$(date -u +%Y-%m-%dT%H:%M:%SZ)" "\${1}" "\$rc" "\$edited" "\$ho_pass" "\$ho_fail" >> "$ws_out/journal.jsonl"
+    ;;
+esac
+exit \$rc
+EOF
+    chmod +x "$shim_dir/dotnet"
+}
+
+# ---------------------------------------------------------------------------
+# Agent invocation (or null-agent reference-solution application)
+# ---------------------------------------------------------------------------
+run_agent() {
+    local ws="$1" ws_out="$2" shim_dir="$3"
+    local prompt
+    prompt="You are working in $ws/src. Read $ws/spec.md and implement the missing operations it describes, in the existing source files, following the conventions already present. The iteration budget is $ITERATION_BUDGET build/test cycles. Build with 'dotnet build' from $ws/src to check your work. Do not create test files; do not modify the project file. Stop when the spec is fully implemented and the project builds cleanly."
+
+    if [[ $NULL_AGENT -eq 1 ]]; then
+        # Apply the reference solution, then do one observed build (validates
+        # shim + held-out wiring end to end with zero API spend)
+        cp -R "$PAIR_DIR/reference/$ARM/." "$ws/src/"
+        ( cd "$ws/src" && PATH="$shim_dir:$PATH" dotnet build --nologo -v q >/dev/null 2>&1 ) || true
+        echo '{"null_agent":true}' > "$ws_out/agent.json"
+        return 0
+    fi
+
+    local timeout_cmd="timeout"; command -v timeout >/dev/null || timeout_cmd="gtimeout"
+    ( cd "$ws/src" && PATH="$shim_dir:$PATH" $timeout_cmd "$TIMEOUT_SECS" \
+        claude --print --output-format json --dangerously-skip-permissions \
+        "$prompt" > "$ws_out/agent.json" 2> "$ws_out/agent.err" ) || echo "agent exit: $?" >> "$ws_out/agent.err"
+}
+
+# ---------------------------------------------------------------------------
+# Metrics extraction (gates doc §2) -> result.json
+# ---------------------------------------------------------------------------
+extract_metrics() {
+    local ws="$1" ws_out="$2" run_idx="$3"
+    local journal="$ws_out/journal.jsonl"
+    touch "$journal"
+
+    # Final silent held-out run = declared-done state (non-compiling = all fail)
+    local final_pass=0 final_fail=999
+    if CALOR_P0_SHIM_OFF=1 dotnet build "$ws/src/Src.csproj" --nologo -v q > "$ws_out/.src_final.txt" 2>&1; then
+        if CALOR_P0_SHIM_OFF=1 dotnet test "$ws_out/heldout/HeldOut.csproj" --nologo -v q > "$ws_out/.ho_final.txt" 2>&1; then
+            final_fail=0
+            final_pass=$(grep -oE 'Passed:[[:space:]]+[0-9]+' "$ws_out/.ho_final.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
+        else
+            final_fail=$(grep -oE 'Failed:[[:space:]]+[0-9]+' "$ws_out/.ho_final.txt" | grep -oE '[0-9]+' | head -1 || echo 999)
+            final_pass=$(grep -oE 'Passed:[[:space:]]+[0-9]+' "$ws_out/.ho_final.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
+        fi
+    fi
+
+    # Iterations = journaled build/test invocations with edited=true
+    local iterations iters_to_green censored
+    iterations=$(jq -s '[.[] | select(.edited==true)] | length' "$journal")
+    iters_to_green=$(jq -s '[to_entries[] | select(.value.edited==true)] as $its
+        | ([$its[] | select(.value.heldout_fail==0)] | first // null)
+        | if . == null then -1 else (.key + 1) end' "$journal" 2>/dev/null || echo -1)
+    censored=false
+    if [[ "$iters_to_green" == "-1" ]]; then
+        iters_to_green=$((ITERATION_BUDGET + 1)); censored=true
+    fi
+
+    local tokens_in=0 tokens_out=0
+    if [[ -f "$ws_out/agent.json" ]] && jq -e '.usage' "$ws_out/agent.json" >/dev/null 2>&1; then
+        tokens_in=$(jq -r '.usage.input_tokens // 0' "$ws_out/agent.json")
+        tokens_out=$(jq -r '.usage.output_tokens // 0' "$ws_out/agent.json")
+    fi
+
+    jq -n \
+        --arg pair "$PAIR_ID" --arg arm "$ARM" --argjson run "$run_idx" \
+        --argjson success "$([[ $final_fail -eq 0 ]] && echo true || echo false)" \
+        --argjson escaped "$final_fail" --argjson passed "$final_pass" \
+        --argjson iterations "$iterations" --argjson itg "$iters_to_green" \
+        --argjson censored "$censored" \
+        --argjson tin "$tokens_in" --argjson tout "$tokens_out" \
+        --argjson null_agent "$NULL_AGENT" \
+        '{pair:$pair, arm:$arm, run:$run, taskSuccess:$success,
+          escapedBugs:$escaped, heldoutPassed:$passed,
+          iterations:$iterations, iterationsToGreen:$itg, censored:$censored,
+          tokens:{input:$tin, output:$tout}, nullAgent:($null_agent==1)}' \
+        > "$ws_out/result.json"
+    cat "$ws_out/result.json"
+}
+
+# ---------------------------------------------------------------------------
+check_pins
+for (( run=1; run<=RUNS; run++ )); do
+    WS="$(mktemp -d "${TMPDIR:-/tmp}/p0-${PAIR_ID}-${ARM}-XXXXXX")"
+    WS_OUT="$OUT_DIR/$PAIR_ID/$ARM/run-$run"
+    mkdir -p "$WS_OUT"
+    SHIM_DIR="$WS_OUT/.shim"
+
+    materialize "$WS" "$WS_OUT"
+    write_shim "$WS" "$WS_OUT" "$SHIM_DIR"
+    run_agent "$WS" "$WS_OUT" "$SHIM_DIR"
+    extract_metrics "$WS" "$WS_OUT" "$run"
+
+    rm -rf "$WS"
+done

--- a/bench/phase0-agent-native/run-pair.sh
+++ b/bench/phase0-agent-native/run-pair.sh
@@ -266,6 +266,14 @@ extract_metrics() {
 check_pins
 for (( run=1; run<=RUNS; run++ )); do
     WS="$(mktemp -d "${TMPDIR:-/tmp}/p0-${PAIR_ID}-${ARM}-XXXXXX")"
+    # Canonicalize (macOS: $TMPDIR lives behind the /var -> /private/var
+    # symlink). Agent builds run from the *physical* cwd while shim/metrics
+    # builds pass the *logical* $WS path; MSBuild treats the two spellings as
+    # different project identities, and the identity flip makes incremental
+    # clean delete ProjectReference outputs (Calor.Runtime.dll) from src/bin —
+    # every contract-bearing calor-arm pair then fails held-out runs with
+    # FileNotFoundException. One physical path removes the ambiguity.
+    WS="$(cd "$WS" && pwd -P)"
     WS_OUT="$OUT_DIR/$PAIR_ID/$ARM/run-$run"
     mkdir -p "$WS_OUT"
     SHIM_DIR="$WS_OUT/.shim"


### PR DESCRIPTION
## Summary

Implements the Phase 0 execution machinery from `docs/plans/agent-native-strategy.md` §4 and the first wave of fixture pairs, all validated per the gates doc (`docs/plans/agent-native-gates.md`).

- **`run-pair.sh`** — runs one pair in one arm per the gates-doc pins: workspace materialization (agent-visible src + spec; held-out tests kept outside the workspace), a `dotnet` PATH shim that journals build/test iterations (edit detection via src-tree hashing) and silently runs the arm-shared held-out suite after each one against a decoupled src build, `.g.cs` write-block hook for the calor arm, and per-run metrics JSON (task success, escaped bugs, iterations-to-green with censoring, tokens). `--null-agent` applies the reference solution instead of invoking an agent: zero API spend, full-pipeline validation.
- **`run-epoch.sh`** — pairs × arms × runs orchestration with `pins.json` (compiler commit, agent version, model pin) and per-arm rollups.
- **Six new pairs** (7 total with the seed): W1-001 temperature-converter, W2-001 int-stats, W2-002 parity-encoder (contracts inside the modeled-forms whitelist, clean under `--verify`), W3-002 config-store (manifest-covered fs effects), N1-001 string-utils, N1-002 inventory. Each: arm-neutral spec, one arm-shared held-out suite with fixed per-arm shims, independently authored idiomatic fixtures with parity records, complete reference solutions.

## Validation

- **Determinism sweep: 70/70 green** — 5 consecutive null-agent runs per arm, all 7 pairs, both arms (gates doc §0.2 authoring rule).
- Every `.calr` fixture and reference compiles under `--enforce-effects`; contract-bearing files clean under compile-path `--verify`.
- Runner bug found and fixed during authoring: macOS symlinked `mktemp` paths gave MSBuild two identities for one project, deleting `Calor.Runtime.dll` mid-run; workspace paths now canonicalized (`pwd -P`).

## Upstream findings (doc-drift ledger; not fixed here)

- Control-flow docs list `§FOREACH`; the lexer keyword is `§EACH`.
- `mut` is an enforced effect (Calor0410) absent from the `effects.md` code table.
- Standalone `calor verify` doesn't model function bodies (`result` unconstrained → spurious Disproven, incl. on repo samples); compile-path `--verify` is fine.
- Qualified sibling-module calls (`§C{Stats.Sum}`) emit non-compiling C#; unqualified works.

## What's next (not in this PR)

Author remaining pairs to registry proportions → dry-run feasibility calculation (live agents, ~\$-bounded, needs explicit authorization) → freeze suite + gates doc → baseline epoch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)