### PR TITLE
Phase 1: source maps — #line directives from generated C# back to .calr

### DIFF
--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -93,11 +93,28 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         _contractMode = contractMode;
     }
 
+    /// <summary>
+    /// When set, the emitter writes <c>#line</c> directives before each
+    /// statement-level construct so Roslyn diagnostics, debugger sessions and
+    /// stack traces map back to the original <c>.calr</c> source instead of the
+    /// generated <c>.g.cs</c> file. Generated-only regions (headers, contract
+    /// checks, closing braces) are reset with <c>#line default</c> so they
+    /// attribute honestly to the generated file. Null (the default) disables
+    /// source mapping entirely.
+    /// </summary>
+    public string? LineDirectiveFilePath { get; set; }
+
+    // Escaped form of LineDirectiveFilePath, computed once per Emit call.
+    private string? _lineDirectiveFile;
+
     public string Emit(ModuleNode module, string? filePath = null)
     {
         _builder.Clear();
         _indentLevel = 0;
         _currentFilePath = filePath;
+        _lineDirectiveFile = string.IsNullOrEmpty(LineDirectiveFilePath)
+            ? null
+            : EscapeString(LineDirectiveFilePath);
 
         var result = Visit(module);
         return result;
@@ -106,6 +123,48 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     public string Emit(ModuleNode module)
     {
         return Emit(module, null);
+    }
+
+    /// <summary>
+    /// Emits a single statement, sandwiched between <c>#line</c> directives when
+    /// source mapping is enabled (see <see cref="LineDirectiveFilePath"/>).
+    /// Block statements (if/while/for/...) write directly to the builder and
+    /// return an empty string; the trailing empty <c>AppendLine</c> preserves the
+    /// blank line the previous inline emission produced.
+    /// </summary>
+    private void EmitStatement(AstNode statement, bool skipEmptyLine = false)
+    {
+        var mapped = TryBeginLineMapping(statement);
+        var code = statement.Accept(this);
+        if (!skipEmptyLine || !string.IsNullOrEmpty(code))
+        {
+            AppendLine(code);
+        }
+        EndLineMapping(mapped);
+    }
+
+    /// <summary>
+    /// Writes a <c>#line</c> directive mapping the next output line to the
+    /// node's source location. Returns true if a directive was written (caller
+    /// must then close the region with <see cref="EndLineMapping"/>).
+    /// </summary>
+    private bool TryBeginLineMapping(AstNode node)
+    {
+        if (_lineDirectiveFile == null || node.Span.Line <= 0)
+        {
+            return false;
+        }
+
+        AppendLine($"#line {node.Span.Line} \"{_lineDirectiveFile}\"");
+        return true;
+    }
+
+    private void EndLineMapping(bool mapped)
+    {
+        if (mapped)
+        {
+            AppendLine("#line default");
+        }
     }
 
     private void AppendLine(string line = "")
@@ -500,13 +559,14 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             {
                 if (statement is ReturnStatementNode returnStmt && returnStmt.Expression != null)
                 {
+                    var mappedReturn = TryBeginLineMapping(statement);
                     var expr = returnStmt.Expression.Accept(this);
                     AppendLine($"__result__ = {expr};");
+                    EndLineMapping(mappedReturn);
                 }
                 else
                 {
-                    var stmtCode = statement.Accept(this);
-                    AppendLine(stmtCode);
+                    EmitStatement(statement);
                 }
             }
 
@@ -526,8 +586,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             // No postconditions or void return - emit body normally
             foreach (var statement in node.Body)
             {
-                var stmtCode = statement.Accept(this);
-                AppendLine(stmtCode);
+                EmitStatement(statement);
             }
 
             // Emit postconditions for void functions (they can't reference 'result')
@@ -957,8 +1016,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         foreach (var stmt in node.Body)
         {
-            var stmtCode = stmt.Accept(this);
-            AppendLine(stmtCode);
+            EmitStatement(stmt);
         }
 
         Dedent();
@@ -977,8 +1035,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         foreach (var stmt in node.Body)
         {
-            var stmtCode = stmt.Accept(this);
-            AppendLine(stmtCode);
+            EmitStatement(stmt);
         }
 
         Dedent();
@@ -997,8 +1054,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         foreach (var stmt in node.Body)
         {
-            var stmtCode = stmt.Accept(this);
-            AppendLine(stmtCode);
+            EmitStatement(stmt);
         }
 
         Dedent();
@@ -1017,8 +1073,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         foreach (var stmt in node.ThenBody)
         {
-            var stmtCode = stmt.Accept(this);
-            AppendLine(stmtCode);
+            EmitStatement(stmt);
         }
 
         Dedent();
@@ -1034,8 +1089,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
             foreach (var stmt in elseIf.Body)
             {
-                var stmtCode = stmt.Accept(this);
-                AppendLine(stmtCode);
+                EmitStatement(stmt);
             }
 
             Dedent();
@@ -1051,8 +1105,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
             foreach (var stmt in node.ElseBody)
             {
-                var stmtCode = stmt.Accept(this);
-                AppendLine(stmtCode);
+                EmitStatement(stmt);
             }
 
             Dedent();
@@ -1429,13 +1482,14 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             {
                 if (statement is ReturnStatementNode returnStmt && returnStmt.Expression != null)
                 {
+                    var mappedReturn = TryBeginLineMapping(statement);
                     var expr = returnStmt.Expression.Accept(this);
                     AppendLine($"__result__ = {expr};");
+                    EndLineMapping(mappedReturn);
                 }
                 else
                 {
-                    var stmtCode = statement.Accept(this);
-                    AppendLine(stmtCode);
+                    EmitStatement(statement);
                 }
             }
 
@@ -1452,8 +1506,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         {
             foreach (var statement in method.Body)
             {
-                var stmtCode = statement.Accept(this);
-                AppendLine(stmtCode);
+                EmitStatement(statement);
             }
 
             foreach (var ensures in method.Postconditions)
@@ -1570,8 +1623,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
             foreach (var stmt in matchCase.Body)
             {
-                var stmtCode = stmt.Accept(this);
-                AppendLine(stmtCode);
+                EmitStatement(stmt);
             }
 
             AppendLine("break;");
@@ -1855,8 +1907,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
             foreach (var stmt in node.Body)
             {
-                var stmtCode = stmt.Accept(this);
-                AppendLine(stmtCode);
+                EmitStatement(stmt);
             }
 
             Dedent();
@@ -1870,8 +1921,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
             foreach (var stmt in node.Body)
             {
-                var stmtCode = stmt.Accept(this);
-                AppendLine(stmtCode);
+                EmitStatement(stmt);
             }
 
             Dedent();
@@ -2014,8 +2064,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         foreach (var stmt in node.Body)
         {
-            var stmtCode = stmt.Accept(this);
-            AppendLine(stmtCode);
+            EmitStatement(stmt);
         }
 
         Dedent();
@@ -2509,13 +2558,14 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             {
                 if (statement is ReturnStatementNode returnStmt && returnStmt.Expression != null)
                 {
+                    var mappedReturn = TryBeginLineMapping(statement);
                     var expr = returnStmt.Expression.Accept(this);
                     AppendLine($"__result__ = {expr};");
+                    EndLineMapping(mappedReturn);
                 }
                 else
                 {
-                    var stmtCode = statement.Accept(this);
-                    AppendLine(stmtCode);
+                    EmitStatement(statement);
                 }
             }
 
@@ -2545,8 +2595,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         {
             foreach (var statement in node.Body)
             {
-                var stmtCode = statement.Accept(this);
-                AppendLine(stmtCode);
+                EmitStatement(statement);
             }
 
             foreach (var ensures in node.Postconditions)
@@ -2639,13 +2688,14 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             {
                 if (statement is ReturnStatementNode returnStmt && returnStmt.Expression != null)
                 {
+                    var mappedReturn = TryBeginLineMapping(statement);
                     var expr = returnStmt.Expression.Accept(this);
                     AppendLine($"__result__ = {expr};");
+                    EndLineMapping(mappedReturn);
                 }
                 else
                 {
-                    var stmtCode = statement.Accept(this);
-                    AppendLine(stmtCode);
+                    EmitStatement(statement);
                 }
             }
 
@@ -2663,8 +2713,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         {
             foreach (var statement in node.Body)
             {
-                var stmtCode = statement.Accept(this);
-                AppendLine(stmtCode);
+                EmitStatement(statement);
             }
 
             foreach (var ensures in node.Postconditions)
@@ -2971,7 +3020,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
             foreach (var stmt in node.Body)
             {
-                AppendLine(stmt.Accept(this));
+                EmitStatement(stmt);
             }
 
             Dedent();
@@ -3028,7 +3077,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         foreach (var stmt in node.Body)
         {
-            AppendLine(stmt.Accept(this));
+            EmitStatement(stmt);
         }
 
         Dedent();
@@ -3083,7 +3132,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 }
                 else
                 {
-                    AppendLine(stmt.Accept(this));
+                    EmitStatement(stmt);
                 }
             }
 
@@ -3099,7 +3148,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         {
             foreach (var stmt in node.Body)
             {
-                AppendLine(stmt.Accept(this));
+                EmitStatement(stmt);
             }
         }
 
@@ -3156,7 +3205,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         foreach (var stmt in node.Body)
         {
-            AppendLine(stmt.Accept(this));
+            EmitStatement(stmt);
         }
 
         Dedent();
@@ -3175,7 +3224,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         foreach (var stmt in node.TryBody)
         {
-            AppendLine(stmt.Accept(this));
+            EmitStatement(stmt);
         }
 
         Dedent();
@@ -3194,7 +3243,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
             foreach (var stmt in node.FinallyBody)
             {
-                AppendLine(stmt.Accept(this));
+                EmitStatement(stmt);
             }
 
             Dedent();
@@ -3233,7 +3282,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         foreach (var stmt in node.Body)
         {
-            AppendLine(stmt.Accept(this));
+            EmitStatement(stmt);
         }
 
         Dedent();
@@ -3367,7 +3416,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 Indent();
                 foreach (var stmt in node.AddBody)
                 {
-                    AppendLine(stmt.Accept(this));
+                    EmitStatement(stmt);
                 }
                 Dedent();
                 AppendLine("}");
@@ -3381,7 +3430,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 Indent();
                 foreach (var stmt in node.RemoveBody)
                 {
-                    AppendLine(stmt.Accept(this));
+                    EmitStatement(stmt);
                 }
                 Dedent();
                 AppendLine("}");
@@ -4432,16 +4481,14 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         AppendLine($"#if {node.Condition}");
         foreach (var stmt in node.Body)
         {
-            var code = stmt.Accept(this);
-            if (!string.IsNullOrEmpty(code)) AppendLine(code);
+            EmitStatement(stmt, skipEmptyLine: true);
         }
         if (node.ElseBody != null && node.ElseBody.Count > 0)
         {
             AppendLine("#else");
             foreach (var stmt in node.ElseBody)
             {
-                var code = stmt.Accept(this);
-                if (!string.IsNullOrEmpty(code)) AppendLine(code);
+                EmitStatement(stmt, skipEmptyLine: true);
             }
         }
         AppendLine("#endif");
@@ -4852,8 +4899,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         Indent();
         foreach (var stmt in node.Body)
         {
-            var stmtCode = stmt.Accept(this);
-            AppendLine(stmtCode);
+            EmitStatement(stmt);
         }
         Dedent();
         AppendLine("}");
@@ -4868,8 +4914,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         Indent();
         foreach (var stmt in node.Body)
         {
-            var stmtCode = stmt.Accept(this);
-            AppendLine(stmtCode);
+            EmitStatement(stmt);
         }
         Dedent();
         AppendLine("}");
@@ -4885,8 +4930,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         Indent();
         foreach (var stmt in node.Body)
         {
-            var stmtCode = stmt.Accept(this);
-            AppendLine(stmtCode);
+            EmitStatement(stmt);
         }
         Dedent();
         AppendLine("}");

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -786,6 +786,10 @@ public class Program
         // Code generation
         phaseSw.Restart();
         var emitter = new CSharpEmitter(options.ContractMode, options.VerificationResults, inheritanceResult, options.ObligationResults);
+        if (options.EmitLineDirectives && !string.IsNullOrEmpty(filePath))
+        {
+            emitter.LineDirectiveFilePath = filePath;
+        }
         var generatedCode = emitter.Emit(ast);
         phaseSw.Stop();
         telemetry?.TrackPhase("CodeGen", phaseSw.ElapsedMilliseconds, true);
@@ -1010,6 +1014,16 @@ public sealed class CompilationOptions
     /// Default: failed=Error, boundary=AlwaysGuard, timeout=WarnAndGuard.
     /// </summary>
     public Verification.Obligations.ObligationPolicy ObligationPolicy { get; init; } = Verification.Obligations.ObligationPolicy.Default;
+
+    /// <summary>
+    /// Emit <c>#line</c> directives in generated C# mapping each statement back
+    /// to its <c>.calr</c> source location, so Roslyn diagnostics and runtime
+    /// stack traces point at the Calor source instead of the generated file.
+    /// Default: true. Requires a source file path to be passed to
+    /// <see cref="Program.Compile(string, string?, CompilationOptions)"/>;
+    /// with a null path no directives are emitted.
+    /// </summary>
+    public bool EmitLineDirectives { get; init; } = true;
 
     /// <summary>
     /// Experimental feature flags. Used by Phase 0+ of the Calor-native type-system

--- a/src/Calor.Compiler/SelfTest/SelfTestRunner.cs
+++ b/src/Calor.Compiler/SelfTest/SelfTestRunner.cs
@@ -68,7 +68,11 @@ public sealed class SelfTestRunner
             {
                 EnforceEffects = true,
                 ContractMode = ContractMode.Debug,
-                VerifyContracts = false
+                VerifyContracts = false,
+                // Golden files validate codegen shape, not source mapping.
+                // #line directives are covered by dedicated emitter tests;
+                // keeping them out of the goldens avoids noise on every edit.
+                EmitLineDirectives = false
             };
 
             // Normalize input line endings so span offsets are consistent across platforms

--- a/tests/Calor.Compiler.Tests/LineDirectiveTests.cs
+++ b/tests/Calor.Compiler.Tests/LineDirectiveTests.cs
@@ -1,0 +1,90 @@
+using Calor.Compiler;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for #line directive emission (source maps) — Phase 1 item 1 of the
+/// agent-native strategy. Generated C# maps statements back to the .calr
+/// source so Roslyn diagnostics and stack traces point at Calor code.
+/// </summary>
+public class LineDirectiveTests
+{
+    private const string FizzBuzzSource = """
+§M{m001:FizzBuzz}
+  §F{f001:Main:pub} () -> void
+    §E{cw}
+    §L{for1:i:1:100:1}
+      §IF{if1} (== (% i 15) 0)
+        §P "FizzBuzz"
+      §EI (== (% i 3) 0)
+        §P "Fizz"
+      §EL
+        §P i
+""";
+
+    [Fact]
+    public void Compile_WithFilePath_EmitsLineDirectivesByDefault()
+    {
+        var result = Program.Compile(FizzBuzzSource, "fizzbuzz.calr", new CompilationOptions());
+
+        Assert.False(result.HasErrors);
+        // The for loop is on source line 4, the if on line 5, first §P on line 6.
+        Assert.Contains("#line 4 \"fizzbuzz.calr\"", result.GeneratedCode);
+        Assert.Contains("#line 5 \"fizzbuzz.calr\"", result.GeneratedCode);
+        Assert.Contains("#line 6 \"fizzbuzz.calr\"", result.GeneratedCode);
+        // Generated-only regions are reset so they attribute to the .g.cs file.
+        Assert.Contains("#line default", result.GeneratedCode);
+    }
+
+    [Fact]
+    public void Compile_WithLineDirectivesDisabled_EmitsNoDirectives()
+    {
+        var options = new CompilationOptions { EmitLineDirectives = false };
+        var result = Program.Compile(FizzBuzzSource, "fizzbuzz.calr", options);
+
+        Assert.False(result.HasErrors);
+        Assert.DoesNotContain("#line", result.GeneratedCode);
+    }
+
+    [Fact]
+    public void Compile_WithoutFilePath_EmitsNoDirectives()
+    {
+        var result = Program.Compile(FizzBuzzSource, null, new CompilationOptions());
+
+        Assert.False(result.HasErrors);
+        Assert.DoesNotContain("#line", result.GeneratedCode);
+    }
+
+    [Fact]
+    public void Compile_EveryLineMappingIsClosed()
+    {
+        var result = Program.Compile(FizzBuzzSource, "fizzbuzz.calr", new CompilationOptions());
+
+        Assert.False(result.HasErrors);
+        var lines = result.GeneratedCode.Split('\n');
+        var opens = lines.Count(l => l.TrimStart().StartsWith("#line ") && !l.TrimStart().StartsWith("#line default"));
+        var closes = lines.Count(l => l.TrimStart().StartsWith("#line default"));
+        Assert.True(opens > 0);
+        Assert.Equal(opens, closes);
+    }
+
+    [Fact]
+    public void Compile_PathWithBackslashes_IsEscapedInDirective()
+    {
+        var result = Program.Compile(FizzBuzzSource, "src\\fizzbuzz.calr", new CompilationOptions());
+
+        Assert.False(result.HasErrors);
+        Assert.Contains("#line 4 \"src\\\\fizzbuzz.calr\"", result.GeneratedCode);
+    }
+
+    [Fact]
+    public void Compile_GeneratedCodeWithDirectives_ParsesAsValidCSharp()
+    {
+        var result = Program.Compile(FizzBuzzSource, "fizzbuzz.calr", new CompilationOptions());
+
+        Assert.False(result.HasErrors);
+        var tree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(result.GeneratedCode);
+        Assert.Empty(tree.GetDiagnostics().Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error));
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 item 1 of `docs/plans/agent-native-strategy.md` §4 (SOURCE MAPS). The emitter now writes `#line` directives so Roslyn diagnostics, debugger sessions and runtime stack traces point at the `.calr` source instead of the generated `.g.cs` files agents are forbidden to edit.

## Design choices

- **Per-statement sandwich**: every statement-level construct is emitted between `#line <n> "<file.calr>"` and `#line default`. Nested statements re-map inside blocks, so interior lines stay accurate; generated-only regions (auto-generated header, contract checks, closing braces) fall back to `#line default` and attribute honestly to the `.g.cs` file rather than mis-attributing to neighboring `.calr` lines. `#line default` was chosen over `#line hidden` so compile errors in generated regions still get a real location.
- **Single choke point**: the 30+ statement-emission loops in `CSharpEmitter` now route through one `EmitStatement` helper (plus `TryBeginLineMapping`/`EndLineMapping` for the `__result__` return-transform paths).
- **Opt-out, default ON**: `CompilationOptions.EmitLineDirectives = true`. Directives additionally require a source file path, so the hundreds of existing unit tests that call `new CSharpEmitter().Emit(ast)` or `Compile(source)` without a path are untouched.
- **Golden files**: `SelfTestRunner` compiles with `EmitLineDirectives = false` so the embedded `Resources/SelfTest/*.g.cs` goldens stay byte-identical (minimal churn; goldens validate codegen shape, and mapping is covered by the new `LineDirectiveTests`).

## Verification

- Deliberate type error (`§B{x:i32} STR:"oops"`): `dotnet build` reports `bad.calr(4,21): error CS0029`.
- Runtime crash: `DivideByZeroException ... at Crash.CrashModule.Main() in .../crash.calr:line 5`.

## Tests

- `dotnet build` clean (TreatWarningsAsErrors)
- Calor.Compiler.Tests: 5687 passed (incl. 6 new LineDirectiveTests)
- Calor.Conversion.Tests: 280 passed
- Calor.Tasks.Tests: 48, Calor.Semantics.Tests: 37, Calor.Enforcement.Tests: 271 — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MP98bPvHVGbADabAjtSYpg