### PR TITLE
feat(cli): calor run and calor test commands (Phase 1 item 2)

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -33,6 +33,8 @@ dotnet tool update -g calor
 | Command | Description |
 |:--------|:------------|
 | `calor` (default) | Compile Calor source files to C# |
+| `calor run` | Compile and execute a Calor program in one step (no project file required) |
+| `calor test` | Compile Calor sources and run xUnit tests against them (no project file required) |
 | `calor --analyze` | Static analysis: find bugs via dataflow, Z3 verification, and taint tracking |
 | [`calor assess`](/calor/cli/assess/) | Score C# files for Calor migration potential |
 | [`calor init`](/calor/cli/init/) | Initialize Calor with AI agent support and .csproj integration |

--- a/src/Calor.Compiler/Commands/ExecutionWorkspace.cs
+++ b/src/Calor.Compiler/Commands/ExecutionWorkspace.cs
@@ -1,16 +1,19 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.Diagnostics;
 using System.Security;
+using System.Text;
 using Calor.Compiler.Effects;
 
 namespace Calor.Compiler.Commands;
 
 /// <summary>
 /// Shared workspace materialization for the <c>calor run</c> and <c>calor test</c>
-/// commands. Compiles .calr sources in-process (effects enforcement on by default,
-/// same defaults as <see cref="Program.Compile(string, string, CompilationOptions?)"/>),
-/// writes the generated C# into a temporary project referencing the Calor.Runtime
-/// assembly that ships alongside the compiler, and shells out to the dotnet CLI
-/// to build/run/test it. No hand-wired MSBuild required.
+/// commands. Compiles .calr sources in-process via <see cref="CompilationDriver"/>
+/// (the same orchestration as the top-level compile command), writes the generated
+/// C# into a temporary project referencing the Calor.Runtime assembly that ships
+/// alongside the compiler, and shells out to the dotnet CLI to build/run/test it.
+/// No hand-wired MSBuild required.
 /// </summary>
 internal static class ExecutionWorkspace
 {
@@ -19,12 +22,137 @@ internal static class ExecutionWorkspace
         "The .NET SDK (10.0 or later) is required to execute Calor programs. " +
         "Install it from https://dotnet.microsoft.com/download and ensure 'dotnet' is on PATH.";
 
+    /// <summary>Default per-child-process timeout in seconds (overridable via --timeout).</summary>
+    internal const int DefaultTimeoutSeconds = 600;
+
+    /// <summary>Exit code used when a child process exceeds the timeout.</summary>
+    internal const int TimeoutExitCode = 2;
+
     internal sealed record CompiledUnit(string FileName, string GeneratedCode);
 
     /// <summary>
+    /// Settings shared by <c>calor run</c> and <c>calor test</c>, bound from the
+    /// common CLI options declared in <see cref="AddCommonOptions"/>.
+    /// </summary>
+    internal sealed record ExecutionSettings(
+        bool Permissive,
+        bool KeepTemp,
+        bool Verbose,
+        bool EnforceEffects,
+        bool Verify,
+        string ContractMode,
+        int TimeoutSeconds)
+    {
+        public TimeSpan Timeout => TimeSpan.FromSeconds(TimeoutSeconds);
+    }
+
+    /// <summary>
+    /// Declares the CLI options shared by run/test, adds them to
+    /// <paramref name="command"/>, and returns a binder that extracts an
+    /// <see cref="ExecutionSettings"/> from an invocation.
+    /// </summary>
+    internal static Func<InvocationContext, ExecutionSettings> AddCommonOptions(Command command)
+    {
+        var permissiveOption = new Option<bool>(
+            aliases: ["--permissive"],
+            description: "Relax effect enforcement: unknown calls assumed pure, forbidden effects (including cross-module violations) demoted to warnings");
+
+        var keepTempOption = new Option<bool>(
+            aliases: ["--keep-temp"],
+            description: "Preserve the materialized temp project and print its path");
+
+        var verboseOption = new Option<bool>(
+            aliases: ["--verbose", "-v"],
+            description: "Show compilation details and stream build output live");
+
+        var enforceEffectsOption = new Option<bool>(
+            aliases: ["--enforce-effects"],
+            description: "Enforce effect declarations (default: true; pass 'false' to opt out)",
+            getDefaultValue: () => true);
+
+        var verifyOption = new Option<bool>(
+            aliases: ["--verify"],
+            description: "Enable static contract verification with Z3 SMT solver");
+
+        var contractModeOption = new Option<string>(
+            aliases: ["--contract-mode"],
+            description: "Contract enforcement mode: off, debug, or release (default: debug)",
+            getDefaultValue: () => "debug");
+
+        var timeoutOption = new Option<int>(
+            aliases: ["--timeout"],
+            description: $"Timeout in seconds for each child process (build/run/test; default: {DefaultTimeoutSeconds})",
+            getDefaultValue: () => DefaultTimeoutSeconds);
+        timeoutOption.AddValidator(result =>
+        {
+            if (result.GetValueOrDefault<int>() <= 0)
+            {
+                result.ErrorMessage = "Timeout must be a positive number of seconds";
+            }
+        });
+
+        command.AddOption(permissiveOption);
+        command.AddOption(keepTempOption);
+        command.AddOption(verboseOption);
+        command.AddOption(enforceEffectsOption);
+        command.AddOption(verifyOption);
+        command.AddOption(contractModeOption);
+        command.AddOption(timeoutOption);
+
+        return ctx => new ExecutionSettings(
+            Permissive: ctx.ParseResult.GetValueForOption(permissiveOption),
+            KeepTemp: ctx.ParseResult.GetValueForOption(keepTempOption),
+            Verbose: ctx.ParseResult.GetValueForOption(verboseOption),
+            EnforceEffects: ctx.ParseResult.GetValueForOption(enforceEffectsOption),
+            Verify: ctx.ParseResult.GetValueForOption(verifyOption),
+            ContractMode: ctx.ParseResult.GetValueForOption(contractModeOption) ?? "debug",
+            TimeoutSeconds: ctx.ParseResult.GetValueForOption(timeoutOption));
+    }
+
+    internal sealed record PreparedExecution(string Dotnet, List<CompiledUnit> Units);
+
+    /// <summary>
+    /// Shared run/test prologue: resolve sources, locate the dotnet CLI, and
+    /// compile everything. Returns null with <paramref name="exitCode"/> set
+    /// when any step fails.
+    /// </summary>
+    internal static PreparedExecution? Prepare(string path, ExecutionSettings settings, out int exitCode)
+    {
+        exitCode = 0;
+
+        var sources = ResolveSources(path, out var error);
+        if (sources == null)
+        {
+            Console.Error.WriteLine($"Error: {error}");
+            exitCode = 2;
+            return null;
+        }
+
+        var dotnet = FindDotnet();
+        if (dotnet == null)
+        {
+            Console.Error.WriteLine(DotnetMissingMessage);
+            exitCode = 2;
+            return null;
+        }
+
+        var units = CompileSources(sources, settings);
+        if (units == null)
+        {
+            exitCode = 1;
+            return null;
+        }
+
+        return new PreparedExecution(dotnet, units);
+    }
+
+    /// <summary>
     /// Resolves a path argument (a .calr file or a directory containing .calr files)
-    /// to the list of source files. Returns null and sets <paramref name="error"/>
-    /// when the path is invalid or contains no Calor sources.
+    /// to the list of source files. Files under bin/, obj/, or reference/ directory
+    /// segments are skipped (with a stderr warning listing them) — reference/ holds
+    /// benchmark-pair reference solutions that duplicate the primary modules.
+    /// Returns null and sets <paramref name="error"/> when the path is invalid or
+    /// contains no Calor sources.
     /// </summary>
     internal static List<FileInfo>? ResolveSources(string path, out string error)
     {
@@ -43,11 +171,27 @@ internal static class ExecutionWorkspace
 
         if (Directory.Exists(path))
         {
-            var sources = Directory.EnumerateFiles(path, "*.calr", SearchOption.AllDirectories)
-                .Where(f => !IsInExcludedDirectory(path, f))
-                .OrderBy(f => f, StringComparer.Ordinal)
-                .Select(f => new FileInfo(Path.GetFullPath(f)))
-                .ToList();
+            var sources = new List<FileInfo>();
+            var skipped = new List<string>();
+            foreach (var file in Directory.EnumerateFiles(path, "*.calr", SearchOption.AllDirectories)
+                         .OrderBy(f => f, StringComparer.Ordinal))
+            {
+                if (IsInExcludedDirectory(path, file))
+                {
+                    skipped.Add(Path.GetRelativePath(path, file));
+                }
+                else
+                {
+                    sources.Add(new FileInfo(Path.GetFullPath(file)));
+                }
+            }
+
+            if (skipped.Count > 0)
+            {
+                Console.Error.WriteLine(
+                    $"Warning: skipping {skipped.Count} .calr file(s) under bin/, obj/, or reference/ directories: " +
+                    string.Join(", ", skipped));
+            }
 
             if (sources.Count == 0)
             {
@@ -66,89 +210,51 @@ internal static class ExecutionWorkspace
     {
         var relative = Path.GetRelativePath(root, file);
         var segments = relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        return segments.Any(s =>
+        // Only directory segments count — the file name itself is never an exclusion key.
+        return segments.Take(segments.Length - 1).Any(s =>
             s.Equals("bin", StringComparison.OrdinalIgnoreCase) ||
             s.Equals("obj", StringComparison.OrdinalIgnoreCase) ||
-            s.Equals("tests", StringComparison.OrdinalIgnoreCase));
+            s.Equals("reference", StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
-    /// Compiles all sources in-process. Effects enforcement is ON by default;
-    /// <paramref name="permissive"/> switches unknown-call handling to the
-    /// permissive policy (unknown calls assumed pure, forbidden effects demoted
-    /// to warnings). Prints diagnostics to stderr and returns null on errors.
+    /// Compiles all sources in-process through <see cref="CompilationDriver"/> —
+    /// the same orchestration as the top-level compile command, so warnings
+    /// (including permissive demotions) are always printed and cross-module
+    /// effect enforcement honors the permissive policy. Returns null on errors.
     /// </summary>
-    internal static List<CompiledUnit>? CompileSources(IReadOnlyList<FileInfo> sources, bool permissive, bool verbose)
+    internal static List<CompiledUnit>? CompileSources(IReadOnlyList<FileInfo> sources, ExecutionSettings settings)
     {
         var units = new List<CompiledUnit>();
         var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var modules = new List<(Ast.ModuleNode Ast, string FilePath)>();
-        var anyErrors = false;
+        var policy = settings.Permissive ? UnknownCallPolicy.Permissive : UnknownCallPolicy.Strict;
 
-        foreach (var file in sources)
-        {
-            if (verbose)
+        var result = CompilationDriver.CompileAll(
+            sources,
+            file => new CompilationOptions
             {
-                Console.WriteLine($"Compiling: {file.FullName}");
-            }
-
-            var source = File.ReadAllText(file.FullName);
-            var options = new CompilationOptions
-            {
-                Verbose = verbose,
-                EnforceEffects = true,
-                UnknownCallPolicy = permissive ? UnknownCallPolicy.Permissive : UnknownCallPolicy.Strict,
+                Verbose = settings.Verbose,
+                EnforceEffects = settings.EnforceEffects,
+                UnknownCallPolicy = policy,
+                VerifyContracts = settings.Verify,
+                ContractMode = CompilationDriver.ParseContractMode(settings.ContractMode),
                 ProjectDirectory = Path.GetDirectoryName(file.FullName)
-            };
-
-            var result = Program.Compile(source, file.FullName, options);
-            if (result.HasErrors)
+            },
+            crossModuleEnforcement: settings.EnforceEffects,
+            crossModulePolicy: policy,
+            onCompiled: (file, compileResult) =>
             {
-                foreach (var diagnostic in result.Diagnostics)
+                var baseName = Path.GetFileNameWithoutExtension(file.Name);
+                var fileName = $"{baseName}.g.cs";
+                for (var i = 2; !usedNames.Add(fileName); i++)
                 {
-                    Console.Error.WriteLine(diagnostic);
+                    fileName = $"{baseName}_{i}.g.cs";
                 }
 
-                anyErrors = true;
-                continue;
-            }
+                units.Add(new CompiledUnit(fileName, compileResult.GeneratedCode));
+            });
 
-            var baseName = Path.GetFileNameWithoutExtension(file.Name);
-            var fileName = $"{baseName}.g.cs";
-            for (var i = 2; !usedNames.Add(fileName); i++)
-            {
-                fileName = $"{baseName}_{i}.g.cs";
-            }
-
-            units.Add(new CompiledUnit(fileName, result.GeneratedCode));
-
-            if (result.Ast != null)
-            {
-                modules.Add((result.Ast, file.FullName));
-            }
-        }
-
-        // Cross-module effect enforcement, same as the top-level compile command.
-        if (!anyErrors && modules.Count > 1)
-        {
-            var registry = CrossModuleEffectRegistry.Build(modules);
-            foreach (var diagnostic in registry.BuildDiagnostics)
-            {
-                Console.Error.WriteLine(diagnostic);
-            }
-
-            var crossDiagnostics = new CrossModuleEffectEnforcementPass().Enforce(modules, registry);
-            foreach (var diagnostic in crossDiagnostics)
-            {
-                Console.Error.WriteLine(diagnostic);
-                if (diagnostic.IsError)
-                {
-                    anyErrors = true;
-                }
-            }
-        }
-
-        return anyErrors ? null : units;
+        return result.AnyErrors ? null : units;
     }
 
     /// <summary>
@@ -184,7 +290,7 @@ internal static class ExecutionWorkspace
             ? $"""
                  <ItemGroup>
                    <Reference Include="Calor.Runtime">
-                     <HintPath>{SecurityElement.Escape(runtimePath)}</HintPath>
+                     <HintPath>{EscapeForMsBuildValue(runtimePath)}</HintPath>
                      <Private>true</Private>
                    </Reference>
                  </ItemGroup>
@@ -213,6 +319,24 @@ internal static class ExecutionWorkspace
     }
 
     /// <summary>
+    /// Escapes a path for use as an MSBuild element value: first MSBuild special
+    /// characters (%, $, @, ', ;, ?, *) so the evaluator takes them literally,
+    /// then XML entities so the project file stays well-formed.
+    /// </summary>
+    internal static string EscapeForMsBuildValue(string value)
+    {
+        var msbuildEscaped = value
+            .Replace("%", "%25") // must be first — the escapes below introduce '%'
+            .Replace("$", "%24")
+            .Replace("@", "%40")
+            .Replace("'", "%27")
+            .Replace(";", "%3B")
+            .Replace("?", "%3F")
+            .Replace("*", "%2A");
+        return SecurityElement.Escape(msbuildEscaped) ?? msbuildEscaped;
+    }
+
+    /// <summary>
     /// Locates the dotnet CLI on PATH (or DOTNET_ROOT). Returns null when the
     /// .NET SDK is not installed.
     /// </summary>
@@ -225,7 +349,8 @@ internal static class ExecutionWorkspace
         {
             try
             {
-                var candidate = Path.Combine(dir.Trim(), exeName);
+                // Windows PATH entries may be quoted ("C:\Program Files\dotnet").
+                var candidate = Path.Combine(dir.Trim().Trim('"'), exeName);
                 if (File.Exists(candidate))
                 {
                     return candidate;
@@ -252,9 +377,10 @@ internal static class ExecutionWorkspace
 
     /// <summary>
     /// Runs a process with inherited stdio (output streams directly to the console)
-    /// and returns its exit code.
+    /// and returns its exit code. If the process exceeds <paramref name="timeout"/>,
+    /// its entire process tree is killed and <see cref="TimeoutExitCode"/> is returned.
     /// </summary>
-    internal static int RunProcess(string fileName, IReadOnlyList<string> arguments, string workingDirectory)
+    internal static int RunProcess(string fileName, IReadOnlyList<string> arguments, string workingDirectory, TimeSpan timeout)
     {
         var psi = new ProcessStartInfo
         {
@@ -275,16 +401,24 @@ internal static class ExecutionWorkspace
             return 2;
         }
 
-        process.WaitForExit();
+        if (!process.WaitForExit((int)timeout.TotalMilliseconds))
+        {
+            KillProcessTree(process);
+            Console.Error.WriteLine($"Error: process timed out after {timeout.TotalSeconds:0}s: {fileName} {string.Join(' ', arguments)}");
+            return TimeoutExitCode;
+        }
+
         return process.ExitCode;
     }
 
     /// <summary>
     /// Runs a process capturing its combined output. Used for build steps so
-    /// MSBuild noise stays hidden unless the build fails (or --verbose is set),
-    /// in which case the full output is replayed.
+    /// MSBuild noise stays hidden unless the build fails, in which case the
+    /// buffered output is replayed. With <paramref name="stream"/> (--verbose)
+    /// output is streamed to the console live instead of buffered. Applies the
+    /// same timeout/kill-tree semantics as <see cref="RunProcess"/>.
     /// </summary>
-    internal static int RunProcessCaptured(string fileName, IReadOnlyList<string> arguments, string workingDirectory, bool echoAlways)
+    internal static int RunProcessCaptured(string fileName, IReadOnlyList<string> arguments, string workingDirectory, bool stream, TimeSpan timeout)
     {
         var psi = new ProcessStartInfo
         {
@@ -300,34 +434,90 @@ internal static class ExecutionWorkspace
             psi.ArgumentList.Add(arg);
         }
 
-        using var process = Process.Start(psi);
-        if (process == null)
+        var stdOut = new StringBuilder();
+        var stdErr = new StringBuilder();
+
+        using var process = new Process();
+        process.StartInfo = psi;
+        process.OutputDataReceived += (_, e) =>
         {
-            Console.Error.WriteLine($"Error: failed to start process: {fileName}");
+            if (e.Data == null) return;
+            if (stream)
+            {
+                Console.Out.WriteLine(e.Data);
+            }
+            else
+            {
+                lock (stdOut) stdOut.AppendLine(e.Data);
+            }
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data == null) return;
+            if (stream)
+            {
+                Console.Error.WriteLine(e.Data);
+            }
+            else
+            {
+                lock (stdErr) stdErr.AppendLine(e.Data);
+            }
+        };
+
+        try
+        {
+            if (!process.Start())
+            {
+                Console.Error.WriteLine($"Error: failed to start process: {fileName}");
+                return 2;
+            }
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            Console.Error.WriteLine($"Error: failed to start process: {fileName} ({ex.Message})");
             return 2;
         }
 
-        var stdOutTask = process.StandardOutput.ReadToEndAsync();
-        var stdErrTask = process.StandardError.ReadToEndAsync();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        if (!process.WaitForExit((int)timeout.TotalMilliseconds))
+        {
+            KillProcessTree(process);
+            Console.Error.WriteLine($"Error: process timed out after {timeout.TotalSeconds:0}s: {fileName} {string.Join(' ', arguments)}");
+            return TimeoutExitCode;
+        }
+
+        // A second, untimed WaitForExit drains the async output handlers
+        // (WaitForExit(int) returning true does not wait for stream EOF).
         process.WaitForExit();
 
-        var stdOut = stdOutTask.GetAwaiter().GetResult();
-        var stdErr = stdErrTask.GetAwaiter().GetResult();
-
-        if (echoAlways || process.ExitCode != 0)
+        if (!stream && process.ExitCode != 0)
         {
-            if (stdOut.Length > 0)
+            lock (stdOut)
             {
-                Console.Out.Write(stdOut);
+                if (stdOut.Length > 0) Console.Out.Write(stdOut.ToString());
             }
 
-            if (stdErr.Length > 0)
+            lock (stdErr)
             {
-                Console.Error.Write(stdErr);
+                if (stdErr.Length > 0) Console.Error.Write(stdErr.ToString());
             }
         }
 
         return process.ExitCode;
+    }
+
+    private static void KillProcessTree(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+            // Best-effort: the process may have exited between the timeout and the kill.
+        }
     }
 
     /// <summary>

--- a/src/Calor.Compiler/Commands/ExecutionWorkspace.cs
+++ b/src/Calor.Compiler/Commands/ExecutionWorkspace.cs
@@ -1,0 +1,357 @@
+using System.Diagnostics;
+using System.Security;
+using Calor.Compiler.Effects;
+
+namespace Calor.Compiler.Commands;
+
+/// <summary>
+/// Shared workspace materialization for the <c>calor run</c> and <c>calor test</c>
+/// commands. Compiles .calr sources in-process (effects enforcement on by default,
+/// same defaults as <see cref="Program.Compile(string, string, CompilationOptions?)"/>),
+/// writes the generated C# into a temporary project referencing the Calor.Runtime
+/// assembly that ships alongside the compiler, and shells out to the dotnet CLI
+/// to build/run/test it. No hand-wired MSBuild required.
+/// </summary>
+internal static class ExecutionWorkspace
+{
+    internal const string DotnetMissingMessage =
+        "Error: the 'dotnet' CLI was not found on PATH. " +
+        "The .NET SDK (10.0 or later) is required to execute Calor programs. " +
+        "Install it from https://dotnet.microsoft.com/download and ensure 'dotnet' is on PATH.";
+
+    internal sealed record CompiledUnit(string FileName, string GeneratedCode);
+
+    /// <summary>
+    /// Resolves a path argument (a .calr file or a directory containing .calr files)
+    /// to the list of source files. Returns null and sets <paramref name="error"/>
+    /// when the path is invalid or contains no Calor sources.
+    /// </summary>
+    internal static List<FileInfo>? ResolveSources(string path, out string error)
+    {
+        error = string.Empty;
+
+        if (File.Exists(path))
+        {
+            if (!path.EndsWith(".calr", StringComparison.OrdinalIgnoreCase))
+            {
+                error = $"Not a Calor source file (expected .calr extension): {path}";
+                return null;
+            }
+
+            return [new FileInfo(Path.GetFullPath(path))];
+        }
+
+        if (Directory.Exists(path))
+        {
+            var sources = Directory.EnumerateFiles(path, "*.calr", SearchOption.AllDirectories)
+                .Where(f => !IsInExcludedDirectory(path, f))
+                .OrderBy(f => f, StringComparer.Ordinal)
+                .Select(f => new FileInfo(Path.GetFullPath(f)))
+                .ToList();
+
+            if (sources.Count == 0)
+            {
+                error = $"No .calr files found in directory: {path}";
+                return null;
+            }
+
+            return sources;
+        }
+
+        error = $"File or directory not found: {path}";
+        return null;
+    }
+
+    private static bool IsInExcludedDirectory(string root, string file)
+    {
+        var relative = Path.GetRelativePath(root, file);
+        var segments = relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return segments.Any(s =>
+            s.Equals("bin", StringComparison.OrdinalIgnoreCase) ||
+            s.Equals("obj", StringComparison.OrdinalIgnoreCase) ||
+            s.Equals("tests", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Compiles all sources in-process. Effects enforcement is ON by default;
+    /// <paramref name="permissive"/> switches unknown-call handling to the
+    /// permissive policy (unknown calls assumed pure, forbidden effects demoted
+    /// to warnings). Prints diagnostics to stderr and returns null on errors.
+    /// </summary>
+    internal static List<CompiledUnit>? CompileSources(IReadOnlyList<FileInfo> sources, bool permissive, bool verbose)
+    {
+        var units = new List<CompiledUnit>();
+        var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var modules = new List<(Ast.ModuleNode Ast, string FilePath)>();
+        var anyErrors = false;
+
+        foreach (var file in sources)
+        {
+            if (verbose)
+            {
+                Console.WriteLine($"Compiling: {file.FullName}");
+            }
+
+            var source = File.ReadAllText(file.FullName);
+            var options = new CompilationOptions
+            {
+                Verbose = verbose,
+                EnforceEffects = true,
+                UnknownCallPolicy = permissive ? UnknownCallPolicy.Permissive : UnknownCallPolicy.Strict,
+                ProjectDirectory = Path.GetDirectoryName(file.FullName)
+            };
+
+            var result = Program.Compile(source, file.FullName, options);
+            if (result.HasErrors)
+            {
+                foreach (var diagnostic in result.Diagnostics)
+                {
+                    Console.Error.WriteLine(diagnostic);
+                }
+
+                anyErrors = true;
+                continue;
+            }
+
+            var baseName = Path.GetFileNameWithoutExtension(file.Name);
+            var fileName = $"{baseName}.g.cs";
+            for (var i = 2; !usedNames.Add(fileName); i++)
+            {
+                fileName = $"{baseName}_{i}.g.cs";
+            }
+
+            units.Add(new CompiledUnit(fileName, result.GeneratedCode));
+
+            if (result.Ast != null)
+            {
+                modules.Add((result.Ast, file.FullName));
+            }
+        }
+
+        // Cross-module effect enforcement, same as the top-level compile command.
+        if (!anyErrors && modules.Count > 1)
+        {
+            var registry = CrossModuleEffectRegistry.Build(modules);
+            foreach (var diagnostic in registry.BuildDiagnostics)
+            {
+                Console.Error.WriteLine(diagnostic);
+            }
+
+            var crossDiagnostics = new CrossModuleEffectEnforcementPass().Enforce(modules, registry);
+            foreach (var diagnostic in crossDiagnostics)
+            {
+                Console.Error.WriteLine(diagnostic);
+                if (diagnostic.IsError)
+                {
+                    anyErrors = true;
+                }
+            }
+        }
+
+        return anyErrors ? null : units;
+    }
+
+    /// <summary>
+    /// Creates an isolated temp workspace. Empty Directory.Build.props/targets
+    /// insulate the materialized projects from any repository-level MSBuild
+    /// customization above the temp directory.
+    /// </summary>
+    internal static string CreateWorkspace(string prefix)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"{prefix}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "Directory.Build.props"), "<Project />");
+        File.WriteAllText(Path.Combine(dir, "Directory.Build.targets"), "<Project />");
+        return dir;
+    }
+
+    /// <summary>
+    /// Writes the generated C# files and a .csproj into <paramref name="projectDir"/>.
+    /// The project references the Calor.Runtime assembly shipped next to the running
+    /// compiler (works both for repo dev builds, where the ProjectReference copies it
+    /// to the compiler output, and for the installed global tool).
+    /// </summary>
+    internal static string WriteProject(string projectDir, string projectName, bool executable, IReadOnlyList<CompiledUnit> units)
+    {
+        Directory.CreateDirectory(projectDir);
+        foreach (var unit in units)
+        {
+            File.WriteAllText(Path.Combine(projectDir, unit.FileName), unit.GeneratedCode);
+        }
+
+        var runtimePath = Path.Combine(AppContext.BaseDirectory, "Calor.Runtime.dll");
+        var runtimeReference = File.Exists(runtimePath)
+            ? $"""
+                 <ItemGroup>
+                   <Reference Include="Calor.Runtime">
+                     <HintPath>{SecurityElement.Escape(runtimePath)}</HintPath>
+                     <Private>true</Private>
+                   </Reference>
+                 </ItemGroup>
+               """
+            : "  <!-- Calor.Runtime.dll not found next to the compiler; runtime types unavailable -->";
+
+        var csproj = $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+
+              <PropertyGroup>
+                <OutputType>{(executable ? "Exe" : "Library")}</OutputType>
+                <TargetFramework>net10.0</TargetFramework>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+                <AssemblyName>{projectName}</AssemblyName>
+              </PropertyGroup>
+
+            {runtimeReference}
+
+            </Project>
+            """;
+
+        var csprojPath = Path.Combine(projectDir, $"{projectName}.csproj");
+        File.WriteAllText(csprojPath, csproj);
+        return csprojPath;
+    }
+
+    /// <summary>
+    /// Locates the dotnet CLI on PATH (or DOTNET_ROOT). Returns null when the
+    /// .NET SDK is not installed.
+    /// </summary>
+    internal static string? FindDotnet()
+    {
+        var exeName = OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet";
+
+        var pathVar = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        foreach (var dir in pathVar.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            try
+            {
+                var candidate = Path.Combine(dir.Trim(), exeName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+            catch (ArgumentException)
+            {
+                // Malformed PATH entry — skip it.
+            }
+        }
+
+        var dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+        if (!string.IsNullOrEmpty(dotnetRoot))
+        {
+            var candidate = Path.Combine(dotnetRoot, exeName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Runs a process with inherited stdio (output streams directly to the console)
+    /// and returns its exit code.
+    /// </summary>
+    internal static int RunProcess(string fileName, IReadOnlyList<string> arguments, string workingDirectory)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = fileName,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false
+        };
+
+        foreach (var arg in arguments)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        using var process = Process.Start(psi);
+        if (process == null)
+        {
+            Console.Error.WriteLine($"Error: failed to start process: {fileName}");
+            return 2;
+        }
+
+        process.WaitForExit();
+        return process.ExitCode;
+    }
+
+    /// <summary>
+    /// Runs a process capturing its combined output. Used for build steps so
+    /// MSBuild noise stays hidden unless the build fails (or --verbose is set),
+    /// in which case the full output is replayed.
+    /// </summary>
+    internal static int RunProcessCaptured(string fileName, IReadOnlyList<string> arguments, string workingDirectory, bool echoAlways)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = fileName,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        foreach (var arg in arguments)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        using var process = Process.Start(psi);
+        if (process == null)
+        {
+            Console.Error.WriteLine($"Error: failed to start process: {fileName}");
+            return 2;
+        }
+
+        var stdOutTask = process.StandardOutput.ReadToEndAsync();
+        var stdErrTask = process.StandardError.ReadToEndAsync();
+        process.WaitForExit();
+
+        var stdOut = stdOutTask.GetAwaiter().GetResult();
+        var stdErr = stdErrTask.GetAwaiter().GetResult();
+
+        if (echoAlways || process.ExitCode != 0)
+        {
+            if (stdOut.Length > 0)
+            {
+                Console.Out.Write(stdOut);
+            }
+
+            if (stdErr.Length > 0)
+            {
+                Console.Error.Write(stdErr);
+            }
+        }
+
+        return process.ExitCode;
+    }
+
+    /// <summary>
+    /// Deletes the workspace unless --keep-temp was requested, in which case its
+    /// path is printed so the materialized project can be inspected.
+    /// </summary>
+    internal static void FinishWorkspace(string workspace, bool keepTemp)
+    {
+        if (keepTemp)
+        {
+            Console.WriteLine($"Workspace kept at: {workspace}");
+            return;
+        }
+
+        try
+        {
+            Directory.Delete(workspace, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; temp directories are reaped by the OS eventually.
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/src/Calor.Compiler/Commands/RunCommand.cs
+++ b/src/Calor.Compiler/Commands/RunCommand.cs
@@ -15,73 +15,44 @@ public static class RunCommand
     {
         var pathArgument = new Argument<string>(
             name: "path",
-            description: "A .calr file, or a directory containing .calr files (bin/, obj/ and tests/ subdirectories are excluded)");
-
-        var permissiveOption = new Option<bool>(
-            aliases: ["--permissive"],
-            description: "Relax effect enforcement: unknown calls assumed pure, forbidden effects demoted to warnings");
-
-        var keepTempOption = new Option<bool>(
-            aliases: ["--keep-temp"],
-            description: "Preserve the materialized temp project and print its path");
-
-        var verboseOption = new Option<bool>(
-            aliases: ["--verbose", "-v"],
-            description: "Show compilation and build details");
+            description: "A .calr file, or a directory containing .calr files (bin/, obj/ and reference/ subdirectories are excluded)");
 
         var command = new Command("run", "Compile and execute a Calor program (no project file required)")
         {
-            pathArgument,
-            permissiveOption,
-            keepTempOption,
-            verboseOption
+            pathArgument
         };
 
-        command.SetHandler(async (InvocationContext ctx) =>
+        var bindSettings = ExecutionWorkspace.AddCommonOptions(command);
+
+        command.SetHandler((InvocationContext ctx) =>
         {
             var path = ctx.ParseResult.GetValueForArgument(pathArgument);
-            var permissive = ctx.ParseResult.GetValueForOption(permissiveOption);
-            var keepTemp = ctx.ParseResult.GetValueForOption(keepTempOption);
-            var verbose = ctx.ParseResult.GetValueForOption(verboseOption);
-            ctx.ExitCode = await Task.Run(() => Execute(path, permissive, keepTemp, verbose));
+            ctx.ExitCode = Execute(path, bindSettings(ctx));
         });
 
         return command;
     }
 
-    private static int Execute(string path, bool permissive, bool keepTemp, bool verbose)
+    private static int Execute(string path, ExecutionWorkspace.ExecutionSettings settings)
     {
-        var sources = ExecutionWorkspace.ResolveSources(path, out var error);
-        if (sources == null)
+        var prepared = ExecutionWorkspace.Prepare(path, settings, out var exitCode);
+        if (prepared == null)
         {
-            Console.Error.WriteLine($"Error: {error}");
-            return 2;
-        }
-
-        var dotnet = ExecutionWorkspace.FindDotnet();
-        if (dotnet == null)
-        {
-            Console.Error.WriteLine(ExecutionWorkspace.DotnetMissingMessage);
-            return 2;
-        }
-
-        var units = ExecutionWorkspace.CompileSources(sources, permissive, verbose);
-        if (units == null)
-        {
-            return 1;
+            return exitCode;
         }
 
         var workspace = ExecutionWorkspace.CreateWorkspace("calor-run");
         try
         {
             var projectPath = ExecutionWorkspace.WriteProject(
-                Path.Combine(workspace, "app"), "CalorApp", executable: true, units);
+                Path.Combine(workspace, "app"), "CalorApp", executable: true, prepared.Units);
 
             var outDir = Path.Combine(workspace, "out");
-            var buildExit = ExecutionWorkspace.RunProcessCaptured(dotnet,
-                ["build", projectPath, "--nologo", "-o", outDir, "-v", verbose ? "minimal" : "quiet"],
+            var buildExit = ExecutionWorkspace.RunProcessCaptured(prepared.Dotnet,
+                ["build", projectPath, "--nologo", "-o", outDir, "-v", settings.Verbose ? "minimal" : "quiet"],
                 workspace,
-                echoAlways: verbose);
+                stream: settings.Verbose,
+                settings.Timeout);
             if (buildExit != 0)
             {
                 Console.Error.WriteLine("Error: build of the generated C# project failed (see output above).");
@@ -90,13 +61,14 @@ public static class RunCommand
 
             // Run from the user's current directory so relative-path file IO in the
             // program behaves as expected; exit code is the program's exit code.
-            return ExecutionWorkspace.RunProcess(dotnet,
+            return ExecutionWorkspace.RunProcess(prepared.Dotnet,
                 [Path.Combine(outDir, "CalorApp.dll")],
-                Environment.CurrentDirectory);
+                Environment.CurrentDirectory,
+                settings.Timeout);
         }
         finally
         {
-            ExecutionWorkspace.FinishWorkspace(workspace, keepTemp);
+            ExecutionWorkspace.FinishWorkspace(workspace, settings.KeepTemp);
         }
     }
 }

--- a/src/Calor.Compiler/Commands/RunCommand.cs
+++ b/src/Calor.Compiler/Commands/RunCommand.cs
@@ -1,0 +1,102 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+
+namespace Calor.Compiler.Commands;
+
+/// <summary>
+/// CLI command that compiles and executes a Calor program in one step:
+/// <c>calor run file.calr</c> or <c>calor run dir/</c>. Materializes a temporary
+/// executable project from the generated C#, builds it with the dotnet CLI,
+/// runs it streaming its output, and propagates the program's exit code.
+/// </summary>
+public static class RunCommand
+{
+    public static Command Create()
+    {
+        var pathArgument = new Argument<string>(
+            name: "path",
+            description: "A .calr file, or a directory containing .calr files (bin/, obj/ and tests/ subdirectories are excluded)");
+
+        var permissiveOption = new Option<bool>(
+            aliases: ["--permissive"],
+            description: "Relax effect enforcement: unknown calls assumed pure, forbidden effects demoted to warnings");
+
+        var keepTempOption = new Option<bool>(
+            aliases: ["--keep-temp"],
+            description: "Preserve the materialized temp project and print its path");
+
+        var verboseOption = new Option<bool>(
+            aliases: ["--verbose", "-v"],
+            description: "Show compilation and build details");
+
+        var command = new Command("run", "Compile and execute a Calor program (no project file required)")
+        {
+            pathArgument,
+            permissiveOption,
+            keepTempOption,
+            verboseOption
+        };
+
+        command.SetHandler(async (InvocationContext ctx) =>
+        {
+            var path = ctx.ParseResult.GetValueForArgument(pathArgument);
+            var permissive = ctx.ParseResult.GetValueForOption(permissiveOption);
+            var keepTemp = ctx.ParseResult.GetValueForOption(keepTempOption);
+            var verbose = ctx.ParseResult.GetValueForOption(verboseOption);
+            ctx.ExitCode = await Task.Run(() => Execute(path, permissive, keepTemp, verbose));
+        });
+
+        return command;
+    }
+
+    private static int Execute(string path, bool permissive, bool keepTemp, bool verbose)
+    {
+        var sources = ExecutionWorkspace.ResolveSources(path, out var error);
+        if (sources == null)
+        {
+            Console.Error.WriteLine($"Error: {error}");
+            return 2;
+        }
+
+        var dotnet = ExecutionWorkspace.FindDotnet();
+        if (dotnet == null)
+        {
+            Console.Error.WriteLine(ExecutionWorkspace.DotnetMissingMessage);
+            return 2;
+        }
+
+        var units = ExecutionWorkspace.CompileSources(sources, permissive, verbose);
+        if (units == null)
+        {
+            return 1;
+        }
+
+        var workspace = ExecutionWorkspace.CreateWorkspace("calor-run");
+        try
+        {
+            var projectPath = ExecutionWorkspace.WriteProject(
+                Path.Combine(workspace, "app"), "CalorApp", executable: true, units);
+
+            var outDir = Path.Combine(workspace, "out");
+            var buildExit = ExecutionWorkspace.RunProcessCaptured(dotnet,
+                ["build", projectPath, "--nologo", "-o", outDir, "-v", verbose ? "minimal" : "quiet"],
+                workspace,
+                echoAlways: verbose);
+            if (buildExit != 0)
+            {
+                Console.Error.WriteLine("Error: build of the generated C# project failed (see output above).");
+                return buildExit;
+            }
+
+            // Run from the user's current directory so relative-path file IO in the
+            // program behaves as expected; exit code is the program's exit code.
+            return ExecutionWorkspace.RunProcess(dotnet,
+                [Path.Combine(outDir, "CalorApp.dll")],
+                Environment.CurrentDirectory);
+        }
+        finally
+        {
+            ExecutionWorkspace.FinishWorkspace(workspace, keepTemp);
+        }
+    }
+}

--- a/src/Calor.Compiler/Commands/TestCommand.cs
+++ b/src/Calor.Compiler/Commands/TestCommand.cs
@@ -9,69 +9,46 @@ namespace Calor.Compiler.Commands;
 /// materialized as a temporary class library; when the target directory has a
 /// tests/ subdirectory of C# files (the benchmark-pair layout: src .calr +
 /// tests/*.cs), a generated xUnit project referencing the library runs them via
-/// <c>dotnet test</c>. Otherwise <c>dotnet test</c> runs on the materialized
-/// library itself, which validates that the generated C# builds.
+/// <c>dotnet test</c>. When no tests are found, the library is still built to
+/// validate the generated C#, and the command exits with
+/// <see cref="NoTestsExitCode"/>.
 /// </summary>
 public static class TestCommand
 {
+    /// <summary>
+    /// Exit code when the target compiled and built but no tests were found —
+    /// distinct from test failure (non-zero from dotnet test) and usage errors (2).
+    /// </summary>
+    public const int NoTestsExitCode = 3;
+
     public static Command Create()
     {
         var pathArgument = new Argument<string>(
             name: "path",
-            description: "A .calr file, or a directory containing .calr files (with an optional tests/ subdirectory of *.cs xUnit tests)");
-
-        var permissiveOption = new Option<bool>(
-            aliases: ["--permissive"],
-            description: "Relax effect enforcement: unknown calls assumed pure, forbidden effects demoted to warnings");
-
-        var keepTempOption = new Option<bool>(
-            aliases: ["--keep-temp"],
-            description: "Preserve the materialized temp projects and print their path");
-
-        var verboseOption = new Option<bool>(
-            aliases: ["--verbose", "-v"],
-            description: "Show compilation and build details");
+            description: "A .calr file, or a directory containing .calr files (with an optional tests/ subdirectory of *.cs xUnit tests; bin/, obj/ and reference/ subdirectories are excluded)");
 
         var command = new Command("test", "Compile Calor sources and run tests against them (no project file required)")
         {
-            pathArgument,
-            permissiveOption,
-            keepTempOption,
-            verboseOption
+            pathArgument
         };
 
-        command.SetHandler(async (InvocationContext ctx) =>
+        var bindSettings = ExecutionWorkspace.AddCommonOptions(command);
+
+        command.SetHandler((InvocationContext ctx) =>
         {
             var path = ctx.ParseResult.GetValueForArgument(pathArgument);
-            var permissive = ctx.ParseResult.GetValueForOption(permissiveOption);
-            var keepTemp = ctx.ParseResult.GetValueForOption(keepTempOption);
-            var verbose = ctx.ParseResult.GetValueForOption(verboseOption);
-            ctx.ExitCode = await Task.Run(() => Execute(path, permissive, keepTemp, verbose));
+            ctx.ExitCode = Execute(path, bindSettings(ctx));
         });
 
         return command;
     }
 
-    private static int Execute(string path, bool permissive, bool keepTemp, bool verbose)
+    private static int Execute(string path, ExecutionWorkspace.ExecutionSettings settings)
     {
-        var sources = ExecutionWorkspace.ResolveSources(path, out var error);
-        if (sources == null)
+        var prepared = ExecutionWorkspace.Prepare(path, settings, out var exitCode);
+        if (prepared == null)
         {
-            Console.Error.WriteLine($"Error: {error}");
-            return 2;
-        }
-
-        var dotnet = ExecutionWorkspace.FindDotnet();
-        if (dotnet == null)
-        {
-            Console.Error.WriteLine(ExecutionWorkspace.DotnetMissingMessage);
-            return 2;
-        }
-
-        var units = ExecutionWorkspace.CompileSources(sources, permissive, verbose);
-        if (units == null)
-        {
-            return 1;
+            return exitCode;
         }
 
         var testFiles = FindTestFiles(path);
@@ -80,26 +57,39 @@ public static class TestCommand
         try
         {
             var srcProjectPath = ExecutionWorkspace.WriteProject(
-                Path.Combine(workspace, "src"), "CalorSrc", executable: false, units);
+                Path.Combine(workspace, "src"), "CalorSrc", executable: false, prepared.Units);
 
-            string testTarget;
-            if (testFiles.Count > 0)
+            if (testFiles.Count == 0)
             {
-                testTarget = WriteTestProject(Path.Combine(workspace, "tests"), testFiles);
-            }
-            else
-            {
-                Console.WriteLine("No tests/ directory with .cs files found — running 'dotnet test' on the compiled sources only.");
-                testTarget = srcProjectPath;
+                // No tests to run: still build the library so the generated C#
+                // is validated, then report the distinct "no tests" exit code.
+                var buildExit = ExecutionWorkspace.RunProcessCaptured(prepared.Dotnet,
+                    ["build", srcProjectPath, "--nologo", "-v", settings.Verbose ? "minimal" : "quiet"],
+                    workspace,
+                    stream: settings.Verbose,
+                    settings.Timeout);
+                if (buildExit != 0)
+                {
+                    Console.Error.WriteLine("Error: build of the generated C# project failed (see output above).");
+                    return buildExit;
+                }
+
+                Console.Error.WriteLine(
+                    "No tests found: no tests/ directory with .cs files next to the sources. " +
+                    "The generated C# builds successfully.");
+                return NoTestsExitCode;
             }
 
-            return ExecutionWorkspace.RunProcess(dotnet,
-                ["test", testTarget, "--nologo", "-v", verbose ? "normal" : "minimal"],
-                workspace);
+            var testProjectPath = WriteTestProject(Path.Combine(workspace, "tests"), testFiles);
+
+            return ExecutionWorkspace.RunProcess(prepared.Dotnet,
+                ["test", testProjectPath, "--nologo", "-v", settings.Verbose ? "normal" : "minimal"],
+                workspace,
+                settings.Timeout);
         }
         finally
         {
-            ExecutionWorkspace.FinishWorkspace(workspace, keepTemp);
+            ExecutionWorkspace.FinishWorkspace(workspace, settings.KeepTemp);
         }
     }
 
@@ -145,8 +135,9 @@ public static class TestCommand
             File.Copy(sourcePath, Path.Combine(projectDir, targetName), overwrite: true);
         }
 
-        // Package versions match the repository's own test projects so they
-        // resolve from the local NuGet cache in typical dev environments.
+        // Package versions match the phase0 benchmark harness pins
+        // (bench/phase0-agent-native/run-pair.sh) so both execution paths
+        // resolve identical test-stack versions from the local NuGet cache.
         const string csproj = """
             <Project Sdk="Microsoft.NET.Sdk">
 
@@ -158,9 +149,9 @@ public static class TestCommand
               </PropertyGroup>
 
               <ItemGroup>
-                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-                <PackageReference Include="xunit" Version="2.6.2" />
-                <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+                <PackageReference Include="xunit" Version="2.9.2" />
+                <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
               </ItemGroup>
 
               <ItemGroup>

--- a/src/Calor.Compiler/Commands/TestCommand.cs
+++ b/src/Calor.Compiler/Commands/TestCommand.cs
@@ -1,0 +1,177 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+
+namespace Calor.Compiler.Commands;
+
+/// <summary>
+/// CLI command that compiles Calor sources and runs tests against them:
+/// <c>calor test file.calr</c> or <c>calor test dir/</c>. The sources are
+/// materialized as a temporary class library; when the target directory has a
+/// tests/ subdirectory of C# files (the benchmark-pair layout: src .calr +
+/// tests/*.cs), a generated xUnit project referencing the library runs them via
+/// <c>dotnet test</c>. Otherwise <c>dotnet test</c> runs on the materialized
+/// library itself, which validates that the generated C# builds.
+/// </summary>
+public static class TestCommand
+{
+    public static Command Create()
+    {
+        var pathArgument = new Argument<string>(
+            name: "path",
+            description: "A .calr file, or a directory containing .calr files (with an optional tests/ subdirectory of *.cs xUnit tests)");
+
+        var permissiveOption = new Option<bool>(
+            aliases: ["--permissive"],
+            description: "Relax effect enforcement: unknown calls assumed pure, forbidden effects demoted to warnings");
+
+        var keepTempOption = new Option<bool>(
+            aliases: ["--keep-temp"],
+            description: "Preserve the materialized temp projects and print their path");
+
+        var verboseOption = new Option<bool>(
+            aliases: ["--verbose", "-v"],
+            description: "Show compilation and build details");
+
+        var command = new Command("test", "Compile Calor sources and run tests against them (no project file required)")
+        {
+            pathArgument,
+            permissiveOption,
+            keepTempOption,
+            verboseOption
+        };
+
+        command.SetHandler(async (InvocationContext ctx) =>
+        {
+            var path = ctx.ParseResult.GetValueForArgument(pathArgument);
+            var permissive = ctx.ParseResult.GetValueForOption(permissiveOption);
+            var keepTemp = ctx.ParseResult.GetValueForOption(keepTempOption);
+            var verbose = ctx.ParseResult.GetValueForOption(verboseOption);
+            ctx.ExitCode = await Task.Run(() => Execute(path, permissive, keepTemp, verbose));
+        });
+
+        return command;
+    }
+
+    private static int Execute(string path, bool permissive, bool keepTemp, bool verbose)
+    {
+        var sources = ExecutionWorkspace.ResolveSources(path, out var error);
+        if (sources == null)
+        {
+            Console.Error.WriteLine($"Error: {error}");
+            return 2;
+        }
+
+        var dotnet = ExecutionWorkspace.FindDotnet();
+        if (dotnet == null)
+        {
+            Console.Error.WriteLine(ExecutionWorkspace.DotnetMissingMessage);
+            return 2;
+        }
+
+        var units = ExecutionWorkspace.CompileSources(sources, permissive, verbose);
+        if (units == null)
+        {
+            return 1;
+        }
+
+        var testFiles = FindTestFiles(path);
+
+        var workspace = ExecutionWorkspace.CreateWorkspace("calor-test");
+        try
+        {
+            var srcProjectPath = ExecutionWorkspace.WriteProject(
+                Path.Combine(workspace, "src"), "CalorSrc", executable: false, units);
+
+            string testTarget;
+            if (testFiles.Count > 0)
+            {
+                testTarget = WriteTestProject(Path.Combine(workspace, "tests"), testFiles);
+            }
+            else
+            {
+                Console.WriteLine("No tests/ directory with .cs files found — running 'dotnet test' on the compiled sources only.");
+                testTarget = srcProjectPath;
+            }
+
+            return ExecutionWorkspace.RunProcess(dotnet,
+                ["test", testTarget, "--nologo", "-v", verbose ? "normal" : "minimal"],
+                workspace);
+        }
+        finally
+        {
+            ExecutionWorkspace.FinishWorkspace(workspace, keepTemp);
+        }
+    }
+
+    /// <summary>
+    /// Finds test sources for the v1 benchmark-pair layout: a tests/ subdirectory
+    /// with top-level *.cs files, plus an optional tests/shims/TestShim.calor.cs
+    /// (the Calor-arm shim, copied in as TestShim.cs).
+    /// </summary>
+    private static List<(string SourcePath, string TargetName)> FindTestFiles(string path)
+    {
+        var files = new List<(string SourcePath, string TargetName)>();
+        if (!Directory.Exists(path))
+        {
+            return files;
+        }
+
+        var testsDir = Path.Combine(path, "tests");
+        if (!Directory.Exists(testsDir))
+        {
+            return files;
+        }
+
+        foreach (var file in Directory.EnumerateFiles(testsDir, "*.cs", SearchOption.TopDirectoryOnly)
+                     .OrderBy(f => f, StringComparer.Ordinal))
+        {
+            files.Add((file, Path.GetFileName(file)));
+        }
+
+        var calorShim = Path.Combine(testsDir, "shims", "TestShim.calor.cs");
+        if (File.Exists(calorShim))
+        {
+            files.Add((calorShim, "TestShim.cs"));
+        }
+
+        return files;
+    }
+
+    private static string WriteTestProject(string projectDir, List<(string SourcePath, string TargetName)> testFiles)
+    {
+        Directory.CreateDirectory(projectDir);
+        foreach (var (sourcePath, targetName) in testFiles)
+        {
+            File.Copy(sourcePath, Path.Combine(projectDir, targetName), overwrite: true);
+        }
+
+        // Package versions match the repository's own test projects so they
+        // resolve from the local NuGet cache in typical dev environments.
+        const string csproj = """
+            <Project Sdk="Microsoft.NET.Sdk">
+
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+                <IsPackable>false</IsPackable>
+              </PropertyGroup>
+
+              <ItemGroup>
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+                <PackageReference Include="xunit" Version="2.6.2" />
+                <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+              </ItemGroup>
+
+              <ItemGroup>
+                <ProjectReference Include="../src/CalorSrc.csproj" />
+              </ItemGroup>
+
+            </Project>
+            """;
+
+        var csprojPath = Path.Combine(projectDir, "CalorTests.csproj");
+        File.WriteAllText(csprojPath, csproj);
+        return csprojPath;
+    }
+}

--- a/src/Calor.Compiler/CompilationDriver.cs
+++ b/src/Calor.Compiler/CompilationDriver.cs
@@ -1,0 +1,130 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Effects;
+
+namespace Calor.Compiler;
+
+/// <summary>
+/// Shared multi-file compile orchestration used by the top-level compile command
+/// (<see cref="Program"/>) and by <c>calor run</c> / <c>calor test</c>
+/// (<c>ExecutionWorkspace</c>). One place owns the loop semantics:
+/// <list type="bullet">
+///   <item>Each file is compiled with options from <c>optionsFactory</c>.</item>
+///   <item>Warnings are always printed to stderr — including warnings produced by
+///     demotion under the permissive policy — not only when a file has errors.</item>
+///   <item>Cross-module effect enforcement runs over the successfully compiled
+///     modules regardless of whether other files failed, and honors the
+///     <see cref="UnknownCallPolicy"/> (permissive demotes violations to warnings).</item>
+/// </list>
+/// </summary>
+internal static class CompilationDriver
+{
+    internal sealed record FileResult(FileInfo File, CompilationResult Result);
+
+    internal sealed record DriverResult(List<FileResult> Compiled, bool AnyErrors);
+
+    /// <summary>
+    /// Compiles all <paramref name="sources"/> in order. <paramref name="onCompiled"/>
+    /// is invoked for each successfully compiled file (e.g. to write its output),
+    /// before cross-module enforcement runs.
+    /// </summary>
+    /// <param name="crossModuleEnforcement">
+    /// Whether to run cross-module effect enforcement when more than one module
+    /// compiled successfully. The top-level compile command always passes true
+    /// (its historical behavior); run/test pass their effective effects-enforcement
+    /// setting.
+    /// </param>
+    internal static DriverResult CompileAll(
+        IReadOnlyList<FileInfo> sources,
+        Func<FileInfo, CompilationOptions> optionsFactory,
+        bool crossModuleEnforcement,
+        UnknownCallPolicy crossModulePolicy,
+        Action<FileInfo, CompilationResult>? onCompiled = null)
+    {
+        var compiled = new List<FileResult>();
+        var modules = new List<(ModuleNode Ast, string FilePath)>();
+        var anyErrors = false;
+
+        foreach (var file in sources)
+        {
+            var options = optionsFactory(file);
+            if (options.Verbose)
+            {
+                Console.WriteLine($"Compiling: {file.FullName}");
+            }
+
+            var source = File.ReadAllText(file.FullName);
+            var result = Program.Compile(source, file.FullName, options);
+
+            PrintDiagnostics(result.Diagnostics, includeAll: result.HasErrors);
+
+            if (result.HasErrors)
+            {
+                anyErrors = true;
+                continue;
+            }
+
+            compiled.Add(new FileResult(file, result));
+            onCompiled?.Invoke(file, result);
+
+            if (result.Ast != null)
+            {
+                modules.Add((result.Ast, file.FullName));
+            }
+        }
+
+        // Cross-module effect enforcement over successfully compiled modules —
+        // runs even when other files failed, so all reportable violations surface
+        // in one pass (top-level compile semantics).
+        if (crossModuleEnforcement && modules.Count > 1)
+        {
+            var registry = CrossModuleEffectRegistry.Build(modules);
+            foreach (var diagnostic in registry.BuildDiagnostics)
+            {
+                Console.Error.WriteLine(diagnostic);
+            }
+
+            var crossPass = new CrossModuleEffectEnforcementPass(crossModulePolicy);
+            var crossDiagnostics = crossPass.Enforce(modules, registry);
+
+            foreach (var diagnostic in crossDiagnostics)
+            {
+                Console.Error.WriteLine(diagnostic);
+                if (diagnostic.IsError)
+                {
+                    anyErrors = true;
+                }
+            }
+        }
+
+        return new DriverResult(compiled, anyErrors);
+    }
+
+    /// <summary>
+    /// Prints diagnostics to stderr. Errors and warnings are always printed;
+    /// informational diagnostics are included only when the compilation failed
+    /// (preserving the historical quiet-on-success output).
+    /// </summary>
+    private static void PrintDiagnostics(DiagnosticBag diagnostics, bool includeAll)
+    {
+        foreach (var diagnostic in diagnostics)
+        {
+            if (includeAll || diagnostic.IsError || diagnostic.IsWarning)
+            {
+                Console.Error.WriteLine(diagnostic);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses a --contract-mode CLI value ("off", "debug", "release"; case-insensitive).
+    /// Unrecognized values fall back to <see cref="ContractMode.Debug"/>.
+    /// </summary>
+    internal static ContractMode ParseContractMode(string? contractMode) =>
+        contractMode?.ToLowerInvariant() switch
+        {
+            "off" => ContractMode.Off,
+            "release" => ContractMode.Release,
+            _ => ContractMode.Debug
+        };
+}

--- a/src/Calor.Compiler/Effects/CrossModuleEffectEnforcementPass.cs
+++ b/src/Calor.Compiler/Effects/CrossModuleEffectEnforcementPass.cs
@@ -12,11 +12,19 @@ namespace Calor.Compiler.Effects;
 /// Unlike the per-module <see cref="EffectEnforcementPass"/>, this pass:
 ///   - Works across multiple modules using their declared (contract) effects
 ///   - Sees bare-name cross-module calls (e.g., §C{SaveOrder})
-///   - Reports cross-module violations as errors unconditionally — Permissive mode in
-///     the per-file pass only demotes unknown-call warnings, not known-callee mismatches
+///   - Honors <see cref="UnknownCallPolicy"/>: under <see cref="UnknownCallPolicy.Permissive"/>
+///     cross-module violations are demoted to warnings (matching the per-file pass's
+///     permissive treatment of forbidden effects); otherwise they are errors
 /// </summary>
 public sealed class CrossModuleEffectEnforcementPass
 {
+    private readonly UnknownCallPolicy _policy;
+
+    public CrossModuleEffectEnforcementPass(UnknownCallPolicy policy = UnknownCallPolicy.Strict)
+    {
+        _policy = policy;
+    }
+
     /// <summary>
     /// Enforce cross-module effect propagation over a collection of module summaries.
     /// Null or missing list fields on a summary are tolerated as empty — this keeps
@@ -62,7 +70,7 @@ public sealed class CrossModuleEffectEnforcementPass
         return Enforce(summaries, registry);
     }
 
-    private static void CheckCaller(
+    private void CheckCaller(
         EffectCallerSummary caller,
         string filePath,
         HashSet<string> internalNames,
@@ -144,7 +152,7 @@ public sealed class CrossModuleEffectEnforcementPass
         return false;
     }
 
-    private static void VerifyEffects(
+    private void VerifyEffects(
         EffectCallerSummary caller,
         string callerFilePath,
         CrossModuleResolution resolution,
@@ -158,6 +166,11 @@ public sealed class CrossModuleEffectEnforcementPass
         var diagnosticSpan = new TextSpan(0, 0, caller.DiagnosticLine, caller.DiagnosticColumn);
         // Caller names for class methods are formatted "ClassName.MethodName".
         var callerKind = caller.CallerName.Contains('.') ? "Method" : "Function";
+        // Permissive mode demotes cross-module violations to warnings, mirroring the
+        // per-file pass's permissive handling of forbidden effects.
+        var severity = _policy == UnknownCallPolicy.Permissive
+            ? DiagnosticSeverity.Warning
+            : DiagnosticSeverity.Error;
 
         foreach (var (kind, value) in forbidden)
         {
@@ -167,7 +180,7 @@ public sealed class CrossModuleEffectEnforcementPass
                 $"via cross-module call to '{resolution.FunctionName}' (in module '{resolution.ModuleName}') " +
                 $"but does not declare it.",
                 diagnosticSpan,
-                DiagnosticSeverity.Error,
+                severity,
                 callerFilePath));
         }
     }

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -261,7 +261,10 @@ public class Program
         return result;
     }
 
-    private static async Task<int> CompileAsync(FileInfo[]? input, FileInfo? output, bool verbose, bool strictApi, bool requireDocs, bool enforceEffects, bool strictEffects, bool permissiveEffects, string contractMode, bool verify, bool noCache, bool clearCache, int verificationTimeout, bool analyze, bool allFindings = false, string[]? experimentalFlags = null, bool strictBindInference = true)
+    private static Task<int> CompileAsync(FileInfo[]? input, FileInfo? output, bool verbose, bool strictApi, bool requireDocs, bool enforceEffects, bool strictEffects, bool permissiveEffects, string contractMode, bool verify, bool noCache, bool clearCache, int verificationTimeout, bool analyze, bool allFindings = false, string[]? experimentalFlags = null, bool strictBindInference = true)
+        => Task.FromResult(CompileCore(input, output, verbose, strictApi, requireDocs, enforceEffects, strictEffects, permissiveEffects, contractMode, verify, noCache, clearCache, verificationTimeout, analyze, allFindings, experimentalFlags, strictBindInference));
+
+    private static int CompileCore(FileInfo[]? input, FileInfo? output, bool verbose, bool strictApi, bool requireDocs, bool enforceEffects, bool strictEffects, bool permissiveEffects, string contractMode, bool verify, bool noCache, bool clearCache, int verificationTimeout, bool analyze, bool allFindings, string[]? experimentalFlags, bool strictBindInference)
     {
         try
         {
@@ -314,122 +317,78 @@ public class Program
                 return 1;
             }
 
-            var parsedContractMode = contractMode?.ToLowerInvariant() switch
-            {
-                "off" => ContractMode.Off,
-                "release" => ContractMode.Release,
-                _ => ContractMode.Debug
-            };
+            var parsedContractMode = CompilationDriver.ParseContractMode(contractMode);
 
-            var compiledModules = new List<(Ast.ModuleNode Ast, string FilePath)>();
-            var anyErrors = false;
-
-            foreach (var file in input)
-            {
-                if (verbose)
+            var driverResult = CompilationDriver.CompileAll(
+                input,
+                file =>
                 {
-                    Console.WriteLine($"Compiling: {file.FullName}");
-                }
-
-                var source = await File.ReadAllTextAsync(file.FullName);
-                var cacheOptions = new VerificationCacheOptions
-                {
-                    Enabled = !noCache,
-                    ClearBeforeVerification = clearCache,
-                    ProjectDirectory = Path.GetDirectoryName(file.FullName)
-                };
-                var options = new CompilationOptions
-                {
-                    Verbose = verbose,
-                    StrictApi = strictApi,
-                    RequireDocs = requireDocs,
-                    EnforceEffects = enforceEffects,
-                    StrictEffects = strictEffects,
-                    UnknownCallPolicy = permissiveEffects ? UnknownCallPolicy.Permissive : UnknownCallPolicy.Strict,
-                    ContractMode = parsedContractMode,
-                    VerifyContracts = verify,
-                    ProjectDirectory = Path.GetDirectoryName(file.FullName),
-                    VerificationCacheOptions = cacheOptions,
-                    VerificationTimeoutMs = (uint)verificationTimeout,
-                    EnableVerificationAnalyses = analyze,
-                    VerificationAnalysisOptions = analyze ? new Analysis.VerificationAnalysisOptions
+                    var cacheOptions = new VerificationCacheOptions
                     {
-                        BugPatternOptions = new Analysis.BugPatterns.BugPatternOptions
+                        Enabled = !noCache,
+                        ClearBeforeVerification = clearCache,
+                        ProjectDirectory = Path.GetDirectoryName(file.FullName)
+                    };
+                    return new CompilationOptions
+                    {
+                        Verbose = verbose,
+                        StrictApi = strictApi,
+                        RequireDocs = requireDocs,
+                        EnforceEffects = enforceEffects,
+                        StrictEffects = strictEffects,
+                        UnknownCallPolicy = permissiveEffects ? UnknownCallPolicy.Permissive : UnknownCallPolicy.Strict,
+                        ContractMode = parsedContractMode,
+                        VerifyContracts = verify,
+                        ProjectDirectory = Path.GetDirectoryName(file.FullName),
+                        VerificationCacheOptions = cacheOptions,
+                        VerificationTimeoutMs = (uint)verificationTimeout,
+                        EnableVerificationAnalyses = analyze,
+                        VerificationAnalysisOptions = analyze ? new Analysis.VerificationAnalysisOptions
                         {
-                            ReportOnlyVerified = !allFindings,
-                            Z3TimeoutMs = (uint)verificationTimeout
-                        },
-                        TaintOptions = new Analysis.Security.TaintAnalysisOptions
-                        {
-                            MinTaintHops = allFindings ? 1 : 2
-                        }
-                    } : null,
-                    ExperimentalFlags = experimentalFlags != null && experimentalFlags.Length > 0
-                        ? new ExperimentalFlags(experimentalFlags)
-                        : ExperimentalFlags.None,
-                    StrictBindInference = strictBindInference
-                };
-                var result = Compile(source, file.FullName, options);
-
-                if (result.HasErrors)
+                            BugPatternOptions = new Analysis.BugPatterns.BugPatternOptions
+                            {
+                                ReportOnlyVerified = !allFindings,
+                                Z3TimeoutMs = (uint)verificationTimeout
+                            },
+                            TaintOptions = new Analysis.Security.TaintAnalysisOptions
+                            {
+                                MinTaintHops = allFindings ? 1 : 2
+                            }
+                        } : null,
+                        ExperimentalFlags = experimentalFlags != null && experimentalFlags.Length > 0
+                            ? new ExperimentalFlags(experimentalFlags)
+                            : ExperimentalFlags.None,
+                        StrictBindInference = strictBindInference
+                    };
+                },
+                // Cross-module enforcement always ran for the top-level compile
+                // command (independent of --enforce-effects); preserved here.
+                crossModuleEnforcement: true,
+                crossModulePolicy: permissiveEffects ? UnknownCallPolicy.Permissive : UnknownCallPolicy.Strict,
+                onCompiled: (file, result) =>
                 {
-                    foreach (var diagnostic in result.Diagnostics)
+                    // Determine output path
+                    var outputPath = (output?.FullName)
+                        ?? Path.ChangeExtension(file.FullName, ".g.cs");
+
+                    // Ensure output directory exists
+                    var outputDir = Path.GetDirectoryName(outputPath);
+                    if (!string.IsNullOrEmpty(outputDir) && !Directory.Exists(outputDir))
                     {
-                        Console.Error.WriteLine(diagnostic);
+                        Directory.CreateDirectory(outputDir);
                     }
-                    anyErrors = true;
-                    continue;
-                }
 
-                // Determine output path
-                var outputPath = (output?.FullName)
-                    ?? Path.ChangeExtension(file.FullName, ".g.cs");
+                    File.WriteAllText(outputPath, result.GeneratedCode);
 
-                // Ensure output directory exists
-                var outputDir = Path.GetDirectoryName(outputPath);
-                if (!string.IsNullOrEmpty(outputDir) && !Directory.Exists(outputDir))
-                {
-                    Directory.CreateDirectory(outputDir);
-                }
-
-                await File.WriteAllTextAsync(outputPath, result.GeneratedCode);
-
-                if (verbose)
-                {
-                    Console.WriteLine($"Output written to: {outputPath}");
-                }
-
-                Console.WriteLine($"Compilation successful: {outputPath}");
-
-                if (result.Ast != null)
-                {
-                    compiledModules.Add((result.Ast, file.FullName));
-                }
-            }
-
-            // Cross-module effect enforcement across successfully compiled modules.
-            if (compiledModules.Count > 1)
-            {
-                var registry = Effects.CrossModuleEffectRegistry.Build(compiledModules);
-                foreach (var diagnostic in registry.BuildDiagnostics)
-                {
-                    Console.Error.WriteLine(diagnostic);
-                }
-
-                var crossPass = new Effects.CrossModuleEffectEnforcementPass();
-                var crossDiagnostics = crossPass.Enforce(compiledModules, registry);
-
-                foreach (var diagnostic in crossDiagnostics)
-                {
-                    Console.Error.WriteLine(diagnostic);
-                    if (diagnostic.IsError)
+                    if (verbose)
                     {
-                        anyErrors = true;
+                        Console.WriteLine($"Output written to: {outputPath}");
                     }
-                }
-            }
 
-            return anyErrors ? 1 : 0;
+                    Console.WriteLine($"Compilation successful: {outputPath}");
+                });
+
+            return driverResult.AnyErrors ? 1 : 0;
         }
         catch (Exception ex)
         {

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -235,6 +235,8 @@ public class Program
         rootCommand.AddCommand(CoverageCommand.Create());
         rootCommand.AddCommand(SelfTestCommand.Create());
         rootCommand.AddCommand(EvaluationCommand.Create());
+        rootCommand.AddCommand(RunCommand.Create());
+        rootCommand.AddCommand(TestCommand.Create());
 
         // Initialize telemetry for subcommands
         // Parse --no-telemetry early from args

--- a/src/Calor.Sdk/Sdk/Sdk.targets
+++ b/src/Calor.Sdk/Sdk/Sdk.targets
@@ -6,6 +6,8 @@
     <!-- CalorCompilerOverride: point at a local Calor.Tasks.dll to use a dev-built compiler -->
     <CalorTasksAssembly Condition="'$(CalorCompilerOverride)' != '' and '$(CalorTasksAssembly)' == ''">$(CalorCompilerOverride)</CalorTasksAssembly>
     <CalorTasksAssembly Condition="'$(CalorTasksAssembly)' == ''">$(MSBuildThisFileDirectory)..\tasks\net10.0\Calor.Tasks.dll</CalorTasksAssembly>
+    <!-- Effect enforcement: default true, matching CompilationOptions.EnforceEffects -->
+    <CalorEnforceEffects Condition="'$(CalorEnforceEffects)' == ''">true</CalorEnforceEffects>
   </PropertyGroup>
 
   <!-- IL analysis: resolve runtime directory for BCL implementation assemblies -->
@@ -42,6 +44,7 @@
         OutputDirectory="$(CalorOutputDirectory)"
         ProjectDirectory="$(MSBuildProjectDirectory)"
         Verbose="$(CalorVerbose)"
+        EnforceEffects="$(CalorEnforceEffects)"
         EnableILAnalysis="$(CalorEnableILAnalysis)"
         ReferencedAssemblies="@(ReferencePath)"
         RuntimeDirectory="$(_CalorRuntimeDir)"

--- a/src/Calor.Tasks/BuildStateCache.cs
+++ b/src/Calor.Tasks/BuildStateCache.cs
@@ -116,24 +116,21 @@ internal static class BuildStateCache
         }
     }
 
-    // Cached since options don't change within a process lifetime.
-    // When codegen-affecting properties are added, this must take them as explicit parameters.
-    private static readonly string CachedOptionsHash = ComputeOptionsHashCore();
-
-    public static string ComputeOptionsHash() => CachedOptionsHash;
-
-    private static string ComputeOptionsHashCore()
+    public static string ComputeOptionsHash(bool enforceEffects = true)
     {
-        // Currently the task only passes Verbose (excluded — doesn't affect output or diagnostics).
-        // The hash exists for forward compatibility. When properties like ContractMode,
-        // EnforceEffects, StrictEffects, RequireDocs, StrictApi are added to the task,
-        // they MUST be added here as explicit parameters.
+        // Diagnostics-affecting options must be folded in: an option flip between
+        // builds has to invalidate cached (skipped) files, otherwise violations that
+        // the new option set would report are silently missed on warm builds.
+        // When properties like ContractMode, StrictEffects, RequireDocs, StrictApi
+        // are added to the task, they MUST be added here as explicit parameters.
+        // (Verbose is excluded — it doesn't affect output or diagnostics.)
         //
         // The set of EffectKind enum values is also folded in: cached EffectSummary entries
         // reference kinds by name, and a kind added/removed/renamed in a compiler upgrade
         // must force a cold rebuild so old summaries don't silently drop effects on parse.
         using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         sha.AppendData(Encoding.UTF8.GetBytes("options:v1"));
+        sha.AppendData(Encoding.UTF8.GetBytes($"|enforceEffects:{enforceEffects}"));
         sha.AppendData(Encoding.UTF8.GetBytes("|effectkinds:"));
         foreach (var kind in Enum.GetNames(typeof(Calor.Compiler.Effects.EffectKind)))
         {

--- a/src/Calor.Tasks/CompileCalor.cs
+++ b/src/Calor.Tasks/CompileCalor.cs
@@ -66,6 +66,14 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
     public string DepsFilePath { get; set; } = string.Empty;
 
     /// <summary>
+    /// Enforce effect declarations (§E coverage) during compilation, including
+    /// cross-module enforcement. Default: true, matching
+    /// <see cref="Calor.Compiler.CompilationOptions.EnforceEffects"/>.
+    /// Set the MSBuild property <c>CalorEnforceEffects</c> to override.
+    /// </summary>
+    public bool EnforceEffects { get; set; } = true;
+
+    /// <summary>
     /// Semicolon- or comma-separated list of experimental feature flag names to enable.
     /// Plumbed through to <see cref="Calor.Compiler.CompilationOptions.ExperimentalFlags"/>.
     /// Unknown flags are accepted silently — see <see cref="Calor.Compiler.ExperimentalFlags"/>.
@@ -100,7 +108,7 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
         // 2. Compute global hashes
         var tasksAssemblyPath = typeof(CompileCalor).Assembly.Location;
         var compilerHash = BuildStateCache.ComputeCompilerHash(tasksAssemblyPath);
-        var optionsHash = BuildStateCache.ComputeOptionsHash();
+        var optionsHash = BuildStateCache.ComputeOptionsHash(EnforceEffects);
         var manifestHash = BuildStateCache.ComputeManifestHash(ProjectDirectory);
 
         // 3. Global invalidation check
@@ -288,6 +296,7 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
                 var compileOptions = new CompilationOptions
                 {
                     Verbose = Verbose,
+                    EnforceEffects = EnforceEffects,
                     ProjectDirectory = ProjectDirectory,
                     Context = compilationContext,
                     EnableILAnalysis = EnableILAnalysis,
@@ -388,7 +397,7 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
         //     the build cache, warm builds get complete cross-module coverage without any
         //     re-parsing: skipped files contribute their cached summary and freshly-compiled
         //     files contribute a newly-built one.
-        if (moduleSummaries.Count > 1)
+        if (EnforceEffects && moduleSummaries.Count > 1)
         {
             try
             {

--- a/tests/Calor.Compiler.Tests/CliMultiFileTests.cs
+++ b/tests/Calor.Compiler.Tests/CliMultiFileTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Xunit;
 
 namespace Calor.Compiler.Tests;
@@ -6,7 +5,7 @@ namespace Calor.Compiler.Tests;
 /// <summary>
 /// End-to-end CLI tests: invoke calor.dll as a subprocess with multiple --input flags
 /// and verify cross-module effect enforcement fires through the real command-line pipeline
-/// (System.CommandLine parsing → CompileAsync → CrossModuleEffectEnforcementPass).
+/// (System.CommandLine parsing → CompilationDriver → CrossModuleEffectEnforcementPass).
 /// </summary>
 public class CliMultiFileTests : IDisposable
 {
@@ -21,52 +20,13 @@ public class CliMultiFileTests : IDisposable
     public void Dispose()
     {
         try { Directory.Delete(_tempDir, recursive: true); } catch { }
-    }
-
-    private static string FindCalorDll()
-    {
-        var dir = Directory.GetCurrentDirectory();
-        while (dir != null)
-        {
-            var candidate = Path.Combine(dir, "src", "Calor.Compiler", "bin", "Debug", "net10.0", "calor.dll");
-            if (File.Exists(candidate)) return candidate;
-            candidate = Path.Combine(dir, "src", "Calor.Compiler", "bin", "Release", "net10.0", "calor.dll");
-            if (File.Exists(candidate)) return candidate;
-            var parent = Directory.GetParent(dir);
-            if (parent == null) break;
-            dir = parent.FullName;
-        }
-        throw new InvalidOperationException("calor.dll not found — build the compiler first.");
+        GC.SuppressFinalize(this);
     }
 
     private (int ExitCode, string StdOut, string StdErr) RunCli(params string[] args)
-    {
-        var dll = FindCalorDll();
-        var argLine = "\"" + dll + "\" --no-telemetry " + string.Join(" ", args);
+        => CliTestHarness.RunCli(_tempDir, args);
 
-        var psi = new ProcessStartInfo
-        {
-            FileName = "dotnet",
-            Arguments = argLine,
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true,
-            WorkingDirectory = _tempDir
-        };
-
-        using var proc = Process.Start(psi)
-            ?? throw new InvalidOperationException("Failed to start calor CLI process.");
-
-        var stdOut = proc.StandardOutput.ReadToEnd();
-        var stdErr = proc.StandardError.ReadToEnd();
-        proc.WaitForExit(60_000);
-
-        return (proc.ExitCode, stdOut, stdErr);
-    }
-
-    [Fact]
-    public void MultiFile_CrossModuleEffect_Violation_Errors()
+    private (string APath, string BPath) WriteCrossModuleViolationPair()
     {
         var aPath = Path.Combine(_tempDir, "a.calr");
         var bPath = Path.Combine(_tempDir, "b.calr");
@@ -83,6 +43,13 @@ public class CliMultiFileTests : IDisposable
                 §C{SaveOrder}
                 §/C
             """);
+        return (aPath, bPath);
+    }
+
+    [Fact]
+    public void MultiFile_CrossModuleEffect_Violation_Errors()
+    {
+        var (aPath, bPath) = WriteCrossModuleViolationPair();
 
         var (exit, stdOut, stdErr) = RunCli("--input", aPath, "--input", bPath);
 
@@ -91,6 +58,22 @@ public class CliMultiFileTests : IDisposable
         Assert.Contains("Calor0410", combined);
         Assert.Contains("HandleRequest", combined);
         Assert.Contains("db:w", combined);
+    }
+
+    [Fact]
+    public void MultiFile_CrossModuleEffect_Violation_PermissiveEffects_WarnsAndSucceeds()
+    {
+        // --permissive-effects must reach the cross-module pass: the violation is
+        // demoted to a warning (still visible on stderr) and the compile succeeds.
+        var (aPath, bPath) = WriteCrossModuleViolationPair();
+
+        var (exit, stdOut, stdErr) = RunCli(
+            "--input", aPath, "--input", bPath, "--permissive-effects");
+
+        Assert.True(exit == 0, $"Expected exit 0 under --permissive-effects. Exit={exit}\nStdOut:\n{stdOut}\nStdErr:\n{stdErr}");
+        Assert.Contains("warning Calor0410", stdErr);
+        Assert.Contains("HandleRequest", stdErr);
+        Assert.DoesNotContain("error Calor0410", stdOut + stdErr);
     }
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/CliTestHarness.cs
+++ b/tests/Calor.Compiler.Tests/CliTestHarness.cs
@@ -1,0 +1,92 @@
+using System.Diagnostics;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Shared helpers for CLI-level subprocess tests: locates the built calor.dll
+/// (Release preferred over Debug) and invokes it with captured output.
+/// </summary>
+internal static class CliTestHarness
+{
+    private static readonly Lazy<string> RepoRoot = new(FindRepoRootCore);
+    private static readonly Lazy<string> CalorDll = new(FindCalorDllCore);
+
+    /// <summary>Walks up from the test working directory to the repository root.</summary>
+    internal static string FindRepoRoot() => RepoRoot.Value;
+
+    /// <summary>
+    /// Locates the built calor.dll, probing Release before Debug (matching the
+    /// benchmark harness, which runs against Release builds).
+    /// </summary>
+    internal static string FindCalorDll() => CalorDll.Value;
+
+    private static string FindRepoRootCore()
+    {
+        var dir = Directory.GetCurrentDirectory();
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir, "Calor.sln")))
+            {
+                return dir;
+            }
+
+            var parent = Directory.GetParent(dir);
+            if (parent == null) break;
+            dir = parent.FullName;
+        }
+
+        throw new InvalidOperationException("Repository root (Calor.sln) not found from " + Directory.GetCurrentDirectory());
+    }
+
+    private static string FindCalorDllCore()
+    {
+        foreach (var config in new[] { "Release", "Debug" })
+        {
+            var candidate = Path.Combine(FindRepoRoot(), "src", "Calor.Compiler", "bin", config, "net10.0", "calor.dll");
+            if (File.Exists(candidate)) return candidate;
+        }
+
+        throw new InvalidOperationException("calor.dll not found — build the compiler first.");
+    }
+
+    /// <summary>
+    /// Runs <c>dotnet calor.dll --no-telemetry [args]</c> from
+    /// <paramref name="workingDirectory"/> and returns exit code plus captured
+    /// stdout/stderr. Kills the process tree on timeout.
+    /// </summary>
+    internal static (int ExitCode, string StdOut, string StdErr) RunCli(
+        string workingDirectory, params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory
+        };
+        psi.ArgumentList.Add(FindCalorDll());
+        psi.ArgumentList.Add("--no-telemetry");
+        foreach (var arg in args)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start calor CLI process.");
+
+        // Read both streams concurrently to avoid pipe-buffer deadlocks.
+        var stdOutTask = proc.StandardOutput.ReadToEndAsync();
+        var stdErrTask = proc.StandardError.ReadToEndAsync();
+
+        // Generous timeout: some of these tests restore/build/run real dotnet projects.
+        if (!proc.WaitForExit(300_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            throw new TimeoutException("calor CLI did not exit within 5 minutes: " + string.Join(" ", args));
+        }
+
+        return (proc.ExitCode, stdOutTask.Result, stdErrTask.Result);
+    }
+}

--- a/tests/Calor.Compiler.Tests/RunTestCommandTests.cs
+++ b/tests/Calor.Compiler.Tests/RunTestCommandTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Xunit;
 
 namespace Calor.Compiler.Tests;
@@ -25,70 +24,8 @@ public class RunTestCommandTests : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    private static string FindRepoRoot()
-    {
-        var dir = Directory.GetCurrentDirectory();
-        while (dir != null)
-        {
-            if (File.Exists(Path.Combine(dir, "samples", "FizzBuzz", "fizzbuzz.calr")))
-            {
-                return dir;
-            }
-
-            var parent = Directory.GetParent(dir);
-            if (parent == null) break;
-            dir = parent.FullName;
-        }
-
-        throw new InvalidOperationException("Repository root not found from " + Directory.GetCurrentDirectory());
-    }
-
-    private static string FindCalorDll()
-    {
-        var root = FindRepoRoot();
-        foreach (var config in new[] { "Debug", "Release" })
-        {
-            var candidate = Path.Combine(root, "src", "Calor.Compiler", "bin", config, "net10.0", "calor.dll");
-            if (File.Exists(candidate)) return candidate;
-        }
-
-        throw new InvalidOperationException("calor.dll not found — build the compiler first.");
-    }
-
     private (int ExitCode, string StdOut, string StdErr) RunCli(params string[] args)
-    {
-        var psi = new ProcessStartInfo
-        {
-            FileName = "dotnet",
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true,
-            WorkingDirectory = _tempDir
-        };
-        psi.ArgumentList.Add(FindCalorDll());
-        psi.ArgumentList.Add("--no-telemetry");
-        foreach (var arg in args)
-        {
-            psi.ArgumentList.Add(arg);
-        }
-
-        using var proc = Process.Start(psi)
-            ?? throw new InvalidOperationException("Failed to start calor CLI process.");
-
-        // Read both streams concurrently to avoid pipe-buffer deadlocks.
-        var stdOutTask = proc.StandardOutput.ReadToEndAsync();
-        var stdErrTask = proc.StandardError.ReadToEndAsync();
-
-        // Generous timeout: these tests restore/build/run real dotnet projects.
-        if (!proc.WaitForExit(300_000))
-        {
-            try { proc.Kill(entireProcessTree: true); } catch { }
-            throw new TimeoutException("calor CLI did not exit within 5 minutes: " + string.Join(" ", args));
-        }
-
-        return (proc.ExitCode, stdOutTask.Result, stdErrTask.Result);
-    }
+        => CliTestHarness.RunCli(_tempDir, args);
 
     // ------------------------------------------------------------------
     // calor run
@@ -97,7 +34,7 @@ public class RunTestCommandTests : IDisposable
     [Fact]
     public void Run_FizzBuzzSample_PrintsFizzBuzzAndExitsZero()
     {
-        var sample = Path.Combine(FindRepoRoot(), "samples", "FizzBuzz", "fizzbuzz.calr");
+        var sample = Path.Combine(CliTestHarness.FindRepoRoot(), "samples", "FizzBuzz", "fizzbuzz.calr");
 
         var (exitCode, stdOut, stdErr) = RunCli("run", sample);
 
@@ -172,6 +109,67 @@ public class RunTestCommandTests : IDisposable
     }
 
     // ------------------------------------------------------------------
+    // effect enforcement on calor run
+    // ------------------------------------------------------------------
+
+    private string WritePureViolator()
+    {
+        // Declares §E{} (pure) but prints — a forbidden 'cw' effect.
+        var file = Path.Combine(_tempDir, "pureviolator.calr");
+        File.WriteAllText(file, """
+            §M{m001:PureViolator}
+              §F{f001:Main:pub} () -> void
+                §E{}
+                §P "side effect!"
+            """);
+        return file;
+    }
+
+    [Fact]
+    public void Run_EffectViolation_Strict_ExitsOneWithError()
+    {
+        var (exitCode, _, stdErr) = RunCli("run", WritePureViolator());
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("error Calor04", stdErr);
+    }
+
+    [Fact]
+    public void Run_EffectViolation_Permissive_RunsAndPrintsDemotedWarning()
+    {
+        var (exitCode, stdOut, stdErr) = RunCli("run", WritePureViolator(), "--permissive");
+
+        Assert.True(exitCode == 0, $"expected exit 0, got {exitCode}. stderr: {stdErr}\nstdout: {stdOut}");
+        Assert.Contains("side effect!", stdOut);
+        // The demoted warning must be visible even though compilation succeeded.
+        Assert.Contains("warning Calor04", stdErr);
+    }
+
+    [Fact]
+    public void Run_EffectViolation_EnforceEffectsFalse_RunsWithoutDiagnostics()
+    {
+        var (exitCode, stdOut, stdErr) = RunCli("run", WritePureViolator(), "--enforce-effects", "false");
+
+        Assert.True(exitCode == 0, $"expected exit 0, got {exitCode}. stderr: {stdErr}\nstdout: {stdOut}");
+        Assert.DoesNotContain("Calor04", stdErr);
+    }
+
+    [Fact]
+    public void TopLevelCompile_PermissiveEffects_WarningVisibleOnSuccess()
+    {
+        // Same visibility guarantee on the top-level compile command: demoted
+        // warnings print even though the compilation succeeds.
+        var file = WritePureViolator();
+
+        var (exitCode, stdOut, stdErr) = RunCli(
+            "--input", file, "--enforce-effects", "--permissive-effects");
+
+        Assert.True(exitCode == 0, $"expected exit 0, got {exitCode}. stderr: {stdErr}\nstdout: {stdOut}");
+        Assert.Contains("warning Calor04", stdErr);
+        Assert.Contains("Compilation successful", stdOut);
+    }
+
+    // ------------------------------------------------------------------
     // calor test
     // ------------------------------------------------------------------
 
@@ -225,7 +223,7 @@ public class RunTestCommandTests : IDisposable
     }
 
     [Fact]
-    public void Test_SingleFileWithoutTests_BuildsAndExitsZero()
+    public void Test_SingleFileWithoutTests_BuildsAndExitsThree()
     {
         var file = Path.Combine(_tempDir, "lib.calr");
         File.WriteAllText(file, """
@@ -236,7 +234,48 @@ public class RunTestCommandTests : IDisposable
 
         var (exitCode, stdOut, stdErr) = RunCli("test", file);
 
+        Assert.True(exitCode == 3, $"expected exit 3 (no tests found), got {exitCode}. stderr: {stdErr}\nstdout: {stdOut}");
+        Assert.Contains("No tests found", stdErr);
+    }
+
+    [Fact]
+    public void Test_BenchmarkPairDirectory_N1003CsvRow_PassesAndExitsZero()
+    {
+        // The real benchmark-pair layout: calor/ sources, a same-module copy under
+        // reference/calor/, and tests/ with a Calor-arm shim. reference/ must be
+        // excluded (with a warning) or the materialized project fails with CS0101.
+        // The checked-in calor/ fixture is the unsolved scaffold by design, so the
+        // pair is copied and solved (reference implementation applied) to get a
+        // green run — reference/ stays in place to exercise the exclusion.
+        var pairDir = Path.Combine(CliTestHarness.FindRepoRoot(),
+            "bench", "phase0-agent-native", "pairs", "N1-003-csv-row");
+        Assert.True(Directory.Exists(pairDir), $"benchmark pair not found: {pairDir}");
+
+        var pairCopy = Path.Combine(_tempDir, "N1-003-csv-row");
+        CopyDirectory(pairDir, pairCopy);
+        File.Copy(
+            Path.Combine(pairCopy, "reference", "calor", "CsvRow.calr"),
+            Path.Combine(pairCopy, "calor", "CsvRow.calr"),
+            overwrite: true);
+
+        var (exitCode, stdOut, stdErr) = RunCli("test", pairCopy);
+
         Assert.True(exitCode == 0, $"expected exit 0, got {exitCode}. stderr: {stdErr}\nstdout: {stdOut}");
-        Assert.Contains("No tests/ directory", stdOut);
+        Assert.Contains("skipping", stdErr);
+        Assert.Contains("reference", stdErr);
+    }
+
+    private static void CopyDirectory(string source, string target)
+    {
+        Directory.CreateDirectory(target);
+        foreach (var dir in Directory.GetDirectories(source, "*", SearchOption.AllDirectories))
+        {
+            Directory.CreateDirectory(Path.Combine(target, Path.GetRelativePath(source, dir)));
+        }
+
+        foreach (var file in Directory.GetFiles(source, "*", SearchOption.AllDirectories))
+        {
+            File.Copy(file, Path.Combine(target, Path.GetRelativePath(source, file)));
+        }
     }
 }

--- a/tests/Calor.Compiler.Tests/RunTestCommandTests.cs
+++ b/tests/Calor.Compiler.Tests/RunTestCommandTests.cs
@@ -1,0 +1,242 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// End-to-end CLI tests for `calor run` and `calor test`: invoke calor.dll as a
+/// subprocess so System.CommandLine parsing, workspace materialization, the
+/// dotnet build/run/test pipeline, and exit-code propagation are all exercised
+/// through the real command-line surface.
+/// </summary>
+public class RunTestCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public RunTestCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "calor-runtest-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = Directory.GetCurrentDirectory();
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir, "samples", "FizzBuzz", "fizzbuzz.calr")))
+            {
+                return dir;
+            }
+
+            var parent = Directory.GetParent(dir);
+            if (parent == null) break;
+            dir = parent.FullName;
+        }
+
+        throw new InvalidOperationException("Repository root not found from " + Directory.GetCurrentDirectory());
+    }
+
+    private static string FindCalorDll()
+    {
+        var root = FindRepoRoot();
+        foreach (var config in new[] { "Debug", "Release" })
+        {
+            var candidate = Path.Combine(root, "src", "Calor.Compiler", "bin", config, "net10.0", "calor.dll");
+            if (File.Exists(candidate)) return candidate;
+        }
+
+        throw new InvalidOperationException("calor.dll not found — build the compiler first.");
+    }
+
+    private (int ExitCode, string StdOut, string StdErr) RunCli(params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            WorkingDirectory = _tempDir
+        };
+        psi.ArgumentList.Add(FindCalorDll());
+        psi.ArgumentList.Add("--no-telemetry");
+        foreach (var arg in args)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start calor CLI process.");
+
+        // Read both streams concurrently to avoid pipe-buffer deadlocks.
+        var stdOutTask = proc.StandardOutput.ReadToEndAsync();
+        var stdErrTask = proc.StandardError.ReadToEndAsync();
+
+        // Generous timeout: these tests restore/build/run real dotnet projects.
+        if (!proc.WaitForExit(300_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("calor CLI did not exit within 5 minutes: " + string.Join(" ", args));
+        }
+
+        return (proc.ExitCode, stdOutTask.Result, stdErrTask.Result);
+    }
+
+    // ------------------------------------------------------------------
+    // calor run
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Run_FizzBuzzSample_PrintsFizzBuzzAndExitsZero()
+    {
+        var sample = Path.Combine(FindRepoRoot(), "samples", "FizzBuzz", "fizzbuzz.calr");
+
+        var (exitCode, stdOut, stdErr) = RunCli("run", sample);
+
+        Assert.True(exitCode == 0, $"expected exit 0, got {exitCode}. stderr: {stdErr}\nstdout: {stdOut}");
+        Assert.Contains("FizzBuzz", stdOut);
+        Assert.Contains("Fizz", stdOut);
+        Assert.Contains("Buzz", stdOut);
+        Assert.Contains("14", stdOut); // plain numbers printed too
+    }
+
+    [Fact]
+    public void Run_ProgramWithIntMain_PropagatesExitCode()
+    {
+        var file = Path.Combine(_tempDir, "exitcoder.calr");
+        File.WriteAllText(file, """
+            §M{m001:ExitCoder}
+              §F{f001:Main:pub} () -> i32
+                §R INT:3
+            """);
+
+        var (exitCode, stdOut, stdErr) = RunCli("run", file);
+
+        Assert.True(exitCode == 3, $"expected exit 3, got {exitCode}. stderr: {stdErr}\nstdout: {stdOut}");
+    }
+
+    [Fact]
+    public void Run_CompileError_ExitsOneWithDiagnostics()
+    {
+        var file = Path.Combine(_tempDir, "broken.calr");
+        File.WriteAllText(file, """
+            §M{m001:Broken}
+              §F{f001:Main:pub} () -> void
+                §P undefined_variable_xyz
+            """);
+
+        var (exitCode, _, stdErr) = RunCli("run", file);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Calor", stdErr); // a Calor diagnostic code was printed
+    }
+
+    [Fact]
+    public void Run_MissingFile_ExitsTwo()
+    {
+        var (exitCode, _, stdErr) = RunCli("run", Path.Combine(_tempDir, "does-not-exist.calr"));
+
+        Assert.Equal(2, exitCode);
+        Assert.Contains("not found", stdErr);
+    }
+
+    [Fact]
+    public void Run_KeepTemp_PrintsWorkspacePath()
+    {
+        var file = Path.Combine(_tempDir, "hello.calr");
+        File.WriteAllText(file, """
+            §M{m001:Hello}
+              §F{f001:Main:pub} () -> void
+                §E{cw}
+                §P "hello from calor run"
+            """);
+
+        var (exitCode, stdOut, stdErr) = RunCli("run", file, "--keep-temp");
+
+        Assert.True(exitCode == 0, $"expected exit 0, got {exitCode}. stderr: {stdErr}\nstdout: {stdOut}");
+        Assert.Contains("hello from calor run", stdOut);
+        Assert.Contains("Workspace kept at:", stdOut);
+
+        var line = stdOut.Split('\n').First(l => l.Contains("Workspace kept at:"));
+        var workspace = line.Split("Workspace kept at:")[1].Trim();
+        Assert.True(Directory.Exists(workspace), $"kept workspace should exist: {workspace}");
+        try { Directory.Delete(workspace, recursive: true); } catch { }
+    }
+
+    // ------------------------------------------------------------------
+    // calor test
+    // ------------------------------------------------------------------
+
+    private void WriteMathFixture(string dir, bool withBug)
+    {
+        Directory.CreateDirectory(dir);
+        Directory.CreateDirectory(Path.Combine(dir, "tests"));
+
+        File.WriteAllText(Path.Combine(dir, "mathutil.calr"), $$"""
+            §M{m001:MathUtil}
+              §F{f001:Add:pub} (i32:a, i32:b) -> i32
+                §R (+ a {{(withBug ? "(+ b INT:1)" : "b")}})
+            """);
+
+        File.WriteAllText(Path.Combine(dir, "tests", "MathUtilTests.cs"), """
+            using Xunit;
+
+            namespace MathUtil.Tests;
+
+            public class MathUtilTests
+            {
+                [Fact]
+                public void Add_ReturnsSum() => Assert.Equal(5, global::MathUtil.MathUtilModule.Add(2, 3));
+
+                [Fact]
+                public void Add_Zero() => Assert.Equal(7, global::MathUtil.MathUtilModule.Add(7, 0));
+            }
+            """);
+    }
+
+    [Fact]
+    public void Test_PairLayoutFixture_PassesAndExitsZero()
+    {
+        var fixtureDir = Path.Combine(_tempDir, "math-pass");
+        WriteMathFixture(fixtureDir, withBug: false);
+
+        var (exitCode, stdOut, stdErr) = RunCli("test", fixtureDir);
+
+        Assert.True(exitCode == 0, $"expected exit 0, got {exitCode}. stderr: {stdErr}\nstdout: {stdOut}");
+    }
+
+    [Fact]
+    public void Test_FailingTests_ExitNonZero()
+    {
+        var fixtureDir = Path.Combine(_tempDir, "math-fail");
+        WriteMathFixture(fixtureDir, withBug: true);
+
+        var (exitCode, _, _) = RunCli("test", fixtureDir);
+
+        Assert.NotEqual(0, exitCode);
+    }
+
+    [Fact]
+    public void Test_SingleFileWithoutTests_BuildsAndExitsZero()
+    {
+        var file = Path.Combine(_tempDir, "lib.calr");
+        File.WriteAllText(file, """
+            §M{m001:LibOnly}
+              §F{f001:Double:pub} (i32:x) -> i32
+                §R (* x INT:2)
+            """);
+
+        var (exitCode, stdOut, stdErr) = RunCli("test", file);
+
+        Assert.True(exitCode == 0, $"expected exit 0, got {exitCode}. stderr: {stdErr}\nstdout: {stdOut}");
+        Assert.Contains("No tests/ directory", stdOut);
+    }
+}


### PR DESCRIPTION
Implements Phase 1 item 2 from `docs/plans/agent-native-strategy.md` §4: shipped CLI surface for executing Calor programs. Today running any `.calr` requires hand-wiring an MSBuild project against Calor.Tasks/Calor.Sdk; these commands remove that step.

## `calor run <file.calr|dir>`
- Compiles in-process with **effects enforcement ON by default**; `--permissive` switches to the permissive unknown-call policy (unknown calls assumed pure, forbidden effects demoted to warnings). Multi-file directories also get cross-module effect enforcement, same as the top-level compile command.
- Materializes a temp Exe project from the generated C#, referencing the `Calor.Runtime.dll` shipped next to the compiler assembly, then `dotnet build` (output captured, replayed on failure) + runs the built dll streaming output from the user's cwd.
- Propagates the program's exit code (including `int Main`).

## `calor test <file.calr|dir>`
- Same materialization as a Library. If the target dir has a `tests/` subdir of `*.cs` (v1 targets the benchmark-pair layout, including `tests/shims/TestShim.calor.cs` picked up as the Calor-arm shim), generates an xUnit project referencing it and runs `dotnet test`; otherwise `dotnet test` runs on the materialized library alone (validates the generated C# builds; exits 0).

## Both
- `--keep-temp` preserves the workspace and prints its path.
- Clear error + exit 2 when the dotnet SDK is missing from PATH/DOTNET_ROOT; compile errors exit 1 with diagnostics on stderr.

## Scope decision
In-process compilation instead of importing `Sdk.targets`: the `CompileCalor` MSBuild task exposes no enforcement/permissive parameters, and `Calor.Tasks.dll` does not ship with the `calor` global tool — while `Calor.Runtime.dll` does (ProjectReference). The materialized project therefore works identically for repo dev builds and the installed tool, with the enforcement pin honored in-process.

## Tests
8 new CLI-level subprocess tests (`RunTestCommandTests`): FizzBuzz sample output, int-Main exit-code propagation, compile-error and missing-file exit codes, `--keep-temp`, pair-layout pass and fail, single-file no-tests case. Full solution build (TreatWarningsAsErrors) clean; `Calor.Compiler.Tests`: 5689 passed / 0 failed / 7 skipped (pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MP98bPvHVGbADabAjtSYpg