### PR TITLE
feat(diagnostics): structured output plumbing + SARIF dedup (Phase 1 item 3, part 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ C# Source → Roslyn Parse → SyntaxTree → RoslynSyntaxVisitor → AST → Ca
 | `Ids/IdScanner.cs` | 330 | IAstVisitor — scans/validates node IDs |
 | `Verification/ExpressionSimplifier.cs` | 1,400 | IAstVisitor\<T\> — simplifies expressions for Z3 |
 | `Analysis/BugPatterns/Patterns/` | dir | Checkers: div-by-zero, null-deref, off-by-one, overflow, index-OOB |
-| `Diagnostics/Diagnostic.cs` | — | All diagnostic codes (Calor0001–Calor0899) |
+| `Diagnostics/Diagnostic.cs` | — | All diagnostic codes (Calor0001–Calor1399) |
 
 All paths relative to `src/Calor.Compiler/`.
 
@@ -139,7 +139,7 @@ Example (current syntax — see `samples/FizzBuzz/fizzbuzz.calr`):
 - **VariableSymbol.IsParameter** — distinguishes function parameters from locals; used by analysis passes
 - **BoundCallExpression.Target** is a `string` — `NullDereferenceChecker` checks for `.unwrap` suffix
 - **Option\<T\> and Result\<T,E\>** are valid generic types in Calor's type system
-- **Diagnostic codes** — Calor0001–0099 (lexer), 0100–0199 (parser), 0200–0299 (semantic), 0300–0399 (contracts), 0400–0499 (effects), 0500–0599 (patterns), 0600–0699 (API strictness), 0700–0799 (semantics version), 0800–0899 (ID validation)
+- **Diagnostic codes** — Calor0001–0099 (lexer), 0100–0199 (parser), 0200–0299 (semantic), 0300–0399 (contracts), 0400–0499 (effects), 0500–0599 (patterns), 0600–0699 (API strictness), 0700–0799 (semantics version), 0800–0899 (ID validation), 0900–0999 (dataflow/bug patterns/taint), 1000–1099 (codegen/interop), 1100–1199 (refinements/obligations), 1200–1299 (experimental), 1300–1399 (CLI: lint findings and command-level errors)
 
 ## Project Layout
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -48,6 +48,10 @@ dotnet tool update -g calor
 | `calor lsp` | Start Language Server Protocol server for IDE features |
 | [`calor hook`](/calor/cli/hook/) | Claude Code hook commands (internal) |
 
+Machine-readable diagnostics: the compile and lint commands support
+`--format json|sarif` — see [Structured Output](/calor/cli/structured-output/)
+for the JSON schema, SARIF mapping, and exit-code contract.
+
 ---
 
 ## Compilation (Default Command)
@@ -65,6 +69,7 @@ calor --input file.calr --output file.g.cs
 | `--input`, `-i` | Input Calor file path (required) |
 | `--output`, `-o` | Output C# file path (required) |
 | `--verbose`, `-v` | Show detailed compilation output |
+| `--format`, `-f` | Diagnostic output format: `text` (default), `json`, or `sarif` — see [Structured Output](/calor/cli/structured-output/) |
 
 ### Example
 

--- a/docs/cli/structured-output.md
+++ b/docs/cli/structured-output.md
@@ -1,0 +1,151 @@
+---
+layout: default
+title: Structured Output
+parent: CLI Reference
+nav_order: 15
+permalink: /cli/structured-output/
+---
+
+# Structured Diagnostic Output (`--format json|sarif`)
+
+The root compile command (`calor --input …`) and `calor lint` support a
+`--format` option that switches diagnostic output from human-readable text to a
+machine-readable document on **stdout**:
+
+```bash
+calor --input file.calr --format json     # unified JSON schema (below)
+calor --input file.calr --format sarif    # SARIF 2.1.0
+calor lint file.calr --format json        # lint findings in the same schema
+```
+
+| Value | Output |
+|:------|:-------|
+| `text` (default) | Human-readable diagnostics on **stderr**; nothing structured on stdout |
+| `json` | Unified JSON diagnostic document on **stdout** |
+| `sarif` | [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) log on **stdout** |
+
+On the root command `--format` has the short alias `-f`. On `calor lint` there
+is **no short alias** — `-f` means `--fix` there; spell out `--format`.
+
+## Output-stream contract
+
+In a structured format (`json` or `sarif`):
+
+- **stdout carries exactly one parseable document** — nothing else. Verbose
+  phase messages (`--verbose`), status lines ("Compilation successful: …"),
+  and other human-oriented output are routed to **stderr**.
+- **A document is always emitted**, including early-exit error paths that never
+  reach the compiler pipeline: a missing `--input` file, an invalid argument
+  combination, an unhandled crash, a `lint` target that doesn't exist or isn't
+  a `.calr` file. These paths inject CLI-level diagnostics (`Calor1300`–`Calor1399`)
+  into the document so `calor … --format json | jq .` never fails to parse.
+- All severities are serialized, including `info`. Text mode prints the same
+  set of diagnostics (to stderr), so text and structured output never disagree
+  about what was reported.
+
+## JSON schema
+
+```json
+{
+  "version": "1.0",
+  "diagnostics": [
+    {
+      "code": "Calor0250",
+      "message": "Binding 'x' requires a type or an initializer",
+      "severity": "error",
+      "location": {
+        "file": "/abs/path/broken.calr",
+        "line": 3,
+        "column": 5,
+        "length": 4
+      },
+      "suggestion": "Change 'wrong' to 'right'",
+      "fix": {
+        "description": "Change 'wrong' to 'right'",
+        "edits": [
+          {
+            "filePath": "/abs/path/broken.calr",
+            "startLine": 4, "startColumn": 7,
+            "endLine": 4, "endColumn": 12,
+            "newText": "right"
+          }
+        ]
+      }
+    }
+  ],
+  "summary": { "total": 1, "errors": 1, "warnings": 0, "info": 0 }
+}
+```
+
+Field notes:
+
+- `version` — schema version of this document, currently `"1.0"`.
+- `diagnostics[]` — one entry per diagnostic, aggregated across all input files.
+  - `code` — stable `CalorNNNN` diagnostic code (see the band table below).
+  - `severity` — `"error"`, `"warning"`, or `"info"`.
+  - `location.file` — may be `null` for diagnostics without a file (e.g. some
+    usage errors); `line`/`column` are 1-based; `length` is the span length in
+    characters.
+  - `suggestion` / `fix` — present only when the compiler attaches a suggested
+    fix. `fix.edits[]` are machine-applicable text edits (1-based line/column,
+    end-exclusive replace of the region with `newText`).
+- `summary` — counts over `diagnostics[]`; `total` always equals the array length.
+
+Fields that are `null` are omitted from the serialized output.
+
+## SARIF mapping
+
+`--format sarif` emits a SARIF 2.1.0 log with a single run:
+
+| Unified concept | SARIF location |
+|:----------------|:---------------|
+| Tool | `runs[0].tool.driver.name` = `"calor"` (`"calor-assess"` for `calor assess`) |
+| Diagnostic code | `results[].ruleId`, with metadata in `tool.driver.rules[]` (`id`, `shortDescription`, `helpUri`) |
+| Severity | `results[].level`: error → `"error"`, warning → `"warning"`, info → `"note"` |
+| Message | `results[].message.text` |
+| Location | `results[].locations[0].physicalLocation` — `artifactLocation.uri` (file), `region.startLine`/`startColumn`/`endColumn` |
+| Fix | `results[].fixes[]` — `description.text` plus `artifactChanges[].replacements[]` (`deletedRegion` + `insertedContent.text`) |
+
+Only rules for codes actually present in the results are enumerated in
+`tool.driver.rules[]`.
+
+## Exit codes
+
+Exit codes are independent of `--format` — a structured document is emitted
+*and* the process exits nonzero on failure:
+
+| Command | Exit code | Meaning |
+|:--------|:----------|:--------|
+| `calor --input …` | 0 | compiled without errors (warnings/info allowed) |
+| | 1 | compilation errors, missing input file, usage error, or crash |
+| `calor lint` | 0 | all files clean |
+| | 1 | lint issues found (and not `--fix`ing them) |
+| | 2 | file-level errors: file not found, non-`.calr` input, parse failure, or a processing exception |
+
+## CLI diagnostic codes (Calor1300–Calor1399)
+
+Diagnostics raised by the CLI commands themselves (not the compilation
+pipeline) so they can flow through the structured formats:
+
+| Code | Meaning |
+|:-----|:--------|
+| `Calor1300` | Lint: line has trailing whitespace |
+| `Calor1301` | Lint: construct ID is not abbreviated (e.g. `f001` → `f1`, `for1` → `l1`) |
+| `Calor1302` | Lint: input file not found |
+| `Calor1303` | Lint: input file is not a `.calr` file |
+| `Calor1304` | Lint: unexpected error while processing a file |
+| `Calor1310` | Compile: `--input` file not found |
+| `Calor1311` | Compile: invalid argument combination (e.g. `--output` with multiple inputs) |
+| `Calor1312` | Compile: unhandled internal error |
+
+## Notes on specific commands
+
+- **`calor lint --fix --format json`** — the document lists the issues that
+  were *found* in this run; when `--fix` succeeds those issues have been
+  rewritten in place by the time the command exits (the "Fixed: file" status
+  line goes to stderr). There is no per-diagnostic `fixed` marker yet.
+- **`calor assess --format sarif`** uses the same shared SARIF serializer with
+  tool name `calor-assess` and per-dimension rule IDs (`Calor-<Dimension>`).
+- **`calor verify --format json`** embeds this schema's `diagnostics[]` array
+  per file (alongside its legacy flat `errors`/`warnings` string arrays), but
+  its top-level document is command-specific.

--- a/src/Calor.Compiler/Commands/AssessCommand.cs
+++ b/src/Calor.Compiler/Commands/AssessCommand.cs
@@ -4,7 +4,9 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Calor.Compiler.Analysis;
+using Calor.Compiler.Diagnostics;
 using Calor.Compiler.Init;
+using Calor.Compiler.Parsing;
 using Calor.Compiler.Telemetry;
 
 namespace Calor.Compiler.Commands;
@@ -294,51 +296,42 @@ public static class AssessCommand
         });
     }
 
+    /// <summary>
+    /// SARIF output is produced by the shared <see cref="SarifDiagnosticFormatter"/>
+    /// (single SARIF implementation for the whole CLI); assess results are mapped
+    /// to <see cref="Diagnostic"/> instances with per-dimension rule IDs, and rule
+    /// metadata (descriptions, migration-doc help URIs) is supplied via the
+    /// formatter's provider hooks.
+    /// </summary>
     private static string FormatSarif(ProjectAnalysisResult result, int threshold)
     {
-        var sarif = new SarifLog
-        {
-            Schema = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
-            Version = "2.1.0",
-            Runs = new List<SarifRun>
-            {
-                new SarifRun
-                {
-                    Tool = new SarifTool
+        var diagnostics = result.GetFilesAboveThreshold(threshold)
+            .SelectMany(f => f.Dimensions
+                .Where(kv => kv.Value.PatternCount > 0)
+                .Select(kv => new Diagnostic(
+                    $"Calor-{kv.Key}",
+                    $"Score: {kv.Value.RawScore:F0}/100. {kv.Value.PatternCount} patterns detected. " +
+                    $"Examples: {string.Join(", ", kv.Value.Examples.Take(3))}",
+                    new TextSpan(0, 0, 1, 1),
+                    f.Priority switch
                     {
-                        Driver = new SarifDriver
-                        {
-                            Name = "calor-assess",
-                            Version = "1.0.0",
-                            InformationUri = "https://github.com/calor-lang/calor",
-                            Rules = GetSarifRules()
-                        }
+                        MigrationPriority.Critical => DiagnosticSeverity.Error,
+                        MigrationPriority.High => DiagnosticSeverity.Warning,
+                        _ => DiagnosticSeverity.Info
                     },
-                    Results = result.GetFilesAboveThreshold(threshold)
-                        .SelectMany(f => CreateSarifResults(f))
-                        .ToList()
-                }
-            }
-        };
-
-        return JsonSerializer.Serialize(sarif, new JsonSerializerOptions
-        {
-            WriteIndented = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        });
-    }
-
-    private static List<SarifRule> GetSarifRules()
-    {
-        return Enum.GetValues<ScoreDimension>()
-            .Select(d => new SarifRule
-            {
-                Id = $"Calor-{d}",
-                ShortDescription = new SarifMessage { Text = GetDimensionDescription(d) },
-                HelpUri = $"https://calor-lang.org/docs/migration/{d.ToString().ToLower()}"
-            })
+                    f.RelativePath)))
             .ToList();
+
+        var formatter = new SarifDiagnosticFormatter(
+            toolName: "calor-assess",
+            ruleDescriptionProvider: ruleId =>
+                Enum.TryParse<ScoreDimension>(ruleId.Replace("Calor-", ""), out var dimension)
+                    ? GetDimensionDescription(dimension)
+                    : "Calor migration opportunity",
+            ruleHelpUriProvider: ruleId =>
+                $"https://calor-lang.org/docs/migration/{ruleId.Replace("Calor-", "").ToLowerInvariant()}");
+
+        return formatter.Format(diagnostics);
     }
 
     private static string GetDimensionDescription(ScoreDimension dimension) => dimension switch
@@ -353,42 +346,6 @@ public static class AssessCommand
         ScoreDimension.LinqPotential => "Code uses LINQ patterns that map to Calor collection operations",
         _ => "Calor migration opportunity"
     };
-
-    private static IEnumerable<SarifResult> CreateSarifResults(FileMigrationScore file)
-    {
-        foreach (var (dimension, score) in file.Dimensions.Where(kv => kv.Value.PatternCount > 0))
-        {
-            yield return new SarifResult
-            {
-                RuleId = $"Calor-{dimension}",
-                Level = file.Priority switch
-                {
-                    MigrationPriority.Critical => "error",
-                    MigrationPriority.High => "warning",
-                    _ => "note"
-                },
-                Message = new SarifMessage
-                {
-                    Text = $"Score: {score.RawScore:F0}/100. {score.PatternCount} patterns detected. " +
-                           $"Examples: {string.Join(", ", score.Examples.Take(3))}"
-                },
-                Locations = new List<SarifLocation>
-                {
-                    new SarifLocation
-                    {
-                        PhysicalLocation = new SarifPhysicalLocation
-                        {
-                            ArtifactLocation = new SarifArtifactLocation
-                            {
-                                Uri = file.RelativePath
-                            },
-                            Region = new SarifRegion { StartLine = 1 }
-                        }
-                    }
-                }
-            };
-        }
-    }
 
     // JSON output classes
     private sealed class JsonOutput
@@ -435,74 +392,5 @@ public static class AssessCommand
         public double Weight { get; init; }
         public int PatternCount { get; init; }
         public required List<string> Examples { get; init; }
-    }
-
-    // SARIF output classes
-    private sealed class SarifLog
-    {
-        [JsonPropertyName("$schema")]
-        public required string Schema { get; init; }
-        public required string Version { get; init; }
-        public required List<SarifRun> Runs { get; init; }
-    }
-
-    private sealed class SarifRun
-    {
-        public required SarifTool Tool { get; init; }
-        public required List<SarifResult> Results { get; init; }
-    }
-
-    private sealed class SarifTool
-    {
-        public required SarifDriver Driver { get; init; }
-    }
-
-    private sealed class SarifDriver
-    {
-        public required string Name { get; init; }
-        public required string Version { get; init; }
-        public string? InformationUri { get; init; }
-        public required List<SarifRule> Rules { get; init; }
-    }
-
-    private sealed class SarifRule
-    {
-        public required string Id { get; init; }
-        public required SarifMessage ShortDescription { get; init; }
-        public string? HelpUri { get; init; }
-    }
-
-    private sealed class SarifResult
-    {
-        public required string RuleId { get; init; }
-        public required string Level { get; init; }
-        public required SarifMessage Message { get; init; }
-        public required List<SarifLocation> Locations { get; init; }
-    }
-
-    private sealed class SarifMessage
-    {
-        public required string Text { get; init; }
-    }
-
-    private sealed class SarifLocation
-    {
-        public required SarifPhysicalLocation PhysicalLocation { get; init; }
-    }
-
-    private sealed class SarifPhysicalLocation
-    {
-        public required SarifArtifactLocation ArtifactLocation { get; init; }
-        public required SarifRegion Region { get; init; }
-    }
-
-    private sealed class SarifArtifactLocation
-    {
-        public required string Uri { get; init; }
-    }
-
-    private sealed class SarifRegion
-    {
-        public int StartLine { get; init; }
     }
 }

--- a/src/Calor.Compiler/Commands/LintCommand.cs
+++ b/src/Calor.Compiler/Commands/LintCommand.cs
@@ -36,20 +36,28 @@ public static class LintCommand
             aliases: ["--verbose", "-v"],
             description: "Show detailed lint issues");
 
+        // No -f short alias: it is taken by --fix on this command.
+        var formatOption = new Option<string>(
+            aliases: ["--format"],
+            getDefaultValue: () => "text",
+            description: "Output format: text (human-readable), json, or sarif (machine-readable diagnostics on stdout)");
+        formatOption.FromAmong("text", "json", "sarif");
+
         var command = new Command("lint", "Check and fix Calor code for agent-optimal format")
         {
             inputArgument,
             fixOption,
             checkOption,
-            verboseOption
+            verboseOption,
+            formatOption
         };
 
-        command.SetHandler(ExecuteAsync, inputArgument, fixOption, checkOption, verboseOption);
+        command.SetHandler(ExecuteAsync, inputArgument, fixOption, checkOption, verboseOption, formatOption);
 
         return command;
     }
 
-    private static async Task ExecuteAsync(FileInfo[] files, bool fix, bool check, bool verbose)
+    private static async Task ExecuteAsync(FileInfo[] files, bool fix, bool check, bool verbose, string format)
     {
         var telemetry = CalorTelemetry.IsInitialized ? CalorTelemetry.Instance : null;
         telemetry?.SetCommand("lint");
@@ -59,6 +67,14 @@ public static class LintCommand
             telemetry.SetAgents(CalorConfigManager.GetAgentString(discovered?.Config));
         }
         var sw = Stopwatch.StartNew();
+
+        // Structured output (--format json|sarif): all diagnostics (parse errors
+        // and lint style issues) are aggregated and serialized through the shared
+        // DiagnosticFormatter surface to stdout; human-oriented status messages
+        // move to stderr so stdout stays machine-parseable.
+        var structuredOutput = !format.Equals("text", StringComparison.OrdinalIgnoreCase);
+        var diagnosticSink = structuredOutput ? new DiagnosticBag() : null;
+        var statusOut = structuredOutput ? Console.Error : Console.Out;
 
         var totalFiles = 0;
         var filesWithIssues = 0;
@@ -86,13 +102,17 @@ public static class LintCommand
             try
             {
                 var result = await LintFileAsync(file.FullName, verbose);
+                diagnosticSink?.AddRange(result.Diagnostics);
 
                 if (!result.ParseSuccess)
                 {
-                    Console.Error.WriteLine($"Error parsing {file.Name}:");
-                    foreach (var error in result.ParseErrors)
+                    if (!structuredOutput)
                     {
-                        Console.Error.WriteLine($"  {error}");
+                        Console.Error.WriteLine($"Error parsing {file.Name}:");
+                        foreach (var error in result.ParseErrors)
+                        {
+                            Console.Error.WriteLine($"  {error}");
+                        }
                     }
                     errorFiles++;
                     continue;
@@ -104,7 +124,7 @@ public static class LintCommand
                 {
                     filesWithIssues++;
 
-                    if (verbose || (!fix && !check))
+                    if (!structuredOutput && (verbose || (!fix && !check)))
                     {
                         Console.WriteLine($"{file.Name}: {result.Issues.Count} issue(s)");
                         foreach (var issue in result.Issues)
@@ -116,15 +136,15 @@ public static class LintCommand
                     if (fix)
                     {
                         await File.WriteAllTextAsync(file.FullName, result.FixedContent);
-                        Console.WriteLine($"Fixed: {file.Name}");
+                        statusOut.WriteLine($"Fixed: {file.Name}");
                         fixedFiles++;
                     }
-                    else if (check)
+                    else if (check && !structuredOutput)
                     {
                         Console.WriteLine($"Would fix: {file.Name} ({result.Issues.Count} issues)");
                     }
                 }
-                else if (verbose)
+                else if (verbose && !structuredOutput)
                 {
                     Console.WriteLine($"{file.Name}: OK");
                 }
@@ -136,8 +156,14 @@ public static class LintCommand
             }
         }
 
+        if (diagnosticSink != null)
+        {
+            var formatter = DiagnosticFormatterFactory.Create(format);
+            Console.WriteLine(formatter.Format(diagnosticSink));
+        }
+
         // Summary
-        if (verbose || files.Length > 1)
+        if (!structuredOutput && (verbose || files.Length > 1))
         {
             Console.WriteLine();
             Console.WriteLine($"Linted {totalFiles} file(s), {totalIssues} issue(s) found");
@@ -238,6 +264,16 @@ public static class LintCommand
         var diagnostics = new DiagnosticBag();
         diagnostics.SetFilePath(filePath);
 
+        // Report style issues as warnings so they flow through the shared
+        // structured diagnostic output (--format json|sarif).
+        foreach (var issue in issues)
+        {
+            diagnostics.ReportWarning(
+                new TextSpan(0, 0, issue.Line, 1),
+                DiagnosticCode.LintStyleIssue,
+                issue.Message);
+        }
+
         var lexer = new Lexer(source, diagnostics);
         var tokens = lexer.TokenizeAllForParser();
 
@@ -249,7 +285,8 @@ public static class LintCommand
                 ParseErrors = diagnostics.Errors.Select(e => e.Message).ToList(),
                 Issues = issues,
                 OriginalContent = source,
-                FixedContent = source
+                FixedContent = source,
+                Diagnostics = diagnostics
             };
         }
 
@@ -264,7 +301,8 @@ public static class LintCommand
                 ParseErrors = diagnostics.Errors.Select(e => e.Message).ToList(),
                 Issues = issues,
                 OriginalContent = source,
-                FixedContent = source
+                FixedContent = source,
+                Diagnostics = diagnostics
             };
         }
 
@@ -278,7 +316,8 @@ public static class LintCommand
             ParseErrors = new List<string>(),
             Issues = issues,
             OriginalContent = source,
-            FixedContent = fixedContent
+            FixedContent = fixedContent,
+            Diagnostics = diagnostics
         };
     }
 
@@ -289,6 +328,7 @@ public static class LintCommand
         public required List<LintIssue> Issues { get; init; }
         public required string OriginalContent { get; init; }
         public required string FixedContent { get; init; }
+        public required DiagnosticBag Diagnostics { get; init; }
     }
 
     private sealed record LintIssue(int Line, string Message);

--- a/src/Calor.Compiler/Commands/LintCommand.cs
+++ b/src/Calor.Compiler/Commands/LintCommand.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Calor.Compiler.Diagnostics;
@@ -36,11 +37,12 @@ public static class LintCommand
             aliases: ["--verbose", "-v"],
             description: "Show detailed lint issues");
 
-        // No -f short alias: it is taken by --fix on this command.
+        // Unlike the root command, --format has NO -f short alias here: -f is
+        // taken by --fix on lint. Documented in docs/cli/structured-output.md.
         var formatOption = new Option<string>(
             aliases: ["--format"],
             getDefaultValue: () => "text",
-            description: "Output format: text (human-readable), json, or sarif (machine-readable diagnostics on stdout)");
+            description: "Output format: text (human-readable), json, or sarif (machine-readable diagnostics on stdout). Note: no -f alias on lint (-f means --fix).");
         formatOption.FromAmong("text", "json", "sarif");
 
         var command = new Command("lint", "Check and fix Calor code for agent-optimal format")
@@ -52,12 +54,23 @@ public static class LintCommand
             formatOption
         };
 
-        command.SetHandler(ExecuteAsync, inputArgument, fixOption, checkOption, verboseOption, formatOption);
+        // Set the exit code through InvocationContext: Main returns InvokeAsync's
+        // result as the process exit code, which would stomp a bare
+        // Environment.ExitCode assignment (lint --check must exit nonzero on issues).
+        command.SetHandler(async (InvocationContext ctx) =>
+        {
+            ctx.ExitCode = await ExecuteAsync(
+                ctx.ParseResult.GetValueForArgument(inputArgument),
+                ctx.ParseResult.GetValueForOption(fixOption),
+                ctx.ParseResult.GetValueForOption(checkOption),
+                ctx.ParseResult.GetValueForOption(verboseOption),
+                ctx.ParseResult.GetValueForOption(formatOption) ?? "text");
+        });
 
         return command;
     }
 
-    private static async Task ExecuteAsync(FileInfo[] files, bool fix, bool check, bool verbose, string format)
+    private static async Task<int> ExecuteAsync(FileInfo[] files, bool fix, bool check, bool verbose, string format)
     {
         var telemetry = CalorTelemetry.IsInitialized ? CalorTelemetry.Instance : null;
         telemetry?.SetCommand("lint");
@@ -88,6 +101,12 @@ public static class LintCommand
 
             if (!file.Exists)
             {
+                diagnosticSink?.Add(new Diagnostic(
+                    DiagnosticCode.LintFileNotFound,
+                    $"File not found: {file.FullName}",
+                    new TextSpan(0, 0, 1, 1),
+                    DiagnosticSeverity.Error,
+                    file.FullName));
                 Console.Error.WriteLine($"Error: File not found: {file.FullName}");
                 errorFiles++;
                 continue;
@@ -95,7 +114,16 @@ public static class LintCommand
 
             if (!file.Extension.Equals(".calr", StringComparison.OrdinalIgnoreCase))
             {
-                Console.Error.WriteLine($"Warning: Skipping non-Calor file: {file.Name}");
+                // Not lintable — an error in all output modes so `calor lint`
+                // never silently exits 0 after skipping its input.
+                diagnosticSink?.Add(new Diagnostic(
+                    DiagnosticCode.LintUnsupportedFileType,
+                    $"Cannot lint non-Calor file: {file.Name}",
+                    new TextSpan(0, 0, 1, 1),
+                    DiagnosticSeverity.Error,
+                    file.FullName));
+                Console.Error.WriteLine($"Error: Cannot lint non-Calor file: {file.Name}");
+                errorFiles++;
                 continue;
             }
 
@@ -151,6 +179,12 @@ public static class LintCommand
             }
             catch (Exception ex)
             {
+                diagnosticSink?.Add(new Diagnostic(
+                    DiagnosticCode.LintProcessingError,
+                    $"Error processing {file.Name}: {ex.Message}",
+                    new TextSpan(0, 0, 1, 1),
+                    DiagnosticSeverity.Error,
+                    file.FullName));
                 Console.Error.WriteLine($"Error processing {file.Name}: {ex.Message}");
                 errorFiles++;
             }
@@ -177,27 +211,32 @@ public static class LintCommand
             }
         }
 
-        // Exit code
+        // Exit code: 2 = file/processing errors, 1 = lint issues found
+        // (without --fix), 0 = clean. Returned (not set via Environment.ExitCode,
+        // which Main's InvokeAsync return value would stomp).
+        var exitCode = 0;
         if (errorFiles > 0)
         {
-            Environment.ExitCode = 2;
+            exitCode = 2;
         }
         else if ((check || !fix) && filesWithIssues > 0)
         {
-            Environment.ExitCode = 1;
+            exitCode = 1;
         }
 
         sw.Stop();
-        telemetry?.TrackCommand("lint", Environment.ExitCode, new Dictionary<string, string>
+        telemetry?.TrackCommand("lint", exitCode, new Dictionary<string, string>
         {
             ["durationMs"] = sw.ElapsedMilliseconds.ToString(),
             ["fileCount"] = totalFiles.ToString(),
             ["issueCount"] = totalIssues.ToString()
         });
-        if (Environment.ExitCode != 0)
+        if (exitCode != 0)
         {
             IssueReporter.PromptForIssue(telemetry?.OperationId ?? "unknown", "lint", "Lint check failed");
         }
+
+        return exitCode;
     }
 
     private static async Task<LintResult> LintFileAsync(string filePath, bool verbose)
@@ -218,7 +257,7 @@ public static class LintCommand
             // Check for trailing whitespace
             if (line.Length > 0 && line.TrimEnd('\r') != line.TrimEnd('\r').TrimEnd())
             {
-                issues.Add(new LintIssue(lineNum, "Line has trailing whitespace"));
+                issues.Add(new LintIssue(lineNum, DiagnosticCode.LintTrailingWhitespace, "Line has trailing whitespace"));
             }
 
             // Check for non-abbreviated IDs: m001, f001, etc.
@@ -230,7 +269,7 @@ public static class LintCommand
                 var number = paddedIdMatch.Groups[3].Value;
                 var oldId = prefix + zeros + number;
                 var newId = prefix + number;
-                issues.Add(new LintIssue(lineNum, $"ID should be abbreviated: use '{newId}' instead of '{oldId}'"));
+                issues.Add(new LintIssue(lineNum, DiagnosticCode.LintNonAbbreviatedId, $"ID should be abbreviated: use '{newId}' instead of '{oldId}'"));
             }
 
             // Check for verbose loop/condition IDs: for1, if1, while1, do1
@@ -253,7 +292,7 @@ public static class LintCommand
                 {
                     var oldId = match.Groups[1].Value + match.Groups[2].Value;
                     var newId = replacement + match.Groups[2].Value;
-                    issues.Add(new LintIssue(lineNum, $"ID should be abbreviated: use '{newId}' instead of '{oldId}'"));
+                    issues.Add(new LintIssue(lineNum, DiagnosticCode.LintNonAbbreviatedId, $"ID should be abbreviated: use '{newId}' instead of '{oldId}'"));
                 }
             }
 
@@ -270,7 +309,7 @@ public static class LintCommand
         {
             diagnostics.ReportWarning(
                 new TextSpan(0, 0, issue.Line, 1),
-                DiagnosticCode.LintStyleIssue,
+                issue.Code,
                 issue.Message);
         }
 
@@ -331,5 +370,5 @@ public static class LintCommand
         public required DiagnosticBag Diagnostics { get; init; }
     }
 
-    private sealed record LintIssue(int Line, string Message);
+    private sealed record LintIssue(int Line, string Code, string Message);
 }

--- a/src/Calor.Compiler/Commands/VerifyCommand.cs
+++ b/src/Calor.Compiler/Commands/VerifyCommand.cs
@@ -220,13 +220,25 @@ public static class VerifyCommand
             }
         }
 
+        // Compiler diagnostics are serialized through the shared
+        // JsonDiagnosticFormatter so the per-diagnostic schema
+        // (file/line/column/severity/code/message + fix edits) is identical to
+        // `calor --format json`. The legacy flat errors/warnings string arrays
+        // are kept for backward compatibility with existing consumers.
+        JsonElement diagnosticsElement;
+        using (var doc = JsonDocument.Parse(new JsonDiagnosticFormatter().Format(result.Diagnostics)))
+        {
+            diagnosticsElement = doc.RootElement.GetProperty("diagnostics").Clone();
+        }
+
         return new FileVerificationResult(
             file.Name,
             file.FullName,
             new SummaryOutput(summary.Proven, summary.Unproven, summary.Disproven, summary.Unsupported, summary.Skipped),
             functions,
             result.Diagnostics.Errors.Select(d => d.Message).ToList(),
-            result.Diagnostics.Warnings.Select(d => d.Message).ToList());
+            result.Diagnostics.Warnings.Select(d => d.Message).ToList(),
+            diagnosticsElement);
     }
 
     private static string FormatOutput(List<FileVerificationResult> results, string format)
@@ -373,7 +385,8 @@ public static class VerifyCommand
         SummaryOutput Summary,
         List<FunctionVerificationOutput> Functions,
         List<string> Errors,
-        List<string> Warnings)
+        List<string> Warnings,
+        JsonElement Diagnostics)
     {
         public bool HasDisproven => Summary.Disproven > 0;
     }

--- a/src/Calor.Compiler/CompilationDriver.cs
+++ b/src/Calor.Compiler/CompilationDriver.cs
@@ -34,12 +34,20 @@ internal static class CompilationDriver
     /// (its historical behavior); run/test pass their effective effects-enforcement
     /// setting.
     /// </param>
+    /// <param name="diagnosticSink">
+    /// When non-null, diagnostics (per-file and cross-module) are collected into
+    /// this bag instead of being printed to stderr. Used by structured output
+    /// modes (<c>--format json|sarif</c>) where a <see cref="Diagnostics.IDiagnosticFormatter"/>
+    /// serializes the aggregate at the end; fix information is preserved via
+    /// <see cref="DiagnosticBag.AddRange"/>.
+    /// </param>
     internal static DriverResult CompileAll(
         IReadOnlyList<FileInfo> sources,
         Func<FileInfo, CompilationOptions> optionsFactory,
         bool crossModuleEnforcement,
         UnknownCallPolicy crossModulePolicy,
-        Action<FileInfo, CompilationResult>? onCompiled = null)
+        Action<FileInfo, CompilationResult>? onCompiled = null,
+        DiagnosticBag? diagnosticSink = null)
     {
         var compiled = new List<FileResult>();
         var modules = new List<(ModuleNode Ast, string FilePath)>();
@@ -56,7 +64,14 @@ internal static class CompilationDriver
             var source = File.ReadAllText(file.FullName);
             var result = Program.Compile(source, file.FullName, options);
 
-            PrintDiagnostics(result.Diagnostics, includeAll: result.HasErrors);
+            if (diagnosticSink != null)
+            {
+                diagnosticSink.AddRange(result.Diagnostics);
+            }
+            else
+            {
+                PrintDiagnostics(result.Diagnostics, includeAll: result.HasErrors);
+            }
 
             if (result.HasErrors)
             {
@@ -81,7 +96,14 @@ internal static class CompilationDriver
             var registry = CrossModuleEffectRegistry.Build(modules);
             foreach (var diagnostic in registry.BuildDiagnostics)
             {
-                Console.Error.WriteLine(diagnostic);
+                if (diagnosticSink != null)
+                {
+                    diagnosticSink.Add(diagnostic);
+                }
+                else
+                {
+                    Console.Error.WriteLine(diagnostic);
+                }
             }
 
             var crossPass = new CrossModuleEffectEnforcementPass(crossModulePolicy);
@@ -89,7 +111,15 @@ internal static class CompilationDriver
 
             foreach (var diagnostic in crossDiagnostics)
             {
-                Console.Error.WriteLine(diagnostic);
+                if (diagnosticSink != null)
+                {
+                    diagnosticSink.Add(diagnostic);
+                }
+                else
+                {
+                    Console.Error.WriteLine(diagnostic);
+                }
+
                 if (diagnostic.IsError)
                 {
                     anyErrors = true;

--- a/src/Calor.Compiler/CompilationDriver.cs
+++ b/src/Calor.Compiler/CompilationDriver.cs
@@ -58,7 +58,7 @@ internal static class CompilationDriver
             var options = optionsFactory(file);
             if (options.Verbose)
             {
-                Console.WriteLine($"Compiling: {file.FullName}");
+                (options.StatusWriter ?? Console.Out).WriteLine($"Compiling: {file.FullName}");
             }
 
             var source = File.ReadAllText(file.FullName);
@@ -70,7 +70,7 @@ internal static class CompilationDriver
             }
             else
             {
-                PrintDiagnostics(result.Diagnostics, includeAll: result.HasErrors);
+                PrintDiagnostics(result.Diagnostics);
             }
 
             if (result.HasErrors)
@@ -131,18 +131,16 @@ internal static class CompilationDriver
     }
 
     /// <summary>
-    /// Prints diagnostics to stderr. Errors and warnings are always printed;
-    /// informational diagnostics are included only when the compilation failed
-    /// (preserving the historical quiet-on-success output).
+    /// Prints every diagnostic — including Info severity — to stderr. This
+    /// deliberately matches the structured output modes (--format json|sarif),
+    /// which serialize all severities, so text and machine output report the
+    /// same set of diagnostics.
     /// </summary>
-    private static void PrintDiagnostics(DiagnosticBag diagnostics, bool includeAll)
+    private static void PrintDiagnostics(DiagnosticBag diagnostics)
     {
         foreach (var diagnostic in diagnostics)
         {
-            if (includeAll || diagnostic.IsError || diagnostic.IsWarning)
-            {
-                Console.Error.WriteLine(diagnostic);
-            }
+            Console.Error.WriteLine(diagnostic);
         }
     }
 

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -336,6 +336,16 @@ public static class DiagnosticCode
     /// </summary>
     public const string LegacyCloserForm = "Calor0830";
 
+    // CLI style lint (Calor0850-0859) — issues surfaced by `calor lint`
+
+    /// <summary>
+    /// Warning (lint): a style issue reported by <c>calor lint</c> —
+    /// trailing whitespace or a non-abbreviated construct ID. Used so
+    /// lint findings flow through the shared structured diagnostic
+    /// output (<c>--format json|sarif</c>) with a stable code.
+    /// </summary>
+    public const string LintStyleIssue = "Calor0850";
+
     // Contract simplification (Calor0330-0339)
 
     /// <summary>

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -336,16 +336,6 @@ public static class DiagnosticCode
     /// </summary>
     public const string LegacyCloserForm = "Calor0830";
 
-    // CLI style lint (Calor0850-0859) — issues surfaced by `calor lint`
-
-    /// <summary>
-    /// Warning (lint): a style issue reported by <c>calor lint</c> —
-    /// trailing whitespace or a non-abbreviated construct ID. Used so
-    /// lint findings flow through the shared structured diagnostic
-    /// output (<c>--format json|sarif</c>) with a stable code.
-    /// </summary>
-    public const string LintStyleIssue = "Calor0850";
-
     // Contract simplification (Calor0330-0339)
 
     /// <summary>
@@ -599,6 +589,60 @@ public static class DiagnosticCode
     /// compilation when the <c>pilot-hello-world</c> flag is enabled.
     /// </summary>
     public const string ExperimentalFlagPilot = "Calor1200";
+
+    // CLI diagnostics (Calor1300-1399) — issues surfaced by CLI commands
+    // themselves (file resolution, usage errors, lint style findings) rather
+    // than by the compilation pipeline. Carrying stable codes lets them flow
+    // through the structured output formats (--format json|sarif).
+
+    // `calor lint` style findings (Calor1300-1309)
+
+    /// <summary>
+    /// Warning (lint): a line has trailing whitespace.
+    /// </summary>
+    public const string LintTrailingWhitespace = "Calor1300";
+
+    /// <summary>
+    /// Warning (lint): a construct ID is not in abbreviated form
+    /// (e.g. <c>f001</c> instead of <c>f1</c>, or <c>for1</c> instead of <c>l1</c>).
+    /// </summary>
+    public const string LintNonAbbreviatedId = "Calor1301";
+
+    /// <summary>
+    /// Error (lint): an input file passed to <c>calor lint</c> does not exist.
+    /// </summary>
+    public const string LintFileNotFound = "Calor1302";
+
+    /// <summary>
+    /// Error (lint): an input file passed to <c>calor lint</c> is not a
+    /// <c>.calr</c> file and cannot be linted.
+    /// </summary>
+    public const string LintUnsupportedFileType = "Calor1303";
+
+    /// <summary>
+    /// Error (lint): an unexpected exception occurred while linting a file.
+    /// </summary>
+    public const string LintProcessingError = "Calor1304";
+
+    // Root compile command (Calor1310-1319)
+
+    /// <summary>
+    /// Error (CLI): an input file passed via <c>--input</c> does not exist.
+    /// </summary>
+    public const string CliInputNotFound = "Calor1310";
+
+    /// <summary>
+    /// Error (CLI): invalid combination of command-line arguments
+    /// (e.g. <c>--output</c> with multiple <c>--input</c> files).
+    /// </summary>
+    public const string CliUsageError = "Calor1311";
+
+    /// <summary>
+    /// Error (CLI): an unhandled exception occurred during compilation.
+    /// Emitted so structured output modes (<c>--format json|sarif</c>) still
+    /// produce a parseable document on crash paths.
+    /// </summary>
+    public const string CliInternalError = "Calor1312";
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Diagnostics/DiagnosticBag.cs
+++ b/src/Calor.Compiler/Diagnostics/DiagnosticBag.cs
@@ -42,6 +42,15 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         _diagnostics.Add(new Diagnostic(code, message, span, severity, _currentFilePath));
     }
 
+    /// <summary>
+    /// Adds an already-constructed diagnostic (e.g. from cross-module passes
+    /// that produce <see cref="Diagnostic"/> instances directly).
+    /// </summary>
+    public void Add(Diagnostic diagnostic)
+    {
+        _diagnostics.Add(diagnostic);
+    }
+
     public void ReportError(TextSpan span, string code, string message)
         => Report(span, code, message, DiagnosticSeverity.Error);
 

--- a/src/Calor.Compiler/Diagnostics/DiagnosticFormatter.cs
+++ b/src/Calor.Compiler/Diagnostics/DiagnosticFormatter.cs
@@ -440,6 +440,14 @@ public sealed class SarifDiagnosticFormatter : IDiagnosticFormatter
         DiagnosticCode.CodeGenSyntaxError => "Generated C# code contains syntax errors",
         DiagnosticCode.UnterminatedCSharpInteropBlock => "Unterminated C# interop block",
         DiagnosticCode.CSharpInteropBlockPreserved => "C# code preserved in interop block",
+        DiagnosticCode.LintTrailingWhitespace => "Line has trailing whitespace",
+        DiagnosticCode.LintNonAbbreviatedId => "Construct ID is not in abbreviated form",
+        DiagnosticCode.LintFileNotFound => "Lint input file not found",
+        DiagnosticCode.LintUnsupportedFileType => "Lint input file is not a .calr file",
+        DiagnosticCode.LintProcessingError => "Unexpected error while linting a file",
+        DiagnosticCode.CliInputNotFound => "Input file not found",
+        DiagnosticCode.CliUsageError => "Invalid command-line argument combination",
+        DiagnosticCode.CliInternalError => "Unhandled compiler error",
         _ => "Calor compiler diagnostic"
     };
 

--- a/src/Calor.Compiler/Diagnostics/DiagnosticFormatter.cs
+++ b/src/Calor.Compiler/Diagnostics/DiagnosticFormatter.cs
@@ -210,6 +210,36 @@ public sealed class SarifDiagnosticFormatter : IDiagnosticFormatter
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
+    private readonly string _toolName;
+    private readonly Func<string, string>? _ruleDescriptionProvider;
+    private readonly Func<string, string>? _ruleHelpUriProvider;
+
+    /// <summary>
+    /// Creates the default SARIF formatter for compiler diagnostics
+    /// (tool name "calor", rule metadata from <see cref="DiagnosticCode"/>).
+    /// </summary>
+    public SarifDiagnosticFormatter() : this("calor")
+    {
+    }
+
+    /// <summary>
+    /// Creates a SARIF formatter for a specific tool surface. Commands that emit
+    /// non-compiler rule IDs (e.g. <c>calor assess</c>) supply their own tool name
+    /// and rule metadata providers instead of maintaining a duplicate SARIF object model.
+    /// </summary>
+    /// <param name="toolName">SARIF tool.driver.name (e.g. "calor-assess").</param>
+    /// <param name="ruleDescriptionProvider">Maps a rule ID to its short description; null uses compiler defaults.</param>
+    /// <param name="ruleHelpUriProvider">Maps a rule ID to its help URI; null uses compiler defaults.</param>
+    public SarifDiagnosticFormatter(
+        string toolName,
+        Func<string, string>? ruleDescriptionProvider = null,
+        Func<string, string>? ruleHelpUriProvider = null)
+    {
+        _toolName = toolName;
+        _ruleDescriptionProvider = ruleDescriptionProvider;
+        _ruleHelpUriProvider = ruleHelpUriProvider;
+    }
+
     public string Format(IEnumerable<Diagnostic> diagnostics)
     {
         var sarif = new SarifLog
@@ -224,7 +254,7 @@ public sealed class SarifDiagnosticFormatter : IDiagnosticFormatter
                     {
                         Driver = new SarifToolDriver
                         {
-                            Name = "calor",
+                            Name = _toolName,
                             Version = "1.0.0",
                             InformationUri = "https://github.com/calor-lang/calor",
                             Rules = GetRules(diagnostics)
@@ -360,7 +390,7 @@ public sealed class SarifDiagnosticFormatter : IDiagnosticFormatter
                     {
                         Driver = new SarifToolDriver
                         {
-                            Name = "calor",
+                            Name = _toolName,
                             Version = "1.0.0",
                             InformationUri = "https://github.com/calor-lang/calor",
                             Rules = GetRules(diagnostics)
@@ -374,7 +404,7 @@ public sealed class SarifDiagnosticFormatter : IDiagnosticFormatter
         return JsonSerializer.Serialize(sarif, s_options);
     }
 
-    private static List<SarifRule> GetRules(IEnumerable<Diagnostic> diagnostics)
+    private List<SarifRule> GetRules(IEnumerable<Diagnostic> diagnostics)
     {
         return diagnostics
             .Select(d => d.Code)
@@ -382,8 +412,12 @@ public sealed class SarifDiagnosticFormatter : IDiagnosticFormatter
             .Select(code => new SarifRule
             {
                 Id = code,
-                ShortDescription = new SarifMessage { Text = GetRuleDescription(code) },
-                HelpUri = $"https://calor-lang.org/docs/diagnostics/{code}"
+                ShortDescription = new SarifMessage
+                {
+                    Text = _ruleDescriptionProvider?.Invoke(code) ?? GetRuleDescription(code)
+                },
+                HelpUri = _ruleHelpUriProvider?.Invoke(code)
+                    ?? $"https://calor-lang.org/docs/diagnostics/{code}"
             })
             .ToList();
     }

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -280,56 +280,62 @@ public class Program
         // move to stderr so stdout stays machine-parseable.
         var structuredOutput = !format.Equals("text", StringComparison.OrdinalIgnoreCase);
         var diagnosticSink = structuredOutput ? new DiagnosticBag() : null;
+        var structuredEmitted = false;
+
+        // In structured mode a JSON/SARIF document is ALWAYS emitted to stdout,
+        // including early-exit error paths (missing input, usage errors, crashes),
+        // so machine consumers never have to special-case an empty stdout.
+        int Finish(int exitCode)
+        {
+            if (diagnosticSink != null && !structuredEmitted)
+            {
+                structuredEmitted = true;
+                Console.WriteLine(DiagnosticFormatterFactory.Create(format).Format(diagnosticSink));
+            }
+            return exitCode;
+        }
+
         try
         {
-            // If no input provided, show help
+            // If no input provided, show help. In structured mode the help text
+            // goes to stderr so stdout stays reserved for the (empty) document.
             if (input == null || input.Length == 0)
             {
-                Console.WriteLine("Calor Compiler - Compiles Calor source to C# and migrates between languages");
-                Console.WriteLine();
-                Console.WriteLine("Usage:");
-                Console.WriteLine("  calor --input <file.calr> [--output <file.cs>]   Compile a single Calor file");
-                Console.WriteLine("  calor --input <a.calr> --input <b.calr>          Compile multiple files with cross-module effect checking");
-                Console.WriteLine("  calor convert <file>                             Convert between C# and Calor");
-                Console.WriteLine("  calor migrate <project>                          Migrate entire project");
-                Console.WriteLine("  calor assess <directory>                         Assess C# for migration potential");
-                Console.WriteLine("  calor benchmark [options]                        Compare token economics");
-                Console.WriteLine("  calor init --ai <agent>                          Initialize for AI coding agents");
-                Console.WriteLine("  calor format <files>                             Format Calor source files");
-                Console.WriteLine("  calor feature-check <feature>                    Check C# feature support");
-                Console.WriteLine("  calor coverage <file>                            Analyze C# file for conversion coverage");
-                Console.WriteLine();
-                Console.WriteLine("Strictness options:");
-                Console.WriteLine("  --strict-api      Require §BREAKING markers for public API changes");
-                Console.WriteLine("  --require-docs    Require documentation on public functions");
-                Console.WriteLine("  --enforce-effects Enforce effect declarations (default: false)");
-                Console.WriteLine("  --strict-effects  Promote unknown external call warnings to errors");
-                Console.WriteLine("  --permissive-effects  Permissive mode for converted code (suppress effect errors)");
-                Console.WriteLine("  --contract-mode   Contract mode: off, debug, release (default: debug)");
-                Console.WriteLine("  --verify          Enable static contract verification with Z3");
-                Console.WriteLine("  --verification-timeout  Z3 solver timeout per contract in ms (default: 5000)");
-                Console.WriteLine("  --analyze         Enable advanced analyses (dataflow, bugs, taint)");
-                Console.WriteLine("  --no-cache        Disable verification result caching");
-                Console.WriteLine("  --clear-cache     Clear verification cache before compiling");
-                Console.WriteLine("  --format          Diagnostic output format: text, json, sarif (default: text)");
-                Console.WriteLine();
-                Console.WriteLine("Run 'calor --help' for more information.");
-                return 0;
+                var helpOut = structuredOutput ? Console.Error : Console.Out;
+                WriteHelp(helpOut);
+                return Finish(0);
             }
 
+            var anyMissing = false;
             foreach (var file in input)
             {
                 if (!file.Exists)
                 {
+                    diagnosticSink?.Add(new Diagnostic(
+                        DiagnosticCode.CliInputNotFound,
+                        $"Input file not found: {file.FullName}",
+                        new TextSpan(0, 0, 1, 1),
+                        DiagnosticSeverity.Error,
+                        file.FullName));
                     Console.Error.WriteLine($"Error: Input file not found: {file.FullName}");
-                    return 1;
+                    anyMissing = true;
                 }
+            }
+            if (anyMissing)
+            {
+                return Finish(1);
             }
 
             if (output != null && input.Length > 1)
             {
-                Console.Error.WriteLine("Error: --output is only supported when compiling a single file. When passing multiple --input files, generated .g.cs files are written alongside each input.");
-                return 1;
+                const string usageError = "--output is only supported when compiling a single file. When passing multiple --input files, generated .g.cs files are written alongside each input.";
+                diagnosticSink?.Add(new Diagnostic(
+                    DiagnosticCode.CliUsageError,
+                    usageError,
+                    new TextSpan(0, 0, 1, 1),
+                    DiagnosticSeverity.Error));
+                Console.Error.WriteLine($"Error: {usageError}");
+                return Finish(1);
             }
 
             var parsedContractMode = CompilationDriver.ParseContractMode(contractMode);
@@ -347,6 +353,9 @@ public class Program
                     return new CompilationOptions
                     {
                         Verbose = verbose,
+                        // Keep stdout machine-parseable in structured mode:
+                        // verbose phase messages go to stderr.
+                        StatusWriter = structuredOutput ? Console.Error : null,
                         StrictApi = strictApi,
                         RequireDocs = requireDocs,
                         EnforceEffects = enforceEffects,
@@ -408,19 +417,51 @@ public class Program
                 },
                 diagnosticSink: diagnosticSink);
 
-            if (diagnosticSink != null)
-            {
-                var formatter = DiagnosticFormatterFactory.Create(format);
-                Console.WriteLine(formatter.Format(diagnosticSink));
-            }
-
-            return driverResult.AnyErrors ? 1 : 0;
+            return Finish(driverResult.AnyErrors ? 1 : 0);
         }
         catch (Exception ex)
         {
             Console.Error.WriteLine($"Error: {ex.Message}");
-            return 1;
+            diagnosticSink?.Add(new Diagnostic(
+                DiagnosticCode.CliInternalError,
+                $"Unhandled error: {ex.Message}",
+                new TextSpan(0, 0, 1, 1),
+                DiagnosticSeverity.Error));
+            return Finish(1);
         }
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("Calor Compiler - Compiles Calor source to C# and migrates between languages");
+        writer.WriteLine();
+        writer.WriteLine("Usage:");
+        writer.WriteLine("  calor --input <file.calr> [--output <file.cs>]   Compile a single Calor file");
+        writer.WriteLine("  calor --input <a.calr> --input <b.calr>          Compile multiple files with cross-module effect checking");
+        writer.WriteLine("  calor convert <file>                             Convert between C# and Calor");
+        writer.WriteLine("  calor migrate <project>                          Migrate entire project");
+        writer.WriteLine("  calor assess <directory>                         Assess C# for migration potential");
+        writer.WriteLine("  calor benchmark [options]                        Compare token economics");
+        writer.WriteLine("  calor init --ai <agent>                          Initialize for AI coding agents");
+        writer.WriteLine("  calor format <files>                             Format Calor source files");
+        writer.WriteLine("  calor feature-check <feature>                    Check C# feature support");
+        writer.WriteLine("  calor coverage <file>                            Analyze C# file for conversion coverage");
+        writer.WriteLine();
+        writer.WriteLine("Strictness options:");
+        writer.WriteLine("  --strict-api      Require §BREAKING markers for public API changes");
+        writer.WriteLine("  --require-docs    Require documentation on public functions");
+        writer.WriteLine("  --enforce-effects Enforce effect declarations (default: false)");
+        writer.WriteLine("  --strict-effects  Promote unknown external call warnings to errors");
+        writer.WriteLine("  --permissive-effects  Permissive mode for converted code (suppress effect errors)");
+        writer.WriteLine("  --contract-mode   Contract mode: off, debug, release (default: debug)");
+        writer.WriteLine("  --verify          Enable static contract verification with Z3");
+        writer.WriteLine("  --verification-timeout  Z3 solver timeout per contract in ms (default: 5000)");
+        writer.WriteLine("  --analyze         Enable advanced analyses (dataflow, bugs, taint)");
+        writer.WriteLine("  --no-cache        Disable verification result caching");
+        writer.WriteLine("  --clear-cache     Clear verification cache before compiling");
+        writer.WriteLine("  --format          Diagnostic output format: text, json, sarif (default: text)");
+        writer.WriteLine();
+        writer.WriteLine("Run 'calor --help' for more information.");
     }
 
     /// <summary>
@@ -440,6 +481,10 @@ public class Program
         diagnostics.SetFilePath(filePath);
         var telemetry = CalorTelemetry.IsInitialized ? CalorTelemetry.Instance : null;
         var phaseSw = new Stopwatch();
+
+        // Verbose/status messages go through the configurable status writer so
+        // structured output modes can keep stdout machine-parseable.
+        var status = options.StatusWriter ?? Console.Out;
 
         // Experimental pilot flag — emits one info diagnostic per compilation when
         // the pilot-hello-world flag is enabled. Verifies end-to-end plumbing from
@@ -477,7 +522,7 @@ public class Program
 
         if (options.Verbose)
         {
-            Console.WriteLine($"Lexer produced {tokens.Count} tokens");
+            status.WriteLine($"Lexer produced {tokens.Count} tokens");
         }
 
         if (diagnostics.HasErrors)
@@ -495,7 +540,7 @@ public class Program
 
         if (options.Verbose)
         {
-            Console.WriteLine("Parsing completed successfully");
+            status.WriteLine("Parsing completed successfully");
         }
 
         if (diagnostics.HasErrors)
@@ -515,7 +560,7 @@ public class Program
 
             if (options.Verbose)
             {
-                Console.WriteLine("Type checking completed");
+                status.WriteLine("Type checking completed");
             }
 
             if (diagnostics.HasErrors)
@@ -570,7 +615,7 @@ public class Program
 
             if (options.Verbose)
             {
-                Console.WriteLine("API strictness checking completed");
+                status.WriteLine("API strictness checking completed");
             }
         }
 
@@ -592,7 +637,7 @@ public class Program
 
             if (options.Verbose)
             {
-                Console.WriteLine("Effect enforcement completed");
+                status.WriteLine("Effect enforcement completed");
             }
         }
 
@@ -614,7 +659,7 @@ public class Program
 
         if (options.Verbose)
         {
-            Console.WriteLine("Contract inheritance checking completed");
+            status.WriteLine("Contract inheritance checking completed");
         }
 
         if (diagnostics.HasErrors)
@@ -632,7 +677,7 @@ public class Program
 
         if (options.Verbose)
         {
-            Console.WriteLine("Contract semantic verification completed");
+            status.WriteLine("Contract semantic verification completed");
         }
 
         // Contract simplification pass
@@ -644,7 +689,7 @@ public class Program
 
         if (options.Verbose)
         {
-            Console.WriteLine("Contract simplification completed");
+            status.WriteLine("Contract simplification completed");
         }
 
         // Refinement type obligation generation and verification (optional)
@@ -716,7 +761,7 @@ public class Program
             if (options.Verbose)
             {
                 var summary = obligationTracker.GetSummary();
-                Console.WriteLine($"Obligation verification: {summary.Total} total, " +
+                status.WriteLine($"Obligation verification: {summary.Total} total, " +
                     $"{summary.Discharged} discharged, {summary.Failed} failed, " +
                     $"{summary.Boundary} boundary, {summary.Timeout} timeout");
             }
@@ -741,7 +786,7 @@ public class Program
 
             if (options.Verbose)
             {
-                Console.WriteLine("Contract verification completed");
+                status.WriteLine("Contract verification completed");
             }
         }
 
@@ -764,7 +809,7 @@ public class Program
 
             if (options.Verbose)
             {
-                Console.WriteLine($"Verification analyses completed: {options.VerificationAnalysisResult.FunctionsAnalyzed} functions, " +
+                status.WriteLine($"Verification analyses completed: {options.VerificationAnalysisResult.FunctionsAnalyzed} functions, " +
                     $"{options.VerificationAnalysisResult.BugPatternsFound} bug patterns, " +
                     $"{options.VerificationAnalysisResult.TaintVulnerabilities} taint issues");
             }
@@ -783,7 +828,7 @@ public class Program
 
         if (options.Verbose)
         {
-            Console.WriteLine("Code generation completed successfully");
+            status.WriteLine("Code generation completed successfully");
         }
 
         // Compilation outcome & determinism telemetry (Phase 5)
@@ -860,6 +905,10 @@ public class Program
                 < 800 => "Verification",
                 < 900 => "Import",
                 < 1000 => "Conversion",
+                < 1100 => "CodeGen",
+                < 1200 => "Verification",
+                < 1300 => "Experimental",
+                < 1400 => "Cli",
                 _ => "Other"
             };
         }
@@ -876,6 +925,14 @@ public sealed class CompilationOptions
     /// Enable verbose output.
     /// </summary>
     public bool Verbose { get; init; }
+
+    /// <summary>
+    /// Writer for verbose/status messages emitted during compilation phases.
+    /// Null (the default) means standard output. Structured output modes
+    /// (<c>--format json|sarif</c>) redirect this to standard error so stdout
+    /// stays reserved for the machine-readable diagnostic document.
+    /// </summary>
+    public TextWriter? StatusWriter { get; init; }
 
     /// <summary>
     /// Enable strict API mode: requires §BREAKING markers for public API changes.

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -116,6 +116,12 @@ public class Program
             description: "Enable an experimental feature flag (repeatable). Flag names are defined in docs/experiments/registry.json. Unknown flags are accepted silently.")
         { Arity = ArgumentArity.ZeroOrMore };
 
+        var formatOption = new Option<string>(
+            aliases: ["--format", "-f"],
+            getDefaultValue: () => "text",
+            description: "Diagnostic output format: text (human-readable, stderr), json, or sarif (machine-readable, stdout)");
+        formatOption.FromAmong("text", "json", "sarif");
+
         var rootCommand = new RootCommand("Calor Compiler - Compiles Calor source to C# and migrates between languages")
         {
             inputOption,
@@ -136,7 +142,8 @@ public class Program
             allFindingsOption,
             strictBindInferenceOption,
             noStrictBindInferenceOption,
-            experimentalOption
+            experimentalOption,
+            formatOption
         };
 
         // Legacy compile handler (when --input is provided)
@@ -173,6 +180,7 @@ public class Program
             // --no-strict-bind-inference always wins over the default
             if (noStrictBindInference) strictBindInference = false;
             var experimental = ctx.ParseResult.GetValueForOption(experimentalOption) ?? Array.Empty<string>();
+            var format = ctx.ParseResult.GetValueForOption(formatOption) ?? "text";
 
             telemetry?.TrackEvent("CompileOptions", new Dictionary<string, string>
             {
@@ -192,7 +200,7 @@ public class Program
 
             try
             {
-                ctx.ExitCode = await CompileAsync(input, output, verbose, strictApi, requireDocs, enforceEffects, strictEffects, permissiveEffects, contractMode, verify, noCache, clearCache, verificationTimeout, analyze, allFindings, experimental, strictBindInference);
+                ctx.ExitCode = await CompileAsync(input, output, verbose, strictApi, requireDocs, enforceEffects, strictEffects, permissiveEffects, contractMode, verify, noCache, clearCache, verificationTimeout, analyze, allFindings, experimental, strictBindInference, format);
             }
             catch (Exception ex)
             {
@@ -261,11 +269,17 @@ public class Program
         return result;
     }
 
-    private static Task<int> CompileAsync(FileInfo[]? input, FileInfo? output, bool verbose, bool strictApi, bool requireDocs, bool enforceEffects, bool strictEffects, bool permissiveEffects, string contractMode, bool verify, bool noCache, bool clearCache, int verificationTimeout, bool analyze, bool allFindings = false, string[]? experimentalFlags = null, bool strictBindInference = true)
-        => Task.FromResult(CompileCore(input, output, verbose, strictApi, requireDocs, enforceEffects, strictEffects, permissiveEffects, contractMode, verify, noCache, clearCache, verificationTimeout, analyze, allFindings, experimentalFlags, strictBindInference));
+    private static Task<int> CompileAsync(FileInfo[]? input, FileInfo? output, bool verbose, bool strictApi, bool requireDocs, bool enforceEffects, bool strictEffects, bool permissiveEffects, string contractMode, bool verify, bool noCache, bool clearCache, int verificationTimeout, bool analyze, bool allFindings = false, string[]? experimentalFlags = null, bool strictBindInference = true, string format = "text")
+        => Task.FromResult(CompileCore(input, output, verbose, strictApi, requireDocs, enforceEffects, strictEffects, permissiveEffects, contractMode, verify, noCache, clearCache, verificationTimeout, analyze, allFindings, experimentalFlags, strictBindInference, format));
 
-    private static int CompileCore(FileInfo[]? input, FileInfo? output, bool verbose, bool strictApi, bool requireDocs, bool enforceEffects, bool strictEffects, bool permissiveEffects, string contractMode, bool verify, bool noCache, bool clearCache, int verificationTimeout, bool analyze, bool allFindings, string[]? experimentalFlags, bool strictBindInference)
+    private static int CompileCore(FileInfo[]? input, FileInfo? output, bool verbose, bool strictApi, bool requireDocs, bool enforceEffects, bool strictEffects, bool permissiveEffects, string contractMode, bool verify, bool noCache, bool clearCache, int verificationTimeout, bool analyze, bool allFindings, string[]? experimentalFlags, bool strictBindInference, string format = "text")
     {
+        // Structured diagnostic output (--format json|sarif): diagnostics are
+        // aggregated across files and serialized once through the shared
+        // DiagnosticFormatter surface to stdout; human-oriented status messages
+        // move to stderr so stdout stays machine-parseable.
+        var structuredOutput = !format.Equals("text", StringComparison.OrdinalIgnoreCase);
+        var diagnosticSink = structuredOutput ? new DiagnosticBag() : null;
         try
         {
             // If no input provided, show help
@@ -297,6 +311,7 @@ public class Program
                 Console.WriteLine("  --analyze         Enable advanced analyses (dataflow, bugs, taint)");
                 Console.WriteLine("  --no-cache        Disable verification result caching");
                 Console.WriteLine("  --clear-cache     Clear verification cache before compiling");
+                Console.WriteLine("  --format          Diagnostic output format: text, json, sarif (default: text)");
                 Console.WriteLine();
                 Console.WriteLine("Run 'calor --help' for more information.");
                 return 0;
@@ -380,13 +395,24 @@ public class Program
 
                     File.WriteAllText(outputPath, result.GeneratedCode);
 
+                    // In structured mode stdout is reserved for the serialized
+                    // diagnostics; status messages go to stderr.
+                    var statusOut = structuredOutput ? Console.Error : Console.Out;
+
                     if (verbose)
                     {
-                        Console.WriteLine($"Output written to: {outputPath}");
+                        statusOut.WriteLine($"Output written to: {outputPath}");
                     }
 
-                    Console.WriteLine($"Compilation successful: {outputPath}");
-                });
+                    statusOut.WriteLine($"Compilation successful: {outputPath}");
+                },
+                diagnosticSink: diagnosticSink);
+
+            if (diagnosticSink != null)
+            {
+                var formatter = DiagnosticFormatterFactory.Create(format);
+                Console.WriteLine(formatter.Format(diagnosticSink));
+            }
 
             return driverResult.AnyErrors ? 1 : 0;
         }

--- a/tests/Calor.Compiler.Tests/StructuredOutputTests.cs
+++ b/tests/Calor.Compiler.Tests/StructuredOutputTests.cs
@@ -110,6 +110,59 @@ public class StructuredOutputTests : IDisposable
         Assert.Equal(0, doc.RootElement.GetProperty("summary").GetProperty("errors").GetInt32());
     }
 
+    [Fact]
+    public void Compile_FormatJson_Verbose_KeepsStdoutPureJson()
+    {
+        var file = WriteGoodFile();
+
+        var (exitCode, stdOut, stdErr) = RunCli("--input", file, "--format", "json", "--verbose");
+
+        Assert.True(exitCode == 0, $"expected exit 0, got {exitCode}. stderr: {stdErr}");
+
+        // stdout must parse as a single JSON document even with --verbose:
+        // all verbose phase messages are routed to stderr in structured mode.
+        using var doc = JsonDocument.Parse(stdOut);
+        Assert.Equal(0, doc.RootElement.GetProperty("summary").GetProperty("errors").GetInt32());
+
+        Assert.Contains("Lexer produced", stdErr);
+        Assert.Contains("Code generation completed", stdErr);
+    }
+
+    [Fact]
+    public void Compile_FormatJson_MissingInput_EmitsDocumentAndExitsNonzero()
+    {
+        var missing = Path.Combine(_tempDir, "nope.calr");
+
+        var (exitCode, stdOut, _) = RunCli("--input", missing, "--format", "json");
+
+        Assert.Equal(1, exitCode);
+
+        // Structured mode must ALWAYS emit a document, even on early-exit
+        // error paths that never reach the compilation pipeline.
+        using var doc = JsonDocument.Parse(stdOut);
+        var diagnostics = doc.RootElement.GetProperty("diagnostics");
+        Assert.True(diagnostics.GetArrayLength() >= 1);
+        Assert.Equal(DiagnosticCode.CliInputNotFound, diagnostics[0].GetProperty("code").GetString());
+        Assert.Equal("error", diagnostics[0].GetProperty("severity").GetString());
+        Assert.EndsWith("nope.calr", diagnostics[0].GetProperty("location").GetProperty("file").GetString());
+        Assert.True(doc.RootElement.GetProperty("summary").GetProperty("errors").GetInt32() >= 1);
+    }
+
+    [Fact]
+    public void Compile_FormatSarif_MissingInput_EmitsDocumentAndExitsNonzero()
+    {
+        var missing = Path.Combine(_tempDir, "nope.calr");
+
+        var (exitCode, stdOut, _) = RunCli("--input", missing, "--format", "sarif");
+
+        Assert.Equal(1, exitCode);
+
+        using var doc = JsonDocument.Parse(stdOut);
+        var results = doc.RootElement.GetProperty("runs")[0].GetProperty("results");
+        Assert.True(results.GetArrayLength() >= 1);
+        Assert.Equal(DiagnosticCode.CliInputNotFound, results[0].GetProperty("ruleId").GetString());
+    }
+
     // ------------------------------------------------------------------
     // calor --input <file> --format sarif
     // ------------------------------------------------------------------
@@ -194,17 +247,18 @@ public class StructuredOutputTests : IDisposable
             "    §E{cw}\n" +
             "    §P \"hi\"\n");
 
-        // Note: lint exit codes are not asserted here — `calor lint` sets
-        // Environment.ExitCode, which Main's returned InvokeAsync result
-        // overrides (pre-existing behavior, unchanged by structured output).
-        var (_, stdOut, _) = RunCli("lint", file, "--format", "json");
+        var (exitCode, stdOut, _) = RunCli("lint", file, "--format", "json");
+
+        // Lint issues found (no --fix) → exit 1, propagated through
+        // InvocationContext.ExitCode so InvokeAsync returns it.
+        Assert.Equal(1, exitCode);
 
         using var doc = JsonDocument.Parse(stdOut);
         var diagnostics = doc.RootElement.GetProperty("diagnostics");
         Assert.True(diagnostics.GetArrayLength() >= 1);
 
         var issue = diagnostics[0];
-        Assert.Equal(DiagnosticCode.LintStyleIssue, issue.GetProperty("code").GetString());
+        Assert.Equal(DiagnosticCode.LintTrailingWhitespace, issue.GetProperty("code").GetString());
         Assert.Equal("warning", issue.GetProperty("severity").GetString());
         Assert.Equal(1, issue.GetProperty("location").GetProperty("line").GetInt32());
         Assert.Contains("whitespace", issue.GetProperty("message").GetString());
@@ -216,10 +270,89 @@ public class StructuredOutputTests : IDisposable
         var file = Path.Combine(_tempDir, "badparse.calr");
         File.WriteAllText(file, "§M{m001:Bad}\n  §F{f001:Main:pub () -> void\n");
 
-        var (_, stdOut, _) = RunCli("lint", file, "--format", "json");
+        var (exitCode, stdOut, _) = RunCli("lint", file, "--format", "json");
+
+        Assert.Equal(2, exitCode); // parse failure counts as an error file
 
         using var doc = JsonDocument.Parse(stdOut);
         Assert.True(doc.RootElement.GetProperty("summary").GetProperty("errors").GetInt32() >= 1);
+    }
+
+    [Fact]
+    public void Lint_FormatJson_MissingFile_InjectsDiagnosticAndExitsNonzero()
+    {
+        var missing = Path.Combine(_tempDir, "missing.calr");
+
+        var (exitCode, stdOut, _) = RunCli("lint", missing, "--format", "json");
+
+        Assert.Equal(2, exitCode);
+
+        using var doc = JsonDocument.Parse(stdOut);
+        var diagnostics = doc.RootElement.GetProperty("diagnostics");
+        Assert.True(diagnostics.GetArrayLength() >= 1);
+        Assert.Equal(DiagnosticCode.LintFileNotFound, diagnostics[0].GetProperty("code").GetString());
+        Assert.Equal("error", diagnostics[0].GetProperty("severity").GetString());
+        Assert.True(doc.RootElement.GetProperty("summary").GetProperty("errors").GetInt32() >= 1);
+    }
+
+    [Fact]
+    public void Lint_FormatJson_NonCalorFile_InjectsDiagnosticAndExitsNonzero()
+    {
+        var csFile = Path.Combine(_tempDir, "notcalor.cs");
+        File.WriteAllText(csFile, "public class C { }");
+
+        var (exitCode, stdOut, _) = RunCli("lint", csFile, "--format", "json");
+
+        Assert.Equal(2, exitCode);
+
+        using var doc = JsonDocument.Parse(stdOut);
+        var diagnostics = doc.RootElement.GetProperty("diagnostics");
+        Assert.True(diagnostics.GetArrayLength() >= 1);
+        Assert.Equal(DiagnosticCode.LintUnsupportedFileType, diagnostics[0].GetProperty("code").GetString());
+    }
+
+    [Fact]
+    public void Lint_Check_TextMode_WithIssues_ExitsNonzero()
+    {
+        var file = Path.Combine(_tempDir, "check.calr");
+        File.WriteAllText(file,
+            "§M{m001:Check}   \n" +
+            "  §F{f001:Main:pub} () -> void\n" +
+            "    §E{cw}\n" +
+            "    §P \"hi\"\n");
+
+        var (exitCode, _, _) = RunCli("lint", file, "--check");
+
+        Assert.Equal(1, exitCode);
+    }
+
+    // ------------------------------------------------------------------
+    // Info-level diagnostics are reported consistently: both text mode and
+    // the structured formats include Info severity.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Compile_InfoDiagnostics_AppearInBothTextAndJson()
+    {
+        var file = WriteGoodFile();
+
+        // The pilot experimental flag deterministically emits one Info
+        // diagnostic (Calor1200) per compilation.
+        var (textExit, _, textErr) = RunCli(
+            "--input", file, "--experimental", "pilot-hello-world");
+        Assert.Equal(0, textExit);
+        Assert.Contains("Calor1200", textErr);
+
+        var (jsonExit, stdOut, _) = RunCli(
+            "--input", file, "--experimental", "pilot-hello-world", "--format", "json");
+        Assert.Equal(0, jsonExit);
+
+        using var doc = JsonDocument.Parse(stdOut);
+        var diagnostics = doc.RootElement.GetProperty("diagnostics");
+        Assert.Contains(diagnostics.EnumerateArray(), d =>
+            d.GetProperty("code").GetString() == "Calor1200" &&
+            d.GetProperty("severity").GetString() == "info");
+        Assert.True(doc.RootElement.GetProperty("summary").GetProperty("info").GetInt32() >= 1);
     }
 
     // ------------------------------------------------------------------

--- a/tests/Calor.Compiler.Tests/StructuredOutputTests.cs
+++ b/tests/Calor.Compiler.Tests/StructuredOutputTests.cs
@@ -1,0 +1,363 @@
+using System.Text.Json;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Round-trip tests for the unified structured diagnostic output
+/// (Phase 1 item 3, agent-native strategy): compile files with known errors
+/// through the real CLI with <c>--format json|sarif</c>, parse the output,
+/// and assert the machine-readable schema (file/line/column/severity/code/
+/// message + fix edits) produced by the shared DiagnosticFormatter surface.
+/// </summary>
+public class StructuredOutputTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public StructuredOutputTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "calor-structured-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private (int ExitCode, string StdOut, string StdErr) RunCli(params string[] args)
+        => CliTestHarness.RunCli(_tempDir, args);
+
+    private string WriteBrokenFile()
+    {
+        // §B{x} with no type and no initializer is a deterministic
+        // compile-time error (Calor0250, bind validation) at line 3.
+        var file = Path.Combine(_tempDir, "broken.calr");
+        File.WriteAllText(file, """
+            §M{m001:Broken}
+              §F{f001:Main:pub} () -> void
+                §B{x}
+            """);
+        return file;
+    }
+
+    private string WriteGoodFile()
+    {
+        var file = Path.Combine(_tempDir, "good.calr");
+        File.WriteAllText(file, """
+            §M{m001:Good}
+              §F{f001:Main:pub} () -> void
+                §E{cw}
+                §P "hello"
+            """);
+        return file;
+    }
+
+    // ------------------------------------------------------------------
+    // calor --input <file> --format json
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Compile_FormatJson_ErrorFile_EmitsParseableUnifiedSchema()
+    {
+        var file = WriteBrokenFile();
+
+        var (exitCode, stdOut, stdErr) = RunCli("--input", file, "--format", "json");
+
+        Assert.Equal(1, exitCode);
+
+        // stdout must be pure JSON (jq-compatible)
+        using var doc = JsonDocument.Parse(stdOut);
+        var root = doc.RootElement;
+
+        Assert.Equal("1.0", root.GetProperty("version").GetString());
+
+        var diagnostics = root.GetProperty("diagnostics");
+        Assert.True(diagnostics.GetArrayLength() >= 1, $"expected diagnostics, stderr: {stdErr}");
+
+        var first = diagnostics[0];
+        Assert.Equal("Calor0250", first.GetProperty("code").GetString());
+        Assert.False(string.IsNullOrEmpty(first.GetProperty("message").GetString()));
+        Assert.Equal("error", first.GetProperty("severity").GetString());
+
+        var location = first.GetProperty("location");
+        Assert.EndsWith("broken.calr", location.GetProperty("file").GetString());
+        Assert.Equal(3, location.GetProperty("line").GetInt32());
+        Assert.True(location.GetProperty("column").GetInt32() >= 1);
+
+        var summary = root.GetProperty("summary");
+        Assert.True(summary.GetProperty("errors").GetInt32() >= 1);
+        Assert.Equal(summary.GetProperty("total").GetInt32(), diagnostics.GetArrayLength());
+    }
+
+    [Fact]
+    public void Compile_FormatJson_SuccessFile_EmitsEmptyDiagnosticsAndKeepsStdoutClean()
+    {
+        var file = WriteGoodFile();
+
+        var (exitCode, stdOut, stdErr) = RunCli("--input", file, "--format", "json");
+
+        Assert.True(exitCode == 0, $"expected exit 0, got {exitCode}. stderr: {stdErr}");
+
+        // Status messages must not pollute machine-readable stdout
+        Assert.DoesNotContain("Compilation successful", stdOut);
+        Assert.Contains("Compilation successful", stdErr);
+
+        using var doc = JsonDocument.Parse(stdOut);
+        Assert.Equal(0, doc.RootElement.GetProperty("summary").GetProperty("errors").GetInt32());
+    }
+
+    // ------------------------------------------------------------------
+    // calor --input <file> --format sarif
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Compile_FormatSarif_ErrorFile_EmitsSarif210()
+    {
+        var file = WriteBrokenFile();
+
+        var (exitCode, stdOut, _) = RunCli("--input", file, "--format", "sarif");
+
+        Assert.Equal(1, exitCode);
+
+        using var doc = JsonDocument.Parse(stdOut);
+        var root = doc.RootElement;
+
+        Assert.Equal("2.1.0", root.GetProperty("version").GetString());
+        Assert.Contains("sarif-schema-2.1.0", root.GetProperty("$schema").GetString());
+
+        var run = root.GetProperty("runs")[0];
+        var driver = run.GetProperty("tool").GetProperty("driver");
+        Assert.Equal("calor", driver.GetProperty("name").GetString());
+
+        var results = run.GetProperty("results");
+        Assert.True(results.GetArrayLength() >= 1);
+
+        var result = results[0];
+        Assert.StartsWith("Calor", result.GetProperty("ruleId").GetString());
+        Assert.Equal("error", result.GetProperty("level").GetString());
+        Assert.False(string.IsNullOrEmpty(result.GetProperty("message").GetProperty("text").GetString()));
+
+        var region = result.GetProperty("locations")[0]
+            .GetProperty("physicalLocation")
+            .GetProperty("region");
+        Assert.True(region.GetProperty("startLine").GetInt32() >= 1);
+
+        // Rules metadata present for every emitted code
+        var rules = driver.GetProperty("rules");
+        Assert.True(rules.GetArrayLength() >= 1);
+        Assert.StartsWith("Calor", rules[0].GetProperty("id").GetString());
+    }
+
+    // ------------------------------------------------------------------
+    // Default text behavior unchanged
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Compile_DefaultTextFormat_PrintsDiagnosticsToStderrNotJson()
+    {
+        var file = WriteBrokenFile();
+
+        var (exitCode, stdOut, stdErr) = RunCli("--input", file);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Calor", stdErr); // human-readable diagnostics on stderr
+        Assert.DoesNotContain("\"diagnostics\"", stdOut); // no JSON payload in text mode
+    }
+
+    [Fact]
+    public void Compile_UnknownFormat_IsRejected()
+    {
+        var file = WriteBrokenFile();
+
+        var (exitCode, _, stdErr) = RunCli("--input", file, "--format", "xml");
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("xml", stdErr);
+    }
+
+    // ------------------------------------------------------------------
+    // calor lint --format json
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Lint_FormatJson_ReportsStyleIssuesAsWarnings()
+    {
+        var file = Path.Combine(_tempDir, "style.calr");
+        // Trailing whitespace on the module line is a lint style issue.
+        File.WriteAllText(file,
+            "§M{m001:Style}   \n" +
+            "  §F{f001:Main:pub} () -> void\n" +
+            "    §E{cw}\n" +
+            "    §P \"hi\"\n");
+
+        // Note: lint exit codes are not asserted here — `calor lint` sets
+        // Environment.ExitCode, which Main's returned InvokeAsync result
+        // overrides (pre-existing behavior, unchanged by structured output).
+        var (_, stdOut, _) = RunCli("lint", file, "--format", "json");
+
+        using var doc = JsonDocument.Parse(stdOut);
+        var diagnostics = doc.RootElement.GetProperty("diagnostics");
+        Assert.True(diagnostics.GetArrayLength() >= 1);
+
+        var issue = diagnostics[0];
+        Assert.Equal(DiagnosticCode.LintStyleIssue, issue.GetProperty("code").GetString());
+        Assert.Equal("warning", issue.GetProperty("severity").GetString());
+        Assert.Equal(1, issue.GetProperty("location").GetProperty("line").GetInt32());
+        Assert.Contains("whitespace", issue.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public void Lint_FormatJson_ParseError_SurfacesErrorDiagnostics()
+    {
+        var file = Path.Combine(_tempDir, "badparse.calr");
+        File.WriteAllText(file, "§M{m001:Bad}\n  §F{f001:Main:pub () -> void\n");
+
+        var (_, stdOut, _) = RunCli("lint", file, "--format", "json");
+
+        using var doc = JsonDocument.Parse(stdOut);
+        Assert.True(doc.RootElement.GetProperty("summary").GetProperty("errors").GetInt32() >= 1);
+    }
+
+    // ------------------------------------------------------------------
+    // calor assess --format sarif (shared SARIF implementation)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Assess_FormatSarif_UsesSharedSarifFormatter()
+    {
+        var csFile = Path.Combine(_tempDir, "Sample.cs");
+        File.WriteAllText(csFile, """
+            public class Sample
+            {
+                public int Divide(int a, int b)
+                {
+                    if (b == 0) throw new System.ArgumentException("b");
+                    return a / b;
+                }
+
+                public string? Find(string? name)
+                {
+                    if (name == null) return null;
+                    return name.Trim();
+                }
+            }
+            """);
+
+        var (exitCode, stdOut, stdErr) = RunCli("assess", _tempDir, "--format", "sarif");
+
+        Assert.True(exitCode == 0 || exitCode == 1, $"unexpected exit {exitCode}. stderr: {stdErr}");
+
+        using var doc = JsonDocument.Parse(stdOut);
+        var root = doc.RootElement;
+        Assert.Equal("2.1.0", root.GetProperty("version").GetString());
+
+        var driver = root.GetProperty("runs")[0].GetProperty("tool").GetProperty("driver");
+        Assert.Equal("calor-assess", driver.GetProperty("name").GetString());
+
+        // Results (if any patterns detected) carry per-dimension rule IDs and
+        // rules carry migration-doc help URIs supplied via the provider hooks.
+        var rules = driver.GetProperty("rules");
+        if (rules.GetArrayLength() > 0)
+        {
+            Assert.StartsWith("Calor-", rules[0].GetProperty("id").GetString());
+            Assert.Contains("/docs/migration/", rules[0].GetProperty("helpUri").GetString());
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // calor verify --format json embeds the unified diagnostic schema
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Verify_FormatJson_IncludesUnifiedDiagnosticsArray()
+    {
+        var file = WriteGoodFile();
+
+        var (exitCode, stdOut, stdErr) = RunCli("verify", file, "--format", "json");
+
+        Assert.True(exitCode == 0, $"expected exit 0, got {exitCode}. stderr: {stdErr}");
+
+        using var doc = JsonDocument.Parse(stdOut);
+        var files = doc.RootElement.GetProperty("files");
+        Assert.True(files.GetArrayLength() == 1);
+
+        // The new unified diagnostics array coexists with legacy errors/warnings.
+        var fileEntry = files[0];
+        Assert.Equal(JsonValueKind.Array, fileEntry.GetProperty("diagnostics").ValueKind);
+        Assert.Equal(JsonValueKind.Array, fileEntry.GetProperty("errors").ValueKind);
+        Assert.Equal(JsonValueKind.Array, fileEntry.GetProperty("warnings").ValueKind);
+    }
+
+    // ------------------------------------------------------------------
+    // Fix edits round-trip (machine-applicable edits in JSON and SARIF)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void JsonFormatter_FixEdits_RoundTripThroughParsedJson()
+    {
+        var bag = new DiagnosticBag();
+        bag.SetFilePath("test.calr");
+
+        var fix = new SuggestedFix(
+            "Change 'wrong' to 'right'",
+            TextEdit.Replace("test.calr", 4, 7, 4, 12, "right"));
+        bag.ReportErrorWithFix(new TextSpan(0, 5, 4, 7), "Calor0101", "id mismatch", fix);
+
+        var json = new JsonDiagnosticFormatter().Format(bag);
+
+        using var doc = JsonDocument.Parse(json);
+        var entry = doc.RootElement.GetProperty("diagnostics")[0];
+
+        Assert.Equal("Calor0101", entry.GetProperty("code").GetString());
+        Assert.Equal("Change 'wrong' to 'right'", entry.GetProperty("suggestion").GetString());
+
+        var fixElement = entry.GetProperty("fix");
+        Assert.Equal("Change 'wrong' to 'right'", fixElement.GetProperty("description").GetString());
+
+        var edit = fixElement.GetProperty("edits")[0];
+        Assert.Equal("test.calr", edit.GetProperty("filePath").GetString());
+        Assert.Equal(4, edit.GetProperty("startLine").GetInt32());
+        Assert.Equal(7, edit.GetProperty("startColumn").GetInt32());
+        Assert.Equal(4, edit.GetProperty("endLine").GetInt32());
+        Assert.Equal(12, edit.GetProperty("endColumn").GetInt32());
+        Assert.Equal("right", edit.GetProperty("newText").GetString());
+    }
+
+    [Fact]
+    public void SarifFormatter_FixEdits_RoundTripThroughParsedSarif()
+    {
+        var bag = new DiagnosticBag();
+        bag.SetFilePath("test.calr");
+
+        var fix = new SuggestedFix(
+            "Change 'wrong' to 'right'",
+            TextEdit.Replace("test.calr", 4, 7, 4, 12, "right"));
+        bag.ReportErrorWithFix(new TextSpan(0, 5, 4, 7), "Calor0101", "id mismatch", fix);
+
+        var sarif = new SarifDiagnosticFormatter().Format(bag);
+
+        using var doc = JsonDocument.Parse(sarif);
+        var result = doc.RootElement.GetProperty("runs")[0].GetProperty("results")[0];
+
+        var sarifFix = result.GetProperty("fixes")[0];
+        Assert.Equal("Change 'wrong' to 'right'",
+            sarifFix.GetProperty("description").GetProperty("text").GetString());
+
+        var change = sarifFix.GetProperty("artifactChanges")[0];
+        Assert.Equal("test.calr",
+            change.GetProperty("artifactLocation").GetProperty("uri").GetString());
+
+        var replacement = change.GetProperty("replacements")[0];
+        var deleted = replacement.GetProperty("deletedRegion");
+        Assert.Equal(4, deleted.GetProperty("startLine").GetInt32());
+        Assert.Equal(7, deleted.GetProperty("startColumn").GetInt32());
+        Assert.Equal(4, deleted.GetProperty("endLine").GetInt32());
+        Assert.Equal(12, deleted.GetProperty("endColumn").GetInt32());
+        Assert.Equal("right",
+            replacement.GetProperty("insertedContent").GetProperty("text").GetString());
+    }
+}


### PR DESCRIPTION
DiagnosticFormatter-based structured output: `--format text|json|sarif` on the root compile command and `calor lint`; duplicate SARIF object model in AssessCommand deleted; round-trip tests through the real CLI.

## Scope (Phase 1 item 3, part 1)

This PR is **plumbing only**. The remaining parts of Phase 1 item 3 are **NOT included** and will follow separately:

- diagnostic taxonomy work
- vacuity checking
- whitelist serialization

Serialization surface, precisely: **SARIF is unified** (compile, lint, and assess all go through the shared `SarifDiagnosticFormatter`); the bespoke JSON outputs of `assess`, `verify`, `benchmark`, and `hook` remain command-specific (follow-up). `verify --format json` now embeds the unified per-diagnostic schema in a `diagnostics[]` array alongside its legacy `errors`/`warnings` arrays.

## Contract

Documented in `docs/cli/structured-output.md` (JSON schema, SARIF mapping, exit codes). Key guarantees:

- In `--format json|sarif`, stdout carries exactly one parseable document — verbose/status output goes to stderr (including `--verbose` phase messages).
- A document is **always** emitted, including early-exit paths: missing `--input` (`Calor1310`), usage errors (`Calor1311`), crashes (`Calor1312`), lint file-not-found / non-`.calr` / processing errors (`Calor1302`–`Calor1304`).
- Lint style findings carry distinct codes in a new CLI band: `Calor1300` (trailing whitespace), `Calor1301` (non-abbreviated ID) — moved out of the 0800–0899 ID-validation range.
- `calor lint` now returns its exit code through `InvocationContext` so `lint --check` with issues actually exits 1 (previously `Environment.ExitCode` was stomped by `Main`'s `InvokeAsync` return value).

## Behavior changes riding along

- **Info-level diagnostics are now consistent between text and structured output.** Previously text mode suppressed Info diagnostics unless the compile had errors while JSON serialized all of them; both now report all severities (text prints Info to stderr).
- **`assess --format sarif` rule enumeration**: `tool.driver.rules[]` now lists only rules for codes present in the results (previously all `ScoreDimension` values were always enumerated).
- **`lint --fix --format json` semantics**: the document lists the issues found in this run; with `--fix` they have already been rewritten by exit. No per-diagnostic `fixed` marker (documented; candidate follow-up).
- **`lint` on a non-`.calr` file is now an error (exit 2)** in all output modes, instead of a stderr warning with exit 0 — lint no longer silently skips its input.
- **`lint --format`** has no `-f` short alias (`-f` is `--fix` on lint); the root command keeps `--format`/`-f`.

## Known issue not fixed here

The `Environment.ExitCode`-stomping pattern fixed for `lint` also exists in other commands (`benchmark`, `convert`, `coverage`, `effects`, `evaluation`, `feature-check`, `format`, `ids`, `init`, `lsp`, `mcp`, `migrate`, `self-test`, `verify`). Their exit codes are unreliable for the same reason; fixing them is a mechanical follow-up.

## Validation

Build warning-clean (`TreatWarningsAsErrors`); `tests/Calor.Compiler.Tests` green including 18 StructuredOutputTests CLI round-trip tests; manual smokes: `--format json --verbose` stdout parses as JSON, `lint missing.calr --format json` exits 2 with a `Calor1302` document, `--input nope.calr --format json` exits 1 with a `Calor1310` document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MP98bPvHVGbADabAjtSYpg
