### PR TITLE
Phase 1 item 5: write-path robustness — fixable indent diagnostics, calor format --heal, MCP auto-heal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Write-path robustness (Phase 1 item 5): fixable indentation diagnostics, `calor format --heal`, MCP auto-heal (#699).**
+  - New diagnostics with machine-applicable fixes: `Calor0008` (tab indentation, warning), `Calor0009` (non-standard indent width, warning), `Calor0117` (misaligned `§EI`/`§EL` in statement position, error); `Calor0099` mixed-indentation/dedent-mismatch errors now carry fixes. `Calor0117` fixes are scoped to the current function and are never emitted when applying them would not change the line (a no-op fix would trap agent apply→recheck loops in an infinite cycle).
+  - **Note for existing code:** the `Calor0008`/`Calor0009` warnings fire on legacy tab-indented and 4-space-indented files that previously compiled silently. Such files still compile — the warnings carry one-pass fixes (`calor format --heal`, `calor check --apply`, or the attached edits) that re-indent to the canonical 2 spaces per level.
+  - `calor format --heal`: best-effort source-level repair (structural closers, indentation re-derivation, chain-clause re-alignment) for files too broken for the AST formatter. Healing is **not semantics-preserving**: ambiguous re-anchoring decisions are reported per `file:line` (`--check` prints an `ambiguousDecisions` count), and if the healed output still fails to parse the command reports it and exits 1 instead of silently succeeding.
+  - MCP `calor_check` (`diagnose` action): `apply: true` returns `fixedSource`/`fixesApplied`, plus `healed: true` when the source-level healer ran; a healed response's `success`/`errorCount`/`diagnostics` describe the post-heal `fixedSource`.
+
 ## [0.6.8] - 2026-07-01
 
 ### Benchmark Results (Statistical: 30 runs)

--- a/docs/cli/format.md
+++ b/docs/cli/format.md
@@ -56,6 +56,7 @@ calor format MyModule.calr --diff
 | `--write` | `-w` | `false` | Write formatted output back to the file(s) |
 | `--diff` | `-d` | `false` | Show diff of formatting changes |
 | `--verbose` | `-v` | `false` | Enable verbose output |
+| `--heal` | — | `false` | Best-effort source-level repair of files too broken for the AST formatter. **Not semantics-preserving** — see [Heal Mode](#heal-mode) |
 
 ---
 
@@ -104,6 +105,49 @@ Example CI configuration:
 - name: Check Calor formatting
   run: calor format src/**/*.calr --check
 ```
+
+---
+
+## Heal Mode
+
+The regular format path requires a file that parses. `--heal` works on raw
+text, so it can repair exactly the class of files the AST formatter must
+reject:
+
+```bash
+# Preview the healed source on stdout
+calor format Broken.calr --heal
+
+# Repair in place
+calor format Broken.calr --heal --write
+
+# CI / agent loop: report only (prints an ambiguousDecisions count per file)
+calor format Broken.calr --heal --check
+```
+
+What it repairs:
+
+- **Forbidden structural closers** (`§/F`, `§/M`, …, `Calor0830`) are stripped; lines left empty by the strip are deleted
+- **Indentation** is re-derived from the file's own relative nesting and normalized to 2 spaces per level (tabs expanded, 3-/4-space levels collapsed, misaligned dedents snapped to the nearest enclosing level)
+- **Chain clauses** (`§EI`/`§EL` for `§IF`, `§CA`/`§FI` for `§TR`) are re-aligned to the column of the opener they belong to
+- **Whitespace**: trailing whitespace stripped, CRLF → LF
+
+`§RAW`/`§CSHARP` payloads and multi-line bracketed expressions are preserved
+verbatim. The transform is idempotent: healing already-healed output changes
+nothing.
+
+> **Warning — heal is NOT semantics-preserving.**
+> Healing guesses the author's intent. In particular, a statement written at
+> the same column as a misplaced `§EI`/`§EL` is *re-anchored into that
+> clause's body* — it could equally have been meant as a statement after the
+> if-chain. Every such control-flow guess is reported as a warning with its
+> `file:line` (and `--check` prints an `ambiguousDecisions` count per file).
+> **Always review the healed output before committing it.**
+
+If the healed output still fails to parse — including when heal changed
+nothing — a `heal could not repair` note with the remaining errors is printed
+to stderr and the command exits `1`. Heal never silently succeeds on a file
+that is still broken.
 
 ---
 
@@ -235,7 +279,7 @@ Formatting MyModule.calr...
 | Code | Meaning |
 |:-----|:--------|
 | `0` | Success (or all files formatted in `--check` mode) |
-| `1` | Unformatted files found (`--check` mode) |
+| `1` | Unformatted files found (`--check` mode), or `--heal` output still fails to parse |
 | `2` | Error processing files |
 
 ---

--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -222,6 +222,7 @@ Get machine-readable diagnostics from Calor source code. Includes suggestions an
 ```json
 {
   "source": "string (required) - Calor source code to diagnose",
+  "apply": "boolean - Apply all available fix edits and return the fixed source; if errors remain, a source-level heal is attempted (default: false)",
   "options": {
     "strictApi": "boolean - Enable strict API checking (default: false)",
     "requireDocs": "boolean - Require documentation on public functions (default: false)"
@@ -260,11 +261,32 @@ Get machine-readable diagnostics from Calor source code. Includes suggestions an
 }
 ```
 
+With `"apply": true` the response additionally contains:
+
+```json
+{
+  "fixedSource": "string - the source after applying every machine-applicable fix edit",
+  "fixesApplied": 2,
+  "healed": true
+}
+```
+
+`healed` is present (and `true`) only when the targeted fix edits were not
+enough and the source-level healer (the same transform as
+`calor format --heal`) was applied on top and strictly reduced the error
+count. **When `healed` is `true`, `success`, `errorCount`, `warningCount`,
+and `diagnostics` describe the post-heal recheck of `fixedSource`** — all
+diagnostic coordinates match `fixedSource`, not the original input. Note
+that healing is not semantics-preserving (it guesses control flow when
+re-anchoring ambiguous statements) — review `fixedSource` before using it.
+
 **Fix-Supported Diagnostics:**
 - Typos in operators (e.g., "cotains" → "contains")
 - Mismatched closing tag IDs
 - Undefined variables with similar names in scope
 - C# constructs with Calor alternatives (e.g., "nameof" → use string literal)
+- Indentation issues: tabs (`Calor0008`), non-standard widths (`Calor0009`), mixed/misaligned dedents (`Calor0099`), misaligned `§EI`/`§EL` clauses (`Calor0117`)
+- Forbidden structural closers (`Calor0830`)
 
 ### calor_validate_snippet
 

--- a/docs/syntax-reference/index.md
+++ b/docs/syntax-reference/index.md
@@ -147,6 +147,17 @@ level). There are no closer tags — an explicit `§/X` was removed in
 Phase 4d and now raises `Calor0830`. See
 [Structure Tags](/calor/syntax-reference/structure-tags/) for details.
 
+The compiler diagnoses non-canonical indentation, and each of these
+diagnostics carries a machine-applicable fix (surfaced via `calor check`
+and the MCP `calor_check` tool; `calor format --heal` repairs the same
+issues at the source level):
+
+| Code | Severity | Meaning |
+|:-----|:---------|:--------|
+| `Calor0008` | warning | Leading whitespace uses tabs. One warning per file with one fix edit per tab line (each tab becomes 2 spaces). Fires on legacy tab-indented files that previously parsed silently. |
+| `Calor0009` | warning | Indentation step is not 2 spaces (e.g. 3- or 4-space levels). The file still parses — indentation is stack-relative — but the fix re-indents every offending line to its canonical `2 × level` column. Fires on legacy 4-space files that previously parsed silently. |
+| `Calor0117` | error | A `§EI`/`§EL` clause sits in statement position because it does not align with any open `§IF` (usually dedented too far). When the current function contains a `§IF` and re-indenting would actually change the line, the fix re-indents the clause to that `§IF`'s column. |
+
 ---
 
 ## Detailed Reference

--- a/src/Calor.Compiler/Commands/FormatCommand.cs
+++ b/src/Calor.Compiler/Commands/FormatCommand.cs
@@ -43,7 +43,10 @@ public static class FormatCommand
             aliases: ["--heal"],
             description: "Best-effort source-level repair: strip forbidden structural closers, " +
                          "normalize indentation to 2-space levels from structural nesting, and fix " +
-                         "common whitespace issues. Works on files too broken for the AST formatter. Idempotent.");
+                         "common whitespace issues. Works on files too broken for the AST formatter. Idempotent. " +
+                         "WARNING: healing is NOT semantics-preserving — re-anchoring ambiguous statements " +
+                         "into a chain-clause body guesses the intended control flow (each guess is reported " +
+                         "as a warning). Always review the healed output.");
 
         var command = new Command("format", "Format Calor source files to canonical style")
         {
@@ -112,13 +115,30 @@ public static class FormatCommand
 
                 var isFormatted = result.Original == result.Formatted;
 
+                // Healing is NOT semantics-preserving: surface every
+                // control-flow guess with a file:line so the author can
+                // review the healed output.
+                if (heal && result.Ambiguities.Count > 0)
+                {
+                    foreach (var ambiguity in result.Ambiguities)
+                    {
+                        Console.Error.WriteLine(
+                            $"Warning: {file.FullName}:{ambiguity.Line}: {ambiguity.Message}");
+                    }
+                    Console.Error.WriteLine(
+                        "Warning: heal guesses control flow when re-anchoring statements and is " +
+                        "NOT semantics-preserving — review the healed output.");
+                }
+
                 if (!isFormatted)
                 {
                     hasUnformatted = true;
 
                     if (check)
                     {
-                        Console.WriteLine($"{(heal ? "Would heal" : "Would reformat")}: {file.Name}");
+                        Console.WriteLine(heal
+                            ? $"Would heal: {file.Name} (ambiguousDecisions: {result.Ambiguities.Count})"
+                            : $"Would reformat: {file.Name}");
                     }
                     else if (write)
                     {
@@ -228,7 +248,8 @@ public static class FormatCommand
             Success = true,
             Original = source,
             Formatted = healed,
-            Errors = new List<string>()
+            Errors = new List<string>(),
+            Ambiguities = healer.Ambiguities.ToList()
         };
     }
 
@@ -347,5 +368,8 @@ public static class FormatCommand
         public required string Original { get; init; }
         public required string Formatted { get; init; }
         public required List<string> Errors { get; init; }
+
+        /// <summary>Control-flow guesses made by the healer (heal path only).</summary>
+        public List<HealAmbiguity> Ambiguities { get; init; } = new();
     }
 }

--- a/src/Calor.Compiler/Commands/FormatCommand.cs
+++ b/src/Calor.Compiler/Commands/FormatCommand.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.Diagnostics;
 using Calor.Compiler.Diagnostics;
 using Calor.Compiler.Formatting;
@@ -58,12 +59,25 @@ public static class FormatCommand
             healOption
         };
 
-        command.SetHandler(ExecuteAsync, inputArgument, checkOption, writeOption, diffOption, verboseOption, healOption);
+        // Return the exit code through the handler (ctx.ExitCode) instead of
+        // stomping Environment.ExitCode: the root command's InvokeAsync
+        // result is what Program.Main returns, so a code parked only on
+        // Environment.ExitCode is overwritten by Main's return value.
+        command.SetHandler(async (InvocationContext ctx) =>
+        {
+            ctx.ExitCode = await ExecuteAsync(
+                ctx.ParseResult.GetValueForArgument(inputArgument),
+                ctx.ParseResult.GetValueForOption(checkOption),
+                ctx.ParseResult.GetValueForOption(writeOption),
+                ctx.ParseResult.GetValueForOption(diffOption),
+                ctx.ParseResult.GetValueForOption(verboseOption),
+                ctx.ParseResult.GetValueForOption(healOption));
+        });
 
         return command;
     }
 
-    private static async Task ExecuteAsync(FileInfo[] files, bool check, bool write, bool diff, bool verbose, bool heal)
+    private static async Task<int> ExecuteAsync(FileInfo[] files, bool check, bool write, bool diff, bool verbose, bool heal)
     {
         var telemetry = CalorTelemetry.IsInitialized ? CalorTelemetry.Instance : null;
         telemetry?.SetCommand("format");
@@ -197,26 +211,28 @@ public static class FormatCommand
         // Exit code. A heal that leaves (or found and could not touch) parse
         // errors must not exit 0 — silence would let an agent loop believe
         // the file was repaired.
+        int exitCode = 0;
         if (errorFiles > 0)
         {
-            Environment.ExitCode = 2;
+            exitCode = 2;
         }
         else if ((check && hasUnformatted) || unrepairedFiles > 0)
         {
-            Environment.ExitCode = 1;
+            exitCode = 1;
         }
 
         sw.Stop();
-        telemetry?.TrackCommand("format", Environment.ExitCode, new Dictionary<string, string>
+        telemetry?.TrackCommand("format", exitCode, new Dictionary<string, string>
         {
             ["durationMs"] = sw.ElapsedMilliseconds.ToString(),
             ["fileCount"] = totalFiles.ToString(),
             ["errorCount"] = errorFiles.ToString()
         });
-        if (Environment.ExitCode != 0)
+        if (exitCode != 0)
         {
             IssueReporter.PromptForIssue(telemetry?.OperationId ?? "unknown", "format", "Format check failed");
         }
+        return exitCode;
     }
 
     /// <summary>

--- a/src/Calor.Compiler/Commands/FormatCommand.cs
+++ b/src/Calor.Compiler/Commands/FormatCommand.cs
@@ -39,21 +39,28 @@ public static class FormatCommand
             aliases: ["--verbose", "-v"],
             description: "Enable verbose output");
 
+        var healOption = new Option<bool>(
+            aliases: ["--heal"],
+            description: "Best-effort source-level repair: strip forbidden structural closers, " +
+                         "normalize indentation to 2-space levels from structural nesting, and fix " +
+                         "common whitespace issues. Works on files too broken for the AST formatter. Idempotent.");
+
         var command = new Command("format", "Format Calor source files to canonical style")
         {
             inputArgument,
             checkOption,
             writeOption,
             diffOption,
-            verboseOption
+            verboseOption,
+            healOption
         };
 
-        command.SetHandler(ExecuteAsync, inputArgument, checkOption, writeOption, diffOption, verboseOption);
+        command.SetHandler(ExecuteAsync, inputArgument, checkOption, writeOption, diffOption, verboseOption, healOption);
 
         return command;
     }
 
-    private static async Task ExecuteAsync(FileInfo[] files, bool check, bool write, bool diff, bool verbose)
+    private static async Task ExecuteAsync(FileInfo[] files, bool check, bool write, bool diff, bool verbose, bool heal)
     {
         var telemetry = CalorTelemetry.IsInitialized ? CalorTelemetry.Instance : null;
         telemetry?.SetCommand("format");
@@ -88,7 +95,9 @@ public static class FormatCommand
 
             try
             {
-                var result = await FormatFileAsync(file.FullName, verbose);
+                var result = heal
+                    ? await HealFileAsync(file.FullName)
+                    : await FormatFileAsync(file.FullName, verbose);
 
                 if (!result.Success)
                 {
@@ -109,12 +118,12 @@ public static class FormatCommand
 
                     if (check)
                     {
-                        Console.WriteLine($"Would reformat: {file.Name}");
+                        Console.WriteLine($"{(heal ? "Would heal" : "Would reformat")}: {file.Name}");
                     }
                     else if (write)
                     {
                         await File.WriteAllTextAsync(file.FullName, result.Formatted);
-                        Console.WriteLine($"Formatted: {file.Name}");
+                        Console.WriteLine($"{(heal ? "Healed" : "Formatted")}: {file.Name}");
                         formattedFiles++;
                     }
                     else
@@ -176,6 +185,51 @@ public static class FormatCommand
         {
             IssueReporter.PromptForIssue(telemetry?.OperationId ?? "unknown", "format", "Format check failed");
         }
+    }
+
+    /// <summary>
+    /// <c>--heal</c> path: source-level best-effort repair via
+    /// <see cref="SourceHealer"/>. Unlike <see cref="FormatFileAsync"/> this
+    /// never requires the input to parse — that is the point: it repairs
+    /// files the AST formatter must reject. If the healed output still fails
+    /// to parse, the remaining diagnostics are printed to stderr as a
+    /// heads-up, but healing still succeeds (best effort).
+    /// </summary>
+    private static async Task<FormatResult> HealFileAsync(string filePath)
+    {
+        var source = await File.ReadAllTextAsync(filePath);
+
+        var healer = new SourceHealer();
+        var healed = healer.Heal(source);
+
+        if (healed != source)
+        {
+            var diagnostics = new DiagnosticBag();
+            diagnostics.SetFilePath(filePath);
+            var lexer = new Lexer(healed, diagnostics);
+            var tokens = lexer.TokenizeAllForParser();
+            if (!diagnostics.HasErrors)
+            {
+                var parser = new Parser(tokens, diagnostics);
+                parser.Parse();
+            }
+            if (diagnostics.HasErrors)
+            {
+                Console.Error.WriteLine($"Note: {Path.GetFileName(filePath)} still has parse errors after healing:");
+                foreach (var error in diagnostics.Errors.Take(5))
+                {
+                    Console.Error.WriteLine($"  {error}");
+                }
+            }
+        }
+
+        return new FormatResult
+        {
+            Success = true,
+            Original = source,
+            Formatted = healed,
+            Errors = new List<string>()
+        };
     }
 
     private static async Task<FormatResult> FormatFileAsync(string filePath, bool verbose)

--- a/src/Calor.Compiler/Commands/FormatCommand.cs
+++ b/src/Calor.Compiler/Commands/FormatCommand.cs
@@ -78,6 +78,7 @@ public static class FormatCommand
         var totalFiles = 0;
         var formattedFiles = 0;
         var errorFiles = 0;
+        var unrepairedFiles = 0; // heal ran but the output still fails to parse
 
         foreach (var file in files)
         {
@@ -114,6 +115,11 @@ public static class FormatCommand
                 }
 
                 var isFormatted = result.Original == result.Formatted;
+
+                if (result.ResidualParseErrors)
+                {
+                    unrepairedFiles++;
+                }
 
                 // Healing is NOT semantics-preserving: surface every
                 // control-flow guess with a file:line so the author can
@@ -182,14 +188,20 @@ public static class FormatCommand
             {
                 Console.WriteLine($"  Errors: {errorFiles}");
             }
+            if (unrepairedFiles > 0)
+            {
+                Console.WriteLine($"  Still failing to parse after heal: {unrepairedFiles}");
+            }
         }
 
-        // Exit code
+        // Exit code. A heal that leaves (or found and could not touch) parse
+        // errors must not exit 0 — silence would let an agent loop believe
+        // the file was repaired.
         if (errorFiles > 0)
         {
             Environment.ExitCode = 2;
         }
-        else if (check && hasUnformatted)
+        else if ((check && hasUnformatted) || unrepairedFiles > 0)
         {
             Environment.ExitCode = 1;
         }
@@ -211,9 +223,10 @@ public static class FormatCommand
     /// <c>--heal</c> path: source-level best-effort repair via
     /// <see cref="SourceHealer"/>. Unlike <see cref="FormatFileAsync"/> this
     /// never requires the input to parse — that is the point: it repairs
-    /// files the AST formatter must reject. If the healed output still fails
-    /// to parse, the remaining diagnostics are printed to stderr as a
-    /// heads-up, but healing still succeeds (best effort).
+    /// files the AST formatter must reject. The healed output is ALWAYS
+    /// re-parsed — including when it is identical to the input, so a heal
+    /// no-op on a broken file never exits silently — and residual errors are
+    /// reported on stderr and drive a nonzero exit code.
     /// </summary>
     private static async Task<FormatResult> HealFileAsync(string filePath)
     {
@@ -222,24 +235,23 @@ public static class FormatCommand
         var healer = new SourceHealer();
         var healed = healer.Heal(source);
 
-        if (healed != source)
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath(filePath);
+        var lexer = new Lexer(healed, diagnostics);
+        var tokens = lexer.TokenizeAllForParser();
+        if (!diagnostics.HasErrors)
         {
-            var diagnostics = new DiagnosticBag();
-            diagnostics.SetFilePath(filePath);
-            var lexer = new Lexer(healed, diagnostics);
-            var tokens = lexer.TokenizeAllForParser();
-            if (!diagnostics.HasErrors)
+            var parser = new Parser(tokens, diagnostics);
+            parser.Parse();
+        }
+        if (diagnostics.HasErrors)
+        {
+            Console.Error.WriteLine(healed == source
+                ? $"Note: {Path.GetFileName(filePath)} has parse errors that heal could not repair (no changes made):"
+                : $"Note: {Path.GetFileName(filePath)} still has parse errors after healing; heal could not fully repair it:");
+            foreach (var error in diagnostics.Errors.Take(5))
             {
-                var parser = new Parser(tokens, diagnostics);
-                parser.Parse();
-            }
-            if (diagnostics.HasErrors)
-            {
-                Console.Error.WriteLine($"Note: {Path.GetFileName(filePath)} still has parse errors after healing:");
-                foreach (var error in diagnostics.Errors.Take(5))
-                {
-                    Console.Error.WriteLine($"  {error}");
-                }
+                Console.Error.WriteLine($"  {error}");
             }
         }
 
@@ -249,7 +261,8 @@ public static class FormatCommand
             Original = source,
             Formatted = healed,
             Errors = new List<string>(),
-            Ambiguities = healer.Ambiguities.ToList()
+            Ambiguities = healer.Ambiguities.ToList(),
+            ResidualParseErrors = diagnostics.HasErrors
         };
     }
 
@@ -371,5 +384,8 @@ public static class FormatCommand
 
         /// <summary>Control-flow guesses made by the healer (heal path only).</summary>
         public List<HealAmbiguity> Ambiguities { get; init; } = new();
+
+        /// <summary>True when the healed output still fails to parse (heal path only).</summary>
+        public bool ResidualParseErrors { get; init; }
     }
 }

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -26,6 +26,24 @@ public static class DiagnosticCode
     public const string UnknownSectionMarker = "Calor0006";
     public const string InvalidSectionOperator = "Calor0007";
 
+    /// <summary>
+    /// Warning: leading whitespace uses tab characters. Calor indentation is
+    /// canonically 2 spaces per level; tabs are tolerated (each counts as one
+    /// column) but easily produce dedent mismatches when later lines use
+    /// spaces. Reported once per file with a machine-applicable fix that
+    /// rewrites every tab-indented line (tab → 2 spaces).
+    /// </summary>
+    public const string TabIndentation = "Calor0008";
+
+    /// <summary>
+    /// Warning: a new indentation level is not exactly 2 spaces deeper than
+    /// its parent (e.g. 3- or 4-space steps). The file may still parse —
+    /// indentation is stack-relative — but non-standard widths are the top
+    /// source of agent authoring thrash. Carries a machine-applicable fix
+    /// that re-indents the line to the canonical 2-spaces-per-level column.
+    /// </summary>
+    public const string NonStandardIndentWidth = "Calor0009";
+
     // Phase 3 lexer errors (RFC §4.1)
     public const string MixedIndentation = "Calor0099";
 
@@ -59,6 +77,16 @@ public static class DiagnosticCode
     /// legitimately take a fourth modifier field.
     /// </summary>
     public const string MalformedFunctionHeader = "Calor0116";
+
+    /// <summary>
+    /// Error: a <c>§EI</c>/<c>§EL</c> clause appears where a statement was
+    /// expected — its indentation does not align with any open <c>§IF</c>.
+    /// The most common agent mistake is dedenting the clause too far (past
+    /// the <c>§IF</c> column) so the if-chain closes before the clause is
+    /// seen. Carries a machine-applicable fix that re-indents the clause to
+    /// the column of the nearest preceding <c>§IF</c>.
+    /// </summary>
+    public const string MisalignedElseClause = "Calor0117";
 
     // Call-elision diagnostics (Calor0150-0159) — RFC v0.6 call-closer-elision
 

--- a/src/Calor.Compiler/Formatting/SourceHealer.cs
+++ b/src/Calor.Compiler/Formatting/SourceHealer.cs
@@ -35,6 +35,24 @@ namespace Calor.Compiler.Formatting;
 /// statement into a chain-clause body (see <see cref="Ambiguities"/>) is a
 /// guess about the author's intended control flow. Callers must surface
 /// ambiguous decisions and tell the author to review the healed output.</para>
+///
+/// <para><b>Design decision — this is intentionally a second layout engine.</b>
+/// The healer re-implements the lexer's layout heuristics on raw text because
+/// it must work on exactly the files the lexer/parser reject; it cannot call
+/// into them. Known divergences from the lexer
+/// (<c>Lexer.PostProcessIndent</c>):
+/// (1) bracket continuation is an approximation — <see cref="BracketDelta"/>
+/// counts brackets textually (skipping strings/char literals/<c>//</c>
+/// comments) instead of tracking token-level depth, and continuations are
+/// capped (<see cref="MaxBracketContinuationLines"/> lines, ended by any
+/// §-tag line) whereas the lexer's are unbounded;
+/// (2) block structure is inferred empirically (a line followed by a deeper
+/// line opens a block) instead of from tag semantics.
+/// Tab measurement is deliberately kept ALIGNED at 2 columns per tab, the
+/// same width the lexer's Calor0008 fix substitutes.
+/// Maintenance rule: any change to the lexer's layout rules (indent stack,
+/// tab handling, implicit bracket continuations) must be mirrored here and
+/// covered in <c>WritePathRobustnessTests</c>.</para>
 /// </summary>
 public sealed class SourceHealer
 {
@@ -194,16 +212,16 @@ public sealed class SourceHealer
                 continue;
             }
 
-            // Expand leading tabs and measure the indent. Tabs count as 4
-            // columns for MEASUREMENT only: levels are re-derived and emitted
-            // at 2 spaces each regardless, and width 4 orders tab-indented
-            // lines correctly against both 2- and 4-space neighbours in
-            // files that mix conventions.
+            // Expand leading tabs and measure the indent. Tabs count as 2
+            // columns for MEASUREMENT only (levels are re-derived and emitted
+            // at 2 spaces each regardless) — the same width the lexer's
+            // Calor0008 fix uses when replacing tab indentation, so both
+            // layout engines order tab-indented lines identically.
             int ws = 0;
             var indent = new StringBuilder();
             while (ws < trimmedEnd.Length && (trimmedEnd[ws] == ' ' || trimmedEnd[ws] == '\t'))
             {
-                indent.Append(trimmedEnd[ws] == '\t' ? "    " : " ");
+                indent.Append(trimmedEnd[ws] == '\t' ? "  " : " ");
                 ws++;
             }
 

--- a/src/Calor.Compiler/Formatting/SourceHealer.cs
+++ b/src/Calor.Compiler/Formatting/SourceHealer.cs
@@ -131,12 +131,23 @@ public sealed class SourceHealer
     private static string[] SplitLines(string text)
         => text.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
 
+    /// <summary>
+    /// Upper bound on how many lines a bracket continuation may span. A
+    /// single unbalanced <c>{</c>/<c>(</c> (the canonical agent typo:
+    /// <c>§F{f1:Main:pub ( ) -> void</c> with the header brace never closed)
+    /// would otherwise mark every following line as continuation and make
+    /// heal a silent no-op on the whole file. Genuine multi-line bracketed
+    /// expressions are short; long C# payloads belong in §RAW/§CSHARP blocks.
+    /// </summary>
+    private const int MaxBracketContinuationLines = 10;
+
     private static LineInfo[] ClassifyLines(List<(string Text, int OriginalLine)> lines)
     {
         var infos = new LineInfo[lines.Count];
         bool inRawBlock = false;
         string rawEndMarker = "";
         int bracketDepth = 0;
+        int continuationRun = 0;
 
         for (int i = 0; i < lines.Count; i++)
         {
@@ -156,13 +167,24 @@ public sealed class SourceHealer
 
             if (bracketDepth > 0)
             {
-                // Continuation of a multi-line bracketed expression: the
-                // parser ignores its indentation, and its content may be a
-                // §CS{…} C# payload — pass through untouched (except CR).
-                info.Verbatim = true;
-                info.Original = line.TrimEnd('\r');
-                bracketDepth = Math.Max(0, bracketDepth + BracketDelta(line));
-                continue;
+                // A continuation may not cross a line that starts a §-tag,
+                // and may not exceed MaxBracketContinuationLines: past either
+                // bound the open bracket is assumed to be an authoring typo
+                // (never closed), and the line is treated as structural again.
+                bool startsStructuralTag = line.TrimStart(' ', '\t').StartsWith('§');
+                if (!startsStructuralTag && continuationRun < MaxBracketContinuationLines)
+                {
+                    // Continuation of a multi-line bracketed expression: the
+                    // parser ignores its indentation, and its content may be a
+                    // §CS{…} C# payload — pass through untouched (except CR).
+                    info.Verbatim = true;
+                    info.Original = line.TrimEnd('\r');
+                    bracketDepth = Math.Max(0, bracketDepth + BracketDelta(line));
+                    continuationRun = bracketDepth > 0 ? continuationRun + 1 : 0;
+                    continue;
+                }
+                bracketDepth = 0;
+                continuationRun = 0;
             }
 
             var trimmedEnd = line.TrimEnd();

--- a/src/Calor.Compiler/Formatting/SourceHealer.cs
+++ b/src/Calor.Compiler/Formatting/SourceHealer.cs
@@ -144,12 +144,16 @@ public sealed class SourceHealer
                 continue;
             }
 
-            // Expand leading tabs (2 spaces each) and measure the indent.
+            // Expand leading tabs and measure the indent. Tabs count as 4
+            // columns for MEASUREMENT only: levels are re-derived and emitted
+            // at 2 spaces each regardless, and width 4 orders tab-indented
+            // lines correctly against both 2- and 4-space neighbours in
+            // files that mix conventions.
             int ws = 0;
             var indent = new StringBuilder();
             while (ws < trimmedEnd.Length && (trimmedEnd[ws] == ' ' || trimmedEnd[ws] == '\t'))
             {
-                indent.Append(trimmedEnd[ws] == '\t' ? "  " : " ");
+                indent.Append(trimmedEnd[ws] == '\t' ? "    " : " ");
                 ws++;
             }
 
@@ -190,9 +194,16 @@ public sealed class SourceHealer
     /// <summary>An open block on the relevel stack.</summary>
     private sealed class OpenBlock
     {
-        /// <summary>Raw (as-written) indent of the opener line — updated when a
-        /// chain clause re-anchors the block at its own written indent.</summary>
+        /// <summary>Raw (as-written) indent of the opener line.</summary>
         public int OpenRaw;
+        /// <summary>
+        /// Raw indent used for pop comparisons: a line stays inside this
+        /// block while written deeper than <c>AnchorRaw</c>. Normally equals
+        /// <see cref="OpenRaw"/>; a chain clause written at body level moves
+        /// it just below the clause's own indent so the clause body (written
+        /// at the clause's level) still nests inside the block.
+        /// </summary>
+        public int AnchorRaw;
         /// <summary>Canonical level of the opener line (0 = top level).</summary>
         public int Level;
         public string Tag = "";
@@ -223,16 +234,19 @@ public sealed class SourceHealer
                 && TryFindChainOpener(stack, openerTag, r, out int openerIndex))
             {
                 // Chain clause: align with its opener's column, popping any
-                // blocks opened inside the preceding clause body. Re-anchor
-                // the opener at the clause's written indent so the clause
-                // body (written relative to the clause) levels correctly.
+                // blocks opened inside the preceding clause body. When the
+                // clause was written DEEPER than its opener (the classic
+                // body-level §EI mistake), re-anchor the block just below
+                // the clause's written indent so the clause body — written
+                // at the clause's own level — still nests inside the block.
                 stack.RemoveRange(openerIndex + 1, stack.Count - openerIndex - 1);
-                level = stack[openerIndex].Level;
-                stack[openerIndex].OpenRaw = r;
+                var opener = stack[openerIndex];
+                level = opener.Level;
+                opener.AnchorRaw = r > opener.OpenRaw ? r - 1 : opener.OpenRaw;
             }
             else
             {
-                while (stack.Count > 0 && r <= stack[^1].OpenRaw)
+                while (stack.Count > 0 && r <= stack[^1].AnchorRaw)
                 {
                     stack.RemoveAt(stack.Count - 1);
                 }
@@ -245,7 +259,7 @@ public sealed class SourceHealer
                 // on broken input.)
                 if (info.NextStructuralIndent > r)
                 {
-                    stack.Add(new OpenBlock { OpenRaw = r, Level = level, Tag = info.Tag ?? "" });
+                    stack.Add(new OpenBlock { OpenRaw = r, AnchorRaw = r, Level = level, Tag = info.Tag ?? "" });
                 }
             }
 

--- a/src/Calor.Compiler/Formatting/SourceHealer.cs
+++ b/src/Calor.Compiler/Formatting/SourceHealer.cs
@@ -1,0 +1,378 @@
+using System.Text;
+using Calor.Compiler.Migration;
+
+namespace Calor.Compiler.Formatting;
+
+/// <summary>
+/// Source-level, best-effort repair of the most common Calor authoring
+/// mistakes ("write-path robustness", agent-native strategy Phase 1 item 5).
+/// Unlike <see cref="CalorFormatter"/> — which needs a parseable file — the
+/// healer works on raw text, so it can repair exactly the class of files the
+/// AST formatter cannot touch:
+///
+///   1. Forbidden structural closers (<c>§/F</c>, <c>§/M</c>, …, Calor0830)
+///      are stripped via <see cref="CloserHealMigrator"/>; a line left
+///      whitespace-only by the strip is deleted.
+///   2. Indentation is re-derived from the file's own relative nesting and
+///      normalized to 2 spaces per level: tabs are expanded, 3-/4-space
+///      levels collapse to 2, and misaligned dedents snap to the nearest
+///      enclosing level.
+///   3. Chain clauses (<c>§EI</c>/<c>§EL</c> for <c>§IF</c>, <c>§CA</c>/
+///      <c>§FI</c> for <c>§TR</c>) are re-aligned to the column of the
+///      opener they belong to, even when the author put them at body level
+///      or dedented them too far.
+///   4. Trailing whitespace is stripped and line endings normalize to LF.
+///
+/// Verbatim regions are preserved untouched: <c>§RAW…§/RAW</c> and
+/// <c>§CSHARP…§/CSHARP</c> blocks, plus any line that starts inside an
+/// unclosed bracket/brace (multi-line expressions, <c>§CS{…}</c>).
+///
+/// The transform is idempotent: healed output re-heals to itself, because
+/// every emitted indent is exactly the canonical column its own structure
+/// implies on re-reading.
+/// </summary>
+public sealed class SourceHealer
+{
+    /// <summary>Chain-clause tags and the opener tag each aligns with.</summary>
+    private static readonly Dictionary<string, string> ChainClauseOpeners = new(StringComparer.Ordinal)
+    {
+        ["EI"] = "IF",
+        ["EL"] = "IF",
+        ["CA"] = "TR",
+        ["FI"] = "TR",
+    };
+
+    /// <summary>Heal a Calor source text. Returns the healed text (may equal the input).</summary>
+    public string Heal(string source)
+    {
+        if (string.IsNullOrEmpty(source))
+        {
+            return source;
+        }
+
+        bool endsWithNewline = source.EndsWith('\n');
+
+        // Step 1 — strip forbidden structural closers at the source level.
+        var (stripped, removals) = new CloserHealMigrator().Process(source, "heal");
+
+        // The migrator removes closer text but keeps the line; delete lines
+        // that were non-blank before the strip and whitespace-only after it.
+        var originalLines = SplitLines(source);
+        var lines = SplitLines(stripped);
+        if (removals.Count > 0 && originalLines.Length == lines.Length)
+        {
+            lines = lines
+                .Where((line, i) => !(string.IsNullOrWhiteSpace(line)
+                                      && !string.IsNullOrWhiteSpace(originalLines[i])))
+                .ToArray();
+        }
+
+        // Step 2 — classify lines (verbatim regions, bracket continuations)
+        // and normalize whitespace on structural lines.
+        var infos = ClassifyLines(lines);
+
+        // Step 3 — re-derive indentation from relative nesting.
+        var healed = Relevel(infos);
+
+        var result = string.Join('\n', healed);
+        result = result.TrimEnd('\r', '\n');
+        if (endsWithNewline)
+        {
+            result += "\n";
+        }
+        return result;
+    }
+
+    private sealed class LineInfo
+    {
+        /// <summary>Line emitted exactly as-is (raw/interop content, bracket continuation).</summary>
+        public bool Verbatim;
+        public bool Blank;
+        /// <summary>Indent width after tab expansion (structural lines only).</summary>
+        public int RawIndent;
+        /// <summary>Trimmed line content (no leading/trailing whitespace).</summary>
+        public string Content = "";
+        /// <summary>Original text (used when <see cref="Verbatim"/>).</summary>
+        public string Original = "";
+        /// <summary>Leading §-tag letters (e.g. "IF", "EI", "/C"), or null.</summary>
+        public string? Tag;
+        /// <summary>Raw indent of the next non-blank structural line, or -1.</summary>
+        public int NextStructuralIndent = -1;
+    }
+
+    private static string[] SplitLines(string text)
+        => text.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+
+    private static LineInfo[] ClassifyLines(string[] lines)
+    {
+        var infos = new LineInfo[lines.Length];
+        bool inRawBlock = false;
+        string rawEndMarker = "";
+        int bracketDepth = 0;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var info = new LineInfo { Original = line };
+            infos[i] = info;
+
+            if (inRawBlock)
+            {
+                info.Verbatim = true;
+                if (line.Contains(rawEndMarker, StringComparison.Ordinal))
+                {
+                    inRawBlock = false;
+                }
+                continue;
+            }
+
+            if (bracketDepth > 0)
+            {
+                // Continuation of a multi-line bracketed expression: the
+                // parser ignores its indentation, and its content may be a
+                // §CS{…} C# payload — pass through untouched (except CR).
+                info.Verbatim = true;
+                info.Original = line.TrimEnd('\r');
+                bracketDepth = Math.Max(0, bracketDepth + BracketDelta(line));
+                continue;
+            }
+
+            var trimmedEnd = line.TrimEnd();
+            if (trimmedEnd.Length == 0)
+            {
+                info.Blank = true;
+                continue;
+            }
+
+            // Expand leading tabs (2 spaces each) and measure the indent.
+            int ws = 0;
+            var indent = new StringBuilder();
+            while (ws < trimmedEnd.Length && (trimmedEnd[ws] == ' ' || trimmedEnd[ws] == '\t'))
+            {
+                indent.Append(trimmedEnd[ws] == '\t' ? "  " : " ");
+                ws++;
+            }
+
+            info.RawIndent = indent.Length;
+            info.Content = trimmedEnd[ws..];
+            info.Tag = LeadingTag(info.Content);
+
+            bracketDepth = Math.Max(0, bracketDepth + BracketDelta(trimmedEnd));
+
+            // Verbatim block openers: content until the end marker must not
+            // be touched. (A same-line end marker needs no mode change.)
+            if (ContainsMarker(info.Content, "§RAW") && !info.Content.Contains("§/RAW", StringComparison.Ordinal))
+            {
+                inRawBlock = true;
+                rawEndMarker = "§/RAW";
+            }
+            else if (ContainsMarker(info.Content, "§CSHARP") && !info.Content.Contains("§/CSHARP", StringComparison.Ordinal))
+            {
+                inRawBlock = true;
+                rawEndMarker = "§/CSHARP";
+            }
+        }
+
+        // Opener detection input: raw indent of the next structural line.
+        int next = -1;
+        for (int i = lines.Length - 1; i >= 0; i--)
+        {
+            infos[i].NextStructuralIndent = next;
+            if (!infos[i].Verbatim && !infos[i].Blank)
+            {
+                next = infos[i].RawIndent;
+            }
+        }
+
+        return infos;
+    }
+
+    /// <summary>An open block on the relevel stack.</summary>
+    private sealed class OpenBlock
+    {
+        /// <summary>Raw (as-written) indent of the opener line — updated when a
+        /// chain clause re-anchors the block at its own written indent.</summary>
+        public int OpenRaw;
+        /// <summary>Canonical level of the opener line (0 = top level).</summary>
+        public int Level;
+        public string Tag = "";
+    }
+
+    private static List<string> Relevel(LineInfo[] infos)
+    {
+        var output = new List<string>(infos.Length);
+        var stack = new List<OpenBlock>();
+
+        foreach (var info in infos)
+        {
+            if (info.Verbatim)
+            {
+                output.Add(info.Original);
+                continue;
+            }
+            if (info.Blank)
+            {
+                output.Add("");
+                continue;
+            }
+
+            int r = info.RawIndent;
+            int level;
+
+            if (info.Tag != null && ChainClauseOpeners.TryGetValue(info.Tag, out var openerTag)
+                && TryFindChainOpener(stack, openerTag, r, out int openerIndex))
+            {
+                // Chain clause: align with its opener's column, popping any
+                // blocks opened inside the preceding clause body. Re-anchor
+                // the opener at the clause's written indent so the clause
+                // body (written relative to the clause) levels correctly.
+                stack.RemoveRange(openerIndex + 1, stack.Count - openerIndex - 1);
+                level = stack[openerIndex].Level;
+                stack[openerIndex].OpenRaw = r;
+            }
+            else
+            {
+                while (stack.Count > 0 && r <= stack[^1].OpenRaw)
+                {
+                    stack.RemoveAt(stack.Count - 1);
+                }
+                level = stack.Count;
+
+                // Empirical opener detection: a structural line followed by a
+                // deeper structural line opens a block. (Arrow-form one-liners
+                // and plain statements are never followed by deeper lines in
+                // intent, so relative indentation is the most robust signal
+                // on broken input.)
+                if (info.NextStructuralIndent > r)
+                {
+                    stack.Add(new OpenBlock { OpenRaw = r, Level = level, Tag = info.Tag ?? "" });
+                }
+            }
+
+            output.Add(new string(' ', 2 * level) + info.Content);
+        }
+
+        return output;
+    }
+
+    /// <summary>
+    /// Finds the chain-clause opener (e.g. the <c>§IF</c> an <c>§EI</c>
+    /// belongs to): the stack entry with the matching tag whose written
+    /// indent is closest to the clause's written indent; ties prefer the
+    /// innermost candidate.
+    /// </summary>
+    private static bool TryFindChainOpener(List<OpenBlock> stack, string openerTag, int rawIndent, out int index)
+    {
+        index = -1;
+        int bestDistance = int.MaxValue;
+        for (int i = 0; i < stack.Count; i++)
+        {
+            if (!string.Equals(stack[i].Tag, openerTag, StringComparison.Ordinal))
+            {
+                continue;
+            }
+            int distance = Math.Abs(stack[i].OpenRaw - rawIndent);
+            if (distance <= bestDistance)
+            {
+                bestDistance = distance;
+                index = i;
+            }
+        }
+        return index >= 0;
+    }
+
+    /// <summary>Extracts the leading §-tag letters of a line ("IF", "EI", "/C", …), or null.</summary>
+    private static string? LeadingTag(string content)
+    {
+        if (content.Length < 2 || content[0] != '§')
+        {
+            return null;
+        }
+        int i = 1;
+        if (i < content.Length && content[i] == '/')
+        {
+            i++;
+        }
+        int start = 1;
+        while (i < content.Length && (char.IsAsciiLetterUpper(content[i]) || char.IsAsciiDigit(content[i])))
+        {
+            i++;
+        }
+        return i > start ? content[start..i] : null;
+    }
+
+    /// <summary>True when the line begins with the given marker followed by a non-tag character.</summary>
+    private static bool ContainsMarker(string content, string marker)
+    {
+        int idx = content.IndexOf(marker, StringComparison.Ordinal);
+        if (idx < 0)
+        {
+            return false;
+        }
+        int after = idx + marker.Length;
+        return after >= content.Length
+            || !(char.IsAsciiLetterUpper(content[after]) || char.IsAsciiDigit(content[after]));
+    }
+
+    /// <summary>
+    /// Net bracket/brace/paren depth change of a line, skipping string
+    /// literals, char literals, and <c>//</c> comments — mirrors the lexer's
+    /// implicit-continuation rules closely enough for healing purposes.
+    /// </summary>
+    private static int BracketDelta(string line)
+    {
+        int delta = 0;
+        for (int i = 0; i < line.Length; i++)
+        {
+            char c = line[i];
+            switch (c)
+            {
+                case '"':
+                    i++;
+                    while (i < line.Length && line[i] != '"')
+                    {
+                        if (line[i] == '\\')
+                        {
+                            i++;
+                        }
+                        i++;
+                    }
+                    break;
+                case '\'':
+                    // Skip a short char literal ('x' or '\n'); a lone quote
+                    // is left alone.
+                    int close = -1;
+                    for (int j = i + 1; j < line.Length && j <= i + 3; j++)
+                    {
+                        if (line[j] == '\'')
+                        {
+                            close = j;
+                            break;
+                        }
+                    }
+                    if (close > i)
+                    {
+                        i = close;
+                    }
+                    break;
+                case '/':
+                    if (i + 1 < line.Length && line[i + 1] == '/')
+                    {
+                        return delta; // line comment: ignore the rest
+                    }
+                    break;
+                case '(':
+                case '[':
+                case '{':
+                    delta++;
+                    break;
+                case ')':
+                case ']':
+                case '}':
+                    delta--;
+                    break;
+            }
+        }
+        return delta;
+    }
+}

--- a/src/Calor.Compiler/Formatting/SourceHealer.cs
+++ b/src/Calor.Compiler/Formatting/SourceHealer.cs
@@ -30,6 +30,11 @@ namespace Calor.Compiler.Formatting;
 /// The transform is idempotent: healed output re-heals to itself, because
 /// every emitted indent is exactly the canonical column its own structure
 /// implies on re-reading.
+///
+/// <para><b>Healing is NOT semantics-preserving.</b> Re-anchoring a trailing
+/// statement into a chain-clause body (see <see cref="Ambiguities"/>) is a
+/// guess about the author's intended control flow. Callers must surface
+/// ambiguous decisions and tell the author to review the healed output.</para>
 /// </summary>
 public sealed class SourceHealer
 {
@@ -42,9 +47,23 @@ public sealed class SourceHealer
         ["FI"] = "TR",
     };
 
+    private readonly List<HealAmbiguity> _ambiguities = new();
+
+    /// <summary>
+    /// Control-flow guesses made by the most recent <see cref="Heal"/> call.
+    /// Healing is NOT semantics-preserving: when a chain clause (<c>§EI</c>/
+    /// <c>§EL</c>/<c>§CA</c>/<c>§FI</c>) was written deeper than its opener,
+    /// any following statement written at the clause's own column is
+    /// ambiguous — it could belong to the clause body or be a sibling after
+    /// the chain. The healer keeps it inside the clause body and records the
+    /// decision here so callers can surface it for review.
+    /// </summary>
+    public IReadOnlyList<HealAmbiguity> Ambiguities => _ambiguities;
+
     /// <summary>Heal a Calor source text. Returns the healed text (may equal the input).</summary>
     public string Heal(string source)
     {
+        _ambiguities.Clear();
         if (string.IsNullOrEmpty(source))
         {
             return source;
@@ -57,14 +76,21 @@ public sealed class SourceHealer
 
         // The migrator removes closer text but keeps the line; delete lines
         // that were non-blank before the strip and whitespace-only after it.
+        // Original 1-based line numbers ride along so ambiguity reports
+        // reference the file as the author wrote it.
         var originalLines = SplitLines(source);
-        var lines = SplitLines(stripped);
-        if (removals.Count > 0 && originalLines.Length == lines.Length)
+        var strippedLines = SplitLines(stripped);
+        bool canDropEmptied = removals.Count > 0 && originalLines.Length == strippedLines.Length;
+        var lines = new List<(string Text, int OriginalLine)>(strippedLines.Length);
+        for (int i = 0; i < strippedLines.Length; i++)
         {
-            lines = lines
-                .Where((line, i) => !(string.IsNullOrWhiteSpace(line)
-                                      && !string.IsNullOrWhiteSpace(originalLines[i])))
-                .ToArray();
+            if (canDropEmptied
+                && string.IsNullOrWhiteSpace(strippedLines[i])
+                && !string.IsNullOrWhiteSpace(originalLines[i]))
+            {
+                continue; // line emptied by the closer strip
+            }
+            lines.Add((strippedLines[i], i + 1));
         }
 
         // Step 2 — classify lines (verbatim regions, bracket continuations)
@@ -72,7 +98,7 @@ public sealed class SourceHealer
         var infos = ClassifyLines(lines);
 
         // Step 3 — re-derive indentation from relative nesting.
-        var healed = Relevel(infos);
+        var healed = Relevel(infos, _ambiguities);
 
         var result = string.Join('\n', healed);
         result = result.TrimEnd('\r', '\n');
@@ -98,22 +124,24 @@ public sealed class SourceHealer
         public string? Tag;
         /// <summary>Raw indent of the next non-blank structural line, or -1.</summary>
         public int NextStructuralIndent = -1;
+        /// <summary>1-based line number in the original (pre-strip) source.</summary>
+        public int OriginalLine;
     }
 
     private static string[] SplitLines(string text)
         => text.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
 
-    private static LineInfo[] ClassifyLines(string[] lines)
+    private static LineInfo[] ClassifyLines(List<(string Text, int OriginalLine)> lines)
     {
-        var infos = new LineInfo[lines.Length];
+        var infos = new LineInfo[lines.Count];
         bool inRawBlock = false;
         string rawEndMarker = "";
         int bracketDepth = 0;
 
-        for (int i = 0; i < lines.Length; i++)
+        for (int i = 0; i < lines.Count; i++)
         {
-            var line = lines[i];
-            var info = new LineInfo { Original = line };
+            var line = lines[i].Text;
+            var info = new LineInfo { Original = line, OriginalLine = lines[i].OriginalLine };
             infos[i] = info;
 
             if (inRawBlock)
@@ -179,7 +207,7 @@ public sealed class SourceHealer
 
         // Opener detection input: raw indent of the next structural line.
         int next = -1;
-        for (int i = lines.Length - 1; i >= 0; i--)
+        for (int i = lines.Count - 1; i >= 0; i--)
         {
             infos[i].NextStructuralIndent = next;
             if (!infos[i].Verbatim && !infos[i].Blank)
@@ -207,9 +235,20 @@ public sealed class SourceHealer
         /// <summary>Canonical level of the opener line (0 = top level).</summary>
         public int Level;
         public string Tag = "";
+        /// <summary>
+        /// Written indent of the chain clause that re-anchored this block
+        /// deeper (<see cref="AnchorRaw"/> ≠ <see cref="OpenRaw"/>), or -1.
+        /// A following statement written at exactly this column is an
+        /// ambiguous re-anchoring decision — see <see cref="Ambiguities"/>.
+        /// </summary>
+        public int ClauseRaw = -1;
+        /// <summary>Original line of that clause (valid when ClauseRaw ≥ 0).</summary>
+        public int ClauseLine;
+        /// <summary>Tag of that clause, e.g. "EI" (valid when ClauseRaw ≥ 0).</summary>
+        public string ClauseTag = "";
     }
 
-    private static List<string> Relevel(LineInfo[] infos)
+    private static List<string> Relevel(LineInfo[] infos, List<HealAmbiguity> ambiguities)
     {
         var output = new List<string>(infos.Length);
         var stack = new List<OpenBlock>();
@@ -242,7 +281,18 @@ public sealed class SourceHealer
                 stack.RemoveRange(openerIndex + 1, stack.Count - openerIndex - 1);
                 var opener = stack[openerIndex];
                 level = opener.Level;
-                opener.AnchorRaw = r > opener.OpenRaw ? r - 1 : opener.OpenRaw;
+                if (r > opener.OpenRaw)
+                {
+                    opener.AnchorRaw = r - 1;
+                    opener.ClauseRaw = r;
+                    opener.ClauseLine = info.OriginalLine;
+                    opener.ClauseTag = info.Tag!;
+                }
+                else
+                {
+                    opener.AnchorRaw = opener.OpenRaw;
+                    opener.ClauseRaw = -1;
+                }
             }
             else
             {
@@ -251,6 +301,19 @@ public sealed class SourceHealer
                     stack.RemoveAt(stack.Count - 1);
                 }
                 level = stack.Count;
+
+                // Ambiguous re-anchoring: this statement is written at the
+                // same column as a chain clause that we re-anchored deeper.
+                // Keeping it inside the clause body is a control-flow GUESS —
+                // it could equally be a sibling after the chain. Record the
+                // decision so the CLI can tell the author to review it.
+                if (stack.Count > 0 && stack[^1].ClauseRaw == r)
+                {
+                    ambiguities.Add(new HealAmbiguity(info.OriginalLine,
+                        $"statement is at the same column as the §{stack[^1].ClauseTag} on line " +
+                        $"{stack[^1].ClauseLine}; heal kept it inside that clause's body, but it may have " +
+                        "been intended as a statement after the chain — review the healed control flow"));
+                }
 
                 // Empirical opener detection: a structural line followed by a
                 // deeper structural line opens a block. (Arrow-form one-liners
@@ -390,3 +453,10 @@ public sealed class SourceHealer
         return delta;
     }
 }
+
+/// <summary>
+/// A control-flow guess made while healing. Line is the 1-based line number
+/// in the original source; Message explains the decision the healer took and
+/// why it is ambiguous.
+/// </summary>
+public readonly record struct HealAmbiguity(int Line, string Message);

--- a/src/Calor.Compiler/Mcp/Tools/CheckTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/CheckTool.cs
@@ -38,7 +38,7 @@ public sealed class CheckTool : McpToolBase
                 },
                 "apply": {
                     "type": "boolean",
-                    "description": "When true, automatically apply all available fix edits and return the fixed source alongside diagnostics (diagnose action, default: false)"
+                    "description": "When true, automatically apply all available fix edits and return the fixed source alongside diagnostics; if errors remain, a source-level heal (indentation + structural-closer repair) is attempted (diagnose action, default: false)"
                 },
                 "strictApi": {
                     "type": "boolean",
@@ -192,9 +192,29 @@ public sealed class CheckTool : McpToolBase
 
             string? fixedSource = null;
             var fixesApplied = 0;
+            bool healed = false;
             if (applyFixes)
             {
                 fixedSource = ApplyFixes(source, result.Diagnostics.DiagnosticsWithFixes, out fixesApplied);
+
+                // Auto-heal: if errors remain after applying the targeted fix
+                // edits, run the source-level healer (same transform as
+                // `calor format --heal`) and keep the result when it strictly
+                // reduces the error count. This lets agent check→fix loops
+                // self-heal indentation/closer thrash without a round-trip.
+                if (result.HasErrors)
+                {
+                    var candidate = new SourceHealer().Heal(fixedSource);
+                    if (candidate != fixedSource)
+                    {
+                        var recheck = Program.Compile(candidate, "mcp-input.calr", compileOptions);
+                        if (recheck.Diagnostics.Errors.Count < result.Diagnostics.Errors.Count)
+                        {
+                            fixedSource = candidate;
+                            healed = true;
+                        }
+                    }
+                }
             }
 
             var output = new DiagnoseOutput
@@ -204,7 +224,8 @@ public sealed class CheckTool : McpToolBase
                 WarningCount = diagnostics.Count(d => d.Severity == "warning"),
                 Diagnostics = diagnostics,
                 FixedSource = fixedSource,
-                FixesApplied = applyFixes ? fixesApplied : null
+                FixesApplied = applyFixes ? fixesApplied : null,
+                Healed = healed ? true : null
             };
 
             return Task.FromResult(McpToolResult.Json(output, isError: result.HasErrors));
@@ -724,6 +745,14 @@ public sealed class CheckTool : McpToolBase
         [JsonPropertyName("fixesApplied")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public int? FixesApplied { get; init; }
+
+        /// <summary>
+        /// True when the source-level healer (calor format --heal) was applied
+        /// on top of the targeted fix edits because errors remained.
+        /// </summary>
+        [JsonPropertyName("healed")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? Healed { get; init; }
     }
 
     private sealed class DiagnoseDiagnosticOutput

--- a/src/Calor.Compiler/Mcp/Tools/CheckTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/CheckTool.cs
@@ -148,47 +148,7 @@ public sealed class CheckTool : McpToolBase
             };
 
             var result = Program.Compile(source, "mcp-input.calr", compileOptions);
-
-            var fixLookup = result.Diagnostics.DiagnosticsWithFixes
-                .GroupBy(dwf => (dwf.Span.Line, dwf.Span.Column, dwf.Code, dwf.Message))
-                .ToDictionary(g => g.Key, g => g.First());
-
-            var diagnostics = result.Diagnostics.Select(d =>
-            {
-                var diagOutput = new DiagnoseDiagnosticOutput
-                {
-                    Severity = d.IsError ? "error" : "warning",
-                    Code = d.Code.ToString(),
-                    Message = d.Message,
-                    Line = d.Span.Line,
-                    Column = d.Span.Column
-                };
-
-                var key = (d.Span.Line, d.Span.Column, d.Code, d.Message);
-                if (fixLookup.TryGetValue(key, out var diagnosticWithFix))
-                {
-                    diagOutput.Suggestion = diagnosticWithFix.Fix.Description;
-                    diagOutput.Fix = new FixOutput
-                    {
-                        Description = diagnosticWithFix.Fix.Description,
-                        Edits = diagnosticWithFix.Fix.Edits.Select(e => new EditOutput
-                        {
-                            StartLine = e.StartLine,
-                            StartColumn = e.StartColumn,
-                            EndLine = e.EndLine,
-                            EndColumn = e.EndColumn,
-                            NewText = e.NewText
-                        }).ToList()
-                    };
-                }
-
-                if (diagOutput.Suggestion == null)
-                {
-                    diagOutput.CommonMistake = FindCommonMistake(d.Message, d.Code.ToString());
-                }
-
-                return diagOutput;
-            }).ToList();
+            var diagnostics = BuildDiagnoseDiagnostics(result);
 
             string? fixedSource = null;
             var fixesApplied = 0;
@@ -212,6 +172,13 @@ public sealed class CheckTool : McpToolBase
                         {
                             fixedSource = candidate;
                             healed = true;
+
+                            // The response must describe the state of
+                            // fixedSource, not the pre-heal input: replace the
+                            // diagnostics (so coordinates match fixedSource)
+                            // and derive success/isError from the recheck.
+                            result = recheck;
+                            diagnostics = BuildDiagnoseDiagnostics(recheck);
                         }
                     }
                 }
@@ -234,6 +201,54 @@ public sealed class CheckTool : McpToolBase
         {
             return Task.FromResult(McpToolResult.Error($"Diagnose failed: {ex.Message}"));
         }
+    }
+
+    /// <summary>
+    /// Projects a compilation's diagnostics (with any machine-applicable
+    /// fixes and common-mistake hints) into the diagnose response shape.
+    /// </summary>
+    private static List<DiagnoseDiagnosticOutput> BuildDiagnoseDiagnostics(CompilationResult result)
+    {
+        var fixLookup = result.Diagnostics.DiagnosticsWithFixes
+            .GroupBy(dwf => (dwf.Span.Line, dwf.Span.Column, dwf.Code, dwf.Message))
+            .ToDictionary(g => g.Key, g => g.First());
+
+        return result.Diagnostics.Select(d =>
+        {
+            var diagOutput = new DiagnoseDiagnosticOutput
+            {
+                Severity = d.IsError ? "error" : "warning",
+                Code = d.Code.ToString(),
+                Message = d.Message,
+                Line = d.Span.Line,
+                Column = d.Span.Column
+            };
+
+            var key = (d.Span.Line, d.Span.Column, d.Code, d.Message);
+            if (fixLookup.TryGetValue(key, out var diagnosticWithFix))
+            {
+                diagOutput.Suggestion = diagnosticWithFix.Fix.Description;
+                diagOutput.Fix = new FixOutput
+                {
+                    Description = diagnosticWithFix.Fix.Description,
+                    Edits = diagnosticWithFix.Fix.Edits.Select(e => new EditOutput
+                    {
+                        StartLine = e.StartLine,
+                        StartColumn = e.StartColumn,
+                        EndLine = e.EndLine,
+                        EndColumn = e.EndColumn,
+                        NewText = e.NewText
+                    }).ToList()
+                };
+            }
+
+            if (diagOutput.Suggestion == null)
+            {
+                diagOutput.CommonMistake = FindCommonMistake(d.Message, d.Code.ToString());
+            }
+
+            return diagOutput;
+        }).ToList();
     }
 
     private static string ApplyFixes(string source, IReadOnlyList<DiagnosticWithFix> diagnosticsWithFixes, out int fixesApplied)
@@ -748,7 +763,10 @@ public sealed class CheckTool : McpToolBase
 
         /// <summary>
         /// True when the source-level healer (calor format --heal) was applied
-        /// on top of the targeted fix edits because errors remained.
+        /// on top of the targeted fix edits because errors remained. When true,
+        /// success/errorCount/warningCount/diagnostics describe the post-heal
+        /// recheck of fixedSource — coordinates match fixedSource, not the
+        /// original input.
         /// </summary>
         [JsonPropertyName("healed")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Calor.Compiler/Parsing/Lexer.cs
+++ b/src/Calor.Compiler/Parsing/Lexer.cs
@@ -398,6 +398,16 @@ public sealed class Lexer
         bool atLineStart = true;
         int currentIndent = 0;
         bool sawMixedIndent = false;
+        bool currentIndentHasTab = false;
+
+        // Aggregated fixable indentation issues (reported once per file, at
+        // EOF, with one machine-applicable edit per offending line so a
+        // single fix application heals the whole file).
+        var tabIndentEdits = new List<TextEdit>();
+        var widthEdits = new List<TextEdit>();
+        Token? firstTabIndentTok = null;
+        Token? firstWidthTok = null;
+        var filePath = _diagnostics.CurrentFilePath ?? "";
 
         for (int i = 0; i < raw.Count; i++)
         {
@@ -414,9 +424,25 @@ public sealed class Lexer
                 if (hasTab && hasSpace && !sawMixedIndent)
                 {
                     sawMixedIndent = true;
-                    _diagnostics.ReportError(tok.Span, DiagnosticCode.MixedIndentation,
-                        "Mixed tabs and spaces in leading whitespace. Use one or the other consistently.");
+                    var fix = new SuggestedFix(
+                        "Replace leading whitespace with spaces (each tab becomes 2 spaces)",
+                        TextEdit.Replace(filePath, tok.Span.Line, 1,
+                            tok.Span.Line, text.Length + 1, ExpandIndentTabs(text)));
+                    _diagnostics.ReportErrorWithFix(tok.Span, DiagnosticCode.MixedIndentation,
+                        "Mixed tabs and spaces in leading whitespace. Use one or the other consistently.",
+                        fix);
                 }
+                else if (hasTab && !hasSpace)
+                {
+                    // Tab-only indentation: tolerated (each tab counts as one
+                    // column) but non-canonical and a frequent source of
+                    // dedent mismatches. Collect one edit per line; reported
+                    // once at EOF as Calor0008 with all edits in a single fix.
+                    firstTabIndentTok ??= tok;
+                    tabIndentEdits.Add(TextEdit.Replace(filePath, tok.Span.Line, 1,
+                        tok.Span.Line, text.Length + 1, ExpandIndentTabs(text)));
+                }
+                currentIndentHasTab = hasTab;
                 currentIndent = text.Length;
                 continue; // do not emit whitespace
             }
@@ -428,6 +454,7 @@ public sealed class Lexer
                     yield return tok;
                     atLineStart = true;
                     currentIndent = 0;
+                    currentIndentHasTab = false;
                 }
                 else
                 {
@@ -455,9 +482,10 @@ public sealed class Lexer
                 }
                 else
                 {
+                    int lastPopped = top;
                     while (indentStack.Peek() > currentIndent)
                     {
-                        indentStack.Pop();
+                        lastPopped = indentStack.Pop();
                         yield return new Token(TokenKind.Dedent, "",
                             new TextSpan(tok.Span.Start, 0, tok.Span.Line, 1));
                     }
@@ -466,9 +494,42 @@ public sealed class Lexer
                         if (!sawMixedIndent)
                         {
                             sawMixedIndent = true;
-                            _diagnostics.ReportError(tok.Span, DiagnosticCode.MixedIndentation,
-                                $"Dedent to column {currentIndent} does not match any enclosing indent level.");
+                            // Snap to the nearest enclosing level: either the
+                            // level just below (stack top) or the one just
+                            // above (last popped). Ties prefer the deeper
+                            // level (an off-by-one dedent usually means the
+                            // line was meant to stay inside the block).
+                            int below = indentStack.Peek();
+                            int target = (currentIndent - below) < (lastPopped - currentIndent)
+                                ? below
+                                : lastPopped;
+                            var fix = new SuggestedFix(
+                                $"Re-indent line to the enclosing indent level ({target} spaces)",
+                                TextEdit.Replace(filePath, tok.Span.Line, 1,
+                                    tok.Span.Line, currentIndent + 1, new string(' ', target)));
+                            _diagnostics.ReportErrorWithFix(tok.Span, DiagnosticCode.MixedIndentation,
+                                $"Dedent to column {currentIndent} does not match any enclosing indent level.",
+                                fix);
                         }
+                    }
+                }
+
+                // Non-standard indent width (e.g. 3- or 4-space levels). The
+                // file still parses — indentation is stack-relative — but the
+                // line is not at its canonical 2-spaces-per-level column.
+                // Collect one edit per offending line (siblings included);
+                // level count is width-independent, so applying all edits in
+                // one pass heals the whole file. Reported once at EOF as
+                // Calor0009. Tab-indented lines are handled by Calor0008 and
+                // dedent mismatches by the Calor0099 fix above.
+                if (!currentIndentHasTab && indentStack.Peek() == currentIndent)
+                {
+                    int canonical = 2 * (indentStack.Count - 1);
+                    if (canonical != currentIndent)
+                    {
+                        firstWidthTok ??= tok;
+                        widthEdits.Add(TextEdit.Replace(filePath, tok.Span.Line, 1,
+                            tok.Span.Line, currentIndent + 1, new string(' ', canonical)));
                     }
                 }
                 atLineStart = false;
@@ -491,6 +552,26 @@ public sealed class Lexer
 
             if (tok.Kind == TokenKind.Eof)
             {
+                // Report aggregated fixable indentation issues once per file.
+                if (firstTabIndentTok is { } tabTok)
+                {
+                    _diagnostics.ReportWarningWithFix(tabTok.Span, DiagnosticCode.TabIndentation,
+                        $"Leading whitespace uses tabs on {tabIndentEdits.Count} line(s). " +
+                        "Calor indentation is canonically 2 spaces per level.",
+                        new SuggestedFix(
+                            "Replace tab indentation with spaces (each tab becomes 2 spaces)",
+                            tabIndentEdits));
+                }
+                if (firstWidthTok is { } widthTok)
+                {
+                    _diagnostics.ReportWarningWithFix(widthTok.Span, DiagnosticCode.NonStandardIndentWidth,
+                        $"Indentation step is not 2 spaces on {widthEdits.Count} line(s). " +
+                        "Calor indentation is canonically 2 spaces per level.",
+                        new SuggestedFix(
+                            "Re-indent to 2 spaces per level",
+                            widthEdits));
+                }
+
                 // Drain remaining indent stack.
                 while (indentStack.Count > 1)
                 {
@@ -514,6 +595,13 @@ public sealed class Lexer
             yield return tok;
         }
     }
+
+    /// <summary>
+    /// Expands leading-whitespace tabs to 2 spaces each (spaces preserved).
+    /// Used to build machine-applicable indentation fixes.
+    /// </summary>
+    internal static string ExpandIndentTabs(string leadingWhitespace)
+        => leadingWhitespace.Replace("\t", "  ", StringComparison.Ordinal);
 
     public List<Token> TokenizeWithIndentAll()
         => TokenizeWithIndent().ToList();

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -25,6 +25,14 @@ public sealed class Parser
     private int _inOuterCallArgDepth;
 
     /// <summary>
+    /// The most recently parsed <c>§IF</c> opener token. Used by
+    /// <see cref="ParseStatement"/>'s stray-<c>§EI</c>/<c>§EL</c> recovery
+    /// to build a re-indentation fix that aligns a misaligned else clause
+    /// with the <c>§IF</c> it most plausibly belongs to.
+    /// </summary>
+    private Token? _lastIfToken;
+
+    /// <summary>
     /// Phase 4d — TokenKinds whose textual form is a legacy structural
     /// closing tag (<c>§/M</c>, <c>§/F</c>, <c>§/CL</c>, …) that indent
     /// form has fully replaced. Encountering any of these in the token
@@ -1496,9 +1504,58 @@ public sealed class Parser
             var expr = ParseExpression();
             return new ExpressionStatementNode(expr.Span, expr);
         }
+        // Stray §EI/§EL: the clause was dedented past its §IF, so the
+        // if-chain closed before the clause was seen and it now sits in
+        // statement position. Report with a re-indentation fix and recover.
+        else if (Check(TokenKind.ElseIf) || Check(TokenKind.Else))
+        {
+            return ParseMisalignedElseClause();
+        }
 
         _diagnostics.ReportUnexpectedToken(Current.Span, "statement", Current.Kind);
         Advance();
+        return null;
+    }
+
+    /// <summary>
+    /// Error recovery for a <c>§EI</c>/<c>§EL</c> clause encountered in
+    /// statement position (Calor0117). The clause's indentation did not
+    /// align with any open <c>§IF</c> — almost always because it was
+    /// dedented too far. Emits a machine-applicable fix that re-indents the
+    /// clause line to the column of the most recently parsed <c>§IF</c>,
+    /// then consumes the clause header so the following body parses as
+    /// ordinary statements instead of cascading unexpected-token errors.
+    /// </summary>
+    private StatementNode? ParseMisalignedElseClause()
+    {
+        var clauseToken = Advance(); // §EI or §EL
+        var tag = clauseToken.Kind == TokenKind.ElseIf ? "§EI" : "§EL";
+        var message = $"'{tag}' is not aligned with any open §IF — the if-chain already closed at a " +
+            "shallower indent level. Indent the clause to the same column as its §IF.";
+
+        if (_lastIfToken is { } ifTok)
+        {
+            int targetIndent = Math.Max(0, ifTok.Span.Column - 1);
+            int leadingLength = Math.Max(0, clauseToken.Span.Column - 1);
+            var fix = new SuggestedFix(
+                $"Re-indent '{tag}' to column {ifTok.Span.Column} (aligned with the §IF on line {ifTok.Span.Line})",
+                TextEdit.Replace(_diagnostics.CurrentFilePath ?? "", clauseToken.Span.Line, 1,
+                    clauseToken.Span.Line, leadingLength + 1, new string(' ', targetIndent)));
+            _diagnostics.ReportErrorWithFix(clauseToken.Span,
+                DiagnosticCode.MisalignedElseClause, message, fix);
+        }
+        else
+        {
+            _diagnostics.ReportError(clauseToken.Span,
+                DiagnosticCode.MisalignedElseClause, message);
+        }
+
+        // Consume the §EI condition so the clause body that follows parses
+        // as ordinary statements.
+        if (clauseToken.Kind == TokenKind.ElseIf && IsExpressionStart())
+        {
+            ParseExpression();
+        }
         return null;
     }
 
@@ -4381,6 +4438,7 @@ public sealed class Parser
     private IfStatementNode ParseIfStatement()
     {
         var startToken = Expect(TokenKind.If);
+        _lastIfToken = startToken;
         var attrs = ParseAttributes();
 
         // Interpret if attributes

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -673,6 +673,7 @@ public sealed class Parser
     private FunctionNode ParseFunction()
     {
         var startToken = Expect(TokenKind.Func);
+        _lastIfToken = null; // scope Calor0117 fixes to this function's §IFs
         var headerOpen = Current;
         var attrs = ParseAttributes();
         CheckMalformedFunctionHeader(startToken, attrs, headerOpen, Peek(-1));
@@ -867,6 +868,7 @@ public sealed class Parser
     private FunctionNode ParseAsyncFunction()
     {
         var startToken = Expect(TokenKind.AsyncFunc);
+        _lastIfToken = null; // scope Calor0117 fixes to this function's §IFs
         var headerOpen = Current;
         var attrs = ParseAttributes();
         CheckMalformedFunctionHeader(startToken, attrs, headerOpen, Peek(-1));
@@ -1525,6 +1527,13 @@ public sealed class Parser
     /// clause line to the column of the most recently parsed <c>§IF</c>,
     /// then consumes the clause header so the following body parses as
     /// ordinary statements instead of cascading unexpected-token errors.
+    ///
+    /// Two guards keep the fix honest: <c>_lastIfToken</c> is reset at every
+    /// function/method boundary, so a stray clause in a function with no
+    /// <c>§IF</c> never gets a fix pointing at a different function's
+    /// <c>§IF</c>; and a fix is only emitted when applying it would actually
+    /// change the line — a no-op fix (clause already at the target column)
+    /// would send an agent apply→recheck loop into an infinite cycle.
     /// </summary>
     private StatementNode? ParseMisalignedElseClause()
     {
@@ -1533,7 +1542,13 @@ public sealed class Parser
         var message = $"'{tag}' is not aligned with any open §IF — the if-chain already closed at a " +
             "shallower indent level. Indent the clause to the same column as its §IF.";
 
-        if (_lastIfToken is { } ifTok)
+        // The edit replaces the clause line's leading columns with spaces;
+        // it is a no-op when the clause already sits at the target column.
+        // (Leading tabs cannot make same-width leading text differ here:
+        // token columns are computed after the lexer's tab handling, and
+        // tab-indented lines are already covered by Calor0008/Calor0099.)
+        if (_lastIfToken is { } ifTok
+            && ifTok.Span.Column != clauseToken.Span.Column)
         {
             int targetIndent = Math.Max(0, ifTok.Span.Column - 1);
             int leadingLength = Math.Max(0, clauseToken.Span.Column - 1);
@@ -7550,6 +7565,7 @@ public sealed class Parser
     private MethodNode ParseMethodDefinition()
     {
         var startToken = Expect(TokenKind.Method);
+        _lastIfToken = null; // scope Calor0117 fixes to this method's §IFs
         var attrs = ParseAttributes();
         var csharpAttrs = ParseCSharpAttributes();
 
@@ -7692,6 +7708,7 @@ public sealed class Parser
     private MethodNode ParseAsyncMethodDefinition()
     {
         var startToken = Expect(TokenKind.AsyncMethod);
+        _lastIfToken = null; // scope Calor0117 fixes to this method's §IFs
         var attrs = ParseAttributes();
         var csharpAttrs = ParseCSharpAttributes();
 

--- a/tests/Calor.Compiler.Tests/Mcp/DiagnoseToolFixTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/DiagnoseToolFixTests.cs
@@ -209,24 +209,19 @@ public class DiagnoseToolFixTests
         Assert.Contains("§F", message);
     }
 
+    private const string LegacyCloserSource =
+        "§M{m1:Calc}\n  §F{f1:Add:pub}\n    §I{i32:a}\n    §I{i32:b}\n    §O{i32}\n    §R (+ a b)\n  §/F{f1}\n§/M{m1}";
+
     [Fact]
-    public async Task ExecuteAsync_WithLegacyClosers_Apply_HealsToCompilingSource()
+    public async Task ExecuteAsync_WithLegacyClosers_ReportsCalor0830WithFix()
     {
-        // Closer-form source hard-errors (Calor0830). With apply=true the
-        // diagnose path must strip the closers via their SuggestedFix and
-        // return source that compiles clean indent-only.
-        var args = JsonDocument.Parse("""
-            {
-                "action": "diagnose",
-                "apply": true,
-                "source": "§M{m1:Calc}\n  §F{f1:Add:pub}\n    §I{i32:a}\n    §I{i32:b}\n    §O{i32}\n    §R (+ a b)\n  §/F{f1}\n§/M{m1}"
-            }
-            """).RootElement;
+        // Closer-form source hard-errors (Calor0830) and the diagnostic must
+        // carry a machine-applicable fix stripping the closer.
+        var args = JsonSerializer.SerializeToElement(new { action = "diagnose", source = LegacyCloserSource });
 
         var result = await _tool.ExecuteAsync(args);
         var json = JsonDocument.Parse(result.Content[0].Text!).RootElement;
 
-        // A Calor0830 diagnostic must be present with a fix attached.
         var hasCloserDiag = false;
         foreach (var diag in json.GetProperty("diagnostics").EnumerateArray())
         {
@@ -239,11 +234,37 @@ public class DiagnoseToolFixTests
             }
         }
         Assert.True(hasCloserDiag, "Expected a Calor0830 diagnostic");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithLegacyClosers_Apply_HealsToCompilingSource()
+    {
+        // With apply=true the diagnose path strips the closers via their
+        // SuggestedFix (plus the source healer for the emptied lines) and
+        // returns source that compiles clean indent-only. When healed=true,
+        // success/errorCount/diagnostics describe the POST-heal fixedSource —
+        // the pre-heal Calor0830s are consumed by the repair, not echoed with
+        // stale coordinates.
+        var args = JsonDocument.Parse("""
+            {
+                "action": "diagnose",
+                "apply": true,
+                "source": "§M{m1:Calc}\n  §F{f1:Add:pub}\n    §I{i32:a}\n    §I{i32:b}\n    §O{i32}\n    §R (+ a b)\n  §/F{f1}\n§/M{m1}"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+        var json = JsonDocument.Parse(result.Content[0].Text!).RootElement;
 
         Assert.True(json.TryGetProperty("fixedSource", out var fixedSourceEl));
         var healed = fixedSourceEl.GetString()!;
         Assert.DoesNotContain("§/", healed);
         Assert.True(json.GetProperty("fixesApplied").GetInt32() >= 2);
+
+        // The repair fully fixed the file, so the response reflects that.
+        Assert.True(json.GetProperty("success").GetBoolean());
+        Assert.Equal(0, json.GetProperty("errorCount").GetInt32());
+        Assert.False(result.IsError);
 
         // Re-diagnose the healed source: it must now compile clean.
         var reArgs = JsonSerializer.SerializeToElement(new { action = "diagnose", source = healed });

--- a/tests/Calor.Compiler.Tests/WritePathRobustnessTests.cs
+++ b/tests/Calor.Compiler.Tests/WritePathRobustnessTests.cs
@@ -503,13 +503,21 @@ public class WritePathRobustnessTests
         var toolResult = await tool.ExecuteAsync(args);
 
         var doc = System.Text.Json.JsonDocument.Parse(toolResult.Content![0].Text!);
-        Assert.False(doc.RootElement.GetProperty("success").GetBoolean());
         Assert.True(doc.RootElement.GetProperty("healed").GetBoolean());
 
         var fixedSource = doc.RootElement.GetProperty("fixedSource").GetString();
         Assert.NotNull(fixedSource);
         Assert.False(ParseSource(fixedSource!).HasErrors,
             $"healed fixedSource should parse:\n{fixedSource}");
+
+        // When healed==true the response must describe fixedSource, not the
+        // pre-heal input: the heal fully repaired this file, so the recheck
+        // is clean and the tool result is not an error.
+        Assert.True(doc.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal(0, doc.RootElement.GetProperty("errorCount").GetInt32());
+        Assert.DoesNotContain(doc.RootElement.GetProperty("diagnostics").EnumerateArray(),
+            d => d.GetProperty("severity").GetString() == "error");
+        Assert.False(toolResult.IsError);
     }
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/WritePathRobustnessTests.cs
+++ b/tests/Calor.Compiler.Tests/WritePathRobustnessTests.cs
@@ -176,6 +176,55 @@ public class WritePathRobustnessTests
             string.Join("\n", ParseSource(healed).Errors.Select(e => e.Message)));
     }
 
+    [Fact]
+    public void MisalignedElseClause_InFunctionWithNoIf_EmitsNoFix()
+    {
+        // Reviewer probe: f1 contains a §IF at the same column as f2's stray
+        // §EI. Before the _lastIfToken function-boundary reset, the fix
+        // referenced f1's §IF — and because the clause already sat at that
+        // column, applying it was a no-op: apply → identical file → same
+        // error, forever (a probe-confirmed infinite agent loop).
+        var source = string.Join('\n',
+            "§M{m1:T}",
+            "  §F{f1:A:pub} () -> void",
+            "    §IF{i1} (== 1 1)",
+            "      §P \"a\"",
+            "  §F{f2:B:pub} () -> void",
+            "    §EI (== 1 2)",
+            "      §P \"b\"");
+
+        var diagnostics = ParseSource(source);
+
+        Assert.True(diagnostics.HasErrors);
+        Assert.Contains(diagnostics.Errors, d => d.Code == DiagnosticCode.MisalignedElseClause);
+        // No fix: there is no §IF in this function to align with.
+        Assert.DoesNotContain(diagnostics.DiagnosticsWithFixes,
+            d => d.Code == DiagnosticCode.MisalignedElseClause);
+    }
+
+    [Fact]
+    public void MisalignedElseClause_ClauseAlreadyAtIfColumn_EmitsNoNoOpFix()
+    {
+        // Same-function variant of the no-op hazard: the stray clause is
+        // already at its §IF's column, but the chain closed early because a
+        // statement at the same column ended the if. Re-indenting to the §IF
+        // column would not change the file, so no fix may be emitted.
+        var source = string.Join('\n',
+            "§M{m1:T}",
+            "  §F{f1:A:pub} () -> void",
+            "    §IF{i1} (== 1 1)",
+            "      §P \"a\"",
+            "    §P \"x\"",
+            "    §EI (== 1 2)",
+            "      §P \"b\"");
+
+        var diagnostics = ParseSource(source);
+
+        Assert.Contains(diagnostics.Errors, d => d.Code == DiagnosticCode.MisalignedElseClause);
+        Assert.DoesNotContain(diagnostics.DiagnosticsWithFixes,
+            d => d.Code == DiagnosticCode.MisalignedElseClause);
+    }
+
     // ===== 2. SourceHealer =====
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/WritePathRobustnessTests.cs
+++ b/tests/Calor.Compiler.Tests/WritePathRobustnessTests.cs
@@ -361,6 +361,51 @@ public class WritePathRobustnessTests
     }
 
     [Fact]
+    public void Heal_UnclosedHeaderBrace_DoesNotVerbatimizeRestOfFile()
+    {
+        // Reviewer probe: `§F{f1:Main:pub ( )` leaves the header brace
+        // unclosed. Before the continuation cap, every following line was
+        // classified as bracket continuation and heal silently no-opped on
+        // the whole file. A continuation must end at a line starting with §.
+        var source = string.Join('\n',
+            "§M{m1:T}",
+            "  §F{f1:Main:pub ( ) -> void", // missing closing }
+            "      §P \"x\"",               // over-indented: must still normalize
+            "      §P \"y\"");
+
+        var healed = new SourceHealer().Heal(source);
+
+        var expected = string.Join('\n',
+            "§M{m1:T}",
+            "  §F{f1:Main:pub ( ) -> void",
+            "    §P \"x\"",
+            "    §P \"y\"");
+        Assert.Equal(expected, healed);
+    }
+
+    [Fact]
+    public void Heal_BracketContinuation_IsCappedAtTenLines()
+    {
+        // An unclosed bracket followed by many non-§ lines: only the first
+        // ten remain verbatim continuations; past the cap, lines are
+        // structural again (an unclosed bracket is assumed to be a typo).
+        var continuation = Enumerable.Range(1, 11).Select(n => $"      line{n}");
+        var source = string.Join('\n', new[]
+        {
+            "§M{m1:T}",
+            "  §B{x:str} (concat \"a\"", // unclosed ( — continuation begins
+        }.Concat(continuation));
+
+        var healed = new SourceHealer().Heal(source).Split('\n');
+
+        // Lines 3..12 (continuations 1..10) are verbatim: indent preserved.
+        Assert.Equal("      line1", healed[2]);
+        Assert.Equal("      line10", healed[11]);
+        // Line 13 (continuation 11) is past the cap: releveled.
+        Assert.Equal("    line11", healed[12]);
+    }
+
+    [Fact]
     public void Heal_TrailingWhitespaceAndCrlf_Normalized()
     {
         var source = "§M{m1:T}\r\n  §F{f1:Main:pub} () -> void   \r\n    §P \"x\"\t\r\n";

--- a/tests/Calor.Compiler.Tests/WritePathRobustnessTests.cs
+++ b/tests/Calor.Compiler.Tests/WritePathRobustnessTests.cs
@@ -1,0 +1,392 @@
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Formatting;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Phase 1 item 5 — write-path robustness. Covers:
+///   1. Fault-tolerant indentation diagnostics with machine-applicable fixes
+///      (tabs, mixed whitespace, non-standard widths, misaligned dedents,
+///      misaligned §EI/§EL clauses).
+///   2. <c>SourceHealer</c> (calor format --heal): closer stripping,
+///      indentation re-derivation, chain-clause re-alignment, idempotence.
+///   3. The MCP calor_check auto-heal path.
+/// </summary>
+public class WritePathRobustnessTests
+{
+    private const string CanonicalFizzBuzz = """
+        §M{m1:FizzBuzz}
+          §F{f1:Main:pub} () -> void
+            §E{cw}
+            §L{l1:i:1:100:1}
+              §IF{i1} (== (% i 15) 0)
+                §P "FizzBuzz"
+              §EI (== (% i 3) 0)
+                §P "Fizz"
+              §EI (== (% i 5) 0)
+                §P "Buzz"
+              §EL
+                §P i
+        """;
+
+    private static DiagnosticBag ParseSource(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath("test.calr");
+        var lexer = new Lexer(source, diagnostics);
+        var tokens = lexer.TokenizeAllForParser();
+        if (!diagnostics.HasErrors)
+        {
+            var parser = new Parser(tokens, diagnostics);
+            parser.Parse();
+        }
+        return diagnostics;
+    }
+
+    /// <summary>
+    /// Applies every fix edit in a diagnostic bag to the source (bottom-up so
+    /// coordinates stay valid) — mirrors the MCP calor_check apply path.
+    /// </summary>
+    private static string ApplyAllFixes(string source, DiagnosticBag diagnostics)
+    {
+        var lines = source.Split('\n').ToList();
+        var edits = diagnostics.DiagnosticsWithFixes
+            .SelectMany(d => d.Fix.Edits)
+            .OrderByDescending(e => e.StartLine)
+            .ThenByDescending(e => e.StartColumn);
+
+        foreach (var edit in edits)
+        {
+            Assert.Equal(edit.StartLine, edit.EndLine); // all our fixes are single-line
+            var line = lines[edit.StartLine - 1];
+            var before = line[..(edit.StartColumn - 1)];
+            var after = edit.EndColumn - 1 <= line.Length ? line[(edit.EndColumn - 1)..] : "";
+            lines[edit.StartLine - 1] = before + edit.NewText + after;
+        }
+
+        return string.Join('\n', lines);
+    }
+
+    // ===== 1. Indentation diagnostics with fixes =====
+
+    [Fact]
+    public void TabIndentation_ReportsSingleWarning_WithEditsForEveryTabLine()
+    {
+        var source = "§M{m1:T}\n\t§F{f1:Main:pub} () -> void\n\t\t§P \"x\"";
+
+        var diagnostics = ParseSource(source);
+
+        Assert.False(diagnostics.HasErrors);
+        var warning = Assert.Single(diagnostics.Warnings,
+            d => d.Code == DiagnosticCode.TabIndentation);
+        var withFix = Assert.Single(diagnostics.DiagnosticsWithFixes,
+            d => d.Code == DiagnosticCode.TabIndentation);
+        Assert.Equal(2, withFix.Fix.Edits.Count);
+        Assert.Contains("2 line(s)", warning.Message);
+
+        var healed = ApplyAllFixes(source, diagnostics);
+        Assert.Equal("§M{m1:T}\n  §F{f1:Main:pub} () -> void\n    §P \"x\"", healed);
+
+        var recheck = ParseSource(healed);
+        Assert.False(recheck.HasErrors);
+        Assert.Empty(recheck.Warnings);
+    }
+
+    [Fact]
+    public void MixedIndentation_ReportsError_WithFixThatHeals()
+    {
+        // Body line indented with tab + 2 spaces (3 columns, mixed).
+        var source = "§M{m1:T}\n  §F{f1:Main:pub} () -> void\n\t  §P \"x\"";
+
+        var diagnostics = ParseSource(source);
+
+        Assert.True(diagnostics.HasErrors);
+        var withFix = Assert.Single(diagnostics.DiagnosticsWithFixes,
+            d => d.Code == DiagnosticCode.MixedIndentation);
+        Assert.Single(withFix.Fix.Edits);
+
+        var healed = ApplyAllFixes(source, diagnostics);
+        Assert.Equal("§M{m1:T}\n  §F{f1:Main:pub} () -> void\n    §P \"x\"", healed);
+        Assert.False(ParseSource(healed).HasErrors);
+    }
+
+    [Fact]
+    public void NonStandardIndentWidth_FourSpaceFile_FixNormalizesInOnePass()
+    {
+        var source = "§M{m1:T}\n    §F{f1:Main:pub} () -> void\n        §P \"a\"\n        §P \"b\"";
+
+        var diagnostics = ParseSource(source);
+
+        Assert.False(diagnostics.HasErrors); // 4-space parses; canonical width is advisory
+        var withFix = Assert.Single(diagnostics.DiagnosticsWithFixes,
+            d => d.Code == DiagnosticCode.NonStandardIndentWidth);
+        Assert.Equal(3, withFix.Fix.Edits.Count); // §F line + both §P siblings
+
+        var healed = ApplyAllFixes(source, diagnostics);
+        Assert.Equal("§M{m1:T}\n  §F{f1:Main:pub} () -> void\n    §P \"a\"\n    §P \"b\"", healed);
+
+        var recheck = ParseSource(healed);
+        Assert.False(recheck.HasErrors);
+        Assert.Empty(recheck.Warnings);
+    }
+
+    [Fact]
+    public void DedentMismatch_ReportsError_WithFixSnappingToNearestLevel()
+    {
+        // Third statement dedents to column 3 — matches no enclosing level
+        // (levels are 0/2/4). The fix snaps to the deeper level (4).
+        var source = "§M{m1:T}\n  §F{f1:Main:pub} () -> void\n    §P \"a\"\n   §P \"b\"";
+
+        var diagnostics = ParseSource(source);
+
+        Assert.True(diagnostics.HasErrors);
+        var withFix = Assert.Single(diagnostics.DiagnosticsWithFixes,
+            d => d.Code == DiagnosticCode.MixedIndentation);
+        Assert.Equal("    ", withFix.Fix.Edits[0].NewText);
+
+        var healed = ApplyAllFixes(source, diagnostics);
+        Assert.False(ParseSource(healed).HasErrors);
+    }
+
+    [Fact]
+    public void MisalignedElseClause_InStatementPosition_ReportsFixAligningWithIf()
+    {
+        // §EI dedented to the loop-body level (statement position): the
+        // if-chain closed before the clause was seen.
+        var source = string.Join('\n',
+            "§M{m1:T}",
+            "  §F{f1:Main:pub} () -> void",
+            "    §L{l1:i:1:10:1}",
+            "      §IF{i1} (== i 1)",
+            "        §P \"a\"",
+            "    §EI (== i 2)",
+            "        §P \"b\"");
+
+        var diagnostics = ParseSource(source);
+
+        Assert.True(diagnostics.HasErrors);
+        var withFix = Assert.Single(diagnostics.DiagnosticsWithFixes,
+            d => d.Code == DiagnosticCode.MisalignedElseClause);
+        Assert.Equal("      ", withFix.Fix.Edits[0].NewText); // aligned with §IF at column 7
+
+        var healed = ApplyAllFixes(source, diagnostics);
+        Assert.False(ParseSource(healed).HasErrors,
+            string.Join("\n", ParseSource(healed).Errors.Select(e => e.Message)));
+    }
+
+    // ===== 2. SourceHealer =====
+
+    [Fact]
+    public void Heal_CanonicalFile_IsUnchanged()
+    {
+        var healer = new SourceHealer();
+        Assert.Equal(CanonicalFizzBuzz, healer.Heal(CanonicalFizzBuzz));
+    }
+
+    [Fact]
+    public void Heal_TabIndentation_NormalizesToTwoSpaces()
+    {
+        var source = "§M{m1:T}\n\t§F{f1:Main:pub} () -> void\n\t\t§P \"x\"";
+
+        var healed = new SourceHealer().Heal(source);
+
+        Assert.Equal("§M{m1:T}\n  §F{f1:Main:pub} () -> void\n    §P \"x\"", healed);
+        Assert.False(ParseSource(healed).HasErrors);
+    }
+
+    [Fact]
+    public void Heal_FourSpaceIndentation_NormalizesToTwoSpaces()
+    {
+        var source = "§M{m1:T}\n    §F{f1:Main:pub} () -> void\n        §P \"a\"\n        §P \"b\"";
+
+        var healed = new SourceHealer().Heal(source);
+
+        Assert.Equal("§M{m1:T}\n  §F{f1:Main:pub} () -> void\n    §P \"a\"\n    §P \"b\"", healed);
+    }
+
+    [Fact]
+    public void Heal_StripsStructuralClosers_AndDropsEmptiedLines()
+    {
+        var source = string.Join('\n',
+            "§M{m1:T}",
+            "  §F{f1:Main:pub} () -> void",
+            "    §P \"x\"",
+            "  §/F{f1}",
+            "§/M{m1}");
+
+        var healed = new SourceHealer().Heal(source);
+
+        Assert.Equal("§M{m1:T}\n  §F{f1:Main:pub} () -> void\n    §P \"x\"", healed);
+        Assert.False(ParseSource(healed).HasErrors);
+    }
+
+    [Fact]
+    public void Heal_ElseClauseAtBodyLevel_RealignsWithIf()
+    {
+        var source = string.Join('\n',
+            "§M{m1:T}",
+            "  §F{f1:Main:pub} () -> void",
+            "    §IF{i1} (== 1 1)",
+            "      §P \"a\"",
+            "      §EI (== 1 2)", // written at body level
+            "        §P \"b\"");
+
+        var healed = new SourceHealer().Heal(source);
+
+        var expected = string.Join('\n',
+            "§M{m1:T}",
+            "  §F{f1:Main:pub} () -> void",
+            "    §IF{i1} (== 1 1)",
+            "      §P \"a\"",
+            "    §EI (== 1 2)",
+            "      §P \"b\"");
+        Assert.Equal(expected, healed);
+        Assert.False(ParseSource(healed).HasErrors);
+    }
+
+    [Fact]
+    public void Heal_ElseClauseDedentedTooFar_RealignsWithIf()
+    {
+        var source = string.Join('\n',
+            "§M{m1:T}",
+            "  §F{f1:Main:pub} () -> void",
+            "    §IF{i1} (== 1 1)",
+            "      §P \"a\"",
+            "§EI (== 1 2)", // dedented to module level
+            "      §P \"b\"");
+
+        var healed = new SourceHealer().Heal(source);
+
+        var expected = string.Join('\n',
+            "§M{m1:T}",
+            "  §F{f1:Main:pub} () -> void",
+            "    §IF{i1} (== 1 1)",
+            "      §P \"a\"",
+            "    §EI (== 1 2)",
+            "      §P \"b\"");
+        Assert.Equal(expected, healed);
+        Assert.False(ParseSource(healed).HasErrors);
+    }
+
+    [Fact]
+    public void Heal_TrailingWhitespaceAndCrlf_Normalized()
+    {
+        var source = "§M{m1:T}\r\n  §F{f1:Main:pub} () -> void   \r\n    §P \"x\"\t\r\n";
+
+        var healed = new SourceHealer().Heal(source);
+
+        Assert.Equal("§M{m1:T}\n  §F{f1:Main:pub} () -> void\n    §P \"x\"\n", healed);
+    }
+
+    [Fact]
+    public void Heal_RawBlockContent_IsPreservedVerbatim()
+    {
+        var source = string.Join('\n',
+            "§M{m1:T}",
+            "    §F{f1:Main:pub} () -> void",
+            "        §RAW",
+            "   int x = 1;   ",
+            "\tConsole.WriteLine(x);",
+            "        §/RAW");
+
+        var healed = new SourceHealer().Heal(source);
+
+        // Structure normalized, raw payload untouched.
+        Assert.Contains("\n   int x = 1;   \n", healed);
+        Assert.Contains("\n\tConsole.WriteLine(x);\n", healed);
+        Assert.StartsWith("§M{m1:T}\n  §F{f1:Main:pub} () -> void\n    §RAW\n", healed);
+    }
+
+    [Theory]
+    [InlineData("§M{m1:T}\n\t§F{f1:Main:pub} () -> void\n\t\t§P \"x\"")]
+    [InlineData("§M{m1:T}\n    §F{f1:Main:pub} () -> void\n        §P \"a\"\n        §P \"b\"")]
+    [InlineData("§M{m1:T}\n  §F{f1:Main:pub} () -> void\n    §P \"x\"\n  §/F{f1}\n§/M{m1}")]
+    [InlineData("§M{m1:T}\n  §F{f1:Main:pub} () -> void\n    §IF{i1} (== 1 1)\n      §P \"a\"\n      §EI (== 1 2)\n        §P \"b\"")]
+    [InlineData("§M{m1:T}\n  §F{f1:Main:pub} () -> void\n    §IF{i1} (== 1 1)\n      §P \"a\"\n§EI (== 1 2)\n      §P \"b\"")]
+    public void Heal_IsIdempotent(string source)
+    {
+        var healer = new SourceHealer();
+        var once = healer.Heal(source);
+        var twice = healer.Heal(once);
+        Assert.Equal(once, twice);
+    }
+
+    [Fact]
+    public void Heal_MangledFizzBuzz_RestoresCompilingFile()
+    {
+        // 4-space indentation, tab lines, a body-level §EI, and legacy closers.
+        var mangled = string.Join('\n',
+            "§M{m1:FizzBuzz}",
+            "    §F{f1:Main:pub} () -> void",
+            "        §E{cw}",
+            "        §L{l1:i:1:100:1}",
+            "            §IF{i1} (== (% i 15) 0)",
+            "                §P \"FizzBuzz\"",
+            "                §EI (== (% i 3) 0)",
+            "                §P \"Fizz\"",
+            "            §EL",
+            "                §P i",
+            "        §/L{l1}",
+            "    §/F{f1}",
+            "§/M{m1}");
+
+        var healed = new SourceHealer().Heal(mangled);
+
+        var diagnostics = ParseSource(healed);
+        Assert.False(diagnostics.HasErrors,
+            $"healed output should parse:\n{healed}\n---\n{string.Join("\n", diagnostics.Errors.Select(e => e.Message))}");
+        Assert.Equal(healed, new SourceHealer().Heal(healed));
+        Assert.DoesNotContain("§/F", healed);
+        Assert.DoesNotContain("§/M", healed);
+    }
+
+    // ===== 3. MCP calor_check auto-heal =====
+
+    [Fact]
+    public async Task CheckTool_DiagnoseApply_HealsSourceWhenFixEditsAreNotEnough()
+    {
+        // Two dedent mismatches: only the first is reported with a fix (the
+        // lexer gates indentation errors to one per file), so applying fix
+        // edits alone still leaves a broken file — only the source healer
+        // can finish the repair.
+        var source = string.Join('\n',
+            "§M{m1:T}",
+            "  §F{f1:A:pub} () -> void",
+            "    §E{cw}",
+            "    §P \"a\"",
+            "   §P \"b\"",
+            "  §F{f2:B:pub} () -> void",
+            "    §E{cw}",
+            "    §P \"c\"",
+            "   §P \"d\"");
+
+        var tool = new Calor.Compiler.Mcp.Tools.CheckTool();
+        var args = System.Text.Json.JsonDocument.Parse(
+            $"{{\"action\": \"diagnose\", \"apply\": true, \"source\": {System.Text.Json.JsonSerializer.Serialize(source)}}}").RootElement;
+        var toolResult = await tool.ExecuteAsync(args);
+
+        var doc = System.Text.Json.JsonDocument.Parse(toolResult.Content![0].Text!);
+        Assert.False(doc.RootElement.GetProperty("success").GetBoolean());
+        Assert.True(doc.RootElement.GetProperty("healed").GetBoolean());
+
+        var fixedSource = doc.RootElement.GetProperty("fixedSource").GetString();
+        Assert.NotNull(fixedSource);
+        Assert.False(ParseSource(fixedSource!).HasErrors,
+            $"healed fixedSource should parse:\n{fixedSource}");
+    }
+
+    [Fact]
+    public async Task CheckTool_DiagnoseApply_CleanSource_DoesNotHeal()
+    {
+        var tool = new Calor.Compiler.Mcp.Tools.CheckTool();
+        var args = System.Text.Json.JsonDocument.Parse(
+            $"{{\"action\": \"diagnose\", \"apply\": true, \"source\": {System.Text.Json.JsonSerializer.Serialize(CanonicalFizzBuzz)}}}").RootElement;
+        var toolResult = await tool.ExecuteAsync(args);
+
+        var doc = System.Text.Json.JsonDocument.Parse(toolResult.Content![0].Text!);
+        Assert.True(doc.RootElement.GetProperty("success").GetBoolean());
+        Assert.False(doc.RootElement.TryGetProperty("healed", out _));
+    }
+}

--- a/tests/Calor.Compiler.Tests/WritePathRobustnessTests.cs
+++ b/tests/Calor.Compiler.Tests/WritePathRobustnessTests.cs
@@ -320,6 +320,47 @@ public class WritePathRobustnessTests
     }
 
     [Fact]
+    public void Heal_AmbiguousTrailingStatement_IsReportedWithOriginalLine()
+    {
+        // Reviewer probe: §P "b" sits at the same column as the body-level
+        // §EI above it. Heal keeps it inside the clause body — a control-flow
+        // GUESS that must be surfaced, not silently applied.
+        var source = string.Join('\n',
+            "§M{m1:T}",
+            "  §F{f1:Main:pub} () -> void",
+            "    §IF{i1} (== 1 1)",
+            "      §P \"a\"",
+            "      §EI (== 1 2)", // written at body level
+            "      §P \"b\"");    // ambiguous: clause body or statement after the chain?
+
+        var healer = new SourceHealer();
+        var healed = healer.Heal(source);
+
+        var ambiguity = Assert.Single(healer.Ambiguities);
+        Assert.Equal(6, ambiguity.Line);
+        Assert.Contains("§EI", ambiguity.Message);
+        Assert.Contains("line 5", ambiguity.Message);
+
+        // The guess itself: §P "b" healed into the else-if body.
+        var expected = string.Join('\n',
+            "§M{m1:T}",
+            "  §F{f1:Main:pub} () -> void",
+            "    §IF{i1} (== 1 1)",
+            "      §P \"a\"",
+            "    §EI (== 1 2)",
+            "      §P \"b\"");
+        Assert.Equal(expected, healed);
+    }
+
+    [Fact]
+    public void Heal_UnambiguousFile_ReportsNoAmbiguities()
+    {
+        var healer = new SourceHealer();
+        healer.Heal(CanonicalFizzBuzz);
+        Assert.Empty(healer.Ambiguities);
+    }
+
+    [Fact]
     public void Heal_TrailingWhitespaceAndCrlf_Normalized()
     {
         var source = "§M{m1:T}\r\n  §F{f1:Main:pub} () -> void   \r\n    §P \"x\"\t\r\n";


### PR DESCRIPTION
Implements agent-native strategy §4 Phase 1 item 5. Benchmark epochs (epochs/hardness-check-002/VERDICT.md) measured agents paying 2.7x iterations on green-field Calor authoring, mostly indentation/closer thrash. This PR makes the write path self-healing at three layers.

## 1. Fault-tolerant indentation diagnostics (machine-applicable fixes)

Lexer (`PostProcessIndent`) and parser now attach `SuggestedFix`/`TextEdit` payloads to the most common agent mistakes:

| Code | Mistake | Fix |
|------|---------|-----|
| `Calor0008` (new, warning) | tab indentation | one warning per file, one edit per tab line (tab → 2 spaces) |
| `Calor0009` (new, warning) | non-standard indent width (3-/4-space levels) | one warning per file, one edit per line re-indenting to the canonical `2 × level` column (level count is width-independent, so one apply pass heals the whole file, siblings included) |
| `Calor0099` (existing, now with fix) | mixed tabs+spaces | expand leading whitespace to spaces |
| `Calor0099` (existing, now with fix) | dedent matching no enclosing level | snap to nearest level (ties prefer deeper — off-by-one dedents usually meant to stay in the block) |
| `Calor0117` (new, error) | `§EI`/`§EL` dedented past its `§IF` (stray in statement position) | re-indent clause to the column of the most recent `§IF` **in the same function**; parser recovers by consuming the clause header to stop cascade errors |

`Calor0117` fix-honesty guards (review revision): `_lastIfToken` resets at every function/method boundary, so a stray clause in a function with no `§IF` never gets a fix pointing at another function's `§IF`; and a fix is only emitted when applying it would actually change the line. Both close a probe-confirmed infinite agent loop (no-op fix → apply → identical file → same error, forever).

## 2. `calor format --heal`

New `SourceHealer` (`Formatting/SourceHealer.cs`) — source-level, works on files too broken for the AST formatter:
- strips forbidden structural closers (reuses `CloserHealMigrator`) and drops lines the strip emptied
- re-derives indentation from the file's own relative nesting; emits 2 spaces/level (empirical opener detection: a line followed by a deeper line opens a block — no tag table needed for openers, so arrow-form one-liners just work)
- re-aligns chain clauses (`§EI`/`§EL`→`§IF`, `§CA`/`§FI`→`§TR`) structurally, handling both body-level and over-dedented clauses
- strips trailing whitespace, expands tabs, normalizes CRLF→LF
- preserves `§RAW`/`§CSHARP` payloads and bracket-continuation lines (incl. multi-line `§CS{…}`) verbatim; a continuation is capped at 10 lines and ends at any line starting with a §-tag, so a single unclosed `{`/`(` (e.g. `§F{f1:Main:pub ( )`) cannot verbatim-ize the rest of the file
- idempotent: `heal(heal(x)) == heal(x)` (covered by tests)

**Heal is NOT semantics-preserving (review revision).** Re-anchoring a trailing statement into a chain-clause body is a control-flow guess: a statement at the same column as a body-level `§EI` could belong to the clause body *or* follow the chain. Every such decision is reported as a `Warning: file:line` on stderr (plus a summary warning), `--check` prints an `ambiguousDecisions` count per file, and the `--heal` help text and `docs/cli/format.md` carry the warning prominently.

**Exit behavior (review revision):** the healed output is always re-parsed — including when heal changed nothing — and residual parse errors print a `heal could not repair` note on stderr and exit `1`. Heal never silently exits 0 on a still-broken file. Relatedly, `format` now returns its exit code through the command handler (`InvocationContext.ExitCode`) instead of stomping `Environment.ExitCode`, which `Program.Main`'s return value used to overwrite (so `--check` always exited 0); the change is scoped to `FormatCommand` to avoid colliding with the parallel lint fix in #698.

### Recorded decision: a second layout engine

`SourceHealer` intentionally re-implements the lexer's layout heuristics on raw text — it must work on exactly the files the lexer/parser reject, so it cannot call into them. The class doc records the decision, the known divergences (textual bracket counting via `BracketDelta` with a capped continuation span vs. the lexer's unbounded token-level tracking; empirical opener detection vs. tag semantics), and the maintenance rule: **any lexer layout change must be mirrored in `SourceHealer` and covered in `WritePathRobustnessTests`.** The tab-measurement divergence was eliminated in this revision: tabs now measure 2 columns, the same width the `Calor0008` fix substitutes (was 4).

## 3. MCP `calor_check` auto-heal

In the `diagnose` action's `apply` path: after applying targeted fix edits, if errors remain, the source healer runs and its output is kept only when it strictly reduces the error count. Response gains an optional `"healed": true` field.

**Response consistency (review revision):** when `healed` is true, `success`/`errorCount`/`warningCount`/`diagnostics` are replaced by the post-heal recheck of `fixedSource` — coordinates match `fixedSource`, and `isError` derives from the post-heal state. Previously the response echoed pre-heal diagnostics whose coordinates no longer matched the returned source.

## Validation

- `dotnet build` clean (TreatWarningsAsErrors)
- full `dotnet test tests/Calor.Compiler.Tests` green
- `WritePathRobustnessTests` (27 tests): each fix round-trips to a parsing file; heal idempotence over mangled inputs; mangled-FizzBuzz heals to byte-exact canonical form; MCP heal/no-heal paths; reviewer probes — two-function stray `§EI` (no cross-function/no-op fix), ambiguous trailing statement (reported with `file:line`), unclosed header brace (rest of file still healed; CLI reports unrepaired + exits 1)
- manual CLI probes: `--check` exit codes verified for unformatted (1), unrepairable-after-heal (1), and clean (0) files

## Coverage decisions / cut lines

- Indent-error reporting stays gated to one per file (existing behavior) to avoid cascades; the aggregated warnings carry per-line edits, and the healer covers anything the gate hides.
- `§EI` written at body level parses today without diagnostics (parser accepts it); only the formatter/healer re-aligns it (and reports the ambiguity).
- Healer chain-alignment covers `§IF`/`§TR` chains; match-case (`§K`) needs no special handling (arrow bodies).
- Bracket continuations longer than 10 lines (e.g. very long multi-line `§CS{…}` payloads) are treated as typos past the cap; long C# belongs in `§RAW`/`§CSHARP` blocks, which are unbounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MP98bPvHVGbADabAjtSYpg
