### PR TITLE
feat(cli): doc drift detection — calor self-check docs (Phase 1 item 6, part 1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,9 @@ jobs:
     # cited CalorNNNN codes exist (and cited bands are non-empty), the effect
     # table in docs/syntax-reference/effects.md matches the effect registry in
     # both directions, the Calor13xx table in docs/cli/structured-output.md is
-    # complete, and no doc hardcodes the current version.
+    # complete, no doc hardcodes the current version, and every fenced
+    # ```calor example declaring a complete program (starts with §M) still
+    # parses with the current compiler.
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,33 @@ jobs:
       - name: Run all tests
         run: dotnet test -c Release --no-build --verbosity normal
 
+  spec-drift:
+    # Phase 1 item 6 (agent-native strategy): agent-facing docs are machine-
+    # checked against the implementation. Fails when CLAUDE.md or docs/ cite
+    # §-keywords, diagnostic codes, or effect codes that don't exist, when an
+    # implemented effect code is undocumented, or when a doc hardcodes the
+    # current version.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build compiler
+        run: dotnet build src/Calor.Compiler -c Release --no-restore
+
+      - name: Check agent-facing docs against the implementation
+        run: dotnet run --project src/Calor.Compiler -c Release --no-build -- self-check docs
+
   enforcement-tests:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,10 +31,13 @@ jobs:
 
   spec-drift:
     # Phase 1 item 6 (agent-native strategy): agent-facing docs are machine-
-    # checked against the implementation. Fails when CLAUDE.md or docs/ cite
-    # §-keywords, diagnostic codes, or effect codes that don't exist, when an
-    # implemented effect code is undocumented, or when a doc hardcodes the
-    # current version.
+    # checked against the implementation. Covered files: CLAUDE.md, every
+    # docs/syntax-reference/*.md, and every docs/cli/*.md (plus docs/**/*.md
+    # for the version scan). Checks: documented §-keywords exist in the lexer,
+    # cited CalorNNNN codes exist (and cited bands are non-empty), the effect
+    # table in docs/syntax-reference/effects.md matches the effect registry in
+    # both directions, the Calor13xx table in docs/cli/structured-output.md is
+    # complete, and no doc hardcodes the current version.
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,36 +29,18 @@ jobs:
       - name: Run all tests
         run: dotnet test -c Release --no-build --verbosity normal
 
-  spec-drift:
-    # Phase 1 item 6 (agent-native strategy): agent-facing docs are machine-
-    # checked against the implementation. Covered files: CLAUDE.md, every
-    # docs/syntax-reference/*.md, and every docs/cli/*.md (plus docs/**/*.md
-    # for the version scan). Checks: documented §-keywords exist in the lexer,
-    # cited CalorNNNN codes exist (and cited bands are non-empty), the effect
-    # table in docs/syntax-reference/effects.md matches the effect registry in
-    # both directions, the Calor13xx table in docs/cli/structured-output.md is
-    # complete, no doc hardcodes the current version, and every fenced
-    # ```calor example declaring a complete program (starts with §M) still
-    # parses with the current compiler.
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '10.0.x'
-
-      - name: Restore dependencies
-        run: dotnet restore
-
-      - name: Build compiler
-        run: dotnet build src/Calor.Compiler -c Release --no-restore
-
-      - name: Check agent-facing docs against the implementation
+      # Spec drift (Phase 1 item 6, agent-native strategy): agent-facing docs
+      # are machine-checked against the implementation, reusing this job's
+      # build. Covered files: CLAUDE.md, every docs/syntax-reference/*.md, and
+      # every docs/cli/*.md (plus docs/**/*.md for the version scan). Checks:
+      # documented §-keywords exist in the lexer, cited CalorNNNN codes exist
+      # (and cited bands are non-empty), the effect table in
+      # docs/syntax-reference/effects.md matches the effect registry in both
+      # directions, the Calor13xx table in docs/cli/structured-output.md is
+      # complete, no doc hardcodes the current version, and every fenced
+      # ```calor example declaring a complete program (starts with §M) still
+      # parses with the current compiler.
+      - name: Check agent-facing docs against the implementation (spec drift)
         run: dotnet run --project src/Calor.Compiler -c Release --no-build -- self-check docs
 
   enforcement-tests:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,9 +93,10 @@ The only closers you should ever write are `§/C` (call argument lists) and `§/
 §IV (expr)                 Invariant
 ```
 
-Example (current syntax — see `samples/FizzBuzz/fizzbuzz.calr`):
+Example (current syntax — see `samples/FizzBuzz/fizzbuzz.calr`; fenced
+` ```calor ` blocks starting with `§M` are parse-checked by `calor self-check docs`):
 
-```
+```calor
 §M{m001:FizzBuzz}
   §F{f001:Main:pub} () -> void
     §E{cw}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ The only closers you should ever write are `§/C` (call argument lists) and `§/
 §E{codes}                  Effects (§E{} = pure)
 §Q (expr)                  Precondition
 §S (expr)                  Postcondition
-§INV                       Invariant
+§IV (expr)                 Invariant
 ```
 
 Example (current syntax — see `samples/FizzBuzz/fizzbuzz.calr`):
@@ -139,7 +139,7 @@ Example (current syntax — see `samples/FizzBuzz/fizzbuzz.calr`):
 - **VariableSymbol.IsParameter** — distinguishes function parameters from locals; used by analysis passes
 - **BoundCallExpression.Target** is a `string` — `NullDereferenceChecker` checks for `.unwrap` suffix
 - **Option\<T\> and Result\<T,E\>** are valid generic types in Calor's type system
-- **Diagnostic codes** — Calor0001–0099 (lexer), 0100–0199 (parser), 0200–0299 (semantic), 0300–0399 (contracts), 0400–0499 (effects), 0500–0599 (patterns), 0600–0699 (API strictness), 0700–0799 (semantics version), 0800–0899 (ID validation), 0900–0999 (dataflow/bug patterns/taint), 1000–1099 (codegen/interop), 1100–1199 (refinements/obligations), 1200–1299 (experimental), 1300–1399 (CLI: lint findings and command-level errors)
+- **Diagnostic codes** — Calor0001–0099 (lexer), 0100–0199 (parser), 0200–0299 (semantic), 0300–0399 (contracts), 0400–0499 (effects), 0500–0599 (patterns), 0600–0699 (API strictness), 0700–0799 (semantics version + contract verification results), 0800–0899 (ID validation), 0900–0999 (dataflow/bug patterns/taint), 1000–1099 (codegen/interop), 1100–1199 (refinements/obligations), 1200–1299 (experimental), 1300–1399 (CLI: lint findings and command-level errors)
 
 ## Project Layout
 

--- a/docs/cli/compile.md
+++ b/docs/cli/compile.md
@@ -51,7 +51,7 @@ calor -v -i MyModule.calr -o MyModule.g.cs
 | `--no-cache` | | No | Disable verification result caching |
 | `--clear-cache` | | No | Clear verification cache before compiling |
 | `--contract-mode` | | No | Contract enforcement mode: off, debug, release (default: debug) |
-| `--strict-api` | | No | Require §BREAKING markers for public API changes |
+| `--strict-api` | | No | Require `§BR` breaking-change markers for public API changes |
 | `--require-docs` | | No | Require documentation on public functions |
 | `--enforce-effects` | | No | Enforce effect declarations (default: true) |
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -45,7 +45,7 @@ dotnet tool update -g calor
 | [`calor format`](/calor/cli/format/) | Format Calor source files to canonical style |
 | [`calor fix`](/calor/cli/fix/) | Bulk, reversible source rewrites (e.g. drop legacy closing-tag IDs) |
 | [`calor mcp`](/calor/cli/mcp/) | Start MCP server for AI agent tool integration |
-| `calor self-check docs` | Verify agent-facing docs against the implementation (keywords, diagnostic codes, effect codes, version); exits nonzero on drift |
+| [`calor self-check docs`](/calor/cli/self-check/) | Verify agent-facing docs against the implementation (keywords, diagnostic codes, effect codes, parseable examples, version); exits nonzero on drift |
 | `calor lsp` | Start Language Server Protocol server for IDE features |
 | [`calor hook`](/calor/cli/hook/) | Claude Code hook commands (internal) |
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -45,6 +45,7 @@ dotnet tool update -g calor
 | [`calor format`](/calor/cli/format/) | Format Calor source files to canonical style |
 | [`calor fix`](/calor/cli/fix/) | Bulk, reversible source rewrites (e.g. drop legacy closing-tag IDs) |
 | [`calor mcp`](/calor/cli/mcp/) | Start MCP server for AI agent tool integration |
+| `calor self-check docs` | Verify agent-facing docs against the implementation (keywords, diagnostic codes, effect codes, version); exits nonzero on drift |
 | `calor lsp` | Start Language Server Protocol server for IDE features |
 | [`calor hook`](/calor/cli/hook/) | Claude Code hook commands (internal) |
 

--- a/docs/cli/self-check.md
+++ b/docs/cli/self-check.md
@@ -1,0 +1,99 @@
+---
+layout: default
+title: self-check
+parent: CLI Reference
+nav_order: 16
+permalink: /cli/self-check/
+---
+
+# calor self-check docs
+
+Machine-checks agent-facing documentation against the compiler
+implementation and exits nonzero when they contradict each other
+("doc drift"). This is **drift detection, not single-sourcing**: docs are
+still written by hand, and prose or behavioral inaccuracies that don't
+take one of the checked forms below will not be caught.
+
+```bash
+calor self-check docs                 # check the enclosing repository
+calor self-check docs --root /path    # explicit repository root
+calor self-check docs --format json   # unified diagnostic schema on stdout
+calor self-check docs --format sarif  # SARIF 2.1.0 on stdout
+```
+
+Exit codes: `0` no drift, `1` drift findings, `2` no repository root found.
+Findings use the `Calor1320`–`Calor1328` band (see
+[Structured Output](/calor/cli/structured-output/)).
+
+## Covered files
+
+- `CLAUDE.md`
+- every `docs/syntax-reference/*.md`
+- every `docs/cli/*.md`
+- the **version scan only** additionally covers all of `docs/**/*.md`,
+  excluding dated records under `docs/plans/`, `docs/experiments/`,
+  `docs/design/`, and `docs/process/`
+
+## Checks
+
+| Check | Finding |
+|:------|:--------|
+| Every documented `§`-keyword (e.g. `§EACH`, `§/C`) exists in the lexer's keyword table | `Calor1320` |
+| Every cited `CalorNNNN` diagnostic code is defined in the compiler | `Calor1321` |
+| Every cited diagnostic band (e.g. `Calor0800`–`0899`) contains at least one implemented code | `Calor1322` |
+| Every effect code in `docs/syntax-reference/effects.md`'s "Effect Codes" table is known to the effect registry | `Calor1323` |
+| Every implemented (non-legacy) effect code appears in that table | `Calor1324` |
+| No covered doc hardcodes the current `Directory.Build.props` version | `Calor1325` |
+| Required files/sections are present and readable | `Calor1326` |
+| Every implemented `Calor13xx` code is listed in `docs/cli/structured-output.md`'s table | `Calor1327` |
+| Every complete-program example still parses (see below) | `Calor1328` |
+
+## Parse-checked examples
+
+Fenced code blocks tagged `calor` whose **first non-blank line starts with
+`§M`** declare a complete program by convention and are lexed and parsed
+with the real compiler on every run — if the syntax rots, the check fails
+with `Calor1328` at the offending doc line. Blocks that do not start with
+`§M` are treated as deliberate fragments and are skipped.
+
+## Meta-notation policy
+
+Docs legitimately talk *about* notation: placeholders such as a generic
+closer tag written as slash-X, hypothetical diagnostic codes, or foreign
+code snippets. Two escapes exist:
+
+1. **Foreign fences are never scanned.** A fenced block whose info string
+   is anything other than `calor` (for example ```` ```text ````,
+   ```` ```csharp ````, ```` ```bash ````) is invisible to the keyword and
+   diagnostic-code scans. Bare ```` ``` ```` fences and ```` ```calor ````
+   fences **are** scanned. The version scan looks inside all fences — a
+   hardcoded version in an install snippet is exactly what it exists to
+   catch — and honors only the marker below.
+
+2. **The suppression marker.** A line containing `<!-- drift:ignore -->`
+   suppresses all drift findings on the **next** line. Placed on the line
+   before a ```` ```calor ```` fence, it exempts that block from the parse
+   check. The HTML comment is invisible in rendered docs and may trail
+   existing text (useful inside tables):
+
+   ```text
+   <!-- drift:ignore -->
+   Closer tags were removed — an explicit §/X raises Calor0830.
+   ```
+
+Prefer the foreign-fence escape for whole blocks and the marker for single
+lines; both should be rare. If the checker flags something real, fix the
+doc (or the registry it is checked against) instead of suppressing.
+
+## What it cannot catch
+
+Semantic and prose drift: wrong descriptions of behavior, stale line
+counts or file paths, outdated flag defaults, incorrect *output* examples,
+rotted `calor` fragments (blocks not starting with `§M`), undocumented
+features (other than effect codes and the `Calor13xx` table, which are
+checked for completeness), and anything in files outside the covered set.
+
+## CI
+
+The check runs on every PR as a step of the `test` job in
+`.github/workflows/test.yml`, reusing that job's build.

--- a/docs/cli/structured-output.md
+++ b/docs/cli/structured-output.md
@@ -137,6 +137,14 @@ pipeline) so they can flow through the structured formats:
 | `Calor1310` | Compile: `--input` file not found |
 | `Calor1311` | Compile: invalid argument combination (e.g. `--output` with multiple inputs) |
 | `Calor1312` | Compile: unhandled internal error |
+| `Calor1320` | Docs drift (`calor self-check docs`): documented §-keyword does not exist in the lexer |
+| `Calor1321` | Docs drift: cited diagnostic code is not defined in the compiler |
+| `Calor1322` | Docs drift: documented diagnostic band contains no implemented codes |
+| `Calor1323` | Docs drift: documented effect code is unknown to the effect registry |
+| `Calor1324` | Docs drift: implemented effect code missing from the effect-code docs |
+| `Calor1325` | Docs drift: doc file hardcodes the current compiler version |
+| `Calor1326` | Docs drift: a file or doc section the self-check needs is missing |
+| `Calor1327` | Docs drift: CLI diagnostic code missing from this table |
 
 ## Notes on specific commands
 
@@ -149,3 +157,6 @@ pipeline) so they can flow through the structured formats:
 - **`calor verify --format json`** embeds this schema's `diagnostics[]` array
   per file (alongside its legacy flat `errors`/`warnings` string arrays), but
   its top-level document is command-specific.
+- **`calor self-check docs --format json`** emits the unified schema on stdout
+  with docs-drift findings (`Calor1320`–`Calor1327`) and exits 1 when drift is
+  found (text mode reports the same findings on stderr).

--- a/docs/cli/structured-output.md
+++ b/docs/cli/structured-output.md
@@ -145,6 +145,7 @@ pipeline) so they can flow through the structured formats:
 | `Calor1325` | Docs drift: doc file hardcodes the current compiler version |
 | `Calor1326` | Docs drift: a file or doc section the self-check needs is missing |
 | `Calor1327` | Docs drift: CLI diagnostic code missing from this table |
+| `Calor1328` | Docs drift: fenced ```` ```calor ```` example (complete program starting with `§M`) no longer parses |
 
 ## Notes on specific commands
 
@@ -158,5 +159,5 @@ pipeline) so they can flow through the structured formats:
   per file (alongside its legacy flat `errors`/`warnings` string arrays), but
   its top-level document is command-specific.
 - **`calor self-check docs --format json`** emits the unified schema on stdout
-  with docs-drift findings (`Calor1320`–`Calor1327`) and exits 1 when drift is
+  with docs-drift findings (`Calor1320`–`Calor1328`) and exits 1 when drift is
   found (text mode reports the same findings on stderr).

--- a/docs/syntax-reference/calls.md
+++ b/docs/syntax-reference/calls.md
@@ -62,7 +62,7 @@ arguments use form (3) or (4).
 6. **The inline argument must start on the same source line as
    `§C{target}`.** A candidate argument that begins on a later line is
    treated as a sibling statement / expression, not as the call's
-   argument. Without this rule, a `§IF` / `§MATCH` / `§NEW` on the next
+   argument. Without this rule, a `§IF` / `§W` / `§NEW` on the next
    line at the same indent would be silently absorbed as the argument
    (because each of those tokens is also an expression-start). Writing
    `§C{Foo}` on one line and `§IF{c} ... §EL → ...` on the next always

--- a/docs/syntax-reference/control-flow.md
+++ b/docs/syntax-reference/control-flow.md
@@ -179,12 +179,12 @@ Use `§EACHKV` to iterate over key-value pairs in a dictionary.
     §P key
 ```
 
-### Comparison with §FOREACH
+### Comparison with §EACH
 
 | Loop Type | Use Case |
 |:----------|:---------|
 | `§L{id:var:from:to:step}` | Numeric ranges |
-| `§FOREACH{id:var} collection` | Lists, arrays, sets |
+| `§EACH{id:var} collection` | Lists, arrays, sets |
 | `§EACHKV{id:k:v} dict` | Dictionaries (key-value pairs) |
 
 ---

--- a/docs/syntax-reference/effects.md
+++ b/docs/syntax-reference/effects.md
@@ -63,12 +63,26 @@ Place the effect declaration after the output type:
 | `fs:r` | Filesystem read | Read from filesystem | `File.ReadAllText()` |
 | `fs:w` | Filesystem write | Write to filesystem | `File.WriteAllText()` |
 | `fs:rw` | Filesystem read/write | Read and write filesystem | `File.Copy()` |
+| `net` | Network | Unspecified network access | `Socket` operations |
 | `net:r` | Network read | HTTP GET, etc. | `HttpClient.GetStringAsync()` |
 | `net:w` | Network write | HTTP POST, etc. | `HttpClient.PostAsync()` |
 | `net:rw` | Network read/write | HTTP operations | `HttpClient.SendAsync()` |
+| `http` | HTTP | HTTP client operations | `HttpClient` usage |
+| `db` | Database | Unspecified database access | Connection setup |
 | `db:r` | Database read | Database queries | `SELECT` queries |
 | `db:w` | Database write | Database mutations | `INSERT/UPDATE/DELETE` |
 | `db:rw` | Database read/write | Database operations | ORM calls |
+| `env` | Environment | Unspecified environment access | `Environment` usage |
+| `env:r` | Environment read | Read environment variables | `Environment.GetEnvironmentVariable()` |
+| `env:w` | Environment write | Write environment variables | `Environment.SetEnvironmentVariable()` |
+| `env:rw` | Environment read/write | Environment operations | Read-modify-write of env vars |
+| `proc` | Process | Spawn or control processes | `Process.Start()` |
+| `mut` | Mutation | Writes to heap state (fields, collections) | `list.Add()`, field assignment |
+| `mut:col` | Collection mutation | Mutates a collection | `dict[key] = value` |
+| `alloc` | Allocation | Explicit memory allocation | `stackalloc`, unsafe buffers |
+| `time` | Time | Reads the clock (nondeterministic) | `DateTime.Now` |
+| `rand` | Randomness | Random number generation (nondeterministic) | `Random.Next()` |
+| `throw` | Exception | Intentionally throws exceptions | `throw` statements |
 
 ---
 

--- a/docs/syntax-reference/index.md
+++ b/docs/syntax-reference/index.md
@@ -42,8 +42,8 @@ Complete reference for Calor syntax. Calor uses Lisp-style expressions for all o
 | Print | `§P expr` | `§P "Hello"` |
 | Return | `§R expr` | `§R (+ a b)` |
 | Binding | `§B{name} expr` | `§B{x} (+ 1 2)` (see [Bindings](/calor/syntax-reference/binding/)) |
-| Operations | `(op args...)` | `(+ a b)`, `(== x 0)` |
-| Block end | _dedent_ (Python-style) | _(no closer tag needed)_ |
+| Operations | `(op args...)` | `(+ a b)`, `(== x 0)` | <!-- drift:ignore -->
+| Block end | _dedent_ (Python-style) | _(no `§/X` needed)_ |
 | List | `§LIST{id:type}` | `§LIST{nums:i32}` |
 | Dictionary | `§DICT{id:kType:vType}` | `§DICT{ages:str:i32}` |
 | HashSet | `§HSET{id:type}` | `§HSET{tags:str}` |
@@ -142,9 +142,9 @@ to reference the element from external tooling (e.g. `calor navigate`).
       §EL → §P i
 ```
 
-Blocks are delimited by **indentation** (default 2 spaces per nesting
-level). There are no structural closer tags — explicit closers were
-removed in Phase 4d and now raise `Calor0830`. See
+Blocks are delimited by **indentation** (default 2 spaces per nesting <!-- drift:ignore -->
+level). There are no closer tags — an explicit `§/X` was removed in
+Phase 4d and now raises `Calor0830`. See
 [Structure Tags](/calor/syntax-reference/structure-tags/) for details.
 
 The compiler diagnoses non-canonical indentation, and each of these

--- a/docs/syntax-reference/index.md
+++ b/docs/syntax-reference/index.md
@@ -35,7 +35,7 @@ Complete reference for Calor syntax. Calor uses Lisp-style expressions for all o
 | Ensures | `§S expr` | `§S (>= result 0)` |
 | For Loop | `§L{var:from:to:step}` | `§L{i:1:100:1}` |
 | While Loop | `§WH condition` | `§WH (> i 0)` |
-| Do-While Loop | `§DO` (body indented) | `§DO` then `§WHILE cond` |
+| Do-While Loop | `§DO{id}` (body indented) | `§DO{do1}` then `§/DO{do1} cond` |
 | If/ElseIf/Else | `§IF cond` then `§EI` / `§EL` at same column | `§IF (> x 0)` |
 | Call | `§C{target}...§/C` | `§C{Math.Max} §A 1 §A 2 §/C` |
 | C# Attribute | `[@Name]` or `[@Name(args)]` | `[@HttpPost]`, `[@Route("api")]` |
@@ -43,7 +43,7 @@ Complete reference for Calor syntax. Calor uses Lisp-style expressions for all o
 | Return | `§R expr` | `§R (+ a b)` |
 | Binding | `§B{name} expr` | `§B{x} (+ 1 2)` (see [Bindings](/calor/syntax-reference/binding/)) |
 | Operations | `(op args...)` | `(+ a b)`, `(== x 0)` |
-| Block end | _dedent_ (Python-style) | _(no `§/X` needed)_ |
+| Block end | _dedent_ (Python-style) | _(no closer tag needed)_ |
 | List | `§LIST{id:type}` | `§LIST{nums:i32}` |
 | Dictionary | `§DICT{id:kType:vType}` | `§DICT{ages:str:i32}` |
 | HashSet | `§HSET{id:type}` | `§HSET{tags:str}` |
@@ -55,7 +55,7 @@ Complete reference for Calor syntax. Calor uses Lisp-style expressions for all o
 | Count | `§CNT{coll}` | `§CNT{nums}` |
 | Dict Foreach | `§EACHKV{id:k:v} dict` | `§EACHKV{e1:k:v} ages` |
 | Enum | `§EN{id:name}` | `§EN{e001:Color}` |
-| Enum Extension | `§EXT{id:enumName}` | `§EXT{ext001:Color}` |
+| Enum Extension | `§EEXT{id:enumName}` | `§EEXT{ext001:Color}` |
 | Switch | `§W{id} expr` | `§W{sw1} score` |
 | Case | `§K pattern → result` | `§K 200 → "OK"` |
 | Wildcard | `§K _` | `§K _ → "default"` |
@@ -143,8 +143,8 @@ to reference the element from external tooling (e.g. `calor navigate`).
 ```
 
 Blocks are delimited by **indentation** (default 2 spaces per nesting
-level). There are no closer tags — an explicit `§/X` was removed in
-Phase 4d and now raises `Calor0830`. See
+level). There are no structural closer tags — explicit closers were
+removed in Phase 4d and now raise `Calor0830`. See
 [Structure Tags](/calor/syntax-reference/structure-tags/) for details.
 
 The compiler diagnoses non-canonical indentation, and each of these

--- a/docs/syntax-reference/structure-tags.md
+++ b/docs/syntax-reference/structure-tags.md
@@ -669,8 +669,8 @@ dedents back to (or past) the parent column.
 2. Tabs and spaces must not be mixed within a block
 3. Chain continuations (`§EI`, `§EL`, `§K`, `§WHEN`, `§CA`, `§FI`)
    sit at the **same** column as their parent (`§IF`, `§W`, `§TR`),
-   not indented inside it
-4. Closer tags were removed in Phase 4d — writing an explicit closer raises `Calor0830`
+   not indented inside it <!-- drift:ignore -->
+4. Closer tags were removed in Phase 4d — an explicit `§/X` raises `Calor0830`
 
 ### Example
 
@@ -849,8 +849,8 @@ Attributes can be attached to:
 
 ## Why Indent-Based Blocks?
 
-1. **Familiar to agents** - LLMs trained on Python have strong priors for indentation
-2. **Tag-light** - No closer tags to type, no mismatched-closer errors
+1. **Familiar to agents** - LLMs trained on Python have strong priors for indentation <!-- drift:ignore -->
+2. **Tag-light** - No `§/X` to type, no mismatched-closer errors
 3. **Refactoring safe** - Stable IDs on openers still survive code movement
 4. **Lower edit cost** - In edit-workload studies, indent form reduced agent token cost by ~16% with no regression in correctness
 

--- a/docs/syntax-reference/structure-tags.md
+++ b/docs/syntax-reference/structure-tags.md
@@ -670,7 +670,7 @@ dedents back to (or past) the parent column.
 3. Chain continuations (`§EI`, `§EL`, `§K`, `§WHEN`, `§CA`, `§FI`)
    sit at the **same** column as their parent (`§IF`, `§W`, `§TR`),
    not indented inside it
-4. Closer tags were removed in Phase 4d — an explicit `§/X` raises `Calor0830`
+4. Closer tags were removed in Phase 4d — writing an explicit closer raises `Calor0830`
 
 ### Example
 
@@ -850,7 +850,7 @@ Attributes can be attached to:
 ## Why Indent-Based Blocks?
 
 1. **Familiar to agents** - LLMs trained on Python have strong priors for indentation
-2. **Tag-light** - No `§/X` to type, no mismatched-closer errors
+2. **Tag-light** - No closer tags to type, no mismatched-closer errors
 3. **Refactoring safe** - Stable IDs on openers still survive code movement
 4. **Lower edit cost** - In edit-workload studies, indent form reduced agent token cost by ~16% with no regression in correctness
 

--- a/src/Calor.Compiler/Commands/SelfCheckCommand.cs
+++ b/src/Calor.Compiler/Commands/SelfCheckCommand.cs
@@ -1,0 +1,103 @@
+using System.CommandLine;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.SelfCheck;
+
+namespace Calor.Compiler.Commands;
+
+/// <summary>
+/// <c>calor self-check docs</c> — machine-checks agent-facing documentation
+/// (CLAUDE.md, docs/syntax-reference, docs/cli) against the implementation:
+/// §-keywords vs the lexer, diagnostic codes vs DiagnosticCode, effect codes
+/// vs the effect registry, and hardcoded version strings. Exits nonzero when
+/// drift is found. Phase 1 item 6 of the agent-native strategy.
+/// </summary>
+public static class SelfCheckCommand
+{
+    public static Command Create()
+    {
+        var command = new Command("self-check",
+            "Verify that agent-facing artifacts stay in sync with the implementation");
+        command.AddCommand(CreateDocsCommand());
+        return command;
+    }
+
+    private static Command CreateDocsCommand()
+    {
+        var rootOption = new Option<string?>(
+            aliases: ["--root", "-r"],
+            description: "Repository root (default: nearest ancestor of the current directory containing CLAUDE.md and Directory.Build.props)");
+
+        var formatOption = new Option<string>(
+            aliases: ["--format"],
+            getDefaultValue: () => "text",
+            description: "Output format: text (human-readable, stderr) or json (structured document on stdout)");
+        formatOption.FromAmong("text", "json");
+
+        var docsCommand = new Command("docs",
+            "Check agent-facing docs (CLAUDE.md, syntax reference, CLI docs) against the compiler implementation: " +
+            "documented §-keywords must exist in the lexer, cited diagnostic codes in DiagnosticCode, " +
+            "effect codes in the effect registry (both directions), and no doc may hardcode the current version")
+        {
+            rootOption,
+            formatOption
+        };
+
+        docsCommand.SetHandler(Execute, rootOption, formatOption);
+        return docsCommand;
+    }
+
+    private static void Execute(string? root, string format)
+    {
+        var resolvedRoot = root ?? FindRepositoryRoot(Directory.GetCurrentDirectory());
+        if (resolvedRoot == null)
+        {
+            Console.Error.WriteLine(
+                "error: could not locate a repository root (a directory containing CLAUDE.md and Directory.Build.props); pass --root");
+            Environment.ExitCode = 2;
+            return;
+        }
+
+        var diagnostics = new List<Diagnostic>();
+        var inputs = DocDriftChecker.LoadFromRepository(resolvedRoot, diagnostics);
+        diagnostics.AddRange(DocDriftChecker.Check(inputs));
+
+        if (format.Equals("json", StringComparison.OrdinalIgnoreCase))
+        {
+            // Structured-output contract: exactly one parseable document on stdout.
+            Console.WriteLine(new JsonDiagnosticFormatter().Format(diagnostics));
+        }
+        else
+        {
+            foreach (var diagnostic in diagnostics)
+            {
+                Console.Error.WriteLine(diagnostic.ToString());
+            }
+
+            Console.Error.WriteLine(diagnostics.Count == 0
+                ? $"calor self-check docs — no drift found (root: {resolvedRoot})"
+                : $"calor self-check docs — {diagnostics.Count} drift finding(s) (root: {resolvedRoot})");
+        }
+
+        if (diagnostics.Count > 0)
+        {
+            Environment.ExitCode = 1;
+        }
+    }
+
+    private static string? FindRepositoryRoot(string startDirectory)
+    {
+        var dir = new DirectoryInfo(startDirectory);
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "CLAUDE.md")) &&
+                File.Exists(Path.Combine(dir.FullName, "Directory.Build.props")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/src/Calor.Compiler/Commands/SelfCheckCommand.cs
+++ b/src/Calor.Compiler/Commands/SelfCheckCommand.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.CommandLine.Invocation;
 using Calor.Compiler.Diagnostics;
 using Calor.Compiler.SelfCheck;
 
@@ -42,19 +43,23 @@ public static class SelfCheckCommand
             formatOption
         };
 
-        docsCommand.SetHandler(Execute, rootOption, formatOption);
+        docsCommand.SetHandler((InvocationContext ctx) =>
+        {
+            var root = ctx.ParseResult.GetValueForOption(rootOption);
+            var format = ctx.ParseResult.GetValueForOption(formatOption) ?? "text";
+            ctx.ExitCode = Execute(root, format);
+        });
         return docsCommand;
     }
 
-    private static void Execute(string? root, string format)
+    private static int Execute(string? root, string format)
     {
         var resolvedRoot = root ?? FindRepositoryRoot(Directory.GetCurrentDirectory());
         if (resolvedRoot == null)
         {
             Console.Error.WriteLine(
                 "error: could not locate a repository root (a directory containing CLAUDE.md and Directory.Build.props); pass --root");
-            Environment.ExitCode = 2;
-            return;
+            return 2;
         }
 
         var diagnostics = new List<Diagnostic>();
@@ -78,10 +83,7 @@ public static class SelfCheckCommand
                 : $"calor self-check docs — {diagnostics.Count} drift finding(s) (root: {resolvedRoot})");
         }
 
-        if (diagnostics.Count > 0)
-        {
-            Environment.ExitCode = 1;
-        }
+        return diagnostics.Count > 0 ? 1 : 0;
     }
 
     private static string? FindRepositoryRoot(string startDirectory)

--- a/src/Calor.Compiler/Commands/SelfCheckCommand.cs
+++ b/src/Calor.Compiler/Commands/SelfCheckCommand.cs
@@ -35,9 +35,14 @@ public static class SelfCheckCommand
         formatOption.FromAmong("text", "json");
 
         var docsCommand = new Command("docs",
-            "Check agent-facing docs (CLAUDE.md, syntax reference, CLI docs) against the compiler implementation: " +
-            "documented §-keywords must exist in the lexer, cited diagnostic codes in DiagnosticCode, " +
-            "effect codes in the effect registry (both directions), and no doc may hardcode the current version")
+            "Check agent-facing docs against the compiler implementation. " +
+            "Covered files: CLAUDE.md, docs/syntax-reference/*.md, and docs/cli/*.md " +
+            "(plus docs/**/*.md for the version scan). Checks: (1) every documented §-keyword " +
+            "exists in the lexer; (2) every cited CalorNNNN diagnostic code exists (and cited " +
+            "bands are non-empty); (3) effect codes in docs/syntax-reference/effects.md match " +
+            "the effect registry in both directions; (4) the Calor13xx table in " +
+            "docs/cli/structured-output.md is complete; (5) no doc hardcodes the current version. " +
+            "Exits 1 when drift is found")
         {
             rootOption,
             formatOption

--- a/src/Calor.Compiler/Commands/SelfCheckCommand.cs
+++ b/src/Calor.Compiler/Commands/SelfCheckCommand.cs
@@ -41,8 +41,11 @@ public static class SelfCheckCommand
             "exists in the lexer; (2) every cited CalorNNNN diagnostic code exists (and cited " +
             "bands are non-empty); (3) effect codes in docs/syntax-reference/effects.md match " +
             "the effect registry in both directions; (4) the Calor13xx table in " +
-            "docs/cli/structured-output.md is complete; (5) no doc hardcodes the current version. " +
-            "Exits 1 when drift is found")
+            "docs/cli/structured-output.md is complete; (5) no doc hardcodes the current version; " +
+            "(6) every fenced ```calor example that declares a complete program (first non-blank " +
+            "line starts with §M) parses with the current compiler. " +
+            "Suppress an intentional-meta-notation finding by putting <!-- drift:ignore --> on the " +
+            "preceding line (see docs/cli/self-check.md). Exits 1 when drift is found")
         {
             rootOption,
             formatOption

--- a/src/Calor.Compiler/Commands/SelfCheckCommand.cs
+++ b/src/Calor.Compiler/Commands/SelfCheckCommand.cs
@@ -31,8 +31,8 @@ public static class SelfCheckCommand
         var formatOption = new Option<string>(
             aliases: ["--format"],
             getDefaultValue: () => "text",
-            description: "Output format: text (human-readable, stderr) or json (structured document on stdout)");
-        formatOption.FromAmong("text", "json");
+            description: "Output format: text (human-readable, stderr), json (unified schema on stdout), or sarif (SARIF 2.1.0 on stdout)");
+        formatOption.FromAmong("text", "json", "sarif");
 
         var docsCommand = new Command("docs",
             "Check agent-facing docs against the compiler implementation. " +
@@ -74,10 +74,11 @@ public static class SelfCheckCommand
         var inputs = DocDriftChecker.LoadFromRepository(resolvedRoot, diagnostics);
         diagnostics.AddRange(DocDriftChecker.Check(inputs));
 
-        if (format.Equals("json", StringComparison.OrdinalIgnoreCase))
+        if (format.Equals("json", StringComparison.OrdinalIgnoreCase) ||
+            format.Equals("sarif", StringComparison.OrdinalIgnoreCase))
         {
             // Structured-output contract: exactly one parseable document on stdout.
-            Console.WriteLine(new JsonDiagnosticFormatter().Format(diagnostics));
+            Console.WriteLine(DiagnosticFormatterFactory.Create(format).Format(diagnostics));
         }
         else
         {

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -242,6 +242,34 @@ public static class DiagnosticCode
     /// </summary>
     public const string SemanticsVersionIncompatible = "Calor0701";
 
+    // Contract verification results (Calor0702-0705) — emitted by
+    // Verification/ContractVerificationPass. Note: the verification pass also
+    // reuses Calor0700 (Z3 unavailable, info) and Calor0701 (precondition may
+    // be violated, warning) with meanings that differ from the semantics-version
+    // constants above; that pre-existing collision is preserved for
+    // compatibility and is scheduled for renumbering.
+
+    /// <summary>
+    /// Warning: Z3 disproved a postcondition; a counterexample is reported.
+    /// </summary>
+    public const string PostconditionMayBeViolated = "Calor0702";
+
+    /// <summary>
+    /// Info: a postcondition was statically proven; its runtime check is elided.
+    /// </summary>
+    public const string PostconditionProven = "Calor0703";
+
+    /// <summary>
+    /// Info: per-module contract verification summary (proven / unproven /
+    /// potentially violated / unsupported counts).
+    /// </summary>
+    public const string VerificationSummary = "Calor0704";
+
+    /// <summary>
+    /// Info (verbose): verification cache statistics.
+    /// </summary>
+    public const string VerificationCacheStats = "Calor0705";
+
     // ID errors (Calor0800-0899)
     /// <summary>
     /// Error: Declaration is missing a required ID.
@@ -671,6 +699,57 @@ public static class DiagnosticCode
     /// produce a parseable document on crash paths.
     /// </summary>
     public const string CliInternalError = "Calor1312";
+
+    // `calor self-check docs` drift findings (Calor1320-1329) — agent-facing
+    // documentation contradicts the implementation. See SelfCheck/DocDriftChecker.
+
+    /// <summary>
+    /// Error (docs drift): a §-keyword cited in agent-facing docs does not
+    /// exist in the lexer's keyword table (the "§FOREACH vs §EACH" class).
+    /// </summary>
+    public const string DocDriftUnknownKeyword = "Calor1320";
+
+    /// <summary>
+    /// Error (docs drift): a diagnostic code cited in agent-facing docs is not
+    /// defined in <see cref="DiagnosticCode"/> (the "Calor0820 vs Calor0830" class).
+    /// </summary>
+    public const string DocDriftUnknownDiagnosticCode = "Calor1321";
+
+    /// <summary>
+    /// Error (docs drift): a documented diagnostic-code range (band) contains
+    /// no implemented diagnostic codes.
+    /// </summary>
+    public const string DocDriftEmptyDiagnosticRange = "Calor1322";
+
+    /// <summary>
+    /// Error (docs drift): an effect code listed in the docs is unknown to the
+    /// compiler's effect-code registry.
+    /// </summary>
+    public const string DocDriftUnknownEffectCode = "Calor1323";
+
+    /// <summary>
+    /// Error (docs drift): an implemented (non-legacy) effect code is missing
+    /// from the effect-code documentation (the undocumented-<c>mut</c> class).
+    /// </summary>
+    public const string DocDriftUndocumentedEffectCode = "Calor1324";
+
+    /// <summary>
+    /// Error (docs drift): a doc file hardcodes the current compiler version
+    /// string; versions belong in Directory.Build.props only (the stale-version class).
+    /// </summary>
+    public const string DocDriftHardcodedVersion = "Calor1325";
+
+    /// <summary>
+    /// Error (docs drift): a file or doc section the self-check needs is
+    /// missing or unreadable.
+    /// </summary>
+    public const string DocDriftMissingInput = "Calor1326";
+
+    /// <summary>
+    /// Error (docs drift): a CLI diagnostic code (Calor1300-1399) is not listed
+    /// in docs/cli/structured-output.md's code table.
+    /// </summary>
+    public const string DocDriftUndocumentedCliCode = "Calor1327";
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -750,6 +750,13 @@ public static class DiagnosticCode
     /// in docs/cli/structured-output.md's code table.
     /// </summary>
     public const string DocDriftUndocumentedCliCode = "Calor1327";
+
+    /// <summary>
+    /// Error (docs drift): a fenced ```calor example that declares a complete
+    /// program (first non-blank line starts with §M) no longer lexes/parses
+    /// with the current compiler — the example has rotted.
+    /// </summary>
+    public const string DocDriftExampleParseError = "Calor1328";
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -247,7 +247,8 @@ public static class DiagnosticCode
     // reuses Calor0700 (Z3 unavailable, info) and Calor0701 (precondition may
     // be violated, warning) with meanings that differ from the semantics-version
     // constants above; that pre-existing collision is preserved for
-    // compatibility and is scheduled for renumbering.
+    // compatibility and its renumbering is tracked in
+    // https://github.com/juanmicrosoft/calor/issues/702.
 
     /// <summary>
     /// Warning: Z3 disproved a postcondition; a counterexample is reported.

--- a/src/Calor.Compiler/Effects/EffectTypes.cs
+++ b/src/Calor.Compiler/Effects/EffectTypes.cs
@@ -43,61 +43,95 @@ public sealed class EffectInfo : IEquatable<EffectInfo>
 }
 
 /// <summary>
-/// Shared utility for converting internal effect category/value pairs to compact surface codes.
-/// Used by both CalorEmitter and CalorFormatter to ensure consistent serialization.
+/// One entry in the effect-code registry: an internal category/value pair and its
+/// compact surface code. <paramref name="Legacy"/> entries are accepted for backward
+/// compatibility but are not part of the documented surface (and are excluded from
+/// the docs-drift check's "must be documented" set).
+/// </summary>
+public sealed record EffectCodeEntry(string Category, string Value, string Compact, bool Legacy = false);
+
+/// <summary>
+/// Shared registry for converting internal effect category/value pairs to compact surface codes.
+/// Used by both CalorEmitter and CalorFormatter to ensure consistent serialization, and by
+/// <c>calor self-check docs</c> as the single source of truth for documented effect codes.
 /// </summary>
 public static class EffectCodes
 {
+    /// <summary>
+    /// The full effect-code registry. Single source of truth: docs
+    /// (docs/syntax-reference/effects.md) are checked against this table by
+    /// <c>calor self-check docs</c>. Add new effect codes here.
+    /// </summary>
+    public static readonly IReadOnlyList<EffectCodeEntry> Registry =
+    [
+        // Console I/O
+        new("io", "console_write", "cw"),
+        new("io", "console_read", "cr"),
+        // File I/O
+        new("io", "filesystem_write", "fs:w"),
+        new("io", "filesystem_read", "fs:r"),
+        new("io", "filesystem_readwrite", "fs:rw"),
+        // File I/O (legacy formatter values)
+        new("io", "file_write", "fw", Legacy: true),
+        new("io", "file_read", "fr", Legacy: true),
+        new("io", "file_delete", "fd", Legacy: true),
+        // Network
+        new("io", "network", "net"),
+        new("io", "network_read", "net:r"),
+        new("io", "network_write", "net:w"),
+        new("io", "network_readwrite", "net:rw"),
+        new("io", "http", "http"),
+        // Database
+        new("io", "database", "db"),
+        new("io", "database_read", "db:r"),
+        new("io", "database_write", "db:w"),
+        new("io", "database_readwrite", "db:rw"),
+        // Legacy database codes (keep for backward compat)
+        new("io", "dbr", "db:r", Legacy: true),
+        new("io", "dbw", "db:w", Legacy: true),
+        // Environment / process
+        new("io", "environment", "env"),
+        new("io", "environment_read", "env:r"),
+        new("io", "environment_write", "env:w"),
+        new("io", "environment_readwrite", "env:rw"),
+        new("io", "process", "proc"),
+        // Mutation
+        new("mutation", "heap_write", "mut"),
+        new("mutation", "collection", "mut:col"),
+        // Memory
+        new("memory", "allocation", "alloc"),
+        // Nondeterminism
+        new("nondeterminism", "time", "time"),
+        new("nondeterminism", "random", "rand"),
+        // Exception
+        new("exception", "intentional", "throw"),
+    ];
+
+    private static readonly Dictionary<(string Category, string Value), string> CompactByInternal =
+        Registry.ToDictionary(e => (e.Category, e.Value), e => e.Compact);
+
+    /// <summary>
+    /// All compact surface codes the compiler knows, including legacy forms.
+    /// </summary>
+    public static readonly IReadOnlyCollection<string> KnownCompactCodes =
+        Registry.Select(e => e.Compact).Distinct(StringComparer.Ordinal).ToArray();
+
+    /// <summary>
+    /// The compact surface codes that must appear in the effect-code documentation
+    /// (all non-legacy codes).
+    /// </summary>
+    public static readonly IReadOnlyCollection<string> DocumentedCompactCodes =
+        Registry.Where(e => !e.Legacy).Select(e => e.Compact).Distinct(StringComparer.Ordinal).ToArray();
+
     /// <summary>
     /// Convert internal effect category/value to compact code.
     /// E.g., ("io", "console_write") → "cw", ("io", "filesystem_read") → "fs:r"
     /// </summary>
     public static string ToCompact(string category, string value)
     {
-        return (category.ToLowerInvariant(), value.ToLowerInvariant()) switch
-        {
-            // Console I/O
-            ("io", "console_write") => "cw",
-            ("io", "console_read") => "cr",
-            // File I/O
-            ("io", "filesystem_write") => "fs:w",
-            ("io", "filesystem_read") => "fs:r",
-            ("io", "filesystem_readwrite") => "fs:rw",
-            // File I/O (legacy formatter values)
-            ("io", "file_write") => "fw",
-            ("io", "file_read") => "fr",
-            ("io", "file_delete") => "fd",
-            // Network
-            ("io", "network") => "net",
-            ("io", "network_read") => "net:r",
-            ("io", "network_write") => "net:w",
-            ("io", "network_readwrite") => "net:rw",
-            ("io", "http") => "http",
-            // Database
-            ("io", "database") => "db",
-            ("io", "database_read") => "db:r",
-            ("io", "database_write") => "db:w",
-            ("io", "database_readwrite") => "db:rw",
-            // Legacy database codes (keep for backward compat)
-            ("io", "dbr") => "db:r",
-            ("io", "dbw") => "db:w",
-            // Environment / process
-            ("io", "environment") => "env",
-            ("io", "environment_read") => "env:r",
-            ("io", "environment_write") => "env:w",
-            ("io", "environment_readwrite") => "env:rw",
-            ("io", "process") => "proc",
-            // Mutation
-            ("mutation", "heap_write") => "mut",
-            ("mutation", "collection") => "mut:col",
-            // Memory
-            ("memory", "allocation") => "alloc",
-            // Nondeterminism
-            ("nondeterminism", "time") => "time",
-            ("nondeterminism", "random") => "rand",
-            // Exception
-            ("exception", "intentional") => "throw",
-            _ => value // Pass through unknown values
-        };
+        return CompactByInternal.TryGetValue(
+            (category.ToLowerInvariant(), value.ToLowerInvariant()), out var compact)
+            ? compact
+            : value; // Pass through unknown values
     }
 }

--- a/src/Calor.Compiler/Parsing/Lexer.cs
+++ b/src/Calor.Compiler/Parsing/Lexer.cs
@@ -298,11 +298,15 @@ public sealed class Lexer
 
     /// <summary>
     /// Every §-keyword the lexer accepts, including forms handled outside the
-    /// keyword dictionary (preprocessor conditionals §PP / §/PP). Single source
-    /// of truth for the docs-drift check (<c>calor self-check docs</c>).
+    /// keyword dictionary: preprocessor conditionals (§PP / §/PP / §PPE),
+    /// inline C# expressions (§CS), raw passthrough blocks (§RAW / §/RAW),
+    /// and C# interop blocks (§CSHARP / §/CSHARP). Single source of truth for
+    /// the docs-drift check (<c>calor self-check docs</c>).
     /// </summary>
     public static IReadOnlyCollection<string> KeywordNames { get; } =
-        Keywords.Keys.Concat(["PP", "/PP"]).ToArray();
+        Keywords.Keys
+            .Concat(["PP", "/PP", "PPE", "CS", "RAW", "/RAW", "CSHARP", "/CSHARP"])
+            .ToArray();
 
     public Lexer(string source, DiagnosticBag diagnostics)
     {

--- a/src/Calor.Compiler/Parsing/Lexer.cs
+++ b/src/Calor.Compiler/Parsing/Lexer.cs
@@ -296,6 +296,14 @@ public sealed class Lexer
         ["Pf"] = TokenKind.PrintF,          // §Pf = Console.Write
     };
 
+    /// <summary>
+    /// Every §-keyword the lexer accepts, including forms handled outside the
+    /// keyword dictionary (preprocessor conditionals §PP / §/PP). Single source
+    /// of truth for the docs-drift check (<c>calor self-check docs</c>).
+    /// </summary>
+    public static IReadOnlyCollection<string> KeywordNames { get; } =
+        Keywords.Keys.Concat(["PP", "/PP"]).ToArray();
+
     public Lexer(string source, DiagnosticBag diagnostics)
     {
         _source = source ?? throw new ArgumentNullException(nameof(source));

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -242,6 +242,7 @@ public class Program
         rootCommand.AddCommand(FeatureCheckCommand.Create());
         rootCommand.AddCommand(CoverageCommand.Create());
         rootCommand.AddCommand(SelfTestCommand.Create());
+        rootCommand.AddCommand(SelfCheckCommand.Create());
         rootCommand.AddCommand(EvaluationCommand.Create());
         rootCommand.AddCommand(RunCommand.Create());
         rootCommand.AddCommand(TestCommand.Create());

--- a/src/Calor.Compiler/SelfCheck/DocDriftChecker.cs
+++ b/src/Calor.Compiler/SelfCheck/DocDriftChecker.cs
@@ -1,0 +1,468 @@
+using System.Text.RegularExpressions;
+using Calor.Compiler.Diagnostics;
+
+namespace Calor.Compiler.SelfCheck;
+
+/// <summary>
+/// A documentation file to check: a display path and its full content.
+/// </summary>
+public sealed record DocFile(string Path, string Content);
+
+/// <summary>
+/// Inputs to <see cref="DocDriftChecker"/>: the implementation-derived ground
+/// truth (keywords, diagnostic codes, effect codes, version) plus the doc
+/// contents to verify against it. Tests construct this directly with fake doc
+/// strings; the CLI builds it from the repository via
+/// <see cref="DocDriftChecker.LoadFromRepository"/>.
+/// </summary>
+public sealed class DocDriftInputs
+{
+    /// <summary>Current compiler version (from Directory.Build.props).</summary>
+    public required string Version { get; init; }
+
+    /// <summary>Every §-keyword the lexer accepts.</summary>
+    public required IReadOnlyCollection<string> LexerKeywords { get; init; }
+
+    /// <summary>Every diagnostic code defined in <see cref="DiagnosticCode"/>.</summary>
+    public required IReadOnlyCollection<string> DiagnosticCodes { get; init; }
+
+    /// <summary>Every compact effect code the compiler knows (including legacy forms).</summary>
+    public required IReadOnlyCollection<string> KnownEffectCodes { get; init; }
+
+    /// <summary>The non-legacy compact effect codes that must be documented.</summary>
+    public required IReadOnlyCollection<string> DocumentedEffectCodes { get; init; }
+
+    /// <summary>Docs whose §-keyword references must all exist in the lexer.</summary>
+    public IReadOnlyList<DocFile> KeywordDocs { get; init; } = [];
+
+    /// <summary>Docs whose CalorNNNN citations must all exist in <see cref="DiagnosticCode"/>.</summary>
+    public IReadOnlyList<DocFile> DiagnosticCodeDocs { get; init; } = [];
+
+    /// <summary>
+    /// The effect-code reference doc (docs/syntax-reference/effects.md): its
+    /// "Effect Codes" table is checked in both directions (unknown codes flagged,
+    /// and every documented effect code must be present).
+    /// </summary>
+    public DocFile? EffectsReferenceDoc { get; init; }
+
+    /// <summary>
+    /// Additional docs with an "Effect Codes" table checked forward-only
+    /// (listed codes must exist; the table need not be complete).
+    /// </summary>
+    public IReadOnlyList<DocFile> EffectDocsForwardOnly { get; init; } = [];
+
+    /// <summary>
+    /// The CLI structured-output doc: its Calor1300-band table must list every
+    /// implemented 1300-band code and vice versa.
+    /// </summary>
+    public DocFile? CliCodesDoc { get; init; }
+
+    /// <summary>Docs scanned for a hardcoded current version string.</summary>
+    public IReadOnlyList<DocFile> VersionScanDocs { get; init; } = [];
+}
+
+/// <summary>
+/// Machine-checks agent-facing documentation against the implementation
+/// (Phase 1 item 6: spec single-sourcing + drift detection). Every finding is
+/// a <see cref="Diagnostic"/> in the Calor1320-1329 band.
+/// </summary>
+public static class DocDriftChecker
+{
+    // §KEYWORD or §/KEYWORD references in docs. Keywords are case-sensitive
+    // (e.g. §Pf); a reference is the longest run of identifier characters
+    // after '§' (attributes like {id:...} start at '{' and are excluded).
+    private static readonly Regex KeywordRef = new(@"§(/?[A-Za-z][A-Za-z0-9_]*)", RegexOptions.Compiled);
+
+    // A diagnostic-band citation like "Calor0001–0099", "Calor1300-Calor1399",
+    // or "`Calor1300`–`Calor1399`". Range endpoints need not exist as concrete
+    // codes, but the band must contain at least one implemented code.
+    private static readonly Regex CodeRange = new(
+        @"Calor(?<lo>\d{4})`?\s*[–—-]\s*`?(?:Calor)?(?<hi>\d{4})", RegexOptions.Compiled);
+
+    private static readonly Regex CodeRef = new(@"Calor\d{4}", RegexOptions.Compiled);
+
+    // A markdown table row whose first cell is a backticked effect code,
+    // e.g. "| `fs:rw` | Filesystem read/write | ... |".
+    private static readonly Regex EffectTableRow = new(
+        @"^\|\s*`(?<code>[a-z][a-z0-9]*(?::[a-z0-9]+)*)`\s*\|", RegexOptions.Compiled);
+
+    // A markdown table row whose first cell is a backticked diagnostic code.
+    private static readonly Regex CliCodeTableRow = new(
+        @"^\|\s*`(?<code>Calor\d{4})`\s*\|", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Runs every drift check and returns the findings (empty list = no drift).
+    /// </summary>
+    public static List<Diagnostic> Check(DocDriftInputs inputs)
+    {
+        var diagnostics = new List<Diagnostic>();
+
+        foreach (var doc in inputs.KeywordDocs)
+        {
+            CheckKeywords(doc, inputs.LexerKeywords, diagnostics);
+        }
+
+        foreach (var doc in inputs.DiagnosticCodeDocs)
+        {
+            CheckDiagnosticCodes(doc, inputs.DiagnosticCodes, diagnostics);
+        }
+
+        if (inputs.EffectsReferenceDoc is { } effectsDoc)
+        {
+            CheckEffectCodes(effectsDoc, inputs, requireComplete: true, diagnostics);
+        }
+
+        foreach (var doc in inputs.EffectDocsForwardOnly)
+        {
+            CheckEffectCodes(doc, inputs, requireComplete: false, diagnostics);
+        }
+
+        if (inputs.CliCodesDoc is { } cliDoc)
+        {
+            CheckCliCodeTable(cliDoc, inputs.DiagnosticCodes, diagnostics);
+        }
+
+        foreach (var doc in inputs.VersionScanDocs)
+        {
+            CheckHardcodedVersion(doc, inputs.Version, diagnostics);
+        }
+
+        return diagnostics;
+    }
+
+    /// <summary>
+    /// Builds checker inputs from a repository root, reporting missing files as
+    /// <see cref="DiagnosticCode.DocDriftMissingInput"/> findings.
+    /// </summary>
+    public static DocDriftInputs LoadFromRepository(string root, List<Diagnostic> loadErrors)
+    {
+        var version = ReadVersion(Path.Combine(root, "Directory.Build.props"), loadErrors);
+
+        var claudeMd = LoadDoc(root, "CLAUDE.md", loadErrors);
+        var syntaxIndex = LoadDoc(root, Path.Combine("docs", "syntax-reference", "index.md"), loadErrors);
+        var effectsDoc = LoadDoc(root, Path.Combine("docs", "syntax-reference", "effects.md"), loadErrors);
+        var cliCodesDoc = LoadDoc(root, Path.Combine("docs", "cli", "structured-output.md"), loadErrors);
+
+        var cliDocs = LoadDocsInDirectory(root, Path.Combine("docs", "cli"), loadErrors);
+
+        // Version scan covers all agent-facing docs. Dated planning/experiment
+        // records legitimately cite historical versions and are excluded.
+        string[] versionScanExclusions = ["plans", "experiments", "design", "process"];
+        var versionDocs = LoadDocsInDirectory(root, "docs", loadErrors, recursive: true)
+            .Where(d => !versionScanExclusions.Any(x =>
+                d.Path.StartsWith(Path.Combine("docs", x) + Path.DirectorySeparatorChar, StringComparison.Ordinal)))
+            .ToList();
+
+        return new DocDriftInputs
+        {
+            Version = version,
+            LexerKeywords = Parsing.Lexer.KeywordNames,
+            DiagnosticCodes = GetImplementedDiagnosticCodes(),
+            KnownEffectCodes = Effects.EffectCodes.KnownCompactCodes,
+            DocumentedEffectCodes = Effects.EffectCodes.DocumentedCompactCodes,
+            KeywordDocs = NonNull(claudeMd, syntaxIndex),
+            DiagnosticCodeDocs = NonNull(claudeMd).Concat(cliDocs).ToList(),
+            EffectsReferenceDoc = effectsDoc,
+            EffectDocsForwardOnly = NonNull(syntaxIndex),
+            CliCodesDoc = cliCodesDoc,
+            VersionScanDocs = NonNull(claudeMd).Concat(versionDocs).ToList(),
+        };
+    }
+
+    /// <summary>
+    /// Every diagnostic code declared as a constant on <see cref="DiagnosticCode"/>.
+    /// </summary>
+    public static IReadOnlyCollection<string> GetImplementedDiagnosticCodes()
+    {
+        return typeof(DiagnosticCode)
+            .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+            .Where(f => f.IsLiteral && f.FieldType == typeof(string))
+            .Select(f => (string)f.GetRawConstantValue()!)
+            .Where(v => CodeRef.IsMatch(v))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static void CheckKeywords(
+        DocFile doc, IReadOnlyCollection<string> keywords, List<Diagnostic> diagnostics)
+    {
+        var keywordSet = keywords as ISet<string> ?? new HashSet<string>(keywords, StringComparer.Ordinal);
+        ForEachLine(doc, (line, lineNumber) =>
+        {
+            foreach (Match match in KeywordRef.Matches(line))
+            {
+                var name = match.Groups[1].Value;
+                if (!keywordSet.Contains(name))
+                {
+                    diagnostics.Add(Drift(
+                        DiagnosticCode.DocDriftUnknownKeyword,
+                        $"Documented keyword '§{name}' does not exist in the lexer's keyword table",
+                        doc.Path, lineNumber, match.Index + 1));
+                }
+            }
+        });
+    }
+
+    private static void CheckDiagnosticCodes(
+        DocFile doc, IReadOnlyCollection<string> codes, List<Diagnostic> diagnostics)
+    {
+        var codeSet = codes as ISet<string> ?? new HashSet<string>(codes, StringComparer.Ordinal);
+        var codeNumbers = codes
+            .Select(c => int.Parse(c["Calor".Length..]))
+            .ToArray();
+
+        ForEachLine(doc, (line, lineNumber) =>
+        {
+            // Band citations first: "Calor0800–0899", "Calor1300-Calor1399".
+            var rangeSpans = new List<(int Start, int End)>();
+            foreach (Match range in CodeRange.Matches(line))
+            {
+                rangeSpans.Add((range.Index, range.Index + range.Length));
+                var lo = int.Parse(range.Groups["lo"].Value);
+                var hi = int.Parse(range.Groups["hi"].Value);
+                if (!codeNumbers.Any(n => n >= lo && n <= hi))
+                {
+                    diagnostics.Add(Drift(
+                        DiagnosticCode.DocDriftEmptyDiagnosticRange,
+                        $"Documented diagnostic band Calor{lo:D4}-Calor{hi:D4} contains no implemented diagnostic codes",
+                        doc.Path, lineNumber, range.Index + 1));
+                }
+            }
+
+            // Standalone citations (not part of a band citation) must exist exactly.
+            foreach (Match match in CodeRef.Matches(line))
+            {
+                if (rangeSpans.Any(s => match.Index >= s.Start && match.Index < s.End))
+                {
+                    continue;
+                }
+
+                if (!codeSet.Contains(match.Value))
+                {
+                    diagnostics.Add(Drift(
+                        DiagnosticCode.DocDriftUnknownDiagnosticCode,
+                        $"Documented diagnostic code '{match.Value}' is not defined in DiagnosticCode",
+                        doc.Path, lineNumber, match.Index + 1));
+                }
+            }
+        });
+    }
+
+    private static void CheckEffectCodes(
+        DocFile doc, DocDriftInputs inputs, bool requireComplete, List<Diagnostic> diagnostics)
+    {
+        var known = inputs.KnownEffectCodes as ISet<string>
+            ?? new HashSet<string>(inputs.KnownEffectCodes, StringComparer.Ordinal);
+
+        var (rows, sectionLine) = FindEffectTableRows(doc);
+        if (sectionLine == 0)
+        {
+            diagnostics.Add(Drift(
+                DiagnosticCode.DocDriftMissingInput,
+                "No 'Effect Codes' section with a code table was found",
+                doc.Path, 1, 1));
+            return;
+        }
+
+        var documented = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (code, lineNumber, column) in rows)
+        {
+            documented.Add(code);
+            if (!known.Contains(code))
+            {
+                diagnostics.Add(Drift(
+                    DiagnosticCode.DocDriftUnknownEffectCode,
+                    $"Documented effect code '{code}' is unknown to the compiler's effect-code registry",
+                    doc.Path, lineNumber, column));
+            }
+        }
+
+        if (requireComplete)
+        {
+            foreach (var code in inputs.DocumentedEffectCodes)
+            {
+                if (!documented.Contains(code))
+                {
+                    diagnostics.Add(Drift(
+                        DiagnosticCode.DocDriftUndocumentedEffectCode,
+                        $"Implemented effect code '{code}' is missing from the Effect Codes table",
+                        doc.Path, sectionLine, 1));
+                }
+            }
+        }
+    }
+
+    private static void CheckCliCodeTable(
+        DocFile doc, IReadOnlyCollection<string> codes, List<Diagnostic> diagnostics)
+    {
+        var listed = new HashSet<string>(StringComparer.Ordinal);
+        var tableLine = 0;
+        ForEachLine(doc, (line, lineNumber) =>
+        {
+            var match = CliCodeTableRow.Match(line);
+            if (match.Success)
+            {
+                listed.Add(match.Groups["code"].Value);
+                if (tableLine == 0)
+                {
+                    tableLine = lineNumber;
+                }
+            }
+        });
+
+        if (tableLine == 0)
+        {
+            diagnostics.Add(Drift(
+                DiagnosticCode.DocDriftMissingInput,
+                "No CLI diagnostic-code table (rows starting with a backticked Calor13xx code) was found",
+                doc.Path, 1, 1));
+            return;
+        }
+
+        // Every implemented 1300-band code must be listed. (Codes in the table
+        // that do not exist are caught by the standalone-citation check, which
+        // also scans this file.)
+        foreach (var code in codes.OrderBy(c => c, StringComparer.Ordinal))
+        {
+            var number = int.Parse(code["Calor".Length..]);
+            if (number is >= 1300 and <= 1399 && !listed.Contains(code))
+            {
+                diagnostics.Add(Drift(
+                    DiagnosticCode.DocDriftUndocumentedCliCode,
+                    $"CLI diagnostic code '{code}' is not listed in the CLI diagnostic-code table",
+                    doc.Path, tableLine, 1));
+            }
+        }
+    }
+
+    private static void CheckHardcodedVersion(
+        DocFile doc, string version, List<Diagnostic> diagnostics)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return;
+        }
+
+        var pattern = new Regex($@"(?<![0-9.]){Regex.Escape(version)}(?![0-9.])");
+        ForEachLine(doc, (line, lineNumber) =>
+        {
+            foreach (Match match in pattern.Matches(line))
+            {
+                diagnostics.Add(Drift(
+                    DiagnosticCode.DocDriftHardcodedVersion,
+                    $"Doc hardcodes the current compiler version '{version}'; version is single-sourced in Directory.Build.props",
+                    doc.Path, lineNumber, match.Index + 1));
+            }
+        });
+    }
+
+    private static (List<(string Code, int Line, int Column)> Rows, int SectionLine) FindEffectTableRows(DocFile doc)
+    {
+        var rows = new List<(string, int, int)>();
+        var sectionLine = 0;
+        var inSection = false;
+
+        var lines = doc.Content.Split('\n');
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            if (Regex.IsMatch(line, @"^#{1,6}\s+Effect Codes\s*$"))
+            {
+                inSection = true;
+                sectionLine = i + 1;
+                continue;
+            }
+
+            if (inSection && Regex.IsMatch(line, @"^#{1,6}\s"))
+            {
+                inSection = false;
+                continue;
+            }
+
+            if (inSection)
+            {
+                var match = EffectTableRow.Match(line);
+                if (match.Success)
+                {
+                    rows.Add((match.Groups["code"].Value, i + 1, match.Groups["code"].Index + 1));
+                }
+            }
+        }
+
+        return (rows, sectionLine);
+    }
+
+    private static void ForEachLine(DocFile doc, Action<string, int> action)
+    {
+        var lines = doc.Content.Split('\n');
+        for (var i = 0; i < lines.Length; i++)
+        {
+            action(lines[i], i + 1);
+        }
+    }
+
+    private static Diagnostic Drift(string code, string message, string path, int line, int column)
+        => new(code, DiagnosticSeverity.Error, message, path, line, column);
+
+    private static string ReadVersion(string propsPath, List<Diagnostic> loadErrors)
+    {
+        if (!File.Exists(propsPath))
+        {
+            loadErrors.Add(Drift(
+                DiagnosticCode.DocDriftMissingInput,
+                $"Directory.Build.props not found at '{propsPath}'",
+                propsPath, 1, 1));
+            return "";
+        }
+
+        var match = Regex.Match(File.ReadAllText(propsPath), @"<Version>\s*([^<\s]+)\s*</Version>");
+        if (!match.Success)
+        {
+            loadErrors.Add(Drift(
+                DiagnosticCode.DocDriftMissingInput,
+                $"No <Version> element found in '{propsPath}'",
+                propsPath, 1, 1));
+            return "";
+        }
+
+        return match.Groups[1].Value;
+    }
+
+    private static DocFile? LoadDoc(string root, string relativePath, List<Diagnostic> loadErrors)
+    {
+        var fullPath = Path.Combine(root, relativePath);
+        if (!File.Exists(fullPath))
+        {
+            loadErrors.Add(Drift(
+                DiagnosticCode.DocDriftMissingInput,
+                $"Expected doc file not found: '{relativePath}'",
+                relativePath, 1, 1));
+            return null;
+        }
+
+        return new DocFile(relativePath, File.ReadAllText(fullPath));
+    }
+
+    private static List<DocFile> LoadDocsInDirectory(
+        string root, string relativeDir, List<Diagnostic> loadErrors, bool recursive = false)
+    {
+        var fullDir = Path.Combine(root, relativeDir);
+        if (!Directory.Exists(fullDir))
+        {
+            loadErrors.Add(Drift(
+                DiagnosticCode.DocDriftMissingInput,
+                $"Expected docs directory not found: '{relativeDir}'",
+                relativeDir, 1, 1));
+            return [];
+        }
+
+        return Directory
+            .EnumerateFiles(fullDir, "*.md", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .Select(p => new DocFile(Path.GetRelativePath(root, p), File.ReadAllText(p)))
+            .ToList();
+    }
+
+    private static List<DocFile> NonNull(params DocFile?[] docs)
+        => docs.Where(d => d != null).Select(d => d!).ToList();
+}

--- a/src/Calor.Compiler/SelfCheck/DocDriftChecker.cs
+++ b/src/Calor.Compiler/SelfCheck/DocDriftChecker.cs
@@ -143,7 +143,12 @@ public static class DocDriftChecker
         var effectsDoc = LoadDoc(root, Path.Combine("docs", "syntax-reference", "effects.md"), loadErrors);
         var cliCodesDoc = LoadDoc(root, Path.Combine("docs", "cli", "structured-output.md"), loadErrors);
 
+        var syntaxDocs = LoadDocsInDirectory(root, Path.Combine("docs", "syntax-reference"), loadErrors);
         var cliDocs = LoadDocsInDirectory(root, Path.Combine("docs", "cli"), loadErrors);
+
+        // The scanned set for the keyword and diagnostic-code checks:
+        // CLAUDE.md + every docs/syntax-reference/*.md + every docs/cli/*.md.
+        var scannedDocs = NonNull(claudeMd).Concat(syntaxDocs).Concat(cliDocs).ToList();
 
         // Version scan covers all agent-facing docs. Dated planning/experiment
         // records legitimately cite historical versions and are excluded.
@@ -160,8 +165,8 @@ public static class DocDriftChecker
             DiagnosticCodes = GetImplementedDiagnosticCodes(),
             KnownEffectCodes = Effects.EffectCodes.KnownCompactCodes,
             DocumentedEffectCodes = Effects.EffectCodes.DocumentedCompactCodes,
-            KeywordDocs = NonNull(claudeMd, syntaxIndex),
-            DiagnosticCodeDocs = NonNull(claudeMd).Concat(cliDocs).ToList(),
+            KeywordDocs = scannedDocs,
+            DiagnosticCodeDocs = scannedDocs,
             EffectsReferenceDoc = effectsDoc,
             EffectDocsForwardOnly = NonNull(syntaxIndex),
             CliCodesDoc = cliCodesDoc,

--- a/src/Calor.Compiler/SelfCheck/DocDriftChecker.cs
+++ b/src/Calor.Compiler/SelfCheck/DocDriftChecker.cs
@@ -91,6 +91,14 @@ public static class DocDriftChecker
         @"^\|\s*`(?<code>Calor\d{4})`\s*\|", RegexOptions.Compiled);
 
     /// <summary>
+    /// Inline suppression marker (meta-notation escape). A line containing
+    /// this marker suppresses all drift findings on the <em>next</em> line —
+    /// use it for intentional placeholders like <c>§/X</c> or hypothetical
+    /// diagnostic codes. See docs/cli/self-check.md.
+    /// </summary>
+    public const string SuppressionMarker = "<!-- drift:ignore -->";
+
+    /// <summary>
     /// Runs every drift check and returns the findings (empty list = no drift).
     /// </summary>
     public static List<Diagnostic> Check(DocDriftInputs inputs)
@@ -192,20 +200,26 @@ public static class DocDriftChecker
         DocFile doc, IReadOnlyCollection<string> keywords, List<Diagnostic> diagnostics)
     {
         var keywordSet = keywords as ISet<string> ?? new HashSet<string>(keywords, StringComparer.Ordinal);
-        ForEachLine(doc, (line, lineNumber) =>
+        foreach (var line in ClassifyLines(doc))
         {
-            foreach (Match match in KeywordRef.Matches(line))
+            if (line.InForeignFence || line.Suppressed)
+            {
+                continue;
+            }
+
+            foreach (Match match in KeywordRef.Matches(line.Text))
             {
                 var name = match.Groups[1].Value;
                 if (!keywordSet.Contains(name))
                 {
                     diagnostics.Add(Drift(
                         DiagnosticCode.DocDriftUnknownKeyword,
-                        $"Documented keyword '§{name}' does not exist in the lexer's keyword table",
-                        doc.Path, lineNumber, match.Index + 1));
+                        $"Documented keyword '§{name}' does not exist in the lexer's keyword table " +
+                        $"(if this is intentional meta-notation, put '{SuppressionMarker}' on the preceding line)",
+                        doc.Path, line.Number, match.Index + 1));
                 }
             }
-        });
+        }
     }
 
     private static void CheckDiagnosticCodes(
@@ -216,11 +230,16 @@ public static class DocDriftChecker
             .Select(c => int.Parse(c["Calor".Length..]))
             .ToArray();
 
-        ForEachLine(doc, (line, lineNumber) =>
+        foreach (var line in ClassifyLines(doc))
         {
+            if (line.InForeignFence || line.Suppressed)
+            {
+                continue;
+            }
+
             // Band citations first: "Calor0800–0899", "Calor1300-Calor1399".
             var rangeSpans = new List<(int Start, int End)>();
-            foreach (Match range in CodeRange.Matches(line))
+            foreach (Match range in CodeRange.Matches(line.Text))
             {
                 rangeSpans.Add((range.Index, range.Index + range.Length));
                 var lo = int.Parse(range.Groups["lo"].Value);
@@ -230,12 +249,12 @@ public static class DocDriftChecker
                     diagnostics.Add(Drift(
                         DiagnosticCode.DocDriftEmptyDiagnosticRange,
                         $"Documented diagnostic band Calor{lo:D4}-Calor{hi:D4} contains no implemented diagnostic codes",
-                        doc.Path, lineNumber, range.Index + 1));
+                        doc.Path, line.Number, range.Index + 1));
                 }
             }
 
             // Standalone citations (not part of a band citation) must exist exactly.
-            foreach (Match match in CodeRef.Matches(line))
+            foreach (Match match in CodeRef.Matches(line.Text))
             {
                 if (rangeSpans.Any(s => match.Index >= s.Start && match.Index < s.End))
                 {
@@ -246,11 +265,12 @@ public static class DocDriftChecker
                 {
                     diagnostics.Add(Drift(
                         DiagnosticCode.DocDriftUnknownDiagnosticCode,
-                        $"Documented diagnostic code '{match.Value}' is not defined in DiagnosticCode",
-                        doc.Path, lineNumber, match.Index + 1));
+                        $"Documented diagnostic code '{match.Value}' is not defined in DiagnosticCode " +
+                        $"(if this is intentional meta-notation, put '{SuppressionMarker}' on the preceding line)",
+                        doc.Path, line.Number, match.Index + 1));
                 }
             }
-        });
+        }
     }
 
     private static void CheckEffectCodes(
@@ -270,10 +290,10 @@ public static class DocDriftChecker
         }
 
         var documented = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var (code, lineNumber, column) in rows)
+        foreach (var (code, lineNumber, column, suppressed) in rows)
         {
             documented.Add(code);
-            if (!known.Contains(code))
+            if (!known.Contains(code) && !suppressed)
             {
                 diagnostics.Add(Drift(
                     DiagnosticCode.DocDriftUnknownEffectCode,
@@ -348,22 +368,30 @@ public static class DocDriftChecker
             return;
         }
 
+        // The version scan deliberately looks inside all fenced blocks (a
+        // hardcoded version in an install snippet is exactly the drift it
+        // exists to catch); only the suppression marker exempts a line.
         var pattern = new Regex($@"(?<![0-9.]){Regex.Escape(version)}(?![0-9.])");
-        ForEachLine(doc, (line, lineNumber) =>
+        foreach (var line in ClassifyLines(doc))
         {
-            foreach (Match match in pattern.Matches(line))
+            if (line.Suppressed)
+            {
+                continue;
+            }
+
+            foreach (Match match in pattern.Matches(line.Text))
             {
                 diagnostics.Add(Drift(
                     DiagnosticCode.DocDriftHardcodedVersion,
                     $"Doc hardcodes the current compiler version '{version}'; version is single-sourced in Directory.Build.props",
-                    doc.Path, lineNumber, match.Index + 1));
+                    doc.Path, line.Number, match.Index + 1));
             }
-        });
+        }
     }
 
-    private static (List<(string Code, int Line, int Column)> Rows, int SectionLine) FindEffectTableRows(DocFile doc)
+    private static (List<(string Code, int Line, int Column, bool Suppressed)> Rows, int SectionLine) FindEffectTableRows(DocFile doc)
     {
-        var rows = new List<(string, int, int)>();
+        var rows = new List<(string, int, int, bool)>();
         var sectionLine = 0;
         var inSection = false;
 
@@ -389,7 +417,8 @@ public static class DocDriftChecker
                 var match = EffectTableRow.Match(line);
                 if (match.Success)
                 {
-                    rows.Add((match.Groups["code"].Value, i + 1, match.Groups["code"].Index + 1));
+                    var suppressed = i > 0 && lines[i - 1].Contains(SuppressionMarker, StringComparison.Ordinal);
+                    rows.Add((match.Groups["code"].Value, i + 1, match.Groups["code"].Index + 1, suppressed));
                 }
             }
         }
@@ -404,6 +433,46 @@ public static class DocDriftChecker
         {
             action(lines[i], i + 1);
         }
+    }
+
+    /// <summary>
+    /// One markdown line with its scan classification: whether keyword /
+    /// diagnostic-code scanning applies (false inside fenced code blocks whose
+    /// info string is something other than <c>calor</c>, e.g. ```csharp or
+    /// ```text — bare ``` fences and ```calor fences are scanned), and whether
+    /// the preceding line carried the <see cref="SuppressionMarker"/>.
+    /// </summary>
+    private sealed record ScannedLine(string Text, int Number, bool InForeignFence, bool Suppressed);
+
+    private static List<ScannedLine> ClassifyLines(DocFile doc)
+    {
+        var lines = doc.Content.Split('\n');
+        var result = new List<ScannedLine>(lines.Length);
+        string? fenceInfo = null; // non-null while inside a fenced code block
+        var previousHadMarker = false;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var trimmed = line.TrimEnd('\r').TrimStart();
+            var isFenceDelimiter = trimmed.StartsWith("```", StringComparison.Ordinal);
+            var inForeignFence = fenceInfo is not (null or "" or "calor");
+
+            if (isFenceDelimiter)
+            {
+                fenceInfo = fenceInfo == null
+                    ? trimmed[3..].Trim()   // opening fence: capture the info string
+                    : null;                 // closing fence
+                // The opening delimiter line itself is skipped for foreign
+                // fences (its info string is not Calor syntax either way).
+                inForeignFence = inForeignFence || fenceInfo is not (null or "" or "calor");
+            }
+
+            result.Add(new ScannedLine(line, i + 1, inForeignFence, previousHadMarker));
+            previousHadMarker = line.Contains(SuppressionMarker, StringComparison.Ordinal);
+        }
+
+        return result;
     }
 
     private static Diagnostic Drift(string code, string message, string path, int line, int column)

--- a/src/Calor.Compiler/SelfCheck/DocDriftChecker.cs
+++ b/src/Calor.Compiler/SelfCheck/DocDriftChecker.cs
@@ -39,6 +39,14 @@ public sealed class DocDriftInputs
     public IReadOnlyList<DocFile> DiagnosticCodeDocs { get; init; } = [];
 
     /// <summary>
+    /// Docs whose fenced <c>```calor</c> examples are parse-checked with the
+    /// real lexer and parser. Only blocks whose first non-blank line starts
+    /// with §M are checked (the complete-program convention); anything else is
+    /// treated as a deliberate fragment and skipped.
+    /// </summary>
+    public IReadOnlyList<DocFile> ParseExampleDocs { get; init; } = [];
+
+    /// <summary>
     /// The effect-code reference doc (docs/syntax-reference/effects.md): its
     /// "Effect Codes" table is checked in both directions (unknown codes flagged,
     /// and every documented effect code must be present).
@@ -115,6 +123,11 @@ public static class DocDriftChecker
             CheckDiagnosticCodes(doc, inputs.DiagnosticCodes, diagnostics);
         }
 
+        foreach (var doc in inputs.ParseExampleDocs)
+        {
+            CheckCalorExamples(doc, diagnostics);
+        }
+
         if (inputs.EffectsReferenceDoc is { } effectsDoc)
         {
             CheckEffectCodes(effectsDoc, inputs, requireComplete: true, diagnostics);
@@ -175,6 +188,7 @@ public static class DocDriftChecker
             DocumentedEffectCodes = Effects.EffectCodes.DocumentedCompactCodes,
             KeywordDocs = scannedDocs,
             DiagnosticCodeDocs = scannedDocs,
+            ParseExampleDocs = scannedDocs,
             EffectsReferenceDoc = effectsDoc,
             EffectDocsForwardOnly = NonNull(syntaxIndex),
             CliCodesDoc = cliCodesDoc,
@@ -271,6 +285,104 @@ public static class DocDriftChecker
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Parse-checks fenced <c>```calor</c> examples with the real lexer and
+    /// parser. A block whose first non-blank line starts with §M declares a
+    /// complete program and must parse cleanly; any other block is a fragment
+    /// and is skipped. A <see cref="SuppressionMarker"/> on the line before
+    /// the opening fence exempts the whole block.
+    /// </summary>
+    private static void CheckCalorExamples(DocFile doc, List<Diagnostic> diagnostics)
+    {
+        foreach (var block in FindCalorFences(doc))
+        {
+            var firstContent = block.Lines.FirstOrDefault(l => !string.IsNullOrWhiteSpace(l));
+            if (block.Suppressed ||
+                firstContent == null ||
+                !firstContent.TrimStart().StartsWith("§M", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var source = string.Join("\n", block.Lines) + "\n";
+            var bag = new DiagnosticBag();
+            try
+            {
+                var lexer = new Parsing.Lexer(source, bag);
+                var tokens = lexer.TokenizeAllForParser();
+                if (!bag.HasErrors)
+                {
+                    _ = new Parsing.Parser(tokens, bag).Parse();
+                }
+            }
+            catch (Exception ex)
+            {
+                diagnostics.Add(Drift(
+                    DiagnosticCode.DocDriftExampleParseError,
+                    $"Fenced calor example crashed the parser: {ex.Message}",
+                    doc.Path, block.FirstContentLine, 1));
+                continue;
+            }
+
+            foreach (var error in bag.Errors)
+            {
+                diagnostics.Add(Drift(
+                    DiagnosticCode.DocDriftExampleParseError,
+                    $"Fenced calor example no longer parses: {error.Code}: {error.Message}",
+                    doc.Path,
+                    block.FirstContentLine + Math.Max(error.Span.Line - 1, 0),
+                    Math.Max(error.Span.Column, 1)));
+            }
+        }
+    }
+
+    /// <summary>A fenced ```calor block: its content lines (CR stripped), the
+    /// document line number of the first content line, and whether the line
+    /// before the opening fence carried the suppression marker.</summary>
+    private sealed record CalorFence(List<string> Lines, int FirstContentLine, bool Suppressed);
+
+    private static List<CalorFence> FindCalorFences(DocFile doc)
+    {
+        var fences = new List<CalorFence>();
+        var lines = doc.Content.Split('\n');
+        string? fenceInfo = null;
+        CalorFence? current = null;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var trimmed = lines[i].TrimEnd('\r').TrimStart();
+            if (trimmed.StartsWith("```", StringComparison.Ordinal))
+            {
+                if (fenceInfo == null)
+                {
+                    fenceInfo = trimmed[3..].Trim();
+                    if (fenceInfo == "calor")
+                    {
+                        var suppressed = i > 0 &&
+                            lines[i - 1].Contains(SuppressionMarker, StringComparison.Ordinal);
+                        current = new CalorFence([], i + 2, suppressed);
+                    }
+                }
+                else
+                {
+                    if (current != null)
+                    {
+                        fences.Add(current);
+                        current = null;
+                    }
+
+                    fenceInfo = null;
+                }
+
+                continue;
+            }
+
+            current?.Lines.Add(lines[i].TrimEnd('\r'));
+        }
+
+        return fences;
     }
 
     private static void CheckEffectCodes(

--- a/src/Calor.Compiler/Verification/ContractVerificationPass.cs
+++ b/src/Calor.Compiler/Verification/ContractVerificationPass.cs
@@ -81,7 +81,7 @@ public sealed class ContractVerificationPass
                 {
                     _diagnostics.ReportInfo(
                         module.Span,
-                        "Calor0705",
+                        DiagnosticCode.VerificationCacheStats,
                         $"Verification cache: {stats.Hits} hits, {stats.Misses} misses ({stats.HitRate:F1}% hit rate)");
                 }
             }
@@ -174,7 +174,7 @@ public sealed class ContractVerificationPass
             {
                 _diagnostics.ReportWarning(
                     postNode.Span,
-                    "Calor0702",
+                    DiagnosticCode.PostconditionMayBeViolated,
                     $"Postcondition may be violated in function '{function.Name}'. {postResult.CounterexampleDescription}");
             }
         }
@@ -191,7 +191,7 @@ public sealed class ContractVerificationPass
                 {
                     _diagnostics.ReportInfo(
                         postNode.Span,
-                        "Calor0703",
+                        DiagnosticCode.PostconditionProven,
                         $"Postcondition statically verified in function '{function.Name}'. Runtime check elided.");
                 }
             }
@@ -211,11 +211,11 @@ public sealed class ContractVerificationPass
 
         if (summary.Disproven > 0)
         {
-            _diagnostics.ReportInfo(module.Span, "Calor0704", message);
+            _diagnostics.ReportInfo(module.Span, DiagnosticCode.VerificationSummary, message);
         }
         else if (_options.Verbose)
         {
-            _diagnostics.ReportInfo(module.Span, "Calor0704", message);
+            _diagnostics.ReportInfo(module.Span, DiagnosticCode.VerificationSummary, message);
         }
     }
 

--- a/tests/Calor.Compiler.Tests/DocDriftCheckerTests.cs
+++ b/tests/Calor.Compiler.Tests/DocDriftCheckerTests.cs
@@ -1,0 +1,272 @@
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Effects;
+using Calor.Compiler.Parsing;
+using Calor.Compiler.SelfCheck;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for the docs-drift checker behind <c>calor self-check docs</c>
+/// (Phase 1 item 6: spec single-sourcing). Each test injects a fake drifted
+/// doc string and asserts the drift is detected — or that clean docs pass.
+/// </summary>
+public class DocDriftCheckerTests
+{
+    private static DocDriftInputs BaseInputs(
+        DocFile[]? keywordDocs = null,
+        DocFile[]? diagnosticCodeDocs = null,
+        DocFile? effectsReferenceDoc = null,
+        DocFile[]? effectDocsForwardOnly = null,
+        DocFile? cliCodesDoc = null,
+        DocFile[]? versionScanDocs = null)
+    {
+        return new DocDriftInputs
+        {
+            Version = "0.9.9",
+            LexerKeywords = ["M", "F", "EACH", "/C", "IV", "Pf", "PP", "/PP"],
+            DiagnosticCodes = ["Calor0001", "Calor0830", "Calor1300", "Calor1310", "Calor1320"],
+            KnownEffectCodes = ["cw", "mut", "mut:col", "fw"],
+            DocumentedEffectCodes = ["cw", "mut", "mut:col"],
+            KeywordDocs = keywordDocs ?? [],
+            DiagnosticCodeDocs = diagnosticCodeDocs ?? [],
+            EffectsReferenceDoc = effectsReferenceDoc,
+            EffectDocsForwardOnly = effectDocsForwardOnly ?? [],
+            CliCodesDoc = cliCodesDoc,
+            VersionScanDocs = versionScanDocs ?? [],
+        };
+    }
+
+    // --- Keyword drift (the §FOREACH-vs-§EACH class) ---
+
+    [Fact]
+    public void UnknownKeywordIsDetected()
+    {
+        var doc = new DocFile("fake.md", "Use `§FOREACH{id}` to loop over collections.");
+        var findings = DocDriftChecker.Check(BaseInputs(keywordDocs: [doc]));
+
+        var finding = Assert.Single(findings);
+        Assert.Equal(DiagnosticCode.DocDriftUnknownKeyword, finding.Code);
+        Assert.Contains("§FOREACH", finding.Message);
+        Assert.Equal("fake.md", finding.FilePath);
+        Assert.Equal(1, finding.Span.Line);
+    }
+
+    [Fact]
+    public void KnownKeywordsPass()
+    {
+        var doc = new DocFile("fake.md",
+            "`§M{Name}` opens a module, `§EACH` iterates, `§/C` closes calls,\n" +
+            "`§IV (expr)` declares an invariant, `§Pf` prints, `§PP{X}`...`§/PP{X}` wraps.");
+        var findings = DocDriftChecker.Check(BaseInputs(keywordDocs: [doc]));
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void UnknownClosingKeywordIsDetected()
+    {
+        var doc = new DocFile("fake.md", "Close with `§/FOREACH`.");
+        var findings = DocDriftChecker.Check(BaseInputs(keywordDocs: [doc]));
+
+        var finding = Assert.Single(findings);
+        Assert.Equal(DiagnosticCode.DocDriftUnknownKeyword, finding.Code);
+        Assert.Contains("§/FOREACH", finding.Message);
+    }
+
+    // --- Diagnostic-code drift (the Calor0820-vs-0830 class) ---
+
+    [Fact]
+    public void UnknownDiagnosticCodeIsDetected()
+    {
+        var doc = new DocFile("fake.md", "Closer tags raise `Calor0820`.");
+        var findings = DocDriftChecker.Check(BaseInputs(diagnosticCodeDocs: [doc]));
+
+        var finding = Assert.Single(findings);
+        Assert.Equal(DiagnosticCode.DocDriftUnknownDiagnosticCode, finding.Code);
+        Assert.Contains("Calor0820", finding.Message);
+    }
+
+    [Fact]
+    public void KnownDiagnosticCodeAndPopulatedRangePass()
+    {
+        var doc = new DocFile("fake.md",
+            "Closer tags raise `Calor0830`. Bands: Calor0001–0099 (lexer), `Calor1300`–`Calor1399` (CLI).");
+        var findings = DocDriftChecker.Check(BaseInputs(diagnosticCodeDocs: [doc]));
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void EmptyDiagnosticRangeIsDetected()
+    {
+        var doc = new DocFile("fake.md", "Reserved: Calor5000–5099 (future).");
+        var findings = DocDriftChecker.Check(BaseInputs(diagnosticCodeDocs: [doc]));
+
+        var finding = Assert.Single(findings);
+        Assert.Equal(DiagnosticCode.DocDriftEmptyDiagnosticRange, finding.Code);
+    }
+
+    [Fact]
+    public void RangeEndpointsAreNotRequiredToExistIndividually()
+    {
+        // Calor1399 does not exist as a concrete code, but the 1300 band is populated.
+        var doc = new DocFile("fake.md", "CLI codes are Calor1300-Calor1399.");
+        var findings = DocDriftChecker.Check(BaseInputs(diagnosticCodeDocs: [doc]));
+
+        Assert.Empty(findings);
+    }
+
+    // --- Effect-code drift (the undocumented-mut class) ---
+
+    private const string EffectsDocHeader = "# Effects\n\n## Effect Codes\n\n| Code | Effect |\n|:-----|:-------|\n";
+
+    [Fact]
+    public void UndocumentedEffectCodeIsDetected()
+    {
+        // 'mut' and 'mut:col' are implemented but missing from the table.
+        var doc = new DocFile("effects.md", EffectsDocHeader + "| `cw` | Console write |\n");
+        var findings = DocDriftChecker.Check(BaseInputs(effectsReferenceDoc: doc));
+
+        Assert.Equal(2, findings.Count);
+        Assert.All(findings, f => Assert.Equal(DiagnosticCode.DocDriftUndocumentedEffectCode, f.Code));
+        Assert.Contains(findings, f => f.Message.Contains("'mut'"));
+        Assert.Contains(findings, f => f.Message.Contains("'mut:col'"));
+    }
+
+    [Fact]
+    public void UnknownEffectCodeIsDetected()
+    {
+        var doc = new DocFile("effects.md", EffectsDocHeader +
+            "| `cw` | Console write |\n| `mut` | Mutation |\n| `mut:col` | Collection mutation |\n| `zap` | Not real |\n");
+        var findings = DocDriftChecker.Check(BaseInputs(effectsReferenceDoc: doc));
+
+        var finding = Assert.Single(findings);
+        Assert.Equal(DiagnosticCode.DocDriftUnknownEffectCode, finding.Code);
+        Assert.Contains("'zap'", finding.Message);
+    }
+
+    [Fact]
+    public void CompleteEffectTablePasses()
+    {
+        var doc = new DocFile("effects.md", EffectsDocHeader +
+            "| `cw` | Console write |\n| `mut` | Mutation |\n| `mut:col` | Collection mutation |\n");
+        var findings = DocDriftChecker.Check(BaseInputs(effectsReferenceDoc: doc));
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void LegacyEffectCodesAreAcceptedButNotRequired()
+    {
+        // 'fw' is legacy: allowed in the table, but its absence is not drift.
+        var doc = new DocFile("effects.md", EffectsDocHeader +
+            "| `cw` | Console write |\n| `mut` | Mutation |\n| `mut:col` | Collection mutation |\n| `fw` | Legacy file write |\n");
+        var findings = DocDriftChecker.Check(BaseInputs(effectsReferenceDoc: doc));
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void ForwardOnlyEffectDocNeedNotBeComplete()
+    {
+        var doc = new DocFile("index.md", EffectsDocHeader + "| `cw` | Console write |\n");
+        var findings = DocDriftChecker.Check(BaseInputs(effectDocsForwardOnly: [doc]));
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void MissingEffectCodesSectionIsDetected()
+    {
+        var doc = new DocFile("effects.md", "# Effects\n\nNo table here.\n");
+        var findings = DocDriftChecker.Check(BaseInputs(effectsReferenceDoc: doc));
+
+        var finding = Assert.Single(findings);
+        Assert.Equal(DiagnosticCode.DocDriftMissingInput, finding.Code);
+    }
+
+    // --- CLI code-table completeness ---
+
+    [Fact]
+    public void MissingCliCodeTableEntryIsDetected()
+    {
+        var doc = new DocFile("structured-output.md",
+            "| Code | Meaning |\n|:-----|:--------|\n| `Calor1300` | Lint finding |\n| `Calor1310` | Input not found |\n");
+        var findings = DocDriftChecker.Check(BaseInputs(cliCodesDoc: doc));
+
+        var finding = Assert.Single(findings);
+        Assert.Equal(DiagnosticCode.DocDriftUndocumentedCliCode, finding.Code);
+        Assert.Contains("Calor1320", finding.Message);
+    }
+
+    [Fact]
+    public void CompleteCliCodeTablePasses()
+    {
+        var doc = new DocFile("structured-output.md",
+            "| `Calor1300` | Lint |\n| `Calor1310` | Input |\n| `Calor1320` | Drift |\n");
+        var findings = DocDriftChecker.Check(BaseInputs(cliCodesDoc: doc));
+
+        Assert.Empty(findings);
+    }
+
+    // --- Hardcoded version (the stale-0.3.5 class) ---
+
+    [Fact]
+    public void HardcodedCurrentVersionIsDetected()
+    {
+        var doc = new DocFile("fake.md", "Install calor 0.9.9 from NuGet.");
+        var findings = DocDriftChecker.Check(BaseInputs(versionScanDocs: [doc]));
+
+        var finding = Assert.Single(findings);
+        Assert.Equal(DiagnosticCode.DocDriftHardcodedVersion, finding.Code);
+    }
+
+    [Fact]
+    public void OtherVersionStringsAreNotFlagged()
+    {
+        var doc = new DocFile("fake.md",
+            "Historic release 0.3.5; unrelated 10.9.9 and 0.9.9.1 and v0.9.90 are fine.");
+        var findings = DocDriftChecker.Check(BaseInputs(versionScanDocs: [doc]));
+
+        Assert.Empty(findings);
+    }
+
+    // --- Ground truth wiring: the real registries are enumerable ---
+
+    [Fact]
+    public void LexerExposesKeywordsIncludingSpecialForms()
+    {
+        Assert.Contains("EACH", Lexer.KeywordNames);
+        Assert.Contains("IV", Lexer.KeywordNames);
+        Assert.Contains("PP", Lexer.KeywordNames);
+        Assert.Contains("/PP", Lexer.KeywordNames);
+        Assert.DoesNotContain("FOREACH", Lexer.KeywordNames);
+        Assert.DoesNotContain("INV", Lexer.KeywordNames);
+    }
+
+    [Fact]
+    public void EffectCodeRegistryPreservesToCompactBehavior()
+    {
+        Assert.Equal("cw", EffectCodes.ToCompact("io", "console_write"));
+        Assert.Equal("fs:r", EffectCodes.ToCompact("IO", "Filesystem_Read"));
+        Assert.Equal("mut:col", EffectCodes.ToCompact("mutation", "collection"));
+        Assert.Equal("db:r", EffectCodes.ToCompact("io", "dbr"));
+        Assert.Equal("something_else", EffectCodes.ToCompact("io", "something_else"));
+
+        Assert.Contains("mut", EffectCodes.DocumentedCompactCodes);
+        Assert.Contains("mut:col", EffectCodes.DocumentedCompactCodes);
+        Assert.DoesNotContain("fw", EffectCodes.DocumentedCompactCodes);
+        Assert.Contains("fw", EffectCodes.KnownCompactCodes);
+    }
+
+    [Fact]
+    public void ImplementedDiagnosticCodesIncludeKnownConstants()
+    {
+        var codes = DocDriftChecker.GetImplementedDiagnosticCodes();
+        Assert.Contains("Calor0830", codes);
+        Assert.Contains("Calor0702", codes); // verification-pass code, registered via constant
+        Assert.Contains("Calor1320", codes);
+        Assert.DoesNotContain("Calor9876", codes);
+    }
+}

--- a/tests/Calor.Compiler.Tests/DocDriftCheckerTests.cs
+++ b/tests/Calor.Compiler.Tests/DocDriftCheckerTests.cs
@@ -210,6 +210,74 @@ public class DocDriftCheckerTests
         Assert.Empty(findings);
     }
 
+    // --- Meta-notation escapes: foreign fences and the suppression marker ---
+
+    [Fact]
+    public void FencedBlocksWithForeignInfoStringAreNotScanned()
+    {
+        var doc = new DocFile("fake.md",
+            "Prose.\n\n```text\n§FOREACH is hypothetical here.\n```\n\n" +
+            "```csharp\n// mentions Calor9876 in C# code\nvar s = \"§BOGUS\";\n```\n");
+        var findings = DocDriftChecker.Check(BaseInputs(keywordDocs: [doc], diagnosticCodeDocs: [doc]));
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void BareAndCalorFencesAreStillScanned()
+    {
+        var doc = new DocFile("fake.md",
+            "```\n§FOREACH{x} items\n```\n\n```calor\n§FOREACH{y} items\n```\n");
+        var findings = DocDriftChecker.Check(BaseInputs(keywordDocs: [doc]));
+
+        Assert.Equal(2, findings.Count);
+        Assert.All(findings, f => Assert.Equal(DiagnosticCode.DocDriftUnknownKeyword, f.Code));
+        Assert.Equal(new[] { 2, 6 }, findings.Select(f => f.Span.Line).OrderBy(l => l).ToArray());
+    }
+
+    [Fact]
+    public void SuppressionMarkerCoversTheNextLineOnly()
+    {
+        var doc = new DocFile("fake.md",
+            "<!-- drift:ignore -->\nAn explicit `§/X` raises an error.\nBut `§/Y` here is drift.\n");
+        var findings = DocDriftChecker.Check(BaseInputs(keywordDocs: [doc]));
+
+        var finding = Assert.Single(findings);
+        Assert.Contains("§/Y", finding.Message);
+        Assert.Equal(3, finding.Span.Line);
+    }
+
+    [Fact]
+    public void SuppressionMarkerMayTrailThePrecedingLine()
+    {
+        var doc = new DocFile("fake.md",
+            "| Ops | `(+ a b)` | <!-- drift:ignore -->\n| Block end | _(no `§/X` needed)_ |\n");
+        var findings = DocDriftChecker.Check(BaseInputs(keywordDocs: [doc]));
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void SuppressionMarkerAppliesToDiagnosticCodeAndVersionScans()
+    {
+        var doc = new DocFile("fake.md",
+            "<!-- drift:ignore -->\nA hypothetical `Calor9876` code.\n" +
+            "<!-- drift:ignore -->\nHistoric example: version 0.9.9 shipped it.\n");
+        var findings = DocDriftChecker.Check(BaseInputs(diagnosticCodeDocs: [doc], versionScanDocs: [doc]));
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void UnknownKeywordMessageMentionsTheSuppressionMarker()
+    {
+        var doc = new DocFile("fake.md", "Use `§BOGUS` here.");
+        var findings = DocDriftChecker.Check(BaseInputs(keywordDocs: [doc]));
+
+        var finding = Assert.Single(findings);
+        Assert.Contains(DocDriftChecker.SuppressionMarker, finding.Message);
+    }
+
     // --- Hardcoded version (the stale-0.3.5 class) ---
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/DocDriftCheckerTests.cs
+++ b/tests/Calor.Compiler.Tests/DocDriftCheckerTests.cs
@@ -241,6 +241,12 @@ public class DocDriftCheckerTests
         Assert.Contains("IV", Lexer.KeywordNames);
         Assert.Contains("PP", Lexer.KeywordNames);
         Assert.Contains("/PP", Lexer.KeywordNames);
+        Assert.Contains("PPE", Lexer.KeywordNames);
+        Assert.Contains("CS", Lexer.KeywordNames);
+        Assert.Contains("RAW", Lexer.KeywordNames);
+        Assert.Contains("/RAW", Lexer.KeywordNames);
+        Assert.Contains("CSHARP", Lexer.KeywordNames);
+        Assert.Contains("/CSHARP", Lexer.KeywordNames);
         Assert.DoesNotContain("FOREACH", Lexer.KeywordNames);
         Assert.DoesNotContain("INV", Lexer.KeywordNames);
     }
@@ -268,5 +274,69 @@ public class DocDriftCheckerTests
         Assert.Contains("Calor0702", codes); // verification-pass code, registered via constant
         Assert.Contains("Calor1320", codes);
         Assert.DoesNotContain("Calor9876", codes);
+    }
+
+    // --- Coverage probes: LoadFromRepository must scan the full doc set.
+    // Reviewer cases: §BOGUS planted in docs/syntax-reference/structure-tags.md
+    // and Calor9876 planted in docs/syntax-reference/index.md must be detected.
+
+    private static string CreateFakeRepo(
+        string structureTagsContent = "# Structure Tags\n",
+        string syntaxIndexContent = "# Syntax Reference\n")
+    {
+        var root = Path.Combine(Path.GetTempPath(), "calor-drift-probe-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "docs", "syntax-reference"));
+        Directory.CreateDirectory(Path.Combine(root, "docs", "cli"));
+        File.WriteAllText(
+            Path.Combine(root, "Directory.Build.props"),
+            "<Project><PropertyGroup><Version>9.9.9</Version></PropertyGroup></Project>");
+        File.WriteAllText(Path.Combine(root, "CLAUDE.md"), "# CLAUDE\n");
+        File.WriteAllText(Path.Combine(root, "docs", "syntax-reference", "index.md"), syntaxIndexContent);
+        File.WriteAllText(Path.Combine(root, "docs", "syntax-reference", "structure-tags.md"), structureTagsContent);
+        File.WriteAllText(Path.Combine(root, "docs", "syntax-reference", "effects.md"), "# Effects\n");
+        File.WriteAllText(Path.Combine(root, "docs", "cli", "structured-output.md"), "# Structured Output\n");
+        return root;
+    }
+
+    private static List<Diagnostic> CheckFakeRepo(string root)
+    {
+        try
+        {
+            var loadErrors = new List<Diagnostic>();
+            var inputs = DocDriftChecker.LoadFromRepository(root, loadErrors);
+            var findings = DocDriftChecker.Check(inputs);
+            findings.AddRange(loadErrors);
+            return findings;
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RepositoryScanDetectsUnknownKeywordPlantedInStructureTagsDoc()
+    {
+        var root = CreateFakeRepo(
+            structureTagsContent: "# Structure Tags\n\nClose every block with `§BOGUS`.\n");
+        var findings = CheckFakeRepo(root);
+
+        var finding = Assert.Single(findings, f => f.Code == DiagnosticCode.DocDriftUnknownKeyword);
+        Assert.Contains("§BOGUS", finding.Message);
+        Assert.Contains("structure-tags.md", finding.FilePath);
+        Assert.Equal(3, finding.Span.Line);
+    }
+
+    [Fact]
+    public void RepositoryScanDetectsUnknownDiagnosticCodePlantedInSyntaxIndex()
+    {
+        var root = CreateFakeRepo(
+            syntaxIndexContent: "# Syntax Reference\n\nViolations raise `Calor9876`.\n");
+        var findings = CheckFakeRepo(root);
+
+        var finding = Assert.Single(findings, f => f.Code == DiagnosticCode.DocDriftUnknownDiagnosticCode);
+        Assert.Contains("Calor9876", finding.Message);
+        Assert.Contains("index.md", finding.FilePath);
+        Assert.Equal(3, finding.Span.Line);
     }
 }

--- a/tests/Calor.Compiler.Tests/DocDriftCheckerTests.cs
+++ b/tests/Calor.Compiler.Tests/DocDriftCheckerTests.cs
@@ -16,6 +16,7 @@ public class DocDriftCheckerTests
     private static DocDriftInputs BaseInputs(
         DocFile[]? keywordDocs = null,
         DocFile[]? diagnosticCodeDocs = null,
+        DocFile[]? parseExampleDocs = null,
         DocFile? effectsReferenceDoc = null,
         DocFile[]? effectDocsForwardOnly = null,
         DocFile? cliCodesDoc = null,
@@ -30,6 +31,7 @@ public class DocDriftCheckerTests
             DocumentedEffectCodes = ["cw", "mut", "mut:col"],
             KeywordDocs = keywordDocs ?? [],
             DiagnosticCodeDocs = diagnosticCodeDocs ?? [],
+            ParseExampleDocs = parseExampleDocs ?? [],
             EffectsReferenceDoc = effectsReferenceDoc,
             EffectDocsForwardOnly = effectDocsForwardOnly ?? [],
             CliCodesDoc = cliCodesDoc,
@@ -276,6 +278,75 @@ public class DocDriftCheckerTests
 
         var finding = Assert.Single(findings);
         Assert.Contains(DocDriftChecker.SuppressionMarker, finding.Message);
+    }
+
+    // --- Parse-the-examples (the rotted-snippet class) ---
+
+    private const string FizzBuzzExample =
+        "§M{m001:FizzBuzz}\n" +
+        "  §F{f001:Main:pub} () -> void\n" +
+        "    §E{cw}\n" +
+        "    §L{for1:i:1:100:1}\n" +
+        "      §IF{if1} (== (% i 15) 0)\n" +
+        "        §P \"FizzBuzz\"\n" +
+        "      §EI (== (% i 3) 0)\n" +
+        "        §P \"Fizz\"\n" +
+        "      §EL\n" +
+        "        §P i\n";
+
+    [Fact]
+    public void CompleteProgramExampleThatParsesPasses()
+    {
+        var doc = new DocFile("fake.md", "Example:\n\n```calor\n" + FizzBuzzExample + "```\n");
+        var findings = DocDriftChecker.Check(BaseInputs(parseExampleDocs: [doc]));
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void RottedCompleteProgramExampleIsDetected()
+    {
+        // §FOREACH does not lex; a doc example using it has rotted.
+        var doc = new DocFile("fake.md",
+            "Example:\n\n```calor\n§M{m1:Loops}\n  §F{f1:Sum:pub} (i32[]:items) -> void\n    §FOREACH{e1:x} items\n      §P x\n```\n");
+        var findings = DocDriftChecker.Check(BaseInputs(parseExampleDocs: [doc]));
+
+        Assert.NotEmpty(findings);
+        Assert.All(findings, f => Assert.Equal(DiagnosticCode.DocDriftExampleParseError, f.Code));
+        var finding = findings[0];
+        Assert.Equal("fake.md", finding.FilePath);
+        Assert.Equal(6, finding.Span.Line); // §FOREACH sits on doc line 6
+    }
+
+    [Fact]
+    public void CalorFragmentsNotStartingWithModuleAreSkipped()
+    {
+        // No §M on the first non-blank line => deliberate fragment, not parsed.
+        var doc = new DocFile("fake.md",
+            "```calor\n// Before (inconsistent)\n§FOREACH{e1:x} items\n```\n");
+        var findings = DocDriftChecker.Check(BaseInputs(parseExampleDocs: [doc]));
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void SuppressionMarkerBeforeFenceExemptsTheExample()
+    {
+        var doc = new DocFile("fake.md",
+            "<!-- drift:ignore -->\n```calor\n§M{m1:Hypothetical}\n  §FUTURE syntax sketch\n```\n");
+        var findings = DocDriftChecker.Check(BaseInputs(parseExampleDocs: [doc]));
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void NonCalorFencesAreNotParseChecked()
+    {
+        var doc = new DocFile("fake.md",
+            "```\n§M{m1:Bare}\n  §FOREACH{e1:x} items\n```\n\n```text\n§M{m2:Text}\n  §FOREACH{e2:x} items\n```\n");
+        var findings = DocDriftChecker.Check(BaseInputs(parseExampleDocs: [doc]));
+
+        Assert.Empty(findings);
     }
 
     // --- Hardcoded version (the stale-0.3.5 class) ---


### PR DESCRIPTION
## Summary

Adds **doc drift detection** — `calor self-check docs` — for Phase 1 item 6 of the agent-native strategy, addressing the four-rounds-four-drift-findings pattern in agent-facing docs.

**Honest framing: this is detection, not single-sourcing.** The docs are still written by hand; this PR adds a checker that catches a specific set of mechanical contradictions between docs and implementation, and a CI step that fails when it finds one. It is "part 1": generating docs from the implementation (true single-sourcing) is not attempted here.

### What it checks

Covered files: `CLAUDE.md`, every `docs/syntax-reference/*.md`, every `docs/cli/*.md` (the version scan additionally covers all of `docs/**/*.md` minus dated plans/experiments/design/process records).

1. **§-keywords** cited anywhere in the covered docs must exist in the lexer keyword table (the §FOREACH class) — `Calor1320`
2. **Diagnostic codes** cited anywhere in the covered docs must exist in `DiagnosticCode`; cited bands must contain at least one implemented code — `Calor1321`/`Calor1322`
3. **Effect codes**: `effects.md`'s table checked against the effect registry in both directions — `Calor1323`/`Calor1324`
4. **Hardcoded versions**: no doc may repeat the current `Directory.Build.props` version — `Calor1325`
5. **CLI code table**: every implemented 1300-band code must be listed in `structured-output.md` (self-enforcing) — `Calor1327`
6. **Parse the examples**: every fenced ```` ```calor ```` block whose first non-blank line starts with `§M` (the complete-program convention) is lexed and parsed with the real compiler; rot surfaces as `Calor1328`. Blocks not starting with `§M` are fragments and are skipped.

### What it cannot catch

Prose and behavioral drift are out of scope — a doc can still pass while being wrong about:
- **semantics**: what a construct *does* (e.g. wrong description of `§EACH` iteration order, wrong effect enforcement behavior);
- **prose accuracy**: stale line counts, wrong file paths, outdated CLI flag descriptions or defaults, incorrect examples of *output*;
- **fragments**: ```` ```calor ```` blocks not starting with `§M` are never parsed;
- **anything in non-covered files** (samples/, editors/, website prose) beyond the version scan;
- **omissions**: features that exist but are simply undocumented (except effect codes and the 1300-band table, which are checked for completeness).

### Meta-notation policy

Docs legitimately talk *about* notation. Two escapes, documented in `docs/cli/self-check.md`:
- fenced blocks tagged with a non-`calor` info string (```` ```text ````, ```` ```csharp ````, …) are never scanned;
- `<!-- drift:ignore -->` on a line suppresses findings on the next line (and, before a ```` ```calor ```` fence, exempts that block from the parse check).

### Single-sourced ground truth
- `EffectCodes` refactored to an enumerable table-driven registry with a `Legacy` flag (behavior unchanged; covered by tests)
- `Lexer.KeywordNames` exposes the keyword table including all special forms handled outside the dictionary (`§PP`/`§/PP`/`§PPE`, `§CS`, `§RAW`/`§/RAW`, `§CSHARP`/`§/CSHARP`)
- Verification pass's raw `Calor0702`–`Calor0705` literals registered as named `DiagnosticCode` constants (the pre-existing 0700/0701 band collision is documented in-source and tracked for renumbering)

### Drift found and fixed
On main: `§INV`→`§IV` (CLAUDE.md), `§DO`…`§WHILE`→`§/DO{id}` and `§EXT`→`§EEXT` (syntax index), 14 undocumented effect codes, `Calor0702` cited but unregistered.
Found by widening the scan on this branch: `§MATCH`→`§W` (calls.md), `§FOREACH`→`§EACH` (control-flow.md), `§BREAKING`→`§BR` (compile.md), `§RAW`/`§CSHARP` missing from the keyword ground truth (format.md was right; the registry was incomplete).

### CI
`calor self-check docs` runs as a step of the existing test job (reuses its build) on every PR.

### Tests
Unit tests inject fake drifted doc strings per check, probe tests build a fake repo on disk to pin the covered file set (the reviewer's §BOGUS-in-structure-tags.md and Calor9876-in-index.md cases), and parse-check tests cover a rotted example, fragments, and suppression. Build warning-clean.
