### PR TITLE
fix(convert): block-bodied lambda emits valid nested Calor (fixes #705)

### DIFF
--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -1065,6 +1065,36 @@ public sealed class CalorEmitter : IAstVisitor<string>
         EmitBlockEnd($"§/W{{{id}}}");
     }
 
+    /// <summary>
+    /// Emits a hoisted block-bodied lambda as a binding in explicit block form:
+    /// <c>§B{...} §LAM{header}</c> on the opener line, body statements indented one
+    /// level under it, and <c>§/LAM{id}</c> at the binding's own column. This mirrors
+    /// the match-expression binding path and, crucially, routes body statements
+    /// through the normal statement visitor so their indentation tracks the current
+    /// scope instead of a fixed column (the #705 defect).
+    /// </summary>
+    private void EmitBlockLambdaAsBindingInitializer(string bindHeader, LambdaExpressionNode lambda)
+    {
+        var headerParts = new List<string> { lambda.Id };
+        if (lambda.IsStatic) headerParts.Add("static");
+        if (lambda.IsAsync) headerParts.Add("async");
+        foreach (var p in lambda.Parameters)
+        {
+            headerParts.Add(p.Name);
+            headerParts.Add(p.TypeName != null ? TypeMapper.CSharpToCalor(p.TypeName) : "object");
+        }
+        var header = string.Join(":", headerParts);
+
+        AppendLine($"{bindHeader} §LAM{{{header}}}");
+        Indent();
+        foreach (var stmt in lambda.StatementBody!)
+        {
+            stmt.Accept(this);
+        }
+        Dedent();
+        AppendLine($"§/LAM{{{lambda.Id}}}");
+    }
+
     public string Visit(CallStatementNode node)
     {
         // Emit named argument labels as §A[name] value when present.
@@ -1281,6 +1311,18 @@ public sealed class CalorEmitter : IAstVisitor<string>
         if (node.Initializer is MatchExpressionNode matchExpr)
         {
             EmitMatchExpressionAsBindingInitializer(bindHeader, matchExpr);
+            return "";
+        }
+
+        // Block-bodied lambda initializer must use block form so its statements are
+        // emitted at the correct nested indent and §/LAM lands at the §B column.
+        // The naive `Initializer.Accept(this)` returns a multi-line string with a
+        // fixed indent that gets jammed onto the §B line and dedents below the
+        // enclosing scope, producing unparseable output (#705).
+        if (node.Initializer is LambdaExpressionNode { IsExpressionLambda: false, StatementBody.Count: > 0 } blockLambda
+            && !(blockLambda.StatementBody.Count <= 2 && !blockLambda.StatementBody.Any(s => s is FallbackCommentNode)))
+        {
+            EmitBlockLambdaAsBindingInitializer(bindHeader, blockLambda);
             return "";
         }
 

--- a/tests/Calor.Conversion.Tests/ConversionCatalog.cs
+++ b/tests/Calor.Conversion.Tests/ConversionCatalog.cs
@@ -379,6 +379,28 @@ public static class ConversionCatalog
         }
         """);
 
+    public static readonly ConversionSnippet BlockLambdaArgument = new(
+        "07-04", "Lambdas", "Block-bodied lambda passed as an argument (#705)",
+        """
+        using System;
+        using System.Linq;
+
+        public static class BlockLambdaDemo
+        {
+            public static void Run()
+            {
+                Handle("/x", () =>
+                {
+                    var nums = Enumerable.Range(1, 5).ToArray();
+                    var total = nums.Sum();
+                    return total;
+                });
+            }
+
+            public static void Handle(string route, Func<int> handler) { }
+        }
+        """);
+
     // ── 08: Modern C# ──
 
     public static readonly ConversionSnippet RequiredProperties = new(
@@ -962,6 +984,7 @@ public static class ConversionCatalog
         DelegateDeclarations,
         LambdaExpressions,
         StaticLambda,
+        BlockLambdaArgument,
         RequiredProperties,
         TupleLiteral,
         EmptyCollection,

--- a/tests/Calor.Conversion.Tests/Snapshots/07-04.approved.calr
+++ b/tests/Calor.Conversion.Tests/Snapshots/07-04.approved.calr
@@ -1,0 +1,18 @@
+§M{m001:Test_07_04}
+  §U{System}
+  §U{System.Linq}
+
+  §CL{c001:BlockLambdaDemo:pub:stat}
+    §MT{m002:Run:pub:stat}
+      §B{_lam005} §LAM{lam003}
+        §B{_chainRange004} §C{Enumerable.Range} §A 1 §A 5 §/C
+        §B{nums} §C{_chainRange004.ToArray}
+        §B{total} §C{nums.Sum}
+        §R total
+      §/LAM{lam003}
+      §C{Handle} §A "/x" §A _lam005 §/C
+
+    §MT{m006:Handle:pub:stat} (str:route, Func<i32>:handler)
+      §R
+
+


### PR DESCRIPTION
## The bug
A block-bodied lambda passed as an argument converted to **unparseable Calor**: the hoisted §B{_lam} binding's multi-line §LAM initializer (fixed 2-space body indent, §/LAM at column 0) went through AppendLine, which indents only the first line — so the body dedented to column 2 and §/LAM to column 0 regardless of scope (Calor0099). The stock ASP.NET minimal-API template hit it immediately.

## The fix
Surgical, mirroring the existing MatchExpression binding special-case: `Visit(BindStatementNode)` detects a block-lambda initializer and emits it via `EmitBlockLambdaAsBindingInitializer` — body statements routed through the normal statement visitor so indentation tracks scope, §/LAM at the §B column. A general AppendLine multi-line fix was **rejected** because it over-indents §ANON's absolute-indent output (snapshot 13-09) — the fix stays localized.

## Scope
- #705's **secondary use-before-def in chains does not reproduce** after this fix (both chained repros validate clean; hoist order is the visitor's and is correct once indentation is valid).
- The **§CSHARP fallback** ask is split to a follow-up issue (its primary trigger — block lambdas producing invalid output — is now gone).

## Verification
- New catalog case 07-04 (block lambda as argument); `RoundTrip_CalorParseSucceeds` guards that generated Calor parses.
- Generated output compiles end-to-end (`calor --input`).
- Conversion suite 286 green; compiler/emitter suites green; §ANON snapshot unchanged.

Fixes #705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)