### PR TITLE
feat(self-check): single-source AGENTS.md from CLAUDE.md (closes #708)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,178 @@
+# AGENTS.md — Calor Compiler
+<!-- Generated from CLAUDE.md by `calor self-check docs --fix`. Edit CLAUDE.md, not this file (#708). -->
+
+Calor is a DSL designed for AI agents that compiles to C# on .NET 10. The compiler lives in `src/Calor.Compiler/` and is packaged as the `calor` global tool. Version is tracked in `Directory.Build.props` (check there for the current version; do not trust a number written in docs).
+
+## Build & Test
+
+```bash
+dotnet build          # Build all projects
+dotnet test           # Run all tests
+dotnet test --filter "FullyQualifiedName~ClassName"  # Run specific tests
+```
+
+- .NET 10 SDK required (pinned in `global.json` to 10.0.100, rollForward: latestMinor)
+- `TreatWarningsAsErrors` is enabled globally — fix all warnings before committing
+- GPG signing workaround (1Password agent): `git -c commit.gpgsign=false commit -m "message"`
+
+### Test Projects
+
+| Project | What it covers |
+|---------|---------------|
+| `Calor.Compiler.Tests` | Lexer, parser, emitter, analysis unit tests |
+| `Calor.Conversion.Tests` | C# → Calor snapshot-based conversion tests |
+| `Calor.Evaluation` | Runtime evaluation and execution |
+| `Calor.Semantics.Tests` | Binding and semantic analysis |
+| `Calor.Verification.Tests` | Z3 contract verification |
+| `Calor.Enforcement.Tests` | Effect enforcement and taint analysis |
+
+Tests use **xUnit**. Conversion tests are snapshot-based (golden files in `TestData/`).
+
+## Architecture — Compilation Pipeline
+
+### Calor → C# (compilation)
+
+```
+Source → Lexer → Tokens → Parser → AST → Binder → BoundTree → Analysis → CSharpEmitter → C#
+                                                      ↓
+                                              Bug patterns, contracts,
+                                              effects, verification (Z3)
+```
+
+### C# → Calor (migration)
+
+```
+C# Source → Roslyn Parse → SyntaxTree → RoslynSyntaxVisitor → AST → CalorEmitter → Calor
+                                              ↓
+                                     Unsupported features →
+                                     CSharpInteropBlockNode (raw C# preserved)
+```
+
+### Key Files (with approximate line counts)
+
+| File | Lines | Role |
+|------|-------|------|
+| `Parsing/Lexer.cs` | 1,400 | Tokenizer — section markers, typed literals, keywords |
+| `Parsing/Parser.cs` | 8,900 | Recursive descent parser → AST |
+| `Ast/AstNode.cs` | 480 | IAstVisitor / IAstVisitor\<T\> interfaces (~236 methods each) |
+| `Ast/*.cs` | 29 files | AST node classes organized by feature |
+| `Binding/Binder.cs` | 520 | Two-pass binding: symbol registration + body binding |
+| `Binding/BoundNodes.cs` | 500 | Bound tree nodes, VariableSymbol, FunctionSymbol |
+| `CodeGen/CSharpEmitter.cs` | 4,600 | IAstVisitor\<string\> — generates C# from AST |
+| `Migration/RoslynSyntaxVisitor.cs` | 6,500 | CSharpSyntaxWalker — converts C# → Calor AST |
+| `Migration/CalorEmitter.cs` | 2,800 | IAstVisitor\<string\> — generates Calor from AST |
+| `Migration/FeatureSupport.cs` | 810 | Feature support registry for C# → Calor migration |
+| `Ids/IdScanner.cs` | 330 | IAstVisitor — scans/validates node IDs |
+| `Verification/ExpressionSimplifier.cs` | 1,400 | IAstVisitor\<T\> — simplifies expressions for Z3 |
+| `Analysis/BugPatterns/Patterns/` | dir | Checkers: div-by-zero, null-deref, off-by-one, overflow, index-OOB |
+| `Diagnostics/Diagnostic.cs` | — | All diagnostic codes (Calor0001–Calor1399) |
+
+All paths relative to `src/Calor.Compiler/`.
+
+## Calor Syntax Quick Reference
+
+Block structure is **indentation-only** (2 spaces per level, Python-style). **Never
+write structural closer tags** — the main block closers (`§/M`, `§/F`, `§/L`, `§/I`,
+`§/W`, `§/WH`, `§/CL`, `§/MT`, `§/IFACE`, and others) raise a hard error (`Calor0830`);
+a few remaining closer forms are still tolerated by the parser but always optional.
+The only closers you should ever write are `§/C` (call argument lists) and `§/LAM`
+(block lambdas).
+
+```
+§M{id:Name}                Module
+§F{id:name:vis} (T:x) -> R  Function with inline signature
+§B{name:type}              Immutable binding
+§B{~name:type}             Mutable binding
+§L{id:var:from:to:step}    For loop
+§IF{id} (cond)             If (body indented)
+§EI (cond)                  ElseIf (at parent column)
+§EL                         Else (at parent column)
+§C{object.method} §A arg §/C  Method call with argument
+§E{codes}                  Effects (§E{} = pure)
+§Q (expr)                  Precondition
+§S (expr)                  Postcondition
+§IV (expr)                 Invariant
+```
+
+Example (current syntax — see `samples/FizzBuzz/fizzbuzz.calr`; fenced
+` ```calor ` blocks starting with `§M` are parse-checked by `calor self-check docs`):
+
+```calor
+§M{m001:FizzBuzz}
+  §F{f001:Main:pub} () -> void
+    §E{cw}
+    §L{for1:i:1:100:1}
+      §IF{if1} (== (% i 15) 0)
+        §P "FizzBuzz"
+      §EI (== (% i 3) 0)
+        §P "Fizz"
+      §EL
+        §P i
+```
+
+**Typed literals:** `INT:42`, `STR:"hello"`, `BOOL:true`, `FLOAT:3.14`
+
+## Adding New AST Nodes — Checklist
+
+1. **Node class** in `Ast/` with `Accept(IAstVisitor)` and `Accept<T>(IAstVisitor<T>)` methods
+2. **Visitor interfaces** — add `Visit` methods to both `IAstVisitor` and `IAstVisitor<T>` in `Ast/AstNode.cs`
+3. **All visitors** — implement in every IAstVisitor implementer:
+   - `CodeGen/CSharpEmitter.cs` (C# generation)
+   - `Migration/CalorEmitter.cs` (Calor generation)
+   - `Ids/IdScanner.cs` (ID scanning)
+   - `Verification/ExpressionSimplifier.cs` (Z3 simplification)
+4. **Lexer** — add token kind in `Parsing/Token.cs` (update `IsKeyword` range), add keyword to dictionary in `Parsing/Lexer.cs`
+5. **Parser** — add to `ParsePrimaryExpression` switch + `IsExpressionStart()` (for expressions) or `ParseStatement` dispatch (for statements)
+6. **C# converter** — add switch cases and conversion methods in `Migration/RoslynSyntaxVisitor.cs`
+7. **Feature registry** — add entry in `Migration/FeatureSupport.cs`
+
+### Critical Parser Patterns
+
+- **`ParseAttributes()`** already splits on `:` into `_pos0`, `_pos1`, etc. — **never re-split** `attrs["_pos0"]` on `:`
+- **`IsExpressionStart()`** must include all new expression token kinds — otherwise binding initializers silently fail to parse
+- **Closing tags with IDs** (e.g. `§/UNSAFE{u1}`) need `ParseAttributes()` after `Advance()` to consume the ID block
+- **`ParseValue()`** handles `*` for pointer types and `[,]` for multi-dimensional array types
+
+## Key Conventions
+
+- **Visitor pattern everywhere** — every AST node has `Accept` methods; all tree operations implement `IAstVisitor` or `IAstVisitor<T>`
+- **CSharpInteropBlockNode** — when `RoslynSyntaxVisitor` encounters unsupported C# features, it wraps the raw C# in this node (preserves code verbatim with metadata about the unsupported feature)
+- **MemberPreprocessorBlockNode** — wraps class members in conditional `#if` blocks; supports `§PP{CONDITION}` ... `§/PP{CONDITION}` syntax with chained else branches
+- **VariableSymbol.IsParameter** — distinguishes function parameters from locals; used by analysis passes
+- **BoundCallExpression.Target** is a `string` — `NullDereferenceChecker` checks for `.unwrap` suffix
+- **Option\<T\> and Result\<T,E\>** are valid generic types in Calor's type system
+- **Diagnostic codes** — Calor0001–0099 (lexer), 0100–0199 (parser), 0200–0299 (semantic), 0300–0399 (contracts), 0400–0499 (effects), 0500–0599 (patterns), 0600–0699 (API strictness), 0700–0799 (semantics version + contract verification results), 0800–0899 (ID validation), 0900–0999 (dataflow/bug patterns/taint), 1000–1099 (codegen/interop), 1100–1199 (refinements/obligations), 1200–1299 (experimental), 1300–1399 (CLI: lint findings and command-level errors)
+
+## Project Layout
+
+```
+src/
+  Calor.Compiler/        Core compiler, CLI tool (calor)
+  Calor.Runtime/         Runtime support for generated C#
+  Calor.LanguageServer/  LSP server for IDE integration
+  Calor.Sdk/             Public SDK for programmatic compilation
+  Calor.Tasks/           MSBuild task integration
+tests/
+  Calor.Compiler.Tests/  Compiler unit + integration tests
+  Calor.Conversion.Tests/ C# ↔ Calor snapshot tests
+  Calor.Evaluation/      Runtime evaluation tests
+  Calor.Semantics.Tests/ Semantic analysis tests
+  Calor.Verification.Tests/ Z3 verification tests
+  Calor.Enforcement.Tests/  Effect enforcement tests
+  TestData/              Golden files for snapshot testing
+tools/
+  Calor.RoundTrip.Harness/ Round-trip verification tool
+samples/                 Example Calor programs
+docs/                    Syntax reference, guides, philosophy
+editors/                 VSCode extension
+```
+
+## Benchmarks
+
+Benchmarks live in `benchmarks/`. When writing or modifying benchmarks, ensure they are **not biased towards Calor** — benchmarks must be fair and representative comparisons.
+
+## Dependencies
+
+- **Microsoft.CodeAnalysis.CSharp 5.3.0** — Roslyn, for C# parsing in the migration pipeline (supports C# 14)
+- **System.CommandLine 2.0.0-beta4** — CLI argument parsing
+- **Z3 4.15.7** — SMT solver for contract verification (custom ARM64 build)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md — Calor Compiler
-<!-- Generated from CLAUDE.md by `calor self-check docs --fix`. Edit CLAUDE.md, not this file (#708). -->
+<!-- Generated from CLAUDE.md by `calor self-check docs --fix`. Edit CLAUDE.md, not this file. -->
 
 Calor is a DSL designed for AI agents that compiles to C# on .NET 10. The compiler lives in `src/Calor.Compiler/` and is packaged as the `calor` global tool. Version is tracked in `Directory.Build.props` (check there for the current version; do not trust a number written in docs).
 

--- a/docs/cli/self-check.md
+++ b/docs/cli/self-check.md
@@ -111,5 +111,5 @@ calor self-check docs --fix
 ```
 
 `--fix` rewrites `AGENTS.md` from `CLAUDE.md` (idempotent; writes only on change).
-The CI `spec-drift` step runs `self-check docs` without `--fix`, so an un-regenerated
+The CI step "Check agent-facing docs against the implementation (spec drift)" runs `self-check docs` without `--fix`, so an un-regenerated
 `AGENTS.md` fails the build.

--- a/docs/cli/self-check.md
+++ b/docs/cli/self-check.md
@@ -97,3 +97,19 @@ checked for completeness), and anything in files outside the covered set.
 
 The check runs on every PR as a step of the `test` job in
 `.github/workflows/test.yml`, reusing that job's build.
+
+## Generated mirror docs (AGENTS.md)
+
+`AGENTS.md` is a **generated** derivative of `CLAUDE.md` — identical content with
+the H1 title swapped and a "generated" banner — so the two agent manuals cannot
+drift. It is single-sourced from `CLAUDE.md` and checked by `self-check docs`
+(`Calor1329` when out of sync or missing). Do not hand-edit `AGENTS.md`; edit
+`CLAUDE.md` and regenerate:
+
+```
+calor self-check docs --fix
+```
+
+`--fix` rewrites `AGENTS.md` from `CLAUDE.md` (idempotent; writes only on change).
+The CI `spec-drift` step runs `self-check docs` without `--fix`, so an un-regenerated
+`AGENTS.md` fails the build.

--- a/docs/cli/structured-output.md
+++ b/docs/cli/structured-output.md
@@ -162,6 +162,7 @@ pipeline) so they can flow through the structured formats:
 | `Calor1326` | Docs drift: a file or doc section the self-check needs is missing |
 | `Calor1327` | Docs drift: CLI diagnostic code missing from this table |
 | `Calor1328` | Docs drift: fenced ```` ```calor ```` example (complete program starting with `§M`) no longer parses |
+| `Calor1329` | Docs drift: a generated mirror doc (AGENTS.md) is out of sync with its single source (CLAUDE.md) |
 
 ## Notes on specific commands
 
@@ -175,5 +176,5 @@ pipeline) so they can flow through the structured formats:
   per file (alongside its legacy flat `errors`/`warnings` string arrays), but
   its top-level document is command-specific.
 - **`calor self-check docs --format json`** emits the unified schema on stdout
-  with docs-drift findings (`Calor1320`–`Calor1328`) and exits 1 when drift is
+  with docs-drift findings (`Calor1320`–`Calor1329`) and exits 1 when drift is
   found (text mode reports the same findings on stderr).

--- a/src/Calor.Compiler/Commands/SelfCheckCommand.cs
+++ b/src/Calor.Compiler/Commands/SelfCheckCommand.cs
@@ -78,7 +78,27 @@ public static class SelfCheckCommand
 
         if (fix)
         {
-            return RegenerateMirrors(resolvedRoot);
+            // Regenerate mirror docs, then fall through to the full check so --fix
+            // never silently skips the other drift checks (keywords, codes, effects,
+            // versions, examples) and reports success. A source-missing error is fatal;
+            // an anchor mismatch is surfaced as a finding by the check below.
+            switch (DocDriftChecker.RegenerateAgentsMd(resolvedRoot))
+            {
+                case DocDriftChecker.MirrorRegenResult.SourceMissing:
+                    Console.Error.WriteLine("error: CLAUDE.md not found; cannot regenerate AGENTS.md");
+                    return 2;
+                case DocDriftChecker.MirrorRegenResult.AnchorMismatch:
+                    Console.Error.WriteLine(
+                        $"warning: CLAUDE.md H1 does not match '{DocDriftChecker.ClaudeTitleAnchor}'; " +
+                        "AGENTS.md not regenerated (reported below)");
+                    break;
+                case DocDriftChecker.MirrorRegenResult.Written:
+                    Console.Error.WriteLine($"Regenerated {DocDriftChecker.MirrorAgentsRelativePath} from CLAUDE.md.");
+                    break;
+                case DocDriftChecker.MirrorRegenResult.AlreadyInSync:
+                    Console.Error.WriteLine($"{DocDriftChecker.MirrorAgentsRelativePath} already in sync with CLAUDE.md.");
+                    break;
+            }
         }
 
         var diagnostics = new List<Diagnostic>();
@@ -104,34 +124,6 @@ public static class SelfCheckCommand
         }
 
         return diagnostics.Count > 0 ? 1 : 0;
-    }
-
-    /// <summary>
-    /// Regenerates generated mirror docs from their single source. Currently:
-    /// AGENTS.md from CLAUDE.md (#708). Idempotent; writes only on change.
-    /// </summary>
-    private static int RegenerateMirrors(string root)
-    {
-        var claudePath = Path.Combine(root, "CLAUDE.md");
-        if (!File.Exists(claudePath))
-        {
-            Console.Error.WriteLine($"error: CLAUDE.md not found at '{claudePath}'");
-            return 2;
-        }
-
-        var expected = DocDriftChecker.AgentsMdFromClaudeMd(File.ReadAllText(claudePath));
-        var agentsPath = Path.Combine(root, DocDriftChecker.MirrorAgentsRelativePath);
-        var current = File.Exists(agentsPath) ? File.ReadAllText(agentsPath).Replace("\r\n", "\n") : null;
-
-        if (current == expected)
-        {
-            Console.Error.WriteLine($"{DocDriftChecker.MirrorAgentsRelativePath} already in sync with CLAUDE.md.");
-            return 0;
-        }
-
-        File.WriteAllText(agentsPath, expected);
-        Console.Error.WriteLine($"Regenerated {DocDriftChecker.MirrorAgentsRelativePath} from CLAUDE.md.");
-        return 0;
     }
 
     private static string? FindRepositoryRoot(string startDirectory)

--- a/src/Calor.Compiler/Commands/SelfCheckCommand.cs
+++ b/src/Calor.Compiler/Commands/SelfCheckCommand.cs
@@ -34,6 +34,10 @@ public static class SelfCheckCommand
             description: "Output format: text (human-readable, stderr), json (unified schema on stdout), or sarif (SARIF 2.1.0 on stdout)");
         formatOption.FromAmong("text", "json", "sarif");
 
+        var fixOption = new Option<bool>(
+            aliases: ["--fix"],
+            description: "Regenerate generated mirror docs (AGENTS.md from CLAUDE.md) instead of only reporting drift");
+
         var docsCommand = new Command("docs",
             "Check agent-facing docs against the compiler implementation. " +
             "Covered files: CLAUDE.md, docs/syntax-reference/*.md, and docs/cli/*.md " +
@@ -43,24 +47,26 @@ public static class SelfCheckCommand
             "the effect registry in both directions; (4) the Calor13xx table in " +
             "docs/cli/structured-output.md is complete; (5) no doc hardcodes the current version; " +
             "(6) every fenced ```calor example that declares a complete program (first non-blank " +
-            "line starts with §M) parses with the current compiler. " +
+            "line starts with §M) parses with the current compiler; (7) AGENTS.md is in sync with its single source CLAUDE.md (--fix regenerates it). " +
             "Suppress an intentional-meta-notation finding by putting <!-- drift:ignore --> on the " +
             "preceding line (see docs/cli/self-check.md). Exits 1 when drift is found")
         {
             rootOption,
-            formatOption
+            formatOption,
+            fixOption
         };
 
         docsCommand.SetHandler((InvocationContext ctx) =>
         {
             var root = ctx.ParseResult.GetValueForOption(rootOption);
             var format = ctx.ParseResult.GetValueForOption(formatOption) ?? "text";
-            ctx.ExitCode = Execute(root, format);
+            var fix = ctx.ParseResult.GetValueForOption(fixOption);
+            ctx.ExitCode = Execute(root, format, fix);
         });
         return docsCommand;
     }
 
-    private static int Execute(string? root, string format)
+    private static int Execute(string? root, string format, bool fix = false)
     {
         var resolvedRoot = root ?? FindRepositoryRoot(Directory.GetCurrentDirectory());
         if (resolvedRoot == null)
@@ -68,6 +74,11 @@ public static class SelfCheckCommand
             Console.Error.WriteLine(
                 "error: could not locate a repository root (a directory containing CLAUDE.md and Directory.Build.props); pass --root");
             return 2;
+        }
+
+        if (fix)
+        {
+            return RegenerateMirrors(resolvedRoot);
         }
 
         var diagnostics = new List<Diagnostic>();
@@ -93,6 +104,34 @@ public static class SelfCheckCommand
         }
 
         return diagnostics.Count > 0 ? 1 : 0;
+    }
+
+    /// <summary>
+    /// Regenerates generated mirror docs from their single source. Currently:
+    /// AGENTS.md from CLAUDE.md (#708). Idempotent; writes only on change.
+    /// </summary>
+    private static int RegenerateMirrors(string root)
+    {
+        var claudePath = Path.Combine(root, "CLAUDE.md");
+        if (!File.Exists(claudePath))
+        {
+            Console.Error.WriteLine($"error: CLAUDE.md not found at '{claudePath}'");
+            return 2;
+        }
+
+        var expected = DocDriftChecker.AgentsMdFromClaudeMd(File.ReadAllText(claudePath));
+        var agentsPath = Path.Combine(root, DocDriftChecker.MirrorAgentsRelativePath);
+        var current = File.Exists(agentsPath) ? File.ReadAllText(agentsPath).Replace("\r\n", "\n") : null;
+
+        if (current == expected)
+        {
+            Console.Error.WriteLine($"{DocDriftChecker.MirrorAgentsRelativePath} already in sync with CLAUDE.md.");
+            return 0;
+        }
+
+        File.WriteAllText(agentsPath, expected);
+        Console.Error.WriteLine($"Regenerated {DocDriftChecker.MirrorAgentsRelativePath} from CLAUDE.md.");
+        return 0;
     }
 
     private static string? FindRepositoryRoot(string startDirectory)

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -758,6 +758,14 @@ public static class DiagnosticCode
     /// with the current compiler — the example has rotted.
     /// </summary>
     public const string DocDriftExampleParseError = "Calor1328";
+
+    /// <summary>
+    /// Error (docs drift): a mirror doc (AGENTS.md) is out of sync with its
+    /// single source (CLAUDE.md). The mirror is a deterministic title-swapped
+    /// derivative — regenerate it with <c>calor self-check docs --fix</c> rather
+    /// than hand-editing, so the two agent manuals cannot silently diverge.
+    /// </summary>
+    public const string DocDriftMirrorOutOfSync = "Calor1329";
 }
 
 /// <summary>

--- a/src/Calor.Compiler/SelfCheck/DocDriftChecker.cs
+++ b/src/Calor.Compiler/SelfCheck/DocDriftChecker.cs
@@ -208,10 +208,23 @@ public static class DocDriftChecker
         var mirrorDocs = new List<MirrorDoc>();
         if (claudeMd is { } claude)
         {
-            var agentsPath = Path.Combine(root, MirrorAgentsRelativePath);
-            var actual = File.Exists(agentsPath) ? File.ReadAllText(agentsPath) : null;
-            mirrorDocs.Add(new MirrorDoc(
-                MirrorAgentsRelativePath, "CLAUDE.md", actual, AgentsMdFromClaudeMd(claude.Content)));
+            if (TryAgentsMdFromClaudeMd(claude.Content, out var expected))
+            {
+                var agentsPath = Path.Combine(root, MirrorAgentsRelativePath);
+                var actual = File.Exists(agentsPath) ? File.ReadAllText(agentsPath) : null;
+                mirrorDocs.Add(new MirrorDoc(MirrorAgentsRelativePath, "CLAUDE.md", actual, expected));
+            }
+            else
+            {
+                // The transform anchors on CLAUDE.md's H1; if that changed, the
+                // mirror can't be generated. Surface it loudly (never a silent guess).
+                loadErrors.Add(Drift(
+                    DiagnosticCode.DocDriftMirrorOutOfSync,
+                    $"CLAUDE.md H1 no longer matches the expected anchor '{ClaudeTitleAnchor}' — " +
+                    "the AGENTS.md mirror transform cannot run. Restore the H1 or update the anchor " +
+                    "in DocDriftChecker.",
+                    "CLAUDE.md", 1, 1));
+            }
         }
 
         return new DocDriftInputs
@@ -235,22 +248,68 @@ public static class DocDriftChecker
     /// <summary>Repo-relative path of the generated agent-manual mirror.</summary>
     public const string MirrorAgentsRelativePath = "AGENTS.md";
 
+    /// <summary>The CLAUDE.md H1 the AGENTS.md transform anchors on.</summary>
+    public const string ClaudeTitleAnchor = "# CLAUDE.md — Calor Compiler";
+
+    private const string AgentsHead =
+        "# AGENTS.md — Calor Compiler\n" +
+        "<!-- Generated from CLAUDE.md by `calor self-check docs --fix`. Edit CLAUDE.md, not this file. -->";
+
     /// <summary>
     /// The single-source transform: AGENTS.md is CLAUDE.md with the H1 title
     /// swapped and a generated-file banner, so editing CLAUDE.md and running
     /// <c>calor self-check docs --fix</c> keeps the two agent manuals identical
-    /// in content. Deterministic and idempotent.
+    /// in content. Deterministic and idempotent. Returns false (no silent guess)
+    /// when CLAUDE.md's H1 does not match <see cref="ClaudeTitleAnchor"/>.
     /// </summary>
-    public static string AgentsMdFromClaudeMd(string claudeContent)
+    public static bool TryAgentsMdFromClaudeMd(string claudeContent, out string result)
     {
         var normalized = claudeContent.Replace("\r\n", "\n");
-        const string claudeTitle = "# CLAUDE.md — Calor Compiler";
-        const string agentsHead =
-            "# AGENTS.md — Calor Compiler\n" +
-            "<!-- Generated from CLAUDE.md by `calor self-check docs --fix`. Edit CLAUDE.md, not this file (#708). -->";
-        return normalized.StartsWith(claudeTitle, StringComparison.Ordinal)
-            ? agentsHead + normalized[claudeTitle.Length..]
-            : agentsHead + "\n\n" + normalized;
+        if (!normalized.StartsWith(ClaudeTitleAnchor, StringComparison.Ordinal))
+        {
+            result = "";
+            return false;
+        }
+        result = AgentsHead + normalized[ClaudeTitleAnchor.Length..];
+        return true;
+    }
+
+    /// <summary>
+    /// Throwing convenience wrapper over <see cref="TryAgentsMdFromClaudeMd"/>.
+    /// </summary>
+    public static string AgentsMdFromClaudeMd(string claudeContent) =>
+        TryAgentsMdFromClaudeMd(claudeContent, out var result)
+            ? result
+            : throw new InvalidOperationException(
+                $"CLAUDE.md H1 does not match the expected anchor '{ClaudeTitleAnchor}'.");
+
+    /// <summary>Outcome of regenerating the AGENTS.md mirror from CLAUDE.md.</summary>
+    public enum MirrorRegenResult { AlreadyInSync, Written, SourceMissing, AnchorMismatch }
+
+    /// <summary>
+    /// Regenerates AGENTS.md from CLAUDE.md under <paramref name="root"/>. Idempotent:
+    /// writes only when the on-disk mirror differs from the transform. Does not write
+    /// on <see cref="MirrorRegenResult.SourceMissing"/> or <see cref="MirrorRegenResult.AnchorMismatch"/>.
+    /// </summary>
+    public static MirrorRegenResult RegenerateAgentsMd(string root)
+    {
+        var claudePath = Path.Combine(root, "CLAUDE.md");
+        if (!File.Exists(claudePath))
+        {
+            return MirrorRegenResult.SourceMissing;
+        }
+        if (!TryAgentsMdFromClaudeMd(File.ReadAllText(claudePath), out var expected))
+        {
+            return MirrorRegenResult.AnchorMismatch;
+        }
+        var agentsPath = Path.Combine(root, MirrorAgentsRelativePath);
+        var current = File.Exists(agentsPath) ? File.ReadAllText(agentsPath).Replace("\r\n", "\n") : null;
+        if (current == expected)
+        {
+            return MirrorRegenResult.AlreadyInSync;
+        }
+        File.WriteAllText(agentsPath, expected);
+        return MirrorRegenResult.Written;
     }
 
     private static void CheckMirror(MirrorDoc mirror, List<Diagnostic> diagnostics)

--- a/src/Calor.Compiler/SelfCheck/DocDriftChecker.cs
+++ b/src/Calor.Compiler/SelfCheck/DocDriftChecker.cs
@@ -67,7 +67,21 @@ public sealed class DocDriftInputs
 
     /// <summary>Docs scanned for a hardcoded current version string.</summary>
     public IReadOnlyList<DocFile> VersionScanDocs { get; init; } = [];
+
+    /// <summary>
+    /// Mirror docs that must equal a deterministic transform of a single source
+    /// (e.g. AGENTS.md is CLAUDE.md with the title swapped). Guards against the
+    /// two agent manuals silently diverging (#708).
+    /// </summary>
+    public IReadOnlyList<MirrorDoc> MirrorDocs { get; init; } = [];
 }
+
+/// <summary>
+/// A doc that is a generated derivative of a single source. <see cref="Expected"/>
+/// is the source run through its transform; <see cref="Actual"/> is what is on
+/// disk (or null if the mirror file is missing).
+/// </summary>
+public sealed record MirrorDoc(string MirrorPath, string SourcePath, string? Actual, string Expected);
 
 /// <summary>
 /// Machine-checks agent-facing documentation against the implementation
@@ -148,6 +162,11 @@ public static class DocDriftChecker
             CheckHardcodedVersion(doc, inputs.Version, diagnostics);
         }
 
+        foreach (var mirror in inputs.MirrorDocs)
+        {
+            CheckMirror(mirror, diagnostics);
+        }
+
         return diagnostics;
     }
 
@@ -182,6 +201,19 @@ public static class DocDriftChecker
                 d.Path.StartsWith(Path.Combine("docs", x) + Path.DirectorySeparatorChar, StringComparison.Ordinal)))
             .ToList();
 
+        // AGENTS.md is a generated mirror of CLAUDE.md (title-swapped) so the two
+        // agent manuals cannot drift (#708). It is NOT in the keyword/diagnostic
+        // scan sets — that would double-report every finding already raised on
+        // CLAUDE.md; the mirror check covers it instead.
+        var mirrorDocs = new List<MirrorDoc>();
+        if (claudeMd is { } claude)
+        {
+            var agentsPath = Path.Combine(root, MirrorAgentsRelativePath);
+            var actual = File.Exists(agentsPath) ? File.ReadAllText(agentsPath) : null;
+            mirrorDocs.Add(new MirrorDoc(
+                MirrorAgentsRelativePath, "CLAUDE.md", actual, AgentsMdFromClaudeMd(claude.Content)));
+        }
+
         return new DocDriftInputs
         {
             Version = version,
@@ -196,7 +228,44 @@ public static class DocDriftChecker
             EffectDocsForwardOnly = NonNull(syntaxIndex),
             CliCodesDoc = cliCodesDoc,
             VersionScanDocs = NonNull(claudeMd).Concat(versionDocs).ToList(),
+            MirrorDocs = mirrorDocs,
         };
+    }
+
+    /// <summary>Repo-relative path of the generated agent-manual mirror.</summary>
+    public const string MirrorAgentsRelativePath = "AGENTS.md";
+
+    /// <summary>
+    /// The single-source transform: AGENTS.md is CLAUDE.md with the H1 title
+    /// swapped and a generated-file banner, so editing CLAUDE.md and running
+    /// <c>calor self-check docs --fix</c> keeps the two agent manuals identical
+    /// in content. Deterministic and idempotent.
+    /// </summary>
+    public static string AgentsMdFromClaudeMd(string claudeContent)
+    {
+        var normalized = claudeContent.Replace("\r\n", "\n");
+        const string claudeTitle = "# CLAUDE.md — Calor Compiler";
+        const string agentsHead =
+            "# AGENTS.md — Calor Compiler\n" +
+            "<!-- Generated from CLAUDE.md by `calor self-check docs --fix`. Edit CLAUDE.md, not this file (#708). -->";
+        return normalized.StartsWith(claudeTitle, StringComparison.Ordinal)
+            ? agentsHead + normalized[claudeTitle.Length..]
+            : agentsHead + "\n\n" + normalized;
+    }
+
+    private static void CheckMirror(MirrorDoc mirror, List<Diagnostic> diagnostics)
+    {
+        var normalizedActual = mirror.Actual?.Replace("\r\n", "\n");
+        if (normalizedActual == mirror.Expected)
+        {
+            return;
+        }
+        var reason = mirror.Actual == null ? "is missing" : "is out of sync with";
+        diagnostics.Add(Drift(
+            DiagnosticCode.DocDriftMirrorOutOfSync,
+            $"{mirror.MirrorPath} {reason} its single source {mirror.SourcePath} — " +
+            $"regenerate it with `calor self-check docs --fix` (do not hand-edit; edit {mirror.SourcePath}).",
+            mirror.MirrorPath, 1, 1));
     }
 
     /// <summary>

--- a/tests/Calor.Compiler.Tests/DocDriftCheckerTests.cs
+++ b/tests/Calor.Compiler.Tests/DocDriftCheckerTests.cs
@@ -87,6 +87,74 @@ public class DocDriftCheckerTests
         Assert.Contains("is missing", finding.Message);
     }
 
+    [Fact]
+    public void AgentsMdTransform_ThrowsOnAnchorMismatch()
+    {
+        Assert.False(DocDriftChecker.TryAgentsMdFromClaudeMd("# Something Else\n\nbody\n", out _));
+        Assert.Throws<InvalidOperationException>(() =>
+            DocDriftChecker.AgentsMdFromClaudeMd("# Something Else\n"));
+    }
+
+    // --- RegenerateAgentsMd file-IO path (--fix) ---
+
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "calor-mirror-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void Regenerate_WritesWhenMissingOrStale_ThenIsIdempotent()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "CLAUDE.md"), SampleClaude);
+            var agents = Path.Combine(dir, "AGENTS.md");
+
+            // Missing → written.
+            Assert.Equal(DocDriftChecker.MirrorRegenResult.Written, DocDriftChecker.RegenerateAgentsMd(dir));
+            Assert.Equal(DocDriftChecker.AgentsMdFromClaudeMd(SampleClaude), File.ReadAllText(agents));
+
+            // Already in sync → no write (idempotent).
+            var before = File.GetLastWriteTimeUtc(agents);
+            Assert.Equal(DocDriftChecker.MirrorRegenResult.AlreadyInSync, DocDriftChecker.RegenerateAgentsMd(dir));
+            Assert.Equal(before, File.GetLastWriteTimeUtc(agents));
+
+            // Stale → rewritten.
+            File.WriteAllText(agents, "hand edited\n");
+            Assert.Equal(DocDriftChecker.MirrorRegenResult.Written, DocDriftChecker.RegenerateAgentsMd(dir));
+            Assert.Equal(DocDriftChecker.AgentsMdFromClaudeMd(SampleClaude), File.ReadAllText(agents));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Regenerate_SourceMissing_DoesNotWrite()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            Assert.Equal(DocDriftChecker.MirrorRegenResult.SourceMissing, DocDriftChecker.RegenerateAgentsMd(dir));
+            Assert.False(File.Exists(Path.Combine(dir, "AGENTS.md")));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Regenerate_AnchorMismatch_DoesNotWrite()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "CLAUDE.md"), "# Renamed Title\n\nbody\n");
+            Assert.Equal(DocDriftChecker.MirrorRegenResult.AnchorMismatch, DocDriftChecker.RegenerateAgentsMd(dir));
+            Assert.False(File.Exists(Path.Combine(dir, "AGENTS.md")));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
     // --- Keyword drift (the §FOREACH-vs-§EACH class) ---
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/DocDriftCheckerTests.cs
+++ b/tests/Calor.Compiler.Tests/DocDriftCheckerTests.cs
@@ -20,7 +20,8 @@ public class DocDriftCheckerTests
         DocFile? effectsReferenceDoc = null,
         DocFile[]? effectDocsForwardOnly = null,
         DocFile? cliCodesDoc = null,
-        DocFile[]? versionScanDocs = null)
+        DocFile[]? versionScanDocs = null,
+        MirrorDoc[]? mirrorDocs = null)
     {
         return new DocDriftInputs
         {
@@ -36,7 +37,54 @@ public class DocDriftCheckerTests
             EffectDocsForwardOnly = effectDocsForwardOnly ?? [],
             CliCodesDoc = cliCodesDoc,
             VersionScanDocs = versionScanDocs ?? [],
+            MirrorDocs = mirrorDocs ?? [],
         };
+    }
+
+    // --- Mirror-doc drift (AGENTS.md single-sourced from CLAUDE.md, #708) ---
+
+    private const string SampleClaude =
+        "# CLAUDE.md — Calor Compiler\n\nBuild with `dotnet build`. Use `§F{id:Name:pub}`.\n";
+
+    [Fact]
+    public void AgentsMdTransform_SwapsTitle_AddsBanner_IsIdempotent()
+    {
+        var once = DocDriftChecker.AgentsMdFromClaudeMd(SampleClaude);
+        Assert.StartsWith("# AGENTS.md — Calor Compiler\n", once);
+        Assert.Contains("Generated from CLAUDE.md", once);
+        Assert.DoesNotContain("# CLAUDE.md — Calor Compiler", once);
+        // Body is preserved verbatim after the swapped head.
+        Assert.Contains("Build with `dotnet build`. Use `§F{id:Name:pub}`.", once);
+        // Regenerating from CLAUDE.md yields the same bytes (deterministic).
+        Assert.Equal(once, DocDriftChecker.AgentsMdFromClaudeMd(SampleClaude));
+    }
+
+    [Fact]
+    public void MirrorInSync_PassesClean()
+    {
+        var expected = DocDriftChecker.AgentsMdFromClaudeMd(SampleClaude);
+        var mirror = new MirrorDoc("AGENTS.md", "CLAUDE.md", expected, expected);
+        Assert.Empty(DocDriftChecker.Check(BaseInputs(mirrorDocs: [mirror])));
+    }
+
+    [Fact]
+    public void MirrorOutOfSync_IsDetected()
+    {
+        var expected = DocDriftChecker.AgentsMdFromClaudeMd(SampleClaude);
+        var mirror = new MirrorDoc("AGENTS.md", "CLAUDE.md", expected + "hand edit\n", expected);
+        var finding = Assert.Single(DocDriftChecker.Check(BaseInputs(mirrorDocs: [mirror])));
+        Assert.Equal(DiagnosticCode.DocDriftMirrorOutOfSync, finding.Code);
+        Assert.Contains("out of sync", finding.Message);
+    }
+
+    [Fact]
+    public void MirrorMissing_IsDetected()
+    {
+        var expected = DocDriftChecker.AgentsMdFromClaudeMd(SampleClaude);
+        var mirror = new MirrorDoc("AGENTS.md", "CLAUDE.md", Actual: null, expected);
+        var finding = Assert.Single(DocDriftChecker.Check(BaseInputs(mirrorDocs: [mirror])));
+        Assert.Equal(DiagnosticCode.DocDriftMirrorOutOfSync, finding.Code);
+        Assert.Contains("is missing", finding.Message);
     }
 
     // --- Keyword drift (the §FOREACH-vs-§EACH class) ---


### PR DESCRIPTION
Root `AGENTS.md` was an untracked byte-copy of CLAUDE.md outside every drift check — the rot pattern self-check exists to prevent.

## Design decision (why a generated mirror, not a pointer — review #4)
Tools that read `AGENTS.md` (Codex, the agentsmd.net convention) consume it **directly as their instruction file and do not follow a reference to another file**. A 3-line "see CLAUDE.md" pointer would leave those agents with no instructions. Verbatim content is therefore required — which is the whole premise of #708→#711 (multi-agent support). Given that, the mirror is generated from a single source (CLAUDE.md) and drift-checked so the two manuals cannot diverge.

**Acknowledged cost (review #3):** every CLAUDE.md edit must be followed by `calor self-check docs --fix` and a doubled commit, or CI's spec-drift step fails. This PR ships the enforcement; a CI auto-regenerate / pre-commit-hook ergonomic (so web-UI/toolchain-less docs PRs aren't blocked) is a worthwhile **follow-up**, not built here.

## What this does
- `AGENTS.md` = generated mirror of CLAUDE.md (title-swapped + banner), committed and tracked.
- `self-check docs` verifies it in sync (**Calor1329**); divergent/missing/anchor-changed → CI fail.
- `calor self-check docs --fix` regenerates it, **then runs the full check** (review #1: never silently skips other checks).
- Not in the keyword/diagnostic scans (identical to already-scanned CLAUDE.md → would double-report).

## Review dispositions
- **#1 (--fix skipped all checks, exit 0):** fixed — regenerate then fall through to the full check; verified it now fails on injected keyword drift.
- **#2 (silent malformed double-H1 on title change):** fixed — strict transform; anchor mismatch is a loud Calor1329 and writes nothing; verified.
- **#5a (no RegenerateAgentsMd coverage):** extracted a testable path + 4 tests (write/idempotent/source-missing/anchor-mismatch).
- **#5d (issue-jargon in agent-facing banner):** removed `#708`.
- **#5e (CI step name):** corrected in self-check.md.
- **#3/#4:** addressed above (explicit design decision + acknowledged tax + follow-up).

## Verification
Full suite green (5813); self-check clean; both demonstrated defects re-tested.

Closes #708.

🤖 Generated with [Claude Code](https://claude.com/claude-code)