### PR TITLE
fix: renumber contract-verification codes to Calor0710–0715 (#702)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Diagnostic renumbering — contract-verification results moved to Calor0710–0715 (#702).** The contract-verification pass previously reused `Calor0700`/`Calor0701`, which already meant `SemanticsVersionMismatch`/`SemanticsVersionIncompatible` — one number, two meanings. All verification-result codes now occupy a disjoint sub-band and each has a named `DiagnosticCode` constant: Z3-unavailable `Calor0700→0710`, precondition-may-be-violated `Calor0701→0711`, postcondition-may-be-violated `Calor0702→0712`, postcondition-proven `Calor0703→0713`, verification-summary `Calor0704→0714`, verification-cache-stats `Calor0705→0715`. `Calor0700`/`Calor0701` now unambiguously mean the semantics-version diagnostics. **Action for agents:** any tooling filtering verification output on `Calor0700`–`Calor0705` must switch to `Calor0710`–`Calor0715`.
+
 ## [0.7.0] - 2026-07-16
 
 ### Benchmark Results (Statistical: 30 runs)

--- a/docs/cli/compile.md
+++ b/docs/cli/compile.md
@@ -240,7 +240,7 @@ When enabled, the compiler uses the Z3 theorem prover to statically verify contr
 Example output:
 ```
 Contract verification complete: 3 proven, 1 unproven, 1 potentially violated, 0 unsupported
-warning Calor0702: Postcondition may be violated in function 'BadFunction'. Counterexample: x=0, y=1
+warning Calor0712: Postcondition may be violated in function 'BadFunction'. Counterexample: x=0, y=1
 ```
 
 For proven contracts, the generated C# includes:

--- a/docs/philosophy/static-verification.md
+++ b/docs/philosophy/static-verification.md
@@ -84,7 +84,7 @@ Z3 found a counterexample showing the contract can be violated. A warning is emi
 ```
 
 ```
-warning Calor0702: Postcondition may be violated in function 'BadDecrement'.
+warning Calor0712: Postcondition may be violated in function 'BadDecrement'.
   Contract: (>= result 0)
   Counterexample: x = 0
   Result: -1

--- a/docs/semantics/versioning.md
+++ b/docs/semantics/versioning.md
@@ -298,7 +298,7 @@ public enum VersionCompatibility
 Add to `src/Calor.Compiler/Diagnostics/Diagnostic.cs`:
 
 ```csharp
-// Semantics version (Calor0700-0799)
+// Semantics version (Calor0700-0709; contract-verification results live in 0710-0715)
 public const string SemanticsVersionMismatch = "Calor0700";     // Warning
 public const string SemanticsVersionIncompatible = "Calor0701"; // Error
 ```

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -242,14 +242,14 @@ public static class DiagnosticCode
     /// </summary>
     public const string SemanticsVersionIncompatible = "Calor0701";
 
-    // Contract verification results (Calor0710-0719) — emitted by
-    // Verification/ContractVerificationPass. This sub-band is disjoint from the
-    // semantics-version codes above: prior to #702, the verification pass reused
-    // Calor0700 (Z3 unavailable) and Calor0701 (precondition may be violated),
-    // colliding with SemanticsVersionMismatch/Incompatible. All verification
-    // results now live in 0710-0719 so no code number carries two meanings.
-    // Agents that filtered on the old 0700-0705 numbers must switch to 0710-0715
-    // (see CHANGELOG.md).
+    // Contract verification results (Calor0710-0719 reserved; 0710-0715 assigned)
+    // — emitted by Verification/ContractVerificationPass. This sub-band is disjoint
+    // from the semantics-version codes above: prior to #702, the verification pass
+    // reused Calor0700 (Z3 unavailable) and Calor0701 (precondition may be violated),
+    // colliding with SemanticsVersionMismatch/Incompatible. All verification results
+    // now live in 0710-0715 so no code number carries two meanings; 0716-0719 are
+    // reserved headroom for future verification diagnostics. Agents that filtered on
+    // the old 0700-0705 numbers must switch to 0710-0715 (see CHANGELOG.md).
 
     /// <summary>
     /// Info: static contract verification was skipped because the Z3 SMT solver

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -242,34 +242,49 @@ public static class DiagnosticCode
     /// </summary>
     public const string SemanticsVersionIncompatible = "Calor0701";
 
-    // Contract verification results (Calor0702-0705) — emitted by
-    // Verification/ContractVerificationPass. Note: the verification pass also
-    // reuses Calor0700 (Z3 unavailable, info) and Calor0701 (precondition may
-    // be violated, warning) with meanings that differ from the semantics-version
-    // constants above; that pre-existing collision is preserved for
-    // compatibility and its renumbering is tracked in
-    // https://github.com/juanmicrosoft/calor/issues/702.
+    // Contract verification results (Calor0710-0719) — emitted by
+    // Verification/ContractVerificationPass. This sub-band is disjoint from the
+    // semantics-version codes above: prior to #702, the verification pass reused
+    // Calor0700 (Z3 unavailable) and Calor0701 (precondition may be violated),
+    // colliding with SemanticsVersionMismatch/Incompatible. All verification
+    // results now live in 0710-0719 so no code number carries two meanings.
+    // Agents that filtered on the old 0700-0705 numbers must switch to 0710-0715
+    // (see CHANGELOG.md).
+
+    /// <summary>
+    /// Info: static contract verification was skipped because the Z3 SMT solver
+    /// is not available. (Renumbered from Calor0700 in #702.)
+    /// </summary>
+    public const string Z3Unavailable = "Calor0710";
+
+    /// <summary>
+    /// Warning: Z3 disproved a precondition; a counterexample is reported.
+    /// (Renumbered from Calor0701 in #702.)
+    /// </summary>
+    public const string PreconditionMayBeViolated = "Calor0711";
 
     /// <summary>
     /// Warning: Z3 disproved a postcondition; a counterexample is reported.
+    /// (Renumbered from Calor0702 in #702.)
     /// </summary>
-    public const string PostconditionMayBeViolated = "Calor0702";
+    public const string PostconditionMayBeViolated = "Calor0712";
 
     /// <summary>
     /// Info: a postcondition was statically proven; its runtime check is elided.
+    /// (Renumbered from Calor0703 in #702.)
     /// </summary>
-    public const string PostconditionProven = "Calor0703";
+    public const string PostconditionProven = "Calor0713";
 
     /// <summary>
     /// Info: per-module contract verification summary (proven / unproven /
-    /// potentially violated / unsupported counts).
+    /// potentially violated / unsupported counts). (Renumbered from Calor0704 in #702.)
     /// </summary>
-    public const string VerificationSummary = "Calor0704";
+    public const string VerificationSummary = "Calor0714";
 
     /// <summary>
-    /// Info (verbose): verification cache statistics.
+    /// Info (verbose): verification cache statistics. (Renumbered from Calor0705 in #702.)
     /// </summary>
-    public const string VerificationCacheStats = "Calor0705";
+    public const string VerificationCacheStats = "Calor0715";
 
     // ID errors (Calor0800-0899)
     /// <summary>

--- a/src/Calor.Compiler/Verification/ContractVerificationPass.cs
+++ b/src/Calor.Compiler/Verification/ContractVerificationPass.cs
@@ -34,7 +34,7 @@ public sealed class ContractVerificationPass
         {
             _diagnostics.ReportInfo(
                 module.Span,
-                "Calor0700",
+                DiagnosticCode.Z3Unavailable,
                 "Static contract verification skipped: Z3 SMT solver is not available. " +
                 "Install the Z3 native library for static verification support.");
 
@@ -159,7 +159,7 @@ public sealed class ContractVerificationPass
             {
                 _diagnostics.ReportWarning(
                     preNode.Span,
-                    "Calor0701",
+                    DiagnosticCode.PreconditionMayBeViolated,
                     $"Precondition may be violated in function '{function.Name}'. {preResult.CounterexampleDescription}");
             }
         }

--- a/tests/Calor.Compiler.Tests/DiagnosticCodeTests.cs
+++ b/tests/Calor.Compiler.Tests/DiagnosticCodeTests.cs
@@ -1,0 +1,82 @@
+using System.Reflection;
+using Calor.Compiler.Diagnostics;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Z3-independent guards for the diagnostic-code numbering. These run in every
+/// CI environment (unlike Calor.Verification.Tests, which self-skips without the
+/// Z3 native library), so a fat-fingered renumber of the verification sub-band
+/// cannot slip through a Z3-less CI. Regression guard for #702, which killed the
+/// Calor0700/0701 collision between semantics-version and contract-verification
+/// diagnostics by moving all verification results into a disjoint 0710-0715 band.
+/// </summary>
+public class DiagnosticCodeTests
+{
+    [Fact]
+    public void SemanticsVersionCodes_HaveTheirCanonicalValues()
+    {
+        Assert.Equal("Calor0700", DiagnosticCode.SemanticsVersionMismatch);
+        Assert.Equal("Calor0701", DiagnosticCode.SemanticsVersionIncompatible);
+    }
+
+    [Fact]
+    public void ContractVerificationCodes_OccupyTheDisjoint0710Band()
+    {
+        // These literal values are the contract the CHANGELOG publishes to agents
+        // filtering verification output. Changing a number here is a breaking
+        // change and must be a deliberate edit, not an accident.
+        Assert.Equal("Calor0710", DiagnosticCode.Z3Unavailable);
+        Assert.Equal("Calor0711", DiagnosticCode.PreconditionMayBeViolated);
+        Assert.Equal("Calor0712", DiagnosticCode.PostconditionMayBeViolated);
+        Assert.Equal("Calor0713", DiagnosticCode.PostconditionProven);
+        Assert.Equal("Calor0714", DiagnosticCode.VerificationSummary);
+        Assert.Equal("Calor0715", DiagnosticCode.VerificationCacheStats);
+    }
+
+    [Fact]
+    public void VerificationAndSemanticsVersionBands_DoNotCollide()
+    {
+        // The whole point of #702: no verification code shares a number with a
+        // semantics-version code. Assert the property directly so any future code
+        // added to either group that re-introduces a collision fails here.
+        var semanticsVersion = new[]
+        {
+            DiagnosticCode.SemanticsVersionMismatch,
+            DiagnosticCode.SemanticsVersionIncompatible,
+        };
+        var verification = new[]
+        {
+            DiagnosticCode.Z3Unavailable,
+            DiagnosticCode.PreconditionMayBeViolated,
+            DiagnosticCode.PostconditionMayBeViolated,
+            DiagnosticCode.PostconditionProven,
+            DiagnosticCode.VerificationSummary,
+            DiagnosticCode.VerificationCacheStats,
+        };
+
+        Assert.Empty(semanticsVersion.Intersect(verification));
+    }
+
+    [Fact]
+    public void AllDiagnosticCodeConstants_AreUnique()
+    {
+        // Broader backstop: no two DiagnosticCode constants share a value at all.
+        // Catches a collision reintroduced anywhere in the code space, not just the
+        // two bands #702 touched.
+        var values = typeof(DiagnosticCode)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(f => f.IsLiteral && f.FieldType == typeof(string))
+            .Select(f => (string)f.GetValue(null)!)
+            .ToList();
+
+        var duplicates = values
+            .GroupBy(v => v)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToList();
+
+        Assert.Empty(duplicates);
+    }
+}

--- a/tests/Calor.Compiler.Tests/DocDriftCheckerTests.cs
+++ b/tests/Calor.Compiler.Tests/DocDriftCheckerTests.cs
@@ -526,7 +526,7 @@ public class DocDriftCheckerTests
     {
         var codes = DocDriftChecker.GetImplementedDiagnosticCodes();
         Assert.Contains("Calor0830", codes);
-        Assert.Contains("Calor0702", codes); // verification-pass code, registered via constant
+        Assert.Contains("Calor0712", codes); // verification-pass code, registered via constant
         Assert.Contains("Calor1320", codes);
         Assert.DoesNotContain("Calor9876", codes);
     }

--- a/tests/Calor.Verification.Tests/IntegrationTests.cs
+++ b/tests/Calor.Verification.Tests/IntegrationTests.cs
@@ -1,4 +1,5 @@
 using Calor.Compiler;
+using Calor.Compiler.Diagnostics;
 using Calor.Compiler.Verification.Z3;
 using Xunit;
 
@@ -116,7 +117,7 @@ public class IntegrationTests
         // If Z3 wasn't available, should have info message
         if (!Z3ContextFactory.IsAvailable)
         {
-            var infos = result.Diagnostics.Where(d => d.Code == "Calor0700").ToList();
+            var infos = result.Diagnostics.Where(d => d.Code == DiagnosticCode.Z3Unavailable).ToList();
             Assert.NotEmpty(infos);
         }
     }


### PR DESCRIPTION
Closes #702.

## The collision

`Calor0700`/`Calor0701` meant two different things at once:

- **Semantics-version** — `DiagnosticCode.SemanticsVersionMismatch` (0700) / `SemanticsVersionIncompatible` (0701)
- **Contract verification** — the pass emitted `"Calor0700"` (Z3 unavailable, info) and `"Calor0701"` (precondition may be violated, warning) as **bare string literals**, while its siblings 0702–0705 were named constants.

An agent filtering verification output on `Calor07xx` could not tell a version error from a Z3-unavailable notice.

## The fix

Every verification-result code moves to a disjoint, contiguous **0710–0715** sub-band, and the two previously-literal codes gain named constants:

| Meaning | Old | New | Constant |
|---|---|---|---|
| Z3 unavailable (info) | `Calor0700`† | `Calor0710` | `Z3Unavailable` *(new)* |
| Precondition may be violated (warn) | `Calor0701`† | `Calor0711` | `PreconditionMayBeViolated` *(new)* |
| Postcondition may be violated (warn) | `Calor0702` | `Calor0712` | `PostconditionMayBeViolated` |
| Postcondition proven (info) | `Calor0703` | `Calor0713` | `PostconditionProven` |
| Verification summary (info) | `Calor0704` | `Calor0714` | `VerificationSummary` |
| Verification cache stats (info) | `Calor0705` | `Calor0715` | `VerificationCacheStats` |

† emitted as a string literal, colliding with the semantics-version constant of the same number.

`Calor0700`/`Calor0701` now unambiguously mean the semantics-version diagnostics. `0716–0719` are reserved headroom.

### On the suggested "deprecation window"
The issue floated keeping the old numbers recognized during a transition. These are pre-1.0 info/warning diagnostics gated on by no stable contract, and a real window would mean **emitting both** old and new codes for a release — noise that defeats the disambiguation. Instead the renumber is clean and called out loudly in the CHANGELOG for agents that filter on `Calor07xx`. This is a conscious break: an unmigrated consumer still filtering `Calor0700/0701` will now match semantics-version diagnostics — acceptable for no-contract info/warn codes, but flagged here so the merger owns the call.

## Changes
- `Diagnostic.cs` — new `Z3Unavailable`/`PreconditionMayBeViolated` constants; 0702–0705 → 0712–0715; comment documents the former collision and the reserved-vs-assigned range.
- `ContractVerificationPass.cs` — the two literals replaced with the named constants.
- `docs/cli/compile.md`, `docs/philosophy/static-verification.md` — sample output `Calor0702` → `Calor0712`; `docs/semantics/versioning.md` — band comment no longer claims the whole 07xx range.
- `IntegrationTests.cs` (asserts `DiagnosticCode.Z3Unavailable`), `DocDriftCheckerTests.cs` — updated.
- **`DiagnosticCodeTests.cs` (new)** — Z3-independent guards, run in every CI env: pins the literal 0710–0715 values, asserts the verification/semantics-version bands don't intersect (#702's core property), and a repo-wide "no two DiagnosticCode constants share a value" backstop.
- `CHANGELOG.md` — Unreleased entry with the full mapping and the agent action item.

## Verification
- `dotnet build` — 0 warnings (TreatWarningsAsErrors).
- Compiler.Tests DiagnosticCodeTests (4) + DocDriftCheckerTests (41), Verification.Tests (253 where Z3 present), VersioningTests (7) — all green. `VersioningTests` still pins 0700/0701 to the semantics-version constants, confirming they were left intact.
- `calor self-check docs` — no drift.

## Review response (PR #720 review)
- **Stacked-PR concern** — resolved: #719 has since merged to `main`; this branch was rebased onto current `main` so the visible diff is now only the renumber + the hardening below.
- **Untested emit sites in Z3-less CI** — addressed with the new `DiagnosticCodeTests` (constants run everywhere, so a fat-fingered renumber can't pass a Z3-less CI).
- **Silent break for old consumers** — acknowledged as a conscious decision (see above).
- **Stale band comment / reserved-range wording** — fixed in `versioning.md` and `Diagnostic.cs`.

## Acceptance criteria (#702)
- ✅ No diagnostic code number has two meanings.
- ✅ `calor self-check docs` stays green.
- ✅ Release notes call out the renumbering for agents filtering on `Calor07xx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)