### PR TITLE
docs: v0.9 "Loop" execution plan — metrics and proof points for review

### DIFF
--- a/docs/plans/loop-plan-v0.8.md
+++ b/docs/plans/loop-plan-v0.8.md
@@ -1,0 +1,160 @@
+# The Loop — v0.8 Execution Plan
+
+**Status:** Draft v1 — for review (success metrics and proof points in §4–§5 are the review target)
+**Author:** Juan Rivera (with Claude Code)
+**Created:** 2026-07-23
+**Parent:** [`agent-native-strategy.md`](agent-native-strategy.md) (v4.1) and [`agent-native-gates.md`](agent-native-gates.md). This plan does **not** modify any frozen gate criterion; everything it adds to measurement is observational instrument-layer metrics (§4), registered under the gates doc's supersession discipline before any comparison run.
+
+---
+
+## 0. Objective
+
+> **Minimize latency × iterations × ambiguity of the agent edit–feedback cycle, and prove the reduction with paired measurements.**
+
+The strategy doc's sub-claims 1–2 (fewer escaped bugs, bigger safe changes) are adjudicated by the frozen gates. This plan builds the *instrument* those gates run on — the loop the agent actually experiences — and separately proves that the v0.8 loop beats the v0.7 loop on loop-specific metrics. The two claims are kept apart on purpose: gate metrics tell us whether Calor beats C#; loop metrics tell us whether our tooling investment is paying off, at much lower measurement cost.
+
+Non-goals (kill list, per strategy doc): AST-only storage, direct-to-IL (revisited only via the PP-L1 decision gate below), custom metadata tables, event-sourced runtime semantics.
+
+---
+
+## 1. Audit delta: the loop at v0.7.0 (updates strategy doc §1.2, audited 2026-07-23)
+
+Progress since the v4.1 audit (which covered v0.6.7):
+
+| §1.2 item | Status at v0.7.0 |
+|---|---|
+| No source mapping | **Fixed** — `CSharpEmitter` emits `#line` directives with `#line default` resets (`CodeGen/CSharpEmitter.cs:161–230`) |
+| No `calor run` / `calor test` | **Fixed** — `RunCommand`, `TestCommand`, plus `WatchCommand` registered in `Program.cs:253–255` |
+| Structured output fragmented / dead `DiagnosticFormatter` | **Partially fixed** — `JsonDiagnosticFormatter`/`SarifDiagnosticFormatter` now wired into `compile` (`Program.cs:127`, `CompilationDriver`), `verify` (`VerifyCommand.cs:229`), `watch` (`WatchCommand.cs:349`), `lint`, `self-check`. Remaining fragmentation is the subject of WS1. |
+| Verification cliffs silent; `UNKNOWN`/timeout conflated | **Open** — WS1 |
+| Diagnostics span-positional, not declaration-anchored | **Open** — WS1 |
+
+Loop-specific gaps that remain, with file anchors:
+
+1. **No single envelope.** `AssessCommand.cs:300–325` still carries a private SARIF path; `effects`/`benchmark` use ad-hoc JSON; **no MCP tool** (`Mcp/Tools/*.cs`) emits the shared `JsonDiagnosticFormatter` schema — each returns its own shape. An agent that learns to parse `calor compile --format json` learns nothing transferable to `calor_check` or `calor_verify`.
+2. **Diagnostics don't name nodes.** Envelopes carry spans, not the enclosing declaration ID (`f001`), even though IDs are the language's addressing primitive and `Ids/IdScanner.cs` can produce the mapping cheaply.
+3. **Counterexamples are not reliably in the machine path.** Z3 produces concrete models, but there is no guarantee the JSON envelope for a refuted obligation carries the model; `UNKNOWN` and timeout are conflated (`Z3Verifier.cs:~117`); `Unsupported` fallbacks remain silent (strategy §1.2 item 4).
+4. **Preview exists, apply doesn't.** `EditPreviewTool` gives a safe/safe_with_warnings/breaking verdict on whole-source before/after strings. There is no node-addressed read, no transactional apply, and no project context — every MCP tool call is a stateless single-string operation.
+5. **No warm state in the MCP server.** `Incremental/BuildStateCache.cs` (format 2.0, with effect summaries and output-hash validation) serves the CLI and MSBuild, but the MCP server re-does everything per call. Feedback latency under agent load is unmeasured.
+6. **No loop telemetry.** The E2E harness (`tests/E2E/agent-tasks/`) and Phase 0 infrastructure (`bench/phase0-agent-native/`) record task outcomes and iteration counts, but not per-iteration feedback latency, envelope validity, or whether the agent's next edit targeted the node the diagnostic named.
+
+---
+
+## 2. Workstreams
+
+Ordering rationale: WS1 defines the data format every other workstream produces and every metric consumes; WS4's baseline epoch must run **before** WS2/WS3 land, or the A/B comparison in PP-L5 is unrecoverable.
+
+### WS1 — One envelope everywhere (size: M)
+
+Single-source, versioned JSON envelope for every diagnostic-producing surface.
+
+Deliverables:
+
+- **D1.1 Envelope schema v1** (documented in `docs/cli/`, validated in CI by `self-check`): schema version; diagnostic code; span; **enclosing declaration ID** (nearest ancestor with an ID, via `IdScanner`; null if IDs absent — IDs stay optional per language policy); severity; machine-applicable fix hint where one exists; and a `verification` payload for contract diagnostics.
+- **D1.2 Verification payload**: proof status as a closed enum — `proven | refuted | unknown | timeout | unsupported` — separating the currently conflated `UNKNOWN`/timeout and naming the `unsupported` cliff instead of silently keeping the runtime check. `refuted` **must** carry the concrete Z3 model (variable assignments) when the solver produced one.
+- **D1.3 Adoption sweep**: `compile`, `verify`, `effects`, `assess` (delete the private SARIF model at `AssessCommand.cs:300`), `run`, `test`, `watch` all emit schema v1; every MCP tool result embeds the same envelope for its diagnostics.
+- **D1.4 Schema conformance test**: one test that round-trips every command's JSON output through the schema validator, so drift is a build failure, not a rediscovery (this is the single-sourcing fix the strategy doc's revision log asks for).
+
+Exit criteria: zero ad-hoc diagnostic JSON shapes in `src/` (grep-enforceable); envelope coverage metric (§4, M-E1) reads 100 %; refuted-with-model attach rate (M-E2) measured and reported.
+
+### WS2 — Verified mutation loop in the MCP server (size: L)
+
+From "preview a whole-file rewrite" to "transactionally apply a node-addressed edit."
+
+Deliverables:
+
+- **D2.1 Project sessions**: MCP server gains a session-scoped project context (open a directory/`.calorproj`, hold parsed ASTs + bound state), replacing per-call single-string statelessness. This is the prerequisite for both apply and warmth (WS3).
+- **D2.2 `calor_get_node`**: read a declaration (source text + structure) by ID.
+- **D2.3 `calor_edit_apply`**: given a node ID and replacement source for that node, run the `EditPreviewTool` check set (compile, contracts, effects, references) against the *project* context, then **apply atomically or reject with the envelope** (including counterexamples). Verdict thresholds configurable: default applies `safe` and `safe_with_warnings`, rejects `breaking`.
+- **D2.4 Whole-file fallback parity**: the same transactional check-then-apply for full-file writes, so the A/B in PP-L3 compares *edit granularities* under identical checking, not "checked vs unchecked."
+
+Exit criteria: an agent can complete a multi-edit task in the E2E harness exclusively through MCP (no raw file writes), with first-apply validity and reject precision measured (§4, M-L2/M-L4).
+
+### WS3 — Warm feedback (size: M)
+
+- **D3.1 Warm project state**: sessions from D2.1 reuse `BuildStateCache` semantics in memory — reparse/rebind only dirtied files, reuse effect summaries, keep the Roslyn workspace alive for in-memory emit.
+- **D3.2 Latency instrumentation**: every MCP check/apply and every `watch` rebuild logs edit→envelope wall time into the loop telemetry stream (WS4).
+- **D3.3 Latency fixture**: a pinned ~10 k-line multi-module Calor project (generated, checked in under `bench/`) as the standard latency workload — P50/P99 mean nothing without a pinned workload.
+
+Exit criteria: PP-L1 measured on the fixture; results published in the v0.8 release notes whichever way they land.
+
+### WS4 — Loop instrumentation and the baseline epoch (size: M)
+
+- **D4.1 Loop telemetry schema**: per-iteration records (task, arm, iteration n, feedback latency, envelope schema-valid?, diagnostics returned [codes + node IDs], edit target node IDs, edit mechanism [MCP node / MCP file / raw file], apply verdict) written as JSONL next to the existing harness outputs (`runs.jsonl` convention from the Phase 2 monitoring setup).
+- **D4.2 Harness integration**: `tests/E2E/agent-tasks/` and `bench/phase0-agent-native/run-pair.sh` emit D4.1 records. Gate-relevant runs are untouched — telemetry is write-only observation.
+- **D4.3 Baseline epoch (v0.7 loop)**: before WS2/WS3 merge, run the E2E task set on v0.7.0-era tooling with telemetry on, pinned model, N repetitions per the gates doc's re-run rules. This is the control arm for PP-L5 and the source of provisional→final thresholds for PP-L4.
+- **D4.4 Metric registration**: the §4 metric definitions and §5 thresholds are appended to the gates doc as *instrument metrics* (observational; no gate criterion changes) before the comparison epoch runs — same pre-registration discipline, same "no post-hoc exclusion" rule.
+
+Exit criteria: baseline epoch archived under `bench/` with pins recorded; thresholds frozen.
+
+---
+
+## 3. Sequencing
+
+| Milestone | Contents | Depends on |
+|---|---|---|
+| **M1** | WS1 complete (envelope everywhere, conformance test) | — |
+| **M2** | WS4 D4.1–D4.3: telemetry + **baseline epoch on the v0.7 loop** | M1 (envelope validity is a recorded field) |
+| **M3** | WS2 mutation loop | M1; D2.1 unblocks WS3 |
+| **M4** | WS3 warm feedback + latency fixture | D2.1 |
+| **M5** | Comparison epoch (v0.8 loop vs M2 baseline), PP adjudication, published report | M2–M4, D4.4 |
+
+The one hard rule: **M2 before M3/M4 merge to main.** Shipping the improvements before the baseline exists destroys the A/B.
+
+---
+
+## 4. Success metrics (definitions)
+
+All machine-adjudicable; loop metrics follow the gates doc's conventions (per-pair means, paired ratios, censoring at budget+1) so numbers are comparable across documents. Envelope metrics are properties of the toolchain; loop metrics are properties of agent runs.
+
+**Envelope metrics** (measured in CI, per build):
+
+- **M-E1 Envelope coverage** — % of diagnostic-producing CLI commands and MCP tools whose JSON output validates against schema v1. Target: 100 %, enforced by D1.4.
+- **M-E2 Counterexample attach rate** — of contract diagnostics with status `refuted` on scalar obligations, % whose envelope carries a concrete model. (Denominator excludes `unknown`/`timeout`/`unsupported`, which are separately counted — see M-E3.)
+- **M-E3 Cliff visibility** — % of verification obligations whose outcome is reported as one of the five explicit statuses (i.e., no silent fallback path remains). Audited by a test enumerating fallback sites in `Z3Verifier.cs`/`ContractTranslator.cs`.
+
+**Loop metrics** (measured per harness epoch, pinned model):
+
+- **M-L1 Feedback latency** — edit→envelope wall time, P50/P99, on the pinned latency fixture (D3.3), warm session.
+- **M-L2 First-apply validity** — % of agent edit attempts that parse + bind on first application, split by edit mechanism (MCP node edit / MCP file edit / raw file write).
+- **M-L3 Diagnostic actionability** — of failing iterations where the envelope named ≥1 node ID, % where the agent's next edit touched a named node. A *proxy* metric, Goodhart-prone (§7); it never gates anything alone.
+- **M-L4 Reject precision** — of `calor_edit_apply` rejections, % that were true positives (applying the rejected edit anyway — replayed offline — produces a failing build/verify/held-out-test state). False rejects are loop poison: they burn agent iterations on compliant edits.
+- **M-L5 Iterations-to-green / tokens-to-green** — exactly as defined in the gates doc §2 (harness-observed, silent held-out tests, censored at budget+1), reused verbatim, reported per arm.
+
+---
+
+## 5. Proof points (the go/no-go claims — review these)
+
+Thresholds marked **[P]** are provisional until the M2 baseline epoch freezes them (D4.4); the others are absolute. Each proof point states its decision rule — what we do on hit *and* on miss — so the epoch adjudicates itself.
+
+| # | Claim | Measurement | Threshold | On hit | On miss |
+|---|---|---|---|---|---|
+| **PP-L1** | Warm feedback is fast enough that backend latency is a non-issue | M-L1 on D3.3 fixture | P50 ≤ 300 ms, P99 ≤ 1 s | **Direct-to-IL permanently retired**; latency argument closed with data | Profile; only if the ceiling is Roslyn emit itself does a backend conversation reopen — with this data attached |
+| **PP-L2** | Every failure the agent sees is machine-actionable | M-E1, M-E2, M-E3 | M-E1 = 100 %; M-E2 ≥ 90 %; M-E3 = 100 % | WS1 exits; envelope schema v1 frozen | Ship blocks: v0.8 does not release with silent cliffs or schema drift |
+| **PP-L3** | Node-addressed edits beat whole-file rewrites | M-L2 + tokens per accepted edit, MCP-node arm vs MCP-file arm (identical checking, D2.4) | M-L2(node) ≥ 95 %; tokens/accepted-edit ≥ 30 % lower **[P]** | `calor_edit_apply` becomes the recommended agent path in `calor init` guidance | Keep transactional file-level apply; demote node addressing to navigation-only; saves us from building on an unproven editing model |
+| **PP-L4** | Diagnostics steer the agent, not just inform it | M-L3 | ≥ 70 % **[P]** | Evidence that node-anchored envelopes work; cite in strategy doc §1.1 | Qualitative transcript review of misses; likely fix is envelope content (hints), not more metrics |
+| **PP-L5** | The v0.8 loop beats the v0.7 loop | M-L5 median paired ratio, v0.8 arm vs M2 baseline, same tasks/model/budget, Calor-only | ≥ 15 % fewer median iterations-to-green **[P]**, censored fraction not worse | The loop program continues into v0.9 (verification tiers) with the same measurement discipline | The tooling bet is not paying off as built — stop, analyze transcripts, and re-plan before v0.9 spends more |
+| **PP-L6** | Loop work didn't corrupt the science | All frozen gate metrics on a smoke epoch | No frozen gate metric regresses beyond the gates doc's noise rule | — | Regression is a release blocker regardless of PP-L1–L5 |
+
+Two adversarial notes for the review, pre-empted: (1) PP-L5 compares Calor-to-Calor, so it cannot be contaminated by task-pair bias between languages — it reuses the same pairs both arms; (2) PP-L3's 95 % is deliberately near-absolute because a *checked* node edit that fails to parse means the addressing model itself is broken, not the agent.
+
+---
+
+## 6. Decision gates summary
+
+- **PP-L1 hit → kill direct-to-IL forever.** This is the cheapest way to permanently close the most expensive item on the old proposal.
+- **PP-L3 miss → don't build v0.9 on node-addressed editing.** The mutation API stays, but as plumbing, not as the strategic bet.
+- **PP-L5 miss → freeze loop investment** until transcript analysis explains where iterations actually go. If iterations are spent on verification `unknown`s rather than bad diagnostics, the v0.9 priority flips from loop tooling to verification tiers.
+- **PP-L6 is unconditional** — instrument work never gets to move the science.
+
+## 7. Risks
+
+1. **Goodhart on M-L3** — an agent can "touch the named node" uselessly. Mitigation: M-L3 is never a gate alone; PP-L4's miss-path is transcript review, and M-L5 (which can't be gamed without actually going green) anchors PP-L5.
+2. **MCP statefulness refactor (D2.1) is the riskiest engineering** — it touches every tool. Mitigation: sessions are additive (stateless single-string paths remain for existing tools); land behind a capability flag; `SelfTestTool` extended to exercise session lifecycle.
+3. **Baseline invalidation** — if WS1 envelope changes alter agent behavior, the M2 baseline must run on the *envelope-bearing* v0.7-loop build (M1 before M2 exists precisely for this; the baseline isolates WS2+WS3, not WS1). Stated here so nobody "fixes" the ordering later.
+4. **Measurement cost** — two epochs (baseline + comparison) at gates-doc rigor, plus re-runs. Cheaper than one wrong architecture bet; the spend goes through the same authorization process as Phase 2 (`phase-2-spend-authorisation.md`).
+5. **Audit drift at bus factor 1** — the strategy doc's revision log found factual drift three rounds running. D1.4's conformance test and this doc's §1 audit table (dated, file-anchored) are the mitigations; §1 should be re-audited at M5.
+
+## 8. Relationship to v0.9
+
+On PP-L5 hit, v0.9 ("The Guarantees") inherits this instrument: verification tiers (async Z3, never blocking the edit loop), capability-parameter evolution of `§E`, and contract provenance tiers are all *measured on the same loop telemetry* — which is the point of building the instrument first.

--- a/docs/plans/loop-plan-v0.9.md
+++ b/docs/plans/loop-plan-v0.9.md
@@ -167,3 +167,14 @@ Milestone map (recorded here so the numbering stops drifting — versioning runs
 | **v0.11** | The Wedge | Onboarding into mixed C#/Calor solutions; validated on the same loop telemetry |
 
 On PP-L5 hit, **v0.10 ("The Guarantees")** inherits this instrument: verification tiers (async Z3, never blocking the edit loop), capability-parameter evolution of `§E`, and contract provenance tiers are all *measured on the same loop telemetry* — which is the point of building the instrument first. **v0.11 ("The Wedge")** — mixed-project onboarding and the curated top-N package manifests — is likewise judged on loop metrics, so the per-module adoption story is measured, not asserted.
+
+### Package ingestion (`calor import <package>`) — placement
+
+A recurring idea — *import a .NET package and generate its annotations* — is **not one milestone item**. It splits along the effect/contract seam, and each half lands where its safety story lives. This productizes existing machinery (`calor effects suggest`, the IL analyzer in `Effects/IL/`, and the v4 plan in [`dotnet-ecosystem-effect-manifests.md`](dotnet-ecosystem-effect-manifests.md)) into a first-class command, rather than new design.
+
+| Half | Milestone | Rationale | Machinery today |
+|---|---|---|---|
+| **Effect manifest generation** | **v0.11 (The Wedge)** — early, as it is a *prerequisite* of onboarding | The Wedge cannot consume a real C# solution without effect manifests for its NuGet dependencies; this *is* the "curated top-N package manifests" line | Mostly exists — IL derivation for concrete chains (prototype: definitive for BCL leaves), `effects suggest` templates; the gap is curated interface-level manifests for dynamic dispatch (`ILogger`/`IMediator`/`DbContext`, where union-all is sound but too broad) |
+| **Contract synthesis (`§Q`/`§S`)** | **v0.10 (The Guarantees)** — gated behind provenance tiers | Synthesizing behavioral contracts from signatures/XML docs yields plausibly-wrong contracts; a trusted wrong contract poisons verification. Must be tagged `assumed` (assumption, never proof), never `verified` without human audit | New |
+
+Both halves plug into this plan's instrument: `calor import` emits the WS1 envelope (§2) and stamps **provenance** on every annotation, so an agent can distinguish `derived` (sound: IL-traced effects, nullability) from `assumed` (synthesized guess) programmatically. The honest limit stays the v4 plan's limit — IL analysis resolves concrete call chains, not irreducible dynamic dispatch — so ingestion **surfaces** what it could not resolve rather than silently under-approximating.

--- a/docs/plans/loop-plan-v0.9.md
+++ b/docs/plans/loop-plan-v0.9.md
@@ -134,7 +134,7 @@ Thresholds marked **[P]** are provisional until the M2 baseline epoch freezes th
 | **PP-L2** | Every failure the agent sees is machine-actionable | M-E1, M-E2, M-E3 | M-E1 = 100 %; M-E2 ≥ 90 %; M-E3 = 100 % | WS1 exits; envelope schema v1 frozen | Ship blocks: v0.9 does not release with silent cliffs or schema drift |
 | **PP-L3** | Node-addressed edits beat whole-file rewrites | M-L2 + tokens per accepted edit, MCP-node arm vs MCP-file arm (identical checking, D2.4) | M-L2(node) ≥ 95 %; tokens/accepted-edit ≥ 30 % lower **[P]** | `calor_edit_apply` becomes the recommended agent path in `calor init` guidance | Keep transactional file-level apply; demote node addressing to navigation-only; saves us from building on an unproven editing model |
 | **PP-L4** | Diagnostics steer the agent, not just inform it | M-L3 | ≥ 70 % **[P]** | Evidence that node-anchored envelopes work; cite in strategy doc §1.1 | Qualitative transcript review of misses; likely fix is envelope content (hints), not more metrics |
-| **PP-L5** | The v0.9 loop beats the baseline loop | M-L5 median paired ratio, v0.9 arm vs M2 baseline, same tasks/model/budget, Calor-only | ≥ 15 % fewer median iterations-to-green **[P]**, censored fraction not worse | The loop program continues into v1.0 (verification tiers) with the same measurement discipline | The tooling bet is not paying off as built — stop, analyze transcripts, and re-plan before v1.0 spends more |
+| **PP-L5** | The v0.9 loop beats the baseline loop | M-L5 median paired ratio, v0.9 arm vs M2 baseline, same tasks/model/budget, Calor-only | ≥ 15 % fewer median iterations-to-green **[P]**, censored fraction not worse | The loop program continues into v0.10 (verification tiers) with the same measurement discipline | The tooling bet is not paying off as built — stop, analyze transcripts, and re-plan before v0.10 spends more |
 | **PP-L6** | Loop work didn't corrupt the science | All frozen gate metrics on a smoke epoch | No frozen gate metric regresses beyond the gates doc's noise rule | — | Regression is a release blocker regardless of PP-L1–L5 |
 
 Two adversarial notes for the review, pre-empted: (1) PP-L5 compares Calor-to-Calor, so it cannot be contaminated by task-pair bias between languages — it reuses the same pairs both arms; (2) PP-L3's 95 % is deliberately near-absolute because a *checked* node edit that fails to parse means the addressing model itself is broken, not the agent.
@@ -144,8 +144,8 @@ Two adversarial notes for the review, pre-empted: (1) PP-L5 compares Calor-to-Ca
 ## 6. Decision gates summary
 
 - **PP-L1 hit → kill direct-to-IL forever.** This is the cheapest way to permanently close the most expensive item on the old proposal.
-- **PP-L3 miss → don't build v1.0 on node-addressed editing.** The mutation API stays, but as plumbing, not as the strategic bet.
-- **PP-L5 miss → freeze loop investment** until transcript analysis explains where iterations actually go. If iterations are spent on verification `unknown`s rather than bad diagnostics, the v1.0 priority flips from loop tooling to verification tiers.
+- **PP-L3 miss → don't build v0.10 on node-addressed editing.** The mutation API stays, but as plumbing, not as the strategic bet.
+- **PP-L5 miss → freeze loop investment** until transcript analysis explains where iterations actually go. If iterations are spent on verification `unknown`s rather than bad diagnostics, the v0.10 priority flips from loop tooling to verification tiers.
 - **PP-L6 is unconditional** — instrument work never gets to move the science.
 
 ## 7. Risks
@@ -156,6 +156,6 @@ Two adversarial notes for the review, pre-empted: (1) PP-L5 compares Calor-to-Ca
 4. **Measurement cost** — two epochs (baseline + comparison) at gates-doc rigor, plus re-runs. Cheaper than one wrong architecture bet; the spend goes through the same authorization process as Phase 2 (`phase-2-spend-authorisation.md`).
 5. **Audit drift at bus factor 1** — the strategy doc's revision log found factual drift three rounds running. D1.4's conformance test and this doc's §1 audit table (dated, file-anchored) are the mitigations; §1 should be re-audited at M5.
 
-## 8. Relationship to v1.0
+## 8. Relationship to v0.10
 
-On PP-L5 hit, v1.0 ("The Guarantees") inherits this instrument: verification tiers (async Z3, never blocking the edit loop), capability-parameter evolution of `§E`, and contract provenance tiers are all *measured on the same loop telemetry* — which is the point of building the instrument first.
+On PP-L5 hit, v0.10 ("The Guarantees") inherits this instrument: verification tiers (async Z3, never blocking the edit loop), capability-parameter evolution of `§E`, and contract provenance tiers are all *measured on the same loop telemetry* — which is the point of building the instrument first.

--- a/docs/plans/loop-plan-v0.9.md
+++ b/docs/plans/loop-plan-v0.9.md
@@ -1,172 +1,178 @@
 # The Loop — v0.9 Execution Plan
 
-**Status:** Draft v1 — for review (success metrics and proof points in §4–§5 are the review target)
+**Status:** Draft v2 — revised per adversarial review round 1 (verdict on v1: 55%, 2 CRITICAL / 9 MAJOR / 6 MINOR; dispositions in §10). Success metrics (§4) and proof points (§5) remain the review target.
 **Author:** Juan Rivera (with Claude Code)
-**Created:** 2026-07-23
-**Target release:** v0.9.0 (the Loop lands here, not v0.8.0). The §1 audit is a snapshot of the current v0.7.0 codebase; the control arm is the *pre-improvement* loop (WS1-only build), captured mid-development rather than pinned to any released version — see §2 WS4 and the baseline-invalidation risk in §7.
-**Parent:** [`agent-native-strategy.md`](agent-native-strategy.md) (v4.1) and [`agent-native-gates.md`](agent-native-gates.md). This plan does **not** modify any frozen gate criterion; everything it adds to measurement is observational instrument-layer metrics (§4), registered under the gates doc's supersession discipline before any comparison run.
+**Created:** 2026-07-23 (v1 and v2 same day)
+**Parent:** [`agent-native-strategy.md`](agent-native-strategy.md) (v4.1 **including the §9 postscript**) and [`agent-native-gates.md`](agent-native-gates.md). This plan adds observational instrument-layer metrics only, via an **instrument-metrics annex** to be added to the gates doc *before* its freeze (§2 D4.4) — additive-only, observational-only, no gate-criterion cross-references. Note the gates are currently **frozen-ready but parked** per strategy §9 (the 2a gate is unfalsifiable at authorable fixture scale); this plan does not pretend otherwise.
+**Sibling registration:** [`machine-zone.md`](machine-zone.md) pre-registers experiment **E1/E1a** on the text-vs-structured-edit question. E1 **governs** that hypothesis (§9 of this doc); PP-L3 here is its implementation-grade successor and runs only if E1 leaves H1 alive.
+**Target release:** v0.9.0 (the Loop lands here, not v0.8.0). The §1 audit is a snapshot of the current v0.7.0 codebase; the A/B control arm is the *pre-improvement* (WS1-only) **build** — an archived commit, not a released version and not an early *run* — see §3 and §7 risk 3.
 
 ---
 
 ## 0. Objective
 
-> **Minimize latency × iterations × ambiguity of the agent edit–feedback cycle, and prove the reduction with paired measurements.**
+> **Minimize latency × iterations × ambiguity of the agent edit–feedback cycle, and prove the reduction with paired, simultaneous measurements.**
 
-The strategy doc's sub-claims 1–2 (fewer escaped bugs, bigger safe changes) are adjudicated by the frozen gates. This plan builds the *instrument* those gates run on — the loop the agent actually experiences — and separately proves that the v0.9 loop beats the pre-improvement baseline loop on loop-specific metrics. The two claims are kept apart on purpose: gate metrics tell us whether Calor beats C#; loop metrics tell us whether our tooling investment is paying off, at much lower measurement cost.
+The strategy doc's sub-claims 1–2 (fewer escaped bugs, bigger safe changes) are adjudicated by the (parked) gates. This plan builds the *instrument* those gates run on — the loop the agent actually experiences — and separately proves that the v0.9 loop beats the pre-improvement baseline loop on loop-specific metrics. The two claims are kept apart on purpose: gate metrics tell us whether Calor beats C#; loop metrics tell us whether our tooling investment is paying off, at much lower measurement cost.
 
-Non-goals (kill list, per strategy doc): AST-only storage, direct-to-IL (revisited only via the PP-L1 decision gate below), custom metadata tables, event-sourced runtime semantics.
+Non-goals: AST-only storage, direct-to-IL compilation, custom ECMA-335 metadata tables, event-sourced runtime semantics. These come from an external "Agent-Native Calor Architecture" proposal reviewed 2026-07-23 (not an in-repo document; the strategy doc's own deferred list is separate — runtime-evidence loop, canonical non-file program store, full ownership/linear types). PP-L1's decision gate references that external proposal, cited as such.
 
 ---
 
-## 1. Audit delta: the loop at v0.7.0 (updates strategy doc §1.2, audited 2026-07-23)
+## 1. Audit delta: the loop at v0.7.0 (updates strategy doc §1.2)
+
+**Audit rule (new in v2, per review C1):** every file:line anchor in this section is grep-verified on the audit date against a recorded commit. This audit: **2026-07-23, commit `22be666`**. Rationale: four consecutive strategy-doc review rounds found §1 audit errors, and v1 of *this* plan repeated the failure (see §10 C1).
 
 Progress since the v4.1 audit (which covered v0.6.7):
 
-| §1.2 item | Status at v0.7.0 |
+| §1.2 item | Status at `22be666` |
 |---|---|
 | No source mapping | **Fixed** — `CSharpEmitter` emits `#line` directives with `#line default` resets (`CodeGen/CSharpEmitter.cs:161–230`) |
 | No `calor run` / `calor test` | **Fixed** — `RunCommand`, `TestCommand`, plus `WatchCommand` registered in `Program.cs:253–255` |
-| Structured output fragmented / dead `DiagnosticFormatter` | **Partially fixed** — `JsonDiagnosticFormatter`/`SarifDiagnosticFormatter` now wired into `compile` (`Program.cs:127`, `CompilationDriver`), `verify` (`VerifyCommand.cs:229`), `watch` (`WatchCommand.cs:349`), `lint`, `self-check`. Remaining fragmentation is the subject of WS1. |
-| Verification cliffs silent; `UNKNOWN`/timeout conflated | **Open** — WS1 |
+| Structured output fragmented / dead `DiagnosticFormatter` | **Substantially fixed** — `JsonDiagnosticFormatter`/`SarifDiagnosticFormatter` wired into `compile` (`Program.cs:127`, `CompilationDriver`), `verify` (`VerifyCommand.cs:229`), `watch` (`WatchCommand.cs:349`), `lint`, `self-check`; commit `b162480` (2026-07-15, "structured output plumbing + SARIF dedup — Phase 1 item 3, part 1") **also unified SARIF behind the shared formatter, including `assess`** — part of WS1's scope is already delivered. Remaining fragmentation: WS1. |
+| Verification cliffs silent; `UNKNOWN`/timeout conflated | **Open** — `Z3Verifier.cs:99–117` maps solver exceptions and `UNKNOWN` (timeout or too complex) to the same `Unproven` |
 | Diagnostics span-positional, not declaration-anchored | **Open** — WS1 |
 
-Loop-specific gaps that remain, with file anchors:
+Loop-specific gaps that remain:
 
-1. **No single envelope.** `AssessCommand.cs:300–325` still carries a private SARIF path; `effects`/`benchmark` use ad-hoc JSON; **no MCP tool** (`Mcp/Tools/*.cs`) emits the shared `JsonDiagnosticFormatter` schema — each returns its own shape. An agent that learns to parse `calor compile --format json` learns nothing transferable to `calor_check` or `calor_verify`.
+1. **No single envelope.** `effects` and `benchmark` use ad-hoc JSON shapes; **no MCP tool** (`Mcp/Tools/*.cs` — zero formatter references in `Mcp/`) emits the shared `JsonDiagnosticFormatter` schema. An agent that learns to parse `calor compile --format json` learns nothing transferable to `calor_check` or `calor_verify`. *(v1 also claimed `AssessCommand.cs:300` carried a private SARIF model; false at the audit date — fixed by `b162480`. See §10 C1.)*
 2. **Diagnostics don't name nodes.** Envelopes carry spans, not the enclosing declaration ID (`f001`), even though IDs are the language's addressing primitive and `Ids/IdScanner.cs` can produce the mapping cheaply.
-3. **Counterexamples are not reliably in the machine path.** Z3 produces concrete models, but there is no guarantee the JSON envelope for a refuted obligation carries the model; `UNKNOWN` and timeout are conflated (`Z3Verifier.cs:~117`); `Unsupported` fallbacks remain silent (strategy §1.2 item 4).
-4. **Preview exists, apply doesn't.** `EditPreviewTool` gives a safe/safe_with_warnings/breaking verdict on whole-source before/after strings. There is no node-addressed read, no transactional apply, and no project context — every MCP tool call is a stateless single-string operation.
-5. **No warm state in the MCP server.** `Incremental/BuildStateCache.cs` (format 2.0, with effect summaries and output-hash validation) serves the CLI and MSBuild, but the MCP server re-does everything per call. Feedback latency under agent load is unmeasured.
+3. **Counterexamples are not reliably in the machine path.** Z3 produces concrete models, but nothing guarantees the JSON envelope for a refuted obligation carries the model; `UNKNOWN`, timeout, and solver error are conflated; `Unsupported` fallbacks remain silent at scattered exception-fallback sites across `Z3Verifier.cs`/`ContractTranslator.cs` (strategy §1.2 item 4: "a blacklist by accident").
+4. **Preview exists, apply doesn't.** `EditPreviewTool` gives a safe/safe_with_warnings/breaking verdict on whole-source before/after strings. No node-addressed read, no transactional apply, no project context — every MCP tool call is a stateless single-string operation (`McpServer.cs` is a ~200-line stateless dispatcher).
+5. **No warm state in the MCP server.** `Incremental/BuildStateCache.cs` (format 2.0, effect summaries, output-hash validation) serves the CLI and MSBuild; the MCP server re-does everything per call.
 6. **No loop telemetry.** The E2E harness (`tests/E2E/agent-tasks/`) and Phase 0 infrastructure (`bench/phase0-agent-native/`) record task outcomes and iteration counts, but not per-iteration feedback latency, envelope validity, or whether the agent's next edit targeted the node the diagnostic named.
+7. **Write-path robustness absent** *(new in v2, per review M3)*: strategy §9 explicitly elevated fault-tolerant parsing + canonical-formatter auto-heal "by the epochs' evidence." No prior workstream contained it; it is now D2.5.
 
 ---
 
 ## 2. Workstreams
 
-Ordering rationale: WS1 defines the data format every other workstream produces and every metric consumes; WS4's baseline epoch must run **before** WS2/WS3 land, or the A/B comparison in PP-L5 is unrecoverable.
+Ordering rationale: WS1 defines the data format every other workstream produces and every metric consumes; WS4's baseline build must be archived **before** WS2/WS3 merge, or the A/B isolation in PP-L5 is unrecoverable.
 
-### WS1 — One envelope everywhere (size: M)
+### WS1 — One envelope everywhere (size: M; part already landed via `b162480`)
 
-Single-source, versioned JSON envelope for every diagnostic-producing surface.
+- **D1.1 Envelope schema v1**, documented in `docs/cli/` with an **enumerated denominator**: the schema doc lists every diagnostic-producing CLI command and MCP tool by name (the `Commands/` directory holds 24 command files; the list is maintained there, not inferred by grep). Fields: schema version; diagnostic code; span; **enclosing declaration ID** (nearest ancestor with an ID via `IdScanner`; null when IDs absent — IDs stay optional per language policy); severity; machine-applicable fix hint where one exists; `verification` payload for contract diagnostics.
+- **D1.2 Verification payload with a choke point** *(revised per review M7)*: proof status as a closed enum — `proven | refuted | unknown | timeout | unsupported` — assigned at a **single exit path**: all verification outcomes route through one status-assigning function, and the conformance test verifies the choke point has no bypasses (grep for construction of the result type outside it). This is what makes "no silent cliffs" a stable property rather than whack-a-mole enumeration of known fallback sites. `refuted` **must** carry the concrete Z3 model when the solver produced one.
+- **D1.3 Adoption sweep** over the full D1.1 denominator — including `effects`, `benchmark`, `fix`, `ids`, `analyze-convertibility`, and every MCP tool — not the v1 shortlist. (SARIF unification for `assess` already landed in `b162480`.)
+- **D1.4 Schema conformance test**: round-trips every enumerated command's JSON output through the schema validator in CI, so drift is a build failure. D1.4 — not grep — is the enforcement mechanism for "zero ad-hoc shapes."
+- **D1.5 Verification-outcome fixture corpus** *(new per review M7)*: a committed set of `.calr` fixtures known to produce each of the five statuses (refuted-with-model, unknown, timeout, unsupported, proven), so M-E2/M-E3 have a defined CI corpus instead of "whatever the build happens to verify."
 
-Deliverables:
+Exit criteria: M-E1 = 100 % over the enumerated denominator; M-E2/M-E3 measured on D1.5 and reported.
 
-- **D1.1 Envelope schema v1** (documented in `docs/cli/`, validated in CI by `self-check`): schema version; diagnostic code; span; **enclosing declaration ID** (nearest ancestor with an ID, via `IdScanner`; null if IDs absent — IDs stay optional per language policy); severity; machine-applicable fix hint where one exists; and a `verification` payload for contract diagnostics.
-- **D1.2 Verification payload**: proof status as a closed enum — `proven | refuted | unknown | timeout | unsupported` — separating the currently conflated `UNKNOWN`/timeout and naming the `unsupported` cliff instead of silently keeping the runtime check. `refuted` **must** carry the concrete Z3 model (variable assignments) when the solver produced one.
-- **D1.3 Adoption sweep**: `compile`, `verify`, `effects`, `assess` (delete the private SARIF model at `AssessCommand.cs:300`), `run`, `test`, `watch` all emit schema v1; every MCP tool result embeds the same envelope for its diagnostics.
-- **D1.4 Schema conformance test**: one test that round-trips every command's JSON output through the schema validator, so drift is a build failure, not a rediscovery (this is the single-sourcing fix the strategy doc's revision log asks for).
+### WS2 — Verified mutation loop in the MCP server (size: L — sized concerns in §7 risk 2)
 
-Exit criteria: zero ad-hoc diagnostic JSON shapes in `src/` (grep-enforceable); envelope coverage metric (§4, M-E1) reads 100 %; refuted-with-model attach rate (M-E2) measured and reported.
+- **D2.1 Project sessions**: session-scoped project context in the MCP server (open a **directory; project-file format TBD and priced inside this deliverable** — no `.calorproj` exists today), holding parsed ASTs + bound state, with **dirty-state invalidation** when files change behind the session's back (the analogous "load-time reconciliation" problem was priced at phase scale in strategy 2a item 2 — it is named here so it can't be discovered mid-build).
+- **D2.2 `calor_get_node`**: read a declaration (source + structure) by ID.
+- **D2.3 `calor_edit_apply`**: given a node ID and replacement source, run the `EditPreviewTool` check set against the project context, then apply atomically or reject with the envelope (counterexamples included). Default applies `safe`/`safe_with_warnings`, rejects `breaking`.
+- **D2.4 Whole-file fallback parity**: the same transactional check-then-apply for full-file writes, so PP-L3 compares *edit granularities* under identical checking.
+- **D2.5 Write-path robustness** *(new per review M3)*: fault-tolerant parser mode + canonical-formatter auto-heal for common serialization slips (indentation, spacing) — the item strategy §9 elevated on epoch evidence. Sits in WS2 because it is the write path's other half: E1 (machine-zone) may show a cheap exemplar or auto-heal captures most of the benefit structured edits were hypothesized to deliver.
+- **Scope gate from E1** *(new per review M3)*: if machine-zone E1 kills H1 (the text-serialization-tax hypothesis), D2.2/D2.3 descope to navigation + transactional file-level apply (D2.4 + D2.5) — which is PP-L3's miss path arriving early and cheaply.
 
-### WS2 — Verified mutation loop in the MCP server (size: L)
-
-From "preview a whole-file rewrite" to "transactionally apply a node-addressed edit."
-
-Deliverables:
-
-- **D2.1 Project sessions**: MCP server gains a session-scoped project context (open a directory/`.calorproj`, hold parsed ASTs + bound state), replacing per-call single-string statelessness. This is the prerequisite for both apply and warmth (WS3).
-- **D2.2 `calor_get_node`**: read a declaration (source text + structure) by ID.
-- **D2.3 `calor_edit_apply`**: given a node ID and replacement source for that node, run the `EditPreviewTool` check set (compile, contracts, effects, references) against the *project* context, then **apply atomically or reject with the envelope** (including counterexamples). Verdict thresholds configurable: default applies `safe` and `safe_with_warnings`, rejects `breaking`.
-- **D2.4 Whole-file fallback parity**: the same transactional check-then-apply for full-file writes, so the A/B in PP-L3 compares *edit granularities* under identical checking, not "checked vs unchecked."
-
-Exit criteria: an agent can complete a multi-edit task in the E2E harness exclusively through MCP (no raw file writes), with first-apply validity and reject precision measured (§4, M-L2/M-L4).
+Exit criteria: an agent completes a multi-edit E2E task exclusively through MCP (requires the D4.2 arm-constraint capability), with M-L2 and M-L4 measured.
 
 ### WS3 — Warm feedback (size: M)
 
-- **D3.1 Warm project state**: sessions from D2.1 reuse `BuildStateCache` semantics in memory — reparse/rebind only dirtied files, reuse effect summaries, keep the Roslyn workspace alive for in-memory emit.
-- **D3.2 Latency instrumentation**: every MCP check/apply and every `watch` rebuild logs edit→envelope wall time into the loop telemetry stream (WS4).
-- **D3.3 Latency fixture**: a pinned ~10 k-line multi-module Calor project (generated, checked in under `bench/`) as the standard latency workload — P50/P99 mean nothing without a pinned workload.
+- **D3.1 Warm project state**: sessions reuse `BuildStateCache` semantics in memory — reparse/rebind only dirtied files, reuse effect summaries, keep the Roslyn workspace alive for in-memory emit.
+- **D3.2 Latency instrumentation**: every MCP check/apply and `watch` rebuild logs edit→envelope wall time into the loop telemetry stream.
+- **D3.3 Latency fixture with governance** *(revised per review m4)*: a pinned ~10 k-line multi-module generated Calor project, with stated content criteria — contract density, effect-declaration density, and cross-module reference depth matched to the current sample/test corpus percentiles (recorded in the fixture's README) — an owner, a regeneration policy (regenerate + re-baseline on minor version bumps), and a stated sample count for P50/P99 (≥ 200 timed edits per measurement).
 
-Exit criteria: PP-L1 measured on the fixture; results published in the v0.9 release notes whichever way they land.
+Exit criteria: PP-L1 measured on D3.3; results published in the v0.9 release notes whichever way they land.
 
-### WS4 — Loop instrumentation and the baseline epoch (size: M)
+### WS4 — Loop instrumentation, baseline, and measurement (size: M)
 
-- **D4.1 Loop telemetry schema**: per-iteration records (task, arm, iteration n, feedback latency, envelope schema-valid?, diagnostics returned [codes + node IDs], edit target node IDs, edit mechanism [MCP node / MCP file / raw file], apply verdict) written as JSONL next to the existing harness outputs (`runs.jsonl` convention from the Phase 2 monitoring setup).
-- **D4.2 Harness integration**: `tests/E2E/agent-tasks/` and `bench/phase0-agent-native/run-pair.sh` emit D4.1 records. Gate-relevant runs are untouched — telemetry is write-only observation.
-- **D4.3 Baseline epoch (pre-improvement loop)**: before WS2/WS3 merge, run the E2E task set on the **WS1-only build** (envelope in place, WS2/WS3 not yet merged) with telemetry on, pinned model, N repetitions per the gates doc's re-run rules. This build — not a released version number — is the control arm for PP-L5 and the source of provisional→final thresholds for PP-L4. Pinning the baseline to the immediate pre-WS2/WS3 build (rather than v0.7.0 or v0.8.0) is what keeps the A/B measuring WS2+WS3 and nothing else.
-- **D4.4 Metric registration**: the §4 metric definitions and §5 thresholds are appended to the gates doc as *instrument metrics* (observational; no gate criterion changes) before the comparison epoch runs — same pre-registration discipline, same "no post-hoc exclusion" rule.
+- **D4.1 Loop telemetry schema**: per-iteration JSONL records — task, arm, iteration n, feedback latency, envelope schema-valid?, diagnostics returned (codes + node IDs), edit target node IDs, edit mechanism (MCP node / MCP file / raw file), apply verdict, and *(new per reviews M6/m5)* the **full rejected-edit payload + content-addressed project snapshot reference** for replay, plus **raw-file-edit node attribution** (parse before/after, diff, map spans to IDs — priced here, not assumed).
+- **D4.2 Harness integration**: `tests/E2E/agent-tasks/` and `bench/phase0-agent-native/run-pair.sh` emit D4.1 records, **plus an arm-constraint capability** *(new per review M4)*: the harness can restrict an arm's permitted edit mechanism (MCP-node-only / MCP-file-only / raw), required by PP-L3's arms and WS2's exit criterion. Gate-relevant runs are untouched; telemetry is write-only observation.
+- **D4.3 Baseline build + threshold epoch** *(role narrowed per review C2)*: before WS2/WS3 merge, (a) **archive the WS1-only commit** — this build is the control *arm* for M5, checked out and run **at M5 time**, not now; (b) run a **threshold epoch** on it — telemetry shakedown plus the data that freezes [P] thresholds for PP-L4/PP-L5. This epoch is *not* the PP-L5 control run; comparing it longitudinally against a later epoch is exactly what the parent's measurement protocol forbids.
+- **D4.4 Metric registration**: the §4 definitions and §5 thresholds enter the gates doc via a new **instrument-metrics annex** (additive-only, observational-only, own version counter), added *before* the gates doc's freeze — the gates doc's §7 supersession rule has no mechanism for post-freeze additions, so the annex must exist first *(per review M1)*.
+- **D4.5 Feasibility dry-run** *(new per review M5)*: before D4.4 freezes any [P] threshold, a variance estimate (pattern: `bench/phase0-agent-native/epochs/feasibility-dry-001`) must show the threshold is decidable at the authorized spend on the stated task count and N. Iterations-to-green is small-integer and censored; with modification tasks already at 1.0× parity (machine-zone measured ledger), plausible baseline medians are 2–4 iterations, and 15 % of 3 is sub-integer — the dry-run decides whether the PP-L5 threshold, task count, or N moves. "An undetectable gate is unfalsifiability wearing statistics" (strategy §6) applies to instrument metrics too.
+- **D4.6 Reject-replay harness** *(new per review M6)*: force-applies archived rejected edits (from D4.1 payloads) against their snapshots and runs build/verify/held-out tests, producing M-L4. Below a minimum of **20 rejects per epoch**, M-L4 is *reported, not adjudicated*.
 
-Exit criteria: baseline epoch archived under `bench/` with pins recorded; thresholds frozen.
+Exit criteria: baseline build archived with pins; thresholds frozen via D4.5; annex registered.
 
 ---
 
 ## 3. Sequencing
 
-| Milestone | Contents | Depends on |
-|---|---|---|
-| **M1** | WS1 complete (envelope everywhere, conformance test) | — |
-| **M2** | WS4 D4.1–D4.3: telemetry + **baseline epoch on the pre-improvement (WS1-only) loop** | M1 (envelope validity is a recorded field) |
-| **M3** | WS2 mutation loop | M1; D2.1 unblocks WS3 |
-| **M4** | WS3 warm feedback + latency fixture | D2.1 |
-| **M5** | Comparison epoch (v0.9 loop vs M2 baseline), PP adjudication, published report | M2–M4, D4.4 |
+Calendar boxes are estimates recorded per the parent's planning discipline ("every phase has a calendar box and budget line"); they are confirmed or corrected at each milestone kickoff, and epoch spend is authorized through the `phase-2-spend-authorisation.md` process **with numbers entered before M2 kickoff** — three epochs total (threshold, comparison, PP-L6 smoke), not two as v1 under-counted.
 
-The one hard rule: **M2 before M3/M4 merge to main.** Shipping the improvements before the baseline exists destroys the A/B.
+| Milestone | Contents | Box (est.) | Depends on |
+|---|---|---|---|
+| **M1** | WS1 complete (envelope, choke point, conformance test, fixture corpus) | 3 wk | — |
+| **M2** | WS4 D4.1–D4.3, D4.5: telemetry, **baseline build archived**, threshold epoch, feasibility dry-run | 2 wk | M1 |
+| **M3** | WS2 mutation loop (scope-gated by machine-zone E1) | 6–8 wk | M1; E1 verdict |
+| **M4** | WS3 warm feedback + latency fixture | 3 wk | D2.1 |
+| **M5** | **One simultaneous comparison epoch** (§5 PP-L5, PP-L3 sub-epoch), PP adjudication, published report | 2–3 wk | M2–M4, D4.4 |
+
+**The hard rule, restated correctly** *(per review C2)*: what must precede WS2/WS3's merge is **archiving the control build** (build provenance), not running the control epoch (epoch timing). At M5, the control commit is checked out and both arms run **simultaneously, same day, same pins, same tasks** — per-task paired ratios, per the parent's rule that raw longitudinal comparisons are not evidence.
+
+**M5 arm design** *(per review C2)*:
+- **Arm A**: archived WS1-only build (from D4.3a).
+- **Arm B**: Arm A's commit **+ WS2/WS3 merged** — an isolation build, so the delta is attributable to WS2+WS3 and nothing else (main is not frozen; v0.9 HEAD contains unrelated changes and is *not* the attribution arm).
+- **Arm C (optional, separately labeled)**: v0.9 HEAD — supports the *product* claim "the v0.9 toolchain beats the WS1-only toolchain," which is honest but is not a WS2+WS3 attribution claim.
 
 ---
 
 ## 4. Success metrics (definitions)
 
-All machine-adjudicable; loop metrics follow the gates doc's conventions (per-pair means, paired ratios, censoring at budget+1) so numbers are comparable across documents. Envelope metrics are properties of the toolchain; loop metrics are properties of agent runs.
+**Toolchain metrics** (properties of the build, measured in CI — no agent, no model):
 
-**Envelope metrics** (measured in CI, per build):
+- **M-E1 Envelope coverage** — % of the D1.1-enumerated denominator whose JSON output validates against schema v1. Target 100 %, enforced by D1.4.
+- **M-E2 Counterexample attach rate** — over the D1.5 corpus: of `refuted` scalar obligations, % whose envelope carries a concrete model.
+- **M-E3 Cliff visibility** — over the D1.5 corpus: % of obligations reporting one of the five statuses, with the choke-point bypass test (D1.2) as the structural guarantee — the corpus checks behavior; the choke point makes the property stable *(per review M7)*.
+- **M-L1 Feedback latency** — edit→envelope wall time, P50/P99, ≥ 200 timed edits on the D3.3 fixture, warm session. *(Reclassified from loop metrics in v1 — it needs no agent.)*
 
-- **M-E1 Envelope coverage** — % of diagnostic-producing CLI commands and MCP tools whose JSON output validates against schema v1. Target: 100 %, enforced by D1.4.
-- **M-E2 Counterexample attach rate** — of contract diagnostics with status `refuted` on scalar obligations, % whose envelope carries a concrete model. (Denominator excludes `unknown`/`timeout`/`unsupported`, which are separately counted — see M-E3.)
-- **M-E3 Cliff visibility** — % of verification obligations whose outcome is reported as one of the five explicit statuses (i.e., no silent fallback path remains). Audited by a test enumerating fallback sites in `Z3Verifier.cs`/`ContractTranslator.cs`.
+**Loop metrics** (properties of agent runs, per epoch, pinned model). Conventions follow the gates doc **with one explicit redefinition** *(per review m6)*: a "pair" here is *the same task run on two builds* (Calor-only A/B), not the gates doc's C#/Calor fixture pair; per-pair means and median-of-paired-ratios carry over unchanged; censoring at budget+1 carries over unchanged.
 
-**Loop metrics** (measured per harness epoch, pinned model):
-
-- **M-L1 Feedback latency** — edit→envelope wall time, P50/P99, on the pinned latency fixture (D3.3), warm session.
-- **M-L2 First-apply validity** — % of agent edit attempts that parse + bind on first application, split by edit mechanism (MCP node edit / MCP file edit / raw file write).
-- **M-L3 Diagnostic actionability** — of failing iterations where the envelope named ≥1 node ID, % where the agent's next edit touched a named node. A *proxy* metric, Goodhart-prone (§7); it never gates anything alone.
-- **M-L4 Reject precision** — of `calor_edit_apply` rejections, % that were true positives (applying the rejected edit anyway — replayed offline — produces a failing build/verify/held-out-test state). False rejects are loop poison: they burn agent iterations on compliant edits.
-- **M-L5 Iterations-to-green / tokens-to-green** — exactly as defined in the gates doc §2 (harness-observed, silent held-out tests, censored at budget+1), reused verbatim, reported per arm.
+- **M-L2 First-apply validity** — % of agent edit attempts that parse + bind on first application, split by edit mechanism.
+- **M-L3 Diagnostic actionability** — of failing iterations whose envelope named ≥ 1 node ID, % where the next edit touched a named node. Raw-file edits are attributed via D4.1's before/after node mapping, so the denominator does not silently narrow to MCP-mediated edits *(per review m5)*. Goodhart-prone; never gates alone.
+- **M-L4 Reject precision** — via D4.6 replay; minimum 20 rejects per epoch to adjudicate, else reported-only.
+- **M-L5 Iterations-to-green / tokens-to-green** — as defined in the gates doc §2, with the pair redefinition above. **Censored-fraction rule** *(per review m6)*: an arm's censored fraction may not exceed the other arm's by more than 5 points absolute; beyond that the epoch is reported but PP-L5 is not adjudicated on it.
 
 ---
 
-## 5. Proof points (the go/no-go claims — review these)
+## 5. Proof points (go/no-go claims — review these)
 
-Thresholds marked **[P]** are provisional until the M2 baseline epoch freezes them (D4.4); the others are absolute. Each proof point states its decision rule — what we do on hit *and* on miss — so the epoch adjudicates itself.
+**[P]** thresholds are provisional until D4.5's feasibility dry-run confirms decidability and D4.4 freezes them; the dry-run may move a threshold, the task count, or N **before** freezing — never after.
 
 | # | Claim | Measurement | Threshold | On hit | On miss |
 |---|---|---|---|---|---|
-| **PP-L1** | Warm feedback is fast enough that backend latency is a non-issue | M-L1 on D3.3 fixture | P50 ≤ 300 ms, P99 ≤ 1 s | **Direct-to-IL permanently retired**; latency argument closed with data | Profile; only if the ceiling is Roslyn emit itself does a backend conversation reopen — with this data attached |
-| **PP-L2** | Every failure the agent sees is machine-actionable | M-E1, M-E2, M-E3 | M-E1 = 100 %; M-E2 ≥ 90 %; M-E3 = 100 % | WS1 exits; envelope schema v1 frozen | Ship blocks: v0.9 does not release with silent cliffs or schema drift |
-| **PP-L3** | Node-addressed edits beat whole-file rewrites | M-L2 + tokens per accepted edit, MCP-node arm vs MCP-file arm (identical checking, D2.4) | M-L2(node) ≥ 95 %; tokens/accepted-edit ≥ 30 % lower **[P]** | `calor_edit_apply` becomes the recommended agent path in `calor init` guidance | Keep transactional file-level apply; demote node addressing to navigation-only; saves us from building on an unproven editing model |
-| **PP-L4** | Diagnostics steer the agent, not just inform it | M-L3 | ≥ 70 % **[P]** | Evidence that node-anchored envelopes work; cite in strategy doc §1.1 | Qualitative transcript review of misses; likely fix is envelope content (hints), not more metrics |
-| **PP-L5** | The v0.9 loop beats the baseline loop | M-L5 median paired ratio, v0.9 arm vs M2 baseline, same tasks/model/budget, Calor-only | ≥ 15 % fewer median iterations-to-green **[P]**, censored fraction not worse | The loop program continues into v0.10 (verification tiers) with the same measurement discipline | The tooling bet is not paying off as built — stop, analyze transcripts, and re-plan before v0.10 spends more |
-| **PP-L6** | Loop work didn't corrupt the science | All frozen gate metrics on a smoke epoch | No frozen gate metric regresses beyond the gates doc's noise rule | — | Regression is a release blocker regardless of PP-L1–L5 |
-
-Two adversarial notes for the review, pre-empted: (1) PP-L5 compares Calor-to-Calor, so it cannot be contaminated by task-pair bias between languages — it reuses the same pairs both arms; (2) PP-L3's 95 % is deliberately near-absolute because a *checked* node edit that fails to parse means the addressing model itself is broken, not the agent.
+| **PP-L1** | Warm feedback is fast enough that backend latency is a non-issue | M-L1 on D3.3 | P50 ≤ 300 ms, P99 ≤ 1 s | Direct-to-IL (external proposal, §0) permanently retired; latency argument closed with data | Profile; only if the ceiling is Roslyn emit itself does a backend conversation reopen |
+| **PP-L2** | Every failure the agent sees is machine-actionable | M-E1, M-E2, M-E3 | M-E1 = 100 %; M-E2 ≥ 90 %; M-E3 = 100 % (choke-point-backed) | WS1 exits; schema v1 frozen | Ship blocker: v0.9 does not release with silent cliffs or schema drift |
+| **PP-L3** | Node-addressed edits beat checked whole-file rewrites | Named **sub-epoch of M5**: arm B constrained MCP-node vs arm B constrained MCP-file (D4.2 arm-constraint), identical checking (D2.4) | M-L2(node) ≥ 95 %; tokens/accepted-edit lower by **[P]** (frozen from post-M3 pilot runs, pre-registered before the sub-epoch — the M2 baseline has no node mechanism and cannot source this threshold) | `calor_edit_apply` becomes the recommended agent path | Node addressing demoted to navigation-only; D2.4+D2.5 remain. **Runs only if machine-zone E1 leaves H1 alive** (§9) |
+| **PP-L4** | Diagnostics steer the agent | M-L3 | ≥ 70 % **[P]** (frozen from the D4.3 threshold epoch) | Evidence node-anchored envelopes work | Transcript review of misses; likely fix is envelope content, not more metrics |
+| **PP-L5** | WS2+WS3 reduce iterations | M-L5 median paired ratio, **M5 arm A vs arm B, simultaneous** | ≥ 15 % fewer median iterations-to-green **[P]** (subject to D4.5 — may be re-based on the measured baseline median), censored rule per §4 | Loop program continues into v0.10 with the same discipline | The tooling bet is not paying off as built — stop, analyze transcripts, re-plan before v0.10 spends more |
+| **PP-L6** | Loop work didn't corrupt the science | *(narrowed per review M2)* (a) automated harness-config invariance check (gates doc §0.2 machinery) on a smoke epoch; (b) neutral-task iterations-to-green parity, arm A vs arm B, adjudicated by the gates doc §6.1 bootstrap | (a) zero config drift; (b) no significant regression per §6.1 | — | Release blocker regardless of PP-L1–L5. **Stated limit:** the escaped-bugs dimension is unmonitorable at authorable fixture scale (strategy §9: zero-vs-zero) until `real-scale-benchmark-design.md` lands — PP-L6 does not pretend to cover it |
 
 ---
 
 ## 6. Decision gates summary
 
-- **PP-L1 hit → kill direct-to-IL forever.** This is the cheapest way to permanently close the most expensive item on the old proposal.
-- **PP-L3 miss → don't build v0.10 on node-addressed editing.** The mutation API stays, but as plumbing, not as the strategic bet.
-- **PP-L5 miss → freeze loop investment** until transcript analysis explains where iterations actually go. If iterations are spent on verification `unknown`s rather than bad diagnostics, the v0.10 priority flips from loop tooling to verification tiers.
-- **PP-L6 is unconditional** — instrument work never gets to move the science.
+- **PP-L1 hit → direct-to-IL retired permanently**, with the external proposal cited as the source of the idea and this data as its disposal.
+- **E1 kills H1 → WS2 descopes before it is built** (D2.2/D2.3 dropped; D2.4/D2.5 proceed). PP-L3 never runs; its miss-path outcome is adopted at zero measurement cost.
+- **PP-L3 miss → don't build v0.10 on node-addressed editing.**
+- **PP-L5 miss → freeze loop investment** pending transcript analysis. If iterations are spent on verification `unknown`s rather than bad diagnostics, v0.10's priority flips from loop tooling to verification tiers.
+- **PP-L6 is unconditional** within its stated coverage.
 
 ## 7. Risks
 
-1. **Goodhart on M-L3** — an agent can "touch the named node" uselessly. Mitigation: M-L3 is never a gate alone; PP-L4's miss-path is transcript review, and M-L5 (which can't be gamed without actually going green) anchors PP-L5.
-2. **MCP statefulness refactor (D2.1) is the riskiest engineering** — it touches every tool. Mitigation: sessions are additive (stateless single-string paths remain for existing tools); land behind a capability flag; `SelfTestTool` extended to exercise session lifecycle.
-3. **Baseline invalidation** — if WS1 envelope changes alter agent behavior, the M2 baseline must run on the *envelope-bearing* WS1-only build (M1 before M2 exists precisely for this; the baseline isolates WS2+WS3, not WS1). Because the Loop ships in v0.9.0 with a v0.8.0 presumably in between, the control arm is deliberately the immediate pre-WS2/WS3 build, **not** a released version — pinning to v0.7.0 or v0.8.0 would fold their unrelated deltas into the measured effect. Stated here so nobody "fixes" the ordering — or the baseline's version pin — later.
-4. **Measurement cost** — two epochs (baseline + comparison) at gates-doc rigor, plus re-runs. Cheaper than one wrong architecture bet; the spend goes through the same authorization process as Phase 2 (`phase-2-spend-authorisation.md`).
-5. **Audit drift at bus factor 1** — the strategy doc's revision log found factual drift three rounds running. D1.4's conformance test and this doc's §1 audit table (dated, file-anchored) are the mitigations; §1 should be re-audited at M5.
+1. **Goodhart on M-L3** — mitigated: never gates alone; PP-L4 miss-path is transcript review; M-L5 anchors.
+2. **WS2 sizing** — the MCP server is a ~200-line stateless dispatcher; D2.1 adds session lifecycle, a project model over a format that does not yet exist, dirty-state invalidation, transactional apply, and parity paths. The 6–8 wk box is the honesty mechanism: if kickoff scoping busts it, the E1 scope gate and PP-L3's miss path define what to cut (D2.2/D2.3), not schedule slip.
+3. **Baseline invalidation** — the control is an **archived build run simultaneously at M5**, not an early epoch (v1 had this wrong — §10 C2). The M2 threshold epoch's results are never compared longitudinally against M5's.
+4. **Measurement cost** — **three** epochs (threshold, comparison incl. PP-L3 sub-epoch, PP-L6 smoke) plus D4.5 dry-runs and D4.6 replays; authorized with numbers via `phase-2-spend-authorisation.md` before M2.
+5. **Audit drift at bus factor 1** — v1 of this plan demonstrated the failure mode in its own §1 (§10 C1). Mitigations: the §1 anchor-verification rule (grep-verified, commit-stamped), D1.4 conformance in CI, re-audit at M5.
+6. **Registration drift between sibling docs** — two live pre-registrations existed for the text-vs-structured question (this plan's PP-L3 and machine-zone's E1). §9 resolves governance; any future overlap goes through the same explicit-governance rule.
 
 ## 8. Relationship to the milestones that follow
 
-Milestone map (recorded here so the numbering stops drifting — versioning runs 0.9 → 0.10 → 0.11, not toward 1.0):
+Milestone map — **version ↔ parent-phase mapping made explicit** *(per review M9)*; versioning runs 0.9 → 0.10 → 0.11, not toward 1.0:
 
-| Version | Theme | Relationship to this plan |
-|---|---|---|
-| **v0.9** | **The Loop** (this doc) | Builds the instrument |
-| **v0.10** | The Guarantees | Runs on the instrument |
-| **v0.11** | The Wedge | Onboarding into mixed C#/Calor solutions; validated on the same loop telemetry |
+| Version | Theme | Parent-strategy phase terrain | Note |
+|---|---|---|---|
+| **v0.9** | **The Loop** (this doc) | Phase 1 dev-loop items + instrument work | Builds the instrument |
+| **v0.10** | The Guarantees | Phase 2b terrain (verification depth) | **Deliberate deviation, argued below** |
+| **v0.11** | The Wedge | Phase 2a terrain (onboarding/adoption) | Judged on loop metrics |
 
-On PP-L5 hit, **v0.10 ("The Guarantees")** inherits this instrument: verification tiers (async Z3, never blocking the edit loop), capability-parameter evolution of `§E`, and contract provenance tiers are all *measured on the same loop telemetry* — which is the point of building the instrument first. **v0.11 ("The Wedge")** — mixed-project onboarding and the curated top-N package manifests — is likewise judged on loop metrics, so the per-module adoption story is measured, not asserted.
+**The deviation, stated plainly** *(per review M9)*: the parent gates Phase 2b **behind** a passed 2a gate — depth only after wedge demand is proven (the Spec# lesson, strategy §2.1). This map schedules Guarantees-terrain before Wedge-terrain, which inverts that gating. The argument for the inversion: the 2a gate is **parked as unfalsifiable at authorable scale** (strategy §9), so "wait for a passed 2a gate" currently means "wait indefinitely," while verification-tier work is what the loop's own telemetry (PP-L5 miss-path analysis) may demand next. This is a supersession of parent-strategy sequencing and needs sign-off as such at v0.10 planning — recorded here so it is decided, not drifted into.
 
 ### Package ingestion (`calor import <package>`) — placement
 
@@ -174,7 +180,33 @@ A recurring idea — *import a .NET package and generate its annotations* — is
 
 | Half | Milestone | Rationale | Machinery today |
 |---|---|---|---|
-| **Effect manifest generation** | **v0.11 (The Wedge)** — early, as it is a *prerequisite* of onboarding | The Wedge cannot consume a real C# solution without effect manifests for its NuGet dependencies; this *is* the "curated top-N package manifests" line | Mostly exists — IL derivation for concrete chains (prototype: definitive for BCL leaves), `effects suggest` templates; the gap is curated interface-level manifests for dynamic dispatch (`ILogger`/`IMediator`/`DbContext`, where union-all is sound but too broad) |
+| **Effect manifest generation** | **v0.11 (The Wedge)** — early, as a *prerequisite* of onboarding | The Wedge cannot consume a real C# solution without effect manifests for its NuGet dependencies; this *is* the "curated top-N package manifests" line | Mostly exists — IL derivation for concrete chains (prototype: definitive for BCL leaves), `effects suggest` templates; the gap is curated interface-level manifests for dynamic dispatch (`ILogger`/`IMediator`/`DbContext`, where union-all is sound but too broad) |
 | **Contract synthesis (`§Q`/`§S`)** | **v0.10 (The Guarantees)** — gated behind provenance tiers | Synthesizing behavioral contracts from signatures/XML docs yields plausibly-wrong contracts; a trusted wrong contract poisons verification. Must be tagged `assumed` (assumption, never proof), never `verified` without human audit | New |
 
-Both halves plug into this plan's instrument: `calor import` emits the WS1 envelope (§2) and stamps **provenance** on every annotation, so an agent can distinguish `derived` (sound: IL-traced effects, nullability) from `assumed` (synthesized guess) programmatically. The honest limit stays the v4 plan's limit — IL analysis resolves concrete call chains, not irreducible dynamic dispatch — so ingestion **surfaces** what it could not resolve rather than silently under-approximating.
+Both halves plug into this plan's instrument: `calor import` emits the WS1 envelope and stamps **provenance** on every annotation, so an agent can distinguish `derived` (sound: IL-traced effects, nullability) from `assumed` (synthesized guess) programmatically. The honest limit stays the v4 plan's limit — IL analysis resolves concrete call chains, not irreducible dynamic dispatch — so ingestion **surfaces** what it could not resolve rather than silently under-approximating.
+
+## 9. Registration reconciliation with `machine-zone.md`
+
+The text-vs-structured-edit question has one governing registration: **machine-zone E1/E1a** (three prompt arms — baseline, in-context exemplar, structured-edit interface — on the two 2.7× green-field pairs; `epochs/e1a-attribution/` exists). E1 adjudicates the *hypothesis* (H1: a text-serialization tax exists that structured edits would eliminate). This plan's PP-L3 is the *implementation-grade successor*: it measures the real `calor_edit_apply` only if E1 leaves H1 alive. If E1 kills H1 — e.g., the cheap exemplar alone collapses the ratio — WS2 descopes per §2's scope gate and PP-L3 never runs. One question, one governing registration, one conditional follow-up; no duplicate live registrations.
+
+## 10. Revision log
+
+**Draft v2 (2026-07-23)** — adversarial review round 1 (independent agent; verdict on v1: 55 %). Dispositions:
+
+- **C1 (accepted)**: §1 falsely claimed `AssessCommand` carried a private SARIF model; fixed by `b162480` 8 days before the audit date. §1 corrected, `b162480` credited as delivered WS1 scope, anchor-verification rule added.
+- **C2 (accepted)**: PP-L5 was a raw longitudinal comparison (forbidden by parent protocol) with a treatment arm (v0.9 HEAD) that did not isolate WS2+WS3. M5 redesigned as one simultaneous epoch; arm B is baseline+WS2/WS3 isolation build; v0.9 HEAD demoted to optional product-claim arm; D4.3's epoch narrowed to threshold-freezing.
+- **M1 (accepted)**: "frozen gates" framing corrected (frozen-ready, parked per strategy §9); instrument-metrics annex must be added to the gates doc pre-freeze.
+- **M2 (accepted)**: PP-L6 narrowed to config-invariance + §6.1-adjudicated neutral-task parity; escaped-bugs dimension explicitly out of coverage until real-scale redesign.
+- **M3 (accepted)**: §9 reconciliation with machine-zone E1 added; E1 governs; WS2 scope-gated on E1; write-path robustness added as D2.5.
+- **M4 (accepted)**: PP-L3 rescheduled as an M5 sub-epoch with D4.2 arm-constraint capability; threshold source corrected to post-M3 pilots (M2 baseline cannot source it).
+- **M5 (accepted)**: D4.5 feasibility dry-run required before threshold freeze; detectability threat (sub-integer 15 % at 2–4 iteration medians) stated.
+- **M6 (accepted)**: D4.6 reject-replay harness + snapshot capture in D4.1; 20-reject adjudication floor.
+- **M7 (accepted)**: D1.2 choke-point single exit path; D1.5 fixture corpus for M-E2/M-E3.
+- **M8 (partially accepted)**: calendar boxes added as kickoff-confirmed estimates; epoch count corrected to three; spend routed through the authorization process with numbers required before M2. Dollar figures are deliberately not invented in this doc.
+- **M9 (accepted)**: version↔phase mapping added; the Guarantees-before-Wedge inversion of parent 2a→2b gating flagged as a deliberate deviation requiring sign-off at v0.10 planning.
+- **m1 (accepted)**: kill list re-attributed to the external proposal; strategy doc's actual deferred list stated.
+- **m2 (accepted)**: `.calorproj` corrected to "format TBD, priced in D2.1."
+- **m3 (accepted)**: D1.3 sweep expanded to the enumerated denominator; grep dropped as enforcement in favor of D1.4.
+- **m4 (accepted)**: D3.3 governance (content criteria, owner, regeneration policy, sample count).
+- **m5 (accepted)**: raw-file-edit node attribution priced into D4.1.
+- **m6 (accepted)**: censored-fraction rule defined; pair redefinition made explicit; M-L1 reclassified as a toolchain metric.

--- a/docs/plans/loop-plan-v0.9.md
+++ b/docs/plans/loop-plan-v0.9.md
@@ -1,8 +1,9 @@
-# The Loop — v0.8 Execution Plan
+# The Loop — v0.9 Execution Plan
 
 **Status:** Draft v1 — for review (success metrics and proof points in §4–§5 are the review target)
 **Author:** Juan Rivera (with Claude Code)
 **Created:** 2026-07-23
+**Target release:** v0.9.0 (the Loop lands here, not v0.8.0). The §1 audit is a snapshot of the current v0.7.0 codebase; the control arm is the *pre-improvement* loop (WS1-only build), captured mid-development rather than pinned to any released version — see §2 WS4 and the baseline-invalidation risk in §7.
 **Parent:** [`agent-native-strategy.md`](agent-native-strategy.md) (v4.1) and [`agent-native-gates.md`](agent-native-gates.md). This plan does **not** modify any frozen gate criterion; everything it adds to measurement is observational instrument-layer metrics (§4), registered under the gates doc's supersession discipline before any comparison run.
 
 ---
@@ -11,7 +12,7 @@
 
 > **Minimize latency × iterations × ambiguity of the agent edit–feedback cycle, and prove the reduction with paired measurements.**
 
-The strategy doc's sub-claims 1–2 (fewer escaped bugs, bigger safe changes) are adjudicated by the frozen gates. This plan builds the *instrument* those gates run on — the loop the agent actually experiences — and separately proves that the v0.8 loop beats the v0.7 loop on loop-specific metrics. The two claims are kept apart on purpose: gate metrics tell us whether Calor beats C#; loop metrics tell us whether our tooling investment is paying off, at much lower measurement cost.
+The strategy doc's sub-claims 1–2 (fewer escaped bugs, bigger safe changes) are adjudicated by the frozen gates. This plan builds the *instrument* those gates run on — the loop the agent actually experiences — and separately proves that the v0.9 loop beats the pre-improvement baseline loop on loop-specific metrics. The two claims are kept apart on purpose: gate metrics tell us whether Calor beats C#; loop metrics tell us whether our tooling investment is paying off, at much lower measurement cost.
 
 Non-goals (kill list, per strategy doc): AST-only storage, direct-to-IL (revisited only via the PP-L1 decision gate below), custom metadata tables, event-sourced runtime semantics.
 
@@ -76,13 +77,13 @@ Exit criteria: an agent can complete a multi-edit task in the E2E harness exclus
 - **D3.2 Latency instrumentation**: every MCP check/apply and every `watch` rebuild logs edit→envelope wall time into the loop telemetry stream (WS4).
 - **D3.3 Latency fixture**: a pinned ~10 k-line multi-module Calor project (generated, checked in under `bench/`) as the standard latency workload — P50/P99 mean nothing without a pinned workload.
 
-Exit criteria: PP-L1 measured on the fixture; results published in the v0.8 release notes whichever way they land.
+Exit criteria: PP-L1 measured on the fixture; results published in the v0.9 release notes whichever way they land.
 
 ### WS4 — Loop instrumentation and the baseline epoch (size: M)
 
 - **D4.1 Loop telemetry schema**: per-iteration records (task, arm, iteration n, feedback latency, envelope schema-valid?, diagnostics returned [codes + node IDs], edit target node IDs, edit mechanism [MCP node / MCP file / raw file], apply verdict) written as JSONL next to the existing harness outputs (`runs.jsonl` convention from the Phase 2 monitoring setup).
 - **D4.2 Harness integration**: `tests/E2E/agent-tasks/` and `bench/phase0-agent-native/run-pair.sh` emit D4.1 records. Gate-relevant runs are untouched — telemetry is write-only observation.
-- **D4.3 Baseline epoch (v0.7 loop)**: before WS2/WS3 merge, run the E2E task set on v0.7.0-era tooling with telemetry on, pinned model, N repetitions per the gates doc's re-run rules. This is the control arm for PP-L5 and the source of provisional→final thresholds for PP-L4.
+- **D4.3 Baseline epoch (pre-improvement loop)**: before WS2/WS3 merge, run the E2E task set on the **WS1-only build** (envelope in place, WS2/WS3 not yet merged) with telemetry on, pinned model, N repetitions per the gates doc's re-run rules. This build — not a released version number — is the control arm for PP-L5 and the source of provisional→final thresholds for PP-L4. Pinning the baseline to the immediate pre-WS2/WS3 build (rather than v0.7.0 or v0.8.0) is what keeps the A/B measuring WS2+WS3 and nothing else.
 - **D4.4 Metric registration**: the §4 metric definitions and §5 thresholds are appended to the gates doc as *instrument metrics* (observational; no gate criterion changes) before the comparison epoch runs — same pre-registration discipline, same "no post-hoc exclusion" rule.
 
 Exit criteria: baseline epoch archived under `bench/` with pins recorded; thresholds frozen.
@@ -94,10 +95,10 @@ Exit criteria: baseline epoch archived under `bench/` with pins recorded; thresh
 | Milestone | Contents | Depends on |
 |---|---|---|
 | **M1** | WS1 complete (envelope everywhere, conformance test) | — |
-| **M2** | WS4 D4.1–D4.3: telemetry + **baseline epoch on the v0.7 loop** | M1 (envelope validity is a recorded field) |
+| **M2** | WS4 D4.1–D4.3: telemetry + **baseline epoch on the pre-improvement (WS1-only) loop** | M1 (envelope validity is a recorded field) |
 | **M3** | WS2 mutation loop | M1; D2.1 unblocks WS3 |
 | **M4** | WS3 warm feedback + latency fixture | D2.1 |
-| **M5** | Comparison epoch (v0.8 loop vs M2 baseline), PP adjudication, published report | M2–M4, D4.4 |
+| **M5** | Comparison epoch (v0.9 loop vs M2 baseline), PP adjudication, published report | M2–M4, D4.4 |
 
 The one hard rule: **M2 before M3/M4 merge to main.** Shipping the improvements before the baseline exists destroys the A/B.
 
@@ -130,10 +131,10 @@ Thresholds marked **[P]** are provisional until the M2 baseline epoch freezes th
 | # | Claim | Measurement | Threshold | On hit | On miss |
 |---|---|---|---|---|---|
 | **PP-L1** | Warm feedback is fast enough that backend latency is a non-issue | M-L1 on D3.3 fixture | P50 ≤ 300 ms, P99 ≤ 1 s | **Direct-to-IL permanently retired**; latency argument closed with data | Profile; only if the ceiling is Roslyn emit itself does a backend conversation reopen — with this data attached |
-| **PP-L2** | Every failure the agent sees is machine-actionable | M-E1, M-E2, M-E3 | M-E1 = 100 %; M-E2 ≥ 90 %; M-E3 = 100 % | WS1 exits; envelope schema v1 frozen | Ship blocks: v0.8 does not release with silent cliffs or schema drift |
+| **PP-L2** | Every failure the agent sees is machine-actionable | M-E1, M-E2, M-E3 | M-E1 = 100 %; M-E2 ≥ 90 %; M-E3 = 100 % | WS1 exits; envelope schema v1 frozen | Ship blocks: v0.9 does not release with silent cliffs or schema drift |
 | **PP-L3** | Node-addressed edits beat whole-file rewrites | M-L2 + tokens per accepted edit, MCP-node arm vs MCP-file arm (identical checking, D2.4) | M-L2(node) ≥ 95 %; tokens/accepted-edit ≥ 30 % lower **[P]** | `calor_edit_apply` becomes the recommended agent path in `calor init` guidance | Keep transactional file-level apply; demote node addressing to navigation-only; saves us from building on an unproven editing model |
 | **PP-L4** | Diagnostics steer the agent, not just inform it | M-L3 | ≥ 70 % **[P]** | Evidence that node-anchored envelopes work; cite in strategy doc §1.1 | Qualitative transcript review of misses; likely fix is envelope content (hints), not more metrics |
-| **PP-L5** | The v0.8 loop beats the v0.7 loop | M-L5 median paired ratio, v0.8 arm vs M2 baseline, same tasks/model/budget, Calor-only | ≥ 15 % fewer median iterations-to-green **[P]**, censored fraction not worse | The loop program continues into v0.9 (verification tiers) with the same measurement discipline | The tooling bet is not paying off as built — stop, analyze transcripts, and re-plan before v0.9 spends more |
+| **PP-L5** | The v0.9 loop beats the baseline loop | M-L5 median paired ratio, v0.9 arm vs M2 baseline, same tasks/model/budget, Calor-only | ≥ 15 % fewer median iterations-to-green **[P]**, censored fraction not worse | The loop program continues into v1.0 (verification tiers) with the same measurement discipline | The tooling bet is not paying off as built — stop, analyze transcripts, and re-plan before v1.0 spends more |
 | **PP-L6** | Loop work didn't corrupt the science | All frozen gate metrics on a smoke epoch | No frozen gate metric regresses beyond the gates doc's noise rule | — | Regression is a release blocker regardless of PP-L1–L5 |
 
 Two adversarial notes for the review, pre-empted: (1) PP-L5 compares Calor-to-Calor, so it cannot be contaminated by task-pair bias between languages — it reuses the same pairs both arms; (2) PP-L3's 95 % is deliberately near-absolute because a *checked* node edit that fails to parse means the addressing model itself is broken, not the agent.
@@ -143,18 +144,18 @@ Two adversarial notes for the review, pre-empted: (1) PP-L5 compares Calor-to-Ca
 ## 6. Decision gates summary
 
 - **PP-L1 hit → kill direct-to-IL forever.** This is the cheapest way to permanently close the most expensive item on the old proposal.
-- **PP-L3 miss → don't build v0.9 on node-addressed editing.** The mutation API stays, but as plumbing, not as the strategic bet.
-- **PP-L5 miss → freeze loop investment** until transcript analysis explains where iterations actually go. If iterations are spent on verification `unknown`s rather than bad diagnostics, the v0.9 priority flips from loop tooling to verification tiers.
+- **PP-L3 miss → don't build v1.0 on node-addressed editing.** The mutation API stays, but as plumbing, not as the strategic bet.
+- **PP-L5 miss → freeze loop investment** until transcript analysis explains where iterations actually go. If iterations are spent on verification `unknown`s rather than bad diagnostics, the v1.0 priority flips from loop tooling to verification tiers.
 - **PP-L6 is unconditional** — instrument work never gets to move the science.
 
 ## 7. Risks
 
 1. **Goodhart on M-L3** — an agent can "touch the named node" uselessly. Mitigation: M-L3 is never a gate alone; PP-L4's miss-path is transcript review, and M-L5 (which can't be gamed without actually going green) anchors PP-L5.
 2. **MCP statefulness refactor (D2.1) is the riskiest engineering** — it touches every tool. Mitigation: sessions are additive (stateless single-string paths remain for existing tools); land behind a capability flag; `SelfTestTool` extended to exercise session lifecycle.
-3. **Baseline invalidation** — if WS1 envelope changes alter agent behavior, the M2 baseline must run on the *envelope-bearing* v0.7-loop build (M1 before M2 exists precisely for this; the baseline isolates WS2+WS3, not WS1). Stated here so nobody "fixes" the ordering later.
+3. **Baseline invalidation** — if WS1 envelope changes alter agent behavior, the M2 baseline must run on the *envelope-bearing* WS1-only build (M1 before M2 exists precisely for this; the baseline isolates WS2+WS3, not WS1). Because the Loop ships in v0.9.0 with a v0.8.0 presumably in between, the control arm is deliberately the immediate pre-WS2/WS3 build, **not** a released version — pinning to v0.7.0 or v0.8.0 would fold their unrelated deltas into the measured effect. Stated here so nobody "fixes" the ordering — or the baseline's version pin — later.
 4. **Measurement cost** — two epochs (baseline + comparison) at gates-doc rigor, plus re-runs. Cheaper than one wrong architecture bet; the spend goes through the same authorization process as Phase 2 (`phase-2-spend-authorisation.md`).
 5. **Audit drift at bus factor 1** — the strategy doc's revision log found factual drift three rounds running. D1.4's conformance test and this doc's §1 audit table (dated, file-anchored) are the mitigations; §1 should be re-audited at M5.
 
-## 8. Relationship to v0.9
+## 8. Relationship to v1.0
 
-On PP-L5 hit, v0.9 ("The Guarantees") inherits this instrument: verification tiers (async Z3, never blocking the edit loop), capability-parameter evolution of `§E`, and contract provenance tiers are all *measured on the same loop telemetry* — which is the point of building the instrument first.
+On PP-L5 hit, v1.0 ("The Guarantees") inherits this instrument: verification tiers (async Z3, never blocking the edit loop), capability-parameter evolution of `§E`, and contract provenance tiers are all *measured on the same loop telemetry* — which is the point of building the instrument first.

--- a/docs/plans/loop-plan-v0.9.md
+++ b/docs/plans/loop-plan-v0.9.md
@@ -156,6 +156,14 @@ Two adversarial notes for the review, pre-empted: (1) PP-L5 compares Calor-to-Ca
 4. **Measurement cost** — two epochs (baseline + comparison) at gates-doc rigor, plus re-runs. Cheaper than one wrong architecture bet; the spend goes through the same authorization process as Phase 2 (`phase-2-spend-authorisation.md`).
 5. **Audit drift at bus factor 1** — the strategy doc's revision log found factual drift three rounds running. D1.4's conformance test and this doc's §1 audit table (dated, file-anchored) are the mitigations; §1 should be re-audited at M5.
 
-## 8. Relationship to v0.10
+## 8. Relationship to the milestones that follow
 
-On PP-L5 hit, v0.10 ("The Guarantees") inherits this instrument: verification tiers (async Z3, never blocking the edit loop), capability-parameter evolution of `§E`, and contract provenance tiers are all *measured on the same loop telemetry* — which is the point of building the instrument first.
+Milestone map (recorded here so the numbering stops drifting — versioning runs 0.9 → 0.10 → 0.11, not toward 1.0):
+
+| Version | Theme | Relationship to this plan |
+|---|---|---|
+| **v0.9** | **The Loop** (this doc) | Builds the instrument |
+| **v0.10** | The Guarantees | Runs on the instrument |
+| **v0.11** | The Wedge | Onboarding into mixed C#/Calor solutions; validated on the same loop telemetry |
+
+On PP-L5 hit, **v0.10 ("The Guarantees")** inherits this instrument: verification tiers (async Z3, never blocking the edit loop), capability-parameter evolution of `§E`, and contract provenance tiers are all *measured on the same loop telemetry* — which is the point of building the instrument first. **v0.11 ("The Wedge")** — mixed-project onboarding and the curated top-N package manifests — is likewise judged on loop metrics, so the per-module adoption story is measured, not asserted.

--- a/docs/plans/loop-plan-v0.9.md
+++ b/docs/plans/loop-plan-v0.9.md
@@ -1,6 +1,6 @@
 # The Loop — v0.9 Execution Plan
 
-**Status:** Draft v2 — revised per adversarial review round 1 (verdict on v1: 55%, 2 CRITICAL / 9 MAJOR / 6 MINOR; dispositions in §10). Success metrics (§4) and proof points (§5) remain the review target.
+**Status:** Draft v2.1 — v2 (adversarial review round 1 applied; dispositions in §10) + program-level decision structure: WS5 wedge probe pulled into v0.9, Calls 1–3 in §6.2, one-way door register in §6.3. Success metrics (§4) and proof points (§5) remain the review target.
 **Author:** Juan Rivera (with Claude Code)
 **Created:** 2026-07-23 (v1 and v2 same day)
 **Parent:** [`agent-native-strategy.md`](agent-native-strategy.md) (v4.1 **including the §9 postscript**) and [`agent-native-gates.md`](agent-native-gates.md). This plan adds observational instrument-layer metrics only, via an **instrument-metrics annex** to be added to the gates doc *before* its freeze (§2 D4.4) — additive-only, observational-only, no gate-criterion cross-references. Note the gates are currently **frozen-ready but parked** per strategy §9 (the 2a gate is unfalsifiable at authorable fixture scale); this plan does not pretend otherwise.
@@ -89,11 +89,22 @@ Exit criteria: PP-L1 measured on D3.3; results published in the v0.9 release not
 
 Exit criteria: baseline build archived with pins; thresholds frozen via D4.5; annex registered.
 
+### WS5 — Wedge probe (size: S–M; new in v2.1)
+
+The program's differentiated-value claim — *enforcement catches what agent-generated C# evidence misses* — is currently 0-for-165 observed (zero escaped bugs in either arm across all epochs to date; strategy §9 parked the 2a gate over exactly this). Waiting until v0.11 to test it means carrying the whole program on an unmeasured claim. WS5 pulls the decisive measurement into v0.9 at probe scale, sidestepping the "organic bugs don't occur at authorable fixture scale" problem with **injected defects**.
+
+- **D5.1 Injected-defect fixture set**: mixed-project tasks (Calor module inside a C# solution) seeded with regressions of the kinds enforcement claims to catch — an undeclared side effect on an enforcement-covered path, a violated `§Q`/`§S` contract on scalar code, a capability/effect laundered through a covered call chain. Defects are injected on paths the enforcement machinery *claims* to cover (the known delegate/dispatch holes are excluded and listed — the probe measures the claim as stated, not the known gaps).
+- **D5.2 Probe epoch**: paired arms per gates-doc conventions — Calor arm with enforcement on vs C# arm with its full toolkit (NRT, analyzers, agent-generated tests, per strategy §0) — measuring **catch-rate delta**: the fraction of injected defects surfaced *before* declared-done in each arm. Threshold pre-registered via D4.4/D4.5 before the epoch runs.
+- **Honest limit, stated up front**: injected defects measure *detection capability*, not organic incidence. A hit proves the mechanism works where it claims to; it does not prove real codebases produce these defects at rates that matter — that remains `real-scale-benchmark-design.md` territory. A zero-vs-zero result, however, is decisive in the other direction: if enforcement cannot catch even *seeded* defects that the C# arm misses, the differentiated-value claim has failed its third and easiest measurement.
+- **Registration note**: distinct question from machine-zone §7's red-team gate (which measures spec-diff review as a *human-review replacement*); no registration overlap.
+
+WS5 depends only on M1 (envelope) and existing harness machinery — it runs parallel to M3/M4 and is adjudicated at M5 as part of Call 2 (§6).
+
 ---
 
 ## 3. Sequencing
 
-Calendar boxes are estimates recorded per the parent's planning discipline ("every phase has a calendar box and budget line"); they are confirmed or corrected at each milestone kickoff, and epoch spend is authorized through the `phase-2-spend-authorisation.md` process **with numbers entered before M2 kickoff** — three epochs total (threshold, comparison, PP-L6 smoke), not two as v1 under-counted.
+Calendar boxes are estimates recorded per the parent's planning discipline ("every phase has a calendar box and budget line"); they are confirmed or corrected at each milestone kickoff, and epoch spend is authorized through the `phase-2-spend-authorisation.md` process **with numbers entered before M2 kickoff** — **four** epochs total (threshold, comparison, PP-L6 smoke, wedge probe).
 
 | Milestone | Contents | Box (est.) | Depends on |
 |---|---|---|---|
@@ -101,7 +112,8 @@ Calendar boxes are estimates recorded per the parent's planning discipline ("eve
 | **M2** | WS4 D4.1–D4.3, D4.5: telemetry, **baseline build archived**, threshold epoch, feasibility dry-run | 2 wk | M1 |
 | **M3** | WS2 mutation loop (scope-gated by machine-zone E1) | 6–8 wk | M1; E1 verdict |
 | **M4** | WS3 warm feedback + latency fixture | 3 wk | D2.1 |
-| **M5** | **One simultaneous comparison epoch** (§5 PP-L5, PP-L3 sub-epoch), PP adjudication, published report | 2–3 wk | M2–M4, D4.4 |
+| **M4b** | WS5 wedge probe (fixtures + probe epoch) — runs parallel to M3/M4 | 2–3 wk | M1; D4.4 registration |
+| **M5** | **One simultaneous comparison epoch** (§5 PP-L5, PP-L3 sub-epoch), PP adjudication incl. PP-W1, published report, **Call 2 (§6)** | 2–3 wk | M2–M4b, D4.4 |
 
 **The hard rule, restated correctly** *(per review C2)*: what must precede WS2/WS3's merge is **archiving the control build** (build provenance), not running the control epoch (epoch timing). At M5, the control commit is checked out and both arms run **simultaneously, same day, same pins, same tasks** — per-task paired ratios, per the parent's rule that raw longitudinal comparisons are not evidence.
 
@@ -142,10 +154,13 @@ Calendar boxes are estimates recorded per the parent's planning discipline ("eve
 | **PP-L4** | Diagnostics steer the agent | M-L3 | ≥ 70 % **[P]** (frozen from the D4.3 threshold epoch) | Evidence node-anchored envelopes work | Transcript review of misses; likely fix is envelope content, not more metrics |
 | **PP-L5** | WS2+WS3 reduce iterations | M-L5 median paired ratio, **M5 arm A vs arm B, simultaneous** | ≥ 15 % fewer median iterations-to-green **[P]** (subject to D4.5 — may be re-based on the measured baseline median), censored rule per §4 | Loop program continues into v0.10 with the same discipline | The tooling bet is not paying off as built — stop, analyze transcripts, re-plan before v0.10 spends more |
 | **PP-L6** | Loop work didn't corrupt the science | *(narrowed per review M2)* (a) automated harness-config invariance check (gates doc §0.2 machinery) on a smoke epoch; (b) neutral-task iterations-to-green parity, arm A vs arm B, adjudicated by the gates doc §6.1 bootstrap | (a) zero config drift; (b) no significant regression per §6.1 | — | Release blocker regardless of PP-L1–L5. **Stated limit:** the escaped-bugs dimension is unmonitorable at authorable fixture scale (strategy §9: zero-vs-zero) until `real-scale-benchmark-design.md` lands — PP-L6 does not pretend to cover it |
+| **PP-W1** | Enforcement catches seeded defects the C# arm misses | WS5 probe epoch: catch-rate delta on D5.1 injected defects, Calor-enforcement arm vs C#-full-toolkit arm | Positive catch-rate delta at a pre-registered margin **[P]** (frozen via D4.5 before the probe epoch) | The differentiated-value claim has its first observed instance; v0.10/v0.11 proceed with it as the centerpiece | **Zero-vs-zero at seeded-defect scale = the claim has failed its third and easiest measurement.** Feeds Call 2 (§6): the program pivots or stops — this is pre-committed now, while neutral, precisely so sunk cost cannot renegotiate it later |
 
 ---
 
-## 6. Decision gates summary
+## 6. Decision structure
+
+### 6.1 Per-milestone gates
 
 - **PP-L1 hit → direct-to-IL retired permanently**, with the external proposal cited as the source of the idea and this data as its disposal.
 - **E1 kills H1 → WS2 descopes before it is built** (D2.2/D2.3 dropped; D2.4/D2.5 proceed). PP-L3 never runs; its miss-path outcome is adopted at zero measurement cost.
@@ -153,12 +168,29 @@ Calendar boxes are estimates recorded per the parent's planning discipline ("eve
 - **PP-L5 miss → freeze loop investment** pending transcript analysis. If iterations are spent on verification `unknown`s rather than bad diagnostics, v0.10's priority flips from loop tooling to verification tiers.
 - **PP-L6 is unconditional** within its stated coverage.
 
+### 6.2 Program-level calls (new in v2.1)
+
+Per-milestone gates decide *what to build next*; these three calls decide *whether the program continues*. They are pre-committed here, while neutral, because each milestone will otherwise end with plausible reasons to continue — sunk cost must not get a vote it wasn't given in advance.
+
+- **Call 1 (cheap, at M2 + E1 verdict):** E1's H1 disposition plus the D4.5 feasibility dry-run. Decides WS2's scope and whether the [P] thresholds are decidable at authorized spend. Already implied by v2; named here as a call.
+- **Call 2 (the program go/no-go, at M5):** adjudicated on **PP-L5 and PP-W1 together**. PP-W1 carries more weight: PP-L5 measures whether our tooling helps agents converge; PP-W1 measures whether the language's differentiated claim is real at all. Pre-committed criterion: **PP-W1 zero-vs-zero → the program pivots or stops** — v0.10/v0.11 do not proceed on the current thesis regardless of how the loop metrics look. PP-W1 hit + PP-L5 any → proceed, with v0.10 shaped by the PP-L5 transcript analysis. This is the point at which "should we go further" is decided — **not** at the Wedge.
+- **Call 3 (the one-way door, before any v0.11 adoption push):** external adoption is gated on Calls 1–2 having passed. By design this call should be nearly decided by the time it arrives.
+
+### 6.3 One-way door register (new in v2.1)
+
+Everything in v0.9–v0.10 is a **two-way door**: instrument work, verification tiers, even killing WS2 are all reversible at the cost of time spent. The register exists to name the exceptions so they cannot be walked through by drift:
+
+| Door | One-way because | Opens only on |
+|---|---|---|
+| **v0.11 Wedge adoption step** — real external teams put Calor modules in production C# solutions | Creates obligations that outlive a program decision: migration paths, compatibility promises, maintenance expectations, reputational exposure to adopters if later killed | Calls 1–2 passed; explicit sign-off at v0.11 planning |
+| **Time at bus factor 1** | Not a door but a compounding cost: every model generation improves at C# for free while the program spends calendar time. Recorded so schedule slips are read against it | — (mitigated by Call 2's early placement) |
+
 ## 7. Risks
 
 1. **Goodhart on M-L3** — mitigated: never gates alone; PP-L4 miss-path is transcript review; M-L5 anchors.
 2. **WS2 sizing** — the MCP server is a ~200-line stateless dispatcher; D2.1 adds session lifecycle, a project model over a format that does not yet exist, dirty-state invalidation, transactional apply, and parity paths. The 6–8 wk box is the honesty mechanism: if kickoff scoping busts it, the E1 scope gate and PP-L3's miss path define what to cut (D2.2/D2.3), not schedule slip.
 3. **Baseline invalidation** — the control is an **archived build run simultaneously at M5**, not an early epoch (v1 had this wrong — §10 C2). The M2 threshold epoch's results are never compared longitudinally against M5's.
-4. **Measurement cost** — **three** epochs (threshold, comparison incl. PP-L3 sub-epoch, PP-L6 smoke) plus D4.5 dry-runs and D4.6 replays; authorized with numbers via `phase-2-spend-authorisation.md` before M2.
+4. **Measurement cost** — **four** epochs (threshold, comparison incl. PP-L3 sub-epoch, PP-L6 smoke, WS5 wedge probe) plus D4.5 dry-runs and D4.6 replays; authorized with numbers via `phase-2-spend-authorisation.md` before M2.
 5. **Audit drift at bus factor 1** — v1 of this plan demonstrated the failure mode in its own §1 (§10 C1). Mitigations: the §1 anchor-verification rule (grep-verified, commit-stamped), D1.4 conformance in CI, re-audit at M5.
 6. **Registration drift between sibling docs** — two live pre-registrations existed for the text-vs-structured question (this plan's PP-L3 and machine-zone's E1). §9 resolves governance; any future overlap goes through the same explicit-governance rule.
 
@@ -210,3 +242,9 @@ The text-vs-structured-edit question has one governing registration: **machine-z
 - **m4 (accepted)**: D3.3 governance (content criteria, owner, regeneration policy, sample count).
 - **m5 (accepted)**: raw-file-edit node attribution priced into D4.1.
 - **m6 (accepted)**: censored-fraction rule defined; pair redefinition made explicit; M-L1 reclassified as a toolchain metric.
+
+**Draft v2.1 (2026-07-23)** — program-level decision structure, prompted by the question "should we go all the way to the Wedge before making a call, and is this a one-way door?":
+
+- **WS5 wedge probe** added: injected-defect measurement of the differentiated-value claim (enforcement vs C# full toolkit), pulled from v0.11 into v0.9 at probe scale (M4b, parallel to M3/M4). New proof point **PP-W1**; epoch count corrected to four.
+- **§6 restructured**: per-milestone gates (6.1) separated from **program-level Calls 1–3** (6.2). Call 2 at M5 is the program go/no-go, adjudicated on PP-L5 + PP-W1 with PP-W1 carrying more weight; its kill criterion (PP-W1 zero-vs-zero → pivot or stop) is pre-committed now so sunk cost cannot renegotiate it.
+- **§6.3 one-way door register**: names the v0.11 adoption step as the program's sole one-way door, gated on Calls 1–2; everything in v0.9–v0.10 is explicitly two-way.


### PR DESCRIPTION
Adds `docs/plans/loop-plan-v0.9.md` — a detailed, executable plan for the **v0.9.0** "Loop" milestone, positioned as instrument-layer work under `agent-native-strategy.md` (v4.1) and `agent-native-gates.md`. It adds observational metrics only; no frozen gate criteria are touched.

> **Milestone note:** the Loop lands in **v0.9.0**, not v0.8.0 (an earlier draft numbered it v0.8). "The Guarantees" is pushed to v1.0 accordingly. The §1 audit remains a snapshot of the current **v0.7.0** codebase; the A/B control arm is the *pre-improvement (WS1-only) build* captured mid-development, **not** a released version — pinning it to v0.7.0 or v0.8.0 would fold their unrelated deltas into the measured WS2+WS3 effect.

## What's in the plan

- **§1 Audit delta** — updates the strategy doc's §1.2 dev-loop audit to v0.7.0 with file anchors: source mapping (`#line`), `run`/`test`/`watch`, and formatter wiring are done; envelope fragmentation, node-anchored diagnostics, counterexample attachment, MCP apply, warmth, and loop telemetry remain.
- **§2 Four workstreams** — WS1 unified diagnostic envelope (incl. `proven|refuted|unknown|timeout|unsupported` status enum and mandatory Z3 models on `refuted`), WS2 verified node-addressed mutation loop in the MCP server (`calor_edit_apply` with transactional check-then-apply), WS3 warm project sessions + pinned 10k-line latency fixture, WS4 loop telemetry + a **baseline epoch on the pre-improvement loop before improvements merge**.
- **§4 Metrics** — envelope metrics (coverage, counterexample attach rate, cliff visibility) and loop metrics (feedback latency, first-apply validity, diagnostic actionability, reject precision, iterations-to-green reused verbatim from the gates doc).
- **§5 Proof points** — PP-L1..L6, each with threshold and an explicit on-hit/on-miss decision rule (e.g., PP-L1 hit permanently retires direct-to-IL; PP-L5 miss freezes loop investment pending transcript analysis).
- **§6–§7** — decision gates and risks, including the Goodhart exposure on the actionability proxy, the D2.1 statefulness refactor risk, and baseline-invalidation.

## Review focus

The success metrics (§4) and proof-point thresholds (§5) are the review target — thresholds marked **[P]** are provisional until the M2 baseline epoch freezes them under the gates doc's pre-registration discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNStBf24W6EYwifnM9ekrc