### PR TITLE
ci: fix VS Code publish — suppress IL3000 on guarded single-file Assembly.Location

### DIFF
--- a/src/Calor.Compiler/Incremental/BuildStateCache.cs
+++ b/src/Calor.Compiler/Incremental/BuildStateCache.cs
@@ -153,6 +153,8 @@ internal static class BuildStateCache
     /// assembly version string when the on-disk location is unavailable
     /// (e.g., single-file publish), so upgrades still invalidate the cache.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000",
+        Justification = "Assembly.Location is checked for empty string; falls back to the version string in single-file mode.")]
     public static string ComputeCliCompilerHash()
     {
         var assembly = typeof(BuildStateCache).Assembly;

--- a/src/Calor.Compiler/SelfCheck/ExemplarCompileChecker.cs
+++ b/src/Calor.Compiler/SelfCheck/ExemplarCompileChecker.cs
@@ -231,6 +231,8 @@ public static class ExemplarCompileChecker
 
     private static IReadOnlyList<MetadataReference> References() => _references.Value;
 
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000",
+        Justification = "Assembly.Location is checked for empty string; the reference is skipped in single-file mode.")]
     private static IReadOnlyList<MetadataReference> BuildReferences()
     {
         var tpa = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? "";


### PR DESCRIPTION
The **Publish VS Code Extension** workflow has been red since the 0.7.0 release — surfaced while auditing CI health before cutting 0.8.0.

## Cause

The extension's Language Server is published as a **single-file** app (`build-server.sh`: `-p:PublishSingleFile=true --self-contained`). That enables the `IL3000` analyzer, and under `TreatWarningsAsErrors` the build fails on two `Assembly.Location` reads in `Calor.Compiler`:

```
BuildStateCache.cs(159): error IL3000: Assembly.Location.get always returns an empty string … single-file
ExemplarCompileChecker.cs(245): error IL3000: …
```

The normal `Tests` CI builds non-single-file, so it never saw these — which is why this stayed hidden.

## Fix

Both call sites **already** handle the empty string `Assembly.Location` returns in a single-file app:
- `BuildStateCache.ComputeCliCompilerHash` falls back to the assembly version string.
- `ExemplarCompileChecker.BuildReferences` skips the reference when the path is empty.

So the runtime is correct; only the analyzer needed silencing. Added `[UnconditionalSuppressMessage("SingleFile", "IL3000", …)]` to both — matching the existing suppression already on `CSharpToCalorConverter.GetBasicMetadataReferences`.

## Verification

Reproduced the exact publish locally:
```
dotnet publish src/Calor.LanguageServer/... -r osx-arm64 --self-contained -p:PublishSingleFile=true …
```
- **Before:** fails with both IL3000 errors.
- **After:** produces the `calor-lsp` single-file binary, no errors.

Normal build, `self-check docs`, and the incremental/exemplar test suites are unaffected (the attribute is inert outside single-file publish).

> Scripts + two `src/` edits with existing suppression precedent; no new `.cs`, so `calor-first-guard` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)