### PR TITLE
feat: M3 — MCP project sessions + transactional file write (loop plan WS2 D2.1/D2.4)

### DIFF
--- a/docs/cli/envelope-schema.md
+++ b/docs/cli/envelope-schema.md
@@ -171,11 +171,15 @@ Classes:
 | `calor_structure` | E | **Yes** | parse errors as envelope entries |
 | `calor_format` | E | **Yes** | parser + `Calor0800`-band diagnostics as envelope entries with `declarationId` |
 | `calor_fix` | D | **Yes** (by audit) | applied-fix records only; verified no diagnostic-shaped data hides in the payload |
+| `calor_session_open` | E | **Yes** | per-file parse errors as envelope entries under `diagnostics[]` (loop plan WS2 D2.1) |
+| `calor_session_close` | X | — | session lifecycle only; no source-anchored diagnostics |
+| `calor_file_write` | E | **Yes** | check-set errors as envelope entries (`compilationResult.errors`, same shape as `calor_edit_preview`); apply verdict + heal payload alongside (loop plan WS2 D2.4/D2.5) |
 | `calor_help` | X | — | documentation lookup; no source-anchored diagnostics |
 | `calor_self_test` | X | — | golden-diff scenarios |
 
 **M-E1 (envelope coverage)** = adopted E+D surfaces / all E+D surfaces =
-**29/29 = 100 %** as of the final D1.3 sweep — the WS1 exit criterion is met.
+**31/31 = 100 %** (29 at the final D1.3 sweep, +`calor_session_open` and
+`calor_file_write` from loop plan M3/WS2) — the WS1 exit criterion is met.
 Any new command or MCP tool must be added to this table (with an envelope
 adoption or a reviewed exemption) before it ships; the conformance suite and
 this table are the drift guards.

--- a/docs/plans/loop-m3-ws2.md
+++ b/docs/plans/loop-m3-ws2.md
@@ -33,11 +33,23 @@ format would be unpriced scope. Revisit trigger: WS3 D3.3 (10k-line fixture)
 or v0.10 multi-project needs.
 
 **Dirty-state invalidation is stat-on-access, not a watcher.** Each tool call
-that touches session state re-stats its files (mtime/size gate, then SHA-256
-content hash — the `BuildStateCache.IsFileUpToDate` two-level pattern) and
-reparses only changed files. A filesystem watcher adds lifecycle complexity a
-single-client stdio server does not need. Revisit trigger: WS3 D3.1 warm-state
-latency work, where re-stat cost appears in M-L1.
+that touches session state re-stats its files (mtime/size gate; SHA-256 hash
+to suppress reparses of touched-but-unchanged files — the
+`BuildStateCache.IsFileUpToDate` pattern) and reparses only changed files. A
+filesystem watcher adds lifecycle complexity a single-client stdio server
+does not need. Stated limitation (BuildStateCache semantics): an edit that
+preserves both mtime and size is not detected until the stat next changes.
+Revisit trigger: WS3 D3.1 warm-state latency work, where re-stat cost appears
+in M-L1.
+
+**Write confinement is canonical-path containment.** Every `calor_file_write`
+must land, after symlink resolution, under the session root — or under the
+server's working directory when no session is given; session roots are
+themselves confined under the server's working directory, since a session
+confers write access. Writes to the same file are serialized in-process and
+on-disk content is revalidated against what was checked before the rename;
+races with *external* writers on the final rename remain (only OS file locks
+would close them) and are accepted for a single-client stdio server.
 
 **Sessions are optional on the write path.** `calor_file_write` works without
 a session (checks scoped to the single file, original = current disk content);
@@ -75,5 +87,10 @@ If PR 3 needs a new file, its allowlist entry rides in PR 2.
 - Warm/incremental rebind (WS3 D3.1) — sessions here cache parse state only;
   perf is out of scope until M4.
 - Node-addressed anything (retired with PP-L3).
-- MCP write access for non-`.calr` files — the write tool refuses paths
-  outside the session/allowed extension, matching the harness hook's boundary.
+- MCP write access for non-`.calr` files — the write tool refuses them, and
+  confines every write per the canonical-path decision in §2, matching the
+  harness hook's boundary.
+- Binding in the check set — the write-path checks are parse-level (plus
+  contracts/effects/reference heuristics); running the binder project-wide at
+  check time is WS3 warm-state territory. M-L2 ("parse + bind") is measured
+  by the harness on the resulting build, not inferred from the tool verdict.

--- a/src/Calor.Compiler/Mcp/McpMessageHandler.cs
+++ b/src/Calor.Compiler/Mcp/McpMessageHandler.cs
@@ -15,6 +15,7 @@ public sealed class McpMessageHandler
     private static readonly TimeSpan DefaultToolTimeout = TimeSpan.FromSeconds(60);
 
     private readonly Dictionary<string, IMcpTool> _tools;
+    private readonly Sessions.ProjectSessionManager _projectSessions = new();
     private readonly Dictionary<string, McpResource> _resources;
     private readonly Dictionary<string, McpPrompt> _prompts;
     private readonly bool _verbose;
@@ -58,6 +59,11 @@ public sealed class McpMessageHandler
         // ── Edit support & formatting ───────────────────────
         RegisterTool(new EditPreviewTool());
         RegisterTool(new FormatTool());
+
+        // ── Project sessions & transactional writes (loop plan WS2 D2.1/D2.4)
+        RegisterTool(new SessionOpenTool(_projectSessions));
+        RegisterTool(new SessionCloseTool(_projectSessions));
+        RegisterTool(new FileWriteTool(_projectSessions));
 
         // ── Refinement types & obligations ──────────────────
         RegisterTool(new RefineTool());
@@ -766,6 +772,11 @@ public sealed class McpMessageHandler
         - Effects: §E{cw,db:w,net:rw}
 
         WORKFLOW: Read calor://primer at session start. Use calor_help for unfamiliar syntax. Use calor_verify for contract checking.
+
+        EDITING .calr FILES: Prefer calor_file_write — it auto-heals indentation slips, checks the
+        edit (compile, contracts, effects, references), and applies atomically or rejects breaking
+        edits with diagnostics. For multi-file projects, calor_session_open first and pass the
+        sessionId so checks see the whole project; calor_session_close when done.
         """;
 
     // ── Test helpers (for McpRegistryValidationTests) ──────────────

--- a/src/Calor.Compiler/Mcp/Sessions/ProjectSession.cs
+++ b/src/Calor.Compiler/Mcp/Sessions/ProjectSession.cs
@@ -8,9 +8,11 @@ namespace Calor.Compiler.Mcp.Sessions;
 /// Session-scoped project context for the MCP server (loop plan WS2 D2.1).
 /// A session opens a directory and holds the parse state of every .calr file
 /// under it. Dirty-state invalidation is stat-on-access: <see cref="Refresh"/>
-/// re-stats known files (mtime/size gate, then content hash — the
-/// BuildStateCache two-level pattern) and reparses only files that changed
-/// behind the session's back; it also picks up added and deleted files.
+/// re-stats known files and reparses the ones whose stat changed, and picks
+/// up added and deleted files. The stat gate has BuildStateCache semantics —
+/// an edit that preserves both mtime and size is not detected until the stat
+/// next changes; the content hash exists to suppress reparses of touched-but-
+/// unchanged files, not to catch stat-preserving edits.
 /// No project-file format exists in v0.9 — the directory is the project
 /// (docs/plans/loop-m3-ws2.md §2).
 /// </summary>
@@ -20,10 +22,21 @@ internal sealed class ProjectSession
     // that are clearly not a Calor project workspace.
     internal const int MaxFiles = 2000;
 
+    private static readonly EnumerationOptions Enumeration = new()
+    {
+        RecurseSubdirectories = true,
+        // Skipping reparse points keeps enumeration from following symlink
+        // cycles and from pulling in files outside the root; symlinked .calr
+        // entries inside the root are deliberately not part of a session.
+        AttributesToSkip = FileAttributes.ReparsePoint | FileAttributes.Hidden | FileAttributes.System,
+    };
+
     private readonly Dictionary<string, SessionFileState> _files = new(StringComparer.Ordinal);
     private readonly object _sync = new();
 
     public string Id { get; }
+
+    /// <summary>Canonical (symlink-resolved) root; the write-confinement boundary.</summary>
     public string RootDirectory { get; }
 
     private ProjectSession(string id, string rootDirectory)
@@ -39,24 +52,26 @@ internal sealed class ProjectSession
     /// </summary>
     public static ProjectSession Open(string id, string rootDirectory)
     {
-        var root = Path.GetFullPath(rootDirectory);
+        var root = CanonicalPath.Resolve(rootDirectory);
         var session = new ProjectSession(id, root);
 
-        var paths = Directory.EnumerateFiles(root, "*.calr", SearchOption.AllDirectories).ToList();
-        if (paths.Count > MaxFiles)
-            throw new InvalidOperationException(
-                $"Directory contains {paths.Count} .calr files, exceeding the session limit of {MaxFiles}");
+        foreach (var path in Directory.EnumerateFiles(root, "*.calr", Enumeration))
+        {
+            if (session._files.Count >= MaxFiles)
+                throw new InvalidOperationException(
+                    $"Directory contains more than {MaxFiles} .calr files — not opening a session over it");
 
-        foreach (var path in paths)
-            session._files[Path.GetFullPath(path)] = SessionFileState.Load(Path.GetFullPath(path));
+            var fullPath = Path.GetFullPath(path);
+            session._files[fullPath] = SessionFileState.Load(fullPath);
+        }
 
         return session;
     }
 
     /// <summary>
     /// Re-stats every known file and re-enumerates the directory, reparsing
-    /// only files whose content actually changed. Returns what changed so
-    /// callers can report it.
+    /// only files whose stat changed. Returns what changed so callers can
+    /// report it. See the class remarks for the stat gate's limits.
     /// </summary>
     public RefreshResult Refresh()
     {
@@ -67,7 +82,7 @@ internal sealed class ProjectSession
             var removed = 0;
 
             var onDisk = Directory.Exists(RootDirectory)
-                ? Directory.EnumerateFiles(RootDirectory, "*.calr", SearchOption.AllDirectories)
+                ? Directory.EnumerateFiles(RootDirectory, "*.calr", Enumeration)
                     .Select(Path.GetFullPath)
                     .ToHashSet(StringComparer.Ordinal)
                 : new HashSet<string>(StringComparer.Ordinal);
@@ -80,43 +95,58 @@ internal sealed class ProjectSession
 
             foreach (var path in onDisk)
             {
-                if (!_files.TryGetValue(path, out var state))
+                try
                 {
-                    _files[path] = SessionFileState.Load(path);
-                    added++;
-                    continue;
+                    if (!_files.TryGetValue(path, out var state))
+                    {
+                        _files[path] = SessionFileState.Load(path);
+                        added++;
+                        continue;
+                    }
+
+                    var info = new FileInfo(path);
+                    if (info.LastWriteTimeUtc == state.LastWriteUtc && info.Length == state.FileSize)
+                        continue;
+
+                    // Stat changed — hash to decide whether the content did
+                    // (a touch without an edit must not trigger a reparse).
+                    var source = File.ReadAllText(path);
+                    var hash = SessionFileState.HashContent(source);
+                    if (hash == state.ContentHash)
+                    {
+                        state.LastWriteUtc = info.LastWriteTimeUtc;
+                        state.FileSize = info.Length;
+                        continue;
+                    }
+
+                    _files[path] = SessionFileState.FromContent(path, source, hash, info);
+                    reparsed++;
                 }
-
-                // Level 1: mtime/size stat gate. Level 2: content hash — a
-                // touch without a content change must not trigger a reparse.
-                var info = new FileInfo(path);
-                if (info.LastWriteTimeUtc == state.LastWriteUtc && info.Length == state.FileSize)
-                    continue;
-
-                var source = File.ReadAllText(path);
-                var hash = SessionFileState.HashContent(source);
-                if (hash == state.ContentHash)
+                catch (IOException)
                 {
-                    state.LastWriteUtc = info.LastWriteTimeUtc;
-                    state.FileSize = info.Length;
-                    continue;
+                    // Deleted or unreadable mid-refresh: drop it; the next
+                    // Refresh re-adds it if it reappears.
+                    if (_files.Remove(path))
+                        removed++;
                 }
-
-                _files[path] = SessionFileState.FromContent(path, source, hash, info);
-                reparsed++;
+                catch (UnauthorizedAccessException)
+                {
+                    if (_files.Remove(path))
+                        removed++;
+                }
             }
 
             return new RefreshResult(reparsed, added, removed);
         }
     }
 
-    /// <summary>True when <paramref name="absolutePath"/> is inside the session root.</summary>
+    /// <summary>
+    /// True when <paramref name="absolutePath"/> is inside the session root
+    /// after symlink resolution — a lexical prefix match alone would let a
+    /// symlinked subdirectory escape the boundary.
+    /// </summary>
     public bool ContainsPath(string absolutePath)
-    {
-        var normalized = Path.GetFullPath(absolutePath);
-        return normalized.StartsWith(RootDirectory + Path.DirectorySeparatorChar, StringComparison.Ordinal)
-            || string.Equals(Path.GetDirectoryName(normalized), RootDirectory, StringComparison.Ordinal);
-    }
+        => CanonicalPath.IsUnder(CanonicalPath.Resolve(absolutePath), RootDirectory);
 
     /// <summary>Snapshot of the session's file states, for read-only iteration.</summary>
     public List<SessionFileState> SnapshotFiles()
@@ -148,6 +178,9 @@ internal sealed class ProjectSession
 /// <summary>Per-file state held by a <see cref="ProjectSession"/>.</summary>
 internal sealed class SessionFileState
 {
+    /// <summary>Matches McpToolBase.MaxSourceLength — a session refuses to load what a tool refuses to accept.</summary>
+    internal const long MaxFileBytes = 512 * 1024;
+
     public string Path { get; }
     public string Source { get; }
     public string ContentHash { get; }
@@ -168,8 +201,18 @@ internal sealed class SessionFileState
 
     public static SessionFileState Load(string path)
     {
+        var info = new FileInfo(path);
+        if (info.Length > MaxFileBytes)
+        {
+            return new SessionFileState(path, "", $"oversize:{info.Length}", info.LastWriteTimeUtc, info.Length,
+                ParseResult.Failed(new List<string>
+                {
+                    $"File exceeds the {MaxFileBytes / 1024} KB session limit and was not parsed: {path}"
+                }));
+        }
+
         var source = File.ReadAllText(path);
-        return FromContent(path, source, HashContent(source), new FileInfo(path));
+        return FromContent(path, source, HashContent(source), info);
     }
 
     public static SessionFileState FromContent(string path, string source, string hash, FileInfo info)
@@ -178,4 +221,69 @@ internal sealed class SessionFileState
 
     public static string HashContent(string source)
         => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(source)));
+}
+
+/// <summary>
+/// Canonical-path helpers for write confinement. Containment decisions must
+/// compare real filesystem locations: <see cref="Path.GetFullPath(string)"/>
+/// is lexical only, so a symlinked subdirectory inside a root that points
+/// outside it would pass a plain prefix check.
+/// </summary>
+internal static class CanonicalPath
+{
+    private const int MaxLinkDepth = 40;
+
+    /// <summary>
+    /// Resolves symlinks in every component of <paramref name="path"/>.
+    /// Components past the deepest existing one are appended lexically —
+    /// nothing that does not exist can be a link.
+    /// </summary>
+    public static string Resolve(string path) => ResolveCore(Path.GetFullPath(path), 0);
+
+    /// <summary>True when <paramref name="canonicalPath"/> equals or is under <paramref name="canonicalRoot"/>.</summary>
+    public static bool IsUnder(string canonicalPath, string canonicalRoot)
+        => string.Equals(canonicalPath, canonicalRoot, StringComparison.Ordinal)
+           || canonicalPath.StartsWith(canonicalRoot + Path.DirectorySeparatorChar, StringComparison.Ordinal);
+
+    private static string ResolveCore(string full, int depth)
+    {
+        if (depth > MaxLinkDepth)
+            throw new IOException($"Too many levels of symbolic links resolving '{full}'");
+
+        var root = Path.GetPathRoot(full)!;
+        var parts = full[root.Length..].Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+        var current = root.TrimEnd(Path.DirectorySeparatorChar);
+        if (current.Length == 0)
+            current = root;
+
+        for (var i = 0; i < parts.Length; i++)
+        {
+            current = Path.Combine(current, parts[i]);
+
+            FileSystemInfo info = Directory.Exists(current)
+                ? new DirectoryInfo(current)
+                : new FileInfo(current);
+            if (!info.Exists)
+            {
+                for (var j = i + 1; j < parts.Length; j++)
+                    current = Path.Combine(current, parts[j]);
+                return current;
+            }
+
+            var target = info.ResolveLinkTarget(returnFinalTarget: true);
+            if (target != null)
+            {
+                // The link target's own components may contain further links
+                // (and ".." segments that GetFullPath collapses lexically), so
+                // resolve the recombined path from scratch.
+                var remainder = string.Join(Path.DirectorySeparatorChar, parts[(i + 1)..]);
+                var combined = remainder.Length == 0
+                    ? target.FullName
+                    : Path.Combine(target.FullName, remainder);
+                return ResolveCore(Path.GetFullPath(combined), depth + 1);
+            }
+        }
+
+        return current;
+    }
 }

--- a/src/Calor.Compiler/Mcp/Sessions/ProjectSession.cs
+++ b/src/Calor.Compiler/Mcp/Sessions/ProjectSession.cs
@@ -1,0 +1,181 @@
+using System.Security.Cryptography;
+using System.Text;
+using Calor.Compiler.Mcp.Tools;
+
+namespace Calor.Compiler.Mcp.Sessions;
+
+/// <summary>
+/// Session-scoped project context for the MCP server (loop plan WS2 D2.1).
+/// A session opens a directory and holds the parse state of every .calr file
+/// under it. Dirty-state invalidation is stat-on-access: <see cref="Refresh"/>
+/// re-stats known files (mtime/size gate, then content hash — the
+/// BuildStateCache two-level pattern) and reparses only files that changed
+/// behind the session's back; it also picks up added and deleted files.
+/// No project-file format exists in v0.9 — the directory is the project
+/// (docs/plans/loop-m3-ws2.md §2).
+/// </summary>
+internal sealed class ProjectSession
+{
+    // Sessions hold whole-project parse state in memory; refuse directories
+    // that are clearly not a Calor project workspace.
+    internal const int MaxFiles = 2000;
+
+    private readonly Dictionary<string, SessionFileState> _files = new(StringComparer.Ordinal);
+    private readonly object _sync = new();
+
+    public string Id { get; }
+    public string RootDirectory { get; }
+
+    private ProjectSession(string id, string rootDirectory)
+    {
+        Id = id;
+        RootDirectory = rootDirectory;
+    }
+
+    /// <summary>
+    /// Opens a session over <paramref name="rootDirectory"/>, parsing every
+    /// .calr file under it. Throws <see cref="InvalidOperationException"/>
+    /// when the directory exceeds <see cref="MaxFiles"/>.
+    /// </summary>
+    public static ProjectSession Open(string id, string rootDirectory)
+    {
+        var root = Path.GetFullPath(rootDirectory);
+        var session = new ProjectSession(id, root);
+
+        var paths = Directory.EnumerateFiles(root, "*.calr", SearchOption.AllDirectories).ToList();
+        if (paths.Count > MaxFiles)
+            throw new InvalidOperationException(
+                $"Directory contains {paths.Count} .calr files, exceeding the session limit of {MaxFiles}");
+
+        foreach (var path in paths)
+            session._files[Path.GetFullPath(path)] = SessionFileState.Load(Path.GetFullPath(path));
+
+        return session;
+    }
+
+    /// <summary>
+    /// Re-stats every known file and re-enumerates the directory, reparsing
+    /// only files whose content actually changed. Returns what changed so
+    /// callers can report it.
+    /// </summary>
+    public RefreshResult Refresh()
+    {
+        lock (_sync)
+        {
+            var reparsed = 0;
+            var added = 0;
+            var removed = 0;
+
+            var onDisk = Directory.Exists(RootDirectory)
+                ? Directory.EnumerateFiles(RootDirectory, "*.calr", SearchOption.AllDirectories)
+                    .Select(Path.GetFullPath)
+                    .ToHashSet(StringComparer.Ordinal)
+                : new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var stale in _files.Keys.Where(p => !onDisk.Contains(p)).ToList())
+            {
+                _files.Remove(stale);
+                removed++;
+            }
+
+            foreach (var path in onDisk)
+            {
+                if (!_files.TryGetValue(path, out var state))
+                {
+                    _files[path] = SessionFileState.Load(path);
+                    added++;
+                    continue;
+                }
+
+                // Level 1: mtime/size stat gate. Level 2: content hash — a
+                // touch without a content change must not trigger a reparse.
+                var info = new FileInfo(path);
+                if (info.LastWriteTimeUtc == state.LastWriteUtc && info.Length == state.FileSize)
+                    continue;
+
+                var source = File.ReadAllText(path);
+                var hash = SessionFileState.HashContent(source);
+                if (hash == state.ContentHash)
+                {
+                    state.LastWriteUtc = info.LastWriteTimeUtc;
+                    state.FileSize = info.Length;
+                    continue;
+                }
+
+                _files[path] = SessionFileState.FromContent(path, source, hash, info);
+                reparsed++;
+            }
+
+            return new RefreshResult(reparsed, added, removed);
+        }
+    }
+
+    /// <summary>True when <paramref name="absolutePath"/> is inside the session root.</summary>
+    public bool ContainsPath(string absolutePath)
+    {
+        var normalized = Path.GetFullPath(absolutePath);
+        return normalized.StartsWith(RootDirectory + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+            || string.Equals(Path.GetDirectoryName(normalized), RootDirectory, StringComparison.Ordinal);
+    }
+
+    /// <summary>Snapshot of the session's file states, for read-only iteration.</summary>
+    public List<SessionFileState> SnapshotFiles()
+    {
+        lock (_sync)
+        {
+            return _files.Values.ToList();
+        }
+    }
+
+    /// <summary>
+    /// Records the result of an applied write, so subsequent checks in this
+    /// session see the new content without re-reading the file.
+    /// </summary>
+    public void UpdateFile(string absolutePath, string source, ParseResult parse)
+    {
+        var path = Path.GetFullPath(absolutePath);
+        var info = new FileInfo(path);
+        lock (_sync)
+        {
+            _files[path] = new SessionFileState(path, source, SessionFileState.HashContent(source),
+                info.LastWriteTimeUtc, info.Length, parse);
+        }
+    }
+
+    public readonly record struct RefreshResult(int Reparsed, int Added, int Removed);
+}
+
+/// <summary>Per-file state held by a <see cref="ProjectSession"/>.</summary>
+internal sealed class SessionFileState
+{
+    public string Path { get; }
+    public string Source { get; }
+    public string ContentHash { get; }
+    public DateTime LastWriteUtc { get; set; }
+    public long FileSize { get; set; }
+    public ParseResult Parse { get; }
+
+    public SessionFileState(string path, string source, string contentHash,
+        DateTime lastWriteUtc, long fileSize, ParseResult parse)
+    {
+        Path = path;
+        Source = source;
+        ContentHash = contentHash;
+        LastWriteUtc = lastWriteUtc;
+        FileSize = fileSize;
+        Parse = parse;
+    }
+
+    public static SessionFileState Load(string path)
+    {
+        var source = File.ReadAllText(path);
+        return FromContent(path, source, HashContent(source), new FileInfo(path));
+    }
+
+    public static SessionFileState FromContent(string path, string source, string hash, FileInfo info)
+        => new(path, source, hash, info.LastWriteTimeUtc, info.Length,
+            CalorSourceHelper.Parse(source, path));
+
+    public static string HashContent(string source)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(source)));
+}

--- a/src/Calor.Compiler/Mcp/Sessions/ProjectSessionManager.cs
+++ b/src/Calor.Compiler/Mcp/Sessions/ProjectSessionManager.cs
@@ -1,0 +1,62 @@
+namespace Calor.Compiler.Mcp.Sessions;
+
+/// <summary>
+/// Owns the live <see cref="ProjectSession"/> instances for one MCP server
+/// process (loop plan WS2 D2.1). The stdio server has a single client, but
+/// tool calls can run concurrently under the handler's semaphore, so access
+/// is locked.
+/// </summary>
+internal sealed class ProjectSessionManager
+{
+    internal const int MaxSessions = 16;
+
+    private readonly Dictionary<string, ProjectSession> _sessions = new(StringComparer.Ordinal);
+    private readonly object _sync = new();
+
+    /// <summary>
+    /// Opens a session over a directory. Throws
+    /// <see cref="InvalidOperationException"/> when the session cap or the
+    /// per-session file cap is exceeded.
+    /// </summary>
+    public ProjectSession Open(string rootDirectory)
+    {
+        lock (_sync)
+        {
+            if (_sessions.Count >= MaxSessions)
+                throw new InvalidOperationException(
+                    $"Session limit of {MaxSessions} reached — close a session with calor_session_close first");
+
+            var id = $"cs-{Guid.NewGuid():N}"[..15];
+            var session = ProjectSession.Open(id, rootDirectory);
+            _sessions[session.Id] = session;
+            return session;
+        }
+    }
+
+    public ProjectSession? Get(string sessionId)
+    {
+        lock (_sync)
+        {
+            return _sessions.TryGetValue(sessionId, out var session) ? session : null;
+        }
+    }
+
+    public bool Close(string sessionId)
+    {
+        lock (_sync)
+        {
+            return _sessions.Remove(sessionId);
+        }
+    }
+
+    public int Count
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _sessions.Count;
+            }
+        }
+    }
+}

--- a/src/Calor.Compiler/Mcp/Tools/EditPreviewTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/EditPreviewTool.cs
@@ -283,26 +283,64 @@ public sealed class EditPreviewTool : McpToolBase
 
     internal static void CheckReferences(ParseResult originalParse, ParseResult modifiedParse, ReferenceCheckResult result)
     {
-        var origIds = CollectSymbolIds(originalParse.Ast!);
-        var modIds = CollectSymbolIds(modifiedParse.Ast!);
-
-        // Check for symbols referenced in modified code that were removed
-        var removedSymbols = origIds.Except(modIds).ToList();
-        if (removedSymbols.Count > 0)
+        // Functions are checked against actual call targets in the modified
+        // AST — declarations are referenced by NAME at call sites (§C{add}),
+        // not by declaration id (f001), so an id-substring scan would both
+        // miss real dangling calls and flag ids that only appear in strings.
+        var removedFunctions = CollectFunctionNames(originalParse.Ast!)
+            .Except(CollectFunctionNames(modifiedParse.Ast!))
+            .ToList();
+        if (removedFunctions.Count > 0)
         {
-            // Check if any remaining code references removed symbols
-            var modSource = modifiedParse.Source!;
-            foreach (var symbol in removedSymbols)
+            var callTargets = CollectCallTargets(modifiedParse.Ast!);
+            foreach (var name in removedFunctions)
             {
-                if (modSource.Contains(symbol))
+                if (callTargets.Contains(name))
                 {
-                    result.DanglingReferences.Add($"Symbol '{symbol}' was removed but is still referenced");
+                    result.DanglingReferences.Add($"Function '{name}' was removed but is still called");
                 }
+            }
+        }
+
+        // Types have no call-graph equivalent; use a whole-word text match
+        // (still a heuristic, but bounded — no substring hits inside longer
+        // identifiers).
+        var removedTypes = CollectTypeNames(originalParse.Ast!)
+            .Except(CollectTypeNames(modifiedParse.Ast!))
+            .ToList();
+        foreach (var name in removedTypes)
+        {
+            if (ContainsWholeWord(modifiedParse.Source!, name))
+            {
+                result.DanglingReferences.Add($"Type '{name}' was removed but is still referenced");
             }
         }
 
         result.HasDanglingReferences = result.DanglingReferences.Count > 0;
     }
+
+    /// <summary>Top-level function names — what call sites actually reference.</summary>
+    internal static HashSet<string> CollectFunctionNames(ModuleNode ast)
+        => ast.Functions.Select(f => f.Name).ToHashSet(StringComparer.Ordinal);
+
+    /// <summary>Class, interface, and enum names.</summary>
+    internal static HashSet<string> CollectTypeNames(ModuleNode ast)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var cls in ast.Classes) names.Add(cls.Name);
+        foreach (var iface in ast.Interfaces) names.Add(iface.Name);
+        foreach (var enumDef in ast.Enums) names.Add(enumDef.Name);
+        return names;
+    }
+
+    /// <summary>Every call-target name in the module, as written at the call sites.</summary>
+    internal static HashSet<string> CollectCallTargets(ModuleNode ast)
+        => Analysis.CallGraphAnalysis.Build(ast).ForwardGraph.Values
+            .SelectMany(calls => calls.Select(c => c.Callee))
+            .ToHashSet(StringComparer.Ordinal);
+
+    internal static bool ContainsWholeWord(string source, string word)
+        => Regex.IsMatch(source, $@"\b{Regex.Escape(word)}\b");
 
     internal static string DetermineVerdict(CompilationCheckResult compile, ContractCheckResult contracts,
         EffectCheckResult effects, ReferenceCheckResult references)

--- a/src/Calor.Compiler/Mcp/Tools/EditPreviewTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/EditPreviewTool.cs
@@ -150,7 +150,7 @@ public sealed class EditPreviewTool : McpToolBase
         }));
     }
 
-    private static EditSummaryInfo ComputeEditSummary(string original, string modified,
+    internal static EditSummaryInfo ComputeEditSummary(string original, string modified,
         ParseResult originalParse, ParseResult modifiedParse)
     {
         var origLines = original.Split('\n');
@@ -186,7 +186,7 @@ public sealed class EditPreviewTool : McpToolBase
         };
     }
 
-    private static HashSet<string> CollectSymbolIds(ModuleNode ast)
+    internal static HashSet<string> CollectSymbolIds(ModuleNode ast)
     {
         var ids = new HashSet<string>();
         foreach (var func in ast.Functions) ids.Add(func.Id);
@@ -200,7 +200,7 @@ public sealed class EditPreviewTool : McpToolBase
         return ids;
     }
 
-    private static void CheckContracts(ParseResult originalParse, ParseResult modifiedParse, ContractCheckResult result)
+    internal static void CheckContracts(ParseResult originalParse, ParseResult modifiedParse, ContractCheckResult result)
     {
         if (!originalParse.IsSuccess || !modifiedParse.IsSuccess) return;
 
@@ -264,7 +264,7 @@ public sealed class EditPreviewTool : McpToolBase
         return result;
     }
 
-    private static void CheckEffects(ParseResult modifiedParse, EffectCheckResult result)
+    internal static void CheckEffects(ParseResult modifiedParse, EffectCheckResult result)
     {
         if (!modifiedParse.IsSuccess) return;
 
@@ -281,7 +281,7 @@ public sealed class EditPreviewTool : McpToolBase
         result.HasViolations = result.EffectViolations.Count > 0;
     }
 
-    private static void CheckReferences(ParseResult originalParse, ParseResult modifiedParse, ReferenceCheckResult result)
+    internal static void CheckReferences(ParseResult originalParse, ParseResult modifiedParse, ReferenceCheckResult result)
     {
         var origIds = CollectSymbolIds(originalParse.Ast!);
         var modIds = CollectSymbolIds(modifiedParse.Ast!);
@@ -304,7 +304,7 @@ public sealed class EditPreviewTool : McpToolBase
         result.HasDanglingReferences = result.DanglingReferences.Count > 0;
     }
 
-    private static string DetermineVerdict(CompilationCheckResult compile, ContractCheckResult contracts,
+    internal static string DetermineVerdict(CompilationCheckResult compile, ContractCheckResult contracts,
         EffectCheckResult effects, ReferenceCheckResult references)
     {
         if (compile.Checked && !compile.ModifiedCompiles)
@@ -322,7 +322,7 @@ public sealed class EditPreviewTool : McpToolBase
         return "safe";
     }
 
-    private static List<string> GenerateRecommendations(CompilationCheckResult compile, ContractCheckResult contracts,
+    internal static List<string> GenerateRecommendations(CompilationCheckResult compile, ContractCheckResult contracts,
         EffectCheckResult effects, ReferenceCheckResult references)
     {
         var recs = new List<string>();
@@ -357,7 +357,7 @@ public sealed class EditPreviewTool : McpToolBase
         [JsonPropertyName("recommendations")] public List<string> Recommendations { get; init; } = new();
     }
 
-    private sealed class EditSummaryInfo
+    internal sealed class EditSummaryInfo
     {
         [JsonPropertyName("linesAdded")] public int LinesAdded { get; init; }
         [JsonPropertyName("linesRemoved")] public int LinesRemoved { get; init; }
@@ -366,7 +366,7 @@ public sealed class EditPreviewTool : McpToolBase
         [JsonPropertyName("symbolsRemoved")] public List<string> SymbolsRemoved { get; init; } = new();
     }
 
-    private sealed class CompilationCheckResult
+    internal sealed class CompilationCheckResult
     {
         [JsonPropertyName("checked")] public bool Checked { get; set; }
         [JsonPropertyName("originalCompiles")] public bool OriginalCompiles { get; set; }
@@ -375,7 +375,7 @@ public sealed class EditPreviewTool : McpToolBase
         [JsonPropertyName("errors")] public List<EnvelopeDiagnostic> Errors { get; set; } = new();
     }
 
-    private sealed class ContractCheckResult
+    internal sealed class ContractCheckResult
     {
         [JsonPropertyName("checked")] public bool Checked { get; set; }
         [JsonPropertyName("originalContractCount")] public int OriginalContractCount { get; set; }
@@ -383,14 +383,14 @@ public sealed class EditPreviewTool : McpToolBase
         [JsonPropertyName("issues")] public List<string> Issues { get; set; } = new();
     }
 
-    private sealed class EffectCheckResult
+    internal sealed class EffectCheckResult
     {
         [JsonPropertyName("checked")] public bool Checked { get; set; }
         [JsonPropertyName("hasViolations")] public bool HasViolations { get; set; }
         [JsonPropertyName("effectViolations")] public List<string> EffectViolations { get; set; } = new();
     }
 
-    private sealed class ReferenceCheckResult
+    internal sealed class ReferenceCheckResult
     {
         [JsonPropertyName("checked")] public bool Checked { get; set; }
         [JsonPropertyName("hasDanglingReferences")] public bool HasDanglingReferences { get; set; }

--- a/src/Calor.Compiler/Mcp/Tools/FileWriteTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/FileWriteTool.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Calor.Compiler.Diagnostics;
@@ -12,17 +13,32 @@ namespace Calor.Compiler.Mcp.Tools;
 /// check set (compile, contracts, effects, references) against the current
 /// on-disk content, applies atomically (temp file + rename) when the verdict
 /// is safe or safe_with_warnings, and rejects breaking edits with envelope
-/// schema v1.1 diagnostics and the file untouched. With a sessionId from
-/// calor_session_open, reference checks widen to the session's whole file
-/// set. Auto-heal (WS2 D2.5) fixes common serialization slips — forbidden
-/// closer tags, indentation drift — before checking; the healed text is what
-/// gets written.
+/// schema v1.1 diagnostics and the file untouched. Auto-heal (WS2 D2.5)
+/// fixes common serialization slips before checking; healed content always
+/// caps the verdict at safe_with_warnings because healing is not guaranteed
+/// semantics-preserving.
+///
+/// Write confinement: every write must land, after symlink resolution, under
+/// the session root (when a sessionId is given) or under the server's
+/// working directory (when not). Writes are serialized per canonical path
+/// and the on-disk content is revalidated against what was checked before
+/// the rename; a concurrent external writer can still race the final rename,
+/// which only OS-level file locking could close.
 /// </summary>
 public sealed class FileWriteTool : McpToolBase
 {
     private readonly ProjectSessionManager _sessions;
+    private readonly string _defaultWriteRoot;
 
-    internal FileWriteTool(ProjectSessionManager sessions) => _sessions = sessions;
+    // One gate per canonical path, process-wide: check→apply must not
+    // interleave for the same file across concurrent tool calls.
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> PathGates = new(StringComparer.Ordinal);
+
+    internal FileWriteTool(ProjectSessionManager sessions, string? defaultWriteRoot = null)
+    {
+        _sessions = sessions;
+        _defaultWriteRoot = CanonicalPath.Resolve(defaultWriteRoot ?? Environment.CurrentDirectory);
+    }
 
     public override string Name => "calor_file_write";
 
@@ -30,8 +46,10 @@ public sealed class FileWriteTool : McpToolBase
         "Write a .calr file transactionally: the content is auto-healed (indentation, " +
         "forbidden closers), checked (compile, contracts, effects, references), then " +
         "applied atomically — or rejected with diagnostics and the file left untouched " +
-        "when the edit is breaking. Creates the file if it does not exist. Pass a " +
-        "sessionId from calor_session_open to check references across the whole project.";
+        "when the edit is breaking. Creates the file if it does not exist. Writes are " +
+        "confined to the session root (or the server's working directory without a " +
+        "session). Pass a sessionId from calor_session_open to check references across " +
+        "the whole project.";
 
     public override McpToolAnnotations? Annotations => new() { DestructiveHint = true, IdempotentHint = true };
 
@@ -68,6 +86,25 @@ public sealed class FileWriteTool : McpToolBase
 
     public override async Task<McpToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
     {
+        try
+        {
+            return await ExecuteCoreAsync(arguments, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // The tool contract is result-or-error, never a protocol crash:
+            // IO races (file deleted mid-check), invalid path characters, and
+            // permission failures all surface as tool errors.
+            return McpToolResult.Error($"calor_file_write failed: {ex.Message}");
+        }
+    }
+
+    private async Task<McpToolResult> ExecuteCoreAsync(JsonElement? arguments, CancellationToken cancellationToken)
+    {
         var path = GetString(arguments, "path");
         var content = GetString(arguments, "content");
 
@@ -84,13 +121,14 @@ public sealed class FileWriteTool : McpToolBase
         if (pathError != null)
             return pathError;
 
-        if (!path.EndsWith(".calr", StringComparison.OrdinalIgnoreCase))
+        // Confinement runs on the canonical (symlink-resolved) path: a
+        // lexical check would let a symlinked subdirectory point outside the
+        // boundary. The suffix is checked on the canonical name too, so a
+        // .calr symlink to a non-.calr target does not slip through.
+        var canonicalPath = CanonicalPath.Resolve(path);
+        if (!canonicalPath.EndsWith(".calr", StringComparison.OrdinalIgnoreCase))
             return McpToolResult.Error("calor_file_write only writes .calr files");
 
-        var absolutePath = Path.GetFullPath(path);
-
-        // Resolve the session first so its state is fresh before we read the
-        // original content (dirty-state invalidation, D2.1).
         ProjectSession? session = null;
         var sessionId = GetString(arguments, "sessionId");
         if (!string.IsNullOrEmpty(sessionId))
@@ -98,15 +136,36 @@ public sealed class FileWriteTool : McpToolBase
             session = _sessions.Get(sessionId);
             if (session == null)
                 return McpToolResult.Error($"Unknown sessionId '{sessionId}' — open one with calor_session_open");
-            if (!session.ContainsPath(absolutePath))
+            if (!CanonicalPath.IsUnder(canonicalPath, session.RootDirectory))
                 return McpToolResult.Error($"Path is outside the session root '{session.RootDirectory}'");
             session.Refresh();
         }
+        else if (!CanonicalPath.IsUnder(canonicalPath, _defaultWriteRoot))
+        {
+            return McpToolResult.Error(
+                $"Path is outside the server's write root '{_defaultWriteRoot}' — " +
+                "open a session over the target directory with calor_session_open, or write within the working directory");
+        }
 
+        var gate = PathGates.GetOrAdd(canonicalPath, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(cancellationToken);
+        try
+        {
+            return await CheckAndApplyAsync(canonicalPath, content, session, arguments, cancellationToken);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private static async Task<McpToolResult> CheckAndApplyAsync(string canonicalPath, string content,
+        ProjectSession? session, JsonElement? arguments, CancellationToken cancellationToken)
+    {
         var (runCompile, runContracts, runEffects, runReferences) = ParseCheckSelection(arguments);
 
-        var originalSource = File.Exists(absolutePath)
-            ? await File.ReadAllTextAsync(absolutePath, cancellationToken)
+        var originalSource = File.Exists(canonicalPath)
+            ? await File.ReadAllTextAsync(canonicalPath, cancellationToken)
             : "";
 
         // Auto-heal before checking (D2.5). The healed text is authoritative:
@@ -117,9 +176,9 @@ public sealed class FileWriteTool : McpToolBase
         var healApplied = heal && !string.Equals(finalContent, content, StringComparison.Ordinal);
 
         var originalParse = originalSource.Length > 0
-            ? CalorSourceHelper.Parse(originalSource, absolutePath)
+            ? CalorSourceHelper.Parse(originalSource, canonicalPath)
             : null;
-        var modifiedParse = CalorSourceHelper.Parse(finalContent, absolutePath);
+        var modifiedParse = CalorSourceHelper.Parse(finalContent, canonicalPath);
 
         var compilationResult = new EditPreviewTool.CompilationCheckResult { Checked = runCompile };
         if (runCompile)
@@ -145,28 +204,50 @@ public sealed class FileWriteTool : McpToolBase
         if (runReferences && modifiedParse.IsSuccess && originalParse is { IsSuccess: true })
         {
             EditPreviewTool.CheckReferences(originalParse, modifiedParse, referenceResult);
-            CheckProjectReferences(session, absolutePath, originalParse, modifiedParse, referenceResult);
+            CheckProjectReferences(session, canonicalPath, originalParse, modifiedParse, referenceResult);
         }
 
         var verdict = EditPreviewTool.DetermineVerdict(compilationResult, contractResult, effectResult, referenceResult);
+
+        // Healing is not guaranteed semantics-preserving (SourceHealer's
+        // contract) — an auto-written healed file is never plain "safe".
+        if (healApplied && verdict == "safe")
+            verdict = "safe_with_warnings";
+
         var applied = verdict != "breaking";
 
         if (applied)
         {
-            await WriteAtomicAsync(absolutePath, finalContent, cancellationToken);
-            session?.UpdateFile(absolutePath, finalContent, modifiedParse);
+            // Revalidate before the rename: the checks above ran against
+            // originalSource, and an external writer may have changed the
+            // file since it was read (the per-path gate only serializes
+            // in-process callers).
+            if (File.Exists(canonicalPath))
+            {
+                var current = await File.ReadAllTextAsync(canonicalPath, cancellationToken);
+                if (!string.Equals(current, originalSource, StringComparison.Ordinal))
+                    return McpToolResult.Error(
+                        "File changed on disk while the edit was being checked — re-read it and retry");
+            }
+
+            await WriteAtomicAsync(canonicalPath, finalContent, cancellationToken);
+            session?.UpdateFile(canonicalPath, finalContent, modifiedParse);
         }
 
         var editSummary = originalParse != null
             ? EditPreviewTool.ComputeEditSummary(originalSource, finalContent, originalParse, modifiedParse)
             : null;
 
+        var recommendations = EditPreviewTool.GenerateRecommendations(compilationResult, contractResult, effectResult, referenceResult);
+        if (healApplied)
+            recommendations.Insert(0, "Content was auto-healed — review writtenContent; healing is not guaranteed semantics-preserving");
+
         return McpToolResult.Json(new FileWriteOutput
         {
             Success = true,
             Applied = applied,
             Verdict = verdict,
-            Path = absolutePath,
+            Path = canonicalPath,
             Created = applied && originalSource.Length == 0,
             HealApplied = healApplied,
             HealNotes = healer.Ambiguities
@@ -178,15 +259,16 @@ public sealed class FileWriteTool : McpToolBase
             ContractVerification = contractResult,
             EffectAnalysis = effectResult,
             ReferenceIntegrity = referenceResult,
-            Recommendations = EditPreviewTool.GenerateRecommendations(compilationResult, contractResult, effectResult, referenceResult)
+            Recommendations = recommendations
         });
     }
 
     /// <summary>
-    /// Project-wide half of the reference check (D2.1 + D2.4): symbols this
-    /// edit removes must not still be referenced by other files in the
-    /// session. Uses the same textual-containment heuristic as the in-file
-    /// check so both halves have identical strictness.
+    /// Project-wide half of the reference check (D2.1 + D2.4): declarations
+    /// this edit removes must not still be referenced by other files in the
+    /// session. Functions are matched against actual call targets in each
+    /// file's AST; types fall back to a whole-word text match — the same
+    /// strictness as the in-file check.
     /// </summary>
     private static void CheckProjectReferences(ProjectSession? session, string editedPath,
         ParseResult originalParse, ParseResult modifiedParse, EditPreviewTool.ReferenceCheckResult result)
@@ -194,10 +276,13 @@ public sealed class FileWriteTool : McpToolBase
         if (session == null)
             return;
 
-        var removedSymbols = EditPreviewTool.CollectSymbolIds(originalParse.Ast!)
-            .Except(EditPreviewTool.CollectSymbolIds(modifiedParse.Ast!))
+        var removedFunctions = EditPreviewTool.CollectFunctionNames(originalParse.Ast!)
+            .Except(EditPreviewTool.CollectFunctionNames(modifiedParse.Ast!))
             .ToList();
-        if (removedSymbols.Count == 0)
+        var removedTypes = EditPreviewTool.CollectTypeNames(originalParse.Ast!)
+            .Except(EditPreviewTool.CollectTypeNames(modifiedParse.Ast!))
+            .ToList();
+        if (removedFunctions.Count == 0 && removedTypes.Count == 0)
             return;
 
         foreach (var file in session.SnapshotFiles())
@@ -205,14 +290,36 @@ public sealed class FileWriteTool : McpToolBase
             if (string.Equals(file.Path, editedPath, StringComparison.Ordinal))
                 continue;
 
-            foreach (var symbol in removedSymbols)
+            var relative = Path.GetRelativePath(session.RootDirectory, file.Path);
+
+            if (removedFunctions.Count > 0)
             {
-                if (file.Source.Contains(symbol, StringComparison.Ordinal))
+                // Parsed files are checked against real call targets; files
+                // that do not parse fall back to whole-word text so a broken
+                // neighbor cannot hide a dangling call entirely.
+                if (file.Parse.IsSuccess)
                 {
-                    var relative = Path.GetRelativePath(session.RootDirectory, file.Path);
-                    result.DanglingReferences.Add(
-                        $"Symbol '{symbol}' was removed but is still referenced in {relative}");
+                    var callTargets = EditPreviewTool.CollectCallTargets(file.Parse.Ast!);
+                    foreach (var name in removedFunctions.Where(callTargets.Contains))
+                    {
+                        result.DanglingReferences.Add(
+                            $"Function '{name}' was removed but is still called in {relative}");
+                    }
                 }
+                else
+                {
+                    foreach (var name in removedFunctions.Where(n => EditPreviewTool.ContainsWholeWord(file.Source, n)))
+                    {
+                        result.DanglingReferences.Add(
+                            $"Function '{name}' was removed but may still be referenced in {relative} (file does not parse)");
+                    }
+                }
+            }
+
+            foreach (var name in removedTypes.Where(n => EditPreviewTool.ContainsWholeWord(file.Source, n)))
+            {
+                result.DanglingReferences.Add(
+                    $"Type '{name}' was removed but is still referenced in {relative}");
             }
         }
 
@@ -234,17 +341,23 @@ public sealed class FileWriteTool : McpToolBase
     /// <summary>
     /// Atomic apply: write to a temp file in the target directory, then
     /// rename over the destination. The destination never holds partial
-    /// content, even on a crash mid-write.
+    /// content, and a pre-existing file keeps its permission bits.
     /// </summary>
     private static async Task WriteAtomicAsync(string absolutePath, string content, CancellationToken cancellationToken)
     {
         var directory = Path.GetDirectoryName(absolutePath)!;
         Directory.CreateDirectory(directory);
 
+        UnixFileMode? existingMode = null;
+        if (!OperatingSystem.IsWindows() && File.Exists(absolutePath))
+            existingMode = File.GetUnixFileMode(absolutePath);
+
         var tempPath = Path.Combine(directory, $".{Path.GetFileName(absolutePath)}.{Guid.NewGuid():N}.tmp");
         try
         {
             await File.WriteAllTextAsync(tempPath, content, cancellationToken);
+            if (!OperatingSystem.IsWindows() && existingMode.HasValue)
+                File.SetUnixFileMode(tempPath, existingMode.Value);
             File.Move(tempPath, absolutePath, overwrite: true);
         }
         finally

--- a/src/Calor.Compiler/Mcp/Tools/FileWriteTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/FileWriteTool.cs
@@ -1,0 +1,277 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Formatting;
+using Calor.Compiler.Mcp.Sessions;
+
+namespace Calor.Compiler.Mcp.Tools;
+
+/// <summary>
+/// MCP tool for transactional whole-file writes of .calr sources (loop plan
+/// WS2 D2.4): heal → check → apply-or-reject. Runs the calor_edit_preview
+/// check set (compile, contracts, effects, references) against the current
+/// on-disk content, applies atomically (temp file + rename) when the verdict
+/// is safe or safe_with_warnings, and rejects breaking edits with envelope
+/// schema v1.1 diagnostics and the file untouched. With a sessionId from
+/// calor_session_open, reference checks widen to the session's whole file
+/// set. Auto-heal (WS2 D2.5) fixes common serialization slips — forbidden
+/// closer tags, indentation drift — before checking; the healed text is what
+/// gets written.
+/// </summary>
+public sealed class FileWriteTool : McpToolBase
+{
+    private readonly ProjectSessionManager _sessions;
+
+    internal FileWriteTool(ProjectSessionManager sessions) => _sessions = sessions;
+
+    public override string Name => "calor_file_write";
+
+    public override string Description =>
+        "Write a .calr file transactionally: the content is auto-healed (indentation, " +
+        "forbidden closers), checked (compile, contracts, effects, references), then " +
+        "applied atomically — or rejected with diagnostics and the file left untouched " +
+        "when the edit is breaking. Creates the file if it does not exist. Pass a " +
+        "sessionId from calor_session_open to check references across the whole project.";
+
+    public override McpToolAnnotations? Annotations => new() { DestructiveHint = true, IdempotentHint = true };
+
+    protected override string GetInputSchemaJson() => """
+        {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path of the .calr file to write (created if missing)"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The complete new file content"
+                },
+                "sessionId": {
+                    "type": "string",
+                    "description": "Optional session from calor_session_open; widens reference checks to the session's file set"
+                },
+                "checks": {
+                    "type": "array",
+                    "items": { "type": "string", "enum": ["compile", "contracts", "effects", "references"] },
+                    "description": "Which checks to run (default: all)"
+                },
+                "heal": {
+                    "type": "boolean",
+                    "description": "Auto-heal indentation/closer slips before checking (default: true)"
+                }
+            },
+            "required": ["path", "content"],
+            "additionalProperties": false
+        }
+        """;
+
+    public override async Task<McpToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        var path = GetString(arguments, "path");
+        var content = GetString(arguments, "content");
+
+        if (string.IsNullOrEmpty(path))
+            return McpToolResult.Error("'path' is required");
+        if (string.IsNullOrEmpty(content))
+            return McpToolResult.Error("'content' is required and must not be empty");
+
+        var sizeError = ValidateSourceSize(content, "content");
+        if (sizeError != null)
+            return sizeError;
+
+        var pathError = ValidatePath(path);
+        if (pathError != null)
+            return pathError;
+
+        if (!path.EndsWith(".calr", StringComparison.OrdinalIgnoreCase))
+            return McpToolResult.Error("calor_file_write only writes .calr files");
+
+        var absolutePath = Path.GetFullPath(path);
+
+        // Resolve the session first so its state is fresh before we read the
+        // original content (dirty-state invalidation, D2.1).
+        ProjectSession? session = null;
+        var sessionId = GetString(arguments, "sessionId");
+        if (!string.IsNullOrEmpty(sessionId))
+        {
+            session = _sessions.Get(sessionId);
+            if (session == null)
+                return McpToolResult.Error($"Unknown sessionId '{sessionId}' — open one with calor_session_open");
+            if (!session.ContainsPath(absolutePath))
+                return McpToolResult.Error($"Path is outside the session root '{session.RootDirectory}'");
+            session.Refresh();
+        }
+
+        var (runCompile, runContracts, runEffects, runReferences) = ParseCheckSelection(arguments);
+
+        var originalSource = File.Exists(absolutePath)
+            ? await File.ReadAllTextAsync(absolutePath, cancellationToken)
+            : "";
+
+        // Auto-heal before checking (D2.5). The healed text is authoritative:
+        // it is what gets checked and, on a green verdict, what gets written.
+        var heal = GetBool(arguments, "heal", defaultValue: true);
+        var healer = new SourceHealer();
+        var finalContent = heal ? healer.Heal(content) : content;
+        var healApplied = heal && !string.Equals(finalContent, content, StringComparison.Ordinal);
+
+        var originalParse = originalSource.Length > 0
+            ? CalorSourceHelper.Parse(originalSource, absolutePath)
+            : null;
+        var modifiedParse = CalorSourceHelper.Parse(finalContent, absolutePath);
+
+        var compilationResult = new EditPreviewTool.CompilationCheckResult { Checked = runCompile };
+        if (runCompile)
+        {
+            compilationResult.OriginalCompiles = originalParse?.IsSuccess ?? true;
+            compilationResult.ModifiedCompiles = modifiedParse.IsSuccess;
+            compilationResult.Errors = modifiedParse.ToEnvelopeDiagnostics();
+        }
+
+        var contractResult = new EditPreviewTool.ContractCheckResult { Checked = runContracts };
+        if (runContracts && originalParse != null && modifiedParse.IsSuccess)
+        {
+            EditPreviewTool.CheckContracts(originalParse, modifiedParse, contractResult);
+        }
+
+        var effectResult = new EditPreviewTool.EffectCheckResult { Checked = runEffects };
+        if (runEffects && modifiedParse.IsSuccess)
+        {
+            EditPreviewTool.CheckEffects(modifiedParse, effectResult);
+        }
+
+        var referenceResult = new EditPreviewTool.ReferenceCheckResult { Checked = runReferences };
+        if (runReferences && modifiedParse.IsSuccess && originalParse is { IsSuccess: true })
+        {
+            EditPreviewTool.CheckReferences(originalParse, modifiedParse, referenceResult);
+            CheckProjectReferences(session, absolutePath, originalParse, modifiedParse, referenceResult);
+        }
+
+        var verdict = EditPreviewTool.DetermineVerdict(compilationResult, contractResult, effectResult, referenceResult);
+        var applied = verdict != "breaking";
+
+        if (applied)
+        {
+            await WriteAtomicAsync(absolutePath, finalContent, cancellationToken);
+            session?.UpdateFile(absolutePath, finalContent, modifiedParse);
+        }
+
+        var editSummary = originalParse != null
+            ? EditPreviewTool.ComputeEditSummary(originalSource, finalContent, originalParse, modifiedParse)
+            : null;
+
+        return McpToolResult.Json(new FileWriteOutput
+        {
+            Success = true,
+            Applied = applied,
+            Verdict = verdict,
+            Path = absolutePath,
+            Created = applied && originalSource.Length == 0,
+            HealApplied = healApplied,
+            HealNotes = healer.Ambiguities
+                .Select(a => $"line {a.Line}: {a.Message}")
+                .ToList(),
+            WrittenContent = applied && healApplied ? finalContent : null,
+            EditSummary = editSummary,
+            CompilationResult = compilationResult,
+            ContractVerification = contractResult,
+            EffectAnalysis = effectResult,
+            ReferenceIntegrity = referenceResult,
+            Recommendations = EditPreviewTool.GenerateRecommendations(compilationResult, contractResult, effectResult, referenceResult)
+        });
+    }
+
+    /// <summary>
+    /// Project-wide half of the reference check (D2.1 + D2.4): symbols this
+    /// edit removes must not still be referenced by other files in the
+    /// session. Uses the same textual-containment heuristic as the in-file
+    /// check so both halves have identical strictness.
+    /// </summary>
+    private static void CheckProjectReferences(ProjectSession? session, string editedPath,
+        ParseResult originalParse, ParseResult modifiedParse, EditPreviewTool.ReferenceCheckResult result)
+    {
+        if (session == null)
+            return;
+
+        var removedSymbols = EditPreviewTool.CollectSymbolIds(originalParse.Ast!)
+            .Except(EditPreviewTool.CollectSymbolIds(modifiedParse.Ast!))
+            .ToList();
+        if (removedSymbols.Count == 0)
+            return;
+
+        foreach (var file in session.SnapshotFiles())
+        {
+            if (string.Equals(file.Path, editedPath, StringComparison.Ordinal))
+                continue;
+
+            foreach (var symbol in removedSymbols)
+            {
+                if (file.Source.Contains(symbol, StringComparison.Ordinal))
+                {
+                    var relative = Path.GetRelativePath(session.RootDirectory, file.Path);
+                    result.DanglingReferences.Add(
+                        $"Symbol '{symbol}' was removed but is still referenced in {relative}");
+                }
+            }
+        }
+
+        result.HasDanglingReferences = result.DanglingReferences.Count > 0;
+    }
+
+    private static (bool Compile, bool Contracts, bool Effects, bool References) ParseCheckSelection(JsonElement? arguments)
+    {
+        var requested = GetStringArray(arguments, "checks");
+        if (requested.Count == 0)
+            return (true, true, true, true);
+
+        return (requested.Contains("compile"),
+                requested.Contains("contracts"),
+                requested.Contains("effects"),
+                requested.Contains("references"));
+    }
+
+    /// <summary>
+    /// Atomic apply: write to a temp file in the target directory, then
+    /// rename over the destination. The destination never holds partial
+    /// content, even on a crash mid-write.
+    /// </summary>
+    private static async Task WriteAtomicAsync(string absolutePath, string content, CancellationToken cancellationToken)
+    {
+        var directory = Path.GetDirectoryName(absolutePath)!;
+        Directory.CreateDirectory(directory);
+
+        var tempPath = Path.Combine(directory, $".{Path.GetFileName(absolutePath)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            await File.WriteAllTextAsync(tempPath, content, cancellationToken);
+            File.Move(tempPath, absolutePath, overwrite: true);
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
+    }
+
+    private sealed class FileWriteOutput
+    {
+        [JsonPropertyName("success")] public bool Success { get; init; }
+        [JsonPropertyName("applied")] public bool Applied { get; init; }
+        [JsonPropertyName("verdict")] public string? Verdict { get; init; }
+        [JsonPropertyName("path")] public string? Path { get; init; }
+        [JsonPropertyName("created")] public bool Created { get; init; }
+        [JsonPropertyName("healApplied")] public bool HealApplied { get; init; }
+        [JsonPropertyName("healNotes")] public List<string> HealNotes { get; init; } = new();
+        /// <summary>The content actually written when healing changed it — the caller's view of the file is stale otherwise.</summary>
+        [JsonPropertyName("writtenContent")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? WrittenContent { get; init; }
+        [JsonPropertyName("editSummary")] public EditPreviewTool.EditSummaryInfo? EditSummary { get; init; }
+        [JsonPropertyName("compilationResult")] public EditPreviewTool.CompilationCheckResult? CompilationResult { get; init; }
+        [JsonPropertyName("contractVerification")] public EditPreviewTool.ContractCheckResult? ContractVerification { get; init; }
+        [JsonPropertyName("effectAnalysis")] public EditPreviewTool.EffectCheckResult? EffectAnalysis { get; init; }
+        [JsonPropertyName("referenceIntegrity")] public EditPreviewTool.ReferenceCheckResult? ReferenceIntegrity { get; init; }
+        [JsonPropertyName("recommendations")] public List<string> Recommendations { get; init; } = new();
+    }
+}

--- a/src/Calor.Compiler/Mcp/Tools/SessionTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/SessionTool.cs
@@ -1,0 +1,156 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Mcp.Sessions;
+
+namespace Calor.Compiler.Mcp.Tools;
+
+/// <summary>
+/// MCP tool that opens a session-scoped project context over a directory
+/// (loop plan WS2 D2.1). The session holds parse state for every .calr file
+/// under the root and keeps it fresh via stat-on-access invalidation; pass
+/// the returned sessionId to calor_file_write to widen its reference checks
+/// to the whole project.
+/// </summary>
+public sealed class SessionOpenTool : McpToolBase
+{
+    private readonly ProjectSessionManager _sessions;
+
+    internal SessionOpenTool(ProjectSessionManager sessions) => _sessions = sessions;
+
+    public override string Name => "calor_session_open";
+
+    public override string Description =>
+        "Open a project session over a directory. Parses every .calr file under it and " +
+        "returns a sessionId plus per-file parse status. Pass the sessionId to " +
+        "calor_file_write so its checks see the whole project; the session re-checks " +
+        "files changed on disk automatically.";
+
+    protected override string GetInputSchemaJson() => """
+        {
+            "type": "object",
+            "properties": {
+                "directory": {
+                    "type": "string",
+                    "description": "Root directory of the project (all .calr files under it, recursively)"
+                }
+            },
+            "required": ["directory"],
+            "additionalProperties": false
+        }
+        """;
+
+    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        var directory = GetString(arguments, "directory");
+        if (string.IsNullOrEmpty(directory))
+            return Task.FromResult(McpToolResult.Error("'directory' is required"));
+
+        var pathError = ValidatePath(directory, "directory");
+        if (pathError != null)
+            return Task.FromResult(pathError);
+
+        if (!Directory.Exists(directory))
+            return Task.FromResult(McpToolResult.Error($"Directory not found: {directory}"));
+
+        ProjectSession session;
+        try
+        {
+            session = _sessions.Open(directory);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Task.FromResult(McpToolResult.Error(ex.Message));
+        }
+
+        var files = session.SnapshotFiles().OrderBy(f => f.Path, StringComparer.Ordinal).ToList();
+        var diagnostics = files.SelectMany(f => f.Parse.ToEnvelopeDiagnostics()).ToList();
+
+        return Task.FromResult(McpToolResult.Json(new SessionOpenOutput
+        {
+            Success = true,
+            SessionId = session.Id,
+            RootDirectory = session.RootDirectory,
+            FileCount = files.Count,
+            ParseErrorFileCount = files.Count(f => !f.Parse.IsSuccess),
+            Files = files.Select(f => new SessionFileInfo
+            {
+                Path = Path.GetRelativePath(session.RootDirectory, f.Path),
+                Parses = f.Parse.IsSuccess
+            }).ToList(),
+            Diagnostics = diagnostics
+        }));
+    }
+
+    private sealed class SessionOpenOutput
+    {
+        [JsonPropertyName("success")] public bool Success { get; init; }
+        [JsonPropertyName("sessionId")] public string? SessionId { get; init; }
+        [JsonPropertyName("rootDirectory")] public string? RootDirectory { get; init; }
+        [JsonPropertyName("fileCount")] public int FileCount { get; init; }
+        [JsonPropertyName("parseErrorFileCount")] public int ParseErrorFileCount { get; init; }
+        [JsonPropertyName("files")] public List<SessionFileInfo> Files { get; init; } = new();
+        /// <summary>Envelope schema v1.1 entries for files that fail to parse.</summary>
+        [JsonPropertyName("diagnostics")] public List<EnvelopeDiagnostic> Diagnostics { get; init; } = new();
+    }
+
+    private sealed class SessionFileInfo
+    {
+        [JsonPropertyName("path")] public string? Path { get; init; }
+        [JsonPropertyName("parses")] public bool Parses { get; init; }
+    }
+}
+
+/// <summary>
+/// MCP tool that closes a project session opened by calor_session_open,
+/// releasing its in-memory parse state.
+/// </summary>
+public sealed class SessionCloseTool : McpToolBase
+{
+    private readonly ProjectSessionManager _sessions;
+
+    internal SessionCloseTool(ProjectSessionManager sessions) => _sessions = sessions;
+
+    public override string Name => "calor_session_close";
+
+    public override string Description =>
+        "Close a project session opened by calor_session_open and release its in-memory state.";
+
+    public override McpToolAnnotations? Annotations => new() { IdempotentHint = true };
+
+    protected override string GetInputSchemaJson() => """
+        {
+            "type": "object",
+            "properties": {
+                "sessionId": {
+                    "type": "string",
+                    "description": "The session to close"
+                }
+            },
+            "required": ["sessionId"],
+            "additionalProperties": false
+        }
+        """;
+
+    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        var sessionId = GetString(arguments, "sessionId");
+        if (string.IsNullOrEmpty(sessionId))
+            return Task.FromResult(McpToolResult.Error("'sessionId' is required"));
+
+        var closed = _sessions.Close(sessionId);
+        return Task.FromResult(McpToolResult.Json(new SessionCloseOutput
+        {
+            Success = true,
+            SessionId = sessionId,
+            Closed = closed
+        }));
+    }
+
+    private sealed class SessionCloseOutput
+    {
+        [JsonPropertyName("success")] public bool Success { get; init; }
+        [JsonPropertyName("sessionId")] public string? SessionId { get; init; }
+        [JsonPropertyName("closed")] public bool Closed { get; init; }
+    }
+}

--- a/src/Calor.Compiler/Mcp/Tools/SessionTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/SessionTool.cs
@@ -10,13 +10,19 @@ namespace Calor.Compiler.Mcp.Tools;
 /// (loop plan WS2 D2.1). The session holds parse state for every .calr file
 /// under the root and keeps it fresh via stat-on-access invalidation; pass
 /// the returned sessionId to calor_file_write to widen its reference checks
-/// to the whole project.
+/// to the whole project. Session roots are confined to the server's working
+/// directory: a session is also a write-confinement boundary.
 /// </summary>
 public sealed class SessionOpenTool : McpToolBase
 {
     private readonly ProjectSessionManager _sessions;
+    private readonly string _serverRoot;
 
-    internal SessionOpenTool(ProjectSessionManager sessions) => _sessions = sessions;
+    internal SessionOpenTool(ProjectSessionManager sessions, string? serverRoot = null)
+    {
+        _sessions = sessions;
+        _serverRoot = CanonicalPath.Resolve(serverRoot ?? Environment.CurrentDirectory);
+    }
 
     public override string Name => "calor_session_open";
 
@@ -42,31 +48,46 @@ public sealed class SessionOpenTool : McpToolBase
 
     public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
     {
+        try
+        {
+            return Task.FromResult(ExecuteCore(arguments));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // The whole flow touches the filesystem (canonicalization
+            // included — an invalid path throws in Path.GetFullPath):
+            // failures surface as tool errors, not protocol crashes.
+            return Task.FromResult(McpToolResult.Error($"calor_session_open failed: {ex.Message}"));
+        }
+    }
+
+    private McpToolResult ExecuteCore(JsonElement? arguments)
+    {
         var directory = GetString(arguments, "directory");
         if (string.IsNullOrEmpty(directory))
-            return Task.FromResult(McpToolResult.Error("'directory' is required"));
+            return McpToolResult.Error("'directory' is required");
 
         var pathError = ValidatePath(directory, "directory");
         if (pathError != null)
-            return Task.FromResult(pathError);
+            return pathError;
 
         if (!Directory.Exists(directory))
-            return Task.FromResult(McpToolResult.Error($"Directory not found: {directory}"));
+            return McpToolResult.Error($"Directory not found: {directory}");
 
-        ProjectSession session;
-        try
-        {
-            session = _sessions.Open(directory);
-        }
-        catch (InvalidOperationException ex)
-        {
-            return Task.FromResult(McpToolResult.Error(ex.Message));
-        }
+        // A session confers write access to its root (calor_file_write), so
+        // session roots are confined, after symlink resolution, to the
+        // directory the server was started in.
+        var canonicalRoot = CanonicalPath.Resolve(directory);
+        if (!CanonicalPath.IsUnder(canonicalRoot, _serverRoot))
+            return McpToolResult.Error(
+                $"Directory is outside the server's root '{_serverRoot}' — start the MCP server in (an ancestor of) the project directory");
+
+        var session = _sessions.Open(canonicalRoot);
 
         var files = session.SnapshotFiles().OrderBy(f => f.Path, StringComparer.Ordinal).ToList();
         var diagnostics = files.SelectMany(f => f.Parse.ToEnvelopeDiagnostics()).ToList();
 
-        return Task.FromResult(McpToolResult.Json(new SessionOpenOutput
+        return McpToolResult.Json(new SessionOpenOutput
         {
             Success = true,
             SessionId = session.Id,
@@ -79,7 +100,7 @@ public sealed class SessionOpenTool : McpToolBase
                 Parses = f.Parse.IsSuccess
             }).ToList(),
             Diagnostics = diagnostics
-        }));
+        });
     }
 
     private sealed class SessionOpenOutput

--- a/tests/Calor.Compiler.Tests/Mcp/SessionAndFileWriteToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/SessionAndFileWriteToolTests.cs
@@ -9,12 +9,17 @@ namespace Calor.Compiler.Tests.Mcp;
 /// <summary>
 /// Tests for the project-session tools (calor_session_open/close, loop plan
 /// WS2 D2.1) and the transactional file write tool (calor_file_write, D2.4)
-/// with auto-heal (D2.5).
+/// with auto-heal (D2.5) and canonical-path write confinement.
 /// </summary>
 public sealed class SessionAndFileWriteToolTests : IDisposable
 {
     private readonly string _root;
     private readonly ProjectSessionManager _manager = new();
+
+    // Both tools are rooted at the test directory: confinement is relative
+    // to the server root (the working directory in production).
+    private SessionOpenTool OpenTool => new(_manager, _root);
+    private FileWriteTool WriteTool => new(_manager, _root);
 
     private const string MathSource = """
         §M{m001:MathModule}
@@ -41,6 +46,16 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
           §F{f010:describe:pub}
             §O{str}
             §R STR:"standalone module"
+        """;
+
+    /// <summary>A module with a real call site targeting `add` by name.</summary>
+    private const string CallerSource = """
+        §M{m003:CallerModule}
+          §F{f020:callsAdd:pub}
+            §I{i32:x}
+            §O{i32}
+            §B{total:i32} §C{add} §A x §A INT:1 §/C
+            §R total
         """;
 
     public SessionAndFileWriteToolTests()
@@ -71,7 +86,7 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
 
     private async Task<string> OpenSessionAsync()
     {
-        var result = await new SessionOpenTool(_manager).ExecuteAsync(Args(new { directory = _root }));
+        var result = await OpenTool.ExecuteAsync(Args(new { directory = _root }));
         return Payload(result).GetProperty("sessionId").GetString()!;
     }
 
@@ -83,7 +98,7 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
         WriteFile("math.calr", MathSource);
         WriteFile("other.calr", OtherSource);
 
-        var result = await new SessionOpenTool(_manager).ExecuteAsync(Args(new { directory = _root }));
+        var result = await OpenTool.ExecuteAsync(Args(new { directory = _root }));
         var payload = Payload(result);
 
         Assert.True(payload.GetProperty("success").GetBoolean());
@@ -98,7 +113,7 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
     {
         WriteFile("broken.calr", "§M{m001:Broken}\n  §F{f001:bad:pub\n");
 
-        var payload = Payload(await new SessionOpenTool(_manager).ExecuteAsync(Args(new { directory = _root })));
+        var payload = Payload(await OpenTool.ExecuteAsync(Args(new { directory = _root })));
 
         Assert.Equal(1, payload.GetProperty("parseErrorFileCount").GetInt32());
         var diagnostics = payload.GetProperty("diagnostics").EnumerateArray().ToList();
@@ -109,10 +124,38 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
     [Fact]
     public async Task SessionOpen_MissingDirectory_ReturnsError()
     {
-        var result = await new SessionOpenTool(_manager)
+        var result = await OpenTool
             .ExecuteAsync(Args(new { directory = Path.Combine(_root, "does-not-exist") }));
 
         Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task SessionOpen_OutsideServerRoot_ReturnsError()
+    {
+        var outside = Directory.CreateDirectory(
+            Path.Combine(Path.GetTempPath(), $"calor-outside-root-{Guid.NewGuid():N}")).FullName;
+        try
+        {
+            var result = await OpenTool.ExecuteAsync(Args(new { directory = outside }));
+            Assert.True(result.IsError);
+        }
+        finally
+        {
+            Directory.Delete(outside, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SessionOpen_OversizeFile_ReportedAsParseError()
+    {
+        WriteFile("math.calr", MathSource);
+        WriteFile("huge.calr", new string('x', 600 * 1024));
+
+        var payload = Payload(await OpenTool.ExecuteAsync(Args(new { directory = _root })));
+
+        Assert.Equal(2, payload.GetProperty("fileCount").GetInt32());
+        Assert.Equal(1, payload.GetProperty("parseErrorFileCount").GetInt32());
     }
 
     [Fact]
@@ -136,7 +179,7 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
     {
         var path = WriteFile("math.calr", MathSource);
 
-        var payload = Payload(await new FileWriteTool(_manager)
+        var payload = Payload(await WriteTool
             .ExecuteAsync(Args(new { path, content = MathSourceWithoutAdd })));
 
         Assert.True(payload.GetProperty("applied").GetBoolean());
@@ -150,7 +193,7 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
     {
         var path = WriteFile("math.calr", MathSource);
 
-        var payload = Payload(await new FileWriteTool(_manager)
+        var payload = Payload(await WriteTool
             .ExecuteAsync(Args(new { path, content = "§M{m001:Broken}\n  §F{f001:bad:pub\n" })));
 
         Assert.False(payload.GetProperty("applied").GetBoolean());
@@ -164,7 +207,7 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
     {
         var path = Path.Combine(_root, "fresh.calr");
 
-        var payload = Payload(await new FileWriteTool(_manager)
+        var payload = Payload(await WriteTool
             .ExecuteAsync(Args(new { path, content = OtherSource })));
 
         Assert.True(payload.GetProperty("applied").GetBoolean());
@@ -175,7 +218,7 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
     [Fact]
     public async Task FileWrite_NonCalrPath_ReturnsError()
     {
-        var result = await new FileWriteTool(_manager)
+        var result = await WriteTool
             .ExecuteAsync(Args(new { path = Path.Combine(_root, "notes.txt"), content = "hello" }));
 
         Assert.True(result.IsError);
@@ -201,7 +244,7 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
             """;
         var path = WriteFile("math.calr", withContract);
 
-        var payload = Payload(await new FileWriteTool(_manager)
+        var payload = Payload(await WriteTool
             .ExecuteAsync(Args(new { path, content = withoutContract })));
 
         Assert.True(payload.GetProperty("applied").GetBoolean());
@@ -209,14 +252,72 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
         Assert.NotEmpty(payload.GetProperty("contractVerification").GetProperty("issues").EnumerateArray());
     }
 
+    // ── calor_file_write: write confinement ─────────────────────────────
+
+    [Fact]
+    public async Task FileWrite_NoSession_OutsideWriteRoot_ReturnsError()
+    {
+        var outside = Path.Combine(Path.GetTempPath(), $"calor-noconfine-{Guid.NewGuid():N}", "escape.calr");
+
+        var result = await WriteTool.ExecuteAsync(Args(new { path = outside, content = OtherSource }));
+
+        Assert.True(result.IsError);
+        Assert.False(File.Exists(outside));
+        Assert.False(Directory.Exists(Path.GetDirectoryName(outside)!));
+    }
+
+    [Fact]
+    public async Task FileWrite_SymlinkedSubdirectoryEscape_ReturnsError()
+    {
+        if (OperatingSystem.IsWindows()) return; // symlink creation needs elevation on Windows
+
+        var outside = Directory.CreateDirectory(
+            Path.Combine(Path.GetTempPath(), $"calor-symlink-target-{Guid.NewGuid():N}")).FullName;
+        try
+        {
+            Directory.CreateSymbolicLink(Path.Combine(_root, "link"), outside);
+
+            // Lexically inside the root; physically outside via the symlink.
+            var result = await WriteTool.ExecuteAsync(Args(new
+            {
+                path = Path.Combine(_root, "link", "escape.calr"),
+                content = OtherSource
+            }));
+
+            Assert.True(result.IsError);
+            Assert.False(File.Exists(Path.Combine(outside, "escape.calr")));
+        }
+        finally
+        {
+            Directory.Delete(outside, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task FileWrite_PreservesUnixFileMode()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var path = WriteFile("math.calr", MathSource);
+        var restricted = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        File.SetUnixFileMode(path, restricted);
+
+        var payload = Payload(await WriteTool
+            .ExecuteAsync(Args(new { path, content = MathSourceWithoutAdd })));
+
+        Assert.True(payload.GetProperty("applied").GetBoolean());
+        Assert.Equal(restricted, File.GetUnixFileMode(path));
+    }
+
     // ── calor_file_write: auto-heal (D2.5) ──────────────────────────────
 
     [Fact]
-    public async Task FileWrite_HealsForbiddenClosersBeforeChecking()
+    public async Task FileWrite_HealsForbiddenClosers_AndCapsVerdictAtWarnings()
     {
         var path = WriteFile("math.calr", MathSource);
         // §/F and §/M are hard errors (Calor0830) — the healer must strip
-        // them so the write survives instead of rejecting.
+        // them so the write survives instead of rejecting. Healing is not
+        // semantics-preserving, so the verdict must not stay plain "safe".
         const string withClosers = """
             §M{m001:MathModule}
               §F{f002:multiply:pub}
@@ -227,11 +328,12 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
             §/M
             """;
 
-        var payload = Payload(await new FileWriteTool(_manager)
+        var payload = Payload(await WriteTool
             .ExecuteAsync(Args(new { path, content = withClosers })));
 
         Assert.True(payload.GetProperty("applied").GetBoolean());
         Assert.True(payload.GetProperty("healApplied").GetBoolean());
+        Assert.Equal("safe_with_warnings", payload.GetProperty("verdict").GetString());
         var written = payload.GetProperty("writtenContent").GetString()!;
         Assert.DoesNotContain("§/F", written);
         Assert.Equal(written, File.ReadAllText(path));
@@ -250,7 +352,7 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
               §/F
             """;
 
-        var payload = Payload(await new FileWriteTool(_manager)
+        var payload = Payload(await WriteTool
             .ExecuteAsync(Args(new { path, content = withClosers, heal = false })));
 
         Assert.False(payload.GetProperty("applied").GetBoolean());
@@ -265,7 +367,7 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
     {
         var path = WriteFile("math.calr", MathSource);
 
-        var result = await new FileWriteTool(_manager)
+        var result = await WriteTool
             .ExecuteAsync(Args(new { path, content = MathSource, sessionId = "cs-nope" }));
 
         Assert.True(result.IsError);
@@ -278,35 +380,50 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
         var sessionId = await OpenSessionAsync();
         var outside = Path.Combine(Path.GetTempPath(), $"outside-{Guid.NewGuid():N}.calr");
 
-        var result = await new FileWriteTool(_manager)
+        var result = await WriteTool
             .ExecuteAsync(Args(new { path = outside, content = MathSource, sessionId }));
 
         Assert.True(result.IsError);
     }
 
     [Fact]
-    public async Task FileWrite_RemovingSymbolReferencedByOtherFile_RejectsAsBreaking()
+    public async Task FileWrite_RemovingCalledFunction_RejectsAsBreaking()
     {
         var mathPath = WriteFile("math.calr", MathSource);
-        // The reference check uses symbol-id containment, matching the
-        // in-file heuristic: this file mentions f001.
-        WriteFile("caller.calr", """
-            §M{m003:CallerModule}
-              §F{f020:label:pub}
-                §O{str}
-                §R STR:"wraps f001"
-            """);
+        WriteFile("caller.calr", CallerSource); // real call site: §C{add}
         var sessionId = await OpenSessionAsync();
 
-        var payload = Payload(await new FileWriteTool(_manager)
+        var payload = Payload(await WriteTool
             .ExecuteAsync(Args(new { path = mathPath, content = MathSourceWithoutAdd, sessionId })));
 
         Assert.False(payload.GetProperty("applied").GetBoolean());
         Assert.Equal("breaking", payload.GetProperty("verdict").GetString());
         var dangling = payload.GetProperty("referenceIntegrity").GetProperty("danglingReferences")
             .EnumerateArray().Select(e => e.GetString()).ToList();
-        Assert.Contains(dangling, d => d!.Contains("f001") && d.Contains("caller.calr"));
+        Assert.Contains(dangling, d => d!.Contains("'add'") && d.Contains("caller.calr"));
         Assert.Equal(MathSource, File.ReadAllText(mathPath));
+    }
+
+    [Fact]
+    public async Task FileWrite_StringMentionOfRemovedFunction_DoesNotBlock()
+    {
+        // The reference check matches call targets, not raw text: a file that
+        // merely mentions the removed function's name inside a string literal
+        // must not veto the write.
+        var mathPath = WriteFile("math.calr", MathSource);
+        WriteFile("prose.calr", """
+            §M{m004:ProseModule}
+              §F{f030:label:pub}
+                §O{str}
+                §R STR:"documentation mentions add and f001 in prose"
+            """);
+        var sessionId = await OpenSessionAsync();
+
+        var payload = Payload(await WriteTool
+            .ExecuteAsync(Args(new { path = mathPath, content = MathSourceWithoutAdd, sessionId })));
+
+        Assert.True(payload.GetProperty("applied").GetBoolean());
+        Assert.Equal("safe", payload.GetProperty("verdict").GetString());
     }
 
     [Fact]
@@ -316,19 +433,16 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
         var otherPath = WriteFile("other.calr", OtherSource);
         var sessionId = await OpenSessionAsync();
 
-        // Change other.calr behind the session's back so it now references
-        // f001. Dirty-state invalidation must pick this up on the next call.
-        File.WriteAllText(otherPath, """
-            §M{m002:OtherModule}
-              §F{f010:describe:pub}
-                §O{str}
-                §R STR:"now mentions f001"
-            """);
-        // The stat gate is mtime/size — force a distinct mtime in case the
-        // filesystem's timestamp granularity makes the two writes identical.
+        // Change other.calr behind the session's back so it now really calls
+        // add. Dirty-state invalidation must pick this up on the next call.
+        File.WriteAllText(otherPath, CallerSource);
+        // The invalidation gate is a stat check: force a distinct mtime so
+        // this test is deterministic across filesystems with coarse
+        // timestamp granularity. (A same-size edit that also preserves the
+        // stat is a documented non-detection — BuildStateCache semantics.)
         File.SetLastWriteTimeUtc(otherPath, DateTime.UtcNow.AddSeconds(5));
 
-        var payload = Payload(await new FileWriteTool(_manager)
+        var payload = Payload(await WriteTool
             .ExecuteAsync(Args(new { path = mathPath, content = MathSourceWithoutAdd, sessionId })));
 
         Assert.False(payload.GetProperty("applied").GetBoolean());
@@ -342,14 +456,14 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
         WriteFile("other.calr", OtherSource);
         var sessionId = await OpenSessionAsync();
 
-        // First write removes f001, which nothing references, so it applies.
-        var first = Payload(await new FileWriteTool(_manager)
+        // First write removes add, which nothing calls, so it applies.
+        var first = Payload(await WriteTool
             .ExecuteAsync(Args(new { path = mathPath, content = MathSourceWithoutAdd, sessionId })));
         Assert.True(first.GetProperty("applied").GetBoolean());
 
         // A second identical write must see the session's updated state:
         // original now equals the new content, so the edit is a no-op and safe.
-        var second = Payload(await new FileWriteTool(_manager)
+        var second = Payload(await WriteTool
             .ExecuteAsync(Args(new { path = mathPath, content = MathSourceWithoutAdd, sessionId })));
         Assert.True(second.GetProperty("applied").GetBoolean());
         Assert.Equal("safe", second.GetProperty("verdict").GetString());

--- a/tests/Calor.Compiler.Tests/Mcp/SessionAndFileWriteToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/SessionAndFileWriteToolTests.cs
@@ -1,0 +1,370 @@
+using System.Text.Json;
+using Calor.Compiler.Mcp;
+using Calor.Compiler.Mcp.Sessions;
+using Calor.Compiler.Mcp.Tools;
+using Xunit;
+
+namespace Calor.Compiler.Tests.Mcp;
+
+/// <summary>
+/// Tests for the project-session tools (calor_session_open/close, loop plan
+/// WS2 D2.1) and the transactional file write tool (calor_file_write, D2.4)
+/// with auto-heal (D2.5).
+/// </summary>
+public sealed class SessionAndFileWriteToolTests : IDisposable
+{
+    private readonly string _root;
+    private readonly ProjectSessionManager _manager = new();
+
+    private const string MathSource = """
+        §M{m001:MathModule}
+          §F{f001:add:pub}
+            §I{i32:x, i32:y}
+            §O{i32}
+            §R (+ x y)
+          §F{f002:multiply:pub}
+            §I{i32:a, i32:b}
+            §O{i32}
+            §R (* a b)
+        """;
+
+    private const string MathSourceWithoutAdd = """
+        §M{m001:MathModule}
+          §F{f002:multiply:pub}
+            §I{i32:a, i32:b}
+            §O{i32}
+            §R (* a b)
+        """;
+
+    private const string OtherSource = """
+        §M{m002:OtherModule}
+          §F{f010:describe:pub}
+            §O{str}
+            §R STR:"standalone module"
+        """;
+
+    public SessionAndFileWriteToolTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "calor-mcp-session-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch (IOException) { }
+    }
+
+    private string WriteFile(string name, string content)
+    {
+        var path = Path.Combine(_root, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private static JsonElement Args(object value) => JsonSerializer.SerializeToElement(value);
+
+    private static JsonElement Payload(McpToolResult result)
+    {
+        Assert.False(result.IsError, $"Expected success result, got error: {result.Content[0].Text}");
+        return JsonDocument.Parse(result.Content[0].Text!).RootElement;
+    }
+
+    private async Task<string> OpenSessionAsync()
+    {
+        var result = await new SessionOpenTool(_manager).ExecuteAsync(Args(new { directory = _root }));
+        return Payload(result).GetProperty("sessionId").GetString()!;
+    }
+
+    // ── calor_session_open / calor_session_close ────────────────────────
+
+    [Fact]
+    public async Task SessionOpen_ParsesFilesAndReturnsSessionId()
+    {
+        WriteFile("math.calr", MathSource);
+        WriteFile("other.calr", OtherSource);
+
+        var result = await new SessionOpenTool(_manager).ExecuteAsync(Args(new { directory = _root }));
+        var payload = Payload(result);
+
+        Assert.True(payload.GetProperty("success").GetBoolean());
+        Assert.False(string.IsNullOrEmpty(payload.GetProperty("sessionId").GetString()));
+        Assert.Equal(2, payload.GetProperty("fileCount").GetInt32());
+        Assert.Equal(0, payload.GetProperty("parseErrorFileCount").GetInt32());
+        Assert.Empty(payload.GetProperty("diagnostics").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task SessionOpen_ReportsParseErrorsAsEnvelopeDiagnostics()
+    {
+        WriteFile("broken.calr", "§M{m001:Broken}\n  §F{f001:bad:pub\n");
+
+        var payload = Payload(await new SessionOpenTool(_manager).ExecuteAsync(Args(new { directory = _root })));
+
+        Assert.Equal(1, payload.GetProperty("parseErrorFileCount").GetInt32());
+        var diagnostics = payload.GetProperty("diagnostics").EnumerateArray().ToList();
+        Assert.NotEmpty(diagnostics);
+        Assert.Equal("error", diagnostics[0].GetProperty("severity").GetString());
+    }
+
+    [Fact]
+    public async Task SessionOpen_MissingDirectory_ReturnsError()
+    {
+        var result = await new SessionOpenTool(_manager)
+            .ExecuteAsync(Args(new { directory = Path.Combine(_root, "does-not-exist") }));
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task SessionClose_ClosesOnceThenReportsAlreadyClosed()
+    {
+        WriteFile("math.calr", MathSource);
+        var sessionId = await OpenSessionAsync();
+        var closeTool = new SessionCloseTool(_manager);
+
+        var first = Payload(await closeTool.ExecuteAsync(Args(new { sessionId })));
+        var second = Payload(await closeTool.ExecuteAsync(Args(new { sessionId })));
+
+        Assert.True(first.GetProperty("closed").GetBoolean());
+        Assert.False(second.GetProperty("closed").GetBoolean());
+    }
+
+    // ── calor_file_write: transactional apply ───────────────────────────
+
+    [Fact]
+    public async Task FileWrite_ValidEdit_AppliesAndUpdatesDisk()
+    {
+        var path = WriteFile("math.calr", MathSource);
+
+        var payload = Payload(await new FileWriteTool(_manager)
+            .ExecuteAsync(Args(new { path, content = MathSourceWithoutAdd })));
+
+        Assert.True(payload.GetProperty("applied").GetBoolean());
+        Assert.Equal("safe", payload.GetProperty("verdict").GetString());
+        Assert.False(payload.GetProperty("healApplied").GetBoolean());
+        Assert.Equal(MathSourceWithoutAdd, File.ReadAllText(path));
+    }
+
+    [Fact]
+    public async Task FileWrite_ParseError_RejectsAndLeavesFileUntouched()
+    {
+        var path = WriteFile("math.calr", MathSource);
+
+        var payload = Payload(await new FileWriteTool(_manager)
+            .ExecuteAsync(Args(new { path, content = "§M{m001:Broken}\n  §F{f001:bad:pub\n" })));
+
+        Assert.False(payload.GetProperty("applied").GetBoolean());
+        Assert.Equal("breaking", payload.GetProperty("verdict").GetString());
+        Assert.NotEmpty(payload.GetProperty("compilationResult").GetProperty("errors").EnumerateArray());
+        Assert.Equal(MathSource, File.ReadAllText(path));
+    }
+
+    [Fact]
+    public async Task FileWrite_CreatesMissingFile()
+    {
+        var path = Path.Combine(_root, "fresh.calr");
+
+        var payload = Payload(await new FileWriteTool(_manager)
+            .ExecuteAsync(Args(new { path, content = OtherSource })));
+
+        Assert.True(payload.GetProperty("applied").GetBoolean());
+        Assert.True(payload.GetProperty("created").GetBoolean());
+        Assert.Equal(OtherSource, File.ReadAllText(path));
+    }
+
+    [Fact]
+    public async Task FileWrite_NonCalrPath_ReturnsError()
+    {
+        var result = await new FileWriteTool(_manager)
+            .ExecuteAsync(Args(new { path = Path.Combine(_root, "notes.txt"), content = "hello" }));
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task FileWrite_ContractRemoval_AppliesWithWarnings()
+    {
+        const string withContract = """
+            §M{m001:MathModule}
+              §F{f001:add:pub}
+                §I{i32:x, i32:y}
+                §O{i32}
+                §Q (>= x INT:0)
+                §R (+ x y)
+            """;
+        const string withoutContract = """
+            §M{m001:MathModule}
+              §F{f001:add:pub}
+                §I{i32:x, i32:y}
+                §O{i32}
+                §R (+ x y)
+            """;
+        var path = WriteFile("math.calr", withContract);
+
+        var payload = Payload(await new FileWriteTool(_manager)
+            .ExecuteAsync(Args(new { path, content = withoutContract })));
+
+        Assert.True(payload.GetProperty("applied").GetBoolean());
+        Assert.Equal("safe_with_warnings", payload.GetProperty("verdict").GetString());
+        Assert.NotEmpty(payload.GetProperty("contractVerification").GetProperty("issues").EnumerateArray());
+    }
+
+    // ── calor_file_write: auto-heal (D2.5) ──────────────────────────────
+
+    [Fact]
+    public async Task FileWrite_HealsForbiddenClosersBeforeChecking()
+    {
+        var path = WriteFile("math.calr", MathSource);
+        // §/F and §/M are hard errors (Calor0830) — the healer must strip
+        // them so the write survives instead of rejecting.
+        const string withClosers = """
+            §M{m001:MathModule}
+              §F{f002:multiply:pub}
+                §I{i32:a, i32:b}
+                §O{i32}
+                §R (* a b)
+              §/F
+            §/M
+            """;
+
+        var payload = Payload(await new FileWriteTool(_manager)
+            .ExecuteAsync(Args(new { path, content = withClosers })));
+
+        Assert.True(payload.GetProperty("applied").GetBoolean());
+        Assert.True(payload.GetProperty("healApplied").GetBoolean());
+        var written = payload.GetProperty("writtenContent").GetString()!;
+        Assert.DoesNotContain("§/F", written);
+        Assert.Equal(written, File.ReadAllText(path));
+    }
+
+    [Fact]
+    public async Task FileWrite_HealDisabled_RejectsForbiddenClosers()
+    {
+        var path = WriteFile("math.calr", MathSource);
+        const string withClosers = """
+            §M{m001:MathModule}
+              §F{f002:multiply:pub}
+                §I{i32:a, i32:b}
+                §O{i32}
+                §R (* a b)
+              §/F
+            """;
+
+        var payload = Payload(await new FileWriteTool(_manager)
+            .ExecuteAsync(Args(new { path, content = withClosers, heal = false })));
+
+        Assert.False(payload.GetProperty("applied").GetBoolean());
+        Assert.Equal("breaking", payload.GetProperty("verdict").GetString());
+        Assert.Equal(MathSource, File.ReadAllText(path));
+    }
+
+    // ── calor_file_write: session integration (D2.1) ────────────────────
+
+    [Fact]
+    public async Task FileWrite_UnknownSession_ReturnsError()
+    {
+        var path = WriteFile("math.calr", MathSource);
+
+        var result = await new FileWriteTool(_manager)
+            .ExecuteAsync(Args(new { path, content = MathSource, sessionId = "cs-nope" }));
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task FileWrite_PathOutsideSessionRoot_ReturnsError()
+    {
+        WriteFile("math.calr", MathSource);
+        var sessionId = await OpenSessionAsync();
+        var outside = Path.Combine(Path.GetTempPath(), $"outside-{Guid.NewGuid():N}.calr");
+
+        var result = await new FileWriteTool(_manager)
+            .ExecuteAsync(Args(new { path = outside, content = MathSource, sessionId }));
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task FileWrite_RemovingSymbolReferencedByOtherFile_RejectsAsBreaking()
+    {
+        var mathPath = WriteFile("math.calr", MathSource);
+        // The reference check uses symbol-id containment, matching the
+        // in-file heuristic: this file mentions f001.
+        WriteFile("caller.calr", """
+            §M{m003:CallerModule}
+              §F{f020:label:pub}
+                §O{str}
+                §R STR:"wraps f001"
+            """);
+        var sessionId = await OpenSessionAsync();
+
+        var payload = Payload(await new FileWriteTool(_manager)
+            .ExecuteAsync(Args(new { path = mathPath, content = MathSourceWithoutAdd, sessionId })));
+
+        Assert.False(payload.GetProperty("applied").GetBoolean());
+        Assert.Equal("breaking", payload.GetProperty("verdict").GetString());
+        var dangling = payload.GetProperty("referenceIntegrity").GetProperty("danglingReferences")
+            .EnumerateArray().Select(e => e.GetString()).ToList();
+        Assert.Contains(dangling, d => d!.Contains("f001") && d.Contains("caller.calr"));
+        Assert.Equal(MathSource, File.ReadAllText(mathPath));
+    }
+
+    [Fact]
+    public async Task FileWrite_SessionSeesFilesChangedBehindItsBack()
+    {
+        var mathPath = WriteFile("math.calr", MathSource);
+        var otherPath = WriteFile("other.calr", OtherSource);
+        var sessionId = await OpenSessionAsync();
+
+        // Change other.calr behind the session's back so it now references
+        // f001. Dirty-state invalidation must pick this up on the next call.
+        File.WriteAllText(otherPath, """
+            §M{m002:OtherModule}
+              §F{f010:describe:pub}
+                §O{str}
+                §R STR:"now mentions f001"
+            """);
+        // The stat gate is mtime/size — force a distinct mtime in case the
+        // filesystem's timestamp granularity makes the two writes identical.
+        File.SetLastWriteTimeUtc(otherPath, DateTime.UtcNow.AddSeconds(5));
+
+        var payload = Payload(await new FileWriteTool(_manager)
+            .ExecuteAsync(Args(new { path = mathPath, content = MathSourceWithoutAdd, sessionId })));
+
+        Assert.False(payload.GetProperty("applied").GetBoolean());
+        Assert.Equal("breaking", payload.GetProperty("verdict").GetString());
+    }
+
+    [Fact]
+    public async Task FileWrite_AppliedWriteUpdatesSessionState()
+    {
+        var mathPath = WriteFile("math.calr", MathSource);
+        WriteFile("other.calr", OtherSource);
+        var sessionId = await OpenSessionAsync();
+
+        // First write removes f001, which nothing references, so it applies.
+        var first = Payload(await new FileWriteTool(_manager)
+            .ExecuteAsync(Args(new { path = mathPath, content = MathSourceWithoutAdd, sessionId })));
+        Assert.True(first.GetProperty("applied").GetBoolean());
+
+        // A second identical write must see the session's updated state:
+        // original now equals the new content, so the edit is a no-op and safe.
+        var second = Payload(await new FileWriteTool(_manager)
+            .ExecuteAsync(Args(new { path = mathPath, content = MathSourceWithoutAdd, sessionId })));
+        Assert.True(second.GetProperty("applied").GetBoolean());
+        Assert.Equal("safe", second.GetProperty("verdict").GetString());
+    }
+
+    // ── Registration ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Handler_RegistersSessionAndFileWriteTools()
+    {
+        var handler = new McpMessageHandler(verbose: false);
+        var tools = handler.GetRegisteredToolNamesForTest();
+
+        Assert.Contains("calor_session_open", tools);
+        Assert.Contains("calor_session_close", tools);
+        Assert.Contains("calor_file_write", tools);
+    }
+}


### PR DESCRIPTION
## Summary

M3 implementation slice 1 per the kickoff record (`docs/plans/loop-m3-ws2.md`, #796):

- **D2.1 Project sessions** — `calor_session_open` / `calor_session_close`: session-scoped project context in the MCP server. Opens a directory, parses every `.calr` file under it, holds state in memory. Dirty-state invalidation is stat-on-access (mtime/size gate, then SHA-256 content hash — the `BuildStateCache` two-level pattern) and picks up files changed, added, or deleted behind the session's back. No project-file format introduced (priced decision, kickoff §2).
- **D2.4 Transactional whole-file apply** — `calor_file_write`: runs the `calor_edit_preview` check set (compile / contracts / effects / references) against the current on-disk content, applies atomically (temp file + rename in the target directory) on `safe`/`safe_with_warnings`, rejects `breaking` with envelope schema v1.1 diagnostics and the file untouched. With a `sessionId`, reference checks widen to the whole project at identical strictness (same symbol-containment heuristic as the in-file check).
- **D2.5, auto-heal half** — `SourceHealer` wired into the write path: forbidden closers / indentation slips are healed before checking (default on, `heal: false` to disable); the healed text is what gets written, returned as `writtenContent` with ambiguities as `healNotes`. The fault-tolerant parse mode half of D2.5 is PR 3.
- Check core of `EditPreviewTool` widened `private → internal` so both tools share one check set (D2.4's "identical checking" requirement) — no logic changes.
- Envelope denominator updated per the WS1 forward rule: `calor_session_open` (E), `calor_file_write` (E), `calor_session_close` (X, lifecycle-only); M-E1 = 31/31.

## Dependencies

Depends on #796 (calor-first allowlist entries for the four new C# files). **calor-first-guard will fail here until #796 merges and this branch is rebased onto main** — the guard requires allowlist entries on main at the merge base and a PR cannot self-exempt.

## Test plan

- 17 new tests in `SessionAndFileWriteToolTests`: session open/parse-error/close lifecycle, apply/reject transactionality (file untouched on `breaking`), file creation, heal-then-apply vs `heal:false` reject, unknown-session and outside-root refusals, cross-file dangling-reference rejection, behind-the-back change invalidation, post-apply session-state freshness, handler registration.
- Full suite green locally: 7,600+ tests across all projects, 0 failures (`TreatWarningsAsErrors` on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)