### PR TITLE
feat: M3 — harness MCP registration, mcp-file gate opened, M-L2/M-L4 write stream (loop plan WS2/D4.2)

### DIFF
--- a/bench/phase0-agent-native/loop-telemetry-schema.md
+++ b/bench/phase0-agent-native/loop-telemetry-schema.md
@@ -55,6 +55,35 @@ censors at budget+1; censored fractions are reported per arm.
   `loop-baseline-ws1`) has no apply path, and the schema must be frozen
   **before** the treatment build exists so both arms emit identical shapes.
 
+## Companion stream: `mcp-writes.jsonl` (mcp-write/1)
+
+Live `mcp-file` arms register the calor MCP server (M3 PR 4), and
+`calor_file_write` journals **one record per write attempt** into
+`mcp-writes.jsonl` in the run's out dir (env `CALOR_MCP_WRITE_LOG`, set in the
+server registration). This is M-L2's per-attempt stream for the mcp-file
+mechanism — the journal's per-iteration `apply_verdict` remains reserved-null;
+per-attempt granularity lives here instead, because one iteration can contain
+several write attempts and the shim cannot observe MCP traffic.
+
+| Field | Type | Notes |
+|:------|:-----|:------|
+| `schema` | `"mcp-write/1"` | discriminator |
+| `ts` | string (ISO-8601 UTC) | attempt time |
+| `path` | string | canonical target path |
+| `verdict` | `"safe"` \| `"safe_with_warnings"` \| `"breaking"` | check-set verdict |
+| `applied` | bool | whether the atomic apply ran (`verdict != "breaking"`) |
+| `healApplied` | bool | auto-heal changed the content before checking (D2.5) |
+| `created` | bool | the write created the file |
+| `rejectPayload` | string \| null | path of the archived rejected-edit payload (`rejects/`, env `CALOR_MCP_REJECT_DIR`) — D4.6 replay input for M-L4 |
+
+Notes: revalidation races (file changed on disk mid-check → retry error) are
+not journaled — they carry no verdict information. `extract_metrics`
+aggregates the stream into `result.json` as
+`mcpWrites: {attempts, applied, rejected, healed}` (null when the stream is
+absent). **M-L2(mcp-file)** = `applied / attempts`. **M-L4** consumes the
+`rejectPayload` archives; below 20 rejects per epoch it stays reported-only
+(Annex A).
+
 ## Compatibility
 
 `extract_metrics` in `run-pair.sh` computes `iterations`, `iterationsToGreen`,

--- a/bench/phase0-agent-native/loop-telemetry-schema.md
+++ b/bench/phase0-agent-native/loop-telemetry-schema.md
@@ -77,10 +77,15 @@ several write attempts and the shim cannot observe MCP traffic.
 | `rejectPayload` | string \| null | path of the archived rejected-edit payload (`rejects/`, env `CALOR_MCP_REJECT_DIR`) — D4.6 replay input for M-L4 |
 
 Notes: revalidation races (file changed on disk mid-check → retry error) are
-not journaled — they carry no verdict information. `extract_metrics`
+not journaled — they carry no verdict information. Reject payload archiving
+caps at 200 per server process (records keep flowing past the cap with
+`rejectPayload: null`; Annex A adjudicates M-L4 at ≥20). `extract_metrics`
 aggregates the stream into `result.json` as
-`mcpWrites: {attempts, applied, rejected, healed}` (null when the stream is
-absent). **M-L2(mcp-file)** = `applied / attempts`. **M-L4** consumes the
+`mcpWrites: {attempts, applied, appliedUnhealed, rejected, healed}` (null
+when the stream is absent). **M-L2(mcp-file)** = `applied / attempts`, which
+is first-apply-**after-autoheal** validity because the tool heals before
+checking; `appliedUnhealed / attempts` is the strict form — report both in
+cross-mechanism comparisons (Annex A A-1.1). **M-L4** consumes the
 `rejectPayload` archives; below 20 rejects per epoch it stays reported-only
 (Annex A).
 

--- a/bench/phase0-agent-native/run-pair.sh
+++ b/bench/phase0-agent-native/run-pair.sh
@@ -294,21 +294,19 @@ EOF
     # no-session write-confinement root — is the task tree itself. Write
     # telemetry (M-L2) and reject payloads (M-L4/D4.6) land in the run's out
     # dir via the env the server is started with.
+    # Built with jq (not a heredoc) so paths are JSON-escaped, and the write
+    # root is pinned via --root rather than trusting the client to spawn the
+    # server with a particular CWD (review of #799 item 1): a wrong implicit
+    # root would silently reject every task-tree write and fabricate the
+    # guaranteed-failure data the old gate existed to prevent.
     if [[ "$ARM" == "calor" && "$EDIT_MECHANISM" == "mcp-file" && $NULL_AGENT -eq 0 ]]; then
-        cat > "$ws_out/mcp-config.json" <<EOF
-{
-  "mcpServers": {
-    "calor": {
-      "command": "dotnet",
-      "args": ["$CALOR_CLI_DLL", "mcp", "--stdio"],
-      "env": {
-        "CALOR_MCP_WRITE_LOG": "$ws_out/mcp-writes.jsonl",
-        "CALOR_MCP_REJECT_DIR": "$ws_out/rejects"
-      }
-    }
-  }
-}
-EOF
+        jq -n --arg dll "$CALOR_CLI_DLL" --arg root "$ws/src" \
+              --arg log "$ws_out/mcp-writes.jsonl" --arg rej "$ws_out/rejects" \
+            '{mcpServers: {calor: {
+                command: "dotnet",
+                args: [$dll, "mcp", "--stdio", "--root", $root],
+                env: {CALOR_MCP_WRITE_LOG: $log, CALOR_MCP_REJECT_DIR: $rej}}}}' \
+            > "$ws_out/mcp-config.json"
     fi
 
     # Baseline src-tree hash (mirrors the shim's computation): without it the
@@ -636,8 +634,12 @@ extract_metrics() {
     # without the MCP write path (raw arms, older builds).
     local mcp_writes
     if [[ -s "$ws_out/mcp-writes.jsonl" ]]; then
+        # appliedUnhealed nets auto-heal out of M-L2: applied counts writes
+        # the tool healed first, so applied/attempts is first-apply-AFTER-
+        # AUTOHEAL validity; appliedUnhealed/attempts is the strict form.
         mcp_writes=$(jq -s '{attempts: length,
                              applied: [.[] | select(.applied)] | length,
+                             appliedUnhealed: [.[] | select(.applied and (.healApplied | not))] | length,
                              rejected: [.[] | select(.applied | not)] | length,
                              healed: [.[] | select(.healApplied)] | length}' \
                      "$ws_out/mcp-writes.jsonl")

--- a/bench/phase0-agent-native/run-pair.sh
+++ b/bench/phase0-agent-native/run-pair.sh
@@ -109,19 +109,19 @@ done
 case "$EDIT_MECHANISM" in
     raw) ;;
     mcp-file)
-        # GATED until a real MCP write path exists (review of #758 item 1):
-        # the harness registers no MCP server and Calor exposes no
-        # file-writing MCP tool (calor_edit_preview is preview-only), so a
-        # live mcp-file run blocks every edit path and can only manufacture
-        # guaranteed-failure data. Allowed under --null-agent so labels /
-        # pins / record plumbing stay testable; unblocks when WS2 D2.4
-        # (transactional file-level apply) ships an MCP write tool and the
-        # harness registers the server.
-        if [[ "$NULL_AGENT" != "1" ]]; then
-            echo "ERROR: --edit-mechanism mcp-file is gated: no MCP file-write tool exists yet (WS2 D2.4); a live run would block all edits and fabricate failure data. Use --null-agent for plumbing tests." >&2
+        # UNGATED (loop plan M3 PR 4): WS2 D2.4 shipped the transactional MCP
+        # write path (calor_file_write, #797) with write-path robustness
+        # (#798), and the harness now registers the calor MCP server for this
+        # arm (see the mcp-config block in prep and the --mcp-config args on
+        # the claude invocation). Enforcement stays two-sided: the PreToolUse
+        # hook blocks raw Edit/Write on .calr, and the prompt states the
+        # constraint. Live runs are calor-arm only — the C# arm has no .calr
+        # surface to constrain. calor.dll presence is checked after CLI
+        # resolution below.
+        if [[ "$NULL_AGENT" != "1" && "$ARM" != "calor" ]]; then
+            echo "ERROR: --edit-mechanism mcp-file applies to the calor arm only (the C# arm has no .calr edit surface)" >&2
             exit 2
         fi
-        echo "WARNING: mcp-file arm is plumbing-only under --null-agent until WS2 D2.4 ships an MCP write path" >&2
         ;;
     mcp-node)
         # Accepted for forward-compatible labeling only: node-level MCP edit
@@ -178,6 +178,13 @@ for cli_cfg in Release Debug; do
 done
 if [[ "$ARM" == "calor" && -z "$CALOR_CLI_DLL" ]]; then
     echo "WARNING: calor.dll not found (build src/Calor.Compiler first); calor-arm records will carry envelope_valid=null and empty edit_target_ids" >&2
+fi
+# A live mcp-file arm cannot run without the MCP server binary: the hook
+# blocks raw .calr edits, so a missing server would strand the agent with no
+# edit path at all and fabricate guaranteed-failure data.
+if [[ "$EDIT_MECHANISM" == "mcp-file" && $NULL_AGENT -eq 0 && -z "$CALOR_CLI_DLL" ]]; then
+    echo "ERROR: --edit-mechanism mcp-file needs calor.dll to register the MCP server (build src/Calor.Compiler -c Release first)" >&2
+    exit 2
 fi
 
 # ---------------------------------------------------------------------------
@@ -275,6 +282,30 @@ EOF
         ]
       }
     ]
+  }
+}
+EOF
+    fi
+
+    # MCP server registration for the live mcp-file arm (loop plan M3 PR 4):
+    # exactly one server, passed via --mcp-config + --strict-mcp-config so
+    # user-level MCP config cannot bleed into the arm. claude runs from
+    # $ws/src, so the server's working directory — calor_file_write's
+    # no-session write-confinement root — is the task tree itself. Write
+    # telemetry (M-L2) and reject payloads (M-L4/D4.6) land in the run's out
+    # dir via the env the server is started with.
+    if [[ "$ARM" == "calor" && "$EDIT_MECHANISM" == "mcp-file" && $NULL_AGENT -eq 0 ]]; then
+        cat > "$ws_out/mcp-config.json" <<EOF
+{
+  "mcpServers": {
+    "calor": {
+      "command": "dotnet",
+      "args": ["$CALOR_CLI_DLL", "mcp", "--stdio"],
+      "env": {
+        "CALOR_MCP_WRITE_LOG": "$ws_out/mcp-writes.jsonl",
+        "CALOR_MCP_REJECT_DIR": "$ws_out/rejects"
+      }
+    }
   }
 }
 EOF
@@ -517,16 +548,22 @@ run_agent() {
     local model_args=()
     [[ -n "${CLAUDE_MODEL:-}" && "${CLAUDE_MODEL}" != "default" ]] && model_args=(--model "$CLAUDE_MODEL")
 
+    # MCP registration args (written by prep for the live mcp-file arm only):
+    # --strict-mcp-config keeps the arm hermetic — the agent sees exactly the
+    # calor server, never user-level MCP config.
+    local mcp_args=()
+    [[ -f "$ws_out/mcp-config.json" ]] && mcp_args=(--mcp-config "$ws_out/mcp-config.json" --strict-mcp-config)
+
     local rc=0
     if [[ -n "$timeout_bin" ]]; then
         ( cd "$ws/src" && PATH="$shim_dir:$PATH" \
             "$timeout_bin" -k 10 "$TIMEOUT_SECS" \
-            claude --print --output-format json --dangerously-skip-permissions "${model_args[@]}" \
+            claude --print --output-format json --dangerously-skip-permissions "${model_args[@]}" "${mcp_args[@]}" \
             "$prompt" > "$ws_out/agent.json" 2> "$ws_out/agent.err" ) || rc=$?
     else
         set -m
         ( cd "$ws/src" && PATH="$shim_dir:$PATH" \
-            claude --print --output-format json --dangerously-skip-permissions "${model_args[@]}" \
+            claude --print --output-format json --dangerously-skip-permissions "${model_args[@]}" "${mcp_args[@]}" \
             "$prompt" > "$ws_out/agent.json" 2> "$ws_out/agent.err" ) &
         local agent_pid=$!
         ( sleep "$TIMEOUT_SECS" && kill -9 -- "-$agent_pid" 2>/dev/null ) &
@@ -593,6 +630,21 @@ extract_metrics() {
         envelope_valid_all=null
     fi
 
+    # M-L2 per-attempt stream (loop plan M3 PR 4): calor_file_write journals
+    # one record per attempt into mcp-writes.jsonl; applied/attempts is
+    # first-apply validity for the mcp-file mechanism. null when the arm ran
+    # without the MCP write path (raw arms, older builds).
+    local mcp_writes
+    if [[ -s "$ws_out/mcp-writes.jsonl" ]]; then
+        mcp_writes=$(jq -s '{attempts: length,
+                             applied: [.[] | select(.applied)] | length,
+                             rejected: [.[] | select(.applied | not)] | length,
+                             healed: [.[] | select(.healApplied)] | length}' \
+                     "$ws_out/mcp-writes.jsonl")
+    else
+        mcp_writes=null
+    fi
+
     jq -n \
         --arg pair "$PAIR_ID" --arg arm "$ARM_LABEL" --argjson run "$run_idx" \
         --argjson success "$([[ $final_fail -eq 0 ]] && echo true || echo false)" \
@@ -602,11 +654,13 @@ extract_metrics() {
         --argjson tin "$tokens_in" --argjson tout "$tokens_out" \
         --argjson null_agent "$NULL_AGENT" \
         --argjson mean_lat "$mean_lat" --argjson env_all "$envelope_valid_all" \
+        --argjson mcp_writes "$mcp_writes" \
         '{pair:$pair, arm:$arm, run:$run, taskSuccess:$success,
           escapedBugs:$escaped, heldoutPassed:$passed,
           iterations:$iterations, iterationsToGreen:$itg, censored:$censored,
           invalid:false,
           meanFeedbackLatencyMs:$mean_lat, envelopeValidAll:$env_all,
+          mcpWrites:$mcp_writes,
           tokens:{input:$tin, output:$tout}, nullAgent:($null_agent==1)}' \
         > "$ws_out/result.json"
     cat "$ws_out/result.json"

--- a/docs/plans/agent-native-gates.md
+++ b/docs/plans/agent-native-gates.md
@@ -99,7 +99,8 @@ After freezing, this document may be superseded only for a **documented empirica
 
 ## Annex A — Instrument metrics (loop plan v0.9, D4.4)
 
-**Annex version: A-1.0 (frozen 2026-07-24).** This annex is **additive-only
+**Annex version: A-1.1 (thresholds frozen at A-1.0, 2026-07-24; additive
+clarification A-1.1, 2026-07-25).** This annex is **additive-only
 with respect to the main document**: no §1–§7 machine-adjudicable gate
 criterion references any metric defined here, and nothing here alters the
 C#-vs-Calor gate decisions those sections govern. The annex's own proof-point
@@ -134,7 +135,13 @@ pairing, and censoring follow §2 of this document.
   excluding the harness's silent held-out observation and telemetry
   bookkeeping (arm-fairness; see schema doc).
 - **M-L2 first-apply validity** — % of edited iterations whose build exits 0,
-  split by `edit_mechanism`.
+  split by `edit_mechanism`. **Heal accounting (A-1.1)**: on the `mcp-file`
+  mechanism the per-attempt stream (`mcp-writes.jsonl`, schema doc) is the
+  source, and `calor_file_write` auto-heals before checking — so
+  `applied/attempts` is first-apply-**after-autoheal** validity, crediting
+  the tool for slips it repaired. The stream journals `healApplied` per
+  record and the run summary carries `appliedUnhealed`; cross-mechanism
+  comparisons against raw arms must report both forms.
 - **M-L3 diagnostic actionability** — of failing edited iterations whose
   envelope named ≥1 `declarationId`, % where the next edited iteration's
   `edit_target_ids` intersects the named set. **Adjudication floor: 20
@@ -159,6 +166,12 @@ D4.5 rule ("the dry-run may move a threshold, the task count, or N before
 freezing — never after") applied as written.
 
 ### A.3 Annex revision log
+
+**A-1.1 (2026-07-25).** Additive clarification, no threshold changes: M-L2's
+`mcp-file` sourcing (per-attempt `mcp-writes.jsonl` stream, M3 PR 4) and its
+heal accounting — `applied/attempts` is first-apply-after-autoheal validity;
+`appliedUnhealed` is the strict form; both reported in cross-mechanism
+comparisons (review of #799).
 
 **A-1.0 (2026-07-24).** Initial freeze. Definitions from loop plan §4;
 thresholds per the `loop-feasibility-dry-002` verdict

--- a/src/Calor.Compiler/Commands/McpCommand.cs
+++ b/src/Calor.Compiler/Commands/McpCommand.cs
@@ -20,18 +20,26 @@ public static class McpCommand
             aliases: ["--verbose", "-v"],
             description: "Enable verbose output to stderr for debugging");
 
+        var rootOption = new Option<string?>(
+            aliases: ["--root"],
+            description: "Confinement root for project sessions and file writes " +
+                         "(calor_session_open/calor_file_write). Defaults to the server " +
+                         "process working directory — which depends on how the MCP client " +
+                         "spawns the server, so pin it explicitly in harness/CI setups.");
+
         var command = new Command("mcp", "Start the Calor MCP server for AI coding agents")
         {
             stdioOption,
-            verboseOption
+            verboseOption,
+            rootOption
         };
 
-        command.SetHandler(ExecuteAsync, stdioOption, verboseOption);
+        command.SetHandler(ExecuteAsync, stdioOption, verboseOption, rootOption);
 
         return command;
     }
 
-    private static async Task ExecuteAsync(bool stdio, bool verbose)
+    private static async Task ExecuteAsync(bool stdio, bool verbose, string? root)
     {
         if (!stdio)
         {
@@ -40,9 +48,16 @@ public static class McpCommand
             return;
         }
 
+        if (root != null && !Directory.Exists(root))
+        {
+            Console.Error.WriteLine($"Error: --root directory not found: {root}");
+            Environment.ExitCode = 1;
+            return;
+        }
+
         try
         {
-            var server = McpServer.CreateStdio(verbose);
+            var server = McpServer.CreateStdio(verbose, root);
             await server.RunAsync();
         }
         catch (Exception ex)

--- a/src/Calor.Compiler/Mcp/McpMessageHandler.cs
+++ b/src/Calor.Compiler/Mcp/McpMessageHandler.cs
@@ -31,7 +31,7 @@ public sealed class McpMessageHandler
             : Math.Max(512L * 1024L * 1024L, (long)(GC.GetGCMemoryInfo().TotalAvailableMemoryBytes * 0.5));
     private CancellationToken _serverCancellation;
 
-    public McpMessageHandler(bool verbose = false, TextWriter? log = null)
+    public McpMessageHandler(bool verbose = false, TextWriter? log = null, string? rootDirectory = null)
     {
         _verbose = verbose;
         _log = log;
@@ -61,9 +61,13 @@ public sealed class McpMessageHandler
         RegisterTool(new FormatTool());
 
         // ── Project sessions & transactional writes (loop plan WS2 D2.1/D2.4)
-        RegisterTool(new SessionOpenTool(_projectSessions));
+        // rootDirectory pins the write-confinement root explicitly (mcp
+        // --root); when null the tools fall back to the server process CWD —
+        // which depends on how the MCP client spawned us, so harnesses
+        // should always pin it.
+        RegisterTool(new SessionOpenTool(_projectSessions, rootDirectory));
         RegisterTool(new SessionCloseTool(_projectSessions));
-        RegisterTool(new FileWriteTool(_projectSessions));
+        RegisterTool(new FileWriteTool(_projectSessions, rootDirectory));
 
         // ── Refinement types & obligations ──────────────────
         RegisterTool(new RefineTool());

--- a/src/Calor.Compiler/Mcp/McpServer.cs
+++ b/src/Calor.Compiler/Mcp/McpServer.cs
@@ -28,13 +28,14 @@ public sealed class McpServer
     /// Creates an MCP server with a TextReader for input.
     /// Prefer this constructor when a blocking TextReader is available (e.g., Console.In).
     /// </summary>
-    public McpServer(TextReader reader, Stream output, bool verbose = false, TextWriter? log = null)
+    public McpServer(TextReader reader, Stream output, bool verbose = false, TextWriter? log = null,
+        string? rootDirectory = null)
     {
         _reader = reader ?? throw new ArgumentNullException(nameof(reader));
         _output = output ?? throw new ArgumentNullException(nameof(output));
         _verbose = verbose;
         _log = log;
-        _handler = new McpMessageHandler(verbose, log);
+        _handler = new McpMessageHandler(verbose, log, rootDirectory);
     }
 
     /// <summary>
@@ -42,7 +43,7 @@ public sealed class McpServer
     /// Uses Console.In which properly blocks when no data is available,
     /// unlike raw Console.OpenStandardInput() which can spin on empty reads.
     /// </summary>
-    public static McpServer CreateStdio(bool verbose = false)
+    public static McpServer CreateStdio(bool verbose = false, string? rootDirectory = null)
     {
         // Ensure UTF-8 encoding for stdin/stdout to handle § and other non-ASCII correctly
         Console.InputEncoding = Encoding.UTF8;
@@ -50,7 +51,7 @@ public sealed class McpServer
 
         var output = Console.OpenStandardOutput();
         var log = verbose ? Console.Error : null;
-        return new McpServer(Console.In, output, verbose, log);
+        return new McpServer(Console.In, output, verbose, log, rootDirectory);
     }
 
     /// <summary>

--- a/src/Calor.Compiler/Mcp/Tools/FileWriteTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/FileWriteTool.cs
@@ -40,10 +40,22 @@ public sealed class FileWriteTool : McpToolBase
     private static SemaphoreSlim GateFor(string canonicalPath)
         => PathGates[(canonicalPath.GetHashCode(StringComparison.Ordinal) & int.MaxValue) % PathGates.Length];
 
-    internal FileWriteTool(ProjectSessionManager sessions, string? defaultWriteRoot = null)
+    private readonly string? _writeLogPath;
+    private readonly string? _rejectDir;
+    private static readonly object WriteLogSync = new();
+
+    internal FileWriteTool(ProjectSessionManager sessions, string? defaultWriteRoot = null,
+        string? writeLogPath = null, string? rejectDir = null)
     {
         _sessions = sessions;
         _defaultWriteRoot = CanonicalPath.Resolve(defaultWriteRoot ?? Environment.CurrentDirectory);
+
+        // Loop telemetry (plan D4.1/D4.6): the harness sets these env vars in
+        // the MCP server registration so every write attempt is journaled
+        // (M-L2 first-apply validity) and every reject's payload is archived
+        // for the reject-replay harness (M-L4). Absent → no logging.
+        _writeLogPath = writeLogPath ?? Environment.GetEnvironmentVariable("CALOR_MCP_WRITE_LOG");
+        _rejectDir = rejectDir ?? Environment.GetEnvironmentVariable("CALOR_MCP_REJECT_DIR");
     }
 
     public override string Name => "calor_file_write";
@@ -165,7 +177,7 @@ public sealed class FileWriteTool : McpToolBase
         }
     }
 
-    private static async Task<McpToolResult> CheckAndApplyAsync(string canonicalPath, string content,
+    private async Task<McpToolResult> CheckAndApplyAsync(string canonicalPath, string content,
         ProjectSession? session, JsonElement? arguments, CancellationToken cancellationToken)
     {
         var (runCompile, runContracts, runEffects, runReferences) = ParseCheckSelection(arguments);
@@ -265,6 +277,9 @@ public sealed class FileWriteTool : McpToolBase
         if (healApplied)
             recommendations.Insert(0, "Content was auto-healed — review writtenContent; healing is not guaranteed semantics-preserving");
 
+        LogWriteAttempt(canonicalPath, verdict, applied, healApplied,
+            created: applied && !fileExistedAtRead, finalContent);
+
         return McpToolResult.Json(new FileWriteOutput
         {
             Success = true,
@@ -362,6 +377,59 @@ public sealed class FileWriteTool : McpToolBase
                 requested.Contains("contracts"),
                 requested.Contains("effects"),
                 requested.Contains("references"));
+    }
+
+    /// <summary>
+    /// Appends one JSONL record per write attempt to the harness-configured
+    /// log (M-L2's per-attempt stream), archiving rejected content for
+    /// reject-replay (M-L4/D4.6). Telemetry must never fail the write path —
+    /// all IO errors are swallowed. Revalidation races (retry errors) are
+    /// deliberately not logged: they carry no verdict information.
+    /// </summary>
+    private void LogWriteAttempt(string path, string verdict, bool applied, bool healApplied,
+        bool created, string content)
+    {
+        if (_writeLogPath == null)
+            return;
+
+        try
+        {
+            string? rejectPayloadPath = null;
+            if (!applied && _rejectDir != null)
+            {
+                Directory.CreateDirectory(_rejectDir);
+                rejectPayloadPath = System.IO.Path.Combine(_rejectDir,
+                    $"{DateTime.UtcNow:yyyyMMddTHHmmssfff}Z-{Guid.NewGuid().ToString("N")[..8]}.json");
+                File.WriteAllText(rejectPayloadPath, JsonSerializer.Serialize(new
+                {
+                    ts = DateTime.UtcNow.ToString("o"),
+                    path,
+                    verdict,
+                    rejectedContent = content
+                }, McpJsonOptions.Default));
+            }
+
+            var record = JsonSerializer.Serialize(new
+            {
+                schema = "mcp-write/1",
+                ts = DateTime.UtcNow.ToString("o"),
+                path,
+                verdict,
+                applied,
+                healApplied,
+                created,
+                rejectPayload = rejectPayloadPath
+            }, McpJsonOptions.Default);
+
+            lock (WriteLogSync)
+            {
+                File.AppendAllText(_writeLogPath, record + Environment.NewLine);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Swallowed by design; see summary.
+        }
     }
 
     /// <summary>

--- a/src/Calor.Compiler/Mcp/Tools/FileWriteTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/FileWriteTool.cs
@@ -44,6 +44,13 @@ public sealed class FileWriteTool : McpToolBase
     private readonly string? _rejectDir;
     private static readonly object WriteLogSync = new();
 
+    // Reject payloads carry full file content (≤512 KB each); cap the archive
+    // so a reject-spamming run cannot grow it without bound. Records keep
+    // flowing to the write log past the cap — only the payload is dropped
+    // (Annex A adjudicates M-L4 at ≥20 rejects, far below this).
+    private const int MaxRejectArchives = 200;
+    private static int _rejectsArchived;
+
     internal FileWriteTool(ProjectSessionManager sessions, string? defaultWriteRoot = null,
         string? writeLogPath = null, string? rejectDir = null)
     {
@@ -395,7 +402,7 @@ public sealed class FileWriteTool : McpToolBase
         try
         {
             string? rejectPayloadPath = null;
-            if (!applied && _rejectDir != null)
+            if (!applied && _rejectDir != null && Interlocked.Increment(ref _rejectsArchived) <= MaxRejectArchives)
             {
                 Directory.CreateDirectory(_rejectDir);
                 rejectPayloadPath = System.IO.Path.Combine(_rejectDir,

--- a/tests/Calor.Compiler.Tests/Mcp/SessionAndFileWriteToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/SessionAndFileWriteToolTests.cs
@@ -469,6 +469,56 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
         Assert.Equal("safe", second.GetProperty("verdict").GetString());
     }
 
+    // ── Write telemetry (M-L2 / M-L4 stream) ────────────────────────────
+
+    [Fact]
+    public async Task FileWrite_LogsAppliedAttempt_WhenLogConfigured()
+    {
+        var path = WriteFile("math.calr", MathSource);
+        var logPath = Path.Combine(_root, "mcp-writes.jsonl");
+        var tool = new FileWriteTool(_manager, _root, writeLogPath: logPath);
+
+        var payload = Payload(await tool.ExecuteAsync(Args(new { path, content = MathSourceWithoutAdd })));
+        Assert.True(payload.GetProperty("applied").GetBoolean());
+
+        var records = File.ReadAllLines(logPath).Select(l => JsonDocument.Parse(l).RootElement).ToList();
+        Assert.Single(records);
+        Assert.Equal("mcp-write/1", records[0].GetProperty("schema").GetString());
+        Assert.True(records[0].GetProperty("applied").GetBoolean());
+        Assert.Equal("safe", records[0].GetProperty("verdict").GetString());
+    }
+
+    [Fact]
+    public async Task FileWrite_LogsRejectAndArchivesPayload()
+    {
+        var path = WriteFile("math.calr", MathSource);
+        var logPath = Path.Combine(_root, "mcp-writes.jsonl");
+        var rejectDir = Path.Combine(_root, "rejects");
+        var tool = new FileWriteTool(_manager, _root, writeLogPath: logPath, rejectDir: rejectDir);
+        const string broken = "§M{m001:Broken}\n  §F{f001:bad:pub\n";
+
+        var payload = Payload(await tool.ExecuteAsync(Args(new { path, content = broken, heal = false })));
+        Assert.False(payload.GetProperty("applied").GetBoolean());
+
+        var record = JsonDocument.Parse(File.ReadAllLines(logPath).Single()).RootElement;
+        Assert.False(record.GetProperty("applied").GetBoolean());
+        Assert.Equal("breaking", record.GetProperty("verdict").GetString());
+        var rejectPayloadPath = record.GetProperty("rejectPayload").GetString();
+        Assert.NotNull(rejectPayloadPath);
+        var archived = JsonDocument.Parse(File.ReadAllText(rejectPayloadPath!)).RootElement;
+        Assert.Equal(broken, archived.GetProperty("rejectedContent").GetString());
+    }
+
+    [Fact]
+    public async Task FileWrite_NoLogConfigured_WritesNoTelemetry()
+    {
+        var path = WriteFile("math.calr", MathSource);
+
+        Payload(await WriteTool.ExecuteAsync(Args(new { path, content = MathSourceWithoutAdd })));
+
+        Assert.False(File.Exists(Path.Combine(_root, "mcp-writes.jsonl")));
+    }
+
     // ── Registration ────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

M3 PR 4 (final slice, per `docs/plans/loop-m3-ws2.md` §3): the harness side of the WS2 mutation loop.

- **The #758 gate opens.** Its stated unblock condition — "WS2 D2.4 ships an MCP write tool and the harness registers the server" — is met by #797/#798. `run-pair.sh` now registers the calor MCP server for live `mcp-file` arms via `--mcp-config` + `--strict-mcp-config` (hermetic: the agent sees exactly one server, user-level MCP config cannot bleed into the arm). The server starts from `$ws/src`, so its no-session write-confinement root is the task tree itself.
- **Enforcement stays two-sided:** the PreToolUse hook blocking raw `Edit`/`Write` on `.calr` is unchanged, and the prompt constraint stands. Live `mcp-file` is calor-arm only and errors without `calor.dll` — a hook-blocked arm with no server would strand the agent and fabricate guaranteed-failure data. `--null-agent` plumbing mode is unchanged.
- **M-L2/M-L4 sourcing:** `calor_file_write` journals one `mcp-write/1` JSONL record per attempt (`CALOR_MCP_WRITE_LOG`) and archives rejected content (`CALOR_MCP_REJECT_DIR`) for the D4.6 reject-replay harness. Env comes from the server registration; absent → zero logging (telemetry can never fail the write path). `extract_metrics` aggregates the stream into `result.json` as `mcpWrites: {attempts, applied, rejected, healed}` — **M-L2(mcp-file) = applied/attempts**. The journal's `apply_verdict` stays reserved-null by design: one iteration can contain several write attempts and the shim cannot observe MCP traffic, so per-attempt granularity lives in the companion stream (documented in `loop-telemetry-schema.md`).

## Verification

- `bash -n` clean; full null-agent smoke run of the `mcp-file` arm green end-to-end (`mcpWrites: null` as expected — no server in plumbing mode).
- Live server driven over NDJSON against the Release binary: applied write (`safe`, file updated), rejected write (`breaking`, file untouched), both journaled, reject payload archived with the rejected content.
- `claude --strict-mcp-config` flag presence confirmed against the installed CLI.
- 3 new telemetry tests; all 40 MCP tests green; full suite green.

## What this unlocks

The WS2 exit criterion is now runnable: an agent completing a multi-edit E2E task exclusively through the MCP file tools, with M-L2 measured from the write stream and M-L4 reported from reject payloads (Annex A: reported-only below 20 rejects). That run spends API budget, so it's a deliberate next step, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)