### PR TITLE
feat: M4 — edit→envelope latency instrumentation: mcp-write/2 + watch-rebuild/1 (loop plan WS3 D3.2)

### DIFF
--- a/bench/phase0-agent-native/loop-telemetry-schema.md
+++ b/bench/phase0-agent-native/loop-telemetry-schema.md
@@ -55,7 +55,7 @@ censors at budget+1; censored fractions are reported per arm.
   `loop-baseline-ws1`) has no apply path, and the schema must be frozen
   **before** the treatment build exists so both arms emit identical shapes.
 
-## Companion stream: `mcp-writes.jsonl` (mcp-write/1)
+## Companion stream: `mcp-writes.jsonl` (mcp-write/2)
 
 Live `mcp-file` arms register the calor MCP server (M3 PR 4), and
 `calor_file_write` journals **one record per write attempt** into
@@ -67,14 +67,21 @@ several write attempts and the shim cannot observe MCP traffic.
 
 | Field | Type | Notes |
 |:------|:-----|:------|
-| `schema` | `"mcp-write/1"` | discriminator |
+| `schema` | `"mcp-write/2"` | discriminator; archived M3-era records are `"mcp-write/1"` (identical minus the four latency fields) |
 | `ts` | string (ISO-8601 UTC) | attempt time |
 | `path` | string | canonical target path |
 | `verdict` | `"safe"` \| `"safe_with_warnings"` \| `"breaking"` | check-set verdict |
 | `applied` | bool | whether the atomic apply ran (`verdict != "breaking"`) |
 | `healApplied` | bool | auto-heal changed the content before checking (D2.5) |
 | `created` | bool | the write created the file |
-| `rejectPayload` | string \| null | path of the archived rejected-edit payload (`rejects/`, env `CALOR_MCP_REJECT_DIR`) — D4.6 replay input for M-L4 |
+| `rejectPayload` | string \| null | path of the archived rejected-edit payload (`rejects/`, env `CALOR_MCP_REJECT_DIR`) — D4.6 replay input for M-L4. **Absent when null** — the MCP serializer drops null fields |
+| `latencyMs` | int | **M-L1's adjudicating measurement** (WS3 D3.2): edit→envelope wall time, tool-call receipt → verdict record — covers session refresh, per-path gate wait, heal, parse, check set, and atomic apply |
+| `refreshMs` | int | phase: session stat-on-access refresh (0 without a session) |
+| `checkMs` | int | phase: read + heal + parse + check set through verdict |
+| `applyMs` | int | phase: revalidate + atomic write (0 on reject) |
+
+Machine-validatable schema: `mcp-write.schema.json` (accepts both `/1` and
+`/2`; the latency fields are always emitted by `/2` writers).
 
 Notes: revalidation races (file changed on disk mid-check → retry error) are
 not journaled — they carry no verdict information. Reject payload archiving
@@ -89,9 +96,35 @@ cross-mechanism comparisons (Annex A A-1.1). **M-L4** consumes the
 `rejectPayload` archives; below 20 rejects per epoch it stays reported-only
 (Annex A).
 
+## Companion stream: watch rebuilds (watch-rebuild/1)
+
+`calor watch` appends **one record per rebuild** to the file named by env
+`CALOR_WATCH_REBUILD_LOG` (WS3 D3.2). This is the reported-not-adjudicating
+latency surface for PP-L1 (the M4 kickoff decision: M-L1 adjudicates on the
+MCP write path, the loop mechanism the harness constrains arms to).
+
+| Field | Type | Notes |
+|:------|:-----|:------|
+| `schema` | `"watch-rebuild/1"` | discriminator |
+| `ts` | string (ISO-8601 UTC) | rebuild completion time |
+| `rebuild` | int | 1-based rebuild ordinal (1 = initial compile) |
+| `initial` | bool | initial compile vs change-triggered rebuild |
+| `compiled` | int | files compiled this rebuild |
+| `skipped` | int | files served from the incremental cache |
+| `anyErrors` | bool | rebuild had errors |
+| `latencyMs` | int | rebuild start → NDJSON envelope written. **Excludes the debounce window by definition** — debounce is a configured delay, not feedback cost |
+| `debounceMs` | int | the configured debounce, recorded alongside so reported numbers carry their config |
+
+A rebuild that finds no sources emits no envelope and no record. Machine
+schema: `watch-rebuild.schema.json`.
+
 ## Compatibility
 
 `extract_metrics` in `run-pair.sh` computes `iterations`, `iterationsToGreen`,
 `censored`, and `escapedBugs` from the same fields as v1 (`edited`,
 `heldout_fail`) — v2 is additive. Epoch `pins.json` gains
 `telemetrySchema: "loop-telemetry/2"` so mixed-schema epochs are detectable.
+The `mcp-write/1 → /2` bump is likewise additive: `extract_metrics` does not
+filter on the discriminator, so its `mcpWrites` aggregation is unaffected.
+`validate-telemetry.sh` dispatches every record on its `schema` field to the
+matching schema file and rejects unknown discriminators.

--- a/bench/phase0-agent-native/loop-telemetry-schema.md
+++ b/bench/phase0-agent-native/loop-telemetry-schema.md
@@ -75,13 +75,15 @@ several write attempts and the shim cannot observe MCP traffic.
 | `healApplied` | bool | auto-heal changed the content before checking (D2.5) |
 | `created` | bool | the write created the file |
 | `rejectPayload` | string \| null | path of the archived rejected-edit payload (`rejects/`, env `CALOR_MCP_REJECT_DIR`) — D4.6 replay input for M-L4. **Absent when null** — the MCP serializer drops null fields |
-| `latencyMs` | int | **M-L1's adjudicating measurement** (WS3 D3.2): edit→envelope wall time, tool-call receipt → verdict record — covers session refresh, per-path gate wait, heal, parse, check set, and atomic apply |
+| `latencyMs` | int | **M-L1's adjudicating measurement** (WS3 D3.2): wall time from tool-call receipt (tool handler entry, after protocol parse) to the verdict being journaled — covers session refresh, per-path gate wait, heal, parse, check set, and atomic apply. **Outside the clock, stated once here as the normative boundary:** protocol-layer request parsing, result-envelope serialization after the verdict, and reject-payload archiving. All excluded segments are microsecond-to-low-ms scale against a 300 ms P50 gate |
 | `refreshMs` | int | phase: session stat-on-access refresh (0 without a session) |
 | `checkMs` | int | phase: read + heal + parse + check set through verdict |
 | `applyMs` | int | phase: revalidate + atomic write (0 on reject) |
 
 Machine-validatable schema: `mcp-write.schema.json` (accepts both `/1` and
-`/2`; the latency fields are always emitted by `/2` writers).
+`/2`; the four latency fields are **required** on `/2` and forbidden on
+`/1`, so a writer regression that stops emitting the adjudicating number
+fails validation instead of sailing through).
 
 Notes: revalidation races (file changed on disk mid-check → retry error) are
 not journaled — they carry no verdict information. Reject payload archiving
@@ -107,12 +109,12 @@ MCP write path, the loop mechanism the harness constrains arms to).
 |:------|:-----|:------|
 | `schema` | `"watch-rebuild/1"` | discriminator |
 | `ts` | string (ISO-8601 UTC) | rebuild completion time |
-| `rebuild` | int | 1-based rebuild ordinal (1 = initial compile) |
+| `rebuild` | int | 1-based monotonic rebuild counter. **Logged ordinals may have gaps**: a rebuild that finds no sources consumes an ordinal but writes no record, so the first record is not guaranteed to be `rebuild: 1` |
 | `initial` | bool | initial compile vs change-triggered rebuild |
 | `compiled` | int | files compiled this rebuild |
 | `skipped` | int | files served from the incremental cache |
 | `anyErrors` | bool | rebuild had errors |
-| `latencyMs` | int | rebuild start → NDJSON envelope written. **Excludes the debounce window by definition** — debounce is a configured delay, not feedback cost |
+| `latencyMs` | int | rebuild start → NDJSON envelope written under `--format json`. Under `--format text` no envelope exists and the boundary is rebuild start → compile end — M-L1 measurement runs use `--format json`. **Excludes the debounce window by definition** — debounce is a configured delay, not feedback cost |
 | `debounceMs` | int | the configured debounce, recorded alongside so reported numbers carry their config |
 
 A rebuild that finds no sources emits no envelope and no record. Machine

--- a/bench/phase0-agent-native/mcp-write.schema.json
+++ b/bench/phase0-agent-native/mcp-write.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "calor-loop-mcp-write",
   "title": "Calor MCP write-attempt record (mcp-write/1, mcp-write/2)",
-  "description": "One record per calor_file_write attempt (loop plan D4.1/WS2; latency fields per WS3 D3.2). mcp-write/2 is additive over /1: the four latency fields are always emitted by /2 writers and absent on archived /1 records. rejectPayload is dropped entirely when null (the MCP serializer omits null fields), so it is optional here.",
+  "description": "One record per calor_file_write attempt (loop plan D4.1/WS2; latency fields per WS3 D3.2). mcp-write/2 REQUIRES the four latency fields — latencyMs is PP-L1's adjudicating measurement, so a writer that stops emitting it must fail validation; archived /1 records must not carry them. rejectPayload is dropped entirely when null (the MCP serializer omits null fields), so it is optional here.",
   "type": "object",
   "required": ["schema", "ts", "path", "verdict", "applied", "healApplied", "created"],
   "additionalProperties": false,
@@ -19,5 +19,15 @@
     "refreshMs": { "type": "integer", "minimum": 0 },
     "checkMs": { "type": "integer", "minimum": 0 },
     "applyMs": { "type": "integer", "minimum": 0 }
+  },
+  "if": { "properties": { "schema": { "const": "mcp-write/2" } } },
+  "then": { "required": ["latencyMs", "refreshMs", "checkMs", "applyMs"] },
+  "else": {
+    "properties": {
+      "latencyMs": false,
+      "refreshMs": false,
+      "checkMs": false,
+      "applyMs": false
+    }
   }
 }

--- a/bench/phase0-agent-native/mcp-write.schema.json
+++ b/bench/phase0-agent-native/mcp-write.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "calor-loop-mcp-write",
+  "title": "Calor MCP write-attempt record (mcp-write/1, mcp-write/2)",
+  "description": "One record per calor_file_write attempt (loop plan D4.1/WS2; latency fields per WS3 D3.2). mcp-write/2 is additive over /1: the four latency fields are always emitted by /2 writers and absent on archived /1 records. rejectPayload is dropped entirely when null (the MCP serializer omits null fields), so it is optional here.",
+  "type": "object",
+  "required": ["schema", "ts", "path", "verdict", "applied", "healApplied", "created"],
+  "additionalProperties": false,
+  "properties": {
+    "schema": { "enum": ["mcp-write/1", "mcp-write/2"] },
+    "ts": { "type": "string", "minLength": 20 },
+    "path": { "type": "string", "minLength": 1 },
+    "verdict": { "enum": ["safe", "safe_with_warnings", "breaking"] },
+    "applied": { "type": "boolean" },
+    "healApplied": { "type": "boolean" },
+    "created": { "type": "boolean" },
+    "rejectPayload": { "type": ["string", "null"] },
+    "latencyMs": { "type": "integer", "minimum": 0 },
+    "refreshMs": { "type": "integer", "minimum": 0 },
+    "checkMs": { "type": "integer", "minimum": 0 },
+    "applyMs": { "type": "integer", "minimum": 0 }
+  }
+}

--- a/bench/phase0-agent-native/validate-telemetry.sh
+++ b/bench/phase0-agent-native/validate-telemetry.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # ============================================================================
-# validate-telemetry.sh <journal.jsonl> [more.jsonl ...]
+# validate-telemetry.sh [--expect <discriminator>] <journal.jsonl> [more.jsonl ...]
 #
 # Validates every line of the given telemetry file(s), dispatching on each
 # record's "schema" discriminator (loop plan D4.1/D4.2; latency streams per
@@ -9,11 +9,17 @@
 #   mcp-write/1 | mcp-write/2   -> mcp-write.schema.json
 #   watch-rebuild/1             -> watch-rebuild.schema.json
 #
+# --expect <discriminator> additionally asserts stream purity: every record
+# must carry exactly that discriminator (restores the old tool's "v2-only
+# journal" guarantee — a misrouted record type in a single-stream file is
+# an error, not a valid line).
+#
 # Strategy (no new dependencies assumed):
 #   1. python3 + jsonschema installed  -> full JSON Schema validation
 #   2. python3 only                    -> hand-rolled check: full field
 #      semantics for loop-telemetry/2; generic required/allowed/type/enum
-#      checks derived from the schema file for the flat record types
+#      checks (including const-discriminated if/then/else conditionals)
+#      derived from the schema file for the flat record types
 #   3. no python3                      -> clear failure message, exit 3
 #
 # Records with no "schema" field (v1) or an unknown discriminator are
@@ -23,7 +29,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-[[ $# -ge 1 ]] || { echo "Usage: validate-telemetry.sh <journal.jsonl> [more.jsonl ...]" >&2; exit 2; }
+EXPECT=""
+if [[ "${1:-}" == "--expect" ]]; then
+    [[ $# -ge 2 ]] || { echo "--expect needs a discriminator" >&2; exit 2; }
+    EXPECT="$2"
+    shift 2
+fi
+
+[[ $# -ge 1 ]] || { echo "Usage: validate-telemetry.sh [--expect <discriminator>] <journal.jsonl> [more.jsonl ...]" >&2; exit 2; }
 for s in loop-telemetry.schema.json mcp-write.schema.json watch-rebuild.schema.json; do
     [[ -f "$SCRIPT_DIR/$s" ]] || { echo "Schema not found: $SCRIPT_DIR/$s" >&2; exit 2; }
 done
@@ -37,13 +50,14 @@ if ! command -v python3 >/dev/null 2>&1; then
     exit 3
 fi
 
-python3 - "$SCRIPT_DIR" "$@" <<'PYEOF'
+python3 - "$SCRIPT_DIR" "$EXPECT" "$@" <<'PYEOF'
 import json
 import re
 import sys
 
 script_dir = sys.argv[1]
-files = sys.argv[2:]
+expect = sys.argv[2] or None
+files = sys.argv[3:]
 
 
 def load(name):
@@ -71,17 +85,46 @@ except ImportError:
     MECH_ENUM = {"raw", "mcp-file", "mcp-node", "unknown"}
     VERDICT_ENUM = {"applied", "rejected", None}
 
+    def _is_integer(v):
+        # JSON Schema semantics: an integer-valued float satisfies
+        # "integer" (draft 2020-12) — the fallback must agree with the
+        # jsonschema path so a file cannot pass on one machine and fail
+        # on another.
+        if isinstance(v, bool):
+            return False
+        return isinstance(v, int) or (isinstance(v, float) and v.is_integer())
+
     def check_generic(record, schema):
         """Required/allowed/type/enum checks for flat record schemas
-        (mcp-write, watch-rebuild) derived from the schema document."""
+        (mcp-write, watch-rebuild) derived from the schema document,
+        including const-discriminated if/then/else conditionals."""
         errs = []
         allowed = set(schema["properties"].keys())
-        for k in schema["required"]:
+        required = list(schema["required"])
+        forbidden = set()
+
+        # if/then/else limited to the shape our schemas use: `if` matching
+        # a const on one property; `then` adding required fields; `else`
+        # forbidding fields via `"field": false`.
+        cond = schema.get("if")
+        if cond:
+            matches = all(
+                record.get(k) == spec.get("const")
+                for k, spec in cond.get("properties", {}).items())
+            branch = schema.get("then") if matches else schema.get("else")
+            if branch:
+                required += branch.get("required", [])
+                forbidden |= {k for k, spec in branch.get("properties", {}).items()
+                              if spec is False}
+
+        for k in required:
             if k not in record:
                 errs.append(f"missing required field: {k}")
         for k in record:
             if k not in allowed:
                 errs.append(f"unexpected field (additionalProperties=false): {k}")
+            elif k in forbidden:
+                errs.append(f"field not allowed for this schema version: {k}")
         if errs:
             return errs
         for k, v in record.items():
@@ -95,7 +138,7 @@ except ImportError:
                 types = types if isinstance(types, list) else [types]
                 ok = any(
                     (t == "string" and isinstance(v, str))
-                    or (t == "integer" and isinstance(v, int) and not isinstance(v, bool))
+                    or (t == "integer" and _is_integer(v))
                     or (t == "boolean" and isinstance(v, bool))
                     or (t == "null" and v is None)
                     for t in types)
@@ -104,7 +147,7 @@ except ImportError:
                     continue
             if isinstance(v, str) and "minLength" in spec and len(v) < spec["minLength"]:
                 errs.append(f"{k} shorter than minLength {spec['minLength']}")
-            if isinstance(v, int) and not isinstance(v, bool) and "minimum" in spec and v < spec["minimum"]:
+            if _is_integer(v) and "minimum" in spec and v < spec["minimum"]:
                 errs.append(f"{k} below minimum {spec['minimum']}")
         return errs
 
@@ -204,6 +247,10 @@ for path in files:
             if discriminator not in SCHEMAS:
                 bad += 1
                 print(f"{path}:{lineno}: unknown or missing schema discriminator: {discriminator!r}")
+                continue
+            if expect is not None and discriminator != expect:
+                bad += 1
+                print(f"{path}:{lineno}: stream purity: expected {expect!r}, got {discriminator!r}")
                 continue
             errors = check(record, discriminator)
             if errors:

--- a/bench/phase0-agent-native/validate-telemetry.sh
+++ b/bench/phase0-agent-native/validate-telemetry.sh
@@ -2,25 +2,31 @@
 # ============================================================================
 # validate-telemetry.sh <journal.jsonl> [more.jsonl ...]
 #
-# Validates every line of the given journal file(s) against the normative
-# loop-telemetry/2 schema (loop-telemetry.schema.json, loop plan D4.1/D4.2).
+# Validates every line of the given telemetry file(s), dispatching on each
+# record's "schema" discriminator (loop plan D4.1/D4.2; latency streams per
+# WS3 D3.2):
+#   loop-telemetry/2            -> loop-telemetry.schema.json
+#   mcp-write/1 | mcp-write/2   -> mcp-write.schema.json
+#   watch-rebuild/1             -> watch-rebuild.schema.json
 #
 # Strategy (no new dependencies assumed):
 #   1. python3 + jsonschema installed  -> full JSON Schema validation
-#   2. python3 only                    -> hand-rolled check of required
-#      fields, enums, types, and the additionalProperties allowlist
+#   2. python3 only                    -> hand-rolled check: full field
+#      semantics for loop-telemetry/2; generic required/allowed/type/enum
+#      checks derived from the schema file for the flat record types
 #   3. no python3                      -> clear failure message, exit 3
 #
-# v1 records (no "schema" field) are rejected: this tool asserts a v2-only
-# journal. Exit 0 = all lines valid; 1 = at least one invalid line.
+# Records with no "schema" field (v1) or an unknown discriminator are
+# rejected. Exit 0 = all lines valid; 1 = at least one invalid line.
 # ============================================================================
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCHEMA="$SCRIPT_DIR/loop-telemetry.schema.json"
 
 [[ $# -ge 1 ]] || { echo "Usage: validate-telemetry.sh <journal.jsonl> [more.jsonl ...]" >&2; exit 2; }
-[[ -f "$SCHEMA" ]] || { echo "Schema not found: $SCHEMA" >&2; exit 2; }
+for s in loop-telemetry.schema.json mcp-write.schema.json watch-rebuild.schema.json; do
+    [[ -f "$SCRIPT_DIR/$s" ]] || { echo "Schema not found: $SCRIPT_DIR/$s" >&2; exit 2; }
+done
 for f in "$@"; do
     [[ -f "$f" ]] || { echo "No such file: $f" >&2; exit 2; }
 done
@@ -31,45 +37,87 @@ if ! command -v python3 >/dev/null 2>&1; then
     exit 3
 fi
 
-python3 - "$SCHEMA" "$@" <<'PYEOF'
+python3 - "$SCRIPT_DIR" "$@" <<'PYEOF'
 import json
+import re
 import sys
 
-schema_path = sys.argv[1]
+script_dir = sys.argv[1]
 files = sys.argv[2:]
 
-with open(schema_path, "r", encoding="utf-8") as f:
-    schema = json.load(f)
+
+def load(name):
+    with open(f"{script_dir}/{name}", "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+SCHEMAS = {
+    "loop-telemetry/2": load("loop-telemetry.schema.json"),
+    "mcp-write/1": load("mcp-write.schema.json"),
+    "mcp-write/2": load("mcp-write.schema.json"),
+    "watch-rebuild/1": load("watch-rebuild.schema.json"),
+}
 
 try:
     import jsonschema  # type: ignore
-    validator = jsonschema.Draft202012Validator(schema)
+    validators = {k: jsonschema.Draft202012Validator(v) for k, v in SCHEMAS.items()}
     mode = "jsonschema (full schema validation)"
 
-    def check(record):
-        return [e.message for e in validator.iter_errors(record)]
+    def check(record, discriminator):
+        return [e.message for e in validators[discriminator].iter_errors(record)]
 except ImportError:
     mode = "hand-rolled (python3 stdlib; install 'jsonschema' for full validation)"
-    ALLOWED = set(schema["properties"].keys())
-    REQUIRED = schema["required"]
     CMD_ENUM = {"build", "test", "run"}
     MECH_ENUM = {"raw", "mcp-file", "mcp-node", "unknown"}
     VERDICT_ENUM = {"applied", "rejected", None}
 
-    def check(record):  # noqa: C901 - deliberately exhaustive
+    def check_generic(record, schema):
+        """Required/allowed/type/enum checks for flat record schemas
+        (mcp-write, watch-rebuild) derived from the schema document."""
         errs = []
-        if not isinstance(record, dict):
-            return ["record is not a JSON object"]
-        for k in REQUIRED:
+        allowed = set(schema["properties"].keys())
+        for k in schema["required"]:
             if k not in record:
                 errs.append(f"missing required field: {k}")
         for k in record:
-            if k not in ALLOWED:
+            if k not in allowed:
                 errs.append(f"unexpected field (additionalProperties=false): {k}")
         if errs:
             return errs
-        if record["schema"] != "loop-telemetry/2":
-            errs.append(f"schema must be loop-telemetry/2, got {record['schema']!r}")
+        for k, v in record.items():
+            spec = schema["properties"][k]
+            if "const" in spec and v != spec["const"]:
+                errs.append(f"{k} must be {spec['const']!r}, got {v!r}")
+            if "enum" in spec and v not in spec["enum"]:
+                errs.append(f"{k} must be one of {spec['enum']}, got {v!r}")
+            types = spec.get("type")
+            if types is not None:
+                types = types if isinstance(types, list) else [types]
+                ok = any(
+                    (t == "string" and isinstance(v, str))
+                    or (t == "integer" and isinstance(v, int) and not isinstance(v, bool))
+                    or (t == "boolean" and isinstance(v, bool))
+                    or (t == "null" and v is None)
+                    for t in types)
+                if not ok:
+                    errs.append(f"{k} must have type {types}, got {type(v).__name__}")
+                    continue
+            if isinstance(v, str) and "minLength" in spec and len(v) < spec["minLength"]:
+                errs.append(f"{k} shorter than minLength {spec['minLength']}")
+            if isinstance(v, int) and not isinstance(v, bool) and "minimum" in spec and v < spec["minimum"]:
+                errs.append(f"{k} below minimum {spec['minimum']}")
+        return errs
+
+    def check_loop_telemetry(record, schema):  # noqa: C901 - deliberately exhaustive
+        errs = []
+        for k in schema["required"]:
+            if k not in record:
+                errs.append(f"missing required field: {k}")
+        for k in record:
+            if k not in set(schema["properties"].keys()):
+                errs.append(f"unexpected field (additionalProperties=false): {k}")
+        if errs:
+            return errs
         for k in ("ts", "pair", "arm", "src_tree_hash"):
             if not isinstance(record[k], str) or not record[k]:
                 errs.append(f"{k} must be a non-empty string")
@@ -107,7 +155,6 @@ except ImportError:
                         or set(d) - {"code", "declarationId"}):
                     errs.append(f"bad diagnostics entry: {d!r}")
                     continue
-                import re
                 if not re.fullmatch(r"Calor[0-9]{4}", d["code"]):
                     errs.append(f"diagnostic code does not match ^Calor[0-9]{{4}}$: {d['code']!r}")
                 if "declarationId" in d and (not isinstance(d["declarationId"], str) or not d["declarationId"]):
@@ -128,6 +175,12 @@ except ImportError:
                 errs.append("rejected_edit must be null or {snapshotRef(>=8 chars), payloadPath}")
         return errs
 
+    def check(record, discriminator):
+        schema = SCHEMAS[discriminator]
+        if discriminator == "loop-telemetry/2":
+            return check_loop_telemetry(record, schema)
+        return check_generic(record, schema)
+
 total = 0
 bad = 0
 for path in files:
@@ -143,7 +196,16 @@ for path in files:
                 bad += 1
                 print(f"{path}:{lineno}: not valid JSON: {e}")
                 continue
-            errors = check(record)
+            if not isinstance(record, dict):
+                bad += 1
+                print(f"{path}:{lineno}: record is not a JSON object")
+                continue
+            discriminator = record.get("schema")
+            if discriminator not in SCHEMAS:
+                bad += 1
+                print(f"{path}:{lineno}: unknown or missing schema discriminator: {discriminator!r}")
+                continue
+            errors = check(record, discriminator)
             if errors:
                 bad += 1
                 for err in errors:

--- a/bench/phase0-agent-native/watch-rebuild.schema.json
+++ b/bench/phase0-agent-native/watch-rebuild.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "calor-loop-watch-rebuild",
+  "title": "Calor watch rebuild record (watch-rebuild/1)",
+  "description": "One record per `calor watch` rebuild (loop plan WS3 D3.2). latencyMs is rebuild-start to envelope-written wall time; the configured debounce window is excluded by definition and recorded alongside as debounceMs.",
+  "type": "object",
+  "required": ["schema", "ts", "rebuild", "initial", "compiled", "skipped", "anyErrors", "latencyMs", "debounceMs"],
+  "additionalProperties": false,
+  "properties": {
+    "schema": { "const": "watch-rebuild/1" },
+    "ts": { "type": "string", "minLength": 20 },
+    "rebuild": { "type": "integer", "minimum": 1 },
+    "initial": { "type": "boolean" },
+    "compiled": { "type": "integer", "minimum": 0 },
+    "skipped": { "type": "integer", "minimum": 0 },
+    "anyErrors": { "type": "boolean" },
+    "latencyMs": { "type": "integer", "minimum": 0 },
+    "debounceMs": { "type": "integer", "minimum": 0 }
+  }
+}

--- a/src/Calor.Compiler/Commands/WatchCommand.cs
+++ b/src/Calor.Compiler/Commands/WatchCommand.cs
@@ -1,6 +1,8 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Threading.Channels;
 using Calor.Compiler.Diagnostics;
 using Calor.Compiler.Effects;
@@ -130,7 +132,7 @@ internal sealed class WatchSession
         string ContractMode,
         int DebounceMs);
 
-    internal sealed record RebuildResult(int Compiled, int Skipped, bool AnyErrors);
+    internal sealed record RebuildResult(int Compiled, int Skipped, bool AnyErrors, long ElapsedMs);
 
     private readonly IReadOnlyList<string> _paths;
     private readonly WatchSettings _settings;
@@ -141,11 +143,14 @@ internal sealed class WatchSession
     private string? _stateDirectory;
     private bool _clearCachePending;
     private int _rebuildCount;
+    private readonly string? _rebuildLogPath;
+    private readonly object _rebuildLogSync = new();
 
     /// <summary>Raised after every rebuild (including the initial compile). Test hook.</summary>
     internal event Action<RebuildResult>? RebuildCompleted;
 
-    internal WatchSession(IReadOnlyList<string> paths, WatchSettings settings, TextWriter output, TextWriter status)
+    internal WatchSession(IReadOnlyList<string> paths, WatchSettings settings, TextWriter output, TextWriter status,
+        string? rebuildLogPath = null)
     {
         _paths = paths;
         _settings = settings;
@@ -153,6 +158,11 @@ internal sealed class WatchSession
         _status = status;
         _structuredOutput = !settings.Format.Equals("text", StringComparison.OrdinalIgnoreCase);
         _clearCachePending = settings.ClearCache;
+
+        // Loop telemetry (WS3 D3.2 / M-L1): when the harness sets this env
+        // var, every rebuild appends one watch-rebuild/1 JSONL record with
+        // its edit→envelope wall time. Absent → no logging.
+        _rebuildLogPath = rebuildLogPath ?? Environment.GetEnvironmentVariable("CALOR_WATCH_REBUILD_LOG");
     }
 
     /// <summary>Test hook: feeds a change event as if the file-system watcher had raised it.</summary>
@@ -257,12 +267,18 @@ internal sealed class WatchSession
     /// </summary>
     private void Rebuild(bool initial)
     {
+        // Edit→envelope wall time (WS3 D3.2 / M-L1): rebuild start to the
+        // envelope's write — the debounce window is a configured delay, not
+        // feedback cost, and is deliberately outside this clock (it is
+        // recorded alongside in the telemetry record instead).
+        var timer = Stopwatch.StartNew();
         var rebuildNumber = ++_rebuildCount;
         var sources = ResolveSources();
         if (sources.Count == 0)
         {
+            // No sources → no envelope; nothing to time or journal.
             _status.WriteLine("No .calr files found; waiting for changes...");
-            RebuildCompleted?.Invoke(new RebuildResult(0, 0, AnyErrors: false));
+            RebuildCompleted?.Invoke(new RebuildResult(0, 0, AnyErrors: false, timer.ElapsedMilliseconds));
             return;
         }
 
@@ -358,12 +374,54 @@ internal sealed class WatchSession
             _output.Flush();
         }
 
+        var elapsedMs = timer.ElapsedMilliseconds;
         var label = initial ? "Initial compile" : $"Rebuild #{rebuildNumber - 1}";
         _status.WriteLine(
             $"{label}: {summary.Compiled} compiled, {summary.Skipped} up-to-date" +
-            (summary.AnyErrors ? " — FAILED" : " — ok"));
+            (summary.AnyErrors ? " — FAILED" : " — ok") + $" ({elapsedMs} ms)");
 
-        RebuildCompleted?.Invoke(new RebuildResult(summary.Compiled, summary.Skipped, summary.AnyErrors));
+        LogRebuild(rebuildNumber, initial, summary, elapsedMs);
+        RebuildCompleted?.Invoke(new RebuildResult(summary.Compiled, summary.Skipped, summary.AnyErrors, elapsedMs));
+    }
+
+    /// <summary>
+    /// Appends one watch-rebuild/1 JSONL record per rebuild to the
+    /// harness-configured log (WS3 D3.2): edit→envelope wall time with the
+    /// configured debounce recorded alongside, since the wall time excludes
+    /// it by definition. Telemetry must never fail the watch loop — all IO
+    /// errors are swallowed, mirroring the mcp-write stream.
+    /// </summary>
+    private void LogRebuild(int rebuildNumber, bool initial, DriverResultSummary summary, long elapsedMs)
+    {
+        if (_rebuildLogPath == null)
+        {
+            return;
+        }
+
+        try
+        {
+            var record = JsonSerializer.Serialize(new
+            {
+                schema = "watch-rebuild/1",
+                ts = DateTime.UtcNow.ToString("o"),
+                rebuild = rebuildNumber,
+                initial,
+                compiled = summary.Compiled,
+                skipped = summary.Skipped,
+                anyErrors = summary.AnyErrors,
+                latencyMs = elapsedMs,
+                debounceMs = _settings.DebounceMs
+            });
+
+            lock (_rebuildLogSync)
+            {
+                File.AppendAllText(_rebuildLogPath, record + Environment.NewLine);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Swallowed by design; see summary.
+        }
     }
 
     private readonly record struct DriverResultSummary(int Compiled, int Skipped, bool AnyErrors);

--- a/src/Calor.Compiler/Commands/WatchCommand.cs
+++ b/src/Calor.Compiler/Commands/WatchCommand.cs
@@ -144,7 +144,9 @@ internal sealed class WatchSession
     private bool _clearCachePending;
     private int _rebuildCount;
     private readonly string? _rebuildLogPath;
-    private readonly object _rebuildLogSync = new();
+    // Process-wide, matching FileWriteTool.WriteLogSync: two sessions in
+    // one process pointed at the same log must not interleave appends.
+    private static readonly object RebuildLogSync = new();
 
     /// <summary>Raised after every rebuild (including the initial compile). Test hook.</summary>
     internal event Action<RebuildResult>? RebuildCompleted;
@@ -413,7 +415,7 @@ internal sealed class WatchSession
                 debounceMs = _settings.DebounceMs
             });
 
-            lock (_rebuildLogSync)
+            lock (RebuildLogSync)
             {
                 File.AppendAllText(_rebuildLogPath, record + Environment.NewLine);
             }

--- a/src/Calor.Compiler/Mcp/Tools/FileWriteTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/FileWriteTool.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Calor.Compiler.Diagnostics;
@@ -130,6 +131,12 @@ public sealed class FileWriteTool : McpToolBase
 
     private async Task<McpToolResult> ExecuteCoreAsync(JsonElement? arguments, CancellationToken cancellationToken)
     {
+        // Edit→envelope wall time (WS3 D3.2 / M-L1): the clock starts at
+        // tool-call receipt and covers refresh, gate wait, heal, parse,
+        // check set, and atomic apply — everything between the agent's
+        // write request and the verdict it gets back.
+        var timer = Stopwatch.StartNew();
+
         var path = GetString(arguments, "path");
         var content = GetString(arguments, "content");
 
@@ -155,6 +162,7 @@ public sealed class FileWriteTool : McpToolBase
             return McpToolResult.Error("calor_file_write only writes .calr files");
 
         ProjectSession? session = null;
+        long refreshMs = 0;
         var sessionId = GetString(arguments, "sessionId");
         if (!string.IsNullOrEmpty(sessionId))
         {
@@ -163,7 +171,9 @@ public sealed class FileWriteTool : McpToolBase
                 return McpToolResult.Error($"Unknown sessionId '{sessionId}' — open one with calor_session_open");
             if (!CanonicalPath.IsUnder(canonicalPath, session.RootDirectory))
                 return McpToolResult.Error($"Path is outside the session root '{session.RootDirectory}'");
+            var beforeRefresh = timer.ElapsedMilliseconds;
             session.Refresh();
+            refreshMs = timer.ElapsedMilliseconds - beforeRefresh;
         }
         else if (!CanonicalPath.IsUnder(canonicalPath, _defaultWriteRoot))
         {
@@ -176,7 +186,7 @@ public sealed class FileWriteTool : McpToolBase
         await gate.WaitAsync(cancellationToken);
         try
         {
-            return await CheckAndApplyAsync(canonicalPath, content, session, arguments, cancellationToken);
+            return await CheckAndApplyAsync(canonicalPath, content, session, arguments, timer, refreshMs, cancellationToken);
         }
         finally
         {
@@ -185,9 +195,11 @@ public sealed class FileWriteTool : McpToolBase
     }
 
     private async Task<McpToolResult> CheckAndApplyAsync(string canonicalPath, string content,
-        ProjectSession? session, JsonElement? arguments, CancellationToken cancellationToken)
+        ProjectSession? session, JsonElement? arguments, Stopwatch timer, long refreshMs,
+        CancellationToken cancellationToken)
     {
         var (runCompile, runContracts, runEffects, runReferences) = ParseCheckSelection(arguments);
+        var checkStartMs = timer.ElapsedMilliseconds;
 
         // Zero-length entries are never opened: FIFOs stat as size 0 and a
         // blocking read on one would hang the call (and the stripe gate).
@@ -249,6 +261,8 @@ public sealed class FileWriteTool : McpToolBase
             verdict = "safe_with_warnings";
 
         var applied = verdict != "breaking";
+        var checkMs = timer.ElapsedMilliseconds - checkStartMs;
+        var applyStartMs = timer.ElapsedMilliseconds;
 
         if (applied)
         {
@@ -276,6 +290,8 @@ public sealed class FileWriteTool : McpToolBase
             session?.UpdateFile(canonicalPath, finalContent, modifiedParse);
         }
 
+        var applyMs = timer.ElapsedMilliseconds - applyStartMs;
+
         var editSummary = originalParse != null
             ? EditPreviewTool.ComputeEditSummary(originalSource, finalContent, originalParse, modifiedParse)
             : null;
@@ -285,7 +301,9 @@ public sealed class FileWriteTool : McpToolBase
             recommendations.Insert(0, "Content was auto-healed — review writtenContent; healing is not guaranteed semantics-preserving");
 
         LogWriteAttempt(canonicalPath, verdict, applied, healApplied,
-            created: applied && !fileExistedAtRead, finalContent);
+            created: applied && !fileExistedAtRead, finalContent,
+            latencyMs: timer.ElapsedMilliseconds, refreshMs: refreshMs,
+            checkMs: checkMs, applyMs: applyMs);
 
         return McpToolResult.Json(new FileWriteOutput
         {
@@ -407,12 +425,14 @@ public sealed class FileWriteTool : McpToolBase
     /// <summary>
     /// Appends one JSONL record per write attempt to the harness-configured
     /// log (M-L2's per-attempt stream), archiving rejected content for
-    /// reject-replay (M-L4/D4.6). Telemetry must never fail the write path —
-    /// all IO errors are swallowed. Revalidation races (retry errors) are
-    /// deliberately not logged: they carry no verdict information.
+    /// reject-replay (M-L4/D4.6). mcp-write/2 adds the edit→envelope wall
+    /// time and its phase breakdown (WS3 D3.2 / M-L1). Telemetry must never
+    /// fail the write path — all IO errors are swallowed. Revalidation races
+    /// (retry errors) are deliberately not logged: they carry no verdict
+    /// information.
     /// </summary>
     private void LogWriteAttempt(string path, string verdict, bool applied, bool healApplied,
-        bool created, string content)
+        bool created, string content, long latencyMs, long refreshMs, long checkMs, long applyMs)
     {
         if (_writeLogPath == null)
             return;
@@ -436,14 +456,18 @@ public sealed class FileWriteTool : McpToolBase
 
             var record = JsonSerializer.Serialize(new
             {
-                schema = "mcp-write/1",
+                schema = "mcp-write/2",
                 ts = DateTime.UtcNow.ToString("o"),
                 path,
                 verdict,
                 applied,
                 healApplied,
                 created,
-                rejectPayload = rejectPayloadPath
+                rejectPayload = rejectPayloadPath,
+                latencyMs,
+                refreshMs,
+                checkMs,
+                applyMs
             }, McpJsonOptions.Default);
 
             lock (WriteLogSync)

--- a/tests/Calor.Compiler.Tests/Mcp/SessionAndFileWriteToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/SessionAndFileWriteToolTests.cs
@@ -555,9 +555,16 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
 
         var records = File.ReadAllLines(logPath).Select(l => JsonDocument.Parse(l).RootElement).ToList();
         Assert.Single(records);
-        Assert.Equal("mcp-write/1", records[0].GetProperty("schema").GetString());
+        Assert.Equal("mcp-write/2", records[0].GetProperty("schema").GetString());
         Assert.True(records[0].GetProperty("applied").GetBoolean());
         Assert.Equal("safe", records[0].GetProperty("verdict").GetString());
+
+        // Latency fields (WS3 D3.2): total plus the phase breakdown, all
+        // non-negative; refresh is 0 here because the write ran sessionless.
+        Assert.True(records[0].GetProperty("latencyMs").GetInt64() >= 0);
+        Assert.Equal(0, records[0].GetProperty("refreshMs").GetInt64());
+        Assert.True(records[0].GetProperty("checkMs").GetInt64() >= 0);
+        Assert.True(records[0].GetProperty("applyMs").GetInt64() >= 0);
     }
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/Mcp/SessionAndFileWriteToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/SessionAndFileWriteToolTests.cs
@@ -628,10 +628,20 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
 
         // Latency fields (WS3 D3.2): total plus the phase breakdown, all
         // non-negative; refresh is 0 here because the write ran sessionless.
-        Assert.True(records[0].GetProperty("latencyMs").GetInt64() >= 0);
-        Assert.Equal(0, records[0].GetProperty("refreshMs").GetInt64());
-        Assert.True(records[0].GetProperty("checkMs").GetInt64() >= 0);
-        Assert.True(records[0].GetProperty("applyMs").GetInt64() >= 0);
+        // The phases are disjoint segments of one monotonic clock sampled
+        // last, so their sum can never exceed the total — this deterministic
+        // invariant pins the marks' ordering and point-of-sample (a swapped
+        // or pre-sampled implementation fails it).
+        var latency = records[0].GetProperty("latencyMs").GetInt64();
+        var refresh = records[0].GetProperty("refreshMs").GetInt64();
+        var check = records[0].GetProperty("checkMs").GetInt64();
+        var apply = records[0].GetProperty("applyMs").GetInt64();
+        Assert.True(latency >= 0);
+        Assert.Equal(0, refresh);
+        Assert.True(check >= 0);
+        Assert.True(apply >= 0);
+        Assert.True(refresh + check + apply <= latency,
+            $"phase sum {refresh}+{check}+{apply} exceeds latencyMs {latency}");
     }
 
     [Fact]
@@ -647,12 +657,22 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
         Assert.False(payload.GetProperty("applied").GetBoolean());
 
         var record = JsonDocument.Parse(File.ReadAllLines(logPath).Single()).RootElement;
+        Assert.Equal("mcp-write/2", record.GetProperty("schema").GetString());
         Assert.False(record.GetProperty("applied").GetBoolean());
         Assert.Equal("breaking", record.GetProperty("verdict").GetString());
         var rejectPayloadPath = record.GetProperty("rejectPayload").GetString();
         Assert.NotNull(rejectPayloadPath);
         var archived = JsonDocument.Parse(File.ReadAllText(rejectPayloadPath!)).RootElement;
         Assert.Equal(broken, archived.GetProperty("rejectedContent").GetString());
+
+        // Reject-path latency record (WS3 D3.2): the apply block is skipped
+        // entirely, so applyMs measures nothing but the skipped branch;
+        // the phase-sum invariant holds on rejects too.
+        var latency = record.GetProperty("latencyMs").GetInt64();
+        var check = record.GetProperty("checkMs").GetInt64();
+        var apply = record.GetProperty("applyMs").GetInt64();
+        Assert.True(apply <= 1, $"reject applyMs should be ~0, got {apply}");
+        Assert.True(record.GetProperty("refreshMs").GetInt64() + check + apply <= latency);
     }
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/Mcp/SessionAndFileWriteToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/SessionAndFileWriteToolTests.cs
@@ -699,7 +699,10 @@ public sealed class SessionAndFileWriteToolTests : IDisposable
         var latency = record.GetProperty("latencyMs").GetInt64();
         var check = record.GetProperty("checkMs").GetInt64();
         var apply = record.GetProperty("applyMs").GetInt64();
-        Assert.True(apply <= 1, $"reject applyMs should be ~0, got {apply}");
+        // Loose bound: on reject only a skipped branch sits between the two
+        // clock samples, but a GC pause or scheduler preemption can land
+        // there — 50 ms keeps the intent (apply did not run) flake-free.
+        Assert.True(apply <= 50, $"reject applyMs should be ~0, got {apply}");
         Assert.True(record.GetProperty("refreshMs").GetInt64() + check + apply <= latency);
     }
 

--- a/tests/Calor.Compiler.Tests/WatchRebuildTelemetryTests.cs
+++ b/tests/Calor.Compiler.Tests/WatchRebuildTelemetryTests.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+using Calor.Compiler.Commands;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Tests for the watch rebuild latency instrumentation (loop plan WS3 D3.2):
+/// RebuildResult carries elapsed wall time, and a configured rebuild log
+/// receives one watch-rebuild/1 JSONL record per rebuild.
+/// </summary>
+public sealed class WatchRebuildTelemetryTests : IDisposable
+{
+    private readonly string _root;
+
+    public WatchRebuildTelemetryTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "calor-watch-telemetry-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch (IOException) { }
+    }
+
+    private static WatchSession.WatchSettings Settings(string format) => new(
+        Format: format,
+        Verbose: false,
+        NoCache: true,
+        ClearCache: false,
+        StrictApi: false,
+        RequireDocs: false,
+        EnforceEffects: false,
+        StrictEffects: false,
+        PermissiveEffects: false,
+        ContractMode: "off",
+        DebounceMs: 25);
+
+    /// <summary>
+    /// Runs a WatchSession through its initial rebuild only: the session is
+    /// cancelled from the RebuildCompleted hook, so RunAsync returns after
+    /// the first compile without waiting on the change channel.
+    /// </summary>
+    private async Task<WatchSession.RebuildResult> RunInitialRebuildAsync(string format, string? rebuildLogPath)
+    {
+        var session = new WatchSession(new[] { _root }, Settings(format),
+            TextWriter.Null, TextWriter.Null, rebuildLogPath);
+        using var cts = new CancellationTokenSource();
+        WatchSession.RebuildResult? observed = null;
+        session.RebuildCompleted += result =>
+        {
+            observed = result;
+            cts.Cancel();
+        };
+
+        await session.RunAsync(cts.Token, useFileSystemWatchers: false);
+        Assert.NotNull(observed);
+        return observed!;
+    }
+
+    [Fact]
+    public async Task Rebuild_ReportsElapsedWallTime()
+    {
+        File.WriteAllText(Path.Combine(_root, "mod.calr"), """
+            §M{m001:WatchMod}
+              §F{f001:answer:pub}
+                §O{i32}
+                §R INT:42
+            """);
+
+        var result = await RunInitialRebuildAsync("text", rebuildLogPath: null);
+
+        Assert.Equal(1, result.Compiled);
+        Assert.False(result.AnyErrors);
+        Assert.True(result.ElapsedMs >= 0);
+    }
+
+    [Fact]
+    public async Task Rebuild_WritesWatchRebuildRecord_WhenLogConfigured()
+    {
+        File.WriteAllText(Path.Combine(_root, "mod.calr"), """
+            §M{m001:WatchMod}
+              §F{f001:answer:pub}
+                §O{i32}
+                §R INT:42
+            """);
+        var logPath = Path.Combine(_root, "watch-rebuilds.jsonl");
+
+        await RunInitialRebuildAsync("json", logPath);
+
+        var record = JsonDocument.Parse(File.ReadAllLines(logPath).Single()).RootElement;
+        Assert.Equal("watch-rebuild/1", record.GetProperty("schema").GetString());
+        Assert.Equal(1, record.GetProperty("rebuild").GetInt32());
+        Assert.True(record.GetProperty("initial").GetBoolean());
+        Assert.Equal(1, record.GetProperty("compiled").GetInt32());
+        Assert.Equal(0, record.GetProperty("skipped").GetInt32());
+        Assert.False(record.GetProperty("anyErrors").GetBoolean());
+        Assert.True(record.GetProperty("latencyMs").GetInt64() >= 0);
+        Assert.Equal(25, record.GetProperty("debounceMs").GetInt32());
+    }
+
+    [Fact]
+    public async Task Rebuild_NoLogConfigured_WritesNoTelemetry()
+    {
+        File.WriteAllText(Path.Combine(_root, "mod.calr"), """
+            §M{m001:WatchMod}
+              §F{f001:answer:pub}
+                §O{i32}
+                §R INT:42
+            """);
+
+        await RunInitialRebuildAsync("text", rebuildLogPath: null);
+
+        Assert.False(File.Exists(Path.Combine(_root, "watch-rebuilds.jsonl")));
+    }
+}


### PR DESCRIPTION
## Summary

D3.2 per the M4 kickoff (#801), stacked on #802. Both loop surfaces now log edit→envelope wall time into the loop telemetry streams; measurement boundaries per the kickoff's priced decision.

**MCP write path (M-L1's adjudicating surface):**
- `Stopwatch` from tool-call receipt in `ExecuteCoreAsync` through the verdict record — covers session refresh, per-path gate wait, heal, parse, check set, and atomic apply.
- `mcp-write/1` → **`mcp-write/2`** (additive): `latencyMs` + phase breakdown `refreshMs`/`checkMs`/`applyMs` (`applyMs` bounded to the revalidate+rename block only; 0 on reject).
- `extract_metrics` is unaffected — it never filtered on the discriminator (verified).

**Watch path (reported, not adjudicating):**
- `Rebuild` is timed from start to NDJSON-envelope-written — the debounce window is excluded by definition (configured delay, not feedback cost) and recorded alongside as `debounceMs`.
- New **`watch-rebuild/1`** JSONL stream via env `CALOR_WATCH_REBUILD_LOG` (mirrors the `CALOR_MCP_WRITE_LOG` pattern, IO errors swallowed); `RebuildResult` gains `ElapsedMs`; status line now shows rebuild wall time. The shared envelope schema v1.1 is untouched.

**Bench (telemetry contract):**
- Machine schemas added: `mcp-write.schema.json` (accepts `/1` archives and `/2`; closes the no-machine-schema gap noted at kickoff) and `watch-rebuild.schema.json`. `rejectPayload` is optional in-schema because the MCP serializer drops null fields (verified against the ws2-exit-e2e-001 archives).
- `validate-telemetry.sh` now dispatches every record on its `schema` discriminator to the matching schema file (unknown → invalid); the hand-rolled fallback gains a generic flat-schema checker. Archived epoch journals re-validate green; a deliberately malformed record is rejected with precise errors.
- `loop-telemetry-schema.md` documents both streams and the compatibility story.

## Tests

New `WatchRebuildTelemetryTests` (elapsed reported, record written when configured, no telemetry otherwise — first direct `WatchSession` coverage); latency-field assertions added to the mcp-write logging test. Full suite green (7,438 passed, 0 failed). `run-pair.sh` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)