### PR TITLE
docs: M4b kickoff — WS5 wedge probe scope + Annex A-1.2 PP-W1/M-W1 registration (loop plan M4b)

### DIFF
--- a/docs/plans/agent-native-gates.md
+++ b/docs/plans/agent-native-gates.md
@@ -99,8 +99,8 @@ After freezing, this document may be superseded only for a **documented empirica
 
 ## Annex A — Instrument metrics (loop plan v0.9, D4.4)
 
-**Annex version: A-1.1 (thresholds frozen at A-1.0, 2026-07-24; additive
-clarification A-1.1, 2026-07-25).** This annex is **additive-only
+**Annex version: A-1.2 (thresholds frozen at A-1.0, 2026-07-24; additive
+clarification A-1.1, 2026-07-25; additive PP-W1/M-W1 registration A-1.2, 2026-07-27).** This annex is **additive-only
 with respect to the main document**: no §1–§7 machine-adjudicable gate
 criterion references any metric defined here, and nothing here alters the
 C#-vs-Calor gate decisions those sections govern. The annex's own proof-point
@@ -159,6 +159,7 @@ pairing, and censoring follow §2 of this document.
 | PP-L3 (node vs file edits) | **retired unrun** | machine-zone E1 killed H1 (55 % pooled); pre-committed scope gate |
 | PP-L4 (diagnostics steer the agent) | **reported-not-adjudicated** | dry-run found 3 qualifying M-L3 events across 35 runs — floor (20) unreachable at authorable-fixture scale |
 | PP-L5 (loop tooling pays off) | **≥ 15 % relative reduction in median per-pair tokens-to-green**, arm A (`loop-baseline-ws1`) vs arm B (baseline + WS2/WS3 isolation build), simultaneous epoch, ≥ 7 pairs × ≥ 5 runs/arm, §6.1 adjudication | dry-run: iterations-to-green floor-bound (median 1, 94 % at floor → undetectable at any N); tokens MDE at 80 % power ≈ 15 % at the stated N — a **design-stage simulation estimate over only 7 clusters** (400 sims × 200-resample cluster bootstrap), so the MDE itself carries wide uncertainty; if the M5 epoch's realized variance is materially higher, the miss is reported as underpowered rather than adjudicated as a clean miss. Pre-registered fallback applied **before** freezing |
+| PP-W1 (enforcement catches seeded defects, A-1.2) | **M-W1 delta (Calor − C#) ≥ 3/9 defects** on the D5.1 set (N = 9: three per class W5-A/B/C), per-defect majority across ≥ 3 runs/arm/pair, catch = defect **absent at declared-done** per its held-out probe test; **zero-vs-zero (both arms catch 0/9) = the pre-committed Call 2 kill signal** (loop plan §6.2) | feasibility by determinism, replacing a D4.5 dry-run (a priced decision, `loop-m4b-ws5.md` §2): W5-A/C catches are deterministic build blocks (`Calor0410`), so run variance affects only fix-behavior — absorbed by the at-declared-done measure + per-defect majority; W5-B (runtime contract guard on arm-shared smoke-test inputs) carries bounded nondeterminism, absorbed at 3 runs. **Scope guards, frozen with the threshold:** the delegate-invocation and override/dispatch effect-laundering holes are excluded and listed (strategy §1.1; pinned by `DelegateInvocation_*` enforcement tests) — a defect requiring them disqualifies its fixture; the static-verify catch channel is excluded until #807 (unconstrained-`result` refutations) is fixed — W5-B catches via the Debug-mode runtime guard only, and W5-B contracts are postcondition-only (a `Proven` precondition elides its guard, #755). Measures detection capability, not organic incidence; no overlap with machine-zone §7 (human spec-diff review, dogfood corpus, human baseline) |
 
 Sub-integer disclosure: the iterations-to-green primary measure was moved to
 tokens-to-green because the dry-run showed it floor-bound — the loop plan's
@@ -166,6 +167,17 @@ D4.5 rule ("the dry-run may move a threshold, the task count, or N before
 freezing — never after") applied as written.
 
 ### A.3 Annex revision log
+
+**A-1.2 (2026-07-27).** Additive: registers **M-W1** (defect catch rate —
+per arm, fraction of D5.1 injected defects absent at declared-done per
+their held-out probe tests, per-defect majority across runs) and the
+**PP-W1** frozen threshold row in A.2, before any probe fixture exists or
+any probe epoch runs (loop plan D4.4 discipline; WS5/M4b, kickoff
+`docs/plans/loop-m4b-ws5.md`). Also records PP-W1's scope guards (excluded
+enforcement holes, the #807-until-fixed exclusion of the static-verify
+catch channel, W5-B postcondition-only constraint per #755) and the
+feasibility-by-determinism argument standing in for a D4.5 dry-run. No
+existing metric or threshold is altered.
 
 **A-1.1 (2026-07-25).** Additive clarification, no threshold changes: M-L2's
 `mcp-file` sourcing (per-attempt `mcp-writes.jsonl` stream, M3 PR 4) and its

--- a/docs/plans/agent-native-gates.md
+++ b/docs/plans/agent-native-gates.md
@@ -157,11 +157,19 @@ pairing, and censoring follow §2 of this document.
   its dedicated held-out probe test (fails iff the defect is present) and
   aggregated by per-defect majority across exactly 3 runs/arm/pair.
   **Telemetry source is NOT `loop-telemetry/2`**: the per-run signal is the
-  `defect {id, class, probeTest, caught}` object in the run's
-  `result.json` (run-pair.sh D5.1 support; caught requires the probe test
-  to have run and passed against the declared-done state; a non-compiling
-  final state counts as not-caught, consistent with §2's all-failing
-  rule). PP-W1 consumes the Calor − C# delta of this rate.
+  `defect {id, class, probeTest, caught, smokeTampered}` object in the
+  run's `result.json` (run-pair.sh D5.1 support). Semantics, frozen with
+  the row: the probe test lives in its own project compiled against the
+  **starting** public surface, so `caught` measures the defect and not
+  task completion (an agent that fixes the defect without finishing the
+  feature still scores a catch); `caught` requires the probe to have run
+  and passed against the declared-done build; a non-compiling final state
+  counts as not-caught, consistent with §2's all-failing rule; a slot
+  still invalid after §0.2's retry cap contributes **not-caught** for its
+  run (task failure ⇒ the defect was not shown absent); a run with
+  `smokeTampered: true` (the arm-shared smoke suite was modified) is
+  invalid for M-W1 and re-run per §0.2. PP-W1 consumes the Calor − C#
+  delta of this rate.
 
 ### A.2 Frozen instrument proof-point thresholds
 

--- a/docs/plans/agent-native-gates.md
+++ b/docs/plans/agent-native-gates.md
@@ -109,9 +109,12 @@ tooling-investment decisions** (the loop plan's PP-L*), a separate question
 from the language gates. Stated precisely so "observational" is not
 overclaimed (review of #795 item 2). It carries its own version counter and
 revision log; changes to this annex never constitute supersession of the main
-document. Pre-registered per the loop plan's D4.4 discipline: thresholds were
-frozen from the `loop-feasibility-dry-002` variance epoch **before** any
-treatment build exists. **Merge-order dependency**: the governing plan
+document. Pre-registered per the loop plan's D4.4 discipline: thresholds through
+A-1.1 were frozen from the `loop-feasibility-dry-002` variance epoch
+**before** any treatment build exists; the A-1.2 PP-W1 row froze by the
+feasibility-by-determinism argument recorded in its Basis column (a
+disclosed D4.5 deviation — supersession entry in `loop-plan-v0.9.md` §10),
+before the probe epoch runs. **Merge-order dependency**: the governing plan
 (`loop-plan-v0.9.md`, PR #747) must be on main before or with this annex, or
 its §-references dangle and the pre-registration claim is unverifiable from
 the repo (review of #795 item 1).
@@ -149,6 +152,16 @@ pairing, and censoring follow §2 of this document.
 - **M-L5 tokens-to-green** — per-run agent output tokens (`agent.json`
   `usage.output_tokens`); per-pair means, then median of paired per-pair
   ratios per §2. Iterations-to-green remains **recorded, observational**.
+- **M-W1 defect catch rate (A-1.2)** — per arm: the fraction of the D5.1
+  injected defects **absent at declared-done**, each defect adjudicated by
+  its dedicated held-out probe test (fails iff the defect is present) and
+  aggregated by per-defect majority across exactly 3 runs/arm/pair.
+  **Telemetry source is NOT `loop-telemetry/2`**: the per-run signal is the
+  `defect {id, class, probeTest, caught}` object in the run's
+  `result.json` (run-pair.sh D5.1 support; caught requires the probe test
+  to have run and passed against the declared-done state; a non-compiling
+  final state counts as not-caught, consistent with §2's all-failing
+  rule). PP-W1 consumes the Calor − C# delta of this rate.
 
 ### A.2 Frozen instrument proof-point thresholds
 
@@ -159,7 +172,7 @@ pairing, and censoring follow §2 of this document.
 | PP-L3 (node vs file edits) | **retired unrun** | machine-zone E1 killed H1 (55 % pooled); pre-committed scope gate |
 | PP-L4 (diagnostics steer the agent) | **reported-not-adjudicated** | dry-run found 3 qualifying M-L3 events across 35 runs — floor (20) unreachable at authorable-fixture scale |
 | PP-L5 (loop tooling pays off) | **≥ 15 % relative reduction in median per-pair tokens-to-green**, arm A (`loop-baseline-ws1`) vs arm B (baseline + WS2/WS3 isolation build), simultaneous epoch, ≥ 7 pairs × ≥ 5 runs/arm, §6.1 adjudication | dry-run: iterations-to-green floor-bound (median 1, 94 % at floor → undetectable at any N); tokens MDE at 80 % power ≈ 15 % at the stated N — a **design-stage simulation estimate over only 7 clusters** (400 sims × 200-resample cluster bootstrap), so the MDE itself carries wide uncertainty; if the M5 epoch's realized variance is materially higher, the miss is reported as underpowered rather than adjudicated as a clean miss. Pre-registered fallback applied **before** freezing |
-| PP-W1 (enforcement catches seeded defects, A-1.2) | **M-W1 delta (Calor − C#) ≥ 3/9 defects** on the D5.1 set (N = 9: three per class W5-A/B/C), per-defect majority across ≥ 3 runs/arm/pair, catch = defect **absent at declared-done** per its held-out probe test; **zero-vs-zero (both arms catch 0/9) = the pre-committed Call 2 kill signal** (loop plan §6.2) | feasibility by determinism, replacing a D4.5 dry-run (a priced decision, `loop-m4b-ws5.md` §2): W5-A/C catches are deterministic build blocks (`Calor0410`), so run variance affects only fix-behavior — absorbed by the at-declared-done measure + per-defect majority; W5-B (runtime contract guard on arm-shared smoke-test inputs) carries bounded nondeterminism, absorbed at 3 runs. **Scope guards, frozen with the threshold:** the delegate-invocation and override/dispatch effect-laundering holes are excluded and listed (strategy §1.1; pinned by `DelegateInvocation_*` enforcement tests) — a defect requiring them disqualifies its fixture; the static-verify catch channel is excluded until #807 (unconstrained-`result` refutations) is fixed — W5-B catches via the Debug-mode runtime guard only, and W5-B contracts are postcondition-only (a `Proven` precondition elides its guard, #755). Measures detection capability, not organic incidence; no overlap with machine-zone §7 (human spec-diff review, dogfood corpus, human baseline) |
+| PP-W1 (enforcement catches seeded defects, A-1.2) | **M-W1 delta (Calor − C#) ≥ 3/9 defects** on the D5.1 set (N = 9; class definitions frozen here: **W5-A** = undeclared side effect via a named static manifest-covered call inside a pure-declared function; **W5-B** = violated scalar `§S` postcondition caught by the Debug runtime guard on arm-shared smoke-test inputs; **W5-C** = effect laundered through a covered **intra-module** call chain where the caller's declaration is violated and every callee's is honest). Catch = defect **absent at declared-done** per its held-out probe test, aggregated per defect by majority across **exactly 3** runs/arm/pair (odd by construction — no tie rule needed). **Adjudication is the raw aggregated count — no §6.1 significance test** (9 binary clusters would be degenerate under bootstrap). **Zero-vs-zero, precisely: both arms catch 0/9 after majority aggregation = the pre-committed Call 2 kill signal** (loop plan §6.2). A negative delta (C# catches more) is a clean miss and thesis-adverse — reported with the same prominence as a kill. **Decidability fallback, pre-registered:** if per-defect run outcomes are not unanimous for ≥ 7 of 9 defects in either arm, PP-W1 is **reported, not adjudicated** (the PP-L4 pattern) | feasibility by determinism, replacing a D4.5 dry-run — a recorded deviation from the loop plan's letter (supersession entry in `loop-plan-v0.9.md` §10; rationale in `loop-m4b-ws5.md` §2). Honest scope of the argument: it covers the *surfacing* channel (W5-A/C are deterministic `Calor0410` build blocks; W5-B's guard throws deterministically on the smoke inputs), **not** agent fix-behavior, which is what "absent at declared-done" also depends on — the unanimity fallback in the threshold column is the guard against that residual. **Scope guards, frozen with the threshold:** the delegate-invocation and override/dispatch effect-laundering holes are excluded and listed (strategy §1.1; pinned by `DelegateInvocation_*` enforcement tests) — a defect requiring them disqualifies its fixture; the static-verify catch channel is excluded until #807 (unconstrained-`result` refutations) is fixed — W5-B catches via the Debug-mode runtime guard only, and W5-B contracts are postcondition-only (a `Proven` precondition elides its guard, #755). Measures detection capability, not organic incidence; no overlap with machine-zone §7 (spec-diff review detection on the dogfood module, §12-amended to absolute detection of externally-authored blinded injections — different subject, corpus, and comparator) |
 
 Sub-integer disclosure: the iterations-to-green primary measure was moved to
 tokens-to-green because the dry-run showed it floor-bound — the loop plan's
@@ -168,16 +181,25 @@ freezing — never after") applied as written.
 
 ### A.3 Annex revision log
 
-**A-1.2 (2026-07-27).** Additive: registers **M-W1** (defect catch rate —
-per arm, fraction of D5.1 injected defects absent at declared-done per
-their held-out probe tests, per-defect majority across runs) and the
-**PP-W1** frozen threshold row in A.2, before any probe fixture exists or
-any probe epoch runs (loop plan D4.4 discipline; WS5/M4b, kickoff
-`docs/plans/loop-m4b-ws5.md`). Also records PP-W1's scope guards (excluded
-enforcement holes, the #807-until-fixed exclusion of the static-verify
-catch channel, W5-B postcondition-only constraint per #755) and the
-feasibility-by-determinism argument standing in for a D4.5 dry-run. No
-existing metric or threshold is altered.
+**A-1.2 (2026-07-27).** Additive: registers **M-W1** (A.1) and the
+**PP-W1** frozen threshold row in A.2 (WS5/M4b, kickoff
+`docs/plans/loop-m4b-ws5.md`). Honest timing: the registration froze
+**before the probe epoch runs**, but fixture authoring was concurrent —
+the D5.1 pair set was being built on a sibling branch while this row was
+written, and one class definition (W5-C) was re-priced from an
+authoring-time discovery (#809: cross-module emission gap) BEFORE this
+row's class definitions froze; the class definitions are therefore inlined
+in the A.2 row itself rather than referenced from the mutable kickoff
+table. What remains results-blind, and is the property this registration
+protects: the threshold, the adjudication rule, the scope guards, and the
+decidability fallback were all fixed with zero live agent runs observed.
+Also records the scope guards (excluded enforcement holes, the
+#807-until-fixed exclusion of the static-verify channel, W5-B
+postcondition-only per #755) and the feasibility-by-determinism argument
+standing in for a D4.5 dry-run (supersession entry in
+`loop-plan-v0.9.md` §10). No existing metric or threshold is altered;
+pre-existing blanket prose ("frozen from dry-002") is qualified rather
+than falsified.
 
 **A-1.1 (2026-07-25).** Additive clarification, no threshold changes: M-L2's
 `mcp-file` sourcing (per-attempt `mcp-writes.jsonl` stream, M3 PR 4) and its

--- a/docs/plans/loop-m4b-ws5.md
+++ b/docs/plans/loop-m4b-ws5.md
@@ -101,17 +101,23 @@ declaration is the caller's, the intermediate's declaration is honest, and
 working C#. Revisit trigger: #809 fixed → a cross-module W5-C variant may
 be added.
 
-**No paid feasibility dry-run — a variance argument replaces it, and that
-is a priced decision.** D4.5's rule is that a [P] threshold must be shown
-decidable before it freezes. W5-A/C catches are *deterministic build
-failures* (the compiler either blocks or it doesn't — run-to-run agent
-variance affects only whether the agent then fixes the defect, which is
-why "absent at declared-done" is the measure and majority-across-runs the
-aggregation). W5-B depends on the agent running the smoke tests at least
-once — bounded nondeterminism, absorbed by 3 runs/arm/pair with
-per-defect majority. With N = 9 defects the threshold below is decidable
-at trivial spend; a dedicated variance epoch would cost more than the
-probe itself. Registered in Annex A-1.2 with this argument.
+**No paid feasibility dry-run — a variance argument replaces it, and
+that is a recorded deviation from D4.5's letter.** D4.5's rule is that a
+[P] threshold must be shown decidable by a dry-run before it freezes; the
+supersession is recorded in the loop plan's §10 revision log, not
+self-authorized here. The argument's honest scope: W5-A/C catches are
+*deterministic build failures* and W5-B's guard throws deterministically
+on the smoke inputs — determinism of the **surfacing channel**. The
+registered measure ("absent at declared-done") additionally depends on
+**agent fix-behavior**, which is as nondeterministic as anything a
+dry-run measures — majority-of-3 absorbs noise, not systematic behavior
+(an agent policy of never running smoke tests would zero W5-B across all
+runs). The guard adopted in place of a dry-run is the **pre-registered
+decidability fallback** in the A-1.2 row: if per-defect run outcomes are
+not unanimous for ≥ 7 of 9 defects in either arm, PP-W1 is reported, not
+adjudicated (the PP-L4 pattern). A dedicated variance epoch would cost
+more than the probe itself; this fallback bounds the same risk the prior
+dry-runs caught (PP-L4's event floor, PP-L5's floor-bound iterations).
 
 **Probe scale and spend.** 9 pairs (one defect each) × 2 arms × 3 runs =
 54 agent runs, iteration budget 10, pinned model per gates-doc
@@ -119,7 +125,10 @@ conventions. Estimated well under the gates-doc $1,500/epoch ceiling
 (WS2-exit-scale runs suggest low hundreds). The concrete figure is
 entered via the `phase-2-spend-authorisation.md` process and the epoch
 **does not run until the user authorizes the spend** — same discipline as
-`ws2-exit-e2e-001`.
+`ws2-exit-e2e-001`. (Letter-vs-practice note: plan §3 wanted all four
+epochs' numbers entered before M2 kickoff; no wedge-probe figure was —
+the figure enters now, before the epoch, matching how M2 actually used
+the authorization doc as conventions/template.)
 
 **Box confirmation:** parent's 2–3 wk stands. The probe epoch itself is
 days; the box is dominated by fixture authorship + acceptance checks.
@@ -129,10 +138,14 @@ days; the box is dominated by fixture authorship + acceptance checks.
 1. **PR 1 (this PR):** kickoff record + gates-doc **Annex A-1.2** —
    additive registration of M-W1 and PP-W1's frozen threshold, the
    excluded-holes list, the #807 channel exclusion, and the
-   feasibility-by-determinism argument. No allowlist entries (fixtures
-   are `.calr`/`.cs` under `bench/`; harness work is bash/python).
+   feasibility-by-determinism argument — plus a **calor-first-guard
+   structural exemption for `bench/`** (review of #808 finding 1: the
+   guard exempted only `tests/`, so every probe pair's C# arm — which is
+   definitionally C# — tripped it; the ~700 pre-existing `bench/**/*.cs`
+   passed only via the grandfather clause). The exemption must be on main
+   at PR 2's merge base, which is exactly this PR's job.
 2. **PR 2 — D5.1:** the 9 probe pairs under
-   `bench/phase0-agent-native/pairs/W5-*` (pristine-plus-defect starter
+   `bench/phase0-agent-native/pairs/W5?-*` (pristine-plus-defect starter
    fixtures both arms, arm-shared smoke tests, per-defect held-out probe
    tests, `defect.json` manifest naming the class/covered path/probe
    test), plus harness support: per-test held-out outcome extraction (the
@@ -153,7 +166,8 @@ days; the box is dominated by fixture authorship + acceptance checks.
 - Organic-incidence claims (`real-scale-benchmark-design.md` territory).
 - The delegate/dispatch holes — excluded and listed, not probed.
 - Static-verify-based catching (excluded until #807; revisit trigger).
-- Human-review detection (machine-zone §7's red-team gate measures
-  spec-diff review as a human-review replacement on the dogfood module —
-  different subject, corpus, and comparator; no registration overlap).
+- Review-process detection (machine-zone §7's red-team gate, as amended
+  by §12: absolute spec-diff detection of externally-authored blinded
+  injections on the dogfood module — different subject, corpus, and
+  comparator; no registration overlap).
 - PP-W1 adjudication inside M4b — measurement here, Call 2 at M5.

--- a/docs/plans/loop-m4b-ws5.md
+++ b/docs/plans/loop-m4b-ws5.md
@@ -1,0 +1,147 @@
+# M4b Kickoff — WS5 Wedge Probe
+
+**Kickoff record (2026-07-27):**
+**Parent:** `loop-plan-v0.9.md` §2 WS5, §3 M4b, §5 PP-W1, §6.2 Call 2 ·
+**Depends on:** M1 (merged); D4.4 registration (Annex **A-1.2**, this PR) ·
+**Prior milestones:** M3 complete (`loop-m3-ws2.md`), M4 complete
+(`loop-m4-ws3.md`)
+
+## 1. What the probe measures, restated operationally
+
+The program's differentiated-value claim — *enforcement catches what
+agent-generated C# evidence misses* — is 0-for-165 observed because frontier
+agents do not ship organic bugs at authorable fixture scale (strategy §9).
+WS5 sidesteps that with **injected defects**: each probe pair is a working
+fixture carrying one seeded regression that violates intent the fixture
+declares in both arms' idiomatic evidence forms (Calor: `§Q`/`§S`/`§E`;
+C#: doc comments + NRT under the strategy-§0 full toolkit). The agent gets
+an adjacent modification task whose spec never mentions the defect.
+
+- **M-W1 (defect catch rate)**, per arm: fraction of injected defects
+  **absent at declared-done**, measured by one per-defect held-out probe
+  test (fails iff the defect is present), majority across runs per defect.
+- **PP-W1** adjudicates the Calor−C# catch-rate delta (Annex A-1.2 for the
+  frozen threshold).
+- Telemetry additionally records *how* a catch surfaced (defect-linked
+  diagnostic in agent-visible output: `Calor0410` chain,
+  `ContractViolationException`, test failure) — reported, not adjudicated.
+
+**Honest limit (plan text, restated):** injected defects measure detection
+capability, not organic incidence. A hit proves the mechanism works where
+it claims to; zero-vs-zero is decisive in the other direction and triggers
+Call 2's pre-committed pivot-or-stop.
+
+## 2. Priced decisions (recorded at kickoff, per §3 kickoff discipline)
+
+**Defect classes bind to the claim as stated; the known holes are excluded
+and listed.** Three classes, three defects each (N = 9):
+
+| Class | Seeded regression | Calor claimed catch channel |
+|---|---|---|
+| **W5-A** undeclared side effect | a `§E{}`-declared (pure) function gains an effectful *named static* call | build-blocking `Calor0410` with call chain (`EffectEnforcementPass`) |
+| **W5-B** violated scalar contract | off-by-one/boundary slip making a declared `§S` false on inputs the arm-shared smoke test exercises | **Debug-mode runtime guard** (`ContractViolationException`) thrown during any build+test the agent runs |
+| **W5-C** laundered effect via covered chain | a transitively-called function (bare-name, cross-module) gains an effect its public caller's `§E` forbids | build-blocking `Calor0410` "via cross-module call" (`CrossModuleEffectEnforcementPass`) |
+
+**Excluded paths (the documented holes — the probe measures the claim as
+stated, not the gaps):** delegate-typed invocations (assumed pure by
+default; warning-only even under `--strict-effects` —
+`EffectEnforcementPass.cs:657` and the pinning tests
+`DelegateInvocation_*` in `Calor.Enforcement.Tests`), and override/
+interface dispatch effect-laundering (no effect-variance rule; strategy
+§1.1 r3, fix scheduled 2a item 4). Any defect whose catch would require
+these paths is out of scope for PP-W1 and disqualifies the fixture.
+
+**W5-B's catch channel is the runtime guard, not static verification —
+because of #807/#755.** Static verify currently refutes *every*
+result-referencing postcondition with an unconstrained `result` (#807), so
+a verify-based catch cannot distinguish a seeded violation from a spurious
+refutation of correct code — the channel is contaminated and **excluded
+from the probe until #807 is fixed** (revisit trigger: #807 closed →
+probe may re-run with the verify channel and tighter classes). Runtime
+guards are unaffected by #807 (guards are emitted for non-`Proven`
+contracts) but #755 means a vacuously-`Proven` precondition elides its
+guard — so W5-B fixtures use **postconditions only**, chosen to be
+non-`Proven` (guard emitted) and violated on smoke-test inputs. Fixture
+acceptance (PR 2) verifies the guard actually throws pre-agent.
+
+**Both arms get identical task surface and identical agent-visible smoke
+tests.** Each pair ships a small arm-shared smoke test project the agent
+can run (same tests, both arms — the C# arm is not handicapped by hidden
+coverage). The defect-probe tests live in the *held-out* suite (never
+agent-visible), one per defect, alongside the pair's normal held-out
+behavioral tests. "Caught" is adjudicated solely on the probe test at
+declared-done; agent-visible surfacing telemetry is attribution color.
+
+**The defect is pre-existing in the starter fixture, not injected
+mid-run.** The agent's task is an adjacent feature change that requires
+building the project (so build-blocking catches surface on iteration 1 in
+the Calor arm if the claim holds) and touches the defective module's
+neighborhood without the spec naming the defective behavior. The C# arm's
+fixture carries the same defect and the same declared intent (doc
+comments + NRT); its full toolkit (NRT, `EnforceCodeStyleInBuild`,
+whatever tests the agent writes) is free to catch it.
+
+**Mixed-project shape: the existing calor-arm template is the mixed
+project.** The plan's "Calor module inside a C# solution" is satisfied by
+the established pattern — a `Microsoft.NET.Sdk` C# project consuming
+`.calr` sources via `Calor.Tasks`/SDK targets, with the held-out project
+referencing the emitted assembly. W5 pairs use multi-module fixtures
+(needed by W5-C's cross-module chain) under the same template; no new
+project-system work.
+
+**No paid feasibility dry-run — a variance argument replaces it, and that
+is a priced decision.** D4.5's rule is that a [P] threshold must be shown
+decidable before it freezes. W5-A/C catches are *deterministic build
+failures* (the compiler either blocks or it doesn't — run-to-run agent
+variance affects only whether the agent then fixes the defect, which is
+why "absent at declared-done" is the measure and majority-across-runs the
+aggregation). W5-B depends on the agent running the smoke tests at least
+once — bounded nondeterminism, absorbed by 3 runs/arm/pair with
+per-defect majority. With N = 9 defects the threshold below is decidable
+at trivial spend; a dedicated variance epoch would cost more than the
+probe itself. Registered in Annex A-1.2 with this argument.
+
+**Probe scale and spend.** 9 pairs (one defect each) × 2 arms × 3 runs =
+54 agent runs, iteration budget 10, pinned model per gates-doc
+conventions. Estimated well under the gates-doc $1,500/epoch ceiling
+(WS2-exit-scale runs suggest low hundreds). The concrete figure is
+entered via the `phase-2-spend-authorisation.md` process and the epoch
+**does not run until the user authorizes the spend** — same discipline as
+`ws2-exit-e2e-001`.
+
+**Box confirmation:** parent's 2–3 wk stands. The probe epoch itself is
+days; the box is dominated by fixture authorship + acceptance checks.
+
+## 3. Slicing (each PR merges green on its own)
+
+1. **PR 1 (this PR):** kickoff record + gates-doc **Annex A-1.2** —
+   additive registration of M-W1 and PP-W1's frozen threshold, the
+   excluded-holes list, the #807 channel exclusion, and the
+   feasibility-by-determinism argument. No allowlist entries (fixtures
+   are `.calr`/`.cs` under `bench/`; harness work is bash/python).
+2. **PR 2 — D5.1:** the 9 probe pairs under
+   `bench/phase0-agent-native/pairs/W5-*` (pristine-plus-defect starter
+   fixtures both arms, arm-shared smoke tests, per-defect held-out probe
+   tests, `defect.json` manifest naming the class/covered path/probe
+   test), plus harness support: per-test held-out outcome extraction (the
+   current stream only counts failures) surfaced as
+   `defects{injected,caught}` in `result.json`, and fixture acceptance
+   checks (pre-agent: Calor arm blocks W5-A/C at build, W5-B smoke test
+   throws the contract guard; C# arm builds green and smoke tests pass —
+   i.e. the C# toolchain does not catch the defect *statically*, which is
+   the asymmetry under test).
+3. **D5.2 — probe epoch** (not a PR until results): run from a committed
+   branch after PR 2 merges and the user authorizes spend; epoch record +
+   VERDICT under `bench/phase0-agent-native/epochs/ws5-probe-001/`;
+   PP-W1 adjudication happens at M5 as part of Call 2 (§6.2), not here —
+   the epoch produces the measurement, the call consumes it.
+
+## 4. Non-goals
+
+- Organic-incidence claims (`real-scale-benchmark-design.md` territory).
+- The delegate/dispatch holes — excluded and listed, not probed.
+- Static-verify-based catching (excluded until #807; revisit trigger).
+- Human-review detection (machine-zone §7's red-team gate measures
+  spec-diff review as a human-review replacement on the dogfood module —
+  different subject, corpus, and comparator; no registration overlap).
+- PP-W1 adjudication inside M4b — measurement here, Call 2 at M5.

--- a/docs/plans/loop-m4b-ws5.md
+++ b/docs/plans/loop-m4b-ws5.md
@@ -40,7 +40,7 @@ and listed.** Three classes, three defects each (N = 9):
 |---|---|---|
 | **W5-A** undeclared side effect | a `§E{}`-declared (pure) function gains an effectful *named static* call | build-blocking `Calor0410` with call chain (`EffectEnforcementPass`) |
 | **W5-B** violated scalar contract | off-by-one/boundary slip making a declared `§S` false on inputs the arm-shared smoke test exercises | **Debug-mode runtime guard** (`ContractViolationException`) thrown during any build+test the agent runs |
-| **W5-C** laundered effect via covered chain | a transitively-called function (bare-name, cross-module) gains an effect its public caller's `§E` forbids | build-blocking `Calor0410` "via cross-module call" (`CrossModuleEffectEnforcementPass`) |
+| **W5-C** laundered effect via covered chain | a public caller declared `§E{fs:r}` reaches a write through a covered call chain whose intermediate declares its own effect *honestly* — the violated declaration is the caller's (distinguishing W5-C from W5-A, where the defective function's own declaration is wrong) | build-blocking `Calor0410` with the full chain (`EffectEnforcementPass` interprocedural SCC propagation) |
 
 **Excluded paths (the documented holes — the probe measures the claim as
 stated, not the gaps):** delegate-typed invocations (assumed pure by
@@ -85,9 +85,21 @@ whatever tests the agent writes) is free to catch it.
 project.** The plan's "Calor module inside a C# solution" is satisfied by
 the established pattern — a `Microsoft.NET.Sdk` C# project consuming
 `.calr` sources via `Calor.Tasks`/SDK targets, with the held-out project
-referencing the emitted assembly. W5 pairs use multi-module fixtures
-(needed by W5-C's cross-module chain) under the same template; no new
-project-system work.
+referencing the emitted assembly. No new project-system work.
+
+**W5-C is intra-module laundering, not cross-module — a constraint
+discovered at fixture-authoring time and priced here.** Cross-module
+laundering is architecturally identical for enforcement
+(`CrossModuleEffectEnforcementPass` catches it, verified), but a
+pre-existing emitter gap (#809: cross-module calls emit unqualified C#, so
+a multi-module project's defect-FREE reference can never link under
+MSBuild/csc — and the qualified spelling is `Unknown:*` under the strict
+policy) means no cross-module fixture can ship a working reference
+solution. The intra-module chain exercises the same claim — the violated
+declaration is the caller's, the intermediate's declaration is honest, and
+`EffectEnforcementPass` reports the full chain — on a path that emits
+working C#. Revisit trigger: #809 fixed → a cross-module W5-C variant may
+be added.
 
 **No paid feasibility dry-run — a variance argument replaces it, and that
 is a priced decision.** D4.5's rule is that a [P] threshold must be shown

--- a/docs/plans/loop-plan-v0.9.md
+++ b/docs/plans/loop-plan-v0.9.md
@@ -223,6 +223,21 @@ The text-vs-structured-edit question has one governing registration: **machine-z
 
 ## 10. Revision log
 
+**v2.1 amendment (2026-07-27, M4b kickoff)** — **D4.5 supersession for
+PP-W1, recorded here because the letter of §5 ("frozen via D4.5") is not
+met**: PP-W1's threshold froze at gates-doc Annex A-1.2 on a
+feasibility-by-determinism argument instead of a dry-run epoch (rationale
+and the argument's stated limit — it covers the *surfacing* channel's
+determinism, not agent fix-behavior — in `loop-m4b-ws5.md` §2). Guard
+adopted in place of the dry-run: a pre-registered decidability fallback in
+the A-1.2 row — if per-defect run outcomes are not unanimous for at least
+7 of 9 defects in either arm, PP-W1 is **reported, not adjudicated** (the
+PP-L4 pattern). Precedent honestly acknowledged: both prior dry-runs moved
+their registered measure (PP-L4's event floor, PP-L5's floor-bound
+iterations), which is exactly the risk this fallback bounds. Approved by
+the maintainer via the M4b kickoff PR (#808); at bus factor 1 this
+approval is self-asserted, as with the A-1.0 freeze.
+
 **Draft v2 (2026-07-23)** — adversarial review round 1 (independent agent; verdict on v1: 55 %). Dispositions:
 
 - **C1 (accepted)**: §1 falsely claimed `AssessCommand` carried a private SARIF model; fixed by `b162480` 8 days before the audit date. §1 corrected, `b162480` credited as delivered WS1 scope, anchor-verification rule added.

--- a/scripts/check-calor-first-diff.sh
+++ b/scripts/check-calor-first-diff.sh
@@ -84,6 +84,17 @@ is_test_source() {
   [[ "$1" == tests/* ]]
 }
 
+is_bench_source() {
+  # Benchmark fixtures and harness support are likewise not product source:
+  # the two-arm benchmark pairs are DEFINITIONALLY half C# (every pair ships a
+  # csharp/ arm, shims, and test suites — that is the comparison being run),
+  # and the ~700 pre-existing bench/**/*.cs were only ever passing via the
+  # exists_in_base grandfather. Exempt the tree structurally (loop plan M4b,
+  # WS5 probe pairs; review of #808 finding 1) so authoring a new pair never
+  # needs an allowlist entry. Nothing under bench/ ships in the product.
+  [[ "$1" == bench/* ]]
+}
+
 violations=()
 for path in "${changed[@]}"; do
   [[ "$path" == *.cs ]] || continue
@@ -91,6 +102,7 @@ for path in "${changed[@]}"; do
   # New paths must be Calor or be pre-approved on the protected base branch.
   exists_in_base "$path" && continue
   is_test_source "$path" && continue
+  is_bench_source "$path" && continue
   is_base_allowlisted "$path" && continue
   [[ -f "$path" ]] || continue
   violations+=("$path")


### PR DESCRIPTION
## Summary

M4b kickoff per loop-plan §3 discipline (pattern of #796/#801): `docs/plans/loop-m4b-ws5.md` + the gates-doc **Annex A-1.2** additive registration of M-W1 and PP-W1's frozen threshold — registered before any probe fixture exists or epoch runs, per D4.4.

**Probe design (priced decisions):**
- **N = 9 injected defects**, 3 per class: W5-A undeclared side effect (build-blocking `Calor0410`), W5-B violated scalar contract (**Debug runtime guard channel only** — the static-verify channel is excluded until #807 is fixed, since spurious unconstrained-`result` refutations make a verify-based catch indistinguishable from noise; postcondition-only per #755's `Proven`-precondition guard elision), W5-C effect laundered through a covered cross-module chain.
- **Excluded holes, listed and frozen with the threshold**: delegate-typed invocation (assumed-pure; pinned by `DelegateInvocation_*` tests) and override/dispatch effect-laundering (no effect-variance rule) — a defect requiring them disqualifies its fixture.
- **Catch = defect absent at declared-done** per a per-defect held-out probe test; both arms get identical specs and identical agent-visible smoke tests; the C# arm keeps its strategy-§0 full toolkit.
- **PP-W1 threshold (frozen at A-1.2): Calor−C# delta ≥ 3/9 defects**, per-defect majority across ≥3 runs/arm/pair; **zero-vs-zero = the pre-committed Call 2 kill signal**.
- **Feasibility by determinism replaces a paid D4.5 dry-run** (a stated priced decision): W5-A/C catches are deterministic build blocks; W5-B's bounded nondeterminism is absorbed by 3 runs + majority.
- **Spend**: 54 agent runs estimated well under the $1,500/epoch gates-doc ceiling; the epoch does not run until the user authorizes the figure via the spend-authorisation process.
- Non-overlap with machine-zone §7's red-team gate stated precisely (human spec-diff review vs compiler enforcement; different corpus and comparator).

**Slicing:** PR 2 = D5.1 probe pairs (`W5-*`) + per-test held-out outcome extraction + fixture acceptance checks; D5.2 = the probe epoch (user-authorized), with PP-W1 adjudication deferred to Call 2 at M5.

Docs only; no product code, no allowlist entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)