### PR TITLE
M5 harness — --calor-dll per-arm build-pin for the A/B comparison epoch (loop plan M5)

### DIFF
--- a/bench/phase0-agent-native/run-pair.sh
+++ b/bench/phase0-agent-native/run-pair.sh
@@ -90,6 +90,7 @@ ITERATION_BUDGET=10
 TIMEOUT_SECS=600
 EXEMPLAR_FILE=""
 EDIT_MECHANISM="raw"
+CALOR_DLL_OVERRIDE=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -100,11 +101,12 @@ while [[ $# -gt 0 ]]; do
         --null-agent) NULL_AGENT=1; shift ;;
         --exemplar) EXEMPLAR_FILE="$2"; shift 2 ;;
         --edit-mechanism) EDIT_MECHANISM="$2"; shift 2 ;;
+        --calor-dll) CALOR_DLL_OVERRIDE="$2"; shift 2 ;;
         *) echo "Unknown arg: $1" >&2; exit 2 ;;
     esac
 done
 
-[[ -n "$PAIR_DIR" && -n "$ARM" ]] || { echo "Usage: --pair <dir> --arm calor|csharp [--runs N] [--null-agent] [--exemplar <file>] [--edit-mechanism raw|mcp-file|mcp-node] [--out <dir>]" >&2; exit 2; }
+[[ -n "$PAIR_DIR" && -n "$ARM" ]] || { echo "Usage: --pair <dir> --arm calor|csharp [--runs N] [--null-agent] [--exemplar <file>] [--edit-mechanism raw|mcp-file|mcp-node] [--calor-dll <path>] [--out <dir>]" >&2; exit 2; }
 [[ "$ARM" == "calor" || "$ARM" == "csharp" ]] || { echo "--arm must be calor|csharp" >&2; exit 2; }
 case "$EDIT_MECHANISM" in
     raw) ;;
@@ -172,12 +174,23 @@ OUT_DIR="$(cd "$OUT_DIR" && pwd)"
 # ---------------------------------------------------------------------------
 TELEMETRY_HELPERS="$SCRIPT_DIR/telemetry-helpers.py"
 CALOR_CLI_DLL=""
-for cli_cfg in Release Debug; do
-    if [[ -f "$REPO_ROOT/src/Calor.Compiler/bin/$cli_cfg/net10.0/calor.dll" ]]; then
-        CALOR_CLI_DLL="$REPO_ROOT/src/Calor.Compiler/bin/$cli_cfg/net10.0/calor.dll"
-        break
-    fi
-done
+if [[ -n "$CALOR_DLL_OVERRIDE" ]]; then
+    # Per-arm build-pin (loop plan M5): pin the calor CLI/MCP-server build
+    # explicitly so an A/B epoch runs two compiler builds against identical
+    # tasks/pins/fixtures (arm A = loop-baseline-ws1; arm B = baseline +
+    # WS2/WS3 isolation). The pinned dll drives envelope generation, `ids
+    # index`, and — for mcp-file arms — the calor MCP write server. When
+    # unset, auto-detect the current checkout's build (Release preferred).
+    [[ -f "$CALOR_DLL_OVERRIDE" ]] || { echo "ERROR: --calor-dll path not found: $CALOR_DLL_OVERRIDE" >&2; exit 2; }
+    CALOR_CLI_DLL="$(cd "$(dirname "$CALOR_DLL_OVERRIDE")" && pwd -P)/$(basename "$CALOR_DLL_OVERRIDE")"
+else
+    for cli_cfg in Release Debug; do
+        if [[ -f "$REPO_ROOT/src/Calor.Compiler/bin/$cli_cfg/net10.0/calor.dll" ]]; then
+            CALOR_CLI_DLL="$REPO_ROOT/src/Calor.Compiler/bin/$cli_cfg/net10.0/calor.dll"
+            break
+        fi
+    done
+fi
 if [[ "$ARM" == "calor" && -z "$CALOR_CLI_DLL" ]]; then
     echo "WARNING: calor.dll not found (build src/Calor.Compiler first); calor-arm records will carry envelope_valid=null and empty edit_target_ids" >&2
 fi

--- a/bench/phase0-agent-native/run-pair.sh
+++ b/bench/phase0-agent-native/run-pair.sh
@@ -175,14 +175,29 @@ OUT_DIR="$(cd "$OUT_DIR" && pwd)"
 TELEMETRY_HELPERS="$SCRIPT_DIR/telemetry-helpers.py"
 CALOR_CLI_DLL=""
 if [[ -n "$CALOR_DLL_OVERRIDE" ]]; then
-    # Per-arm build-pin (loop plan M5): pin the calor CLI/MCP-server build
-    # explicitly so an A/B epoch runs two compiler builds against identical
-    # tasks/pins/fixtures (arm A = loop-baseline-ws1; arm B = baseline +
-    # WS2/WS3 isolation). The pinned dll drives envelope generation, `ids
-    # index`, and — for mcp-file arms — the calor MCP write server. When
-    # unset, auto-detect the current checkout's build (Release preferred).
+    # Per-arm build-pin (loop plan M5). Pins the calor CLI / MCP-server /
+    # envelope build: the dll that drives envelope generation, `ids index`,
+    # and (for mcp-file arms) the calor MCP write server. It does NOT repoint
+    # the arm's own `dotnet build` — the CalorArm csproj template binds
+    # Calor.Tasks / Calor.Sdk / Calor.Runtime and the emitter to __REPO_ROOT__
+    # (the current checkout). For the M5 A/B this is exactly correct: WS2/WS3's
+    # src/ delta lives entirely in the MCP / session / envelope / parse-tolerant
+    # surface this pin governs and touches NONE of Calor.Tasks/Sdk/Runtime or
+    # CodeGen (verified empty diff loop-baseline-ws1..main), so both arms
+    # compile identically and the whole arm-A-vs-arm-B delta is captured by the
+    # pin. A workstream that changed codegen/Calor.Tasks would instead require
+    # a per-arm checkout, not just --calor-dll. When unset, auto-detect the
+    # current checkout's build (Release preferred).
     [[ -f "$CALOR_DLL_OVERRIDE" ]] || { echo "ERROR: --calor-dll path not found: $CALOR_DLL_OVERRIDE" >&2; exit 2; }
     CALOR_CLI_DLL="$(cd "$(dirname "$CALOR_DLL_OVERRIDE")" && pwd -P)/$(basename "$CALOR_DLL_OVERRIDE")"
+    # Reject a path that exists but is not a runnable calor CLI: a live mcp-file
+    # arm would otherwise register `dotnet <bogus> mcp` (a server that never
+    # starts), strand the agent behind the .calr edit hook, and fabricate
+    # guaranteed-failure data — the hazard the mcp-file gate below guards.
+    if ! dotnet "$CALOR_CLI_DLL" --help >/dev/null 2>&1; then
+        echo "ERROR: --calor-dll is not a runnable calor CLI (dotnet '$CALOR_CLI_DLL' --help failed)" >&2
+        exit 2
+    fi
 else
     for cli_cfg in Release Debug; do
         if [[ -f "$REPO_ROOT/src/Calor.Compiler/bin/$cli_cfg/net10.0/calor.dll" ]]; then
@@ -874,12 +889,14 @@ extract_metrics() {
         --argjson mean_lat "$mean_lat" --argjson env_all "$envelope_valid_all" \
         --argjson mcp_writes "$mcp_writes" \
         --argjson defect "$defect" \
+        --arg calor_dll "$CALOR_CLI_DLL" --arg edit_mech "$EDIT_MECHANISM" \
         '{pair:$pair, arm:$arm, run:$run, taskSuccess:$success,
           escapedBugs:$escaped, heldoutPassed:$passed,
           iterations:$iterations, iterationsToGreen:$itg, censored:$censored,
           invalid:false,
           meanFeedbackLatencyMs:$mean_lat, envelopeValidAll:$env_all,
           mcpWrites:$mcp_writes, defect:$defect,
+          calorDll:$calor_dll, editMechanism:$edit_mech,
           tokens:{input:$tin, output:$tout}, nullAgent:($null_agent==1)}' \
         > "$ws_out/result.json"
     cat "$ws_out/result.json"


### PR DESCRIPTION
## M5 harness prerequisite: per-arm build-pin

`run-pair.sh` loaded `calor.dll` from the current checkout only (Release-preferred, Debug-fallback via `CALOR_CLI_DLL`). M5's PP-L5 needs **two compiler builds run against identical tasks/pins/fixtures** — arm A = `loop-baseline-ws1` (raw edits, cold feedback), arm B = baseline + WS2/WS3 isolation (mcp-file, warm feedback).

**Change:** add `--calor-dll <path>` overriding `CALOR_CLI_DLL` (which drives envelope generation, `ids index`, and — for `mcp-file` arms — the calor MCP write server). Unset keeps the existing auto-detect. A missing path errors explicitly. One localized edit (default + arg-parse case + detection override + usage string); no behavior change when the flag is absent.

### Shakedown (zero live-agent spend, null-agent) — all pass
Built both arms and ran the null-agent path pinned to each:
- **Discriminator** — baseline (arm A) `calor mcp --help` has **0** `--root`; isolation (arm B) has **1**: the two builds are genuinely different (arm A lacks the WS2 write path).
- **Bad path** — `--calor-dll /nonexistent` → exit 2, `ERROR: --calor-dll path not found`.
- **Arm A** (baseline dll, `raw`) → `taskSuccess:true, envelopeValidAll:true`.
- **Arm B** (isolation dll, `mcp-file`) → `taskSuccess:true, envelopeValidAll:true`.
- **Routing proof** — arm-A run internals (`.shim/dotnet`) reference the baseline worktree dll; arm-B's reference the main/isolation dll; **zero cross-leakage** (arm A never touches the main path, arm B never touches the worktree path).

### Context
Arm-B isolation build verified earlier (branch `m5-arm-b-isolation` @ `122851ae`; `src/` diff vs baseline = exactly the 12 WS2/WS3 files; note arm B's compiler is byte-identical to main's since M2/M4b/WS5 never touched `src/`). Arm A builds from the `loop-baseline-ws1` worktree (Z3 native seeded from main — identical across arms — so it compiles in seconds).

Follows the M5 kickoff (#812). Next after this lands: pre-run feasibility confirm → **spend authorization** → the live ≥70-run epoch. Spend is **not** requested here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Known follow-up (out of scope here)
`run-epoch.sh` iterates `calor`/`csharp` and does not forward `--calor-dll` or a per-arm mechanism, so it cannot yet express the M5 A/B (two calor builds: raw/baseline vs mcp-file/isolation). Driving M5 needs either two `run-pair.sh` invocations per pair or a small M5 orchestrator — the next step after this run-pair change lands. Also: `--calor-dll` pins the CLI/MCP-server/envelope build, not the arm's MSBuild compile (Calor.Tasks/Sdk/emitter, bound to the checkout); that is exactly correct for M5 because WS2/WS3 touched none of those (empty diff `loop-baseline-ws1..main`), but a codegen-changing workstream would need per-arm checkouts.
