### PR TITLE
M5 — comparison-epoch orchestrator + analyzer (two-build A/B driver, loop plan M5)

### DIFF
--- a/bench/phase0-agent-native/m5-analyze.py
+++ b/bench/phase0-agent-native/m5-analyze.py
@@ -3,128 +3,166 @@
 
 Reads an m5-comparison epoch dir (produced by run-m5-epoch.sh) and computes:
   - PP-L5: median paired tokens-to-green ratio (armB/armA) on the warm set,
-           one-sided cluster bootstrap vs the 0.85 threshold (gates Annex A / §6.1).
-  - PP-L6(b): neutral-set iterations-to-green parity (armB/armA), same bootstrap.
-  - Censored caps: 40% absolute (neutral) and 5pp differential (loop plan §4/m6).
-Writes analysis.json and prints a report. PP adjudication semantics are frozen
-in agent-native-gates.md — this only computes them.
+           adjudicated by the gates §6.1 decision rule.
+  - PP-L6(b): neutral-set iterations-to-green parity (no significant regression),
+              same bootstrap, plus the censored caps.
 
-M-L5 tokens-to-green = per-run agent output tokens; per-pair means, then the
-median of paired per-pair ratios (gates §2). A run is censored if invalid or
-never-green (iterationsToGreen > budget). Bootstrap is seeded for reproducibility.
+Frozen definitions (agent-native-gates.md), implemented here — not changed:
+  - M-L5 tokens-to-green = per-run agent output tokens; per-pair means, then the
+    median of paired per-pair ratios (§2).
+  - §6.1 decision rule: cluster bootstrap over pairs, RUNS NESTED WITHIN PAIRS,
+    one-sided, alpha=0.05. Pass iff the point estimate meets the threshold AND
+    the one-sided 95% CI excludes zero effect (ratio = 1.0). No third outcome.
+  - Censored: 40% absolute cap on neutral tasks (either arm) invalidates; a 5pp
+    differential (loop plan §4/m6) makes PP-L5 reported-not-adjudicated.
+
+A run is censored if invalid or never-green (iterationsToGreen > budget). The
+two-level bootstrap is seeded for reproducibility.
 """
 import json, sys, glob, os, random, statistics
 
 EPOCH = sys.argv[1] if len(sys.argv) > 1 else "."
 ARM_A, ARM_B = "calor", "calor+mcp-file"   # run-pair ARM_LABELs (raw vs mcp-file)
 BOOT = 2000
+ALPHA = 0.05
 random.seed(4537)
 
 pins = json.load(open(os.path.join(EPOCH, "pins.json")))
-WARM = set(pins.get("ppL5", {}).get("pairs", []))
-NEUTRAL = set(pins.get("ppL6", {}).get("pairs", []))
+WARM = list(pins.get("ppL5", {}).get("pairs", []))
+NEUTRAL = list(pins.get("ppL6", {}).get("pairs", []))
 THRESH = pins.get("ppL5", {}).get("threshold", 0.85)
 
-# runs[pairId][arm] = list of {tokensOut, itg, censored}
+# runs[pairId][arm] = list of {tokensOut, itg, invalid, censored}
 runs = {}
-budget = None
 for f in sorted(glob.glob(os.path.join(EPOCH, "*", "*", "run-*", "result.json"))):
     r = json.load(open(f))
     pid = "-".join(r["pair"].split("-")[:2])
-    arm = r["arm"]
-    runs.setdefault(pid, {}).setdefault(arm, []).append({
-        "tokensOut": r.get("tokens", {}).get("output", 0),
+    runs.setdefault(pid, {}).setdefault(r["arm"], []).append({
+        "tokensOut": (r.get("tokens", {}) or {}).get("output", 0),
         "itg": r.get("iterationsToGreen"),
-        "invalid": r.get("invalid", False),
-        # never-green: itg beyond the iteration budget (budget+1 sentinel) or invalid
+        "invalid": bool(r.get("invalid", False)),
         "censored": bool(r.get("censored", False)) or bool(r.get("invalid", False)),
     })
 
-def arm_pair_mean(pid, arm, field):
-    """Mean of `field` over the pair's non-invalid runs for an arm (None if none)."""
-    xs = [x[field] for x in runs.get(pid, {}).get(arm, []) if not x["invalid"] and x[field] is not None]
-    return statistics.mean(xs) if xs else None
+def vals(pid, arm, field):
+    """field values over the pair's NON-INVALID runs for an arm (M-L5 uses
+    per-run tokens; never-green-but-valid runs count, per the frozen def)."""
+    return [x[field] for x in runs.get(pid, {}).get(arm, [])
+            if not x["invalid"] and x[field] is not None]
+
+def paired_pids(pids, field):
+    return [p for p in pids if vals(p, ARM_A, field) and vals(p, ARM_B, field)
+            and statistics.mean(vals(p, ARM_A, field)) > 0]
+
+def point_ratio(pid, field):
+    a = statistics.mean(vals(pid, ARM_A, field)); b = statistics.mean(vals(pid, ARM_B, field))
+    return b / a
+
+def point_median(pids, field):
+    pp = paired_pids(pids, field)
+    if not pp:
+        return (None, 0)
+    return (statistics.median([point_ratio(p, field) for p in pp]), len(pp))
+
+def two_level_bootstrap(pids, field):
+    """Cluster bootstrap over pairs with runs resampled WITHIN each resampled
+    pair (gates §6.1). Returns the sorted list of bootstrap median-ratios."""
+    pp = paired_pids(pids, field)
+    if len(pp) < 2:
+        return []
+    a_runs = {p: vals(p, ARM_A, field) for p in pp}
+    b_runs = {p: vals(p, ARM_B, field) for p in pp}
+    boots = []
+    n = len(pp)
+    for _ in range(BOOT):
+        rs = []
+        for _ in range(n):
+            p = pp[random.randrange(n)]
+            ar, br = a_runs[p], b_runs[p]
+            am = statistics.mean(random.choice(ar) for _ in ar)
+            bm = statistics.mean(random.choice(br) for _ in br)
+            if am > 0:
+                rs.append(bm / am)
+        if rs:
+            boots.append(statistics.median(rs))
+    boots.sort()
+    return boots
+
+def one_sided_upper(boots):   # 95th percentile — one-sided 95% upper bound
+    return boots[min(len(boots) - 1, int(0.95 * len(boots)))] if boots else None
+
+def one_sided_lower(boots):   # 5th percentile — one-sided 95% lower bound
+    return boots[int(0.05 * len(boots))] if boots else None
+
+def p_ge(boots, x):
+    return (sum(1 for m in boots if m >= x) / len(boots)) if boots else None
 
 def censored_frac(pids, arm):
     tot = cen = 0
     for pid in pids:
         for x in runs.get(pid, {}).get(arm, []):
             tot += 1; cen += 1 if x["censored"] else 0
-    return (cen / tot) if tot else 0.0, cen, tot
+    return ((cen / tot) if tot else 0.0, cen, tot)
 
-def paired_ratios(pids, field):
-    """List of (pid, armB_mean/armA_mean) over pairs where both arms have data."""
-    out = []
-    for pid in sorted(pids):
-        a = arm_pair_mean(pid, ARM_A, field); b = arm_pair_mean(pid, ARM_B, field)
-        if a and b and a > 0:
-            out.append((pid, b / a))
-    return out
+# ---- PP-L5 (warm set, tokens-to-green): reduction gate, threshold 0.85 ----
+pt, n_warm = point_median(WARM, "tokensOut")
+boots5 = two_level_bootstrap(WARM, "tokensOut")
+upper5 = one_sided_upper(boots5)                 # one-sided 95% upper bound
+p_zero5 = p_ge(boots5, 1.0)                       # P(median >= 1.0): excludes zero effect iff < alpha
+a_cf5 = censored_frac(WARM, ARM_A); b_cf5 = censored_frac(WARM, ARM_B)
+diff5_ok = abs(a_cf5[0] - b_cf5[0]) <= 0.05
+decidable5 = (n_warm >= 2) and diff5_ok
+meets_thresh = (pt is not None and pt <= THRESH)
+excludes_zero5 = (p_zero5 is not None and p_zero5 < ALPHA)   # one-sided 95% CI excludes 1.0
+ppl5_hit = (meets_thresh and excludes_zero5) if decidable5 else None
 
-def median(xs): return statistics.median(xs) if xs else None
-
-def cluster_bootstrap_median(ratios, one_sided_thresh):
-    """One-sided cluster bootstrap over pairs (gates §6.1). Returns
-    (point_median, ci_lo, ci_hi, p_ge_thresh) — p = P(bootstrap median >= thresh),
-    i.e. one-sided support for 'median < thresh'. Significant if p < 0.05."""
-    vals = [r for _, r in ratios]
-    if len(vals) < 2:
-        return (median(vals), None, None, None)
-    boots = []
-    n = len(vals)
-    for _ in range(BOOT):
-        sample = [vals[random.randrange(n)] for _ in range(n)]
-        boots.append(statistics.median(sample))
-    boots.sort()
-    lo = boots[int(0.025 * BOOT)]; hi = boots[int(0.975 * BOOT)]
-    p_ge = sum(1 for m in boots if m >= one_sided_thresh) / BOOT
-    return (statistics.median(vals), lo, hi, p_ge)
-
-# ---- PP-L5 (warm set, tokens-to-green) ----
-warm_ratios = paired_ratios(WARM, "tokensOut")
-pt, lo, hi, p = cluster_bootstrap_median(warm_ratios, THRESH)
-a_cf = censored_frac(WARM, ARM_A); b_cf = censored_frac(WARM, ARM_B)
-diff_cap_ok = abs(a_cf[0] - b_cf[0]) <= 0.05
-neutral_cap_ok = True  # 40% cap applies to NEUTRAL tasks (checked in PP-L6)
-ppl5_decidable = len(warm_ratios) >= 2 and diff_cap_ok
-ppl5_hit = (p is not None and p < 0.05) if ppl5_decidable else None
-
-# ---- PP-L6 (neutral set, iterations-to-green parity + censored caps) ----
-neut_ratios = paired_ratios(NEUTRAL, "itg")
-npt, nlo, nhi, npp = cluster_bootstrap_median(neut_ratios, 1.0)
+# ---- PP-L6(b) (neutral set, itg parity): no-significant-regression + caps ----
+npt, n_neut = point_median(NEUTRAL, "itg")
+boots6 = two_level_bootstrap(NEUTRAL, "itg")
+lower6 = one_sided_lower(boots6)
+# regression = armB significantly WORSE (itg ratio significantly > 1.0)
+p_reg = (sum(1 for m in boots6 if m <= 1.0) / len(boots6)) if boots6 else None
+sig_regression = (p_reg is not None and p_reg < ALPHA)  # one-sided 95% lower bound > 1.0
 na_cf = censored_frac(NEUTRAL, ARM_A); nb_cf = censored_frac(NEUTRAL, ARM_B)
-neutral_40_ok = na_cf[0] <= 0.40 and nb_cf[0] <= 0.40
-neutral_diff_ok = abs(na_cf[0] - nb_cf[0]) <= 0.05
+cap40_ok = na_cf[0] <= 0.40 and nb_cf[0] <= 0.40
+diff6_ok = abs(na_cf[0] - nb_cf[0]) <= 0.05
+ppl6_pass = (cap40_ok and diff6_ok and not sig_regression) if (n_neut >= 2 and boots6) else None
 
 analysis = {
   "epochId": pins.get("epochId"), "kind": "m5-comparison",
-  "armA": pins.get("armA"), "armB": pins.get("armB"),
+  "armA": pins.get("armA"), "armB": pins.get("armB"), "boot": BOOT, "alpha": ALPHA,
   "ppL5": {
      "metric": "tokens-to-green", "threshold": THRESH,
-     "medianPairedRatio_BoverA": pt, "ci95": [lo, hi], "pBootstrap_ge_thresh": p,
-     "decidable": ppl5_decidable, "hit": ppl5_hit,
-     "nPairs": len(warm_ratios),
-     "perPair": [{"pair": pid, "ratio": round(r, 4)} for pid, r in warm_ratios],
-     "censoredFrac": {"armA": round(a_cf[0], 3), "armB": round(b_cf[0], 3), "diffWithin5pp": diff_cap_ok},
-     "note": "hit = one-sided cluster bootstrap rejects median>=0.85 at a=0.05; if !decidable or diff>5pp, reported-not-adjudicated (gates)",
+     "medianPairedRatio_BoverA": pt, "nPairs": n_warm,
+     "oneSided95UpperBound": upper5, "pMedian_ge_1.0": p_zero5,
+     "meetsThreshold": meets_thresh, "excludesZeroEffect": excludes_zero5,
+     "decidable": decidable5, "hit": ppl5_hit,
+     "perPair": [{"pair": p, "ratio": round(point_ratio(p, "tokensOut"), 4)}
+                 for p in paired_pids(WARM, "tokensOut")],
+     "censoredFrac": {"armA": round(a_cf5[0], 3), "armB": round(b_cf5[0], 3), "diffWithin5pp": diff5_ok},
+     "rule": "gates §6.1: hit iff point<=0.85 AND one-sided 95% CI excludes ratio 1.0; !decidable if <2 warm pairs or censored-diff>5pp",
   },
   "ppL6": {
-     "neutralItgMedianRatio_BoverA": npt, "ci95": [nlo, nhi],
+     "metric": "neutral iterations-to-green parity (no significant regression)",
+     "medianPairedRatio_BoverA": npt, "nPairs": n_neut,
+     "oneSided95LowerBound": lower6, "pMedian_le_1.0": p_reg,
+     "significantRegression": sig_regression, "pass": ppl6_pass,
      "censoredFrac": {"armA": round(na_cf[0], 3), "armB": round(nb_cf[0], 3),
-                      "cap40_ok": neutral_40_ok, "diffWithin5pp": neutral_diff_ok},
-     "nPairs": len(neut_ratios),
-     "note": "release blocker: no significant neutral regression + config invariance (config invariance enforced per-run by check_pins)",
+                      "cap40_ok": cap40_ok, "diffWithin5pp": diff6_ok},
+     "note": "release blocker; config invariance also enforced per-run by run-pair.sh check_pins",
   },
 }
 json.dump(analysis, open(os.path.join(EPOCH, "analysis.json"), "w"), indent=2)
 
-def fmt(x): return "n/a" if x is None else (f"{x:.4f}" if isinstance(x, float) else str(x))
-print(f"=== M5 {analysis['epochId']} — PP-L5 (tokens-to-green) ===")
-print(f"  warm pairs with data: {len(warm_ratios)}   median paired ratio B/A: {fmt(pt)}  (threshold <= {THRESH})")
-print(f"  95% CI [{fmt(lo)}, {fmt(hi)}]   p(median>=thresh)={fmt(p)}   decidable={ppl5_decidable}  HIT={ppl5_hit}")
-print(f"  censored: armA {a_cf[0]*100:.0f}%  armB {b_cf[0]*100:.0f}%  (diff<=5pp: {diff_cap_ok})")
-for pid, r in warm_ratios: print(f"    {pid}: B/A={r:.3f}")
+def f(x): return "n/a" if x is None else (f"{x:.4f}" if isinstance(x, float) else str(x))
+print(f"=== M5 {analysis['epochId']} — PP-L5 (tokens-to-green, gates §6.1) ===")
+print(f"  warm pairs with data: {n_warm}   median paired ratio B/A: {f(pt)}  (threshold <= {THRESH})")
+print(f"  one-sided 95% upper bound: {f(upper5)}   P(median>=1.0)={f(p_zero5)}")
+print(f"  meetsThreshold={meets_thresh}  excludesZeroEffect(1.0)={excludes_zero5}  decidable={decidable5}  ==> HIT={ppl5_hit}")
+print(f"  censored: armA {a_cf5[0]*100:.0f}%  armB {b_cf5[0]*100:.0f}%  (diff<=5pp: {diff5_ok})")
+for p in paired_pids(WARM, "tokensOut"):
+    print(f"    {p}: B/A={point_ratio(p,'tokensOut'):.3f}")
 print(f"=== PP-L6 (neutral parity) ===")
-print(f"  neutral pairs: {len(neut_ratios)}   itg median ratio B/A: {fmt(npt)}  CI[{fmt(nlo)},{fmt(nhi)}]")
-print(f"  censored: armA {na_cf[0]*100:.0f}%  armB {nb_cf[0]*100:.0f}%  (40% cap: {neutral_40_ok}, diff<=5pp: {neutral_diff_ok})")
+print(f"  neutral pairs: {n_neut}   itg median ratio B/A: {f(npt)}  one-sided 95% lower: {f(lower6)}")
+print(f"  significantRegression={sig_regression}  censored armA {na_cf[0]*100:.0f}% armB {nb_cf[0]*100:.0f}%  (40% cap: {cap40_ok}, diff<=5pp: {diff6_ok})  ==> PASS={ppl6_pass}")
 print("wrote analysis.json")

--- a/bench/phase0-agent-native/m5-analyze.py
+++ b/bench/phase0-agent-native/m5-analyze.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""M5 comparison-epoch adjudicator (loop plan v0.9 / loop-m5-comparison.md).
+
+Reads an m5-comparison epoch dir (produced by run-m5-epoch.sh) and computes:
+  - PP-L5: median paired tokens-to-green ratio (armB/armA) on the warm set,
+           one-sided cluster bootstrap vs the 0.85 threshold (gates Annex A / §6.1).
+  - PP-L6(b): neutral-set iterations-to-green parity (armB/armA), same bootstrap.
+  - Censored caps: 40% absolute (neutral) and 5pp differential (loop plan §4/m6).
+Writes analysis.json and prints a report. PP adjudication semantics are frozen
+in agent-native-gates.md — this only computes them.
+
+M-L5 tokens-to-green = per-run agent output tokens; per-pair means, then the
+median of paired per-pair ratios (gates §2). A run is censored if invalid or
+never-green (iterationsToGreen > budget). Bootstrap is seeded for reproducibility.
+"""
+import json, sys, glob, os, random, statistics
+
+EPOCH = sys.argv[1] if len(sys.argv) > 1 else "."
+ARM_A, ARM_B = "calor", "calor+mcp-file"   # run-pair ARM_LABELs (raw vs mcp-file)
+BOOT = 2000
+random.seed(4537)
+
+pins = json.load(open(os.path.join(EPOCH, "pins.json")))
+WARM = set(pins.get("ppL5", {}).get("pairs", []))
+NEUTRAL = set(pins.get("ppL6", {}).get("pairs", []))
+THRESH = pins.get("ppL5", {}).get("threshold", 0.85)
+
+# runs[pairId][arm] = list of {tokensOut, itg, censored}
+runs = {}
+budget = None
+for f in sorted(glob.glob(os.path.join(EPOCH, "*", "*", "run-*", "result.json"))):
+    r = json.load(open(f))
+    pid = "-".join(r["pair"].split("-")[:2])
+    arm = r["arm"]
+    runs.setdefault(pid, {}).setdefault(arm, []).append({
+        "tokensOut": r.get("tokens", {}).get("output", 0),
+        "itg": r.get("iterationsToGreen"),
+        "invalid": r.get("invalid", False),
+        # never-green: itg beyond the iteration budget (budget+1 sentinel) or invalid
+        "censored": bool(r.get("censored", False)) or bool(r.get("invalid", False)),
+    })
+
+def arm_pair_mean(pid, arm, field):
+    """Mean of `field` over the pair's non-invalid runs for an arm (None if none)."""
+    xs = [x[field] for x in runs.get(pid, {}).get(arm, []) if not x["invalid"] and x[field] is not None]
+    return statistics.mean(xs) if xs else None
+
+def censored_frac(pids, arm):
+    tot = cen = 0
+    for pid in pids:
+        for x in runs.get(pid, {}).get(arm, []):
+            tot += 1; cen += 1 if x["censored"] else 0
+    return (cen / tot) if tot else 0.0, cen, tot
+
+def paired_ratios(pids, field):
+    """List of (pid, armB_mean/armA_mean) over pairs where both arms have data."""
+    out = []
+    for pid in sorted(pids):
+        a = arm_pair_mean(pid, ARM_A, field); b = arm_pair_mean(pid, ARM_B, field)
+        if a and b and a > 0:
+            out.append((pid, b / a))
+    return out
+
+def median(xs): return statistics.median(xs) if xs else None
+
+def cluster_bootstrap_median(ratios, one_sided_thresh):
+    """One-sided cluster bootstrap over pairs (gates §6.1). Returns
+    (point_median, ci_lo, ci_hi, p_ge_thresh) — p = P(bootstrap median >= thresh),
+    i.e. one-sided support for 'median < thresh'. Significant if p < 0.05."""
+    vals = [r for _, r in ratios]
+    if len(vals) < 2:
+        return (median(vals), None, None, None)
+    boots = []
+    n = len(vals)
+    for _ in range(BOOT):
+        sample = [vals[random.randrange(n)] for _ in range(n)]
+        boots.append(statistics.median(sample))
+    boots.sort()
+    lo = boots[int(0.025 * BOOT)]; hi = boots[int(0.975 * BOOT)]
+    p_ge = sum(1 for m in boots if m >= one_sided_thresh) / BOOT
+    return (statistics.median(vals), lo, hi, p_ge)
+
+# ---- PP-L5 (warm set, tokens-to-green) ----
+warm_ratios = paired_ratios(WARM, "tokensOut")
+pt, lo, hi, p = cluster_bootstrap_median(warm_ratios, THRESH)
+a_cf = censored_frac(WARM, ARM_A); b_cf = censored_frac(WARM, ARM_B)
+diff_cap_ok = abs(a_cf[0] - b_cf[0]) <= 0.05
+neutral_cap_ok = True  # 40% cap applies to NEUTRAL tasks (checked in PP-L6)
+ppl5_decidable = len(warm_ratios) >= 2 and diff_cap_ok
+ppl5_hit = (p is not None and p < 0.05) if ppl5_decidable else None
+
+# ---- PP-L6 (neutral set, iterations-to-green parity + censored caps) ----
+neut_ratios = paired_ratios(NEUTRAL, "itg")
+npt, nlo, nhi, npp = cluster_bootstrap_median(neut_ratios, 1.0)
+na_cf = censored_frac(NEUTRAL, ARM_A); nb_cf = censored_frac(NEUTRAL, ARM_B)
+neutral_40_ok = na_cf[0] <= 0.40 and nb_cf[0] <= 0.40
+neutral_diff_ok = abs(na_cf[0] - nb_cf[0]) <= 0.05
+
+analysis = {
+  "epochId": pins.get("epochId"), "kind": "m5-comparison",
+  "armA": pins.get("armA"), "armB": pins.get("armB"),
+  "ppL5": {
+     "metric": "tokens-to-green", "threshold": THRESH,
+     "medianPairedRatio_BoverA": pt, "ci95": [lo, hi], "pBootstrap_ge_thresh": p,
+     "decidable": ppl5_decidable, "hit": ppl5_hit,
+     "nPairs": len(warm_ratios),
+     "perPair": [{"pair": pid, "ratio": round(r, 4)} for pid, r in warm_ratios],
+     "censoredFrac": {"armA": round(a_cf[0], 3), "armB": round(b_cf[0], 3), "diffWithin5pp": diff_cap_ok},
+     "note": "hit = one-sided cluster bootstrap rejects median>=0.85 at a=0.05; if !decidable or diff>5pp, reported-not-adjudicated (gates)",
+  },
+  "ppL6": {
+     "neutralItgMedianRatio_BoverA": npt, "ci95": [nlo, nhi],
+     "censoredFrac": {"armA": round(na_cf[0], 3), "armB": round(nb_cf[0], 3),
+                      "cap40_ok": neutral_40_ok, "diffWithin5pp": neutral_diff_ok},
+     "nPairs": len(neut_ratios),
+     "note": "release blocker: no significant neutral regression + config invariance (config invariance enforced per-run by check_pins)",
+  },
+}
+json.dump(analysis, open(os.path.join(EPOCH, "analysis.json"), "w"), indent=2)
+
+def fmt(x): return "n/a" if x is None else (f"{x:.4f}" if isinstance(x, float) else str(x))
+print(f"=== M5 {analysis['epochId']} — PP-L5 (tokens-to-green) ===")
+print(f"  warm pairs with data: {len(warm_ratios)}   median paired ratio B/A: {fmt(pt)}  (threshold <= {THRESH})")
+print(f"  95% CI [{fmt(lo)}, {fmt(hi)}]   p(median>=thresh)={fmt(p)}   decidable={ppl5_decidable}  HIT={ppl5_hit}")
+print(f"  censored: armA {a_cf[0]*100:.0f}%  armB {b_cf[0]*100:.0f}%  (diff<=5pp: {diff_cap_ok})")
+for pid, r in warm_ratios: print(f"    {pid}: B/A={r:.3f}")
+print(f"=== PP-L6 (neutral parity) ===")
+print(f"  neutral pairs: {len(neut_ratios)}   itg median ratio B/A: {fmt(npt)}  CI[{fmt(nlo)},{fmt(nhi)}]")
+print(f"  censored: armA {na_cf[0]*100:.0f}%  armB {nb_cf[0]*100:.0f}%  (40% cap: {neutral_40_ok}, diff<=5pp: {neutral_diff_ok})")
+print("wrote analysis.json")

--- a/bench/phase0-agent-native/run-m5-epoch.sh
+++ b/bench/phase0-agent-native/run-m5-epoch.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# ============================================================================
+# M5 comparison-epoch orchestrator (loop plan v0.9 milestone M5).
+#
+# Runs ONE simultaneous A/B epoch over two calor toolchain BUILDS against
+# identical pairs/pins/fixtures, per docs/plans/loop-m5-comparison.md:
+#   - arm A = loop-baseline-ws1 build      -> --edit-mechanism raw   (cold)
+#   - arm B = baseline + WS2/WS3 isolation -> --edit-mechanism mcp-file (warm)
+# Both are the CALOR arm; they differ only in the pinned build (--calor-dll,
+# #813) and the edit mechanism — which is the WS2/WS3 tooling delta PP-L5
+# measures. Everything else (pairs, task specs, held-out suites, harness) is
+# the current checkout, so tasks/pins are byte-identical across arms.
+#
+# Adjudication is done by m5-analyze.py on the produced results:
+#   - PP-L5: median paired tokens-to-green ratio (armB/armA) <= 0.85 on the warm
+#            set (W2+W3), one-sided cluster bootstrap alpha=0.05 (gates §6.1).
+#   - PP-L6: neutral-set (N1) iterations-to-green parity + censored caps; this
+#            driver also stamps per-run build provenance (calorDll) via #813.
+#
+# Live (non-null) runs consume agent API spend — get explicit authorization and
+# pin the model via CLAUDE_MODEL. --null-agent is a zero-spend plumbing check.
+#
+# Usage:
+#   CLAUDE_MODEL=claude-opus-4-8 ./run-m5-epoch.sh \
+#       --epoch m5-compare-001 \
+#       --arm-a-dll <baseline-build>/calor.dll \
+#       --arm-b-dll <isolation-build>/calor.dll \
+#       [--arm-a-commit <sha>] [--arm-b-commit <sha>] \
+#       [--runs 5] [--pairs "W2 W3 N1"] [--null-agent]
+# ============================================================================
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+EPOCH=""; ARM_A_DLL=""; ARM_B_DLL=""; ARM_A_COMMIT=""; ARM_B_COMMIT=""
+RUNS=5; NULL_FLAG=""; PAIR_FILTER=""
+# Frozen M5 sets (loop-m5-comparison.md §3): warm = PP-L5, neutral N1 = PP-L6(b).
+WARM_PAIRS=(W2-001 W2-002 W2-003 W2-004 W2-005 W3-001 W3-002 W3-003 W3-004)
+NEUTRAL_PAIRS=(N1-001 N1-002 N1-003 N1-005)
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --epoch) EPOCH="$2"; shift 2 ;;
+        --arm-a-dll) ARM_A_DLL="$2"; shift 2 ;;
+        --arm-b-dll) ARM_B_DLL="$2"; shift 2 ;;
+        --arm-a-commit) ARM_A_COMMIT="$2"; shift 2 ;;
+        --arm-b-commit) ARM_B_COMMIT="$2"; shift 2 ;;
+        --runs) RUNS="$2"; shift 2 ;;
+        --pairs) PAIR_FILTER="$2"; shift 2 ;;
+        --null-agent) NULL_FLAG="--null-agent"; shift ;;
+        *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+[[ -n "$EPOCH" && -n "$ARM_A_DLL" && -n "$ARM_B_DLL" ]] || {
+    echo "Usage: --epoch <id> --arm-a-dll <path> --arm-b-dll <path> [--arm-a-commit <sha>] [--arm-b-commit <sha>] [--runs N] [--pairs \"W2 W3 N1\"] [--null-agent]" >&2
+    exit 2; }
+
+# Default provenance shas (loop-baseline-ws1 is an annotated tag -> resolve to
+# its commit; arm B defaults to the current checkout's HEAD).
+[[ -n "$ARM_A_COMMIT" ]] || ARM_A_COMMIT="$(git -C "$REPO_ROOT" rev-parse 'loop-baseline-ws1^{commit}' 2>/dev/null || echo unknown)"
+[[ -n "$ARM_B_COMMIT" ]] || ARM_B_COMMIT="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+
+# ---------------------------------------------------------------------------
+# Pre-flight: both builds must exist, be runnable, and be GENUINELY different
+# (the whole epoch is void if both arms silently share a build). The WS2 write
+# path (`calor mcp --root`) is the discriminator: arm A (baseline) lacks it,
+# arm B (isolation) has it.
+# ---------------------------------------------------------------------------
+[[ -f "$ARM_A_DLL" ]] || { echo "ERROR: --arm-a-dll not found: $ARM_A_DLL" >&2; exit 2; }
+[[ -f "$ARM_B_DLL" ]] || { echo "ERROR: --arm-b-dll not found: $ARM_B_DLL" >&2; exit 2; }
+ARM_A_DLL="$(cd "$(dirname "$ARM_A_DLL")" && pwd -P)/$(basename "$ARM_A_DLL")"
+ARM_B_DLL="$(cd "$(dirname "$ARM_B_DLL")" && pwd -P)/$(basename "$ARM_B_DLL")"
+[[ "$ARM_A_DLL" != "$ARM_B_DLL" ]] || { echo "ERROR: arm-A and arm-B dll are the same path — no A/B contrast" >&2; exit 2; }
+a_root="$(dotnet "$ARM_A_DLL" mcp --help 2>/dev/null | grep -c -- '--root' || true)"
+b_root="$(dotnet "$ARM_B_DLL" mcp --help 2>/dev/null | grep -c -- '--root' || true)"
+[[ "$a_root" == "0" ]] || { echo "ERROR: arm-A dll unexpectedly HAS the WS2 --root write path (expected the baseline build without it) — dlls swapped?" >&2; exit 2; }
+[[ "$b_root" -ge "1" ]] || { echo "ERROR: arm-B dll LACKS the WS2 --root write path (expected the WS2/WS3 isolation build) — wrong build?" >&2; exit 2; }
+
+# Resolve the pair set (default: warm + neutral = full M5).
+declare -a PAIRS=()
+if [[ -z "$PAIR_FILTER" ]]; then
+    PAIRS=("${WARM_PAIRS[@]}" "${NEUTRAL_PAIRS[@]}")
+else
+    for grp in $PAIR_FILTER; do
+        case "$grp" in
+            W2) PAIRS+=(W2-001 W2-002 W2-003 W2-004 W2-005) ;;
+            W3) PAIRS+=(W3-001 W3-002 W3-003 W3-004) ;;
+            N1) PAIRS+=("${NEUTRAL_PAIRS[@]}") ;;
+            warm) PAIRS+=("${WARM_PAIRS[@]}") ;;
+            neutral) PAIRS+=("${NEUTRAL_PAIRS[@]}") ;;
+            *) PAIRS+=("$grp") ;;   # explicit pair id (e.g. W2-003)
+        esac
+    done
+fi
+
+OUT="$SCRIPT_DIR/epochs/$EPOCH"
+mkdir -p "$OUT"
+
+# Pins (gates §1) — records BOTH builds so the record proves arm A ran the
+# baseline and arm B ran the isolation (pins.json elsewhere carries one commit).
+jq -n \
+    --arg epoch "$EPOCH" \
+    --arg model "${CLAUDE_MODEL:-default}" \
+    --arg agent_version "$(claude --version 2>/dev/null || echo unavailable)" \
+    --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg mode "${NULL_FLAG:-live}" \
+    --argjson runs "$RUNS" \
+    --arg a_commit "$ARM_A_COMMIT" --arg a_dll "$ARM_A_DLL" \
+    --arg b_commit "$ARM_B_COMMIT" --arg b_dll "$ARM_B_DLL" \
+    --arg suite_dirty "$(git -C "$REPO_ROOT" status --porcelain "$SCRIPT_DIR" | wc -l | tr -d ' ')" \
+    --argjson pairs "$(printf '%s\n' "${PAIRS[@]}" | jq -R . | jq -s .)" \
+    --argjson warm "$(printf '%s\n' "${WARM_PAIRS[@]}" | jq -R . | jq -s .)" \
+    --argjson neutral "$(printf '%s\n' "${NEUTRAL_PAIRS[@]}" | jq -R . | jq -s .)" \
+    '{epochId:$epoch, kind:"m5-comparison", modelPin:$model, agentVersion:$agent_version,
+      startedAt:$date, mode:$mode, runsPerArm:$runs, suiteDirtyFiles:($suite_dirty|tonumber),
+      armA:{label:"calor", role:"baseline (WS1-only)", commit:$a_commit, calorDll:$a_dll, editMechanism:"raw"},
+      armB:{label:"calor+mcp-file", role:"baseline + WS2/WS3 isolation", commit:$b_commit, calorDll:$b_dll, editMechanism:"mcp-file"},
+      ppL5:{metric:"tokens-to-green", threshold:0.85, note:">=15% median paired-ratio reduction, one-sided cluster bootstrap a=0.05 (gates Annex A)", pairs:$warm},
+      ppL6:{check:"neutral iterations-to-green parity + config invariance", pairs:$neutral},
+      suite:$pairs, telemetrySchema:"loop-telemetry/2"}' \
+    > "$OUT/pins.json"
+echo "=== M5 epoch $EPOCH ==="
+echo "arm A: $ARM_A_COMMIT (raw)      $ARM_A_DLL"
+echo "arm B: $ARM_B_COMMIT (mcp-file) $ARM_B_DLL"
+echo "pairs (${#PAIRS[@]}): ${PAIRS[*]}"
+echo "runs/arm: $RUNS   mode: ${NULL_FLAG:-live}   model: ${CLAUDE_MODEL:-default}"
+
+run_arm() {  # <pair_dir> <mechanism> <dll>
+    local pair_dir="$1" mech="$2" dll="$3"
+    "$SCRIPT_DIR/run-pair.sh" --pair "$pair_dir" --arm calor \
+        --edit-mechanism "$mech" --calor-dll "$dll" --runs "$RUNS" \
+        $NULL_FLAG --out "$OUT" \
+        | jq -c --unbuffered '{pair,arm,run,taskSuccess,iterationsToGreen,editMechanism,calorDll:(.calorDll|split("/")|.[-4:]|join("/")),tokensOut:.tokens.output,censored,invalid}'
+}
+
+for pid in "${PAIRS[@]}"; do
+    pair_dir="$(echo "$SCRIPT_DIR"/pairs/${pid}-*)"
+    [[ -d "$pair_dir" ]] || { echo "WARNING: pair not found, skipping: $pid" >&2; continue; }
+    echo "=== $pid / arm A (baseline, raw) ==="
+    run_arm "$pair_dir" raw "$ARM_A_DLL"
+    echo "=== $pid / arm B (isolation, mcp-file) ==="
+    run_arm "$pair_dir" mcp-file "$ARM_B_DLL"
+done
+
+echo "--- M5 collection complete; adjudicate with: bench/phase0-agent-native/m5-analyze.py $OUT ---"

--- a/bench/phase0-agent-native/run-m5-epoch.sh
+++ b/bench/phase0-agent-native/run-m5-epoch.sh
@@ -130,7 +130,7 @@ run_arm() {  # <pair_dir> <mechanism> <dll>
     "$SCRIPT_DIR/run-pair.sh" --pair "$pair_dir" --arm calor \
         --edit-mechanism "$mech" --calor-dll "$dll" --runs "$RUNS" \
         $NULL_FLAG --out "$OUT" \
-        | jq -c --unbuffered '{pair,arm,run,taskSuccess,iterationsToGreen,editMechanism,calorDll:(.calorDll|split("/")|.[-4:]|join("/")),tokensOut:.tokens.output,censored,invalid}'
+        | jq -c --unbuffered '{pair,arm,run,taskSuccess,iterationsToGreen,editMechanism,calorDll:((.calorDll // "")|split("/")|.[-4:]|join("/")),tokensOut:(.tokens.output // 0),censored,invalid}'
 }
 
 for pid in "${PAIRS[@]}"; do

--- a/bench/phase0-agent-native/run-pair.sh
+++ b/bench/phase0-agent-native/run-pair.sh
@@ -913,10 +913,12 @@ write_invalid_result() {
         --argjson itg "$((ITERATION_BUDGET + 1))" \
         --argjson escaped "$HELDOUT_TEST_COUNT" \
         --argjson null_agent "$NULL_AGENT" \
+        --arg calor_dll "$CALOR_CLI_DLL" --arg edit_mech "$EDIT_MECHANISM" \
         '{pair:$pair, arm:$arm, run:$run, taskSuccess:false,
           escapedBugs:$escaped, heldoutPassed:0,
           iterations:0, iterationsToGreen:$itg, censored:true,
           invalid:true, defect:null,
+          calorDll:$calor_dll, editMechanism:$edit_mech,
           tokens:{input:0, output:0}, nullAgent:($null_agent==1)}' \
         > "$ws_out/result.json"
     cat "$ws_out/result.json"


### PR DESCRIPTION
## M5 comparison-epoch orchestrator + analyzer

Closes the #813 follow-up: `run-epoch.sh` iterates calor/csharp and can't express the M5 two-build A/B. Two new files under `bench/phase0-agent-native/`.

### `run-m5-epoch.sh` — the driver
One simultaneous A/B epoch over two calor **builds** against identical pairs/pins, via the `--calor-dll` build-pin (#813):
- **arm A** = `loop-baseline-ws1` build → `--edit-mechanism raw` (baseline, cold)
- **arm B** = baseline + WS2/WS3 isolation → `--edit-mechanism mcp-file` (warm)

Both `--arm calor`; the build + mechanism delta **is** the WS2/WS3 tooling PP-L5 measures. Only the pinned build differs — pairs/specs/held-out/harness are the current checkout, so tasks/pins are byte-identical across arms.

**Pre-flight guards** against the epoch-voiding case where both arms silently share a build: distinct dll paths **and** the WS2 `mcp --root` discriminator (arm A must lack it, arm B must have it) — fail-fast on a swap or wrong build. `pins.json` records **both** build commits + dll paths + mechanisms + the frozen PP-L5 (0.85) / PP-L6 config and the warm/neutral pair sets.

### `m5-analyze.py` — the adjudicator
- **PP-L5**: median paired **tokens-to-green** ratio (armB/armA) on the warm set (W2×5+W3×4), **one-sided cluster bootstrap** vs 0.85 (gates §6.1), with the 5pp differential-censored guard → reported-not-adjudicated when <2 warm pairs or censored-diff >5pp.
- **PP-L6**: neutral (N1) iterations-to-green parity + the 40% censored cap (config invariance is enforced per-run by `check_pins`).

### Null-agent shakedown (zero spend) — passed
Ran 1 warm + 1 neutral pair × both arms: preflight passed, both arms routed to their pinned builds (arm A → baseline worktree dll, arm B → main dll, **verified distinct**), `pins.json` carried both commits (arm A `4f235cdc`, arm B `f51fe2c4`), and the analyzer ran cleanly on the collected results (correctly reporting "not decidable" on the degenerate null data rather than crashing).

### Usage / next steps
```
CLAUDE_MODEL=claude-opus-4-8 ./run-m5-epoch.sh --epoch m5-compare-001 \
  --arm-a-dll <baseline-build>/calor.dll --arm-b-dll <isolation-build>/calor.dll [--runs 5]
```
After this lands, the remaining gates before the live epoch are: pre-run feasibility confirm and **spend authorization**. Spend is **not** requested here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
