### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-29
+
+### Benchmark Results (Statistical: 30 runs)
+- **Overall Advantage**: 1.32x (Calor leads, 32.0%)
+- **Categories**: Calor wins 7, C# wins 1
+- **Highlights**:
+  - Comprehension: 1.84x (Calor)
+  - ErrorDetection: 1.49x (Calor, large effect d≈1.2)
+  - TokenEconomics: 1.42x (Calor)
+  - RefactoringStability: 1.38x (Calor, large effect d≈7.1)
+  - EditPrecision: 1.36x (Calor, large effect d≈4.9)
+  - InformationDensity: 0.98x (C#, medium effect)
+- **Benchmarks Evaluated**: 217 (Calor compiles 217/217, C# 216/217)
+
+### Measured (the Loop program, v0.9's centerpiece)
+- **PP-L5 HIT — the WS2+WS3 agent loop tooling reduces convergence cost ~35%.** One simultaneous A/B comparison epoch (`m5-compare-001`, 130 runs, pinned model): median paired tokens-to-green ratio 0.6465 (arm B = MCP transactional writes + warm sessions vs arm A = WS1-only baseline), one-sided 95% CI excluding zero effect, all 9 warm pairs improved. PP-L6 (science-integrity guard) passed; PP-L1 (warm feedback P50 2 ms / P99 9 ms edit→envelope) published under Added below.
+- **PP-W1 HIT — enforcement catches seeded defects the C# toolkit misses.** Injected-defect probe epoch (`ws5-probe-001`, 9 defect pairs × both arms): Calor 9/9 vs C# 4/9 (Δ+5), concentrated in the runtime-contract channel (`§Q`/`§S` guards) plus effect build-blocks. Full records under `bench/phase0-agent-native/epochs/`.
+
 ### Added
 - **Warm-feedback latency measured and published (loop plan WS3/M4, PP-L1: PASS).** On the pinned 10k-line multi-module latency fixture (`bench/phase0-agent-native/latency/`, 106 files, 230 committed timed edits), the MCP transactional write path (`calor_file_write`, warm session) measures **P50 2 ms / P99 9 ms** edit→envelope — against PP-L1 thresholds of 300 ms / 1 s. `calor watch` incremental rebuilds on the same fixture measure P50 27 ms / P99 32 ms (excluding the configured 200 ms debounce, recorded alongside); cold session open and cold watch compile of all 106 files are ~110 ms and ~390 ms. Full run record: `bench/phase0-agent-native/latency/ml1-002/` (adjudicating, run on merged main; `ml1-001/` is the agreeing pre-merge record). Instrumentation shipped with this release: `mcp-write/2` telemetry records carry `latencyMs` with a refresh/check/apply phase breakdown, and `calor watch` journals `watch-rebuild/1` records to `CALOR_WATCH_REBUILD_LOG` and prints per-rebuild wall time.
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.8.0</Version>
+    <Version>0.9.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "calor",
   "displayName": "Calor Language",
   "description": "Language support for the Calor programming language",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "publisher": "calor-dev",
   "license": "Apache-2.0",
   "icon": "icons/calor-icon.png",

--- a/website/content/changelog.mdx
+++ b/website/content/changelog.mdx
@@ -10,6 +10,25 @@ All notable changes to Calor, organized by release.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-29
+
+The Loop release: the agent edit–feedback cycle is now a first-class, measured product surface — one machine-readable envelope across every CLI command and MCP tool, a transactional MCP write path with warm project sessions, and millisecond-scale edit feedback. Measured on paired A/B epochs: the new loop tooling cuts agent tokens-to-green ~35%, and Calor's enforcement caught 9/9 seeded defects where the C# toolkit caught 4/9.
+
+### Added
+- **Transactional MCP write path with project sessions.** `calor_session_open`/`calor_session_close` hold parsed project state; `calor_file_write` runs heal → check → atomic-apply-or-reject with the full diagnostic envelope on reject, project-wide reference checking, and write confinement under a pinned root (`calor mcp --root`).
+- **Fault-tolerant parse mode.** Broken files produce partial ASTs plus diagnostics (never a compile pass), so sessions keep working context across syntax errors; parser depth guards prevent runaway nesting from killing the process.
+- **Warm feedback.** Sessions reuse parse/bind state and a lazy call-target index; MCP edit→envelope latency measures P50 2 ms / P99 9 ms on a pinned 10k-line fixture, with `calor watch` incremental rebuilds at P50 27 ms. Telemetry streams (`mcp-write/2`, `watch-rebuild/1`) journal per-edit latency breakdowns.
+- **Verification-outcome honesty.** All verification outcomes route through a single five-status choke point (`proven | refuted | unknown | timeout | unsupported`); refuted contracts carry concrete counterexample models; a committed fixture corpus pins every status in CI.
+
+### Changed
+- **One envelope everywhere.** Every diagnostic-producing CLI command and MCP tool emits the shared envelope schema v1.1 (diagnostic code, span, enclosing declaration ID, severity, fix hint, verification payload) — 100% coverage over the enumerated surface, enforced by CI conformance tests. See [CLI envelope schema](/docs/cli/envelope-schema/).
+- **`calor verify` exits 1 on refuted contracts** (missing files and compile errors too); proven/inconclusive outcomes keep exit 0.
+
+### Fixed
+- **CLI exit codes propagate on error paths** across `verify`, `convert`, `coverage`, `benchmark`, `migrate`, and the `effects` subcommands (previously stomped to 0 by the invocation pipeline).
+- **JSON mode always emits exactly one envelope document**, including on error paths, with CLI-band diagnostics (`Calor1310`–`1312`).
+- **Counterexample rendering filters internal solver variables** across all producers.
+
 ## [0.8.0] - 2026-07-23
 
 The correctness-hardening release: every exit-0-then-broken-`dotnet build` hole in the binding/rebind/shadowing family is now caught at `calor -i` with a clear diagnostic, plus a systemic pass to keep every diagnostic agent-friendly.

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calor-website",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/website/public/data/benchmark-results.json
+++ b/website/public/data/benchmark-results.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
-  "timestamp": "2026-07-23T18:57:36.826575Z",
-  "commit": "d6cd0dc6",
+  "timestamp": "2026-07-29T16:11:50.260611Z",
+  "commit": "db8c1e4b",
   "frameworkVersion": "1.0.0",
   "summary": {
     "overallAdvantage": 1.32,

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -15,9 +15,9 @@ export function WhatsNewBanner() {
         <div className="flex items-center justify-center gap-3 text-sm">
           <Sparkles className="h-4 w-4 text-calor-cerulean flex-shrink-0" />
           <p className="text-center">
-            <span className="font-semibold text-calor-cerulean">v0.8.0</span>
+            <span className="font-semibold text-calor-cerulean">v0.9.0</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">The correctness-hardening release: every exit-0-then-broken-build hole in the binding, rebind, and shadowing family is now caught at <code>calor -i</code> with a clear diagnostic (<code>Calor0254</code>&ndash;<code>0258</code>); every diagnostic surface-spells types for agents; and <code>calor convert --passthrough</code> keeps converter output always parseable.</span>
+            <span className="text-foreground">The Loop release: one machine-readable envelope across every command and MCP tool, a transactional MCP write path with warm sessions (P50 2 ms edit feedback), and paired A/B measurements showing ~35% fewer agent tokens-to-green and 9/9 vs 4/9 seeded-defect catches against the C# toolkit.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"


### PR DESCRIPTION
## Summary
- Bump version to 0.9.0 (the Loop release — loop plan v0.9 program complete, PP-L6 release blocker cleared at m5-compare-001)
- Update CHANGELOG.md with release date, benchmark results, and the program's measured results (PP-L5/PP-W1)
- Update website changelog and WhatsNewBanner
- Update benchmark results JSON for website dashboard

## Benchmark Results (Statistical: 30 runs)
- **Overall Advantage**: 1.32x (Calor leads, 32.0%)
- **Categories**: Calor wins 7, C# wins 1 (Comprehension 1.84x, ErrorDetection 1.49x, TokenEconomics 1.42x, RefactoringStability 1.38x, EditPrecision 1.36x; InformationDensity 0.98x C#)
- **Benchmarks Evaluated**: 217 (Calor compiles 217/217, C# 216/217)

## Checklist
- [x] Version updated in Directory.Build.props
- [x] Version updated in editors/vscode/package.json
- [x] Version updated in website/package.json
- [x] CHANGELOG.md updated with version, date, and benchmark summary
- [x] website/content/changelog.mdx updated with version and changes (no benchmark stats)
- [x] website/src/components/landing/WhatsNewBanner.tsx updated with version and headline
- [x] website/public/data/benchmark-results.json updated with latest results

🤖 Generated with [Claude Code](https://claude.com/claude-code)
