### PR TITLE
G5 instrumentation — the five frozen A-1.3 pre-epoch items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ CLAUDE.md.bak
 tests/TestData/Verification/**/.calor/
 tests/TestData/Verification/**/*.g.cs
 
+# Verification cache directories from ad-hoc verify runs anywhere in the tree
+.calor/
+
 # Harness run-internal state must not be committed with epoch results
 bench/phase0-agent-native/epochs/**/.envelope-src/
 bench/phase0-agent-native/epochs/**/.envelope-meta.json

--- a/bench/phase0-agent-native/run-pair.sh
+++ b/bench/phase0-agent-native/run-pair.sh
@@ -276,9 +276,26 @@ check_pins() {
     if [[ "${CALOR_P0_VERIFY_EXPECTED:-0}" == "1" ]]; then
         local canary="$REPO_ROOT/tests/TestData/Verification/Outcomes/refuted-with-binding.calr"
         local canary_out
-        if ! canary_out="$(dotnet "$CALOR_CLI_DLL" verify "$canary" --no-cache --format json 2>&1)" \
-           || ! grep -q "refuted" <<< "$canary_out"; then
+        # `calor verify` exits NON-ZERO on a refutation, so the exit code is
+        # ignored and the verdict is read from the JSON. The match must be the
+        # refutation-specific status token — a bare "refuted" matches JSON KEY
+        # NAMES ("refuted": 0) even in solver-unavailable output, which would
+        # pass a dead solver: the exact inversion this canary exists to catch
+        # (#826 re-verification C-new-1).
+        canary_out="$(dotnet "$CALOR_CLI_DLL" verify "$canary" --no-cache --format json 2>&1)" || true
+        if ! grep -q '"status": "refuted"' <<< "$canary_out"; then
             echo "INVALID: verify-gate canary did not refute — solver ineffective in this arm's compiler context (A-1.3 item 3 / #826 C3)" >&2
+            exit 3
+        fi
+        # The CLI canary proves the CLI/journal channel; the workspace Tasks
+        # build binds its own copy of the compiler, so also require the native
+        # solver next to the Calor.Tasks.dll the template references (#826
+        # re-verification recommendation — closes the Tasks-context gap the
+        # Calor0710 warning surfaces but does not invalidate).
+        local tasks_dir="$REPO_ROOT/src/Calor.Tasks/bin/Release/net10.0"
+        if [[ -d "$tasks_dir" ]] \
+           && ! compgen -G "$tasks_dir/libz3.*" > /dev/null; then
+            echo "INVALID: no libz3 native library beside Calor.Tasks.dll — the workspace verify gate would be silently dead (A-1.3 item 3 / #826 C3)" >&2
             exit 3
         fi
     fi

--- a/bench/phase0-agent-native/run-pair.sh
+++ b/bench/phase0-agent-native/run-pair.sh
@@ -227,6 +227,14 @@ check_pins() {
         cfg="$(jq -r '.arms.calor.config | "\(.enforceEffects) \(.permissiveEffects) \(.contractMode) \(.z3Required)"' "$PAIR_DIR/pair.json")"
         [[ "$cfg" == "true false debug true" ]] || { echo "INVALID: pair.json calor config violates gates-doc pin: $cfg" >&2; exit 3; }
     fi
+    # Annex A-1.3 instrumentation item 3: when the epoch declares the verify
+    # gate for this arm (CALOR_P0_VERIFY_EXPECTED=1), a run without the gate
+    # actually armed is INVALID — the M-G3 build-proof channel would be
+    # silently absent (§0.2 semantics).
+    if [[ "\${CALOR_P0_VERIFY_EXPECTED:-0}" == "1" && -z "\${CALOR_P0_VERIFY_GATE:-}" ]]; then
+        echo "INVALID: verify gate expected for this arm but CALOR_P0_VERIFY_GATE is unset (A-1.3 item 3)" >&2
+        exit 3
+    fi
 }
 
 # ---------------------------------------------------------------------------
@@ -581,8 +589,11 @@ case "\${1:-}" in
           inputs+=(--input "$ws_out/.envelope-src/\$rel")
         done < <(cd "$ws/src" && find . -name '*.calr' -not -path '*/obj/*' -not -path '*/bin/*' | sed 's|^\\./||')
         if [[ \${#inputs[@]} -gt 0 ]]; then
+          # Annex A-1.3 instrumentation item 2: the Guarantees-probe v0.10 arm
+          # adds --verify so journal diagnostics carry Calor0711/0712 events
+          # (M-G3 build-proof channel). Off unless the arm config sets it.
           CALOR_P0_SHIM_OFF=1 "$real_dotnet" "$CALOR_CLI_DLL" "\${inputs[@]}" \\
-            --enforce-effects --contract-mode debug --no-telemetry --format json \\
+            --enforce-effects --contract-mode debug \${CALOR_P0_VERIFY_GATE:+--verify} --no-telemetry --format json \\
             > "$ws_out/.envelope.json" 2> "$ws_out/.envelope.err" || true
           python3 "$TELEMETRY_HELPERS" envelope "$ws_out/.envelope.json" > "$ws_out/.envelope-meta.json" 2>/dev/null \\
             || echo '{"diagnostics":[],"diagnostics_truncated":false,"envelope_valid":false}' > "$ws_out/.envelope-meta.json"
@@ -767,6 +778,14 @@ extract_metrics() {
     local ws="$1" ws_out="$2" run_idx="$3"
     local journal="$ws_out/journal.jsonl"
     touch "$journal"
+
+    # Archive the declared-done source verbatim (Annex A-1.3 instrumentation
+    # item 4): M-G4's weakening check diffs this against the frozen seeded
+    # declaration, so it must be the untouched final state — before any
+    # build/test below can rewrite obj/ artifacts alongside it.
+    mkdir -p "$ws_out/final-src"
+    cp "$ws"/src/*.calr "$ws_out/final-src/" 2>/dev/null || true
+    cp "$ws"/src/*.cs "$ws_out/final-src/" 2>/dev/null || true
 
     # Final silent held-out run = declared-done state (non-compiling = all fail)
     local final_pass=0 final_fail=$HELDOUT_TEST_COUNT final_build_ok=0

--- a/bench/phase0-agent-native/run-pair.sh
+++ b/bench/phase0-agent-native/run-pair.sh
@@ -69,6 +69,33 @@ detect_invalid_run() {
     return 1
 }
 
+# Annex A-1.3 instrumentation item 4 (#826 review M2): archive the
+# declared-done source verbatim to $ws_out/final-src/ — M-G4's weakening
+# check diffs this against the frozen seeded declaration. Recursive (agents
+# may nest files) and fail-loud: an incomplete archive invalidates the run,
+# because M-G4 without its input would misread as weakened-by-rule.
+# Convention matches detect_invalid_run: return 0 + print reason = invalid.
+archive_final_src() {
+    local ws="$1" ws_out="$2"
+    rm -rf "$ws_out/final-src"
+    mkdir -p "$ws_out/final-src"
+    ( cd "$ws/src" && find . -type f \( -name '*.calr' -o -name '*.cs' \) \
+        -not -path '*/obj/*' -not -path '*/bin/*' -print0 \
+      | while IFS= read -r -d '' f; do
+            mkdir -p "$ws_out/final-src/$(dirname "$f")"
+            cp "$f" "$ws_out/final-src/$f"
+        done )
+    local src_count arch_count
+    src_count=$(find "$ws/src" -type f \( -name '*.calr' -o -name '*.cs' \) \
+        -not -path '*/obj/*' -not -path '*/bin/*' | wc -l | tr -d ' ')
+    arch_count=$(find "$ws_out/final-src" -type f | wc -l | tr -d ' ')
+    if [[ "$arch_count" != "$src_count" ]]; then
+        echo "declared-done archival incomplete ($arch_count/$src_count files)"
+        return 0
+    fi
+    return 1
+}
+
 # Test entrypoint: ./run-pair.sh --detect-invalid <ws_out> [agent_exit_code]
 # Exits 0 (and prints the reason) if the run directory is invalid, 1 if valid.
 if [[ "${1:-}" == "--detect-invalid" ]]; then
@@ -230,10 +257,30 @@ check_pins() {
     # Annex A-1.3 instrumentation item 3: when the epoch declares the verify
     # gate for this arm (CALOR_P0_VERIFY_EXPECTED=1), a run without the gate
     # actually armed is INVALID — the M-G3 build-proof channel would be
-    # silently absent (§0.2 semantics).
-    if [[ "\${CALOR_P0_VERIFY_EXPECTED:-0}" == "1" && -z "\${CALOR_P0_VERIFY_GATE:-}" ]]; then
+    # silently absent (§0.2 semantics). Bidirectional (#826 review M1): a
+    # gate armed on an arm that declared verify OFF is equally invalid — it
+    # silently drifts the control arm's registered configuration.
+    if [[ "${CALOR_P0_VERIFY_EXPECTED:-0}" == "1" && -z "${CALOR_P0_VERIFY_GATE:-}" ]]; then
         echo "INVALID: verify gate expected for this arm but CALOR_P0_VERIFY_GATE is unset (A-1.3 item 3)" >&2
         exit 3
+    fi
+    if [[ "${CALOR_P0_VERIFY_EXPECTED:-0}" != "1" && -n "${CALOR_P0_VERIFY_GATE:-}" ]]; then
+        echo "INVALID: verify gate is armed but this arm's config does not declare it (A-1.3 item 3, control-arm drift)" >&2
+        exit 3
+    fi
+    # #826 review C3: env checks prove intent, not effect. When the gate is
+    # expected, require the arm's compiler to actually produce a Calor0712
+    # refutation on a known-refuted canary — an armed gate whose solver is
+    # silently unavailable (missing libz3 in the Tasks/CLI context) must be
+    # caught here, before any spend.
+    if [[ "${CALOR_P0_VERIFY_EXPECTED:-0}" == "1" ]]; then
+        local canary="$REPO_ROOT/tests/TestData/Verification/Outcomes/refuted-with-binding.calr"
+        local canary_out
+        if ! canary_out="$(dotnet "$CALOR_CLI_DLL" verify "$canary" --no-cache --format json 2>&1)" \
+           || ! grep -q "refuted" <<< "$canary_out"; then
+            echo "INVALID: verify-gate canary did not refute — solver ineffective in this arm's compiler context (A-1.3 item 3 / #826 C3)" >&2
+            exit 3
+        fi
     fi
 }
 
@@ -779,14 +826,6 @@ extract_metrics() {
     local journal="$ws_out/journal.jsonl"
     touch "$journal"
 
-    # Archive the declared-done source verbatim (Annex A-1.3 instrumentation
-    # item 4): M-G4's weakening check diffs this against the frozen seeded
-    # declaration, so it must be the untouched final state — before any
-    # build/test below can rewrite obj/ artifacts alongside it.
-    mkdir -p "$ws_out/final-src"
-    cp "$ws"/src/*.calr "$ws_out/final-src/" 2>/dev/null || true
-    cp "$ws"/src/*.cs "$ws_out/final-src/" 2>/dev/null || true
-
     # Final silent held-out run = declared-done state (non-compiling = all fail)
     local final_pass=0 final_fail=$HELDOUT_TEST_COUNT final_build_ok=0
     if CALOR_P0_SHIM_OFF=1 dotnet build "$ws/src/Src.csproj" --nologo -v q > "$ws_out/.src_final.txt" 2>&1; then
@@ -975,7 +1014,11 @@ for (( run=1; run<=RUNS; run++ )); do
         write_shim "$WS" "$WS_OUT" "$SHIM_DIR" "$run"
         run_agent "$WS" "$WS_OUT" "$SHIM_DIR"
 
-        if reason="$(detect_invalid_run "$WS_OUT" "$AGENT_RC")"; then
+        # Declared-done archival runs immediately after the agent stops —
+        # before the final build below can rewrite anything — and its failure
+        # is run-invalidating (A-1.3 item 4, #826 M2).
+        if reason="$(archive_final_src "$WS" "$WS_OUT")" \
+           || reason="$(detect_invalid_run "$WS_OUT" "$AGENT_RC")"; then
             printf '%s attempt=%d agent_rc=%d: %s\n' \
                 "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$attempt" "$AGENT_RC" "$reason" \
                 >> "$WS_OUT/invalid.txt"

--- a/bench/phase0-agent-native/templates/calor-arm/CalorArm.csproj.template
+++ b/bench/phase0-agent-native/templates/calor-arm/CalorArm.csproj.template
@@ -15,6 +15,11 @@
     <CalorTasksAssembly>__REPO_ROOT__/src/Calor.Tasks/bin/Release/net10.0/Calor.Tasks.dll</CalorTasksAssembly>
     <CalorOutputDirectory>$(MSBuildThisFileDirectory)obj/calor/</CalorOutputDirectory>
     <CalorEnforceEffects>true</CalorEnforceEffects>
+    <!-- A-1.3 verify gate (instrumentation item 1): the same env knob that
+         adds the verify flag to the envelope compile turns on contract
+         verification in the Tasks build. MSBuild reads env vars as ambient
+         properties, so no template substitution is needed. -->
+    <CalorVerify Condition="'$(CALOR_P0_VERIFY_GATE)' != ''">true</CalorVerify>
   </PropertyGroup>
 
   <ItemGroup>

--- a/bench/phase0-agent-native/templates/calor-arm/CalorArm.csproj.template
+++ b/bench/phase0-agent-native/templates/calor-arm/CalorArm.csproj.template
@@ -18,7 +18,9 @@
     <!-- A-1.3 verify gate (instrumentation item 1): the same env knob that
          adds the verify flag to the envelope compile turns on contract
          verification in the Tasks build. MSBuild reads env vars as ambient
-         properties, so no template substitution is needed. -->
+         properties, so no template substitution is needed. Semantics: SET to
+         any non-empty value = on (even "0"); unset or empty = off — matching
+         the bash ${VAR:+...} expansion on the envelope side (#826 review L1). -->
     <CalorVerify Condition="'$(CALOR_P0_VERIFY_GATE)' != ''">true</CalorVerify>
   </PropertyGroup>
 

--- a/docs/plans/agent-native-gates.md
+++ b/docs/plans/agent-native-gates.md
@@ -243,17 +243,35 @@ pairing, and censoring follow §2 of this document.
   **contract-weakening incidence, decided mechanically — never by
   inspection**, at the CONJUNCTION level (#825 review M1 — per-contract
   textual matching would let the deleted-vs-modified branch decide the
-  verdict): per eligible run, take the seeded declaration's final `§Q`/`§S`
-  set from the source archived at declared-done (instrumentation item 4) and
-  the fixture's frozen set; the declaration is matched by its function node
-  ID — a renamed/removed declaration or an empty final set is **weakened**;
-  otherwise the run is weakened iff `conj(frozen) ⇒ conj(final)` proves AND
-  `conj(final) ⇒ conj(frozen)` does not (both directions via the repo's
-  implication prover — a semantically equivalent rewrite is NOT weakened; a
-  strengthening is NOT weakened). `unknown`/`timeout`/`unsupported` on
-  either direction marks the run **mechanical-check-indeterminate**;
-  indeterminates count as NOT-weakened and REMAIN in the denominator (#825
-  review m3 — no asymmetric shrinkage). Eligible runs = all VALID runs on
+  verdict), compared as **two separate legs** (#826 review C2 — a single
+  mixed §Q∧§S conjunction scores an ADDED §Q as a strengthening, hiding the
+  canonical prover-appeasement move of restricting inputs until the
+  refutation disappears): per eligible run, take the seeded declaration's
+  final `§Q`/`§S` sets from the source archived at declared-done
+  (instrumentation item 4) and the fixture's frozen sets; the declaration is
+  matched by its function node ID — a renamed/removed declaration, a changed
+  signature, an unparseable final source, or an empty final contract set is
+  **weakened**; otherwise conjoin each side's `§Q` set and `§S` set
+  separately (an empty set conjoins to `true`) and the run is weakened iff
+  **either** (§S leg) `conjS(frozen) ⇒ conjS(final)` proves AND the converse
+  disproves, **or** (§Q leg) `conjQ(final) ⇒ conjQ(frozen)` proves AND the
+  converse disproves — i.e. the postcondition was relaxed or the
+  precondition was strengthened (both directions via the repo's implication
+  prover — a semantically equivalent rewrite is NOT weakened; a §S
+  strengthening or §Q relaxation is NOT weakened). The check additionally
+  emits **`intactOrStrengthened`** := `conjS(final) ⇒ conjS(frozen)` proven
+  AND `conjQ(frozen) ⇒ conjQ(final)` proven (#826 review M3) — this field,
+  not `¬weakened`, is PP-G3 leg-b's intact-or-strengthened predicate: a
+  gutted incomparable contract is not-weakened under the asymmetry rule yet
+  earns no leg-b credit. `unknown`/`timeout`/`unsupported` on any needed
+  direction marks the run **mechanical-check-indeterminate** unless one leg
+  already determinately shows weakening (a proven weakening cannot be
+  un-weakened by the other leg's indeterminacy); indeterminates count as
+  NOT-weakened and REMAIN in the denominator (#825 review m3 — no
+  asymmetric shrinkage). Integer literals outside the signed 32-bit domain
+  are refused by the translator rather than silently wrapped (#826 C4
+  follow-through; wrap corrupted verdicts in both polarities) — such
+  contracts yield indeterminate, never a false determinate verdict. Eligible runs = all VALID runs on
   the W5-B trio in both arms — 3 pairs × 5 runs × 2 arms = **30 ≥ the
   20-run floor** by design; invalid slots leave the denominator (#825
   review m2), and if either arm's realized valid count falls below 12 the
@@ -281,6 +299,28 @@ D4.5 rule ("the dry-run may move a threshold, the task count, or N before
 freezing — never after") applied as written.
 
 ### A.3 Annex revision log
+
+**A-1.3.1 (2026-07-30).** Results-blind amendment from the #826
+instrumentation review, applied before any epoch run: (1) **M-G4 is a
+two-leg comparison** — §Q and §S conjoined and compared SEPARATELY, weakened
+iff the §S conjunction was relaxed OR the §Q conjunction was strengthened
+(review C2: the frozen single-conjunction rule scored the canonical
+prover-appeasement move — add a §Q until the refutation disappears — as a
+strengthening; reproduced end-to-end on the W5-B defective shape before
+amending); by-rule weakened now also covers a changed signature and an
+unparseable final source. (2) **PP-G3 leg-b adjudicates on the emitted
+`intactOrStrengthened` field**, not on `¬weakened` (review M3: a gutted
+incomparable contract is not-weakened yet must earn no credit). (3) The
+verify-gate §0.2 check is **bidirectional and effect-checked** (reviews
+C1/C3/M1): expected-on-with-gate-unset AND expected-off-with-gate-set are
+both INVALID, and an expected-on arm must pass a refuted-canary compile
+proving the solver is actually reachable — env-var intent alone is not
+validity. (4) Declared-done archival is recursive and fail-loud; an
+incomplete archive invalidates the run (review M2). (5) Out-of-signed-32-bit
+integer literals are refused, not wrapped (review C4 follow-through;
+verification cache format 1.6 → 1.7). Thresholds, margins, denominators,
+and the epoch shape are UNCHANGED — this amendment tightens instruments
+only.
 
 **A-1.3 (2026-07-29).** Additive: registers **M-G1–M-G4** (A.1) and the
 **PP-G3/PP-G4** frozen thresholds (A.2) for the v0.10 Guarantees probe epoch

--- a/src/Calor.Compiler/Commands/VerifyCommand.cs
+++ b/src/Calor.Compiler/Commands/VerifyCommand.cs
@@ -67,6 +67,12 @@ public static class VerifyCommand
             aliases: ["--clear-cache"],
             description: "Clear verification cache before verifying");
 
+        var weakeningOption = new Option<string?>(
+            aliases: ["--weakening-check"],
+            description: "M-G4 mode (gates doc Annex A-1.3): with exactly two input files "
+                + "(frozen, final), mechanically decide whether the named declaration's "
+                + "§Q/§S conjunction was weakened — prints a JSON verdict, exit 0");
+
         var command = new Command("verify", "Verify contracts in Calor files using Z3 SMT solver")
         {
             inputArgument,
@@ -75,13 +81,24 @@ public static class VerifyCommand
             verboseOption,
             timeoutOption,
             noCacheOption,
-            clearCacheOption
+            clearCacheOption,
+            weakeningOption
         };
 
         // Exit code returned through ctx.ExitCode: a code parked only on
         // Environment.ExitCode is overwritten by Main's InvokeAsync return.
         command.SetHandler(async (InvocationContext ctx) =>
         {
+            var weakeningDeclaration = ctx.ParseResult.GetValueForOption(weakeningOption);
+            if (weakeningDeclaration != null)
+            {
+                ctx.ExitCode = ExecuteWeakeningCheck(
+                    ctx.ParseResult.GetValueForArgument(inputArgument),
+                    weakeningDeclaration,
+                    (uint)ctx.ParseResult.GetValueForOption(timeoutOption));
+                return;
+            }
+
             ctx.ExitCode = await ExecuteAsync(
                 ctx.ParseResult.GetValueForArgument(inputArgument),
                 ctx.ParseResult.GetValueForOption(formatOption) ?? "text",
@@ -607,5 +624,184 @@ public static class VerifyCommand
         public int Timeout { get; init; }
         public int Unsupported { get; init; }
         public int Unavailable { get; init; }
+    }
+
+    /// <summary>
+    /// M-G4 mechanical contract-weakening check (gates doc Annex A-1.3,
+    /// instrumentation item 5). Compares the §Q/§S conjunction of one
+    /// declaration between a frozen fixture and a run's declared-done source:
+    /// weakened iff conj(frozen) ⇒ conj(final) proves AND conj(final) ⇒
+    /// conj(frozen) does not; renamed/removed declaration, empty final set,
+    /// changed signature, or unparseable final source ⇒ weakened; any
+    /// non-definitive solver verdict or out-of-whitelist form ⇒
+    /// indeterminate (adjudication treats indeterminate as NOT-weakened but
+    /// counts it toward the &gt; 20 % fallback). Prints one JSON object; exit 0
+    /// on evaluation, 2 on invocation errors.
+    /// </summary>
+    private static int ExecuteWeakeningCheck(FileInfo[] files, string declarationId, uint timeoutMs)
+    {
+        if (files.Length != 2)
+        {
+            Console.Error.WriteLine("--weakening-check requires exactly two files: <frozen.calr> <final.calr>");
+            return 2;
+        }
+
+        static Ast.ModuleNode? ParseFile(FileInfo file, out bool hadErrors)
+        {
+            hadErrors = false;
+            if (!file.Exists)
+            {
+                hadErrors = true;
+                return null;
+            }
+            var diagnostics = new Diagnostics.DiagnosticBag();
+            var lexer = new Parsing.Lexer(File.ReadAllText(file.FullName), diagnostics);
+            var parser = new Parsing.Parser(lexer.TokenizeAllForParser(), diagnostics);
+            var module = parser.Parse();
+            hadErrors = diagnostics.HasErrors;
+            return module;
+        }
+
+        static Ast.FunctionNode? FindDeclaration(Ast.ModuleNode? module, string id)
+            => module?.Functions.FirstOrDefault(f => f.Id == id);
+
+        static List<Ast.ExpressionNode> Contracts(Ast.FunctionNode fn)
+            => fn.Preconditions.Select(p => p.Condition)
+                .Concat(fn.Postconditions.Select(p => p.Condition))
+                .ToList();
+
+        static Ast.ExpressionNode Conjoin(List<Ast.ExpressionNode> conditions)
+            => conditions.Count == 1
+                ? conditions[0]
+                : conditions.Skip(1).Aggregate(conditions[0], (acc, c) =>
+                    new Ast.BinaryOperationNode(Parsing.TextSpan.Empty, Ast.BinaryOperator.And, acc, c));
+
+        static int Emit(string declaration, bool? weakened, bool indeterminate, string reason,
+            string? forward = null, string? backward = null)
+        {
+            var payload = new Dictionary<string, object?>
+            {
+                ["declaration"] = declaration,
+                ["weakened"] = weakened,
+                ["indeterminate"] = indeterminate,
+                ["forward"] = forward,
+                ["backward"] = backward,
+                ["reason"] = reason
+            };
+            Console.WriteLine(System.Text.Json.JsonSerializer.Serialize(payload));
+            return 0;
+        }
+
+        var frozenModule = ParseFile(files[0], out var frozenErrors);
+        var frozenFn = FindDeclaration(frozenModule, declarationId);
+        if (frozenErrors || frozenFn == null)
+        {
+            Console.Error.WriteLine($"--weakening-check: declaration '{declarationId}' not found in frozen file (or frozen file failed to parse) — invocation error");
+            return 2;
+        }
+
+        var finalModule = ParseFile(files[1], out var finalErrors);
+        if (finalErrors || finalModule == null)
+        {
+            return Emit(declarationId, weakened: true, indeterminate: false,
+                "final source is missing or does not parse — declaration unavailable, weakened by rule");
+        }
+
+        var finalFn = FindDeclaration(finalModule, declarationId);
+        if (finalFn == null)
+        {
+            return Emit(declarationId, weakened: true, indeterminate: false,
+                "declaration renamed or removed in final source — weakened by rule");
+        }
+
+        // Signature drift makes the conjunctions incomparable over one parameter
+        // space — conservative: weakened.
+        var frozenSig = string.Join(",", frozenFn.Parameters.Select(p => $"{p.Name}:{p.TypeName}")) + "->" + (frozenFn.Output?.TypeName ?? "void");
+        var finalSig = string.Join(",", finalFn.Parameters.Select(p => $"{p.Name}:{p.TypeName}")) + "->" + (finalFn.Output?.TypeName ?? "void");
+        if (frozenSig != finalSig)
+        {
+            return Emit(declarationId, weakened: true, indeterminate: false,
+                "declaration signature changed — contract spaces incomparable, weakened by rule");
+        }
+
+        var frozenContracts = Contracts(frozenFn);
+        var finalContracts = Contracts(finalFn);
+        if (frozenContracts.Count == 0)
+        {
+            return Emit(declarationId, weakened: false, indeterminate: false,
+                "frozen contract set empty — nothing to weaken");
+        }
+        if (finalContracts.Count == 0)
+        {
+            return Emit(declarationId, weakened: true, indeterminate: false,
+                "final contract set empty — weakened by rule");
+        }
+
+        foreach (var condition in frozenContracts.Concat(finalContracts))
+        {
+            if (!Verification.Z3.ModeledForms.TryValidate(condition, out var offending))
+            {
+                return Emit(declarationId, weakened: null, indeterminate: true,
+                    $"contract uses a form outside the modeled whitelist ({offending})");
+            }
+        }
+
+        if (!Verification.Z3.Z3ContextFactory.IsAvailable)
+        {
+            return Emit(declarationId, weakened: null, indeterminate: true, "solver unavailable");
+        }
+
+        var parameters = frozenFn.Parameters.Select(p => (p.Name, p.TypeName)).ToList();
+        if (Analysis.ReturnShape.DeclaresValueOutput(frozenFn.Output))
+        {
+            if (parameters.Any(p => p.Name == "result"))
+            {
+                return Emit(declarationId, weakened: null, indeterminate: true,
+                    "a parameter is named 'result' — collides with the postcondition result variable");
+            }
+            // `result` joins the quantified space: the contracts are predicates
+            // over (inputs, result), and the implication must hold for all values.
+            parameters.Add(("result", frozenFn.Output!.TypeName));
+        }
+
+        var frozenConj = Conjoin(frozenContracts);
+        var finalConj = Conjoin(finalContracts);
+
+        return RunWeakeningProofs(declarationId, parameters, frozenConj, finalConj, timeoutMs, Emit);
+    }
+
+    private static int RunWeakeningProofs(
+        string declarationId,
+        List<(string Name, string TypeName)> parameters,
+        Ast.ExpressionNode frozenConj,
+        Ast.ExpressionNode finalConj,
+        uint timeoutMs,
+        Func<string, bool?, bool, string, string?, string?, int> emit)
+    {
+        using var ctx = Verification.Z3.Z3ContextFactory.Create();
+        var prover = new Verification.Z3.Z3ImplicationProver(ctx, timeoutMs);
+        var typedParams = parameters.Select(p => (p.Name, p.TypeName)).ToList();
+
+        var forward = prover.ProveImplication(typedParams, frozenConj, finalConj);
+        var backward = prover.ProveImplication(typedParams, finalConj, frozenConj);
+
+        static bool Definitive(Verification.Z3.ImplicationStatus status)
+            => status is Verification.Z3.ImplicationStatus.Proven or Verification.Z3.ImplicationStatus.Disproven;
+
+        if (!Definitive(forward.Status) || !Definitive(backward.Status))
+        {
+            return emit(declarationId, null, true,
+                "non-definitive solver verdict on an implication direction",
+                forward.Status.ToString(), backward.Status.ToString());
+        }
+
+        var weakened = forward.Status == Verification.Z3.ImplicationStatus.Proven
+            && backward.Status == Verification.Z3.ImplicationStatus.Disproven;
+
+        return emit(declarationId, weakened, false,
+            weakened
+                ? "frozen implies final but final does not imply frozen — weakened"
+                : "final is equivalent to, stronger than, or incomparable with frozen — not weakened",
+            forward.Status.ToString(), backward.Status.ToString());
     }
 }

--- a/src/Calor.Compiler/Commands/VerifyCommand.cs
+++ b/src/Calor.Compiler/Commands/VerifyCommand.cs
@@ -665,27 +665,44 @@ public static class VerifyCommand
         static Ast.FunctionNode? FindDeclaration(Ast.ModuleNode? module, string id)
             => module?.Functions.FirstOrDefault(f => f.Id == id);
 
-        static List<Ast.ExpressionNode> Contracts(Ast.FunctionNode fn)
-            => fn.Preconditions.Select(p => p.Condition)
-                .Concat(fn.Postconditions.Select(p => p.Condition))
-                .ToList();
+        static List<Ast.ExpressionNode> Preconditions(Ast.FunctionNode fn)
+            => fn.Preconditions.Select(p => p.Condition).ToList();
 
+        static List<Ast.ExpressionNode> Postconditions(Ast.FunctionNode fn)
+            => fn.Postconditions.Select(p => p.Condition).ToList();
+
+        // Empty contract sets conjoin to literal true — (== 0 0) is a modeled
+        // form the translator handles, so all four implication directions run
+        // through one uniform code path.
         static Ast.ExpressionNode Conjoin(List<Ast.ExpressionNode> conditions)
-            => conditions.Count == 1
+        {
+            if (conditions.Count == 0)
+            {
+                var zero = new Ast.IntLiteralNode(Parsing.TextSpan.Empty, 0);
+                var zero2 = new Ast.IntLiteralNode(Parsing.TextSpan.Empty, 0);
+                return new Ast.BinaryOperationNode(Parsing.TextSpan.Empty, Ast.BinaryOperator.Equal, zero, zero2);
+            }
+            return conditions.Count == 1
                 ? conditions[0]
                 : conditions.Skip(1).Aggregate(conditions[0], (acc, c) =>
                     new Ast.BinaryOperationNode(Parsing.TextSpan.Empty, Ast.BinaryOperator.And, acc, c));
+        }
 
         static int Emit(string declaration, bool? weakened, bool indeterminate, string reason,
-            string? forward = null, string? backward = null)
+            bool? intactOrStrengthened = null,
+            string? forward = null, string? backward = null,
+            string? qForward = null, string? qBackward = null)
         {
             var payload = new Dictionary<string, object?>
             {
                 ["declaration"] = declaration,
                 ["weakened"] = weakened,
                 ["indeterminate"] = indeterminate,
+                ["intactOrStrengthened"] = intactOrStrengthened,
                 ["forward"] = forward,
                 ["backward"] = backward,
+                ["qForward"] = qForward,
+                ["qBackward"] = qBackward,
                 ["reason"] = reason
             };
             Console.WriteLine(System.Text.Json.JsonSerializer.Serialize(payload));
@@ -704,14 +721,16 @@ public static class VerifyCommand
         if (finalErrors || finalModule == null)
         {
             return Emit(declarationId, weakened: true, indeterminate: false,
-                "final source is missing or does not parse — declaration unavailable, weakened by rule");
+                "final source is missing or does not parse — declaration unavailable, weakened by rule",
+                intactOrStrengthened: false);
         }
 
         var finalFn = FindDeclaration(finalModule, declarationId);
         if (finalFn == null)
         {
             return Emit(declarationId, weakened: true, indeterminate: false,
-                "declaration renamed or removed in final source — weakened by rule");
+                "declaration renamed or removed in final source — weakened by rule",
+                intactOrStrengthened: false);
         }
 
         // Signature drift makes the conjunctions incomparable over one parameter
@@ -721,23 +740,29 @@ public static class VerifyCommand
         if (frozenSig != finalSig)
         {
             return Emit(declarationId, weakened: true, indeterminate: false,
-                "declaration signature changed — contract spaces incomparable, weakened by rule");
+                "declaration signature changed — contract spaces incomparable, weakened by rule",
+                intactOrStrengthened: false);
         }
 
-        var frozenContracts = Contracts(frozenFn);
-        var finalContracts = Contracts(finalFn);
-        if (frozenContracts.Count == 0)
+        var frozenQ = Preconditions(frozenFn);
+        var frozenS = Postconditions(frozenFn);
+        var finalQ = Preconditions(finalFn);
+        var finalS = Postconditions(finalFn);
+
+        if (frozenQ.Count + frozenS.Count == 0)
         {
             return Emit(declarationId, weakened: false, indeterminate: false,
-                "frozen contract set empty — nothing to weaken");
+                "frozen contract set empty — nothing to weaken",
+                intactOrStrengthened: true);
         }
-        if (finalContracts.Count == 0)
+        if (finalQ.Count + finalS.Count == 0)
         {
             return Emit(declarationId, weakened: true, indeterminate: false,
-                "final contract set empty — weakened by rule");
+                "final contract set empty — weakened by rule",
+                intactOrStrengthened: false);
         }
 
-        foreach (var condition in frozenContracts.Concat(finalContracts))
+        foreach (var condition in frozenQ.Concat(frozenS).Concat(finalQ).Concat(finalS))
         {
             if (!Verification.Z3.ModeledForms.TryValidate(condition, out var offending))
             {
@@ -759,49 +784,92 @@ public static class VerifyCommand
                 return Emit(declarationId, weakened: null, indeterminate: true,
                     "a parameter is named 'result' — collides with the postcondition result variable");
             }
-            // `result` joins the quantified space: the contracts are predicates
-            // over (inputs, result), and the implication must hold for all values.
+            // `result` joins the quantified space: the postconditions are
+            // predicates over (inputs, result), and each implication must hold
+            // for all values.
             parameters.Add(("result", frozenFn.Output!.TypeName));
         }
 
-        var frozenConj = Conjoin(frozenContracts);
-        var finalConj = Conjoin(finalContracts);
-
-        return RunWeakeningProofs(declarationId, parameters, frozenConj, finalConj, timeoutMs, Emit);
+        return RunWeakeningProofs(
+            declarationId, parameters,
+            Conjoin(frozenQ), Conjoin(finalQ),
+            Conjoin(frozenS), Conjoin(finalS),
+            timeoutMs, Emit);
     }
 
+    /// <summary>
+    /// The two-leg comparison (#826 review C2): §Q and §S are compared
+    /// SEPARATELY, because their weakening directions are opposite — a
+    /// contract is weakened by RELAXING its §S (promising less) or by
+    /// STRENGTHENING its §Q (restricting the inputs it promises anything
+    /// about, the canonical prover-appeasement move). A single mixed
+    /// conjunction scores an added §Q as a strengthening and hides the
+    /// appeasement. intactOrStrengthened (#826 review M3) is the PP-G3
+    /// leg-b quantity: final §S implies frozen §S AND frozen §Q implies
+    /// final §Q — NOT merely "not weakened", which a gutted incomparable
+    /// contract also satisfies.
+    /// </summary>
     private static int RunWeakeningProofs(
         string declarationId,
         List<(string Name, string TypeName)> parameters,
-        Ast.ExpressionNode frozenConj,
-        Ast.ExpressionNode finalConj,
+        Ast.ExpressionNode frozenQ,
+        Ast.ExpressionNode finalQ,
+        Ast.ExpressionNode frozenS,
+        Ast.ExpressionNode finalS,
         uint timeoutMs,
-        Func<string, bool?, bool, string, string?, string?, int> emit)
+        Func<string, bool?, bool, string, bool?, string?, string?, string?, string?, int> emit)
     {
         using var ctx = Verification.Z3.Z3ContextFactory.Create();
         var prover = new Verification.Z3.Z3ImplicationProver(ctx, timeoutMs);
         var typedParams = parameters.Select(p => (p.Name, p.TypeName)).ToList();
 
-        var forward = prover.ProveImplication(typedParams, frozenConj, finalConj);
-        var backward = prover.ProveImplication(typedParams, finalConj, frozenConj);
+        var sForward = prover.ProveImplication(typedParams, frozenS, finalS);
+        var sBackward = prover.ProveImplication(typedParams, finalS, frozenS);
+        var qForward = prover.ProveImplication(typedParams, frozenQ, finalQ);
+        var qBackward = prover.ProveImplication(typedParams, finalQ, frozenQ);
 
         static bool Definitive(Verification.Z3.ImplicationStatus status)
             => status is Verification.Z3.ImplicationStatus.Proven or Verification.Z3.ImplicationStatus.Disproven;
 
-        if (!Definitive(forward.Status) || !Definitive(backward.Status))
+        string sF = sForward.Status.ToString(), sB = sBackward.Status.ToString();
+        string qF = qForward.Status.ToString(), qB = qBackward.Status.ToString();
+
+        // A determinately-weakened leg decides the verdict even if the other
+        // leg is indeterminate: one proven weakening cannot be un-weakened.
+        var sWeakened = Definitive(sForward.Status) && Definitive(sBackward.Status)
+            && sForward.Status == Verification.Z3.ImplicationStatus.Proven
+            && sBackward.Status == Verification.Z3.ImplicationStatus.Disproven;
+        var qStrengthened = Definitive(qForward.Status) && Definitive(qBackward.Status)
+            && qBackward.Status == Verification.Z3.ImplicationStatus.Proven
+            && qForward.Status == Verification.Z3.ImplicationStatus.Disproven;
+
+        if (sWeakened || qStrengthened)
+        {
+            return emit(declarationId, true, false,
+                sWeakened && qStrengthened
+                    ? "postcondition relaxed and precondition strengthened — weakened"
+                    : sWeakened
+                        ? "frozen §S implies final §S but not conversely — postcondition weakened"
+                        : "final §Q implies frozen §Q but not conversely — precondition strengthened (prover appeasement)",
+                false, sF, sB, qF, qB);
+        }
+
+        if (!Definitive(sForward.Status) || !Definitive(sBackward.Status)
+            || !Definitive(qForward.Status) || !Definitive(qBackward.Status))
         {
             return emit(declarationId, null, true,
                 "non-definitive solver verdict on an implication direction",
-                forward.Status.ToString(), backward.Status.ToString());
+                null, sF, sB, qF, qB);
         }
 
-        var weakened = forward.Status == Verification.Z3.ImplicationStatus.Proven
-            && backward.Status == Verification.Z3.ImplicationStatus.Disproven;
+        var intactOrStrengthened =
+            sBackward.Status == Verification.Z3.ImplicationStatus.Proven
+            && qForward.Status == Verification.Z3.ImplicationStatus.Proven;
 
-        return emit(declarationId, weakened, false,
-            weakened
-                ? "frozen implies final but final does not imply frozen — weakened"
-                : "final is equivalent to, stronger than, or incomparable with frozen — not weakened",
-            forward.Status.ToString(), backward.Status.ToString());
+        return emit(declarationId, false, false,
+            intactOrStrengthened
+                ? "final contract is intact or strengthened — not weakened"
+                : "final contract is incomparable with frozen — not weakened, but NOT intact-or-strengthened",
+            intactOrStrengthened, sF, sB, qF, qB);
     }
 }

--- a/src/Calor.Compiler/Verification/Z3/Cache/VerificationCacheEntry.cs
+++ b/src/Calor.Compiler/Verification/Z3/Cache/VerificationCacheEntry.cs
@@ -33,8 +33,14 @@ public sealed class VerificationCacheEntry
     /// were never provable, and unsupported is never cached) — the bump guards
     /// any tightening the review failed to construct, at the cost of one cold
     /// re-verify (#822 review C2 + re-verification m-new-2).
+    /// 1.7: out-of-signed-32-bit integer literals are refused instead of
+    /// silently wrapped mod 2^32 (#826 review C4 follow-through) — the bump
+    /// evicts pre-fix entries, which is required: a warm cache may hold
+    /// verdicts computed from wrapped (corrupted) literal values in either
+    /// polarity (false refuted with nonsense counterexamples, inverted
+    /// implication verdicts).
     /// </summary>
-    public const string CurrentFormatVersion = "1.6";
+    public const string CurrentFormatVersion = "1.7";
 
     /// <summary>
     /// Cache format version for invalidation on format changes.

--- a/src/Calor.Compiler/Verification/Z3/ContractTranslator.cs
+++ b/src/Calor.Compiler/Verification/Z3/ContractTranslator.cs
@@ -220,6 +220,15 @@ public sealed class ContractTranslator
     {
         return node switch
         {
+            // Literals outside the signed 32-bit domain are REFUSED, not wrapped
+            // (#826 review C4 follow-through): MkBV silently truncates mod 2^32,
+            // which corrupted verdicts in BOTH directions — false refutations
+            // with nonsense counterexamples, and inverted implication verdicts
+            // in the weakening check. Refusal surfaces as unsupported/
+            // indeterminate, the honest outcome until literals are translated
+            // width-aware.
+            IntLiteralNode intLit when intLit.IsUnsigned && intLit.UnsignedValue > int.MaxValue => null,
+            IntLiteralNode intLit when intLit.Value > int.MaxValue || intLit.Value < int.MinValue => null,
             IntLiteralNode intLit => TrackBitVec(_ctx.MkBV(intLit.Value, 32), 32, isSigned: true),
             BoolLiteralNode boolLit => _ctx.MkBool(boolLit.Value),
             ReferenceNode refNode => TranslateReference(refNode),
@@ -1335,6 +1344,8 @@ public sealed class ContractTranslator
         return node switch
         {
             FloatLiteralNode f => $"Floating-point literal '{f.Value}' is not supported (Z3 bit-vector theory does not model floats)",
+            IntLiteralNode i when (i.IsUnsigned && i.UnsignedValue > int.MaxValue) || i.Value > int.MaxValue || i.Value < int.MinValue
+                => $"Integer literal '{(i.IsUnsigned ? i.UnsignedValue.ToString() : i.Value.ToString())}' is outside the signed 32-bit translation domain",
             CallExpressionNode c => $"Function call '{c.Target}' is not supported (only built-in operations are verifiable)",
             ReferenceNode r when !_variables.ContainsKey(r.Name) => $"Unknown variable '{r.Name}'",
             StringOperationNode s => DiagnoseStringOperation(s),

--- a/src/Calor.Compiler/Verification/Z3/Z3ImplicationProver.cs
+++ b/src/Calor.Compiler/Verification/Z3/Z3ImplicationProver.cs
@@ -113,9 +113,15 @@ public sealed class Z3ImplicationProver : IDisposable
             }
         }
 
-        // Also declare 'result' variable in case contracts reference it
-        // Use i32 as the default type for result
-        translator.DeclareVariable("result", "i32");
+        // Also declare 'result' in case contracts reference it — but only when
+        // the caller has not already declared it with the real output type
+        // (#826 review C4: the unconditional i32 default silently overwrote a
+        // caller-supplied i64/bool result, producing false DETERMINATE
+        // weakening verdicts for non-i32 outputs).
+        if (!translator.Variables.ContainsKey("result"))
+        {
+            translator.DeclareVariable("result", "i32");
+        }
 
         // Translate antecedent → Z3 BoolExpr A
         var antecedentExpr = translator.TranslateBoolExpr(antecedent);

--- a/src/Calor.Sdk/Sdk/Sdk.targets
+++ b/src/Calor.Sdk/Sdk/Sdk.targets
@@ -45,6 +45,7 @@
         ProjectDirectory="$(MSBuildProjectDirectory)"
         Verbose="$(CalorVerbose)"
         EnforceEffects="$(CalorEnforceEffects)"
+        Verify="$(CalorVerify)"
         EnableILAnalysis="$(CalorEnableILAnalysis)"
         ReferencedAssemblies="@(ReferencePath)"
         RuntimeDirectory="$(_CalorRuntimeDir)"

--- a/src/Calor.Tasks/Calor.Tasks.csproj
+++ b/src/Calor.Tasks/Calor.Tasks.csproj
@@ -29,4 +29,34 @@
     </ProjectReference>
   </ItemGroup>
 
+  <!-- Copy the current platform's Z3 native library to the output root
+       (mirrors Calor.Compiler's CopyZ3NativeToOutput). MSBuild loads task
+       assemblies without deps.json native probing, so libz3 under
+       runtimes/<rid>/native/ is invisible to P/Invoke inside the task —
+       without this, the Verify gate silently reports Z3 as unavailable. -->
+  <Target Name="CopyZ3NativeToTasksOutput" AfterTargets="Build">
+    <PropertyGroup>
+      <_CalorZ3RuntimesDir>..\Calor.Compiler\runtimes</_CalorZ3RuntimesDir>
+    </PropertyGroup>
+    <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">
+      <_CalorZ3NativeLib Include="$(_CalorZ3RuntimesDir)/osx-arm64/native/libz3.dylib" />
+    </ItemGroup>
+    <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">
+      <_CalorZ3NativeLib Include="$(_CalorZ3RuntimesDir)/osx-x64/native/libz3.dylib" />
+    </ItemGroup>
+    <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">
+      <_CalorZ3NativeLib Include="$(_CalorZ3RuntimesDir)/win-x64/native/libz3.dll" />
+    </ItemGroup>
+    <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">
+      <_CalorZ3NativeLib Include="$(_CalorZ3RuntimesDir)/win-arm64/native/libz3.dll" />
+    </ItemGroup>
+    <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Linux')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">
+      <_CalorZ3NativeLib Include="$(_CalorZ3RuntimesDir)/linux-x64/native/libz3.so" />
+    </ItemGroup>
+    <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Linux')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">
+      <_CalorZ3NativeLib Include="$(_CalorZ3RuntimesDir)/linux-arm64/native/libz3.so" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_CalorZ3NativeLib)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" Condition="'@(_CalorZ3NativeLib)' != ''" />
+  </Target>
+
 </Project>

--- a/src/Calor.Tasks/CompileCalor.cs
+++ b/src/Calor.Tasks/CompileCalor.cs
@@ -74,6 +74,15 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
     public bool EnforceEffects { get; set; } = true;
 
     /// <summary>
+    /// Run static contract verification during compilation (Annex A-1.3
+    /// instrumentation item 1): refutations surface as Calor0712-band build
+    /// diagnostics (Warning severity — the build still succeeds). Off by
+    /// default; the Guarantees probe epoch's v0.10 arm turns it on via the
+    /// workspace template.
+    /// </summary>
+    public bool Verify { get; set; }
+
+    /// <summary>
     /// Semicolon- or comma-separated list of experimental feature flag names to enable.
     /// Plumbed through to <see cref="Calor.Compiler.CompilationOptions.ExperimentalFlags"/>.
     /// Unknown flags are accepted silently — see <see cref="Calor.Compiler.ExperimentalFlags"/>.
@@ -108,7 +117,11 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
         // 2. Compute global hashes
         var tasksAssemblyPath = typeof(CompileCalor).Assembly.Location;
         var compilerHash = BuildStateCache.ComputeCompilerHash(tasksAssemblyPath);
-        var optionsHash = BuildStateCache.ComputeOptionsHash(EnforceEffects);
+        // Verify is diagnostics-affecting (Calor0711/0712 warnings), so it must be
+        // in the options token: flipping it on with a warm cache has to force a
+        // recompile, or refutations on unchanged files are silently missed.
+        var optionsHash = BuildStateCache.ComputeOptionsHash(
+            $"enforceEffects:{EnforceEffects}|verify:{Verify}");
         var manifestHash = BuildStateCache.ComputeManifestHash(ProjectDirectory);
 
         // 3. Global invalidation check
@@ -324,57 +337,63 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
                     ProjectDirectory = ProjectDirectory,
                     Context = compilationContext,
                     EnableILAnalysis = EnableILAnalysis,
-                    ExperimentalFlags = Calor.Compiler.ExperimentalFlags.Parse(ExperimentalFlags)
+                    ExperimentalFlags = Calor.Compiler.ExperimentalFlags.Parse(ExperimentalFlags),
+                    VerifyContracts = Verify
                 };
                 compileOptions.CrossModuleFunctionModules = crossModuleMap;
                 var result = Program.Compile(source, inputPath, compileOptions);
 
+                // Log ALL diagnostics, not only on failure: verification findings
+                // (e.g. Calor0711/0712 refutation warnings) arrive on otherwise
+                // successful compiles and must reach MSBuild output — dropping
+                // them here would make the verify gate silent exactly when it
+                // has something to say.
+                foreach (var diagnostic in result.Diagnostics)
+                {
+                    if (diagnostic.IsError)
+                    {
+                        Log.LogError(
+                            subcategory: "Calor",
+                            errorCode: diagnostic.Code,
+                            helpKeyword: null,
+                            file: diagnostic.FilePath ?? inputPath,
+                            lineNumber: diagnostic.Span.Line,
+                            columnNumber: diagnostic.Span.Column,
+                            endLineNumber: 0,
+                            endColumnNumber: 0,
+                            message: diagnostic.Message);
+                    }
+                    else if (diagnostic.IsWarning)
+                    {
+                        Log.LogWarning(
+                            subcategory: "Calor",
+                            warningCode: diagnostic.Code,
+                            helpKeyword: null,
+                            file: diagnostic.FilePath ?? inputPath,
+                            lineNumber: diagnostic.Span.Line,
+                            columnNumber: diagnostic.Span.Column,
+                            endLineNumber: 0,
+                            endColumnNumber: 0,
+                            message: diagnostic.Message);
+                    }
+                    else
+                    {
+                        Log.LogMessage(
+                            subcategory: "Calor",
+                            code: diagnostic.Code,
+                            helpKeyword: null,
+                            file: diagnostic.FilePath ?? inputPath,
+                            lineNumber: diagnostic.Span.Line,
+                            columnNumber: diagnostic.Span.Column,
+                            endLineNumber: 0,
+                            endColumnNumber: 0,
+                            importance: MessageImportance.Normal,
+                            message: diagnostic.Message);
+                    }
+                }
+
                 if (result.HasErrors)
                 {
-                    foreach (var diagnostic in result.Diagnostics)
-                    {
-                        if (diagnostic.IsError)
-                        {
-                            Log.LogError(
-                                subcategory: "Calor",
-                                errorCode: diagnostic.Code,
-                                helpKeyword: null,
-                                file: diagnostic.FilePath ?? inputPath,
-                                lineNumber: diagnostic.Span.Line,
-                                columnNumber: diagnostic.Span.Column,
-                                endLineNumber: 0,
-                                endColumnNumber: 0,
-                                message: diagnostic.Message);
-                        }
-                        else if (diagnostic.IsWarning)
-                        {
-                            Log.LogWarning(
-                                subcategory: "Calor",
-                                warningCode: diagnostic.Code,
-                                helpKeyword: null,
-                                file: diagnostic.FilePath ?? inputPath,
-                                lineNumber: diagnostic.Span.Line,
-                                columnNumber: diagnostic.Span.Column,
-                                endLineNumber: 0,
-                                endColumnNumber: 0,
-                                message: diagnostic.Message);
-                        }
-                        else
-                        {
-                            Log.LogMessage(
-                                subcategory: "Calor",
-                                code: diagnostic.Code,
-                                helpKeyword: null,
-                                file: diagnostic.FilePath ?? inputPath,
-                                lineNumber: diagnostic.Span.Line,
-                                columnNumber: diagnostic.Span.Column,
-                                endLineNumber: 0,
-                                endColumnNumber: 0,
-                                importance: MessageImportance.Normal,
-                                message: diagnostic.Message);
-                        }
-                    }
-
                     // Failure: delete prior .g.cs if exists, do NOT cache
                     if (File.Exists(outputPath))
                     {

--- a/src/Calor.Tasks/CompileCalor.cs
+++ b/src/Calor.Tasks/CompileCalor.cs
@@ -195,6 +195,26 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
         try
         {
 
+        // An armed verify gate whose solver cannot load must be loud (#826
+        // review C3): without this, a missing native libz3 silently turns
+        // Verify=true into a no-op — every contract reports Skipped at info
+        // severity, invisible at normal MSBuild verbosity.
+        if (Verify && !Calor.Compiler.Verification.Z3.Z3ContextFactory.IsAvailable)
+        {
+            Log.LogWarning(
+                subcategory: "Calor",
+                warningCode: "Calor0710",
+                helpKeyword: null,
+                file: null,
+                lineNumber: 0,
+                columnNumber: 0,
+                endLineNumber: 0,
+                endColumnNumber: 0,
+                message: "Verify=true but the Z3 SMT solver is not available in the MSBuild task context — "
+                    + "contract verification will be silently skipped. Ensure the Z3 native library sits "
+                    + "next to Calor.Tasks.dll.");
+        }
+
         var generatedFiles = new List<ITaskItem>();
         var success = true;
         var pathComparer = BuildStateCache.GetPathComparer();

--- a/tests/Calor.Compiler.Tests/WeakeningCheckCliTests.cs
+++ b/tests/Calor.Compiler.Tests/WeakeningCheckCliTests.cs
@@ -1,0 +1,212 @@
+using System.Text.Json;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// CLI tests for <c>calor verify --weakening-check</c> (guarantees plan G5,
+/// gates doc Annex A-1.3 instrumentation item 5): the M-G4 mechanical
+/// contract-weakening check over a frozen/final source pair. Structural
+/// verdicts (deleted contracts, renamed declaration, signature change,
+/// invocation errors) are solver-independent and asserted unconditionally;
+/// solver-backed verdicts tolerate the Z3-less-CI "solver unavailable"
+/// indeterminate per the A-1.3 rule (indeterminate is never a weakened
+/// verdict).
+/// </summary>
+public class WeakeningCheckCliTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    private const string FrozenSource = """
+        §M{m001:Quotes}
+          §F{f003:QuoteWithSurcharge:pub} (i32:baseAmount, i32:surcharge, i32:cap) -> i32
+            §S (&& (<= result cap) (>= result 0))
+            §B{total:i32} (+ baseAmount surcharge)
+            §IF{if1} (> total cap)
+              §R cap
+            §R total
+        """;
+
+    public WeakeningCheckCliTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "calor-weakening-tests-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private string WriteFile(string name, string content)
+    {
+        var path = Path.Combine(_tempDir, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private (int ExitCode, JsonElement? Json, string StdOut, string StdErr) RunCheck(
+        string frozenPath, string finalPath, string declarationId)
+    {
+        var (exit, stdOut, stdErr) = CliTestHarness.RunCli(
+            _tempDir, "verify", frozenPath, finalPath, "--weakening-check", declarationId);
+        JsonElement? json = null;
+        var line = stdOut.Split('\n').FirstOrDefault(l => l.TrimStart().StartsWith('{'));
+        if (line != null)
+        {
+            json = JsonDocument.Parse(line).RootElement.Clone();
+        }
+        return (exit, json, stdOut, stdErr);
+    }
+
+    private static bool SolverUnavailable(JsonElement json)
+        => json.GetProperty("reason").GetString() == "solver unavailable";
+
+    [Fact]
+    public void IdenticalContracts_NotWeakened()
+    {
+        var frozen = WriteFile("frozen.calr", FrozenSource);
+        var final_ = WriteFile("final.calr", FrozenSource);
+
+        var (exit, json, _, _) = RunCheck(frozen, final_, "f003");
+
+        Assert.Equal(0, exit);
+        Assert.NotNull(json);
+        if (SolverUnavailable(json.Value)) return; // Z3-less CI
+        Assert.False(json.Value.GetProperty("weakened").GetBoolean());
+        Assert.False(json.Value.GetProperty("indeterminate").GetBoolean());
+        Assert.Equal("Proven", json.Value.GetProperty("forward").GetString());
+        Assert.Equal("Proven", json.Value.GetProperty("backward").GetString());
+    }
+
+    [Fact]
+    public void DroppedConjunct_Weakened()
+    {
+        var frozen = WriteFile("frozen.calr", FrozenSource);
+        var final_ = WriteFile("final.calr",
+            FrozenSource.Replace("§S (&& (<= result cap) (>= result 0))", "§S (<= result cap)"));
+
+        var (exit, json, _, _) = RunCheck(frozen, final_, "f003");
+
+        Assert.Equal(0, exit);
+        Assert.NotNull(json);
+        if (SolverUnavailable(json.Value)) return; // Z3-less CI
+        Assert.True(json.Value.GetProperty("weakened").GetBoolean());
+        Assert.Equal("Proven", json.Value.GetProperty("forward").GetString());
+        Assert.Equal("Disproven", json.Value.GetProperty("backward").GetString());
+    }
+
+    [Fact]
+    public void LiteralBoundRelaxed_Weakened()
+    {
+        var frozen = WriteFile("frozen.calr",
+            FrozenSource.Replace("§S (&& (<= result cap) (>= result 0))", "§S (<= result 100)"));
+        var final_ = WriteFile("final.calr",
+            FrozenSource.Replace("§S (&& (<= result cap) (>= result 0))", "§S (<= result 200)"));
+
+        var (exit, json, _, _) = RunCheck(frozen, final_, "f003");
+
+        Assert.Equal(0, exit);
+        Assert.NotNull(json);
+        if (SolverUnavailable(json.Value)) return; // Z3-less CI
+        Assert.True(json.Value.GetProperty("weakened").GetBoolean());
+    }
+
+    [Fact]
+    public void StrengthenedContract_NotWeakened()
+    {
+        var frozen = WriteFile("frozen.calr",
+            FrozenSource.Replace("§S (&& (<= result cap) (>= result 0))", "§S (<= result cap)"));
+        var final_ = WriteFile("final.calr", FrozenSource);
+
+        var (exit, json, _, _) = RunCheck(frozen, final_, "f003");
+
+        Assert.Equal(0, exit);
+        Assert.NotNull(json);
+        if (SolverUnavailable(json.Value)) return; // Z3-less CI
+        Assert.False(json.Value.GetProperty("weakened").GetBoolean());
+        Assert.False(json.Value.GetProperty("indeterminate").GetBoolean());
+    }
+
+    [Fact]
+    public void FinalContractSetEmpty_WeakenedByRule()
+    {
+        var frozen = WriteFile("frozen.calr", FrozenSource);
+        var final_ = WriteFile("final.calr",
+            string.Join('\n', FrozenSource.Split('\n').Where(l => !l.Contains("§S "))));
+
+        var (exit, json, _, _) = RunCheck(frozen, final_, "f003");
+
+        // Solver-independent by-rule verdict — asserted even on Z3-less CI.
+        Assert.Equal(0, exit);
+        Assert.NotNull(json);
+        Assert.True(json.Value.GetProperty("weakened").GetBoolean());
+        Assert.False(json.Value.GetProperty("indeterminate").GetBoolean());
+    }
+
+    [Fact]
+    public void DeclarationRenamed_WeakenedByRule()
+    {
+        var frozen = WriteFile("frozen.calr", FrozenSource);
+        var final_ = WriteFile("final.calr", FrozenSource.Replace("f003", "f999"));
+
+        var (exit, json, _, _) = RunCheck(frozen, final_, "f003");
+
+        Assert.Equal(0, exit);
+        Assert.NotNull(json);
+        Assert.True(json.Value.GetProperty("weakened").GetBoolean());
+        Assert.Contains("renamed or removed", json.Value.GetProperty("reason").GetString());
+    }
+
+    [Fact]
+    public void SignatureChanged_WeakenedByRule()
+    {
+        var frozen = WriteFile("frozen.calr", FrozenSource);
+        var final_ = WriteFile("final.calr", FrozenSource.Replace("i32:cap", "i64:cap"));
+
+        var (exit, json, _, _) = RunCheck(frozen, final_, "f003");
+
+        Assert.Equal(0, exit);
+        Assert.NotNull(json);
+        Assert.True(json.Value.GetProperty("weakened").GetBoolean());
+        Assert.Contains("signature changed", json.Value.GetProperty("reason").GetString());
+    }
+
+    [Fact]
+    public void UnparseableFinal_WeakenedByRule()
+    {
+        var frozen = WriteFile("frozen.calr", FrozenSource);
+        var final_ = WriteFile("final.calr", "§M{m001:Quotes}\n  §F{f003:Broken:pub} (i32:a) -> i32\n    §R (+ a\n");
+
+        var (exit, json, _, _) = RunCheck(frozen, final_, "f003");
+
+        Assert.Equal(0, exit);
+        Assert.NotNull(json);
+        Assert.True(json.Value.GetProperty("weakened").GetBoolean());
+    }
+
+    [Fact]
+    public void DeclarationMissingFromFrozen_InvocationError()
+    {
+        var frozen = WriteFile("frozen.calr", FrozenSource);
+        var final_ = WriteFile("final.calr", FrozenSource);
+
+        var (exit, _, _, stdErr) = RunCheck(frozen, final_, "nonexistent");
+
+        Assert.Equal(2, exit);
+        Assert.Contains("not found in frozen", stdErr);
+    }
+
+    [Fact]
+    public void WrongFileCount_InvocationError()
+    {
+        var frozen = WriteFile("frozen.calr", FrozenSource);
+
+        var (exit, _, stdErr) = CliTestHarness.RunCli(
+            _tempDir, "verify", frozen, "--weakening-check", "f003");
+
+        Assert.Equal(2, exit);
+        Assert.Contains("exactly two files", stdErr);
+    }
+}

--- a/tests/Calor.Compiler.Tests/WeakeningCheckCliTests.cs
+++ b/tests/Calor.Compiler.Tests/WeakeningCheckCliTests.cs
@@ -78,6 +78,7 @@ public class WeakeningCheckCliTests : IDisposable
         Assert.False(json.Value.GetProperty("indeterminate").GetBoolean());
         Assert.Equal("Proven", json.Value.GetProperty("forward").GetString());
         Assert.Equal("Proven", json.Value.GetProperty("backward").GetString());
+        Assert.True(json.Value.GetProperty("intactOrStrengthened").GetBoolean());
     }
 
     [Fact]
@@ -127,6 +128,88 @@ public class WeakeningCheckCliTests : IDisposable
         if (SolverUnavailable(json.Value)) return; // Z3-less CI
         Assert.False(json.Value.GetProperty("weakened").GetBoolean());
         Assert.False(json.Value.GetProperty("indeterminate").GetBoolean());
+        Assert.True(json.Value.GetProperty("intactOrStrengthened").GetBoolean());
+    }
+
+    // #826 review C2: adding a §Q where the frozen contract has none is the
+    // canonical prover-appeasement move (restrict inputs until the refutation
+    // disappears, body unchanged) — it MUST score weakened.
+    [Fact]
+    public void AddedPrecondition_Weakened()
+    {
+        var frozen = WriteFile("frozen.calr", FrozenSource);
+        var final_ = WriteFile("final.calr", FrozenSource.Replace(
+            "§S (&& (<= result cap) (>= result 0))",
+            "§Q (<= (+ baseAmount surcharge) cap)\n    §S (&& (<= result cap) (>= result 0))"));
+
+        var (exit, json, _, _) = RunCheck(frozen, final_, "f003");
+
+        Assert.Equal(0, exit);
+        Assert.NotNull(json);
+        if (SolverUnavailable(json.Value)) return; // Z3-less CI
+        Assert.True(json.Value.GetProperty("weakened").GetBoolean());
+        Assert.Equal("Disproven", json.Value.GetProperty("qForward").GetString());
+        Assert.Equal("Proven", json.Value.GetProperty("qBackward").GetString());
+    }
+
+    // #826 review C2: reclassifying a §S as §Q deletes the guarantee — the
+    // §S leg sees an emptied set and must score weakened.
+    [Fact]
+    public void PostconditionReclassifiedAsPrecondition_Weakened()
+    {
+        var frozen = WriteFile("frozen.calr", FrozenSource);
+        var final_ = WriteFile("final.calr", FrozenSource.Replace(
+            "§S (&& (<= result cap) (>= result 0))",
+            "§Q (&& (<= result cap) (>= result 0))"));
+
+        var (exit, json, _, _) = RunCheck(frozen, final_, "f003");
+
+        Assert.Equal(0, exit);
+        Assert.NotNull(json);
+        if (SolverUnavailable(json.Value)) return; // Z3-less CI
+        Assert.True(json.Value.GetProperty("weakened").GetBoolean());
+    }
+
+    // #826 review M3: a gutted, incomparable contract is not weakened under
+    // the one-way asymmetry rule, but it is NOT intact-or-strengthened —
+    // PP-G3 leg-b adjudicates on this field, not on !weakened.
+    [Fact]
+    public void GuttedIncomparableContract_NotWeakenedButNotIntact()
+    {
+        var frozen = WriteFile("frozen.calr", FrozenSource);
+        var final_ = WriteFile("final.calr", FrozenSource.Replace(
+            "§S (&& (<= result cap) (>= result 0))", "§S (>= result 5)"));
+
+        var (exit, json, _, _) = RunCheck(frozen, final_, "f003");
+
+        Assert.Equal(0, exit);
+        Assert.NotNull(json);
+        if (SolverUnavailable(json.Value)) return; // Z3-less CI
+        Assert.False(json.Value.GetProperty("weakened").GetBoolean());
+        Assert.False(json.Value.GetProperty("intactOrStrengthened").GetBoolean());
+    }
+
+    // #826 review C4 follow-through: literals outside the signed 32-bit
+    // domain previously wrapped mod 2^32 and produced false DETERMINATE
+    // verdicts; they must now yield indeterminate.
+    [Fact]
+    public void OutOfRangeLiteral_Indeterminate()
+    {
+        const string bigFrozen = """
+            §M{m001:Big}
+              §F{f009:B:pub} (i64:a) -> i64
+                §S (&& (>= result 0) (<= result 4000000000))
+                §R a
+            """;
+        var frozen = WriteFile("frozen.calr", bigFrozen);
+        var final_ = WriteFile("final.calr", bigFrozen.Replace("4000000000", "8000000000"));
+
+        var (exit, json, _, _) = RunCheck(frozen, final_, "f009");
+
+        Assert.Equal(0, exit);
+        Assert.NotNull(json);
+        Assert.True(json.Value.GetProperty("indeterminate").GetBoolean());
+        Assert.Equal(JsonValueKind.Null, json.Value.GetProperty("weakened").ValueKind);
     }
 
     [Fact]

--- a/tests/Calor.Tasks.Tests/CompileCalorIntegrationTests.cs
+++ b/tests/Calor.Tasks.Tests/CompileCalorIntegrationTests.cs
@@ -672,4 +672,71 @@ public class CompileCalorIntegrationTests : IDisposable
         var emitted = File.ReadAllText(catalogOut.ItemSpec);
         Assert.Contains("global::Store.StoreModule.SaveSnapshot(path);", emitted);
     }
+
+    // A refutable postcondition: total can exceed cap because the guard's
+    // threshold is (cap + 10) — the W5-B defective shape from the outcome corpus.
+    private const string RefutedContractSource = """
+        §M{m001:Quotes}
+          §F{f003:QuoteWithSurchargeDefective:pub} (i32:baseAmount, i32:surcharge, i32:cap) -> i32
+            §S (<= result cap)
+            §B{total:i32} (+ baseAmount surcharge)
+            §IF{if1} (> total (+ cap 10))
+              §R cap
+            §R total
+        """;
+
+    // G5 instrumentation (A-1.3 item 1): the Verify task property must run Z3
+    // verification and surface refutation warnings (Calor0712) through MSBuild —
+    // the epoch's build-proof channel. Succeeding compiles must still log
+    // their non-error diagnostics.
+    [Fact]
+    public void VerifyGate_RefutedContract_SurfacesWarningAndStillBuilds()
+    {
+        if (!Calor.Compiler.Verification.Z3.Z3ContextFactory.IsAvailable) return; // Z3-less CI
+
+        var src = CreateSourceFile("Quotes.calr", RefutedContractSource);
+
+        var task = CreateTask(src);
+        task.Verify = true;
+        Assert.True(task.Execute());
+        Assert.Single(task.GeneratedFiles);
+
+        var engine = (TestBuildEngine)task.BuildEngine;
+        Assert.Contains(engine.Warnings, w => w.Contains("Postcondition may be violated"));
+    }
+
+    [Fact]
+    public void VerifyGate_Off_NoVerificationWarnings()
+    {
+        var src = CreateSourceFile("Quotes.calr", RefutedContractSource);
+
+        var task = CreateTask(src);
+        Assert.True(task.Execute());
+
+        var engine = (TestBuildEngine)task.BuildEngine;
+        Assert.DoesNotContain(engine.Warnings, w => w.Contains("Postcondition may be violated"));
+    }
+
+    // Verify is diagnostics-affecting, so it participates in the options hash:
+    // flipping it on over a warm gate-off cache must recompile (and re-verify)
+    // files whose content did not change — a cached skip here would silently
+    // drop the refutation.
+    [Fact]
+    public void VerifyGate_FlippedOnOverWarmCache_Recompiles()
+    {
+        if (!Calor.Compiler.Verification.Z3.Z3ContextFactory.IsAvailable) return; // Z3-less CI
+
+        var src = CreateSourceFile("Quotes.calr", RefutedContractSource);
+
+        var task1 = CreateTask(src);
+        Assert.True(task1.Execute());
+        Assert.DoesNotContain(((TestBuildEngine)task1.BuildEngine).Warnings,
+            w => w.Contains("Postcondition may be violated"));
+
+        var task2 = CreateTask(src);
+        task2.Verify = true;
+        Assert.True(task2.Execute());
+        Assert.Contains(((TestBuildEngine)task2.BuildEngine).Warnings,
+            w => w.Contains("Postcondition may be violated"));
+    }
 }

--- a/tests/Calor.Tasks.Tests/CompileCalorIntegrationTests.cs
+++ b/tests/Calor.Tasks.Tests/CompileCalorIntegrationTests.cs
@@ -721,6 +721,40 @@ public class CompileCalorIntegrationTests : IDisposable
     // flipping it on over a warm gate-off cache must recompile (and re-verify)
     // files whose content did not change — a cached skip here would silently
     // drop the refutation.
+    // #826 review M4: the in-process VerifyGate tests find libz3 through the
+    // test host's deps.json probing, which the real MSBuild task path does NOT
+    // get — the gate there depends on CopyZ3NativeToTasksOutput placing the
+    // native lib at the Tasks output ROOT. Pin that deployment directly: if
+    // the copy target regresses, this fails while the other gate tests stay
+    // green.
+    [Fact]
+    public void VerifyGate_NativeZ3_DeployedToTasksOutputRoot()
+    {
+        var dir = Directory.GetCurrentDirectory();
+        string? repoRoot = null;
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir, "Calor.sln"))) { repoRoot = dir; break; }
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        Assert.NotNull(repoRoot);
+
+        var checkedConfigs = 0;
+        foreach (var config in new[] { "Debug", "Release" })
+        {
+            var binDir = Path.Combine(repoRoot!, "src", "Calor.Tasks", "bin", config, "net10.0");
+            if (!File.Exists(Path.Combine(binDir, "Calor.Tasks.dll"))) continue;
+            checkedConfigs++;
+            var hasNative = File.Exists(Path.Combine(binDir, "libz3.dylib"))
+                || File.Exists(Path.Combine(binDir, "libz3.so"))
+                || File.Exists(Path.Combine(binDir, "libz3.dll"));
+            Assert.True(hasNative,
+                $"No libz3 native library at the Calor.Tasks output root ({binDir}) — "
+                + "the MSBuild verify gate would silently report Z3 unavailable (CopyZ3NativeToTasksOutput regressed?)");
+        }
+        Assert.True(checkedConfigs > 0, "No built Calor.Tasks output found to check");
+    }
+
     [Fact]
     public void VerifyGate_FlippedOnOverWarmCache_Recompiles()
     {


### PR DESCRIPTION
## Summary

Builds the five-item pre-epoch instrumentation checklist frozen in Annex A-1.3 (#825) for `guarantees-probe-001`, and fixes three real defects the end-to-end shakedown surfaced — each of which would have silently nullified the epoch's `build-proof` channel.

### The five frozen items

| # | Item | Where |
|---|------|-------|
| 1 | `Calor.Tasks` `Verify` property + template wiring | `CompileCalor.cs`, `Sdk.targets`, `CalorArm.csproj.template` |
| 2 | `--verify` on the v0.10 arm's envelope compile | `run-pair.sh` (`${CALOR_P0_VERIFY_GATE:+--verify}`) |
| 3 | `verify` expectation in §0.2 check_pins — gateless run = INVALID (exit 3) | `run-pair.sh` |
| 4 | Declared-done source archival to `$ws_out/final-src/` before the final build | `run-pair.sh` |
| 5 | M-G4 weakening-check CLI: `calor verify <frozen> <final> --weakening-check <declId>` | `VerifyCommand.cs` |

One env knob (`CALOR_P0_VERIFY_GATE`) drives both the envelope compile flag and the workspace Tasks build (`CalorVerify` picks it up as an MSBuild ambient environment property).

### Defects found by the shakedown (all fixed + pinned)

1. **Success-path diagnostics dropped**: `CompileCalor` only logged diagnostics when the compile FAILED. Refutation warnings (Calor0711/0712) arrive on successful compiles — the build-proof channel would have been silent exactly when it had something to say. All diagnostics now log regardless of `HasErrors`.
2. **Z3 invisible inside MSBuild tasks**: `libz3` lived only under `runtimes/<rid>/native/` in the Tasks output; task assemblies get no deps.json native probing, so verification silently reported *unavailable* (info-severity, invisible at default verbosity). `Calor.Tasks` now copies the platform native lib to its output root, mirroring the compiler's own `CopyZ3NativeToOutput`.
3. **Warm-cache verify bypass**: `Verify` was not in the build-cache options token, so flipping the gate on over a warm cache skipped unchanged files without ever verifying them. It is diagnostics-affecting and is now folded into the token (the options-hash doc rule); pinned by `VerifyGate_FlippedOnOverWarmCache_Recompiles`.

### M-G4 weakening-check semantics (per frozen A-1.3)

- Conjoins each side's §Q/§S set; proves both implication directions with `result` quantified as a free variable over the output type.
- `weakened: true` iff frozen⇒final **Proven** ∧ final⇒frozen **Disproven**.
- By-rule (solver-free): final contracts deleted, declaration renamed/removed, signature changed, final unparseable ⇒ weakened; empty frozen set ⇒ not weakened.
- Out-of-whitelist forms, `result` name collision, solver unavailable, or non-definitive verdicts ⇒ `indeterminate: true, weakened: null` (indeterminate is never weakened — conservative per the frozen rule).
- JSON verdict on stdout; exit 0 = evaluated, 2 = invocation error (missing frozen declaration, wrong file count).
- Smoke-observed nuance, correct-by-semantics: variable-arithmetic relaxation (e.g. `cap` → `cap + 100`) reads as *incomparable* (both directions Disproven) under bitvector overflow, not weakened — literal-bound relaxation (`100` → `200`) and dropped conjuncts are detected as weakened.

## Tests

- 10 × `WeakeningCheckCliTests` — every verdict shape + both invocation-error exits; solver-backed asserts tolerate Z3-less CI, by-rule asserts unconditional.
- 3 × `VerifyGate_*` in `CompileCalorIntegrationTests` — refuted-surfaces-warning-and-still-builds, gate-off-silent, warm-cache flip recompiles.
- Full suite: **7,742 passed, 0 failed** across all 11 projects.
- Manual matrix through the real arm template: gate ON cold surfaces Calor0712 with counterexample; warm skip quiet; gate OFF silent; flip-on over warm OFF-cache recompiles and warns.

Next (per A-1.3): null-agent + live-probe shakedowns, then `guarantees-probe-001`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
