### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-30
+
+### Benchmark Results (Statistical: 30 runs)
+- **Overall Advantage**: 1.32x (Calor leads)
+- **Metrics**: Calor wins 7 categories, C# wins 1
+- **Highlights**:
+  - Comprehension: 1.84x (Calor)
+  - ErrorDetection: 1.49x (Calor)
+  - TokenEconomics: 1.42x (Calor)
+
+### Added (release assembly)
+- **`calor verify --weakening-check <declId> <frozen.calr> <final.calr>`** — mechanical contract-weakening verdict between two versions of a declaration (guarantees plan G5 / gates Annex A-1.3.1 two-leg rule): weakened iff the `§S` conjunction was relaxed OR the `§Q` conjunction was strengthened (the prover-appeasement move); emits JSON with `weakened`/`indeterminate`/`intactOrStrengthened` and all four implication directions. By-rule verdicts (renamed/removed declaration, changed signature, unparseable final, emptied contract set) need no solver.
+- **`CalorVerify` MSBuild property** — `Verify="$(CalorVerify)"` on the `Calor.Tasks` compile task runs Z3 contract verification inside MSBuild builds; refutation warnings (`Calor0711`/`Calor0712`) surface as MSBuild warnings on successful compiles (previously the task dropped all non-error diagnostics on success), an armed-but-solverless gate warns loudly (`Calor0710`), the native Z3 library deploys to the Tasks output root (MSBuild task contexts get no deps.json native probing), and `Verify` participates in the incremental-build options hash so flipping it on over a warm cache recompiles.
+
+### Fixed (release assembly)
+- **Integer literals outside the signed 32-bit domain are refused by the contract translator instead of silently wrapped mod 2^32** — the wrap corrupted verdicts in both polarities (false refutations with nonsense counterexamples, inverted implication verdicts). Such contracts now report `unsupported`. Verification cache format 1.7 (pre-fix entries may hold wrapped-literal verdicts).
+
+
 ### Added
 - **Verifier depth: immutable `§B` binding chains are now encodable (guarantees plan G4/D-G3.1).** Result-referencing postconditions over bodies composed of immutable bindings, guard-clause branching, and value returns now prove via SSA-style substitution — including all three W5-B probe contract shapes (`total = a + b; if (total > cap) return cap; return total ⊨ result <= cap`), the surface PP-G3's threshold depends on. Soundness edges pinned: mutable (`§B{~}`) bindings, use-before-declaration, and branch-local bindings leaking into fall-through all refuse (`unsupported`); rebinding shadows lexically; a *dividing* initializer keeps its side condition anchored at the binding site (an unused dividing initializer still yields `assumed`, and a branch-local one is conditionally-evaluated → `unsupported`); nesting depth and substitution size are bounded. Cache keys cover binding content (no format bump needed: `§B` bodies were previously `unsupported`, which is never cached). **Deferred with rationale:** the D1 (narrow-type promotion) and D2 (literal signedness) divergence fixes turn out not to be cheap — both change translator width semantics with cache and test-matrix impact — and stay recorded in the divergence table.
 - **`assumed` goes live: *body*-division-carrying proofs are now conditional, not silently strengthened (guarantees plan D-G2.5 — the seven-status vocabulary's first `assumed` producer).** A result-referencing postcondition proof over a body containing `/` or `%` was reached under divisor-nonzero side conditions; it now reports **`assumed`** with the canonical assumption `exceptional-paths:division …` (envelope `assumptions` list, `Calor0720` info diagnostic) instead of plain `proven`. Behavior change: such proofs **no longer elide the runtime postcondition check** — `assumed` never elides, per the frozen D-G2.2 rule. Refutations under the same side conditions stay `refuted` (their models are genuine non-throwing executions). Corpus fixture `assumed-division.calr` pins the shape end-to-end (status, assumption, kept guard, wire payload). The verification cache format bumps to 1.5: a warm cache holding a pre-producer plain-`proven` verdict for a division body would otherwise keep eliding the guard the `assumed` verdict deliberately keeps. **Stated limit:** division inside *contract expressions* (`§Q`/`§S` themselves) is still totalized with no side conditions — a pre-existing divergence now recorded as D8 in `docs/verification-modeled-forms.md`, to be routed through the same producer in a later slice.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.9.0</Version>
+    <Version>0.10.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "calor",
   "displayName": "Calor Language",
   "description": "Language support for the Calor programming language",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publisher": "calor-dev",
   "license": "Apache-2.0",
   "icon": "icons/calor-icon.png",

--- a/website/content/changelog.mdx
+++ b/website/content/changelog.mdx
@@ -10,6 +10,23 @@ All notable changes to Calor, organized by release.
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-30
+
+The Guarantees release: every verification verdict an agent sees is now sound, honestly statused, and provenance-aware — and the upgrade is measured. On a paired A/B probe epoch, all three seeded contract defects moved from runtime exceptions to build-time refutations under the new verify gate, with zero catch regression and zero contract weakening across 30 eligible runs.
+
+### Added
+- **Sound result binding (#807 closed).** Result-referencing postconditions are checked against the encoded function body (SSA-style substitution over immutable `§B` chains, guard-clause branching, and value returns); bodies outside the encodable surface report honest `unsupported` — never a refutation against an unconstrained `result`.
+- **Seven-status verdict vocabulary.** `assumed` (holds conditionally on a named assumption set — division side conditions are the first producer; never elides runtime checks) and `unavailable` (no solver present) join the five existing statuses; vacuous proofs carry a `vacuous` flag and keep their runtime checks. Envelope schema 2.0.
+- **Positive modeled-forms whitelist.** `unsupported` is decided by an enumerated, CI-byte-checked whitelist rather than by accident; out-of-surface contracts name the offending construct.
+- **Cross-module linking (#809 closed).** Bare-name calls across modules emit qualified C# and link under MSBuild/csc, covering both the CLI multi-input driver and the MSBuild task.
+- **MSBuild verify gate.** `CalorVerify=true` runs Z3 contract verification inside builds; refutation warnings surface as MSBuild warnings with declaration attribution.
+- **Mechanical weakening check.** `calor verify --weakening-check` decides whether a declaration's contract was weakened between two versions (postcondition relaxed or precondition strengthened), with an intact-or-strengthened verdict for CI gating.
+
+### Fixed
+- **Precondition guards are never elided on satisfiability results (#755).** Only genuine ∀-proofs elide checks.
+- **Contract-level vacuity is loud.** Jointly-unsatisfiable precondition sets no longer mint silent Proven verdicts.
+- **`%` semantics corrected** (`bvsrem`, C# remainder), **out-of-32-bit literals refused** instead of silently wrapped, and the flagship proven-contracts sample repaired to prove 14/14 soundly.
+
 ## [0.9.0] - 2026-07-29
 
 The Loop release: the agent edit–feedback cycle is now a first-class, measured product surface — one machine-readable envelope across every CLI command and MCP tool, a transactional MCP write path with warm project sessions, and millisecond-scale edit feedback. Measured on paired A/B epochs: the new loop tooling cuts agent tokens-to-green ~35%, and Calor's enforcement caught 9/9 seeded defects where the C# toolkit caught 4/9.

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calor-website",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/website/public/data/benchmark-results.json
+++ b/website/public/data/benchmark-results.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
-  "timestamp": "2026-07-29T16:11:50.260611Z",
-  "commit": "db8c1e4b",
+  "timestamp": "2026-07-30T21:49:23.911401Z",
+  "commit": "dfa7371c",
   "frameworkVersion": "1.0.0",
   "summary": {
     "overallAdvantage": 1.32,

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -15,9 +15,9 @@ export function WhatsNewBanner() {
         <div className="flex items-center justify-center gap-3 text-sm">
           <Sparkles className="h-4 w-4 text-calor-cerulean flex-shrink-0" />
           <p className="text-center">
-            <span className="font-semibold text-calor-cerulean">v0.9.0</span>
+            <span className="font-semibold text-calor-cerulean">v0.10.0</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">The Loop release: one machine-readable envelope across every command and MCP tool, a transactional MCP write path with warm sessions (P50 2 ms edit feedback), and paired A/B measurements showing ~35% fewer agent tokens-to-green and 9/9 vs 4/9 seeded-defect catches against the C# toolkit.</span>
+            <span className="text-foreground">The Guarantees release: sound, honestly-statused verification verdicts — result-bound postcondition proofs, a seven-status vocabulary with assumption provenance, cross-module linking, and an MSBuild verify gate that surfaces contract refutations at build time. Measured A/B: all three seeded contract defects moved from runtime exceptions to build-time refutations with zero catch regression and zero contract weakening.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"


### PR DESCRIPTION
## Summary
- Bump version to 0.10.0 (Directory.Build.props, VS Code extension, website)
- CHANGELOG.md: [Unreleased] → [0.10.0] with 30-run statistical benchmark results; release-assembly entries added for the #826 product surface (--weakening-check CLI, CalorVerify MSBuild gate, out-of-32-bit literal refusal / cache 1.7)
- Website changelog + WhatsNewBanner updated for The Guarantees release
- benchmark-results.json refreshed for the dashboard

## Benchmark Results (Statistical: 30 runs)
Overall advantage 1.32x (Calor); Calor wins 7 categories, C# wins 1. Highlights: Comprehension 1.84x, ErrorDetection 1.49x, TokenEconomics 1.42x.

## Checklist
- [x] Version updated in Directory.Build.props
- [x] Version updated in editors/vscode/package.json
- [x] Version updated in website/package.json
- [x] CHANGELOG.md updated with version, date, and benchmark summary
- [x] website/content/changelog.mdx updated (no benchmark stats)
- [x] website/src/components/landing/WhatsNewBanner.tsx updated
- [x] website/public/data/benchmark-results.json updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)