### PR TITLE
feat: WS-W3 adoption surface — calor import, review packet v1, playbook + tested eject

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -44,6 +44,8 @@ dotnet tool update -g calor
 | [`calor benchmark`](/calor/cli/benchmark/) | Compare Calor vs C# across evaluation metrics |
 | [`calor format`](/calor/cli/format/) | Format Calor source files to canonical style |
 | [`calor fix`](/calor/cli/fix/) | Bulk, reversible source rewrites (e.g. drop legacy closing-tag IDs) |
+| `calor import` | Generate effect manifests (and assumed-provenance contract facts) for a package's public surface |
+| `calor review-packet` | Assemble a per-change review packet that leads with the unproven remainder |
 | [`calor mcp`](/calor/cli/mcp/) | Start MCP server for AI agent tool integration |
 | [`calor self-check docs`](/calor/cli/self-check/) | Verify agent-facing docs against the implementation (keywords, diagnostic codes, effect codes, parseable examples, version); exits nonzero on drift |
 | `calor lsp` | Start Language Server Protocol server for IDE features |

--- a/docs/cli/structured-output.md
+++ b/docs/cli/structured-output.md
@@ -180,6 +180,13 @@ pipeline) so they can flow through the structured formats:
 | `Calor1344` | Convert: `--validate` found a parse error in the generated output (warning — the output was still written) |
 | `Calor1345` | Convert: command-level failure — input not found, unknown file type, timeout, or crash |
 | `Calor1346` | Format/Lint: `format --write` or `lint --fix` refused without the experimental acknowledgment — the formatter write path is release-policy-disabled (#793/#760); pass `--experimental` or set `CALOR_EXPERIMENTAL_FORMAT_WRITE=1` |
+| `Calor1350` | Import: package or assembly not found (`.dll` path missing, or NuGet package id absent from the global packages folder at the requested version) |
+| `Calor1351` | Import: unresolved public members (Tier C) — their effects are UNKNOWN and are NOT emitted into the manifest (an empty effect list would mean pure); each is listed in the report with a reason |
+| `Calor1352` | Import: command-level failure — unreadable assembly, write failure, or crash |
+| `Calor1353` | Import: contract facts synthesized from assembly metadata with `assumed` provenance — annotation-only; never consumed by verification as trusted, never `Proven`, never elides runtime checks |
+| `Calor1355` | Review packet: command-level failure — input missing, compile failure, git diff failure, or crash |
+| `Calor1356` | Review packet: refinement-type honesty note (#782) — refinement obligations are compile-time analysis only; no runtime guard is emitted for them |
+| `Calor1357` | Review packet: produced under an explicit waiver (`--permissive-effects` or `--contract-mode off`) — disclosed on the packet's first line |
 
 ## Notes on specific commands
 

--- a/docs/cli/structured-output.md
+++ b/docs/cli/structured-output.md
@@ -187,6 +187,7 @@ pipeline) so they can flow through the structured formats:
 | `Calor1355` | Review packet: command-level failure — input missing, compile failure, git diff failure, or crash |
 | `Calor1356` | Review packet: refinement-type honesty note (#782) — refinement obligations are compile-time analysis only; no runtime guard is emitted for them |
 | `Calor1357` | Review packet: produced under an explicit waiver (`--permissive-effects` or `--contract-mode off`) — disclosed on the packet's first line |
+| `Calor1358` | Review packet: a `--changed` selector matched no declaration id or name in the given files (likely a typo) — its caller impact is absent from the packet |
 
 ## Notes on specific commands
 

--- a/docs/guides/adoption-playbook.md
+++ b/docs/guides/adoption-playbook.md
@@ -97,8 +97,11 @@ calor import path/to/Some.Assembly.dll
 
 Three tiers, honestly labeled:
 
-- **Derived (Tier A)** — IL analysis resolved the concrete call chain.
-  Emitted with provenance `inferred`.
+- **Derived (Tier A)** — IL analysis resolved the ENTIRE concrete call
+  chain with no unverified assumptions. Emitted with provenance `inferred`.
+  A chain that touches a callee missing from the loaded assemblies, a
+  bodiless declaration, or a delegate invocation is never emitted as
+  derived — it goes to unresolved instead, naming the assumption.
 - **Curated (Tier B)** — already covered by the compiler's reviewed
   interface-level manifests (`ILogger`, `DbContext`, `IConfiguration`,
   `IMediator`, Serilog, FluentValidation, Polly, caching, …). Not re-emitted.
@@ -124,8 +127,11 @@ The packet leads with the **unproven remainder** — every contract that is
 not cleanly proven, with its status (`refuted | assumed | unknown | timeout
 | unsupported | unavailable`), assumption lists, vacuity flags, and
 counterexamples — then the per-module interop fraction, waiver disclosures,
-and the direct callers of what changed. `--json` emits the same content in
-the CLI envelope for tooling.
+and the direct callers of what changed (resolved across all files in the
+invocation). `--json` emits the same content in the CLI envelope for
+tooling. `--baseline-ref` approximation: a declaration's extent runs to the
+next declaration's start, so an edit between declarations attributes to the
+preceding one — conservative over-inclusion, never omission.
 
 The point of the packet is what it does NOT claim: `Proven` means proven
 under the modeled semantics; everything else stays visible with its reason.

--- a/docs/guides/adoption-playbook.md
+++ b/docs/guides/adoption-playbook.md
@@ -1,0 +1,169 @@
+# Calor Adoption Playbook
+
+This is the adopter-side guide to putting Calor modules inside an existing
+C# solution, one module at a time — and to leaving again. It is deliberately
+honest about what you get, what is unproven, and what it costs to exit.
+
+Read this first; the step-by-step mechanics live in
+[Adding Calor to Existing Projects](adding-calor-to-existing-projects.md).
+
+## Read this before adopting (disclosures)
+
+- **Pre-1.0.** Calor is pre-1.0 software. Syntax and semantics are versioned
+  (`§SEMVER`) and breaking changes are documented per release, but no
+  compatibility promise beyond that exists yet. Check `Directory.Build.props`
+  in the repo for the current version; do not trust version numbers written
+  in prose.
+- **Bus factor 1.** Calor has a single maintainer. The mitigation is
+  structural, not aspirational: the eject story below is a tested feature —
+  the generated C# is readable, buildable, and yours. If the project stops,
+  you `calor convert` your modules to C# and delete the dependency.
+- **Refinement types are NOT runtime-enforced (#782).** Refinement-type
+  obligations are compile-time analysis only; no runtime guard is emitted
+  for them. The review packet states this on every run. Contracts (`§Q`/`§S`)
+  DO get runtime checks — refinements do not.
+- **Explicit waivers void guarantees.** Building with `--permissive-effects`
+  voids the effect guarantee (unknown calls are assumed pure); building with
+  `--contract-mode off` voids the contract guarantee (no runtime checks).
+  Any review packet produced under either says so on its first line.
+
+## The per-module flow
+
+Calor adoption is per-module: a `.calr` file beside your `.cs` files,
+compiled by the MSBuild SDK into C# your solution consumes normally. The
+wedge is **pure/contract-dense modules plus first-order effect-checked
+code** — start there, not with your most delegate-heavy service layer.
+
+### 1. Install the SDK
+
+The consumer shape (this is the exact shape CI tests against the published
+package — see `tests/SdkConsumer/`):
+
+`global.json`:
+
+```json
+{
+  "msbuild-sdks": {
+    "Calor.Sdk": "<version>"
+  }
+}
+```
+
+Your module project:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Calor.Sdk" />
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <CalorVerify>true</CalorVerify>
+  </PropertyGroup>
+</Project>
+```
+
+`.calr` files in the project compile to C# during build; `CalorVerify=true`
+turns on the Z3 verify gate so contract refutations surface at build time.
+
+### 2. Write the first module
+
+```calor
+§M{m001:Pricing}
+  §F{f001:ClampToCap:pub} (i32:amount, i32:cap) -> i32
+    §Q (>= cap 0)
+    §S (<= result cap)
+    §IF{if1} (> amount cap)
+      §R cap
+    §R amount
+```
+
+- `§Q` preconditions and `§S` postconditions are proven with Z3 where the
+  forms are modeled, and kept as runtime checks where they are not.
+- `§E{...}` declares effects; `§E{}` means pure and is enforced — an
+  undeclared effect is a build error with the full call chain.
+- Syntax reference: [syntax docs](../index.md) and the quick reference in
+  the repo `CLAUDE.md`; effect codes in
+  [effect-manifests.md](effect-manifests.md).
+
+### 3. Import your dependencies' effects
+
+Your module calls third-party packages; the effect system needs to know
+what those calls do. `calor import` generates a manifest for a package's
+public surface:
+
+```bash
+calor import Serilog --project .
+calor import path/to/Some.Assembly.dll
+```
+
+Three tiers, honestly labeled:
+
+- **Derived (Tier A)** — IL analysis resolved the concrete call chain.
+  Emitted with provenance `inferred`.
+- **Curated (Tier B)** — already covered by the compiler's reviewed
+  interface-level manifests (`ILogger`, `DbContext`, `IConfiguration`,
+  `IMediator`, Serilog, FluentValidation, Polly, caching, …). Not re-emitted.
+- **Unresolved (Tier C)** — dynamic dispatch or analysis limits. Surfaced
+  loudly in the report and NOT written into the manifest — an unresolved
+  member is never silently treated as pure. Fill these in by hand
+  (`calor effects suggest` generates templates).
+
+`calor import` also synthesizes mechanical contract facts from assembly
+metadata (non-null parameters from NRT annotations, non-negativity from
+unsigned types) into a `.calor-contracts.json` sidecar. **These carry
+`assumed` provenance and are annotation-only**: verification never consumes
+them as trusted, they can never produce `Proven`, and they never remove a
+runtime check.
+
+### 4. Review changes with the packet
+
+```bash
+calor review-packet src/pricing.calr --baseline-ref origin/main
+```
+
+The packet leads with the **unproven remainder** — every contract that is
+not cleanly proven, with its status (`refuted | assumed | unknown | timeout
+| unsupported | unavailable`), assumption lists, vacuity flags, and
+counterexamples — then the per-module interop fraction, waiver disclosures,
+and the direct callers of what changed. `--json` emits the same content in
+the CLI envelope for tooling.
+
+The point of the packet is what it does NOT claim: `Proven` means proven
+under the modeled semantics; everything else stays visible with its reason.
+
+## The eject story (tested)
+
+You can leave at any time. `calor convert` on a `.calr` file produces the
+standalone C# — the same C# the SDK builds — and the degradation semantics
+are documented and covered by a dedicated test suite
+(`tests/Calor.Conversion.Tests/EjectStoryTests.cs`):
+
+| Calor construct | After eject (C#) |
+|---|---|
+| `§Q` precondition | Runtime check: `if (!(cond)) throw ContractViolationException(...)` — always retained (never elided, even when proven) |
+| `§S` postcondition | Runtime check on return, same exception shape. `calor convert` does not run verification, so ejected output retains every check — elision only ever happens inside verified SDK builds on a non-vacuous ∀-proof |
+| `§S` on a body with early/nested returns | NO runtime check — the lowering refuses loudly (`Calor1001`, the #764 stopgap) rather than emit a check that could be silently skipped; static verification is unaffected |
+| Contracts with `--contract-mode off` | Stripped entirely (the waiver you chose) |
+| `§E` effect declarations | No runtime footprint — effects were compile-time discipline; the enforcement disappears, the behavior does not change |
+| Refinement-type obligations | Comments / retained checks per obligation status (they were never runtime-enforced — #782) |
+| Option/Result types | Ordinary `Calor.Runtime` generic types; keep the (small, MIT-licensed) `Calor.Runtime` package or inline the types |
+| Unsupported constructs during C#→Calor migration | Were preserved verbatim as interop blocks — they eject as the original C# |
+
+What ejecting costs you: the proofs, the effect discipline, and the
+contract vocabulary — the generated runtime checks and behavior stay. That
+is the trade, stated plainly.
+
+## Roadmap note (not built, deliberately)
+
+A human-recorded `Justified(who, why, when)` disposition for assumed/unknown
+proof results (strategy §5.1) is designed but **adopter-gated**: it ships
+when a named adopter with a non-maintainer reviewer exists to consume it
+(wedge plan D-W3.5). A persisted semantic index with `calor query` and
+index-backed blast radius is likewise deferred (wedge plan §9); the review
+packet currently uses the per-build in-memory call graph.
+
+## Links
+
+- [Adding Calor to Existing Projects](adding-calor-to-existing-projects.md) — step-by-step mechanics, troubleshooting
+- [Effect manifests](effect-manifests.md) — manifest format, layering, priorities
+- [Verify command](../cli/verify.md) — seven-status vocabulary, JSON envelope
+- [Structured output](../cli/structured-output.md) — envelope schema, CLI diagnostic codes

--- a/src/Calor.Compiler/Commands/ConvertCommand.cs
+++ b/src/Calor.Compiler/Commands/ConvertCommand.cs
@@ -470,6 +470,24 @@ public static class ConvertCommand
             envelope.Data.Success = true;
         }
 
+        // Non-error diagnostics must be visible on the default text path too
+        // (review M3): the Calor1001 postcondition-refusal warning changes
+        // what the ejected C# enforces at runtime — an eject that prints only
+        // "✓ Conversion successful" while a §S check was dropped is a silent
+        // degradation. Envelope mode already carries them under diagnostics.
+        if (envelope == null)
+        {
+            var nonErrors = result.Diagnostics.Where(d => !d.IsError).ToList();
+            if (nonErrors.Count > 0)
+            {
+                Console.Error.WriteLine($"{nonErrors.Count} warning(s)/note(s):");
+                foreach (var diag in nonErrors)
+                {
+                    Console.Error.WriteLine($"  {diag}");
+                }
+            }
+        }
+
         statusOut.WriteLine($"✓ Conversion successful");
         statusOut.WriteLine($"Output: {outputPath}");
         return 0;

--- a/src/Calor.Compiler/Commands/ImportCommand.cs
+++ b/src/Calor.Compiler/Commands/ImportCommand.cs
@@ -1,0 +1,435 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Effects;
+using Calor.Compiler.Effects.IL;
+using Calor.Compiler.Effects.Manifests;
+
+namespace Calor.Compiler.Commands;
+
+/// <summary>
+/// <c>calor import &lt;package&gt;</c> — the adoption-surface half of package
+/// ingestion (wedge plan v0.11 D-W3.1 / D-W3.2).
+///
+/// Effect half: generates a <c>.calor-effects.json</c> manifest for a
+/// package's public surface via the three-tier strategy — Tier A IL
+/// derivation for concrete call chains (provenance <c>inferred</c>), Tier B
+/// curated manifests reported as already-covered, Tier C unresolved members
+/// surfaced loudly (never silently under-approximated).
+///
+/// Contract half (narrow mechanical set): §Q non-null facts from NRT
+/// metadata and non-negativity facts from unsigned parameter types, written
+/// to a <c>.calor-contracts.json</c> sidecar with <c>assumed</c> provenance.
+/// The sidecar is annotation-only: no compiler surface consumes it as
+/// trusted input to verification or elision (the consumption path is the
+/// recorded D-W3.2 shed point).
+/// </summary>
+public static class ImportCommand
+{
+    public static Command Create()
+    {
+        var packageArgument = new Argument<string>(
+            name: "package",
+            description: "NuGet package id (resolved from the global packages folder) or a path to a .dll");
+
+        var versionOption = new Option<string?>(
+            aliases: ["--version"],
+            description: "Package version to import (default: highest version in the packages folder)");
+
+        var referencesOption = new Option<string[]>(
+            aliases: ["--references", "-r"],
+            description: "Additional assembly files or directories loaded for call-chain resolution")
+        { Arity = ArgumentArity.ZeroOrMore, AllowMultipleArgumentsPerToken = true };
+
+        var projectOption = new Option<DirectoryInfo?>(
+            aliases: ["--project", "-p"],
+            description: "Project directory for loading project-local manifests");
+
+        var solutionOption = new Option<DirectoryInfo?>(
+            aliases: ["--solution", "-s"],
+            description: "Solution directory for loading solution-level manifests");
+
+        var outputOption = new Option<FileInfo?>(
+            aliases: ["--output", "-o"],
+            description: "Manifest output path (default: <package>.calor-effects.json)");
+
+        var noContractsOption = new Option<bool>(
+            aliases: ["--no-contracts"],
+            description: "Skip the mechanical contract synthesis (assumed-provenance sidecar)");
+
+        var jsonOption = new Option<bool>(
+            aliases: ["--json"],
+            description: "Emit the envelope document to stdout instead of writing files");
+
+        var command = new Command("import",
+            "Generate effect manifests (and assumed-provenance contract facts) for a package's public surface")
+        {
+            packageArgument,
+            versionOption,
+            referencesOption,
+            projectOption,
+            solutionOption,
+            outputOption,
+            noContractsOption,
+            jsonOption
+        };
+
+        // Exit code returned through ctx.ExitCode: a code parked only on
+        // Environment.ExitCode is overwritten by Main's InvokeAsync return.
+        command.SetHandler((InvocationContext ctx) =>
+        {
+            ctx.ExitCode = Execute(
+                ctx.ParseResult.GetValueForArgument(packageArgument),
+                ctx.ParseResult.GetValueForOption(versionOption),
+                ctx.ParseResult.GetValueForOption(referencesOption) ?? [],
+                ctx.ParseResult.GetValueForOption(projectOption),
+                ctx.ParseResult.GetValueForOption(solutionOption),
+                ctx.ParseResult.GetValueForOption(outputOption),
+                ctx.ParseResult.GetValueForOption(noContractsOption),
+                ctx.ParseResult.GetValueForOption(jsonOption));
+        });
+
+        return command;
+    }
+
+    private static int Execute(
+        string package,
+        string? version,
+        string[] references,
+        DirectoryInfo? project,
+        DirectoryInfo? solution,
+        FileInfo? output,
+        bool noContracts,
+        bool json)
+    {
+        try
+        {
+            // Resolve the import target: a dll path or a NuGet package id.
+            var target = ResolveTarget(package, version);
+            if (target is null)
+            {
+                var message = File.Exists(package) || package.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+                    ? $"Assembly not found: {package}"
+                    : $"Package '{package}' not found in the NuGet global packages folder"
+                      + (version is null ? "" : $" at version {version}")
+                      + ". Pass a .dll path, or restore the package first.";
+                if (json)
+                {
+                    Console.WriteLine(EnvelopeWriter.Serialize("import", null,
+                        [new Diagnostic(DiagnosticCode.ImportInputNotFound, DiagnosticSeverity.Error,
+                            message, filePath: null, line: 1, column: 1)]));
+                }
+                Console.Error.WriteLine($"Error: {message}");
+                return 1;
+            }
+
+            var referencePaths = ExpandReferencePaths(references);
+
+            var loader = new ManifestLoader();
+            var resolver = new EffectResolver(loader);
+            resolver.Initialize(project?.FullName, solution?.FullName);
+
+            var ilOptions = new ILAnalysisOptions
+            {
+                RuntimeDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location),
+                NuGetPackageRoot = GetNuGetPackagesRoot()
+            };
+
+            var report = PackageManifestGenerator.Generate(
+                target.AssemblyPaths,
+                referencePaths,
+                resolver,
+                library: target.Library,
+                libraryVersion: target.Version,
+                synthesizeContracts: !noContracts,
+                ilOptions: ilOptions);
+
+            var diagnostics = new List<Diagnostic>();
+            if (report.Unresolved.Count > 0)
+            {
+                diagnostics.Add(new Diagnostic(
+                    DiagnosticCode.ImportUnresolvedEffects, DiagnosticSeverity.Warning,
+                    $"{report.Unresolved.Count} public member(s) could not be resolved (Tier C): "
+                    + "their effects are UNKNOWN and are NOT emitted as pure. "
+                    + "Add curated or supplemental manifest entries for the members listed in the report.",
+                    filePath: null, line: 1, column: 1));
+            }
+            if (report.SynthesizedContracts.Count > 0)
+            {
+                diagnostics.Add(new Diagnostic(
+                    DiagnosticCode.ImportSynthesizedContractsAssumed, DiagnosticSeverity.Info,
+                    $"{report.SynthesizedContracts.Count} contract fact(s) synthesized with 'assumed' provenance. "
+                    + "They are annotation-only: verification never consumes them as trusted and they never elide runtime checks.",
+                    filePath: null, line: 1, column: 1));
+            }
+
+            var jsonOptions = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
+
+            string? manifestPath = null;
+            string? contractsPath = null;
+            if (!json)
+            {
+                var stem = target.Library ?? Path.GetFileNameWithoutExtension(target.AssemblyPaths[0]);
+                manifestPath = output?.FullName ?? Path.Combine(
+                    project?.FullName ?? Directory.GetCurrentDirectory(),
+                    $"{stem}.calor-effects.json");
+                File.WriteAllText(manifestPath, JsonSerializer.Serialize(report.Manifest, jsonOptions));
+
+                if (!noContracts && report.SynthesizedContracts.Count > 0)
+                {
+                    contractsPath = manifestPath.EndsWith(".calor-effects.json", StringComparison.Ordinal)
+                        ? manifestPath[..^".calor-effects.json".Length] + ".calor-contracts.json"
+                        : manifestPath + ".calor-contracts.json";
+                    File.WriteAllText(contractsPath, JsonSerializer.Serialize(new ContractSidecar(
+                        Library: target.Library,
+                        LibraryVersion: target.Version,
+                        GeneratedBy: "calor import",
+                        GeneratedAt: DateTime.UtcNow.ToString("O"),
+                        Provenance: PackageManifestGenerator.AssumedProvenance,
+                        Note: "Annotation-only synthesized contract facts. Never consumed by verification as trusted; never eligible for Proven or runtime-check elision.",
+                        Contracts: report.SynthesizedContracts), jsonOptions));
+                }
+            }
+
+            var data = BuildEnvelopeData(report, manifestPath, contractsPath);
+
+            if (json)
+            {
+                Console.WriteLine(EnvelopeWriter.Serialize("import", data, diagnostics));
+                return 0;
+            }
+
+            PrintTextReport(report, manifestPath, contractsPath);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            if (json)
+            {
+                Console.WriteLine(EnvelopeWriter.Serialize("import", null,
+                    [new Diagnostic(DiagnosticCode.ImportCommandError, DiagnosticSeverity.Error,
+                        $"Import failed: {ex.Message}", filePath: null, line: 1, column: 1)]));
+            }
+            Console.Error.WriteLine($"Error: Import failed: {ex.Message}");
+            return 1;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Target resolution
+    // ------------------------------------------------------------------
+
+    private sealed record ImportTarget(IReadOnlyList<string> AssemblyPaths, string? Library, string? Version);
+
+    private static ImportTarget? ResolveTarget(string package, string? version)
+    {
+        // Direct assembly path
+        if (package.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+        {
+            return File.Exists(package)
+                ? new ImportTarget([Path.GetFullPath(package)], Path.GetFileNameWithoutExtension(package), null)
+                : null;
+        }
+
+        // NuGet package id in the global packages folder
+        var root = GetNuGetPackagesRoot();
+        if (root is null)
+            return null;
+
+        var packageDir = Path.Combine(root, package.ToLowerInvariant());
+        if (!Directory.Exists(packageDir))
+            return null;
+
+        string? versionDir = null;
+        if (version is not null)
+        {
+            var candidate = Path.Combine(packageDir, version);
+            if (Directory.Exists(candidate))
+                versionDir = candidate;
+        }
+        else
+        {
+            versionDir = Directory.GetDirectories(packageDir)
+                .OrderByDescending(d => ParseVersionKey(Path.GetFileName(d)))
+                .ThenByDescending(d => Path.GetFileName(d), StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+        }
+
+        if (versionDir is null)
+            return null;
+
+        var libDir = Path.Combine(versionDir, "lib");
+        if (!Directory.Exists(libDir))
+            return null;
+
+        var tfmDir = Directory.GetDirectories(libDir)
+            .OrderBy(d => TfmRank(Path.GetFileName(d)))
+            .ThenBy(d => Path.GetFileName(d), StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+        if (tfmDir is null)
+            return null;
+
+        var dlls = Directory.GetFiles(tfmDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .OrderBy(f => f, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (dlls.Count == 0)
+            return null;
+
+        return new ImportTarget(dlls, package, Path.GetFileName(versionDir));
+    }
+
+    private static string? GetNuGetPackagesRoot()
+    {
+        var env = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (!string.IsNullOrEmpty(env) && Directory.Exists(env))
+            return env;
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrEmpty(home))
+            return null;
+        var fallback = Path.Combine(home, ".nuget", "packages");
+        return Directory.Exists(fallback) ? fallback : null;
+    }
+
+    private static (int Major, int Minor, int Patch) ParseVersionKey(string? name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return (0, 0, 0);
+        var core = name.Split('-', '+')[0];
+        var parts = core.Split('.');
+        return (
+            parts.Length > 0 && int.TryParse(parts[0], out var maj) ? maj : 0,
+            parts.Length > 1 && int.TryParse(parts[1], out var min) ? min : 0,
+            parts.Length > 2 && int.TryParse(parts[2], out var pat) ? pat : 0);
+    }
+
+    /// <summary>Lower rank = preferred target framework.</summary>
+    private static int TfmRank(string tfm) => tfm.ToLowerInvariant() switch
+    {
+        "net10.0" => 0,
+        "net9.0" => 1,
+        "net8.0" => 2,
+        "net7.0" => 3,
+        "net6.0" => 4,
+        "net5.0" => 5,
+        "netstandard2.1" => 6,
+        "netstandard2.0" => 7,
+        _ => 100
+    };
+
+    private static List<string> ExpandReferencePaths(string[] references)
+    {
+        var paths = new List<string>();
+        foreach (var reference in references)
+        {
+            if (Directory.Exists(reference))
+            {
+                paths.AddRange(Directory.GetFiles(reference, "*.dll", SearchOption.TopDirectoryOnly)
+                    .OrderBy(f => f, StringComparer.OrdinalIgnoreCase));
+            }
+            else if (File.Exists(reference))
+            {
+                paths.Add(Path.GetFullPath(reference));
+            }
+        }
+        return paths;
+    }
+
+    // ------------------------------------------------------------------
+    // Output
+    // ------------------------------------------------------------------
+
+    private sealed record ContractSidecar(
+        string? Library,
+        string? LibraryVersion,
+        string GeneratedBy,
+        string GeneratedAt,
+        string Provenance,
+        string Note,
+        IReadOnlyList<SynthesizedContract> Contracts);
+
+    private static object BuildEnvelopeData(PackageImportReport report, string? manifestPath, string? contractsPath)
+    {
+        return new
+        {
+            library = report.Library,
+            libraryVersion = report.LibraryVersion,
+            targetAssemblies = report.TargetAssemblies,
+            counts = new
+            {
+                publicMethods = report.PublicMethodCount,
+                derived = report.Derived.Count,
+                curated = report.Curated.Count,
+                unresolved = report.Unresolved.Count,
+                synthesizedContracts = report.SynthesizedContracts.Count
+            },
+            provenance = new
+            {
+                derived = PackageManifestGenerator.DerivedConfidence,
+                synthesizedContracts = PackageManifestGenerator.AssumedProvenance,
+                note = "Nothing emitted by calor import carries 'verified' confidence."
+            },
+            manifestPath,
+            contractsPath,
+            manifest = report.Manifest,
+            derived = report.Derived,
+            curated = report.Curated,
+            unresolved = report.Unresolved,
+            synthesizedContracts = report.SynthesizedContracts,
+            loadErrors = report.LoadErrors.Count > 0 ? report.LoadErrors : null
+        };
+    }
+
+    private static void PrintTextReport(PackageImportReport report, string? manifestPath, string? contractsPath)
+    {
+        var title = report.Library is null
+            ? string.Join(", ", report.TargetAssemblies)
+            : $"{report.Library} {report.LibraryVersion}".TrimEnd();
+        Console.WriteLine($"Imported {title}");
+        Console.WriteLine($"  Public members analyzed: {report.PublicMethodCount}");
+        Console.WriteLine($"  Derived via IL analysis (Tier A, provenance: {PackageManifestGenerator.DerivedConfidence}): {report.Derived.Count}");
+        Console.WriteLine($"  Covered by curated manifests (Tier B): {report.Curated.Count}");
+        Console.WriteLine($"  Unresolved (Tier C — effects UNKNOWN, not emitted): {report.Unresolved.Count}");
+        if (report.SynthesizedContracts.Count > 0)
+        {
+            Console.WriteLine($"  Synthesized contract facts (provenance: {PackageManifestGenerator.AssumedProvenance}, annotation-only): {report.SynthesizedContracts.Count}");
+        }
+
+        if (report.Unresolved.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Unresolved members (add curated or supplemental manifest entries):");
+            foreach (var group in report.Unresolved.GroupBy(u => u.Type).OrderBy(g => g.Key, StringComparer.Ordinal))
+            {
+                Console.WriteLine($"  {group.Key}");
+                foreach (var entry in group.Take(20))
+                    Console.WriteLine($"    {entry.Member}  [{entry.Kind}] — {entry.Reason}");
+                if (group.Count() > 20)
+                    Console.WriteLine($"    … and {group.Count() - 20} more");
+            }
+        }
+
+        if (report.LoadErrors.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Load errors:");
+            foreach (var error in report.LoadErrors)
+                Console.WriteLine($"  [ERROR] {error}");
+        }
+
+        Console.WriteLine();
+        if (manifestPath is not null)
+            Console.WriteLine($"Manifest written to {manifestPath}");
+        if (contractsPath is not null)
+        {
+            Console.WriteLine($"Contract facts written to {contractsPath} (assumed provenance — annotation-only; never consumed by verification as trusted)");
+        }
+    }
+}

--- a/src/Calor.Compiler/Commands/ImportCommand.cs
+++ b/src/Calor.Compiler/Commands/ImportCommand.cs
@@ -126,6 +126,10 @@ public static class ImportCommand
             }
 
             var referencePaths = ExpandReferencePaths(references);
+            // Explicit --references first (they win the AssemblyIndex
+            // first-loaded-wins collision rule), then the package's own
+            // dependency closure.
+            referencePaths.AddRange(target.DependencyAssemblyPaths);
 
             var loader = new ManifestLoader();
             var resolver = new EffectResolver(loader);
@@ -134,7 +138,8 @@ public static class ImportCommand
             var ilOptions = new ILAnalysisOptions
             {
                 RuntimeDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location),
-                NuGetPackageRoot = GetNuGetPackagesRoot()
+                NuGetPackageRoot = GetNuGetPackagesRoot(),
+                DepsFilePath = target.DepsFilePath
             };
 
             var report = PackageManifestGenerator.Generate(
@@ -145,6 +150,23 @@ public static class ImportCommand
                 libraryVersion: target.Version,
                 synthesizeContracts: !noContracts,
                 ilOptions: ilOptions);
+
+            // M1: an input that is not a usable assembly must fail loudly —
+            // no exit 0, no empty manifest on disk.
+            if (report.PublicMethodCount == 0 && report.LoadErrors.Count > 0)
+            {
+                var message = "Import failed: no usable assembly metadata in "
+                    + string.Join(", ", target.AssemblyPaths.Select(Path.GetFileName))
+                    + " — " + string.Join("; ", report.LoadErrors);
+                if (json)
+                {
+                    Console.WriteLine(EnvelopeWriter.Serialize("import", null,
+                        [new Diagnostic(DiagnosticCode.ImportCommandError, DiagnosticSeverity.Error,
+                            message, filePath: null, line: 1, column: 1)]));
+                }
+                Console.Error.WriteLine($"Error: {message}");
+                return 1;
+            }
 
             var diagnostics = new List<Diagnostic>();
             if (report.Unresolved.Count > 0)
@@ -226,16 +248,31 @@ public static class ImportCommand
     // Target resolution
     // ------------------------------------------------------------------
 
-    private sealed record ImportTarget(IReadOnlyList<string> AssemblyPaths, string? Library, string? Version);
+    private sealed record ImportTarget(
+        IReadOnlyList<string> AssemblyPaths,
+        string? Library,
+        string? Version,
+        IReadOnlyList<string> DependencyAssemblyPaths,
+        string? DepsFilePath);
 
     private static ImportTarget? ResolveTarget(string package, string? version)
     {
         // Direct assembly path
         if (package.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
         {
-            return File.Exists(package)
-                ? new ImportTarget([Path.GetFullPath(package)], Path.GetFileNameWithoutExtension(package), null)
-                : null;
+            if (!File.Exists(package))
+                return null;
+            var fullPath = Path.GetFullPath(package);
+            // A sibling deps.json lets the analyzer resolve reference
+            // assemblies to implementation assemblies (C1: tier A needs the
+            // dependency closure before falling back to unresolved).
+            var depsPath = Path.ChangeExtension(fullPath, ".deps.json");
+            return new ImportTarget(
+                [fullPath],
+                Path.GetFileNameWithoutExtension(fullPath),
+                Version: null,
+                DependencyAssemblyPaths: [],
+                DepsFilePath: File.Exists(depsPath) ? depsPath : null);
         }
 
         // NuGet package id in the global packages folder
@@ -282,7 +319,97 @@ public static class ImportCommand
         if (dlls.Count == 0)
             return null;
 
-        return new ImportTarget(dlls, package, Path.GetFileName(versionDir));
+        // C1: wire the package's own dependency closure (from the .nuspec,
+        // resolved against the global packages folder) so Tier-A analysis has
+        // the assemblies a chain needs before falling back to unresolved.
+        var dependencyDlls = ResolvePackageDependencyClosure(root, package);
+
+        return new ImportTarget(dlls, package, Path.GetFileName(versionDir), dependencyDlls, DepsFilePath: null);
+    }
+
+    /// <summary>
+    /// Walks the .nuspec dependency graph of <paramref name="packageId"/>
+    /// through the global packages folder, collecting each installed
+    /// dependency's best-TFM lib assemblies. Dependencies that are not
+    /// restored locally are simply absent — their chains then surface as
+    /// unresolved (Tier C), never as silently pure.
+    /// </summary>
+    private static List<string> ResolvePackageDependencyClosure(string packagesRoot, string packageId)
+    {
+        var result = new List<string>();
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { packageId };
+        var queue = new Queue<string>(ReadNuspecDependencyIds(packagesRoot, packageId));
+
+        while (queue.Count > 0)
+        {
+            var depId = queue.Dequeue();
+            if (!visited.Add(depId))
+                continue;
+
+            var depDir = Path.Combine(packagesRoot, depId.ToLowerInvariant());
+            if (!Directory.Exists(depDir))
+                continue; // not restored — chains through it stay unresolved, honestly
+
+            var versionDir = Directory.GetDirectories(depDir)
+                .OrderByDescending(d => ParseVersionKey(Path.GetFileName(d)))
+                .ThenByDescending(d => Path.GetFileName(d), StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+            if (versionDir is null)
+                continue;
+
+            var libDir = Path.Combine(versionDir, "lib");
+            if (Directory.Exists(libDir))
+            {
+                var tfmDir = Directory.GetDirectories(libDir)
+                    .OrderBy(d => TfmRank(Path.GetFileName(d)))
+                    .ThenBy(d => Path.GetFileName(d), StringComparer.OrdinalIgnoreCase)
+                    .FirstOrDefault();
+                if (tfmDir is not null)
+                {
+                    result.AddRange(Directory.GetFiles(tfmDir, "*.dll", SearchOption.TopDirectoryOnly)
+                        .OrderBy(f => f, StringComparer.OrdinalIgnoreCase));
+                }
+            }
+
+            foreach (var transitive in ReadNuspecDependencyIds(packagesRoot, depId))
+                queue.Enqueue(transitive);
+        }
+
+        return result;
+    }
+
+    private static IEnumerable<string> ReadNuspecDependencyIds(string packagesRoot, string packageId)
+    {
+        var packageDir = Path.Combine(packagesRoot, packageId.ToLowerInvariant());
+        if (!Directory.Exists(packageDir))
+            return [];
+
+        var versionDir = Directory.GetDirectories(packageDir)
+            .OrderByDescending(d => ParseVersionKey(Path.GetFileName(d)))
+            .ThenByDescending(d => Path.GetFileName(d), StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+        if (versionDir is null)
+            return [];
+
+        var nuspec = Path.Combine(versionDir, $"{packageId.ToLowerInvariant()}.nuspec");
+        if (!File.Exists(nuspec))
+            return [];
+
+        try
+        {
+            var doc = System.Xml.Linq.XDocument.Load(nuspec);
+            return doc.Descendants()
+                .Where(e => e.Name.LocalName == "dependency")
+                .Select(e => e.Attribute("id")?.Value)
+                .Where(id => !string.IsNullOrEmpty(id))
+                .Select(id => id!)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+        catch (Exception ex) when (ex is System.Xml.XmlException or IOException)
+        {
+            return [];
+        }
     }
 
     private static string? GetNuGetPackagesRoot()

--- a/src/Calor.Compiler/Commands/ReviewPacketCommand.cs
+++ b/src/Calor.Compiler/Commands/ReviewPacketCommand.cs
@@ -1,0 +1,284 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Reporting;
+
+namespace Calor.Compiler.Commands;
+
+/// <summary>
+/// <c>calor review-packet</c> — the verification centerpiece's adoption
+/// artifact (wedge plan v0.11 D-W3.3): a per-change report that LEADS with
+/// the unproven remainder over the seven-status vocabulary, with assumption
+/// lists, vacuity flags, per-module interop/permissive fractions, waiver
+/// disclosures on the first line (strategy §5.2), caller impact from the
+/// in-memory call graph, and the #782 refinement honesty note.
+/// </summary>
+public static class ReviewPacketCommand
+{
+    public static Command Create()
+    {
+        var filesArgument = new Argument<FileInfo[]>(
+            name: "files",
+            description: "The Calor source file(s) the packet covers")
+        {
+            Arity = ArgumentArity.OneOrMore
+        };
+
+        var changedOption = new Option<string[]>(
+            aliases: ["--changed"],
+            description: "Declaration id or name treated as changed (repeatable); drives the caller-impact section")
+        { Arity = ArgumentArity.ZeroOrMore, AllowMultipleArgumentsPerToken = true };
+
+        var baselineRefOption = new Option<string?>(
+            aliases: ["--baseline-ref"],
+            description: "Git ref to diff against; changed declarations are derived from the diff's line ranges");
+
+        var permissiveOption = new Option<bool>(
+            aliases: ["--permissive-effects"],
+            description: "The module is built with permissive effects — disclosed as a waiver on the packet's first line");
+
+        var contractModeOption = new Option<string>(
+            aliases: ["--contract-mode"],
+            getDefaultValue: () => "debug",
+            description: "Contract mode the module is built with: debug, release, or off (off = waiver, disclosed first)");
+
+        var timeoutOption = new Option<int>(
+            aliases: ["--timeout", "-t"],
+            getDefaultValue: () => 5000,
+            description: "Z3 solver timeout per contract in milliseconds");
+
+        var outputOption = new Option<FileInfo?>(
+            aliases: ["--output", "-o"],
+            description: "Write the markdown packet to a file (default: stdout)");
+
+        var jsonOption = new Option<bool>(
+            aliases: ["--json"],
+            description: "Emit the envelope document (packet under data) to stdout");
+
+        var command = new Command("review-packet",
+            "Assemble a per-change review packet that leads with the unproven remainder")
+        {
+            filesArgument,
+            changedOption,
+            baselineRefOption,
+            permissiveOption,
+            contractModeOption,
+            timeoutOption,
+            outputOption,
+            jsonOption
+        };
+
+        // Exit code returned through ctx.ExitCode: a code parked only on
+        // Environment.ExitCode is overwritten by Main's InvokeAsync return.
+        command.SetHandler((InvocationContext ctx) =>
+        {
+            ctx.ExitCode = Execute(
+                ctx.ParseResult.GetValueForArgument(filesArgument),
+                ctx.ParseResult.GetValueForOption(changedOption) ?? [],
+                ctx.ParseResult.GetValueForOption(baselineRefOption),
+                ctx.ParseResult.GetValueForOption(permissiveOption),
+                ctx.ParseResult.GetValueForOption(contractModeOption) ?? "debug",
+                (uint)Math.Max(1, ctx.ParseResult.GetValueForOption(timeoutOption)),
+                ctx.ParseResult.GetValueForOption(outputOption),
+                ctx.ParseResult.GetValueForOption(jsonOption));
+        });
+
+        return command;
+    }
+
+    private static int Execute(
+        FileInfo[] files,
+        string[] changed,
+        string? baselineRef,
+        bool permissiveEffects,
+        string contractMode,
+        uint timeoutMs,
+        FileInfo? output,
+        bool json)
+    {
+        try
+        {
+            var inputs = new List<ReviewPacketBuilder.InputFile>();
+            foreach (var file in files)
+            {
+                if (!file.Exists)
+                {
+                    var message = $"File not found: {file.FullName}";
+                    if (json)
+                    {
+                        Console.WriteLine(EnvelopeWriter.Serialize("review-packet", null,
+                            [new Diagnostic(DiagnosticCode.ReviewPacketCommandError, DiagnosticSeverity.Error,
+                                message, file.FullName, line: 1, column: 1)]));
+                    }
+                    Console.Error.WriteLine($"Error: {message}");
+                    return 1;
+                }
+                inputs.Add(new ReviewPacketBuilder.InputFile(file.FullName, File.ReadAllText(file.FullName)));
+            }
+
+            IReadOnlyDictionary<string, IReadOnlyList<(int, int)>>? changedRanges = null;
+            if (baselineRef is not null)
+            {
+                changedRanges = ComputeChangedLineRanges(files, baselineRef, out var gitError);
+                if (gitError is not null)
+                {
+                    if (json)
+                    {
+                        Console.WriteLine(EnvelopeWriter.Serialize("review-packet", null,
+                            [new Diagnostic(DiagnosticCode.ReviewPacketCommandError, DiagnosticSeverity.Error,
+                                gitError, filePath: null, line: 1, column: 1)]));
+                    }
+                    Console.Error.WriteLine($"Error: {gitError}");
+                    return 1;
+                }
+            }
+
+            var contractChecksOff = contractMode.Equals("off", StringComparison.OrdinalIgnoreCase);
+            var result = ReviewPacketBuilder.Build(inputs, new ReviewPacketBuilder.Options(
+                PermissiveEffects: permissiveEffects,
+                ContractChecksOff: contractChecksOff,
+                VerificationTimeoutMs: timeoutMs,
+                ChangedDeclarations: changed.Length > 0 ? changed : null,
+                ChangedLineRanges: changedRanges,
+                BaselineRef: baselineRef));
+
+            var diagnostics = new List<Diagnostic>(result.CompileDiagnostics);
+            if (result.Packet.Waivers.Count > 0)
+            {
+                diagnostics.Add(new Diagnostic(
+                    DiagnosticCode.ReviewPacketWaiverDisclosure, DiagnosticSeverity.Warning,
+                    string.Join(" ", result.Packet.Waivers),
+                    filePath: null, line: 1, column: 1));
+            }
+            if (result.AnyRefinementTypes)
+            {
+                diagnostics.Add(new Diagnostic(
+                    DiagnosticCode.ReviewPacketRefinementHonesty, DiagnosticSeverity.Info,
+                    ReviewPacketBuilder.RefinementHonestyNote,
+                    filePath: null, line: 1, column: 1));
+            }
+
+            if (json)
+            {
+                Console.WriteLine(EnvelopeWriter.Serialize("review-packet", result.Packet, diagnostics));
+                return result.HasCompileErrors ? 1 : 0;
+            }
+
+            var markdown = ReviewPacketBuilder.RenderMarkdown(result.Packet);
+            if (output is not null)
+            {
+                File.WriteAllText(output.FullName, markdown);
+                Console.WriteLine($"Review packet written to {output.FullName}");
+            }
+            else
+            {
+                Console.WriteLine(markdown);
+            }
+
+            if (result.HasCompileErrors)
+            {
+                Console.Error.WriteLine("Warning: one or more files failed to compile; the packet covers only the files that compiled.");
+                foreach (var diagnostic in result.CompileDiagnostics.Where(d => d.IsError).Take(20))
+                    Console.Error.WriteLine($"  {diagnostic}");
+                return 1;
+            }
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            if (json)
+            {
+                Console.WriteLine(EnvelopeWriter.Serialize("review-packet", null,
+                    [new Diagnostic(DiagnosticCode.ReviewPacketCommandError, DiagnosticSeverity.Error,
+                        $"Review packet failed: {ex.Message}", filePath: null, line: 1, column: 1)]));
+            }
+            Console.Error.WriteLine($"Error: Review packet failed: {ex.Message}");
+            return 1;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Git diff → changed line ranges
+    // ------------------------------------------------------------------
+
+    private static readonly Regex HunkHeader = new(
+        @"^@@ -\d+(?:,\d+)? \+(?<start>\d+)(?:,(?<count>\d+))? @@",
+        RegexOptions.Compiled);
+
+    private static IReadOnlyDictionary<string, IReadOnlyList<(int, int)>>? ComputeChangedLineRanges(
+        FileInfo[] files,
+        string baselineRef,
+        out string? error)
+    {
+        error = null;
+        var result = new Dictionary<string, IReadOnlyList<(int, int)>>(StringComparer.Ordinal);
+
+        foreach (var file in files)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                WorkingDirectory = file.DirectoryName ?? Directory.GetCurrentDirectory(),
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+            startInfo.ArgumentList.Add("diff");
+            startInfo.ArgumentList.Add("-U0");
+            startInfo.ArgumentList.Add(baselineRef);
+            startInfo.ArgumentList.Add("--");
+            startInfo.ArgumentList.Add(file.FullName);
+
+            try
+            {
+                using var process = Process.Start(startInfo);
+                if (process is null)
+                {
+                    error = "Failed to start git for --baseline-ref diff.";
+                    return null;
+                }
+                var stdout = process.StandardOutput.ReadToEnd();
+                var stderr = process.StandardError.ReadToEnd();
+                process.WaitForExit();
+                if (process.ExitCode is not (0 or 1))
+                {
+                    error = $"git diff against '{baselineRef}' failed: {stderr.Trim()}";
+                    return null;
+                }
+
+                var ranges = new List<(int, int)>();
+                foreach (var line in stdout.Split('\n'))
+                {
+                    var match = HunkHeader.Match(line);
+                    if (!match.Success)
+                        continue;
+                    var start = int.Parse(match.Groups["start"].Value);
+                    var count = match.Groups["count"].Success ? int.Parse(match.Groups["count"].Value) : 1;
+                    if (count == 0)
+                    {
+                        // Pure deletion at this position: treat the surrounding
+                        // line as changed so the enclosing declaration is flagged.
+                        ranges.Add((Math.Max(1, start), Math.Max(1, start)));
+                    }
+                    else
+                    {
+                        ranges.Add((start, start + count - 1));
+                    }
+                }
+
+                if (ranges.Count > 0)
+                    result[file.FullName] = ranges;
+            }
+            catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or IOException)
+            {
+                error = $"Failed to run git for --baseline-ref: {ex.Message}";
+                return null;
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/Calor.Compiler/Commands/ReviewPacketCommand.cs
+++ b/src/Calor.Compiler/Commands/ReviewPacketCommand.cs
@@ -33,7 +33,9 @@ public static class ReviewPacketCommand
 
         var baselineRefOption = new Option<string?>(
             aliases: ["--baseline-ref"],
-            description: "Git ref to diff against; changed declarations are derived from the diff's line ranges");
+            description: "Git ref to diff against; changed declarations are derived from the diff's line ranges. "
+                + "Approximation: a declaration's extent runs to the next declaration's start, so an edit between "
+                + "declarations attributes to the preceding one (conservative over-inclusion, never omission)");
 
         var permissiveOption = new Option<bool>(
             aliases: ["--permissive-effects"],
@@ -145,6 +147,14 @@ public static class ReviewPacketCommand
                 BaselineRef: baselineRef));
 
             var diagnostics = new List<Diagnostic>(result.CompileDiagnostics);
+            foreach (var selector in result.UnmatchedChangedDeclarations)
+            {
+                diagnostics.Add(new Diagnostic(
+                    DiagnosticCode.ReviewPacketUnknownChangedDeclaration, DiagnosticSeverity.Warning,
+                    $"--changed '{selector}' matched no declaration id or name in the given files — "
+                    + "its caller impact is absent from this packet. Check for a typo.",
+                    filePath: null, line: 1, column: 1));
+            }
             if (result.Packet.Waivers.Count > 0)
             {
                 diagnostics.Add(new Diagnostic(
@@ -164,6 +174,13 @@ public static class ReviewPacketCommand
             {
                 Console.WriteLine(EnvelopeWriter.Serialize("review-packet", result.Packet, diagnostics));
                 return result.HasCompileErrors ? 1 : 0;
+            }
+
+            foreach (var selector in result.UnmatchedChangedDeclarations)
+            {
+                Console.Error.WriteLine(
+                    $"Warning: --changed '{selector}' matched no declaration id or name in the given files "
+                    + "— its caller impact is absent from this packet. Check for a typo.");
             }
 
             var markdown = ReviewPacketBuilder.RenderMarkdown(result.Packet);

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -963,6 +963,69 @@ public static class DiagnosticCode
     /// pass --experimental or set CALOR_EXPERIMENTAL_FORMAT_WRITE=1 (W1 Slice 2).
     /// </summary>
     public const string FormatWriteExperimentalRequired = "Calor1346";
+
+    // `calor import` command diagnostics (Calor1350-1354) — package ingestion
+    // (wedge plan v0.11 D-W3.1/D-W3.2). Tier C honesty rides Calor1351: an
+    // unresolved public member is surfaced loudly, never emitted as pure.
+
+    /// <summary>
+    /// Error (import): the package or assembly passed to <c>calor import</c>
+    /// could not be resolved — the .dll does not exist, or the NuGet package id
+    /// is not present in the global packages folder (at the requested version).
+    /// </summary>
+    public const string ImportInputNotFound = "Calor1350";
+
+    /// <summary>
+    /// Warning (import): one or more public members could not be resolved by
+    /// IL analysis or curated manifests (Tier C). Their effects are UNKNOWN and
+    /// are deliberately NOT emitted into the manifest — emitting them would
+    /// under-approximate (an empty effect list means pure). The report lists
+    /// each unresolved member with a reason.
+    /// </summary>
+    public const string ImportUnresolvedEffects = "Calor1351";
+
+    /// <summary>
+    /// Error (import): a command-level failure — unreadable assembly, write
+    /// failure, or an unhandled crash. Emitted so <c>--json</c> always produces
+    /// a parseable envelope document.
+    /// </summary>
+    public const string ImportCommandError = "Calor1352";
+
+    /// <summary>
+    /// Info (import): contract facts were synthesized from assembly metadata
+    /// (NRT non-null parameters, unsigned-type range facts) with <c>assumed</c>
+    /// provenance. They are annotation-only output: verification never consumes
+    /// them as trusted, they can never produce <c>Proven</c>, and they never
+    /// elide runtime checks (wedge plan D-W3.2 / M-T1).
+    /// </summary>
+    public const string ImportSynthesizedContractsAssumed = "Calor1353";
+
+    // `calor review-packet` command diagnostics (Calor1355-1359) — the
+    // per-change review artifact (wedge plan v0.11 D-W3.3).
+
+    /// <summary>
+    /// Error (review-packet): a command-level failure — input file missing,
+    /// compile failure, git diff failure, or an unhandled crash. Emitted so
+    /// <c>--json</c> always produces a parseable envelope document.
+    /// </summary>
+    public const string ReviewPacketCommandError = "Calor1355";
+
+    /// <summary>
+    /// Info (review-packet): the analyzed module(s) carry refinement-type
+    /// obligations, and refinement types are NOT runtime-enforced (#782):
+    /// refinement obligations are compile-time analysis only — no runtime
+    /// guard is emitted for them. Stated per the W1 kickoff honesty item
+    /// (wedge-w1-prereqs.md §1.1).
+    /// </summary>
+    public const string ReviewPacketRefinementHonesty = "Calor1356";
+
+    /// <summary>
+    /// Warning (review-packet): the packet was produced under an explicit
+    /// waiver — <c>--permissive-effects</c> (voids the effect guarantee) or
+    /// <c>--contract-mode off</c> (voids the contract guarantee). The waiver
+    /// is disclosed on the first line of the packet (strategy §5.2).
+    /// </summary>
+    public const string ReviewPacketWaiverDisclosure = "Calor1357";
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -1026,6 +1026,14 @@ public static class DiagnosticCode
     /// is disclosed on the first line of the packet (strategy §5.2).
     /// </summary>
     public const string ReviewPacketWaiverDisclosure = "Calor1357";
+
+    /// <summary>
+    /// Warning (review-packet): a <c>--changed</c> selector matched no
+    /// declaration id or name in the given files — its caller impact is
+    /// silently absent from the packet otherwise, so the mismatch (likely a
+    /// typo) is surfaced loudly.
+    /// </summary>
+    public const string ReviewPacketUnknownChangedDeclaration = "Calor1358";
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Effects/EffectResolver.cs
+++ b/src/Calor.Compiler/Effects/EffectResolver.cs
@@ -48,8 +48,13 @@ public sealed class EffectResolver
     {
         EnsureInitialized();
 
-        // Build cache key
-        var signature = BuildSignature(fullyQualifiedType, methodName, parameterTypes);
+        // Build cache key. The "m:" prefix keeps this entry point's cache
+        // disjoint from ResolveSetter/ResolveGetter/ResolveConstructor —
+        // without it, Resolve(T, "set_X") and ResolveSetter(T, "X") build the
+        // IDENTICAL key, and whichever runs first poisons the other's result
+        // (observed: the IL propagator probed Resolve(...) first and cached
+        // Unknown, making manifest-covered setters look like assumptions).
+        var signature = "m:" + BuildSignature(fullyQualifiedType, methodName, parameterTypes);
         if (_methodCache.TryGetValue(signature, out var cached))
             return cached;
 
@@ -65,7 +70,7 @@ public sealed class EffectResolver
     {
         EnsureInitialized();
 
-        var signature = $"{fullyQualifiedType}::get_{propertyName}()";
+        var signature = $"g:{fullyQualifiedType}::get_{propertyName}()";
         if (_methodCache.TryGetValue(signature, out var cached))
             return cached;
 
@@ -81,7 +86,7 @@ public sealed class EffectResolver
     {
         EnsureInitialized();
 
-        var signature = $"{fullyQualifiedType}::set_{propertyName}()";
+        var signature = $"s:{fullyQualifiedType}::set_{propertyName}()";
         if (_methodCache.TryGetValue(signature, out var cached))
             return cached;
 
@@ -98,7 +103,7 @@ public sealed class EffectResolver
         EnsureInitialized();
 
         var paramSig = $"({string.Join(",", parameterTypes)})";
-        var signature = $"{fullyQualifiedType}::.ctor{paramSig}";
+        var signature = $"c:{fullyQualifiedType}::.ctor{paramSig}";
 
         if (_methodCache.TryGetValue(signature, out var cached))
             return cached;

--- a/src/Calor.Compiler/Effects/IL/TransitiveEffectPropagator.cs
+++ b/src/Calor.Compiler/Effects/IL/TransitiveEffectPropagator.cs
@@ -1,6 +1,16 @@
 namespace Calor.Compiler.Effects.IL;
 
 /// <summary>
+/// Per-method result of detailed propagation: resolution status, unioned
+/// effects, and the assumed-pure leaves the method's transitive chain touched
+/// (empty = every leaf was manifest-covered or fully analyzed IL).
+/// </summary>
+public sealed record ILMethodOutcome(
+    ILResolutionStatus Status,
+    EffectSet Effects,
+    IReadOnlyCollection<MethodKey> AssumedPureLeaves);
+
+/// <summary>
 /// Propagates effects transitively through the IL call graph.
 ///
 /// Phase 1 (Graph construction): Demand-driven BFS from entry points.
@@ -37,20 +47,37 @@ public sealed class TransitiveEffectPropagator
     public Dictionary<MethodKey, (ILResolutionStatus Status, EffectSet Effects)> Propagate(
         IEnumerable<MethodKey> entryPoints)
     {
+        return PropagateDetailed(entryPoints)
+            .ToDictionary(kvp => kvp.Key, kvp => (kvp.Value.Status, kvp.Value.Effects));
+    }
+
+    /// <summary>
+    /// Like <see cref="Propagate"/> but additionally reports, per method, the
+    /// set of assumed-pure leaves its transitive chain touched — callees that
+    /// were seeded pure NOT because a manifest covered them but because they
+    /// were missing from the loaded assemblies or had no IL body (extern,
+    /// abstract, delegate <c>Invoke</c>). A non-empty set means the effect
+    /// result rests on unverified assumptions; honest consumers (calor import
+    /// Tier A) must not present such a method as cleanly derived.
+    /// </summary>
+    public Dictionary<MethodKey, ILMethodOutcome> PropagateDetailed(IEnumerable<MethodKey> entryPoints)
+    {
         // Phase 1: Build call graph via demand-driven BFS
-        var (forwardEdges, seeds, incomplete) = BuildCallGraph(entryPoints);
+        var (forwardEdges, seeds, incomplete, assumedLeaves) = BuildCallGraph(entryPoints);
 
         // Phase 2: Tarjan SCC + fixpoint propagation
-        return PropagateEffects(forwardEdges, seeds, incomplete);
+        return PropagateEffects(forwardEdges, seeds, incomplete, assumedLeaves);
     }
 
     private (Dictionary<MethodKey, List<CallEdge>> ForwardEdges,
              Dictionary<MethodKey, EffectSet> Seeds,
-             HashSet<MethodKey> Incomplete) BuildCallGraph(IEnumerable<MethodKey> entryPoints)
+             HashSet<MethodKey> Incomplete,
+             HashSet<MethodKey> AssumedLeaves) BuildCallGraph(IEnumerable<MethodKey> entryPoints)
     {
         var forwardEdges = new Dictionary<MethodKey, List<CallEdge>>();
         var seeds = new Dictionary<MethodKey, EffectSet>();
         var incomplete = new HashSet<MethodKey>();
+        var assumedLeaves = new HashSet<MethodKey>();
         var visited = new HashSet<MethodKey>();
 
         // Sort entry points for determinism
@@ -80,8 +107,16 @@ public sealed class TransitiveEffectPropagator
                 continue;
             }
 
-            // Find method in loaded assemblies
+            // Find method in loaded assemblies. Generic instantiations carry
+            // decorated type names ("Foo`1<System.String>") while the type
+            // index holds open definitions — retry on the bare name (the open
+            // definition's IL body is what any instantiation executes).
             var location = _assemblyIndex.FindMethod(method);
+            if (location == null && method.TypeName.Contains('<'))
+            {
+                location = _assemblyIndex.FindMethod(
+                    BareTypeName(method.TypeName), method.MethodName);
+            }
             if (location == null)
             {
                 // Method not in any loaded assembly. If it's an external BCL/framework
@@ -89,15 +124,19 @@ public sealed class TransitiveEffectPropagator
                 // Rationale: marking every unresolvable BCL method as Incomplete would make
                 // ALL chains Incomplete (every method eventually calls Object:.ctor, exception
                 // constructors, etc.). Methods with effects should be covered by manifests.
+                // The assumption is RECORDED: PropagateDetailed surfaces it per method so
+                // consumers that need honesty (calor import) can refuse to trust the chain.
                 seeds[method] = EffectSet.Empty;
+                assumedLeaves.Add(method);
                 continue;
             }
 
             if (!location.HasBody)
             {
-                // Method exists but has no IL body (extern, P/Invoke, abstract).
-                // Same reasoning: treat as pure if manifests didn't cover it.
+                // Method exists but has no IL body (extern, P/Invoke, abstract,
+                // delegate Invoke). Same reasoning — and same recording.
                 seeds[method] = EffectSet.Empty;
+                assumedLeaves.Add(method);
                 continue;
             }
 
@@ -119,10 +158,14 @@ public sealed class TransitiveEffectPropagator
             {
                 if (edge.IsVirtual)
                 {
-                    // Skip known-unresolvable interfaces — don't include in graph
-                    if (_options.SkipInterfaces.Contains(edge.Callee.TypeName))
+                    // Skip known-unresolvable interfaces — don't include in graph.
+                    // Compare on the OPEN generic name: IL callees on generic
+                    // instantiations carry "IEnumerable`1<System.String>" and
+                    // would otherwise bypass the skip lists entirely.
+                    var calleeTypeName = BareTypeName(edge.Callee.TypeName);
+                    if (_options.SkipInterfaces.Contains(calleeTypeName))
                         continue;
-                    if (_options.UbiquitousInterfaces.Contains(edge.Callee.TypeName))
+                    if (_options.UbiquitousInterfaces.Contains(calleeTypeName))
                         continue;
 
                     keptEdges.Add(edge);
@@ -151,7 +194,7 @@ public sealed class TransitiveEffectPropagator
             forwardEdges[method] = keptEdges;
         }
 
-        return (forwardEdges, seeds, incomplete);
+        return (forwardEdges, seeds, incomplete, assumedLeaves);
     }
 
     /// <summary>
@@ -161,8 +204,13 @@ public sealed class TransitiveEffectPropagator
     /// </summary>
     private EffectResolution ResolveFromManifest(MethodKey method)
     {
+        // Manifests are keyed by open generic names ("IEnumerable`1"); IL
+        // callees on instantiations carry "IEnumerable`1<System.String>" —
+        // resolve on the bare name.
+        var typeName = BareTypeName(method.TypeName);
+
         // Try standard method resolution first
-        var result = _manifestResolver.Resolve(method.TypeName, method.MethodName);
+        var result = _manifestResolver.Resolve(typeName, method.MethodName);
         if (result.Status != EffectResolutionStatus.Unknown)
             return result;
 
@@ -170,7 +218,7 @@ public sealed class TransitiveEffectPropagator
         if (method.MethodName.StartsWith("set_") && method.MethodName.Length > 4)
         {
             var propertyName = method.MethodName[4..];
-            result = _manifestResolver.ResolveSetter(method.TypeName, propertyName);
+            result = _manifestResolver.ResolveSetter(typeName, propertyName);
             if (result.Status != EffectResolutionStatus.Unknown)
                 return result;
         }
@@ -179,7 +227,7 @@ public sealed class TransitiveEffectPropagator
         if (method.MethodName.StartsWith("get_") && method.MethodName.Length > 4)
         {
             var propertyName = method.MethodName[4..];
-            result = _manifestResolver.ResolveGetter(method.TypeName, propertyName);
+            result = _manifestResolver.ResolveGetter(typeName, propertyName);
             if (result.Status != EffectResolutionStatus.Unknown)
                 return result;
         }
@@ -187,7 +235,7 @@ public sealed class TransitiveEffectPropagator
         // Constructor: .ctor → ResolveConstructor(type)
         if (method.MethodName == ".ctor")
         {
-            result = _manifestResolver.ResolveConstructor(method.TypeName);
+            result = _manifestResolver.ResolveConstructor(typeName);
             if (result.Status != EffectResolutionStatus.Unknown)
                 return result;
         }
@@ -195,10 +243,18 @@ public sealed class TransitiveEffectPropagator
         return result;
     }
 
-    private Dictionary<MethodKey, (ILResolutionStatus, EffectSet)> PropagateEffects(
+    /// <summary>Strips a generic instantiation suffix: "IEnumerable`1&lt;System.String&gt;" → "IEnumerable`1".</summary>
+    private static string BareTypeName(string typeName)
+    {
+        var angle = typeName.IndexOf('<');
+        return angle < 0 ? typeName : typeName[..angle];
+    }
+
+    private Dictionary<MethodKey, ILMethodOutcome> PropagateEffects(
         Dictionary<MethodKey, List<CallEdge>> forwardEdges,
         Dictionary<MethodKey, EffectSet> seeds,
-        HashSet<MethodKey> incomplete)
+        HashSet<MethodKey> incomplete,
+        HashSet<MethodKey> assumedLeaves)
     {
         // Build the set of all known methods
         var allMethods = new HashSet<MethodKey>();
@@ -216,18 +272,23 @@ public sealed class TransitiveEffectPropagator
 
         // Process SCCs in reverse topological order (leaves first — Tarjan gives this)
         var computed = new Dictionary<MethodKey, (ILResolutionStatus Status, EffectSet Effects)>();
+        // Parallel lattice: per method, which assumed-pure leaves its chain touched.
+        var assumptions = new Dictionary<MethodKey, HashSet<MethodKey>>();
+        var emptySet = new HashSet<MethodKey>();
 
         // Seed entries
         foreach (var (method, effects) in seeds)
         {
             var status = effects.IsEmpty ? ILResolutionStatus.ResolvedPure : ILResolutionStatus.Resolved;
             computed[method] = (status, effects);
+            assumptions[method] = assumedLeaves.Contains(method) ? [method] : emptySet;
         }
 
         // Incomplete entries
         foreach (var method in incomplete)
         {
             computed.TryAdd(method, (ILResolutionStatus.Incomplete, EffectSet.Unknown));
+            assumptions.TryAdd(method, emptySet);
         }
 
         foreach (var scc in sccs)
@@ -242,15 +303,59 @@ public sealed class TransitiveEffectPropagator
                     : effects.IsEmpty ? ILResolutionStatus.ResolvedPure
                     : ILResolutionStatus.Resolved;
                 computed[method] = (status, effects);
+                assumptions[method] = UnionCalleeAssumptions(method, forwardEdges, assumptions, emptySet);
             }
             else
             {
                 // Multi-method SCC — fixpoint iteration
                 ProcessSccFixpoint(scc, forwardEdges, computed, seeds, incomplete);
+
+                // Assumptions inside an SCC are shared: every member's chain can
+                // reach every other member, so the union over the whole SCC (plus
+                // each member's callees outside it) applies to all members.
+                var sccUnion = new HashSet<MethodKey>();
+                foreach (var member in scc)
+                {
+                    if (assumptions.TryGetValue(member, out var own))
+                        sccUnion.UnionWith(own);
+                    sccUnion.UnionWith(UnionCalleeAssumptions(member, forwardEdges, assumptions, emptySet));
+                }
+                var shared = sccUnion.Count == 0 ? emptySet : sccUnion;
+                foreach (var member in scc)
+                    assumptions[member] = shared;
             }
         }
 
-        return computed;
+        var outcomes = new Dictionary<MethodKey, ILMethodOutcome>(computed.Count);
+        foreach (var (method, value) in computed)
+        {
+            outcomes[method] = new ILMethodOutcome(
+                value.Status,
+                value.Effects,
+                assumptions.TryGetValue(method, out var set) ? set : emptySet);
+        }
+        return outcomes;
+    }
+
+    private static HashSet<MethodKey> UnionCalleeAssumptions(
+        MethodKey method,
+        Dictionary<MethodKey, List<CallEdge>> forwardEdges,
+        Dictionary<MethodKey, HashSet<MethodKey>> assumptions,
+        HashSet<MethodKey> emptySet)
+    {
+        if (!forwardEdges.TryGetValue(method, out var edges) || edges.Count == 0)
+            return emptySet;
+
+        HashSet<MethodKey>? union = null;
+        foreach (var edge in edges)
+        {
+            if (assumptions.TryGetValue(edge.Callee, out var calleeSet) && calleeSet.Count > 0)
+            {
+                union ??= [];
+                union.UnionWith(calleeSet);
+            }
+        }
+        return union ?? emptySet;
     }
 
     private static (EffectSet Effects, bool IsComplete) ComputeMethodEffects(

--- a/src/Calor.Compiler/Effects/Manifests/PackageManifestGenerator.cs
+++ b/src/Calor.Compiler/Effects/Manifests/PackageManifestGenerator.cs
@@ -1,0 +1,804 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Calor.Compiler.Effects.IL;
+
+namespace Calor.Compiler.Effects.Manifests;
+
+/// <summary>
+/// Productizes the three-tier effect-resolution strategy
+/// (docs/plans/dotnet-ecosystem-effect-manifests.md v4) into a manifest
+/// generator for a package's public surface — the engine behind
+/// <c>calor import</c> (wedge plan v0.11 D-W3.1):
+///
+/// <list type="bullet">
+/// <item><b>Tier A</b> — compile-time IL derivation for concrete call chains,
+/// via the existing <see cref="ILEffectAnalyzer"/> machinery. Emitted with
+/// provenance <c>inferred</c> (derived).</item>
+/// <item><b>Tier B</b> — methods already covered by curated manifests
+/// (built-in, user, solution, project) are reported as <c>curated</c> and
+/// never re-emitted.</item>
+/// <item><b>Tier C</b> — anything unresolved (irreducible dynamic dispatch,
+/// analysis limits, bodiless declarations without curated coverage) is
+/// surfaced loudly in the report, never silently under-approximated.</item>
+/// </list>
+///
+/// Contract synthesis (D-W3.2, narrow mechanical set): non-null §Q facts from
+/// NRT metadata and non-negativity facts from unsigned parameter types. Every
+/// synthesized contract carries <c>assumed</c> provenance and is emitted as
+/// annotation-only output — the consumption path into verification is
+/// deliberately not wired (recorded shed point; see the import command docs).
+/// Nothing this generator emits ever carries <c>verified</c> confidence.
+/// </summary>
+public sealed class PackageManifestGenerator
+{
+    /// <summary>Provenance value for Tier-A IL-derived entries.</summary>
+    public const string DerivedConfidence = "inferred";
+
+    /// <summary>Provenance value for synthesized contracts. Never trusted.</summary>
+    public const string AssumedProvenance = "assumed";
+
+    private PackageManifestGenerator() { }
+
+    /// <summary>
+    /// Generates the import report for a package's public surface.
+    /// </summary>
+    /// <param name="targetAssemblyPaths">Assemblies whose public surface is imported.</param>
+    /// <param name="referenceAssemblyPaths">Additional assemblies loaded for call-chain resolution only.</param>
+    /// <param name="resolver">Initialized manifest resolver (curated tiers).</param>
+    /// <param name="library">NuGet package id, when known.</param>
+    /// <param name="libraryVersion">Package version, when known.</param>
+    /// <param name="synthesizeContracts">Whether to run the D-W3.2 mechanical contract synthesis.</param>
+    /// <param name="ilOptions">IL analysis options (runtime directory etc.).</param>
+    public static PackageImportReport Generate(
+        IReadOnlyList<string> targetAssemblyPaths,
+        IReadOnlyList<string> referenceAssemblyPaths,
+        EffectResolver resolver,
+        string? library = null,
+        string? libraryVersion = null,
+        bool synthesizeContracts = true,
+        ILAnalysisOptions? ilOptions = null)
+    {
+        var report = new PackageImportReport
+        {
+            Library = library,
+            LibraryVersion = libraryVersion,
+            TargetAssemblies = targetAssemblyPaths.Select(Path.GetFileName).ToList()!
+        };
+
+        // Enumerate the public surface of the target assemblies directly —
+        // visibility and body information is needed for honest classification,
+        // which AssemblyIndex does not expose.
+        var surface = new List<PublicMethod>();
+        foreach (var path in targetAssemblyPaths)
+            EnumeratePublicSurface(path, surface, report);
+
+        // The unit of classification is the (type, member, kind) group —
+        // manifest entries are name-keyed, so overloads are unioned and any
+        // unresolved overload makes the whole member unresolved (dropping it
+        // silently would under-approximate the member).
+        var groups = surface
+            .GroupBy(m => (m.Key.TypeName, m.DisplayMember, m.Kind))
+            .OrderBy(g => g.Key.TypeName, StringComparer.Ordinal)
+            .ThenBy(g => g.Key.DisplayMember, StringComparer.Ordinal)
+            .ToList();
+
+        report.PublicMethodCount = groups.Count;
+
+        // Tier B first: members already covered by curated manifests.
+        var uncovered = new List<IGrouping<(string TypeName, string DisplayMember, ImportMemberKind Kind), PublicMethod>>();
+        foreach (var group in groups)
+        {
+            var resolution = ResolveCurated(resolver, group.First());
+            if (resolution.Status != EffectResolutionStatus.Unknown)
+            {
+                report.Curated.Add(new ImportedEntry(
+                    group.Key.TypeName, group.Key.DisplayMember, KindLabel(group.Key.Kind),
+                    SurfaceCodes(resolution.Effects), resolution.Source ?? "manifest"));
+            }
+            else
+            {
+                uncovered.Add(group);
+            }
+        }
+
+        // Tier A: IL derivation for concrete chains — only members whose
+        // every overload has a body. A bodiless method (interface/abstract/
+        // extern) has no chain to trace; without curated coverage the member
+        // is unresolved — loudly (Tier C).
+        var bodied = uncovered.Where(g => g.All(m => m.HasBody)).ToList();
+        var bodiless = uncovered.Where(g => g.Any(m => !m.HasBody)).ToList();
+
+        var ilResults = AnalyzeBodied(
+            bodied.SelectMany(g => g).ToList(),
+            targetAssemblyPaths, referenceAssemblyPaths, resolver, ilOptions);
+
+        foreach (var group in bodied)
+        {
+            var union = EffectSet.Empty;
+            var incomplete = false;
+            foreach (var overload in group)
+            {
+                if (ilResults.TryGetValue(overload.Key, out var result)
+                    && result.Status != ILResolutionStatus.Incomplete)
+                {
+                    union = union.Union(result.Effects);
+                }
+                else
+                {
+                    incomplete = true;
+                    break;
+                }
+            }
+
+            if (incomplete)
+            {
+                report.Unresolved.Add(new UnresolvedEntry(
+                    group.Key.TypeName, group.Key.DisplayMember, KindLabel(group.Key.Kind),
+                    "incomplete: dynamic dispatch, indirect calls, or analysis limits — supply a curated or supplemental manifest entry"));
+            }
+            else
+            {
+                report.Derived.Add(new ImportedEntry(
+                    group.Key.TypeName, group.Key.DisplayMember, KindLabel(group.Key.Kind),
+                    SurfaceCodes(union), "il-analysis"));
+            }
+        }
+
+        foreach (var group in bodiless)
+        {
+            report.Unresolved.Add(new UnresolvedEntry(
+                group.Key.TypeName, group.Key.DisplayMember, KindLabel(group.Key.Kind),
+                "no body: interface, abstract, or extern declaration — needs a curated (Tier B) or supplemental (Tier C) manifest entry"));
+        }
+
+        report.Unresolved.Sort((a, b) =>
+        {
+            var byType = string.Compare(a.Type, b.Type, StringComparison.Ordinal);
+            return byType != 0 ? byType : string.Compare(a.Member, b.Member, StringComparison.Ordinal);
+        });
+
+        report.Manifest = BuildManifest(report, library, libraryVersion);
+
+        if (synthesizeContracts)
+        {
+            foreach (var path in targetAssemblyPaths)
+                SynthesizeContracts(path, report);
+        }
+
+        return report;
+    }
+
+    // ------------------------------------------------------------------
+    // Public-surface enumeration
+    // ------------------------------------------------------------------
+
+    private sealed record PublicMethod(
+        MethodKey Key,
+        string DisplayMember,
+        ImportMemberKind Kind,
+        bool HasBody);
+
+    private static void EnumeratePublicSurface(string assemblyPath, List<PublicMethod> surface, PackageImportReport report)
+    {
+        if (!File.Exists(assemblyPath))
+        {
+            report.LoadErrors.Add($"Assembly not found: {assemblyPath}");
+            return;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(assemblyPath);
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+            {
+                report.LoadErrors.Add($"No metadata: {assemblyPath}");
+                return;
+            }
+
+            var reader = peReader.GetMetadataReader();
+            foreach (var typeHandle in reader.TypeDefinitions)
+            {
+                TypeDefinition typeDef;
+                try { typeDef = reader.GetTypeDefinition(typeHandle); }
+                catch (BadImageFormatException) { continue; }
+
+                if (!IsPubliclyVisible(reader, typeDef))
+                    continue;
+
+                var typeName = MethodKey.GetFullTypeName(reader, typeHandle);
+                if (typeName.StartsWith('<') || typeName.Contains("<PrivateImplementationDetails>", StringComparison.Ordinal))
+                    continue;
+
+                foreach (var methodHandle in typeDef.GetMethods())
+                {
+                    MethodDefinition methodDef;
+                    try { methodDef = reader.GetMethodDefinition(methodHandle); }
+                    catch (BadImageFormatException) { continue; }
+
+                    var attrs = methodDef.Attributes;
+                    if ((attrs & MethodAttributes.MemberAccessMask) != MethodAttributes.Public)
+                        continue;
+
+                    var name = reader.GetString(methodDef.Name);
+                    if (name == ".cctor" || name.StartsWith('<'))
+                        continue;
+
+                    var kind = ClassifyMember(name, attrs);
+                    if (kind == ImportMemberKind.Skipped)
+                        continue;
+
+                    var isAbstract = (attrs & MethodAttributes.Abstract) != 0;
+                    var hasBody = !isAbstract
+                        && (attrs & MethodAttributes.PinvokeImpl) == 0
+                        && methodDef.RelativeVirtualAddress != 0;
+
+                    MethodKey key;
+                    try { key = MethodKey.FromDefinition(reader, methodHandle); }
+                    catch (BadImageFormatException) { continue; }
+
+                    var display = kind switch
+                    {
+                        ImportMemberKind.Getter or ImportMemberKind.Setter => name[4..],
+                        ImportMemberKind.Constructor => ".ctor",
+                        _ => name
+                    };
+
+                    surface.Add(new PublicMethod(key, display, kind, hasBody));
+                }
+            }
+        }
+        catch (BadImageFormatException)
+        {
+            report.LoadErrors.Add($"Malformed assembly: {assemblyPath}");
+        }
+        catch (IOException ex)
+        {
+            report.LoadErrors.Add($"Cannot read {assemblyPath}: {ex.Message}");
+        }
+    }
+
+    private static bool IsPubliclyVisible(MetadataReader reader, TypeDefinition typeDef)
+    {
+        var visibility = typeDef.Attributes & TypeAttributes.VisibilityMask;
+        if (visibility == TypeAttributes.Public)
+            return true;
+        if (visibility is TypeAttributes.NestedPublic)
+        {
+            try
+            {
+                var declaring = reader.GetTypeDefinition(typeDef.GetDeclaringType());
+                return IsPubliclyVisible(reader, declaring);
+            }
+            catch (BadImageFormatException) { return false; }
+        }
+        return false;
+    }
+
+    private static string KindLabel(ImportMemberKind kind) => kind switch
+    {
+        ImportMemberKind.Getter => "getter",
+        ImportMemberKind.Setter => "setter",
+        ImportMemberKind.Constructor => "constructor",
+        _ => "method"
+    };
+
+    private static ImportMemberKind ClassifyMember(string name, MethodAttributes attrs)
+    {
+        if (name == ".ctor")
+            return ImportMemberKind.Constructor;
+
+        if ((attrs & MethodAttributes.SpecialName) != 0)
+        {
+            if (name.StartsWith("get_", StringComparison.Ordinal) && name.Length > 4)
+                return ImportMemberKind.Getter;
+            if (name.StartsWith("set_", StringComparison.Ordinal) && name.Length > 4)
+                return ImportMemberKind.Setter;
+            // Event accessors and operators have no manifest surface; skipping
+            // them is a representation gap, not an effect under-approximation —
+            // the resolver never consults them.
+            return ImportMemberKind.Skipped;
+        }
+
+        return ImportMemberKind.Method;
+    }
+
+    // ------------------------------------------------------------------
+    // Tier A / Tier B resolution
+    // ------------------------------------------------------------------
+
+    private static EffectResolution ResolveCurated(EffectResolver resolver, PublicMethod method)
+    {
+        return method.Kind switch
+        {
+            ImportMemberKind.Getter => resolver.ResolveGetter(method.Key.TypeName, method.DisplayMember),
+            ImportMemberKind.Setter => resolver.ResolveSetter(method.Key.TypeName, method.DisplayMember),
+            ImportMemberKind.Constructor => resolver.ResolveConstructor(method.Key.TypeName),
+            _ => resolver.Resolve(method.Key.TypeName, method.DisplayMember)
+        };
+    }
+
+    private static Dictionary<MethodKey, (ILResolutionStatus Status, EffectSet Effects)> AnalyzeBodied(
+        List<PublicMethod> bodied,
+        IReadOnlyList<string> targetAssemblyPaths,
+        IReadOnlyList<string> referenceAssemblyPaths,
+        EffectResolver resolver,
+        ILAnalysisOptions? ilOptions)
+    {
+        if (bodied.Count == 0)
+            return [];
+
+        var allPaths = targetAssemblyPaths.Concat(referenceAssemblyPaths).Distinct().ToList();
+        var options = ilOptions ?? new ILAnalysisOptions();
+
+        using var index = new AssemblyIndex(allPaths, options);
+        var builder = new ILCallGraphBuilder(index);
+        var stateMachines = new StateMachineResolver(index);
+        var propagator = new TransitiveEffectPropagator(builder, index, stateMachines, resolver, options);
+
+        return propagator.Propagate(bodied.Select(m => m.Key));
+    }
+
+    private static List<string> SurfaceCodes(EffectSet effects)
+    {
+        if (effects.IsUnknown)
+            return ["unknown"];
+        return effects.Effects
+            .Select(e => EffectSetExtensions.ToSurfaceCode(e.Kind, e.Value))
+            .OrderBy(c => c, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static EffectManifest BuildManifest(PackageImportReport report, string? library, string? libraryVersion)
+    {
+        var manifest = new EffectManifest
+        {
+            Version = "1.0",
+            Description = library is null
+                ? "Effects derived by calor import (Tier A IL analysis of concrete call chains)"
+                : $"Effects derived by calor import for {library} (Tier A IL analysis of concrete call chains)",
+            Library = library,
+            LibraryVersion = libraryVersion,
+            GeneratedBy = "calor import",
+            Confidence = DerivedConfidence,
+            GeneratedAt = DateTime.UtcNow.ToString("O")
+        };
+
+        foreach (var typeGroup in report.Derived
+            .GroupBy(e => e.Type)
+            .OrderBy(g => g.Key, StringComparer.Ordinal))
+        {
+            var mapping = new TypeMapping { Type = typeGroup.Key };
+            foreach (var entry in typeGroup.OrderBy(e => e.Member, StringComparer.Ordinal))
+            {
+                switch (entry.Kind)
+                {
+                    case "constructor":
+                        mapping.Constructors ??= [];
+                        mapping.Constructors["()"] = entry.Effects.ToList();
+                        break;
+                    case "getter":
+                        mapping.Getters ??= [];
+                        mapping.Getters[entry.Member] = entry.Effects.ToList();
+                        break;
+                    case "setter":
+                        mapping.Setters ??= [];
+                        mapping.Setters[entry.Member] = entry.Effects.ToList();
+                        break;
+                    default:
+                        mapping.Methods ??= [];
+                        mapping.Methods[entry.Member] = entry.Effects.ToList();
+                        break;
+                }
+            }
+            manifest.Mappings.Add(mapping);
+        }
+
+        return manifest;
+    }
+
+    // ------------------------------------------------------------------
+    // D-W3.2 — mechanical contract synthesis (assumed provenance only)
+    // ------------------------------------------------------------------
+
+    private static void SynthesizeContracts(string assemblyPath, PackageImportReport report)
+    {
+        if (!File.Exists(assemblyPath))
+            return;
+
+        try
+        {
+            using var stream = File.OpenRead(assemblyPath);
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+                return;
+
+            var reader = peReader.GetMetadataReader();
+            foreach (var typeHandle in reader.TypeDefinitions)
+            {
+                TypeDefinition typeDef;
+                try { typeDef = reader.GetTypeDefinition(typeHandle); }
+                catch (BadImageFormatException) { continue; }
+
+                if (!IsPubliclyVisible(reader, typeDef))
+                    continue;
+
+                var typeName = MethodKey.GetFullTypeName(reader, typeHandle);
+                if (typeName.StartsWith('<'))
+                    continue;
+
+                var typeNullableContext = ReadNullableContext(reader, typeDef.GetCustomAttributes());
+
+                foreach (var methodHandle in typeDef.GetMethods())
+                {
+                    try
+                    {
+                        SynthesizeForMethod(reader, methodHandle, typeName, typeNullableContext, report);
+                    }
+                    catch (BadImageFormatException)
+                    {
+                        // Malformed method metadata — skip; synthesis is best-effort
+                        // and never fabricates a contract it could not decode.
+                    }
+                }
+            }
+        }
+        catch (BadImageFormatException) { /* skip malformed assembly */ }
+        catch (IOException) { /* skip unreadable assembly */ }
+    }
+
+    private static void SynthesizeForMethod(
+        MetadataReader reader,
+        MethodDefinitionHandle methodHandle,
+        string typeName,
+        byte? typeNullableContext,
+        PackageImportReport report)
+    {
+        var methodDef = reader.GetMethodDefinition(methodHandle);
+        var attrs = methodDef.Attributes;
+        if ((attrs & MethodAttributes.MemberAccessMask) != MethodAttributes.Public)
+            return;
+
+        var methodName = reader.GetString(methodDef.Name);
+        if (methodName == ".cctor" || methodName.StartsWith('<'))
+            return;
+
+        var paramCategories = DecodeParameterCategories(reader, methodDef.Signature);
+        if (paramCategories.Count == 0)
+            return;
+
+        var methodNullableContext = ReadNullableContext(reader, methodDef.GetCustomAttributes())
+            ?? typeNullableContext;
+
+        // Sequence 0 is the return value; parameters are 1..N.
+        foreach (var paramHandle in methodDef.GetParameters())
+        {
+            var param = reader.GetParameter(paramHandle);
+            if (param.SequenceNumber == 0 || param.SequenceNumber > paramCategories.Count)
+                continue;
+
+            var paramName = reader.GetString(param.Name);
+            if (string.IsNullOrEmpty(paramName))
+                continue;
+
+            var category = paramCategories[param.SequenceNumber - 1];
+            switch (category)
+            {
+                case ParameterCategory.ReferenceType:
+                {
+                    var nullable = ReadNullableAnnotation(reader, param.GetCustomAttributes())
+                        ?? methodNullableContext;
+                    // 1 = non-nullable under NRT. No annotation and no context
+                    // means nullable-oblivious code: no fact is derivable, so
+                    // none is synthesized (never guess).
+                    if (nullable == 1)
+                    {
+                        report.SynthesizedContracts.Add(new SynthesizedContract(
+                            typeName, methodName, paramName,
+                            Kind: "requires-not-null",
+                            Expression: $"(!= {paramName} null)",
+                            Provenance: AssumedProvenance,
+                            Source: "nrt-metadata"));
+                    }
+                    break;
+                }
+                case ParameterCategory.UnsignedInteger:
+                    report.SynthesizedContracts.Add(new SynthesizedContract(
+                        typeName, methodName, paramName,
+                        Kind: "requires-non-negative",
+                        Expression: $"(>= {paramName} 0)",
+                        Provenance: AssumedProvenance,
+                        Source: "unsigned-parameter-type"));
+                    break;
+            }
+        }
+    }
+
+    private enum ParameterCategory { Other, ReferenceType, UnsignedInteger }
+
+    /// <summary>
+    /// Decodes only what the mechanical synthesis needs from a method signature:
+    /// whether each parameter is a reference type or an unsigned integer.
+    /// Anything ambiguous (byref, generic parameters, pointers) is Other —
+    /// synthesis never guesses.
+    /// </summary>
+    private static List<ParameterCategory> DecodeParameterCategories(MetadataReader reader, BlobHandle signatureBlob)
+    {
+        var categories = new List<ParameterCategory>();
+        try
+        {
+            var blob = reader.GetBlobReader(signatureBlob);
+            var header = blob.ReadSignatureHeader();
+            if (header.IsGeneric)
+                blob.ReadCompressedInteger();
+
+            var paramCount = blob.ReadCompressedInteger();
+            SkipTypeShape(ref blob); // return type
+
+            for (var i = 0; i < paramCount; i++)
+                categories.Add(ReadCategory(ref blob));
+        }
+        catch (BadImageFormatException)
+        {
+            return [];
+        }
+        return categories;
+    }
+
+    private static ParameterCategory ReadCategory(ref BlobReader blob)
+    {
+        var typeCode = blob.ReadCompressedInteger();
+        switch (typeCode)
+        {
+            case 0x05: // U1
+            case 0x07: // U2
+            case 0x09: // U4
+            case 0x0B: // U8
+                return ParameterCategory.UnsignedInteger;
+            case 0x0E: // STRING
+            case 0x1C: // OBJECT
+                return ParameterCategory.ReferenceType;
+            case 0x12: // CLASS
+                blob.ReadCompressedInteger(); // TypeDefOrRef token
+                return ParameterCategory.ReferenceType;
+            case 0x1D: // SZARRAY
+                SkipTypeShape(ref blob);
+                return ParameterCategory.ReferenceType;
+            case 0x14: // ARRAY
+                SkipTypeShape(ref blob);
+                var rank = blob.ReadCompressedInteger();
+                _ = rank;
+                var numSizes = blob.ReadCompressedInteger();
+                for (var i = 0; i < numSizes; i++) blob.ReadCompressedInteger();
+                var numLoBounds = blob.ReadCompressedInteger();
+                for (var i = 0; i < numLoBounds; i++) blob.ReadCompressedSignedInteger();
+                return ParameterCategory.ReferenceType;
+            case 0x15: // GENERIC_INST — CLASS/VALUETYPE byte, then type + args
+            {
+                var elementKind = blob.ReadCompressedInteger();
+                blob.ReadCompressedInteger(); // TypeDefOrRef token
+                var argCount = blob.ReadCompressedInteger();
+                for (var i = 0; i < argCount; i++) SkipTypeShape(ref blob);
+                return elementKind == 0x12 ? ParameterCategory.ReferenceType : ParameterCategory.Other;
+            }
+            case 0x1F: // CMOD_OPT
+            case 0x20: // CMOD_REQD
+                blob.ReadCompressedInteger(); // modifier token
+                return ReadCategory(ref blob);
+            default:
+                SkipTypeShapeAfterCode(ref blob, typeCode);
+                return ParameterCategory.Other;
+        }
+    }
+
+    private static void SkipTypeShape(ref BlobReader blob)
+    {
+        var typeCode = blob.ReadCompressedInteger();
+        SkipTypeShapeAfterCode(ref blob, typeCode);
+    }
+
+    private static void SkipTypeShapeAfterCode(ref BlobReader blob, int typeCode)
+    {
+        switch (typeCode)
+        {
+            case 0x01 or 0x02 or 0x03 or 0x04 or 0x05 or 0x06 or 0x07 or 0x08
+                or 0x09 or 0x0A or 0x0B or 0x0C or 0x0D or 0x0E or 0x16 or 0x18
+                or 0x19 or 0x1C:
+                break;
+            case 0x10 or 0x0F or 0x1D or 0x45: // BYREF, PTR, SZARRAY, PINNED
+                SkipTypeShape(ref blob);
+                break;
+            case 0x11 or 0x12: // VALUETYPE, CLASS
+                blob.ReadCompressedInteger();
+                break;
+            case 0x13 or 0x1E: // VAR, MVAR
+                blob.ReadCompressedInteger();
+                break;
+            case 0x14: // ARRAY
+                SkipTypeShape(ref blob);
+                var rank = blob.ReadCompressedInteger();
+                _ = rank;
+                var numSizes = blob.ReadCompressedInteger();
+                for (var i = 0; i < numSizes; i++) blob.ReadCompressedInteger();
+                var numLoBounds = blob.ReadCompressedInteger();
+                for (var i = 0; i < numLoBounds; i++) blob.ReadCompressedSignedInteger();
+                break;
+            case 0x15: // GENERIC_INST
+                blob.ReadCompressedInteger();
+                blob.ReadCompressedInteger();
+                var argCount = blob.ReadCompressedInteger();
+                for (var i = 0; i < argCount; i++) SkipTypeShape(ref blob);
+                break;
+            case 0x1B: // FNPTR
+                blob.ReadSignatureHeader();
+                var paramCount = blob.ReadCompressedInteger();
+                SkipTypeShape(ref blob);
+                for (var i = 0; i < paramCount; i++) SkipTypeShape(ref blob);
+                break;
+            case 0x1F or 0x20: // CMOD
+                blob.ReadCompressedInteger();
+                SkipTypeShape(ref blob);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Reads the scalar byte from a NullableContextAttribute, if present.
+    /// </summary>
+    private static byte? ReadNullableContext(MetadataReader reader, CustomAttributeHandleCollection attributes)
+        => ReadNullableByte(reader, attributes, "NullableContextAttribute");
+
+    /// <summary>
+    /// Reads the top-level nullability byte from a NullableAttribute — the
+    /// scalar form directly, or the first element of the byte[] form (which
+    /// describes the top-level type of a generic/array parameter).
+    /// </summary>
+    private static byte? ReadNullableAnnotation(MetadataReader reader, CustomAttributeHandleCollection attributes)
+        => ReadNullableByte(reader, attributes, "NullableAttribute");
+
+    private static byte? ReadNullableByte(
+        MetadataReader reader,
+        CustomAttributeHandleCollection attributes,
+        string attributeName)
+    {
+        foreach (var attrHandle in attributes)
+        {
+            try
+            {
+                var attr = reader.GetCustomAttribute(attrHandle);
+                if (GetAttributeTypeName(reader, attr) != attributeName)
+                    continue;
+
+                var blob = reader.GetBlobReader(attr.Value);
+                if (blob.Length < 4)
+                    return null;
+                var prolog = blob.ReadUInt16();
+                if (prolog != 0x0001)
+                    return null;
+
+                // Two ctors exist: (byte) and (byte[]).
+                // (byte): 1 value byte + 2 named-arg-count bytes remain.
+                // (byte[]): int32 length + bytes + 2 named-arg-count bytes remain.
+                if (blob.RemainingBytes == 3)
+                    return blob.ReadByte();
+
+                var length = blob.ReadInt32();
+                if (length >= 1 && blob.RemainingBytes >= length)
+                    return blob.ReadByte(); // first element = top-level type
+                return null;
+            }
+            catch (BadImageFormatException)
+            {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static string? GetAttributeTypeName(MetadataReader reader, CustomAttribute attr)
+    {
+        try
+        {
+            switch (attr.Constructor.Kind)
+            {
+                case HandleKind.MemberReference:
+                {
+                    var ctor = reader.GetMemberReference((MemberReferenceHandle)attr.Constructor);
+                    if (ctor.Parent.Kind != HandleKind.TypeReference)
+                        return null;
+                    var typeRef = reader.GetTypeReference((TypeReferenceHandle)ctor.Parent);
+                    return reader.GetString(typeRef.Name);
+                }
+                case HandleKind.MethodDefinition:
+                {
+                    // Roslyn embeds NullableAttribute/NullableContextAttribute
+                    // into the assembly itself; the ctor is then a MethodDefinition.
+                    var ctorDef = reader.GetMethodDefinition((MethodDefinitionHandle)attr.Constructor);
+                    var typeDef = reader.GetTypeDefinition(ctorDef.GetDeclaringType());
+                    return reader.GetString(typeDef.Name);
+                }
+                default:
+                    return null;
+            }
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+    }
+}
+
+/// <summary>Member kind on the import surface.</summary>
+public enum ImportMemberKind
+{
+    Method,
+    Getter,
+    Setter,
+    Constructor,
+    Skipped
+}
+
+/// <summary>A resolved (derived or curated) entry on the import surface.</summary>
+public sealed record ImportedEntry(
+    string Type,
+    string Member,
+    string Kind,
+    IReadOnlyList<string> Effects,
+    string Source);
+
+/// <summary>An unresolved public member — surfaced loudly, never emitted as pure.</summary>
+public sealed record UnresolvedEntry(
+    string Type,
+    string Member,
+    string Kind,
+    string Reason);
+
+/// <summary>
+/// A mechanically synthesized contract fact. Provenance is always
+/// <see cref="PackageManifestGenerator.AssumedProvenance"/>; these facts are
+/// annotation-only output and are never consumed by verification as trusted.
+/// </summary>
+public sealed record SynthesizedContract(
+    string Type,
+    string Method,
+    string Parameter,
+    string Kind,
+    string Expression,
+    string Provenance,
+    string Source);
+
+/// <summary>
+/// The full result of a package import: the derived-only manifest plus the
+/// three-tier classification counts and loud unresolved surface.
+/// </summary>
+public sealed class PackageImportReport
+{
+    public string? Library { get; set; }
+    public string? LibraryVersion { get; set; }
+    public List<string> TargetAssemblies { get; set; } = [];
+
+    /// <summary>
+    /// Distinct public members — (type, member, kind) groups; overloads are
+    /// one member. Always equals Derived + Curated + Unresolved.
+    /// </summary>
+    public int PublicMethodCount { get; set; }
+
+    /// <summary>Tier A: IL-derived entries (provenance: inferred).</summary>
+    public List<ImportedEntry> Derived { get; } = [];
+
+    /// <summary>Tier B: already covered by curated/loaded manifests (provenance: per manifest, at most reviewed).</summary>
+    public List<ImportedEntry> Curated { get; } = [];
+
+    /// <summary>Tier C: unresolved — surfaced loudly, never silently under-approximated.</summary>
+    public List<UnresolvedEntry> Unresolved { get; } = [];
+
+    /// <summary>D-W3.2 synthesized contracts (provenance: assumed, annotation-only).</summary>
+    public List<SynthesizedContract> SynthesizedContracts { get; } = [];
+
+    /// <summary>Assembly-level load problems encountered during enumeration.</summary>
+    public List<string> LoadErrors { get; } = [];
+
+    /// <summary>The derived-only manifest (never contains curated or unresolved members).</summary>
+    public EffectManifest Manifest { get; set; } = new();
+}

--- a/src/Calor.Compiler/Effects/Manifests/PackageManifestGenerator.cs
+++ b/src/Calor.Compiler/Effects/Manifests/PackageManifestGenerator.cs
@@ -13,8 +13,12 @@ namespace Calor.Compiler.Effects.Manifests;
 ///
 /// <list type="bullet">
 /// <item><b>Tier A</b> — compile-time IL derivation for concrete call chains,
-/// via the existing <see cref="ILEffectAnalyzer"/> machinery. Emitted with
-/// provenance <c>inferred</c> (derived).</item>
+/// via the existing IL analysis machinery. Emitted with provenance
+/// <c>inferred</c> (derived) — and ONLY for members whose entire transitive
+/// chain resolved without unverified assumptions: a chain that touches a
+/// callee that is missing from the loaded assemblies, has no IL body, or is
+/// a delegate invocation is routed to Tier C instead (review C1 invariant —
+/// derived-pure must never rest on an assumed-pure leaf).</item>
 /// <item><b>Tier B</b> — methods already covered by curated manifests
 /// (built-in, user, solution, project) are reported as <c>curated</c> and
 /// never re-emitted.</item>
@@ -117,12 +121,15 @@ public sealed class PackageManifestGenerator
         {
             var union = EffectSet.Empty;
             var incomplete = false;
+            var assumedLeaves = new SortedSet<MethodKey>();
             foreach (var overload in group)
             {
                 if (ilResults.TryGetValue(overload.Key, out var result)
                     && result.Status != ILResolutionStatus.Incomplete)
                 {
                     union = union.Union(result.Effects);
+                    foreach (var leaf in result.AssumedPureLeaves)
+                        assumedLeaves.Add(leaf);
                 }
                 else
                 {
@@ -136,6 +143,17 @@ public sealed class PackageManifestGenerator
                 report.Unresolved.Add(new UnresolvedEntry(
                     group.Key.TypeName, group.Key.DisplayMember, KindLabel(group.Key.Kind),
                     "incomplete: dynamic dispatch, indirect calls, or analysis limits — supply a curated or supplemental manifest entry"));
+            }
+            else if (assumedLeaves.Count > 0)
+            {
+                // The chain rests on assumed-pure leaves that no manifest
+                // covered — emitting the union as a clean Tier-A entry would
+                // silently under-approximate (the honesty invariant of the
+                // adversarial review C1 finding). Route to Tier C, naming the
+                // assumptions so the user knows what to cover.
+                report.Unresolved.Add(new UnresolvedEntry(
+                    group.Key.TypeName, group.Key.DisplayMember, KindLabel(group.Key.Kind),
+                    DescribeAssumedLeaves(assumedLeaves)));
             }
             else
             {
@@ -276,6 +294,28 @@ public sealed class PackageManifestGenerator
         return false;
     }
 
+    /// <summary>
+    /// Builds the Tier-C reason for a chain that touched assumed-pure leaves,
+    /// naming up to three so the user knows what to cover with manifests.
+    /// Delegate invocations are called out — they are the classic laundering
+    /// vector, not merely a missing reference.
+    /// </summary>
+    private static string DescribeAssumedLeaves(IReadOnlyCollection<MethodKey> leaves)
+    {
+        static bool IsDelegateInvoke(MethodKey key)
+            => key.MethodName is "Invoke" or "BeginInvoke" or "EndInvoke" or "DynamicInvoke";
+
+        static string Describe(MethodKey key)
+            => IsDelegateInvoke(key)
+                ? $"delegate invocation ({key.TypeName}.{key.MethodName})"
+                : $"assumed-pure leaf {key.TypeName}.{key.MethodName}";
+
+        var named = leaves.Take(3).Select(Describe).ToList();
+        var suffix = leaves.Count > 3 ? $" (+{leaves.Count - 3} more)" : "";
+        return "chain rests on unverified assumptions: " + string.Join("; ", named) + suffix
+            + " — cover the leaves with curated or supplemental manifest entries, or pass their assemblies via --references";
+    }
+
     private static string KindLabel(ImportMemberKind kind) => kind switch
     {
         ImportMemberKind.Getter => "getter",
@@ -319,7 +359,7 @@ public sealed class PackageManifestGenerator
         };
     }
 
-    private static Dictionary<MethodKey, (ILResolutionStatus Status, EffectSet Effects)> AnalyzeBodied(
+    private static Dictionary<MethodKey, ILMethodOutcome> AnalyzeBodied(
         List<PublicMethod> bodied,
         IReadOnlyList<string> targetAssemblyPaths,
         IReadOnlyList<string> referenceAssemblyPaths,
@@ -337,7 +377,7 @@ public sealed class PackageManifestGenerator
         var stateMachines = new StateMachineResolver(index);
         var propagator = new TransitiveEffectPropagator(builder, index, stateMachines, resolver, options);
 
-        return propagator.Propagate(bodied.Select(m => m.Key));
+        return propagator.PropagateDetailed(bodied.Select(m => m.Key));
     }
 
     private static List<string> SurfaceCodes(EffectSet effects)
@@ -355,9 +395,10 @@ public sealed class PackageManifestGenerator
         var manifest = new EffectManifest
         {
             Version = "1.0",
-            Description = library is null
-                ? "Effects derived by calor import (Tier A IL analysis of concrete call chains)"
-                : $"Effects derived by calor import for {library} (Tier A IL analysis of concrete call chains)",
+            Description = (library is null
+                ? "Effects derived by calor import"
+                : $"Effects derived by calor import for {library}")
+                + " (Tier A IL analysis; only members whose full call chains resolved with no unverified assumptions)",
             Library = library,
             LibraryVersion = libraryVersion,
             GeneratedBy = "calor import",

--- a/src/Calor.Compiler/Manifests/bcl-framework-interfaces.calor-effects.json
+++ b/src/Calor.Compiler/Manifests/bcl-framework-interfaces.calor-effects.json
@@ -398,12 +398,45 @@
         "View": [],
         "PartialView": []
       }
+    },
+    {
+      "type": "Microsoft.Extensions.Caching.Memory.IMemoryCache",
+      "methods": {
+        "TryGetValue": [],
+        "CreateEntry": ["mut"],
+        "Remove": ["mut"],
+        "Dispose": []
+      }
+    },
+    {
+      "type": "Microsoft.Extensions.Caching.Memory.CacheExtensions",
+      "methods": {
+        "Get": [],
+        "TryGetValue": [],
+        "Set": ["mut"],
+        "GetOrCreate": ["mut"],
+        "GetOrCreateAsync": ["mut"]
+      }
+    },
+    {
+      "type": "Microsoft.Extensions.Caching.Distributed.IDistributedCache",
+      "methods": {
+        "Get": ["db:r"],
+        "GetAsync": ["db:r"],
+        "Set": ["db:w"],
+        "SetAsync": ["db:w"],
+        "Refresh": ["db:w"],
+        "RefreshAsync": ["db:w"],
+        "Remove": ["db:w"],
+        "RemoveAsync": ["db:w"]
+      }
     }
   ],
   "namespaceDefaults": {
     "Microsoft.Extensions.Logging": ["cw"],
     "Microsoft.Extensions.Configuration": ["env:r"],
     "Microsoft.Extensions.Options": [],
-    "Microsoft.Extensions.DependencyInjection": []
+    "Microsoft.Extensions.DependencyInjection": [],
+    "Microsoft.Extensions.Caching.Memory": []
   }
 }

--- a/src/Calor.Compiler/Manifests/bcl-system.calor-effects.json
+++ b/src/Calor.Compiler/Manifests/bcl-system.calor-effects.json
@@ -174,6 +174,126 @@
         "Clear": ["mut"],
         "ToString": []
       }
+    },
+    {
+      "type": "System.Object",
+      "constructors": { "()": [] },
+      "methods": {
+        "Equals": [],
+        "GetHashCode": [],
+        "GetType": [],
+        "ReferenceEquals": [],
+        "MemberwiseClone": []
+      }
+    },
+    {
+      "type": "System.Nullable`1",
+      "defaultEffects": []
+    },
+    {
+      "type": "System.Type",
+      "methods": {
+        "GetTypeFromHandle": [],
+        "Equals": [],
+        "GetHashCode": [],
+        "ToString": []
+      }
+    },
+    {
+      "type": "System.Func`1",
+      "constructors": { "()": [] }
+    },
+    {
+      "type": "System.Func`2",
+      "constructors": { "()": [] }
+    },
+    {
+      "type": "System.Func`3",
+      "constructors": { "()": [] }
+    },
+    {
+      "type": "System.Func`4",
+      "constructors": { "()": [] }
+    },
+    {
+      "type": "System.Func`5",
+      "constructors": { "()": [] }
+    },
+    {
+      "type": "System.Action",
+      "constructors": { "()": [] }
+    },
+    {
+      "type": "System.Action`1",
+      "constructors": { "()": [] }
+    },
+    {
+      "type": "System.Action`2",
+      "constructors": { "()": [] }
+    },
+    {
+      "type": "System.Action`3",
+      "constructors": { "()": [] }
+    },
+    {
+      "type": "System.Action`4",
+      "constructors": { "()": [] }
+    },
+    {
+      "type": "System.Predicate`1",
+      "constructors": { "()": [] }
+    },
+    {
+      "type": "System.Comparison`1",
+      "constructors": { "()": [] }
+    },
+    {
+      "type": "System.EventHandler",
+      "constructors": { "()": [] }
+    },
+    {
+      "type": "System.EventHandler`1",
+      "constructors": { "()": [] }
+    },
+    {
+      "type": "System.Exception",
+      "defaultEffects": []
+    },
+    {
+      "type": "System.ArgumentException",
+      "defaultEffects": []
+    },
+    {
+      "type": "System.ArgumentNullException",
+      "defaultEffects": []
+    },
+    {
+      "type": "System.ArgumentOutOfRangeException",
+      "defaultEffects": []
+    },
+    {
+      "type": "System.InvalidOperationException",
+      "defaultEffects": []
+    },
+    {
+      "type": "System.NotSupportedException",
+      "defaultEffects": []
+    },
+    {
+      "type": "System.NotImplementedException",
+      "defaultEffects": []
+    },
+    {
+      "type": "System.IndexOutOfRangeException",
+      "defaultEffects": []
+    },
+    {
+      "type": "System.FormatException",
+      "defaultEffects": []
+    },
+    {
+      "type": "System.ObjectDisposedException",
+      "defaultEffects": []
     }
   ],
   "namespaceDefaults": {

--- a/src/Calor.Compiler/Manifests/ecosystem-mediatr-automap-validation-polly.calor-effects.json
+++ b/src/Calor.Compiler/Manifests/ecosystem-mediatr-automap-validation-polly.calor-effects.json
@@ -63,8 +63,27 @@
         "Validate": [],
         "ValidateAsync": [],
         "ValidateAndThrow": ["throw"],
+        "ValidateAndThrowAsync": ["throw"],
+        "RuleFor": ["mut"],
+        "RuleForEach": ["mut"],
+        "Include": ["mut"],
+        "RuleSet": ["mut"],
+        "When": ["mut"],
+        "Unless": ["mut"],
+        "PreValidate": []
+      }
+    },
+    {
+      "type": "FluentValidation.DefaultValidatorExtensions",
+      "methods": {
+        "ValidateAndThrow": ["throw"],
         "ValidateAndThrowAsync": ["throw"]
       }
+    },
+    {
+      "type": "FluentValidation.ValidationContext`1",
+      "defaultEffects": [],
+      "constructors": { "()": [] }
     },
     {
       "type": "FluentValidation.IValidator",

--- a/src/Calor.Compiler/Manifests/ecosystem-serilog.calor-effects.json
+++ b/src/Calor.Compiler/Manifests/ecosystem-serilog.calor-effects.json
@@ -65,6 +65,35 @@
         "ForContext": [],
         "Dispose": []
       }
+    },
+    {
+      "type": "Serilog.Context.LogContext",
+      "methods": {
+        "PushProperty": ["mut"],
+        "Push": ["mut"],
+        "Suspend": ["mut"],
+        "Reset": ["mut"]
+      }
+    },
+    {
+      "type": "Serilog.Configuration.LoggerSinkConfiguration",
+      "defaultEffects": [],
+      "methods": { "*": [] }
+    },
+    {
+      "type": "Serilog.Configuration.LoggerMinimumLevelConfiguration",
+      "defaultEffects": [],
+      "methods": { "*": [] }
+    },
+    {
+      "type": "Serilog.Configuration.LoggerEnrichmentConfiguration",
+      "defaultEffects": [],
+      "methods": { "*": [] }
+    },
+    {
+      "type": "Serilog.Configuration.LoggerAuditSinkConfiguration",
+      "defaultEffects": [],
+      "methods": { "*": [] }
     }
   ],
   "namespaceDefaults": {

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -243,7 +243,9 @@ public class Program
         rootCommand.AddCommand(IdsCommand.Create());
         rootCommand.AddCommand(FixCommand.Create());
         rootCommand.AddCommand(EffectsCommand.Create());
+        rootCommand.AddCommand(ImportCommand.Create());
         rootCommand.AddCommand(VerifyCommand.Create());
+        rootCommand.AddCommand(ReviewPacketCommand.Create());
         rootCommand.AddCommand(LspCommand.Create());
         rootCommand.AddCommand(McpCommand.Create());
         rootCommand.AddCommand(FeatureCheckCommand.Create());

--- a/src/Calor.Compiler/Reporting/ReviewPacket.cs
+++ b/src/Calor.Compiler/Reporting/ReviewPacket.cs
@@ -60,7 +60,14 @@ public sealed class ReviewPacket
 public sealed class ReviewPacketSummary
 {
     public int TotalContracts { get; set; }
+
+    /// <summary>Clean, non-vacuous proven contracts only (m2): a vacuous
+    /// proof never counts here — see <see cref="ProvenVacuous"/>.</summary>
     public int Proven { get; set; }
+
+    /// <summary>Vacuously proven contracts (unsatisfiable §Q set) — part of
+    /// the unproven remainder, never of <see cref="Proven"/>.</summary>
+    public int ProvenVacuous { get; set; }
     public int Refuted { get; set; }
     public int Assumed { get; set; }
     public int Unknown { get; set; }

--- a/src/Calor.Compiler/Reporting/ReviewPacket.cs
+++ b/src/Calor.Compiler/Reporting/ReviewPacket.cs
@@ -1,0 +1,114 @@
+namespace Calor.Compiler.Reporting;
+
+/// <summary>
+/// Review packet v1 (wedge plan v0.11 D-W3.3, strategy §4 2a item 3): a
+/// per-change report over the seven-status vocabulary that LEADS with the
+/// unproven remainder. Scope honesty: this is deliberately less than the
+/// strategy's full packet — index-backed blast radius and invalidated-proof
+/// sets ride the persisted semantic index, which is deferred (wedge plan §9);
+/// v1 ships what the per-build analyses support (per-declaration proof
+/// statuses, assumption lists, vacuity flags, interop/permissive fractions,
+/// in-memory caller impact).
+/// </summary>
+public sealed class ReviewPacket
+{
+    /// <summary>ISO 8601 generation timestamp.</summary>
+    public string GeneratedAt { get; init; } = "";
+
+    /// <summary>
+    /// Explicit waiver disclosures (strategy §5.2). When non-empty these are
+    /// the FIRST LINE of every rendering: <c>--permissive-effects</c> voids
+    /// the effect guarantee; <c>--contract-mode off</c> voids the contract
+    /// guarantee.
+    /// </summary>
+    public List<string> Waivers { get; init; } = [];
+
+    /// <summary>
+    /// Standing honesty notes. Always includes the #782 line: refinement
+    /// types are NOT runtime-enforced — refinement obligations are
+    /// compile-time analysis only.
+    /// </summary>
+    public List<string> HonestyNotes { get; init; } = [];
+
+    /// <summary>Seven-status counts plus the unproven remainder size.</summary>
+    public ReviewPacketSummary Summary { get; init; } = new();
+
+    /// <summary>
+    /// The unproven remainder — every contract whose status is not a clean
+    /// non-vacuous <c>proven</c>, listed first. Vacuous proofs are unproven
+    /// remainder: a vacuous §Q means the function is uncallable.
+    /// </summary>
+    public List<ContractRecord> UnprovenRemainder { get; init; } = [];
+
+    /// <summary>Cleanly proven contracts (non-vacuous), for completeness.</summary>
+    public List<ContractRecord> Proven { get; init; } = [];
+
+    /// <summary>Per-module interop/permissive disclosure.</summary>
+    public List<ModuleDisclosure> Modules { get; init; } = [];
+
+    /// <summary>Declarations treated as changed (explicit ids or git-diff derived).</summary>
+    public List<string> ChangedDeclarations { get; init; } = [];
+
+    /// <summary>Direct callers of each changed declaration (in-memory call graph, per module).</summary>
+    public List<CallerImpactRecord> CallerImpact { get; init; } = [];
+
+    /// <summary>The git ref the change set was diffed against, when one was given.</summary>
+    public string? BaselineRef { get; init; }
+}
+
+/// <summary>Seven-status contract counts for the packet.</summary>
+public sealed class ReviewPacketSummary
+{
+    public int TotalContracts { get; set; }
+    public int Proven { get; set; }
+    public int Refuted { get; set; }
+    public int Assumed { get; set; }
+    public int Unknown { get; set; }
+    public int Timeout { get; set; }
+    public int Unsupported { get; set; }
+    public int Unavailable { get; set; }
+    public int Vacuous { get; set; }
+
+    /// <summary>Everything that is not a clean non-vacuous proven.</summary>
+    public int UnprovenRemainder { get; set; }
+}
+
+/// <summary>One contract's proof record.</summary>
+public sealed record ContractRecord(
+    string File,
+    string Module,
+    string FunctionId,
+    string FunctionName,
+    string ContractKind,
+    int Index,
+    string? Text,
+    string Status,
+    string? Reason,
+    bool Vacuous,
+    IReadOnlyList<string> Assumptions,
+    string? Counterexample);
+
+/// <summary>
+/// Per-module interop and waiver fractions: interop blocks over total members
+/// (module-level and class-level members both counted), plus which waivers
+/// applied to the build that produced this packet.
+/// </summary>
+public sealed record ModuleDisclosure(
+    string Module,
+    string File,
+    int InteropBlocks,
+    int TotalMembers,
+    double InteropFraction,
+    bool PermissiveEffects,
+    bool ContractChecksOff,
+    bool UsesRefinementTypes);
+
+/// <summary>Direct callers of a changed declaration.</summary>
+public sealed record CallerImpactRecord(
+    string ChangedId,
+    string ChangedName,
+    string Module,
+    IReadOnlyList<CallerRef> Callers);
+
+/// <summary>A calling declaration.</summary>
+public sealed record CallerRef(string Id, string Name);

--- a/src/Calor.Compiler/Reporting/ReviewPacketBuilder.cs
+++ b/src/Calor.Compiler/Reporting/ReviewPacketBuilder.cs
@@ -40,7 +40,8 @@ public sealed class ReviewPacketBuilder
         ReviewPacket Packet,
         IReadOnlyList<Diagnostic> CompileDiagnostics,
         bool HasCompileErrors,
-        bool AnyRefinementTypes);
+        bool AnyRefinementTypes,
+        IReadOnlyList<string> UnmatchedChangedDeclarations);
 
     private ReviewPacketBuilder() { }
 
@@ -69,6 +70,7 @@ public sealed class ReviewPacketBuilder
         var compileDiagnostics = new List<Diagnostic>();
         var hasCompileErrors = false;
         var anyRefinements = false;
+        var compiledModules = new List<(InputFile File, ModuleNode Module)>();
 
         foreach (var file in files)
         {
@@ -98,15 +100,21 @@ public sealed class ReviewPacketBuilder
 
             var module = result.Ast;
             anyRefinements |= module.RefinementTypes.Count > 0;
+            compiledModules.Add((file, module));
 
             CollectContracts(packet, file, module, compileOptions.VerificationResults);
             CollectModuleDisclosure(packet, file, module, options);
-            CollectCallerImpact(packet, file, module, options);
         }
+
+        // Caller impact runs over the UNION of all files in the invocation —
+        // a caller in one file of a declaration changed in another must be
+        // found (review M2). Cross-invocation impact stays deferred with the
+        // persisted index (wedge plan §9).
+        var unmatched = CollectCallerImpact(packet, compiledModules, options);
 
         FinalizeSummary(packet);
 
-        return new Result(packet, compileDiagnostics, hasCompileErrors, anyRefinements);
+        return new Result(packet, compileDiagnostics, hasCompileErrors, anyRefinements, unmatched);
     }
 
     // ------------------------------------------------------------------
@@ -233,51 +241,138 @@ public sealed class ReviewPacketBuilder
     // Caller impact — in-memory call graph
     // ------------------------------------------------------------------
 
-    private static void CollectCallerImpact(
+    /// <summary>
+    /// Computes caller impact over the union of every module in the
+    /// invocation: per-module call graphs are built, then call edges are
+    /// re-resolved against the combined declaration set so a caller in one
+    /// file of a declaration defined in another is found (review M2).
+    /// Returns the requested changed-declaration selectors that matched no
+    /// declaration in any module (review m1 — a typo must not silently yield
+    /// an impact-free packet).
+    /// </summary>
+    private static IReadOnlyList<string> CollectCallerImpact(
         ReviewPacket packet,
-        InputFile file,
-        ModuleNode module,
+        IReadOnlyList<(InputFile File, ModuleNode Module)> compiledModules,
         Options options)
     {
-        var explicitIds = options.ChangedDeclarations;
-        IReadOnlyList<(int StartLine, int EndLine)>? ranges = null;
-        options.ChangedLineRanges?.TryGetValue(System.IO.Path.GetFullPath(file.Path), out ranges);
+        var explicitIds = options.ChangedDeclarations ?? [];
+        var anyRanges = options.ChangedLineRanges is { Count: > 0 };
+        if (explicitIds.Count == 0 && !anyRanges)
+            return [];
 
-        if ((explicitIds is null || explicitIds.Count == 0) && (ranges is null || ranges.Count == 0))
-            return;
+        // Combined declaration set + per-module graphs.
+        var declarations = new Dictionary<string, (FunctionNode Node, string Module)>(StringComparer.Ordinal);
+        var nameToIds = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var graphs = new List<(InputFile File, ModuleNode Module, CallGraphAnalysis Graph)>();
 
-        var callGraph = CallGraphAnalysis.Build(module);
-
-        var changed = new List<string>();
-        if (explicitIds is not null)
+        foreach (var (file, module) in compiledModules)
         {
-            foreach (var id in explicitIds)
+            var graph = CallGraphAnalysis.Build(module);
+            graphs.Add((file, module, graph));
+            foreach (var (id, node) in graph.Functions)
             {
-                if (callGraph.Functions.ContainsKey(id))
-                    changed.Add(id);
-                else if (callGraph.FunctionNameToId.TryGetValue(id, out var resolved))
-                    changed.Add(resolved);
+                declarations.TryAdd(id, (node, module.Name));
+                if (!nameToIds.TryGetValue(node.Name, out var ids))
+                {
+                    ids = [];
+                    nameToIds[node.Name] = ids;
+                }
+                if (!ids.Contains(id))
+                    ids.Add(id);
             }
         }
 
-        if (ranges is not null && ranges.Count > 0)
-            changed.AddRange(DeclarationsInRanges(callGraph, ranges));
+        // Cross-module reverse edges: re-resolve every call-site name against
+        // the combined declaration set.
+        var reverse = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        foreach (var (_, _, graph) in graphs)
+        {
+            foreach (var (callerId, callees) in graph.ForwardGraph)
+            {
+                foreach (var (calleeName, _) in callees)
+                {
+                    var bareName = calleeName;
+                    var lastDot = bareName.LastIndexOf('.');
+                    if (lastDot >= 0)
+                        bareName = bareName[(lastDot + 1)..];
+
+                    foreach (var candidate in ResolveNames(calleeName, bareName, declarations, nameToIds))
+                    {
+                        if (!reverse.TryGetValue(candidate, out var callers))
+                        {
+                            callers = new HashSet<string>(StringComparer.Ordinal);
+                            reverse[candidate] = callers;
+                        }
+                        callers.Add(callerId);
+                    }
+                }
+            }
+        }
+
+        // Resolve the changed set.
+        var changed = new List<string>();
+        var unmatched = new List<string>();
+        foreach (var selector in explicitIds)
+        {
+            if (declarations.ContainsKey(selector))
+                changed.Add(selector);
+            else if (nameToIds.TryGetValue(selector, out var ids))
+                changed.AddRange(ids);
+            else
+                unmatched.Add(selector);
+        }
+
+        if (options.ChangedLineRanges is { Count: > 0 } rangesByFile)
+        {
+            foreach (var (file, _, graph) in graphs)
+            {
+                if (rangesByFile.TryGetValue(System.IO.Path.GetFullPath(file.Path), out var ranges)
+                    && ranges is { Count: > 0 })
+                {
+                    changed.AddRange(DeclarationsInRanges(graph, ranges));
+                }
+            }
+        }
 
         foreach (var id in changed.Distinct().OrderBy(c => c, StringComparer.Ordinal))
         {
             if (!packet.ChangedDeclarations.Contains(id))
                 packet.ChangedDeclarations.Add(id);
 
-            var name = callGraph.Functions.TryGetValue(id, out var node) ? node.Name : id;
-            var callers = callGraph.GetCallers(id)
-                .Distinct()
+            var (node, moduleName) = declarations[id];
+            var callers = (reverse.TryGetValue(id, out var callerIds)
+                    ? (IEnumerable<string>)callerIds
+                    : Array.Empty<string>())
+                .Where(callerId => callerId != id)
                 .OrderBy(c => c, StringComparer.Ordinal)
                 .Select(callerId => new CallerRef(
                     callerId,
-                    callGraph.Functions.TryGetValue(callerId, out var callerNode) ? callerNode.Name : callerId))
+                    declarations.TryGetValue(callerId, out var caller) ? caller.Node.Name : callerId))
                 .ToList();
 
-            packet.CallerImpact.Add(new CallerImpactRecord(id, name, module.Name, callers));
+            packet.CallerImpact.Add(new CallerImpactRecord(id, node.Name, moduleName, callers));
+        }
+
+        return unmatched;
+    }
+
+    private static IEnumerable<string> ResolveNames(
+        string calleeName,
+        string bareName,
+        Dictionary<string, (FunctionNode Node, string Module)> declarations,
+        Dictionary<string, List<string>> nameToIds)
+    {
+        if (declarations.ContainsKey(calleeName))
+            yield return calleeName;
+        if (nameToIds.TryGetValue(calleeName, out var direct))
+        {
+            foreach (var id in direct)
+                yield return id;
+        }
+        if (bareName != calleeName && nameToIds.TryGetValue(bareName, out var bare))
+        {
+            foreach (var id in bare)
+                yield return id;
         }
     }
 
@@ -285,7 +380,9 @@ public sealed class ReviewPacketBuilder
     /// Maps changed line ranges to declarations. A declaration's extent is
     /// approximated as [its start line, next declaration's start line - 1]
     /// within the file — sufficient for overlap tests without an end-line on
-    /// the AST node.
+    /// the AST node. Consequence (documented): an edit BETWEEN declarations
+    /// attributes to the preceding declaration — conservative over-inclusion,
+    /// never omission.
     /// </summary>
     private static IEnumerable<string> DeclarationsInRanges(
         CallGraphAnalysis callGraph,
@@ -319,7 +416,11 @@ public sealed class ReviewPacketBuilder
         var all = packet.UnprovenRemainder.Concat(packet.Proven).ToList();
         var summary = packet.Summary;
         summary.TotalContracts = all.Count;
-        summary.Proven = all.Count(c => c.Status == "proven");
+        // 'proven' counts CLEAN proofs only — a vacuous proof is unproven
+        // remainder and must not let automated consumers read
+        // proven == totalContracts as clean (review m2).
+        summary.Proven = all.Count(c => c.Status == "proven" && !c.Vacuous);
+        summary.ProvenVacuous = all.Count(c => c.Status == "proven" && c.Vacuous);
         summary.Refuted = all.Count(c => c.Status == "refuted");
         summary.Assumed = all.Count(c => c.Status == "assumed");
         summary.Unknown = all.Count(c => c.Status == "unknown");

--- a/src/Calor.Compiler/Reporting/ReviewPacketBuilder.cs
+++ b/src/Calor.Compiler/Reporting/ReviewPacketBuilder.cs
@@ -72,6 +72,13 @@ public sealed class ReviewPacketBuilder
         var anyRefinements = false;
         var compiledModules = new List<(InputFile File, ModuleNode Module)>();
 
+        // Multi-file invocations mirror the CLI driver's cross-module map
+        // (G3/#809): without it, a cross-file internal call is an unknown
+        // call to the per-file effect pass and — under the W2 default-on
+        // strictness — fails the compile with Calor0410, dropping the file
+        // from the packet entirely.
+        var crossModuleMap = files.Count > 1 ? BuildCrossModuleFunctionMap(files) : null;
+
         foreach (var file in files)
         {
             var compileOptions = new CompilationOptions
@@ -86,6 +93,7 @@ public sealed class ReviewPacketBuilder
                 ProjectDirectory = options.ProjectDirectory
                     ?? System.IO.Path.GetDirectoryName(System.IO.Path.GetFullPath(file.Path))
             };
+            compileOptions.CrossModuleFunctionModules = crossModuleMap;
 
             var result = Program.Compile(file.Source, file.Path, compileOptions);
 
@@ -115,6 +123,57 @@ public sealed class ReviewPacketBuilder
         FinalizeSummary(packet);
 
         return new Result(packet, compileDiagnostics, hasCompileErrors, anyRefinements, unmatched);
+    }
+
+    /// <summary>
+    /// Builds the bare-name → defining-module map from the in-memory sources,
+    /// matching <c>CompilationDriver.BuildCrossModuleFunctionMap</c>'s rule
+    /// exactly (public AND internal functions; ambiguous names dropped). The
+    /// driver's helper reads from disk — the packet builder's inputs may not
+    /// exist on disk (tests, editor buffers), so the map is built from the
+    /// sources it already holds.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string> BuildCrossModuleFunctionMap(
+        IReadOnlyList<InputFile> files)
+    {
+        var byName = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var file in files)
+        {
+            var diagnostics = new DiagnosticBag();
+            ModuleNode? module;
+            try
+            {
+                var lexer = new Parsing.Lexer(file.Source, diagnostics);
+                var parser = new Parsing.Parser(lexer.TokenizeAllForParser(), diagnostics);
+                module = parser.Parse();
+            }
+            catch (Exception)
+            {
+                // Pre-parse is best-effort; the real compile reports errors.
+                continue;
+            }
+
+            if (module is null || string.IsNullOrEmpty(module.Name) || module.Name == "_global")
+                continue;
+
+            foreach (var fn in module.Functions)
+            {
+                if (fn.Visibility is not (Visibility.Public or Visibility.Internal))
+                    continue;
+                if (!byName.TryGetValue(fn.Name, out var modules))
+                    byName[fn.Name] = modules = [];
+                if (!modules.Contains(module.Name))
+                    modules.Add(module.Name);
+            }
+        }
+
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (name, modules) in byName)
+        {
+            if (modules.Count == 1)
+                map[name] = modules[0];
+        }
+        return map;
     }
 
     // ------------------------------------------------------------------

--- a/src/Calor.Compiler/Reporting/ReviewPacketBuilder.cs
+++ b/src/Calor.Compiler/Reporting/ReviewPacketBuilder.cs
@@ -1,0 +1,447 @@
+using System.Text;
+using Calor.Compiler.Analysis;
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Verification;
+using Calor.Compiler.Verification.Z3;
+
+namespace Calor.Compiler.Reporting;
+
+/// <summary>
+/// Assembles the review packet (D-W3.3) from per-build analyses: contract
+/// verification outcomes (seven-status vocabulary), assumption lists,
+/// vacuity flags, per-module interop/permissive fractions, and caller impact
+/// from the in-memory <see cref="CallGraphAnalysis"/>. No persisted index is
+/// consulted — that scope delta vs the strategy's full packet is recorded in
+/// the wedge plan register (§9).
+/// </summary>
+public sealed class ReviewPacketBuilder
+{
+    /// <summary>The #782 honesty line (W1 kickoff S honesty item).</summary>
+    public const string RefinementHonestyNote =
+        "Refinement types are NOT runtime-enforced (#782): refinement obligations are "
+        + "compile-time analysis only — no runtime guard is emitted for them.";
+
+    /// <summary>Builder options.</summary>
+    public sealed record Options(
+        bool PermissiveEffects = false,
+        bool ContractChecksOff = false,
+        uint VerificationTimeoutMs = 5000,
+        IReadOnlyList<string>? ChangedDeclarations = null,
+        IReadOnlyDictionary<string, IReadOnlyList<(int StartLine, int EndLine)>>? ChangedLineRanges = null,
+        string? BaselineRef = null,
+        string? ProjectDirectory = null);
+
+    /// <summary>One input file: path plus source text.</summary>
+    public sealed record InputFile(string Path, string Source);
+
+    /// <summary>Build result: the packet, plus compile diagnostics per file.</summary>
+    public sealed record Result(
+        ReviewPacket Packet,
+        IReadOnlyList<Diagnostic> CompileDiagnostics,
+        bool HasCompileErrors,
+        bool AnyRefinementTypes);
+
+    private ReviewPacketBuilder() { }
+
+    public static Result Build(IReadOnlyList<InputFile> files, Options options)
+    {
+        var packet = new ReviewPacket
+        {
+            GeneratedAt = DateTime.UtcNow.ToString("O"),
+            BaselineRef = options.BaselineRef
+        };
+
+        if (options.PermissiveEffects)
+        {
+            packet.Waivers.Add(
+                "WAIVER: compiled with --permissive-effects — unknown external calls are assumed pure; "
+                + "the effect guarantee is VOID for these modules (strategy §5.2).");
+        }
+        if (options.ContractChecksOff)
+        {
+            packet.Waivers.Add(
+                "WAIVER: compiled with contract checks OFF — no runtime contract checks are emitted; "
+                + "the contract guarantee is VOID for these modules (strategy §5.2).");
+        }
+        packet.HonestyNotes.Add(RefinementHonestyNote);
+
+        var compileDiagnostics = new List<Diagnostic>();
+        var hasCompileErrors = false;
+        var anyRefinements = false;
+
+        foreach (var file in files)
+        {
+            var compileOptions = new CompilationOptions
+            {
+                VerifyContracts = true,
+                VerificationTimeoutMs = options.VerificationTimeoutMs,
+                EnforceEffects = true,
+                UnknownCallPolicy = options.PermissiveEffects
+                    ? Effects.UnknownCallPolicy.Permissive
+                    : Effects.UnknownCallPolicy.Strict,
+                ContractMode = options.ContractChecksOff ? ContractMode.Off : ContractMode.Debug,
+                ProjectDirectory = options.ProjectDirectory
+                    ?? System.IO.Path.GetDirectoryName(System.IO.Path.GetFullPath(file.Path))
+            };
+
+            var result = Program.Compile(file.Source, file.Path, compileOptions);
+
+            foreach (var diagnostic in result.Diagnostics)
+                compileDiagnostics.Add(diagnostic);
+
+            if (result.HasErrors || result.Ast is null)
+            {
+                hasCompileErrors = true;
+                continue;
+            }
+
+            var module = result.Ast;
+            anyRefinements |= module.RefinementTypes.Count > 0;
+
+            CollectContracts(packet, file, module, compileOptions.VerificationResults);
+            CollectModuleDisclosure(packet, file, module, options);
+            CollectCallerImpact(packet, file, module, options);
+        }
+
+        FinalizeSummary(packet);
+
+        return new Result(packet, compileDiagnostics, hasCompileErrors, anyRefinements);
+    }
+
+    // ------------------------------------------------------------------
+    // Contracts — the seven-status vocabulary, unproven remainder first
+    // ------------------------------------------------------------------
+
+    private static void CollectContracts(
+        ReviewPacket packet,
+        InputFile file,
+        ModuleNode module,
+        ModuleVerificationResult? verification)
+    {
+        if (verification is null)
+            return;
+
+        // Function/method lookup so contract text can be sliced from source.
+        var functionsById = new Dictionary<string, FunctionNode>(StringComparer.Ordinal);
+        foreach (var fn in module.Functions)
+            functionsById.TryAdd(fn.Id, fn);
+
+        foreach (var fnResult in verification.Functions)
+        {
+            functionsById.TryGetValue(fnResult.FunctionId, out var fnNode);
+
+            AddContracts(packet, file, module, fnResult.FunctionId, fnResult.FunctionName,
+                "precondition", fnResult.PreconditionResults,
+                i => SliceText(file.Source, fnNode?.Preconditions, i));
+            AddContracts(packet, file, module, fnResult.FunctionId, fnResult.FunctionName,
+                "postcondition", fnResult.PostconditionResults,
+                i => SliceText(file.Source, fnNode?.Postconditions, i));
+        }
+    }
+
+    private static void AddContracts(
+        ReviewPacket packet,
+        InputFile file,
+        ModuleNode module,
+        string functionId,
+        string functionName,
+        string kind,
+        IReadOnlyList<Verification.Z3.ContractVerificationResult> results,
+        Func<int, string?> textFor)
+    {
+        for (var i = 0; i < results.Count; i++)
+        {
+            var outcome = results[i].EffectiveOutcome;
+            var record = new ContractRecord(
+                File: System.IO.Path.GetFileName(file.Path),
+                Module: module.Name,
+                FunctionId: functionId,
+                FunctionName: functionName,
+                ContractKind: kind,
+                Index: i,
+                Text: textFor(i),
+                Status: outcome.StatusName,
+                Reason: outcome.Reason,
+                Vacuous: outcome.IsVacuous,
+                Assumptions: outcome.Assumptions,
+                Counterexample: outcome.Counterexample?.Render());
+
+            var cleanProven = outcome.Status == ProofStatus.Proven && !outcome.IsVacuous;
+            if (cleanProven)
+                packet.Proven.Add(record);
+            else
+                packet.UnprovenRemainder.Add(record);
+        }
+    }
+
+    private static string? SliceText<TContract>(string source, IReadOnlyList<TContract>? contracts, int index)
+        where TContract : AstNode
+    {
+        if (contracts is null || index < 0 || index >= contracts.Count)
+            return null;
+        var span = contracts[index].Span;
+        if (span.Start < 0 || span.Length <= 0 || span.End > source.Length)
+            return null;
+        return source.Substring(span.Start, span.Length).Trim();
+    }
+
+    // ------------------------------------------------------------------
+    // Interop / permissive fraction per module
+    // ------------------------------------------------------------------
+
+    private static void CollectModuleDisclosure(
+        ReviewPacket packet,
+        InputFile file,
+        ModuleNode module,
+        Options options)
+    {
+        var interop = module.InteropBlocks.Count;
+        var members =
+            module.Functions.Count
+            + module.Interfaces.Count
+            + module.Enums.Count
+            + module.EnumExtensions.Count
+            + module.Delegates.Count;
+
+        foreach (var cls in module.Classes)
+        {
+            interop += cls.InteropBlocks.Count;
+            members +=
+                cls.Fields.Count
+                + cls.Properties.Count
+                + cls.Indexers.Count
+                + cls.Constructors.Count
+                + cls.Methods.Count
+                + cls.Events.Count
+                + cls.OperatorOverloads.Count;
+        }
+
+        var total = members + interop;
+        packet.Modules.Add(new ModuleDisclosure(
+            Module: module.Name,
+            File: System.IO.Path.GetFileName(file.Path),
+            InteropBlocks: interop,
+            TotalMembers: total,
+            InteropFraction: total == 0 ? 0.0 : Math.Round((double)interop / total, 4),
+            PermissiveEffects: options.PermissiveEffects,
+            ContractChecksOff: options.ContractChecksOff,
+            UsesRefinementTypes: module.RefinementTypes.Count > 0));
+    }
+
+    // ------------------------------------------------------------------
+    // Caller impact — in-memory call graph
+    // ------------------------------------------------------------------
+
+    private static void CollectCallerImpact(
+        ReviewPacket packet,
+        InputFile file,
+        ModuleNode module,
+        Options options)
+    {
+        var explicitIds = options.ChangedDeclarations;
+        IReadOnlyList<(int StartLine, int EndLine)>? ranges = null;
+        options.ChangedLineRanges?.TryGetValue(System.IO.Path.GetFullPath(file.Path), out ranges);
+
+        if ((explicitIds is null || explicitIds.Count == 0) && (ranges is null || ranges.Count == 0))
+            return;
+
+        var callGraph = CallGraphAnalysis.Build(module);
+
+        var changed = new List<string>();
+        if (explicitIds is not null)
+        {
+            foreach (var id in explicitIds)
+            {
+                if (callGraph.Functions.ContainsKey(id))
+                    changed.Add(id);
+                else if (callGraph.FunctionNameToId.TryGetValue(id, out var resolved))
+                    changed.Add(resolved);
+            }
+        }
+
+        if (ranges is not null && ranges.Count > 0)
+            changed.AddRange(DeclarationsInRanges(callGraph, ranges));
+
+        foreach (var id in changed.Distinct().OrderBy(c => c, StringComparer.Ordinal))
+        {
+            if (!packet.ChangedDeclarations.Contains(id))
+                packet.ChangedDeclarations.Add(id);
+
+            var name = callGraph.Functions.TryGetValue(id, out var node) ? node.Name : id;
+            var callers = callGraph.GetCallers(id)
+                .Distinct()
+                .OrderBy(c => c, StringComparer.Ordinal)
+                .Select(callerId => new CallerRef(
+                    callerId,
+                    callGraph.Functions.TryGetValue(callerId, out var callerNode) ? callerNode.Name : callerId))
+                .ToList();
+
+            packet.CallerImpact.Add(new CallerImpactRecord(id, name, module.Name, callers));
+        }
+    }
+
+    /// <summary>
+    /// Maps changed line ranges to declarations. A declaration's extent is
+    /// approximated as [its start line, next declaration's start line - 1]
+    /// within the file — sufficient for overlap tests without an end-line on
+    /// the AST node.
+    /// </summary>
+    private static IEnumerable<string> DeclarationsInRanges(
+        CallGraphAnalysis callGraph,
+        IReadOnlyList<(int StartLine, int EndLine)> ranges)
+    {
+        var ordered = callGraph.Functions
+            .OrderBy(kvp => kvp.Value.Span.Line)
+            .ToList();
+
+        for (var i = 0; i < ordered.Count; i++)
+        {
+            var startLine = ordered[i].Value.Span.Line;
+            var endLine = i + 1 < ordered.Count ? ordered[i + 1].Value.Span.Line - 1 : int.MaxValue;
+            foreach (var (rangeStart, rangeEnd) in ranges)
+            {
+                if (rangeStart <= endLine && rangeEnd >= startLine)
+                {
+                    yield return ordered[i].Key;
+                    break;
+                }
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Summary + markdown rendering
+    // ------------------------------------------------------------------
+
+    private static void FinalizeSummary(ReviewPacket packet)
+    {
+        var all = packet.UnprovenRemainder.Concat(packet.Proven).ToList();
+        var summary = packet.Summary;
+        summary.TotalContracts = all.Count;
+        summary.Proven = all.Count(c => c.Status == "proven");
+        summary.Refuted = all.Count(c => c.Status == "refuted");
+        summary.Assumed = all.Count(c => c.Status == "assumed");
+        summary.Unknown = all.Count(c => c.Status == "unknown");
+        summary.Timeout = all.Count(c => c.Status == "timeout");
+        summary.Unsupported = all.Count(c => c.Status == "unsupported");
+        summary.Unavailable = all.Count(c => c.Status == "unavailable");
+        summary.Vacuous = all.Count(c => c.Vacuous);
+        summary.UnprovenRemainder = packet.UnprovenRemainder.Count;
+
+        // Refuted first, then assumed/unknown/timeout/unsupported/unavailable,
+        // vacuous-proven last inside the remainder.
+        packet.UnprovenRemainder.Sort((a, b) =>
+        {
+            var rank = StatusRank(a).CompareTo(StatusRank(b));
+            if (rank != 0) return rank;
+            var byFile = string.Compare(a.File, b.File, StringComparison.Ordinal);
+            if (byFile != 0) return byFile;
+            return string.Compare(a.FunctionId, b.FunctionId, StringComparison.Ordinal);
+        });
+
+        static int StatusRank(ContractRecord record) => record.Status switch
+        {
+            "refuted" => 0,
+            "unsupported" => 1,
+            "unknown" => 2,
+            "timeout" => 3,
+            "assumed" => 4,
+            "unavailable" => 5,
+            _ => 6 // vacuous proven
+        };
+    }
+
+    /// <summary>Renders the packet as markdown. Waivers are the first line.</summary>
+    public static string RenderMarkdown(ReviewPacket packet)
+    {
+        var sb = new StringBuilder();
+
+        // §5.2: waiver disclosure on the first line, before anything else.
+        foreach (var waiver in packet.Waivers)
+            sb.AppendLine($"**{waiver}**");
+        if (packet.Waivers.Count > 0)
+            sb.AppendLine();
+
+        sb.AppendLine("# Review packet");
+        sb.AppendLine();
+        sb.AppendLine($"Generated: {packet.GeneratedAt}"
+            + (packet.BaselineRef is null ? "" : $" · baseline: `{packet.BaselineRef}`"));
+        sb.AppendLine();
+
+        var s = packet.Summary;
+        sb.AppendLine("## Unproven remainder");
+        sb.AppendLine();
+        sb.AppendLine($"**{s.UnprovenRemainder} of {s.TotalContracts} contract(s) are not cleanly proven** "
+            + $"(refuted {s.Refuted}, assumed {s.Assumed}, unknown {s.Unknown}, timeout {s.Timeout}, "
+            + $"unsupported {s.Unsupported}, unavailable {s.Unavailable}, vacuous {s.Vacuous}).");
+        sb.AppendLine();
+
+        if (packet.UnprovenRemainder.Count > 0)
+        {
+            sb.AppendLine("| Status | Declaration | Contract | Detail |");
+            sb.AppendLine("|---|---|---|---|");
+            foreach (var record in packet.UnprovenRemainder)
+            {
+                var status = record.Vacuous ? $"{record.Status} (VACUOUS)" : record.Status;
+                var detail = record.Counterexample is not null
+                    ? $"counterexample: {record.Counterexample}"
+                    : record.Assumptions.Count > 0
+                        ? $"assumes: {string.Join("; ", record.Assumptions)}"
+                        : record.Reason ?? "";
+                var text = record.Text is null ? $"{record.ContractKind}[{record.Index}]" : $"`{record.Text}`";
+                sb.AppendLine($"| {status} | {record.Module}.{record.FunctionName} ({record.FunctionId}) | {text} | {Escape(detail)} |");
+            }
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("## Honesty notes");
+        sb.AppendLine();
+        foreach (var note in packet.HonestyNotes)
+            sb.AppendLine($"- {note}");
+        sb.AppendLine();
+
+        sb.AppendLine("## Module disclosure (interop / waiver fractions)");
+        sb.AppendLine();
+        sb.AppendLine("| Module | File | Interop blocks | Total members | Interop fraction | Permissive effects | Contract checks off | Refinement types |");
+        sb.AppendLine("|---|---|---|---|---|---|---|---|");
+        foreach (var module in packet.Modules)
+        {
+            sb.AppendLine($"| {module.Module} | {module.File} | {module.InteropBlocks} | {module.TotalMembers} "
+                + $"| {module.InteropFraction:P1} | {(module.PermissiveEffects ? "YES (waiver)" : "no")} "
+                + $"| {(module.ContractChecksOff ? "YES (waiver)" : "no")} "
+                + $"| {(module.UsesRefinementTypes ? "yes (NOT runtime-enforced, #782)" : "no")} |");
+        }
+        sb.AppendLine();
+
+        if (packet.CallerImpact.Count > 0)
+        {
+            sb.AppendLine("## Caller impact (in-memory call graph)");
+            sb.AppendLine();
+            foreach (var impact in packet.CallerImpact)
+            {
+                var callers = impact.Callers.Count == 0
+                    ? "no internal callers"
+                    : string.Join(", ", impact.Callers.Select(c => $"{c.Name} ({c.Id})"));
+                sb.AppendLine($"- **{impact.Module}.{impact.ChangedName}** ({impact.ChangedId}) — callers: {callers}");
+            }
+            sb.AppendLine();
+        }
+
+        if (packet.Proven.Count > 0)
+        {
+            sb.AppendLine("## Proven (non-vacuous)");
+            sb.AppendLine();
+            foreach (var record in packet.Proven)
+            {
+                var text = record.Text is null ? $"{record.ContractKind}[{record.Index}]" : $"`{record.Text}`";
+                sb.AppendLine($"- {record.Module}.{record.FunctionName} ({record.FunctionId}): {text}");
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string Escape(string value)
+        => value.Replace("|", "\\|").Replace("\r", " ").Replace("\n", " ");
+}

--- a/tests/Calor.Compiler.Tests/ImportReviewPacketEnvelopeTests.cs
+++ b/tests/Calor.Compiler.Tests/ImportReviewPacketEnvelopeTests.cs
@@ -95,6 +95,31 @@ public class ImportReviewPacketEnvelopeTests : IDisposable
         }
     }
 
+    [Fact]
+    public void Import_GarbageDll_FailsLoudly_WritesNothing()
+    {
+        // M1 pin: a file that is not an assembly must produce Calor1352,
+        // exit 1, and NO manifest file — not a clean exit with an empty
+        // manifest on disk.
+        var garbage = Path.Combine(_tempDir, "garbage.dll");
+        File.WriteAllBytes(garbage, [0xFF, 0xFE, 0x00, 0x01, 0x02]);
+
+        var (exitCode, stdOut, _) = CliTestHarness.RunCli(_tempDir,
+            "import", garbage, "--json");
+
+        Assert.Equal(1, exitCode);
+        var root = ParseSingleDocument(stdOut);
+        var diagnostic = Assert.Single(root.GetProperty("diagnostics").EnumerateArray());
+        Assert.Equal(DiagnosticCode.ImportCommandError, diagnostic.GetProperty("code").GetString());
+
+        // Text mode: same failure, and nothing written.
+        var (textExit, _, textErr) = CliTestHarness.RunCli(_tempDir, "import", garbage);
+        Assert.Equal(1, textExit);
+        Assert.Contains("no usable assembly metadata", textErr);
+        Assert.Empty(Directory.GetFiles(_tempDir, "*.calor-effects.json"));
+        Assert.Empty(Directory.GetFiles(_tempDir, "*.calor-contracts.json"));
+    }
+
     // ------------------------------------------------------------------
     // calor review-packet
     // ------------------------------------------------------------------
@@ -164,6 +189,45 @@ public class ImportReviewPacketEnvelopeTests : IDisposable
 
         var diagnostic = Assert.Single(root.GetProperty("diagnostics").EnumerateArray());
         Assert.Equal(DiagnosticCode.ReviewPacketCommandError, diagnostic.GetProperty("code").GetString());
+    }
+
+    [Fact]
+    public void ReviewPacket_Json_UnknownChangedSelector_WarnsLoudly()
+    {
+        // m1 pin: a typo'd --changed id must not silently yield a packet
+        // with the caller-impact section absent.
+        var module = WriteModule();
+        var (exitCode, stdOut, _) = CliTestHarness.RunCli(_tempDir,
+            "review-packet", module, "--changed", "zz999", "--json");
+
+        Assert.Equal(0, exitCode);
+        var root = ParseSingleDocument(stdOut);
+        var codes = root.GetProperty("diagnostics").EnumerateArray()
+            .Select(d => d.GetProperty("code").GetString()).ToList();
+        Assert.Contains(DiagnosticCode.ReviewPacketUnknownChangedDeclaration, codes);
+    }
+
+    [Fact]
+    public void Convert_TextMode_SurfacesPostconditionRefusalWarning()
+    {
+        // M3 pin: the Calor1001 §S-early-return refusal must be visible on
+        // the DEFAULT eject path, not only under --format json.
+        var path = Path.Combine(_tempDir, "eject.calr");
+        File.WriteAllText(path,
+            "§M{m001:Pricing}\n"
+            + "  §F{f001:ClampToCap:pub} (i32:amount, i32:cap) -> i32\n"
+            + "    §Q (>= cap 0)\n"
+            + "    §S (<= result cap)\n"
+            + "    §IF{if1} (> amount cap)\n"
+            + "      §R cap\n"
+            + "    §R amount\n");
+
+        var (exitCode, stdOut, stdErr) = CliTestHarness.RunCli(_tempDir,
+            "convert", path, "-o", Path.Combine(_tempDir, "eject.out.cs"));
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Conversion successful", stdOut);
+        Assert.Contains("Calor1001", stdErr);
     }
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/ImportReviewPacketEnvelopeTests.cs
+++ b/tests/Calor.Compiler.Tests/ImportReviewPacketEnvelopeTests.cs
@@ -1,0 +1,180 @@
+using System.Text.Json;
+using Calor.Compiler.Diagnostics;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Envelope conformance for the two WS-W3 adoption-surface commands
+/// (<c>calor import</c>, <c>calor review-packet</c>): in JSON mode stdout
+/// carries exactly one parseable envelope document on every path, including
+/// early exits; diagnostics carry the registered Calor135x codes; and the
+/// import provenance invariants (derived = inferred, contracts = assumed,
+/// never verified) survive the CLI boundary.
+/// </summary>
+public class ImportReviewPacketEnvelopeTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ImportReviewPacketEnvelopeTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "calor-w3-envelope-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch (IOException) { }
+    }
+
+    private static JsonElement ParseSingleDocument(string stdOut)
+    {
+        using var doc = JsonDocument.Parse(stdOut);
+        var root = doc.RootElement.Clone();
+        EnvelopeSchemaValidator.ValidateEnvelopeDocument(root);
+        return root;
+    }
+
+    // ------------------------------------------------------------------
+    // calor import
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Import_Json_PackageNotFound_StillEmitsEnvelope()
+    {
+        var (exitCode, stdOut, _) = CliTestHarness.RunCli(_tempDir,
+            "import", "no.such.package.zzz", "--json");
+
+        Assert.Equal(1, exitCode);
+        var root = ParseSingleDocument(stdOut);
+        Assert.Equal("import", root.GetProperty("command").GetString());
+
+        var diagnostic = Assert.Single(root.GetProperty("diagnostics").EnumerateArray());
+        Assert.Equal(DiagnosticCode.ImportInputNotFound, diagnostic.GetProperty("code").GetString());
+        Assert.Equal("error", diagnostic.GetProperty("severity").GetString());
+    }
+
+    [Fact]
+    public void Import_Json_RealAssembly_ReportsTiersAndProvenance()
+    {
+        // Calor.Runtime.dll ships beside the test assembly (transitive
+        // project reference) — a small, real assembly with NRT metadata.
+        var runtimeDll = Path.Combine(AppContext.BaseDirectory, "Calor.Runtime.dll");
+        Assert.True(File.Exists(runtimeDll), $"expected {runtimeDll}");
+
+        var (exitCode, stdOut, _) = CliTestHarness.RunCli(_tempDir,
+            "import", runtimeDll, "--json");
+
+        Assert.Equal(0, exitCode);
+        var root = ParseSingleDocument(stdOut);
+        Assert.Equal("import", root.GetProperty("command").GetString());
+
+        var data = root.GetProperty("data");
+        var counts = data.GetProperty("counts");
+        Assert.True(counts.GetProperty("publicMethods").GetInt32() > 0);
+
+        // The three tiers partition the surface.
+        Assert.Equal(counts.GetProperty("publicMethods").GetInt32(),
+            counts.GetProperty("derived").GetInt32()
+            + counts.GetProperty("curated").GetInt32()
+            + counts.GetProperty("unresolved").GetInt32());
+
+        // Provenance invariants across the CLI boundary (PP-T1 shape).
+        var provenance = data.GetProperty("provenance");
+        Assert.Equal("inferred", provenance.GetProperty("derived").GetString());
+        Assert.Equal("assumed", provenance.GetProperty("synthesizedContracts").GetString());
+
+        var manifest = data.GetProperty("manifest");
+        Assert.Equal("inferred", manifest.GetProperty("confidence").GetString());
+        Assert.NotEqual("verified", manifest.GetProperty("confidence").GetString());
+
+        // Every synthesized contract fact rides the assumed channel.
+        foreach (var contract in data.GetProperty("synthesizedContracts").EnumerateArray())
+        {
+            Assert.Equal("assumed", contract.GetProperty("provenance").GetString());
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // calor review-packet
+    // ------------------------------------------------------------------
+
+    private string WriteModule()
+    {
+        var path = Path.Combine(_tempDir, "pricing.calr");
+        File.WriteAllText(path,
+            "§M{m001:Pricing}\n"
+            + "  §F{f001:ClampToCap:pub} (i32:amount, i32:cap) -> i32\n"
+            + "    §Q (>= cap 0)\n"
+            + "    §IF{if1} (> amount cap)\n"
+            + "      §R cap\n"
+            + "    §R amount\n");
+        return path;
+    }
+
+    [Fact]
+    public void ReviewPacket_Json_EmitsEnvelope_WithHonestyNote()
+    {
+        var module = WriteModule();
+        var (exitCode, stdOut, _) = CliTestHarness.RunCli(_tempDir,
+            "review-packet", module, "--json");
+
+        Assert.Equal(0, exitCode);
+        var root = ParseSingleDocument(stdOut);
+        Assert.Equal("review-packet", root.GetProperty("command").GetString());
+
+        var data = root.GetProperty("data");
+        Assert.True(data.GetProperty("summary").GetProperty("totalContracts").GetInt32() >= 1);
+
+        // The #782 honesty note is unconditional.
+        var notes = data.GetProperty("honestyNotes").EnumerateArray()
+            .Select(n => n.GetString()).ToList();
+        Assert.Contains(notes, n => n != null && n.Contains("#782"));
+    }
+
+    [Fact]
+    public void ReviewPacket_Json_ContractModeOff_DisclosesWaiver()
+    {
+        var module = WriteModule();
+        var (exitCode, stdOut, _) = CliTestHarness.RunCli(_tempDir,
+            "review-packet", module, "--contract-mode", "off", "--json");
+
+        Assert.Equal(0, exitCode);
+        var root = ParseSingleDocument(stdOut);
+
+        var codes = root.GetProperty("diagnostics").EnumerateArray()
+            .Select(d => d.GetProperty("code").GetString()).ToList();
+        Assert.Contains(DiagnosticCode.ReviewPacketWaiverDisclosure, codes);
+
+        var waivers = root.GetProperty("data").GetProperty("waivers").EnumerateArray()
+            .Select(w => w.GetString()).ToList();
+        Assert.Contains(waivers, w => w != null && w.Contains("WAIVER"));
+    }
+
+    [Fact]
+    public void ReviewPacket_Json_MissingFile_StillEmitsEnvelope()
+    {
+        var missing = Path.Combine(_tempDir, "nope.calr");
+        var (exitCode, stdOut, _) = CliTestHarness.RunCli(_tempDir,
+            "review-packet", missing, "--json");
+
+        Assert.Equal(1, exitCode);
+        var root = ParseSingleDocument(stdOut);
+        Assert.Equal("review-packet", root.GetProperty("command").GetString());
+
+        var diagnostic = Assert.Single(root.GetProperty("diagnostics").EnumerateArray());
+        Assert.Equal(DiagnosticCode.ReviewPacketCommandError, diagnostic.GetProperty("code").GetString());
+    }
+
+    [Fact]
+    public void ReviewPacket_Markdown_LeadsWithUnprovenRemainder()
+    {
+        var module = WriteModule();
+        var (exitCode, stdOut, _) = CliTestHarness.RunCli(_tempDir,
+            "review-packet", module);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("## Unproven remainder", stdOut);
+        Assert.Contains("NOT runtime-enforced", stdOut);
+    }
+}

--- a/tests/Calor.Conversion.Tests/EjectStoryTests.cs
+++ b/tests/Calor.Conversion.Tests/EjectStoryTests.cs
@@ -1,0 +1,247 @@
+using System.Reflection;
+using System.Runtime.Loader;
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Calor.Conversion.Tests;
+
+/// <summary>
+/// D-W3.4 (wedge plan v0.11): the eject story as a tested feature. For
+/// representative Calor modules (contracts, effects, options/results), the
+/// Calor → C# conversion must produce C# that (a) compiles via the shared
+/// Slice-3 <see cref="GeneratedCSharpCompiler"/>, (b) preserves behavior at
+/// runtime, and (c) degrades contracts to the documented runtime checks
+/// (retained <c>ContractViolationException</c> guards in debug/release mode;
+/// stripped entirely under the contract-mode-off waiver). The degradation
+/// semantics are documented in docs/guides/adoption-playbook.md — this suite
+/// is what makes that documentation a tested claim instead of a promise.
+/// </summary>
+public class EjectStoryTests
+{
+    // ------------------------------------------------------------------
+    // Fixtures — representative wedge-shaped modules
+    // ------------------------------------------------------------------
+
+    // Single-return body: postcondition lowering refuses early/nested-return
+    // bodies (the #764 T2 stopgap emits Calor1001 and no §S check there) —
+    // that refusal is itself pinned in a test below.
+    private const string ContractsModule = @"§M{m001:Pricing}
+  §F{f001:ClampToCap:pub} (i32:amount, i32:cap) -> i32
+    §Q (>= cap 0)
+    §S (<= result cap)
+    §R §C{Math.Min} §A amount §A cap §/C
+";
+
+    private const string EarlyReturnContractsModule = @"§M{m001:Pricing}
+  §F{f001:ClampToCap:pub} (i32:amount, i32:cap) -> i32
+    §Q (>= cap 0)
+    §S (<= result cap)
+    §IF{if1} (> amount cap)
+      §R cap
+    §R amount
+";
+
+    private const string EffectsModule = @"§M{m001:Greeter}
+  §F{f001:Greet:pub} (str:name) -> void
+    §E{cw}
+    §P name
+";
+
+    private const string OptionsModule = @"§M{m001:Ejected}
+  §F{f001:PickOrDefault:pub} (i32:x, bool:take) -> i32
+    §IF{if1} take
+      §B{opt} §SM x
+      §R §C{opt.UnwrapOr} §A 0 §/C
+    §B{none} §NN{i32}
+    §R §C{none.UnwrapOr} §A -1 §/C
+";
+
+    // ------------------------------------------------------------------
+    // Helpers: emit with a chosen contract mode, compile, execute
+    // ------------------------------------------------------------------
+
+    private static string Emit(string calorSource, EmitContractMode mode)
+    {
+        var diagnostics = new DiagnosticBag();
+        diagnostics.SetFilePath("eject.calr");
+        var lexer = new Lexer(calorSource, diagnostics);
+        var tokens = lexer.TokenizeAllForParser();
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Errors.Select(d => d.Message)));
+        var parser = new Parser(tokens, diagnostics);
+        var module = parser.Parse();
+        Assert.False(diagnostics.HasErrors, string.Join("\n", diagnostics.Errors.Select(d => d.Message)));
+        return new CSharpEmitter(mode).Emit(module);
+    }
+
+    private static Assembly CompileToAssembly(string csharpSource)
+    {
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
+        var preambleTree = CSharpSyntaxTree.ParseText(GeneratedCSharpCompiler.GlobalUsingsPreamble, parseOptions);
+        var sourceTree = CSharpSyntaxTree.ParseText(csharpSource, parseOptions);
+        var compilation = CSharpCompilation.Create(
+            "EjectStory_" + Guid.NewGuid().ToString("N"),
+            [preambleTree, sourceTree],
+            GeneratedCSharpCompiler.References,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = new MemoryStream();
+        var emitResult = compilation.Emit(stream);
+        Assert.True(emitResult.Success, string.Join("\n",
+            emitResult.Diagnostics
+                .Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                .Select(d => d.ToString())));
+
+        stream.Position = 0;
+        var context = new AssemblyLoadContext("eject-story", isCollectible: false);
+        context.Resolving += (_, name) =>
+        {
+            // Resolve Calor.Runtime (and friends) from the reference set the
+            // generated code was compiled against.
+            var path = GeneratedCSharpCompiler.References
+                .OfType<PortableExecutableReference>()
+                .Select(r => r.FilePath)
+                .FirstOrDefault(p => p is not null
+                    && string.Equals(Path.GetFileNameWithoutExtension(p), name.Name, StringComparison.OrdinalIgnoreCase));
+            return path is null ? null : context.LoadFromAssemblyPath(path);
+        };
+        return context.LoadFromStream(stream);
+    }
+
+    private static object? Invoke(Assembly assembly, string moduleName, string method, params object?[] args)
+    {
+        var type = assembly.GetType($"{moduleName}.{moduleName}Module");
+        Assert.NotNull(type);
+        var methodInfo = type.GetMethod(method, BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(methodInfo);
+        return methodInfo.Invoke(null, args);
+    }
+
+    // ------------------------------------------------------------------
+    // (a) Ejected C# compiles via the shared Slice-3 compiler
+    // ------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(ContractsModule)]
+    [InlineData(EffectsModule)]
+    [InlineData(OptionsModule)]
+    public void EjectedModules_CompileCleanly(string calorSource)
+    {
+        var csharp = Emit(calorSource, EmitContractMode.Debug);
+        var validation = GeneratedCSharpCompiler.Validate(csharp);
+        Assert.True(validation.SyntaxSuccess, string.Join("\n", validation.SyntaxErrors.Select(e => e.ToString())));
+        Assert.True(validation.CompilationSuccess, string.Join("\n", validation.FormattedCompilationErrors));
+    }
+
+    // ------------------------------------------------------------------
+    // (b) Behavior is preserved at runtime
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Contracts_BehaviorPreserved_OnValidInputs()
+    {
+        var assembly = CompileToAssembly(Emit(ContractsModule, EmitContractMode.Debug));
+        Assert.Equal(5, Invoke(assembly, "Pricing", "ClampToCap", 5, 10));
+        Assert.Equal(10, Invoke(assembly, "Pricing", "ClampToCap", 25, 10));
+    }
+
+    [Fact]
+    public void Options_BehaviorPreserved()
+    {
+        var assembly = CompileToAssembly(Emit(OptionsModule, EmitContractMode.Debug));
+        Assert.Equal(42, Invoke(assembly, "Ejected", "PickOrDefault", 42, true));
+        Assert.Equal(-1, Invoke(assembly, "Ejected", "PickOrDefault", 42, false));
+    }
+
+    [Fact]
+    public void Effects_BehaviorPreserved_AndNoRuntimeFootprint()
+    {
+        var csharp = Emit(EffectsModule, EmitContractMode.Debug);
+
+        // §E is compile-time discipline only: ejecting drops the enforcement,
+        // not the behavior — no effect machinery appears in the output.
+        Assert.DoesNotContain("EffectSet", csharp);
+        Assert.DoesNotContain("§E", csharp);
+
+        var assembly = CompileToAssembly(csharp);
+        var original = Console.Out;
+        var writer = new StringWriter();
+        try
+        {
+            Console.SetOut(writer);
+            Invoke(assembly, "Greeter", "Greet", "hello-from-ejected-code");
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+        Assert.Contains("hello-from-ejected-code", writer.ToString());
+    }
+
+    // ------------------------------------------------------------------
+    // (c) Documented contract degradation
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Contracts_DegradeToRuntimeChecks_InDebugMode()
+    {
+        var csharp = Emit(ContractsModule, EmitContractMode.Debug);
+
+        // Both §Q and §S survive as runtime guards — `calor convert` runs no
+        // verification, so nothing is elided on the eject path.
+        Assert.Contains("ContractViolationException", csharp);
+        Assert.Contains("ContractKind.Requires", csharp);
+        Assert.Contains("ContractKind.Ensures", csharp);
+    }
+
+    [Fact]
+    public void Contracts_EarlyReturnBody_PostconditionRefusedLoudly_NotSilentlySkipped()
+    {
+        // The #764 stopgap: a §S on an early-return body gets NO runtime
+        // check — the lowering refuses (Calor1001) instead of emitting a
+        // check that could be silently skipped. The §Q guard still emits.
+        var csharp = Emit(EarlyReturnContractsModule, EmitContractMode.Debug);
+        Assert.Contains("ContractKind.Requires", csharp);
+        Assert.DoesNotContain("ContractKind.Ensures", csharp);
+    }
+
+    [Fact]
+    public void Contracts_ViolationThrows_AtRuntime()
+    {
+        var assembly = CompileToAssembly(Emit(ContractsModule, EmitContractMode.Debug));
+
+        // cap < 0 violates §Q (>= cap 0) — the retained guard must throw.
+        var ex = Assert.Throws<TargetInvocationException>(
+            () => Invoke(assembly, "Pricing", "ClampToCap", 5, -1));
+        Assert.NotNull(ex.InnerException);
+        Assert.Equal("ContractViolationException", ex.InnerException!.GetType().Name);
+        Assert.Contains("cap", ex.InnerException.Message);
+    }
+
+    [Fact]
+    public void Contracts_ReleaseMode_KeepsLeanChecks()
+    {
+        var csharp = Emit(ContractsModule, EmitContractMode.Release);
+        Assert.Contains("ContractViolationException", csharp);
+
+        var assembly = CompileToAssembly(csharp);
+        var ex = Assert.Throws<TargetInvocationException>(
+            () => Invoke(assembly, "Pricing", "ClampToCap", 5, -1));
+        Assert.Equal("ContractViolationException", ex.InnerException!.GetType().Name);
+    }
+
+    [Fact]
+    public void Contracts_OffMode_StripsAllChecks_TheDocumentedWaiver()
+    {
+        var csharp = Emit(ContractsModule, EmitContractMode.Off);
+        Assert.DoesNotContain("ContractViolationException", csharp);
+
+        // The waiver strips guards; behavior otherwise unchanged — the same
+        // violating call now runs through and returns the (nonsensical) cap.
+        var assembly = CompileToAssembly(csharp);
+        Assert.Equal(-1, Invoke(assembly, "Pricing", "ClampToCap", 5, -1));
+    }
+}

--- a/tests/Calor.ILAnalysis.Tests/ImportHonestyC1Tests.cs
+++ b/tests/Calor.ILAnalysis.Tests/ImportHonestyC1Tests.cs
@@ -1,0 +1,185 @@
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Effects;
+using Calor.Compiler.Effects.Manifests;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Calor.ILAnalysis.Tests;
+
+/// <summary>
+/// Pins for the adversarial-review C1 finding (PR #841): Tier A must never
+/// emit derived (implicitly pure or effect-underapproximated) entries for
+/// members whose call chains rest on unverified assumptions — callees missing
+/// from the loaded assemblies, bodiless declarations (interface/abstract),
+/// or delegate invocations. Such members are Tier-C unresolved with a reason
+/// naming the assumption, and become derivable when the missing assemblies
+/// are supplied via references.
+/// </summary>
+public class ImportHonestyC1Tests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ImportHonestyC1Tests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "calor-c1-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch (IOException) { }
+    }
+
+    // ------------------------------------------------------------------
+    // Fixture compilation
+    // ------------------------------------------------------------------
+
+    private string CompileFixture(string assemblyName, string source, params string[] referencePaths)
+    {
+        var references = new List<MetadataReference>(GeneratedCSharpCompiler.References);
+        references.AddRange(referencePaths.Select(p => (MetadataReference)MetadataReference.CreateFromFile(p)));
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview))],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var path = Path.Combine(_tempDir, assemblyName + ".dll");
+        var emit = compilation.Emit(path);
+        Assert.True(emit.Success, string.Join("\n",
+            emit.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        return path;
+    }
+
+    private static PackageImportReport Generate(string dll, params string[] references)
+    {
+        var resolver = new EffectResolver();
+        resolver.Initialize();
+        return PackageManifestGenerator.Generate(
+            [dll], references, resolver,
+            library: Path.GetFileNameWithoutExtension(dll),
+            synthesizeContracts: false);
+    }
+
+    // ------------------------------------------------------------------
+    // Repro 1: caller of an interface method must not emit derived-pure
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void InterfaceDispatchCaller_IsUnresolved_NotDerivedPure()
+    {
+        var dll = CompileFixture("C1.Widgets", @"
+namespace Widgets
+{
+    public interface IWidget { void Ping(); }
+    public static class Caller
+    {
+        public static void Poke(IWidget w) => w.Ping();
+    }
+}");
+        var report = Generate(dll);
+
+        var poke = report.Unresolved.FirstOrDefault(u =>
+            u.Type == "Widgets.Caller" && u.Member == "Poke");
+        Assert.NotNull(poke);
+        Assert.Contains("assum", poke.Reason, StringComparison.OrdinalIgnoreCase);
+
+        Assert.DoesNotContain(report.Derived, d => d.Type == "Widgets.Caller" && d.Member == "Poke");
+        Assert.DoesNotContain(report.Manifest.Mappings, m => m.Type == "Widgets.Caller");
+    }
+
+    // ------------------------------------------------------------------
+    // Repro 2: missing reference assembly → unresolved; with -r → derived
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void MissingReference_IsUnresolved_AndDerivesWithReference()
+    {
+        var depB = CompileFixture("C1.DepB", @"
+namespace DepB
+{
+    public static class Sink
+    {
+        public static void WriteLog(string s) => System.IO.File.AppendAllText(""log.txt"", s);
+    }
+}");
+        var depA = CompileFixture("C1.DepA", @"
+namespace DepA
+{
+    public static class Record
+    {
+        public static void Save(string s) => DepB.Sink.WriteLog(s);
+    }
+}", depB);
+
+        // Without Dep.B loaded: Save must be unresolved and the reason must
+        // name the assumed leaf — never an empty (pure) derived entry.
+        var without = Generate(depA);
+        var save = without.Unresolved.FirstOrDefault(u => u.Type == "DepA.Record" && u.Member == "Save");
+        Assert.NotNull(save);
+        Assert.Contains("DepB.Sink.WriteLog", save.Reason);
+        Assert.DoesNotContain(without.Derived, d => d.Type == "DepA.Record" && d.Member == "Save");
+
+        // With Dep.B supplied, the chain resolves to the manifest seed fs:w.
+        var with = Generate(depA, depB);
+        var derived = with.Derived.FirstOrDefault(d => d.Type == "DepA.Record" && d.Member == "Save");
+        Assert.NotNull(derived);
+        Assert.Contains("fs:w", derived.Effects);
+    }
+
+    // ------------------------------------------------------------------
+    // Repro 3: delegate invocation is never derived-pure
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void DelegateInvokingMethod_IsUnresolved_WithDelegateReason()
+    {
+        var dll = CompileFixture("C1.Runners", @"
+namespace Runners
+{
+    public static class Runner
+    {
+        public static int Run(System.Func<int> f) => f();
+    }
+}");
+        var report = Generate(dll);
+
+        var run = report.Unresolved.FirstOrDefault(u => u.Type == "Runners.Runner" && u.Member == "Run");
+        Assert.NotNull(run);
+        Assert.Contains("delegate invocation", run.Reason);
+        Assert.DoesNotContain(report.Derived, d => d.Type == "Runners.Runner" && d.Member == "Run");
+    }
+
+    // ------------------------------------------------------------------
+    // Clean chains still derive (the fix must not nuke Tier A)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void FullyResolvedChain_StillDerives_WithEffects()
+    {
+        var dll = CompileFixture("C1.Clean", @"
+namespace Clean
+{
+    public class Greeter
+    {
+        public void Greet(string name) => System.Console.WriteLine(name);
+        public int Add(int a, int b) => a + b;
+    }
+}");
+        var report = Generate(dll);
+
+        var greet = report.Derived.FirstOrDefault(d => d.Type == "Clean.Greeter" && d.Member == "Greet");
+        Assert.NotNull(greet);
+        Assert.Contains("cw", greet.Effects);
+
+        var add = report.Derived.FirstOrDefault(d => d.Type == "Clean.Greeter" && d.Member == "Add");
+        Assert.NotNull(add);
+        Assert.Empty(add.Effects);
+
+        // The instance constructor chains only through the manifest-covered
+        // System.Object..ctor — clean, so it derives.
+        Assert.Contains(report.Derived, d => d.Type == "Clean.Greeter" && d.Kind == "constructor");
+    }
+}

--- a/tests/Calor.ILAnalysis.Tests/PackageManifestGeneratorTests.cs
+++ b/tests/Calor.ILAnalysis.Tests/PackageManifestGeneratorTests.cs
@@ -1,0 +1,191 @@
+using Calor.Compiler.Effects;
+using Calor.Compiler.Effects.Manifests;
+using Xunit;
+
+namespace Calor.ILAnalysis.Tests;
+
+/// <summary>
+/// D-W3.1/D-W3.2 (wedge plan v0.11): the calor-import engine over a real
+/// assembly. Pins the import-honesty invariants that M-T1 formalizes:
+/// every emitted entry carries provenance, derived entries are 'inferred',
+/// synthesized contracts are 'assumed', nothing is ever 'verified', and
+/// unresolved members never enter the manifest (an empty effect list would
+/// mean pure — under-approximation).
+/// </summary>
+public class PackageManifestGeneratorTests
+{
+    private static readonly string TestAssemblyDir = Path.Combine(
+        AppContext.BaseDirectory, "TestAssemblies");
+
+    private static readonly string DataAccessDll = Path.Combine(TestAssemblyDir, "TestAssembly.DataAccess.dll");
+    private static readonly string ScenariosDll = Path.Combine(TestAssemblyDir, "TestAssembly.Scenarios.dll");
+
+    private static PackageImportReport GenerateReport(string dll, bool contracts = true)
+    {
+        var resolver = new EffectResolver();
+        resolver.Initialize();
+        return PackageManifestGenerator.Generate(
+            [dll], [], resolver,
+            library: Path.GetFileNameWithoutExtension(dll),
+            synthesizeContracts: contracts);
+    }
+
+    // ------------------------------------------------------------------
+    // Tier A: derived entries
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void DataAccess_RepositorySave_DerivedWithDbWrite()
+    {
+        var report = GenerateReport(DataAccessDll);
+
+        var save = report.Derived.FirstOrDefault(e =>
+            e.Type == "TestAssembly.DataAccess.UserRepository" && e.Member == "Save");
+        Assert.NotNull(save);
+        Assert.Equal("il-analysis", save.Source);
+        Assert.Contains("db:w", save.Effects);
+    }
+
+    [Fact]
+    public void DataAccess_ServiceLayer_TransitiveEffectsDerived()
+    {
+        var report = GenerateReport(DataAccessDll);
+
+        var createUser = report.Derived.FirstOrDefault(e =>
+            e.Type == "TestAssembly.DataAccess.UserService" && e.Member == "CreateUser");
+        Assert.NotNull(createUser);
+        Assert.Contains("db:w", createUser.Effects);
+    }
+
+    [Fact]
+    public void Manifest_ContainsOnlyDerivedEntries_WithInferredProvenance()
+    {
+        var report = GenerateReport(DataAccessDll);
+        var manifest = report.Manifest;
+
+        Assert.Equal("calor import", manifest.GeneratedBy);
+        Assert.Equal(PackageManifestGenerator.DerivedConfidence, manifest.Confidence);
+        Assert.NotNull(manifest.GeneratedAt);
+
+        // Nothing calor import emits is ever 'verified' (PP-T1 / M-T1).
+        Assert.NotEqual("verified", manifest.Confidence);
+
+        // Every manifest member corresponds to a derived entry — unresolved
+        // and curated members never enter the emitted manifest.
+        var derivedKeys = report.Derived
+            .Select(d => (d.Type, d.Member, d.Kind))
+            .ToHashSet();
+        foreach (var mapping in manifest.Mappings)
+        {
+            foreach (var method in mapping.Methods?.Keys ?? Enumerable.Empty<string>())
+                Assert.Contains((mapping.Type, method, "method"), derivedKeys);
+            foreach (var getter in mapping.Getters?.Keys ?? Enumerable.Empty<string>())
+                Assert.Contains((mapping.Type, getter, "getter"), derivedKeys);
+            foreach (var setter in mapping.Setters?.Keys ?? Enumerable.Empty<string>())
+                Assert.Contains((mapping.Type, setter, "setter"), derivedKeys);
+            if (mapping.Constructors is { Count: > 0 })
+                Assert.Contains(derivedKeys, k => k.Type == mapping.Type && k.Kind == "constructor");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Tier C: unresolved surfaced loudly, never silently pure
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void InterfaceMethods_AreUnresolved_NotEmittedAsPure()
+    {
+        var report = GenerateReport(ScenariosDll);
+
+        // IStore's methods have no body and no curated manifest entry —
+        // they must land in the unresolved bucket with a reason.
+        var storeMembers = report.Unresolved
+            .Where(u => u.Type == "TestAssembly.Scenarios.IStore")
+            .ToList();
+        Assert.NotEmpty(storeMembers);
+        Assert.All(storeMembers, u => Assert.False(string.IsNullOrWhiteSpace(u.Reason)));
+
+        // And they never appear in the emitted manifest.
+        Assert.DoesNotContain(report.Manifest.Mappings, m => m.Type == "TestAssembly.Scenarios.IStore");
+    }
+
+    [Fact]
+    public void ClassificationBuckets_AreDisjointAndCoverSurface()
+    {
+        var report = GenerateReport(DataAccessDll);
+
+        Assert.True(report.PublicMethodCount > 0);
+        Assert.Equal(report.PublicMethodCount,
+            report.Derived.Count + report.Curated.Count + report.Unresolved.Count);
+    }
+
+    // ------------------------------------------------------------------
+    // D-W3.2: mechanical contract synthesis — assumed provenance only
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Synthesis_NonNullableReferenceParameter_YieldsAssumedNotNullFact()
+    {
+        var report = GenerateReport(DataAccessDll);
+
+        // UserService.CreateUser(string name) under <Nullable>enable</Nullable>
+        var fact = report.SynthesizedContracts.FirstOrDefault(c =>
+            c.Type == "TestAssembly.DataAccess.UserService"
+            && c.Method == "CreateUser"
+            && c.Parameter == "name");
+        Assert.NotNull(fact);
+        Assert.Equal("requires-not-null", fact.Kind);
+        Assert.Equal("(!= name null)", fact.Expression);
+        Assert.Equal(PackageManifestGenerator.AssumedProvenance, fact.Provenance);
+        Assert.Equal("nrt-metadata", fact.Source);
+    }
+
+    [Fact]
+    public void Synthesis_NullableReferenceParameter_YieldsNoFact()
+    {
+        var report = GenerateReport(DataAccessDll);
+
+        // No non-null fact may be synthesized for a T? parameter anywhere.
+        Assert.DoesNotContain(report.SynthesizedContracts, c =>
+            c.Kind == "requires-not-null" && c.Type.EndsWith("User") && c.Parameter == "id");
+    }
+
+    [Fact]
+    public void Synthesis_EveryFact_CarriesAssumedProvenance_NeverVerifiedOrProven()
+    {
+        foreach (var dll in new[] { DataAccessDll, ScenariosDll })
+        {
+            var report = GenerateReport(dll);
+            Assert.All(report.SynthesizedContracts, c =>
+            {
+                Assert.Equal(PackageManifestGenerator.AssumedProvenance, c.Provenance);
+                Assert.NotEqual("verified", c.Provenance);
+                Assert.NotEqual("proven", c.Provenance);
+            });
+        }
+    }
+
+    [Fact]
+    public void Synthesis_Disabled_ProducesNoContracts()
+    {
+        var report = GenerateReport(DataAccessDll, contracts: false);
+        Assert.Empty(report.SynthesizedContracts);
+    }
+
+    // ------------------------------------------------------------------
+    // Missing input handled loudly
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void MissingAssembly_ReportsLoadError()
+    {
+        var resolver = new EffectResolver();
+        resolver.Initialize();
+        var report = PackageManifestGenerator.Generate(
+            [Path.Combine(TestAssemblyDir, "does-not-exist.dll")], [], resolver);
+
+        Assert.NotEmpty(report.LoadErrors);
+        Assert.Equal(0, report.PublicMethodCount);
+        Assert.Empty(report.Manifest.Mappings);
+    }
+}

--- a/tests/Calor.Verification.Tests/ReviewPacketTests.cs
+++ b/tests/Calor.Verification.Tests/ReviewPacketTests.cs
@@ -183,6 +183,82 @@ public class ReviewPacketTests
     }
 
     [Fact]
+    public void Packet_CallerImpact_FindsCrossFileCallers()
+    {
+        // M2 pin (PR #841 review): a caller in one file of a declaration
+        // changed in another file of the SAME invocation must be found.
+        const string lib = @"
+§M{m001:Lib}
+  §F{f100:Square:pub}
+      §I{i32:x}
+      §O{i32}
+      §R (* x x)
+";
+        const string app = @"
+§M{m002:App}
+  §F{f200:UseSquare:pub}
+      §I{i32:y}
+      §O{i32}
+      §R §C{Square} §A y §/C
+";
+        var result = ReviewPacketBuilder.Build(
+            [
+                new ReviewPacketBuilder.InputFile("lib.calr", lib),
+                new ReviewPacketBuilder.InputFile("app.calr", app)
+            ],
+            new ReviewPacketBuilder.Options(ChangedDeclarations: ["f100"]));
+
+        var impact = Assert.Single(result.Packet.CallerImpact);
+        Assert.Equal("f100", impact.ChangedId);
+        Assert.Contains(impact.Callers, c => c.Id == "f200");
+        Assert.Empty(result.UnmatchedChangedDeclarations);
+    }
+
+    [Fact]
+    public void Packet_UnknownChangedSelector_ReportedNotSilent()
+    {
+        // m1 pin: a typo'd --changed selector is surfaced, not swallowed.
+        var result = Build(MixedModule, new ReviewPacketBuilder.Options(
+            ChangedDeclarations: ["zz999"]));
+        Assert.Contains("zz999", result.UnmatchedChangedDeclarations);
+        Assert.Empty(result.Packet.CallerImpact);
+    }
+
+    [SkippableFact]
+    public void Summary_Proven_ExcludesVacuous()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        // m2 pin: a vacuously-proven contract (unsatisfiable §Q set) must not
+        // let summary.proven read clean — proven counts non-vacuous only.
+        const string vacuous = @"
+§M{m001:Vac}
+  §F{f001:Weird:pub}
+      §I{i32:x}
+      §O{i32}
+      §Q (>= x 1)
+      §Q (<= x 0)
+      §S (== result 5)
+      §R 7
+";
+        var result = Build(vacuous);
+        var summary = result.Packet.Summary;
+
+        var vacuousRecords = result.Packet.UnprovenRemainder
+            .Where(c => c.Status == "proven" && c.Vacuous).ToList();
+        Assert.NotEmpty(vacuousRecords);
+        Assert.Equal(vacuousRecords.Count, summary.ProvenVacuous);
+
+        // No clean-proven contract exists in this module, and vacuous ones
+        // never count as proven.
+        Assert.DoesNotContain(result.Packet.Proven, c => c.Vacuous);
+        Assert.True(summary.Proven + summary.ProvenVacuous
+            <= summary.TotalContracts);
+        Assert.DoesNotContain(result.Packet.UnprovenRemainder,
+            c => c.Status == "proven" && !c.Vacuous);
+    }
+
+    [Fact]
     public void Packet_CompileError_SurfacesDiagnosticsAndFlags()
     {
         // A parse-level error: unterminated call argument list.

--- a/tests/Calor.Verification.Tests/ReviewPacketTests.cs
+++ b/tests/Calor.Verification.Tests/ReviewPacketTests.cs
@@ -1,0 +1,193 @@
+using Calor.Compiler.Reporting;
+using Calor.Compiler.Verification.Z3;
+using Xunit;
+
+namespace Calor.Verification.Tests;
+
+/// <summary>
+/// D-W3.3 (wedge plan v0.11): review packet v1 — the per-change report that
+/// leads with the unproven remainder. Pins: seven-status collection with
+/// assumptions/vacuity, waiver disclosure on the first line, per-module
+/// interop fraction, caller impact from the in-memory call graph, and the
+/// #782 refinement honesty note present on every packet.
+/// </summary>
+public class ReviewPacketTests
+{
+    private const string MixedModule = @"
+§M{m001:Pricing}
+  §F{f001:Square:pub}
+      §I{i32:x}
+      §O{i32}
+      §Q (>= x 0)
+      §Q (<= x 46340)
+      §S (>= result 0)
+      §R (* x x)
+
+  §F{f002:BrokenCap:pub}
+      §I{i32:amount}
+      §I{i32:cap}
+      §O{i32}
+      §S (<= result cap)
+      §R amount
+
+  §F{f003:Caller:pub}
+      §I{i32:y}
+      §O{i32}
+      §R §C{Square} §A y §/C
+";
+
+    private static ReviewPacketBuilder.Result Build(
+        string source,
+        ReviewPacketBuilder.Options? options = null)
+    {
+        return ReviewPacketBuilder.Build(
+            [new ReviewPacketBuilder.InputFile("pricing.calr", source)],
+            options ?? new ReviewPacketBuilder.Options());
+    }
+
+    [SkippableFact]
+    public void Packet_LeadsWithUnprovenRemainder_RefutedFirst()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        var result = Build(MixedModule);
+        var packet = result.Packet;
+
+        Assert.False(result.HasCompileErrors);
+        Assert.True(packet.Summary.TotalContracts >= 4);
+        Assert.True(packet.Summary.UnprovenRemainder >= 1);
+
+        // BrokenCap's §S is refutable (amount unconstrained) — it must be in
+        // the remainder, and refuted entries sort before everything else.
+        var refuted = packet.UnprovenRemainder.Where(c => c.Status == "refuted").ToList();
+        Assert.Contains(refuted, c => c.FunctionName == "BrokenCap");
+        if (refuted.Count > 0)
+        {
+            Assert.Equal("refuted", packet.UnprovenRemainder[0].Status);
+            Assert.NotNull(packet.UnprovenRemainder.First(c => c.FunctionName == "BrokenCap").Counterexample);
+        }
+
+        // The remainder never contains a clean non-vacuous proven contract.
+        Assert.DoesNotContain(packet.UnprovenRemainder, c => c.Status == "proven" && !c.Vacuous);
+    }
+
+    [SkippableFact]
+    public void Packet_ContractText_SlicedFromSource()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        var result = Build(MixedModule);
+        var all = result.Packet.UnprovenRemainder.Concat(result.Packet.Proven).ToList();
+        var brokenCap = all.First(c => c.FunctionName == "BrokenCap" && c.ContractKind == "postcondition");
+        Assert.NotNull(brokenCap.Text);
+        Assert.Contains("result", brokenCap.Text);
+    }
+
+    [SkippableFact]
+    public void Markdown_LeadsWithWaiver_WhenPermissive()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        var result = Build(MixedModule, new ReviewPacketBuilder.Options(PermissiveEffects: true));
+        var markdown = ReviewPacketBuilder.RenderMarkdown(result.Packet);
+
+        var firstLine = markdown.Split('\n')[0];
+        Assert.Contains("WAIVER", firstLine);
+        Assert.Contains("--permissive-effects", firstLine);
+        Assert.Contains("VOID", firstLine);
+    }
+
+    [SkippableFact]
+    public void Markdown_LeadsWithWaiver_WhenContractChecksOff()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        var result = Build(MixedModule, new ReviewPacketBuilder.Options(ContractChecksOff: true));
+        var markdown = ReviewPacketBuilder.RenderMarkdown(result.Packet);
+
+        var firstLine = markdown.Split('\n')[0];
+        Assert.Contains("WAIVER", firstLine);
+        Assert.Contains("contract", firstLine, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [SkippableFact]
+    public void Markdown_UnprovenRemainderSection_PrecedesProvenSection()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        var result = Build(MixedModule);
+        var markdown = ReviewPacketBuilder.RenderMarkdown(result.Packet);
+
+        var remainderIndex = markdown.IndexOf("## Unproven remainder", StringComparison.Ordinal);
+        var provenIndex = markdown.IndexOf("## Proven", StringComparison.Ordinal);
+        Assert.True(remainderIndex >= 0);
+        if (provenIndex >= 0)
+            Assert.True(remainderIndex < provenIndex, "unproven remainder must lead");
+    }
+
+    [Fact]
+    public void Packet_AlwaysCarriesRefinementHonestyNote()
+    {
+        // No Z3 needed: the honesty note is unconditional.
+        var result = Build("§M{m001:Empty}\n  §F{f001:Id:pub} (i32:x) -> i32\n    §R x\n");
+        Assert.Contains(ReviewPacketBuilder.RefinementHonestyNote, result.Packet.HonestyNotes);
+
+        var markdown = ReviewPacketBuilder.RenderMarkdown(result.Packet);
+        Assert.Contains("NOT runtime-enforced", markdown);
+        Assert.Contains("#782", markdown);
+    }
+
+    [Fact]
+    public void Packet_ModuleDisclosure_ReportsInteropFraction()
+    {
+        var source = @"
+§M{m001:WithInterop}
+  §F{f001:Pure:pub} (i32:x) -> i32
+    §R x
+
+  §CSHARP{
+    public static int Raw(int x) => x + 1;
+  }§/CSHARP
+";
+        var result = Build(source);
+        var module = Assert.Single(result.Packet.Modules);
+        Assert.Equal(1, module.InteropBlocks);
+        Assert.Equal(2, module.TotalMembers);
+        Assert.Equal(0.5, module.InteropFraction, 3);
+    }
+
+    [Fact]
+    public void Packet_CallerImpact_ListsDirectCallers()
+    {
+        var result = Build(MixedModule, new ReviewPacketBuilder.Options(
+            ChangedDeclarations: ["f001"]));
+
+        var impact = Assert.Single(result.Packet.CallerImpact);
+        Assert.Equal("f001", impact.ChangedId);
+        Assert.Contains(impact.Callers, c => c.Id == "f003");
+    }
+
+    [Fact]
+    public void Packet_ChangedLineRanges_MapToDeclarations()
+    {
+        // Lines covering f002 (BrokenCap) only.
+        var ranges = new Dictionary<string, IReadOnlyList<(int, int)>>(StringComparer.Ordinal)
+        {
+            [System.IO.Path.GetFullPath("pricing.calr")] = [(11, 16)]
+        };
+        var result = Build(MixedModule, new ReviewPacketBuilder.Options(
+            ChangedLineRanges: ranges, BaselineRef: "HEAD"));
+
+        Assert.Contains("f002", result.Packet.ChangedDeclarations);
+        Assert.DoesNotContain("f003", result.Packet.ChangedDeclarations);
+    }
+
+    [Fact]
+    public void Packet_CompileError_SurfacesDiagnosticsAndFlags()
+    {
+        // A parse-level error: unterminated call argument list.
+        var result = Build("§M{m001:Broken}\n  §F{f001:Bad:pub} (i32:x) -> i32\n    §R (+ x\n");
+        Assert.True(result.HasCompileErrors);
+        Assert.NotEmpty(result.CompileDiagnostics);
+    }
+}


### PR DESCRIPTION
Implements WS-W3 from the v0.11 wedge plan (docs/plans/wedge-plan-v0.11.md §2).

## Deliverables

- **D-W3.1 — `calor import <package>`**: three-tier effect-manifest generation. Tier A = IL-derived (existing AssemblyIndex/ILCallGraphBuilder/TransitiveEffectPropagator machinery, `Confidence: inferred`); Tier B = curated manifest chain (reported, not re-emitted); Tier C = unresolved surfaced loudly (`Calor1351`) and **excluded** from the manifest — never silently under-approximated. Classification unit is the (type, member, kind) group; any unresolved overload poisons the member. Nothing is ever emitted as `verified`. Live-validated on Serilog (207 members: 76 derived / 115 curated / 16 unresolved) and MediatR (38: 19/4/15).
- **D-W3.2 — contract synthesis (narrow mechanical set)**: §Q non-null from NRT metadata + `>= 0` from unsigned params, sidecar `<pkg>.calor-contracts.json`, every entry `provenance: "assumed"` (`Calor1353`). **Consumption path deliberately shed** per the plan's shed order — facts are annotation-only; tests pin that no importable fact carries proven/verified provenance.
- **D-W3.3 — review packet v1** (`calor review-packet`): leads with the unproven remainder (seven-status), assumption lists, vacuity flags, counterexamples, per-module interop/waiver fractions with waiver disclosure on the **first line** (`Calor1357`), caller impact from in-memory CallGraphAnalysis (`--changed` / `--baseline-ref` with git-hunk mapping), unconditional #782 refinement-honesty note (`Calor1356`). Index-backed blast radius not built (plan §9 scope delta).
- **D-W3.4 — adoption playbook + tested eject**: docs/guides/adoption-playbook.md (pre-1.0/bus-factor disclosures, M-A1 consumer shape, eject degradation table) + EjectStoryTests (11 tests): ejected C# compiles via GeneratedCSharpCompiler, behavior preserved by executing the ejected assembly, §Q/§S degrade to ContractViolationException guards, Off strips checks, and §S-on-early-return refusal (Calor1001/#764 stopgap) pinned + documented.
- **D-W3.5** — not built (adopter-gated); roadmap note only.

## New diagnostics
Calor1350–1353 (import), Calor1355–1357 (review packet) — registered in Diagnostic.cs + docs/cli/structured-output.md (drift-check green).

## Tier-B manifest additions (+82 lines, extending existing files)
LogContext + Serilog config types; FluentValidation rule-definition mutators + ValidateAndThrow; IMemoryCache/IDistributedCache.

## Tests
+37 new (10 generator incl. provenance pins + partition invariant, 10 review-packet, 11 eject, 6 CLI envelope). Full suite 11 projects, 0 failures.

## Known follow-ups
- Typed Result binding emitter inference bug found by the eject suite (`Result.Ok<object,string>` vs declared `Result<int,string>`) — issue to file.
- D-W3.2 consumption (Assumed-channel wiring) is the recorded reopen point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)