### PR TITLE
feat: WS-W2 strictness batch — close the five effect-soundness holes

### DIFF
--- a/docs/cli/compile.md
+++ b/docs/cli/compile.md
@@ -55,6 +55,7 @@ calor -v -i MyModule.calr -o MyModule.g.cs
 | `--strict-api` | | No | Require `§BR` breaking-change markers for public API changes |
 | `--require-docs` | | No | Require documentation on public functions |
 | `--enforce-effects` | | No | Enforce effect declarations (default: true) |
+| `--no-enforce-effects` | | No | Disable effect enforcement (opt out of the v0.11 default-on behavior) |
 
 ---
 

--- a/docs/syntax-reference/effects.md
+++ b/docs/syntax-reference/effects.md
@@ -283,12 +283,25 @@ You cannot hide an effect by burying it in helper functions.
   §C{f001:Helper}                  // ERROR: cw effect leaks through
 ```
 
+### Soundness Diagnostics (v0.11 strictness batch)
+
+Effect enforcement is fail-closed. The diagnostics on the enforcement surface:
+
+- **Calor0410** — a function uses an effect it does not declare (with call chain).
+- **Calor0411** — an unknown external call; add the callee to a `.calor-effects.json` manifest. Unknown calls contribute worst-case effects, so under the default policy they fail loud rather than being assumed pure.
+- **Calor0418** — invocation of a delegate/function-typed value (a parameter, binding, or field being called). Function-typed values carry no effect contract, so the call is an **error** under enforcement. There is no annotation escape hatch; wrap the call in `§CSHARP` interop (surfaced as an assumption via Calor0419) or compile with `--permissive-effects` (an explicit waiver that demotes the error to a warning).
+- **Calor0419** — the effects of a function are **assumed**, not verified: it contains raw C# interop (`§CSHARP`/`§CS`), an unrecognized construct, or calls a function whose effects are assumed. The assumption propagates to callers through the interprocedural pass. Warning by default; error under `--strict-effects`.
+- **Calor0420** — an override declares effects not covered by its base method's declared `§E` (override `§E` must be a subset of base `§E`). Broader override effects would launder through dynamic dispatch.
+- **Calor0421** — an interface implementation declares effects not covered by the interface method's declared `§E`.
+
+Calls through a receiver whose static type is an in-module interface or class charge the static type's *declared* `§E` — sound because Calor0420/Calor0421 pin every override and implementation to a subset of that declared set. Overrides of **external C# base classes** cannot be variance-checked and are surfaced through the Calor0419 assumption channel.
+
 ### Disabling Enforcement (Not Recommended)
 
 For migration scenarios, you can disable enforcement:
 
 ```bash
-calor compile myprogram.calr --enforce-effects=false
+calor --input myprogram.calr --no-enforce-effects
 ```
 
 Or in MSBuild:

--- a/docs/syntax-reference/effects.md
+++ b/docs/syntax-reference/effects.md
@@ -294,7 +294,7 @@ Effect enforcement is fail-closed. The diagnostics on the enforcement surface:
 - **Calor0420** — an override declares effects not covered by its base method's declared `§E` (override `§E` must be a subset of base `§E`). Broader override effects would launder through dynamic dispatch.
 - **Calor0421** — an interface implementation declares effects not covered by the interface method's declared `§E`.
 
-Calls through a receiver whose static type is an in-module interface or class charge the static type's *declared* `§E` — sound because Calor0420/Calor0421 pin every override and implementation to a subset of that declared set. Overrides of **external C# base classes** cannot be variance-checked and are surfaced through the Calor0419 assumption channel.
+Calls through a receiver whose static type is an in-module interface or class charge the static type's *declared* `§E` — sound because Calor0420/Calor0421 pin every override and implementation to a subset of that declared set, **including implementations inherited from in-module base classes**. Overrides of **external C# base classes**, and interface implementations satisfied by members inherited from external bases, cannot be variance-checked and are surfaced through the Calor0419 assumption channel instead.
 
 ### Disabling Enforcement (Not Recommended)
 

--- a/samples/Collections/collections.calr
+++ b/samples/Collections/collections.calr
@@ -1,6 +1,6 @@
 §M{m001:Collections}
   §F{f001:Main:pub} () -> void
-    §E{cw}
+    §E{cw,mut}
     §C{Console.WriteLine} "=== Calor Collections Demo ==="
     §C{Console.WriteLine} ""
     §C{Console.WriteLine} "--- List Operations ---"

--- a/samples/Generics/generics.calr
+++ b/samples/Generics/generics.calr
@@ -22,6 +22,7 @@
       §ASSIGN _items §NEW{List<T>} §/NEW
 
     §MT{mt101:Add:pub} (T:item) -> void
+      §E{mut}
       §C{_items.Add} item
 
     §MT{mt102:GetAll:pub} () -> ReadList<T>

--- a/src/Calor.Compiler/Analysis/CallGraphAnalysis.cs
+++ b/src/Calor.Compiler/Analysis/CallGraphAnalysis.cs
@@ -57,6 +57,106 @@ public sealed class CallGraphAnalysis
     }
 
     /// <summary>
+    /// Enumerates all classes in a module, including classes wrapped in
+    /// module-level §PP type-preprocessor blocks (any branch — a
+    /// conditional-compilation branch may be active, so every branch's members
+    /// participate in analysis; W2 review C1).
+    /// </summary>
+    public static IEnumerable<ClassDefinitionNode> EnumerateClasses(ModuleNode module)
+    {
+        foreach (var cls in module.Classes)
+            yield return cls;
+        foreach (var block in module.TypePreprocessorBlocks)
+        {
+            var branch = block;
+            while (branch != null)
+            {
+                foreach (var cls in branch.Classes)
+                    yield return cls;
+                branch = branch.ElseBranch;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Enumerates all interfaces in a module, including §PP-wrapped ones.
+    /// </summary>
+    public static IEnumerable<InterfaceDefinitionNode> EnumerateInterfaces(ModuleNode module)
+    {
+        foreach (var iface in module.Interfaces)
+            yield return iface;
+        foreach (var block in module.TypePreprocessorBlocks)
+        {
+            var branch = block;
+            while (branch != null)
+            {
+                foreach (var iface in branch.Interfaces)
+                    yield return iface;
+                branch = branch.ElseBranch;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Enumerates all delegate definitions in a module, including §PP-wrapped ones.
+    /// </summary>
+    public static IEnumerable<DelegateDefinitionNode> EnumerateDelegates(ModuleNode module)
+    {
+        foreach (var del in module.Delegates)
+            yield return del;
+        foreach (var block in module.TypePreprocessorBlocks)
+        {
+            var branch = block;
+            while (branch != null)
+            {
+                foreach (var del in branch.Delegates)
+                    yield return del;
+                branch = branch.ElseBranch;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Enumerates all methods of a class, including methods wrapped in
+    /// class-level §PP member-preprocessor blocks (all branches; W2 review C1 —
+    /// a §PP-wrapped method must not escape effect enforcement).
+    /// </summary>
+    public static IEnumerable<MethodNode> EnumerateMethods(ClassDefinitionNode cls)
+    {
+        foreach (var method in cls.Methods)
+            yield return method;
+        foreach (var block in cls.PreprocessorBlocks)
+        {
+            var branch = block;
+            while (branch != null)
+            {
+                foreach (var method in branch.Methods)
+                    yield return method;
+                branch = branch.ElseBranch;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Enumerates all constructors of a class, including §PP-wrapped ones.
+    /// </summary>
+    public static IEnumerable<ConstructorNode> EnumerateConstructors(ClassDefinitionNode cls)
+    {
+        foreach (var ctor in cls.Constructors)
+            yield return ctor;
+        foreach (var block in cls.PreprocessorBlocks)
+        {
+            var branch = block;
+            while (branch != null)
+            {
+                foreach (var ctor in branch.Constructors)
+                    yield return ctor;
+                branch = branch.ElseBranch;
+            }
+        }
+    }
+
+    /// <summary>
     /// Builds a call graph analysis from a module AST.
     /// </summary>
     public static CallGraphAnalysis Build(ModuleNode ast)
@@ -78,10 +178,11 @@ public sealed class CallGraphAnalysis
             callerToCallees[function.Id] = new List<(string, TextSpan)>();
         }
 
-        // Index class methods and constructors
-        foreach (var cls in ast.Classes)
+        // Index class methods and constructors (including §PP-wrapped members
+        // and §PP-wrapped classes — W2 review C1)
+        foreach (var cls in EnumerateClasses(ast))
         {
-            foreach (var method in cls.Methods)
+            foreach (var method in EnumerateMethods(cls))
             {
                 var wrapped = ToFunctionNode(method, cls.Name);
                 functions[wrapped.Id] = wrapped;
@@ -96,7 +197,7 @@ public sealed class CallGraphAnalysis
                 }
                 ids.Add(wrapped.Id);
             }
-            foreach (var ctor in cls.Constructors)
+            foreach (var ctor in EnumerateConstructors(cls))
             {
                 var wrapped = ToCtorFunctionNode(ctor, cls.Name);
                 functions[wrapped.Id] = wrapped;
@@ -277,6 +378,13 @@ public sealed class CallGraphAnalysis
             case AssignmentStatementNode assign:
                 CollectCallsFromExpression(assign.Target, calls);
                 CollectCallsFromExpression(assign.Value, calls);
+                break;
+            case PreprocessorDirectiveNode pp:
+                // Conditional-compilation branches may be active: collect call
+                // edges from every branch (W2 review C1).
+                CollectCallsFromStatements(pp.Body, calls);
+                if (pp.ElseBody != null)
+                    CollectCallsFromStatements(pp.ElseBody, calls);
                 break;
         }
     }

--- a/src/Calor.Compiler/Commands/WatchCommand.cs
+++ b/src/Calor.Compiler/Commands/WatchCommand.cs
@@ -39,7 +39,8 @@ public static class WatchCommand
         var clearCacheOption = new Option<bool>(["--clear-cache"], "Clear .calor-build-state.json before the initial compile");
         var strictApiOption = new Option<bool>(["--strict-api"], "Enable strict API mode");
         var requireDocsOption = new Option<bool>(["--require-docs"], "Require documentation on public functions and types");
-        var enforceEffectsOption = new Option<bool>(["--enforce-effects"], () => false, "Enforce effect declarations");
+        var enforceEffectsOption = new Option<bool>(["--enforce-effects"], () => true, "Enforce effect declarations (default: true as of v0.11)");
+        var noEnforceEffectsOption = new Option<bool>(["--no-enforce-effects"], () => false, "Disable effect enforcement (opt out of the v0.11 default-on behavior)");
         var strictEffectsOption = new Option<bool>(["--strict-effects"], () => false, "Promote unknown external call warnings (Calor0411) to errors");
         var permissiveEffectsOption = new Option<bool>(["--permissive-effects"], () => false, "Permissive effect mode (unknown calls assumed pure, violations demoted to warnings)");
         var contractModeOption = new Option<string>(["--contract-mode"], () => "debug", "Contract enforcement mode: off, debug, or release");
@@ -62,6 +63,7 @@ public static class WatchCommand
             strictApiOption,
             requireDocsOption,
             enforceEffectsOption,
+            noEnforceEffectsOption,
             strictEffectsOption,
             permissiveEffectsOption,
             contractModeOption,
@@ -77,7 +79,8 @@ public static class WatchCommand
                 ClearCache: ctx.ParseResult.GetValueForOption(clearCacheOption),
                 StrictApi: ctx.ParseResult.GetValueForOption(strictApiOption),
                 RequireDocs: ctx.ParseResult.GetValueForOption(requireDocsOption),
-                EnforceEffects: ctx.ParseResult.GetValueForOption(enforceEffectsOption),
+                EnforceEffects: ctx.ParseResult.GetValueForOption(enforceEffectsOption)
+                    && !ctx.ParseResult.GetValueForOption(noEnforceEffectsOption),
                 StrictEffects: ctx.ParseResult.GetValueForOption(strictEffectsOption),
                 PermissiveEffects: ctx.ParseResult.GetValueForOption(permissiveEffectsOption),
                 ContractMode: ctx.ParseResult.GetValueForOption(contractModeOption) ?? "debug",

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -255,7 +255,7 @@ public static class DiagnosticCode
     public const string UnusedEffectDeclaration = "Calor0401";
     public const string EffectMismatch = "Calor0402";
 
-    // Effect enforcement (Calor0410-0419)
+    // Effect enforcement (Calor0410-0429)
     public const string ForbiddenEffect = "Calor0410";
     public const string UnknownExternalCall = "Calor0411";
     public const string MissingSpecificEffect = "Calor0412";
@@ -268,6 +268,39 @@ public static class DiagnosticCode
     /// Warning: Public Calor function has no §E effect declaration. Cross-module callers cannot verify effect safety.
     /// </summary>
     public const string UndeclaredPublicFunction = "Calor0417";
+
+    /// <summary>
+    /// Error: Invocation of a delegate/function-typed value under effect enforcement.
+    /// Function-typed values carry no effect contract (effect-annotated function types
+    /// are a future design), so their invocation cannot be charged and is rejected.
+    /// Migration policy: wrap in §CSHARP interop (surfaced as an assumption via
+    /// Calor0419) or compile with --permissive-effects (an explicit waiver; demoted
+    /// to a warning).
+    /// </summary>
+    public const string DelegateInvocation = "Calor0418";
+
+    /// <summary>
+    /// Warning (error under --strict-effects): the effects of a function are assumed,
+    /// not verified — it contains C# interop content, an unrecognized construct, or
+    /// calls a function whose effects are assumed. The assumption propagates to
+    /// callers through the SCC pass instead of feeding silently-pure summaries
+    /// into the enforced tier.
+    /// </summary>
+    public const string AssumedEffects = "Calor0419";
+
+    /// <summary>
+    /// Error: an override declares effects not covered by the base method's declared
+    /// effect set (behavioral-subtyping rule: override §E ⊆ base §E). Broader
+    /// override effects would launder through dynamic dispatch.
+    /// </summary>
+    public const string OverrideEffectVariance = "Calor0420";
+
+    /// <summary>
+    /// Error: an interface implementation declares effects not covered by the
+    /// interface method's declared effect set (implementation §E ⊆ interface §E).
+    /// Interface dispatch launders effects identically to overrides.
+    /// </summary>
+    public const string InterfaceEffectVariance = "Calor0421";
 
     // Pattern matching errors (Calor0500-0599)
     public const string NonExhaustiveMatch = "Calor0500";

--- a/src/Calor.Compiler/Effects/EffectEnforcementPass.cs
+++ b/src/Calor.Compiler/Effects/EffectEnforcementPass.cs
@@ -73,20 +73,22 @@ public sealed class EffectEnforcementPass
         _callGraphAnalysis = CallGraphAnalysis.Build(module);
 
         // Phase 1b: index module shape for delegate detection, static-receiver
-        // resolution and variance checks.
+        // resolution and variance checks. All enumerations include §PP-wrapped
+        // types/members (W2 review C1).
         _classesByName = new Dictionary<string, ClassDefinitionNode>(StringComparer.Ordinal);
-        foreach (var cls in module.Classes)
+        foreach (var cls in CallGraphAnalysis.EnumerateClasses(module))
             _classesByName[cls.Name] = cls;
         _interfacesByName = new Dictionary<string, InterfaceDefinitionNode>(StringComparer.Ordinal);
-        foreach (var iface in module.Interfaces)
+        foreach (var iface in CallGraphAnalysis.EnumerateInterfaces(module))
             _interfacesByName[iface.Name] = iface;
-        _delegateTypeNames = new HashSet<string>(module.Delegates.Select(d => d.Name), StringComparer.Ordinal);
+        _delegateTypeNames = new HashSet<string>(
+            CallGraphAnalysis.EnumerateDelegates(module).Select(d => d.Name), StringComparer.Ordinal);
         _ownerClassByFunctionId = new Dictionary<string, ClassDefinitionNode>(StringComparer.Ordinal);
-        foreach (var cls in module.Classes)
+        foreach (var cls in CallGraphAnalysis.EnumerateClasses(module))
         {
-            foreach (var method in cls.Methods)
+            foreach (var method in CallGraphAnalysis.EnumerateMethods(cls))
                 _ownerClassByFunctionId[$"{cls.Name}.{method.Id}"] = cls;
-            foreach (var ctor in cls.Constructors)
+            foreach (var ctor in CallGraphAnalysis.EnumerateConstructors(cls))
                 _ownerClassByFunctionId[$"{cls.Name}.{ctor.Id}"] = cls;
         }
 
@@ -106,28 +108,18 @@ public sealed class EffectEnforcementPass
         // of an assumed-effect function inherits the assumption transitively.
         PropagateAssumptions();
 
-        // Phase 4: Check each function's computed effects against declared effects
-        foreach (var function in module.Functions)
+        // Phase 4: Check every indexed function (top-level functions plus class
+        // methods, including §PP-wrapped ones — W2 review C1) against its
+        // declared effects. Constructors participate in the call graph (for SCC
+        // analysis) but are not checked because:
+        // 1. CTOR has no E{...} declaration syntax yet
+        // 2. Constructors inherently assign to fields (mut) which would always fail
+        // Constructor enforcement requires language-level E support on CTOR first.
+        foreach (var function in _callGraphAnalysis.Functions.Values)
         {
+            if (function.Name.EndsWith("..ctor", StringComparison.Ordinal))
+                continue;
             CheckEffects(function);
-        }
-
-        // Phase 4b: Also check class methods and constructors
-        foreach (var cls in module.Classes)
-        {
-            foreach (var method in cls.Methods)
-            {
-                var wrappedId = $"{cls.Name}.{method.Id}";
-                if (_callGraphAnalysis.Functions.TryGetValue(wrappedId, out var wrapped))
-                {
-                    CheckEffects(wrapped);
-                }
-            }
-            // Note: Constructors participate in the call graph (for SCC analysis)
-            // but are not checked for effects here because:
-            // 1. CTOR has no E{...} declaration syntax yet
-            // 2. Constructors inherently assign to fields (mut) which would always fail
-            // Constructor enforcement requires language-level E support on CTOR first.
         }
     }
 
@@ -368,9 +360,9 @@ public sealed class EffectEnforcementPass
             ? DiagnosticSeverity.Warning
             : DiagnosticSeverity.Error;
 
-        foreach (var cls in module.Classes)
+        foreach (var cls in CallGraphAnalysis.EnumerateClasses(module))
         {
-            foreach (var method in cls.Methods)
+            foreach (var method in CallGraphAnalysis.EnumerateMethods(cls))
             {
                 if (!method.IsOverride)
                     continue;
@@ -407,30 +399,91 @@ public sealed class EffectEnforcementPass
             {
                 foreach (var sig in iface.Methods)
                 {
-                    var impl = cls.Methods.FirstOrDefault(
-                        m => m.Name.Equals(sig.Name, StringComparison.Ordinal));
-                    if (impl == null)
-                        continue;
+                    // W2 review C3: the implementing member may be INHERITED —
+                    // walk the in-module base chain, not just cls.Methods.
+                    // Interface dispatch through an inherited implementation
+                    // launders exactly like a direct one.
+                    var (impl, implOwnerName, externalBaseName) =
+                        FindImplementingMethod(cls, sig.Name);
 
-                    var implDeclared = GetDeclaredEffects(impl.Effects);
-                    var ifaceDeclared = GetDeclaredEffects(sig.Effects);
-                    if (!implDeclared.IsSubsetOf(ifaceDeclared))
+                    if (impl != null)
                     {
-                        var extra = implDeclared.Except(ifaceDeclared)
-                            .Select(e => EffectSetExtensions.ToSurfaceCode(e.Kind, e.Value));
+                        var implDeclared = GetDeclaredEffects(impl.Effects);
+                        var ifaceDeclared = GetDeclaredEffects(sig.Effects);
+                        if (!implDeclared.IsSubsetOf(ifaceDeclared))
+                        {
+                            var extra = implDeclared.Except(ifaceDeclared)
+                                .Select(e => EffectSetExtensions.ToSurfaceCode(e.Kind, e.Value));
+                            var inheritedNote = implOwnerName != null
+                                && !implOwnerName.Equals(cls.Name, StringComparison.Ordinal)
+                                ? $" (implementation inherited from base class '{implOwnerName}')"
+                                : "";
+                            // Point at the implementing member when it is local;
+                            // at the implementing class declaration when inherited.
+                            var span = inheritedNote.Length == 0
+                                ? impl.Effects?.Span ?? impl.Span
+                                : cls.Span;
+                            _diagnostics.Report(
+                                span,
+                                DiagnosticCode.InterfaceEffectVariance,
+                                $"Implementation '{implOwnerName ?? cls.Name}.{impl.Name}' of interface method " +
+                                $"'{iface.Name}.{sig.Name}' on class '{cls.Name}'{inheritedNote} declares effect(s) " +
+                                $"[{string.Join(", ", extra)}] not declared by the interface " +
+                                $"(interface declares: {ifaceDeclared.ToDisplayString()}). " +
+                                "An implementation may not broaden the interface's declared effect set — interface " +
+                                "dispatch launders effects identically to overrides.",
+                                varianceSeverity);
+                        }
+                    }
+                    else if (externalBaseName != null)
+                    {
+                        // The §IMPL is satisfied (if at all) by a member inherited
+                        // from an EXTERNAL base: variance cannot be checked, so the
+                        // interface's declared effect set is only an assumption —
+                        // surfaced like external-base overrides (Calor0419).
+                        var assumedSeverity = _strictEffects
+                            ? DiagnosticSeverity.Error
+                            : DiagnosticSeverity.Warning;
                         _diagnostics.Report(
-                            impl.Effects?.Span ?? impl.Span,
-                            DiagnosticCode.InterfaceEffectVariance,
-                            $"Implementation '{cls.Name}.{impl.Name}' declares effect(s) [{string.Join(", ", extra)}] " +
-                            $"not declared by interface method '{iface.Name}.{sig.Name}' " +
-                            $"(interface declares: {ifaceDeclared.ToDisplayString()}). " +
-                            "An implementation may not broaden the interface's declared effect set — interface " +
-                            "dispatch launders effects identically to overrides.",
-                            varianceSeverity);
+                            cls.Span,
+                            DiagnosticCode.AssumedEffects,
+                            $"Class '{cls.Name}' implements '{iface.Name}.{sig.Name}' through a member that is " +
+                            $"not visible in this module (inherited from external base '{externalBaseName}'). " +
+                            "The interface's declared effect set is ASSUMED for this implementation, not verified.",
+                            assumedSeverity);
                     }
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Finds the member implementing an interface method on a class: the class's
+    /// own methods first (including §PP-wrapped ones), then the in-module
+    /// base-class chain. Returns (method, definingClassName, null) when found;
+    /// (null, null, externalBaseName) when the chain leaves the module without a
+    /// match; (null, null, null) when there is no match and no external base.
+    /// </summary>
+    private (MethodNode? Method, string? OwnerName, string? ExternalBaseName) FindImplementingMethod(
+        ClassDefinitionNode cls, string methodName)
+    {
+        var current = cls;
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        while (current != null && visited.Add(current.Name))
+        {
+            var found = CallGraphAnalysis.EnumerateMethods(current).FirstOrDefault(
+                m => m.Name.Equals(methodName, StringComparison.Ordinal));
+            if (found != null)
+                return (found, current.Name, null);
+
+            var baseName = StripGenericArguments(current.BaseClass);
+            if (baseName == null)
+                return (null, null, null);
+            if (!_classesByName.TryGetValue(baseName, out var baseCls))
+                return (null, null, baseName); // external base
+            current = baseCls;
+        }
+        return (null, null, null);
     }
 
     /// <summary>
@@ -447,7 +500,7 @@ public sealed class EffectEnforcementPass
         {
             if (!_classesByName.TryGetValue(baseName, out var baseCls))
                 return (null, baseName); // external base class
-            var found = baseCls.Methods.FirstOrDefault(
+            var found = CallGraphAnalysis.EnumerateMethods(baseCls).FirstOrDefault(
                 m => m.Name.Equals(methodName, StringComparison.Ordinal));
             if (found != null)
                 return (found, baseName);
@@ -947,9 +1000,14 @@ public sealed class EffectEnforcementPass
                     .Union(InferFromExpression(insert.Index))
                     .Union(InferFromExpression(insert.Value)),
                 DictionaryForeachNode dictForeach => InferFromExpression(dictForeach.Dictionary).Union(InferFromStatements(dictForeach.Body)),
+                // §PP conditional-compilation blocks: any branch may be the active
+                // one, so charge the UNION of all branches (W2 review C1 — a §PP
+                // body must not be silently pure).
+                PreprocessorDirectiveNode pp => InferFromStatements(pp.Body)
+                    .Union(pp.ElseBody != null ? InferFromStatements(pp.ElseBody) : EffectSet.Empty),
                 // No-effect control-flow / declaration-only constructs
                 BreakStatementNode or ContinueStatementNode or GotoStatementNode or LabelStatementNode
-                    or YieldBreakStatementNode or PreprocessorDirectiveNode or ProofObligationNode => EffectSet.Empty,
+                    or YieldBreakStatementNode or ProofObligationNode => EffectSet.Empty,
                 // D-W2.3: interop content — effects are assumed, not silently pure
                 RawCSharpNode => RecordAssumption("contains a raw C# interop statement (§CSHARP)"),
                 FallbackCommentNode => RecordAssumption("contains an unconverted C# fallback statement"),
@@ -981,22 +1039,78 @@ public sealed class EffectEnforcementPass
         private EffectSet InferFromCallStatement(CallStatementNode call)
         {
             var effects = InferFromCallTarget(call.Target, call.Span);
+            return effects.Union(InferFromCallArguments(call.Target, call.Arguments));
+        }
 
-            // Also infer from arguments
-            foreach (var arg in call.Arguments)
+        /// <summary>
+        /// Charges call arguments (W2 review C4). Beyond the argument
+        /// expressions themselves:
+        /// - a bare-name argument that resolves to an internal function/method is
+        ///   a METHOD GROUP — its declared effects are charged at the passing
+        ///   site (conservative and sound: handing an impure callable to anything
+        ///   charges its effects, closing the ConvertAll/Select laundering path);
+        /// - a function-typed VALUE argument passed to a known-pure higher-order
+        ///   name (the bare-name fallback list) is surfaced as a Calor0419
+        ///   assumption — the BCL callee may invoke it invisibly.
+        /// </summary>
+        private EffectSet InferFromCallArguments(string callTarget, IEnumerable<ExpressionNode> arguments)
+        {
+            var effects = EffectSet.Empty;
+            foreach (var arg in arguments)
             {
                 effects = effects.Union(InferFromExpression(arg));
-            }
 
+                if (arg is not ReferenceNode reference || reference.Name.Contains('.'))
+                    continue;
+
+                var valueType = ResolveLocalValueType(reference.Name);
+                if (valueType == null)
+                {
+                    var internalFunc = FindInternalFunctionByName(reference.Name);
+                    if (internalFunc != null)
+                    {
+                        // Method-group argument: charge the referenced internal
+                        // function's declared effects.
+                        effects = effects.Union(GetDeclaredEffects(internalFunc.Effects));
+                    }
+                }
+                else if (IsFunctionTypeName(valueType) && IsKnownPureHigherOrderTarget(callTarget))
+                {
+                    RecordAssumption(
+                        $"passes function-typed value '{reference.Name}' to '{callTarget}', " +
+                        "which may invoke it with unverifiable effects");
+                }
+            }
             return effects;
+        }
+
+        /// <summary>
+        /// True when a dotted call target's bare method name sits on the
+        /// known-pure fallback list — i.e. a BCL higher-order shape that would
+        /// otherwise be charged pure while invoking its delegate argument.
+        /// </summary>
+        private static bool IsKnownPureHigherOrderTarget(string callTarget)
+        {
+            var lastDot = callTarget.LastIndexOf('.');
+            if (lastDot <= 0)
+                return false;
+            return KnownPureMethodNames.Contains(callTarget[(lastDot + 1)..]);
         }
 
         private EffectSet InferFromCallTarget(string target, TextSpan span)
         {
-            // Bare (no-dot) targets: either an internal function/method, a value
-            // invocation (delegate — D-W2.1), or an unresolvable free name.
+            // Bare (no-dot) targets: either a value invocation (delegate — D-W2.1),
+            // an internal function/method, or an unresolvable free name.
+            // Value resolution runs FIRST, mirroring C# scoping: a parameter,
+            // binding, or field SHADOWS a same-named function, and emission
+            // resolves the call to the value — so the effect pass must too
+            // (review C2: a decoy-named delegate parameter must not charge the
+            // shadowed pure function's effects).
             if (!target.Contains('.'))
             {
+                if (ResolveLocalValueType(target) != null)
+                    return InferFromBareNameTarget(target, span);
+
                 var internalByName = FindInternalFunctionByName(target);
                 if (internalByName != null)
                 {
@@ -1018,18 +1132,26 @@ public sealed class EffectEnforcementPass
                 return staticCharge;
             }
 
-            // Check if it's an internal function call by name
-            var internalFunc = FindInternalFunctionByName(target);
-            if (internalFunc != null)
+            // Check if it's an internal function call by name. The bare-method-name
+            // fallback inside FindInternalFunctionByName is only sound when the
+            // receiver could actually be the declaring in-module type — a receiver
+            // whose static type is KNOWN and not that type must not be captured by
+            // a name collision (W2 review C5: `svc.Refresh` on an external-typed
+            // parameter must hit the unknown chain, not `Helper.Refresh`).
+            if (IsDottedInternalFallbackPermitted(target))
             {
-                if (_context.ComputedEffects.TryGetValue(internalFunc.Id, out var computed))
+                var internalFunc = FindInternalFunctionByName(target);
+                if (internalFunc != null)
                 {
-                    return computed;
-                }
-                // If in same SCC, return current approximation
-                if (_context.SccMembers.Contains(internalFunc.Id))
-                {
-                    return _context.ComputedEffects.GetValueOrDefault(internalFunc.Id, EffectSet.Empty);
+                    if (_context.ComputedEffects.TryGetValue(internalFunc.Id, out var computed))
+                    {
+                        return computed;
+                    }
+                    // If in same SCC, return current approximation
+                    if (_context.SccMembers.Contains(internalFunc.Id))
+                    {
+                        return _context.ComputedEffects.GetValueOrDefault(internalFunc.Id, EffectSet.Empty);
+                    }
                 }
             }
 
@@ -1157,6 +1279,32 @@ public sealed class EffectEnforcementPass
         }
 
         /// <summary>
+        /// W2 review C5 — receiver-compatibility gate for the dotted bare-name
+        /// fallback. The fallback (resolving "recv.Method" to a unique in-module
+        /// method named "Method") is permitted only when the receiver head's
+        /// static type is UNRESOLVABLE (the `_calc.Add` cross-class convention —
+        /// fields not visible to the pass). When the head's static type is known:
+        /// in-module receivers with the method on their chain were already charged
+        /// by <see cref="TryChargeStaticReceiverType"/> before this point, so any
+        /// remaining known-typed receiver (external/BCL type, function type, or an
+        /// in-module type that does NOT declare the method) is a name collision —
+        /// the call must go to the unknown chain, never the colliding match.
+        /// </summary>
+        private bool IsDottedInternalFallbackPermitted(string target)
+        {
+            var lastDot = target.LastIndexOf('.');
+            if (lastDot <= 0)
+                return true; // bare names are handled elsewhere
+
+            var receiver = target[..lastDot];
+            var headDot = receiver.IndexOf('.');
+            var head = headDot > 0 ? receiver[..headDot] : receiver;
+
+            var headType = ResolveLocalValueType(head);
+            return headType == null || headType == "?";
+        }
+
+        /// <summary>
         /// D-W2.2 call-site resolution: if the receiver of "recv.Method" is a
         /// parameter/binding/field whose declared static type is an in-module
         /// interface or class, charge that static type's declared §E for the method.
@@ -1244,7 +1392,7 @@ public sealed class EffectEnforcementPass
             var visited = new HashSet<string>(StringComparer.Ordinal);
             while (current != null && visited.Add(current.Name))
             {
-                var method = current.Methods.FirstOrDefault(
+                var method = CallGraphAnalysis.EnumerateMethods(current).FirstOrDefault(
                     m => m.Name.Equals(methodName, StringComparison.Ordinal));
                 if (method != null)
                     return (current.Name, method);
@@ -1648,27 +1796,63 @@ public sealed class EffectEnforcementPass
 
         private EffectSet InferFromExpressionCall(ExpressionCallNode call)
         {
-            var effects = InferFromExpression(call.TargetExpression);
+            var argEffects = EffectSet.Empty;
             foreach (var arg in call.Arguments)
             {
-                effects = effects.Union(InferFromExpression(arg));
+                argEffects = argEffects.Union(InferFromExpression(arg));
             }
-            // A call through an expression-valued target cannot be resolved to a
-            // callee — surface the assumption instead of silently charging nothing.
-            return effects.Union(RecordAssumption(
-                "calls through an expression-valued target whose callee cannot be resolved"));
+
+            // W2 review M1: the expression-call spelling must not demote the
+            // delegate rule. Classify the callee expression:
+            switch (call.TargetExpression)
+            {
+                case ReferenceNode reference:
+                    // `§C f §A x §/C` is the same call as `§C{f} §A x §/C` —
+                    // route through the full named-target resolution (value →
+                    // Calor0418; internal function → its effects; free name →
+                    // unknown chain).
+                    return InferFromCallTarget(reference.Name, call.Span).Union(argEffects);
+
+                case LambdaExpressionNode lambda:
+                    // Immediately-invoked lambda literal: the body IS the callee,
+                    // so its effects are fully charged — no delegate opacity.
+                    return InferFromLambda(lambda).Union(argEffects);
+
+                case CallExpressionNode or ExpressionCallNode:
+                {
+                    // Invoking the RESULT of a call (`GetF()()`): the invoked
+                    // thing is a delegate value — Calor0418, same rule as a
+                    // named delegate invocation (waived to a warning only under
+                    // --permissive-effects).
+                    var severity = _context.Policy == UnknownCallPolicy.Permissive
+                        ? DiagnosticSeverity.Warning
+                        : DiagnosticSeverity.Error;
+                    _context.Diagnostics.Report(
+                        call.Span,
+                        DiagnosticCode.DelegateInvocation,
+                        "Invocation of a returned delegate value is an error under effect enforcement: " +
+                        "function-typed values carry no effect contract, so the call cannot be charged. " +
+                        "Wrap the call in §CSHARP interop (surfaced as an assumption via Calor0419) or " +
+                        "compile with --permissive-effects (an explicit waiver).",
+                        severity);
+                    return InferFromExpression(call.TargetExpression).Union(argEffects);
+                }
+
+                default:
+                    // Other expression-valued targets (e.g. method call on a new
+                    // object) cannot be resolved to a callee — surface the
+                    // assumption instead of silently charging nothing.
+                    return InferFromExpression(call.TargetExpression)
+                        .Union(argEffects)
+                        .Union(RecordAssumption(
+                            "calls through an expression-valued target whose callee cannot be resolved"));
+            }
         }
 
         private EffectSet InferFromCallExpression(CallExpressionNode call)
         {
             var effects = InferFromCallTarget(call.Target, call.Span);
-
-            foreach (var arg in call.Arguments)
-            {
-                effects = effects.Union(InferFromExpression(arg));
-            }
-
-            return effects;
+            return effects.Union(InferFromCallArguments(call.Target, call.Arguments));
         }
 
         private EffectSet InferFromMatchExpression(MatchExpressionNode match)

--- a/src/Calor.Compiler/Effects/EffectEnforcementPass.cs
+++ b/src/Calor.Compiler/Effects/EffectEnforcementPass.cs
@@ -17,6 +17,7 @@ public sealed class EffectEnforcementPass
     private readonly EffectResolver _resolver;
     private readonly UnknownCallPolicy _policy;
     private readonly bool _strictEffects;
+    private readonly HashSet<string> _crossModuleFunctionNames;
 
     // Delegated call graph analysis (populated by Enforce)
     private CallGraphAnalysis _callGraphAnalysis = null!;
@@ -24,17 +25,39 @@ public sealed class EffectEnforcementPass
     // Maps function ID to computed effects
     private readonly Dictionary<string, EffectSet> _computedEffects = new(StringComparer.Ordinal);
 
+    // D-W2.3: per-function assumption provenance (function ID → reasons). A function
+    // with entries here has effects that are ASSUMED, not verified (C# interop content,
+    // an unrecognized construct, an uncheckable external base, or a call into any of
+    // those). The marker propagates to callers after SCC processing and is surfaced
+    // per function via Calor0419 — never silently pure.
+    private readonly Dictionary<string, List<string>> _assumedEffects = new(StringComparer.Ordinal);
+
+    // Module-shape lookups for delegate detection (D-W2.1), static-receiver
+    // call-site charging and declaration-local effect variance (D-W2.2).
+    private Dictionary<string, ClassDefinitionNode> _classesByName = new(StringComparer.Ordinal);
+    private Dictionary<string, InterfaceDefinitionNode> _interfacesByName = new(StringComparer.Ordinal);
+    private HashSet<string> _delegateTypeNames = new(StringComparer.Ordinal);
+    private Dictionary<string, ClassDefinitionNode> _ownerClassByFunctionId = new(StringComparer.Ordinal);
+
     public EffectEnforcementPass(
         DiagnosticBag diagnostics,
         UnknownCallPolicy policy = UnknownCallPolicy.Strict,
         EffectResolver? resolver = null,
         bool strictEffects = false,
         string? projectDirectory = null,
-        string? solutionDirectory = null)
+        string? solutionDirectory = null,
+        IEnumerable<string>? crossModuleFunctionNames = null)
     {
         _diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
         _policy = policy;
         _strictEffects = strictEffects;
+        // Bare public function names exported by OTHER modules in the same
+        // multi-file compilation (unambiguous names only, from the driver's
+        // pre-parse). Calls to these are legitimately bare per-module; the
+        // cross-module pass charges their declared effects.
+        _crossModuleFunctionNames = crossModuleFunctionNames != null
+            ? new HashSet<string>(crossModuleFunctionNames, StringComparer.Ordinal)
+            : new HashSet<string>(StringComparer.Ordinal);
 
         // Initialize the effect resolver with manifests
         _resolver = resolver ?? new EffectResolver();
@@ -49,12 +72,39 @@ public sealed class EffectEnforcementPass
         // Phase 1: Build function map and call graph (includes functions and methods)
         _callGraphAnalysis = CallGraphAnalysis.Build(module);
 
+        // Phase 1b: index module shape for delegate detection, static-receiver
+        // resolution and variance checks.
+        _classesByName = new Dictionary<string, ClassDefinitionNode>(StringComparer.Ordinal);
+        foreach (var cls in module.Classes)
+            _classesByName[cls.Name] = cls;
+        _interfacesByName = new Dictionary<string, InterfaceDefinitionNode>(StringComparer.Ordinal);
+        foreach (var iface in module.Interfaces)
+            _interfacesByName[iface.Name] = iface;
+        _delegateTypeNames = new HashSet<string>(module.Delegates.Select(d => d.Name), StringComparer.Ordinal);
+        _ownerClassByFunctionId = new Dictionary<string, ClassDefinitionNode>(StringComparer.Ordinal);
+        foreach (var cls in module.Classes)
+        {
+            foreach (var method in cls.Methods)
+                _ownerClassByFunctionId[$"{cls.Name}.{method.Id}"] = cls;
+            foreach (var ctor in cls.Constructors)
+                _ownerClassByFunctionId[$"{cls.Name}.{ctor.Id}"] = cls;
+        }
+
         // Phase 2+3: Process SCCs in reverse topological order
         // (Tarjan produces them in reverse topological order already)
         foreach (var scc in _callGraphAnalysis.StronglyConnectedComponents)
         {
             ProcessScc(scc);
         }
+
+        // Phase 3b (D-W2.2): declaration-local effect-variance checks
+        // (override §E ⊆ base §E; implementation §E ⊆ interface §E). External
+        // bases route their overrides to the Assumed channel below.
+        CheckEffectVariance(module);
+
+        // Phase 3c (D-W2.3): propagate assumption provenance to callers — a caller
+        // of an assumed-effect function inherits the assumption transitively.
+        PropagateAssumptions();
 
         // Phase 4: Check each function's computed effects against declared effects
         foreach (var function in module.Functions)
@@ -143,14 +193,29 @@ public sealed class EffectEnforcementPass
 
     private EffectSet InferEffects(FunctionNode function, HashSet<string> sccMembers)
     {
+        var assumptions = new List<string>();
         var context = new InferenceContext(
             _resolver, _computedEffects,
             _callGraphAnalysis.Functions,
             _callGraphAnalysis.FunctionNameToId,
             _callGraphAnalysis.MethodNameToIds,
-            sccMembers, _policy, _strictEffects, _diagnostics, function.Id);
+            sccMembers, _policy, _strictEffects, _diagnostics, function.Id,
+            _crossModuleFunctionNames,
+            _classesByName, _interfacesByName, _delegateTypeNames,
+            _ownerClassByFunctionId.GetValueOrDefault(function.Id),
+            assumptions);
         var inferrer = new EffectInferrer(context);
-        return inferrer.InferFromStatements(function.Body);
+        var effects = inferrer.InferFromStatements(function.Body);
+
+        // Direct in-body assumption reasons REPLACE previous ones so SCC fixpoint
+        // iterations don't accumulate duplicates. (Variance and propagation reasons
+        // are added after all SCCs are processed.)
+        if (assumptions.Count > 0)
+            _assumedEffects[function.Id] = assumptions;
+        else
+            _assumedEffects.Remove(function.Id);
+
+        return effects;
     }
 
     private void CheckEffects(FunctionNode function)
@@ -227,11 +292,37 @@ public sealed class EffectEnforcementPass
                 }
             }
         }
+
+        // D-W2.3: surface assumption provenance. An assumed-effect function satisfies
+        // its declaration only WITH the assumption named; strict mode fails loud.
+        if (_assumedEffects.TryGetValue(function.Id, out var reasons) && reasons.Count > 0)
+        {
+            var assumedSeverity = _strictEffects
+                ? DiagnosticSeverity.Error
+                : DiagnosticSeverity.Warning;
+            var shown = string.Join("; ", reasons.Take(3));
+            if (reasons.Count > 3)
+                shown += $"; and {reasons.Count - 3} more";
+            _diagnostics.Report(
+                function.Effects?.Span ?? function.Span,
+                DiagnosticCode.AssumedEffects,
+                $"Effects of '{function.Name}' are ASSUMED, not verified: {shown}. " +
+                "The declared effect set is accepted as an assumption, not a proof; " +
+                "narrow the interop surface or add manifest coverage to restore verification.",
+                assumedSeverity);
+        }
     }
 
-    private EffectSet GetDeclaredEffects(FunctionNode function)
+    private EffectSet GetDeclaredEffects(FunctionNode function) => GetDeclaredEffects(function.Effects);
+
+    /// <summary>
+    /// Computes the declared effect set from an §E node. A missing declaration is the
+    /// empty (pure) set — consistent with per-function enforcement, where an
+    /// undeclared function may not exhibit any effect.
+    /// </summary>
+    internal static EffectSet GetDeclaredEffects(EffectsNode? effectsNode)
     {
-        if (function.Effects == null || function.Effects.Effects.Count == 0)
+        if (effectsNode == null || effectsNode.Effects.Count == 0)
         {
             return EffectSet.Empty;
         }
@@ -244,7 +335,7 @@ public sealed class EffectEnforcementPass
         // We build (EffectKind, string) tuples directly to match the internal representation
         // used by the enforcement pass and manifest resolver.
         var effects = new List<(EffectKind Kind, string Value)>();
-        foreach (var kv in function.Effects.Effects)
+        foreach (var kv in effectsNode.Effects)
         {
             var kind = ParseEffectCategory(kv.Key);
             var values = kv.Value.Split(',');
@@ -258,6 +349,191 @@ public sealed class EffectEnforcementPass
             }
         }
         return EffectSet.FromInternal(effects);
+    }
+
+    /// <summary>
+    /// D-W2.2 — declaration-local effect-variance checks (behavioral subtyping):
+    /// an override may declare only effects covered by its base method's declared
+    /// set (Calor0420), and an interface implementation only effects covered by the
+    /// interface method's declared set (Calor0421). A missing §E declaration is the
+    /// pure contract, consistent with per-function enforcement. Overrides whose base
+    /// class is external C# (not in this module) cannot be checked and route to the
+    /// Assumed channel (Calor0419). Implementations of external interfaces are not
+    /// per-method attributable and are outside the declared-variance surface; calls
+    /// through such receivers hit the unknown-call chain, which fails loud.
+    /// </summary>
+    private void CheckEffectVariance(ModuleNode module)
+    {
+        var varianceSeverity = _policy == UnknownCallPolicy.Permissive
+            ? DiagnosticSeverity.Warning
+            : DiagnosticSeverity.Error;
+
+        foreach (var cls in module.Classes)
+        {
+            foreach (var method in cls.Methods)
+            {
+                if (!method.IsOverride)
+                    continue;
+
+                var (baseMethod, baseClassName) = FindBaseMethod(cls, method.Name);
+                if (baseMethod != null)
+                {
+                    var overrideDeclared = GetDeclaredEffects(method.Effects);
+                    var baseDeclared = GetDeclaredEffects(baseMethod.Effects);
+                    if (!overrideDeclared.IsSubsetOf(baseDeclared))
+                    {
+                        var extra = overrideDeclared.Except(baseDeclared)
+                            .Select(e => EffectSetExtensions.ToSurfaceCode(e.Kind, e.Value));
+                        _diagnostics.Report(
+                            method.Effects?.Span ?? method.Span,
+                            DiagnosticCode.OverrideEffectVariance,
+                            $"Override '{cls.Name}.{method.Name}' declares effect(s) [{string.Join(", ", extra)}] " +
+                            $"not declared by base method '{baseClassName}.{method.Name}' " +
+                            $"(base declares: {baseDeclared.ToDisplayString()}). " +
+                            "An override may not broaden its base method's effect set — broader effects " +
+                            "would launder through dynamic dispatch.",
+                            varianceSeverity);
+                    }
+                }
+                else if (baseClassName != null)
+                {
+                    // External C# base class — variance cannot be checked declaration-locally.
+                    AddAssumption($"{cls.Name}.{method.Id}",
+                        $"overrides a method of external base class '{baseClassName}', so effect variance cannot be checked");
+                }
+            }
+
+            foreach (var iface in ResolveInterfaceChain(cls))
+            {
+                foreach (var sig in iface.Methods)
+                {
+                    var impl = cls.Methods.FirstOrDefault(
+                        m => m.Name.Equals(sig.Name, StringComparison.Ordinal));
+                    if (impl == null)
+                        continue;
+
+                    var implDeclared = GetDeclaredEffects(impl.Effects);
+                    var ifaceDeclared = GetDeclaredEffects(sig.Effects);
+                    if (!implDeclared.IsSubsetOf(ifaceDeclared))
+                    {
+                        var extra = implDeclared.Except(ifaceDeclared)
+                            .Select(e => EffectSetExtensions.ToSurfaceCode(e.Kind, e.Value));
+                        _diagnostics.Report(
+                            impl.Effects?.Span ?? impl.Span,
+                            DiagnosticCode.InterfaceEffectVariance,
+                            $"Implementation '{cls.Name}.{impl.Name}' declares effect(s) [{string.Join(", ", extra)}] " +
+                            $"not declared by interface method '{iface.Name}.{sig.Name}' " +
+                            $"(interface declares: {ifaceDeclared.ToDisplayString()}). " +
+                            "An implementation may not broaden the interface's declared effect set — interface " +
+                            "dispatch launders effects identically to overrides.",
+                            varianceSeverity);
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Walks the in-module base-class chain looking for a method with the given name.
+    /// Returns (method, definingClassName) when found; (null, firstUnresolvedBaseName)
+    /// when the chain leaves the module (external C# base); (null, null) when there is
+    /// no base class at all.
+    /// </summary>
+    private (MethodNode? Method, string? BaseClassName) FindBaseMethod(ClassDefinitionNode cls, string methodName)
+    {
+        var baseName = StripGenericArguments(cls.BaseClass);
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        while (baseName != null && visited.Add(baseName))
+        {
+            if (!_classesByName.TryGetValue(baseName, out var baseCls))
+                return (null, baseName); // external base class
+            var found = baseCls.Methods.FirstOrDefault(
+                m => m.Name.Equals(methodName, StringComparison.Ordinal));
+            if (found != null)
+                return (found, baseName);
+            baseName = StripGenericArguments(baseCls.BaseClass);
+        }
+        return (null, null);
+    }
+
+    /// <summary>
+    /// Resolves the transitive set of in-module interfaces a class implements
+    /// (declared interfaces plus their base-interface chains). External interface
+    /// names are skipped: they carry no §E declarations to check against.
+    /// </summary>
+    private List<InterfaceDefinitionNode> ResolveInterfaceChain(ClassDefinitionNode cls)
+    {
+        var result = new List<InterfaceDefinitionNode>();
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var queue = new Queue<string>();
+        foreach (var name in cls.ImplementedInterfaces)
+        {
+            var stripped = StripGenericArguments(name);
+            if (stripped != null)
+                queue.Enqueue(stripped);
+        }
+        while (queue.Count > 0)
+        {
+            var name = queue.Dequeue();
+            if (!visited.Add(name))
+                continue;
+            if (!_interfacesByName.TryGetValue(name, out var iface))
+                continue;
+            result.Add(iface);
+            foreach (var baseName in iface.BaseInterfaces)
+            {
+                var stripped = StripGenericArguments(baseName);
+                if (stripped != null)
+                    queue.Enqueue(stripped);
+            }
+        }
+        return result;
+    }
+
+    internal static string? StripGenericArguments(string? typeName)
+    {
+        if (typeName == null)
+            return null;
+        var trimmed = typeName.Trim().TrimEnd('?');
+        var idx = trimmed.IndexOf('<');
+        return idx > 0 ? trimmed[..idx] : trimmed;
+    }
+
+    private void AddAssumption(string functionId, string reason)
+    {
+        if (!_assumedEffects.TryGetValue(functionId, out var list))
+        {
+            list = new List<string>();
+            _assumedEffects[functionId] = list;
+        }
+        if (!list.Contains(reason))
+            list.Add(reason);
+    }
+
+    /// <summary>
+    /// D-W2.3 — transitively marks every caller of an assumed-effect function as
+    /// itself assumed (via the reverse call graph), so the assumption is inherited
+    /// rather than laundered at the first call boundary.
+    /// </summary>
+    private void PropagateAssumptions()
+    {
+        var queue = new Queue<string>(_assumedEffects.Where(kv => kv.Value.Count > 0).Select(kv => kv.Key));
+        var enqueued = new HashSet<string>(queue, StringComparer.Ordinal);
+        while (queue.Count > 0)
+        {
+            var calleeId = queue.Dequeue();
+            var calleeName = _callGraphAnalysis.Functions.TryGetValue(calleeId, out var callee)
+                ? callee.Name
+                : calleeId;
+            foreach (var callerId in _callGraphAnalysis.GetCallers(calleeId))
+            {
+                if (callerId.Equals(calleeId, StringComparison.Ordinal))
+                    continue;
+                AddAssumption(callerId, $"calls '{calleeName}', whose effects are assumed");
+                if (enqueued.Add(callerId))
+                    queue.Enqueue(callerId);
+            }
+        }
     }
 
     internal static EffectKind ParseEffectCategory(string category)
@@ -307,6 +583,25 @@ public sealed class EffectEnforcementPass
         if (shortName.Contains('!') && !shortName.Contains('.') && !shortName.Contains('('))
             return "Calor.Runtime.Result`2";
 
+        // Normalize declared generic collection types ("List<i32>") to their
+        // manifest identities so typed receivers resolve to the correct entries
+        // (e.g. List`1.Add = mut) instead of hitting the unknown-call chain.
+        var genericIdx = shortName.IndexOf('<');
+        if (genericIdx > 0 && shortName.EndsWith('>'))
+        {
+            var baseName = shortName[..genericIdx];
+            var mapped = baseName switch
+            {
+                "List" => "System.Collections.Generic.List`1",
+                "Dictionary" => "System.Collections.Generic.Dictionary`2",
+                "HashSet" => "System.Collections.Generic.HashSet`1",
+                "Task" => "System.Threading.Tasks.Task`1",
+                _ => null
+            };
+            if (mapped != null)
+                return mapped;
+        }
+
         return MapKnownShortTypeName(shortName);
     }
 
@@ -317,6 +612,11 @@ public sealed class EffectEnforcementPass
         "Result" => "Calor.Runtime.Result",
         // BCL types
         "Console" => "System.Console",
+        // Generic collections referenced by bare name (e.g. §NEW{List<i32>}
+        // stores TypeName "List" with separate type arguments)
+        "List" => "System.Collections.Generic.List`1",
+        "Dictionary" => "System.Collections.Generic.Dictionary`2",
+        "HashSet" => "System.Collections.Generic.HashSet`1",
         "File" => "System.IO.File",
         "Directory" => "System.IO.Directory",
         "Path" => "System.IO.Path",
@@ -466,6 +766,17 @@ public sealed class EffectEnforcementPass
         public bool StrictEffects { get; }
         public DiagnosticBag Diagnostics { get; }
         public string CurrentFunctionId { get; }
+        public IReadOnlyCollection<string> CrossModuleFunctionNames { get; }
+        public IReadOnlyDictionary<string, ClassDefinitionNode> ClassesByName { get; }
+        public IReadOnlyDictionary<string, InterfaceDefinitionNode> InterfacesByName { get; }
+        public IReadOnlyCollection<string> DelegateTypeNames { get; }
+        public ClassDefinitionNode? OwnerClass { get; }
+
+        /// <summary>
+        /// Sink for D-W2.3 assumption reasons collected while inferring the current
+        /// function (interop content, unrecognized constructs, expression-target calls).
+        /// </summary>
+        public List<string> Assumptions { get; }
 
         public InferenceContext(
             EffectResolver resolver,
@@ -477,7 +788,13 @@ public sealed class EffectEnforcementPass
             UnknownCallPolicy policy,
             bool strictEffects,
             DiagnosticBag diagnostics,
-            string currentFunctionId)
+            string currentFunctionId,
+            IReadOnlyCollection<string> crossModuleFunctionNames,
+            IReadOnlyDictionary<string, ClassDefinitionNode> classesByName,
+            IReadOnlyDictionary<string, InterfaceDefinitionNode> interfacesByName,
+            IReadOnlyCollection<string> delegateTypeNames,
+            ClassDefinitionNode? ownerClass,
+            List<string> assumptions)
         {
             Resolver = resolver;
             ComputedEffects = computedEffects;
@@ -489,6 +806,12 @@ public sealed class EffectEnforcementPass
             StrictEffects = strictEffects;
             Diagnostics = diagnostics;
             CurrentFunctionId = currentFunctionId;
+            CrossModuleFunctionNames = crossModuleFunctionNames;
+            ClassesByName = classesByName;
+            InterfacesByName = interfacesByName;
+            DelegateTypeNames = delegateTypeNames;
+            OwnerClass = ownerClass;
+            Assumptions = assumptions;
         }
     }
 
@@ -503,6 +826,24 @@ public sealed class EffectEnforcementPass
         /// Known-pure method names (LINQ extension methods and similar).
         /// Used as a last-resort fallback when full type resolution fails
         /// because extension methods are called on instances (e.g., items.OrderBy(...)).
+        ///
+        /// D-W2.4 audit rule: a name stays on this list only if EVERY common BCL
+        /// method with that name is pure (no receiver/argument mutation, no I/O).
+        /// Mutators and receiver-ambiguous names (pure on one common receiver type,
+        /// mutating on another) were purged and now route through the unknown-call
+        /// chain, which fails loud under the strict policy; typed receivers still
+        /// resolve mutators correctly via the manifests (e.g. List`1.Add = mut).
+        /// Purged: Add, AddRange, Remove, RemoveAt, RemoveAll, Clear, Insert, Sort,
+        /// ForEach (delegate-taking, List-mutation idiom), Reverse (List/Array
+        /// mutate in place), Append/AppendLine/AppendFormat (StringBuilder mutates),
+        /// CopyTo (mutates the destination argument), Log (ILogger/Serilog I/O
+        /// collision with Math.Log; Math resolves via manifest).
+        /// Kept deliberately: ConvertAll (returns a new list; pure modulo its
+        /// delegate argument, which is charged at the lambda definition site),
+        /// PadLeft/PadRight (string-only in the BCL, pure), Replace/Insert-free
+        /// string ops (Substring, Trim*, ToUpper/ToLower, Split, Join), Replace
+        /// (string.Replace/Regex.Replace are pure; StringBuilder receivers resolve
+        /// via manifest and native §SB ops are charged as mut by the inferrer).
         /// </summary>
         private static readonly HashSet<string> KnownPureMethodNames = new(StringComparer.Ordinal)
         {
@@ -515,32 +856,30 @@ public sealed class EffectEnforcementPass
             "Sum", "Average", "Min", "Max",
             "Distinct", "DistinctBy", "Union", "UnionBy", "Intersect", "IntersectBy", "Except", "ExceptBy",
             "Skip", "Take", "SkipWhile", "TakeWhile", "SkipLast", "TakeLast",
-            "Reverse", "Concat", "Zip",
+            "Concat", "Zip",
             "Aggregate",
             "ToList", "ToArray", "ToDictionary", "ToHashSet", "ToLookup",
             "OfType", "Cast", "AsEnumerable",
-            "DefaultIfEmpty", "Append", "Prepend",
+            "DefaultIfEmpty", "Prepend",
             "Contains", "SequenceEqual",
             "Range", "Repeat", "Empty",
             "ElementAt", "ElementAtOrDefault",
             "Chunk", "Order", "OrderDescending",
             // Common pure instance methods
             "ToString", "GetHashCode", "Equals", "CompareTo", "GetType",
-            "Clone", "CopyTo", "GetEnumerator",
+            "Clone", "GetEnumerator",
             "Substring", "Trim", "TrimStart", "TrimEnd",
             "StartsWith", "EndsWith", "Contains", "IndexOf", "LastIndexOf",
             "Replace", "Split", "Join", "ToUpper", "ToLower", "ToUpperInvariant", "ToLowerInvariant",
-            "PadLeft", "PadRight", "Insert", "Remove",
-            // Collection methods
-            "Add", "Remove", "Clear", "ContainsKey", "ContainsValue",
-            "TryGetValue", "AddRange", "RemoveAt", "RemoveAll",
-            "Sort", "BinarySearch", "Find", "FindAll", "FindIndex", "FindLast",
-            "Exists", "TrueForAll", "ForEach", "ConvertAll",
-            // StringBuilder
-            "Append", "AppendLine", "AppendFormat",
+            "PadLeft", "PadRight",
+            // Collection read-only methods
+            "ContainsKey", "ContainsValue",
+            "TryGetValue",
+            "BinarySearch", "Find", "FindAll", "FindIndex", "FindLast",
+            "Exists", "TrueForAll", "ConvertAll",
             // Math functions
             "Abs", "Sqrt", "Pow", "Floor", "Ceiling", "Round",
-            "Log", "Log10", "Log2", "Sin", "Cos", "Tan",
+            "Log10", "Log2", "Sin", "Cos", "Tan",
             "Clamp", "Sign", "Truncate",
         };
 
@@ -561,9 +900,13 @@ public sealed class EffectEnforcementPass
 
         private EffectSet InferFromStatement(StatementNode statement)
         {
+            // D-W2.6: this switch is exhaustive over the statement kinds the pass
+            // understands. Anything else falls into the final arm, which routes to
+            // the Assumed channel (Calor0419) — an unknown construct is an
+            // assumption, never silently pure.
             return statement switch
             {
-                PrintStatementNode => EffectSet.From("cw"),
+                PrintStatementNode print => EffectSet.From("cw").Union(InferFromExpression(print.Expression)),
                 CallStatementNode call => InferFromCallStatement(call),
                 IfStatementNode ifStmt => InferFromIf(ifStmt),
                 ForStatementNode forStmt => InferFromFor(forStmt),
@@ -572,21 +915,67 @@ public sealed class EffectEnforcementPass
                 ForeachStatementNode foreach_ => InferFromExpression(foreach_.Collection).Union(InferFromStatements(foreach_.Body)),
                 MatchStatementNode matchStmt => InferFromMatch(matchStmt),
                 TryStatementNode tryStmt => InferFromTry(tryStmt),
-                ThrowStatementNode => EffectSet.From("throw"),
+                ThrowStatementNode throwStmt => EffectSet.From("throw")
+                    .Union(throwStmt.Exception != null ? InferFromExpression(throwStmt.Exception) : EffectSet.Empty),
                 RethrowStatementNode => EffectSet.From("throw"),
                 ReturnStatementNode ret => ret.Expression != null ? InferFromExpression(ret.Expression) : EffectSet.Empty,
                 BindStatementNode bind => bind.Initializer != null ? InferFromExpression(bind.Initializer) : EffectSet.Empty,
                 AssignmentStatementNode assign => InferFromAssignment(assign),
-                // Collection mutations
-                CollectionPushNode => EffectSet.From("mut"),
-                DictionaryPutNode => EffectSet.From("mut"),
-                CollectionRemoveNode => EffectSet.From("mut"),
-                CollectionSetIndexNode => EffectSet.From("mut"),
+                CompoundAssignmentStatementNode compound => InferFromCompoundAssignment(compound),
+                ExpressionStatementNode exprStmt => InferFromExpression(exprStmt.Expression),
+                YieldReturnStatementNode yield => yield.Expression != null ? InferFromExpression(yield.Expression) : EffectSet.Empty,
+                UsingStatementNode usingStmt => InferFromExpression(usingStmt.Resource).Union(InferFromStatements(usingStmt.Body)),
+                SyncBlockNode sync => InferFromExpression(sync.LockExpression).Union(InferFromStatements(sync.Body)),
+                UnsafeBlockNode unsafeBlock => EffectSet.From("unsafe").Union(InferFromStatements(unsafeBlock.Body)),
+                FixedStatementNode fixedStmt => EffectSet.From("unsafe")
+                    .Union(InferFromExpression(fixedStmt.Initializer))
+                    .Union(InferFromStatements(fixedStmt.Body)),
+                // Event handler (un)subscription mutates the event's invocation list.
+                EventSubscribeNode sub => EffectSet.From("mut").Union(InferFromExpression(sub.Handler)),
+                EventUnsubscribeNode unsub => EffectSet.From("mut").Union(InferFromExpression(unsub.Handler)),
+                // Collection mutations (child expressions charged too)
+                CollectionPushNode push => EffectSet.From("mut").Union(InferFromExpression(push.Value)),
+                DictionaryPutNode put => EffectSet.From("mut")
+                    .Union(InferFromExpression(put.Key))
+                    .Union(InferFromExpression(put.Value)),
+                CollectionRemoveNode remove => EffectSet.From("mut").Union(InferFromExpression(remove.KeyOrValue)),
+                CollectionSetIndexNode setIndex => EffectSet.From("mut")
+                    .Union(InferFromExpression(setIndex.Index))
+                    .Union(InferFromExpression(setIndex.Value)),
                 CollectionClearNode => EffectSet.From("mut"),
-                CollectionInsertNode => EffectSet.From("mut"),
-                DictionaryForeachNode dictForeach => InferFromStatements(dictForeach.Body),
-                _ => EffectSet.Empty
+                CollectionInsertNode insert => EffectSet.From("mut")
+                    .Union(InferFromExpression(insert.Index))
+                    .Union(InferFromExpression(insert.Value)),
+                DictionaryForeachNode dictForeach => InferFromExpression(dictForeach.Dictionary).Union(InferFromStatements(dictForeach.Body)),
+                // No-effect control-flow / declaration-only constructs
+                BreakStatementNode or ContinueStatementNode or GotoStatementNode or LabelStatementNode
+                    or YieldBreakStatementNode or PreprocessorDirectiveNode or ProofObligationNode => EffectSet.Empty,
+                // D-W2.3: interop content — effects are assumed, not silently pure
+                RawCSharpNode => RecordAssumption("contains a raw C# interop statement (§CSHARP)"),
+                FallbackCommentNode => RecordAssumption("contains an unconverted C# fallback statement"),
+                // D-W2.6: fail-loud catch-all
+                _ => RecordAssumption($"contains an unrecognized statement construct '{statement.GetType().Name}' whose effects cannot be inferred")
             };
+        }
+
+        private EffectSet InferFromCompoundAssignment(CompoundAssignmentStatementNode compound)
+        {
+            var effects = InferFromExpression(compound.Value);
+            if (compound.Target is FieldAccessNode)
+                effects = effects.Union(EffectSet.From("mut"));
+            return effects;
+        }
+
+        /// <summary>
+        /// Records a D-W2.3 assumption reason for the current function and returns the
+        /// empty effect set: the construct contributes an assumption marker (surfaced
+        /// as Calor0419 and propagated to callers), not silent purity.
+        /// </summary>
+        private EffectSet RecordAssumption(string reason)
+        {
+            if (!_context.Assumptions.Contains(reason))
+                _context.Assumptions.Add(reason);
+            return EffectSet.Empty;
         }
 
         private EffectSet InferFromCallStatement(CallStatementNode call)
@@ -604,6 +993,31 @@ public sealed class EffectEnforcementPass
 
         private EffectSet InferFromCallTarget(string target, TextSpan span)
         {
+            // Bare (no-dot) targets: either an internal function/method, a value
+            // invocation (delegate — D-W2.1), or an unresolvable free name.
+            if (!target.Contains('.'))
+            {
+                var internalByName = FindInternalFunctionByName(target);
+                if (internalByName != null)
+                {
+                    if (_context.ComputedEffects.TryGetValue(internalByName.Id, out var computedBare))
+                        return computedBare;
+                    if (_context.SccMembers.Contains(internalByName.Id))
+                        return _context.ComputedEffects.GetValueOrDefault(internalByName.Id, EffectSet.Empty);
+                }
+                return InferFromBareNameTarget(target, span);
+            }
+
+            // D-W2.2 (call-site leg): a call through a receiver whose static type is an
+            // in-module interface or class charges the static type's DECLARED §E. Sound
+            // for dispatch because the declaration-local variance checks (Calor0420/0421)
+            // pin every override/implementation to a subset of that declared set.
+            var staticCharge = TryChargeStaticReceiverType(target);
+            if (staticCharge != null)
+            {
+                return staticCharge;
+            }
+
             // Check if it's an internal function call by name
             var internalFunc = FindInternalFunctionByName(target);
             if (internalFunc != null)
@@ -654,22 +1068,6 @@ public sealed class EffectEnforcementPass
                 }
             }
 
-            // Single-word targets with no dot are local variable/delegate invocations,
-            // not external calls. Assume pure since we lack type information.
-            // In strict mode, emit a warning so users know the effects are unverified.
-            if (!target.Contains('.'))
-            {
-                if (_context.StrictEffects)
-                {
-                    _context.Diagnostics.Report(
-                        span,
-                        DiagnosticCode.UnknownExternalCall,
-                        $"Delegate/variable invocation '{target}' has unverified effects. Consider wrapping in a function with declared effects.",
-                        DiagnosticSeverity.Warning);
-                }
-                return EffectSet.Empty;
-            }
-
             // Permissive mode: assume pure for unknown calls (no diagnostic)
             if (_context.Policy == UnknownCallPolicy.Permissive)
             {
@@ -679,6 +1077,293 @@ public sealed class EffectEnforcementPass
             // Unknown external call - report diagnostic based on policy
             ReportUnknownCall(target, span);
             return EffectSet.Unknown;
+        }
+
+        /// <summary>
+        /// D-W2.1 detection rule for bare-name call targets that are NOT internal
+        /// functions/methods:
+        /// (a) the name resolves lexically to a parameter of the current function, a
+        ///     §B binding in its body, or a field of the enclosing class — a VALUE is
+        ///     being invoked, which is by construction a delegate/function-typed
+        ///     invocation → unconditional Calor0418 error under enforcement (demoted
+        ///     to a warning only under --permissive-effects, the explicit waiver).
+        ///     There is no annotation escape hatch: effect-annotated function types
+        ///     are a Phase 3 design.
+        /// (b) the name is a free name the pass cannot see (e.g. an inherited member
+        ///     of an external C# base) — routed through the unknown-call chain, which
+        ///     fails loud under the strict policy (Calor0411 + unknown effects)
+        ///     instead of the pre-W2 behavior of silently assuming purity.
+        /// </summary>
+        private EffectSet InferFromBareNameTarget(string target, TextSpan span)
+        {
+            var valueType = ResolveLocalValueType(target);
+            if (valueType != null)
+            {
+                var severity = _context.Policy == UnknownCallPolicy.Permissive
+                    ? DiagnosticSeverity.Warning
+                    : DiagnosticSeverity.Error;
+                var typeDescription = IsFunctionTypeName(valueType)
+                    ? $"function-typed value '{target}' (type '{valueType}')"
+                    : $"value '{target}' (declared type '{valueType}')";
+                _context.Diagnostics.Report(
+                    span,
+                    DiagnosticCode.DelegateInvocation,
+                    $"Invocation of {typeDescription} is an error under effect enforcement: " +
+                    "function-typed values carry no effect contract, so the call cannot be charged. " +
+                    "Wrap the call in §CSHARP interop (surfaced as an assumption via Calor0419) or " +
+                    "compile with --permissive-effects (an explicit waiver).",
+                    severity);
+                return EffectSet.Empty;
+            }
+
+            // A bare public function exported by another module of the same
+            // multi-file compilation (unambiguous, from the driver's pre-parse):
+            // legitimately bare here — the cross-module pass charges its declared
+            // effects, so the per-module pass contributes nothing.
+            if (_context.CrossModuleFunctionNames.Contains(target))
+            {
+                return EffectSet.Empty;
+            }
+
+            // Unresolvable free name: fail closed through the unknown-call chain.
+            if (_context.Policy == UnknownCallPolicy.Permissive)
+            {
+                return EffectSet.Empty;
+            }
+
+            var unknownSeverity = _context.StrictEffects
+                ? DiagnosticSeverity.Error
+                : DiagnosticSeverity.Warning;
+            if (_context.Policy == UnknownCallPolicy.Strict || _context.StrictEffects)
+            {
+                _context.Diagnostics.Report(
+                    span,
+                    DiagnosticCode.UnknownExternalCall,
+                    $"Unknown call target '{target}': not an internal function, parameter, binding, or field " +
+                    "visible to the effect pass. If this is a delegate-typed member, delegate invocation is " +
+                    "disallowed under enforcement (Calor0418); otherwise add the callee to a " +
+                    ".calor-effects.json manifest.",
+                    unknownSeverity);
+            }
+            else if (_context.Policy == UnknownCallPolicy.Warn)
+            {
+                _context.Diagnostics.Report(
+                    span,
+                    DiagnosticCode.UnknownExternalCall,
+                    $"Unknown call target '{target}' - assuming worst-case effects. Consider adding to manifest.",
+                    DiagnosticSeverity.Warning);
+            }
+            return EffectSet.Unknown;
+        }
+
+        /// <summary>
+        /// D-W2.2 call-site resolution: if the receiver of "recv.Method" is a
+        /// parameter/binding/field whose declared static type is an in-module
+        /// interface or class, charge that static type's declared §E for the method.
+        /// Returns null when the receiver's static type is unknown, external, or the
+        /// method is not found on the static type (e.g. extension methods) — callers
+        /// fall through to the existing resolution chain.
+        /// </summary>
+        private EffectSet? TryChargeStaticReceiverType(string target)
+        {
+            var lastDot = target.LastIndexOf('.');
+            if (lastDot <= 0)
+                return null;
+            var receiver = target[..lastDot];
+            var methodName = target[(lastDot + 1)..];
+            if (receiver.Contains('.'))
+                return null; // chained receivers not modeled — fall through
+
+            var receiverType = ResolveLocalValueType(receiver);
+            if (receiverType == null)
+                return null;
+            var typeName = StripGenericArguments(receiverType);
+            if (typeName == null)
+                return null;
+
+            if (_context.InterfacesByName.TryGetValue(typeName, out var iface))
+            {
+                var sig = FindInterfaceMethodSignature(iface, methodName);
+                if (sig != null)
+                {
+                    // Absent §E on the interface method is the declared-pure contract.
+                    return GetDeclaredEffects(sig.Effects);
+                }
+                return null;
+            }
+
+            if (_context.ClassesByName.TryGetValue(typeName, out var cls))
+            {
+                var resolved = FindClassMethod(cls, methodName);
+                if (resolved != null)
+                {
+                    var (ownerName, method) = resolved.Value;
+                    // Prefer the declared contract (dispatch-safe under Calor0420);
+                    // fall back to computed effects when no declaration exists.
+                    if (method.Effects != null)
+                        return GetDeclaredEffects(method.Effects);
+                    var id = $"{ownerName}.{method.Id}";
+                    if (_context.ComputedEffects.TryGetValue(id, out var computed))
+                        return computed;
+                    if (_context.SccMembers.Contains(id))
+                        return _context.ComputedEffects.GetValueOrDefault(id, EffectSet.Empty);
+                }
+                return null;
+            }
+
+            return null;
+        }
+
+        private MethodSignatureNode? FindInterfaceMethodSignature(InterfaceDefinitionNode iface, string methodName)
+        {
+            var visited = new HashSet<string>(StringComparer.Ordinal);
+            var queue = new Queue<InterfaceDefinitionNode>();
+            queue.Enqueue(iface);
+            while (queue.Count > 0)
+            {
+                var current = queue.Dequeue();
+                if (!visited.Add(current.Name))
+                    continue;
+                var sig = current.Methods.FirstOrDefault(
+                    m => m.Name.Equals(methodName, StringComparison.Ordinal));
+                if (sig != null)
+                    return sig;
+                foreach (var baseName in current.BaseInterfaces)
+                {
+                    var stripped = StripGenericArguments(baseName);
+                    if (stripped != null && _context.InterfacesByName.TryGetValue(stripped, out var baseIface))
+                        queue.Enqueue(baseIface);
+                }
+            }
+            return null;
+        }
+
+        private (string OwnerName, MethodNode Method)? FindClassMethod(ClassDefinitionNode cls, string methodName)
+        {
+            var current = cls;
+            var visited = new HashSet<string>(StringComparer.Ordinal);
+            while (current != null && visited.Add(current.Name))
+            {
+                var method = current.Methods.FirstOrDefault(
+                    m => m.Name.Equals(methodName, StringComparison.Ordinal));
+                if (method != null)
+                    return (current.Name, method);
+                var baseName = StripGenericArguments(current.BaseClass);
+                current = baseName != null && _context.ClassesByName.TryGetValue(baseName, out var baseCls)
+                    ? baseCls
+                    : null;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Resolves a bare name to the declared type of the value it denotes:
+        /// current-function parameter, §B binding (anywhere in the body, including
+        /// nested blocks), or enclosing-class field. Returns null for free names.
+        /// A lambda-initialized binding without an explicit type reports the marker
+        /// type "Func&lt;&gt;" (function-typed by construction).
+        /// </summary>
+        private string? ResolveLocalValueType(string name)
+        {
+            if (!_context.Functions.TryGetValue(_context.CurrentFunctionId, out var function))
+                return null;
+
+            foreach (var parameter in function.Parameters)
+            {
+                if (parameter.Name.Equals(name, StringComparison.Ordinal))
+                    return parameter.TypeName;
+            }
+
+            var declaredType = FindLocalDeclarationType(name, function.Body);
+            if (declaredType != null)
+                return declaredType;
+
+            var field = _context.OwnerClass?.Fields.FirstOrDefault(
+                f => f.Name.Equals(name, StringComparison.Ordinal));
+            if (field != null)
+                return field.TypeName;
+
+            return null;
+        }
+
+        private static string? FindLocalDeclarationType(string name, IEnumerable<StatementNode> statements)
+        {
+            foreach (var statement in statements)
+            {
+                switch (statement)
+                {
+                    case BindStatementNode bind when bind.Name.Equals(name, StringComparison.Ordinal):
+                        if (bind.TypeName != null)
+                            return bind.TypeName;
+                        if (bind.Initializer is NewExpressionNode newExpr)
+                            return newExpr.TypeName;
+                        if (bind.Initializer is LambdaExpressionNode)
+                            return "Func<>";
+                        return "?"; // known value, unknown type
+                    case IfStatementNode ifStmt:
+                        var inIf = FindLocalDeclarationType(name, ifStmt.ThenBody)
+                            ?? ifStmt.ElseIfClauses.Select(c => FindLocalDeclarationType(name, c.Body)).FirstOrDefault(t => t != null)
+                            ?? (ifStmt.ElseBody != null ? FindLocalDeclarationType(name, ifStmt.ElseBody) : null);
+                        if (inIf != null) return inIf;
+                        break;
+                    case ForStatementNode forStmt:
+                        if (FindLocalDeclarationType(name, forStmt.Body) is { } inFor) return inFor;
+                        break;
+                    case WhileStatementNode whileStmt:
+                        if (FindLocalDeclarationType(name, whileStmt.Body) is { } inWhile) return inWhile;
+                        break;
+                    case DoWhileStatementNode doWhile:
+                        if (FindLocalDeclarationType(name, doWhile.Body) is { } inDoWhile) return inDoWhile;
+                        break;
+                    case ForeachStatementNode foreachStmt:
+                        if (FindLocalDeclarationType(name, foreachStmt.Body) is { } inForeach) return inForeach;
+                        break;
+                    case MatchStatementNode matchStmt:
+                        var inMatch = matchStmt.Cases.Select(c => FindLocalDeclarationType(name, c.Body)).FirstOrDefault(t => t != null);
+                        if (inMatch != null) return inMatch;
+                        break;
+                    case TryStatementNode tryStmt:
+                        var inTry = FindLocalDeclarationType(name, tryStmt.TryBody)
+                            ?? tryStmt.CatchClauses.Select(c => FindLocalDeclarationType(name, c.Body)).FirstOrDefault(t => t != null)
+                            ?? (tryStmt.FinallyBody != null ? FindLocalDeclarationType(name, tryStmt.FinallyBody) : null);
+                        if (inTry != null) return inTry;
+                        break;
+                    case UsingStatementNode usingStmt:
+                        // §USING{Type:name} declares a typed resource variable.
+                        if (name.Equals(usingStmt.VariableName, StringComparison.Ordinal))
+                            return usingStmt.VariableType ?? "?";
+                        if (FindLocalDeclarationType(name, usingStmt.Body) is { } inUsing) return inUsing;
+                        break;
+                    case SyncBlockNode sync:
+                        if (FindLocalDeclarationType(name, sync.Body) is { } inSync) return inSync;
+                        break;
+                    case UnsafeBlockNode unsafeBlock:
+                        if (FindLocalDeclarationType(name, unsafeBlock.Body) is { } inUnsafe) return inUnsafe;
+                        break;
+                    case FixedStatementNode fixedStmt:
+                        if (FindLocalDeclarationType(name, fixedStmt.Body) is { } inFixed) return inFixed;
+                        break;
+                }
+            }
+            return null;
+        }
+
+        private bool IsFunctionTypeName(string typeName)
+        {
+            var t = typeName.Trim().TrimEnd('?');
+            var stripped = StripGenericArguments(t);
+            if (stripped != null && _context.DelegateTypeNames.Contains(stripped))
+                return true;
+            return t.Equals("Action", StringComparison.Ordinal)
+                || t.StartsWith("Action<", StringComparison.Ordinal)
+                || t.StartsWith("Func<", StringComparison.Ordinal)
+                || t.StartsWith("Predicate<", StringComparison.Ordinal)
+                || t.StartsWith("Comparison<", StringComparison.Ordinal)
+                || t.StartsWith("Converter<", StringComparison.Ordinal)
+                || t.Equals("Delegate", StringComparison.Ordinal)
+                || t.Equals("MulticastDelegate", StringComparison.Ordinal)
+                || t.Equals("EventHandler", StringComparison.Ordinal)
+                || t.StartsWith("EventHandler<", StringComparison.Ordinal);
         }
 
         private void ReportUnknownCall(string target, TextSpan span)
@@ -767,37 +1452,17 @@ public sealed class EffectEnforcementPass
         }
 
         /// <summary>
-        /// Resolves a variable name to its declared type by scanning the current function's
-        /// body for §B (bind) statements with §NEW initializers.
+        /// Resolves a variable name to its manifest-ready declared type: parameters,
+        /// §B bindings (explicit type or §NEW initializer, anywhere in the body),
+        /// §USING resource variables, and enclosing-class fields.
         /// E.g., "§B{client} §NEW{HttpClient}" → "client" resolves to "System.Net.Http.HttpClient".
         /// </summary>
         private string? ResolveVariableType(string variableName)
         {
-            if (!_context.Functions.TryGetValue(_context.CurrentFunctionId, out var function))
+            var declared = ResolveLocalValueType(variableName);
+            if (declared == null || declared == "?" || declared == "Func<>")
                 return null;
-
-            return ScanForVariableType(variableName, function.Body);
-        }
-
-        private static string? ScanForVariableType(string variableName, IEnumerable<StatementNode> statements)
-        {
-            foreach (var stmt in statements)
-            {
-                if (stmt is BindStatementNode bind && bind.Name == variableName && bind.Initializer != null)
-                {
-                    // §B{var} §NEW{TypeName} → resolve TypeName
-                    if (bind.Initializer is NewExpressionNode newExpr)
-                    {
-                        return MapShortTypeNameToFullName(newExpr.TypeName);
-                    }
-                    // §B{var:TypeName} — explicit type declaration
-                    if (bind.TypeName != null)
-                    {
-                        return MapShortTypeNameToFullName(bind.TypeName);
-                    }
-                }
-            }
-            return null;
+            return MapShortTypeNameToFullName(declared);
         }
 
         private EffectSet InferFromIf(IfStatementNode ifStmt)
@@ -873,9 +1538,13 @@ public sealed class EffectEnforcementPass
 
         private EffectSet InferFromExpression(ExpressionNode expr)
         {
+            // D-W2.6: exhaustive over the expression kinds the pass understands;
+            // the final arm routes unrecognized constructs to the Assumed channel
+            // (Calor0419) — never silently pure.
             return expr switch
             {
                 CallExpressionNode call => InferFromCallExpression(call),
+                ExpressionCallNode exprCall => InferFromExpressionCall(exprCall),
                 MatchExpressionNode match => InferFromMatchExpression(match),
                 BinaryOperationNode binOp => InferFromExpression(binOp.Left).Union(InferFromExpression(binOp.Right)),
                 UnaryOperationNode unOp => InferFromExpression(unOp.Operand),
@@ -890,8 +1559,104 @@ public sealed class EffectEnforcementPass
                 ArrayAccessNode array => InferFromExpression(array.Array).Union(InferFromExpression(array.Index)),
                 LambdaExpressionNode lambda => InferFromLambda(lambda),
                 AwaitExpressionNode await_ => InferFromExpression(await_.Awaited),
-                _ => EffectSet.Empty
+                ThrowExpressionNode throwExpr => EffectSet.From("throw").Union(InferFromExpression(throwExpr.Exception)),
+                InterpolatedStringNode interp => InferFromInterpolatedString(interp),
+                NullCoalesceNode coalesce => InferFromExpression(coalesce.Left).Union(InferFromExpression(coalesce.Right)),
+                NullConditionalNode nullCond => InferFromExpression(nullCond.Target),
+                RangeExpressionNode range =>
+                    (range.Start != null ? InferFromExpression(range.Start) : EffectSet.Empty)
+                    .Union(range.End != null ? InferFromExpression(range.End) : EffectSet.Empty),
+                IndexFromEndNode indexFromEnd => InferFromExpression(indexFromEnd.Offset),
+                TypeOperationNode typeOp => InferFromExpression(typeOp.Operand),
+                IsPatternNode isPattern => InferFromExpression(isPattern.Operand),
+                WithExpressionNode with => with.Assignments.Aggregate(
+                    InferFromExpression(with.Target),
+                    (acc, a) => acc.Union(InferFromExpression(a.Value))),
+                ArrayCreationNode arrayCreation =>
+                    (arrayCreation.Size != null ? InferFromExpression(arrayCreation.Size) : EffectSet.Empty)
+                    .Union(InferFromMany(arrayCreation.Initializer)),
+                MultiDimArrayCreationNode multiDim => InferFromMany(multiDim.DimensionSizes),
+                MultiDimArrayAccessNode multiDimAccess =>
+                    InferFromExpression(multiDimAccess.Array).Union(InferFromMany(multiDimAccess.Indices)),
+                ArrayLengthNode arrayLength => InferFromExpression(arrayLength.Array),
+                ListCreationNode listCreation => InferFromMany(listCreation.Elements),
+                SetCreationNode setCreation => InferFromMany(setCreation.Elements),
+                DictionaryCreationNode dictCreation => dictCreation.Entries.Aggregate(
+                    EffectSet.Empty,
+                    (acc, e) => acc.Union(InferFromExpression(e.Key)).Union(InferFromExpression(e.Value))),
+                CollectionContainsNode contains => InferFromExpression(contains.KeyOrValue),
+                CollectionCountNode count => InferFromExpression(count.Collection),
+                TupleLiteralNode tuple => InferFromMany(tuple.Elements),
+                RecordCreationNode record => record.Fields.Aggregate(
+                    EffectSet.Empty, (acc, f) => acc.Union(InferFromExpression(f.Value))),
+                AnonymousObjectCreationNode anonymous => anonymous.Initializers.Aggregate(
+                    EffectSet.Empty, (acc, i) => acc.Union(InferFromExpression(i.Value))),
+                StringOperationNode stringOp => InferFromMany(stringOp.Arguments),
+                CharOperationNode charOp => InferFromMany(charOp.Arguments),
+                // Native §SB modification ops mutate the builder (heap write);
+                // creation/query ops are pure.
+                StringBuilderOperationNode sbOp => (sbOp.Operation switch
+                {
+                    StringBuilderOp.Append or StringBuilderOp.AppendLine or StringBuilderOp.Insert
+                        or StringBuilderOp.Remove or StringBuilderOp.Clear => EffectSet.From("mut"),
+                    _ => EffectSet.Empty
+                }).Union(InferFromMany(sbOp.Arguments)),
+                StackAllocNode stackAlloc =>
+                    (stackAlloc.Size != null ? InferFromExpression(stackAlloc.Size) : EffectSet.Empty)
+                    .Union(InferFromMany(stackAlloc.Initializer)),
+                AddressOfNode addressOf => InferFromExpression(addressOf.Operand),
+                PointerDereferenceNode deref => InferFromExpression(deref.Operand),
+                // No-effect leaves
+                IntLiteralNode or StringLiteralNode or BoolLiteralNode or FloatLiteralNode
+                    or DecimalLiteralNode or ReferenceNode or NoneExpressionNode
+                    or ThisExpressionNode or BaseExpressionNode or SelfRefNode
+                    or GenericTypeNode or TypeOfExpressionNode or NameOfExpressionNode
+                    or SizeOfNode or KeywordArgNode => EffectSet.Empty,
+                // Contract-form quantifiers evaluate over pure predicates
+                ForallExpressionNode or ExistsExpressionNode or ImplicationExpressionNode => EffectSet.Empty,
+                // D-W2.3: interop / unconverted content — assumed, not silently pure
+                RawCSharpExpressionNode => RecordAssumption("contains a raw C# interop expression (§CS)"),
+                FallbackExpressionNode fallback => RecordAssumption(
+                    $"contains an unconverted C# fallback expression ('{fallback.FeatureName}')"),
+                // D-W2.6: fail-loud catch-all
+                _ => RecordAssumption($"contains an unrecognized expression construct '{expr.GetType().Name}' whose effects cannot be inferred")
             };
+        }
+
+        private EffectSet InferFromMany(IEnumerable<ExpressionNode> expressions)
+        {
+            var effects = EffectSet.Empty;
+            foreach (var expression in expressions)
+            {
+                effects = effects.Union(InferFromExpression(expression));
+            }
+            return effects;
+        }
+
+        private EffectSet InferFromInterpolatedString(InterpolatedStringNode interpolated)
+        {
+            var effects = EffectSet.Empty;
+            foreach (var part in interpolated.Parts)
+            {
+                if (part is InterpolatedStringExpressionNode exprPart)
+                {
+                    effects = effects.Union(InferFromExpression(exprPart.Expression));
+                }
+            }
+            return effects;
+        }
+
+        private EffectSet InferFromExpressionCall(ExpressionCallNode call)
+        {
+            var effects = InferFromExpression(call.TargetExpression);
+            foreach (var arg in call.Arguments)
+            {
+                effects = effects.Union(InferFromExpression(arg));
+            }
+            // A call through an expression-valued target cannot be resolved to a
+            // callee — surface the assumption instead of silently charging nothing.
+            return effects.Union(RecordAssumption(
+                "calls through an expression-valued target whose callee cannot be resolved"));
         }
 
         private EffectSet InferFromCallExpression(CallExpressionNode call)
@@ -930,6 +1695,11 @@ public sealed class EffectEnforcementPass
             foreach (var arg in newExpr.Arguments)
             {
                 effects = effects.Union(InferFromExpression(arg));
+            }
+
+            foreach (var initializer in newExpr.Initializers)
+            {
+                effects = effects.Union(InferFromExpression(initializer.Value));
             }
 
             return effects;

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -46,7 +46,12 @@ public class Program
 
         var enforceEffectsOption = new Option<bool>(
             aliases: ["--enforce-effects"],
-            description: "Enforce effect declarations (default: false; opt in for strict checking)",
+            description: "Enforce effect declarations (default: true as of v0.11; use --no-enforce-effects to opt out)",
+            getDefaultValue: () => true);
+
+        var noEnforceEffectsOption = new Option<bool>(
+            aliases: ["--no-enforce-effects"],
+            description: "Disable effect enforcement (opt out of the v0.11 default-on behavior)",
             getDefaultValue: () => false);
 
         var strictEffectsOption = new Option<bool>(
@@ -135,6 +140,7 @@ public class Program
             strictApiOption,
             requireDocsOption,
             enforceEffectsOption,
+            noEnforceEffectsOption,
             strictEffectsOption,
             permissiveEffectsOption,
             contractModeOption,
@@ -172,6 +178,9 @@ public class Program
             var strictApi = ctx.ParseResult.GetValueForOption(strictApiOption);
             var requireDocs = ctx.ParseResult.GetValueForOption(requireDocsOption);
             var enforceEffects = ctx.ParseResult.GetValueForOption(enforceEffectsOption);
+            var noEnforceEffects = ctx.ParseResult.GetValueForOption(noEnforceEffectsOption);
+            // --no-enforce-effects always wins over the default-on behavior (D-W2.5)
+            if (noEnforceEffects) enforceEffects = false;
             var strictEffects = ctx.ParseResult.GetValueForOption(strictEffectsOption);
             var permissiveEffects = ctx.ParseResult.GetValueForOption(permissiveEffectsOption);
             var contractMode = ctx.ParseResult.GetValueForOption(contractModeOption) ?? "debug";
@@ -519,7 +528,8 @@ public class Program
         writer.WriteLine("Strictness options:");
         writer.WriteLine("  --strict-api      Require §BREAKING markers for public API changes");
         writer.WriteLine("  --require-docs    Require documentation on public functions");
-        writer.WriteLine("  --enforce-effects Enforce effect declarations (default: false)");
+        writer.WriteLine("  --enforce-effects Enforce effect declarations (default: true as of v0.11)");
+        writer.WriteLine("  --no-enforce-effects  Disable effect enforcement (opt-out)");
         writer.WriteLine("  --strict-effects  Promote unknown external call warnings to errors");
         writer.WriteLine("  --permissive-effects  Permissive mode for converted code (suppress effect errors)");
         writer.WriteLine("  --contract-mode   Contract mode: off, debug, release (default: debug)");
@@ -700,7 +710,8 @@ public class Program
                 options.UnknownCallPolicy,
                 resolver: sharedResolver,
                 strictEffects: options.StrictEffects,
-                projectDirectory: options.ProjectDirectory);
+                projectDirectory: options.ProjectDirectory,
+                crossModuleFunctionNames: options.CrossModuleFunctionModules?.Keys);
             enforcementPass.Enforce(ast);
             phaseSw.Stop();
             telemetry?.TrackPhase("EffectEnforcement", phaseSw.ElapsedMilliseconds, !diagnostics.HasErrors);

--- a/tests/Calor.Compiler.Tests/CSharpToCalorConversionTests.cs
+++ b/tests/Calor.Compiler.Tests/CSharpToCalorConversionTests.cs
@@ -1456,7 +1456,11 @@ public class CSharpToCalorConversionTests
         Assert.DoesNotContain("§/USE{", conversionResult.CalorSource);
 
         // Step 2: Calor -> C#
-        var compilationResult = Program.Compile(conversionResult.CalorSource!);
+        // WS-W2 (D-W2.3/D-W2.6): §USING bodies now contribute effects and the
+        // converted code carries no §E declarations — compile converted output
+        // with enforcement off per this file's converted-code precedent.
+        var compilationResult = Program.Compile(conversionResult.CalorSource!, null,
+            new CompilationOptions { EnforceEffects = false });
         Assert.False(compilationResult.HasErrors,
             $"Roundtrip failed:\n{string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message))}");
 
@@ -1487,7 +1491,11 @@ public class CSharpToCalorConversionTests
         Assert.NotNull(conversionResult.CalorSource);
 
         // Calor -> C#
-        var compilationResult = Program.Compile(conversionResult.CalorSource!);
+        // WS-W2 (D-W2.3/D-W2.6): §USING bodies now contribute effects and the
+        // converted code carries no §E declarations — compile converted output
+        // with enforcement off per this file's converted-code precedent.
+        var compilationResult = Program.Compile(conversionResult.CalorSource!, null,
+            new CompilationOptions { EnforceEffects = false });
         Assert.False(compilationResult.HasErrors,
             $"Roundtrip failed:\n{string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message))}");
 
@@ -1519,7 +1527,11 @@ public class CSharpToCalorConversionTests
         Assert.NotNull(conversionResult.CalorSource);
 
         // Calor -> C#
-        var compilationResult = Program.Compile(conversionResult.CalorSource!);
+        // WS-W2 (D-W2.3/D-W2.6): §USING bodies now contribute effects and the
+        // converted code carries no §E declarations — compile converted output
+        // with enforcement off per this file's converted-code precedent.
+        var compilationResult = Program.Compile(conversionResult.CalorSource!, null,
+            new CompilationOptions { EnforceEffects = false });
         Assert.False(compilationResult.HasErrors,
             $"Roundtrip failed:\n{string.Join("\n", compilationResult.Diagnostics.Select(d => d.Message))}");
 

--- a/tests/Calor.Compiler.Tests/CliEnforceEffectsDefaultTests.cs
+++ b/tests/Calor.Compiler.Tests/CliEnforceEffectsDefaultTests.cs
@@ -1,0 +1,60 @@
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// D-W2.5 regression pins (WS-W2 strictness batch): the CLI's --enforce-effects
+/// defaults ON as of v0.11, ending the CLI-false/SDK-true split-brain, with
+/// --no-enforce-effects as the explicit opt-out.
+/// </summary>
+public class CliEnforceEffectsDefaultTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public CliEnforceEffectsDefaultTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "calor-cli-ee-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private string WriteEffectViolation()
+    {
+        var path = Path.Combine(_tempDir, "violation.calr");
+        File.WriteAllText(path, """
+            §M{m001:Test}
+              §F{f001:Main:pub}
+                §O{void}
+                §P "undeclared console write"
+            """);
+        return path;
+    }
+
+    [Fact]
+    public void Cli_Default_EnforcesEffects()
+    {
+        var path = WriteEffectViolation();
+
+        var (exitCode, stdOut, stdErr) = CliTestHarness.RunCli(_tempDir, "--input", path);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("Calor0410", stdOut + stdErr);
+    }
+
+    [Fact]
+    public void Cli_NoEnforceEffects_OptsOut()
+    {
+        var path = WriteEffectViolation();
+
+        var (exitCode, stdOut, stdErr) = CliTestHarness.RunCli(
+            _tempDir, "--input", path, "--no-enforce-effects");
+
+        Assert.Equal(0, exitCode);
+        Assert.DoesNotContain("Calor0410", stdOut + stdErr);
+    }
+}

--- a/tests/Calor.Compiler.Tests/CliMultiFileTests.cs
+++ b/tests/Calor.Compiler.Tests/CliMultiFileTests.cs
@@ -239,7 +239,12 @@ public class CliMultiFileTests : IDisposable
                 §/C
             """);
 
-        RunCli("--input", aPath, "--input", bPath, "--input", cPath);
+        // WS-W2 (D-W2.1): an ambiguous cross-module bare name is not in the
+        // unambiguous pre-parse map, so under default enforcement the per-module
+        // pass now fails closed (Calor0411 + Calor0410) instead of assuming
+        // purity. This test pins EMISSION shape, so it compiles under the
+        // --permissive-effects waiver; csc's CS0103 remains the honest failure.
+        RunCli("--input", aPath, "--input", bPath, "--input", cPath, "--permissive-effects");
 
         var emitted = File.ReadAllText(Path.Combine(_tempDir, "c.g.cs"));
         Assert.Contains("Emit();", emitted);
@@ -365,7 +370,12 @@ public class CliMultiFileTests : IDisposable
                 §P x
             """);
 
-        var (exit, stdOut, stdErr) = RunCli("--input", aPath, "--input", bPath);
+        // WS-W2 (D-W2.1): invoking the Func-typed 'Notify' parameter is now a
+        // Calor0418 error under default enforcement (the parameter shadows the
+        // cross-module name for effects exactly as it does for emission). This
+        // test pins EMISSION shape, so it compiles under the
+        // --permissive-effects waiver (Calor0418 demoted to a warning).
+        var (exit, stdOut, stdErr) = RunCli("--input", aPath, "--input", bPath, "--permissive-effects");
         Assert.True(exit == 0, $"compile failed: {stdOut}{stdErr}");
 
         var emitted = File.ReadAllText(Path.Combine(_tempDir, "caller.g.cs"));

--- a/tests/Calor.Compiler.Tests/GenericSyntaxTests.cs
+++ b/tests/Calor.Compiler.Tests/GenericSyntaxTests.cs
@@ -275,6 +275,11 @@ public class GenericSyntaxTests
     [Fact]
     public void E2E_GenericMethod_InClass_CompilesCorrectly()
     {
+        // WS-W2 (D-W2.1): invoking the Func-typed 'converter' parameter is a
+        // Calor0418 error under enforcement (enforced Calor is first-order by
+        // design). This test pins EMISSION shape for generic methods, so it
+        // compiles under the --permissive-effects waiver per the migration
+        // policy (the delegate error is demoted to a warning).
         var calor = """
             §M{m001:Test}
               §CL{c001:Container:pub}
@@ -285,7 +290,12 @@ public class GenericSyntaxTests
                       §R §C{converter} §A input §/C
             """;
 
-        var csharp = CompileToCS(calor);
+        var result = Program.Compile(calor, null, new CompilationOptions
+        {
+            UnknownCallPolicy = Calor.Compiler.Effects.UnknownCallPolicy.Permissive
+        });
+        Assert.False(result.HasErrors, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        var csharp = result.GeneratedCode;
 
         Assert.Contains("public class Container", csharp);
         Assert.Contains("public U Convert<T, U>(T input, Func<T, U> converter)", csharp);

--- a/tests/Calor.Enforcement.Tests/EffectEnforcementTests.cs
+++ b/tests/Calor.Enforcement.Tests/EffectEnforcementTests.cs
@@ -348,10 +348,13 @@ public class EffectEnforcementTests
     }
 
     [Fact]
-    public void DelegateInvocation_SingleWordTarget_DoesNotFail()
+    public void DelegateInvocation_SingleWordTarget_FailsClosed()
     {
-        // Calling a variable (delegate/Func parameter) should not produce
-        // an "unknown external call" error since it's not an external call
+        // WS-W2 (D-W2.1): a bare-name invocation that is not an internal
+        // function no longer passes as silently pure. A free name (here a
+        // delegate-typed member the pass cannot see) routes through the
+        // unknown-call chain and fails closed under the default strict policy.
+        // (Pre-W2 this test pinned the delegate hole: it asserted no failure.)
         var source = @"
 §M{m001:Test}
   §CL{c001:Mapper:pub}
@@ -362,14 +365,17 @@ public class EffectEnforcementTests
 ";
         var result = TestHarness.Compile(source);
 
-        Assert.False(result.HasErrors,
-            $"Delegate invocation should not fail. Errors: {string.Join("; ", result.Diagnostics.Errors.Select(e => e.Message))}");
+        Assert.True(result.HasErrors,
+            "Bare-name invocation of an unresolvable target must fail closed");
+        Assert.Contains(result.Diagnostics,
+            d => d.Code == DiagnosticCode.UnknownExternalCall && d.Message.Contains("transform"));
     }
 
     [Fact]
-    public void DelegateInvocation_InStrictMode_EmitsWarning()
+    public void DelegateInvocation_InStrictMode_IsError()
     {
-        // In strict effects mode, delegate invocations should get a warning
+        // WS-W2 (D-W2.1): under --strict-effects an unresolvable bare-name
+        // invocation is a hard Calor0411 error (pre-W2: warning only).
         var source = @"
 §M{m001:Test}
   §F{f001:UseDelegate:pub}
@@ -384,11 +390,8 @@ public class EffectEnforcementTests
         };
         var result = TestHarness.Compile(source, options);
 
-        // Should not produce errors (delegate invocations are assumed pure)
-        Assert.False(result.HasErrors,
-            $"Delegate invocation should not be an error even in strict mode. Errors: {string.Join("; ", result.Diagnostics.Errors.Select(e => e.Message))}");
-        // But should produce a warning about unverified effects
-        Assert.Contains(result.Diagnostics.Warnings,
+        Assert.True(result.HasErrors, "Unresolvable bare-name invocation must be an error in strict mode");
+        Assert.Contains(result.Diagnostics.Errors,
             d => d.Code == DiagnosticCode.UnknownExternalCall && d.Message.Contains("callback"));
     }
 

--- a/tests/Calor.Enforcement.Tests/StrictnessBatchTests.cs
+++ b/tests/Calor.Enforcement.Tests/StrictnessBatchTests.cs
@@ -1,0 +1,487 @@
+using Calor.Compiler;
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Effects;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Enforcement.Tests;
+
+/// <summary>
+/// Regression pins for the WS-W2 effect-soundness strictness batch (v0.11).
+/// One test region per deliverable:
+///   D-W2.1 delegate invocation = error under enforcement (Calor0418)
+///   D-W2.2 override / interface-implementation effect variance (Calor0420/0421)
+///          + static-receiver call-site charging
+///   D-W2.3 interop → effect-unknown propagating as an assumption (Calor0419)
+///   D-W2.4 KnownPureMethodNames mutator purge (fail-closed unknown-call path)
+///   D-W2.6 unknown constructs are never silently pure (Calor0419)
+/// (D-W2.5, the CLI default flip, is pinned in Calor.Compiler.Tests where the
+/// CLI test harness lives.)
+/// </summary>
+public class StrictnessBatchTests
+{
+    // ========================================================================
+    // D-W2.1 — Delegate invocation is an unconditional error under enforcement
+    // ========================================================================
+
+    [Fact]
+    public void DelegateInvocation_FunctionTypedParameter_IsError()
+    {
+        var source = @"
+§M{m001:Test}
+  §F{f001:Apply:pub}
+      §I{Func<i32,i32>:transform}
+      §I{i32:value}
+      §O{i32}
+      §R §C{transform} §A value §/C
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.True(result.HasErrors, "Invoking a function-typed parameter must fail under enforcement");
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.DelegateInvocation && d.Message.Contains("transform"));
+    }
+
+    [Fact]
+    public void DelegateInvocation_LambdaBoundLocal_IsError()
+    {
+        var source = @"
+§M{m001:Test}
+  §F{f001:UseLambda:pub}
+      §O{i32}
+      §B{f} §LAM{lam1:x:i32} (+ x 1) §/LAM{lam1}
+      §R §C{f} §A INT:1 §/C
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.True(result.HasErrors, "Invoking a lambda-bound local must fail under enforcement");
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.DelegateInvocation && d.Message.Contains("'f'"));
+    }
+
+    [Fact]
+    public void DelegateInvocation_UnderPermissiveEffects_IsWaivedToWarning()
+    {
+        var source = @"
+§M{m001:Test}
+  §F{f001:Apply:pub}
+      §I{Func<i32,i32>:transform}
+      §I{i32:value}
+      §O{i32}
+      §R §C{transform} §A value §/C
+";
+        var result = TestHarness.CompileWithEffects(source, enforceEffects: true,
+            policy: UnknownCallPolicy.Permissive);
+
+        Assert.DoesNotContain(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.DelegateInvocation);
+        Assert.Contains(result.Diagnostics.Warnings,
+            d => d.Code == DiagnosticCode.DelegateInvocation && d.Message.Contains("transform"));
+    }
+
+    [Fact]
+    public void BareNameCall_InternalFunction_StillResolves()
+    {
+        // The delegate error must NOT hit same-module bare-name calls.
+        var source = @"
+§M{m001:Test}
+  §F{f001:Helper:pri}
+      §I{i32:x}
+      §O{i32}
+      §R (+ x 1)
+  §F{f002:Main:pub}
+      §O{i32}
+      §R §C{Helper} §A INT:1 §/C
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.False(result.HasErrors,
+            $"Bare-name internal call must still resolve. Errors: {string.Join("; ", result.Diagnostics.Errors.Select(e => e.Message))}");
+        Assert.DoesNotContain(result.Diagnostics,
+            d => d.Code == DiagnosticCode.DelegateInvocation);
+    }
+
+    [Fact]
+    public void FreeBareName_FailsClosed_NotSilentlyPure()
+    {
+        // Pre-W2 behavior: a free bare-name invocation was silently assumed pure.
+        // Now it routes through the unknown-call chain (Calor0411 + worst-case
+        // effects → Calor0410) under the default strict policy.
+        var source = @"
+§M{m001:Test}
+  §CL{c001:Mapper:pub}
+      §MT{mt001:Apply:pub}
+          §I{i32:value}
+          §O{i32}
+          §R §C{transform} §A value §/C
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.True(result.HasErrors, "A free bare-name invocation must fail closed");
+        Assert.Contains(result.Diagnostics,
+            d => d.Code == DiagnosticCode.UnknownExternalCall && d.Message.Contains("transform"));
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.ForbiddenEffect);
+    }
+
+    // ========================================================================
+    // D-W2.2 — Override + interface-implementation effect variance
+    // ========================================================================
+
+    [Fact]
+    public void OverrideWithBroaderEffects_IsError()
+    {
+        var source = @"
+§M{m001:Test}
+  §CL{c001:Base:pub}
+      §MT{mt001:Render:pub:virt}
+          §O{void}
+          §E{}
+  §CL{c002:Derived:pub}
+      §EXT{Base}
+      §MT{mt002:Render:pub:over}
+          §O{void}
+          §E{cw}
+          §P ""laundered""
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.True(result.HasErrors, "Override broadening the base effect set must fail");
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.OverrideEffectVariance && d.Message.Contains("Render"));
+    }
+
+    [Fact]
+    public void OverrideWithSubsetEffects_Compiles()
+    {
+        var source = @"
+§M{m001:Test}
+  §CL{c001:Base:pub}
+      §MT{mt001:Render:pub:virt}
+          §O{void}
+          §E{cw,fs:w}
+          §P ""base""
+  §CL{c002:Derived:pub}
+      §EXT{Base}
+      §MT{mt002:Render:pub:over}
+          §O{void}
+          §E{cw}
+          §P ""derived""
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.False(result.HasErrors,
+            $"Override with a subset of base effects must compile. Errors: {string.Join("; ", result.Diagnostics.Errors.Select(e => e.Message))}");
+    }
+
+    [Fact]
+    public void InterfaceImplementationWithBroaderEffects_IsError()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IRenderer}
+      §MT{m001:Render}
+          §O{void}
+          §E{}
+  §CL{c001:ConsoleRenderer:pub}
+      §IMPL{IRenderer}
+      §MT{mt001:Render:pub}
+          §O{void}
+          §E{cw}
+          §P ""rendering""
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.True(result.HasErrors, "Implementation broadening the interface effect set must fail");
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.InterfaceEffectVariance && d.Message.Contains("Render"));
+    }
+
+    [Fact]
+    public void InterfaceImplementationWithinDeclaredEffects_Compiles()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IRenderer}
+      §MT{m001:Render}
+          §O{void}
+          §E{cw}
+  §CL{c001:ConsoleRenderer:pub}
+      §IMPL{IRenderer}
+      §MT{mt001:Render:pub}
+          §O{void}
+          §E{cw}
+          §P ""rendering""
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.False(result.HasErrors,
+            $"Implementation within the interface's declared effects must compile. Errors: {string.Join("; ", result.Diagnostics.Errors.Select(e => e.Message))}");
+    }
+
+    [Fact]
+    public void OverrideOfExternalBase_RoutesToAssumedChannel()
+    {
+        // Base class is external C# (not in this module): variance cannot be
+        // checked, so the override is surfaced through the assumption channel.
+        var source = @"
+§M{m001:Test}
+  §CL{c001:MyController:pub}
+      §EXT{SomeExternalBase}
+      §MT{mt001:Handle:pub:over}
+          §O{void}
+          §E{}
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.Contains(result.Diagnostics.Warnings,
+            d => d.Code == DiagnosticCode.AssumedEffects && d.Message.Contains("external base"));
+    }
+
+    [Fact]
+    public void CallThroughInterfaceTypedReceiver_ChargesInterfaceDeclaredEffects()
+    {
+        // D-W2.2 call-site leg: shape.Describe through an IShape-typed parameter
+        // charges the interface's declared §E{cw} — no unknown-call diagnostic,
+        // and the caller must declare cw.
+        var missingDeclaration = @"
+§M{m001:Test}
+  §IFACE{i001:IShape}
+      §MT{m001:Describe}
+          §O{void}
+          §E{cw}
+  §F{f001:Draw:pub}
+      §I{IShape:shape}
+      §O{void}
+      §C{shape.Describe}
+      §/C
+";
+        var failing = TestHarness.Compile(missingDeclaration);
+        Assert.True(failing.HasErrors, "Caller must declare the interface's declared effect");
+        Assert.Contains(failing.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.ForbiddenEffect && d.Message.Contains("Draw"));
+        Assert.DoesNotContain(failing.Diagnostics,
+            d => d.Code == DiagnosticCode.UnknownExternalCall && d.Message.Contains("shape.Describe"));
+
+        var declared = missingDeclaration.Replace("      §O{void}\n      §C{shape.Describe}",
+            "      §O{void}\n      §E{cw}\n      §C{shape.Describe}");
+        var passing = TestHarness.Compile(declared);
+        Assert.False(passing.HasErrors,
+            $"Caller declaring the interface effect must compile. Errors: {string.Join("; ", passing.Diagnostics.Errors.Select(e => e.Message))}");
+    }
+
+    // ========================================================================
+    // D-W2.3 — Interop is effect-unknown, propagating as an assumption
+    // ========================================================================
+
+    [Fact]
+    public void InteropContent_SurfacesAssumption()
+    {
+        var source = @"
+§M{m001:Test}
+  §F{f001:UsesInterop:pub}
+      §O{void}
+      §RAW
+var x = System.Environment.TickCount;
+§/RAW
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.Contains(result.Diagnostics.Warnings,
+            d => d.Code == DiagnosticCode.AssumedEffects
+                && d.Message.Contains("UsesInterop")
+                && d.Message.Contains("interop"));
+    }
+
+    [Fact]
+    public void InteropAssumption_PropagatesToCaller()
+    {
+        var source = @"
+§M{m001:Test}
+  §F{f001:UsesInterop:pub}
+      §O{void}
+      §RAW
+var x = 1;
+§/RAW
+  §F{f002:Caller:pub}
+      §O{void}
+      §C{UsesInterop}
+      §/C
+  §F{f003:Transitive:pub}
+      §O{void}
+      §C{Caller}
+      §/C
+";
+        var result = TestHarness.Compile(source);
+
+        // The direct caller AND the transitive caller inherit the assumption.
+        Assert.Contains(result.Diagnostics.Warnings,
+            d => d.Code == DiagnosticCode.AssumedEffects && d.Message.Contains("'Caller'"));
+        Assert.Contains(result.Diagnostics.Warnings,
+            d => d.Code == DiagnosticCode.AssumedEffects && d.Message.Contains("'Transitive'"));
+    }
+
+    [Fact]
+    public void InteropAssumption_UnderStrictEffects_IsError()
+    {
+        var source = @"
+§M{m001:Test}
+  §F{f001:UsesInterop:pub}
+      §O{void}
+      §RAW
+var x = 1;
+§/RAW
+";
+        var options = new CompilationOptions
+        {
+            EnforceEffects = true,
+            StrictEffects = true
+        };
+        var result = TestHarness.Compile(source, options);
+
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.AssumedEffects && d.Message.Contains("UsesInterop"));
+    }
+
+    // ========================================================================
+    // D-W2.4 — KnownPureMethodNames mutator purge
+    // ========================================================================
+
+    [Fact]
+    public void PurgedMutator_UntypedReceiverAdd_FailsClosed()
+    {
+        // The #785 reproduction: a pure function calling items.Add must no longer
+        // pass strict enforcement. With no type information the call routes
+        // through the unknown-call chain (fail loud), not the purged name list.
+        var source = @"
+§M{m001:Test}
+  §F{f001:AddItem:pub}
+      §O{void}
+      §C{items.Add}
+        §A INT:1
+      §/C
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.True(result.HasErrors, "items.Add in a pure function must fail enforcement");
+        Assert.Contains(result.Diagnostics,
+            d => d.Code == DiagnosticCode.UnknownExternalCall && d.Message.Contains("items.Add"));
+    }
+
+    [Fact]
+    public void TypedListReceiver_Add_ResolvesToMutViaManifest()
+    {
+        // With a typed receiver the manifest resolves List`1.Add = mut: the
+        // caller must declare mut (and gets Calor0410, not Calor0411, without it).
+        var missing = @"
+§M{m001:Test}
+  §F{f001:AddItem:pub}
+      §O{void}
+      §B{List<i32>:items} §NEW{List<i32>} §/NEW
+      §C{items.Add}
+        §A INT:1
+      §/C
+";
+        var failing = TestHarness.Compile(missing);
+        Assert.True(failing.HasErrors, "Typed list Add without §E{mut} must fail");
+        Assert.Contains(failing.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.ForbiddenEffect && d.Message.Contains("mut"));
+        Assert.DoesNotContain(failing.Diagnostics,
+            d => d.Code == DiagnosticCode.UnknownExternalCall && d.Message.Contains("items.Add"));
+    }
+
+    [Fact]
+    public void KeptPureNames_LinqAndStringOps_StillPure()
+    {
+        // Names that survived the audit (genuinely pure across common BCL
+        // receivers) still resolve as pure through the name fallback.
+        var source = @"
+§M{m001:Test}
+  §F{f001:Query:pub}
+      §O{void}
+      §C{items.Where}
+      §/C
+      §C{items.Select}
+      §/C
+      §C{items.ToList}
+      §/C
+      §C{name.Trim}
+      §/C
+      §C{name.PadLeft}
+        §A INT:10
+      §/C
+      §C{items.ConvertAll}
+      §/C
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.False(result.HasErrors,
+            $"Audited-pure names must remain pure. Errors: {string.Join("; ", result.Diagnostics.Errors.Select(e => e.Message))}");
+    }
+
+    // ========================================================================
+    // D-W2.6 — Unknown constructs are never silently pure
+    // ========================================================================
+
+    private sealed class MysteryStatementNode : StatementNode
+    {
+        public MysteryStatementNode() : base(new TextSpan(0, 1, 1, 1)) { }
+        public override void Accept(IAstVisitor visitor) { }
+        public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    }
+
+    [Fact]
+    public void UnknownStatementConstruct_RoutesToAssumedChannel()
+    {
+        // Build a module whose function body contains a statement kind the
+        // enforcement pass has never seen: the catch-all must surface a
+        // Calor0419 assumption, never silently return pure.
+        var span = new TextSpan(0, 1, 1, 1);
+        var function = new FunctionNode(
+            span, "f001", "Mystery", Visibility.Public,
+            Array.Empty<ParameterNode>(),
+            output: null,
+            effects: null,
+            body: new StatementNode[] { new MysteryStatementNode() },
+            attributes: new AttributeCollection());
+        var module = new ModuleNode(
+            span, "m001", "Test",
+            Array.Empty<UsingDirectiveNode>(),
+            new[] { function },
+            new AttributeCollection());
+
+        var diagnostics = new DiagnosticBag();
+        var pass = new EffectEnforcementPass(diagnostics);
+        pass.Enforce(module);
+
+        Assert.Contains(diagnostics,
+            d => d.Code == DiagnosticCode.AssumedEffects
+                && d.Message.Contains("MysteryStatementNode"));
+    }
+
+    [Fact]
+    public void UnknownStatementConstruct_UnderStrictEffects_IsError()
+    {
+        var span = new TextSpan(0, 1, 1, 1);
+        var function = new FunctionNode(
+            span, "f001", "Mystery", Visibility.Public,
+            Array.Empty<ParameterNode>(),
+            output: null,
+            effects: null,
+            body: new StatementNode[] { new MysteryStatementNode() },
+            attributes: new AttributeCollection());
+        var module = new ModuleNode(
+            span, "m001", "Test",
+            Array.Empty<UsingDirectiveNode>(),
+            new[] { function },
+            new AttributeCollection());
+
+        var diagnostics = new DiagnosticBag();
+        var pass = new EffectEnforcementPass(diagnostics, strictEffects: true);
+        pass.Enforce(module);
+
+        Assert.Contains(diagnostics.Errors,
+            d => d.Code == DiagnosticCode.AssumedEffects);
+    }
+}

--- a/tests/Calor.Enforcement.Tests/StrictnessBatchTests.cs
+++ b/tests/Calor.Enforcement.Tests/StrictnessBatchTests.cs
@@ -421,6 +421,310 @@ var x = 1;
     }
 
     // ========================================================================
+    // W2 adversarial review fixes (PR #842) — C2, C1, C3, C4, C5, M1
+    // ========================================================================
+
+    [Fact]
+    public void C2_DecoyNamedDelegateParameter_ShadowsFunction_IsError()
+    {
+        // Review C2: a Func parameter named like a pure module function must be
+        // resolved as the VALUE (matching C# scoping and emission), yielding
+        // Calor0418 — not silently charged as the shadowed pure function.
+        var source = @"
+§M{m001:Shadow}
+  §F{f001:Helper:pub}
+      §O{i32}
+      §E{}
+      §R INT:1
+  §F{f002:Loud:pub}
+      §O{i32}
+      §E{cw}
+      §P ""laundered""
+      §R INT:2
+  §F{f003:Go:pub}
+      §I{Func<i32>:Helper}
+      §O{i32}
+      §E{}
+      §R §C{Helper} §/C
+  §F{f004:Main:pub}
+      §O{void}
+      §E{}
+      §B{r:i32} §C{Go} §A Loud §/C
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.True(result.HasErrors, "Decoy-named delegate invocation must fail");
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.DelegateInvocation && d.Message.Contains("'Helper'"));
+        // C4 companion: Main passes the impure method group 'Loud' — charged at
+        // the passing site, so §E{} on Main is a Calor0410.
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.ForbiddenEffect && d.Message.Contains("Main"));
+    }
+
+    [Fact]
+    public void C1_PpBlock_StatementLeg_ChargesBranchEffects()
+    {
+        // Review C1 (statement leg): effects inside a §PP conditional block are
+        // charged (union of branches) — a §PP body is never silently pure.
+        var source = @"
+§M{m001:PpHole}
+  §F{f001:Sneaky:pub}
+      §O{void}
+      §E{}
+      §PP{DEBUG}
+      §C{Console.WriteLine} ""hidden effect""
+      §/PP{DEBUG}
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.True(result.HasErrors, "§PP-wrapped effects must be charged");
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.ForbiddenEffect
+                && d.Message.Contains("Sneaky") && d.Message.Contains("cw"));
+    }
+
+    [Fact]
+    public void C1_PpBlock_MemberLeg_WrappedMethodIsEnforced()
+    {
+        // Review C1 (member leg): a class method wrapped in a class-level §PP
+        // block must not escape enforcement.
+        var source = @"
+§M{m001:PPM}
+  §CL{c001:Logger:pub}
+      §PP{DEBUG}
+      §MT{mt001:Sneak:pub}
+          §O{void}
+          §E{}
+          §C{Console.WriteLine} §A ""pp-wrapped method effect"" §/C
+      §/PP{DEBUG}
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.True(result.HasErrors, "§PP-wrapped methods must be enforced");
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.ForbiddenEffect
+                && d.Message.Contains("Sneak") && d.Message.Contains("cw"));
+    }
+
+    [Fact]
+    public void C3_InheritedImplementation_BroaderEffects_IsError()
+    {
+        // Review C3: an interface implementation satisfied by an INHERITED
+        // in-module method is variance-checked (Calor0421) — inheritance must
+        // not launder through interface dispatch.
+        var source = @"
+§M{m001:InheritLaunder}
+  §IFACE{i001:IQuiet}
+      §MT{m001:Run}
+          §O{void}
+          §E{}
+  §CL{c001:Loud:pub}
+      §MT{mt001:Run:pub}
+          §O{void}
+          §E{cw}
+          §P ""runs loud""
+  §CL{c002:Sneaky:pub}
+      §EXT{Loud}
+      §IMPL{IQuiet}
+      §MT{mt002:Noop:pub}
+          §O{void}
+          §E{}
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.True(result.HasErrors, "Inherited implementation broadening interface effects must fail");
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.InterfaceEffectVariance
+                && d.Message.Contains("Sneaky") && d.Message.Contains("inherited"));
+    }
+
+    [Fact]
+    public void C3_ExternalInheritedImplementation_RoutesToAssumed()
+    {
+        // Review C3 (external arm): §IMPL satisfied only by a member inherited
+        // from an external base is surfaced via the Calor0419 assumption channel.
+        var source = @"
+§M{m001:ExtImpl}
+  §IFACE{i001:IQuiet}
+      §MT{m001:Run}
+          §O{void}
+          §E{}
+  §CL{c001:Bridge:pub}
+      §EXT{SomeExternalBase}
+      §IMPL{IQuiet}
+      §MT{mt001:Other:pub}
+          §O{void}
+          §E{}
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.Contains(result.Diagnostics.Warnings,
+            d => d.Code == DiagnosticCode.AssumedEffects
+                && d.Message.Contains("SomeExternalBase") && d.Message.Contains("IQuiet.Run"));
+    }
+
+    [Fact]
+    public void C4_MethodGroupArgument_ChargesCalleeDeclaredEffects()
+    {
+        // Review C4: a method-group argument (bare reference to an internal
+        // function) charges that function's declared effects at the passing
+        // site — ConvertAll and friends can no longer launder it.
+        var source = @"
+§M{m001:HigherOrder}
+  §F{f001:LoudMap:pub}
+      §I{i32:x}
+      §O{i32}
+      §E{cw}
+      §P ""mapping""
+      §R x
+  §F{f002:Go:pub}
+      §I{List<i32>:items}
+      §O{void}
+      §E{}
+      §B{r} §C{items.ConvertAll} §A LoudMap §/C
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.True(result.HasErrors, "Method-group argument effects must be charged");
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.ForbiddenEffect
+                && d.Message.Contains("Go") && d.Message.Contains("cw"));
+    }
+
+    [Fact]
+    public void C4_DelegateValueArgument_ToKnownHigherOrderName_SurfacesAssumption()
+    {
+        // Review C4 (value arm): a function-typed VALUE passed to a known-pure
+        // higher-order name (Select) is surfaced as a Calor0419 assumption —
+        // the BCL callee may invoke it invisibly.
+        var source = @"
+§M{m001:HofVal}
+  §F{f001:Go:pub}
+      §I{Func<i32,i32>:f}
+      §I{List<i32>:items}
+      §O{void}
+      §E{}
+      §B{r} §C{items.Select} §A f §/C
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.Contains(result.Diagnostics.Warnings,
+            d => d.Code == DiagnosticCode.AssumedEffects
+                && d.Message.Contains("'f'") && d.Message.Contains("items.Select"));
+    }
+
+    [Fact]
+    public void C5_ExternalTypedReceiver_CollidingMethodName_FailsLoud()
+    {
+        // Review C5: a receiver whose static type is KNOWN and external must not
+        // be captured by an in-module method-name collision — it goes to the
+        // unknown chain (fail loud), for both single and chained receivers.
+        var source = @"
+§M{m001:RC}
+  §CL{c001:Helper:pub}
+      §MT{mt001:Refresh:pub}
+          §O{i32}
+          §E{}
+          §R INT:1
+  §F{f001:GoSingle:pub}
+      §I{SomeExternal:svc}
+      §O{void}
+      §E{}
+      §C{svc.Refresh}
+      §/C
+  §F{f002:GoChained:pub}
+      §I{SomeExternal:svc}
+      §O{void}
+      §E{}
+      §C{svc.conn.Refresh}
+      §/C
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.True(result.HasErrors, "External-typed receiver collisions must fail loud");
+        Assert.Contains(result.Diagnostics,
+            d => d.Code == DiagnosticCode.UnknownExternalCall && d.Message.Contains("svc.Refresh"));
+        Assert.Contains(result.Diagnostics,
+            d => d.Code == DiagnosticCode.UnknownExternalCall && d.Message.Contains("svc.conn.Refresh"));
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.ForbiddenEffect && d.Message.Contains("GoSingle"));
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.ForbiddenEffect && d.Message.Contains("GoChained"));
+    }
+
+    [Fact]
+    public void C5_InModuleTypedReceiver_StillResolves()
+    {
+        // Companion: a receiver statically typed as the in-module declaring
+        // class still resolves (declared-§E charge) — no unknown-call noise.
+        var source = @"
+§M{m001:RC2}
+  §CL{c001:Helper:pub}
+      §MT{mt001:Refresh:pub}
+          §O{i32}
+          §E{}
+          §R INT:1
+  §F{f001:Go:pub}
+      §O{void}
+      §E{}
+      §B{h:Helper} §NEW{Helper} §/NEW
+      §C{h.Refresh}
+      §/C
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.False(result.HasErrors,
+            $"In-module typed receiver must still resolve. Errors: {string.Join("; ", result.Diagnostics.Errors.Select(e => e.Message))}");
+        Assert.DoesNotContain(result.Diagnostics,
+            d => d.Code == DiagnosticCode.UnknownExternalCall);
+    }
+
+    [Fact]
+    public void M1_ExpressionCallSpelling_DelegateValue_IsError()
+    {
+        // Review M1: `§C f §A x §/C` (expression-call spelling) is the same
+        // delegate invocation as `§C{f}` and gets the same Calor0418 error.
+        var source = @"
+§M{m001:Wrap}
+  §F{f001:Apply:pub}
+      §I{Func<i32,i32>:f}
+      §I{i32:x}
+      §O{i32}
+      §E{}
+      §R §C f §A x §/C
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.True(result.HasErrors, "Expression-call delegate invocation must be an error");
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.DelegateInvocation && d.Message.Contains("'f'"));
+    }
+
+    [Fact]
+    public void M1_ReturnedDelegateInvocation_IsError()
+    {
+        // Review M1: invoking the RESULT of a call (`GetF()()`) invokes a
+        // delegate value — Calor0418.
+        var source = @"
+§M{m001:E}
+  §F{f001:GetF:pub}
+      §O{Func<i32>}
+      §E{}
+      §R §LAM{l1} §R INT:1 §/LAM{l1}
+  §F{f002:Go:pub}
+      §O{i32}
+      §E{}
+      §R §C §C{GetF} §/C §/C
+";
+        var result = TestHarness.Compile(source);
+
+        Assert.True(result.HasErrors, "Returned-delegate invocation must be an error");
+        Assert.Contains(result.Diagnostics.Errors,
+            d => d.Code == DiagnosticCode.DelegateInvocation && d.Message.Contains("returned delegate"));
+    }
+
+    // ========================================================================
     // D-W2.6 — Unknown constructs are never silently pure
     // ========================================================================
 

--- a/tests/E2E/agent-tasks/lib/helpers.sh
+++ b/tests/E2E/agent-tasks/lib/helpers.sh
@@ -1471,9 +1471,14 @@ detect_project_type() {
 }
 
 # Verify Calor compilation
+# $3 (optional): extra compiler flags, e.g. "--permissive-effects" for tasks
+# whose subject matter is outside the enforced first-order wedge (WS-W2:
+# delegate invocation is a Calor0418 error under the default-on enforcement;
+# the per-task flag is the explicit migration-policy waiver).
 verify_calor_compilation() {
     local workspace="$1"
     local must_succeed="${2:-true}"
+    local extra_flags="${3:-}"
 
     local original_dir
     original_dir=$(pwd)
@@ -1491,7 +1496,8 @@ verify_calor_compilation() {
         # Capture output for debugging
         local compile_output
         local compile_status=0
-        compile_output=$("$COMPILER" --input "$calr_file" --output "$cs_file" 2>&1) || compile_status=$?
+        # shellcheck disable=SC2086 — extra_flags is intentionally word-split
+        compile_output=$("$COMPILER" --input "$calr_file" --output "$cs_file" $extra_flags 2>&1) || compile_status=$?
 
         if [[ $compile_status -ne 0 ]]; then
             log_debug "Calor compilation failed for $calr_file (exit code: $compile_status)"
@@ -1581,6 +1587,7 @@ verify_csharp_compilation() {
 verify_compilation() {
     local workspace="$1"
     local must_succeed="${2:-true}"
+    local calor_extra_flags="${3:-}"
 
     local project_type
     project_type=$(detect_project_type "$workspace")
@@ -1589,7 +1596,7 @@ verify_compilation() {
 
     case "$project_type" in
         calor)
-            verify_calor_compilation "$workspace" "$must_succeed"
+            verify_calor_compilation "$workspace" "$must_succeed" "$calor_extra_flags"
             ;;
         csharp)
             verify_csharp_compilation "$workspace" "$must_succeed"
@@ -1691,7 +1698,15 @@ verify_task() {
     must_compile=$(json_get_nested_file "$task_file" "verification.compilation.mustSucceed" "true")
 
     if [[ "$must_compile" == "true" ]]; then
-        if ! verify_compilation "$workspace" "true"; then
+        # WS-W2: per-task opt-in waiver for code outside the enforced
+        # first-order wedge (delegate/lambda invocation tasks).
+        local permissive_effects
+        permissive_effects=$(json_get_nested_file "$task_file" "verification.compilation.permissiveEffects" "false")
+        local calor_extra_flags=""
+        if [[ "$permissive_effects" == "true" ]]; then
+            calor_extra_flags="--permissive-effects"
+        fi
+        if ! verify_compilation "$workspace" "true" "$calor_extra_flags"; then
             log_debug "Compilation verification failed"
             return 1
         fi

--- a/tests/E2E/agent-tasks/tasks/lambdas-delegates/01_inline_arrow_lambda/task.json
+++ b/tests/E2E/agent-tasks/tasks/lambdas-delegates/01_inline_arrow_lambda/task.json
@@ -5,8 +5,13 @@
   "fixture": "basic-calor-project",
   "prompt": "Add a public function called ApplyDouble to Calculator.calr that takes an integer x, creates an inline lambda that doubles its input, binds it to a variable, calls the lambda with x, and returns the result.",
   "verification": {
-    "compilation": { "mustSucceed": true },
-    "z3": { "enabled": false }
+    "compilation": {
+      "mustSucceed": true,
+      "permissiveEffects": true
+    },
+    "z3": {
+      "enabled": false
+    }
   },
   "timeout": 120
 }

--- a/tests/E2E/agent-tasks/tasks/lambdas-delegates/02_block_lambda/task.json
+++ b/tests/E2E/agent-tasks/tasks/lambdas-delegates/02_block_lambda/task.json
@@ -5,8 +5,13 @@
   "fixture": "basic-calor-project",
   "prompt": "Add a public function called ApplyComplex to Calculator.calr that uses a block lambda with multiple statements. The lambda takes an integer, checks if it's positive (return doubled value) or not (return 0). Apply the lambda to parameter x and return the result.",
   "verification": {
-    "compilation": { "mustSucceed": true },
-    "z3": { "enabled": false }
+    "compilation": {
+      "mustSucceed": true,
+      "permissiveEffects": true
+    },
+    "z3": {
+      "enabled": false
+    }
   },
   "timeout": 120
 }

--- a/tests/E2E/agent-tasks/tasks/lambdas-delegates/04_event_subscription/task.json
+++ b/tests/E2E/agent-tasks/tasks/lambdas-delegates/04_event_subscription/task.json
@@ -5,8 +5,13 @@
   "fixture": "oop-project",
   "prompt": "Add a public class called EventPublisher to Domain.calr with a public event called OnDataReceived of type EventHandler. Add a public method Subscribe that takes an EventHandler parameter and subscribes it to the event.",
   "verification": {
-    "compilation": { "mustSucceed": true },
-    "z3": { "enabled": false }
+    "compilation": {
+      "mustSucceed": true,
+      "permissiveEffects": true
+    },
+    "z3": {
+      "enabled": false
+    }
   },
   "timeout": 120
 }


### PR DESCRIPTION
Implements WS-W2 from the v0.11 wedge plan (docs/plans/wedge-plan-v0.11.md §2). Merge-order gate satisfied: W1 Slices 1+2 on main; PP-W5 registration frozen results-blind in #839 BEFORE this merge (this PR is part of the epoch treatment arm).

## Deliverables

- **D-W2.1 — delegate invocation = error (Calor0418)**: the "assume pure" no-dot branch is gone. Bare-name targets resolving to a value (param, §B binding, field) invoked ⇒ error (warning only under the explicit `--permissive-effects` waiver); free names route through the unknown-call chain (0411 + worst-case ⇒ 0410) — fail-closed, never silently pure. Cross-module bare calls preserved via the driver's unambiguous pre-parse map plumbed into the pass.
- **D-W2.2 — effect variance, both legs**: override §E ⊆ base §E (**Calor0420**), implementation §E ⊆ interface §E (**Calor0421**), absent §E = pure. Call-site leg (in-module subset): calls through receivers statically typed as in-module interfaces/classes charge the declared §E — dispatch-sound precisely because 0420/0421 pin implementations to subsets. Residual (chained/external/property receivers) falls through to the existing fail-loud chain.
- **D-W2.3 — interop → Assumed (Calor0419), genuinely propagating**: assumption provenance (§RAW/§CS, conversion fallbacks, expression-target calls, unknown constructs, external-base overrides) with transitive closure over the reverse call graph; warning by default, **error under --strict-effects**, still disclosed under permissive.
- **D-W2.4 — mutator purge (#785)**: Add/Remove/Clear/Insert/Sort/Append/CopyTo/Log etc. purged from KnownPureMethodNames; untyped receiver now fails loud (0411 + 0410), typed receivers resolve via manifests with new generic-name normalization (`List<i32>` → ``List`1``). #785 repro dead both ways, pinned.
- **D-W2.5 — CLI default flip**: `--enforce-effects` defaults true on build + watch, `--no-enforce-effects` opt-out; ends the CLI/SDK split-brain.
- **D-W2.6 — catch-alls retired structurally**: both `_ => EffectSet.Empty` sites replaced with exhaustive node-kind switches; unrecognized nodes → Calor0419, never silently pure. Pinned with a synthetic unknown node.

## New diagnostics
Calor0418–0421, registered in Diagnostic.cs + docs/syntax-reference/effects.md (self-check clean).

## Behavioral test changes (all justified in the diff)
Two hole-pinning tests now pin the closure; lambda/delegate emission-shape tests carry the explicit waiver; three §USING conversion tests follow the converted-code precedent; two samples gain honest `mut` declarations; E2E agent-task harness gains per-task `permissiveEffects` (lambdas-delegates 01/02/04).

## Tests
+18 new pins (StrictnessBatchTests 16, CLI default 2 via real subprocess). Full suite: **0 failed / 7,835 passed / 17 skipped**, 0 warnings, self-check docs clean, calor-first guard clean.

## Scope-guard note
The A-1.2/A-1.3 frozen exclusion rows cite the delegate-invocation and dispatch-laundering holes; both are now closed. Additive note to be recorded against the frozen rows (gates doc untouched by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)