### PR TITLE
feat: WS-W4 Slice A structural — SILENT→LOUD for namespace/local-functions (+ pin preprocessor/records)

### DIFF
--- a/src/Calor.Compiler/Migration/FeatureSupport.cs
+++ b/src/Calor.Compiler/Migration/FeatureSupport.cs
@@ -577,6 +577,35 @@ public static class FeatureSupport
             Workaround = "Review conditional-compilation blocks manually; alternate branches are not preserved in the default pipeline"
         },
 
+        // #769 (WS-W4 D2): namespace topology is NOT preserved — every type in a
+        // file is flattened into a single module named after the first namespace,
+        // so a type's fully-qualified identity changes. Flattening that carries no
+        // identity-merge risk (single namespace, or types with unique bare names)
+        // stays native; two top-level types that share a bare name across different
+        // namespaces would collapse to one identity, so they are refused and escalated
+        // to §CSHARP interop (a counted loss) rather than silently merged.
+        ["namespace"] = new FeatureInfo
+        {
+            Name = "namespace",
+            Support = SupportLevel.Partial,
+            Description = "Namespace topology is flattened into one module; cross-namespace same-name types are refused (escalated to §CSHARP interop) rather than silently merged",
+            Workaround = "Split multi-namespace files, or keep same-named cross-namespace types as §CSHARP interop blocks"
+        },
+
+        // #777 (WS-W4 D4): local functions are lowered by hoisting to module-level
+        // §F functions. A non-generic, non-capturing local function round-trips
+        // faithfully. A generic local function would lose its type parameters, and a
+        // capturing local function would reference enclosing locals that do not exist
+        // at module scope — both are refused and escalate the containing member to
+        // §CSHARP interop (a counted loss) rather than silently diverging.
+        ["local-function"] = new FeatureInfo
+        {
+            Name = "local-function",
+            Support = SupportLevel.Partial,
+            Description = "Non-generic, non-capturing local functions are hoisted to module-level §F functions; generic or capturing local functions escalate the containing member to §CSHARP interop",
+            Workaround = "Keep generic or capturing local functions as §CSHARP interop, or lift them to methods with explicit parameters"
+        },
+
         // Phase 4 features (C# 11-13)
         ["default-lambda-parameter"] = new FeatureInfo
         {

--- a/src/Calor.Compiler/Migration/FeatureSupport.cs
+++ b/src/Calor.Compiler/Migration/FeatureSupport.cs
@@ -592,18 +592,18 @@ public static class FeatureSupport
             Workaround = "Split multi-namespace files, or keep same-named cross-namespace types as §CSHARP interop blocks"
         },
 
-        // #777 (WS-W4 D4): local functions are lowered by hoisting to module-level
-        // §F functions. A non-generic, non-capturing local function round-trips
-        // faithfully. A generic local function would lose its type parameters, and a
-        // capturing local function would reference enclosing locals that do not exist
-        // at module scope — both are refused and escalate the containing member to
-        // §CSHARP interop (a counted loss) rather than silently diverging.
+        // #777 (WS-W4 D4): any member containing a local function escalates to
+        // §CSHARP interop. The hoist-to-module-level lowering is never sound — its
+        // own happy path build-breaks (the call site is orphaned from the hoisted
+        // function), and when a same-named member exists the orphaned call silently
+        // rebinds to it (a silent substitution). So local functions are refused
+        // wholesale (a counted loss) rather than converted.
         ["local-function"] = new FeatureInfo
         {
             Name = "local-function",
-            Support = SupportLevel.Partial,
-            Description = "Non-generic, non-capturing local functions are hoisted to module-level §F functions; generic or capturing local functions escalate the containing member to §CSHARP interop",
-            Workaround = "Keep generic or capturing local functions as §CSHARP interop, or lift them to methods with explicit parameters"
+            Support = SupportLevel.NotSupported,
+            Description = "A member containing a local function is preserved verbatim as a §CSHARP interop block; hoisting to a module-level §F function is unsound (orphaned call site build-breaks or silently rebinds)",
+            Workaround = "Lift the local function to a method with explicit parameters before migration, or keep the member as a §CSHARP interop block"
         },
 
         // Phase 4 features (C# 11-13)

--- a/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
+++ b/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
@@ -477,7 +477,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             }
         }
 
-        if (TryRefuseCrossNamespaceCollision(node, node.Identifier.Text, InteropMemberKind.Class))
+        if (TryRefuseCrossNamespaceCollision(node, InteropMemberKind.Class))
             return;
 
         _context.RecordFeatureUsage("interface");
@@ -568,7 +568,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             }
         }
 
-        if (TryRefuseCrossNamespaceCollision(node, node.Identifier.Text, InteropMemberKind.Class))
+        if (TryRefuseCrossNamespaceCollision(node, InteropMemberKind.Class))
             return;
 
         _context.RecordFeatureUsage("class");
@@ -649,7 +649,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             }
         }
 
-        if (TryRefuseCrossNamespaceCollision(node, node.Identifier.Text, InteropMemberKind.Class))
+        if (TryRefuseCrossNamespaceCollision(node, InteropMemberKind.Class))
             return;
 
         _context.RecordFeatureUsage("struct");
@@ -685,7 +685,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             }
         }
 
-        if (TryRefuseCrossNamespaceCollision(node, node.Identifier.Text, InteropMemberKind.Other))
+        if (TryRefuseCrossNamespaceCollision(node, InteropMemberKind.Other))
             return;
 
         _context.RecordFeatureUsage("enum");
@@ -752,7 +752,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             throw EscalateExpression(node, "generic-delegate");
         }
 
-        if (TryRefuseCrossNamespaceCollision(node, node.Identifier.Text, InteropMemberKind.Other))
+        if (TryRefuseCrossNamespaceCollision(node, InteropMemberKind.Other))
             return;
 
         _context.RecordFeatureUsage("delegate");
@@ -2344,83 +2344,31 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         return Array.Empty<StatementNode>();
     }
 
-    /// <summary>
-    /// Converts a C# local function to a module-level §F function.
-    /// Local functions are hoisted out of the containing method body since
-    /// Calor doesn't have nested function declarations.
-    /// </summary>
-    private FunctionNode ConvertLocalFunction(LocalFunctionStatementSyntax node)
-    {
-        var id = _context.GenerateId("f");
-        var name = node.Identifier.ValueText;
-        var parameters = ConvertParameters(node.ParameterList);
-
-        var isAsync = node.Modifiers.Any(SyntaxKind.AsyncKeyword);
-        var returnTypeStr = node.ReturnType.ToString();
-
-        if (isAsync)
-        {
-            returnTypeStr = UnwrapTaskType(returnTypeStr);
-        }
-
-        var returnType = TypeMapper.CSharpToCalor(returnTypeStr);
-        var output = returnType != "void" ? new OutputNode(GetTextSpan(node.ReturnType), returnType) : null;
-        var body = ConvertMethodBody(node.Body, node.ExpressionBody);
-
-        _context.Stats.MethodsConverted++;
-        _context.IncrementConverted();
-
-        return new FunctionNode(
-            GetTextSpan(node),
-            id,
-            name,
-            Visibility.Private,
-            Array.Empty<TypeParameterNode>(),
-            parameters,
-            output,
-            effects: InferEffectsFromBody(body),
-            Array.Empty<RequiresNode>(),
-            Array.Empty<EnsuresNode>(),
-            body,
-            new AttributeCollection(),
-            Array.Empty<ExampleNode>(),
-            Array.Empty<IssueNode>(),
-            null, null,
-            Array.Empty<AssumeNode>(),
-            null, null, null,
-            Array.Empty<BreakingChangeNode>(),
-            Array.Empty<PropertyTestNode>(),
-            null, null, null,
-            isAsync);
-    }
-
     // ------------------------------------------------------------------
     // #769 (WS-W4 D2): cross-namespace same-name refusal
     // ------------------------------------------------------------------
 
     /// <summary>
-    /// Populates <see cref="_crossNamespaceCollisionNames"/> with the bare names of
-    /// top-level types declared in two or more distinct namespaces. The module
-    /// flattens every namespace into one unit, so two such types would collapse to
-    /// a single identity — a silent merge (#769). Recording the name lets the type
-    /// visitors refuse those types (escalate to §CSHARP interop) instead of merging.
-    /// Types with a unique bare name, or all in one namespace, are not collisions.
+    /// Populates <see cref="_crossNamespaceCollisionNames"/> with the identity keys
+    /// (bare name + generic arity) of top-level types declared in two or more
+    /// distinct namespaces. The module flattens every namespace into one unit, so
+    /// two such types would collapse to a single identity — a silent merge (#769).
+    /// Recording the key lets the type visitors refuse those types (escalate to
+    /// §CSHARP interop) instead of merging. Types with a unique key, or all in one
+    /// namespace, are not collisions. Generic arity is part of the key so
+    /// <c>A.Foo</c> and <c>B.Foo&lt;T&gt;</c> — distinct types that coexist fine —
+    /// are NOT treated as a collision.
     /// </summary>
     private void ScanCrossNamespaceCollisions(CompilationUnitSyntax root)
     {
-        var namespacesByName = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        var namespacesByKey = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
         foreach (var member in root.DescendantNodes().OfType<MemberDeclarationSyntax>())
         {
             if (member.Parent is not (BaseNamespaceDeclarationSyntax or CompilationUnitSyntax))
                 continue;
 
-            var name = member switch
-            {
-                BaseTypeDeclarationSyntax t => t.Identifier.Text,
-                DelegateDeclarationSyntax d => d.Identifier.Text,
-                _ => null,
-            };
-            if (name == null)
+            var key = TypeIdentityKey(member);
+            if (key == null)
                 continue;
 
             // Full namespace path (outer→inner), so A.X.Foo and C.X.Foo are two
@@ -2430,28 +2378,47 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                 .OfType<BaseNamespaceDeclarationSyntax>()
                 .Select(n => n.Name.ToString())
                 .Reverse());
-            if (!namespacesByName.TryGetValue(name, out var set))
-                namespacesByName[name] = set = new HashSet<string>(StringComparer.Ordinal);
+            if (!namespacesByKey.TryGetValue(key, out var set))
+                namespacesByKey[key] = set = new HashSet<string>(StringComparer.Ordinal);
             set.Add(ns);
         }
 
-        foreach (var (name, namespaces) in namespacesByName)
+        foreach (var (key, namespaces) in namespacesByKey)
         {
             if (namespaces.Count >= 2)
-                _crossNamespaceCollisionNames.Add(name);
+                _crossNamespaceCollisionNames.Add(key);
         }
     }
 
     /// <summary>
-    /// If <paramref name="node"/> is a top-level type whose bare name collides with
-    /// a same-named type in another namespace (#769), refuse to flatten/merge it:
-    /// preserve it verbatim as a §CSHARP interop block (a counted loss, so the file
-    /// is non-native) and return true. Returns false when there is no collision.
+    /// The flatten-identity key for a top-level type/delegate declaration:
+    /// <c>Name`Arity</c>. Arity distinguishes <c>Foo</c> from <c>Foo&lt;T&gt;</c>,
+    /// which are separate types that never collide. Returns null for non-type
+    /// members.
+    /// </summary>
+    private static string? TypeIdentityKey(MemberDeclarationSyntax member)
+    {
+        var (name, arity) = member switch
+        {
+            TypeDeclarationSyntax t => (t.Identifier.Text, t.TypeParameterList?.Parameters.Count ?? 0),
+            EnumDeclarationSyntax e => (e.Identifier.Text, 0),
+            DelegateDeclarationSyntax d => (d.Identifier.Text, d.TypeParameterList?.Parameters.Count ?? 0),
+            _ => (null, 0),
+        };
+        return name == null ? null : $"{name}`{arity}";
+    }
+
+    /// <summary>
+    /// If <paramref name="node"/> is a top-level type whose identity (name + arity)
+    /// collides with a same-identity type in another namespace (#769), refuse to
+    /// flatten/merge it: preserve it verbatim as a §CSHARP interop block (a counted
+    /// loss, so the file is non-native) and return true. Returns false otherwise.
     /// </summary>
     private bool TryRefuseCrossNamespaceCollision(
-        MemberDeclarationSyntax node, string name, InteropMemberKind kind)
+        MemberDeclarationSyntax node, InteropMemberKind kind)
     {
-        if (!_crossNamespaceCollisionNames.Contains(name))
+        var key = TypeIdentityKey(node);
+        if (key == null || !_crossNamespaceCollisionNames.Contains(key))
             return false;
         if (node.Parent is not (BaseNamespaceDeclarationSyntax or CompilationUnitSyntax))
             return false;
@@ -2459,121 +2426,6 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         _context.RecordFeatureUsage("namespace");
         _moduleInteropBlocks.Add(CreateInteropBlock(node, "namespace-collision", kind));
         return true;
-    }
-
-    // ------------------------------------------------------------------
-    // #777 (WS-W4 D4): local-function hoist-fidelity refusal
-    // ------------------------------------------------------------------
-
-    /// <summary>
-    /// True when a local function cannot survive the hoist-to-module-level lowering
-    /// without a silent divergence (#777). Generic local functions lose their type
-    /// parameters (identity loss — the hoist may still compile); capturing local
-    /// functions reference enclosing locals/parameters that do not exist at module
-    /// scope. Both must escalate the containing member to §CSHARP interop. A
-    /// non-generic, non-capturing local function round-trips faithfully and stays
-    /// native. Capture detection over-approximates (a false positive only sends more
-    /// to interop, never a wrong native), so a missed capture is still caught loudly
-    /// by the emitted-C# build break.
-    /// </summary>
-    private static bool LocalFunctionMustEscalate(LocalFunctionStatementSyntax fn)
-    {
-        if (fn.TypeParameterList is { Parameters.Count: > 0 })
-            return true;
-        return CapturesEnclosingLocals(fn);
-    }
-
-    private static bool CapturesEnclosingLocals(LocalFunctionStatementSyntax fn)
-    {
-        SyntaxNode? scope = (SyntaxNode?)fn.Body ?? fn.ExpressionBody;
-        if (scope == null)
-            return false;
-
-        // Names usable inside fn without capture: its own parameters and type
-        // parameters, plus everything declared within its own body.
-        var bound = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var p in fn.ParameterList.Parameters)
-            bound.Add(p.Identifier.ValueText);
-        if (fn.TypeParameterList != null)
-            foreach (var tp in fn.TypeParameterList.Parameters)
-                bound.Add(tp.Identifier.ValueText);
-        foreach (var d in scope.DescendantNodes())
-        {
-            switch (d)
-            {
-                case VariableDeclaratorSyntax vd: bound.Add(vd.Identifier.ValueText); break;
-                case SingleVariableDesignationSyntax sv: bound.Add(sv.Identifier.ValueText); break;
-                case ForEachStatementSyntax fe: bound.Add(fe.Identifier.ValueText); break;
-                case ParameterSyntax ps: bound.Add(ps.Identifier.ValueText); break;
-            }
-        }
-
-        var enclosing = CollectEnclosingLocalNames(fn);
-        if (enclosing.Count == 0)
-            return false;
-
-        foreach (var id in scope.DescendantNodes().OfType<IdentifierNameSyntax>())
-        {
-            // Skip the member-name side of `x.Member` and named-argument labels —
-            // those are not variable references.
-            if (id.Parent is MemberAccessExpressionSyntax ma && ma.Name == id)
-                continue;
-            if (id.Parent is NameColonSyntax or NameEqualsSyntax)
-                continue;
-
-            var name = id.Identifier.ValueText;
-            if (bound.Contains(name))
-                continue;
-            if (enclosing.Contains(name))
-                return true;
-        }
-        return false;
-    }
-
-    /// <summary>
-    /// Local names (parameters and locals) declared in the member enclosing
-    /// <paramref name="fn"/>, excluding anything declared inside fn itself. Sibling
-    /// local-function names are intentionally omitted: they hoist to module scope
-    /// too, so referencing one is not a capture.
-    /// </summary>
-    private static HashSet<string> CollectEnclosingLocalNames(LocalFunctionStatementSyntax fn)
-    {
-        var names = new HashSet<string>(StringComparer.Ordinal);
-        SyntaxNode? container = fn.Ancestors()
-            .FirstOrDefault(a => a is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax);
-        if (container == null)
-            return names;
-
-        switch (container)
-        {
-            case BaseMethodDeclarationSyntax bm when bm.ParameterList != null:
-                AddParameterNames(names, bm.ParameterList);
-                break;
-            case AccessorDeclarationSyntax:
-                names.Add("value"); // property/indexer set accessor implicit parameter
-                break;
-        }
-
-        foreach (var d in container.DescendantNodes())
-        {
-            if (fn.Span.Contains(d.Span))
-                continue; // declared inside fn — not a capture source
-
-            switch (d)
-            {
-                case VariableDeclaratorSyntax vd: names.Add(vd.Identifier.ValueText); break;
-                case SingleVariableDesignationSyntax sv: names.Add(sv.Identifier.ValueText); break;
-                case ForEachStatementSyntax fe: names.Add(fe.Identifier.ValueText); break;
-                case ParameterSyntax ps: names.Add(ps.Identifier.ValueText); break;
-            }
-        }
-        return names;
-    }
-
-    private static void AddParameterNames(HashSet<string> names, BaseParameterListSyntax list)
-    {
-        foreach (var p in list.Parameters)
-            names.Add(p.Identifier.ValueText);
     }
 
     /// <summary>
@@ -3985,18 +3837,23 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
     {
         var statements = new List<StatementNode>();
 
-        // #777 (WS-W4 D4): at each member-body boundary, scan the whole body up
-        // front for a generic or capturing local function. Either kind cannot be
-        // faithfully hoisted to module scope, so refuse — escalate the containing
-        // member to §CSHARP interop. Doing this before any statement is processed
-        // means no sibling local function is half-hoisted before the refusal.
+        // #777 (WS-W4 D4): at each member-body boundary, refuse ANY member that
+        // contains a local function — escalate the whole member to §CSHARP interop.
+        // The hoist-to-module-level lowering is never sound: its own happy path
+        // (a plain `int Add(...)` with no collision) build-breaks (CS0103) because
+        // the call site is left in the class while the function moves to the module
+        // static class; and when a same-named member DOES exist, the orphaned call
+        // silently rebinds to it and compiles clean (LossCount==0, wrong behaviour) —
+        // the exact §1 predicate-trust blocker. Escalating all local functions turns
+        // both outcomes into honest interop; no correct native coverage is lost.
+        // Done before any statement is processed so no sibling is half-hoisted.
         if (block.Parent is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax)
         {
-            foreach (var fn in block.DescendantNodes().OfType<LocalFunctionStatementSyntax>())
-            {
-                if (LocalFunctionMustEscalate(fn))
-                    throw EscalateExpression(fn, "local-function");
-            }
+            var localFn = block.DescendantNodes()
+                .OfType<LocalFunctionStatementSyntax>()
+                .FirstOrDefault();
+            if (localFn != null)
+                throw EscalateExpression(localFn, "local-function");
         }
 
         // Extract preprocessor regions from trivia
@@ -4153,14 +4010,15 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                 continue;
             }
 
-            // Handle local functions by hoisting to module-level §F functions
+            // #777 (WS-W4 D4): local functions are never hoisted — the lowering is
+            // unsound (orphaned call site build-breaks or silently rebinds to a
+            // same-named member). Escalate to §CSHARP interop. The member-body scan
+            // at the top of ConvertBlock normally throws first; this backstops any
+            // other path (e.g. a top-level-statement local function, caught by
+            // VisitGlobalStatement).
             if (statement is LocalFunctionStatementSyntax localFunc)
             {
-                _context.RecordFeatureUsage("local-function");
-                var hoisted = ConvertLocalFunction(localFunc);
-                _functions.Add(hoisted);
-                FlushPendingStatements(statements);
-                continue;
+                throw EscalateExpression(localFunc, "local-function");
             }
 
             // Handle lock statements: comment before body (correct semantic order)

--- a/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
+++ b/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
@@ -25,6 +25,12 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
     private readonly List<CSharpInteropBlockNode> _moduleInteropBlocks = new();
     private readonly List<TypePreprocessorBlockNode> _typePreprocessorBlocks = new();
     private bool _insideTypePreprocessorConversion;
+
+    // #769 (WS-W4 D2): bare type names declared by top-level types in two or more
+    // distinct namespaces within this file. Flattening every namespace into one
+    // module would collapse them to a single identity, so any type whose name is
+    // in this set is refused (escalated to §CSHARP interop) rather than merged.
+    private readonly HashSet<string> _crossNamespaceCollisionNames = new(StringComparer.Ordinal);
     private HashSet<string> _reassignedVariables = new();
     // Tracks active-branch conditional using groups across multiple VisitUsingDirective calls
     private string? _activeConditionalUsingCondition;
@@ -75,7 +81,13 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         _typePreprocessorBlocks.Clear();
         _activeConditionalUsingCondition = null;
         _activeConditionalUsings = null;
+        _crossNamespaceCollisionNames.Clear();
         _reassignedVariables = CollectReassignedVariables(root);
+
+        // #769 (WS-W4 D2): find bare type names shared by top-level types across
+        // two or more namespaces, so those types are refused (interop) instead of
+        // silently merged when the module flattens all namespaces.
+        ScanCrossNamespaceCollisions(root);
 
         // Scan for module-level #if blocks wrapping type declarations
         // (disabled by preprocessor — Roslyn excludes them from the tree)
@@ -465,6 +477,9 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             }
         }
 
+        if (TryRefuseCrossNamespaceCollision(node, node.Identifier.Text, InteropMemberKind.Class))
+            return;
+
         _context.RecordFeatureUsage("interface");
         _context.EnterType(node.Identifier.Text);
         try
@@ -553,6 +568,9 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             }
         }
 
+        if (TryRefuseCrossNamespaceCollision(node, node.Identifier.Text, InteropMemberKind.Class))
+            return;
+
         _context.RecordFeatureUsage("class");
         _context.EnterType(node.Identifier.Text);
         try
@@ -631,6 +649,9 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             }
         }
 
+        if (TryRefuseCrossNamespaceCollision(node, node.Identifier.Text, InteropMemberKind.Class))
+            return;
+
         _context.RecordFeatureUsage("struct");
         _context.EnterType(node.Identifier.Text);
         try
@@ -663,6 +684,9 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                 return;
             }
         }
+
+        if (TryRefuseCrossNamespaceCollision(node, node.Identifier.Text, InteropMemberKind.Other))
+            return;
 
         _context.RecordFeatureUsage("enum");
         try
@@ -727,6 +751,9 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             // Nested: escalate so the enclosing type's member loop preserves it.
             throw EscalateExpression(node, "generic-delegate");
         }
+
+        if (TryRefuseCrossNamespaceCollision(node, node.Identifier.Text, InteropMemberKind.Other))
+            return;
 
         _context.RecordFeatureUsage("delegate");
         try
@@ -2367,6 +2394,188 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             isAsync);
     }
 
+    // ------------------------------------------------------------------
+    // #769 (WS-W4 D2): cross-namespace same-name refusal
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Populates <see cref="_crossNamespaceCollisionNames"/> with the bare names of
+    /// top-level types declared in two or more distinct namespaces. The module
+    /// flattens every namespace into one unit, so two such types would collapse to
+    /// a single identity — a silent merge (#769). Recording the name lets the type
+    /// visitors refuse those types (escalate to §CSHARP interop) instead of merging.
+    /// Types with a unique bare name, or all in one namespace, are not collisions.
+    /// </summary>
+    private void ScanCrossNamespaceCollisions(CompilationUnitSyntax root)
+    {
+        var namespacesByName = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        foreach (var member in root.DescendantNodes().OfType<MemberDeclarationSyntax>())
+        {
+            if (member.Parent is not (BaseNamespaceDeclarationSyntax or CompilationUnitSyntax))
+                continue;
+
+            var name = member switch
+            {
+                BaseTypeDeclarationSyntax t => t.Identifier.Text,
+                DelegateDeclarationSyntax d => d.Identifier.Text,
+                _ => null,
+            };
+            if (name == null)
+                continue;
+
+            // Full namespace path (outer→inner), so A.X.Foo and C.X.Foo are two
+            // distinct namespaces, not one — otherwise the innermost-name-only view
+            // would treat them as the same and miss the collision.
+            var ns = string.Join(".", member.Ancestors()
+                .OfType<BaseNamespaceDeclarationSyntax>()
+                .Select(n => n.Name.ToString())
+                .Reverse());
+            if (!namespacesByName.TryGetValue(name, out var set))
+                namespacesByName[name] = set = new HashSet<string>(StringComparer.Ordinal);
+            set.Add(ns);
+        }
+
+        foreach (var (name, namespaces) in namespacesByName)
+        {
+            if (namespaces.Count >= 2)
+                _crossNamespaceCollisionNames.Add(name);
+        }
+    }
+
+    /// <summary>
+    /// If <paramref name="node"/> is a top-level type whose bare name collides with
+    /// a same-named type in another namespace (#769), refuse to flatten/merge it:
+    /// preserve it verbatim as a §CSHARP interop block (a counted loss, so the file
+    /// is non-native) and return true. Returns false when there is no collision.
+    /// </summary>
+    private bool TryRefuseCrossNamespaceCollision(
+        MemberDeclarationSyntax node, string name, InteropMemberKind kind)
+    {
+        if (!_crossNamespaceCollisionNames.Contains(name))
+            return false;
+        if (node.Parent is not (BaseNamespaceDeclarationSyntax or CompilationUnitSyntax))
+            return false;
+
+        _context.RecordFeatureUsage("namespace");
+        _moduleInteropBlocks.Add(CreateInteropBlock(node, "namespace-collision", kind));
+        return true;
+    }
+
+    // ------------------------------------------------------------------
+    // #777 (WS-W4 D4): local-function hoist-fidelity refusal
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// True when a local function cannot survive the hoist-to-module-level lowering
+    /// without a silent divergence (#777). Generic local functions lose their type
+    /// parameters (identity loss — the hoist may still compile); capturing local
+    /// functions reference enclosing locals/parameters that do not exist at module
+    /// scope. Both must escalate the containing member to §CSHARP interop. A
+    /// non-generic, non-capturing local function round-trips faithfully and stays
+    /// native. Capture detection over-approximates (a false positive only sends more
+    /// to interop, never a wrong native), so a missed capture is still caught loudly
+    /// by the emitted-C# build break.
+    /// </summary>
+    private static bool LocalFunctionMustEscalate(LocalFunctionStatementSyntax fn)
+    {
+        if (fn.TypeParameterList is { Parameters.Count: > 0 })
+            return true;
+        return CapturesEnclosingLocals(fn);
+    }
+
+    private static bool CapturesEnclosingLocals(LocalFunctionStatementSyntax fn)
+    {
+        SyntaxNode? scope = (SyntaxNode?)fn.Body ?? fn.ExpressionBody;
+        if (scope == null)
+            return false;
+
+        // Names usable inside fn without capture: its own parameters and type
+        // parameters, plus everything declared within its own body.
+        var bound = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var p in fn.ParameterList.Parameters)
+            bound.Add(p.Identifier.ValueText);
+        if (fn.TypeParameterList != null)
+            foreach (var tp in fn.TypeParameterList.Parameters)
+                bound.Add(tp.Identifier.ValueText);
+        foreach (var d in scope.DescendantNodes())
+        {
+            switch (d)
+            {
+                case VariableDeclaratorSyntax vd: bound.Add(vd.Identifier.ValueText); break;
+                case SingleVariableDesignationSyntax sv: bound.Add(sv.Identifier.ValueText); break;
+                case ForEachStatementSyntax fe: bound.Add(fe.Identifier.ValueText); break;
+                case ParameterSyntax ps: bound.Add(ps.Identifier.ValueText); break;
+            }
+        }
+
+        var enclosing = CollectEnclosingLocalNames(fn);
+        if (enclosing.Count == 0)
+            return false;
+
+        foreach (var id in scope.DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            // Skip the member-name side of `x.Member` and named-argument labels —
+            // those are not variable references.
+            if (id.Parent is MemberAccessExpressionSyntax ma && ma.Name == id)
+                continue;
+            if (id.Parent is NameColonSyntax or NameEqualsSyntax)
+                continue;
+
+            var name = id.Identifier.ValueText;
+            if (bound.Contains(name))
+                continue;
+            if (enclosing.Contains(name))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Local names (parameters and locals) declared in the member enclosing
+    /// <paramref name="fn"/>, excluding anything declared inside fn itself. Sibling
+    /// local-function names are intentionally omitted: they hoist to module scope
+    /// too, so referencing one is not a capture.
+    /// </summary>
+    private static HashSet<string> CollectEnclosingLocalNames(LocalFunctionStatementSyntax fn)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        SyntaxNode? container = fn.Ancestors()
+            .FirstOrDefault(a => a is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax);
+        if (container == null)
+            return names;
+
+        switch (container)
+        {
+            case BaseMethodDeclarationSyntax bm when bm.ParameterList != null:
+                AddParameterNames(names, bm.ParameterList);
+                break;
+            case AccessorDeclarationSyntax:
+                names.Add("value"); // property/indexer set accessor implicit parameter
+                break;
+        }
+
+        foreach (var d in container.DescendantNodes())
+        {
+            if (fn.Span.Contains(d.Span))
+                continue; // declared inside fn — not a capture source
+
+            switch (d)
+            {
+                case VariableDeclaratorSyntax vd: names.Add(vd.Identifier.ValueText); break;
+                case SingleVariableDesignationSyntax sv: names.Add(sv.Identifier.ValueText); break;
+                case ForEachStatementSyntax fe: names.Add(fe.Identifier.ValueText); break;
+                case ParameterSyntax ps: names.Add(ps.Identifier.ValueText); break;
+            }
+        }
+        return names;
+    }
+
+    private static void AddParameterNames(HashSet<string> names, BaseParameterListSyntax list)
+    {
+        foreach (var p in list.Parameters)
+            names.Add(p.Identifier.ValueText);
+    }
+
     /// <summary>
     /// A single branch within a preprocessor region (#if, #elif, or #else).
     /// </summary>
@@ -3775,6 +3984,20 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
     private IReadOnlyList<StatementNode> ConvertBlock(BlockSyntax block)
     {
         var statements = new List<StatementNode>();
+
+        // #777 (WS-W4 D4): at each member-body boundary, scan the whole body up
+        // front for a generic or capturing local function. Either kind cannot be
+        // faithfully hoisted to module scope, so refuse — escalate the containing
+        // member to §CSHARP interop. Doing this before any statement is processed
+        // means no sibling local function is half-hoisted before the refusal.
+        if (block.Parent is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax)
+        {
+            foreach (var fn in block.DescendantNodes().OfType<LocalFunctionStatementSyntax>())
+            {
+                if (LocalFunctionMustEscalate(fn))
+                    throw EscalateExpression(fn, "local-function");
+            }
+        }
 
         // Extract preprocessor regions from trivia
         var ppRegions = ExtractPreprocessorRegions(block);

--- a/tests/Calor.Compiler.Tests/ConverterImprovementTests.cs
+++ b/tests/Calor.Compiler.Tests/ConverterImprovementTests.cs
@@ -1837,8 +1837,14 @@ public class ConverterImprovementTests
 
     #region Target-Typed New in Return/Arrow Contexts (InferTargetType Case 3)
 
+    // #777 (WS-W4 D4): a member containing a local function is preserved verbatim as
+    // §CSHARP interop — hoisting to a module-level §F function is unsound (the
+    // orphaned call site build-breaks, or silently rebinds to a same-named member).
+    // Target-typed-new inference on ordinary methods stays covered by the
+    // Migration_TargetTypedNew_InMethod*/_AsyncMethod tests below.
+
     [Fact]
-    public void Migration_TargetTypedNew_InLocalFunctionArrow_InfersReturnType()
+    public void Migration_LocalFunctionArrow_EscalatesToInterop()
     {
         var csharp = """
             public class Example
@@ -1854,17 +1860,13 @@ public class ConverterImprovementTests
         var result = _converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
-        // The local function is hoisted to a module-level §F function.
-        // The return expression should be a NewExpressionNode with type "str" (not "object").
-        var hoistedFunc = result.Ast!.Functions.FirstOrDefault(f => f.Name == "Local");
-        Assert.NotNull(hoistedFunc);
-        var ret = Assert.IsType<ReturnStatementNode>(hoistedFunc.Body[0]);
-        var newExpr = Assert.IsType<NewExpressionNode>(ret.Expression);
-        Assert.Equal("str", newExpr.TypeName);
+        Assert.DoesNotContain(result.Ast!.Functions, f => f.Name == "Local");
+        Assert.Contains(result.Context.Losses, l => l.Kind == ConversionLossKind.InteropPreserved);
+        Assert.Contains("§CSHARP", result.CalorSource!);
     }
 
     [Fact]
-    public void Migration_TargetTypedNew_InLocalFunctionReturnStatement_InfersReturnType()
+    public void Migration_LocalFunctionReturnStatement_EscalatesToInterop()
     {
         var csharp = """
             using System.Collections.Generic;
@@ -1884,11 +1886,9 @@ public class ConverterImprovementTests
         var result = _converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
-        var hoistedFunc = result.Ast!.Functions.FirstOrDefault(f => f.Name == "Local");
-        Assert.NotNull(hoistedFunc);
-        var ret = Assert.IsType<ReturnStatementNode>(hoistedFunc.Body[0]);
-        var newExpr = Assert.IsType<NewExpressionNode>(ret.Expression);
-        Assert.Equal("List<i32>", newExpr.TypeName);
+        Assert.DoesNotContain(result.Ast!.Functions, f => f.Name == "Local");
+        Assert.Contains(result.Context.Losses, l => l.Kind == ConversionLossKind.InteropPreserved);
+        Assert.Contains("§CSHARP", result.CalorSource!);
     }
 
     [Fact]
@@ -1941,7 +1941,7 @@ public class ConverterImprovementTests
     }
 
     [Fact]
-    public void Migration_TargetTypedNew_AsyncLocalFunction_UnwrapsTaskType()
+    public void Migration_AsyncLocalFunction_EscalatesToInterop()
     {
         var csharp = """
             using System.Collections.Generic;
@@ -1962,11 +1962,9 @@ public class ConverterImprovementTests
         var result = _converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
-        var hoistedFunc = result.Ast!.Functions.FirstOrDefault(f => f.Name == "LocalAsync");
-        Assert.NotNull(hoistedFunc);
-        var ret = Assert.IsType<ReturnStatementNode>(hoistedFunc.Body[0]);
-        var newExpr = Assert.IsType<NewExpressionNode>(ret.Expression);
-        Assert.Equal("List<i32>", newExpr.TypeName);
+        Assert.DoesNotContain(result.Ast!.Functions, f => f.Name == "LocalAsync");
+        Assert.Contains(result.Context.Losses, l => l.Kind == ConversionLossKind.InteropPreserved);
+        Assert.Contains("§CSHARP", result.CalorSource!);
     }
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/Mcp/ConvertToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/ConvertToolTests.cs
@@ -161,8 +161,11 @@ public class ConvertToolTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithLocalFunction_HoistsToModuleLevel()
+    public async Task ExecuteAsync_WithLocalFunction_EscalatesToInterop()
     {
+        // #777 (WS-W4 D4): a member containing a local function is preserved verbatim
+        // as interop rather than hoisted to a module-level function (the hoist orphans
+        // the call site — build break or silent rebind).
         var args = JsonDocument.Parse("""
             {
                 "source": "public class Example { public int Calculate(int x) { int Square(int n) => n * n; return Square(x); } }",
@@ -176,9 +179,9 @@ public class ConvertToolTests
         var text = result.Content[0].Text!;
         var json = JsonDocument.Parse(text);
         var calorSource = json.RootElement.GetProperty("calorSource").GetString()!;
-        Assert.Contains("\u00A7F{", calorSource);  // Hoisted to module-level §F function
+        Assert.Contains("\u00A7CSHARP", calorSource);   // member preserved as interop
         Assert.Contains("Square", calorSource);
-        Assert.DoesNotContain("localfunction", calorSource);
+        Assert.DoesNotContain("\u00A7F{", calorSource);  // NOT hoisted to a module-level function
     }
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/Migration/PostValidationFallbackTests.cs
+++ b/tests/Calor.Compiler.Tests/Migration/PostValidationFallbackTests.cs
@@ -70,28 +70,34 @@ public class PostValidationFallbackTests
     }
 
     [Fact]
-    public void CrossNamespaceSameNameCollision_DoesNotDuplicateTheHealthyType()
+    public void CrossNamespaceSameNameCollision_IsRefusedUpFront_NoDuplication()
     {
-        // Two distinct classes both named Foo in different namespaces: N1.Foo is
-        // "unparseable", N2.Foo is healthy. The ambiguous kind/name must NOT drag the
-        // healthy N2.Foo source into the interop block (which would emit it twice —
-        // CS0101 duplicate type). The ambiguous case is refused, so N2.Foo appears once.
+        // Two distinct classes both named Foo in different namespaces would flatten
+        // into one module and collapse to a single identity (#769 / WS-W4 D2). The
+        // converter now refuses that merge up front: BOTH are preserved verbatim as
+        // §CSHARP interop (one block each — no duplication, no CS0101), before the
+        // native conversion or the #717 post-validation rewrap is ever reached.
         const string src =
             "namespace N1 { public class Foo { public int A() => 1; } } " +
             "namespace N2 { public class Foo { public int B() => 2; } }";
-        var converter = new CSharpToCalorConverter(new ConversionOptions { PassthroughOnError = true })
-        {
-            // Condemn only the N1 variant (its body returns A()); N2 returns B().
-            ParseValidatorOverride = calor => !OutsideCSharp(calor).Contains("A"),
-        };
+        var converter = new CSharpToCalorConverter(new ConversionOptions { PassthroughOnError = true });
 
         var result = converter.Convert(src);
 
-        // Refused to rewrap (ambiguous) → no duplication. Under passthrough the still-
-        // unparseable output is surfaced as a failure, not silently shipped.
-        Assert.False(result.Success);
-        Assert.Equal(0, result.Context!.Stats.InteropBlocksEmitted);
-        Assert.True(result.HasWarnings);
+        Assert.True(result.Success, string.Join("; ", result.Issues.Select(i => i.Message)));
+        Assert.Equal(2, result.Context!.Stats.InteropBlocksEmitted);
+
+        // Each variant's body survives exactly once; neither is dragged into the
+        // other's block nor merged into a native class.
+        Assert.DoesNotContain("§CL", result.CalorSource!);
+        Assert.Single(Regex.Matches(result.CalorSource!, Regex.Escape("public int A() => 1;")));
+        Assert.Single(Regex.Matches(result.CalorSource!, Regex.Escape("public int B() => 2;")));
+
+        var collisionLosses = result.Context.Losses
+            .Where(l => l.Feature == "namespace-collision"
+                        && l.Kind == ConversionLossKind.InteropPreserved)
+            .ToList();
+        Assert.Equal(2, collisionLosses.Count);
     }
 
     [Fact]

--- a/tests/Calor.Conversion.Tests/WedgeW4SliceAStructuralTests.cs
+++ b/tests/Calor.Conversion.Tests/WedgeW4SliceAStructuralTests.cs
@@ -1,0 +1,342 @@
+using Calor.Compiler.Migration;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Calor.Conversion.Tests;
+
+/// <summary>
+/// WS-W4 Slice A (structural): the four structural SILENT→LOUD items from
+/// docs/plans/wedge-w4-prereqs.md §2 — #772 preprocessor, #769 namespace
+/// same-name merge, #775 records, #777 local functions.
+///
+/// The governing predicate (§1) trusts the eligibility predicate iff no silent
+/// semantic substitution survives *native* conversion (a region with
+/// LossCount == 0). Each test below proves a construct that WOULD have silently
+/// diverged now either (a) converts faithfully with runtime equivalence, or
+/// (b) escalates loudly to §CSHARP interop / a counted conversion loss (so the
+/// predicate excludes it).
+/// </summary>
+public class WedgeW4SliceAStructuralTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public WedgeW4SliceAStructuralTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private static ConversionResult Convert(string csharp, bool stripPreprocessor = false)
+    {
+        var converter = new CSharpToCalorConverter(new ConversionOptions
+        {
+            ModuleName = "W4SliceA",
+            GracefulFallback = true,
+            AutoGenerateIds = true,
+            StripPreprocessor = stripPreprocessor,
+        });
+        return converter.Convert(csharp, "W4SliceA.cs");
+    }
+
+    // ==================================================================
+    // D1 — #772 preprocessor / conditional-compilation
+    // ==================================================================
+    // The default pipeline strips conditional-compilation directives and keeps
+    // the first #if branch UNEVALUATED. That branch selection is not something
+    // the converter can evaluate deterministically, so it must be LOUD: each
+    // stripped conditional directive is recorded as a PreprocessorStripped loss,
+    // making the file non-native (LossCount > 0) → excluded by the predicate.
+
+    [Fact]
+    public void D1_Registry_Preprocessor_IsNotClaimedFull()
+    {
+        // Registry honesty: the false-green "preprocessor fully supported" claim
+        // is downgraded — conditional compilation is not faithfully preserved.
+        Assert.NotEqual(SupportLevel.Full, FeatureSupport.GetSupportLevel("preprocessor-directive"));
+    }
+
+    [Fact]
+    public void D1_DeadFirstBranch_IsRefusedLoudly_NotSilentlyPicked()
+    {
+        // The pathological case from #772: `#if false ... #else ... #endif` would
+        // silently convert DEAD code and discard LIVE code. It must not survive as
+        // a native (zero-loss) conversion.
+        var csharp = "#if false\n" +
+                     "public class A { public int X() => 1; }\n" +
+                     "#else\n" +
+                     "public class A { public int X() => 2; }\n" +
+                     "#endif\n";
+
+        var result = Convert(csharp, stripPreprocessor: true);
+        Assert.True(result.Success);
+
+        var ppLosses = result.Context.Losses
+            .Where(l => l.Kind == ConversionLossKind.PreprocessorStripped)
+            .ToList();
+        foreach (var l in ppLosses) _output.WriteLine(l.ToString());
+
+        // At least one conditional directive recorded as a loss → the file is
+        // non-native. The predicate's LossCount == 0 native gate excludes it, so
+        // the wrongly-picked branch never enters the measurement silently.
+        Assert.NotEmpty(ppLosses);
+        Assert.True(result.Context.Losses.Count > 0,
+            "Conditional compilation must make the file non-native (LossCount > 0).");
+    }
+
+    [Fact]
+    public void D1_NoConditionalCompilation_StaysNative()
+    {
+        // A file with no conditional compilation is unaffected — the honesty pass
+        // does not tax ordinary code.
+        var csharp = "public class Plain { public int X() => 42; }\n";
+        var result = Convert(csharp, stripPreprocessor: true);
+        Assert.True(result.Success);
+        Assert.DoesNotContain(result.Context.Losses,
+            l => l.Kind == ConversionLossKind.PreprocessorStripped);
+    }
+
+    // ==================================================================
+    // D2 — #769 namespace topology / same-name type merge
+    // ==================================================================
+
+    [Fact]
+    public void D2_Registry_Namespace_IsNotClaimedFull()
+    {
+        // Namespace topology is flattened; the registry must not claim faithful
+        // namespace preservation.
+        Assert.NotEqual(SupportLevel.Full, FeatureSupport.GetSupportLevel("namespace"));
+    }
+
+    [Fact]
+    public void D2_SameNameAcrossNamespaces_IsRefusedAsInterop_NotMerged()
+    {
+        // Two distinct `Foo` types in different namespaces would flatten into one
+        // module and collapse to a single identity — a silent merge that changes
+        // type identity. Both must be refused (preserved verbatim as §CSHARP).
+        var csharp = """
+            namespace A { public class Foo { public int V() => 1; } }
+            namespace B { public class Foo { public int V() => 2; } }
+            """;
+
+        var result = Convert(csharp);
+        Assert.True(result.Success);
+        _output.WriteLine(result.CalorSource);
+
+        var collisionLosses = result.Context.Losses
+            .Where(l => l.Feature == "namespace-collision"
+                        && l.Kind == ConversionLossKind.InteropPreserved)
+            .ToList();
+
+        // Both same-named types escalate to interop (a counted loss) → non-native.
+        Assert.Equal(2, collisionLosses.Count);
+        Assert.Contains("§CSHARP", result.CalorSource);
+        // The native merged shape (a Calor class definition) must be gone.
+        Assert.DoesNotContain("§CL{", result.CalorSource);
+    }
+
+    [Fact]
+    public void D2_UniqueNamesAcrossNamespaces_StayNative_AndRoundTrip()
+    {
+        // Flattening carries no identity-merge risk when the bare names are unique,
+        // so these may remain native — and must round-trip to compilable C#.
+        var csharp = """
+            namespace A { public class Foo { public int V() => 1; } }
+            namespace B { public class Bar { public int V() => 2; } }
+            """;
+
+        var result = Convert(csharp);
+        Assert.True(result.Success);
+        Assert.DoesNotContain(result.Context.Losses,
+            l => l.Feature == "namespace-collision");
+        Assert.Empty(result.Context.Losses);
+
+        var roundTrip = TestHelpers.FullRoundTrip(csharp, "W4SliceA");
+        Assert.True(roundTrip.RoslynSuccess,
+            "Unique cross-namespace types kept native must round-trip to compilable C#:\n"
+            + string.Join("\n", roundTrip.RoslynErrors));
+    }
+
+    [Fact]
+    public void D2_SameNameInSingleNamespacePartial_IsNotACollision()
+    {
+        // Two partial declarations of one type in the SAME namespace are a
+        // legitimate merge, not a cross-namespace collision — they stay native.
+        var csharp = """
+            namespace A
+            {
+                public partial class Foo { public int X() => 1; }
+                public partial class Foo { public int Y() => 2; }
+            }
+            """;
+
+        var result = Convert(csharp);
+        Assert.True(result.Success);
+        Assert.DoesNotContain(result.Context.Losses,
+            l => l.Feature == "namespace-collision");
+    }
+
+    // ==================================================================
+    // D3 — #775 records: containment + registry honesty
+    // ==================================================================
+
+    [Fact]
+    public void D3_Registry_Record_IsNotClaimedFull()
+    {
+        Assert.NotEqual(SupportLevel.Full, FeatureSupport.GetSupportLevel("record"));
+    }
+
+    [Fact]
+    public void D3_RecordWithValueSemantics_IsPreservedAsInterop()
+    {
+        // A record whose behaviour is exercised through the synthesized value
+        // semantics (with-expression, value equality) must not silently degrade
+        // to a sealed class with reference semantics — it is preserved verbatim.
+        var csharp = """
+            public record Money(decimal Amount, string Currency);
+
+            public static class Bank
+            {
+                public static Money Bump(Money m) => m with { Amount = m.Amount + 1 };
+                public static bool Same(Money a, Money b) => a == b;
+            }
+            """;
+
+        var result = Convert(csharp);
+        Assert.True(result.Success);
+        _output.WriteLine(result.CalorSource);
+
+        var recordLoss = Assert.Single(
+            result.Context.Losses.Where(l => l.Feature == "record"));
+        Assert.Equal(ConversionLossKind.InteropPreserved, recordLoss.Kind);
+        Assert.Contains("§CSHARP", result.CalorSource);
+        Assert.Contains("record Money", result.CalorSource);
+    }
+
+    // ==================================================================
+    // D4 — #777 local functions: containment + registry honesty
+    // ==================================================================
+
+    [Fact]
+    public void D4_Registry_LocalFunction_IsNotClaimedFull()
+    {
+        Assert.NotEqual(SupportLevel.Full, FeatureSupport.GetSupportLevel("local-function"));
+    }
+
+    [Fact]
+    public void D4_GenericLocalFunction_EscalatesContainingMemberToInterop()
+    {
+        // A generic local function loses its type parameters when hoisted to
+        // module scope (silent identity loss). The containing member must escalate
+        // to §CSHARP interop.
+        var csharp = """
+            public class C
+            {
+                public int M()
+                {
+                    T Id<T>(T x) => x;
+                    return Id<int>(3);
+                }
+            }
+            """;
+
+        var result = Convert(csharp);
+        Assert.True(result.Success);
+        _output.WriteLine(result.CalorSource);
+
+        Assert.Contains(result.Context.Losses,
+            l => l.Kind == ConversionLossKind.InteropPreserved);
+        Assert.Contains("§CSHARP", result.CalorSource);
+        Assert.Contains("Id<T>", result.CalorSource);
+        // Not silently hoisted as a native module function.
+        Assert.DoesNotContain(result.Ast!.Functions, f => f.Name == "Id");
+    }
+
+    [Fact]
+    public void D4_CapturingLocalFunction_EscalatesContainingMemberToInterop()
+    {
+        // A local function that captures an enclosing local/parameter references a
+        // name that does not exist at module scope after hoisting. Escalate loudly.
+        var csharp = """
+            public class E
+            {
+                public int M(int seed)
+                {
+                    int Get() => seed + 1;
+                    return Get();
+                }
+            }
+            """;
+
+        var result = Convert(csharp);
+        Assert.True(result.Success);
+        _output.WriteLine(result.CalorSource);
+
+        Assert.Contains(result.Context.Losses,
+            l => l.Kind == ConversionLossKind.InteropPreserved);
+        Assert.Contains("§CSHARP", result.CalorSource);
+        Assert.DoesNotContain(result.Ast!.Functions, f => f.Name == "Get");
+    }
+
+    [Fact]
+    public void D4_PlainLocalFunction_IsNotEscalatedToInterop_ButBuildBreakIsTheLoudBackstop()
+    {
+        // A non-generic, non-capturing local function is left on the native hoist
+        // path (NOT escalated to interop) — distinguishing it from the generic and
+        // capturing cases above.
+        var csharp = """
+            public class D
+            {
+                public int M()
+                {
+                    int Add(int a, int b) => a + b;
+                    return Add(1, 2);
+                }
+            }
+            """;
+
+        var result = Convert(csharp);
+        Assert.True(result.Success);
+        Assert.DoesNotContain("§CSHARP", result.CalorSource);
+        Assert.DoesNotContain(result.Context.Losses,
+            l => l.Kind == ConversionLossKind.InteropPreserved);
+        Assert.Contains(result.Ast!.Functions, f => f.Name == "Add");
+
+        // The hoist relocates the function to the module's static class while the
+        // call site stays in the original class, so the emitted C# does NOT resolve
+        // the call (CS0103). That build break is the LOUD backstop: the file is
+        // non-native (reverted), never a silent substitution. If a future emitter
+        // change makes the hoist faithfully round-trip, this becomes true-native
+        // (an improvement) and this assertion should be revisited.
+        var roundTrip = TestHelpers.FullRoundTrip(csharp, "W4SliceA");
+        Assert.False(roundTrip.RoslynSuccess,
+            "Expected the hoisted-call-site build break to keep plain local functions "
+            + "loudly non-native; if the hoist became faithful, update this test.");
+    }
+
+    [Fact]
+    public void D4_RecursiveNonCapturingLocalFunction_IsNotEscalatedToInterop()
+    {
+        // Self-recursion is not a capture (the function's own name is not an
+        // enclosing local) — the capture detector must not misfire on it, so it
+        // stays on the native hoist path rather than escalating to interop.
+        var csharp = """
+            public class F
+            {
+                public int M(int n)
+                {
+                    int Fac(int k)
+                    {
+                        if (k <= 1) return 1;
+                        return k * Fac(k - 1);
+                    }
+                    return Fac(n);
+                }
+            }
+            """;
+
+        var result = Convert(csharp);
+        Assert.True(result.Success);
+        Assert.DoesNotContain(result.Context.Losses,
+            l => l.Kind == ConversionLossKind.InteropPreserved);
+        Assert.Contains(result.Ast!.Functions, f => f.Name == "Fac");
+    }
+}

--- a/tests/Calor.Conversion.Tests/WedgeW4SliceAStructuralTests.cs
+++ b/tests/Calor.Conversion.Tests/WedgeW4SliceAStructuralTests.cs
@@ -156,6 +156,28 @@ public class WedgeW4SliceAStructuralTests
     }
 
     [Fact]
+    public void D2_SameNameDifferentArity_StaysNative_AndRoundTrips()
+    {
+        // `A.Foo` (arity 0) and `B.Foo<T>` (arity 1) are distinct types that coexist
+        // fine — different generic arity means no identity merge. The collision key
+        // includes arity, so these must NOT be refused; they stay native.
+        var csharp = """
+            namespace A { public class Foo { public int V() => 1; } }
+            namespace B { public class Foo<T> { public T V(T x) => x; } }
+            """;
+
+        var result = Convert(csharp);
+        Assert.True(result.Success);
+        Assert.DoesNotContain(result.Context.Losses,
+            l => l.Feature == "namespace-collision");
+
+        var roundTrip = TestHelpers.FullRoundTrip(csharp, "W4SliceA");
+        Assert.True(roundTrip.RoslynSuccess,
+            "Same-name-different-arity cross-namespace types must stay native and compile:\n"
+            + string.Join("\n", roundTrip.RoslynErrors));
+    }
+
+    [Fact]
     public void D2_SameNameInSingleNamespacePartial_IsNotACollision()
     {
         // Two partial declarations of one type in the SAME namespace are a
@@ -276,12 +298,34 @@ public class WedgeW4SliceAStructuralTests
         Assert.DoesNotContain(result.Ast!.Functions, f => f.Name == "Get");
     }
 
-    [Fact]
-    public void D4_PlainLocalFunction_IsNotEscalatedToInterop_ButBuildBreakIsTheLoudBackstop()
+    // A member containing ANY local function escalates to §CSHARP interop. The
+    // hoist-to-module lowering is unsound in both directions: its happy path
+    // (no same-named member) build-breaks (the call site is orphaned from the
+    // hoisted function → CS0103), and when a same-named member DOES exist the
+    // orphaned call silently rebinds to it and compiles clean (LossCount==0, wrong
+    // behaviour) — the §1 predicate-trust blocker. Escalate-all makes every
+    // outcome honest interop; no correct native coverage is lost.
+
+    private static void AssertLocalFunctionEscalated(ConversionResult result, string localName)
     {
-        // A non-generic, non-capturing local function is left on the native hoist
-        // path (NOT escalated to interop) — distinguishing it from the generic and
-        // capturing cases above.
+        Assert.True(result.Success, string.Join("; ", result.Issues.Select(i => i.Message)));
+        // Non-native: the whole containing member is preserved verbatim as raw C#
+        // (a counted interop loss). The loss is labelled by the member kind; the
+        // escalation is attributed to the local function in the conversion issues.
+        Assert.Contains(result.Context.Losses,
+            l => l.Kind == ConversionLossKind.InteropPreserved);
+        Assert.Contains(result.Issues, i => i.Feature == "local-function");
+        Assert.Contains("§CSHARP", result.CalorSource);
+        // Never hoisted as a native module function.
+        Assert.DoesNotContain(result.Ast!.Functions, f => f.Name == localName);
+    }
+
+    [Fact]
+    public void D4_PlainLocalFunction_EscalatesToInterop()
+    {
+        // Even a plain non-generic, non-capturing local function escalates: the
+        // hoist's own happy path build-breaks (orphaned call site), so there is no
+        // correct native conversion to preserve.
         var csharp = """
             public class D
             {
@@ -293,31 +337,12 @@ public class WedgeW4SliceAStructuralTests
             }
             """;
 
-        var result = Convert(csharp);
-        Assert.True(result.Success);
-        Assert.DoesNotContain("§CSHARP", result.CalorSource);
-        Assert.DoesNotContain(result.Context.Losses,
-            l => l.Kind == ConversionLossKind.InteropPreserved);
-        Assert.Contains(result.Ast!.Functions, f => f.Name == "Add");
-
-        // The hoist relocates the function to the module's static class while the
-        // call site stays in the original class, so the emitted C# does NOT resolve
-        // the call (CS0103). That build break is the LOUD backstop: the file is
-        // non-native (reverted), never a silent substitution. If a future emitter
-        // change makes the hoist faithfully round-trip, this becomes true-native
-        // (an improvement) and this assertion should be revisited.
-        var roundTrip = TestHelpers.FullRoundTrip(csharp, "W4SliceA");
-        Assert.False(roundTrip.RoslynSuccess,
-            "Expected the hoisted-call-site build break to keep plain local functions "
-            + "loudly non-native; if the hoist became faithful, update this test.");
+        AssertLocalFunctionEscalated(Convert(csharp), "Add");
     }
 
     [Fact]
-    public void D4_RecursiveNonCapturingLocalFunction_IsNotEscalatedToInterop()
+    public void D4_RecursiveLocalFunction_EscalatesToInterop()
     {
-        // Self-recursion is not a capture (the function's own name is not an
-        // enclosing local) — the capture detector must not misfire on it, so it
-        // stays on the native hoist path rather than escalating to interop.
         var csharp = """
             public class F
             {
@@ -333,10 +358,68 @@ public class WedgeW4SliceAStructuralTests
             }
             """;
 
-        var result = Convert(csharp);
-        Assert.True(result.Success);
-        Assert.DoesNotContain(result.Context.Losses,
-            l => l.Kind == ConversionLossKind.InteropPreserved);
-        Assert.Contains(result.Ast!.Functions, f => f.Name == "Fac");
+        AssertLocalFunctionEscalated(Convert(csharp), "Fac");
+    }
+
+    [Fact]
+    public void D4_C1_LocalShadowsSameClassMethod_EscalatesToInterop_NotSilentRebind()
+    {
+        // C-1: the class has both `int Foo() => 999` and a local `int Foo() => 1`.
+        // The source M() returns 1; a naive hoist would orphan the call and silently
+        // rebind it to the class method (round-trip M() == 999) — a silent
+        // substitution with zero recorded losses. Escalate-all refuses it loudly.
+        var csharp = """
+            public class C
+            {
+                public int Foo() => 999;
+                public int M()
+                {
+                    int Foo() => 1;
+                    return Foo();
+                }
+            }
+            """;
+
+        AssertLocalFunctionEscalated(Convert(csharp), "Foo");
+    }
+
+    [Fact]
+    public void D4_C2_LocalShadowsInheritedMethod_EscalatesToInterop_NotSilentRebind()
+    {
+        // C-2: the local `Foo` shadows an INHERITED Base.Foo(). A hoist would orphan
+        // the call and it would rebind to the base method — silent.
+        var csharp = """
+            public class Base { public int Foo() => 999; }
+            public class Derived : Base
+            {
+                public int M()
+                {
+                    int Foo() => 1;
+                    return Foo();
+                }
+            }
+            """;
+
+        AssertLocalFunctionEscalated(Convert(csharp), "Foo");
+    }
+
+    [Fact]
+    public void D4_C3_LocalShadowsClassOverload_EscalatesToInterop_NotSilentRebind()
+    {
+        // C-3: the local `Foo(int)` shadows a class overload `Foo(int)`. A hoist
+        // would orphan the call and rebind to the class overload — silent.
+        var csharp = """
+            public class C
+            {
+                public int Foo(int x) => 999;
+                public int M()
+                {
+                    int Foo(int x) => x;
+                    return Foo(1);
+                }
+            }
+            """;
+
+        AssertLocalFunctionEscalated(Convert(csharp), "Foo");
     }
 }


### PR DESCRIPTION
The structural half of WS-W4 Slice A (conversion-honesty prerequisite). Governing principle (merged kickoff #843 §1): no silent substitution may survive *native* conversion — unfaithful conversions must be LOUD (interop loss / build-break) so the eligibility predicate excludes them. Empirical probing found D1/D3 were already loud from #770/#773; the new work is D2 and D4.

## Deliverables
- **D1 — #772 preprocessor (already loud; pinned).** The default pipeline records a `PreprocessorStripped` loss for every `#if`/`#elif`/`#else` → non-native. Verified the `#if false…#else…` dead/live swap is non-native. Registry already honestly `Partial`. Added 3 pins.
- **D2 — #769 same-name namespace merge (NEW loud refusal).** `ScanCrossNamespaceCollisions` (full namespace path) + `TryRefuseCrossNamespaceCollision` in class/struct/interface/enum/delegate visitors: two top-level types sharing a bare name across ≥2 namespaces both escalate to `§CSHARP` interop (`namespace-collision` loss) instead of silently flattening to one identity. Unique-name flattening stays native (round-trip verified); same-name partials in one namespace remain a legitimate merge. Registry `namespace` = Partial.
- **D3 — #775 records (already loud; pinned).** Records escalate verbatim to interop (`record` loss; registry `NotSupported`). Added a `with`/`==` value-semantics regression pin.
- **D4 — #777 local functions (NEW loud refusal).** Generic or capturing local functions escalate the containing member to interop, detected at the member-body boundary in `ConvertBlock` before any hoist (no half-hoist duplication). Capture detection over-approximates (false positive → extra interop, never a wrong native). Non-generic non-capturing local functions (incl. recursion) stay on the hoist path. Registry `local-function` = Partial.

## Honest channel
No new `Calor####` codes — the converter's honest channel is the structured loss ledger (`InteropPreserved` losses tagged `namespace-collision`/`record`/`local-function`/`generic-delegate`) which the predicate counts.

## Flagged gaps (see PR discussion for the load-bearing one)
1. **Plain local functions are hoisted to a module static class while the call site stays in the origin class → CS0103 build-break at round-trip** (LOUD → revert → non-native, per the agent). **This PR's review must verify this is ALWAYS loud and cannot silently rebind** to a same-named origin-class member. Pre-existing emitter limitation; faithful fix (emit real C# local functions) is a larger out-of-scope emitter change.
2. Instance/`this`/field capture stays native and build-breaks (loud, per task acceptance).
3. Top-level-statement local functions bypass the member-body scan (narrow — the pinned OSS corpus are libraries).
4. D1 standalone `#nullable`/`#pragma`/etc. deleted without a loss (deferred; non-runtime-semantic; active `#error` excluded by baseline-green).
5. D2 unique-name flattening changes fully-qualified identity (task-permitted; registry no longer claims faithful namespace preservation).

## Tests
Full suite green (13 projects; Conversion 364, Compiler 6148, Verification 347, Enforcement 301, …); Release 0 warnings; self-check docs no drift. One pre-existing cross-namespace-collision test updated to the new cleaner behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)