### PR TITLE
ci: exempt round-trip/real-scale benchmark harness from calor-first guard

### DIFF
--- a/scripts/check-calor-first-diff.sh
+++ b/scripts/check-calor-first-diff.sh
@@ -95,6 +95,20 @@ is_bench_source() {
   [[ "$1" == bench/* ]]
 }
 
+is_harness_source() {
+  # The round-trip / real-scale benchmark harness is benchmark SUPPORT, not
+  # product source — identical rationale to is_bench_source. It measures the
+  # converter (mines corpus history, drives `dotnet test`, manipulates Roslyn),
+  # which cannot be authored in Calor, and NOTHING under it ships in the
+  # product (verified: no src/ project references Calor.RoundTrip.Harness). The
+  # pre-existing harness .cs only ever passed via the exists_in_base grandfather;
+  # exempt the tree structurally (wedge plan v0.11 WS-W4 Slice C — the task-gen
+  # machinery under TaskGen/) so authoring new harness support never needs an
+  # allowlist entry. Scoped to this one tool tree, not tools/ at large — other
+  # tools/ product code stays fully governed.
+  [[ "$1" == tools/Calor.RoundTrip.Harness/* ]]
+}
+
 violations=()
 for path in "${changed[@]}"; do
   [[ "$path" == *.cs ]] || continue
@@ -103,6 +117,7 @@ for path in "${changed[@]}"; do
   exists_in_base "$path" && continue
   is_test_source "$path" && continue
   is_bench_source "$path" && continue
+  is_harness_source "$path" && continue
   is_base_allowlisted "$path" && continue
   [[ -f "$path" ]] || continue
   violations+=("$path")


### PR DESCRIPTION
Extends the calor-first guard's existing structural exemptions (`tests/`, `bench/`) to the round-trip / real-scale benchmark harness tree `tools/Calor.RoundTrip.Harness/`.

## Why
The guard already exempts `bench/` as non-shipping benchmark support ("nothing under bench/ ships in the product"). The round-trip harness is the same kind of thing — it *measures* the converter (mines corpus git history, drives `dotnet test`, manipulates Roslyn), cannot be authored in Calor, and **does not ship** (verified: no `src/` project references `Calor.RoundTrip.Harness`). Its pre-existing `.cs` only ever passed the guard via the `exists_in_base` grandfather.

WS-W4 Slice C (#849) adds task-generation machinery under `tools/Calor.RoundTrip.Harness/TaskGen/`. Without this, each of those ~13 files — and every future harness file in Slices D/E — would need an allowlist entry, despite the allowlist being explicitly for *compiler-internal surfaces that cannot be authored in Calor* (the wrong bucket for benchmark tooling).

## Scope / safety
- Scoped to **exactly one tool tree** (`tools/Calor.RoundTrip.Harness/*`), not `tools/` at large — all other `tools/` product code stays fully governed.
- Mirrors `is_bench_source` precedent and rationale exactly.
- **Landed as its own PR before Slice C** so that PR does not self-exempt (respecting the guard's anti-self-exemption discipline).

No allowlist change; no product-code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)