### PR TITLE
feat: WS-W4 — complete the gold-standard bug-fix-revert task source

### DIFF
--- a/tests/Calor.RoundTrip.Harness.Tests/TaskGenGateTests.cs
+++ b/tests/Calor.RoundTrip.Harness.Tests/TaskGenGateTests.cs
@@ -98,6 +98,20 @@ public class TaskGenGateTests
         Assert.Equal(1.0 / 9.0, acc.EligibilityRate, 3);
     }
 
+    [Fact]
+    public void ExclusionAccounting_CountsRevertSupplyExclusions()
+    {
+        var acc = new ExclusionAccounting();
+        acc.Record(Disp(false, ExclusionReason.MultipleSourceFiles));
+        acc.Record(Disp(false, ExclusionReason.InseparableRevert));
+        acc.Record(Disp(false, ExclusionReason.InseparableRevert));
+
+        Assert.Equal(1, acc.ExcludedMultipleSourceFiles);
+        Assert.Equal(2, acc.ExcludedInseparableRevert);
+        Assert.Equal(0, acc.Eligible);
+        Assert.Equal(3, acc.Considered);
+    }
+
     private static CandidateDisposition Disp(bool eligible, ExclusionReason reason) => new()
     {
         ProjectName = "P",

--- a/tests/Calor.RoundTrip.Harness.Tests/TaskGenMinerTests.cs
+++ b/tests/Calor.RoundTrip.Harness.Tests/TaskGenMinerTests.cs
@@ -65,11 +65,16 @@ public class TaskGenMinerTests
     }
 
     [Fact]
-    public void GitLogArgs_ScopesToLibrarySource()
+    public void GitLogArgs_SurfacesFullNameStatus_NotPathspecRestricted()
     {
-        var args = BugfixMiner.GitLogArgs("src/MediatR", 200);
+        // Pathspec-fix regression pin: the log MUST NOT be pathspec-restricted to the library source,
+        // or --name-status never lists test files and SelectRevertCandidates (which requires a covering
+        // test) can never fire — the 0-live-tasks bug. Classification into source/test is the parser's job.
+        var args = BugfixMiner.GitLogArgs(200);
         Assert.Contains("--name-status", args);
         Assert.Contains("--no-merges", args);
-        Assert.Contains("-- \"src/MediatR\"", args);
+        Assert.Contains("-n 200", args);
+        Assert.DoesNotContain("-- \"", args);        // no pathspec restriction
+        Assert.DoesNotContain("src/", args);
     }
 }

--- a/tests/Calor.RoundTrip.Harness.Tests/TaskGenMinerTests.cs
+++ b/tests/Calor.RoundTrip.Harness.Tests/TaskGenMinerTests.cs
@@ -15,9 +15,17 @@ public class TaskGenMinerTests
     [InlineData("fixes #1234 incorrect boundary", true)]
     [InlineData("Bug: null reference in validator", true)]
     [InlineData("Correct wrong comparison operator", true)]
+    [InlineData("Fix boundary error (#42)", true)]              // fix-word WITH a PR ref is still a fix
     [InlineData("Add new feature for logging", false)]
     [InlineData("Refactor internal API", false)]
     [InlineData("Merge branch 'main' into dev", false)]
+    // A bare (#NNNN) / GH-NNNN reference is NOT fix-evidence: GitHub squash-merges append it to EVERY
+    // PR subject, so these feature-adds/refactors must NOT be classified as fixes (honesty pin — a
+    // bare number would grossly overstate the gold-standard bug-fix supply).
+    [InlineData("Inline TraceId and SpanId JSON string formatting (#2215)", false)]
+    [InlineData("Property factory as AddPropertyIfAbsent parameter (#2149)", false)]
+    [InlineData("Add `LevelAlias.Off` (#1910)", false)]
+    [InlineData("Update dependencies GH-77", false)]
     [InlineData("", false)]
     public void IsFixShaped_Heuristic(string subject, bool expected)
         => Assert.Equal(expected, BugfixMiner.IsFixShaped(subject));

--- a/tests/Calor.RoundTrip.Harness.Tests/TaskGenRevertTests.cs
+++ b/tests/Calor.RoundTrip.Harness.Tests/TaskGenRevertTests.cs
@@ -1,0 +1,261 @@
+using System.Diagnostics;
+using System.Text;
+using Calor.RoundTrip.Harness.TaskGen;
+using Xunit;
+
+namespace Calor.RoundTrip.Harness.Tests;
+
+/// <summary>
+/// Exercises the live bug-fix miner and the source-hunk-only revert against SYNTHETIC git fixtures
+/// (a throwaway repo built per test) — no corpus submodule required. Covers the pathspec fix (test
+/// files now surface in <c>--name-status</c> so <see cref="BugfixMiner.SelectRevertCandidates"/> fires)
+/// and the critical correctness property: reverting a fix reintroduces the defect in the LIBRARY
+/// SOURCE while the covering TEST is kept at its fixed state (never whole-commit-reverted).
+/// </summary>
+public sealed class TaskGenRevertTests : IDisposable
+{
+    private readonly string _repo;
+    private const string Prefix = "src/Lib";
+
+    public TaskGenRevertTests()
+    {
+        _repo = Path.Combine(Path.GetTempPath(), $"calor-miner-fixture-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_repo);
+        Git("init -q");
+        Git("config user.email test@calor.dev");
+        Git("config user.name calor-test");
+        Git("config commit.gpgsign false");
+        Git("config core.autocrlf false");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_repo, recursive: true); } catch { /* best effort */ }
+    }
+
+    // ---- Pathspec fix: test files now surface, so revert candidates can be selected ----
+
+    [Fact]
+    public void MineFixCommits_SurfacesTestFiles_SoRevertCandidatesFire()
+    {
+        SeedInitial();
+        CommitFix(); // fixes src AND touches the covering test
+
+        var fixCommits = BugfixMiner.MineFixCommits(_repo, Prefix, 50);
+        var candidates = BugfixMiner.SelectRevertCandidates(fixCommits);
+
+        var fix = Assert.Single(candidates);
+        Assert.Equal("src/Lib/Calc.cs", Assert.Single(fix.SourceFiles));
+        // The pathspec-fix payoff: the covering test is now visible (was ALWAYS empty under the old
+        // pathspec-restricted log), so SelectRevertCandidates (source>0 AND test>0) can fire at all.
+        Assert.NotEmpty(fix.TestFiles);
+        Assert.Contains("test/Lib.Tests/CalcTests.cs", fix.TestFiles);
+    }
+
+    // ---- Source-hunk-only revert: clean case reintroduces the defect in source, keeps the test ----
+
+    [Fact]
+    public void TryBuildRevertCandidate_ReintroducesDefectInSource_KeepsTest()
+    {
+        SeedInitial();
+        CommitFix();
+
+        var commit = Assert.Single(BugfixMiner.SelectRevertCandidates(BugfixMiner.MineFixCommits(_repo, Prefix, 50)));
+        var result = BugfixMiner.TryBuildRevertCandidate(_repo, commit);
+
+        Assert.True(result.Succeeded);
+        var cand = result.Candidate!;
+        Assert.Equal(MutationSource.RevertBugfix, cand.Source);
+        Assert.Equal("src/Lib/Calc.cs", cand.FileRelPath);
+        Assert.False(BugfixMiner.IsTestPath(cand.FileRelPath)); // the reverted file is SOURCE, never the test
+        Assert.Equal(commit.Sha, cand.RevertedCommit);
+
+        // Defect reintroduced: the reverted source carries the pre-fix (defective) comparison, not the fix.
+        Assert.Contains("x < 10", cand.MutatedSource);
+        Assert.DoesNotContain("x <= 10", cand.MutatedSource);
+
+        // Correctness pivot: a WHOLE-COMMIT revert would also delete the covering test (the fix added it),
+        // destroying the oracle. Prove the hazard is real AND that our candidate avoids it: the pre-fix
+        // test differs from the fixed test (so a whole-commit revert loses coverage), yet our candidate's
+        // mutated payload is the SOURCE file only — the generator keeps the test at its fixed state.
+        var preFixTest = Show($"{commit.Sha}^:test/Lib.Tests/CalcTests.cs");
+        var fixedTest = Show($"{commit.Sha}:test/Lib.Tests/CalcTests.cs");
+        Assert.NotEqual(preFixTest, fixedTest); // the fix added covering-test content
+        Assert.DoesNotContain("Boundary", cand.MutatedSource); // the test's covering method is NOT in the source payload
+    }
+
+    // ---- Far-away later change: still cleanly reverts via 3-way (permissive) ----
+
+    [Fact]
+    public void TryBuildRevertCandidate_LaterUnrelatedChange_StillRevertsCleanly()
+    {
+        SeedInitial();
+        CommitFix();
+        // A later commit edits a DIFFERENT method far from the fix — must not block the revert.
+        Write("src/Lib/Calc.cs", CalcSource(fixComparison: true, extraMethodReturns: 999));
+        CommitAll("tune Helper return value");
+
+        var commit = FixCommit();
+        var result = BugfixMiner.TryBuildRevertCandidate(_repo, commit);
+
+        Assert.True(result.Succeeded);
+        Assert.Contains("x < 10", result.Candidate!.MutatedSource);   // defect reintroduced
+        Assert.Contains("Helper() => 999", result.Candidate!.MutatedSource); // later unrelated change preserved
+    }
+
+    // ---- Adjacent later change on the same line: inseparable → excluded (counted + disclosed) ----
+
+    [Fact]
+    public void TryBuildRevertCandidate_LaterChangeOnFixedLine_ExcludedInseparable()
+    {
+        SeedInitial();
+        CommitFix();
+        // A later commit rewrites the very line the fix touched → reverse-apply must conflict.
+        Write("src/Lib/Calc.cs", CalcSource(fixComparison: true).Replace("x <= 10", "x <= 25"));
+        CommitAll("bump threshold to 25");
+
+        var commit = FixCommit();
+        var result = BugfixMiner.TryBuildRevertCandidate(_repo, commit);
+
+        Assert.False(result.Succeeded);
+        Assert.Null(result.Candidate);
+        Assert.Equal(ExclusionReason.InseparableRevert, result.Exclusion);
+    }
+
+    // ---- CRLF source files: patch must stay byte-exact or every revert spuriously "inseparable" ----
+
+    [Fact]
+    public void TryBuildRevertCandidate_CrlfSource_RevertsCleanly()
+    {
+        // Regression pin: a project with Windows line endings (e.g. FluentValidation) produces a CRLF
+        // `git show` patch. If the git wrapper normalizes CRLF→LF, the patch stops context-matching the
+        // CRLF worktree and EVERY revert is falsely reported inseparable. Store CRLF and require success.
+        Write("src/Lib/Calc.cs", CalcSource(fixComparison: false).Replace("\n", "\r\n"));
+        Write("test/Lib.Tests/CalcTests.cs", TestSource(withBoundary: false).Replace("\n", "\r\n"));
+        CommitAll("initial");
+        Write("src/Lib/Calc.cs", CalcSource(fixComparison: true).Replace("\n", "\r\n"));
+        Write("test/Lib.Tests/CalcTests.cs", TestSource(withBoundary: true).Replace("\n", "\r\n"));
+        CommitAll("Fix off-by-one boundary in Classify #42");
+
+        var commit = FixCommit();
+        var result = BugfixMiner.TryBuildRevertCandidate(_repo, commit);
+
+        Assert.True(result.Succeeded);
+        Assert.Contains("x < 10", result.Candidate!.MutatedSource);   // defect reintroduced
+        Assert.Contains("\r\n", result.Candidate!.MutatedSource);      // CRLF preserved end-to-end
+    }
+
+    // ---- Multi-source-file fix: excluded (single-file predicate scope), disclosed ----
+
+    [Fact]
+    public void TryBuildRevertCandidate_MultipleSourceFiles_ExcludedAndDisclosed()
+    {
+        SeedInitial();
+        Write("src/Lib/Other.cs", "namespace Lib; public static class Other { public static int V() => 1; }\n");
+        CommitAll("add Other");
+        // A fix touching TWO source files plus a test.
+        Write("src/Lib/Calc.cs", CalcSource(fixComparison: true));
+        Write("src/Lib/Other.cs", "namespace Lib; public static class Other { public static int V() => 2; }\n");
+        Write("test/Lib.Tests/CalcTests.cs", TestSource(withBoundary: true));
+        CommitAll("Fix off-by-one and Other #7");
+
+        var commit = Assert.Single(BugfixMiner.SelectRevertCandidates(BugfixMiner.MineFixCommits(_repo, Prefix, 50)));
+        Assert.Equal(2, commit.SourceFiles.Count);
+        var result = BugfixMiner.TryBuildRevertCandidate(_repo, commit);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(ExclusionReason.MultipleSourceFiles, result.Exclusion);
+        Assert.NotNull(result.ExclusionDetail);
+    }
+
+    // ---------- fixture helpers ----------
+
+    private void SeedInitial()
+    {
+        Write("src/Lib/Calc.cs", CalcSource(fixComparison: false)); // pre-fix defect: x < 10
+        Write("test/Lib.Tests/CalcTests.cs", TestSource(withBoundary: false));
+        CommitAll("initial");
+    }
+
+    /// <summary>The bug-fix commit: corrects the boundary in source AND adds the covering test.</summary>
+    private void CommitFix()
+    {
+        Write("src/Lib/Calc.cs", CalcSource(fixComparison: true));   // fixed: x <= 10
+        Write("test/Lib.Tests/CalcTests.cs", TestSource(withBoundary: true)); // adds Boundary() covering test
+        CommitAll("Fix off-by-one boundary in Classify #42");
+    }
+
+    private FixCommit FixCommit() =>
+        Assert.Single(BugfixMiner.SelectRevertCandidates(BugfixMiner.MineFixCommits(_repo, Prefix, 50)));
+
+    private static string CalcSource(bool fixComparison, int extraMethodReturns = 1)
+    {
+        var cmp = fixComparison ? "x <= 10" : "x < 10";
+        // Classify (the fix site) and Helper (the far-away later-change site) are separated by ample
+        // filler so an edit to one is well outside the other's diff context (>3 lines) — a genuine
+        // far-away change that the 3-way reverse-apply must preserve.
+        var sb = new StringBuilder();
+        sb.Append("namespace Lib;\n");
+        sb.Append("public static class Calc\n");
+        sb.Append("{\n");
+        sb.Append($"    public static int Classify(int x) => {cmp} ? 1 : 2;\n");
+        for (var i = 0; i < 12; i++)
+            sb.Append($"    public static int Pad{i}() => {i};\n");
+        sb.Append($"    public static int Helper() => {extraMethodReturns};\n");
+        sb.Append("}\n");
+        return sb.ToString();
+    }
+
+    private static string TestSource(bool withBoundary)
+    {
+        var boundary = withBoundary
+            ? "    public void Boundary() { /* covers the off-by-one at x==10 */ }\n"
+            : "";
+        return
+            "namespace Lib.Tests;\n" +
+            "public class CalcTests\n" +
+            "{\n" +
+            "    public void Basic() { }\n" +
+            boundary +
+            "}\n";
+    }
+
+    private void Write(string relPath, string content)
+    {
+        var abs = Path.Combine(_repo, relPath);
+        Directory.CreateDirectory(Path.GetDirectoryName(abs)!);
+        File.WriteAllText(abs, content);
+    }
+
+    private void CommitAll(string message)
+    {
+        Git("add -A");
+        Git($"commit -q -m \"{message}\"");
+    }
+
+    private string Show(string spec) => Git($"show {spec}").Stdout;
+
+    private (int Exit, string Stdout, string Stderr) Git(string args)
+    {
+        using var process = new Process();
+        process.StartInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            Arguments = args,
+            WorkingDirectory = _repo,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+        process.OutputDataReceived += (_, e) => { if (e.Data != null) stdout.AppendLine(e.Data); };
+        process.ErrorDataReceived += (_, e) => { if (e.Data != null) stderr.AppendLine(e.Data); };
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        process.WaitForExit();
+        return (process.ExitCode, stdout.ToString(), stderr.ToString());
+    }
+}

--- a/tools/Calor.RoundTrip.Harness/Program.cs
+++ b/tools/Calor.RoundTrip.Harness/Program.cs
@@ -23,6 +23,8 @@ switch (command)
         return await RunCommand(cliArgs.Skip(1).ToArray());
     case "gen-tasks":
         return await GenTasksCommand(cliArgs.Skip(1).ToArray());
+    case "mine":
+        return MineCommand(cliArgs.Skip(1).ToArray());
     case "list":
         Console.WriteLine("Known projects:");
         foreach (var p in ProjectConfigs.KnownProjects)
@@ -191,9 +193,25 @@ async Task<int> GenTasksCommand(string[] genArgs)
     var nativeBar = double.TryParse(GetOption(genArgs, "--native-bar"), out var nb) ? nb : 0.70;
     var maxCandidates = int.TryParse(GetOption(genArgs, "--max-candidates"), out var mc) ? mc : 8;
     var target = int.TryParse(GetOption(genArgs, "--target"), out var tg) ? tg : 3;
+    var scanCommits = int.TryParse(GetOption(genArgs, "--scan-commits"), out var sc) ? sc : 2000;
+
+    // Defect source: injected mutations (supplement), revert-upstream-bugfix (gold standard), or both.
+    var sourceArg = (GetOption(genArgs, "--source") ?? "injected").ToLowerInvariant();
+    var sources = sourceArg switch
+    {
+        "revert" => TaskSourceSelection.Revert,
+        "both" => TaskSourceSelection.Both,
+        "injected" => TaskSourceSelection.Injected,
+        _ => (TaskSourceSelection?)null,
+    };
+    if (sources == null)
+    {
+        Console.Error.WriteLine($"Unknown --source '{sourceArg}'. Use one of: injected, revert, both.");
+        return 1;
+    }
 
     var optionsWithValues = new HashSet<string>
-        { "--projects-dir", "--output", "--dotnet", "--native-bar", "--max-candidates", "--target" };
+        { "--projects-dir", "--output", "--dotnet", "--native-bar", "--max-candidates", "--target", "--source", "--scan-commits" };
     var projectNames = new List<string>();
     if (genArgs.Contains("--synthetic"))
         projectNames = ProjectConfigs.SyntheticProjects.ToList();
@@ -235,11 +253,100 @@ async Task<int> GenTasksCommand(string[] genArgs)
         OutputDir = outputDir,
         MaxCandidatesPerProject = maxCandidates,
         TargetEligiblePerProject = target,
+        Sources = sources.Value,
+        RevertScanCommits = scanCommits,
         Fidelity = new FidelityGateConfig { NativeFractionBar = nativeBar, BarIsProvisional = true },
     };
+    Console.WriteLine($"Defect source(s): {sources.Value}" +
+        (sources.Value.HasFlag(TaskSourceSelection.Revert) ? $" (scanning {scanCommits} commits of upstream history)" : ""));
 
     var run = await TaskGenRunner.RunAsync(configs, options);
     return run.TotalEligible > 0 ? 0 : 1;
+}
+
+// Cheap diagnostic: mine the revert-upstream-bugfix SUPPLY per project (git-only, no build/test).
+// Reports the raw fix-shaped supply, the source+covering-test subset (the "candidates" number), and
+// how many yield a clean source-hunk-only revert vs. are excluded (multi-source / inseparable).
+int MineCommand(string[] mineArgs)
+{
+    var projectsDir = GetOption(mineArgs, "--projects-dir") ?? ProjectConfigs.DefaultCorpusDir;
+    projectsDir = Path.GetFullPath(projectsDir.Replace("~", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)));
+    var scanCommits = int.TryParse(GetOption(mineArgs, "--scan-commits"), out var sc) ? sc : 5000;
+    var samples = int.TryParse(GetOption(mineArgs, "--samples"), out var sm) ? sm : 3;
+
+    var optionsWithValues = new HashSet<string> { "--projects-dir", "--scan-commits", "--samples" };
+    var projectNames = new List<string>();
+    if (mineArgs.Contains("--all")) projectNames = ProjectConfigs.KnownProjects.ToList();
+    else
+    {
+        for (int i = 0; i < mineArgs.Length; i++)
+        {
+            if (mineArgs[i].StartsWith("--"))
+            {
+                if (optionsWithValues.Contains(mineArgs[i]) && i + 1 < mineArgs.Length) i++;
+                continue;
+            }
+            projectNames.Add(mineArgs[i]);
+        }
+    }
+    if (projectNames.Count == 0)
+    {
+        Console.Error.WriteLine("No projects specified. Use --all or provide project names.");
+        return 1;
+    }
+
+    int grandFix = 0, grandCand = 0, grandBuildable = 0, grandMulti = 0, grandInsep = 0;
+    foreach (var name in projectNames)
+    {
+        var config = ProjectConfigs.Get(name, projectsDir, "dotnet");
+        if (config == null) { Console.Error.WriteLine($"Unknown project: {name}"); continue; }
+        if (!Directory.Exists(config.OriginalProjectPath))
+        {
+            Console.Error.WriteLine($"{name}: submodule not checked out at {config.OriginalProjectPath} (run: git submodule update --init).");
+            continue;
+        }
+
+        var fixCommits = BugfixMiner.MineFixCommits(config.OriginalProjectPath, config.LibrarySourceRelativePath, scanCommits);
+        var candidates = BugfixMiner.SelectRevertCandidates(fixCommits);
+
+        var verbose = mineArgs.Contains("--verbose");
+        int buildable = 0, multi = 0, insep = 0, shown = 0, insepShown = 0;
+        var samplesList = new List<MutationCandidate>();
+        foreach (var fc in candidates)
+        {
+            var res = BugfixMiner.TryBuildRevertCandidate(config.OriginalProjectPath, fc);
+            if (res.Succeeded) { buildable++; if (shown < samples) { samplesList.Add(res.Candidate!); shown++; } }
+            else if (res.Exclusion == ExclusionReason.MultipleSourceFiles) multi++;
+            else
+            {
+                insep++;
+                if (verbose && insepShown < 5)
+                {
+                    Console.Error.WriteLine($"    [insep] {fc.Sha[..8]} {fc.SourceFiles.FirstOrDefault()} :: {res.ExclusionDetail}");
+                    insepShown++;
+                }
+            }
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(new string('=', 64));
+        Console.WriteLine($"  {name} — revert-bugfix supply (scanned {scanCommits} commits, prefix {config.LibrarySourceRelativePath})");
+        Console.WriteLine(new string('=', 64));
+        Console.WriteLine($"  fix-shaped commits           : {fixCommits.Count}");
+        Console.WriteLine($"  with source + covering test  : {candidates.Count}   <-- revert candidates (SelectRevertCandidates fires)");
+        Console.WriteLine($"    clean source-hunk revert   : {buildable}");
+        Console.WriteLine($"    excluded multi-source-file : {multi}");
+        Console.WriteLine($"    excluded inseparable       : {insep}");
+        foreach (var s in samplesList)
+            Console.WriteLine($"    e.g. revert {s.RevertedCommit?[..8]} in {s.FileRelPath}:{s.Line} — \"{s.RevertedCommitSubject}\"");
+
+        grandFix += fixCommits.Count; grandCand += candidates.Count;
+        grandBuildable += buildable; grandMulti += multi; grandInsep += insep;
+    }
+
+    Console.WriteLine();
+    Console.WriteLine($"TOTAL: fix-shaped={grandFix}, revert-candidates={grandCand}, clean-revert={grandBuildable}, multi-source={grandMulti}, inseparable={grandInsep}");
+    return grandBuildable > 0 ? 0 : 1;
 }
 
 static string? GetOption(string[] args, string flag)
@@ -262,6 +369,7 @@ static void PrintUsage()
           calor-roundtrip run --all [options]             Run for all known projects
           calor-roundtrip gen-tasks <project...> [options] Generate real-scale task bundles (WS-W4 Slice C)
           calor-roundtrip gen-tasks --synthetic [options]  Generate against the in-repo synthetic subjects
+          calor-roundtrip mine <project...> [options]     Report revert-bugfix supply per project (git-only, no build)
           calor-roundtrip list                            List known projects
 
         Options (run):
@@ -273,6 +381,9 @@ static void PrintUsage()
 
         Options (gen-tasks):
           --output <path>          Output directory for task bundles (default: task-bundles)
+          --source <sel>           Defect source: injected | revert | both (default injected).
+                                   'revert' = gold-standard revert-upstream-bugfix; 'injected' = mutation supplement.
+          --scan-commits <n>       Upstream commits to scan for fix commits (revert source; default 2000)
           --native-bar <frac>      Fidelity-gate NativeFraction bar (default provisional 0.70)
           --max-candidates <n>     Max sited candidates considered per project (default 8)
           --target <n>             Stop after this many eligible bundles per project (default 3)

--- a/tools/Calor.RoundTrip.Harness/TaskGen/BugfixMiner.cs
+++ b/tools/Calor.RoundTrip.Harness/TaskGen/BugfixMiner.cs
@@ -51,15 +51,19 @@ public sealed class RevertCandidateResult
 public static partial class BugfixMiner
 {
     /// <summary>
-    /// Fix-shaped iff the subject line names a fix/bug/defect or references an issue, and is not a
-    /// merge or a mere "prefix"/"suffix" false positive. Deliberately conservative — a false
-    /// negative just drops a candidate; a false positive would revert a non-fix.
+    /// Fix-shaped iff the subject line names actual fix vocabulary (fix/bug/defect/regression/crash/…)
+    /// and is not a merge. A bare issue/PR reference (<c>#NNNN</c>, <c>GH-NNNN</c>) is deliberately NOT
+    /// evidence of a fix: GitHub squash-merges append <c>(#NNNN)</c> to EVERY PR subject, so treating a
+    /// bare number as fix-evidence would classify every feature-add and refactor as a "fix" and grossly
+    /// overstate the gold-standard bug-fix supply (reverting a feature-add is behavior-removal, not a
+    /// reintroduced defect). Deliberately conservative — a false negative just drops a candidate; a
+    /// false positive would revert a non-fix.
     /// </summary>
     public static bool IsFixShaped(string subject)
     {
         if (string.IsNullOrWhiteSpace(subject)) return false;
         if (subject.StartsWith("Merge ", StringComparison.OrdinalIgnoreCase)) return false;
-        return FixWord().IsMatch(subject) || IssueRef().IsMatch(subject);
+        return FixWord().IsMatch(subject);
     }
 
     /// <summary>True when the path looks like a test file (a test-ish directory or filename segment).</summary>
@@ -327,11 +331,10 @@ public static partial class BugfixMiner
         return (process.ExitCode, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult());
     }
 
-    [GeneratedRegex(@"\b(fix(es|ed)?|bug|defect|regression|incorrect|wrong|broken)\b", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(
+        @"\b(fix(es|ed)?|bug(fix)?|defect|regression|incorrect(ly)?|wrong(ly)?|broken|crash(es|ed|ing)?|npe|nullref|deadlock|hang(s|ing)?|off-by-one|overflow|underflow|corrupt(s|ed|ion)?|faulty?)\b",
+        RegexOptions.IgnoreCase)]
     private static partial Regex FixWord();
-
-    [GeneratedRegex(@"#\d+|GH-\d+", RegexOptions.IgnoreCase)]
-    private static partial Regex IssueRef();
 
     [GeneratedRegex(@"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")]
     private static partial Regex HunkHeader();

--- a/tools/Calor.RoundTrip.Harness/TaskGen/BugfixMiner.cs
+++ b/tools/Calor.RoundTrip.Harness/TaskGen/BugfixMiner.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 
 namespace Calor.RoundTrip.Harness.TaskGen;
@@ -16,12 +17,36 @@ public sealed class FixCommit
     public List<string> TestFiles { get; init; } = new();
 }
 
+/// <summary>Outcome of trying to build a source-hunk-only revert candidate from a fix commit.</summary>
+public sealed class RevertCandidateResult
+{
+    public required FixCommit Commit { get; init; }
+
+    /// <summary>Non-null when the source-hunk-only revert succeeded — the reverted (defective) candidate.</summary>
+    public MutationCandidate? Candidate { get; init; }
+
+    /// <summary>Non-null when the candidate could NOT be built (counted + disclosed exclusion).</summary>
+    public ExclusionReason? Exclusion { get; init; }
+    public string? ExclusionDetail { get; init; }
+
+    public bool Succeeded => Candidate != null;
+}
+
 /// <summary>
 /// Mines a pinned submodule's git history for bug-fix commits whose fix touches a library source
 /// region AND has an identifiable covering test — the revert-bugfix gold-standard task source
 /// (D-W4.1 primary). The commit-shape heuristic and the <c>git log --name-status</c> parser are
-/// pure (unit-testable with canned output); the live mining shells <c>git</c> against a checked-out
-/// submodule (Slice E — the corpus submodules are absent in the Slice-C environment).
+/// pure (unit-testable with canned output); the live mining and the source-hunk-only revert shell
+/// <c>git</c> against a checked-out submodule (unit-testable with synthetic git fixtures, no corpus).
+///
+/// <para><b>Source-hunk-only revert (the correctness pivot):</b> reverting a bug-fix must reintroduce
+/// the defect in the LIBRARY SOURCE while KEEPING the covering test at its fixed state (the test is
+/// the held-out oracle that now fails). A whole-commit revert would delete the test too, destroying
+/// the oracle. <see cref="TryBuildRevertCandidate"/> therefore reverse-applies ONLY the fix commit's
+/// hunks for the single library-source file (via <c>git apply -R --3way</c> in a throwaway worktree
+/// of the pinned tree) and splices JUST that reverted file into the generator's clone; the test files
+/// in that clone stay at the pinned/fixed state untouched. A fix whose source hunk cannot be cleanly
+/// reverse-applied — or that touches more than one source file — is excluded (counted + disclosed).</para>
 /// </summary>
 public static partial class BugfixMiner
 {
@@ -89,7 +114,9 @@ public static partial class BugfixMiner
             {
                 if (!path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)) continue;
                 if (IsTestPath(path)) commit.TestFiles.Add(path);
-                else if (path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) commit.SourceFiles.Add(path);
+                else if (path.StartsWith(prefix + "/", StringComparison.OrdinalIgnoreCase)
+                    || path.Equals(prefix, StringComparison.OrdinalIgnoreCase))
+                    commit.SourceFiles.Add(path);
             }
             commits.Add(commit);
         }
@@ -104,14 +131,208 @@ public static partial class BugfixMiner
     public static List<FixCommit> SelectRevertCandidates(IEnumerable<FixCommit> commits) =>
         commits.Where(c => c.SourceFiles.Count > 0 && c.TestFiles.Count > 0).ToList();
 
-    /// <summary>The <c>git log</c> invocation whose output <see cref="ParseFixCommits"/> parses.</summary>
-    public static string GitLogArgs(string librarySourcePrefix, int maxCommits) =>
-        $"log --name-status --no-merges -n {maxCommits} " +
-        $"--pretty=format:%x01%H%x02%s -- \"{librarySourcePrefix}\"";
+    /// <summary>
+    /// The <c>git log</c> invocation whose output <see cref="ParseFixCommits"/> parses.
+    ///
+    /// <para><b>Pathspec fix:</b> the log is deliberately NOT pathspec-restricted to the library
+    /// source prefix. The former <c>-- "src/…"</c> restriction meant <c>--name-status</c> only ever
+    /// listed source files, so <see cref="FixCommit.TestFiles"/> was always empty and
+    /// <see cref="SelectRevertCandidates"/> (which requires a covering test) could never fire — 0
+    /// candidates on every real project. Surfacing the FULL name-status lets the parser see BOTH the
+    /// source and the covering-test changes; classification into source/test happens in the parser.</para>
+    /// </summary>
+    public static string GitLogArgs(int maxCommits) =>
+        $"log --name-status --no-merges -n {maxCommits} --pretty=format:%x01%H%x02%s";
+
+    /// <summary>
+    /// Live-mine <paramref name="repoDir"/>'s history for fix-shaped commits (most recent
+    /// <paramref name="maxCommits"/>), classifying each against <paramref name="librarySourcePrefix"/>.
+    /// Shells <c>git</c>; returns the parsed fix commits (unfiltered — call
+    /// <see cref="SelectRevertCandidates"/> for the source+test subset).
+    /// </summary>
+    public static List<FixCommit> MineFixCommits(string repoDir, string librarySourcePrefix, int maxCommits)
+    {
+        var (exit, stdout, _) = Git(repoDir, GitLogArgs(maxCommits));
+        if (exit != 0) return new List<FixCommit>();
+        return ParseFixCommits(stdout, librarySourcePrefix);
+    }
+
+    /// <summary>
+    /// Build a source-hunk-only revert candidate from a fix commit: reverse-apply ONLY the commit's
+    /// hunks for its single library-source file onto the pinned tree, KEEPING the covering test at
+    /// its fixed state (the test lives in a different file the generator never overwrites). The
+    /// reverted (defective) full-file text becomes <see cref="MutationCandidate.MutatedSource"/>.
+    ///
+    /// <para>Excludes (counted + disclosed) when the fix touches more than one source file
+    /// (<see cref="ExclusionReason.MultipleSourceFiles"/> — cannot map to the single-file eligibility
+    /// predicate without reverting more than one region) or when the source hunk cannot be cleanly
+    /// reverse-applied onto the pinned tree (<see cref="ExclusionReason.InseparableRevert"/> — a later
+    /// commit changed the same region, so the defect cannot be reintroduced in isolation).</para>
+    /// </summary>
+    public static RevertCandidateResult TryBuildRevertCandidate(string repoDir, FixCommit commit)
+    {
+        // Single-source-file restriction: the eligibility predicate decides over ONE mutated file's
+        // native conversion. A multi-source-file fix would require reverting >1 region to reintroduce
+        // the defect faithfully — out of scope for the single-file predicate. Disclose, don't fudge.
+        if (commit.SourceFiles.Count != 1)
+            return Excluded(commit, ExclusionReason.MultipleSourceFiles,
+                $"fix touches {commit.SourceFiles.Count} library source files; the single-file eligibility "
+                + "predicate cannot faithfully reintroduce a multi-file defect — excluded.");
+
+        var sourcePath = commit.SourceFiles[0];
+
+        // The fix's diff for the SOURCE FILE ONLY (a/… b/… unified diff). Restricting the pathspec to
+        // the source file is what keeps the covering test out of the revert entirely.
+        var (showExit, patch, _) = Git(repoDir, $"show {commit.Sha} -- \"{sourcePath}\"");
+        if (showExit != 0 || string.IsNullOrWhiteSpace(patch) || !patch.Contains("@@"))
+            return Excluded(commit, ExclusionReason.InseparableRevert,
+                $"could not obtain a source-file diff for {Short(commit.Sha)} on {sourcePath}.");
+
+        string? worktree = null;
+        var patchFile = Path.Combine(Path.GetTempPath(), $"calor-revert-{Guid.NewGuid():N}.patch");
+        try
+        {
+            worktree = Path.Combine(Path.GetTempPath(), $"calor-revert-wt-{Guid.NewGuid():N}");
+            var (wtExit, _, wtErr) = Git(repoDir, $"worktree add --detach -q \"{worktree}\" HEAD");
+            if (wtExit != 0)
+                return Excluded(commit, ExclusionReason.InseparableRevert,
+                    $"could not create a throwaway worktree to compute the revert: {wtErr.Trim()}");
+
+            var worktreeSourceAbs = Path.Combine(worktree, sourcePath);
+            if (!File.Exists(worktreeSourceAbs))
+                return Excluded(commit, ExclusionReason.InseparableRevert,
+                    $"source file {sourcePath} is absent at the pinned HEAD — cannot reverse-apply.");
+
+            var pinnedContent = File.ReadAllText(worktreeSourceAbs);
+            File.WriteAllText(patchFile, patch);
+
+            // Reverse-apply with a 3-way merge so a later, non-overlapping change is preserved and an
+            // overlapping one CONFLICTS LOUDLY (rather than a plain `git apply -R` silently no-op-ing on
+            // shifted context). Any non-zero exit ⇒ the source hunk is not cleanly separable ⇒ exclude.
+            var (applyExit, _, applyErr) = Git(worktree, $"apply -R --3way -p1 \"{patchFile}\"");
+            if (applyExit != 0)
+                return Excluded(commit, ExclusionReason.InseparableRevert,
+                    $"3-way reverse-apply of the fix's source hunk conflicted (a later commit changed the same region): {applyErr.Trim()}");
+
+            var revertedContent = File.ReadAllText(worktreeSourceAbs);
+
+            // Belt-and-suspenders: never emit a partial 3-way result, and never emit a no-op "revert"
+            // that did not actually reintroduce the defect (clause (b) would drop it downstream, but an
+            // honest exclusion reason here keeps the accounting truthful).
+            if (revertedContent.Contains("<<<<<<<", StringComparison.Ordinal)
+                || revertedContent.Contains(">>>>>>>", StringComparison.Ordinal))
+                return Excluded(commit, ExclusionReason.InseparableRevert,
+                    "reverse-apply left conflict markers — the source hunk is not cleanly separable.");
+            if (string.Equals(revertedContent, pinnedContent, StringComparison.Ordinal))
+                return Excluded(commit, ExclusionReason.InseparableRevert,
+                    "reverse-apply was a no-op — the defect was not reintroduced (the fixed region no longer matches).");
+
+            var (line, col, fixedSnippet, defectSnippet) = SummarizePatch(patch);
+            var candidate = new MutationCandidate
+            {
+                FileRelPath = sourcePath,
+                Source = MutationSource.RevertBugfix,
+                Operator = MutationOperatorKind.Revert,
+                OperatorDescription = $"revert upstream fix {Short(commit.Sha)} (reintroduce defect)",
+                Line = line,
+                Column = col,
+                OriginalSnippet = fixedSnippet,   // the FIXED code the pinned tree had
+                MutatedSnippet = defectSnippet,    // the DEFECT the revert reintroduces
+                MutatedSource = revertedContent,
+                RevertedCommit = commit.Sha,
+                RevertedCommitSubject = commit.Subject,
+            };
+            return new RevertCandidateResult { Commit = commit, Candidate = candidate };
+        }
+        finally
+        {
+            if (worktree != null)
+            {
+                Git(repoDir, $"worktree remove --force \"{worktree}\"");
+                Git(repoDir, "worktree prune");
+                if (Directory.Exists(worktree))
+                    try { Directory.Delete(worktree, recursive: true); } catch { /* best effort */ }
+            }
+            if (File.Exists(patchFile))
+                try { File.Delete(patchFile); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>
+    /// Extract, from a unified fix diff, the fixed-file start line and short before/after snippets.
+    /// <c>+</c> lines are the FIXED code (what the pinned tree has); <c>-</c> lines are the DEFECT the
+    /// revert reintroduces. Best-effort provenance — never throws.
+    /// </summary>
+    internal static (int line, int col, string fixedSnippet, string defectSnippet) SummarizePatch(string patch)
+    {
+        var line = 1;
+        const int col = 1;
+        string? fixedSnippet = null;
+        string? defectSnippet = null;
+        foreach (var raw in patch.Split('\n'))
+        {
+            var m = HunkHeader().Match(raw);
+            if (m.Success)
+            {
+                if (int.TryParse(m.Groups[1].Value, out var start))
+                    line = start;
+                continue;
+            }
+            if (raw.StartsWith("+++", StringComparison.Ordinal) || raw.StartsWith("---", StringComparison.Ordinal))
+                continue;
+            if (defectSnippet == null && raw.StartsWith('-') && raw.Length > 1)
+                defectSnippet = raw[1..].Trim();
+            else if (fixedSnippet == null && raw.StartsWith('+') && raw.Length > 1)
+                fixedSnippet = raw[1..].Trim();
+            if (fixedSnippet != null && defectSnippet != null)
+                break;
+        }
+        return (line, col, fixedSnippet ?? "", defectSnippet ?? "");
+    }
+
+    private static RevertCandidateResult Excluded(FixCommit commit, ExclusionReason reason, string detail) =>
+        new() { Commit = commit, Exclusion = reason, ExclusionDetail = detail };
+
+    private static string Short(string sha) => sha[..Math.Min(8, sha.Length)];
+
+    /// <summary>
+    /// Run a git command in <paramref name="workDir"/>, capturing stdout/stderr BYTE-EXACT (synchronous).
+    ///
+    /// <para>Stdout is read with <see cref="StreamReader.ReadToEndAsync()"/> rather than the line-oriented
+    /// <c>OutputDataReceived</c> event: the latter strips <c>\r</c> and re-joins with <c>\n</c>, which
+    /// silently converts a CRLF patch (git show for a Windows-line-ending source file — e.g. all of
+    /// FluentValidation) to LF. That LF patch then fails to context-match the CRLF worktree files, so
+    /// EVERY revert on a CRLF project would spuriously be reported "inseparable". Preserving the exact
+    /// bytes keeps the diff and the tree in the same line-ending form.</para>
+    /// </summary>
+    private static (int Exit, string Stdout, string Stderr) Git(string workDir, string args)
+    {
+        using var process = new Process();
+        process.StartInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            Arguments = args,
+            WorkingDirectory = workDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        process.Start();
+        // Drain both streams concurrently (avoids the classic full-pipe deadlock) while preserving
+        // the exact stdout bytes/line-endings.
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        process.WaitForExit();
+        return (process.ExitCode, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult());
+    }
 
     [GeneratedRegex(@"\b(fix(es|ed)?|bug|defect|regression|incorrect|wrong|broken)\b", RegexOptions.IgnoreCase)]
     private static partial Regex FixWord();
 
     [GeneratedRegex(@"#\d+|GH-\d+", RegexOptions.IgnoreCase)]
     private static partial Regex IssueRef();
+
+    [GeneratedRegex(@"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")]
+    private static partial Regex HunkHeader();
 }

--- a/tools/Calor.RoundTrip.Harness/TaskGen/ExclusionAccounting.cs
+++ b/tools/Calor.RoundTrip.Harness/TaskGen/ExclusionAccounting.cs
@@ -43,6 +43,12 @@ public sealed class ExclusionAccounting
     public int ExcludedHeldOutFilterLeak => _dispositions.Count(d => d.Reason == ExclusionReason.HeldOutFilterLeak);
     public int ExcludedFidelityGate => _dispositions.Count(d => d.Reason == ExclusionReason.FidelityGateBelowBar);
 
+    /// <summary>Revert-supply exclusions: fix commit touches >1 source file (cannot map to the single-file predicate).</summary>
+    public int ExcludedMultipleSourceFiles => _dispositions.Count(d => d.Reason == ExclusionReason.MultipleSourceFiles);
+
+    /// <summary>Revert-supply exclusions: the fix's source hunk could not be cleanly reverse-applied onto the pinned tree.</summary>
+    public int ExcludedInseparableRevert => _dispositions.Count(d => d.Reason == ExclusionReason.InseparableRevert);
+
     public double EligibilityRate => Considered == 0 ? 0.0 : (double)Eligible / Considered;
 
     public Dictionary<string, int> CountByReason() =>

--- a/tools/Calor.RoundTrip.Harness/TaskGen/TaskGenOptions.cs
+++ b/tools/Calor.RoundTrip.Harness/TaskGen/TaskGenOptions.cs
@@ -1,10 +1,34 @@
 namespace Calor.RoundTrip.Harness.TaskGen;
 
+/// <summary>Which defect source(s) a task-generation run draws candidates from.</summary>
+[Flags]
+public enum TaskSourceSelection
+{
+    /// <summary>Standard semantic mutation operators sited in natively-converting regions (the supplement).</summary>
+    Injected = 1,
+
+    /// <summary>Reverting a mined upstream bug-fix commit — the gold-standard REAL-defect source (D-W4.1 primary).</summary>
+    Revert = 2,
+
+    /// <summary>Both sources, merged into one candidate set (each still gated by the same eligibility predicate).</summary>
+    Both = Injected | Revert,
+}
+
 /// <summary>Options for a task-generation run.</summary>
 public sealed class TaskGenOptions
 {
     /// <summary>Output directory for task bundles and the exclusion-accounting report.</summary>
     public required string OutputDir { get; init; }
+
+    /// <summary>
+    /// Which defect source(s) to draw candidates from (default <see cref="TaskSourceSelection.Injected"/>
+    /// — the pre-existing behavior). <see cref="TaskSourceSelection.Revert"/> enables the gold-standard
+    /// revert-upstream-bugfix source; both feed the SAME eligibility predicate + exclusion accounting.
+    /// </summary>
+    public TaskSourceSelection Sources { get; init; } = TaskSourceSelection.Injected;
+
+    /// <summary>How many commits of upstream history to scan for fix-shaped commits (revert source only).</summary>
+    public int RevertScanCommits { get; init; } = 2000;
 
     /// <summary>Upper bound on injected-mutation candidates considered per project (bounds run cost).</summary>
     public int MaxCandidatesPerProject { get; init; } = 8;

--- a/tools/Calor.RoundTrip.Harness/TaskGen/TaskGenReportWriter.cs
+++ b/tools/Calor.RoundTrip.Harness/TaskGen/TaskGenReportWriter.cs
@@ -93,12 +93,12 @@ public static class TaskGenReportWriter
 
         sb.AppendLine("## Exclusion accounting (D-W4.1 — every candidate counted, no silent shrinkage)");
         sb.AppendLine();
-        sb.AppendLine("| Project | Enumerated | Considered | Eligible | Excl (a) | Excl (b) | Excl attribution | Excl leak | Excl no-cover | Excl no-compile | Eligibility rate |");
-        sb.AppendLine("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|");
+        sb.AppendLine("| Project | Enumerated | Considered | Eligible | Excl (a) | Excl (b) | Excl attribution | Excl leak | Excl no-cover | Excl no-compile | Excl multi-src | Excl inseparable | Eligibility rate |");
+        sb.AppendLine("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|");
         foreach (var p in run.Projects)
         {
             var a = p.Accounting;
-            sb.AppendLine($"| {p.ProjectName} | {p.TotalEnumeratedCandidates} | {a.Considered} | {a.Eligible} | {a.ExcludedClauseA} | {a.ExcludedClauseB} | {a.ExcludedAttribution} | {a.ExcludedHeldOutFilterLeak} | {a.ExcludedNoCoveringTest} | {a.ExcludedDidNotCompile} | {a.EligibilityRate:P0} |");
+            sb.AppendLine($"| {p.ProjectName} | {p.TotalEnumeratedCandidates} | {a.Considered} | {a.Eligible} | {a.ExcludedClauseA} | {a.ExcludedClauseB} | {a.ExcludedAttribution} | {a.ExcludedHeldOutFilterLeak} | {a.ExcludedNoCoveringTest} | {a.ExcludedDidNotCompile} | {a.ExcludedMultipleSourceFiles} | {a.ExcludedInseparableRevert} | {a.EligibilityRate:P0} |");
         }
         var totEnumerated = run.Projects.Sum(p => p.TotalEnumeratedCandidates);
         var totConsidered = run.Projects.Sum(p => p.Accounting.Considered);
@@ -108,7 +108,13 @@ public static class TaskGenReportWriter
             $"**{run.Projects.Sum(p => p.Accounting.ExcludedAttribution)}** | **{run.Projects.Sum(p => p.Accounting.ExcludedHeldOutFilterLeak)}** | " +
             $"**{run.Projects.Sum(p => p.Accounting.ExcludedNoCoveringTest)}** | " +
             $"**{run.Projects.Sum(p => p.Accounting.ExcludedDidNotCompile)}** | " +
+            $"**{run.Projects.Sum(p => p.Accounting.ExcludedMultipleSourceFiles)}** | " +
+            $"**{run.Projects.Sum(p => p.Accounting.ExcludedInseparableRevert)}** | " +
             $"**{(totConsidered == 0 ? 0 : (double)totEligible / totConsidered):P0}** |");
+        sb.AppendLine();
+        sb.AppendLine("'Excl multi-src' and 'Excl inseparable' are revert-source SUPPLY exclusions (a mined fix commit ");
+        sb.AppendLine("touching >1 source file, or whose source hunk could not be cleanly reverse-applied onto the pinned ");
+        sb.AppendLine("tree). They are recorded before any build/test cost and are 0 for injected-only runs.");
         sb.AppendLine();
         sb.AppendLine("Eligibility rate is Eligible/Considered (Considered = evaluated candidates; Enumerated is the ");
         sb.AppendLine("full sited set before the per-project cap / early-stop, so the rate is honest about truncation).");

--- a/tools/Calor.RoundTrip.Harness/TaskGen/TaskGenRunner.cs
+++ b/tools/Calor.RoundTrip.Harness/TaskGen/TaskGenRunner.cs
@@ -53,6 +53,8 @@ public static class TaskGenRunner
                 ExcludedNoCoveringTest = p.Accounting.ExcludedNoCoveringTest,
                 ExcludedDidNotCompile = p.Accounting.ExcludedDidNotCompile,
                 ExcludedHeldOutFilterLeak = p.Accounting.ExcludedHeldOutFilterLeak,
+                ExcludedMultipleSourceFiles = p.Accounting.ExcludedMultipleSourceFiles,
+                ExcludedInseparableRevert = p.Accounting.ExcludedInseparableRevert,
                 EligibilityRate = p.Accounting.EligibilityRate,
                 Bundles = p.Bundles.Select(b => b.TaskId).ToList(),
                 Dispositions = p.Accounting.Dispositions,

--- a/tools/Calor.RoundTrip.Harness/TaskGen/TaskGenerator.cs
+++ b/tools/Calor.RoundTrip.Harness/TaskGen/TaskGenerator.cs
@@ -39,19 +39,67 @@ public sealed class TaskGenerator
         Console.WriteLine($"[{project.ProjectName}]   NativeFraction {coverage.NativeFraction:P1} " +
             $"({coverage.ConvertedNative} native of {coverage.TotalConvertibleFiles}); siting mutations in {nativeFiles.Count} native file(s)");
 
-        // --- Site injected mutations in native regions ONLY (governing fact). ---
+        // --- Enumerate candidates from the selected source(s), sited in native regions ONLY. ---
+        var nativeSet = nativeFiles.ToHashSet(StringComparer.Ordinal);
         var enumerated = new List<MutationCandidate>();
-        foreach (var relPath in nativeFiles)
+
+        // Injected mutations (supplement): standard operators over native files.
+        if (options.Sources.HasFlag(TaskSourceSelection.Injected))
         {
-            var absOriginal = Path.Combine(project.OriginalProjectPath, relPath);
-            if (!File.Exists(absOriginal)) continue;
-            var source = await File.ReadAllTextAsync(absOriginal);
-            // NegateCondition always compiles, but inverts a whole branch (all-or-nothing coverage),
-            // so it is dropped from the DEFAULT bounded set to keep the demo focused on point mutations;
-            // the operator itself remains available in InjectedMutationOperators and unit-tested.
-            enumerated.AddRange(InjectedMutationOperators.Enumerate(source, relPath)
-                .Where(c => c.Operator != MutationOperatorKind.NegateCondition));
+            foreach (var relPath in nativeFiles)
+            {
+                var absOriginal = Path.Combine(project.OriginalProjectPath, relPath);
+                if (!File.Exists(absOriginal)) continue;
+                var source = await File.ReadAllTextAsync(absOriginal);
+                // NegateCondition always compiles, but inverts a whole branch (all-or-nothing coverage),
+                // so it is dropped from the DEFAULT bounded set to keep the demo focused on point mutations;
+                // the operator itself remains available in InjectedMutationOperators and unit-tested.
+                enumerated.AddRange(InjectedMutationOperators.Enumerate(source, relPath)
+                    .Where(c => c.Operator != MutationOperatorKind.NegateCondition));
+            }
         }
+
+        // Revert-upstream-bugfix (gold standard): mine fix commits, reintroduce the defect via a
+        // source-hunk-only revert, and feed each through the SAME eligibility predicate. Supply-side
+        // exclusions (multi-source-file / inseparable / not-native) are recorded up front so the
+        // accounting is complete before any build/test cost is spent.
+        if (options.Sources.HasFlag(TaskSourceSelection.Revert))
+        {
+            Console.WriteLine($"[{project.ProjectName}]   mining upstream bug-fix commits (revert source; scanning {options.RevertScanCommits} commits)...");
+            var fixCommits = BugfixMiner.MineFixCommits(
+                project.OriginalProjectPath, project.LibrarySourceRelativePath, options.RevertScanCommits);
+            var revertCommits = BugfixMiner.SelectRevertCandidates(fixCommits);
+            Console.WriteLine($"[{project.ProjectName}]   {fixCommits.Count} fix-shaped commit(s); {revertCommits.Count} with source+covering-test (revert candidates)");
+
+            var minedOk = 0;
+            foreach (var fc in revertCommits)
+            {
+                var res = BugfixMiner.TryBuildRevertCandidate(project.OriginalProjectPath, fc);
+                if (res.Candidate != null)
+                {
+                    // Native-region prefilter (mirror injected): only site where the pristine file
+                    // converts natively. Non-native revert sources are disclosed as clause-(a) exclusions.
+                    if (nativeSet.Contains(res.Candidate.FileRelPath))
+                    {
+                        enumerated.Add(res.Candidate);
+                        minedOk++;
+                    }
+                    else
+                    {
+                        accounting.Record(RevertDisposition(project.ProjectName, fc, res.Candidate.FileRelPath,
+                            ExclusionReason.NotNativeRegion,
+                            $"clause (a): the reverted source file {res.Candidate.FileRelPath} did not convert natively in the pristine probe."));
+                    }
+                }
+                else
+                {
+                    accounting.Record(RevertDisposition(project.ProjectName, fc,
+                        fc.SourceFiles.FirstOrDefault() ?? "?", res.Exclusion!.Value, res.ExclusionDetail!));
+                }
+            }
+            Console.WriteLine($"[{project.ProjectName}]   revert candidates buildable in a native region: {minedOk}");
+        }
+
         var totalEnumerated = enumerated.Count; // honest denominator (minor: before Take/early-stop truncation)
         var candidates = enumerated
             .OrderBy(c => c.FileRelPath, StringComparer.Ordinal)
@@ -320,6 +368,20 @@ public sealed class TaskGenerator
 
     private static EligibilityVerdict Excluded(ExclusionReason reason, string explanation) =>
         new() { Eligible = false, Reason = reason, Explanation = explanation };
+
+    /// <summary>A supply-side (pre-build) disposition for a revert candidate that never reached evaluation.</summary>
+    private static CandidateDisposition RevertDisposition(
+        string projectName, FixCommit fc, string fileRelPath, ExclusionReason reason, string explanation) => new()
+    {
+        ProjectName = projectName,
+        CandidateId = $"revert-{fc.Sha[..Math.Min(8, fc.Sha.Length)]}",
+        FileRelPath = fileRelPath,
+        Operator = MutationOperatorKind.Revert,
+        Source = MutationSource.RevertBugfix,
+        Eligible = false,
+        Reason = reason,
+        Explanation = explanation,
+    };
 
     /// <summary>Clone a config with an overridden working directory and/or test filter.</summary>
     private static RoundTripConfig Clone(RoundTripConfig c, string? workDir, string? testFilter = null) => new()

--- a/tools/Calor.RoundTrip.Harness/TaskGen/TaskModel.cs
+++ b/tools/Calor.RoundTrip.Harness/TaskGen/TaskModel.cs
@@ -83,6 +83,21 @@ public enum ExclusionReason
 
     /// <summary>The candidate's project was excluded by the fidelity gate (NativeFraction below bar).</summary>
     FidelityGateBelowBar,
+
+    /// <summary>
+    /// Revert source only: the mined fix commit touches more than one library-source file, so the
+    /// single-file eligibility predicate cannot faithfully reintroduce the (multi-file) defect. A
+    /// revert-supply exclusion, disclosed before any build/test cost is spent.
+    /// </summary>
+    MultipleSourceFiles,
+
+    /// <summary>
+    /// Revert source only: the fix commit's source-file hunk cannot be cleanly reverse-applied onto
+    /// the pinned tree (a later commit changed the same region → 3-way conflict / no-op), so the
+    /// defect cannot be reintroduced in isolation while keeping the covering test. A revert-supply
+    /// exclusion, disclosed before any build/test cost is spent.
+    /// </summary>
+    InseparableRevert,
 }
 
 /// <summary>One held-out test removed from the visible suite and moved to held-out (C2).</summary>


### PR DESCRIPTION
Completes and wires the revert-upstream-bugfix task source (the gold-standard, real-defect source the Slice-C `BugfixMiner` stubbed). A real-corpus run proved the stub yielded 0 live tasks; this fixes the mining path and reports the honest yield.

## Fixes
- **Pathspec bug**: `GitLogArgs` no longer restricts `git log` to the source prefix (which meant `--name-status` never listed test files → `SelectRevertCandidates` could never fire). Now surfaces both source + test changes; classifier tightened to `prefix + "/"` so sibling test dirs aren't miscounted. Live: **278 revert candidates** (MediatR 9, Serilog 127, FV 142).
- **Source-hunk-only revert**: reverse-applies ONLY the fix commit's library-source hunks (`git apply -R --3way` in a throwaway worktree), keeping the covering test at its fixed state so it becomes the held-out oracle (a whole-commit revert would delete it). Loud on conflict/no-op/multi-source → `InseparableRevert`/`MultipleSourceFiles`, counted + disclosed.
- Two bugs found+fixed validating against the real corpus: silent no-op `git apply -R` (→ `--3way` + reverted≠pinned guard); **CRLF corruption** in git-stdout capture that made ALL FluentValidation reverts falsely inseparable (→ byte-exact read; FV clean reverts 0→3).
- **Wired into `gen-tasks`**: `--source injected|revert|both` (default injected), same eligibility predicate + exclusion accounting; added a cheap `mine` diagnostic command.

## Honest live yield
278 candidates → 17 cleanly-separable single-source reverts (MediatR 1, Serilog 13, FV 3) → **0 eligible through the strict native-region ∩ compiles ∩ survives gates**. Genuine attrition, not breakage (Serilog's `LevelAlias.cs` matched native then correctly hit `DidNotCompile` — a feature-add later code depends on). The bottleneck is {separable single-source revert} ∩ {natively-converting file}: fix-touched files skew complex/interop-heavy. Injected mutations (23 eligible) remain the workable substrate; this source is correct infra + honest measurement, growable later via multi-source reverts (+135 candidates) or corpus expansion.

## Tests
`TaskGenRevertTests` (synthetic git fixtures, corpus-independent): pathspec fix, clean revert, far-away 3-way, adjacent-conflict→Inseparable, CRLF regression, multi-source, whole-commit-would-delete-the-test property. Harness 113 tests green; 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)