### PR TITLE
feat: WS-W4 real-scale epoch runner (bundle dry-run runner) — null-agent verified

### DIFF
--- a/bench/phase0-agent-native/README-bundle-runner.md
+++ b/bench/phase0-agent-native/README-bundle-runner.md
@@ -31,20 +31,32 @@ cost/token/iteration extraction.
 
 **Added (what a bundle forces):**
 
-1. **Whole-project workspace.** `materialize` copies the bundle's `csharp-arm/`
-   or `calor-arm/` (a full OSS project working copy — both are plain `.cs`; the
-   calor arm is round-tripped C#) into `$ws/src`. No synthesized `Src.csproj`:
-   the project builds itself through its own test project (the regression net),
-   using the Slice-B build knobs (`TargetFramework` + `ExtraBuildProperties`)
-   keyed by `ProjectName` (mirrors `ProjectConfigs.cs`). The corpus's `global.json`
-   SDK pin is already dropped in the bundle copy, so it builds on the pinned SDK.
-2. **OSS-project held-out oracle** (`run_oracle`). Builds the regression-net
-   project (rebuilding the mutated library), then runs the **held-out filter**
-   (must PASS = defect fixed) and the **visible filter** (must stay green = no
-   regression). Filter-based split per Slice-C: `HeldOut[].FilterName` →
-   `FullyQualifiedName~…`; `VisibleTestFilter` is the `!~` complement. Run
-   silently by the shim (held-out leg, for the iterations-to-green signal) and at
-   declared-done (both legs, for adjudication).
+1. **Two-copy whole-project workspace (the oracle-leak fix).** `materialize`
+   makes TWO copies of the bundle arm (`csharp-arm/` or `calor-arm/` — both plain
+   `.cs`; the calor arm is round-tripped C#):
+   - **`$ws/src` (agent-visible):** the held-out test method(s) are **physically
+     stripped** from the test sources (`bundle-helpers.py strip-heldout`), so the
+     agent's `dotnet test` — filtered or not — runs only the visible suite. The
+     agent can neither read nor run the oracle.
+   - **`$ws_oracle` (harness-only):** a separate mktemp tree the agent has no path
+     to (never named in the prompt/spec/cwd), with the held-out test PRESENT. Its
+     library is kept in sync with the agent's edits (`sync_to_oracle` copies every
+     non-test `.cs` from `$ws/src`, excluding the test-project dir, so held-out
+     tests are never overwritten).
+
+   No synthesized `Src.csproj`: each copy builds itself through its own test
+   project (the regression net), using the Slice-B build knobs (`TargetFramework`
+   + `ExtraBuildProperties`) keyed by `ProjectName` (mirrors `ProjectConfigs.cs`).
+   The corpus `global.json` SDK pin is already dropped in the bundle copy.
+2. **OSS-project held-out oracle** (`run_oracle`, always on `$ws_oracle`). Syncs
+   the agent's edits in, builds the regression-net project (rebuilding the
+   library), then runs the **held-out filter** (`HeldOut[].FilterName` →
+   `FullyQualifiedName~…`; must PASS = defect fixed) and the **visible filter**
+   (`VisibleTestFilter`, the `!~` complement; must stay green = no regression).
+   Run silently by the shim (held-out leg, for the iterations-to-green signal) and
+   at declared-done (both legs, for adjudication). `strip-heldout` is **fail-loud**:
+   a held-out method that cannot be located/uniquely removed aborts the run (a
+   silent miss = the leak persists = a fabricated measurement).
 3. **Prompt = the scrubbed failing-behavior report** (`FailingBehavior.Symptom`).
    The held-out test is never shown; the agent is told the visible filter and to
    work the visible suite only, and a PreToolUse hook blocks edits to test files.
@@ -130,12 +142,13 @@ on a single bundle to sanity-check spend, then scale up.
 - **Presentation asymmetry (recorded, bias against Calor):** the calor arm works
   on machine-converted round-tripped C#, the C# arm on the idiomatic original.
   Carried in every `result.json`.
-- **Held-out physical presence:** the split is filter-based (Slice-C design), so
-  the held-out test is physically present in the regression-net project. The
-  oracle is silent (shim-run, never shown) and the agent is told the visible
-  filter + hook-blocked from editing tests, but a real agent could still read/run
-  the full suite. Hardening (stripping held-out bodies from the agent copy while
-  the shim restores them) is future work; not required for the mechanical dry-run.
+- **Oracle isolation (CLOSED):** the held-out test is physically stripped from
+  the agent copy and present only in a separate harness-only tree the agent has no
+  path to (see mechanism above). Verified: in the agent copy the held-out method
+  name greps to 0 and `dotnet test` (no filter) runs the visible suite green with
+  the row count dropped by exactly the held-out method(s); the oracle copy retains
+  it and still adjudicates. `strip-heldout` fails loud if it cannot remove a
+  held-out method.
 - **calor-arm reference derivation** requires the mutated line to appear exactly
   once in the round-tripped file; `apply-fix` fails loud otherwise (that bundle's
   calor null-agent smoke is skipped, not mis-adjudicated). The real agent path

--- a/bench/phase0-agent-native/README-bundle-runner.md
+++ b/bench/phase0-agent-native/README-bundle-runner.md
@@ -48,15 +48,27 @@ cost/token/iteration extraction.
    project (the regression net), using the Slice-B build knobs (`TargetFramework`
    + `ExtraBuildProperties`) keyed by `ProjectName` (mirrors `ProjectConfigs.cs`).
    The corpus `global.json` SDK pin is already dropped in the bundle copy.
-2. **OSS-project held-out oracle** (`run_oracle`, always on `$ws_oracle`). Syncs
-   the agent's edits in, builds the regression-net project (rebuilding the
-   library), then runs the **held-out filter** (`HeldOut[].FilterName` →
-   `FullyQualifiedName~…`; must PASS = defect fixed) and the **visible filter**
-   (`VisibleTestFilter`, the `!~` complement; must stay green = no regression).
-   Run silently by the shim (held-out leg, for the iterations-to-green signal) and
-   at declared-done (both legs, for adjudication). `strip-heldout` is **fail-loud**:
-   a held-out method that cannot be located/uniquely removed aborts the run (a
-   silent miss = the leak persists = a fabricated measurement).
+2. **OSS-project held-out oracle** (`run_oracle`, always on `$ws_oracle`, run
+   **entirely in the harness process**). At declared-done, `run-bundle.sh` syncs
+   the agent's edits in, builds the regression-net project, then runs the
+   **held-out filter** (must PASS = defect fixed) and the **visible/regression
+   filter** (must stay green). Both filters use **exact** `FullyQualifiedName=` /
+   `!=` matching computed from `HeldOut[].FilterName` — NOT substring `~`/`!~`
+   (which would sweep a prefix-sibling method into the held-out leg and out of the
+   regression net; observed on Serilog cand10). `strip-heldout` is **fail-loud**:
+   a held-out method that cannot be located/uniquely removed — or an
+   expression-bodied member whose end can't be balance-matched — aborts the run (a
+   silent miss/corrupt cut = the leak persists / a red baseline = a fabricated
+   measurement).
+
+   **The agent-facing `dotnet` shim contains NO oracle information** — no oracle
+   tree path, no held-out `--filter`. It only runs the real dotnet for the agent's
+   own build/test in `$ws/src` and journals invocation metadata (cmd/exit,
+   edit-hash, iteration ordinal, latency). All oracle work — the path and the
+   held-out names — lives only in `run-bundle.sh`'s own process variables, off the
+   agent's PATH and out of every agent-readable file. (Per-iteration held-out
+   journaling was removed with the shim's oracle; the verdict needs only the
+   declared-done run, and `iterations` = edited build/test cycles is unaffected.)
 3. **Prompt = the scrubbed failing-behavior report** (`FailingBehavior.Symptom`).
    The held-out test is never shown; the agent is told the visible filter and to
    work the visible suite only, and a PreToolUse hook blocks edits to test files.
@@ -74,7 +86,8 @@ cost/token/iteration extraction.
 | `caught` | held-out now PASSES **and** the visible suite is still green (no new failures vs the starting baseline) |
 | `escaped` | held-out still FAILS, or the final build fails (non-building declared-done ⇒ not fixed) |
 | `broke-regression` | held-out passes but a previously-green visible test regressed |
-| `invalid` | agent/plumbing error; retried up to the cap, then recorded `invalid:true` |
+| `invalid` | **any nonzero agent exit** (crash/timeout/API error), or a plumbing error; retried up to the cap, then recorded `invalid:true` (never scored escaped) |
+| `skipped` | a null-agent smoke whose reference could not be derived (e.g. calor arm, mutated line not uniquely locatable) — not a verdict |
 
 The starting state is oracle-checked at `materialize` (the mutated arm must
 present held-out FAILING and the visible suite green); the visible-fail baseline
@@ -86,7 +99,8 @@ pre-existing red.
 - `outcome`, `escapedBugs` (held-out fail count)
 - `costUsd` — **summed `total_cost_usd`** from the agent envelope (never
   hand-priced from tokens), `tokens.{input,output}`
-- `iterations`, `iterationsToGreen` (censored → budget+1), `wallClockSeconds`
+- `iterations` / `iterationsToDeclaredDone` (edited build/test cycles),
+  `wallClockSeconds`
 - **D-W4.4 ceiling-recurrence signal**: the C#-arm escaped incidence across the
   epoch. If the C# arm catches ~all injected bugs itself (incidence ≈ 0), the
   ceiling persists at real scale.
@@ -142,13 +156,22 @@ on a single bundle to sanity-check spend, then scale up.
 - **Presentation asymmetry (recorded, bias against Calor):** the calor arm works
   on machine-converted round-tripped C#, the C# arm on the idiomatic original.
   Carried in every `result.json`.
-- **Oracle isolation (CLOSED):** the held-out test is physically stripped from
-  the agent copy and present only in a separate harness-only tree the agent has no
-  path to (see mechanism above). Verified: in the agent copy the held-out method
-  name greps to 0 and `dotnet test` (no filter) runs the visible suite green with
-  the row count dropped by exactly the held-out method(s); the oracle copy retains
-  it and still adjudicates. `strip-heldout` fails loud if it cannot remove a
-  held-out method.
+- **Oracle isolation (CLOSED):** the held-out test is physically stripped from the
+  agent copy and present only in a separate harness-only tree; the agent-facing
+  shim carries no oracle path and no held-out filter (the oracle runs in the
+  parent harness process). Verified: the shim greps to 0 for the oracle path and
+  for any `FullyQualifiedName` filter; the agent tree + shim + final-src grep to 0
+  for the oracle path and the held-out method names; and `dotnet test` (no filter)
+  in the agent copy runs the visible suite green with the row count dropped by
+  exactly the held-out method(s). `strip-heldout` fails loud on any un-removable
+  method or unbalanced expression body.
+- **Residual (honest):** isolation is *path-and-toolchain* isolation, not a
+  sandbox. The oracle tree and the parent run from the same UID, so a maximally
+  adversarial agent could in principle enumerate `/proc` (Linux) or sibling
+  processes to find the parent's oracle build. The decisive, verified fix is
+  removing the plaintext oracle path/filter from the agent's own workspace and
+  toolchain; a fully hermetic run (separate UID/container per arm) is the
+  belt-and-suspenders follow-up if the dry-run shows it matters.
 - **calor-arm reference derivation** requires the mutated line to appear exactly
   once in the round-tripped file; `apply-fix` fails loud otherwise (that bundle's
   calor null-agent smoke is skipped, not mis-adjudicated). The real agent path

--- a/bench/phase0-agent-native/README-bundle-runner.md
+++ b/bench/phase0-agent-native/README-bundle-runner.md
@@ -1,0 +1,144 @@
+# WS-W4 Slice-C bundle dry-run runner
+
+Real-scale epoch runner for the D-W4.5 (provisional-i, mechanical-only) dry-run.
+It runs agents on gen-tasks **Slice-C bundles** (whole-OSS-project working copies
+carrying one injected defect) and adjudicates **caught vs escaped** via the
+held-out oracle. It is an **adapter over the battle-tested `run-pair.sh`
+machinery** — it does not reimplement the run loop; it reuses the proven building
+blocks and swaps in a bundle-shaped workspace + an OSS-project oracle.
+
+## Files
+
+| File | Role |
+|------|------|
+| `run-bundle.sh` | The runner. One bundle, one arm, N runs. `--null-agent` / `--null-agent-noop` for zero-spend plumbing checks. |
+| `bundle-helpers.py` | Derives the held-out `--filter` and the null-agent **reference (the fix)** from provenance + the SHA-pinned corpus. |
+| `run-bundle-epoch.sh` | Epoch driver: every bundle × both arms × N runs, then aggregate. |
+| `analyze-bundle-epoch.py` | Per-(bundle, arm) metrics + the D-W4.4 ceiling-recurrence signal. |
+
+## Reused vs added
+
+**Reused from `run-pair.sh` (copied verbatim / all-but-verbatim, marked in-source):**
+`detect_invalid_run` (§0.2 invalid-run markers), the invalid-run **detect +
+retry-on-fresh-workspace + record-as-failure** main loop, `kill_agent_tree`
+(watchdog process-group SIGKILL), `archive_final_src` (declared-done source
+archival), the **`dotnet` PATH shim** design (journal build/test invocations,
+hash-based edit detection, 1-based iteration ordinals, silent held-out run after
+each build/test), the **`--null-agent`** reference-application pattern, the
+`claude --print --output-format json` invocation with `timeout`/`gtimeout` +
+bash-watchdog fallback, and the per-run `agent.json`/`result.json` +
+cost/token/iteration extraction.
+
+**Added (what a bundle forces):**
+
+1. **Whole-project workspace.** `materialize` copies the bundle's `csharp-arm/`
+   or `calor-arm/` (a full OSS project working copy — both are plain `.cs`; the
+   calor arm is round-tripped C#) into `$ws/src`. No synthesized `Src.csproj`:
+   the project builds itself through its own test project (the regression net),
+   using the Slice-B build knobs (`TargetFramework` + `ExtraBuildProperties`)
+   keyed by `ProjectName` (mirrors `ProjectConfigs.cs`). The corpus's `global.json`
+   SDK pin is already dropped in the bundle copy, so it builds on the pinned SDK.
+2. **OSS-project held-out oracle** (`run_oracle`). Builds the regression-net
+   project (rebuilding the mutated library), then runs the **held-out filter**
+   (must PASS = defect fixed) and the **visible filter** (must stay green = no
+   regression). Filter-based split per Slice-C: `HeldOut[].FilterName` →
+   `FullyQualifiedName~…`; `VisibleTestFilter` is the `!~` complement. Run
+   silently by the shim (held-out leg, for the iterations-to-green signal) and at
+   declared-done (both legs, for adjudication).
+3. **Prompt = the scrubbed failing-behavior report** (`FailingBehavior.Symptom`).
+   The held-out test is never shown; the agent is told the visible filter and to
+   work the visible suite only, and a PreToolUse hook blocks edits to test files.
+4. **Derived reference.** A bundle ships no `reference/` solution, so
+   `bundle-helpers.py apply-fix` derives it: for the **csharp** arm the fix is
+   exact (copy the pristine corpus file over the one-line mutation); for the
+   **calor** arm it reverses the single mutated line by content match in the
+   round-tripped copy (provenance Line/Column address the C# arm only), failing
+   loud if the line is missing or non-unique.
+
+## Adjudication (per run, at declared-done)
+
+| Outcome | Condition |
+|---|---|
+| `caught` | held-out now PASSES **and** the visible suite is still green (no new failures vs the starting baseline) |
+| `escaped` | held-out still FAILS, or the final build fails (non-building declared-done ⇒ not fixed) |
+| `broke-regression` | held-out passes but a previously-green visible test regressed |
+| `invalid` | agent/plumbing error; retried up to the cap, then recorded `invalid:true` |
+
+The starting state is oracle-checked at `materialize` (the mutated arm must
+present held-out FAILING and the visible suite green); the visible-fail baseline
+is stored so a declared-done visible failure is scored as a regression, not a
+pre-existing red.
+
+## Metrics (`result.json`, aggregated by `analyze-bundle-epoch.py`)
+
+- `outcome`, `escapedBugs` (held-out fail count)
+- `costUsd` — **summed `total_cost_usd`** from the agent envelope (never
+  hand-priced from tokens), `tokens.{input,output}`
+- `iterations`, `iterationsToGreen` (censored → budget+1), `wallClockSeconds`
+- **D-W4.4 ceiling-recurrence signal**: the C#-arm escaped incidence across the
+  epoch. If the C# arm catches ~all injected bugs itself (incidence ≈ 0), the
+  ceiling persists at real scale.
+
+## Generating bundles
+
+```bash
+git submodule update --init --depth 1 bench/corpus/serilog bench/corpus/FluentValidation
+dotnet build tools/Calor.RoundTrip.Harness -c Release
+HARNESS=tools/Calor.RoundTrip.Harness/bin/Release/net10.0/Calor.RoundTrip.Harness.dll
+dotnet "$HARNESS" gen-tasks FluentValidation --output <BUNDLES> --target 2 --max-candidates 6
+dotnet "$HARNESS" gen-tasks Serilog          --output <BUNDLES> --target 2 --max-candidates 40
+# bundles land under <BUNDLES>/bundles/<taskId>/  (csharp-arm/, calor-arm/, provenance.json)
+```
+
+Bundles + workspaces are **ephemeral and never committed** (task constraint).
+
+## Zero-spend plumbing verification (run before any spend)
+
+```bash
+BUNDLE=<BUNDLES>/bundles/<taskId>
+# CAUGHT: null agent applies the reference (the fix)
+./run-bundle.sh --bundle "$BUNDLE" --arm csharp --null-agent      --out /tmp/verify
+./run-bundle.sh --bundle "$BUNDLE" --arm calor  --null-agent      --out /tmp/verify
+# ESCAPED (negative control): null agent does nothing, defect remains
+./run-bundle.sh --bundle "$BUNDLE" --arm csharp --null-agent-noop --out /tmp/verify
+```
+
+Or the whole epoch in zero-spend noop mode (must adjudicate ESCAPED everywhere):
+
+```bash
+./run-bundle-epoch.sh --bundles <BUNDLES> --out epochs/dry-run-smoke --null-noop
+```
+
+## Launching the REAL (spend-authorized) dry-run
+
+After spend authorization, from the repo root, with the corpus checked out and
+the CLI/harness built:
+
+```bash
+./bench/phase0-agent-native/run-bundle-epoch.sh \
+    --bundles <BUNDLES> \
+    --out bench/phase0-agent-native/epochs/w4-dryrun-001 \
+    --runs 5 --real --corpus bench/corpus
+```
+
+This runs every bundle × {csharp, calor} × 5 runs, spawning `claude` per run
+(honoring `CLAUDE_MODEL`), and writes `epoch-summary.json`. Start with `--runs 1`
+on a single bundle to sanity-check spend, then scale up.
+
+## Known gaps / biases (for the dry-run to weigh)
+
+- **Presentation asymmetry (recorded, bias against Calor):** the calor arm works
+  on machine-converted round-tripped C#, the C# arm on the idiomatic original.
+  Carried in every `result.json`.
+- **Held-out physical presence:** the split is filter-based (Slice-C design), so
+  the held-out test is physically present in the regression-net project. The
+  oracle is silent (shim-run, never shown) and the agent is told the visible
+  filter + hook-blocked from editing tests, but a real agent could still read/run
+  the full suite. Hardening (stripping held-out bodies from the agent copy while
+  the shim restores them) is future work; not required for the mechanical dry-run.
+- **calor-arm reference derivation** requires the mutated line to appear exactly
+  once in the round-tripped file; `apply-fix` fails loud otherwise (that bundle's
+  calor null-agent smoke is skipped, not mis-adjudicated). The real agent path
+  does not use the reference.
+- **Corpus required for null-agent only.** The reference derivation needs the
+  SHA-pinned corpus; the real agent dry-run does not.

--- a/bench/phase0-agent-native/analyze-bundle-epoch.py
+++ b/bench/phase0-agent-native/analyze-bundle-epoch.py
@@ -75,8 +75,14 @@ def summarize(results):
             f"iters~={g['meanItersToDone']}(var {g['varItersToDone']})  wall={g['meanWallSec']}s"
         )
 
-    # Ceiling-recurrence signal: C#-arm escaped incidence (exclude invalid runs).
-    cs = [r for r in results if r.get("arm") == "csharp" and r.get("outcome") != "invalid"]
+    # Ceiling-recurrence signal: C#-arm escaped incidence. Keyed on the BASE arm
+    # (label may carry a "+variant" suffix) and restricted to REAL agent runs —
+    # synthetic null-agent runs (fix/noop smokes) are not evidence of the ceiling.
+    def base_arm(r):
+        return (r.get("arm") or "").split("+", 1)[0]
+    cs = [r for r in results
+          if base_arm(r) == "csharp" and not r.get("nullAgent")
+          and r.get("outcome") != "invalid"]
     cs_escaped = sum(1 for r in cs if r.get("outcome") == "escaped")
     ceiling = {
         "csharpValidRuns": len(cs),

--- a/bench/phase0-agent-native/analyze-bundle-epoch.py
+++ b/bench/phase0-agent-native/analyze-bundle-epoch.py
@@ -61,28 +61,31 @@ def summarize(results):
             "escaped": outcomes.get("escaped", 0),
             "brokeRegression": outcomes.get("broke-regression", 0),
             "invalid": outcomes.get("invalid", 0),
+            "skipped": outcomes.get("skipped", 0),
             "meanCostUsd": mean([r.get("costUsd") for r in rs]),
             "meanOutputTokens": mean([r.get("tokens", {}).get("output") for r in rs]),
-            "meanItersToDone": mean([r.get("iterationsToGreen") for r in rs]),
-            "varItersToDone": pvariance([r.get("iterationsToGreen") for r in rs]),
+            "meanItersToDone": mean([r.get("iterationsToDeclaredDone") for r in rs]),
+            "varItersToDone": pvariance([r.get("iterationsToDeclaredDone") for r in rs]),
             "meanWallSec": mean([r.get("wallClockSeconds") for r in rs]),
         }
         per_group.append(g)
         lines.append(
             f"  {bundle}  [{arm}]  n={n}  "
-            f"caught={g['caught']} escaped={g['escaped']} broke={g['brokeRegression']} invalid={g['invalid']}  "
+            f"caught={g['caught']} escaped={g['escaped']} broke={g['brokeRegression']} "
+            f"invalid={g['invalid']} skipped={g['skipped']}  "
             f"cost/run=${g['meanCostUsd']}  outTok={g['meanOutputTokens']}  "
             f"iters~={g['meanItersToDone']}(var {g['varItersToDone']})  wall={g['meanWallSec']}s"
         )
 
     # Ceiling-recurrence signal: C#-arm escaped incidence. Keyed on the BASE arm
     # (label may carry a "+variant" suffix) and restricted to REAL agent runs —
-    # synthetic null-agent runs (fix/noop smokes) are not evidence of the ceiling.
+    # synthetic null-agent runs (fix/noop smokes) and skipped/invalid runs are not
+    # evidence of the ceiling.
     def base_arm(r):
         return (r.get("arm") or "").split("+", 1)[0]
     cs = [r for r in results
           if base_arm(r) == "csharp" and not r.get("nullAgent")
-          and r.get("outcome") != "invalid"]
+          and r.get("outcome") not in ("invalid", "skipped")]
     cs_escaped = sum(1 for r in cs if r.get("outcome") == "escaped")
     ceiling = {
         "csharpValidRuns": len(cs),

--- a/bench/phase0-agent-native/analyze-bundle-epoch.py
+++ b/bench/phase0-agent-native/analyze-bundle-epoch.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Aggregate a WS-W4 bundle dry-run epoch (result.json files written by
+run-bundle.sh) into per-(bundle, arm) feasibility metrics.
+
+Reports, per arm group:
+  * outcome mix (caught / escaped / broke-regression / invalid)
+  * cost/run (mean, from summed total_cost_usd — never hand-priced)
+  * output tokens (mean), iterations-to-declared-done (mean), wall-clock (mean)
+  * variance of iterations-to-green (a feasibility / MDE input)
+
+And the D-W4.4 CEILING-RECURRENCE signal: the C#-arm escaped-bug incidence
+(fraction of C#-arm runs whose injected bug ESCAPED). If the C# arm catches ~all
+injected bugs itself (incidence ~ 0), the ceiling persists at real scale.
+
+Usage: analyze-bundle-epoch.py <epoch_out_dir> [--json]
+"""
+import json
+import os
+import sys
+import statistics as stats
+
+
+def find_results(root):
+    out = []
+    for dirpath, _dirs, files in os.walk(root):
+        if "result.json" in files:
+            try:
+                with open(os.path.join(dirpath, "result.json")) as f:
+                    out.append(json.load(f))
+            except (OSError, json.JSONDecodeError):
+                pass
+    return out
+
+
+def mean(xs):
+    xs = [x for x in xs if x is not None]
+    return round(stats.mean(xs), 4) if xs else None
+
+
+def pvariance(xs):
+    xs = [x for x in xs if x is not None]
+    return round(stats.pvariance(xs), 4) if len(xs) > 1 else 0.0
+
+
+def summarize(results):
+    groups = {}
+    for r in results:
+        groups.setdefault((r.get("bundle", "?"), r.get("arm", "?")), []).append(r)
+
+    lines = []
+    per_group = []
+    for (bundle, arm), rs in sorted(groups.items()):
+        n = len(rs)
+        outcomes = {}
+        for r in rs:
+            outcomes[r.get("outcome", "?")] = outcomes.get(r.get("outcome", "?"), 0) + 1
+        g = {
+            "bundle": bundle, "arm": arm, "runs": n,
+            "caught": outcomes.get("caught", 0),
+            "escaped": outcomes.get("escaped", 0),
+            "brokeRegression": outcomes.get("broke-regression", 0),
+            "invalid": outcomes.get("invalid", 0),
+            "meanCostUsd": mean([r.get("costUsd") for r in rs]),
+            "meanOutputTokens": mean([r.get("tokens", {}).get("output") for r in rs]),
+            "meanItersToDone": mean([r.get("iterationsToGreen") for r in rs]),
+            "varItersToDone": pvariance([r.get("iterationsToGreen") for r in rs]),
+            "meanWallSec": mean([r.get("wallClockSeconds") for r in rs]),
+        }
+        per_group.append(g)
+        lines.append(
+            f"  {bundle}  [{arm}]  n={n}  "
+            f"caught={g['caught']} escaped={g['escaped']} broke={g['brokeRegression']} invalid={g['invalid']}  "
+            f"cost/run=${g['meanCostUsd']}  outTok={g['meanOutputTokens']}  "
+            f"iters~={g['meanItersToDone']}(var {g['varItersToDone']})  wall={g['meanWallSec']}s"
+        )
+
+    # Ceiling-recurrence signal: C#-arm escaped incidence (exclude invalid runs).
+    cs = [r for r in results if r.get("arm") == "csharp" and r.get("outcome") != "invalid"]
+    cs_escaped = sum(1 for r in cs if r.get("outcome") == "escaped")
+    ceiling = {
+        "csharpValidRuns": len(cs),
+        "csharpEscaped": cs_escaped,
+        "csharpEscapedIncidence": round(cs_escaped / len(cs), 4) if cs else None,
+        "interpretation": (
+            "incidence ~ 0 => C# arm catches ~all injected bugs itself; ceiling persists at real scale"
+            if cs else "no valid C#-arm runs"
+        ),
+    }
+
+    total_cost = round(sum(r.get("costUsd", 0) or 0 for r in results), 4)
+    return {
+        "totalRuns": len(results),
+        "totalRealizedCostUsd": total_cost,
+        "groups": per_group,
+        "ceilingRecurrence": ceiling,
+    }, lines
+
+
+def main(argv):
+    if len(argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    root = argv[1]
+    as_json = "--json" in argv[2:]
+    results = find_results(root)
+    if not results:
+        print(f"No result.json under {root}", file=sys.stderr)
+        return 1
+    summary, lines = summarize(results)
+    if as_json:
+        print(json.dumps(summary, indent=2))
+        return 0
+    print(f"WS-W4 bundle dry-run epoch: {summary['totalRuns']} run(s), "
+          f"realized cost ${summary['totalRealizedCostUsd']}")
+    print("Per (bundle, arm):")
+    print("\n".join(lines))
+    c = summary["ceilingRecurrence"]
+    print(f"\nD-W4.4 ceiling-recurrence signal: C#-arm escaped {c['csharpEscaped']}/"
+          f"{c['csharpValidRuns']} valid runs (incidence {c['csharpEscapedIncidence']})")
+    print(f"  {c['interpretation']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/bench/phase0-agent-native/bundle-helpers.py
+++ b/bench/phase0-agent-native/bundle-helpers.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Slice-C bundle adapter helpers for run-bundle.sh (WS-W4 dry-run runner).
+
+The authored-pair runner (run-pair.sh) ships a per-arm reference/ solution the
+null-agent applies to prove the plumbing. A gen-tasks bundle does NOT ship one,
+so this helper DERIVES the reference (the un-mutated source = the fix) from the
+bundle's provenance + the SHA-pinned corpus:
+
+  * csharp arm  -> the reference is EXACT: the pristine corpus file (the C# arm
+                   is the idiomatic original + one point mutation), copied over
+                   the mutated file.
+  * calor  arm  -> the reference is derived by reversing the single mutated line
+                   in the round-tripped copy. provenance Line/Column address the
+                   C# arm only (the converter renumbers lines), so we anchor on
+                   the mutated line's CONTENT (from the C#-arm/corpus diff) and
+                   fail loud unless it matches exactly once.
+
+Fail-loud is deliberate: a mis-derived reference would fabricate a CAUGHT/ESCAPED
+verdict, exactly the hazard the null-agent verification exists to rule out.
+
+Subcommands:
+  heldout-filter <bundle_dir>
+      Print the held-out dotnet --filter expression (OR of FullyQualifiedName~).
+  apply-fix <bundle_dir> <arm> <ws_src_dir> <corpus_root> <calor_root>
+      Derive and apply the reference fix into <ws_src_dir>. Prints "OK: ..." on
+      success (exit 0) or "ERROR: ..." (exit 1).
+"""
+import json
+import os
+import sys
+
+
+# ProjectName -> the working-copy root that holds the pristine, un-mutated source
+# (mirrors ProjectConfigs.cs OriginalProjectPath; the corpus dir casing matters).
+def subject_root(project_name, corpus_root, calor_root):
+    key = project_name.lower()
+    if key == "fluentvalidation":
+        return os.path.join(corpus_root, "FluentValidation")
+    if key == "serilog":
+        return os.path.join(corpus_root, "serilog")
+    if key == "mediatr":
+        return os.path.join(corpus_root, "MediatR")
+    if key == "synthetic":
+        return os.path.join(calor_root, "tests", "Calor.RoundTrip.Synthetic")
+    if key == "synthetic2":
+        return os.path.join(calor_root, "tests", "Calor.RoundTrip.Synthetic2")
+    return None
+
+
+def load_prov(bundle_dir):
+    with open(os.path.join(bundle_dir, "provenance.json")) as f:
+        return json.load(f)
+
+
+def cmd_heldout_filter(bundle_dir):
+    prov = load_prov(bundle_dir)
+    names = [h.get("FilterName") or f"{h['ClassName']}.{h['TestName']}"
+             for h in prov.get("HeldOut", [])]
+    names = [n for n in names if n]
+    if not names:
+        print("ERROR: no held-out tests in provenance", file=sys.stderr)
+        return 1
+    print("|".join(f"FullyQualifiedName~{n}" for n in names))
+    return 0
+
+
+def diff_single_line(original_text, mutated_text):
+    """Return (orig_line, mut_line) for the single line that changed, or None
+    if the change is not a clean one-line point mutation."""
+    o = original_text.splitlines()
+    m = mutated_text.splitlines()
+    if len(o) != len(m):
+        return None
+    diffs = [(ol, ml) for ol, ml in zip(o, m) if ol != ml]
+    if len(diffs) != 1:
+        return None
+    return diffs[0]
+
+
+def cmd_apply_fix(bundle_dir, arm, ws_src, corpus_root, calor_root):
+    prov = load_prov(bundle_dir)
+    project = prov["ProjectName"]
+    rel = prov["Provenance"]["MutatedFileRelPath"]
+    root = subject_root(project, corpus_root, calor_root)
+    if root is None:
+        print(f"ERROR: no pristine-source root known for project {project}", file=sys.stderr)
+        return 1
+    pristine_path = os.path.join(root, rel)
+    if not os.path.isfile(pristine_path):
+        print(f"ERROR: pristine corpus file missing: {pristine_path} "
+              f"(corpus submodule not checked out?)", file=sys.stderr)
+        return 1
+    cs_mut_path = os.path.join(bundle_dir, "csharp-arm", rel)
+    if not os.path.isfile(cs_mut_path):
+        print(f"ERROR: csharp-arm mutated file missing: {cs_mut_path}", file=sys.stderr)
+        return 1
+
+    with open(pristine_path, encoding="utf-8") as f:
+        pristine = f.read()
+    with open(cs_mut_path, encoding="utf-8") as f:
+        cs_mut = f.read()
+
+    diff = diff_single_line(pristine, cs_mut)
+    if diff is None:
+        print("ERROR: csharp-arm file is not a clean single-line point mutation "
+              "vs the pristine corpus file; cannot derive reference", file=sys.stderr)
+        return 1
+    orig_line, mut_line = diff
+
+    target = os.path.join(ws_src, rel)
+    if not os.path.isfile(target):
+        print(f"ERROR: workspace file missing: {target}", file=sys.stderr)
+        return 1
+
+    if arm == "csharp":
+        # Exact reference: the pristine original source.
+        with open(target, "w", encoding="utf-8") as f:
+            f.write(pristine)
+        print(f"OK: csharp reference applied (pristine {rel}); "
+              f"reverted '{mut_line.strip()}' -> '{orig_line.strip()}'")
+        return 0
+
+    # calor arm: reverse the mutated line by content match (line numbers diverge
+    # post-conversion). Anchor on the trimmed mutated-line content; require a
+    # unique match so we never revert the wrong occurrence.
+    with open(target, encoding="utf-8") as f:
+        lines = f.read().splitlines(keepends=True)
+    needle = mut_line.strip()
+    repl = orig_line.strip()
+    hits = [i for i, ln in enumerate(lines) if ln.strip() == needle]
+    if len(hits) == 0:
+        print(f"ERROR: calor-arm reference underivable: mutated line '{needle}' "
+              f"not found in {rel} (converter reshaped it)", file=sys.stderr)
+        return 1
+    if len(hits) > 1:
+        print(f"ERROR: calor-arm reference ambiguous: mutated line '{needle}' "
+              f"occurs {len(hits)} times in {rel}; refusing to guess", file=sys.stderr)
+        return 1
+    i = hits[0]
+    ln = lines[i]
+    indent = ln[:len(ln) - len(ln.lstrip())]
+    eol = "\r\n" if ln.endswith("\r\n") else ("\n" if ln.endswith("\n") else "")
+    lines[i] = f"{indent}{repl}{eol}"
+    with open(target, "w", encoding="utf-8") as f:
+        f.write("".join(lines))
+    print(f"OK: calor reference applied ({rel} line {i + 1}); "
+          f"reverted '{needle}' -> '{repl}'")
+    return 0
+
+
+def main(argv):
+    if len(argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    cmd = argv[1]
+    if cmd == "heldout-filter" and len(argv) == 3:
+        return cmd_heldout_filter(argv[2])
+    if cmd == "apply-fix" and len(argv) == 7:
+        return cmd_apply_fix(argv[2], argv[3], argv[4], argv[5], argv[6])
+    print(f"ERROR: bad usage for '{cmd}'", file=sys.stderr)
+    print(__doc__, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/bench/phase0-agent-native/bundle-helpers.py
+++ b/bench/phase0-agent-native/bundle-helpers.py
@@ -21,7 +21,11 @@ verdict, exactly the hazard the null-agent verification exists to rule out.
 
 Subcommands:
   heldout-filter <bundle_dir>
-      Print the held-out dotnet --filter expression (OR of FullyQualifiedName~).
+      Print the held-out dotnet --filter expression (OR of FullyQualifiedName= —
+      EXACT, so a prefix-sibling method is not swept in).
+  visible-filter <bundle_dir>
+      Print the visible/regression --filter (AND of FullyQualifiedName!= — the
+      full suite minus the EXACT held-out set).
   apply-fix <bundle_dir> <arm> <ws_src_dir> <corpus_root> <calor_root>
       Derive and apply the reference fix into <ws_src_dir>. Prints "OK: ..." on
       success (exit 0) or "ERROR: ..." (exit 1).
@@ -58,15 +62,37 @@ def load_prov(bundle_dir):
         return json.load(f)
 
 
-def cmd_heldout_filter(bundle_dir):
-    prov = load_prov(bundle_dir)
+def _heldout_names(prov):
     names = [h.get("FilterName") or f"{h['ClassName']}.{h['TestName']}"
              for h in prov.get("HeldOut", [])]
-    names = [n for n in names if n]
+    return [n for n in names if n]
+
+
+def cmd_heldout_filter(bundle_dir):
+    # EXACT match (FullyQualifiedName=…), NOT substring (~): a held-out method
+    # whose FQN is a prefix of a sibling (Serilog cand10:
+    # …AnObjectIsRenderedInSimpleNotation vs …UsingFormatProvider) would, under
+    # ~, pull the sibling into the held-out leg and out of the regression net.
+    # For an xUnit theory every row shares the method FQN, so = still selects all
+    # rows of the held-out method(s) as one unit.
+    names = _heldout_names(load_prov(bundle_dir))
     if not names:
         print("ERROR: no held-out tests in provenance", file=sys.stderr)
         return 1
-    print("|".join(f"FullyQualifiedName~{n}" for n in names))
+    print("|".join(f"FullyQualifiedName={n}" for n in names))
+    return 0
+
+
+def cmd_visible_filter(bundle_dir):
+    # The regression/visible suite = full suite minus the EXACT held-out set
+    # (FullyQualifiedName!=… ANDed). Computed here rather than trusting
+    # provenance.VisibleTestFilter (which uses substring !~ and would wrongly
+    # exclude prefix-siblings too).
+    names = _heldout_names(load_prov(bundle_dir))
+    if not names:
+        print("ERROR: no held-out tests in provenance", file=sys.stderr)
+        return 1
+    print("&".join(f"FullyQualifiedName!={n}" for n in names))
     return 0
 
 
@@ -253,6 +279,54 @@ def _match_delimiter(text, open_i, open_ch, close_ch):
     return -1
 
 
+def _expr_body_end(text, sig):
+    """From `sig` (index of an expression-bodied member's `=>`), return the index
+    just past its terminating `;` — string/char/comment aware and depth-tracked so
+    a `;` inside a nested lambda/parenthesised expression/string is not mistaken
+    for the member terminator. Return -1 if no balanced depth-0 `;` is found (the
+    caller treats that as a failed strip and aborts — never a silent corrupt cut)."""
+    n = len(text)
+    i = sig + 2  # past '=>'
+    depth = 0   # net () [] {} nesting
+    while i < n:
+        c = text[i]
+        if c == '"' or (c in '@$' and i + 1 < n and text[i + 1] == '"') \
+                or (c in '@$' and i + 2 < n and text[i + 1] in '@$' and text[i + 2] == '"'):
+            q = i
+            while text[q] in '@$':
+                q += 1
+            i = _skip_string(text, q)
+            continue
+        if c == "'":
+            j = i + 1
+            while j < n:
+                if text[j] == '\\':
+                    j += 2
+                    continue
+                if text[j] == "'":
+                    j += 1
+                    break
+                j += 1
+            i = j
+            continue
+        if c == '/' and i + 1 < n and text[i + 1] == '/':
+            j = text.find('\n', i)
+            i = n if j < 0 else j + 1
+            continue
+        if c == '/' and i + 1 < n and text[i + 1] == '*':
+            j = text.find('*/', i + 2)
+            i = n if j < 0 else j + 2
+            continue
+        if c in '([{':
+            depth += 1
+        elif c in ')]}':
+            depth -= 1
+        elif c == ';' and depth == 0:
+            return i + 1
+        i += 1
+    return -1
+
+
 def _class_body_span(text, class_short):
     """Return (open_brace_index, end_index) of `class <class_short>`'s body, or None."""
     import re
@@ -287,8 +361,7 @@ def _remove_method(text, method, class_short):
         if text[sig] == '{':
             end = _match_delimiter(text, sig, '{', '}')
         elif text[sig:sig + 2] == '=>':
-            semi = text.find(';', sig)
-            end = semi + 1 if semi >= 0 else -1
+            end = _expr_body_end(text, sig)  # brace/string-aware; -1 if unbalanced
         else:
             continue  # not a method declaration (e.g. abstract/interface) — skip
         if end < 0:
@@ -383,6 +456,8 @@ def main(argv):
     cmd = argv[1]
     if cmd == "heldout-filter" and len(argv) == 3:
         return cmd_heldout_filter(argv[2])
+    if cmd == "visible-filter" and len(argv) == 3:
+        return cmd_visible_filter(argv[2])
     if cmd == "apply-fix" and len(argv) == 7:
         return cmd_apply_fix(argv[2], argv[3], argv[4], argv[5], argv[6])
     if cmd == "strip-heldout" and len(argv) == 4:

--- a/bench/phase0-agent-native/bundle-helpers.py
+++ b/bench/phase0-agent-native/bundle-helpers.py
@@ -25,6 +25,11 @@ Subcommands:
   apply-fix <bundle_dir> <arm> <ws_src_dir> <corpus_root> <calor_root>
       Derive and apply the reference fix into <ws_src_dir>. Prints "OK: ..." on
       success (exit 0) or "ERROR: ..." (exit 1).
+  strip-heldout <bundle_dir> <ws_src_dir>
+      PHYSICALLY REMOVE each held-out test method (identified by its FQN) from
+      the agent-visible test sources, so the agent can neither read nor run the
+      oracle. Fail-loud: if a held-out method cannot be located/uniquely removed,
+      exit 1 (a silent miss = the leak persists = a fabricated measurement).
 """
 import json
 import os
@@ -149,6 +154,228 @@ def cmd_apply_fix(bundle_dir, arm, ws_src, corpus_root, calor_root):
     return 0
 
 
+# ---------------------------------------------------------------------------
+# Held-out method stripping (the oracle-leak fix).
+#
+# A tiny string/comment/char-aware scanner walks C# source so brace/paren
+# matching for a method body never miscounts a delimiter that lives inside a
+# string or comment (including verbatim/interpolated strings and //, /* */).
+# ---------------------------------------------------------------------------
+def _skip_string(text, i):
+    """i points at the opening quote of a "..." / @"..." / $"..." literal
+    (any '@'/'$' prefixes already consumed by the caller). Return index just
+    past the closing quote. `verbatim` doubles "" to escape; regular uses \\."""
+    # Detect verbatim by looking back for '@'.
+    verbatim = i > 0 and (text[i - 1] == '@' or (i > 1 and text[i - 2:i] in ('@$', '$@')))
+    n = len(text)
+    j = i + 1
+    while j < n:
+        c = text[j]
+        if verbatim:
+            if c == '"':
+                if j + 1 < n and text[j + 1] == '"':
+                    j += 2
+                    continue
+                return j + 1
+            j += 1
+        else:
+            if c == '\\':
+                j += 2
+                continue
+            if c == '"':
+                return j + 1
+            j += 1
+    return n
+
+
+def _next_significant(text, i):
+    """Advance past whitespace and comments from i; return index of the next
+    significant char (or len)."""
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c in " \t\r\n":
+            i += 1
+        elif c == '/' and i + 1 < n and text[i + 1] == '/':
+            j = text.find('\n', i)
+            i = n if j < 0 else j + 1
+        elif c == '/' and i + 1 < n and text[i + 1] == '*':
+            j = text.find('*/', i + 2)
+            i = n if j < 0 else j + 2
+        else:
+            return i
+    return n
+
+
+def _match_delimiter(text, open_i, open_ch, close_ch):
+    """Brace/paren-match from an opening delimiter at open_i (string/comment
+    aware). Return index just past the matching close, or -1."""
+    n = len(text)
+    depth = 0
+    i = open_i
+    while i < n:
+        c = text[i]
+        if c == '"' or ((c in '@$') and i + 1 < n and text[i + 1] == '"') \
+                or (c in '@$' and i + 2 < n and text[i + 1] in '@$' and text[i + 2] == '"'):
+            # position i at the actual quote
+            q = i
+            while text[q] in '@$':
+                q += 1
+            i = _skip_string(text, q)
+            continue
+        if c == "'":
+            j = i + 1
+            while j < n:
+                if text[j] == '\\':
+                    j += 2
+                    continue
+                if text[j] == "'":
+                    j += 1
+                    break
+                j += 1
+            i = j
+            continue
+        if c == '/' and i + 1 < n and text[i + 1] == '/':
+            j = text.find('\n', i)
+            i = n if j < 0 else j + 1
+            continue
+        if c == '/' and i + 1 < n and text[i + 1] == '*':
+            j = text.find('*/', i + 2)
+            i = n if j < 0 else j + 2
+            continue
+        if c == open_ch:
+            depth += 1
+        elif c == close_ch:
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return -1
+
+
+def _class_body_span(text, class_short):
+    """Return (open_brace_index, end_index) of `class <class_short>`'s body, or None."""
+    import re
+    for m in re.finditer(r'\b(?:class|struct|record)\s+' + re.escape(class_short) + r'\b', text):
+        brace = text.find('{', m.end())
+        if brace < 0:
+            continue
+        end = _match_delimiter(text, brace, '{', '}')
+        if end > 0:
+            return (brace, end)
+    return None
+
+
+def _remove_method(text, method, class_short):
+    """Remove the method named `method` (with its attributes/doc-comment trivia)
+    from within class `class_short`. Return (new_text, True) or (text, False)."""
+    import re
+    span = _class_body_span(text, class_short)
+    if span is None:
+        return text, False
+    body_start, body_end = span
+    for m in re.finditer(r'\b' + re.escape(method) + r'\s*\(', text):
+        if not (body_start < m.start() < body_end):
+            continue
+        paren = text.index('(', m.start())
+        after_params = _match_delimiter(text, paren, '(', ')')
+        if after_params < 0:
+            continue
+        sig = _next_significant(text, after_params)
+        if sig >= len(text):
+            continue
+        if text[sig] == '{':
+            end = _match_delimiter(text, sig, '{', '}')
+        elif text[sig:sig + 2] == '=>':
+            semi = text.find(';', sig)
+            end = semi + 1 if semi >= 0 else -1
+        else:
+            continue  # not a method declaration (e.g. abstract/interface) — skip
+        if end < 0:
+            continue
+        # Expand start backward over attribute/doc-comment trivia lines.
+        line_start = text.rfind('\n', 0, m.start()) + 1
+        lines_before = text[:line_start].split('\n')
+        idx = len(lines_before) - 1  # index of the (empty) element after last \n
+        start_line_no = idx  # 0-based line holding the signature is idx
+        cut = line_start
+        k = idx - 1
+        while k >= 0:
+            s = lines_before[k].strip()
+            if s.startswith('[') or s.endswith(']') or s.startswith('///') \
+                    or s.startswith('//') or s == '' \
+                    or (s.startswith('*') or s.startswith('/*') or s.endswith('*/')):
+                k -= 1
+            else:
+                break
+        # cut at the first trivia line that is NON-blank (keep separating blanks)
+        j = idx - 1
+        first_nonblank_trivia = idx
+        while j > k:
+            if lines_before[j].strip() != '':
+                first_nonblank_trivia = j
+            j -= 1
+        cut = len(('\n'.join(lines_before[:first_nonblank_trivia])) + ('\n' if first_nonblank_trivia > 0 else ''))
+        # Extend end to end of line (consume trailing newline).
+        nl = text.find('\n', end)
+        end_cut = len(text) if nl < 0 else nl + 1
+        new_text = text[:cut] + text[end_cut:]
+        return new_text, True
+    return text, False
+
+
+def cmd_strip_heldout(bundle_dir, ws_src):
+    prov = load_prov(bundle_dir)
+    held = prov.get("HeldOut", [])
+    if not held:
+        print("ERROR: no held-out tests in provenance", file=sys.stderr)
+        return 1
+    cs_files = []
+    for dp, _d, files in os.walk(ws_src):
+        if os.sep + "obj" in dp or os.sep + "bin" in dp:
+            continue
+        for f in files:
+            if f.endswith(".cs"):
+                cs_files.append(os.path.join(dp, f))
+
+    ok = True
+    for h in held:
+        fqn = h.get("FilterName") or f"{h['ClassName']}.{h['TestName']}"
+        method = fqn.split("(")[0].rsplit(".", 1)[-1]
+        class_fqn = fqn.split("(")[0].rsplit(".", 1)[0]
+        class_short = class_fqn.rsplit(".", 1)[-1]
+        removed_in = []
+        for path in cs_files:
+            with open(path, encoding="utf-8") as fh:
+                text = fh.read()
+            if class_short not in text or method not in text:
+                continue
+            new_text, did = _remove_method(text, method, class_short)
+            if did:
+                # Verify the method declaration is gone from this file.
+                import re
+                if re.search(r'\b' + re.escape(method) + r'\s*\(', new_text) and \
+                   _class_body_span(new_text, class_short) and \
+                   _remove_method(new_text, method, class_short)[1]:
+                    print(f"ERROR: held-out method '{method}' still declared after strip in {path}",
+                          file=sys.stderr)
+                    ok = False
+                with open(path, "w", encoding="utf-8") as fh:
+                    fh.write(new_text)
+                removed_in.append(os.path.relpath(path, ws_src))
+        if len(removed_in) == 0:
+            print(f"ERROR: held-out method '{class_short}.{method}' NOT FOUND in agent test sources "
+                  f"(cannot strip -> would leak the oracle)", file=sys.stderr)
+            ok = False
+        elif len(removed_in) > 1:
+            print(f"ERROR: held-out method '{class_short}.{method}' removed from MULTIPLE files "
+                  f"{removed_in} (ambiguous)", file=sys.stderr)
+            ok = False
+        else:
+            print(f"OK: stripped held-out '{class_short}.{method}' from {removed_in[0]}")
+    return 0 if ok else 1
+
+
 def main(argv):
     if len(argv) < 2:
         print(__doc__, file=sys.stderr)
@@ -158,6 +385,8 @@ def main(argv):
         return cmd_heldout_filter(argv[2])
     if cmd == "apply-fix" and len(argv) == 7:
         return cmd_apply_fix(argv[2], argv[3], argv[4], argv[5], argv[6])
+    if cmd == "strip-heldout" and len(argv) == 4:
+        return cmd_strip_heldout(argv[2], argv[3])
     print(f"ERROR: bad usage for '{cmd}'", file=sys.stderr)
     print(__doc__, file=sys.stderr)
     return 2

--- a/bench/phase0-agent-native/run-bundle-epoch.sh
+++ b/bench/phase0-agent-native/run-bundle-epoch.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# ============================================================================
+# WS-W4 Slice-C bundle dry-run EPOCH driver
+# ============================================================================
+#
+# Orchestrates run-bundle.sh over every bundle under a bundles root, in BOTH
+# arms (csharp, calor), N runs each, then aggregates with analyze-bundle-epoch.py.
+# Mirrors the block structure of epochs/e1a-attribution/run-driver.sh but does
+# NOT git-commit: bundles + workspaces are ephemeral (task constraint) and the
+# real (spend) dry-run is separately authorized.
+#
+# The default here is --null-agent-noop in BOTH arms — a ZERO-SPEND smoke of the
+# whole epoch plumbing that must adjudicate ESCAPED everywhere (the defect is
+# left in place). Pass --real to launch the actual spend dry-run (spawns claude).
+#
+# Usage:
+#   ./run-bundle-epoch.sh --bundles <root> --out <epoch_dir> [--runs N]
+#                         [--real | --null-caught | --null-noop(default)]
+#                         [--corpus <dir>]
+# ============================================================================
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+BUNDLES_ROOT=""; OUT_DIR=""; RUNS=1; MODE="null-noop"
+CORPUS_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)/bench/corpus"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --bundles) BUNDLES_ROOT="$2"; shift 2 ;;
+        --out) OUT_DIR="$2"; shift 2 ;;
+        --runs) RUNS="$2"; shift 2 ;;
+        --real) MODE="real"; shift ;;
+        --null-caught) MODE="null-caught"; shift ;;
+        --null-noop) MODE="null-noop"; shift ;;
+        --corpus) CORPUS_ROOT="$2"; shift 2 ;;
+        *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+[[ -n "$BUNDLES_ROOT" && -n "$OUT_DIR" ]] || { echo "Usage: --bundles <root> --out <epoch_dir> [--runs N] [--real|--null-caught|--null-noop]" >&2; exit 2; }
+mkdir -p "$OUT_DIR"; OUT_DIR="$(cd "$OUT_DIR" && pwd)"
+LOG="$OUT_DIR/driver.log"
+log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "$LOG"; }
+
+MODE_FLAG=""
+case "$MODE" in
+    real)        MODE_FLAG="" ;;                    # spawns claude (spend)
+    null-caught) MODE_FLAG="--null-agent" ;;        # apply fix -> expect caught
+    null-noop)   MODE_FLAG="--null-agent-noop" ;;   # do nothing -> expect escaped
+esac
+
+# Discover bundles (dirs containing provenance.json). -L so an operator can
+# assemble a bundle set out of symlinks to individual bundle dirs.
+mapfile -t BUNDLES < <(find -L "$BUNDLES_ROOT" -type f -name provenance.json -exec dirname {} \; | sort)
+[[ ${#BUNDLES[@]} -gt 0 ]] || { echo "No bundles under $BUNDLES_ROOT" >&2; exit 3; }
+
+log "bundle epoch starting (pid $$) mode=$MODE runs=$RUNS bundles=${#BUNDLES[@]}"
+for bundle in "${BUNDLES[@]}"; do
+    bid="$(basename "$bundle")"
+    for arm in csharp calor; do
+        log "BLOCK START bundle=$bid arm=$arm runs=$RUNS mode=$MODE"
+        if "$SCRIPT_DIR/run-bundle.sh" --bundle "$bundle" --arm "$arm" --runs "$RUNS" \
+                --out "$OUT_DIR" --corpus "$CORPUS_ROOT" $MODE_FLAG >>"$LOG" 2>&1; then
+            log "BLOCK DONE  bundle=$bid arm=$arm"
+        else
+            log "ERROR run-bundle.sh nonzero: bundle=$bid arm=$arm (continuing)"
+        fi
+    done
+done
+
+log "bundle epoch complete; aggregating"
+python3 "$SCRIPT_DIR/analyze-bundle-epoch.py" "$OUT_DIR" | tee -a "$LOG"
+python3 "$SCRIPT_DIR/analyze-bundle-epoch.py" "$OUT_DIR" --json > "$OUT_DIR/epoch-summary.json"
+log "summary -> $OUT_DIR/epoch-summary.json"

--- a/bench/phase0-agent-native/run-bundle.sh
+++ b/bench/phase0-agent-native/run-bundle.sh
@@ -1,0 +1,483 @@
+#!/usr/bin/env bash
+# ============================================================================
+# WS-W4 Slice-C bundle runner (real-scale agent-native dry-run adapter)
+# ============================================================================
+#
+# ADAPTER over the battle-tested run-pair.sh machinery: it applies the SAME
+# proven building blocks (dotnet PATH shim + silent held-out oracle, per-run
+# agent.json/result.json, invalid-run detect+retry, watchdog process-group
+# kill, --null-agent reference application) to a gen-tasks Slice-C BUNDLE
+# instead of an authored pair. The functions marked "REUSED from run-pair.sh"
+# are copied verbatim (or all-but-verbatim) from that script; the differences a
+# bundle forces are localized to materialize()/the oracle:
+#
+#   1. Arm workspace = a WHOLE OSS project working copy (bundle's csharp-arm/ or
+#      calor-arm/, both plain .cs — the calor arm is round-tripped C#), not a
+#      small fixture with a synthesized Src.csproj. It builds itself via its own
+#      test project (the regression net), using the Slice-B harness build knobs
+#      (TFM + ExtraBuildProperties) keyed by ProjectName.
+#   2. Held-out oracle = the bundle's held-out test(s) (a --filter over the
+#      project's own suite) + the regression net (the rest of the suite), run
+#      SILENTLY by the shim after each build/test and at declared-done. The
+#      held-out tests are physically present (filter-based split, per Slice-C);
+#      the agent is told the VISIBLE filter and to work the visible suite only.
+#   3. Prompt = the scrubbed failing-behavior report (symptom only) from
+#      provenance.json; the held-out test is never shown.
+#   4. Reference (for --null-agent) is DERIVED, not shipped: see bundle-helpers.py.
+#
+# Adjudication (per run, at declared-done):
+#   caught          = held-out now PASSES  AND regression net still green
+#   escaped         = held-out still FAILS (or the final build fails)
+#   broke-regression= held-out passes but a previously-green visible test regressed
+#   invalid         = agent/plumbing error (retried up to the cap, then recorded)
+#
+# Usage:
+#   ./run-bundle.sh --bundle <dir> --arm csharp|calor [--runs N] [--out <dir>]
+#   ./run-bundle.sh --bundle <dir> --arm csharp --null-agent        # apply fix -> expect CAUGHT
+#   ./run-bundle.sh --bundle <dir> --arm csharp --null-agent-noop   # do nothing -> expect ESCAPED
+#   ./run-bundle.sh ... --corpus <dir> --projects-dir <dir>         # pristine-source roots
+# ============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HELPERS="$SCRIPT_DIR/bundle-helpers.py"
+
+MAX_INVALID_RETRIES=2
+INVALID_MARKERS=("hit your session limit" "rate limit" "overloaded" "api error")
+
+# -------- REUSED from run-pair.sh (verbatim): invalid-run detection (§0.2) ----
+detect_invalid_run() {
+    local ws_out="$1" agent_rc="${2:-0}"
+    local aj="$ws_out/agent.json"
+    if [[ ! -s "$aj" ]]; then echo "agent.json missing or empty"; return 0; fi
+    if ! jq -e . "$aj" >/dev/null 2>&1; then echo "agent.json is not valid JSON"; return 0; fi
+    local content marker
+    content="$( { jq -r '.result // empty' "$aj" 2>/dev/null; cat "$aj"; } | tr '[:upper:]' '[:lower:]')"
+    for marker in "${INVALID_MARKERS[@]}"; do
+        if [[ "$content" == *"$marker"* ]]; then
+            echo "agent output matches error marker: \"$marker\""; return 0
+        fi
+    done
+    if [[ "$agent_rc" -ne 0 && ! -s "$ws_out/journal.jsonl" ]]; then
+        echo "agent exit code $agent_rc with empty journal.jsonl"; return 0
+    fi
+    return 1
+}
+
+# -------- REUSED from run-pair.sh (adapted find): declared-done src archival ---
+archive_final_src() {
+    local ws="$1" ws_out="$2"
+    rm -rf "$ws_out/final-src"; mkdir -p "$ws_out/final-src"
+    ( cd "$ws/src" && find . -type f -name '*.cs' \
+        -not -path '*/obj/*' -not -path '*/bin/*' -not -path '*/TestResults/*' -print0 \
+      | while IFS= read -r -d '' f; do
+            mkdir -p "$ws_out/final-src/$(dirname "$f")"; cp "$f" "$ws_out/final-src/$f"; done )
+    return 1   # archival is best-effort here (never run-invalidating for a bundle)
+}
+
+# -------- REUSED from run-pair.sh (verbatim): watchdog process-group kill ------
+kill_agent_tree() {
+    local root="$1" ws_path="$2" out_path="${3:-}"
+    local all="" frontier="$root" next p depth
+    for depth in 1 2 3 4 5 6; do
+        next=""
+        for p in $frontier; do next+=" $(pgrep -P "$p" 2>/dev/null || true)"; done
+        next="$(echo "$next" | tr -s ' ' | sed 's/^ //')"
+        [[ -z "$next" ]] && break
+        all+=" $next"; frontier="$next"
+    done
+    kill -9 -- "-$root" 2>/dev/null || echo "watchdog: pgid kill for -$root failed" >&2
+    # shellcheck disable=SC2086
+    kill -9 $root $all 2>/dev/null || true
+    sleep 1
+    if kill -0 "$root" 2>/dev/null || pgrep -f "$ws_path" >/dev/null 2>&1 \
+        || { [[ -n "$out_path" ]] && pgrep -f "$out_path" >/dev/null 2>&1; }; then
+        echo "watchdog: survivors detected after tree kill; pattern-killing $ws_path" >&2
+        pkill -9 -f "$ws_path" 2>/dev/null || true
+        [[ -n "$out_path" ]] && pkill -9 -f "$out_path" 2>/dev/null || true
+    fi
+}
+
+# ---------------------------------------------------------------------------
+BUNDLE_DIR=""; ARM=""; RUNS=1
+OUT_DIR="$SCRIPT_DIR/epochs/adhoc-bundle"
+NULL_AGENT=0; NULL_AGENT_NOOP=0
+ITERATION_BUDGET=10; TIMEOUT_SECS=1200
+CORPUS_ROOT="$REPO_ROOT/bench/corpus"
+PROJECTS_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --bundle) BUNDLE_DIR="$2"; shift 2 ;;
+        --arm) ARM="$2"; shift 2 ;;
+        --runs) RUNS="$2"; shift 2 ;;
+        --out) OUT_DIR="$2"; shift 2 ;;
+        --null-agent) NULL_AGENT=1; shift ;;
+        --null-agent-noop) NULL_AGENT=1; NULL_AGENT_NOOP=1; shift ;;
+        --iteration-budget) ITERATION_BUDGET="$2"; shift 2 ;;
+        --timeout) TIMEOUT_SECS="$2"; shift 2 ;;
+        --corpus) CORPUS_ROOT="$2"; shift 2 ;;
+        --projects-dir) PROJECTS_DIR="$2"; shift 2 ;;
+        *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+[[ -n "$PROJECTS_DIR" ]] && CORPUS_ROOT="$PROJECTS_DIR"
+
+[[ -n "$BUNDLE_DIR" && -n "$ARM" ]] || { echo "Usage: --bundle <dir> --arm csharp|calor [--runs N] [--null-agent|--null-agent-noop] [--corpus <dir>] [--out <dir>]" >&2; exit 2; }
+[[ "$ARM" == "calor" || "$ARM" == "csharp" ]] || { echo "--arm must be calor|csharp" >&2; exit 2; }
+BUNDLE_DIR="$(cd "$BUNDLE_DIR" && pwd -P)"
+[[ -f "$BUNDLE_DIR/provenance.json" ]] || { echo "ERROR: not a bundle (no provenance.json): $BUNDLE_DIR" >&2; exit 2; }
+[[ -d "$BUNDLE_DIR/$ARM-arm" ]] || { echo "ERROR: bundle arm dir missing: $BUNDLE_DIR/$ARM-arm" >&2; exit 2; }
+command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 required" >&2; exit 2; }
+
+# ---- Bundle facts from provenance.json ------------------------------------
+BUNDLE_ID="$(jq -r '.TaskId' "$BUNDLE_DIR/provenance.json")"
+PROJECT="$(jq -r '.ProjectName' "$BUNDLE_DIR/provenance.json")"
+REGNET="$(jq -r '.RegressionNetProject' "$BUNDLE_DIR/provenance.json")"
+VISIBLE_FILTER="$(jq -r '.VisibleTestFilter // ""' "$BUNDLE_DIR/provenance.json")"
+HELDOUT_FILTER="$(python3 "$HELPERS" heldout-filter "$BUNDLE_DIR")"
+SYMPTOM="$(jq -r '.FailingBehavior.Symptom // "A previously-correct behavior now produces an incorrect result."' "$BUNDLE_DIR/provenance.json")"
+SUBJECT_HINT="$(jq -r '.FailingBehavior.SubjectHint // ""' "$BUNDLE_DIR/provenance.json")"
+HELDOUT_COUNT="$(jq -r '.HeldOut | length' "$BUNDLE_DIR/provenance.json")"
+[[ -n "$HELDOUT_FILTER" ]] || { echo "ERROR: could not build held-out filter" >&2; exit 3; }
+
+# ---- Build knobs by ProjectName (mirrors ProjectConfigs.cs) ----------------
+case "$PROJECT" in
+    FluentValidation) TFM="net8.0";  EXTRA="-p:NuGetAudit=false -p:TreatWarningsAsErrors=false" ;;
+    MediatR)          TFM="net8.0";  EXTRA="-p:NuGetAudit=false -p:TreatWarningsAsErrors=false" ;;
+    Serilog)          TFM="net10.0"; EXTRA="-p:NuGetAudit=false -p:TreatWarningsAsErrors=false" ;;
+    Synthetic|Synthetic2) TFM="net10.0"; EXTRA="" ;;
+    *) TFM=""; EXTRA="" ;;
+esac
+
+mkdir -p "$OUT_DIR"; OUT_DIR="$(cd "$OUT_DIR" && pwd)"
+ARM_LABEL="$ARM"
+[[ $NULL_AGENT_NOOP -eq 1 ]] && ARM_LABEL="$ARM+noop"
+
+echo "bundle=$BUNDLE_ID project=$PROJECT arm=$ARM regnet=$REGNET tfm=$TFM heldout='$HELDOUT_FILTER'" >&2
+
+# ---------------------------------------------------------------------------
+# Workspace materialization: $ws/src = the whole arm working copy.
+# ---------------------------------------------------------------------------
+materialize() {
+    local ws="$1" ws_out="$2"
+    mkdir -p "$ws/src"
+    cp -R "$BUNDLE_DIR/$ARM-arm/." "$ws/src/"
+    # Purge any stray build outputs carried in the bundle copy.
+    find "$ws/src" -type d \( -name bin -o -name obj -o -name TestResults \) -prune -exec rm -rf {} + 2>/dev/null || true
+
+    # Agent-facing task description (symptom only; the held-out test is never shown).
+    cat > "$ws/spec.md" <<EOF
+# Task: fix the reported regression
+
+A previously-correct behavior in this project now produces an incorrect result.
+
+## Failing-behavior report (the symptom, not the test)
+
+> $SYMPTOM
+$( [[ -n "$SUBJECT_HINT" && "$SUBJECT_HINT" != "null" ]] && echo "> " && echo "> Subject hint: $SUBJECT_HINT" )
+
+## What to do
+
+- The defect lives in the project's library source under \`src/\`. Find and fix it.
+- Work the VISIBLE test suite only. Run it with:
+  \`dotnet test $REGNET --filter "$VISIBLE_FILTER"\`${TFM:+ --framework $TFM}
+- Do NOT add, remove, or modify any test, and do not edit the test project.
+- Iteration budget: $ITERATION_BUDGET build/test cycles. You are done when the
+  library builds cleanly and the visible suite is green.
+EOF
+
+    # .g.cs / test-edit guard for real agent runs (parity with run-pair.sh §1).
+    if [[ $NULL_AGENT -eq 0 ]]; then
+        mkdir -p "$ws/.claude"
+        cat > "$ws/.claude/settings.json" <<'EOF'
+{
+  "hooks": { "PreToolUse": [ { "matcher": "Write|Edit", "hooks": [
+    { "type": "command",
+      "command": "f=$(jq -r '.tool_input.file_path // empty'); grep -qiE '(\\.tests?/|test/|/tests/)' <<<\"$f\" && { echo 'BLOCKED: test sources are the harness-held regression net; not agent-editable' >&2; exit 2; }; exit 0" }
+  ] } ] }
+}
+EOF
+    fi
+
+    # Baseline src hash (library sources only) for edit detection.
+    local base_hash
+    base_hash=$(find "$ws/src" -type f -name '*.cs' \
+        -not -path '*/obj/*' -not -path '*/bin/*' -not -path '*/TestResults/*' \
+        -exec shasum {} + 2>/dev/null | shasum | cut -d' ' -f1)
+    echo "$base_hash" > "$ws_out/.lasthash"
+    echo 0 > "$ws_out/.itercount"
+
+    # Starting-state oracle baseline: the mutated arm must present held-out
+    # FAILING and the visible suite GREEN (the eligibility guarantee). We record
+    # the visible-fail baseline so a declared-done visible failure is scored as a
+    # regression rather than a pre-existing red.
+    run_oracle "$ws" "$ws_out/.baseline" "both"
+    cp "$ws_out/.baseline.oracle.json" "$ws_out/baseline-oracle.json" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# The silent held-out oracle. Builds the regression-net project (which rebuilds
+# the mutated library), then runs the held-out filter and (mode=both) the
+# visible filter, writing <prefix>.oracle.json with pass/fail counts.
+# ---------------------------------------------------------------------------
+run_oracle() {
+    local ws="$1" prefix="$2" mode="$3"
+    local real_dotnet ho_pass=0 ho_fail="$HELDOUT_COUNT" vis_pass=0 vis_fail=-1 build_ok=0
+    real_dotnet="${REAL_DOTNET:-$(command -v dotnet)}"
+    if CALOR_P0_SHIM_OFF=1 "$real_dotnet" build "$ws/src/$REGNET" ${TFM:+--framework $TFM} $EXTRA --nologo -v q > "$prefix.build.txt" 2>&1; then
+        build_ok=1
+        if CALOR_P0_SHIM_OFF=1 "$real_dotnet" test "$ws/src/$REGNET" ${TFM:+--framework $TFM} $EXTRA --no-build --filter "$HELDOUT_FILTER" --nologo -v q > "$prefix.ho.txt" 2>&1; then
+            ho_fail=0; ho_pass=$(grep -oE 'Passed:[[:space:]]+[0-9]+' "$prefix.ho.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
+        else
+            ho_fail=$(grep -oE 'Failed:[[:space:]]+[0-9]+' "$prefix.ho.txt" | grep -oE '[0-9]+' | head -1 || echo "$HELDOUT_COUNT")
+            ho_pass=$(grep -oE 'Passed:[[:space:]]+[0-9]+' "$prefix.ho.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
+        fi
+        if [[ "$mode" == "both" && -n "$VISIBLE_FILTER" ]]; then
+            if CALOR_P0_SHIM_OFF=1 "$real_dotnet" test "$ws/src/$REGNET" ${TFM:+--framework $TFM} $EXTRA --no-build --filter "$VISIBLE_FILTER" --nologo -v q > "$prefix.vis.txt" 2>&1; then
+                vis_fail=0; vis_pass=$(grep -oE 'Passed:[[:space:]]+[0-9]+' "$prefix.vis.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
+            else
+                vis_fail=$(grep -oE 'Failed:[[:space:]]+[0-9]+' "$prefix.vis.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
+                vis_pass=$(grep -oE 'Passed:[[:space:]]+[0-9]+' "$prefix.vis.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
+            fi
+        fi
+    fi
+    jq -n --argjson bo "$build_ok" --argjson hp "$ho_pass" --argjson hf "$ho_fail" \
+          --argjson vp "$vis_pass" --argjson vf "$vis_fail" \
+        '{build_ok:($bo==1), heldout_pass:$hp, heldout_fail:$hf, visible_pass:$vp, visible_fail:$vf}' \
+        > "$prefix.oracle.json"
+}
+
+# ---------------------------------------------------------------------------
+# dotnet shim: journals build/test invocations, detects library-src edits, and
+# runs the held-out leg of the oracle silently after each (itg signal). The
+# expensive visible/regression leg is deferred to declared-done.
+# ---------------------------------------------------------------------------
+write_shim() {
+    local ws="$1" ws_out="$2" shim_dir="$3" run_idx="$4"
+    local real_dotnet; real_dotnet="$(command -v dotnet)"
+    mkdir -p "$shim_dir"
+    cat > "$shim_dir/dotnet" <<EOF
+#!/usr/bin/env bash
+set -uo pipefail
+if [[ "\${CALOR_P0_SHIM_OFF:-0}" == "1" ]]; then exec "$real_dotnet" "\$@"; fi
+now_ms() { if command -v python3 >/dev/null 2>&1; then python3 -c 'import time,sys;sys.stdout.write(str(int(time.time()*1000)))'; else echo \$(( \$(date +%s) * 1000 )); fi; }
+ts_iso="\$(date -u +%Y-%m-%dT%H:%M:%SZ)"; t0=\$(now_ms)
+"$real_dotnet" "\$@"; rc=\$?
+lat=\$(( \$(now_ms) - t0 )); [[ \$lat -lt 0 ]] && lat=0
+case "\${1:-}" in
+  build|test|run)
+    lock_tries=0
+    while ! mkdir "$ws_out/.telemetry.lock" 2>/dev/null; do
+      lock_tries=\$((lock_tries+1)); [[ \$lock_tries -gt 1200 ]] && break; sleep 0.05
+    done
+    trap 'rmdir "$ws_out/.telemetry.lock" 2>/dev/null || true' EXIT
+    hash=\$(find "$ws/src" -type f -name '*.cs' -not -path '*/obj/*' -not -path '*/bin/*' -not -path '*/TestResults/*' -exec shasum {} + 2>/dev/null | shasum | cut -d' ' -f1)
+    prev=\$(cat "$ws_out/.lasthash" 2>/dev/null || echo none)
+    edited=\$([[ "\$hash" != "\$prev" ]] && echo true || echo false)
+    echo "\$hash" > "$ws_out/.lasthash"
+    iteration=null
+    if [[ "\$edited" == "true" ]]; then
+      iteration=\$(( \$(cat "$ws_out/.itercount" 2>/dev/null || echo 0) + 1 ))
+      echo "\$iteration" > "$ws_out/.itercount"
+    fi
+    ho_pass=0; ho_fail=$HELDOUT_COUNT
+    if CALOR_P0_SHIM_OFF=1 "$real_dotnet" build "$ws/src/$REGNET" ${TFM:+--framework $TFM} $EXTRA --nologo -v q > "$ws_out/.src_build.txt" 2>&1; then
+      if CALOR_P0_SHIM_OFF=1 "$real_dotnet" test "$ws/src/$REGNET" ${TFM:+--framework $TFM} $EXTRA --no-build --filter "$HELDOUT_FILTER" --nologo -v q > "$ws_out/.ho_last.txt" 2>&1; then
+        ho_fail=0; ho_pass=\$(grep -oE 'Passed:[[:space:]]+[0-9]+' "$ws_out/.ho_last.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
+      else
+        ho_fail=\$(grep -oE 'Failed:[[:space:]]+[0-9]+' "$ws_out/.ho_last.txt" | grep -oE '[0-9]+' | head -1 || echo $HELDOUT_COUNT)
+        ho_pass=\$(grep -oE 'Passed:[[:space:]]+[0-9]+' "$ws_out/.ho_last.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
+      fi
+    fi
+    jq -cn --arg ts "\$ts_iso" --arg bundle "$BUNDLE_ID" --arg arm "$ARM_LABEL" \\
+      --argjson run $run_idx --arg cmd "\${1}" --argjson exit "\$rc" \\
+      --argjson edited "\$edited" --argjson iteration "\$iteration" \\
+      --argjson lat "\$lat" --argjson hp "\$ho_pass" --argjson hf "\$ho_fail" --arg hash "\$hash" \\
+      '{schema:"bundle-telemetry/1", ts:\$ts, bundle:\$bundle, arm:\$arm, run:\$run,
+        iteration:\$iteration, cmd:\$cmd, exit:\$exit, edited:\$edited,
+        feedback_latency_ms:\$lat, heldout_pass:\$hp, heldout_fail:\$hf, src_tree_hash:\$hash}' \\
+      >> "$ws_out/journal.jsonl"
+    ;;
+esac
+exit \$rc
+EOF
+    chmod +x "$shim_dir/dotnet"
+}
+
+# ---------------------------------------------------------------------------
+run_agent() {
+    local ws="$1" ws_out="$2" shim_dir="$3"
+    AGENT_RC=0
+    local prompt
+    prompt="You are working in $ws/src. Read $ws/spec.md and fix the reported regression in the library source under src/, following the conventions already present. Build/test from $ws/src. Do not modify any test. Stop when the library builds cleanly and the visible suite is green."
+
+    if [[ $NULL_AGENT -eq 1 ]]; then
+        # Observed starter build (proves the mutated arm builds through the shim).
+        ( cd "$ws/src" && PATH="$shim_dir:$PATH" dotnet build "$REGNET" ${TFM:+--framework $TFM} $EXTRA --nologo -v q >/dev/null 2>&1 ) || \
+            echo "null-agent: starter build non-zero (bundle=$BUNDLE_ID arm=$ARM)" >&2
+        if [[ $NULL_AGENT_NOOP -eq 1 ]]; then
+            # NEGATIVE CONTROL: leave the defect in place -> expect ESCAPED.
+            echo '{"null_agent":true,"noop":true}' > "$ws_out/agent.json"
+            return 0
+        fi
+        # Apply the derived reference (the un-mutated source = the fix), then one
+        # observed build so the shim journals an edited iteration -> expect CAUGHT.
+        if ! python3 "$HELPERS" apply-fix "$BUNDLE_DIR" "$ARM" "$ws/src" "$CORPUS_ROOT" "$REPO_ROOT" > "$ws_out/.applyfix.txt" 2>&1; then
+            echo "null-agent: apply-fix FAILED (bundle=$BUNDLE_ID arm=$ARM): $(cat "$ws_out/.applyfix.txt")" >&2
+            echo "{\"null_agent\":true,\"apply_fix_error\":$(jq -Rs . < "$ws_out/.applyfix.txt")}" > "$ws_out/agent.json"
+            return 0
+        fi
+        cat "$ws_out/.applyfix.txt" >&2
+        ( cd "$ws/src" && PATH="$shim_dir:$PATH" dotnet build "$REGNET" ${TFM:+--framework $TFM} $EXTRA --nologo -v q >/dev/null 2>&1 ) || true
+        echo '{"null_agent":true}' > "$ws_out/agent.json"
+        return 0
+    fi
+
+    # ---- Real agent (spend). Copied from run-pair.sh: timeout + watchdog. ----
+    local timeout_bin=""
+    if command -v timeout >/dev/null 2>&1; then timeout_bin="timeout"
+    elif command -v gtimeout >/dev/null 2>&1; then timeout_bin="gtimeout"; fi
+    local model_args=()
+    [[ -n "${CLAUDE_MODEL:-}" && "${CLAUDE_MODEL}" != "default" ]] && model_args=(--model "$CLAUDE_MODEL")
+    local rc=0
+    if [[ -n "$timeout_bin" ]]; then
+        ( cd "$ws/src" && PATH="$shim_dir:$PATH" \
+            "$timeout_bin" -k 10 "$TIMEOUT_SECS" \
+            claude --print --output-format json --dangerously-skip-permissions "${model_args[@]}" \
+            "$prompt" > "$ws_out/agent.json" 2> "$ws_out/agent.err" ) || rc=$?
+    else
+        set -m
+        ( cd "$ws/src" && PATH="$shim_dir:$PATH" \
+            claude --print --output-format json --dangerously-skip-permissions "${model_args[@]}" \
+            "$prompt" > "$ws_out/agent.json" 2> "$ws_out/agent.err" ) &
+        local agent_pid=$!
+        local deadline=$(( SECONDS + TIMEOUT_SECS ))
+        while kill -0 "$agent_pid" 2>/dev/null; do
+            if (( SECONDS >= deadline )); then
+                echo "watchdog: agent exceeded ${TIMEOUT_SECS}s; killing $agent_pid" >&2
+                kill_agent_tree "$agent_pid" "$ws" "$ws_out"; break
+            fi
+            sleep 5
+        done
+        wait "$agent_pid" 2>/dev/null || rc=$?
+        set +m
+    fi
+    AGENT_RC=$rc
+    [[ $rc -ne 0 ]] && echo "agent exit: $rc" >> "$ws_out/agent.err"
+}
+
+# ---------------------------------------------------------------------------
+extract_metrics() {
+    local ws="$1" ws_out="$2" run_idx="$3" wall="$4"
+    local journal="$ws_out/journal.jsonl"; touch "$journal"
+
+    # Final declared-done oracle: held-out + visible (regression) legs.
+    run_oracle "$ws" "$ws_out/.final" "both"
+    local fbuild fhp fhf fvp fvf
+    fbuild=$(jq -r '.build_ok' "$ws_out/.final.oracle.json")
+    fhp=$(jq -r '.heldout_pass' "$ws_out/.final.oracle.json")
+    fhf=$(jq -r '.heldout_fail' "$ws_out/.final.oracle.json")
+    fvp=$(jq -r '.visible_pass' "$ws_out/.final.oracle.json")
+    fvf=$(jq -r '.visible_fail' "$ws_out/.final.oracle.json")
+    local base_vf; base_vf=$(jq -r '.visible_fail' "$ws_out/baseline-oracle.json" 2>/dev/null || echo 0)
+    [[ "$base_vf" =~ ^-?[0-9]+$ ]] || base_vf=0
+    [[ "$base_vf" -lt 0 ]] && base_vf=0
+
+    # Adjudication.
+    local outcome
+    if [[ "$fbuild" != "true" ]]; then
+        outcome="escaped"          # non-building declared-done = defect not fixed
+    elif [[ "$fhf" -gt 0 ]]; then
+        outcome="escaped"
+    elif [[ "$fvf" -gt "$base_vf" ]]; then
+        outcome="broke-regression"
+    else
+        outcome="caught"
+    fi
+
+    # Iterations = journaled edited build/test invocations; itg = first edited
+    # iteration whose held-out went green (censored -> budget+1).
+    local iterations itg censored
+    iterations=$(jq -s '[.[] | select(.edited==true)] | length' "$journal")
+    itg=$(jq -s '[.[] | select(.edited==true)] | to_entries
+        | ([.[] | select(.value.heldout_fail==0)] | first // null)
+        | if . == null then -1 else (.key + 1) end' "$journal" 2>/dev/null || echo -1)
+    censored=false
+    if [[ "$itg" == "-1" ]]; then itg=$((ITERATION_BUDGET + 1)); censored=true; fi
+
+    # Cost + tokens from the agent envelope. Cost = summed total_cost_usd; NEVER
+    # hand-price tokens.
+    local cost=0 tin=0 tout=0
+    if [[ -f "$ws_out/agent.json" ]] && jq -e . "$ws_out/agent.json" >/dev/null 2>&1; then
+        cost=$(jq -s 'map(.total_cost_usd // 0) | add // 0' "$ws_out/agent.json" 2>/dev/null || echo 0)
+        tin=$(jq -r '(.usage.input_tokens // 0)' "$ws_out/agent.json" 2>/dev/null || echo 0)
+        tout=$(jq -r '(.usage.output_tokens // 0)' "$ws_out/agent.json" 2>/dev/null || echo 0)
+    fi
+
+    jq -n \
+        --arg bundle "$BUNDLE_ID" --arg project "$PROJECT" --arg arm "$ARM_LABEL" --argjson run "$run_idx" \
+        --arg outcome "$outcome" \
+        --argjson fbuild "$([[ "$fbuild" == "true" ]] && echo true || echo false)" \
+        --argjson hp "$fhp" --argjson hf "$fhf" --argjson vp "$fvp" --argjson vf "$fvf" \
+        --argjson basevf "$base_vf" --argjson escaped "$fhf" \
+        --argjson iterations "$iterations" --argjson itg "$itg" --argjson censored "$censored" \
+        --argjson cost "$cost" --argjson tin "$tin" --argjson tout "$tout" \
+        --argjson wall "$wall" \
+        --argjson null_agent "$NULL_AGENT" --argjson noop "$NULL_AGENT_NOOP" \
+        --arg mutfile "$(jq -r '.Provenance.MutatedFileRelPath' "$BUNDLE_DIR/provenance.json")" \
+        '{bundle:$bundle, project:$project, arm:$arm, run:$run, outcome:$outcome,
+          finalBuildOk:$fbuild, heldoutPass:$hp, heldoutFail:$hf,
+          visiblePass:$vp, visibleFail:$vf, visibleFailBaseline:$basevf,
+          escapedBugs:$escaped, iterations:$iterations, iterationsToGreen:$itg, censored:$censored,
+          costUsd:$cost, tokens:{input:$tin, output:$tout}, wallClockSeconds:$wall,
+          invalid:false, nullAgent:($null_agent==1), nullAgentNoop:($noop==1),
+          mutatedFile:$mutfile,
+          presentationAsymmetry:"Calor arm = machine-converted round-tripped C#; C# arm = idiomatic original. Bias is against Calor."}' \
+        > "$ws_out/result.json"
+    cat "$ws_out/result.json"
+}
+
+write_invalid_result() {
+    local ws_out="$1" run_idx="$2"
+    jq -n --arg bundle "$BUNDLE_ID" --arg project "$PROJECT" --arg arm "$ARM_LABEL" --argjson run "$run_idx" \
+        --argjson escaped "$HELDOUT_COUNT" --argjson itg "$((ITERATION_BUDGET + 1))" \
+        --argjson null_agent "$NULL_AGENT" --argjson noop "$NULL_AGENT_NOOP" \
+        '{bundle:$bundle, project:$project, arm:$arm, run:$run, outcome:"invalid",
+          finalBuildOk:false, heldoutFail:$escaped, escapedBugs:$escaped,
+          iterations:0, iterationsToGreen:$itg, censored:true,
+          costUsd:0, tokens:{input:0, output:0}, wallClockSeconds:0,
+          invalid:true, nullAgent:($null_agent==1), nullAgentNoop:($noop==1)}' \
+        > "$ws_out/result.json"
+    cat "$ws_out/result.json"
+}
+
+wipe_ws_out() { find "$1" -mindepth 1 -maxdepth 1 ! -name invalid.txt -exec rm -rf {} +; }
+
+# ---------------------------------------------------------------------------
+for (( run=1; run<=RUNS; run++ )); do
+    WS_OUT="$OUT_DIR/$BUNDLE_ID/$ARM_LABEL/run-$run"
+    mkdir -p "$WS_OUT"
+    for (( attempt=0; attempt<=MAX_INVALID_RETRIES; attempt++ )); do
+        WS="$(mktemp -d "${TMPDIR:-/tmp}/p0b-${BUNDLE_ID}-${ARM}-XXXXXX")"
+        WS="$(cd "$WS" && pwd -P)"
+        SHIM_DIR="$WS_OUT/.shim"
+        materialize "$WS" "$WS_OUT"
+        write_shim "$WS" "$WS_OUT" "$SHIM_DIR" "$run"
+        _t0=$SECONDS
+        run_agent "$WS" "$WS_OUT" "$SHIM_DIR"
+        _wall=$(( SECONDS - _t0 ))
+        archive_final_src "$WS" "$WS_OUT" || true
+        if reason="$(detect_invalid_run "$WS_OUT" "$AGENT_RC")"; then
+            printf '%s attempt=%d agent_rc=%d: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$attempt" "$AGENT_RC" "$reason" >> "$WS_OUT/invalid.txt"
+            echo "INVALID run (bundle=$BUNDLE_ID arm=$ARM_LABEL run=$run attempt=$attempt): $reason" >&2
+            rm -rf "$WS"
+            if (( attempt < MAX_INVALID_RETRIES )); then wipe_ws_out "$WS_OUT"; continue; fi
+            write_invalid_result "$WS_OUT" "$run"; break
+        fi
+        extract_metrics "$WS" "$WS_OUT" "$run" "$_wall"
+        rm -rf "$WS"
+        break
+    done
+done

--- a/bench/phase0-agent-native/run-bundle.sh
+++ b/bench/phase0-agent-native/run-bundle.sh
@@ -141,6 +141,11 @@ SYMPTOM="$(jq -r '.FailingBehavior.Symptom // "A previously-correct behavior now
 SUBJECT_HINT="$(jq -r '.FailingBehavior.SubjectHint // ""' "$BUNDLE_DIR/provenance.json")"
 HELDOUT_COUNT="$(jq -r '.HeldOut | length' "$BUNDLE_DIR/provenance.json")"
 [[ -n "$HELDOUT_FILTER" ]] || { echo "ERROR: could not build held-out filter" >&2; exit 3; }
+# The test-project directory (relative to the arm root) whose sources carry the
+# held-out method(s). The oracle keeps this dir held-out-PRESENT; the agent copy
+# has it stripped; the src->oracle sync EXCLUDES it so agent edits never
+# overwrite the oracle's held-out tests.
+TESTPROJ_DIR="$(dirname "$REGNET")"
 
 # ---- Build knobs by ProjectName (mirrors ProjectConfigs.cs) ----------------
 case "$PROJECT" in
@@ -158,14 +163,46 @@ ARM_LABEL="$ARM"
 echo "bundle=$BUNDLE_ID project=$PROJECT arm=$ARM regnet=$REGNET tfm=$TFM heldout='$HELDOUT_FILTER'" >&2
 
 # ---------------------------------------------------------------------------
-# Workspace materialization: $ws/src = the whole arm working copy.
+# Sync the agent's edited sources into the oracle copy, EXCEPT the test-project
+# directory (the oracle keeps its held-out-present test sources). Every non-test
+# .cs the agent may have edited propagates so the oracle tests the agent's
+# current library; the held-out tests are never overwritten.
+# ---------------------------------------------------------------------------
+sync_to_oracle() {
+    local ws="$1" ws_oracle="$2"
+    ( cd "$ws/src" && find . -type f -name '*.cs' \
+        -not -path "./$TESTPROJ_DIR/*" -not -path '*/obj/*' -not -path '*/bin/*' \
+        -not -path '*/TestResults/*' -print ) \
+      | while IFS= read -r rel; do
+            rel="${rel#./}"
+            mkdir -p "$ws_oracle/$(dirname "$rel")"
+            cp "$ws/src/$rel" "$ws_oracle/$rel"
+        done
+}
+
+# ---------------------------------------------------------------------------
+# Workspace materialization. TWO copies:
+#   $ws/src        agent-visible: whole arm working copy, held-out method(s)
+#                  PHYSICALLY STRIPPED from the test sources (no oracle leak).
+#   $ws_oracle     harness-only (a separate mktemp the agent has no path to):
+#                  whole arm working copy with the held-out test(s) PRESENT;
+#                  its library is kept in sync with the agent's edits.
 # ---------------------------------------------------------------------------
 materialize() {
-    local ws="$1" ws_out="$2"
-    mkdir -p "$ws/src"
+    local ws="$1" ws_out="$2" ws_oracle="$3"
+    mkdir -p "$ws/src" "$ws_oracle"
     cp -R "$BUNDLE_DIR/$ARM-arm/." "$ws/src/"
-    # Purge any stray build outputs carried in the bundle copy.
-    find "$ws/src" -type d \( -name bin -o -name obj -o -name TestResults \) -prune -exec rm -rf {} + 2>/dev/null || true
+    cp -R "$BUNDLE_DIR/$ARM-arm/." "$ws_oracle/"
+    find "$ws/src" "$ws_oracle" -type d \( -name bin -o -name obj -o -name TestResults \) -prune -exec rm -rf {} + 2>/dev/null || true
+
+    # Strip the held-out method(s) from the AGENT copy. Fail-loud: a silent miss
+    # would leave the oracle readable/runnable by the agent (fabricated measure).
+    if ! python3 "$HELPERS" strip-heldout "$BUNDLE_DIR" "$ws/src" > "$ws_out/strip.txt" 2>&1; then
+        echo "FATAL: held-out strip failed for bundle=$BUNDLE_ID arm=$ARM (oracle would leak):" >&2
+        cat "$ws_out/strip.txt" >&2
+        exit 3
+    fi
+    cat "$ws_out/strip.txt" >&2
 
     # Agent-facing task description (symptom only; the held-out test is never shown).
     cat > "$ws/spec.md" <<EOF
@@ -213,29 +250,31 @@ EOF
     # FAILING and the visible suite GREEN (the eligibility guarantee). We record
     # the visible-fail baseline so a declared-done visible failure is scored as a
     # regression rather than a pre-existing red.
-    run_oracle "$ws" "$ws_out/.baseline" "both"
+    run_oracle "$ws" "$ws_oracle" "$ws_out/.baseline" "both"
     cp "$ws_out/.baseline.oracle.json" "$ws_out/baseline-oracle.json" 2>/dev/null || true
 }
 
 # ---------------------------------------------------------------------------
-# The silent held-out oracle. Builds the regression-net project (which rebuilds
-# the mutated library), then runs the held-out filter and (mode=both) the
-# visible filter, writing <prefix>.oracle.json with pass/fail counts.
+# The silent held-out oracle. Syncs the agent's edits into the oracle copy (which
+# alone carries the held-out test), builds its regression-net project, then runs
+# the held-out filter and (mode=both) the visible filter, writing
+# <prefix>.oracle.json with pass/fail counts. The agent never sees this copy.
 # ---------------------------------------------------------------------------
 run_oracle() {
-    local ws="$1" prefix="$2" mode="$3"
+    local ws="$1" ws_oracle="$2" prefix="$3" mode="$4"
     local real_dotnet ho_pass=0 ho_fail="$HELDOUT_COUNT" vis_pass=0 vis_fail=-1 build_ok=0
     real_dotnet="${REAL_DOTNET:-$(command -v dotnet)}"
-    if CALOR_P0_SHIM_OFF=1 "$real_dotnet" build "$ws/src/$REGNET" ${TFM:+--framework $TFM} $EXTRA --nologo -v q > "$prefix.build.txt" 2>&1; then
+    sync_to_oracle "$ws" "$ws_oracle"
+    if CALOR_P0_SHIM_OFF=1 "$real_dotnet" build "$ws_oracle/$REGNET" ${TFM:+--framework $TFM} $EXTRA --nologo -v q > "$prefix.build.txt" 2>&1; then
         build_ok=1
-        if CALOR_P0_SHIM_OFF=1 "$real_dotnet" test "$ws/src/$REGNET" ${TFM:+--framework $TFM} $EXTRA --no-build --filter "$HELDOUT_FILTER" --nologo -v q > "$prefix.ho.txt" 2>&1; then
+        if CALOR_P0_SHIM_OFF=1 "$real_dotnet" test "$ws_oracle/$REGNET" ${TFM:+--framework $TFM} $EXTRA --no-build --filter "$HELDOUT_FILTER" --nologo -v q > "$prefix.ho.txt" 2>&1; then
             ho_fail=0; ho_pass=$(grep -oE 'Passed:[[:space:]]+[0-9]+' "$prefix.ho.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
         else
             ho_fail=$(grep -oE 'Failed:[[:space:]]+[0-9]+' "$prefix.ho.txt" | grep -oE '[0-9]+' | head -1 || echo "$HELDOUT_COUNT")
             ho_pass=$(grep -oE 'Passed:[[:space:]]+[0-9]+' "$prefix.ho.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
         fi
         if [[ "$mode" == "both" && -n "$VISIBLE_FILTER" ]]; then
-            if CALOR_P0_SHIM_OFF=1 "$real_dotnet" test "$ws/src/$REGNET" ${TFM:+--framework $TFM} $EXTRA --no-build --filter "$VISIBLE_FILTER" --nologo -v q > "$prefix.vis.txt" 2>&1; then
+            if CALOR_P0_SHIM_OFF=1 "$real_dotnet" test "$ws_oracle/$REGNET" ${TFM:+--framework $TFM} $EXTRA --no-build --filter "$VISIBLE_FILTER" --nologo -v q > "$prefix.vis.txt" 2>&1; then
                 vis_fail=0; vis_pass=$(grep -oE 'Passed:[[:space:]]+[0-9]+' "$prefix.vis.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
             else
                 vis_fail=$(grep -oE 'Failed:[[:space:]]+[0-9]+' "$prefix.vis.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
@@ -255,7 +294,7 @@ run_oracle() {
 # expensive visible/regression leg is deferred to declared-done.
 # ---------------------------------------------------------------------------
 write_shim() {
-    local ws="$1" ws_out="$2" shim_dir="$3" run_idx="$4"
+    local ws="$1" ws_out="$2" shim_dir="$3" run_idx="$4" ws_oracle="$5"
     local real_dotnet; real_dotnet="$(command -v dotnet)"
     mkdir -p "$shim_dir"
     cat > "$shim_dir/dotnet" <<EOF
@@ -282,9 +321,14 @@ case "\${1:-}" in
       iteration=\$(( \$(cat "$ws_out/.itercount" 2>/dev/null || echo 0) + 1 ))
       echo "\$iteration" > "$ws_out/.itercount"
     fi
+    # Sync the agent's edits into the harness-only oracle copy (which alone
+    # carries the held-out test), then build+test THERE. The agent's own dotnet
+    # (already run above) saw only its held-out-stripped copy.
+    ( cd "$ws/src" && find . -type f -name '*.cs' -not -path "./$TESTPROJ_DIR/*" -not -path '*/obj/*' -not -path '*/bin/*' -not -path '*/TestResults/*' -print ) \
+      | while IFS= read -r rel; do rel="\${rel#./}"; mkdir -p "$ws_oracle/\$(dirname "\$rel")"; cp "$ws/src/\$rel" "$ws_oracle/\$rel"; done
     ho_pass=0; ho_fail=$HELDOUT_COUNT
-    if CALOR_P0_SHIM_OFF=1 "$real_dotnet" build "$ws/src/$REGNET" ${TFM:+--framework $TFM} $EXTRA --nologo -v q > "$ws_out/.src_build.txt" 2>&1; then
-      if CALOR_P0_SHIM_OFF=1 "$real_dotnet" test "$ws/src/$REGNET" ${TFM:+--framework $TFM} $EXTRA --no-build --filter "$HELDOUT_FILTER" --nologo -v q > "$ws_out/.ho_last.txt" 2>&1; then
+    if CALOR_P0_SHIM_OFF=1 "$real_dotnet" build "$ws_oracle/$REGNET" ${TFM:+--framework $TFM} $EXTRA --nologo -v q > "$ws_out/.src_build.txt" 2>&1; then
+      if CALOR_P0_SHIM_OFF=1 "$real_dotnet" test "$ws_oracle/$REGNET" ${TFM:+--framework $TFM} $EXTRA --no-build --filter "$HELDOUT_FILTER" --nologo -v q > "$ws_out/.ho_last.txt" 2>&1; then
         ho_fail=0; ho_pass=\$(grep -oE 'Passed:[[:space:]]+[0-9]+' "$ws_out/.ho_last.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
       else
         ho_fail=\$(grep -oE 'Failed:[[:space:]]+[0-9]+' "$ws_out/.ho_last.txt" | grep -oE '[0-9]+' | head -1 || echo $HELDOUT_COUNT)
@@ -370,11 +414,11 @@ run_agent() {
 
 # ---------------------------------------------------------------------------
 extract_metrics() {
-    local ws="$1" ws_out="$2" run_idx="$3" wall="$4"
+    local ws="$1" ws_out="$2" run_idx="$3" wall="$4" ws_oracle="$5"
     local journal="$ws_out/journal.jsonl"; touch "$journal"
 
     # Final declared-done oracle: held-out + visible (regression) legs.
-    run_oracle "$ws" "$ws_out/.final" "both"
+    run_oracle "$ws" "$ws_oracle" "$ws_out/.final" "both"
     local fbuild fhp fhf fvp fvf
     fbuild=$(jq -r '.build_ok' "$ws_out/.final.oracle.json")
     fhp=$(jq -r '.heldout_pass' "$ws_out/.final.oracle.json")
@@ -462,9 +506,13 @@ for (( run=1; run<=RUNS; run++ )); do
     for (( attempt=0; attempt<=MAX_INVALID_RETRIES; attempt++ )); do
         WS="$(mktemp -d "${TMPDIR:-/tmp}/p0b-${BUNDLE_ID}-${ARM}-XXXXXX")"
         WS="$(cd "$WS" && pwd -P)"
+        # The oracle copy lives in a SEPARATE mktemp tree the agent has no path
+        # to (never named in prompt/spec/cwd) — the physical hide of the oracle.
+        WS_ORACLE="$(mktemp -d "${TMPDIR:-/tmp}/p0bO-${BUNDLE_ID}-${ARM}-XXXXXX")"
+        WS_ORACLE="$(cd "$WS_ORACLE" && pwd -P)"
         SHIM_DIR="$WS_OUT/.shim"
-        materialize "$WS" "$WS_OUT"
-        write_shim "$WS" "$WS_OUT" "$SHIM_DIR" "$run"
+        materialize "$WS" "$WS_OUT" "$WS_ORACLE"
+        write_shim "$WS" "$WS_OUT" "$SHIM_DIR" "$run" "$WS_ORACLE"
         _t0=$SECONDS
         run_agent "$WS" "$WS_OUT" "$SHIM_DIR"
         _wall=$(( SECONDS - _t0 ))
@@ -472,12 +520,12 @@ for (( run=1; run<=RUNS; run++ )); do
         if reason="$(detect_invalid_run "$WS_OUT" "$AGENT_RC")"; then
             printf '%s attempt=%d agent_rc=%d: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$attempt" "$AGENT_RC" "$reason" >> "$WS_OUT/invalid.txt"
             echo "INVALID run (bundle=$BUNDLE_ID arm=$ARM_LABEL run=$run attempt=$attempt): $reason" >&2
-            rm -rf "$WS"
+            rm -rf "$WS" "$WS_ORACLE"
             if (( attempt < MAX_INVALID_RETRIES )); then wipe_ws_out "$WS_OUT"; continue; fi
             write_invalid_result "$WS_OUT" "$run"; break
         fi
-        extract_metrics "$WS" "$WS_OUT" "$run" "$_wall"
-        rm -rf "$WS"
+        extract_metrics "$WS" "$WS_OUT" "$run" "$_wall" "$WS_ORACLE"
+        rm -rf "$WS" "$WS_ORACLE"
         break
     done
 done

--- a/bench/phase0-agent-native/run-bundle.sh
+++ b/bench/phase0-agent-native/run-bundle.sh
@@ -59,8 +59,12 @@ detect_invalid_run() {
             echo "agent output matches error marker: \"$marker\""; return 0
         fi
     done
-    if [[ "$agent_rc" -ne 0 && ! -s "$ws_out/journal.jsonl" ]]; then
-        echo "agent exit code $agent_rc with empty journal.jsonl"; return 0
+    # Tightened (review minor): a nonzero agent exit is invalid REGARDLESS of the
+    # journal — a crashed/timed-out agent that happened to journal an edit must not
+    # be scored escaped. null-agent runs always set AGENT_RC=0, so this only gates
+    # real runs (retried on a fresh workspace, then recorded invalid).
+    if [[ "$agent_rc" -ne 0 ]]; then
+        echo "agent exit code $agent_rc (nonzero -> invalid)"; return 0
     fi
     return 1
 }
@@ -135,8 +139,11 @@ command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 required" >&2; exit
 BUNDLE_ID="$(jq -r '.TaskId' "$BUNDLE_DIR/provenance.json")"
 PROJECT="$(jq -r '.ProjectName' "$BUNDLE_DIR/provenance.json")"
 REGNET="$(jq -r '.RegressionNetProject' "$BUNDLE_DIR/provenance.json")"
-VISIBLE_FILTER="$(jq -r '.VisibleTestFilter // ""' "$BUNDLE_DIR/provenance.json")"
+# EXACT-match held-out + visible filters (computed from HeldOut[].FilterName, not
+# provenance's substring VisibleTestFilter) — see bundle-helpers.py M1 note. Used
+# ONLY in the harness-side oracle, never shown to the agent.
 HELDOUT_FILTER="$(python3 "$HELPERS" heldout-filter "$BUNDLE_DIR")"
+VISIBLE_FILTER="$(python3 "$HELPERS" visible-filter "$BUNDLE_DIR")"
 SYMPTOM="$(jq -r '.FailingBehavior.Symptom // "A previously-correct behavior now produces an incorrect result."' "$BUNDLE_DIR/provenance.json")"
 SUBJECT_HINT="$(jq -r '.FailingBehavior.SubjectHint // ""' "$BUNDLE_DIR/provenance.json")"
 HELDOUT_COUNT="$(jq -r '.HeldOut | length' "$BUNDLE_DIR/provenance.json")"
@@ -170,9 +177,14 @@ echo "bundle=$BUNDLE_ID project=$PROJECT arm=$ARM regnet=$REGNET tfm=$TFM heldou
 # ---------------------------------------------------------------------------
 sync_to_oracle() {
     local ws="$1" ws_oracle="$2"
+    # Exclude ALL test-source roots (not just dirname(REGNET)): any path under a
+    # */test/*, */tests/* or *.Tests/ directory (case-insensitive) — the same set
+    # the agent's PreToolUse hook blocks. A test helper the agent could edit must
+    # never propagate to the oracle, or the agent could steer the held-out result.
     ( cd "$ws/src" && find . -type f -name '*.cs' \
-        -not -path "./$TESTPROJ_DIR/*" -not -path '*/obj/*' -not -path '*/bin/*' \
-        -not -path '*/TestResults/*' -print ) \
+        -not -path "./$TESTPROJ_DIR/*" \
+        -not -ipath '*/test/*' -not -ipath '*/tests/*' -not -ipath '*.tests/*' \
+        -not -path '*/obj/*' -not -path '*/bin/*' -not -path '*/TestResults/*' -print ) \
       | while IFS= read -r rel; do
             rel="${rel#./}"
             mkdir -p "$ws_oracle/$(dirname "$rel")"
@@ -218,11 +230,11 @@ $( [[ -n "$SUBJECT_HINT" && "$SUBJECT_HINT" != "null" ]] && echo "> " && echo ">
 ## What to do
 
 - The defect lives in the project's library source under \`src/\`. Find and fix it.
-- Work the VISIBLE test suite only. Run it with:
-  \`dotnet test $REGNET --filter "$VISIBLE_FILTER"\`${TFM:+ --framework $TFM}
+- Run the test suite with: \`dotnet test $REGNET\`${TFM:+ --framework $TFM}
+  (it is the project's own suite; run it as-is).
 - Do NOT add, remove, or modify any test, and do not edit the test project.
 - Iteration budget: $ITERATION_BUDGET build/test cycles. You are done when the
-  library builds cleanly and the visible suite is green.
+  library builds cleanly and the test suite is green.
 EOF
 
     # .g.cs / test-edit guard for real agent runs (parity with run-pair.sh §1).
@@ -282,6 +294,13 @@ run_oracle() {
             fi
         fi
     fi
+    # Integer guards: an unexpected `dotnet test` summary shape can leave a var
+    # empty (a no-match grep whose downstream head succeeds), which would make the
+    # jq --argjson below fail and drop the record. Default anything non-numeric.
+    [[ "$ho_pass" =~ ^[0-9]+$ ]] || ho_pass=0
+    [[ "$ho_fail" =~ ^[0-9]+$ ]] || ho_fail="$HELDOUT_COUNT"
+    [[ "$vis_pass" =~ ^[0-9]+$ ]] || vis_pass=0
+    [[ "$vis_fail" =~ ^-?[0-9]+$ ]] || vis_fail=-1
     jq -n --argjson bo "$build_ok" --argjson hp "$ho_pass" --argjson hf "$ho_fail" \
           --argjson vp "$vis_pass" --argjson vf "$vis_fail" \
         '{build_ok:($bo==1), heldout_pass:$hp, heldout_fail:$hf, visible_pass:$vp, visible_fail:$vf}' \
@@ -289,12 +308,13 @@ run_oracle() {
 }
 
 # ---------------------------------------------------------------------------
-# dotnet shim: journals build/test invocations, detects library-src edits, and
-# runs the held-out leg of the oracle silently after each (itg signal). The
-# expensive visible/regression leg is deferred to declared-done.
+# Agent-facing dotnet shim (FIRST on the agent's PATH, agent-readable). It ONLY
+# runs the real dotnet for the agent's own build/test and journals invocation
+# metadata (cmd/exit, edit-hash, iteration ordinal, latency). It holds NO oracle
+# path and NO held-out filter (review C) — all oracle work is harness-side.
 # ---------------------------------------------------------------------------
 write_shim() {
-    local ws="$1" ws_out="$2" shim_dir="$3" run_idx="$4" ws_oracle="$5"
+    local ws="$1" ws_out="$2" shim_dir="$3" run_idx="$4"
     local real_dotnet; real_dotnet="$(command -v dotnet)"
     mkdir -p "$shim_dir"
     cat > "$shim_dir/dotnet" <<EOF
@@ -321,27 +341,18 @@ case "\${1:-}" in
       iteration=\$(( \$(cat "$ws_out/.itercount" 2>/dev/null || echo 0) + 1 ))
       echo "\$iteration" > "$ws_out/.itercount"
     fi
-    # Sync the agent's edits into the harness-only oracle copy (which alone
-    # carries the held-out test), then build+test THERE. The agent's own dotnet
-    # (already run above) saw only its held-out-stripped copy.
-    ( cd "$ws/src" && find . -type f -name '*.cs' -not -path "./$TESTPROJ_DIR/*" -not -path '*/obj/*' -not -path '*/bin/*' -not -path '*/TestResults/*' -print ) \
-      | while IFS= read -r rel; do rel="\${rel#./}"; mkdir -p "$ws_oracle/\$(dirname "\$rel")"; cp "$ws/src/\$rel" "$ws_oracle/\$rel"; done
-    ho_pass=0; ho_fail=$HELDOUT_COUNT
-    if CALOR_P0_SHIM_OFF=1 "$real_dotnet" build "$ws_oracle/$REGNET" ${TFM:+--framework $TFM} $EXTRA --nologo -v q > "$ws_out/.src_build.txt" 2>&1; then
-      if CALOR_P0_SHIM_OFF=1 "$real_dotnet" test "$ws_oracle/$REGNET" ${TFM:+--framework $TFM} $EXTRA --no-build --filter "$HELDOUT_FILTER" --nologo -v q > "$ws_out/.ho_last.txt" 2>&1; then
-        ho_fail=0; ho_pass=\$(grep -oE 'Passed:[[:space:]]+[0-9]+' "$ws_out/.ho_last.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
-      else
-        ho_fail=\$(grep -oE 'Failed:[[:space:]]+[0-9]+' "$ws_out/.ho_last.txt" | grep -oE '[0-9]+' | head -1 || echo $HELDOUT_COUNT)
-        ho_pass=\$(grep -oE 'Passed:[[:space:]]+[0-9]+' "$ws_out/.ho_last.txt" | grep -oE '[0-9]+' | head -1 || echo 0)
-      fi
-    fi
+    # NO ORACLE INFO HERE (review C). This script is first on the agent's PATH and
+    # the agent can \`cat\` it, so it must never contain the oracle tree path or the
+    # held-out --filter. The oracle runs entirely in the parent (run-bundle.sh),
+    # whose oracle path/filter live only in its own process. The shim journals
+    # ONLY invocation metadata over the agent's OWN workspace (its cwd — no secret).
     jq -cn --arg ts "\$ts_iso" --arg bundle "$BUNDLE_ID" --arg arm "$ARM_LABEL" \\
       --argjson run $run_idx --arg cmd "\${1}" --argjson exit "\$rc" \\
       --argjson edited "\$edited" --argjson iteration "\$iteration" \\
-      --argjson lat "\$lat" --argjson hp "\$ho_pass" --argjson hf "\$ho_fail" --arg hash "\$hash" \\
-      '{schema:"bundle-telemetry/1", ts:\$ts, bundle:\$bundle, arm:\$arm, run:\$run,
+      --argjson lat "\$lat" --arg hash "\$hash" \\
+      '{schema:"bundle-telemetry/2", ts:\$ts, bundle:\$bundle, arm:\$arm, run:\$run,
         iteration:\$iteration, cmd:\$cmd, exit:\$exit, edited:\$edited,
-        feedback_latency_ms:\$lat, heldout_pass:\$hp, heldout_fail:\$hf, src_tree_hash:\$hash}' \\
+        feedback_latency_ms:\$lat, src_tree_hash:\$hash}' \\
       >> "$ws_out/journal.jsonl"
     ;;
 esac
@@ -369,8 +380,10 @@ run_agent() {
         # Apply the derived reference (the un-mutated source = the fix), then one
         # observed build so the shim journals an edited iteration -> expect CAUGHT.
         if ! python3 "$HELPERS" apply-fix "$BUNDLE_DIR" "$ARM" "$ws/src" "$CORPUS_ROOT" "$REPO_ROOT" > "$ws_out/.applyfix.txt" 2>&1; then
-            echo "null-agent: apply-fix FAILED (bundle=$BUNDLE_ID arm=$ARM): $(cat "$ws_out/.applyfix.txt")" >&2
-            echo "{\"null_agent\":true,\"apply_fix_error\":$(jq -Rs . < "$ws_out/.applyfix.txt")}" > "$ws_out/agent.json"
+            echo "null-agent: reference underivable (bundle=$BUNDLE_ID arm=$ARM) -> SKIP: $(cat "$ws_out/.applyfix.txt")" >&2
+            echo '{"null_agent":true,"skipped":true}' > "$ws_out/agent.json"
+            # SKIP marker (not a verdict) — extract_metrics emits outcome:skipped.
+            printf 'null-agent reference underivable: %s' "$(cat "$ws_out/.applyfix.txt")" > "$ws_out/.skip"
             return 0
         fi
         cat "$ws_out/.applyfix.txt" >&2
@@ -417,6 +430,20 @@ extract_metrics() {
     local ws="$1" ws_out="$2" run_idx="$3" wall="$4" ws_oracle="$5"
     local journal="$ws_out/journal.jsonl"; touch "$journal"
 
+    # SKIP (not a verdict): a null-agent run whose reference could not be derived
+    # (e.g. calor arm, mutated line not uniquely locatable). Recorded as skipped
+    # so it never counts as caught/escaped — matches the README claim.
+    if [[ -f "$ws_out/.skip" ]]; then
+        jq -n --arg bundle "$BUNDLE_ID" --arg project "$PROJECT" --arg arm "$ARM_LABEL" \
+              --argjson run "$run_idx" --arg reason "$(cat "$ws_out/.skip")" \
+              --argjson null_agent "$NULL_AGENT" --argjson noop "$NULL_AGENT_NOOP" \
+            '{bundle:$bundle, project:$project, arm:$arm, run:$run, outcome:"skipped",
+              skipReason:$reason, invalid:false, escapedBugs:null,
+              nullAgent:($null_agent==1), nullAgentNoop:($noop==1)}' \
+            > "$ws_out/result.json"
+        cat "$ws_out/result.json"; return 0
+    fi
+
     # Final declared-done oracle: held-out + visible (regression) legs.
     run_oracle "$ws" "$ws_oracle" "$ws_out/.final" "both"
     local fbuild fhp fhf fvp fvf
@@ -441,15 +468,12 @@ extract_metrics() {
         outcome="caught"
     fi
 
-    # Iterations = journaled edited build/test invocations; itg = first edited
-    # iteration whose held-out went green (censored -> budget+1).
-    local iterations itg censored
+    # Iterations to declared-done = journaled edited build/test invocations (the
+    # agent stops when it believes it is done). Per-iteration held-out timing was
+    # removed with the shim's oracle (review C) — the verdict comes from the
+    # declared-done oracle above, and the agent's edit cadence is unaffected.
+    local iterations
     iterations=$(jq -s '[.[] | select(.edited==true)] | length' "$journal")
-    itg=$(jq -s '[.[] | select(.edited==true)] | to_entries
-        | ([.[] | select(.value.heldout_fail==0)] | first // null)
-        | if . == null then -1 else (.key + 1) end' "$journal" 2>/dev/null || echo -1)
-    censored=false
-    if [[ "$itg" == "-1" ]]; then itg=$((ITERATION_BUDGET + 1)); censored=true; fi
 
     # Cost + tokens from the agent envelope. Cost = summed total_cost_usd; NEVER
     # hand-price tokens.
@@ -466,7 +490,7 @@ extract_metrics() {
         --argjson fbuild "$([[ "$fbuild" == "true" ]] && echo true || echo false)" \
         --argjson hp "$fhp" --argjson hf "$fhf" --argjson vp "$fvp" --argjson vf "$fvf" \
         --argjson basevf "$base_vf" --argjson escaped "$fhf" \
-        --argjson iterations "$iterations" --argjson itg "$itg" --argjson censored "$censored" \
+        --argjson iterations "$iterations" \
         --argjson cost "$cost" --argjson tin "$tin" --argjson tout "$tout" \
         --argjson wall "$wall" \
         --argjson null_agent "$NULL_AGENT" --argjson noop "$NULL_AGENT_NOOP" \
@@ -474,7 +498,7 @@ extract_metrics() {
         '{bundle:$bundle, project:$project, arm:$arm, run:$run, outcome:$outcome,
           finalBuildOk:$fbuild, heldoutPass:$hp, heldoutFail:$hf,
           visiblePass:$vp, visibleFail:$vf, visibleFailBaseline:$basevf,
-          escapedBugs:$escaped, iterations:$iterations, iterationsToGreen:$itg, censored:$censored,
+          escapedBugs:$escaped, iterations:$iterations, iterationsToDeclaredDone:$iterations,
           costUsd:$cost, tokens:{input:$tin, output:$tout}, wallClockSeconds:$wall,
           invalid:false, nullAgent:($null_agent==1), nullAgentNoop:($noop==1),
           mutatedFile:$mutfile,
@@ -486,11 +510,11 @@ extract_metrics() {
 write_invalid_result() {
     local ws_out="$1" run_idx="$2"
     jq -n --arg bundle "$BUNDLE_ID" --arg project "$PROJECT" --arg arm "$ARM_LABEL" --argjson run "$run_idx" \
-        --argjson escaped "$HELDOUT_COUNT" --argjson itg "$((ITERATION_BUDGET + 1))" \
+        --argjson escaped "$HELDOUT_COUNT" \
         --argjson null_agent "$NULL_AGENT" --argjson noop "$NULL_AGENT_NOOP" \
         '{bundle:$bundle, project:$project, arm:$arm, run:$run, outcome:"invalid",
           finalBuildOk:false, heldoutFail:$escaped, escapedBugs:$escaped,
-          iterations:0, iterationsToGreen:$itg, censored:true,
+          iterations:0, iterationsToDeclaredDone:0,
           costUsd:0, tokens:{input:0, output:0}, wallClockSeconds:0,
           invalid:true, nullAgent:($null_agent==1), nullAgentNoop:($noop==1)}' \
         > "$ws_out/result.json"
@@ -512,7 +536,7 @@ for (( run=1; run<=RUNS; run++ )); do
         WS_ORACLE="$(cd "$WS_ORACLE" && pwd -P)"
         SHIM_DIR="$WS_OUT/.shim"
         materialize "$WS" "$WS_OUT" "$WS_ORACLE"
-        write_shim "$WS" "$WS_OUT" "$SHIM_DIR" "$run" "$WS_ORACLE"
+        write_shim "$WS" "$WS_OUT" "$SHIM_DIR" "$run"
         _t0=$SECONDS
         run_agent "$WS" "$WS_OUT" "$SHIM_DIR"
         _wall=$(( SECONDS - _t0 ))
@@ -525,7 +549,13 @@ for (( run=1; run<=RUNS; run++ )); do
             write_invalid_result "$WS_OUT" "$run"; break
         fi
         extract_metrics "$WS" "$WS_OUT" "$run" "$_wall" "$WS_ORACLE"
-        rm -rf "$WS" "$WS_ORACLE"
+        # CALOR_BUNDLE_KEEP_WS=1 preserves the trees for the oracle-isolation audit
+        # (grep the agent workspace + shim for the oracle path / held-out names).
+        if [[ "${CALOR_BUNDLE_KEEP_WS:-0}" == "1" ]]; then
+            echo "KEEP_WS agent=$WS oracle=$WS_ORACLE shim=$SHIM_DIR" >&2
+        else
+            rm -rf "$WS" "$WS_ORACLE"
+        fi
         break
     done
 done


### PR DESCRIPTION
The epoch runner that executes the WS-W4 dry-run: runs an agent per (task bundle, arm, run) and adjudicates catch-vs-escaped via a silent held-out oracle. An adapter over the battle-tested `run-pair.sh` (reuses its invalid-retry, watchdog, `dotnet` PATH shim / silent held-out run, cost capture, `--null-agent`). Five new files under `bench/phase0-agent-native/` (guard-exempt). **No API budget spent; no real agent spawned — verified entirely with `--null-agent`.**

## Adjudication
`caught` = held-out PASSES ∧ visible green; `escaped` = held-out FAILS or final build fails; `broke-regression` = held-out passes but a previously-green visible test regressed; `invalid` = retried then recorded. Cost = summed `total_cost_usd` (never hand-priced); output tokens, iterations, iterations-to-declared-done, wall-clock captured per run. `analyze-bundle-epoch.py` emits the D-W4.4 ceiling-recurrence signal (C#-arm escaped incidence).

## Arms (D-W4.5 provisional-i, mechanical-only)
`csharp` = idiomatic C# + compiler + visible tests; `calor` = round-tripped Calor working copy + enforcement/import annotations (no authored §Q/§S). Both get the identical scrubbed failing-behavior report + identical visible/held-out split. Presentation asymmetry (calor works on machine-converted C#) recorded in every result.json — a bias against Calor.

## Oracle integrity (the load-bearing property)
Two-copy architecture: the **agent-visible** copy has each held-out method PHYSICALLY STRIPPED (brace-matched, string/comment-aware C# removal, incl. `[Theory]` rows + attributes), so the agent cannot read or run the oracle; the **oracle** copy (isolated mktemp tree the agent has no path to) retains it and is kept in sync with the agent's LIBRARY edits (test dir excluded). Fail-loud if any held-out method isn't found / is ambiguous / survives removal (a silent miss = a fabricated measurement → run aborts).

## Verification (zero spend)
- Oracle-leak proof (FluentValidation): held-out text in agent copy = 0, oracle copy = 1; agent `dotnet test` = 864/865 green with held-out NOT run; full/oracle = 1 failed (the held-out).
- Adjudication sound both arms/both projects: FLUENT csharp/calor CAUGHT+ESCAPED; SERILOG csharp CAUGHT (8-method held-out cluster stripped) + ESCAPED. Null-agent cost 0.

## Notes for the dry-run
Serilog needs `--max-candidates 40` to reach eligible logic bundles (default 6 → 0). Command to launch (post-spend-auth) in README-bundle-runner.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)