### PR TITLE
ci: seed Z3 natives before MSBuild evaluation — restore ~365 silently-skipped verification tests

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -29,6 +29,15 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      # This is the RELEASE GATE. Without seeding, src/Calor.Compiler/{z3,runtimes}/ are
+      # empty at MSBuild evaluation time (they are gitignored), the csproj's
+      # `<None Include="runtimes\**\*">` glob matches nothing, the natives never reach the
+      # test hosts, and all 358 Z3-backed tests SKIP — so the gate that authorizes shipping
+      # to NuGet would go green having verified none of the verification surface. The
+      # `publish` job below already stages the natives before restore for this same reason.
+      - name: Seed Z3 native libraries (before MSBuild evaluation)
+        run: bash src/Calor.Compiler/scripts/download-z3.sh
+
       - name: Restore dependencies
         run: dotnet restore
 
@@ -36,7 +45,21 @@ jobs:
         run: dotnet build -c Release --no-restore
 
       - name: Run all tests
-        run: dotnet test -c Release --no-build --verbosity normal
+        run: |
+          set -euo pipefail
+          dotnet test -c Release --no-build --verbosity normal 2>&1 | tee test-output.log
+
+      # Assert the property that matters, not a filename: no Z3-gated test may skip on the
+      # commit being released. This regression is invisible by construction otherwise —
+      # the tests skip rather than fail.
+      - name: Assert no Z3-gated test silently skipped
+        run: |
+          set -euo pipefail
+          if grep -q "Z3 not available" test-output.log; then
+            echo "::error::Z3-gated tests skipped on the release commit — natives did not reach the test hosts."
+            grep -c "Z3 not available" test-output.log
+            exit 1
+          fi
 
   sdk-consumer:
     # M-A1: a template consumer restores/builds/tests green against the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,22 +55,25 @@ jobs:
       - name: Build
         run: dotnet build -c Release --no-restore
 
-      # Fail loudly if the seeding above ever stops reaching the test hosts. Without this,
-      # a regression is invisible: the tests skip rather than fail.
-      - name: Assert Z3 natives reached the test output
+      - name: Run all tests
         run: |
           set -euo pipefail
-          missing=0
-          for proj in Calor.Verification.Tests Calor.Compiler.Tests; do
-            if ! find "tests/$proj/bin/Release" -name 'libz3.so' -print -quit | grep -q .; then
-              echo "::error::libz3.so is absent from tests/$proj output — Z3-backed tests would silently skip."
-              missing=1
-            fi
-          done
-          exit $missing
+          dotnet test -c Release --no-build --verbosity normal 2>&1 | tee test-output.log
 
-      - name: Run all tests
-        run: dotnet test -c Release --no-build --verbosity normal
+      # Assert the PROPERTY that matters (no Z3-gated test skipped), not the presence of a
+      # filename. An earlier version of this step checked only that some libz3.so existed
+      # anywhere under bin/Release, which would pass on a wrong-RID copy that cannot load,
+      # and could not detect a present-but-unloadable native (e.g. a glibc bump on the
+      # runner). This check fails in all of those cases. Without it the regression is
+      # invisible by construction: the tests skip rather than fail.
+      - name: Assert no Z3-gated test silently skipped
+        run: |
+          set -euo pipefail
+          if grep -q "Z3 not available" test-output.log; then
+            echo "::error::Z3-gated tests skipped — natives did not reach the test hosts."
+            grep -c "Z3 not available" test-output.log
+            exit 1
+          fi
 
       # Spec drift (Phase 1 item 6, agent-native strategy): agent-facing docs
       # are machine-checked against the implementation, reusing this job's
@@ -114,8 +117,20 @@ jobs:
 
       - name: Run regression tests
         run: |
-          dotnet test tests/Calor.Compiler.Tests -c Release --no-build --verbosity normal
+          set -euo pipefail
+          dotnet test tests/Calor.Compiler.Tests -c Release --no-build --verbosity normal 2>&1 | tee test-output.log
           dotnet test tests/Calor.Evaluation -c Release --no-build --verbosity normal
+
+      # This job runs Calor.Compiler.Tests, which carries 44 Z3-gated tests. Same guard as
+      # the `test` job — a skip here would otherwise be silent.
+      - name: Assert no Z3-gated test silently skipped
+        run: |
+          set -euo pipefail
+          if grep -q "Z3 not available" test-output.log; then
+            echo "::error::Z3-gated tests skipped — natives did not reach the test hosts."
+            grep -c "Z3 not available" test-output.log
+            exit 1
+          fi
 
   semantics-tests:
     runs-on: ubuntu-latest
@@ -292,9 +307,12 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      # See the note in the `test` job. The round-trip harness's addressability probe is
-      # Z3-backed for the div-by-zero / index-OOB checks; without the natives it reports
-      # "indeterminable" rather than a verdict.
+      # PRECAUTIONARY, not currently load-bearing — stated honestly because an earlier
+      # version of this comment was wrong. This job runs `harness run --all`, which routes
+      # to RoundTripPipeline and touches no Z3; the Z3-backed addressability probe
+      # (VerificationAddressability) is reachable only from the `gen-tasks` command, and its
+      # tests run in the `test` job. Verified: with and without this step the job's output is
+      # byte-identical. Kept so that adding `gen-tasks` here cannot silently degrade.
       - name: Seed Z3 native libraries (before MSBuild evaluation)
         run: bash src/Calor.Compiler/scripts/download-z3.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,11 +39,35 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      # src/Calor.Compiler/{z3,runtimes}/ are gitignored, so on a fresh checkout the
+      # csproj's `<None Include="runtimes\**\*" CopyToOutputDirectory>` glob — resolved at
+      # MSBuild EVALUATION time — matches nothing, and the natives never propagate to test
+      # projects. The DownloadZ3 target populates those directories later, at EXECUTION
+      # time, which is too late for the glob. The managed Microsoft.Z3.dll still flows via
+      # <Reference Private="true">, so the wrapper loads and dies at P/Invoke, and every
+      # Z3-backed test silently skips. Seeding before restore fixes the ordering.
+      - name: Seed Z3 native libraries (before MSBuild evaluation)
+        run: bash src/Calor.Compiler/scripts/download-z3.sh
+
       - name: Restore dependencies
         run: dotnet restore
 
       - name: Build
         run: dotnet build -c Release --no-restore
+
+      # Fail loudly if the seeding above ever stops reaching the test hosts. Without this,
+      # a regression is invisible: the tests skip rather than fail.
+      - name: Assert Z3 natives reached the test output
+        run: |
+          set -euo pipefail
+          missing=0
+          for proj in Calor.Verification.Tests Calor.Compiler.Tests; do
+            if ! find "tests/$proj/bin/Release" -name 'libz3.so' -print -quit | grep -q .; then
+              echo "::error::libz3.so is absent from tests/$proj output — Z3-backed tests would silently skip."
+              missing=1
+            fi
+          done
+          exit $missing
 
       - name: Run all tests
         run: dotnet test -c Release --no-build --verbosity normal
@@ -73,6 +97,11 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
+
+      # See the note in the `test` job: seed before restore or the natives never reach
+      # the test hosts and every Z3-backed test skips. This job runs Calor.Compiler.Tests.
+      - name: Seed Z3 native libraries (before MSBuild evaluation)
+        run: bash src/Calor.Compiler/scripts/download-z3.sh
 
       - name: Restore dependencies
         run: dotnet restore
@@ -262,6 +291,12 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
+
+      # See the note in the `test` job. The round-trip harness's addressability probe is
+      # Z3-backed for the div-by-zero / index-OOB checks; without the natives it reports
+      # "indeterminable" rather than a verdict.
+      - name: Seed Z3 native libraries (before MSBuild evaluation)
+        run: bash src/Calor.Compiler/scripts/download-z3.sh
 
       - name: Restore and build Calor
         run: |


### PR DESCRIPTION
## The problem

CI has had **effectively zero coverage of the Z3 verification surface** — in a repo whose
v0.10–v0.12 thesis *is* verification.

Baseline from a recent run:

| Assembly | Total | Skipped | Reason |
|---|---|---|---|
| `Calor.Verification.Tests` | 347 | **314** | `Z3 not available` |
| `Calor.Compiler.Tests` | 6155 | **51** | `Z3 not available` |

## The cause — an ordering bug, not a runner limitation

CI downloads Z3 successfully. The natives just never reach the test hosts:

1. `src/Calor.Compiler/{z3,runtimes}/` are **gitignored** → empty on a fresh checkout.
2. `Calor.Compiler.csproj`'s `<None Include="runtimes\**\*" CopyToOutputDirectory>` is a glob
   resolved at MSBuild **evaluation** time → matches nothing → nothing propagates to
   referencing test projects.
3. The `DownloadZ3` target populates those directories at **execution** time
   (`BeforeTargets="BeforeBuild"`) — correct for the compiler's own output, too late for the glob.
4. `CopyZ3NativeToOutput` copies only into `Calor.Compiler`'s own `OutputPath`; it does not
   propagate either.
5. The **managed** `Microsoft.Z3.dll` *does* flow (via `<Reference Private="true">`), so the
   wrapper loads and then fails at P/Invoke.

Step 5 is what makes this silent: `DivisionByZeroChecker` catches the failure and returns
"unknown", which under `ReportOnlyVerified` emits **no diagnostic at all**. No error, no trace.

## The fix

Run the existing checksum-verified download script before `dotnet restore` in the three jobs
that run Z3-dependent test projects (`test`, `enforcement-tests`, `roundtrip-verification`), so
the directories are populated *before* evaluation. The script is idempotent (skips when the
libraries are present) and covers `linux-x64` — cost is one download, ~9s.

Plus an **assertion step** that `libz3.so` actually reached the test output. Without it a
regression here is invisible by construction: the tests skip rather than fail, which is exactly
what let this persist.

## Why it was never noticed locally

A previous build leaves `runtimes/` populated, so the glob matches and everything works. That
asymmetry — not runner capability — is the whole local-vs-CI difference.

## Verification

The proof is the skip count in this PR's own `test` job. Expect `Calor.Verification.Tests` to go
from 314 skipped to ~0, and the new assertion step to pass. **If the skip counts do not move,
this PR has not fixed the problem and should not be merged.**

Found by the adversarial re-review of #856, where a single skipped test was the visible symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
