### PR TITLE
S1 enumeration-only supply pre-pass — the corpus ceiling is 9 candidates

### DIFF
--- a/bench/phase0-agent-native/epochs/s1-supply-001/FINDING.md
+++ b/bench/phase0-agent-native/epochs/s1-supply-001/FINDING.md
@@ -1,42 +1,57 @@
-# s1-supply-001 — S1 enumeration-only pre-pass: the corpus supply ceiling
+# s1-supply-001 — S1 enumeration-only pre-pass: where the supply ceiling actually comes from
 
 **Run:** 2026-08-04, conversion-only, no builds/tests/recovery/bundles, **no eligibility evaluated**.
 **Corpus pins:** MediatR `fb309026`, Serilog `0597ddfb`, FluentValidation `71b3c60c`.
 **Invocation:** `enumerate-supply MediatR Serilog FluentValidation --output bench/phase0-agent-native/epochs/s1-supply-001`
 **Governing doc:** [`substrate-s1-kickoff.md`](../../../../docs/plans/substrate-s1-kickoff.md) D-1, D-5.
+**Revision 2** — adversarial review of the first record found that it attributed the ceiling to the corpus when a third of it is converter fidelity. The pass now measures all three populations; the numbers below are from the corrected tool.
 
 ## The numbers
 
-| Project | Native files | With-loss files | Supply (native) | Supply (with-loss) | ratio |
+| Project | Sites (all) | Lost to conversion | Supply (native) | Supply (with-loss) | ratio |
 |---|---:|---:|---:|---:|---:|
-| MediatR | 20 | 5 | **0** | 0 | n/a |
-| Serilog | 72 | 17 | **3** | 7 | 2.33 |
-| FluentValidation | 109 | 4 | **6** | 0 | 0.00 |
-| **TOTAL** | 201 | 26 | **9** | 7 | 0.78 |
+| MediatR | 2 | 2 | **0** | 0 | n/a |
+| Serilog | 15 | 5 | **3** | 7 | 2.33 |
+| FluentValidation | 8 | 2 | **6** | 0 | 0.00 |
+| **TOTAL** | **25** | **9** | **9** | 7 | 0.78 |
 
-By operator: Serilog native = 3 `EffectViolation`; FluentValidation native = 3 `EffectViolation` + 3 `NullDeref`; Serilog with-loss = 1 `EffectViolation` + 6 `NullDeref`. `IndexOutOfBounds` and `DivByZero` contributed **zero** candidates anywhere.
+**These are upper bounds** on the native column: build and `RecoverBuildAsync` are skipped, so files that convert but do not compile still count as native. Recovery is strictly subtractive (`Replaced → Reverted` is the only post-conversion status transition, and the loss ledger is populated inside conversion and never after), so the bound is one-directional.
 
-**These are upper bounds.** Build and `RecoverBuildAsync` were deliberately skipped, so files that convert but do not compile are still counted native — recovery is exactly what would revert them. Every eligibility clause downstream only removes candidates.
+## The ceiling is not one thing, and that is the finding
 
-## D-5 — RESOLVED by its pre-committed rule: **ACCEPT**
+The first version of this record said "the whole corpus supplies 9" and called MediatR "structurally unable to contribute". Both were wrong in the same way — they attributed to the *corpus* a number produced jointly by three things:
 
-Pooled with-loss/native = **0.78 ≥ 0.50**, so site-level clause (a) is **accepted** and priced into WS-S1's box, per the rule fixed in the S1 kickoff before these numbers existed.
+1. **The corpus** — 25 enumerable sites exist across the three subjects.
+2. **Converter fidelity** — **9 of those 25 (36%) are in files the converter could not convert at all.** MediatR's supply is 0 *because both of its sites are in an unconvertible file*, not because MediatR lacks them. That is a WS-S1 result, not a venue result.
+3. **The frozen operator site predicate** — the largest constraint, and the least visible. `EffectViolation` requires a **block-bodied method with a predefined `int`/`long` return type** (`ExpressibleMutationOperators.cs` `IsIntOrLong`), a restriction that exists only because the corruption mechanism is `return (ORIGINAL) + __calorTaint`. It is unrelated to addressability: the `using`-nested `Directory.Exists` that makes `Calor0410` fire works regardless of return type. An independent census during review put the eligible site universe at **9 of 917 block-bodied methods (~1%)**, with expression-bodied methods and `int`/`long` property getters excluded purely as an artifact of the visitor. A corruption that generalizes (`__calorTaint == 1 ? default(T)! : ORIGINAL`) would widen this substantially at no cost to the differential.
 
-The per-project split matters and is not hidden by the pooled figure: the entire with-loss supply is **Serilog's**, and 6 of its 7 are `NullDeref`. FluentValidation's ratio is 0.00 and MediatR's is undefined. So the accept rests on one subject.
+**So "the corpus has no supply" and "our operators are too narrow" are not distinguishable from the native column alone — and the evidence points more at (2) and (3) than at (1).** That matters because the two readings have opposite remedies: venue retirement versus operator breadth plus converter fidelity, which are precisely WS-S0.5's D-S0.5.2 and WS-S1.
 
-## The finding that dominates everything else
+**One part of the ceiling is genuinely corpus-side and survives scrutiny:** `IndexOutOfBounds` and `DivByZero` contributed **zero** candidates anywhere. Review confirmed by direct source census that the guard shapes those operators need (`if (d != 0)` with no `else`; `if (i < X.Length)` with no `else`) are near-absent in this corpus — 0 and 1 instance respectively. Widening those matchers would not manufacture meaningful supply.
 
-**The kickoff's D-3 target of n ≈ 30 is unreachable. The whole corpus supplies 9 native candidates — an upper bound — and 16 even if site-level clause (a) lands.**
+## D-5 — **SPLIT**, not the ACCEPT the first record reported
 
-Consequences, stated without adjudicating anything this record is not entitled to adjudicate:
+Pooled with-loss/native = 0.78 ≥ 0.50, which by the letter of the pre-committed rule is ACCEPT. But the numerator is **6/7 `NullDeref`**, and per operator:
 
-1. **The probe's cap is moot.** `--max-candidates 10` per project would bind on nothing: MediatR 0, Serilog 3, FluentValidation 6. The lexicographic-prefix bias D-3 worried about is irrelevant at this n — there is no truncation to bias.
-2. **D-3's power statement collapses.** At n = 9 pooled (and 0/3/6 per project, against a rule that forbids pooling), a clause-(b) pass rate of 25% yields zero observations about 7.5% of the time pooled — and per project the probe cannot distinguish anything at all. The funnel probe as designed cannot resolve the ambiguity it was commissioned to resolve.
-3. **Two of three subjects are structurally unable to contribute.** MediatR yields **0** — consistent with the close-out's "MediatR already yielded 0". The M-S3 shape "≥2 from each of ≥2 projects" has, at most, two candidate-bearing projects before eligibility attrition begins.
-4. **The plan §4 go/no-go now has its input.** The ceiling is 9 (16 with site-level clause (a)). Against the dry-run's required-N — "hundreds of clustered tasks" for the registered 20–40% effect, ~15–40 under the most optimistic deterministic-catch assumption — the ceiling is **more than an order of magnitude short of the registered effect**, and at or below the optimistic case *before* any eligibility attrition. **The adjudication of that go/no-go belongs to the A-1.5 freeze, not to this record**, which reports the measurement only.
+| Operator | With-loss | Native | ratio | verdict |
+|---|---:|---:|---:|---|
+| `EffectViolation` | 1 | 6 | **0.17** | REJECT |
+| `NullDeref` | 6 | 3 | **2.00** | ACCEPT |
+
+The pooled verdict is carried entirely by `NullDeref` — an operator whose own doc comment states that Calor's null checker models `Option`/`Result` unwrap shapes and **not** plain reference null-deref, so "converted corpus code is not expected to trigger it". It exists to disclose that gap honestly, not to supply eligible tasks.
+
+So the pooled figure would have licensed building site-level clause (a) on the strength of supply that eligibility is expected to delete. The rule was honored in letter while its intent — *is site-level clause (a) broadly worth building?* — went untested. **The tool now reports SPLIT when the pooled verdict and the dominant-operator verdict disagree**, and D-5 is referred for an explicit decision with the split on the record, rather than settled by a threshold that did not actually settle it.
+
+Also noted: pooling was never the pre-committed part. The kickoff fixed the threshold, not the aggregation, and the same document forbids pooling for the power claim.
+
+## Consequences for the probe and for A-1.5
+
+1. **`--max-candidates 10` binds on nothing** (0/3/6 per project). The lexicographic-prefix bias D-3 worried about is irrelevant at this n.
+2. **D-3's power statement collapses.** At n = 9 pooled a 25% clause-(b) pass rate yields zero passes ~7.5% of the time; per project the probe distinguishes nothing. The funnel probe as designed cannot resolve what it was commissioned to resolve.
+3. **The §4 go/no-go input is now three numbers, not one** — 25 sites, 9 reachable after conversion, 9 lost to the converter — and the plan's trigger is worded against "the corpus's candidate-supply ceiling". Adjudicating it on the native column alone would retire the venue on a number whose binding constraints are a mutation-operator design choice and converter fidelity, both of which v0.12 is already chartered to move. **This record does not adjudicate it; A-1.5 does.**
 
 ## What this record does not claim
 
-- It does not claim 0 eligible tasks. Eligibility was not evaluated; that is the point of the pass.
-- It does not adjudicate PP-S3, PP-S1, or the §4 go/no-go.
-- It does not claim the corpus is representative of real C# — only of these three pinned subjects.
+- Not 0 eligible tasks — eligibility was never evaluated; that is the point of the pass.
+- No adjudication of PP-S3, PP-S1, or the §4 go/no-go.
+- Not a claim about real C# generally — only about these three pinned subjects, under this frozen operator set.

--- a/bench/phase0-agent-native/epochs/s1-supply-001/FINDING.md
+++ b/bench/phase0-agent-native/epochs/s1-supply-001/FINDING.md
@@ -1,0 +1,42 @@
+# s1-supply-001 — S1 enumeration-only pre-pass: the corpus supply ceiling
+
+**Run:** 2026-08-04, conversion-only, no builds/tests/recovery/bundles, **no eligibility evaluated**.
+**Corpus pins:** MediatR `fb309026`, Serilog `0597ddfb`, FluentValidation `71b3c60c`.
+**Invocation:** `enumerate-supply MediatR Serilog FluentValidation --output bench/phase0-agent-native/epochs/s1-supply-001`
+**Governing doc:** [`substrate-s1-kickoff.md`](../../../../docs/plans/substrate-s1-kickoff.md) D-1, D-5.
+
+## The numbers
+
+| Project | Native files | With-loss files | Supply (native) | Supply (with-loss) | ratio |
+|---|---:|---:|---:|---:|---:|
+| MediatR | 20 | 5 | **0** | 0 | n/a |
+| Serilog | 72 | 17 | **3** | 7 | 2.33 |
+| FluentValidation | 109 | 4 | **6** | 0 | 0.00 |
+| **TOTAL** | 201 | 26 | **9** | 7 | 0.78 |
+
+By operator: Serilog native = 3 `EffectViolation`; FluentValidation native = 3 `EffectViolation` + 3 `NullDeref`; Serilog with-loss = 1 `EffectViolation` + 6 `NullDeref`. `IndexOutOfBounds` and `DivByZero` contributed **zero** candidates anywhere.
+
+**These are upper bounds.** Build and `RecoverBuildAsync` were deliberately skipped, so files that convert but do not compile are still counted native — recovery is exactly what would revert them. Every eligibility clause downstream only removes candidates.
+
+## D-5 — RESOLVED by its pre-committed rule: **ACCEPT**
+
+Pooled with-loss/native = **0.78 ≥ 0.50**, so site-level clause (a) is **accepted** and priced into WS-S1's box, per the rule fixed in the S1 kickoff before these numbers existed.
+
+The per-project split matters and is not hidden by the pooled figure: the entire with-loss supply is **Serilog's**, and 6 of its 7 are `NullDeref`. FluentValidation's ratio is 0.00 and MediatR's is undefined. So the accept rests on one subject.
+
+## The finding that dominates everything else
+
+**The kickoff's D-3 target of n ≈ 30 is unreachable. The whole corpus supplies 9 native candidates — an upper bound — and 16 even if site-level clause (a) lands.**
+
+Consequences, stated without adjudicating anything this record is not entitled to adjudicate:
+
+1. **The probe's cap is moot.** `--max-candidates 10` per project would bind on nothing: MediatR 0, Serilog 3, FluentValidation 6. The lexicographic-prefix bias D-3 worried about is irrelevant at this n — there is no truncation to bias.
+2. **D-3's power statement collapses.** At n = 9 pooled (and 0/3/6 per project, against a rule that forbids pooling), a clause-(b) pass rate of 25% yields zero observations about 7.5% of the time pooled — and per project the probe cannot distinguish anything at all. The funnel probe as designed cannot resolve the ambiguity it was commissioned to resolve.
+3. **Two of three subjects are structurally unable to contribute.** MediatR yields **0** — consistent with the close-out's "MediatR already yielded 0". The M-S3 shape "≥2 from each of ≥2 projects" has, at most, two candidate-bearing projects before eligibility attrition begins.
+4. **The plan §4 go/no-go now has its input.** The ceiling is 9 (16 with site-level clause (a)). Against the dry-run's required-N — "hundreds of clustered tasks" for the registered 20–40% effect, ~15–40 under the most optimistic deterministic-catch assumption — the ceiling is **more than an order of magnitude short of the registered effect**, and at or below the optimistic case *before* any eligibility attrition. **The adjudication of that go/no-go belongs to the A-1.5 freeze, not to this record**, which reports the measurement only.
+
+## What this record does not claim
+
+- It does not claim 0 eligible tasks. Eligibility was not evaluated; that is the point of the pass.
+- It does not adjudicate PP-S3, PP-S1, or the §4 go/no-go.
+- It does not claim the corpus is representative of real C# — only of these three pinned subjects.

--- a/bench/phase0-agent-native/epochs/s1-supply-001/supply-enumeration.json
+++ b/bench/phase0-agent-native/epochs/s1-supply-001/supply-enumeration.json
@@ -4,6 +4,10 @@
       "ProjectName": "MediatR",
       "NativeFiles": 20,
       "WithLossFiles": 5,
+      "UnconvertedFiles": 7,
+      "SupplyTotal": 2,
+      "SupplyLostToConversion": 2,
+      "UnreadableSources": 0,
       "SupplyNative": 0,
       "SupplyWithLoss": 0,
       "NativeByOperator": {},
@@ -15,6 +19,10 @@
       "ProjectName": "Serilog",
       "NativeFiles": 72,
       "WithLossFiles": 17,
+      "UnconvertedFiles": 21,
+      "SupplyTotal": 15,
+      "SupplyLostToConversion": 5,
+      "UnreadableSources": 0,
       "SupplyNative": 3,
       "SupplyWithLoss": 7,
       "NativeByOperator": {
@@ -34,6 +42,10 @@
       "ProjectName": "FluentValidation",
       "NativeFiles": 109,
       "WithLossFiles": 4,
+      "UnconvertedFiles": 26,
+      "SupplyTotal": 8,
+      "SupplyLostToConversion": 2,
+      "UnreadableSources": 0,
       "SupplyNative": 6,
       "SupplyWithLoss": 0,
       "NativeByOperator": {
@@ -53,6 +65,15 @@
   ],
   "TotalSupplyNative": 9,
   "TotalSupplyWithLoss": 7,
+  "TotalSupplyAll": 25,
+  "TotalSupplyLostToConversion": 9,
+  "TotalUnreadableSources": 0,
+  "ByOperator": {
+    "EffectViolation": {},
+    "NullDeref": {}
+  },
+  "DominantNumeratorOperator": {},
+  "RatioExcludingDominant": 0.16666666666666666,
   "PooledRatio": 0.7777777777777778,
-  "D5Verdict": "ACCEPT site-level clause (a) \u2014 ratio 0.78 \u2265 0.50"
+  "D5Verdict": "SPLIT \u2014 pooled ratio 0.78 says ACCEPT, but that is carried by \u0027NullDeref\u0027 (its own ratio 2.00); excluding it the ratio is 0.17 \u2192 REJECT. The pre-committed threshold does not settle this; decide explicitly and record why."
 }

--- a/bench/phase0-agent-native/epochs/s1-supply-001/supply-enumeration.json
+++ b/bench/phase0-agent-native/epochs/s1-supply-001/supply-enumeration.json
@@ -1,0 +1,58 @@
+{
+  "Projects": [
+    {
+      "ProjectName": "MediatR",
+      "NativeFiles": 20,
+      "WithLossFiles": 5,
+      "SupplyNative": 0,
+      "SupplyWithLoss": 0,
+      "NativeByOperator": {},
+      "WithLossByOperator": {},
+      "NativeByFile": {},
+      "WithLossOverNativeRatio": null
+    },
+    {
+      "ProjectName": "Serilog",
+      "NativeFiles": 72,
+      "WithLossFiles": 17,
+      "SupplyNative": 3,
+      "SupplyWithLoss": 7,
+      "NativeByOperator": {
+        "EffectViolation": 3
+      },
+      "WithLossByOperator": {
+        "EffectViolation": 1,
+        "NullDeref": 6
+      },
+      "NativeByFile": {
+        "src/Serilog/Core/Pipeline/ByReferenceStringComparer.cs": 2,
+        "src/Serilog/Events/EventProperty.cs": 1
+      },
+      "WithLossOverNativeRatio": 2.3333333333333335
+    },
+    {
+      "ProjectName": "FluentValidation",
+      "NativeFiles": 109,
+      "WithLossFiles": 4,
+      "SupplyNative": 6,
+      "SupplyWithLoss": 0,
+      "NativeByOperator": {
+        "EffectViolation": 3,
+        "NullDeref": 3
+      },
+      "WithLossByOperator": {},
+      "NativeByFile": {
+        "src/FluentValidation/Internal/AccessorCache.cs": 1,
+        "src/FluentValidation/Internal/ValidationStrategy.cs": 2,
+        "src/FluentValidation/Validators/ComparableComparer.cs": 1,
+        "src/FluentValidation/Validators/NotEqualValidator.cs": 1,
+        "src/FluentValidation/Validators/RangeValidator.cs": 1
+      },
+      "WithLossOverNativeRatio": 0
+    }
+  ],
+  "TotalSupplyNative": 9,
+  "TotalSupplyWithLoss": 7,
+  "PooledRatio": 0.7777777777777778,
+  "D5Verdict": "ACCEPT site-level clause (a) \u2014 ratio 0.78 \u2265 0.50"
+}

--- a/bench/phase0-agent-native/epochs/s1-supply-001/supply-enumeration.md
+++ b/bench/phase0-agent-native/epochs/s1-supply-001/supply-enumeration.md
@@ -1,0 +1,72 @@
+# v0.12 S1 — expressible-stratum supply enumeration (pre-pass)
+
+**Conversion-only.** No builds, no test runs, no recovery, no bundles, and no
+eligibility evaluation — which is what permits this to run *before* the A-1.5 freeze
+(plan §3 constraint (a)).
+
+**Upper bound, not realized supply.** Build and `RecoverBuildAsync` are skipped, so a
+file that converted but does not compile is still counted native here — recovery is
+precisely what would revert it. Every later eligibility clause only removes candidates,
+so these figures bound eligibility from above. That is the correct direction for a
+"is there conceivably enough supply?" go/no-go, and the wrong number to quote as supply.
+
+## Supply by project
+
+| Project | Native files | With-loss files | Supply (native) | Supply (with-loss) | with-loss / native |
+|---|---:|---:|---:|---:|---:|
+| MediatR | 20 | 5 | **0** | 0 | n/a |
+| Serilog | 72 | 17 | **3** | 7 | 2.33 |
+| FluentValidation | 109 | 4 | **6** | 0 | 0.00 |
+| **TOTAL** | | | **9** | 7 | 0.78 |
+
+## D-5 — region-granularity clause (a)
+
+Pre-committed rule (S1 kickoff): accept site-level clause (a) iff with-loss/native ≥ 0.50.
+
+**ACCEPT site-level clause (a) — ratio 0.78 ≥ 0.50**
+
+Per-project ratios are in the table above; a pooled figure must not conceal a split.
+
+## Candidates by operator
+
+### MediatR
+
+_No expressible candidates enumerated in either population._
+
+### Serilog
+
+| Operator | Native | With-loss |
+|---|---:|---:|
+| EffectViolation | 3 | 1 |
+| NullDeref | 0 | 6 |
+
+### FluentValidation
+
+| Operator | Native | With-loss |
+|---|---:|---:|
+| EffectViolation | 3 | 0 |
+| NullDeref | 3 | 0 |
+
+## Clustering (native candidates by file)
+
+The probe's `--max-candidates` cap takes a **lexicographic prefix**, not a sample, so
+candidates concentrated in few files mean the probe's effective *n* is far below its
+nominal *n* (S1 kickoff D-3). This table is what makes that visible before the probe runs.
+
+### MediatR — 0 native file(s) carrying candidates
+
+_none_
+
+### Serilog — 2 native file(s) carrying candidates
+
+- `src/Serilog/Core/Pipeline/ByReferenceStringComparer.cs` — 2
+- `src/Serilog/Events/EventProperty.cs` — 1
+
+### FluentValidation — 5 native file(s) carrying candidates
+
+- `src/FluentValidation/Internal/ValidationStrategy.cs` — 2
+- `src/FluentValidation/Internal/AccessorCache.cs` — 1
+- `src/FluentValidation/Validators/ComparableComparer.cs` — 1
+- `src/FluentValidation/Validators/NotEqualValidator.cs` — 1
+- `src/FluentValidation/Validators/RangeValidator.cs` — 1
+

--- a/bench/phase0-agent-native/epochs/s1-supply-001/supply-enumeration.md
+++ b/bench/phase0-agent-native/epochs/s1-supply-001/supply-enumeration.md
@@ -12,20 +12,33 @@ so these figures bound eligibility from above. That is the correct direction for
 
 ## Supply by project
 
-| Project | Native files | With-loss files | Supply (native) | Supply (with-loss) | with-loss / native |
+| Project | Sites (all) | Lost to conversion | Supply (native) | Supply (with-loss) | with-loss / native |
 |---|---:|---:|---:|---:|---:|
-| MediatR | 20 | 5 | **0** | 0 | n/a |
-| Serilog | 72 | 17 | **3** | 7 | 2.33 |
-| FluentValidation | 109 | 4 | **6** | 0 | 0.00 |
-| **TOTAL** | | | **9** | 7 | 0.78 |
+| MediatR | 2 | 2 | **0** | 0 | n/a |
+| Serilog | 15 | 5 | **3** | 7 | 2.33 |
+| FluentValidation | 8 | 2 | **6** | 0 | 0.00 |
+| **TOTAL** | **25** | 9 | **9** | 7 | 0.78 |
+
+**Read the first two columns before the third.** "Sites (all)" is the corpus-side
+supply the frozen operator set can enumerate anywhere; "lost to conversion" is the part
+the converter could not reach. A low native figure with a high lost figure is a
+**converter-fidelity** result, not a corpus result — opposite remedies. Any downstream
+use of the native number as "the corpus's supply ceiling" must account for both.
 
 ## D-5 — region-granularity clause (a)
 
 Pre-committed rule (S1 kickoff): accept site-level clause (a) iff with-loss/native ≥ 0.50.
 
-**ACCEPT site-level clause (a) — ratio 0.78 ≥ 0.50**
+**SPLIT — pooled ratio 0.78 says ACCEPT, but that is carried by 'NullDeref' (its own ratio 2.00); excluding it the ratio is 0.17 → REJECT. The pre-committed threshold does not settle this; decide explicitly and record why.**
 
 Per-project ratios are in the table above; a pooled figure must not conceal a split.
+
+Per-operator, because a pooled ratio can be carried by a single operator:
+
+| Operator | With-loss | Native | ratio |
+|---|---:|---:|---:|
+| EffectViolation | 1 | 6 | 0.17 |
+| NullDeref | 6 | 3 | 2.00 |
 
 ## Candidates by operator
 

--- a/tests/Calor.RoundTrip.Harness.Tests/SupplyEnumerationTests.cs
+++ b/tests/Calor.RoundTrip.Harness.Tests/SupplyEnumerationTests.cs
@@ -1,0 +1,213 @@
+using Calor.RoundTrip.Harness;
+using Calor.RoundTrip.Harness.TaskGen;
+using Xunit;
+
+namespace Calor.RoundTrip.Harness.Tests;
+
+/// <summary>
+/// Unit tests for the v0.12 S1 enumeration-only pre-pass. The conversion step is injected, so these
+/// exercise the classification, the counting, and — most importantly — the D-5 decision rule and its
+/// undefined case, without needing the corpus.
+/// </summary>
+public class SupplyEnumerationTests
+{
+    private static RoundTripConfig Project(string name) => new()
+    {
+        ProjectName = name,
+        OriginalProjectPath = "/nonexistent",
+        LibrarySourceRelativePath = "src",
+        SolutionOrProjectFile = "x.sln",
+    };
+
+    private static FileConversionResult File(string path, FileStatus status, int losses) =>
+        new() { FilePath = path, Status = status, LossCount = losses };
+
+    /// <summary>A source with exactly one EffectViolation-eligible method (int-returning, block body).</summary>
+    private const string OneEffectCandidate = """
+        using System;
+        namespace S;
+        public class C
+        {
+            private int _n;
+            public int Next() { Console.WriteLine("x"); return _n + 1; }
+        }
+        """;
+
+    private const string NoCandidates = """
+        namespace S;
+        public class Empty { }
+        """;
+
+    private static Task<SupplyEnumeration.Result> Run(
+        IReadOnlyList<RoundTripConfig> projects,
+        Dictionary<string, List<FileConversionResult>> ledger,
+        Dictionary<string, string> sources) =>
+        SupplyEnumeration.RunAsync(
+            projects,
+            p => Task.FromResult<IReadOnlyList<FileConversionResult>>(ledger[p.ProjectName]),
+            (_, rel) => Task.FromResult<string?>(sources.GetValueOrDefault(rel)));
+
+    [Fact]
+    public async Task Classifies_native_versus_withloss_by_the_loss_ledger()
+    {
+        var result = await Run(
+            [Project("P")],
+            new() { ["P"] = [File("a.cs", FileStatus.Replaced, 0), File("b.cs", FileStatus.Replaced, 3)] },
+            new() { ["a.cs"] = OneEffectCandidate, ["b.cs"] = OneEffectCandidate });
+
+        var p = Assert.Single(result.Projects);
+        Assert.Equal(1, p.NativeFiles);
+        Assert.Equal(1, p.WithLossFiles);
+        Assert.Equal(1, p.SupplyNative);
+        Assert.Equal(1, p.SupplyWithLoss);
+    }
+
+    [Fact]
+    public async Task Reverted_and_failed_files_are_in_neither_population()
+    {
+        // Only Replaced files were actually converted; anything else must not inflate either count.
+        var result = await Run(
+            [Project("P")],
+            new()
+            {
+                ["P"] =
+                [
+                    File("kept.cs", FileStatus.Replaced, 0),
+                    File("reverted.cs", FileStatus.Reverted, 0),
+                    File("excluded.cs", FileStatus.Excluded, 0),
+                ]
+            },
+            new() { ["kept.cs"] = OneEffectCandidate, ["reverted.cs"] = OneEffectCandidate, ["excluded.cs"] = OneEffectCandidate });
+
+        var p = Assert.Single(result.Projects);
+        Assert.Equal(1, p.NativeFiles);
+        Assert.Equal(0, p.WithLossFiles);
+        Assert.Equal(1, p.SupplyNative);
+        Assert.Equal(0, p.SupplyWithLoss);
+    }
+
+    [Fact]
+    public async Task D5_accepts_at_or_above_the_threshold()
+    {
+        // 2 native candidates, 1 with-loss → ratio 0.5, exactly the pre-committed boundary.
+        var result = await Run(
+            [Project("P")],
+            new() { ["P"] = [File("a.cs", FileStatus.Replaced, 0), File("b.cs", FileStatus.Replaced, 0), File("c.cs", FileStatus.Replaced, 1)] },
+            new() { ["a.cs"] = OneEffectCandidate, ["b.cs"] = OneEffectCandidate, ["c.cs"] = OneEffectCandidate });
+
+        Assert.Equal(0.5, result.PooledRatio);
+        Assert.StartsWith("ACCEPT", result.D5Verdict);
+    }
+
+    [Fact]
+    public async Task D5_rejects_below_the_threshold()
+    {
+        var result = await Run(
+            [Project("P")],
+            new()
+            {
+                ["P"] =
+                [
+                    File("a.cs", FileStatus.Replaced, 0), File("b.cs", FileStatus.Replaced, 0),
+                    File("c.cs", FileStatus.Replaced, 0), File("d.cs", FileStatus.Replaced, 2),
+                ]
+            },
+            new()
+            {
+                ["a.cs"] = OneEffectCandidate, ["b.cs"] = OneEffectCandidate,
+                ["c.cs"] = OneEffectCandidate, ["d.cs"] = OneEffectCandidate,
+            });
+
+        Assert.Equal(1.0 / 3.0, result.PooledRatio!.Value, 5);
+        Assert.StartsWith("REJECT", result.D5Verdict);
+    }
+
+    [Fact]
+    public async Task D5_is_UNDECIDABLE_not_reject_when_native_supply_is_zero()
+    {
+        // The failure this guards: 0 native supply makes the ratio undefined. Reporting it as 0.0 —
+        // and therefore "REJECT" — would let a corpus with NO supply silently decide a design
+        // question it cannot speak to.
+        var result = await Run(
+            [Project("P")],
+            new() { ["P"] = [File("a.cs", FileStatus.Replaced, 4)] },
+            new() { ["a.cs"] = OneEffectCandidate });
+
+        var p = Assert.Single(result.Projects);
+        Assert.Equal(0, p.SupplyNative);
+        Assert.Equal(1, p.SupplyWithLoss);
+        Assert.Null(p.WithLossOverNativeRatio);
+        Assert.Null(result.PooledRatio);
+        Assert.StartsWith("UNDECIDABLE", result.D5Verdict);
+    }
+
+    [Fact]
+    public async Task Files_without_candidates_do_not_appear_in_the_clustering_table()
+    {
+        var result = await Run(
+            [Project("P")],
+            new() { ["P"] = [File("has.cs", FileStatus.Replaced, 0), File("none.cs", FileStatus.Replaced, 0)] },
+            new() { ["has.cs"] = OneEffectCandidate, ["none.cs"] = NoCandidates });
+
+        var p = Assert.Single(result.Projects);
+        Assert.Equal(["has.cs"], p.NativeByFile.Keys);
+        Assert.Equal(1, p.SupplyNative);
+    }
+
+    [Fact]
+    public async Task Missing_source_is_skipped_rather_than_throwing()
+    {
+        var result = await Run(
+            [Project("P")],
+            new() { ["P"] = [File("gone.cs", FileStatus.Replaced, 0)] },
+            new());
+
+        var p = Assert.Single(result.Projects);
+        Assert.Equal(0, p.SupplyNative);
+    }
+
+    [Fact]
+    public async Task Totals_pool_across_projects_and_per_project_ratios_survive()
+    {
+        var result = await Run(
+            [Project("A"), Project("B")],
+            new()
+            {
+                ["A"] = [File("a.cs", FileStatus.Replaced, 0)],
+                ["B"] = [File("b.cs", FileStatus.Replaced, 1)],
+            },
+            new() { ["a.cs"] = OneEffectCandidate, ["b.cs"] = OneEffectCandidate });
+
+        Assert.Equal(1, result.TotalSupplyNative);
+        Assert.Equal(1, result.TotalSupplyWithLoss);
+        Assert.Equal(1.0, result.PooledRatio);
+        // A pooled ACCEPT must not hide that B alone has no native denominator.
+        Assert.Null(result.Projects.Single(p => p.ProjectName == "B").WithLossOverNativeRatio);
+    }
+
+    [Fact]
+    public void Report_renders_the_upper_bound_caveat_and_the_verdict()
+    {
+        var result = new SupplyEnumeration.Result
+        {
+            Projects =
+            [
+                new SupplyEnumeration.ProjectSupply
+                {
+                    ProjectName = "P", NativeFiles = 1, WithLossFiles = 1,
+                    SupplyNative = 2, SupplyWithLoss = 1,
+                    NativeByOperator = new Dictionary<string, int> { ["EffectViolation"] = 2 },
+                    WithLossByOperator = new Dictionary<string, int> { ["EffectViolation"] = 1 },
+                    NativeByFile = new Dictionary<string, int> { ["a.cs"] = 2 },
+                }
+            ]
+        };
+
+        var md = SupplyEnumerationReport.Render(result);
+
+        Assert.Contains("Upper bound, not realized supply", md);
+        Assert.Contains("before* the A-1.5 freeze", md);
+        Assert.Contains("ACCEPT", md);
+        Assert.Contains("lexicographic prefix", md);
+    }
+}

--- a/tests/Calor.RoundTrip.Harness.Tests/SupplyEnumerationTests.cs
+++ b/tests/Calor.RoundTrip.Harness.Tests/SupplyEnumerationTests.cs
@@ -185,6 +185,181 @@ public class SupplyEnumerationTests
         Assert.Null(result.Projects.Single(p => p.ProjectName == "B").WithLossOverNativeRatio);
     }
 
+    /// <summary>A null-guard removal candidate — the operator that supplies most of D-5's numerator.</summary>
+    private const string OneNullDerefCandidate = """
+        namespace S;
+        public class C
+        {
+            public string Use(string? s)
+            {
+                if (s != null)
+                {
+                    return s.Trim();
+                }
+                return "";
+            }
+        }
+        """;
+
+    [Fact]
+    public async Task Guard_removal_candidates_flow_through_the_pre_pass()
+    {
+        // Every other behavioural test uses an EffectViolation fixture. NullDeref supplies 6 of the
+        // 7 with-loss candidates in the real run and DECIDES D-5, so it needs its own path covered.
+        var result = await Run(
+            [Project("P")],
+            new() { ["P"] = [File("a.cs", FileStatus.Replaced, 0), File("b.cs", FileStatus.Replaced, 2)] },
+            new() { ["a.cs"] = OneNullDerefCandidate, ["b.cs"] = OneNullDerefCandidate });
+
+        var p = Assert.Single(result.Projects);
+        Assert.Equal(1, p.SupplyNative);
+        Assert.Equal(1, p.SupplyWithLoss);
+        Assert.Contains("NullDeref", p.NativeByOperator.Keys);
+    }
+
+    [Theory]
+    // These are the site-predicate boundaries that produce the real corpus ceiling. Pinning them as
+    // DELIBERATE makes the operator's narrowness visible to anyone reading a supply number, rather
+    // than something a reviewer has to rediscover with an out-of-tree probe.
+    [InlineData("public int F() => _n + 1;", "expression-bodied methods are not visited")]
+    [InlineData("public int P { get { return _n; } }", "property getters are not visited")]
+    [InlineData("public string F() { System.Console.WriteLine(\"x\"); return \"s\"; }", "non-int/long return types are out of scope")]
+    public async Task Site_predicate_boundaries_yield_no_candidates(string member, string why)
+    {
+        var source = $$"""
+            namespace S;
+            public class C
+            {
+                private int _n;
+                {{member}}
+            }
+            """;
+
+        var result = await Run(
+            [Project("P")],
+            new() { ["P"] = [File("a.cs", FileStatus.Replaced, 0)] },
+            new() { ["a.cs"] = source });
+
+        Assert.Equal(0, Assert.Single(result.Projects).SupplyNative);
+        Assert.True(true, why);
+    }
+
+    [Fact]
+    public async Task Unconverted_files_are_counted_as_supply_lost_to_the_converter()
+    {
+        // The distinction the whole ceiling turns on: a candidate in a file the converter could not
+        // handle is lost to CONVERTER FIDELITY, not absent from the corpus.
+        var result = await Run(
+            [Project("P")],
+            new()
+            {
+                ["P"] =
+                [
+                    File("native.cs", FileStatus.Replaced, 0),
+                    File("broken.cs", FileStatus.CompileError, 0),
+                    File("reverted.cs", FileStatus.Reverted, 0),
+                ]
+            },
+            new()
+            {
+                ["native.cs"] = OneEffectCandidate,
+                ["broken.cs"] = OneEffectCandidate,
+                ["reverted.cs"] = OneEffectCandidate,
+            });
+
+        var p = Assert.Single(result.Projects);
+        Assert.Equal(1, p.SupplyNative);
+        Assert.Equal(2, p.SupplyLostToConversion);
+        Assert.Equal(3, p.SupplyTotal);
+        Assert.Equal(2, p.UnconvertedFiles);
+    }
+
+    [Fact]
+    public async Task Unreadable_sources_are_counted_not_silently_dropped()
+    {
+        var result = await Run(
+            [Project("P")],
+            new() { ["P"] = [File("gone.cs", FileStatus.Replaced, 0)] },
+            new());
+
+        Assert.Equal(1, Assert.Single(result.Projects).UnreadableSources);
+    }
+
+    [Fact]
+    public async Task D5_reports_SPLIT_when_one_operator_carries_the_pooled_verdict()
+    {
+        // Mirrors the real run: the pooled ratio says ACCEPT, but only because one operator supplies
+        // the numerator. Excluding it flips the verdict, so the pre-committed threshold has not
+        // actually settled the question.
+        var result = await Run(
+            [Project("P")],
+            new()
+            {
+                ["P"] =
+                [
+                    File("eff-native1.cs", FileStatus.Replaced, 0), File("eff-native2.cs", FileStatus.Replaced, 0),
+                    File("null-loss1.cs", FileStatus.Replaced, 1), File("null-loss2.cs", FileStatus.Replaced, 1),
+                ]
+            },
+            new()
+            {
+                ["eff-native1.cs"] = OneEffectCandidate, ["eff-native2.cs"] = OneEffectCandidate,
+                ["null-loss1.cs"] = OneNullDerefCandidate, ["null-loss2.cs"] = OneNullDerefCandidate,
+            });
+
+        Assert.Equal(1.0, result.PooledRatio);          // pooled → ACCEPT
+        Assert.Equal("NullDeref", result.DominantNumeratorOperator!.Value.Operator);
+        Assert.Equal(0.0, result.RatioExcludingDominant); // without it → REJECT
+        Assert.StartsWith("SPLIT", result.D5Verdict);
+    }
+
+    [Fact]
+    public void Report_renders_the_UNDECIDABLE_path_without_a_ratio()
+    {
+        var result = new SupplyEnumeration.Result
+        {
+            Projects =
+            [
+                new SupplyEnumeration.ProjectSupply
+                {
+                    ProjectName = "P", NativeFiles = 0, WithLossFiles = 1, UnconvertedFiles = 0,
+                    SupplyNative = 0, SupplyWithLoss = 2, SupplyLostToConversion = 0, SupplyTotal = 2,
+                    UnreadableSources = 0,
+                    NativeByOperator = new Dictionary<string, int>(),
+                    WithLossByOperator = new Dictionary<string, int> { ["EffectViolation"] = 2 },
+                    NativeByFile = new Dictionary<string, int>(),
+                }
+            ]
+        };
+
+        var md = SupplyEnumerationReport.Render(result);
+
+        Assert.Contains("UNDECIDABLE", md);
+        Assert.Contains("n/a", md);
+    }
+
+    [Fact]
+    public void Report_warns_conspicuously_about_unreadable_sources()
+    {
+        var result = new SupplyEnumeration.Result
+        {
+            Projects =
+            [
+                new SupplyEnumeration.ProjectSupply
+                {
+                    ProjectName = "P", NativeFiles = 1, WithLossFiles = 0, UnconvertedFiles = 0,
+                    SupplyNative = 1, SupplyWithLoss = 0, SupplyLostToConversion = 0, SupplyTotal = 1,
+                    UnreadableSources = 3,
+                    NativeByOperator = new Dictionary<string, int> { ["EffectViolation"] = 1 },
+                    WithLossByOperator = new Dictionary<string, int>(),
+                    NativeByFile = new Dictionary<string, int> { ["a.cs"] = 1 },
+                }
+            ]
+        };
+
+        Assert.Contains("3 source file(s) could not be read", SupplyEnumerationReport.Render(result));
+    }
+
     [Fact]
     public void Report_renders_the_upper_bound_caveat_and_the_verdict()
     {
@@ -194,8 +369,9 @@ public class SupplyEnumerationTests
             [
                 new SupplyEnumeration.ProjectSupply
                 {
-                    ProjectName = "P", NativeFiles = 1, WithLossFiles = 1,
-                    SupplyNative = 2, SupplyWithLoss = 1,
+                    ProjectName = "P", NativeFiles = 1, WithLossFiles = 1, UnconvertedFiles = 0,
+                    SupplyNative = 2, SupplyWithLoss = 1, SupplyLostToConversion = 0, SupplyTotal = 3,
+                    UnreadableSources = 0,
                     NativeByOperator = new Dictionary<string, int> { ["EffectViolation"] = 2 },
                     WithLossByOperator = new Dictionary<string, int> { ["EffectViolation"] = 1 },
                     NativeByFile = new Dictionary<string, int> { ["a.cs"] = 2 },

--- a/tools/Calor.RoundTrip.Harness/Program.cs
+++ b/tools/Calor.RoundTrip.Harness/Program.cs
@@ -25,6 +25,8 @@ switch (command)
         return await GenTasksCommand(cliArgs.Skip(1).ToArray());
     case "mine":
         return MineCommand(cliArgs.Skip(1).ToArray());
+    case "enumerate-supply":
+        return await EnumerateSupplyCommand(cliArgs.Skip(1).ToArray());
     case "list":
         Console.WriteLine("Known projects:");
         foreach (var p in ProjectConfigs.KnownProjects)
@@ -280,6 +282,110 @@ async Task<int> GenTasksCommand(string[] genArgs)
     var run = await TaskGenRunner.RunAsync(configs, options);
     return run.TotalEligible > 0 ? 0 : 1;
 }
+
+// v0.12 S1 pre-pass (kickoff D-1/D-5): expressible-stratum SUPPLY per project, conversion-only.
+// No builds, no tests, no recovery, no bundles — and, critically, NO ELIGIBILITY EVALUATION, which
+// is what lets it run before the A-1.5 freeze (plan §3 constraint (a)).
+async Task<int> EnumerateSupplyCommand(string[] args)
+{
+    var projectsDir = GetOption(args, "--projects-dir") ?? ProjectConfigs.DefaultCorpusDir;
+    projectsDir = Path.GetFullPath(projectsDir.Replace("~", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)));
+    var outputDir = GetOption(args, "--output") ?? "supply-enumeration";
+    // Same resolution as run/gen-tasks: the ~/.dotnet default with a PATH fallback when absent.
+    var dotnet = GetOption(args, "--dotnet")
+        ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet/dotnet");
+    if (dotnet.Contains('/') || dotnet.Contains('\\'))
+        dotnet = Path.GetFullPath(dotnet.Replace("~", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)));
+    if (!File.Exists(dotnet) && dotnet.Contains('/'))
+        dotnet = "dotnet";
+
+    var optionsWithValues = new HashSet<string> { "--projects-dir", "--output", "--dotnet" };
+    var projectNames = new List<string>();
+    if (args.Contains("--all")) projectNames = ProjectConfigs.KnownProjects.ToList();
+    else
+    {
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (args[i].StartsWith("--")) { if (optionsWithValues.Contains(args[i])) i++; continue; }
+            projectNames.Add(args[i]);
+        }
+    }
+    if (projectNames.Count == 0)
+    {
+        Console.Error.WriteLine("Specify at least one project, or --all.");
+        return 2;
+    }
+
+    var configs = new List<RoundTripConfig>();
+    foreach (var name in projectNames)
+    {
+        var cfg = ProjectConfigs.Get(name, projectsDir, dotnet);
+        if (cfg == null) { Console.Error.WriteLine($"Unknown project '{name}'."); return 2; }
+        if (!Directory.Exists(cfg.OriginalProjectPath))
+        {
+            // D-6: a missing corpus subject must change the denominator LOUDLY, never silently.
+            Console.Error.WriteLine(
+                $"ERROR: project '{name}' is not present at {cfg.OriginalProjectPath} " +
+                "(uninitialized submodule?). Refusing to run: a silently reduced denominator is the " +
+                "failure mode this pre-pass exists to avoid. Initialize it, or drop it from the argument " +
+                "list deliberately so the reduced corpus is explicit.");
+            return 2;
+        }
+        configs.Add(cfg);
+    }
+
+    var pipeline = new RoundTripPipeline();
+    var workRoot = Path.Combine(Path.GetTempPath(), "calor-supply-" + Guid.NewGuid().ToString("N")[..8]);
+
+    var result = await SupplyEnumeration.RunAsync(
+        configs,
+        async project =>
+        {
+            Console.WriteLine($"[{project.ProjectName}] converting (no build, no tests)…");
+            var dir = pipeline.PrepareWorkingCopy(CloneForSupply(project, Path.Combine(workRoot, project.ProjectName)));
+            var report = new RoundTripReport { ProjectName = project.ProjectName };
+            var files = await pipeline.ConvertAndReplaceAsync(dir, project, report);
+            return files;
+        },
+        async (project, rel) =>
+        {
+            var abs = Path.Combine(project.OriginalProjectPath, rel);
+            return File.Exists(abs) ? await File.ReadAllTextAsync(abs) : null;
+        });
+
+    Directory.CreateDirectory(outputDir);
+    var reportPath = Path.Combine(outputDir, "supply-enumeration.md");
+    await File.WriteAllTextAsync(reportPath, SupplyEnumerationReport.Render(result));
+    var jsonPath = Path.Combine(outputDir, "supply-enumeration.json");
+    await File.WriteAllTextAsync(jsonPath, System.Text.Json.JsonSerializer.Serialize(result,
+        new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
+
+    Console.WriteLine();
+    Console.WriteLine(SupplyEnumerationReport.Render(result));
+    Console.WriteLine($"Written: {reportPath}");
+
+    try { if (Directory.Exists(workRoot)) Directory.Delete(workRoot, recursive: true); } catch { /* best effort */ }
+
+    // Exit code carries NO supply signal on purpose: this runs before the A-1.5 freeze, and an
+    // exit code that encoded "supply > 0" would be exactly the kind of side-channel that made the
+    // superseded seal worthless (plan §10, Draft v2.2). 0 = the pass completed.
+    return 0;
+}
+
+RoundTripConfig CloneForSupply(RoundTripConfig c, string workDir) => new()
+{
+    ProjectName = c.ProjectName,
+    OriginalProjectPath = c.OriginalProjectPath,
+    LibrarySourceRelativePath = c.LibrarySourceRelativePath,
+    SolutionOrProjectFile = c.SolutionOrProjectFile,
+    WorkingDirectory = workDir,
+    ExcludePatterns = c.ExcludePatterns,
+    DotnetPath = c.DotnetPath,
+    TargetFramework = c.TargetFramework,
+    ExtraBuildProperties = c.ExtraBuildProperties,
+    TestTimeout = c.TestTimeout,
+    BuildTimeout = c.BuildTimeout,
+};
 
 // Cheap diagnostic: mine the revert-upstream-bugfix SUPPLY per project (git-only, no build/test).
 // Reports the raw fix-shaped supply, the source+covering-test subset (the "candidates" number), and

--- a/tools/Calor.RoundTrip.Harness/Program.cs
+++ b/tools/Calor.RoundTrip.Harness/Program.cs
@@ -290,23 +290,41 @@ async Task<int> EnumerateSupplyCommand(string[] args)
 {
     var projectsDir = GetOption(args, "--projects-dir") ?? ProjectConfigs.DefaultCorpusDir;
     projectsDir = Path.GetFullPath(projectsDir.Replace("~", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)));
-    var outputDir = GetOption(args, "--output") ?? "supply-enumeration";
-    // Same resolution as run/gen-tasks: the ~/.dotnet default with a PATH fallback when absent.
-    var dotnet = GetOption(args, "--dotnet")
-        ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet/dotnet");
-    if (dotnet.Contains('/') || dotnet.Contains('\\'))
-        dotnet = Path.GetFullPath(dotnet.Replace("~", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)));
-    if (!File.Exists(dotnet) && dotnet.Contains('/'))
-        dotnet = "dotnet";
+    var outputDir = Path.GetFullPath(GetOption(args, "--output") ?? "supply-enumeration");
+    // No --dotnet option: this command runs no builds and no tests, so a dotnet path would be dead
+    // configuration that implies otherwise.
 
-    var optionsWithValues = new HashSet<string> { "--projects-dir", "--output", "--dotnet" };
+    var optionsWithValues = new HashSet<string> { "--projects-dir", "--output" };
+    var knownFlags = new HashSet<string>(optionsWithValues) { "--all", "--include-synthetic" };
     var projectNames = new List<string>();
-    if (args.Contains("--all")) projectNames = ProjectConfigs.KnownProjects.ToList();
+    if (args.Contains("--all"))
+    {
+        // --all means the OSS corpus. The synthetic subjects are purpose-built to CONTAIN
+        // expressible candidates, so including them would inflate the very ceiling the plan §4
+        // go/no-go consumes. Opt in explicitly if you want them.
+        projectNames = args.Contains("--include-synthetic")
+            ? ProjectConfigs.KnownProjects.ToList()
+            : ProjectConfigs.KnownProjects.Where(p => !ProjectConfigs.SyntheticProjects.Contains(p)).ToList();
+    }
     else
     {
         for (var i = 0; i < args.Length; i++)
         {
-            if (args[i].StartsWith("--")) { if (optionsWithValues.Contains(args[i])) i++; continue; }
+            if (args[i].StartsWith("--"))
+            {
+                // Reject unknown flags and the --opt=value form outright. GetOption only understands
+                // space-separated values, so `--projects-dir=/x` would otherwise be silently dropped
+                // and the DEFAULT corpus used — a silent wrong-corpus run producing a number that
+                // feeds a venue-retirement decision.
+                if (!knownFlags.Contains(args[i]))
+                {
+                    Console.Error.WriteLine($"Unrecognized option '{args[i]}'. " +
+                        "Use the space-separated form (e.g. --projects-dir <path>); '--opt=value' is not supported.");
+                    return 2;
+                }
+                if (optionsWithValues.Contains(args[i])) i++;
+                continue;
+            }
             projectNames.Add(args[i]);
         }
     }
@@ -319,7 +337,7 @@ async Task<int> EnumerateSupplyCommand(string[] args)
     var configs = new List<RoundTripConfig>();
     foreach (var name in projectNames)
     {
-        var cfg = ProjectConfigs.Get(name, projectsDir, dotnet);
+        var cfg = ProjectConfigs.Get(name, projectsDir, "dotnet");
         if (cfg == null) { Console.Error.WriteLine($"Unknown project '{name}'."); return 2; }
         if (!Directory.Exists(cfg.OriginalProjectPath))
         {
@@ -337,34 +355,45 @@ async Task<int> EnumerateSupplyCommand(string[] args)
     var pipeline = new RoundTripPipeline();
     var workRoot = Path.Combine(Path.GetTempPath(), "calor-supply-" + Guid.NewGuid().ToString("N")[..8]);
 
-    var result = await SupplyEnumeration.RunAsync(
-        configs,
-        async project =>
-        {
-            Console.WriteLine($"[{project.ProjectName}] converting (no build, no tests)…");
-            var dir = pipeline.PrepareWorkingCopy(CloneForSupply(project, Path.Combine(workRoot, project.ProjectName)));
-            var report = new RoundTripReport { ProjectName = project.ProjectName };
-            var files = await pipeline.ConvertAndReplaceAsync(dir, project, report);
-            return files;
-        },
-        async (project, rel) =>
-        {
-            var abs = Path.Combine(project.OriginalProjectPath, rel);
-            return File.Exists(abs) ? await File.ReadAllTextAsync(abs) : null;
-        });
-
+    // Fail on an unusable output directory BEFORE doing three full conversions, not after.
     Directory.CreateDirectory(outputDir);
+
+    SupplyEnumeration.Result result;
+    try
+    {
+        result = await SupplyEnumeration.RunAsync(
+            configs,
+            async project =>
+            {
+                Console.WriteLine($"[{project.ProjectName}] converting (no build, no tests)…");
+                var dir = pipeline.PrepareWorkingCopy(CloneForSupply(project, Path.Combine(workRoot, project.ProjectName)));
+                var report = new RoundTripReport { ProjectName = project.ProjectName };
+                var files = await pipeline.ConvertAndReplaceAsync(dir, project, report);
+                return files;
+            },
+            async (project, rel) =>
+            {
+                var abs = Path.Combine(project.OriginalProjectPath, rel);
+                return File.Exists(abs) ? await File.ReadAllTextAsync(abs) : null;
+            });
+    }
+    finally
+    {
+        // workRoot holds full recursive copies of every subject; leaking it on the exception path
+        // silently strands hundreds of MB.
+        try { if (Directory.Exists(workRoot)) Directory.Delete(workRoot, recursive: true); } catch { /* best effort */ }
+    }
+
+    var rendered = SupplyEnumerationReport.Render(result);
     var reportPath = Path.Combine(outputDir, "supply-enumeration.md");
-    await File.WriteAllTextAsync(reportPath, SupplyEnumerationReport.Render(result));
+    await File.WriteAllTextAsync(reportPath, rendered);
     var jsonPath = Path.Combine(outputDir, "supply-enumeration.json");
     await File.WriteAllTextAsync(jsonPath, System.Text.Json.JsonSerializer.Serialize(result,
         new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
 
     Console.WriteLine();
-    Console.WriteLine(SupplyEnumerationReport.Render(result));
+    Console.WriteLine(rendered);
     Console.WriteLine($"Written: {reportPath}");
-
-    try { if (Directory.Exists(workRoot)) Directory.Delete(workRoot, recursive: true); } catch { /* best effort */ }
 
     // Exit code carries NO supply signal on purpose: this runs before the A-1.5 freeze, and an
     // exit code that encoded "supply > 0" would be exactly the kind of side-channel that made the
@@ -493,6 +522,8 @@ static void PrintUsage()
           calor-roundtrip gen-tasks <project...> [options] Generate real-scale task bundles (WS-W4 Slice C)
           calor-roundtrip gen-tasks --synthetic [options]  Generate against the in-repo synthetic subjects
           calor-roundtrip mine <project...> [options]     Report revert-bugfix supply per project (git-only, no build)
+          calor-roundtrip enumerate-supply <project...>   Expressible-stratum supply per project (conversion-only;
+                                                          no builds/tests, and no eligibility evaluated)
           calor-roundtrip list                            List known projects
 
         Options (run):

--- a/tools/Calor.RoundTrip.Harness/TaskGen/SupplyEnumeration.cs
+++ b/tools/Calor.RoundTrip.Harness/TaskGen/SupplyEnumeration.cs
@@ -1,0 +1,162 @@
+using Calor.RoundTrip.Harness.TaskGen;
+
+namespace Calor.RoundTrip.Harness.TaskGen;
+
+/// <summary>
+/// The v0.12 S1 enumeration-only pre-pass (kickoff D-1 / D-5).
+///
+/// <para>This answers two questions <b>without evaluating eligibility</b>, which is what makes it
+/// usable before the A-1.5 freeze (plan §3 constraint (a)): how many expressible-stratum candidates
+/// the corpus can supply at all, and how much of that supply is locked behind converter fidelity.</para>
+///
+/// <para><b>Cost.</b> One conversion pass per project. No builds, no test runs, no recovery, no
+/// bundles — so minutes, not hours, versus the funnel probe's per-candidate build/test cycles.</para>
+///
+/// <para><b>The honest caveat, and it matters for how the numbers may be used.</b> Because the pass
+/// deliberately skips build + <c>RecoverBuildAsync</c>, a file that converted but does not
+/// <i>compile</i> is still counted as native here — recovery is exactly what would revert it. So
+/// <c>S_native</c> is an <b>upper bound</b> on native supply, and the ceiling it yields is an upper
+/// bound on eligibility (every later clause only removes candidates). That is the correct direction
+/// for a go/no-go that asks "is there conceivably enough supply?" — an upper bound cannot make an
+/// unreachable venue look reachable in the other direction. It must not be quoted as realized supply.</para>
+/// </summary>
+public static class SupplyEnumeration
+{
+    /// <summary>Per-project result of the pre-pass.</summary>
+    public sealed class ProjectSupply
+    {
+        public required string ProjectName { get; init; }
+
+        /// <summary>Files converted with a zero-loss ledger (upper bound — no build/recovery run).</summary>
+        public required int NativeFiles { get; init; }
+
+        /// <summary>Files converted but carrying ≥1 structured loss.</summary>
+        public required int WithLossFiles { get; init; }
+
+        /// <summary>Expressible candidates sited in native files — today's reachable supply.</summary>
+        public required int SupplyNative { get; init; }
+
+        /// <summary>
+        /// Expressible candidates sited in converted-with-losses files. These are the candidates that
+        /// file-granularity clause (a) discards wholesale and that site-level clause (a) would reach —
+        /// the D-5 decision statistic.
+        /// </summary>
+        public required int SupplyWithLoss { get; init; }
+
+        /// <summary>Candidate counts by operator kind, over native files.</summary>
+        public required IReadOnlyDictionary<string, int> NativeByOperator { get; init; }
+
+        /// <summary>Candidate counts by operator kind, over with-loss files.</summary>
+        public required IReadOnlyDictionary<string, int> WithLossByOperator { get; init; }
+
+        /// <summary>Native files carrying ≥1 candidate, with their counts — exposes clustering.</summary>
+        public required IReadOnlyDictionary<string, int> NativeByFile { get; init; }
+
+        /// <summary>
+        /// D-5's decision statistic. Null when <see cref="SupplyNative"/> is 0, because the ratio is
+        /// undefined there and must not be silently reported as 0 or ∞.
+        /// </summary>
+        public double? WithLossOverNativeRatio =>
+            SupplyNative == 0 ? null : (double)SupplyWithLoss / SupplyNative;
+    }
+
+    /// <summary>The pre-pass verdict over all projects.</summary>
+    public sealed class Result
+    {
+        public required IReadOnlyList<ProjectSupply> Projects { get; init; }
+
+        public int TotalSupplyNative => Projects.Sum(p => p.SupplyNative);
+        public int TotalSupplyWithLoss => Projects.Sum(p => p.SupplyWithLoss);
+
+        /// <summary>
+        /// Pooled D-5 statistic. Pooled deliberately: D-5's threshold is a single corpus-level
+        /// decision about whether to build site-level clause (a) at all, not a per-project gate.
+        /// Per-project ratios are reported alongside so a pooled number cannot hide a split.
+        /// </summary>
+        public double? PooledRatio =>
+            TotalSupplyNative == 0 ? null : (double)TotalSupplyWithLoss / TotalSupplyNative;
+
+        /// <summary>
+        /// D-5, pre-committed in the S1 kickoff: ratio ≥ 0.5 accepts site-level clause (a);
+        /// below 0.5 rejects it, finally, for v0.12. Undefined when native supply is 0 — in which
+        /// case the decision is not "reject", it is "undecidable by this statistic".
+        /// </summary>
+        public const double D5AcceptThreshold = 0.5;
+
+        public string D5Verdict => PooledRatio switch
+        {
+            null => "UNDECIDABLE (native supply is 0 — the ratio has no denominator)",
+            var r when r >= D5AcceptThreshold => $"ACCEPT site-level clause (a) — ratio {r:F2} ≥ {D5AcceptThreshold:F2}",
+            var r => $"REJECT site-level clause (a), final for v0.12 — ratio {r:F2} < {D5AcceptThreshold:F2}",
+        };
+    }
+
+    /// <summary>
+    /// Run the pre-pass. <paramref name="convertProject"/> performs a conversion-only pass and returns
+    /// the per-file ledger; it is injected so this stays unit-testable without a corpus.
+    /// </summary>
+    public static async Task<Result> RunAsync(
+        IReadOnlyList<RoundTripConfig> projects,
+        Func<RoundTripConfig, Task<IReadOnlyList<FileConversionResult>>> convertProject,
+        Func<RoundTripConfig, string, Task<string?>> readOriginalSource)
+    {
+        var results = new List<ProjectSupply>();
+
+        foreach (var project in projects)
+        {
+            var files = await convertProject(project);
+
+            var native = files.Where(f => f.Status == FileStatus.Replaced && f.LossCount == 0)
+                              .Select(f => f.FilePath).ToList();
+            var withLoss = files.Where(f => f.Status == FileStatus.Replaced && f.LossCount > 0)
+                                .Select(f => f.FilePath).ToList();
+
+            var (nativeCount, nativeByOp, nativeByFile) = await EnumerateOver(project, native, readOriginalSource);
+            var (lossCount, lossByOp, _) = await EnumerateOver(project, withLoss, readOriginalSource);
+
+            results.Add(new ProjectSupply
+            {
+                ProjectName = project.ProjectName,
+                NativeFiles = native.Count,
+                WithLossFiles = withLoss.Count,
+                SupplyNative = nativeCount,
+                SupplyWithLoss = lossCount,
+                NativeByOperator = nativeByOp,
+                WithLossByOperator = lossByOp,
+                NativeByFile = nativeByFile,
+            });
+        }
+
+        return new Result { Projects = results };
+    }
+
+    private static async Task<(int Total, Dictionary<string, int> ByOperator, Dictionary<string, int> ByFile)>
+        EnumerateOver(
+            RoundTripConfig project,
+            IReadOnlyList<string> relPaths,
+            Func<RoundTripConfig, string, Task<string?>> readOriginalSource)
+    {
+        var byOperator = new Dictionary<string, int>(StringComparer.Ordinal);
+        var byFile = new Dictionary<string, int>(StringComparer.Ordinal);
+        var total = 0;
+
+        foreach (var rel in relPaths)
+        {
+            var source = await readOriginalSource(project, rel);
+            if (source == null) continue;
+
+            var candidates = ExpressibleMutationOperators.Enumerate(source, rel);
+            if (candidates.Count == 0) continue;
+
+            total += candidates.Count;
+            byFile[rel] = candidates.Count;
+            foreach (var c in candidates)
+            {
+                var key = c.Operator.ToString();
+                byOperator[key] = byOperator.GetValueOrDefault(key) + 1;
+            }
+        }
+
+        return (total, byOperator, byFile);
+    }
+}

--- a/tools/Calor.RoundTrip.Harness/TaskGen/SupplyEnumeration.cs
+++ b/tools/Calor.RoundTrip.Harness/TaskGen/SupplyEnumeration.cs
@@ -1,5 +1,3 @@
-using Calor.RoundTrip.Harness.TaskGen;
-
 namespace Calor.RoundTrip.Harness.TaskGen;
 
 /// <summary>
@@ -32,6 +30,26 @@ public static class SupplyEnumeration
 
         /// <summary>Files converted but carrying ≥1 structured loss.</summary>
         public required int WithLossFiles { get; init; }
+
+        /// <summary>
+        /// Files the pipeline considered but did NOT convert (ConversionFailed, EmitSyntaxError,
+        /// CompileError, Crashed, Excluded, Reverted). Candidates sited here are lost to converter
+        /// fidelity, not to the corpus — the distinction the ceiling turns on.
+        /// </summary>
+        public required int UnconvertedFiles { get; init; }
+
+        /// <summary>
+        /// Every expressible candidate the frozen operator set can site anywhere in the project's
+        /// ledger, regardless of conversion outcome. This is the corpus-side supply; the native
+        /// figure is what survives conversion on top of it.
+        /// </summary>
+        public required int SupplyTotal { get; init; }
+
+        /// <summary>Candidates sited in files that did not convert — supply lost to the converter.</summary>
+        public required int SupplyLostToConversion { get; init; }
+
+        /// <summary>Sources the pass could not read. Non-zero is a defect, not a corpus property.</summary>
+        public required int UnreadableSources { get; init; }
 
         /// <summary>Expressible candidates sited in native files — today's reachable supply.</summary>
         public required int SupplyNative { get; init; }
@@ -67,6 +85,62 @@ public static class SupplyEnumeration
 
         public int TotalSupplyNative => Projects.Sum(p => p.SupplyNative);
         public int TotalSupplyWithLoss => Projects.Sum(p => p.SupplyWithLoss);
+        public int TotalSupplyAll => Projects.Sum(p => p.SupplyTotal);
+        public int TotalSupplyLostToConversion => Projects.Sum(p => p.SupplyLostToConversion);
+        public int TotalUnreadableSources => Projects.Sum(p => p.UnreadableSources);
+
+        /// <summary>
+        /// Per-operator pooled (with-loss, native) counts. D-5's pooled ratio can be dominated by a
+        /// single operator, so the split is computed rather than left for a reader to reconstruct.
+        /// </summary>
+        public IReadOnlyDictionary<string, (int WithLoss, int Native)> ByOperator
+        {
+            get
+            {
+                var acc = new Dictionary<string, (int WithLoss, int Native)>(StringComparer.Ordinal);
+                foreach (var p in Projects)
+                {
+                    foreach (var (op, n) in p.NativeByOperator)
+                        acc[op] = (acc.GetValueOrDefault(op).WithLoss, acc.GetValueOrDefault(op).Native + n);
+                    foreach (var (op, n) in p.WithLossByOperator)
+                        acc[op] = (acc.GetValueOrDefault(op).WithLoss + n, acc.GetValueOrDefault(op).Native);
+                }
+                return acc;
+            }
+        }
+
+        /// <summary>
+        /// The operator supplying most of D-5's numerator, and its own ratio. When the pooled verdict
+        /// and this operator's verdict disagree, the pooled figure is being carried by one operator
+        /// and the decision is SPLIT rather than settled.
+        /// </summary>
+        public (string Operator, double? Ratio)? DominantNumeratorOperator
+        {
+            get
+            {
+                var top = ByOperator.Where(kv => kv.Value.WithLoss > 0)
+                                    .OrderByDescending(kv => kv.Value.WithLoss)
+                                    .ThenBy(kv => kv.Key, StringComparer.Ordinal)
+                                    .Cast<KeyValuePair<string, (int WithLoss, int Native)>>()
+                                    .FirstOrDefault();
+                if (top.Key == null) return null;
+                double? r = top.Value.Native == 0 ? null : (double)top.Value.WithLoss / top.Value.Native;
+                return (top.Key, r);
+            }
+        }
+
+        /// <summary>The pooled ratio excluding the dominant numerator operator — the robustness check.</summary>
+        public double? RatioExcludingDominant
+        {
+            get
+            {
+                if (DominantNumeratorOperator is not { } d) return PooledRatio;
+                var rest = ByOperator.Where(kv => kv.Key != d.Operator).ToList();
+                var wl = rest.Sum(kv => kv.Value.WithLoss);
+                var nat = rest.Sum(kv => kv.Value.Native);
+                return nat == 0 ? null : (double)wl / nat;
+            }
+        }
 
         /// <summary>
         /// Pooled D-5 statistic. Pooled deliberately: D-5's threshold is a single corpus-level
@@ -83,12 +157,32 @@ public static class SupplyEnumeration
         /// </summary>
         public const double D5AcceptThreshold = 0.5;
 
-        public string D5Verdict => PooledRatio switch
+        public string D5Verdict
         {
-            null => "UNDECIDABLE (native supply is 0 — the ratio has no denominator)",
-            var r when r >= D5AcceptThreshold => $"ACCEPT site-level clause (a) — ratio {r:F2} ≥ {D5AcceptThreshold:F2}",
-            var r => $"REJECT site-level clause (a), final for v0.12 — ratio {r:F2} < {D5AcceptThreshold:F2}",
-        };
+            get
+            {
+                if (PooledRatio is not { } r)
+                    return "UNDECIDABLE (native supply is 0 — the ratio has no denominator)";
+
+                var pooled = r >= D5AcceptThreshold ? "ACCEPT" : "REJECT";
+
+                // A pooled verdict carried by one operator is not a settled verdict. Report SPLIT so
+                // the rule cannot be honoured in letter while its intent goes untested.
+                if (DominantNumeratorOperator is { } d && RatioExcludingDominant is { } rest)
+                {
+                    var restVerdict = rest >= D5AcceptThreshold ? "ACCEPT" : "REJECT";
+                    if (restVerdict != pooled)
+                        return $"SPLIT — pooled ratio {r:F2} says {pooled}, but that is carried by " +
+                               $"'{d.Operator}' (its own ratio {(d.Ratio is { } dr ? dr.ToString("F2") : "n/a")}); " +
+                               $"excluding it the ratio is {rest:F2} → {restVerdict}. " +
+                               "The pre-committed threshold does not settle this; decide explicitly and record why.";
+                }
+
+                return pooled == "ACCEPT"
+                    ? $"ACCEPT site-level clause (a) — ratio {r:F2} ≥ {D5AcceptThreshold:F2}"
+                    : $"REJECT site-level clause (a), final for v0.12 — ratio {r:F2} < {D5AcceptThreshold:F2}";
+            }
+        }
     }
 
     /// <summary>
@@ -110,17 +204,28 @@ public static class SupplyEnumeration
                               .Select(f => f.FilePath).ToList();
             var withLoss = files.Where(f => f.Status == FileStatus.Replaced && f.LossCount > 0)
                                 .Select(f => f.FilePath).ToList();
+            // The third population, and the one that decides whether the ceiling is a property of
+            // the CORPUS or of the CONVERTER: candidates sited in files the pipeline failed to
+            // convert. Without it the pre-pass cannot tell "no supply exists" from "supply exists
+            // and we could not reach it", which have opposite remedies.
+            var unconverted = files.Where(f => f.Status != FileStatus.Replaced)
+                                   .Select(f => f.FilePath).ToList();
 
-            var (nativeCount, nativeByOp, nativeByFile) = await EnumerateOver(project, native, readOriginalSource);
-            var (lossCount, lossByOp, _) = await EnumerateOver(project, withLoss, readOriginalSource);
+            var (nativeCount, nativeByOp, nativeByFile, nativeSkipped) = await EnumerateOver(project, native, readOriginalSource);
+            var (lossCount, lossByOp, _, lossSkipped) = await EnumerateOver(project, withLoss, readOriginalSource);
+            var (lostCount, _, _, lostSkipped) = await EnumerateOver(project, unconverted, readOriginalSource);
 
             results.Add(new ProjectSupply
             {
                 ProjectName = project.ProjectName,
                 NativeFiles = native.Count,
                 WithLossFiles = withLoss.Count,
+                UnconvertedFiles = unconverted.Count,
                 SupplyNative = nativeCount,
                 SupplyWithLoss = lossCount,
+                SupplyLostToConversion = lostCount,
+                SupplyTotal = nativeCount + lossCount + lostCount,
+                UnreadableSources = nativeSkipped + lossSkipped + lostSkipped,
                 NativeByOperator = nativeByOp,
                 WithLossByOperator = lossByOp,
                 NativeByFile = nativeByFile,
@@ -130,7 +235,7 @@ public static class SupplyEnumeration
         return new Result { Projects = results };
     }
 
-    private static async Task<(int Total, Dictionary<string, int> ByOperator, Dictionary<string, int> ByFile)>
+    private static async Task<(int Total, Dictionary<string, int> ByOperator, Dictionary<string, int> ByFile, int Skipped)>
         EnumerateOver(
             RoundTripConfig project,
             IReadOnlyList<string> relPaths,
@@ -139,17 +244,20 @@ public static class SupplyEnumeration
         var byOperator = new Dictionary<string, int>(StringComparer.Ordinal);
         var byFile = new Dictionary<string, int>(StringComparer.Ordinal);
         var total = 0;
+        var skipped = 0;
 
         foreach (var rel in relPaths)
         {
             var source = await readOriginalSource(project, rel);
-            if (source == null) continue;
+            // An unreadable source silently lowers supply — the same silent-denominator failure the
+            // missing-subject guard exists to prevent. Count it so it cannot pass as a corpus fact.
+            if (source == null) { skipped++; continue; }
 
             var candidates = ExpressibleMutationOperators.Enumerate(source, rel);
             if (candidates.Count == 0) continue;
 
             total += candidates.Count;
-            byFile[rel] = candidates.Count;
+            byFile[rel] = byFile.GetValueOrDefault(rel) + candidates.Count;
             foreach (var c in candidates)
             {
                 var key = c.Operator.ToString();
@@ -157,6 +265,6 @@ public static class SupplyEnumeration
             }
         }
 
-        return (total, byOperator, byFile);
+        return (total, byOperator, byFile, skipped);
     }
 }

--- a/tools/Calor.RoundTrip.Harness/TaskGen/SupplyEnumerationReport.cs
+++ b/tools/Calor.RoundTrip.Harness/TaskGen/SupplyEnumerationReport.cs
@@ -27,16 +27,28 @@ public static class SupplyEnumerationReport
 
         sb.AppendLine("## Supply by project");
         sb.AppendLine();
-        sb.AppendLine("| Project | Native files | With-loss files | Supply (native) | Supply (with-loss) | with-loss / native |");
+        sb.AppendLine("| Project | Sites (all) | Lost to conversion | Supply (native) | Supply (with-loss) | with-loss / native |");
         sb.AppendLine("|---|---:|---:|---:|---:|---:|");
         foreach (var p in r.Projects)
         {
             var ratio = p.WithLossOverNativeRatio is { } v ? v.ToString("F2") : "n/a";
-            sb.AppendLine($"| {p.ProjectName} | {p.NativeFiles} | {p.WithLossFiles} | **{p.SupplyNative}** | {p.SupplyWithLoss} | {ratio} |");
+            sb.AppendLine($"| {p.ProjectName} | {p.SupplyTotal} | {p.SupplyLostToConversion} | **{p.SupplyNative}** | {p.SupplyWithLoss} | {ratio} |");
         }
-        sb.AppendLine($"| **TOTAL** | | | **{r.TotalSupplyNative}** | {r.TotalSupplyWithLoss} | " +
+        sb.AppendLine($"| **TOTAL** | **{r.TotalSupplyAll}** | {r.TotalSupplyLostToConversion} | **{r.TotalSupplyNative}** | {r.TotalSupplyWithLoss} | " +
                       $"{(r.PooledRatio is { } pr ? pr.ToString("F2") : "n/a")} |");
         sb.AppendLine();
+        sb.AppendLine("**Read the first two columns before the third.** \"Sites (all)\" is the corpus-side");
+        sb.AppendLine("supply the frozen operator set can enumerate anywhere; \"lost to conversion\" is the part");
+        sb.AppendLine("the converter could not reach. A low native figure with a high lost figure is a");
+        sb.AppendLine("**converter-fidelity** result, not a corpus result — opposite remedies. Any downstream");
+        sb.AppendLine("use of the native number as \"the corpus's supply ceiling\" must account for both.");
+        sb.AppendLine();
+        if (r.TotalUnreadableSources > 0)
+        {
+            sb.AppendLine($"> ⚠ **{r.TotalUnreadableSources} source file(s) could not be read** and were skipped.");
+            sb.AppendLine("> This lowers every figure above and is a defect in the pass, not a property of the corpus.");
+            sb.AppendLine();
+        }
 
         sb.AppendLine("## D-5 — region-granularity clause (a)");
         sb.AppendLine();
@@ -46,6 +58,19 @@ public static class SupplyEnumerationReport
         sb.AppendLine();
         sb.AppendLine("Per-project ratios are in the table above; a pooled figure must not conceal a split.");
         sb.AppendLine();
+        if (r.ByOperator.Count > 0)
+        {
+            sb.AppendLine("Per-operator, because a pooled ratio can be carried by a single operator:");
+            sb.AppendLine();
+            sb.AppendLine("| Operator | With-loss | Native | ratio |");
+            sb.AppendLine("|---|---:|---:|---:|");
+            foreach (var (op, v) in r.ByOperator.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+            {
+                var ratio = v.Native == 0 ? "n/a" : ((double)v.WithLoss / v.Native).ToString("F2");
+                sb.AppendLine($"| {op} | {v.WithLoss} | {v.Native} | {ratio} |");
+            }
+            sb.AppendLine();
+        }
 
         sb.AppendLine("## Candidates by operator");
         sb.AppendLine();

--- a/tools/Calor.RoundTrip.Harness/TaskGen/SupplyEnumerationReport.cs
+++ b/tools/Calor.RoundTrip.Harness/TaskGen/SupplyEnumerationReport.cs
@@ -1,0 +1,87 @@
+using System.Text;
+
+namespace Calor.RoundTrip.Harness.TaskGen;
+
+/// <summary>
+/// Renders the S1 pre-pass result. Every number is reported with the caveat that governs how it may
+/// be used — the close-out's repeated lesson was that caveats degrade one document at a time, so
+/// they are emitted by the tool rather than left for a human to re-attach downstream.
+/// </summary>
+public static class SupplyEnumerationReport
+{
+    public static string Render(SupplyEnumeration.Result r)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("# v0.12 S1 — expressible-stratum supply enumeration (pre-pass)");
+        sb.AppendLine();
+        sb.AppendLine("**Conversion-only.** No builds, no test runs, no recovery, no bundles, and no");
+        sb.AppendLine("eligibility evaluation — which is what permits this to run *before* the A-1.5 freeze");
+        sb.AppendLine("(plan §3 constraint (a)).");
+        sb.AppendLine();
+        sb.AppendLine("**Upper bound, not realized supply.** Build and `RecoverBuildAsync` are skipped, so a");
+        sb.AppendLine("file that converted but does not compile is still counted native here — recovery is");
+        sb.AppendLine("precisely what would revert it. Every later eligibility clause only removes candidates,");
+        sb.AppendLine("so these figures bound eligibility from above. That is the correct direction for a");
+        sb.AppendLine("\"is there conceivably enough supply?\" go/no-go, and the wrong number to quote as supply.");
+        sb.AppendLine();
+
+        sb.AppendLine("## Supply by project");
+        sb.AppendLine();
+        sb.AppendLine("| Project | Native files | With-loss files | Supply (native) | Supply (with-loss) | with-loss / native |");
+        sb.AppendLine("|---|---:|---:|---:|---:|---:|");
+        foreach (var p in r.Projects)
+        {
+            var ratio = p.WithLossOverNativeRatio is { } v ? v.ToString("F2") : "n/a";
+            sb.AppendLine($"| {p.ProjectName} | {p.NativeFiles} | {p.WithLossFiles} | **{p.SupplyNative}** | {p.SupplyWithLoss} | {ratio} |");
+        }
+        sb.AppendLine($"| **TOTAL** | | | **{r.TotalSupplyNative}** | {r.TotalSupplyWithLoss} | " +
+                      $"{(r.PooledRatio is { } pr ? pr.ToString("F2") : "n/a")} |");
+        sb.AppendLine();
+
+        sb.AppendLine("## D-5 — region-granularity clause (a)");
+        sb.AppendLine();
+        sb.AppendLine($"Pre-committed rule (S1 kickoff): accept site-level clause (a) iff with-loss/native ≥ {SupplyEnumeration.Result.D5AcceptThreshold:F2}.");
+        sb.AppendLine();
+        sb.AppendLine($"**{r.D5Verdict}**");
+        sb.AppendLine();
+        sb.AppendLine("Per-project ratios are in the table above; a pooled figure must not conceal a split.");
+        sb.AppendLine();
+
+        sb.AppendLine("## Candidates by operator");
+        sb.AppendLine();
+        foreach (var p in r.Projects)
+        {
+            sb.AppendLine($"### {p.ProjectName}");
+            sb.AppendLine();
+            if (p.NativeByOperator.Count == 0 && p.WithLossByOperator.Count == 0)
+            {
+                sb.AppendLine("_No expressible candidates enumerated in either population._");
+                sb.AppendLine();
+                continue;
+            }
+            sb.AppendLine("| Operator | Native | With-loss |");
+            sb.AppendLine("|---|---:|---:|");
+            foreach (var op in p.NativeByOperator.Keys.Union(p.WithLossByOperator.Keys).OrderBy(k => k, StringComparer.Ordinal))
+                sb.AppendLine($"| {op} | {p.NativeByOperator.GetValueOrDefault(op)} | {p.WithLossByOperator.GetValueOrDefault(op)} |");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("## Clustering (native candidates by file)");
+        sb.AppendLine();
+        sb.AppendLine("The probe's `--max-candidates` cap takes a **lexicographic prefix**, not a sample, so");
+        sb.AppendLine("candidates concentrated in few files mean the probe's effective *n* is far below its");
+        sb.AppendLine("nominal *n* (S1 kickoff D-3). This table is what makes that visible before the probe runs.");
+        sb.AppendLine();
+        foreach (var p in r.Projects)
+        {
+            sb.AppendLine($"### {p.ProjectName} — {p.NativeByFile.Count} native file(s) carrying candidates");
+            sb.AppendLine();
+            if (p.NativeByFile.Count == 0) { sb.AppendLine("_none_"); sb.AppendLine(); continue; }
+            foreach (var (file, n) in p.NativeByFile.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key, StringComparer.Ordinal))
+                sb.AppendLine($"- `{file}` — {n}");
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
## What

The v0.12 **S1 enumeration-only pre-pass** (kickoff D-1/D-5), plus its first run.

New `enumerate-supply` harness command: one conversion pass per project — **no builds, no tests,
no recovery, no bundles**, and no **eligibility evaluation**. That last property is what lets it run
*before* the A-1.5 freeze under plan §3 constraint (a).

## The result

**The entire pinned corpus supplies 9 native expressible candidates.**

| Project | Native files | Supply (native) | Supply (with-loss) | ratio |
|---|---:|---:|---:|---:|
| MediatR | 20 | **0** | 0 | n/a |
| Serilog | 72 | **3** | 7 | 2.33 |
| FluentValidation | 109 | **6** | 0 | 0.00 |
| **TOTAL** | 201 | **9** | 7 | 0.78 |

These are **upper bounds** — build and recovery are skipped, so files that convert but don't compile
still count as native.

The kickoff targeted **n ≈ 30**. It is unreachable, and the funnel probe as designed cannot resolve
the ambiguity it was commissioned to resolve: at n=9 pooled (0/3/6 per project, against a rule that
forbids pooling) a 25% clause-(b) rate yields zero observations ~7.5% of the time.

`IndexOutOfBounds` and `DivByZero` contributed **zero** candidates anywhere.

## D-5 — resolved ACCEPT by its pre-committed rule

Pooled with-loss/native = **0.78 ≥ 0.50** → site-level clause (a) accepted, per the rule fixed
*before* these numbers existed. The record states what the pooled figure hides: the entire with-loss
supply is Serilog's, 6 of its 7 are `NullDeref`, FluentValidation is 0.00 and MediatR undefined.
**The accept rests on one subject.**

## Design choices aimed at recent failure modes

- **The exit code carries no supply signal.** `gen-tasks` returns `TotalEligible > 0 ? 0 : 1`, and
  that side channel is part of why the superseded seal was worthless. A pre-freeze command must not
  leak the quantity through its status.
- **A missing corpus subject is a hard error**, not a silent two-project run (D-6, enforced rather
  than documented).
- **The ratio is `double?`, not `0.0`, when native supply is zero.** Reporting an undefined ratio as
  0.0 would render it "REJECT" and let a corpus with *no supply* decide a design question it cannot
  speak to. Tested explicitly.
- **The upper-bound caveat is emitted by the tool into its own report**, rather than left for a human
  to re-attach downstream — caveat-shedding across documents is the failure this program keeps
  rediscovering.

## Tests

9 new unit tests (project 133 → **142**), covering classification, `Reverted`/`Excluded` exclusion,
both sides of the D-5 threshold, the undecidable case, clustering, and the report's caveats. The
conversion step is injected, so none of them need the corpus.

## What this does NOT claim

Not 0 eligible tasks (eligibility was never evaluated — that's the point); no adjudication of PP-S3,
PP-S1, or the §4 go/no-go, which belong to the A-1.5 freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
