### PR TITLE
D-S0.5.2 operator widening — native supply 9 → 204

### DIFF
--- a/bench/phase0-agent-native/epochs/m5-compare-001.driver.log
+++ b/bench/phase0-agent-native/epochs/m5-compare-001.driver.log
@@ -1,0 +1,199 @@
+=== M5 epoch m5-compare-001 ===
+arm A: 4f235cdc498dd7498b41b901d472a6649aaaded3 (raw)      /private/tmp/claude-501/-Users-juanrivera-sources-repos-juanmicrosoft-calor/cf791636-d712-4c3a-981b-86260d88ee6a/scratchpad/arm-a-worktree/src/Calor.Compiler/bin/Release/net10.0/calor.dll
+arm B: 73e2519af40534fae953759406bb53e4e7b259aa (mcp-file) /Users/juanrivera/sources/repos/juanmicrosoft/calor/src/Calor.Compiler/bin/Release/net10.0/calor.dll
+pairs (13): W2-001 W2-002 W2-003 W2-004 W2-005 W3-001 W3-002 W3-003 W3-004 N1-001 N1-002 N1-003 N1-005
+runs/arm: 5   mode: live   model: claude-opus-4-8
+=== W2-001 / arm A (baseline, raw) ===
+{"pair":"W2-001-int-stats","arm":"calor","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5450,"censored":false,"invalid":false}
+{"pair":"W2-001-int-stats","arm":"calor","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":7605,"censored":false,"invalid":false}
+{"pair":"W2-001-int-stats","arm":"calor","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":8290,"censored":false,"invalid":false}
+{"pair":"W2-001-int-stats","arm":"calor","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5207,"censored":false,"invalid":false}
+{"pair":"W2-001-int-stats","arm":"calor","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":3630,"censored":false,"invalid":false}
+=== W2-001 / arm B (isolation, mcp-file) ===
+{"pair":"W2-001-int-stats","arm":"calor+mcp-file","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":3635,"censored":false,"invalid":false}
+{"pair":"W2-001-int-stats","arm":"calor+mcp-file","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4181,"censored":false,"invalid":false}
+{"pair":"W2-001-int-stats","arm":"calor+mcp-file","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":3709,"censored":false,"invalid":false}
+{"pair":"W2-001-int-stats","arm":"calor+mcp-file","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":3249,"censored":false,"invalid":false}
+{"pair":"W2-001-int-stats","arm":"calor+mcp-file","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":3756,"censored":false,"invalid":false}
+=== W2-002 / arm A (baseline, raw) ===
+{"pair":"W2-002-parity-encoder","arm":"calor","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":6900,"censored":false,"invalid":false}
+{"pair":"W2-002-parity-encoder","arm":"calor","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":6817,"censored":false,"invalid":false}
+{"pair":"W2-002-parity-encoder","arm":"calor","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5189,"censored":false,"invalid":false}
+{"pair":"W2-002-parity-encoder","arm":"calor","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5453,"censored":false,"invalid":false}
+{"pair":"W2-002-parity-encoder","arm":"calor","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5496,"censored":false,"invalid":false}
+=== W2-002 / arm B (isolation, mcp-file) ===
+{"pair":"W2-002-parity-encoder","arm":"calor+mcp-file","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4119,"censored":false,"invalid":false}
+{"pair":"W2-002-parity-encoder","arm":"calor+mcp-file","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4289,"censored":false,"invalid":false}
+{"pair":"W2-002-parity-encoder","arm":"calor+mcp-file","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":3980,"censored":false,"invalid":false}
+{"pair":"W2-002-parity-encoder","arm":"calor+mcp-file","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":3452,"censored":false,"invalid":false}
+{"pair":"W2-002-parity-encoder","arm":"calor+mcp-file","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":3462,"censored":false,"invalid":false}
+=== W2-003 / arm A (baseline, raw) ===
+{"pair":"W2-003-window-stats","arm":"calor","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5340,"censored":false,"invalid":false}
+{"pair":"W2-003-window-stats","arm":"calor","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":6976,"censored":false,"invalid":false}
+{"pair":"W2-003-window-stats","arm":"calor","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":6990,"censored":false,"invalid":false}
+{"pair":"W2-003-window-stats","arm":"calor","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":9277,"censored":false,"invalid":false}
+{"pair":"W2-003-window-stats","arm":"calor","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4935,"censored":false,"invalid":false}
+=== W2-003 / arm B (isolation, mcp-file) ===
+INVALID run detected (pair=W2-003-window-stats arm=calor run=1 attempt=0): agent output matches error marker: "api error"
+{"pair":"W2-003-window-stats","arm":"calor+mcp-file","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4590,"censored":false,"invalid":false}
+{"pair":"W2-003-window-stats","arm":"calor+mcp-file","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4274,"censored":false,"invalid":false}
+{"pair":"W2-003-window-stats","arm":"calor+mcp-file","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4896,"censored":false,"invalid":false}
+{"pair":"W2-003-window-stats","arm":"calor+mcp-file","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4318,"censored":false,"invalid":false}
+{"pair":"W2-003-window-stats","arm":"calor+mcp-file","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4848,"censored":false,"invalid":false}
+=== W2-004 / arm A (baseline, raw) ===
+{"pair":"W2-004-interval-clip","arm":"calor","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":6916,"censored":false,"invalid":false}
+{"pair":"W2-004-interval-clip","arm":"calor","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":8707,"censored":false,"invalid":false}
+{"pair":"W2-004-interval-clip","arm":"calor","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":7288,"censored":false,"invalid":false}
+{"pair":"W2-004-interval-clip","arm":"calor","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":3602,"censored":false,"invalid":false}
+{"pair":"W2-004-interval-clip","arm":"calor","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":6927,"censored":false,"invalid":false}
+=== W2-004 / arm B (isolation, mcp-file) ===
+{"pair":"W2-004-interval-clip","arm":"calor+mcp-file","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4301,"censored":false,"invalid":false}
+{"pair":"W2-004-interval-clip","arm":"calor+mcp-file","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":3867,"censored":false,"invalid":false}
+{"pair":"W2-004-interval-clip","arm":"calor+mcp-file","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4273,"censored":false,"invalid":false}
+{"pair":"W2-004-interval-clip","arm":"calor+mcp-file","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":3455,"censored":false,"invalid":false}
+{"pair":"W2-004-interval-clip","arm":"calor+mcp-file","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5007,"censored":false,"invalid":false}
+=== W2-005 / arm A (baseline, raw) ===
+{"pair":"W2-005-scheduler","arm":"calor","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":13679,"censored":false,"invalid":false}
+{"pair":"W2-005-scheduler","arm":"calor","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":13431,"censored":false,"invalid":false}
+{"pair":"W2-005-scheduler","arm":"calor","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":16720,"censored":false,"invalid":false}
+{"pair":"W2-005-scheduler","arm":"calor","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":11635,"censored":false,"invalid":false}
+{"pair":"W2-005-scheduler","arm":"calor","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":14320,"censored":false,"invalid":false}
+=== W2-005 / arm B (isolation, mcp-file) ===
+{"pair":"W2-005-scheduler","arm":"calor+mcp-file","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":11234,"censored":false,"invalid":false}
+{"pair":"W2-005-scheduler","arm":"calor+mcp-file","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":12170,"censored":false,"invalid":false}
+{"pair":"W2-005-scheduler","arm":"calor+mcp-file","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":12719,"censored":false,"invalid":false}
+{"pair":"W2-005-scheduler","arm":"calor+mcp-file","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":16345,"censored":false,"invalid":false}
+{"pair":"W2-005-scheduler","arm":"calor+mcp-file","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":12243,"censored":false,"invalid":false}
+=== W3-001 / arm A (baseline, raw) ===
+{"pair":"W3-001-audit-log","arm":"calor","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4579,"censored":false,"invalid":false}
+{"pair":"W3-001-audit-log","arm":"calor","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4370,"censored":false,"invalid":false}
+{"pair":"W3-001-audit-log","arm":"calor","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5134,"censored":false,"invalid":false}
+{"pair":"W3-001-audit-log","arm":"calor","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4169,"censored":false,"invalid":false}
+{"pair":"W3-001-audit-log","arm":"calor","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4690,"censored":false,"invalid":false}
+=== W3-001 / arm B (isolation, mcp-file) ===
+{"pair":"W3-001-audit-log","arm":"calor+mcp-file","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":3174,"censored":false,"invalid":false}
+{"pair":"W3-001-audit-log","arm":"calor+mcp-file","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":2251,"censored":false,"invalid":false}
+{"pair":"W3-001-audit-log","arm":"calor+mcp-file","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":2988,"censored":false,"invalid":false}
+{"pair":"W3-001-audit-log","arm":"calor+mcp-file","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":2010,"censored":false,"invalid":false}
+{"pair":"W3-001-audit-log","arm":"calor+mcp-file","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":2204,"censored":false,"invalid":false}
+=== W3-002 / arm A (baseline, raw) ===
+{"pair":"W3-002-config-store","arm":"calor","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":8387,"censored":false,"invalid":false}
+{"pair":"W3-002-config-store","arm":"calor","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":8133,"censored":false,"invalid":false}
+{"pair":"W3-002-config-store","arm":"calor","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5296,"censored":false,"invalid":false}
+{"pair":"W3-002-config-store","arm":"calor","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":9257,"censored":false,"invalid":false}
+{"pair":"W3-002-config-store","arm":"calor","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":11746,"censored":false,"invalid":false}
+=== W3-002 / arm B (isolation, mcp-file) ===
+{"pair":"W3-002-config-store","arm":"calor+mcp-file","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4635,"censored":false,"invalid":false}
+{"pair":"W3-002-config-store","arm":"calor+mcp-file","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5522,"censored":false,"invalid":false}
+{"pair":"W3-002-config-store","arm":"calor+mcp-file","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5140,"censored":false,"invalid":false}
+{"pair":"W3-002-config-store","arm":"calor+mcp-file","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":6591,"censored":false,"invalid":false}
+{"pair":"W3-002-config-store","arm":"calor+mcp-file","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4883,"censored":false,"invalid":false}
+=== W3-003 / arm A (baseline, raw) ===
+{"pair":"W3-003-kv-journal","arm":"calor","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":9251,"censored":false,"invalid":false}
+{"pair":"W3-003-kv-journal","arm":"calor","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5863,"censored":false,"invalid":false}
+{"pair":"W3-003-kv-journal","arm":"calor","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":7150,"censored":false,"invalid":false}
+{"pair":"W3-003-kv-journal","arm":"calor","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4954,"censored":false,"invalid":false}
+{"pair":"W3-003-kv-journal","arm":"calor","run":5,"taskSuccess":true,"iterationsToGreen":3,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":15139,"censored":false,"invalid":false}
+=== W3-003 / arm B (isolation, mcp-file) ===
+{"pair":"W3-003-kv-journal","arm":"calor+mcp-file","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5375,"censored":false,"invalid":false}
+{"pair":"W3-003-kv-journal","arm":"calor+mcp-file","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":6012,"censored":false,"invalid":false}
+{"pair":"W3-003-kv-journal","arm":"calor+mcp-file","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":6022,"censored":false,"invalid":false}
+{"pair":"W3-003-kv-journal","arm":"calor+mcp-file","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5641,"censored":false,"invalid":false}
+{"pair":"W3-003-kv-journal","arm":"calor+mcp-file","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5514,"censored":false,"invalid":false}
+=== W3-004 / arm A (baseline, raw) ===
+{"pair":"W3-004-sync-folder","arm":"calor","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":13493,"censored":false,"invalid":false}
+{"pair":"W3-004-sync-folder","arm":"calor","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":14546,"censored":false,"invalid":false}
+{"pair":"W3-004-sync-folder","arm":"calor","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":13837,"censored":false,"invalid":false}
+{"pair":"W3-004-sync-folder","arm":"calor","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":17572,"censored":false,"invalid":false}
+{"pair":"W3-004-sync-folder","arm":"calor","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":20213,"censored":false,"invalid":false}
+=== W3-004 / arm B (isolation, mcp-file) ===
+{"pair":"W3-004-sync-folder","arm":"calor+mcp-file","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":14473,"censored":false,"invalid":false}
+{"pair":"W3-004-sync-folder","arm":"calor+mcp-file","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":11863,"censored":false,"invalid":false}
+watchdog: agent exceeded 600s; killing pid 40587 and descendants
+INVALID run detected (pair=W3-004-sync-folder arm=calor run=3 attempt=0): agent.json missing or empty
+{"pair":"W3-004-sync-folder","arm":"calor+mcp-file","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":14061,"censored":false,"invalid":false}
+{"pair":"W3-004-sync-folder","arm":"calor+mcp-file","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":12530,"censored":false,"invalid":false}
+{"pair":"W3-004-sync-folder","arm":"calor+mcp-file","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":16482,"censored":false,"invalid":false}
+=== N1-001 / arm A (baseline, raw) ===
+watchdog: agent exceeded 600s; killing pid 43699 and descendants
+INVALID run detected (pair=N1-001-string-utils arm=calor run=1 attempt=0): agent.json missing or empty
+{"pair":"N1-001-string-utils","arm":"calor","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":6288,"censored":false,"invalid":false}
+{"pair":"N1-001-string-utils","arm":"calor","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":6659,"censored":false,"invalid":false}
+{"pair":"N1-001-string-utils","arm":"calor","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":8940,"censored":false,"invalid":false}
+watchdog: agent exceeded 600s; killing pid 46983 and descendants
+INVALID run detected (pair=N1-001-string-utils arm=calor run=4 attempt=0): agent.json missing or empty
+{"pair":"N1-001-string-utils","arm":"calor","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":9439,"censored":false,"invalid":false}
+{"pair":"N1-001-string-utils","arm":"calor","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":8648,"censored":false,"invalid":false}
+=== N1-001 / arm B (isolation, mcp-file) ===
+{"pair":"N1-001-string-utils","arm":"calor+mcp-file","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":11157,"censored":false,"invalid":false}
+{"pair":"N1-001-string-utils","arm":"calor+mcp-file","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4919,"censored":false,"invalid":false}
+{"pair":"N1-001-string-utils","arm":"calor+mcp-file","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5078,"censored":false,"invalid":false}
+{"pair":"N1-001-string-utils","arm":"calor+mcp-file","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4512,"censored":false,"invalid":false}
+{"pair":"N1-001-string-utils","arm":"calor+mcp-file","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4404,"censored":false,"invalid":false}
+=== N1-002 / arm A (baseline, raw) ===
+{"pair":"N1-002-inventory","arm":"calor","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4470,"censored":false,"invalid":false}
+{"pair":"N1-002-inventory","arm":"calor","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":7379,"censored":false,"invalid":false}
+{"pair":"N1-002-inventory","arm":"calor","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5307,"censored":false,"invalid":false}
+INVALID run detected (pair=N1-002-inventory arm=calor run=4 attempt=0): agent output matches error marker: "api error"
+{"pair":"N1-002-inventory","arm":"calor","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4066,"censored":false,"invalid":false}
+{"pair":"N1-002-inventory","arm":"calor","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4048,"censored":false,"invalid":false}
+=== N1-002 / arm B (isolation, mcp-file) ===
+{"pair":"N1-002-inventory","arm":"calor+mcp-file","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4965,"censored":false,"invalid":false}
+{"pair":"N1-002-inventory","arm":"calor+mcp-file","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4437,"censored":false,"invalid":false}
+{"pair":"N1-002-inventory","arm":"calor+mcp-file","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4314,"censored":false,"invalid":false}
+{"pair":"N1-002-inventory","arm":"calor+mcp-file","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4356,"censored":false,"invalid":false}
+{"pair":"N1-002-inventory","arm":"calor+mcp-file","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":3652,"censored":false,"invalid":false}
+=== N1-003 / arm A (baseline, raw) ===
+{"pair":"N1-003-csv-row","arm":"calor","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":6133,"censored":false,"invalid":false}
+{"pair":"N1-003-csv-row","arm":"calor","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":9493,"censored":false,"invalid":false}
+{"pair":"N1-003-csv-row","arm":"calor","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":4787,"censored":false,"invalid":false}
+{"pair":"N1-003-csv-row","arm":"calor","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":7832,"censored":false,"invalid":false}
+{"pair":"N1-003-csv-row","arm":"calor","run":5,"taskSuccess":true,"iterationsToGreen":3,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":21623,"censored":false,"invalid":false}
+=== N1-003 / arm B (isolation, mcp-file) ===
+{"pair":"N1-003-csv-row","arm":"calor+mcp-file","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":8180,"censored":false,"invalid":false}
+{"pair":"N1-003-csv-row","arm":"calor+mcp-file","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":8333,"censored":false,"invalid":false}
+{"pair":"N1-003-csv-row","arm":"calor+mcp-file","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":9689,"censored":false,"invalid":false}
+{"pair":"N1-003-csv-row","arm":"calor+mcp-file","run":4,"taskSuccess":true,"iterationsToGreen":2,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":9152,"censored":false,"invalid":false}
+{"pair":"N1-003-csv-row","arm":"calor+mcp-file","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":9357,"censored":false,"invalid":false}
+=== N1-005 / arm A (baseline, raw) ===
+{"pair":"N1-005-order-pipeline","arm":"calor","run":1,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":8740,"censored":false,"invalid":false}
+{"pair":"N1-005-order-pipeline","arm":"calor","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":113,"censored":false,"invalid":false}
+{"pair":"N1-005-order-pipeline","arm":"calor","run":3,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5951,"censored":false,"invalid":false}
+watchdog: agent exceeded 600s; killing pid 73823 and descendants
+INVALID run detected (pair=N1-005-order-pipeline arm=calor run=4 attempt=0): agent.json missing or empty
+watchdog: agent exceeded 600s; killing pid 74388 and descendants
+INVALID run detected (pair=N1-005-order-pipeline arm=calor run=4 attempt=1): agent.json missing or empty
+watchdog: agent exceeded 600s; killing pid 74990 and descendants
+INVALID run detected (pair=N1-005-order-pipeline arm=calor run=4 attempt=2): agent.json missing or empty
+Retry cap reached; counting run 4 as task failure (invalid)
+{"pair":"N1-005-order-pipeline","arm":"calor","run":4,"taskSuccess":false,"iterationsToGreen":11,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":0,"censored":true,"invalid":true}
+watchdog: agent exceeded 600s; killing pid 75590 and descendants
+INVALID run detected (pair=N1-005-order-pipeline arm=calor run=5 attempt=0): agent.json missing or empty
+watchdog: agent exceeded 600s; killing pid 76181 and descendants
+INVALID run detected (pair=N1-005-order-pipeline arm=calor run=5 attempt=1): agent.json missing or empty
+watchdog: agent exceeded 600s; killing pid 76786 and descendants
+INVALID run detected (pair=N1-005-order-pipeline arm=calor run=5 attempt=2): agent.json missing or empty
+Retry cap reached; counting run 5 as task failure (invalid)
+{"pair":"N1-005-order-pipeline","arm":"calor","run":5,"taskSuccess":false,"iterationsToGreen":11,"editMechanism":"raw","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":0,"censored":true,"invalid":true}
+=== N1-005 / arm B (isolation, mcp-file) ===
+watchdog: agent exceeded 600s; killing pid 77672 and descendants
+INVALID run detected (pair=N1-005-order-pipeline arm=calor run=1 attempt=0): agent.json missing or empty
+watchdog: agent exceeded 600s; killing pid 78265 and descendants
+INVALID run detected (pair=N1-005-order-pipeline arm=calor run=1 attempt=1): agent.json missing or empty
+watchdog: agent exceeded 600s; killing pid 78867 and descendants
+INVALID run detected (pair=N1-005-order-pipeline arm=calor run=1 attempt=2): agent.json missing or empty
+Retry cap reached; counting run 1 as task failure (invalid)
+{"pair":"N1-005-order-pipeline","arm":"calor+mcp-file","run":1,"taskSuccess":false,"iterationsToGreen":11,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":0,"censored":true,"invalid":true}
+INVALID run detected (pair=N1-005-order-pipeline arm=calor run=2 attempt=0): agent output matches error marker: "api error"
+{"pair":"N1-005-order-pipeline","arm":"calor+mcp-file","run":2,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":7028,"censored":false,"invalid":false}
+watchdog: agent exceeded 600s; killing pid 80881 and descendants
+INVALID run detected (pair=N1-005-order-pipeline arm=calor run=3 attempt=0): agent.json missing or empty
+INVALID run detected (pair=N1-005-order-pipeline arm=calor run=3 attempt=1): agent output matches error marker: "api error"
+INVALID run detected (pair=N1-005-order-pipeline arm=calor run=3 attempt=2): agent output matches error marker: "api error"
+Retry cap reached; counting run 3 as task failure (invalid)
+{"pair":"N1-005-order-pipeline","arm":"calor+mcp-file","run":3,"taskSuccess":false,"iterationsToGreen":11,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":0,"censored":true,"invalid":true}
+{"pair":"N1-005-order-pipeline","arm":"calor+mcp-file","run":4,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":7288,"censored":false,"invalid":false}
+watchdog: agent exceeded 600s; killing pid 83448 and descendants
+INVALID run detected (pair=N1-005-order-pipeline arm=calor run=5 attempt=0): agent.json missing or empty
+{"pair":"N1-005-order-pipeline","arm":"calor+mcp-file","run":5,"taskSuccess":true,"iterationsToGreen":1,"editMechanism":"mcp-file","calorDll":"bin/Release/net10.0/calor.dll","tokensOut":5745,"censored":false,"invalid":false}
+--- M5 collection complete; adjudicate with: bench/phase0-agent-native/m5-analyze.py /Users/juanrivera/sources/repos/juanmicrosoft/calor/bench/phase0-agent-native/epochs/m5-compare-001 ---

--- a/bench/phase0-agent-native/epochs/s1-supply-002/FINDING.md
+++ b/bench/phase0-agent-native/epochs/s1-supply-002/FINDING.md
@@ -1,0 +1,43 @@
+# s1-supply-002 — D-S0.5.2 operator widening: the ceiling was the operator, not the corpus
+
+**Run:** 2026-08-04, conversion-only, no builds/tests/recovery, **no eligibility evaluated**.
+**Corpus pins:** unchanged — MediatR `fb309026`, Serilog `0597ddfb`, FluentValidation `71b3c60c`.
+**Predecessor:** [`s1-supply-001`](../s1-supply-001/FINDING.md), same corpus, same command, pre-widening operator set.
+**Change under test:** D-S0.5.2 — `EffectViolation`'s corruption generalized beyond `int`/`long`.
+
+## The result
+
+| Project | Sites (all) | Lost to conversion | Supply (native) | Supply (with-loss) |
+|---|---:|---:|---:|---:|
+| MediatR | 48 | 41 | **5** | 2 |
+| Serilog | 181 | 66 | **93** | 22 |
+| FluentValidation | 298 | 144 | **106** | 48 |
+| **TOTAL** | **527** | **251** | **204** | **72** |
+
+Against s1-supply-001 on the identical corpus:
+
+| | before | after | × |
+|---|---:|---:|---:|
+| Corpus sites | 25 | **527** | 21× |
+| Native supply | 9 | **204** | 23× |
+
+## What this settles
+
+**The supply ceiling reported at S1 was an artifact of the mutation operator, not a property of the corpus.** s1-supply-001 measured 9 native candidates and the first draft of its record attributed that to the corpus. The adversarial review argued the binding constraint was the operator's site predicate — `EffectViolation` required a **predefined `int`/`long`** return, because the corruption was arithmetic (`return ORIGINAL + taint`). That restriction was never about addressability: the `using`-nested `Directory.*` effect that makes `Calor0410` fire is independent of the return type.
+
+Generalizing the *corruption* — `bool` flips, everything else `taint == 1 ? default(T)! : ORIGINAL`, with `void`/`ref`/pointer/`async` excluded because the corruption would not compile or would not be a single deterministic point — raised native supply **23×** with **no change to the mechanism under measurement**.
+
+**This is not a bar relaxation, and the distinction is load-bearing.** The injected defect is the same undeclared `fs` effect; the corruption is still deterministic, still single-point, and still intrinsic to the effect, so the papering-over residual that makes the measurement meaningful is unchanged. Per the plan's M-S4 population, an operator change that raised supply by making the injected defect *less real* would count against the honesty invariant. This one changes only which return types the corruption can be expressed for.
+
+## Consequences
+
+1. **The §4 go/no-go input has moved by more than an order of magnitude.** The trigger asks whether required-N exceeds the corpus's candidate-supply ceiling by >10×. Against required-N of ~15–40 (optimistic deterministic-catch) or "hundreds" (the registered 20–40% effect), a ceiling of **204 native / 527 total** is no longer obviously short. **Adjudicating "the venue is unreachable" on the pre-widening 9 would have retired the venue on an artifact.** A-1.5 still owns that adjudication; this record supplies the corrected input.
+2. **The funnel probe becomes worth running.** At n = 9 it could not resolve the ambiguity it was commissioned to resolve. At n = 204 the cap (`--max-candidates`) binds again, so D-3's lexicographic-prefix concern is live once more and sampling matters.
+3. **Converter fidelity is now measurable as a lever, not an anecdote.** 251 of 527 sites (48%) are in files the converter could not convert — a direct, quantified WS-S1 target on the same instrument.
+4. **D-5 flips to the other kind of SPLIT.** Pooled ratio 0.35 → REJECT, but that is carried by `EffectViolation` (0.33); excluding it, `NullDeref` is 2.00 → ACCEPT. In s1-supply-001 the split ran the other way (pooled ACCEPT carried by `NullDeref`). The pre-committed threshold has now failed to settle D-5 under both operator sets, which is itself evidence the statistic is too operator-sensitive to decide the question. **D-5 is referred to A-1.5 for an explicit decision, with both runs on the record.**
+
+## What this record does not claim
+
+- **Not 204 eligible tasks.** Eligibility was not evaluated — no clause (a) beyond conversion status, no clause (b), no addressability probe. The prior run's 3 candidates were 3/3 addressable and **0/3 eligible**; attrition here is unmeasured and could be severe.
+- **Not that the widened corruption is addressable.** The `Calor0410` mechanism is unchanged by construction, but that is an argument, not a measurement. The differential probe must confirm it, and a `default(T)!` returning null for reference types is a plausible new source of `ArmsDiverge`.
+- No adjudication of PP-S1, PP-S3, or the §4 go/no-go.

--- a/bench/phase0-agent-native/epochs/s1-supply-002/FINDING.md
+++ b/bench/phase0-agent-native/epochs/s1-supply-002/FINDING.md
@@ -3,41 +3,84 @@
 **Run:** 2026-08-04, conversion-only, no builds/tests/recovery, **no eligibility evaluated**.
 **Corpus pins:** unchanged — MediatR `fb309026`, Serilog `0597ddfb`, FluentValidation `71b3c60c`.
 **Predecessor:** [`s1-supply-001`](../s1-supply-001/FINDING.md), same corpus, same command, pre-widening operator set.
+**Invocation:** `enumerate-supply MediatR Serilog FluentValidation --output bench/phase0-agent-native/epochs/s1-supply-002`
 **Change under test:** D-S0.5.2 — `EffectViolation`'s corruption generalized beyond `int`/`long`.
+**Revision 2** — adversarial review compiled all 511 candidates and ran the addressability probe this record had declined to run. Numbers below are post-fix.
 
 ## The result
 
 | Project | Sites (all) | Lost to conversion | Supply (native) | Supply (with-loss) |
 |---|---:|---:|---:|---:|
-| MediatR | 48 | 41 | **5** | 2 |
-| Serilog | 181 | 66 | **93** | 22 |
-| FluentValidation | 298 | 144 | **106** | 48 |
-| **TOTAL** | **527** | **251** | **204** | **72** |
+| MediatR | 46 | 39 | **5** | 2 |
+| Serilog | 177 | 65 | **93** | 19 |
+| FluentValidation | 296 | 143 | **105** | 48 |
+| **TOTAL** | **519** | **247** | **203** | **69** |
 
 Against s1-supply-001 on the identical corpus:
 
 | | before | after | × |
 |---|---:|---:|---:|
-| Corpus sites | 25 | **527** | 21× |
-| Native supply | 9 | **204** | 23× |
+| Corpus sites | 25 | **519** | 21× |
+| Native supply | 9 | **203** | 23× |
 
 ## What this settles
 
 **The supply ceiling reported at S1 was an artifact of the mutation operator, not a property of the corpus.** s1-supply-001 measured 9 native candidates and the first draft of its record attributed that to the corpus. The adversarial review argued the binding constraint was the operator's site predicate — `EffectViolation` required a **predefined `int`/`long`** return, because the corruption was arithmetic (`return ORIGINAL + taint`). That restriction was never about addressability: the `using`-nested `Directory.*` effect that makes `Calor0410` fire is independent of the return type.
 
-Generalizing the *corruption* — `bool` flips, everything else `taint == 1 ? default(T)! : ORIGINAL`, with `void`/`ref`/pointer/`async` excluded because the corruption would not compile or would not be a single deterministic point — raised native supply **23×** with **no change to the mechanism under measurement**.
+Generalizing the *corruption* — `bool` flips, everything else `taint == 1 ? default(T)! : ORIGINAL`, with `void`/`ref`/pointer/`async` excluded because the corruption would not compile or would not be a single deterministic point — raised native supply **23×** with **no change to the mechanism under measurement** — a claim now *measured* rather than argued (see below), not merely asserted.
+
+## Composition, and a defect-class change the first draft did not disclose
+
+| corruption form | native candidates | share |
+|---|---:|---:|
+| `AddOne` (`+ taint`, pre-existing) | 6 | 3% |
+| `FlipBool` (`^`) | 38 | 19% |
+| `DefaultWhenTainted` (`default(T)!`) | ~157 | 78% |
+
+**78% of the post-widening supply uses a corruption class with no pre-widening representative, so `9 → 203` is a comparison of operator REACH, not of one experiment's subject count.** Two consequences the first draft asserted away with "still single-point":
+
+- **The `Default` form never evaluates the original expression.** The taint is always 1 by construction, so the `ORIGINAL` branch of the conditional is dead in every execution. On the corpus a majority of those sites elide a call — the defect is "skip the computation and return null", not "perturb the returned value". `AddOne` and `FlipBool` both still evaluate `ORIGINAL`.
+- **It therefore propagates differently.** A null at a distance surfaces as an `NRE` in another frame — plausibly another file — which is direct input to `ArmsDiverge` and to `ConverterAttributed`. Whether that is easier or harder for an agent to fix than an arithmetic mismatch is an open question this widening silently changes the answer to. Downstream clause-(b) attrition is expected to differ by class and is unmeasured.
+
+## Addressability — MEASURED, not argued
+
+The first draft said this was "an argument, not a measurement". The measurement costs minutes on the artifact already in hand, and review ran it over 35 native candidates:
+
+| form | n | addressable |
+|---|---:|---:|
+| `Default` | 17 | 12 (71%) |
+| `FlipBool` | 12 | 9 (75%) |
+| `AddOne` (unchanged) | 6 | 5 (83%) |
+
+**No kind-specific gap** — the failures are kind-independent (converter-baseline `Calor0410` already firing, or not firing at all) and afflict the pre-existing form equally. At ~74% pooled, **the addressable ceiling is ≈150, not 203**, before any clause (a)/(b) attrition.
 
 **This is not a bar relaxation, and the distinction is load-bearing.** The injected defect is the same undeclared `fs` effect; the corruption is still deterministic, still single-point, and still intrinsic to the effect, so the papering-over residual that makes the measurement meaningful is unchanged. Per the plan's M-S4 population, an operator change that raised supply by making the injected defect *less real* would count against the honesty invariant. This one changes only which return types the corruption can be expressed for.
 
 ## Consequences
 
-1. **The §4 go/no-go input has moved by more than an order of magnitude.** The trigger asks whether required-N exceeds the corpus's candidate-supply ceiling by >10×. Against required-N of ~15–40 (optimistic deterministic-catch) or "hundreds" (the registered 20–40% effect), a ceiling of **204 native / 527 total** is no longer obviously short. **Adjudicating "the venue is unreachable" on the pre-widening 9 would have retired the venue on an artifact.** A-1.5 still owns that adjudication; this record supplies the corrected input.
-2. **The funnel probe becomes worth running.** At n = 9 it could not resolve the ambiguity it was commissioned to resolve. At n = 204 the cap (`--max-candidates`) binds again, so D-3's lexicographic-prefix concern is live once more and sampling matters.
-3. **Converter fidelity is now measurable as a lever, not an anecdote.** 251 of 527 sites (48%) are in files the converter could not convert — a direct, quantified WS-S1 target on the same instrument.
+1. **The §4 go/no-go input has moved by more than an order of magnitude.** The trigger asks whether required-N exceeds the corpus's candidate-supply ceiling by >10×. Against required-N of ~15–40 (optimistic deterministic-catch) or "hundreds" (the registered 20–40% effect), a ceiling of **203 native / 519 total** is no longer obviously short. **Adjudicating "the venue is unreachable" on the pre-widening 9 would have retired the venue on an artifact.** A-1.5 still owns that adjudication; this record supplies the corrected input.
+2. **The funnel probe becomes worth running.** At n = 9 it could not resolve the ambiguity it was commissioned to resolve. At n = 203 the cap (`--max-candidates`) binds again, so D-3's lexicographic-prefix concern is live once more and sampling matters.
+3. **Converter fidelity is now measurable as a lever, not an anecdote.** 247 of 519 sites (48%) are in files the converter could not convert — a direct, quantified WS-S1 target on the same instrument.
 4. **D-5 flips to the other kind of SPLIT.** Pooled ratio 0.35 → REJECT, but that is carried by `EffectViolation` (0.33); excluding it, `NullDeref` is 2.00 → ACCEPT. In s1-supply-001 the split ran the other way (pooled ACCEPT carried by `NullDeref`). The pre-committed threshold has now failed to settle D-5 under both operator sets, which is itself evidence the statistic is too operator-sensitive to decide the question. **D-5 is referred to A-1.5 for an explicit decision, with both runs on the record.**
 
 ## What this record does not claim
 
-- **Not 204 eligible tasks.** Eligibility was not evaluated — no clause (a) beyond conversion status, no clause (b), no addressability probe. The prior run's 3 candidates were 3/3 addressable and **0/3 eligible**; attrition here is unmeasured and could be severe.
-- **Not that the widened corruption is addressable.** The `Calor0410` mechanism is unchanged by construction, but that is an argument, not a measurement. The differential probe must confirm it, and a `default(T)!` returning null for reference types is a plausible new source of `ArmsDiverge`.
+- **Not 203 eligible tasks.** Eligibility was not evaluated — no clause (a) beyond conversion status, no clause (b), no addressability probe. The prior run's 3 candidates were 3/3 addressable and **0/3 eligible**; attrition here is unmeasured and could be severe.
+- **Not 150 eligible tasks either.** ~74% addressability is measured, but clause (a)/(b) attrition on top of it is not.
+- **Still operator-capped.** The operator visits only `MethodDeclarationSyntax` bodies: **277 expression-bodied members and 7 block accessors (+54%) remain unvisited** on this corpus. "The ceiling was ours" is *still* true of 203 — it is smaller than it was, not resolved.
 - No adjudication of PP-S1, PP-S3, or the §4 go/no-go.
+
+## A fix that was rejected, recorded because it nearly shipped
+
+Review found 4 candidates that do not compile: 3 from `#pragma`/`#if` trivia landing mid-line after
+the injected block (`CS1040`), and 1 from Serilog's `TimeProvider`, which declares
+`public static TimeProvider System { get; }` and so shadows the namespace for simple-name lookup
+(`CS1061`). None was in the native set, so the headline was unaffected; both are now fixed.
+
+The recommended fix for the second was to qualify the injection as `global::System.IO.…`. **That was
+tried and reverted: it compiles more widely and it silently destroys the mechanism.** The converter's
+`§E`-inference does not recognise the `global::`-qualified call, so `Calor0410` stops firing and
+*every* candidate loses addressability — trading the entire measurement for one site.
+`EffectViolation_IsAddressable_Calor0410_IntroducedByTheMutation` fails under it, which is how it was
+caught. The shipped fix instead **skips** types that shadow `System` (one site on this corpus), and a
+test now pins that choice with the reasoning, so it is not "corrected" back later.

--- a/bench/phase0-agent-native/epochs/s1-supply-002/supply-enumeration.json
+++ b/bench/phase0-agent-native/epochs/s1-supply-002/supply-enumeration.json
@@ -1,0 +1,147 @@
+{
+  "Projects": [
+    {
+      "ProjectName": "MediatR",
+      "NativeFiles": 20,
+      "WithLossFiles": 5,
+      "UnconvertedFiles": 7,
+      "SupplyTotal": 48,
+      "SupplyLostToConversion": 41,
+      "UnreadableSources": 0,
+      "SupplyNative": 5,
+      "SupplyWithLoss": 2,
+      "NativeByOperator": {
+        "EffectViolation": 5
+      },
+      "WithLossByOperator": {
+        "EffectViolation": 2
+      },
+      "NativeByFile": {
+        "src/MediatR/INotificationHandler.cs": 1,
+        "src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs": 2,
+        "src/MediatR/NotificationPublishers/TaskWhenAllPublisher.cs": 1,
+        "src/MediatR/Wrappers/NotificationHandlerWrapper.cs": 1
+      },
+      "WithLossOverNativeRatio": 0.4
+    },
+    {
+      "ProjectName": "Serilog",
+      "NativeFiles": 72,
+      "WithLossFiles": 17,
+      "UnconvertedFiles": 21,
+      "SupplyTotal": 181,
+      "SupplyLostToConversion": 66,
+      "UnreadableSources": 0,
+      "SupplyNative": 93,
+      "SupplyWithLoss": 22,
+      "NativeByOperator": {
+        "EffectViolation": 93
+      },
+      "WithLossByOperator": {
+        "EffectViolation": 16,
+        "NullDeref": 6
+      },
+      "NativeByFile": {
+        "src/Serilog/Capturing/DepthLimiter.cs": 3,
+        "src/Serilog/Configuration/LoggerAuditSinkConfiguration.cs": 4,
+        "src/Serilog/Configuration/LoggerDestructuringConfiguration.cs": 9,
+        "src/Serilog/Configuration/LoggerEnrichmentConfiguration.cs": 7,
+        "src/Serilog/Configuration/LoggerFilterConfiguration.cs": 4,
+        "src/Serilog/Configuration/LoggerSettingsConfiguration.cs": 3,
+        "src/Serilog/Configuration/LoggerSinkConfiguration.cs": 13,
+        "src/Serilog/Context/EnricherStack.cs": 1,
+        "src/Serilog/Context/LogContext.cs": 8,
+        "src/Serilog/Core/Filters/DelegateFilter.cs": 1,
+        "src/Serilog/Core/Pipeline/ByReferenceStringComparer.cs": 4,
+        "src/Serilog/Core/Pipeline/MessageTemplateCache.cs": 1,
+        "src/Serilog/Data/LogEventPropertyValueRewriter.cs": 5,
+        "src/Serilog/Data/LogEventPropertyValueVisitor.cs": 1,
+        "src/Serilog/Events/EventProperty.cs": 3,
+        "src/Serilog/Events/LogEventPropertyValue.cs": 1,
+        "src/Serilog/Events/MessageTemplate.cs": 2,
+        "src/Serilog/Formatting/Display/LevelOutputFormat.cs": 3,
+        "src/Serilog/Guard.cs": 1,
+        "src/Serilog/LoggerExtensions.cs": 1,
+        "src/Serilog/Parsing/TextToken.cs": 1,
+        "src/Serilog/Policies/DelegateDestructuringPolicy.cs": 1,
+        "src/Serilog/Policies/EnumScalarConversionPolicy.cs": 1,
+        "src/Serilog/Policies/PrimitiveScalarConversionPolicy.cs": 1,
+        "src/Serilog/Policies/ProjectedDestructuringPolicy.cs": 1,
+        "src/Serilog/Policies/ReflectionTypesScalarDestructuringPolicy.cs": 1,
+        "src/Serilog/Policies/SimpleScalarConversionPolicy.cs": 1,
+        "src/Serilog/Rendering/Casing.cs": 1,
+        "src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs": 10
+      },
+      "WithLossOverNativeRatio": 0.23655913978494625
+    },
+    {
+      "ProjectName": "FluentValidation",
+      "NativeFiles": 109,
+      "WithLossFiles": 4,
+      "UnconvertedFiles": 26,
+      "SupplyTotal": 298,
+      "SupplyLostToConversion": 144,
+      "UnreadableSources": 0,
+      "SupplyNative": 106,
+      "SupplyWithLoss": 48,
+      "NativeByOperator": {
+        "EffectViolation": 103,
+        "NullDeref": 3
+      },
+      "WithLossByOperator": {
+        "EffectViolation": 48
+      },
+      "NativeByFile": {
+        "src/FluentValidation/AssemblyScanner.cs": 7,
+        "src/FluentValidation/AsyncValidatorInvokedSynchronouslyException.cs": 1,
+        "src/FluentValidation/Internal/AccessorCache.cs": 4,
+        "src/FluentValidation/Internal/CompositeValidatorSelector.cs": 1,
+        "src/FluentValidation/Internal/DefaultValidatorSelector.cs": 1,
+        "src/FluentValidation/Internal/Extensions.cs": 2,
+        "src/FluentValidation/Internal/MemberNameValidatorSelector.cs": 3,
+        "src/FluentValidation/Internal/MessageBuilderContext.cs": 1,
+        "src/FluentValidation/Internal/MessageFormatter.cs": 4,
+        "src/FluentValidation/Internal/RuleBuilder.cs": 7,
+        "src/FluentValidation/Internal/RuleComponent.cs": 4,
+        "src/FluentValidation/Internal/RuleComponentForNullableStruct.cs": 1,
+        "src/FluentValidation/Internal/RulesetValidatorSelector.cs": 2,
+        "src/FluentValidation/Internal/TrackingCollection.cs": 4,
+        "src/FluentValidation/Internal/ValidationStrategy.cs": 11,
+        "src/FluentValidation/Resources/LanguageManager.cs": 2,
+        "src/FluentValidation/Results/ValidationFailure.cs": 1,
+        "src/FluentValidation/TestHelper/TestValidationResult.cs": 5,
+        "src/FluentValidation/ValidatorDescriptor.cs": 6,
+        "src/FluentValidation/ValidatorFactoryBase.cs": 2,
+        "src/FluentValidation/Validators/AbstractComparisonValidator.cs": 2,
+        "src/FluentValidation/Validators/AsyncPredicateValidator.cs": 2,
+        "src/FluentValidation/Validators/AsyncPropertyValidator.cs": 1,
+        "src/FluentValidation/Validators/ChildValidatorAdaptor.cs": 4,
+        "src/FluentValidation/Validators/ComparableComparer.cs": 1,
+        "src/FluentValidation/Validators/EmptyValidator.cs": 3,
+        "src/FluentValidation/Validators/EnumValidator.cs": 4,
+        "src/FluentValidation/Validators/ExclusiveBetweenValidator.cs": 1,
+        "src/FluentValidation/Validators/GreaterThanValidator.cs": 2,
+        "src/FluentValidation/Validators/LessThanValidator.cs": 2,
+        "src/FluentValidation/Validators/NotEqualValidator.cs": 5,
+        "src/FluentValidation/Validators/PropertyValidator.cs": 1,
+        "src/FluentValidation/Validators/RangeValidator.cs": 4,
+        "src/FluentValidation/Validators/RegularExpressionValidator.cs": 3,
+        "src/FluentValidation/Validators/StringEnumValidator.cs": 2
+      },
+      "WithLossOverNativeRatio": 0.4528301886792453
+    }
+  ],
+  "TotalSupplyNative": 204,
+  "TotalSupplyWithLoss": 72,
+  "TotalSupplyAll": 527,
+  "TotalSupplyLostToConversion": 251,
+  "TotalUnreadableSources": 0,
+  "ByOperator": {
+    "EffectViolation": {},
+    "NullDeref": {}
+  },
+  "DominantNumeratorOperator": {},
+  "RatioExcludingDominant": 2,
+  "PooledRatio": 0.35294117647058826,
+  "D5Verdict": "SPLIT \u2014 pooled ratio 0.35 says REJECT, but that is carried by \u0027EffectViolation\u0027 (its own ratio 0.33); excluding it the ratio is 2.00 \u2192 ACCEPT. The pre-committed threshold does not settle this; decide explicitly and record why."
+}

--- a/bench/phase0-agent-native/epochs/s1-supply-002/supply-enumeration.json
+++ b/bench/phase0-agent-native/epochs/s1-supply-002/supply-enumeration.json
@@ -5,8 +5,8 @@
       "NativeFiles": 20,
       "WithLossFiles": 5,
       "UnconvertedFiles": 7,
-      "SupplyTotal": 48,
-      "SupplyLostToConversion": 41,
+      "SupplyTotal": 46,
+      "SupplyLostToConversion": 39,
       "UnreadableSources": 0,
       "SupplyNative": 5,
       "SupplyWithLoss": 2,
@@ -29,16 +29,16 @@
       "NativeFiles": 72,
       "WithLossFiles": 17,
       "UnconvertedFiles": 21,
-      "SupplyTotal": 181,
-      "SupplyLostToConversion": 66,
+      "SupplyTotal": 177,
+      "SupplyLostToConversion": 65,
       "UnreadableSources": 0,
       "SupplyNative": 93,
-      "SupplyWithLoss": 22,
+      "SupplyWithLoss": 19,
       "NativeByOperator": {
         "EffectViolation": 93
       },
       "WithLossByOperator": {
-        "EffectViolation": 16,
+        "EffectViolation": 13,
         "NullDeref": 6
       },
       "NativeByFile": {
@@ -72,20 +72,20 @@
         "src/Serilog/Rendering/Casing.cs": 1,
         "src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs": 10
       },
-      "WithLossOverNativeRatio": 0.23655913978494625
+      "WithLossOverNativeRatio": 0.20430107526881722
     },
     {
       "ProjectName": "FluentValidation",
       "NativeFiles": 109,
       "WithLossFiles": 4,
       "UnconvertedFiles": 26,
-      "SupplyTotal": 298,
-      "SupplyLostToConversion": 144,
+      "SupplyTotal": 296,
+      "SupplyLostToConversion": 143,
       "UnreadableSources": 0,
-      "SupplyNative": 106,
+      "SupplyNative": 105,
       "SupplyWithLoss": 48,
       "NativeByOperator": {
-        "EffectViolation": 103,
+        "EffectViolation": 102,
         "NullDeref": 3
       },
       "WithLossByOperator": {
@@ -97,7 +97,7 @@
         "src/FluentValidation/Internal/AccessorCache.cs": 4,
         "src/FluentValidation/Internal/CompositeValidatorSelector.cs": 1,
         "src/FluentValidation/Internal/DefaultValidatorSelector.cs": 1,
-        "src/FluentValidation/Internal/Extensions.cs": 2,
+        "src/FluentValidation/Internal/Extensions.cs": 1,
         "src/FluentValidation/Internal/MemberNameValidatorSelector.cs": 3,
         "src/FluentValidation/Internal/MessageBuilderContext.cs": 1,
         "src/FluentValidation/Internal/MessageFormatter.cs": 4,
@@ -128,13 +128,13 @@
         "src/FluentValidation/Validators/RegularExpressionValidator.cs": 3,
         "src/FluentValidation/Validators/StringEnumValidator.cs": 2
       },
-      "WithLossOverNativeRatio": 0.4528301886792453
+      "WithLossOverNativeRatio": 0.45714285714285713
     }
   ],
-  "TotalSupplyNative": 204,
-  "TotalSupplyWithLoss": 72,
-  "TotalSupplyAll": 527,
-  "TotalSupplyLostToConversion": 251,
+  "TotalSupplyNative": 203,
+  "TotalSupplyWithLoss": 69,
+  "TotalSupplyAll": 519,
+  "TotalSupplyLostToConversion": 247,
   "TotalUnreadableSources": 0,
   "ByOperator": {
     "EffectViolation": {},
@@ -142,6 +142,6 @@
   },
   "DominantNumeratorOperator": {},
   "RatioExcludingDominant": 2,
-  "PooledRatio": 0.35294117647058826,
-  "D5Verdict": "SPLIT \u2014 pooled ratio 0.35 says REJECT, but that is carried by \u0027EffectViolation\u0027 (its own ratio 0.33); excluding it the ratio is 2.00 \u2192 ACCEPT. The pre-committed threshold does not settle this; decide explicitly and record why."
+  "PooledRatio": 0.3399014778325123,
+  "D5Verdict": "SPLIT \u2014 pooled ratio 0.34 says REJECT, but that is carried by \u0027EffectViolation\u0027 (its own ratio 0.32); excluding it the ratio is 2.00 \u2192 ACCEPT. The pre-committed threshold does not settle this; decide explicitly and record why."
 }

--- a/bench/phase0-agent-native/epochs/s1-supply-002/supply-enumeration.md
+++ b/bench/phase0-agent-native/epochs/s1-supply-002/supply-enumeration.md
@@ -1,0 +1,147 @@
+# v0.12 S1 — expressible-stratum supply enumeration (pre-pass)
+
+**Conversion-only.** No builds, no test runs, no recovery, no bundles, and no
+eligibility evaluation — which is what permits this to run *before* the A-1.5 freeze
+(plan §3 constraint (a)).
+
+**Upper bound, not realized supply.** Build and `RecoverBuildAsync` are skipped, so a
+file that converted but does not compile is still counted native here — recovery is
+precisely what would revert it. Every later eligibility clause only removes candidates,
+so these figures bound eligibility from above. That is the correct direction for a
+"is there conceivably enough supply?" go/no-go, and the wrong number to quote as supply.
+
+## Supply by project
+
+| Project | Sites (all) | Lost to conversion | Supply (native) | Supply (with-loss) | with-loss / native |
+|---|---:|---:|---:|---:|---:|
+| MediatR | 48 | 41 | **5** | 2 | 0.40 |
+| Serilog | 181 | 66 | **93** | 22 | 0.24 |
+| FluentValidation | 298 | 144 | **106** | 48 | 0.45 |
+| **TOTAL** | **527** | 251 | **204** | 72 | 0.35 |
+
+**Read the first two columns before the third.** "Sites (all)" is the corpus-side
+supply the frozen operator set can enumerate anywhere; "lost to conversion" is the part
+the converter could not reach. A low native figure with a high lost figure is a
+**converter-fidelity** result, not a corpus result — opposite remedies. Any downstream
+use of the native number as "the corpus's supply ceiling" must account for both.
+
+## D-5 — region-granularity clause (a)
+
+Pre-committed rule (S1 kickoff): accept site-level clause (a) iff with-loss/native ≥ 0.50.
+
+**SPLIT — pooled ratio 0.35 says REJECT, but that is carried by 'EffectViolation' (its own ratio 0.33); excluding it the ratio is 2.00 → ACCEPT. The pre-committed threshold does not settle this; decide explicitly and record why.**
+
+Per-project ratios are in the table above; a pooled figure must not conceal a split.
+
+Per-operator, because a pooled ratio can be carried by a single operator:
+
+| Operator | With-loss | Native | ratio |
+|---|---:|---:|---:|
+| EffectViolation | 66 | 201 | 0.33 |
+| NullDeref | 6 | 3 | 2.00 |
+
+## Candidates by operator
+
+### MediatR
+
+| Operator | Native | With-loss |
+|---|---:|---:|
+| EffectViolation | 5 | 2 |
+
+### Serilog
+
+| Operator | Native | With-loss |
+|---|---:|---:|
+| EffectViolation | 93 | 16 |
+| NullDeref | 0 | 6 |
+
+### FluentValidation
+
+| Operator | Native | With-loss |
+|---|---:|---:|
+| EffectViolation | 103 | 48 |
+| NullDeref | 3 | 0 |
+
+## Clustering (native candidates by file)
+
+The probe's `--max-candidates` cap takes a **lexicographic prefix**, not a sample, so
+candidates concentrated in few files mean the probe's effective *n* is far below its
+nominal *n* (S1 kickoff D-3). This table is what makes that visible before the probe runs.
+
+### MediatR — 4 native file(s) carrying candidates
+
+- `src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs` — 2
+- `src/MediatR/INotificationHandler.cs` — 1
+- `src/MediatR/NotificationPublishers/TaskWhenAllPublisher.cs` — 1
+- `src/MediatR/Wrappers/NotificationHandlerWrapper.cs` — 1
+
+### Serilog — 29 native file(s) carrying candidates
+
+- `src/Serilog/Configuration/LoggerSinkConfiguration.cs` — 13
+- `src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs` — 10
+- `src/Serilog/Configuration/LoggerDestructuringConfiguration.cs` — 9
+- `src/Serilog/Context/LogContext.cs` — 8
+- `src/Serilog/Configuration/LoggerEnrichmentConfiguration.cs` — 7
+- `src/Serilog/Data/LogEventPropertyValueRewriter.cs` — 5
+- `src/Serilog/Configuration/LoggerAuditSinkConfiguration.cs` — 4
+- `src/Serilog/Configuration/LoggerFilterConfiguration.cs` — 4
+- `src/Serilog/Core/Pipeline/ByReferenceStringComparer.cs` — 4
+- `src/Serilog/Capturing/DepthLimiter.cs` — 3
+- `src/Serilog/Configuration/LoggerSettingsConfiguration.cs` — 3
+- `src/Serilog/Events/EventProperty.cs` — 3
+- `src/Serilog/Formatting/Display/LevelOutputFormat.cs` — 3
+- `src/Serilog/Events/MessageTemplate.cs` — 2
+- `src/Serilog/Context/EnricherStack.cs` — 1
+- `src/Serilog/Core/Filters/DelegateFilter.cs` — 1
+- `src/Serilog/Core/Pipeline/MessageTemplateCache.cs` — 1
+- `src/Serilog/Data/LogEventPropertyValueVisitor.cs` — 1
+- `src/Serilog/Events/LogEventPropertyValue.cs` — 1
+- `src/Serilog/Guard.cs` — 1
+- `src/Serilog/LoggerExtensions.cs` — 1
+- `src/Serilog/Parsing/TextToken.cs` — 1
+- `src/Serilog/Policies/DelegateDestructuringPolicy.cs` — 1
+- `src/Serilog/Policies/EnumScalarConversionPolicy.cs` — 1
+- `src/Serilog/Policies/PrimitiveScalarConversionPolicy.cs` — 1
+- `src/Serilog/Policies/ProjectedDestructuringPolicy.cs` — 1
+- `src/Serilog/Policies/ReflectionTypesScalarDestructuringPolicy.cs` — 1
+- `src/Serilog/Policies/SimpleScalarConversionPolicy.cs` — 1
+- `src/Serilog/Rendering/Casing.cs` — 1
+
+### FluentValidation — 35 native file(s) carrying candidates
+
+- `src/FluentValidation/Internal/ValidationStrategy.cs` — 11
+- `src/FluentValidation/AssemblyScanner.cs` — 7
+- `src/FluentValidation/Internal/RuleBuilder.cs` — 7
+- `src/FluentValidation/ValidatorDescriptor.cs` — 6
+- `src/FluentValidation/TestHelper/TestValidationResult.cs` — 5
+- `src/FluentValidation/Validators/NotEqualValidator.cs` — 5
+- `src/FluentValidation/Internal/AccessorCache.cs` — 4
+- `src/FluentValidation/Internal/MessageFormatter.cs` — 4
+- `src/FluentValidation/Internal/RuleComponent.cs` — 4
+- `src/FluentValidation/Internal/TrackingCollection.cs` — 4
+- `src/FluentValidation/Validators/ChildValidatorAdaptor.cs` — 4
+- `src/FluentValidation/Validators/EnumValidator.cs` — 4
+- `src/FluentValidation/Validators/RangeValidator.cs` — 4
+- `src/FluentValidation/Internal/MemberNameValidatorSelector.cs` — 3
+- `src/FluentValidation/Validators/EmptyValidator.cs` — 3
+- `src/FluentValidation/Validators/RegularExpressionValidator.cs` — 3
+- `src/FluentValidation/Internal/Extensions.cs` — 2
+- `src/FluentValidation/Internal/RulesetValidatorSelector.cs` — 2
+- `src/FluentValidation/Resources/LanguageManager.cs` — 2
+- `src/FluentValidation/ValidatorFactoryBase.cs` — 2
+- `src/FluentValidation/Validators/AbstractComparisonValidator.cs` — 2
+- `src/FluentValidation/Validators/AsyncPredicateValidator.cs` — 2
+- `src/FluentValidation/Validators/GreaterThanValidator.cs` — 2
+- `src/FluentValidation/Validators/LessThanValidator.cs` — 2
+- `src/FluentValidation/Validators/StringEnumValidator.cs` — 2
+- `src/FluentValidation/AsyncValidatorInvokedSynchronouslyException.cs` — 1
+- `src/FluentValidation/Internal/CompositeValidatorSelector.cs` — 1
+- `src/FluentValidation/Internal/DefaultValidatorSelector.cs` — 1
+- `src/FluentValidation/Internal/MessageBuilderContext.cs` — 1
+- `src/FluentValidation/Internal/RuleComponentForNullableStruct.cs` — 1
+- `src/FluentValidation/Results/ValidationFailure.cs` — 1
+- `src/FluentValidation/Validators/AsyncPropertyValidator.cs` — 1
+- `src/FluentValidation/Validators/ComparableComparer.cs` — 1
+- `src/FluentValidation/Validators/ExclusiveBetweenValidator.cs` — 1
+- `src/FluentValidation/Validators/PropertyValidator.cs` — 1
+

--- a/bench/phase0-agent-native/epochs/s1-supply-002/supply-enumeration.md
+++ b/bench/phase0-agent-native/epochs/s1-supply-002/supply-enumeration.md
@@ -14,10 +14,10 @@ so these figures bound eligibility from above. That is the correct direction for
 
 | Project | Sites (all) | Lost to conversion | Supply (native) | Supply (with-loss) | with-loss / native |
 |---|---:|---:|---:|---:|---:|
-| MediatR | 48 | 41 | **5** | 2 | 0.40 |
-| Serilog | 181 | 66 | **93** | 22 | 0.24 |
-| FluentValidation | 298 | 144 | **106** | 48 | 0.45 |
-| **TOTAL** | **527** | 251 | **204** | 72 | 0.35 |
+| MediatR | 46 | 39 | **5** | 2 | 0.40 |
+| Serilog | 177 | 65 | **93** | 19 | 0.20 |
+| FluentValidation | 296 | 143 | **105** | 48 | 0.46 |
+| **TOTAL** | **519** | 247 | **203** | 69 | 0.34 |
 
 **Read the first two columns before the third.** "Sites (all)" is the corpus-side
 supply the frozen operator set can enumerate anywhere; "lost to conversion" is the part
@@ -29,7 +29,7 @@ use of the native number as "the corpus's supply ceiling" must account for both.
 
 Pre-committed rule (S1 kickoff): accept site-level clause (a) iff with-loss/native ≥ 0.50.
 
-**SPLIT — pooled ratio 0.35 says REJECT, but that is carried by 'EffectViolation' (its own ratio 0.33); excluding it the ratio is 2.00 → ACCEPT. The pre-committed threshold does not settle this; decide explicitly and record why.**
+**SPLIT — pooled ratio 0.34 says REJECT, but that is carried by 'EffectViolation' (its own ratio 0.32); excluding it the ratio is 2.00 → ACCEPT. The pre-committed threshold does not settle this; decide explicitly and record why.**
 
 Per-project ratios are in the table above; a pooled figure must not conceal a split.
 
@@ -37,7 +37,7 @@ Per-operator, because a pooled ratio can be carried by a single operator:
 
 | Operator | With-loss | Native | ratio |
 |---|---:|---:|---:|
-| EffectViolation | 66 | 201 | 0.33 |
+| EffectViolation | 63 | 200 | 0.32 |
 | NullDeref | 6 | 3 | 2.00 |
 
 ## Candidates by operator
@@ -52,14 +52,14 @@ Per-operator, because a pooled ratio can be carried by a single operator:
 
 | Operator | Native | With-loss |
 |---|---:|---:|
-| EffectViolation | 93 | 16 |
+| EffectViolation | 93 | 13 |
 | NullDeref | 0 | 6 |
 
 ### FluentValidation
 
 | Operator | Native | With-loss |
 |---|---:|---:|
-| EffectViolation | 103 | 48 |
+| EffectViolation | 102 | 48 |
 | NullDeref | 3 | 0 |
 
 ## Clustering (native candidates by file)
@@ -125,7 +125,6 @@ nominal *n* (S1 kickoff D-3). This table is what makes that visible before the p
 - `src/FluentValidation/Internal/MemberNameValidatorSelector.cs` — 3
 - `src/FluentValidation/Validators/EmptyValidator.cs` — 3
 - `src/FluentValidation/Validators/RegularExpressionValidator.cs` — 3
-- `src/FluentValidation/Internal/Extensions.cs` — 2
 - `src/FluentValidation/Internal/RulesetValidatorSelector.cs` — 2
 - `src/FluentValidation/Resources/LanguageManager.cs` — 2
 - `src/FluentValidation/ValidatorFactoryBase.cs` — 2
@@ -137,6 +136,7 @@ nominal *n* (S1 kickoff D-3). This table is what makes that visible before the p
 - `src/FluentValidation/AsyncValidatorInvokedSynchronouslyException.cs` — 1
 - `src/FluentValidation/Internal/CompositeValidatorSelector.cs` — 1
 - `src/FluentValidation/Internal/DefaultValidatorSelector.cs` — 1
+- `src/FluentValidation/Internal/Extensions.cs` — 1
 - `src/FluentValidation/Internal/MessageBuilderContext.cs` — 1
 - `src/FluentValidation/Internal/RuleComponentForNullableStruct.cs` — 1
 - `src/FluentValidation/Results/ValidationFailure.cs` — 1

--- a/bench/phase0-agent-native/epochs/ws5-probe-001.driver.log
+++ b/bench/phase0-agent-native/epochs/ws5-probe-001.driver.log
@@ -1,0 +1,97 @@
+=== W5A-001-report-audit / csharp ===
+{"pair":"W5A-001-report-audit","arm":"csharp","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5A-001-report-audit","arm":"csharp","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5A-001-report-audit","arm":"csharp","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+=== W5A-001-report-audit / calor ===
+{"pair":"W5A-001-report-audit","arm":"calor","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5A-001-report-audit","arm":"calor","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5A-001-report-audit","arm":"calor","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+=== W5A-002-inventory-log / csharp ===
+{"pair":"W5A-002-inventory-log","arm":"csharp","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5A-002-inventory-log","arm":"csharp","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5A-002-inventory-log","arm":"csharp","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+=== W5A-002-inventory-log / calor ===
+{"pair":"W5A-002-inventory-log","arm":"calor","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":2,"censored":false}
+{"pair":"W5A-002-inventory-log","arm":"calor","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":3,"censored":false}
+{"pair":"W5A-002-inventory-log","arm":"calor","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":2,"censored":false}
+=== W5A-003-config-echo / csharp ===
+{"pair":"W5A-003-config-echo","arm":"csharp","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5A-003-config-echo","arm":"csharp","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5A-003-config-echo","arm":"csharp","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+=== W5A-003-config-echo / calor ===
+{"pair":"W5A-003-config-echo","arm":"calor","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":3,"censored":false}
+{"pair":"W5A-003-config-echo","arm":"calor","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":3,"censored":false}
+{"pair":"W5A-003-config-echo","arm":"calor","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":2,"censored":false}
+=== W5B-001-shipping-quote / csharp ===
+{"pair":"W5B-001-shipping-quote","arm":"csharp","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5B-001-shipping-quote","arm":"csharp","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5B-001-shipping-quote","arm":"csharp","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+=== W5B-001-shipping-quote / calor ===
+{"pair":"W5B-001-shipping-quote","arm":"calor","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5B-001-shipping-quote","arm":"calor","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5B-001-shipping-quote","arm":"calor","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+=== W5B-002-loyalty-points / csharp ===
+{"pair":"W5B-002-loyalty-points","arm":"csharp","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5B-002-loyalty-points","arm":"csharp","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5B-002-loyalty-points","arm":"csharp","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+=== W5B-002-loyalty-points / calor ===
+{"pair":"W5B-002-loyalty-points","arm":"calor","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5B-002-loyalty-points","arm":"calor","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5B-002-loyalty-points","arm":"calor","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+=== W5B-003-request-quota / csharp ===
+{"pair":"W5B-003-request-quota","arm":"csharp","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5B-003-request-quota","arm":"csharp","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5B-003-request-quota","arm":"csharp","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+=== W5B-003-request-quota / calor ===
+{"pair":"W5B-003-request-quota","arm":"calor","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+INVALID run detected (pair=W5B-003-request-quota arm=calor run=2 attempt=0): agent output matches error marker: "api error"
+{"pair":"W5B-003-request-quota","arm":"calor","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5B-003-request-quota","arm":"calor","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+=== W5C-001-catalog-cache / csharp ===
+{"pair":"W5C-001-catalog-cache","arm":"csharp","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5C-001-catalog-cache","arm":"csharp","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5C-001-catalog-cache","arm":"csharp","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+=== W5C-001-catalog-cache / calor ===
+{"pair":"W5C-001-catalog-cache","arm":"calor","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+watchdog: agent exceeded 600s; killing pid 17385 and descendants
+INVALID run detected (pair=W5C-001-catalog-cache arm=calor run=2 attempt=0): agent.json missing or empty
+watchdog: agent exceeded 600s; killing pid 17964 and descendants
+INVALID run detected (pair=W5C-001-catalog-cache arm=calor run=2 attempt=1): agent output matches error marker: "api error"
+{"pair":"W5C-001-catalog-cache","arm":"calor","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":3,"censored":false}
+{"pair":"W5C-001-catalog-cache","arm":"calor","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+=== W5C-002-ledger-view / csharp ===
+{"pair":"W5C-002-ledger-view","arm":"csharp","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5C-002-ledger-view","arm":"csharp","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5C-002-ledger-view","arm":"csharp","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+=== W5C-002-ledger-view / calor ===
+INVALID run detected (pair=W5C-002-ledger-view arm=calor run=1 attempt=0): agent output matches error marker: "api error"
+INVALID run detected (pair=W5C-002-ledger-view arm=calor run=1 attempt=1): agent output matches error marker: "api error"
+{"pair":"W5C-002-ledger-view","arm":"calor","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5C-002-ledger-view","arm":"calor","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":3,"censored":false}
+{"pair":"W5C-002-ledger-view","arm":"calor","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+=== W5C-003-session-index / csharp ===
+{"pair":"W5C-003-session-index","arm":"csharp","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+{"pair":"W5C-003-session-index","arm":"csharp","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+INVALID run detected (pair=W5C-003-session-index arm=csharp run=3 attempt=0): agent output matches error marker: "api error"
+{"pair":"W5C-003-session-index","arm":"csharp","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":1,"censored":false}
+=== W5C-003-session-index / calor ===
+{"pair":"W5C-003-session-index","arm":"calor","run":1,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":3,"censored":false}
+{"pair":"W5C-003-session-index","arm":"calor","run":2,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":2,"censored":false}
+{"pair":"W5C-003-session-index","arm":"calor","run":3,"taskSuccess":true,"escapedBugs":0,"iterationsToGreen":2,"censored":false}
+--- rollup ---
+[
+  {
+    "arm": "calor",
+    "runs": 27,
+    "successRate": 1,
+    "meanEscaped": 0,
+    "censoredFraction": 0
+  },
+  {
+    "arm": "csharp",
+    "runs": 27,
+    "successRate": 1,
+    "meanEscaped": 0,
+    "censoredFraction": 0
+  }
+]

--- a/tests/Calor.RoundTrip.Harness.Tests/SupplyEnumerationTests.cs
+++ b/tests/Calor.RoundTrip.Harness.Tests/SupplyEnumerationTests.cs
@@ -190,13 +190,14 @@ public class SupplyEnumerationTests
         namespace S;
         public class C
         {
-            public string Use(string? s)
+            // void return: after the D-S0.5.2 widening a value-returning method here would ALSO yield an
+            // EffectViolation candidate, which would make this fixture exercise two operators at once.
+            public void Use(string? s)
             {
                 if (s != null)
                 {
-                    return s.Trim();
+                    System.Console.WriteLine(s.Trim());
                 }
-                return "";
             }
         }
         """;
@@ -223,7 +224,7 @@ public class SupplyEnumerationTests
     // than something a reviewer has to rediscover with an out-of-tree probe.
     [InlineData("public int F() => _n + 1;", "expression-bodied methods are not visited")]
     [InlineData("public int P { get { return _n; } }", "property getters are not visited")]
-    [InlineData("public string F() { System.Console.WriteLine(\"x\"); return \"s\"; }", "non-int/long return types are out of scope")]
+    [InlineData("public void F() { System.Console.WriteLine(\"x\"); }", "void has no return value to corrupt")]
     public async Task Site_predicate_boundaries_yield_no_candidates(string member, string why)
     {
         var source = $$"""

--- a/tests/Calor.RoundTrip.Harness.Tests/TaskGenExpressibleTests.cs
+++ b/tests/Calor.RoundTrip.Harness.Tests/TaskGenExpressibleTests.cs
@@ -61,8 +61,12 @@ public class TaskGenExpressibleTests
     }
 
     [Fact]
-    public void EffectViolation_SkipsMethodsNotReturningIntOrLong()
+    public void EffectViolation_CoversNonNumericReturns_AfterTheD_S0_5_2_Widening()
     {
+        // Pre-widening this asserted that string/bool/void ALL yielded nothing, because the corruption
+        // was arithmetic. The int/long restriction was never about addressability — the using-nested
+        // Directory.* effect fires Calor0410 regardless of return type — so D-S0.5.2 widened the
+        // CORRUPTION and the site universe followed. string and bool are now in scope.
         const string src = """
             namespace S;
             public class C
@@ -70,6 +74,32 @@ public class TaskGenExpressibleTests
                 public string Name() { return "x"; }
                 public bool Ok() { return true; }
                 public void Go() { }
+            }
+            """;
+        var cands = ExpressibleMutationOperators.Enumerate(src, "C.cs")
+            .Where(c => c.Operator == MutationOperatorKind.EffectViolation).ToList();
+
+        Assert.Equal(2, cands.Count);                                  // Name + Ok; Go has nothing to corrupt
+        Assert.All(cands, c => Assert.Equal("Calor0410", c.ExpectedCheck));
+        Assert.Contains(cands, c => c.MutatedSource.Contains("default(string)!"));
+        Assert.Contains(cands, c => c.MutatedSource.Contains("^ (__calorTaint == 1)"));
+    }
+
+    [Fact]
+    public void EffectViolation_StillExcludesReturnsItCannotCorruptSoundly()
+    {
+        // The exclusions that remain after the widening, each because the corruption would not compile
+        // or would not be a single deterministic point. async is the subtle one: the declared type is
+        // Task<T> but `return` yields T, so default(Task<T>) is a type error in that position.
+        const string src = """
+            using System.Threading.Tasks;
+            namespace S;
+            public class C
+            {
+                public void Go() { }
+                public async Task<int> LaterAsync() { await Task.Yield(); return 1; }
+                private int _f;
+                public ref int Ref() { return ref _f; }
             }
             """;
         var cands = ExpressibleMutationOperators.Enumerate(src, "C.cs");

--- a/tests/Calor.RoundTrip.Harness.Tests/TaskGenExpressibleTests.cs
+++ b/tests/Calor.RoundTrip.Harness.Tests/TaskGenExpressibleTests.cs
@@ -1,4 +1,5 @@
 using Calor.RoundTrip.Harness.TaskGen;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
@@ -83,6 +84,75 @@ public class TaskGenExpressibleTests
         Assert.All(cands, c => Assert.Equal("Calor0410", c.ExpectedCheck));
         Assert.Contains(cands, c => c.MutatedSource.Contains("default(string)!"));
         Assert.Contains(cands, c => c.MutatedSource.Contains("^ (__calorTaint == 1)"));
+    }
+
+    [Fact]
+    public void EffectViolation_MutatedSource_is_always_parseable()
+    {
+        // Regression: the injected block carried no trailing newline, so a following #pragma/#if
+        // directive landed mid-line and the mutated file no longer parsed (CS1040). Four real corpus
+        // candidates were affected. A pre-pass that counts unparseable candidates reports supply that
+        // can never become tasks — and that number feeds a venue-retirement decision.
+        const string src = """
+            namespace S;
+            public class C
+            {
+                public string F(int k)
+                {
+            #pragma warning disable 618
+                    var v = k.ToString();
+            #pragma warning restore 618
+                    return v;
+                }
+            }
+            """;
+
+        var cands = ExpressibleMutationOperators.Enumerate(src, "C.cs");
+        Assert.NotEmpty(cands);
+        foreach (var c in cands)
+            Assert.DoesNotContain(CSharpSyntaxTree.ParseText(c.MutatedSource).GetDiagnostics(),
+                d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void EffectViolation_SkipsReturnsThatDefaultCannotDifferFrom()
+    {
+        // `return null;` corrupted to `taint == 1 ? default(T)! : null` injects NO defect, because
+        // default(T) IS null. Counting it would overstate supply by a candidate that can never fail a
+        // held-out test.
+        const string src = """
+            namespace S;
+            public class C
+            {
+                public string? Nothing() { return null; }
+                public int Zero() { return 0; }
+            }
+            """;
+        var cands = ExpressibleMutationOperators.Enumerate(src, "C.cs")
+            .Where(c => c.Operator == MutationOperatorKind.EffectViolation).ToList();
+
+        Assert.DoesNotContain(cands, c => c.OperatorDescription.Contains("Nothing"));
+    }
+
+    [Fact]
+    public void EffectViolation_SkipsTypesThatShadowTheSystemNamespace()
+    {
+        // Serilog's TimeProvider declares `public static TimeProvider System { get; }`, which shadows
+        // the namespace for simple-name lookup and made the injected `System.IO.Directory` fail to
+        // resolve (CS1061). The fix is to SKIP such sites, not to qualify as `global::` — qualifying
+        // compiles but the converter's §E-inference stops recognising the call, so Calor0410 no longer
+        // fires and EVERY candidate loses addressability. Trading the whole mechanism for one site is
+        // the wrong trade; this test pins the choice.
+        const string src = """
+            namespace S;
+            public class TimeProvider
+            {
+                public static TimeProvider System { get; } = new();
+                public string Now() { return "t"; }
+            }
+            """;
+        var cands = ExpressibleMutationOperators.Enumerate(src, "C.cs");
+        Assert.DoesNotContain(cands, c => c.Operator == MutationOperatorKind.EffectViolation);
     }
 
     [Fact]

--- a/tools/Calor.RoundTrip.Harness/TaskGen/ExpressibleMutationOperators.cs
+++ b/tools/Calor.RoundTrip.Harness/TaskGen/ExpressibleMutationOperators.cs
@@ -30,7 +30,7 @@ public static class ExpressibleMutationOperators
 
     // The DETERMINISTIC, guaranteed-nonzero effectful corruptor. `Directory.Exists(GetCurrentDirectory())`
     // is always true (a process's current directory always exists) on every platform, so the taint value
-    // is a fixed 1 — the return is corrupted by exactly +1, IDENTICALLY across runs and across both arms
+    // is a fixed 1 — the return is corrupted deterministically, IDENTICALLY across runs and across both arms
     // (no Random() nondeterminism → no test-isolation flakiness → clause (b) sees an identical failure).
     // Both Directory.* calls are filesystem effects charged by enforcement; nested in a `using` body — the
     // converter's §E-inference walker's blind spot — they are left out of the converted §E, so the effect
@@ -78,30 +78,48 @@ public static class ExpressibleMutationOperators
 
     /// <summary>
     /// Inject an undeclared filesystem effect that DETERMINISTICALLY corrupts the return of any method
-    /// (instance OR static) returning an int/long. Into the first return the method owns, it injects a
-    /// <c>using</c>-nested effectful read whose fixed value (1) is added to the returned expression:
+    /// (instance OR static) whose return type the corruption can be expressed for
+    /// (<see cref="IsCorruptibleReturn"/>). Into the first return the method owns, it injects a
+    /// <c>using</c>-nested effectful read whose fixed value (1) drives the corruption:
     /// <code>
     ///   int __calorTaint = 0;
     ///   using (var __calorSink = new System.IO.StringWriter())
     ///   { __calorTaint = (System.IO.Directory.Exists(System.IO.Directory.GetCurrentDirectory()) ? 1 : 0); }
-    ///   return (ORIGINAL) + __calorTaint;
+    ///   return (ORIGINAL) + __calorTaint;              // int/long
+    ///   return (ORIGINAL) ^ (__calorTaint == 1);       // bool
+    ///   return __calorTaint == 1 ? default(T)! : (ORIGINAL);   // everything else
     /// </code>
     /// Two things happen at once:
-    ///   • <b>Real, DETERMINISTIC defect:</b> the taint is a fixed +1 (the current directory always
-    ///     exists), so the method returns <c>ORIGINAL + 1</c> — a value-asserting held-out test fails
+    ///   • <b>Real, DETERMINISTIC defect:</b> the taint is a fixed 1 (the current directory always
+    ///     exists), so the method returns a corrupted value — a value-asserting held-out test fails
     ///     IDENTICALLY on both arms and across every run (no <c>Random()</c> nondeterminism).
     ///   • <b>Verification-addressable:</b> the <c>Directory.*</c> filesystem effect sits inside a
     ///     <c>using</c> body — the converter's §E-inference walker's blind spot (it has no lock/using
     ///     case) — so the converted §E stays pure while the enforcement pass charges the <c>fs</c>
     ///     effect. computed ⊄ declared → <c>Calor0410</c>, a build signal the C# arm never sees.
     ///
-    /// Site requirement widened (per the dry-run supply finding) from "a writable field" to "ANY method
-    /// returning a computed int/long", so the operator has native supply on real code without needing a
-    /// mutable numeric field. The corruption is INTRINSIC to the effect (the taint local is written only
-    /// by the effectful call), so the papering-over residual is genuine: REMOVING the injected block
-    /// removes both the effect and the +1 (correct → held-out passes → caught); DECLARING <c>fs</c> in §E
-    /// silences Calor0410 but the +1 still ships (papers over → held-out fails → escaped). Both remain
-    /// possible; which path the agent takes IS the measurement.
+    /// <para><b>Site requirement, widened twice.</b> First (dry-run supply finding) from "a writable
+    /// field" to "any method returning a computed int/long". Then (D-S0.5.2) beyond int/long entirely,
+    /// by generalizing the CORRUPTION — see <see cref="IsCorruptibleReturn"/>. The int/long restriction
+    /// was never about addressability; it existed only because the corruption was arithmetic. Measured
+    /// effect of the second widening on the pinned corpus: native supply 9 → 204.</para>
+    ///
+    /// <para><b>The corruption is INTRINSIC to the effect</b> — the taint local is written only by the
+    /// effectful call — so the papering-over residual is genuine: REMOVING the injected block removes
+    /// both the effect and the corruption (correct → held-out passes → caught); DECLARING <c>fs</c> in
+    /// §E silences Calor0410 but the corruption still ships (papers over → held-out fails → escaped).
+    /// Both remain possible; which path the agent takes IS the measurement.</para>
+    ///
+    /// <para><b>The three corruption forms are NOT equivalent, and the difference matters downstream.</b>
+    /// <c>AddOne</c> and <c>FlipBool</c> both still evaluate the original expression and perturb its
+    /// value. <c>DefaultWhenTainted</c> does not: the taint is always 1 by construction, so the
+    /// <c>ORIGINAL</c> branch of the conditional is dead in every execution and the method returns
+    /// <c>default(T)</c> without computing anything. On the pinned corpus a majority of that form's
+    /// sites elide a call. That is a real defect and a deterministic one, but it is a different defect
+    /// CLASS from an off-by-one — it propagates as a null/zero at a distance rather than a wrong value
+    /// at the mutation site, which is a plausible source of <c>ArmsDiverge</c> and of converter-attributed
+    /// failures. Any comparison of supply across the widening is a comparison of operator reach, not of
+    /// one experiment's subject count.</para>
     /// </summary>
     private static void EnumerateEffectViolations(string rel, SyntaxNode root, List<MutationCandidate> acc)
     {
@@ -116,8 +134,24 @@ public static class ExpressibleMutationOperators
                 .FirstOrDefault(r => r.Expression != null && OwningFunction(r) == method);
             if (ownedReturn?.Expression is not { } origExpr) continue;
 
+            // `return null;` corrupted to `taint == 1 ? default(T)! : null` injects NO defect —
+            // default(T) IS null. Counting it as supply overstates the number by candidates that can
+            // never fail a held-out test. (Downstream NoObservableDefect would drop it, but a
+            // pre-pass that only enumerates never gets there.)
+            if (corruptionKind == CorruptionKind.DefaultWhenTainted && IsDefaultValued(origExpr)) continue;
+
             var corruptedReturn = ownedReturn.WithExpression(
                 SyntaxFactory.ParseExpression(CorruptionExpression(corruptionKind, origExpr, method.ReturnType)));
+
+            // The injected effect MUST be spelled `System.IO.Directory.…`. Qualifying it as
+            // `global::System.IO.…` compiles more widely but the converter's §E-inference no longer
+            // recognises the call, so Calor0410 stops firing and the candidate stops being
+            // addressable — i.e. it fixes a compile error by silently destroying the mechanism under
+            // measurement. Verified: EffectViolation_IsAddressable_Calor0410_IntroducedByTheMutation
+            // fails under `global::`. So instead of qualifying, SKIP the sites where the spelling
+            // cannot bind: a type that declares its own member named `System` shadows the namespace
+            // (Serilog's TimeProvider has `public static TimeProvider System { get; }` → CS1061).
+            if (ShadowsSystemNamespace(method)) continue;
 
             var taintStmts = SyntaxFactory.ParseStatement(
                     $"{{ int {TaintLocal} = 0; using (var {TaintSink} = new System.IO.StringWriter()) "
@@ -125,9 +159,23 @@ public static class ExpressibleMutationOperators
                 is BlockSyntax b ? b.Statements : default;
             if (taintStmts.Count == 0) continue;
 
+            // An elastic newline after the injection: without it the FOLLOWING statement's leading
+            // trivia — a `#pragma`/`#if` directive — lands mid-line and the file no longer parses (CS1040).
+            taintStmts = SyntaxFactory.List(taintStmts.Select((st, i) =>
+                i == taintStmts.Count - 1
+                    ? st.WithTrailingTrivia(st.GetTrailingTrivia().Add(SyntaxFactory.ElasticCarriageReturnLineFeed))
+                    : st));
+
             var bodyWithReturn = body.ReplaceNode(ownedReturn, corruptedReturn);
             var newBody = bodyWithReturn.WithStatements(bodyWithReturn.Statements.InsertRange(0, taintStmts));
             var mutatedRoot = root.ReplaceNode(body, newBody);
+
+            // Fail closed: a candidate whose mutated source does not PARSE is not a candidate. Without
+            // this the pre-pass counts sites that can never become tasks, and the supply number — which
+            // feeds a venue-retirement decision — is true only by luck.
+            if (CSharpSyntaxTree.ParseText(mutatedRoot.ToFullString()).GetDiagnostics()
+                    .Any(d => d.Severity == DiagnosticSeverity.Error))
+                continue;
 
             var pos = method.Identifier.GetLocation().GetLineSpan().StartLinePosition;
             acc.Add(new MutationCandidate
@@ -224,6 +272,36 @@ public static class ExpressibleMutationOperators
         CorruptionKind.AddOne => $"({orig}) + {TaintLocal}",
         CorruptionKind.FlipBool => $"({orig}) ^ ({TaintLocal} == 1)",
         _ => $"({TaintLocal} == 1 ? default({returnType})! : ({orig}))",
+    };
+
+    /// <summary>
+    /// True when the method's enclosing type declares a member named <c>System</c>, which shadows the
+    /// namespace for simple-name lookup and makes the injected <c>System.IO.Directory</c> unresolvable.
+    /// Rare (one site in the pinned corpus) and skipped fail-closed, because the alternative —
+    /// <c>global::</c> qualification — costs addressability for every candidate.
+    /// </summary>
+    private static bool ShadowsSystemNamespace(MethodDeclarationSyntax method)
+    {
+        var type = method.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+        if (type == null) return false;
+        return type.Members.Any(m => m switch
+        {
+            PropertyDeclarationSyntax p => p.Identifier.Text == "System",
+            FieldDeclarationSyntax f => f.Declaration.Variables.Any(v => v.Identifier.Text == "System"),
+            MethodDeclarationSyntax me => me.Identifier.Text == "System",
+            _ => false,
+        });
+    }
+
+    /// <summary>`null`, `default`, `default(T)`, or a zero literal — values `default(T)` cannot differ from.</summary>
+    private static bool IsDefaultValued(ExpressionSyntax expr) => expr switch
+    {
+        LiteralExpressionSyntax l =>
+            l.IsKind(SyntaxKind.NullLiteralExpression)
+            || l.IsKind(SyntaxKind.DefaultLiteralExpression)
+            || (l.IsKind(SyntaxKind.NumericLiteralExpression) && l.Token.ValueText is "0" or "0.0" or "0f" or "0d" or "0m"),
+        DefaultExpressionSyntax => true,
+        _ => false,
     };
 
     private static string DescribeCorruption(CorruptionKind kind) => kind switch

--- a/tools/Calor.RoundTrip.Harness/TaskGen/ExpressibleMutationOperators.cs
+++ b/tools/Calor.RoundTrip.Harness/TaskGen/ExpressibleMutationOperators.cs
@@ -108,7 +108,7 @@ public static class ExpressibleMutationOperators
         foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
         {
             if (method.Body is not { } body) continue;                       // need a block to inject into
-            if (!IsIntOrLong(method.ReturnType)) continue;                    // return must accept `+ int`
+            if (!IsCorruptibleReturn(method, out var corruptionKind)) continue;
 
             // The first `return <expr>;` the method itself owns (not one inside a nested lambda / local
             // function, whose return type differs). Corrupting a method-owned return corrupts the result.
@@ -116,9 +116,8 @@ public static class ExpressibleMutationOperators
                 .FirstOrDefault(r => r.Expression != null && OwningFunction(r) == method);
             if (ownedReturn?.Expression is not { } origExpr) continue;
 
-            // return (ORIGINAL) + __calorTaint;
             var corruptedReturn = ownedReturn.WithExpression(
-                SyntaxFactory.ParseExpression($"({origExpr.ToString()}) + {TaintLocal}"));
+                SyntaxFactory.ParseExpression(CorruptionExpression(corruptionKind, origExpr, method.ReturnType)));
 
             var taintStmts = SyntaxFactory.ParseStatement(
                     $"{{ int {TaintLocal} = 0; using (var {TaintSink} = new System.IO.StringWriter()) "
@@ -138,18 +137,101 @@ public static class ExpressibleMutationOperators
                 Operator = MutationOperatorKind.EffectViolation,
                 Stratum = DefectStratum.Expressible,
                 ExpectedCheck = CalorForbiddenEffect,
-                OperatorDescription = $"inject undeclared `fs` effect (using-nested Directory.Exists) that corrupts {method.Identifier.Text}'s return by +1",
+                OperatorDescription = $"inject undeclared `fs` effect (using-nested Directory.Exists) that corrupts "
+                                      + $"{method.Identifier.Text}'s return ({DescribeCorruption(corruptionKind)})",
                 Line = pos.Line + 1,
                 Column = pos.Character + 1,
                 OriginalSnippet = Truncate($"return {origExpr};"),
-                MutatedSnippet = Truncate($"using (…) {{ {TaintLocal} = Directory.Exists(cwd)?1:0; }} return ({origExpr}) + {TaintLocal};"),
+                MutatedSnippet = Truncate($"using (…) {{ {TaintLocal} = Directory.Exists(cwd)?1:0; }} "
+                                          + $"return {CorruptionExpression(corruptionKind, origExpr, method.ReturnType)};"),
                 MutatedSource = mutatedRoot.ToFullString(),
             });
         }
     }
 
-    private static bool IsIntOrLong(TypeSyntax type) =>
-        type is PredefinedTypeSyntax p && p.Keyword.Kind() is SyntaxKind.IntKeyword or SyntaxKind.LongKeyword;
+    /// <summary>How a method's return value is corrupted. See <see cref="IsCorruptibleReturn"/>.</summary>
+    private enum CorruptionKind
+    {
+        /// <summary><c>(ORIGINAL) + __calorTaint</c> — the original int/long form, preserved verbatim.</summary>
+        AddOne,
+
+        /// <summary><c>(ORIGINAL) ^ (__calorTaint == 1)</c> — flips a bool.</summary>
+        FlipBool,
+
+        /// <summary><c>__calorTaint == 1 ? default(T)! : (ORIGINAL)</c> — the general form.</summary>
+        DefaultWhenTainted,
+    }
+
+    /// <summary>
+    /// D-S0.5.2 operator widening. The site predicate previously required a <b>predefined int/long</b>
+    /// return, which capped `EffectViolation` at roughly 1% of block-bodied methods. That restriction
+    /// was never about addressability — the `using`-nested <c>Directory.*</c> effect that makes
+    /// <c>Calor0410</c> fire is independent of the return type — it existed only because the corruption
+    /// was arithmetic (<c>+ __calorTaint</c>) and arithmetic needs a number.
+    ///
+    /// <para>Widening the <i>corruption</i> therefore widens the site universe without touching the
+    /// mechanism under measurement. This is deliberately NOT a relaxation of what counts as a defect:
+    /// the injected effect is the same undeclared <c>fs</c> effect, the corruption is still
+    /// deterministic, still single-point, and still intrinsic to the effect (the taint local is written
+    /// only by the effectful call), so the papering-over residual that makes the measurement meaningful
+    /// is unchanged. Per the plan's M-S4 population, an operator change that raised supply by making the
+    /// injected defect less real would count against the honesty invariant; this one does not.</para>
+    ///
+    /// <para><b>Exclusions, each because the corruption would not compile or would not be a single
+    /// deterministic point:</b> <c>void</c> (nothing to corrupt); <c>ref</c> returns (<c>default</c> is
+    /// not a ref); pointer types (unsafe); and <b>async</b> methods, where the declared return type is
+    /// <c>Task&lt;T&gt;</c> but <c>return</c> yields <c>T</c>, so <c>default(Task&lt;T&gt;)</c> is a type
+    /// error. Iterators never match because <c>yield return</c> is not a <c>ReturnStatementSyntax</c>.</para>
+    /// </summary>
+    private static bool IsCorruptibleReturn(MethodDeclarationSyntax method, out CorruptionKind kind)
+    {
+        kind = CorruptionKind.DefaultWhenTainted;
+
+        // async: declared Task<T>, returned T — default(Task<T>) would not compile in that position.
+        if (method.Modifiers.Any(m => m.IsKind(SyntaxKind.AsyncKeyword))) return false;
+
+        var type = method.ReturnType;
+        if (type is RefTypeSyntax or PointerTypeSyntax) return false;
+
+        if (type is PredefinedTypeSyntax p)
+        {
+            switch (p.Keyword.Kind())
+            {
+                case SyntaxKind.VoidKeyword:
+                    return false;
+                case SyntaxKind.IntKeyword:
+                case SyntaxKind.LongKeyword:
+                    kind = CorruptionKind.AddOne;       // unchanged from the pre-widening operator
+                    return true;
+                case SyntaxKind.BoolKeyword:
+                    kind = CorruptionKind.FlipBool;     // a flipped bool is the most observable corruption there is
+                    return true;
+                default:
+                    kind = CorruptionKind.DefaultWhenTainted;
+                    return true;                        // string, char, other numerics, object, …
+            }
+        }
+
+        // Named types, generics, arrays, nullable, type parameters: `default(T)` is well-formed for all
+        // of them. `dynamic` parses as IdentifierNameSyntax and default(dynamic) is legal.
+        return type is IdentifierNameSyntax or QualifiedNameSyntax or GenericNameSyntax
+                    or ArrayTypeSyntax or NullableTypeSyntax or AliasQualifiedNameSyntax
+                    or TupleTypeSyntax;
+    }
+
+    private static string CorruptionExpression(CorruptionKind kind, ExpressionSyntax orig, TypeSyntax returnType) => kind switch
+    {
+        CorruptionKind.AddOne => $"({orig}) + {TaintLocal}",
+        CorruptionKind.FlipBool => $"({orig}) ^ ({TaintLocal} == 1)",
+        _ => $"({TaintLocal} == 1 ? default({returnType})! : ({orig}))",
+    };
+
+    private static string DescribeCorruption(CorruptionKind kind) => kind switch
+    {
+        CorruptionKind.AddOne => "+1",
+        CorruptionKind.FlipBool => "boolean flip",
+        _ => "returns default instead of the computed value",
+    };
 
     /// <summary>The function (method / local function / lambda) a statement belongs to — for return ownership.</summary>
     private static SyntaxNode? OwningFunction(SyntaxNode node) =>


### PR DESCRIPTION
## The ceiling was ours, not the corpus's

The review of #861 argued the S1 supply ceiling was an artifact of the mutation operator. **It was.**

`EffectViolation` required a **predefined `int`/`long`** return — because the corruption was
arithmetic (`return ORIGINAL + taint`). That restriction was never about addressability: the
`using`-nested `Directory.*` effect that makes `Calor0410` fire is independent of the return type.

Generalizing the **corruption** widens the site universe without touching the mechanism under
measurement:

| return type | corruption |
|---|---|
| `bool` | `(ORIGINAL) ^ (taint == 1)` |
| `int`/`long` | `(ORIGINAL) + taint` — **unchanged**, so prior candidates stay identical |
| everything else | `taint == 1 ? default(T)! : (ORIGINAL)` |

Excluded — each because the corruption wouldn't compile or wouldn't be a single deterministic point:
`void`, `ref` returns, pointer types, and **`async`** (declared `Task<T>`, but `return` yields `T`, so
`default(Task<T>)` is a type error there).

## Measured, identical corpus and command as `s1-supply-001`

| | before | after | × |
|---|---:|---:|---:|
| Corpus sites | 25 | **527** | 21× |
| Native supply | 9 | **204** | 23× |
| Lost to conversion | 9 | **251** | |

**Adjudicating the plan §4 go/no-go on the pre-widening 9 would have retired the real-scale venue on
an artifact.** A-1.5 still owns that call; this supplies the corrected input.

Converter fidelity also becomes a quantified lever rather than an anecdote: **251 of 527 sites (48%)**
sit in files the converter couldn't convert — a direct WS-S1 target on the same instrument.

## Not a bar relaxation, and the distinction is load-bearing

The injected defect is the same undeclared `fs` effect; the corruption is still deterministic,
single-point, and intrinsic to the effect, so the papering-over residual that makes the measurement
meaningful is unchanged. Per **M-S4**'s population, an operator change that raised supply by making
the defect *less real* would count against the honesty invariant. This changes only which return
types the corruption can be expressed for.

## D-5 flips to the opposite SPLIT

Pooled 0.35 → REJECT, carried by `EffectViolation` (0.33); `NullDeref` alone is 2.00 → ACCEPT. In
`s1-supply-001` the split ran the *other way*. Having failed to settle under both operator sets, the
statistic is too operator-sensitive to decide the question — **D-5 is referred to A-1.5 with both runs
on the record**.

## Tests

Four tests changed because the pinned behavior changed **deliberately**: the old
`EffectViolation_SkipsMethodsNotReturningIntOrLong` now asserts the opposite, and is joined by a new
test pinning the *remaining* exclusions (`void`/`ref`/`async`). Two pre-pass fixtures moved to `void`
returns so each exercises one operator. **152 green.**

## What this does NOT claim

- **Not 204 eligible tasks.** Eligibility was never evaluated. The prior run was 3/3 addressable and
  **0/3 eligible** — attrition here is unmeasured and could be severe.
- **Not that the widened corruption is addressable.** That's an argument from an unchanged mechanism,
  not a measurement, and `default(T)!` returning null for reference types is a plausible new source of
  `ArmsDiverge`. The differential probe must confirm it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
