### PR TITLE
D-S1.1 ledger read — the ledger is the wrong instrument (95% of the gap isn't losses)

### DIFF
--- a/bench/phase0-agent-native/epochs/s1-ledger-001/FINDING.md
+++ b/bench/phase0-agent-native/epochs/s1-ledger-001/FINDING.md
@@ -1,0 +1,107 @@
+# s1-ledger-001 — D-S1.1 ledger read: the ledger is the wrong instrument
+
+**Run:** 2026-08-04. `harness run MediatR Serilog FluentValidation --dotnet dotnet` — full round-trip
+(convert, build, recover, test, compare), producing the per-file conversion loss ledger.
+**Corpus pins:** MediatR `fb309026`, Serilog `0597ddfb`, FluentValidation `71b3c60c`.
+**Deliverable:** WS-S1 D-S1.1 — "read the ledger as a **marginal-recovery ranking**: a one-loss-away
+file histogram, ranked by files-made-native-if-fixed", feeding **D-S1.1a**'s early abort.
+
+## What D-S1.1 asked for, and what it found
+
+| Project | Native | Denominator | `NativeFraction` | Files needed for M-S1 (0.70) |
+|---|---:|---:|---:|---:|
+| FluentValidation | 74 | 139 | 0.532 | **+24** |
+| MediatR | 15 | 32 | 0.469 | **+8** |
+| Serilog | 44 | 110 | 0.400 | **+33** |
+
+**One-loss-away files — the entire ranked work-list D-S1.1 specified:**
+
+| Project | Loss kind | Files made native if fixed |
+|---|---|---:|
+| MediatR | `InteropPreserved` | 4 |
+| Serilog | `PreprocessorStripped` | 2 |
+| FluentValidation | `InteropPreserved` | 1 |
+| | **Total** | **7** |
+
+**Against a need of 65.** There are no multi-kind loss files anywhere, so 7 is not a floor — it is the
+ledger's *entire* achievable recovery, on any ranking, at any effort.
+
+## The finding: the gap is not made of losses
+
+| Status | FluentValidation | MediatR | Serilog | Total |
+|---|---:|---:|---:|---:|
+| `Replaced` (native) | 74 | 15 | 44 | **133** |
+| `Reverted` | 38 | 6 | 43 | 87 |
+| `CompileError` | 20 | 2 | 15 | 37 |
+| `EmitSyntaxError` | 6 | 5 | 6 | 17 |
+| `Replaced` (with-loss) | 1 | 4 | 2 | **7** |
+| **Denominator** | 139 | 32 | 110 | **281** |
+
+Of the **148-file** non-native gap:
+
+- **7 files (4.7%)** converted and carry a **declared loss** — the loss ledger.
+- **141 files (95.3%)** **never converted or compiled at all** — reverted by build recovery, or failed
+  with a compile/emit error.
+
+**D-S1.1's premise is wrong.** It assumed fidelity work means fixing *declared losses* — the honest
+degradations the ledger records. It doesn't: 95% of the gap is the converter failing outright. The
+ledger is a faithful instrument pointed at 4.7% of the phenomenon.
+
+## D-S1.1a — the early abort fires as written, and firing it would be an artifact
+
+D-S1.1a: *"If the ledger's cumulative achievable recovery cannot reach the M-S1 bar, PP-S1 resolves
+miss at D-S1.1, before D-S1.2 is funded."*
+
+Read literally, **the trigger fires**: 7 achievable against 65 needed, on every project.
+
+**But resolving PP-S1 = miss on this would repeat the exact error this program has already made
+twice** — retiring on an instrument artifact. PP-S1 claims *converter fidelity is movable*. What has
+been shown is that the **loss ledger** cannot move it, which is a fact about the work-list's source,
+not about fidelity. The precedents are on the record: the §4 go/no-go would have retired the venue on
+a pre-widening ceiling of 9 that was an artifact of our own mutation operator; D-5's threshold
+inverted with the operator set and was referred rather than obeyed.
+
+**And the bar is reachable from the right work-list.** Recomputing against the failure statuses:
+
+| Project | Need | Available in `Reverted` + `CompileError` + `EmitSyntaxError` |
+|---|---:|---:|
+| FluentValidation | +24 | 64 |
+| MediatR | +8 | 13 |
+| Serilog | +33 | 64 |
+
+M-S1 is **not structurally unreachable** on any project — it requires fixing 38% / 62% / 52% of that
+project's conversion failures. That is hard, and it is emitter-correctness work rather than
+loss-ledger work, but it is not the "the 40–53% is structural" world PP-S1's miss branch describes.
+
+**This record does not adjudicate PP-S1.** Both readings are stated and the disposition is referred,
+exactly as D-5 was. Deciding unilaterally to continue would be repricing after seeing the answer;
+deciding to abort would retire an L-sized workstream on a proxy that covers 5% of its subject.
+
+## What D-S1.1 should have been, and is now
+
+The ranked work-list for WS-S1 is **not** loss kinds. It is:
+
+1. **`Reverted` — 87 files (59% of the gap).** Converted and replaced, then reverted by build
+   recovery: the project did not compile with them in. Highest-yield and least understood.
+2. **`CompileError` — 37 files (25%).** The converted file did not compile.
+3. **`EmitSyntaxError` — 17 files (11%).** The emitter produced syntactically invalid output — the
+   most clearly-a-bug category, and the smallest.
+
+Ranking *within* those categories by failure cause is the D-S1.1 that should be run, and it needs
+the harness to record **why** each file failed, which it currently does not aggregate.
+
+## Corroboration
+
+The `NativeFraction` figures (0.532 / 0.469 / 0.400) reproduce the Slice B measurement and the
+funnel probe's per-project numbers exactly, so this is the same conversion behaviour measured by a
+third independent path.
+
+## What this record does not claim
+
+- **No adjudication of PP-S1**, M-S1, or the §4 go/no-go.
+- **Not that the 141 failures are easy.** No cause analysis has been done; "reachable in principle"
+  is a statement about arithmetic, not effort.
+- **Not that the 7 ledger files are worthless** — they are simply not a route to the bar.
+- One incidental defect found: `harness run` crashes with an unhandled `Win32Exception` when
+  `~/.dotnet/dotnet` is absent, because — unlike `gen-tasks` and `enumerate-supply` — it has no PATH
+  fallback. Worked around with `--dotnet dotnet`; recorded, not fixed here.

--- a/bench/phase0-agent-native/epochs/s1-ledger-001/FluentValidation-roundtrip.json
+++ b/bench/phase0-agent-native/epochs/s1-ledger-001/FluentValidation-roundtrip.json
@@ -1,0 +1,1249 @@
+{
+  "project": "FluentValidation",
+  "calor_version": "0.10.0",
+  "timestamp": "2026-08-04T23:50:54.0363030\u002B00:00",
+  "duration_seconds": 18.329268,
+  "verdict": "pass",
+  "inconclusive": false,
+  "baseline": {
+    "total": 866,
+    "passed": 865,
+    "failed": 0,
+    "skipped": 1
+  },
+  "round_trip": {
+    "total": 866,
+    "passed": 865,
+    "failed": 0,
+    "skipped": 1
+  },
+  "regressions": 0,
+  "files": {
+    "total": 139,
+    "replaced": 75,
+    "reverted": 38,
+    "conversion_failed": 0,
+    "emit_error": 6,
+    "compile_error": 20,
+    "crashed": 0,
+    "excluded_by_pattern": 2
+  },
+  "avg_conversion_rate": 0.9928057553956835,
+  "build_succeeded": true,
+  "fidelity": {
+    "coverage": {
+      "total_convertible_files": 139,
+      "converted_native": 74,
+      "converted_with_losses": 1,
+      "reverted": 38,
+      "failed_conversion": 26,
+      "excluded_files": 2,
+      "coverage_fraction": 0.539568345323741,
+      "native_fraction": 0.5323741007194245,
+      "loss_kind_counts": {
+        "PreprocessorStripped": 9,
+        "InteropPreserved": 6
+      },
+      "total_interop_blocks": 6,
+      "distinct_gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    "build": {
+      "succeeded": true,
+      "exit_code": 0,
+      "recovery_reverted_files": 38,
+      "error_count": 0
+    },
+    "tests": {
+      "baseline_total": 866,
+      "baseline_passed": 865,
+      "baseline_failed": 0,
+      "baseline_trx_files": 1,
+      "baseline_console_fallback": false,
+      "round_trip_total": 866,
+      "round_trip_passed": 865,
+      "round_trip_failed": 0,
+      "round_trip_trx_files": 1,
+      "round_trip_console_fallback": false,
+      "inventory_delta": 0,
+      "regressions": 0,
+      "new_passes": 0,
+      "comparison_status": "Pass"
+    }
+  },
+  "file_detail": [
+    {
+      "path": "src/FluentValidation/AbstractValidator.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/AssemblyInfo.FluentValidation.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/AssemblyScanner.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/AsyncValidatorInvokedSynchronouslyException.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/DefaultValidatorExtensions.cs",
+      "status": "CompileError",
+      "loss_count": 2,
+      "loss_kinds": {
+        "PreprocessorStripped": 2
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    {
+      "path": "src/FluentValidation/DefaultValidatorExtensions_Validate.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/DefaultValidatorOptions.cs",
+      "status": "Reverted",
+      "loss_count": 3,
+      "loss_kinds": {
+        "InteropPreserved": 3
+      },
+      "interop_blocks": 3,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Enums.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/ICollectionRule.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/IValidationContext.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/IValidationRule.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/IValidationRuleInternal.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/IValidator.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/IValidatorDescriptor.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/IValidatorFactory.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/InlineValidator.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Internal/AccessorCache.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Internal/ChildRulesContainer.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Internal/CollectionPropertyRule.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 3,
+      "loss_kinds": {
+        "PreprocessorStripped": 3
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    {
+      "path": "src/FluentValidation/Internal/CompositeValidatorSelector.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Internal/ConditionBuilder.cs",
+      "status": "Reverted",
+      "loss_count": 2,
+      "loss_kinds": {
+        "InteropPreserved": 2
+      },
+      "interop_blocks": 2,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Internal/DefaultValidatorSelector.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Internal/Extensions.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Internal/ExtensionsInternal.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Internal/IRuleComponent.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Internal/IValidatorSelector.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Internal/IncludeRule.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Internal/MemberNameValidatorSelector.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Internal/MessageBuilderContext.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Internal/MessageFormatter.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Internal/PropertyChain.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Internal/PropertyRule.cs",
+      "status": "Reverted",
+      "loss_count": 2,
+      "loss_kinds": {
+        "PreprocessorStripped": 2
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Internal/RuleBase.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Internal/RuleBuilder.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Internal/RuleComponent.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Internal/RuleComponentForNullableStruct.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Internal/RulesetValidatorSelector.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Internal/TrackingCollection.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Internal/ValidationStrategy.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Resources/ILanguageManager.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/LanguageManager.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/AlbanianLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/ArabicLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/AzerbaijaneseLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/BengaliLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/BosnianLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/BulgarianLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/CatalanLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/ChineseSimplifiedLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/ChineseTraditionalLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/CroatianLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/CzechLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/DanishLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/DutchLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/EnglishLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/EstonianLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/FinnishLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/FrenchLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/GeorgianLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/GermanLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/GreekLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/HebrewLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/HindiLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/HungarianLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/IcelandicLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/IndonesianLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/ItalianLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/JapaneseLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/KazakhLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/KhmerLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/KoreanLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/LatvianLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/MacedonianLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/NorwegianBokmalLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/NorwegianNynorskLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/PersianLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/PolishLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/PortugueseBrazilLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/PortugueseLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/RomanianLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/RomanshLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/RussianLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/SerbianCyrillicLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/SerbianLatinLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/SlovakLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/SlovenianLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/SpanishLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/SwedishLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/TajikLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/TamilLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/TeluguLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/ThaiLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/TurkishLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/UkrainianLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/UzbekCyrillicLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/UzbekLatinLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/VietnameseLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Resources/Languages/WelshLanguage.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Results/ValidationFailure.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Results/ValidationResult.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Syntax.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/TestHelper/ITestValidationContinuation.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/TestHelper/TestValidationResult.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/TestHelper/ValidationTestException.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/TestHelper/ValidatorTestExtensions.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/ValidationException.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 2,
+      "loss_kinds": {
+        "PreprocessorStripped": 2
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    {
+      "path": "src/FluentValidation/ValidatorDescriptor.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/ValidatorFactoryBase.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/ValidatorOptions.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/AbstractComparisonValidator.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Validators/AsyncPredicateValidator.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/AsyncPropertyValidator.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Validators/ChildValidatorAdaptor.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Validators/ComparableComparer.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/CreditCardValidator.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/EmailValidator.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/EmptyValidator.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Validators/EnumValidator.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Validators/EqualValidator.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/ExclusiveBetweenValidator.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/GreaterThanOrEqualValidator.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/GreaterThanValidator.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/IPropertyValidator.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/InclusiveBetweenValidator.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/LengthValidator.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/LessThanOrEqualValidator.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/LessThanValidator.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/NoopPropertyValidator.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/NotEmptyValidator.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/NotEqualValidator.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Validators/NotNullValidator.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/NullValidator.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/PolymorphicValidator.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/PrecisionScaleValidator.cs",
+      "status": "Replaced",
+      "loss_count": 1,
+      "loss_kinds": {
+        "InteropPreserved": 1
+      },
+      "interop_blocks": 1,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/PredicateValidator.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/FluentValidation/Validators/PropertyValidator.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Validators/RangeValidator.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Validators/RegularExpressionValidator.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/FluentValidation/Validators/StringEnumValidator.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    }
+  ]
+}

--- a/bench/phase0-agent-native/epochs/s1-ledger-001/MediatR-roundtrip.json
+++ b/bench/phase0-agent-native/epochs/s1-ledger-001/MediatR-roundtrip.json
@@ -1,0 +1,353 @@
+{
+  "project": "MediatR",
+  "calor_version": "0.10.0",
+  "timestamp": "2026-08-04T23:50:08.5732350\u002B00:00",
+  "duration_seconds": 18.484109,
+  "verdict": "pass",
+  "inconclusive": false,
+  "baseline": {
+    "total": 157,
+    "passed": 155,
+    "failed": 0,
+    "skipped": 2
+  },
+  "round_trip": {
+    "total": 157,
+    "passed": 155,
+    "failed": 0,
+    "skipped": 2
+  },
+  "regressions": 0,
+  "files": {
+    "total": 32,
+    "replaced": 19,
+    "reverted": 6,
+    "conversion_failed": 0,
+    "emit_error": 5,
+    "compile_error": 2,
+    "crashed": 0,
+    "excluded_by_pattern": 2
+  },
+  "avg_conversion_rate": 0.9373475609756098,
+  "build_succeeded": true,
+  "fidelity": {
+    "coverage": {
+      "total_convertible_files": 32,
+      "converted_native": 15,
+      "converted_with_losses": 4,
+      "reverted": 6,
+      "failed_conversion": 7,
+      "excluded_files": 2,
+      "coverage_fraction": 0.59375,
+      "native_fraction": 0.46875,
+      "loss_kind_counts": {
+        "InteropPreserved": 6,
+        "FallbackTodo": 1
+      },
+      "total_interop_blocks": 6,
+      "distinct_gaps": [
+        "foreachvariable"
+      ]
+    },
+    "build": {
+      "succeeded": true,
+      "exit_code": 0,
+      "recovery_reverted_files": 6,
+      "error_count": 0
+    },
+    "tests": {
+      "baseline_total": 157,
+      "baseline_passed": 155,
+      "baseline_failed": 0,
+      "baseline_trx_files": 1,
+      "baseline_console_fallback": false,
+      "round_trip_total": 157,
+      "round_trip_passed": 155,
+      "round_trip_failed": 0,
+      "round_trip_trx_files": 1,
+      "round_trip_console_fallback": false,
+      "inventory_delta": 0,
+      "regressions": 0,
+      "new_passes": 0,
+      "comparison_status": "Pass"
+    }
+  },
+  "file_detail": [
+    {
+      "path": "src/MediatR/IMediator.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/INotificationHandler.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/MediatR/INotificationPublisher.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/IPipelineBehavior.cs",
+      "status": "Replaced",
+      "loss_count": 1,
+      "loss_kinds": {
+        "InteropPreserved": 1
+      },
+      "interop_blocks": 1,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/IPublisher.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/MediatR/IRequestHandler.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/ISender.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/MediatR/IStreamPipelineBehavior.cs",
+      "status": "Replaced",
+      "loss_count": 1,
+      "loss_kinds": {
+        "InteropPreserved": 1
+      },
+      "interop_blocks": 1,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/IStreamRequestHandler.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/Internal/HandlersOrderer.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/Internal/ObjectDetails.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/Mediator.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/MicrosoftExtensionsDI/RequestExceptionActionProcessorStrategy.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/NotificationHandlerExecutor.cs",
+      "status": "Replaced",
+      "loss_count": 1,
+      "loss_kinds": {
+        "InteropPreserved": 1
+      },
+      "interop_blocks": 1,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/NotificationPublishers/ForeachAwaitPublisher.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/NotificationPublishers/TaskWhenAllPublisher.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/MediatR/Pipeline/IRequestExceptionAction.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/Pipeline/IRequestExceptionHandler.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/Pipeline/IRequestPostProcessor.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/Pipeline/IRequestPreProcessor.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/Pipeline/RequestExceptionHandlerState.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/Pipeline/RequestPostProcessorBehavior.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/Pipeline/RequestPreProcessorBehavior.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/Registration/ServiceRegistrar.cs",
+      "status": "CompileError",
+      "loss_count": 1,
+      "loss_kinds": {
+        "FallbackTodo": 1
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "foreachvariable"
+      ]
+    },
+    {
+      "path": "src/MediatR/TypeForwardings.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/Wrappers/NotificationHandlerWrapper.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/MediatR/Wrappers/RequestHandlerWrapper.cs",
+      "status": "Replaced",
+      "loss_count": 2,
+      "loss_kinds": {
+        "InteropPreserved": 2
+      },
+      "interop_blocks": 2,
+      "gaps": []
+    },
+    {
+      "path": "src/MediatR/Wrappers/StreamRequestHandlerWrapper.cs",
+      "status": "Reverted",
+      "loss_count": 1,
+      "loss_kinds": {
+        "InteropPreserved": 1
+      },
+      "interop_blocks": 1,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    }
+  ]
+}

--- a/bench/phase0-agent-native/epochs/s1-ledger-001/Serilog-roundtrip.json
+++ b/bench/phase0-agent-native/epochs/s1-ledger-001/Serilog-roundtrip.json
@@ -1,0 +1,1124 @@
+{
+  "project": "Serilog",
+  "calor_version": "0.10.0",
+  "timestamp": "2026-08-04T23:50:27.0744240\u002B00:00",
+  "duration_seconds": 26.960768,
+  "verdict": "pass",
+  "inconclusive": false,
+  "baseline": {
+    "total": 811,
+    "passed": 811,
+    "failed": 0,
+    "skipped": 0
+  },
+  "round_trip": {
+    "total": 811,
+    "passed": 811,
+    "failed": 0,
+    "skipped": 0
+  },
+  "regressions": 0,
+  "files": {
+    "total": 110,
+    "replaced": 46,
+    "reverted": 43,
+    "conversion_failed": 0,
+    "emit_error": 6,
+    "compile_error": 15,
+    "crashed": 0,
+    "excluded_by_pattern": 8
+  },
+  "avg_conversion_rate": 1,
+  "build_succeeded": true,
+  "fidelity": {
+    "coverage": {
+      "total_convertible_files": 110,
+      "converted_native": 44,
+      "converted_with_losses": 2,
+      "reverted": 43,
+      "failed_conversion": 21,
+      "excluded_files": 8,
+      "coverage_fraction": 0.41818181818181815,
+      "native_fraction": 0.4,
+      "loss_kind_counts": {
+        "PreprocessorStripped": 210,
+        "InteropPreserved": 4,
+        "Dropped": 2,
+        "EmitterFallback": 1
+      },
+      "total_interop_blocks": 5,
+      "distinct_gaps": [
+        "preprocessor-directive",
+        "unsupported-member"
+      ]
+    },
+    "build": {
+      "succeeded": true,
+      "exit_code": 0,
+      "recovery_reverted_files": 43,
+      "error_count": 0
+    },
+    "tests": {
+      "baseline_total": 811,
+      "baseline_passed": 811,
+      "baseline_failed": 0,
+      "baseline_trx_files": 1,
+      "baseline_console_fallback": false,
+      "round_trip_total": 811,
+      "round_trip_passed": 811,
+      "round_trip_failed": 0,
+      "round_trip_trx_files": 1,
+      "round_trip_console_fallback": false,
+      "inventory_delta": 0,
+      "regressions": 0,
+      "new_passes": 0,
+      "comparison_status": "Pass"
+    }
+  },
+  "file_detail": [
+    {
+      "path": "src/Serilog/Capturing/DepthLimiter.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Capturing/MessageTemplateProcessor.cs",
+      "status": "Reverted",
+      "loss_count": 2,
+      "loss_kinds": {
+        "PreprocessorStripped": 2
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Capturing/PropertyBinder.cs",
+      "status": "CompileError",
+      "loss_count": 6,
+      "loss_kinds": {
+        "PreprocessorStripped": 6
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    {
+      "path": "src/Serilog/Capturing/PropertyValueConverter.cs",
+      "status": "CompileError",
+      "loss_count": 5,
+      "loss_kinds": {
+        "PreprocessorStripped": 4,
+        "InteropPreserved": 1
+      },
+      "interop_blocks": 1,
+      "gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    {
+      "path": "src/Serilog/Capturing/TrimConfiguration.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Configuration/BatchingOptions.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Configuration/ILoggerSettings.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Configuration/LoggerAuditSinkConfiguration.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Configuration/LoggerDestructuringConfiguration.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Configuration/LoggerEnrichmentConfiguration.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Configuration/LoggerFilterConfiguration.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Configuration/LoggerMinimumLevelConfiguration.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Configuration/LoggerSettingsConfiguration.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Configuration/LoggerSinkConfiguration.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Context/EnricherStack.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Context/LogContext.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Context/LogContextEnricher.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/Constants.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/CustomDefaultMethodImplementationAttribute.cs",
+      "status": "Replaced",
+      "loss_count": 1,
+      "loss_kinds": {
+        "PreprocessorStripped": 1
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    {
+      "path": "src/Serilog/Core/Enrichers/ConditionalEnricher.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/Enrichers/EmptyEnricher.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/Enrichers/FixedPropertyEnricher.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/Enrichers/PropertyEnricher.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/Enrichers/SafeAggregateEnricher.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/Filters/DelegateFilter.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/IBatchedLogEventSink.cs",
+      "status": "Replaced",
+      "loss_count": 2,
+      "loss_kinds": {
+        "PreprocessorStripped": 2
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    {
+      "path": "src/Serilog/Core/IDestructuringPolicy.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Core/ILogEventEnricher.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/ILogEventFilter.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/ILogEventPropertyFactory.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/ILogEventPropertyValueFactory.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/ILogEventSink.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/ILoggingFailureListener.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/IMessageTemplateParser.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/IScalarConversionPolicy.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Core/ISetLoggingFailureListener.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/LevelOverrideMap.cs",
+      "status": "CompileError",
+      "loss_count": 2,
+      "loss_kinds": {
+        "PreprocessorStripped": 2
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    {
+      "path": "src/Serilog/Core/Logger.cs",
+      "status": "CompileError",
+      "loss_count": 23,
+      "loss_kinds": {
+        "PreprocessorStripped": 23
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    {
+      "path": "src/Serilog/Core/LoggingFailureKind.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/LoggingLevelSwitch.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/LoggingLevelSwitchChangedEventArgs.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/MessageTemplateFormatMethodAttribute.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/Pipeline/ByReferenceStringComparer.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/Pipeline/MessageTemplateCache.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/Pipeline/SilentLogger.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/PropertiesInlineArray.cs",
+      "status": "Reverted",
+      "loss_count": 1,
+      "loss_kinds": {
+        "PreprocessorStripped": 1
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Core/Sinks/AggregateSink.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Core/Sinks/Batching/BatchingSink.cs",
+      "status": "CompileError",
+      "loss_count": 2,
+      "loss_kinds": {
+        "PreprocessorStripped": 2
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    {
+      "path": "src/Serilog/Core/Sinks/Batching/FailureAwareBatchScheduler.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Core/Sinks/ConditionalSink.cs",
+      "status": "Reverted",
+      "loss_count": 2,
+      "loss_kinds": {
+        "PreprocessorStripped": 2
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Core/Sinks/DisposingAggregateSink.cs",
+      "status": "Reverted",
+      "loss_count": 2,
+      "loss_kinds": {
+        "PreprocessorStripped": 2
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Core/Sinks/Fallback/DelegatingLoggingFailureListener.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/Sinks/Fallback/FailureListenerSink.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Core/Sinks/FilteringSink.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/Sinks/OptionalInterfaceForwardingSink.cs",
+      "status": "Reverted",
+      "loss_count": 4,
+      "loss_kinds": {
+        "PreprocessorStripped": 4
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Core/Sinks/RestrictedSink.cs",
+      "status": "Reverted",
+      "loss_count": 2,
+      "loss_kinds": {
+        "PreprocessorStripped": 2
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Core/Sinks/SafeAggregateSink.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Core/Sinks/SecondaryLoggerSink.cs",
+      "status": "Reverted",
+      "loss_count": 2,
+      "loss_kinds": {
+        "PreprocessorStripped": 2
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Data/LogEventPropertyValueRewriter.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Data/LogEventPropertyValueVisitor.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Debugging/LoggingFailedException.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Debugging/SelfLog.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Events/DictionaryValue.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Events/EventProperty.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Events/LevelAlias.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Events/LogEvent.cs",
+      "status": "Reverted",
+      "loss_count": 4,
+      "loss_kinds": {
+        "PreprocessorStripped": 4
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Events/LogEventLevel.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Events/LogEventProperty.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Events/LogEventPropertyValue.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Events/MessageTemplate.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Events/ScalarValue.cs",
+      "status": "Reverted",
+      "loss_count": 1,
+      "loss_kinds": {
+        "PreprocessorStripped": 1
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Events/SequenceValue.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Events/StructureValue.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Filters/Matching.cs",
+      "status": "CompileError",
+      "loss_count": 1,
+      "loss_kinds": {
+        "PreprocessorStripped": 1
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    {
+      "path": "src/Serilog/Formatting/Display/LevelOutputFormat.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs",
+      "status": "CompileError",
+      "loss_count": 2,
+      "loss_kinds": {
+        "PreprocessorStripped": 2
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    {
+      "path": "src/Serilog/Formatting/Display/OutputProperties.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Formatting/Display/PropertiesOutputFormat.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Formatting/ITextFormatter.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Formatting/Json/JsonFormatter.cs",
+      "status": "Reverted",
+      "loss_count": 1,
+      "loss_kinds": {
+        "InteropPreserved": 1
+      },
+      "interop_blocks": 1,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Formatting/Json/JsonValueFormatter.cs",
+      "status": "Reverted",
+      "loss_count": 34,
+      "loss_kinds": {
+        "PreprocessorStripped": 34
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Guard.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/ILogger.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 99,
+      "loss_kinds": {
+        "PreprocessorStripped": 97,
+        "Dropped": 2
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive",
+        "unsupported-member"
+      ]
+    },
+    {
+      "path": "src/Serilog/Log.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 1,
+      "loss_kinds": {
+        "PreprocessorStripped": 1
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    {
+      "path": "src/Serilog/LoggerConfiguration.cs",
+      "status": "CompileError",
+      "loss_count": 4,
+      "loss_kinds": {
+        "PreprocessorStripped": 3,
+        "InteropPreserved": 1
+      },
+      "interop_blocks": 1,
+      "gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    {
+      "path": "src/Serilog/LoggerExtensions.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Parsing/Alignment.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Parsing/AlignmentDirection.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Parsing/Destructuring.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Parsing/MessageTemplateParser.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Parsing/MessageTemplateToken.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Parsing/PropertyToken.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Parsing/TextToken.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Policies/ByteArrayScalarConversionPolicy.cs",
+      "status": "Reverted",
+      "loss_count": 4,
+      "loss_kinds": {
+        "PreprocessorStripped": 4
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Policies/ByteMemoryScalarConversionPolicy.cs",
+      "status": "EmitSyntaxError",
+      "loss_count": 1,
+      "loss_kinds": {
+        "PreprocessorStripped": 1
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    {
+      "path": "src/Serilog/Policies/DelegateDestructuringPolicy.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Policies/EnumScalarConversionPolicy.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Policies/PrimitiveScalarConversionPolicy.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Policies/ProjectedDestructuringPolicy.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Policies/ReflectionTypesScalarDestructuringPolicy.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Policies/SimpleScalarConversionPolicy.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 1: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Rendering/Casing.cs",
+      "status": "Replaced",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Rendering/MessageTemplateRenderer.cs",
+      "status": "CompileError",
+      "loss_count": 4,
+      "loss_kinds": {
+        "PreprocessorStripped": 4
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ]
+    },
+    {
+      "path": "src/Serilog/Rendering/Padding.cs",
+      "status": "Reverted",
+      "loss_count": 1,
+      "loss_kinds": {
+        "PreprocessorStripped": 1
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Rendering/ReusableStringWriter.cs",
+      "status": "Reverted",
+      "loss_count": 1,
+      "loss_kinds": {
+        "PreprocessorStripped": 1
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ],
+      "revert_reason": "build-recovery round 3: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs",
+      "status": "CompileError",
+      "loss_count": 2,
+      "loss_kinds": {
+        "InteropPreserved": 1,
+        "EmitterFallback": 1
+      },
+      "interop_blocks": 2,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Settings/KeyValuePairs/SettingValueConversions.cs",
+      "status": "CompileError",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": []
+    },
+    {
+      "path": "src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs",
+      "status": "Reverted",
+      "loss_count": 0,
+      "loss_kinds": {},
+      "interop_blocks": 0,
+      "gaps": [],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    },
+    {
+      "path": "src/Serilog/Util/TimeProvider.cs",
+      "status": "Reverted",
+      "loss_count": 1,
+      "loss_kinds": {
+        "PreprocessorStripped": 1
+      },
+      "interop_blocks": 0,
+      "gaps": [
+        "preprocessor-directive"
+      ],
+      "revert_reason": "build-recovery round 2: build error in round-tripped output"
+    }
+  ]
+}


### PR DESCRIPTION
## D-S1.1: the ledger is the wrong instrument

WS-S1's D-S1.1 asked for a marginal-recovery ranking over the conversion loss ledger — a
one-loss-away file histogram ranked by files-made-native-if-fixed — feeding **D-S1.1a**'s early abort.

**The entire ranked work-list is 7 files, against a need of 65.**

| Project | Loss kind | Files made native if fixed |
|---|---|---:|
| MediatR | `InteropPreserved` | 4 |
| Serilog | `PreprocessorStripped` | 2 |
| FluentValidation | `InteropPreserved` | 1 |

There are no multi-kind loss files anywhere, so 7 isn't a floor — it's the ledger's **entire**
achievable recovery, on any ranking, at any effort.

## Why: the gap isn't made of losses

Of the **148-file** non-native gap:

| | files | share |
|---|---:|---:|
| converted, carries a **declared loss** (the ledger) | **7** | **4.7%** |
| never converted or compiled at all | **141** | **95.3%** |

`Reverted` 87, `CompileError` 37, `EmitSyntaxError` 17.

**D-S1.1's premise was that fidelity work means fixing declared losses.** It doesn't. The ledger is a
faithful instrument pointed at 4.7% of the phenomenon.

## D-S1.1a fires as written — and firing it would be an artifact

The trigger says: *if the ledger's cumulative achievable recovery cannot reach the M-S1 bar, PP-S1
resolves miss.* Read literally it **fires** — 7 against 65, on every project.

But PP-S1 claims *converter fidelity is movable*. What's been shown is that the **loss ledger** can't
move it — a fact about the work-list's source. This program has nearly made that exact error twice:
the §4 go/no-go would have retired the venue on a ceiling of 9 that was our own mutation operator's
artifact, and D-5's threshold inverted with the operator set and was referred rather than obeyed.

**And the bar is reachable from the right work-list:**

| Project | Need | Available in `Reverted`+`CompileError`+`EmitSyntaxError` |
|---|---:|---:|
| FluentValidation | +24 | 64 |
| MediatR | +8 | 13 |
| Serilog | +33 | 64 |

38% / 62% / 52% of each project's conversion failures. Hard, and emitter-correctness work rather than
ledger work — but not the "the 40–53% is structural" world PP-S1's miss branch describes.

## This record does not adjudicate PP-S1

Both readings are stated and the disposition is **referred**, exactly as D-5 was. Deciding to continue
would be repricing after seeing the answer; deciding to abort would retire an L-sized workstream on a
proxy covering 5% of its subject.

## Corroboration + an incidental defect

`NativeFraction` 0.532 / 0.469 / 0.400 reproduces Slice B and the funnel probe exactly — the same
conversion behaviour by a third independent path.

`harness run` crashes with an unhandled `Win32Exception` when `~/.dotnet/dotnet` is absent — unlike
`gen-tasks` and `enumerate-supply` it has no PATH fallback. Worked around with `--dotnet dotnet`;
recorded, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
