### PR TITLE
PP-A1 = PASS (all 9 frozen items) + disclose the format --write release gate

### DIFF
--- a/docs/cli/format.md
+++ b/docs/cli/format.md
@@ -28,7 +28,7 @@ The `format` command formats Calor source files according to the canonical Calor
 # Format a single file (output to stdout)
 calor format MyModule.calr
 
-# Format and overwrite the file
+# Format and overwrite the file — DISABLED by the release policy (see below)
 calor format MyModule.calr --write
 
 # Check if files are formatted (for CI)
@@ -53,7 +53,7 @@ calor format MyModule.calr --diff
 | Option | Short | Default | Description |
 |:-------|:------|:--------|:------------|
 | `--check` | `-c` | `false` | Check if files are formatted without modifying (exit 1 if not) |
-| `--write` | `-w` | `false` | Write formatted output back to the file(s) |
+| `--write` | `-w` | `false` | Write formatted output back to the file(s). **Disabled by the release policy** — see below |
 | `--diff` | `-d` | `false` | Show diff of formatting changes |
 | `--verbose` | `-v` | `false` | Enable verbose output |
 | `--heal` | — | `false` | Best-effort source-level repair of files too broken for the AST formatter. **Not semantics-preserving** — see [Heal Mode](#heal-mode) |
@@ -115,7 +115,13 @@ This allows you to preview changes before applying them.
 
 ## Write Mode
 
-Use `--write` to format files in place:
+> **`--write` is disabled by the release policy (#793/#760).** The formatter's write path can rewrite
+> identifiers via its ID-abbreviation regexes and drops comments, so it is held behind an explicit
+> experimental opt-in and otherwise errors with `Calor1346`. The read-only modes (default and
+> `--check`) are unaffected. The same policy holds the LSP formatting and rename handlers behind
+> `CALOR_LSP_EXPERIMENTAL`. This is PP-A1 item 7 ("T3 containment") and is deliberate, not a bug.
+
+Use `--write` to format files in place (subject to the gate above):
 
 ```bash
 # Format single file

--- a/docs/plans/pp-a1-adjudication.md
+++ b/docs/plans/pp-a1-adjudication.md
@@ -1,0 +1,52 @@
+# PP-A1 — CI adoption gates: **PASS**
+
+**Adjudicated 2026-08-05** against the list frozen at [`wedge-w1-prereqs.md`](wedge-w1-prereqs.md) §3
+("frozen now, before any results exist"), carried unchanged into v0.12 by the fold-forward decision.
+PP-A1 is a **v0.12.0 release gate**, orthogonal to Call S.
+
+## Item-by-item
+
+| # | Requirement | Evidence | |
+|---|---|---|---|
+| 1 | Functional published `Calor.Sdk`; **M-A1 green in CI** | `sdk-package-consumer` job in `.github/workflows/test.yml`, green on every recent run | ✅ |
+| 2 | Unmasked gates; **publish workflow test-gated** | `publish-nuget.yml` `publish` job declares `needs: [test, sdk-consumer]` — publishing cannot run unless both pass | ✅ |
+| 3 | **Checksummed natives** on every publish path | `scripts/z3-upstream-4.15.7.sha256` + `verify_archive` invoked at 3 sites in `download-z3.sh`; verification precedes extraction on every branch, fail-closed on missing manifest / missing entry / hash mismatch | ✅ |
+| 4 | Complete **options hash** + fail-closed enforcement | `BuildStateCache.ComputeOptionsHash(string)`, consumed at `CompilationDriver.cs:113`; documented contract that diagnostics-affecting options must be folded in so an option flip invalidates skipped files, presentation-only options excluded | ✅ |
+| 5 | **Telemetry opt-in** default, stripped payloads, documented | `CalorTelemetry` activates **only** on `CALOR_TELEMETRY=1`; `--no-telemetry` / `CALOR_TELEMETRY_OPTOUT=1` force off; `AnonymizingTelemetryInitializer` strips payloads; `docs/telemetry.md` | ✅ |
+| 6 | **Slice-1 soundness batch** — T1 trio, D8, D6/D7 adjudicated, T2 stopgap, D1 recorded | `484d6c70` (W1 Slice 1). Dispositions recorded in the `verification-modeled-forms.md` divergence table: **D6** adjudicated with why-not (path unreachable from the elision-relevant surface), **D7** closed by refusal (unregistered fields → `Unsupported`), **D8** closed (divisor `≠0` **and** signed-`MinValue/−1` side conditions; demote to `assumed`; conditional-position divisors `Unsupported`), **D9** `string.Replace` closed by refusal | ✅ |
+| 7 | **T3 containment** — three surfaces gated | `format --write` → runtime refusal, `Calor1346`, citing #793/#760. LSP **formatting** and **rename** register **only** under `CALOR_LSP_EXPERIMENTAL=1` (`Calor.LanguageServer/Program.cs`), with every read-only handler unaffected | ✅ |
+| 8 | **#770 eject-contract** — documented degradation spec | `adoption-playbook.md` §"The eject story (tested)" — a per-construct degradation table (`§S` → runtime check with the same exception shape; interop blocks eject as original C#; elision only inside verified SDK builds on a non-vacuous ∀-proof) | ✅ |
+| 9 | **#761 flip stance** — `EnableTypeChecking` default-on with a CHANGELOG note | Recorded in the frozen list as having a slot, **explicitly "not gate-blocking for W1 exit"**. `EnableTypeChecking` remains default-off; the item's requirement is that the flip be *scheduled*, not shipped | ✅ (by its own terms) |
+
+**All nine satisfied. PP-A1 = PASS.**
+
+## A defect found by the audit, fixed here
+
+Item 7's containment is implemented correctly in code, but **`docs/cli/format.md` documented `--write`
+as an ordinary option** — an example, a table row, and a "Use `--write` to format files in place"
+section, with no mention of the gate. A reader following the docs would hit `Calor1346` with no
+warning, and would reasonably read a deliberate release-policy containment as a bug.
+
+The gate is now disclosed at all three places, naming the diagnostic code, the policy issues, and the
+sibling `CALOR_LSP_EXPERIMENTAL` containment. **The containment itself was already correct; only its
+documentation was not.**
+
+## A near-miss worth recording
+
+An intermediate step of this audit read `Program.cs`'s `WithHandler<FormattingHandler>()` /
+`WithHandler<RenameHandler>()` lines *without their enclosing `if (experimentalWriteHandlers)` block*
+and concluded item 7 was unmet — i.e. that a release blocker had failed. It had not. Grep-level
+evidence about whether something is *gated* is unreliable by construction, because the gate is the
+enclosing context, not the line. Recorded because the same shape would produce a false release-blocking
+claim in any future audit run the same way.
+
+## Scope
+
+- **PASS is against the frozen list only.** Items explicitly excluded there — coverage ratchets,
+  mutation testing, LSP E2E revival, SBOM/hermetic builds, #782/#781 full fixes, #764 full lowering,
+  D1/D2 numeric-semantics fixes — remain out and are not implied by this pass.
+- **Item 9 passes by its own terms**, which require a scheduled slot rather than a shipped flip. If a
+  reader expects `EnableTypeChecking` to be default-on at v0.12.0, it is not.
+- **PP-W5 is the other release gate and is NOT adjudicated here.** It requires a spend-authorized
+  parity epoch (frozen A-1.4 tranche 1, restated additively at A-1.5.6) and is a separate maintainer
+  decision.


### PR DESCRIPTION
Adjudicates **PP-A1**, a v0.12.0 release gate orthogonal to Call S, against the list frozen at `wedge-w1-prereqs.md` §3 *before any results existed*.

**All nine items satisfied**, each with cited evidence:

| # | Evidence |
|---|---|
| 1 | `sdk-package-consumer` job (M-A1) green |
| 2 | `publish` job declares `needs: [test, sdk-consumer]` |
| 3 | sha256 manifest + `verify_archive` ×3, verification precedes extraction, fail-closed |
| 4 | `ComputeOptionsHash` consumed at `CompilationDriver.cs:113` |
| 5 | `CALOR_TELEMETRY=1` required; opt-out forces off; anonymizing initializer; documented |
| 6 | W1 Slice 1 `484d6c70`; **D6/D7/D8/D9** dispositions in the divergence table |
| 7 | `format --write` refuses with **Calor1346**; LSP formatting + rename register **only** under `CALOR_LSP_EXPERIMENTAL` |
| 8 | eject degradation table in `adoption-playbook.md` |
| 9 | passes **by its own terms** — the frozen list marks the #761 flip *"not gate-blocking for W1 exit"* |

## A defect found by the audit, fixed here

Item 7's containment is implemented **correctly** — but `docs/cli/format.md` documented `--write` as an ordinary option in three places with no mention of the gate. A reader following the docs would hit `Calor1346` unwarned and reasonably read a deliberate containment as a bug. Now disclosed at all three sites.

## A near-miss, recorded

An intermediate step read the `WithHandler<FormattingHandler>()` / `WithHandler<RenameHandler>()` lines **without their enclosing `if (experimentalWriteHandlers)` block** and concluded item 7 was unmet — that a release blocker had *failed*. It had not. **Grep-level evidence about whether something is gated is unreliable by construction**, because the gate is the enclosing context, not the line.

## Scope

PASS is against the frozen list only; its explicit exclusions stay excluded. **`EnableTypeChecking` is NOT default-on at v0.12.0** — item 9 requires a scheduled slot, not a shipped flip. **PP-W5 is not adjudicated here**: it needs a spend-authorized epoch and is a separate maintainer decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)