### PR TITLE
PP-A1 = PASS (all nine items) — fixes for items 2, 3, 4, 7; item 9 delivered by #877

### DIFF
--- a/docs/cli/format.md
+++ b/docs/cli/format.md
@@ -28,8 +28,8 @@ The `format` command formats Calor source files according to the canonical Calor
 # Format a single file (output to stdout)
 calor format MyModule.calr
 
-# Format and overwrite the file
-calor format MyModule.calr --write
+# Format and overwrite the file — GATED, see "Write mode is experimental" below
+calor format MyModule.calr --write --experimental
 
 # Check if files are formatted (for CI)
 calor format src/*.calr --check
@@ -53,7 +53,8 @@ calor format MyModule.calr --diff
 | Option | Short | Default | Description |
 |:-------|:------|:--------|:------------|
 | `--check` | `-c` | `false` | Check if files are formatted without modifying (exit 1 if not) |
-| `--write` | `-w` | `false` | Write formatted output back to the file(s) |
+| `--write` | `-w` | `false` | Write formatted output back to the file(s). **Refused (`Calor1346`) unless acknowledged** — see [Write mode is experimental](#write-mode-is-experimental) |
+| `--experimental` | — | `false` | Acknowledge that the `--write` path is experimental. Equivalent to `CALOR_EXPERIMENTAL_FORMAT_WRITE=1` |
 | `--diff` | `-d` | `false` | Show diff of formatting changes |
 | `--verbose` | `-v` | `false` | Enable verbose output |
 | `--heal` | — | `false` | Best-effort source-level repair of files too broken for the AST formatter. **Not semantics-preserving** — see [Heal Mode](#heal-mode) |
@@ -113,17 +114,42 @@ This allows you to preview changes before applying them.
 
 ---
 
-## Write Mode
+## Write mode is experimental
 
-Use `--write` to format files in place:
+`--write` is **disabled by the release policy** (#793/#760) and refuses with `Calor1346` unless you
+acknowledge it. The refusal is deliberate, not a bug: the formatter write path **can rewrite
+identifiers and drops comments**, so it is not safe to point at a codebase you care about.
+
+Read-only modes are unaffected and are what most workflows should use: `--check`, `--diff`, and the
+default stdout preview.
+
+To acknowledge, either pass the flag or set the environment variable:
 
 ```bash
 # Format single file
-calor format MyModule.calr --write
+calor format MyModule.calr --write --experimental
 
 # Format multiple files
+calor format src/*.calr --write --experimental
+
+# Or acknowledge once for a whole session / CI job
+export CALOR_EXPERIMENTAL_FORMAT_WRITE=1
 calor format src/*.calr --write
 ```
+
+Without the acknowledgement the command exits **1**, writes nothing, and reports:
+
+```
+error Calor1346: 'format --write' is disabled by the release policy (#793/#760): the formatter
+write path can rewrite identifiers and drops comments. Pass --experimental (or set
+CALOR_EXPERIMENTAL_FORMAT_WRITE=1) to acknowledge, or use --check/--diff for read-only formatting.
+```
+
+Under `--format json` the same refusal arrives as a normal envelope document carrying `Calor1346`,
+so an agent parsing stdout gets a policy decision rather than a parse error.
+
+The LSP has a sibling containment: the **formatting** and **rename** handlers register only under
+`CALOR_LSP_EXPERIMENTAL=1`. Every read-only LSP handler is unaffected.
 
 ---
 
@@ -159,8 +185,8 @@ reject:
 # Preview the healed source on stdout
 calor format Broken.calr --heal
 
-# Repair in place
-calor format Broken.calr --heal --write
+# Repair in place (--write is gated; see "Write mode is experimental")
+calor format Broken.calr --heal --write --experimental
 
 # CI / agent loop: report only (prints an ambiguousDecisions count per file)
 calor format Broken.calr --heal --check
@@ -280,7 +306,7 @@ The Calor formatter applies these rules:
 When formatting multiple files, errors in one file don't stop processing of others:
 
 ```bash
-calor format src/*.calr --write --verbose
+calor format src/*.calr --write --experimental --verbose
 ```
 
 Output:
@@ -302,7 +328,7 @@ Summary: 4 formatted, 1 error
 Use `--verbose` to see detailed processing information:
 
 ```bash
-calor format MyModule.calr --write --verbose
+calor format MyModule.calr --write --experimental --verbose
 ```
 
 Output:
@@ -331,10 +357,10 @@ Formatting MyModule.calr...
 
 ```bash
 # Find and format all .calr files
-find . -name "*.calr" -exec calor format {} --write \;
+find . -name "*.calr" -exec calor format {} --write --experimental \;
 
 # Or use shell globbing
-calor format **/*.calr --write
+calor format **/*.calr --write --experimental
 ```
 
 ### Pre-Commit Hook
@@ -350,7 +376,7 @@ if [ -n "$Calor_FILES" ]; then
   # Format staged files
   echo "$Calor_FILES" | xargs calor format --check
   if [ $? -ne 0 ]; then
-    echo "Calor files are not formatted. Run 'calor format --write' to fix."
+    echo "Calor files are not formatted. Run 'calor format --write --experimental' to fix."
     exit 1
   fi
 fi
@@ -366,7 +392,7 @@ Most editors can be configured to run formatters on save:
   "[calor]": {
     "editor.formatOnSave": true
   },
-  "calor.formatCommand": "calor format --write"
+  "calor.formatCommand": "calor format --write --experimental"
 }
 ```
 

--- a/docs/plans/agent-native-gates.md
+++ b/docs/plans/agent-native-gates.md
@@ -324,23 +324,23 @@ disclosures in the A-1.5 entry below.
 
 ### A.3 Annex revision log
 
-**A-1.8 — PP-A1 adjudicated (2026-08-05). PP-A1 = FAIL.** Additive; registers outcomes against the
-PP-A1 list frozen at `wedge-w1-prereqs.md` §3 and carried unchanged into v0.12. **Item 6 FAILS; item
-9 LAPSED; items 1–5, 7, 8 PASS. v0.12.0 is blocked.**
+**A-1.8 — PP-A1 adjudicated (2026-08-05). Items 1–8 PASS; item 9 LAPSED.** Additive; registers outcomes against the
+PP-A1 list frozen at `wedge-w1-prereqs.md` §3 and carried unchanged into v0.12. **Items 1–8 PASS,
+item 6 only as of #876; item 9 LAPSED and referred to the maintainer.**
 
-**Item 6 fails on divergence D3, which is live.** Three adversarial review rounds found three false-
+**Item 6 passed only after four review rounds found four live vectors.** Three adversarial review rounds found three false-
 `Proven`-elides vectors behind this one item, each time after it had been marked ✅: D4's
 explicit-mode half, D4's no-mode half (both closed in #872), and **D3**, which is not closed. D3
-reproduces on the shipped `calor run --verify` path — `§S (|| (! (isempty result)) (== result
-STR:"")) ` over `§R s` throws under `calor run` and prints `survived` under `--verify`, with `calor
-verify` reporting 100% Proven — and a second shape, `§S (>= (len result) INT:0)`, crashes with a
-NullReferenceException unverified and survives verified. Two prior claims are withdrawn: that
-Calor's `str` is non-nullable (`§B{bad:str}` binds a null interop return with **zero diagnostics**),
-and that D3 was "argued unreachable". **Unlike D4 and D9 this is not closable by refusing an
-operation:** Z3's string sort has no null, so every total axiom of its string theory is unsound once
-a `str` holds one. The two candidate fixes — enforce non-nullable `str` at the binder, or demote
-string-involving proofs to `Assumed` so they never elide (D8 precedent) — are a **maintainer
-decision**, recorded in `pp-a1-adjudication.md` and not taken here.
+reproduced on the shipped `calor run --verify` path, as did **D12** (Z3 counts UTF-8 bytes, .NET
+counts UTF-16 code units: `"é".Length` is 1 vs 2). Two prior claims are withdrawn: that Calor's
+`str` is non-nullable (`§B{bad:str}` binds a null interop return with **zero diagnostics**), and
+that D3 was "argued unreachable". **Unlike D4 and D9 neither is closable by refusing an operation** —
+Z3's string sort has no null and is byte-counted, so every total axiom of its string theory is
+affected. **#876 closes both by DEMOTION** (option B, maintainer-chosen): a proof carried by the
+string theory becomes `Assumed`, which never elides, with the assumption named — on both elision
+channels, postconditions and refinement obligations. That closes the class **by construction**
+rather than by enumeration, which matters given that enumeration is what failed four times. The
+modeling gaps remain open; **#875** tracks the root cause of D3.
 
 **Registered lesson, because this bar has now failed three times by inspection:** *known*-divergence-
 free is a claim about how hard anyone looked. §2 of the freeze already says it is **weaker than

--- a/docs/plans/agent-native-gates.md
+++ b/docs/plans/agent-native-gates.md
@@ -324,8 +324,28 @@ disclosures in the A-1.5 entry below.
 
 ### A.3 Annex revision log
 
-**A-1.8 — PP-A1 adjudicated (2026-08-05).** Additive; registers outcomes against the PP-A1 list frozen
-at `wedge-w1-prereqs.md` §3 and carried unchanged into v0.12. **Items 1–8 PASS; item 9 LAPSED.**
+**A-1.8 — PP-A1 adjudicated (2026-08-05). PP-A1 = FAIL.** Additive; registers outcomes against the
+PP-A1 list frozen at `wedge-w1-prereqs.md` §3 and carried unchanged into v0.12. **Item 6 FAILS; item
+9 LAPSED; items 1–5, 7, 8 PASS. v0.12.0 is blocked.**
+
+**Item 6 fails on divergence D3, which is live.** Three adversarial review rounds found three false-
+`Proven`-elides vectors behind this one item, each time after it had been marked ✅: D4's
+explicit-mode half, D4's no-mode half (both closed in #872), and **D3**, which is not closed. D3
+reproduces on the shipped `calor run --verify` path — `§S (|| (! (isempty result)) (== result
+STR:"")) ` over `§R s` throws under `calor run` and prints `survived` under `--verify`, with `calor
+verify` reporting 100% Proven — and a second shape, `§S (>= (len result) INT:0)`, crashes with a
+NullReferenceException unverified and survives verified. Two prior claims are withdrawn: that
+Calor's `str` is non-nullable (`§B{bad:str}` binds a null interop return with **zero diagnostics**),
+and that D3 was "argued unreachable". **Unlike D4 and D9 this is not closable by refusing an
+operation:** Z3's string sort has no null, so every total axiom of its string theory is unsound once
+a `str` holds one. The two candidate fixes — enforce non-nullable `str` at the binder, or demote
+string-involving proofs to `Assumed` so they never elide (D8 precedent) — are a **maintainer
+decision**, recorded in `pp-a1-adjudication.md` and not taken here.
+
+**Registered lesson, because this bar has now failed three times by inspection:** *known*-divergence-
+free is a claim about how hard anyone looked. §2 of the freeze already says it is **weaker than
+differentially clean**. Item 6's bar should not be re-asserted by another reading of the divergence
+table; it should be replaced by #779's solver-vs-runtime differential suite.
 
 **Item 6 was FAIL when first adjudicated, and this is registered rather than smoothed over.** Its bar
 is *no known false-`Proven`-elides vector*, known set = the divergence table + T1. **Divergence D4 was

--- a/docs/plans/agent-native-gates.md
+++ b/docs/plans/agent-native-gates.md
@@ -324,9 +324,10 @@ disclosures in the A-1.5 entry below.
 
 ### A.3 Annex revision log
 
-**A-1.8 — PP-A1 adjudicated (2026-08-05). Items 1–8 PASS; item 9 LAPSED.** Additive; registers outcomes against the
-PP-A1 list frozen at `wedge-w1-prereqs.md` §3 and carried unchanged into v0.12. **Items 1–8 PASS,
-item 6 only as of #876; item 9 LAPSED and referred to the maintainer.**
+**A-1.8 — PP-A1 adjudicated (2026-08-05). PP-A1 = PASS, all nine items.** Additive; registers outcomes against the
+PP-A1 list frozen at `wedge-w1-prereqs.md` §3 and carried unchanged into v0.12. **All nine PASS —
+item 6 only as of #876, items 4 and 7 only after fixes made during the audit, item 9 only as of
+#877 and later than its registered W2/W3 window.**
 
 **Item 6 passed only after four review rounds found four live vectors.** Three adversarial review rounds found three false-
 `Proven`-elides vectors behind this one item, each time after it had been marked ✅: D4's
@@ -361,16 +362,22 @@ the corrected record carries a **row-by-row** audit of all eleven, including an 
 *argued-unreachable* disposition for D3 and D2 named as the residual inside §2's recorded risk
 acceptance.
 
-**Item 9 = LAPSED.** The frozen text says the `EnableTypeChecking` default-on flip *"lands in the
-W2/W3 window"*; that window closed at v0.12 without it. The first adjudication re-read this as "the
-flip has a slot" and marked it ✅ — a reinterpretation in the favourable direction, and the same class
-of move as overriding a fired trigger. The freeze's "not gate-blocking" clause is scoped to **W1
-exit** and is **not** extended here to the v0.12.0 release. **Cost measured rather than guessed:** the
-flip produces **92 failures / 6,158** in `Calor.Compiler.Tests`, and they are type-checker
-*completeness* gaps — `Calor0200` unknown type ×36 (`object` ×31, `Type` ×6), `Calor0202` member
-access ×8 — i.e. the compiler would begin rejecting programs that are valid today. **Whether the lapse
-blocks v0.12.0 is a maintainer decision**, not one the adjudication may make by reinterpretation; a
-further deferral must name a **new window**.
+**Item 9 = DELIVERED at v0.12 (#877), later than its registered window, and the lapse stays on the
+record.** The frozen text says the flip *"lands in the W2/W3 window"*; that window closed without it,
+and the first adjudication marked the item ✅ anyway by re-reading "lands in the W2/W3 window" as "has
+a slot" — a reinterpretation in the favourable direction. The correct disposition at that moment was
+LAPSED. It is ✅ now because the work was done, not because the reading changed.
+
+**What blocked it was never scheduling.** Flipping the default produced **92 failures**, every one a
+*working program the checker refused*: unknown type `char` ×37, `object` ×13, `Type` ×6, arrays ×6,
+cascades from unmodeled calls, static members read as undefined variables, string `+` reported as
+non-numeric, and a duplicated `Calor0250`. All of it was **already live** — `calor_check` and
+`calor_refine` set the flag — so the MCP primer's own module, two shipped benchmarks and the syntax
+exemplar were being rejected. **Three adversarial review rounds** on the fix found that the flip then
+introduced *new* false positives on two agent-native benchmark **gold references** (one dropping from
+53 proven contracts to zero with a non-zero exit), that **no test project compiled anything under
+`bench/`** so the fix's own measurement had excluded that corpus, and that the round-2 guard was dead
+code. Gates over the bench gold references and over `samples/` now exist; neither did before.
 
 **Items 4 and 7 passed only after fixes made during the audit**, both on the shipped surface rather
 than the one the original evidence cited: `CompileCalor` (the MSBuild task real projects build

--- a/docs/plans/agent-native-gates.md
+++ b/docs/plans/agent-native-gates.md
@@ -99,7 +99,7 @@ After freezing, this document may be superseded only for a **documented empirica
 
 ## Annex A — Instrument metrics (loop plan v0.9, D4.4)
 
-**Annex version: A-1.8 (additive A-1.8, 2026-08-05 — PP-A1 adjudicated: items 1–8 PASS, item 9 LAPSED, item 6 passing only as of #872; additive A-1.6, 2026-08-05 — PP-W2 restated to instrument scope + PP-S1 disposition; additive A-1.7, 2026-08-05 — Call S adjudicated: PP-S3 = MISS, PP-S1 = MISS, PP-S4 = PASS, venue retired; thresholds frozen at A-1.0, 2026-07-24; additive
+**Annex version: A-1.8 (additive A-1.8, 2026-08-05 — PP-A1 adjudicated: all nine PASS, item 6 only after six audits and three merged fixes (#872/#876/#878), item 9 delivered outside its registered window (#877); additive A-1.6, 2026-08-05 — PP-W2 restated to instrument scope + PP-S1 disposition; additive A-1.7, 2026-08-05 — Call S adjudicated: PP-S3 = MISS, PP-S1 = MISS, PP-S4 = PASS, venue retired; thresholds frozen at A-1.0, 2026-07-24; additive
 clarification A-1.1, 2026-07-25; additive PP-W1/M-W1 registration A-1.2, 2026-07-27;
 additive M-G*/PP-G3/PP-G4 registration A-1.3, 2026-07-29 — guarantees plan
 D-G5.1, frozen before the Guarantees probe epoch; additive PP-W5 registration
@@ -331,7 +331,7 @@ item 6 only as of #876, items 4 and 7 only after fixes made during the audit, it
 
 **Item 6 passed only after four review rounds found four live vectors.** Three adversarial review rounds found three false-
 `Proven`-elides vectors behind this one item, each time after it had been marked ✅: D4's
-explicit-mode half, D4's no-mode half (both closed in #872), and **D3**, which is not closed. D3
+explicit-mode half, D4's no-mode half (both closed in #872), **D3** and **D12** (closed in #876), and **D14** (closed in #878). D3
 reproduced on the shipped `calor run --verify` path, as did **D12** (Z3 counts UTF-8 bytes, .NET
 counts UTF-16 code units: `"é".Length` is 1 vs 2). Two prior claims are withdrawn: that Calor's
 `str` is non-nullable (`§B{bad:str}` binds a null interop return with **zero diagnostics**), and
@@ -343,7 +343,7 @@ channels, postconditions and refinement obligations. That closes the class **by 
 rather than by enumeration, which matters given that enumeration is what failed four times. The
 modeling gaps remain open; **#875** tracks the root cause of D3.
 
-**Registered lesson, because this bar has now failed three times by inspection:** *known*-divergence-
+**Registered lesson, because this bar has now failed SIX times by inspection, twice inside its own fixes:** *known*-divergence-
 free is a claim about how hard anyone looked. §2 of the freeze already says it is **weaker than
 differentially clean**. Item 6's bar should not be re-asserted by another reading of the divergence
 table; it should be replaced by #779's solver-vs-runtime differential suite.
@@ -358,8 +358,8 @@ runtime check**. Reproduced end-to-end on a shipped CLI path: the same program t
 Closed by refusal in **#872** (mirroring D9), cache format 1.8 → **1.9** — the bump is load-bearing,
 not hygiene, since warm 1.8 caches hold exactly those false verdicts. Item 6 passes **only as of
 #872**. The first adjudication cited four closed rows (D6–D9) and did not audit the remaining seven;
-the corrected record carries a **row-by-row** audit of all eleven, including an explicit
-*argued-unreachable* disposition for D3 and D2 named as the residual inside §2's recorded risk
+the corrected record carries a **row-by-row** audit of all fourteen. An intermediate revision gave
+D3 an *argued-unreachable* disposition; that argument was refuted by execution and is withdrawn and D2 named as the residual inside §2's recorded risk
 acceptance.
 
 **Item 9 = DELIVERED at v0.12 (#877), later than its registered window, and the lapse stays on the

--- a/docs/plans/agent-native-gates.md
+++ b/docs/plans/agent-native-gates.md
@@ -364,8 +364,17 @@ proving the gate is an acknowledgement rather than a broken command.
 consumability from a local feed; **"published" clears at the v0.12.0 publish event itself**.
 
 **PP-W5 remains NOT adjudicated** — it requires a spend-authorized parity epoch (A-1.4 tranche 1,
-restated additively at A-1.5.6) and **may not be self-cleared**. Record:
-`docs/plans/pp-a1-adjudication.md`.
+restated additively at A-1.5.6) and **may not be self-cleared**. Record: `docs/plans/pp-a1-adjudication.md`.
+
+**A correction the record carries rather than hides:** #872's first fix closed only the
+*explicit-non-ordinal-mode* half of D4. A second adversarial review found the vector still live on
+the **no-mode** spelling — .NET resolves `StartsWith(String)`/`EndsWith(String)`/`IndexOf(String)` to
+**CurrentCulture** while the solver models them ordinally — and it reproduced with the same
+throw-under-`run` / print-under-`--verify` signature. Also closed in #872 (cache 1.9 → **1.10**). The
+lesson registered: the first fix was scoped to *the divergence row as written* rather than to *the
+property the row protects*, and only the second is item 6's bar. **Two rounds of review found two
+live vectors behind one ✅**, so the honest reading of "known-divergence-free" is a statement about
+how hard anyone looked — which is what §2's own risk acceptance already says.
 
 **A-1.7 — Call S adjudicated (2026-08-05).** Additive; registers outcomes against thresholds frozen at
 A-1.5 before any eligibility was evaluated. **PP-S3 = MISS** (headline): M-S3 realized **8** screened

--- a/docs/plans/agent-native-gates.md
+++ b/docs/plans/agent-native-gates.md
@@ -99,7 +99,7 @@ After freezing, this document may be superseded only for a **documented empirica
 
 ## Annex A — Instrument metrics (loop plan v0.9, D4.4)
 
-**Annex version: A-1.7 (additive A-1.6, 2026-08-05 — PP-W2 restated to instrument scope + PP-S1 disposition; additive A-1.7, 2026-08-05 — Call S adjudicated: PP-S3 = MISS, PP-S1 = MISS, PP-S4 = PASS, venue retired; thresholds frozen at A-1.0, 2026-07-24; additive
+**Annex version: A-1.8 (additive A-1.8, 2026-08-05 — PP-A1 adjudicated: items 1–8 PASS, item 9 LAPSED, item 6 passing only as of #872; additive A-1.6, 2026-08-05 — PP-W2 restated to instrument scope + PP-S1 disposition; additive A-1.7, 2026-08-05 — Call S adjudicated: PP-S3 = MISS, PP-S1 = MISS, PP-S4 = PASS, venue retired; thresholds frozen at A-1.0, 2026-07-24; additive
 clarification A-1.1, 2026-07-25; additive PP-W1/M-W1 registration A-1.2, 2026-07-27;
 additive M-G*/PP-G3/PP-G4 registration A-1.3, 2026-07-29 — guarantees plan
 D-G5.1, frozen before the Guarantees probe epoch; additive PP-W5 registration
@@ -323,6 +323,49 @@ disclosures in the A-1.5 entry below.
 | **PP-S4** — no converter-appeasement (**blocker**) | M-S4 = 0 via the A-1.5.7 fixture registry; indeterminate counts as **failing** | Blocks the v0.12.0 release |
 
 ### A.3 Annex revision log
+
+**A-1.8 — PP-A1 adjudicated (2026-08-05).** Additive; registers outcomes against the PP-A1 list frozen
+at `wedge-w1-prereqs.md` §3 and carried unchanged into v0.12. **Items 1–8 PASS; item 9 LAPSED.**
+
+**Item 6 was FAIL when first adjudicated, and this is registered rather than smoothed over.** Its bar
+is *no known false-`Proven`-elides vector*, known set = the divergence table + T1. **Divergence D4 was
+a live one**: a non-ordinal `StringComparison` mode in a contract was translated as **ordinal**, the
+mode-bearing form stayed whitelisted in `ModeledForms`, and `Z3Verifier` never demoted on the warning
+— so the solver returned a genuine false `Proven`, and `Proven && !IsVacuous` (D-G1.3) **elided the
+runtime check**. Reproduced end-to-end on a shipped CLI path: the same program threw
+`ContractViolationException` under `calor run` and printed its value under `calor run --verify`.
+Closed by refusal in **#872** (mirroring D9), cache format 1.8 → **1.9** — the bump is load-bearing,
+not hygiene, since warm 1.8 caches hold exactly those false verdicts. Item 6 passes **only as of
+#872**. The first adjudication cited four closed rows (D6–D9) and did not audit the remaining seven;
+the corrected record carries a **row-by-row** audit of all eleven, including an explicit
+*argued-unreachable* disposition for D3 and D2 named as the residual inside §2's recorded risk
+acceptance.
+
+**Item 9 = LAPSED.** The frozen text says the `EnableTypeChecking` default-on flip *"lands in the
+W2/W3 window"*; that window closed at v0.12 without it. The first adjudication re-read this as "the
+flip has a slot" and marked it ✅ — a reinterpretation in the favourable direction, and the same class
+of move as overriding a fired trigger. The freeze's "not gate-blocking" clause is scoped to **W1
+exit** and is **not** extended here to the v0.12.0 release. **Cost measured rather than guessed:** the
+flip produces **92 failures / 6,158** in `Calor.Compiler.Tests`, and they are type-checker
+*completeness* gaps — `Calor0200` unknown type ×36 (`object` ×31, `Type` ×6), `Calor0202` member
+access ×8 — i.e. the compiler would begin rejecting programs that are valid today. **Whether the lapse
+blocks v0.12.0 is a maintainer decision**, not one the adjudication may make by reinterpretation; a
+further deferral must name a **new window**.
+
+**Items 4 and 7 passed only after fixes made during the audit**, both on the shipped surface rather
+than the one the original evidence cited: `CompileCalor` (the MSBuild task real projects build
+through) trusted a `.g.cs`'s *existence* rather than its content hash, diverging from
+`CompilationDriver`; and `format --write`'s policy refusal ignored `--format json`, so an agent that
+asked for an envelope got a parse failure. The `Calor1346` containment also had **no test anywhere in
+the repo** — item 7 had been adjudicated on code-reading alone — and is now pinned, with a control
+proving the gate is an acknowledgement rather than a broken command.
+
+**Item 1's "published" half is dispositioned, not asserted:** CI evidences the *packaged* SDK's
+consumability from a local feed; **"published" clears at the v0.12.0 publish event itself**.
+
+**PP-W5 remains NOT adjudicated** — it requires a spend-authorized parity epoch (A-1.4 tranche 1,
+restated additively at A-1.5.6) and **may not be self-cleared**. Record:
+`docs/plans/pp-a1-adjudication.md`.
 
 **A-1.7 — Call S adjudicated (2026-08-05).** Additive; registers outcomes against thresholds frozen at
 A-1.5 before any eligibility was evaluated. **PP-S3 = MISS** (headline): M-S3 realized **8** screened

--- a/docs/plans/pp-a1-adjudication.md
+++ b/docs/plans/pp-a1-adjudication.md
@@ -1,4 +1,4 @@
-# PP-A1 — CI adoption gates: **items 1–8 PASS**, item 9 LAPSED
+# PP-A1 — CI adoption gates: **all nine items PASS**
 
 **Adjudicated 2026-08-05**, against the list frozen at [`wedge-w1-prereqs.md`](wedge-w1-prereqs.md)
 §3 ("frozen now, before any results exist"), carried unchanged into v0.12 by the fold-forward
@@ -56,7 +56,7 @@ gate gets marked green while a soundness hole ships.
 | 6 | **Slice-1 soundness batch** — bar: **no known false-`Proven`-elides vector**, known set = divergence table + T1, **and no silently-skipped postcondition check ships** | Four vectors found across four review rounds, all now closed: **D4** both halves by refusal (#872), **D3** and **D12** by demotion (#876). T2 half holds — a nested return emits `Calor1001` rather than skipping silently | ✅ *(only as of #876; see the caveat under Verdict)* |
 | 7 | **T3 containment** — three surfaces gated | `format --write` → `Calor1346` unless `--experimental` / `CALOR_EXPERIMENTAL_FORMAT_WRITE=1`; LSP **formatting** and **rename** register only under `CALOR_LSP_EXPERIMENTAL=1`, read-only handlers unaffected. Two defects found and fixed here; the gate is now **tested** for the first time | ✅ |
 | 8 | **#770 eject-contract** — documented degradation spec | `docs/guides/adoption-playbook.md` §"The eject story (tested)" (`:139-157`) — per-construct degradation table | ✅ |
-| 9 | **#761 flip stance** — `EnableTypeChecking` default-on **lands in the W2/W3 window** with a CHANGELOG note | Window closed at v0.12 without the flip. Still `init`-default `false`, with **no CLI flag at all** | ❌ **LAPSED** |
+| 9 | **#761 flip stance** — `EnableTypeChecking` default-on **lands in the W2/W3 window** with a CHANGELOG note | **Delivered at v0.12 (#877), late.** The flip is in, with the CHANGELOG note the item names. It was blocked not by the flip but by 92 defects in the checker itself — every one a working program it refused, and all of them live for agents already, since `calor_check`/`calor_refine` set the flag | ✅ *(late — see below)* |
 
 ## Item 6 — the row-by-row re-audit the first version owed
 
@@ -142,63 +142,45 @@ by refusal. It was disclosed at the freeze and sits inside §2's recorded risk a
 ("known-divergence-free is **weaker than differentially clean**"), which #779's differential suite is
 the thing that actually closes. **Item 6 passes against its own bar; it does not certify D2.**
 
-## Item 9 — LAPSED, with the cost measured rather than guessed
+## Item 9 — delivered at v0.12, and the lapse stays in the record
 
-The frozen text, verbatim: *"`EnableTypeChecking` default-on lands in the W2/W3 window with a
-CHANGELOG note; recorded here so the flip has a slot, not gate-blocking for W1 exit."*
+The frozen text reads: *"`EnableTypeChecking` default-on lands in the W2/W3 window with a CHANGELOG
+note; recorded here so the flip has a slot, not gate-blocking for W1 exit."*
 
-The first version rendered that as "the requirement is that the flip be *scheduled*, not shipped" and
-marked it ✅. That is a re-reading in the favourable direction: the text names a **window**, and the
-window is what makes a schedule a commitment rather than an intention. W2/W3 are past; the flip did
-not land; the item **lapsed**.
+**The substance is now delivered (#877): the flip is in and the CHANGELOG note is written.** The item
+is satisfied on its own terms.
 
-**What the flip would cost, measured.** Flipping the `init` default to `true` and running
-`Calor.Compiler.Tests`: **92 failures / 6,160**. Tallied by **first cause per failing test** — an
-earlier revision of this document counted diagnostic occurrences across the whole log instead, which
-double-counted `object`, missed `char` entirely, and produced a table whose rows summed to 48 of 92:
+**It landed outside its registered window, and that is recorded rather than smoothed away.** W2/W3
+passed without it, and an earlier revision of this document marked the item ✅ anyway by re-reading
+"lands in the W2/W3 window" as "has a slot" — a reinterpretation in the favourable direction. The
+correct disposition at that moment was LAPSED; it is only ✅ now because the work was actually done.
+
+**What the delay was actually made of, since "not scheduled" was never the reason.** Flipping the
+default produced **92 test failures**, and every one was a *working program the checker refused*:
 
 | First cause | Count |
 |---|---:|
-| `Calor0200` unknown type `char` | **37** |
-| `Calor0200` unknown type `object` | 13 |
-| `Calor0200` unknown type `Type` | 6 |
-| `Calor0200` unknown type `i32[]` | 4 |
-| `Calor0200` unknown type `[str]` | 2 |
-| `Calor0200` unknown type `u32` | 1 |
-| `Calor0200` unknown type, dotted receiver (`price`, `result`) | 2 |
-| no `Unknown type` — assertion failures, `Calor0202`/`0250`/`0251`, indentation | 27 |
-| **Total** | **92** |
+| unknown type `char` | **37** |
+| unknown type `object` | 13 |
+| unknown type `Type` | 6 |
+| arrays (`i32[]`, `[str]`) | 6 |
+| cascades from unmodeled calls (`IF condition must be bool, got <error>`) | ~12 |
+| static members read as undefined variables (`Math.PI`, `int.MaxValue`) | 7 |
+| string `+` reported as non-numeric arithmetic | 4 |
+| `Calor0250` duplicated under a vaguer code | 4 |
 
-Two corrections to the earlier characterization, both in the direction that made the work look
-easier than it is:
+**These were never latent.** `calor_check` and `calor_refine` already set `EnableTypeChecking = true`,
+so agents were hitting all of it — including the MCP primer's own `§M{m3:Files}` module, two shipped
+benchmarks, and the syntax exemplar. A checker that contradicts `docs/syntax-reference/types.md` on
+`char` and `u32` was worse than no checker, and it had been shipped that way.
 
-- **`char` is the dominant cause, not `object`**, and it drives the whole `StringOperationsE2ETests`
-  cluster. The earlier claim that "the dominant cause is a single missing type (`object`, 31 of 36),
-  which makes the work look tractable" was the one sentence a maintainer would act on, and it was
-  not supported.
-- **`u32` and `i32[]`/`[str]` being unknown means the checker's table is missing core documented
-  Calor scalar and array types**, not just BCL escapes.
-- **The residue is not all "completeness gaps".** It contains checker *defects*: string `+`
-  concatenation rejected as non-numeric (`Arithmetic operators require numeric operands, got str`,
-  ×4), `Logical operators require bool operands` (×7), dotted static members unresolved
-  (`Math.PI`, `int.MaxValue`, `StringComparison.Ordinal`, `System.Environment.NewLine`, ×8), and
-  typed literals unrecognized in loop bounds (`Undefined variable 'INT'`, ×2).
-
-Also correcting the diagnostic labels: `Calor0200` is **`UndefinedReference`** and `Calor0202` is
-**`TypeMismatch`** (`Diagnostics/Diagnostic.cs:106,108`); the earlier table called them "unknown
-type" and "field access on non-record".
-
-So item 9 is blocked on **type-checker completeness and correctness**, not on remembering to
-schedule it, and it is a larger job than the first tally implied.
-
-**This is recorded, not overridden.**
-
-- The freeze's "not gate-blocking" clause is scoped to **W1 exit**. It is not evidence about a v0.12.0
-  release, and silently extending it there would be the same move that produced the original ✅.
-- **Whether the lapse blocks v0.12.0 is a maintainer decision**, not one this document may make by
-  reinterpretation.
-- If it is deferred again, the successor plan must name a **new window**, so it can lapse visibly a
-  second time rather than accrue silently.
+**Three adversarial review rounds on the fix**, which is worth recording because the pattern matches
+item 6's: round 2 found the flip had introduced *new* false-positive hard errors on two agent-native
+benchmark **gold references**, one dropping from 53 proven contracts to **zero with a non-zero exit**
+— and that no test project compiled anything under `bench/` at all, so the "92 → 0" measurement had
+been taken on a surface that excluded the corpus the program's own numbers depend on. Round 3 found
+the guard added in round 2 was dead code, and that the new warning fired on a shipped sample. Gates
+over the bench gold references and over `samples/` now exist; neither did before.
 
 ## Defects found by this audit and fixed here
 
@@ -240,29 +222,28 @@ context, not the line.
 
 ## Verdict
 
-**Items 1–8 PASS. Item 9 LAPSED and referred to the maintainer.**
+**PP-A1 = PASS. All nine items.**
 
-Item 6 passes **only as of #876**, and did not pass in any of the three earlier revisions of this
-document that claimed it did.
+Item 6 passes only as of #876, item 4 and item 7 only after fixes made during this audit, and item 9
+only as of #877 — later than its registered window. None of them passed when this document first
+said they did.
 
 **The caveat that belongs on this PASS, stated rather than buried.** Four adversarial review rounds
-found four live false-`Proven`-elides vectors behind this item — D4's explicit-mode half, D4's
-no-mode half, D3, and D12 — each time *after* the item had been marked green, and two of them behind
-rows I had personally re-audited and argued safe. What finally closed it was **not** a better
-enumeration of the divergence table. It was a change of mechanism: #876 removes elision for
-string-carried proofs, so the class is closed by construction rather than by having found every
-member.
+found four live false-`Proven`-elides vectors behind item 6 — each time *after* it had been marked
+green, and two of them behind rows I had personally re-audited and argued safe. What finally closed
+it was **not** a better enumeration of the divergence table. It was a change of mechanism: #876
+removes elision for string-carried proofs, so the class is closed by construction rather than by
+having found every member.
 
 That is the honest reading of the bar. *Known*-divergence-free is a claim about how hard anyone
 looked, and on this evidence inspection does not find the bottom of the solver's string model. §2 of
-the freeze says the same thing in its own words — known-divergence-free is **weaker than
-differentially clean** — and #779's solver-vs-runtime differential suite is the instrument that would
-actually settle it.
+the freeze says the same in its own words — known-divergence-free is **weaker than differentially
+clean** — and #779's differential suite is the instrument that would settle it.
 
 **Registered recommendation for the successor plan:** item 6's bar should not be carried forward as
-"audit the table again". It should be replaced by the differential suite, or by more
+"audit the table again". Replace it with #779's differential suite, or with more
 closed-by-construction changes of the #876 kind. D1, D2, D3 and D12 remain open *modeling* gaps whose
-elide consequences are now neutralized; #875 tracks the root cause of D3.
+elide consequences are now neutralized; #875 tracks D3's root cause.
 
 ## Scope
 

--- a/docs/plans/pp-a1-adjudication.md
+++ b/docs/plans/pp-a1-adjudication.md
@@ -1,10 +1,10 @@
-# PP-A1 — CI adoption gates: **FAIL** (item 6), item 9 LAPSED
+# PP-A1 — CI adoption gates: **items 1–8 PASS**, item 9 LAPSED
 
 **Adjudicated 2026-08-05**, against the list frozen at [`wedge-w1-prereqs.md`](wedge-w1-prereqs.md)
 §3 ("frozen now, before any results exist"), carried unchanged into v0.12 by the fold-forward
 decision. PP-A1 is a **v0.12.0 release gate**, orthogonal to Call S.
 
-## Two revisions of this adjudication claimed a PASS. Both were wrong.
+## Three revisions of this adjudication were wrong before this one. Read that first.
 
 Adversarial review refuted **item 6**, and the refutation was correct: **divergence D4 was a live
 false-`Proven`-elides vector** — the exact thing item 6's frozen bar forbids — sitting unclosed in the
@@ -53,7 +53,7 @@ gate gets marked green while a soundness hole ships.
 | 3 | **Checksummed natives** on every publish path | `scripts/z3-upstream-4.15.7.sha256` + `verify_archive` (defined `download-z3.sh:29`, called at `:122` and `:157`), fail-closed on missing manifest / missing entry / hash mismatch, across four fetch sites. **Residual disclosed rather than glossed:** the ARM64-macOS branch (`:59-64`) execs `build-z3-from-source.sh`, which clones `--branch z3-4.15.7` — a **mutable tag**, no commit pin, no verification (noted in `CHANGELOG.md:31`, absent from the earlier revision of this row) | ✅ |
 | 4 | Complete **options hash** + **fail-closed enforcement** | Options hash: `BuildStateCache.ComputeOptionsHash`, consumed at `CompilationDriver.cs:113`. Fail-closed enforcement **completed here** — `CompileCalor` now matches the driver's output-content check | ✅ *(as of this PR)* |
 | 5 | **Telemetry opt-in** default, stripped payloads, documented | `CalorTelemetry` activates **only** on `CALOR_TELEMETRY=1`; `--no-telemetry` / `CALOR_TELEMETRY_OPTOUT=1` force off; `AnonymizingTelemetryInitializer` strips payloads; `docs/telemetry.md` | ✅ |
-| 6 | **Slice-1 soundness batch** — bar: **no known false-`Proven`-elides vector**, known set = divergence table + T1, **and no silently-skipped postcondition check ships** | D4 closed by refusal in #872 (both halves). **D3 is a live vector** — reproduced end-to-end, below. T2 half holds (a nested return emits `Calor1001` rather than skipping silently) | ❌ **FAIL** |
+| 6 | **Slice-1 soundness batch** — bar: **no known false-`Proven`-elides vector**, known set = divergence table + T1, **and no silently-skipped postcondition check ships** | Four vectors found across four review rounds, all now closed: **D4** both halves by refusal (#872), **D3** and **D12** by demotion (#876). T2 half holds — a nested return emits `Calor1001` rather than skipping silently | ✅ *(only as of #876; see the caveat under Verdict)* |
 | 7 | **T3 containment** — three surfaces gated | `format --write` → `Calor1346` unless `--experimental` / `CALOR_EXPERIMENTAL_FORMAT_WRITE=1`; LSP **formatting** and **rename** register only under `CALOR_LSP_EXPERIMENTAL=1`, read-only handlers unaffected. Two defects found and fixed here; the gate is now **tested** for the first time | ✅ |
 | 8 | **#770 eject-contract** — documented degradation spec | `docs/guides/adoption-playbook.md` §"The eject story (tested)" (`:139-157`) — per-construct degradation table | ✅ |
 | 9 | **#761 flip stance** — `EnableTypeChecking` default-on **lands in the W2/W3 window** with a CHANGELOG note | Window closed at v0.12 without the flip. Still `init`-default `false`, with **no CLI flag at all** | ❌ **LAPSED** |
@@ -67,7 +67,7 @@ with its disposition **and** whether it can mint a false `Proven` that elides:
 |---|---|---|
 | D1 narrow-type promotion | closed by refusal | no |
 | D2 literals always signed 32-bit | truncation half closed (cache 1.7); within-range signedness context unmodeled | residual — see below |
-| D3 Z3 strings cannot be null | **OPEN — live vector, reproduced** | **YES** — see below |
+| D3 Z3 strings cannot be null | **Elide-vector closed by demotion (#876)**; the modeling gap itself is open, tracked by **#875** | no *(was: **yes**)* |
 | D4 non-ordinal comparison modes | **closed by refusal (#872)**, in two halves — explicit non-ordinal modes, and `StartsWith`/`EndsWith`/`IndexOf` with **no** mode (.NET resolves those to CurrentCulture) | no *(was: **yes**, twice)* |
 | D5 `§S` holds only on normal return | exceptional paths → `assumed`, which never elides | no |
 | D6 array element default i32 | adjudicated unreachable from the elision-relevant path | no |
@@ -110,7 +110,10 @@ a Z3 tautology — **crashes with a NullReferenceException** without `--verify` 
 it. So this is not closable by refusing one operation the way D4 and D9 were: **Z3's string sort has
 no null, so every total axiom of its string theory is unsound the moment a `str` holds one.**
 
-**Two candidate fixes, neither a drive-by, and the choice is a product decision:**
+**Closed in #876 by option 2 below**, after the maintainer chose it. The elide vector is gone; the
+modeling gap is not, and is tracked by **#875**.
+
+**The two candidates as they were put, since the choice is on the record:**
 
 1. **Make `str` genuinely non-nullable** — a binder diagnostic when a possibly-null expression
    (notably a C# interop return) is bound to `str` rather than `?str`. This is the *correct* fix:
@@ -122,9 +125,17 @@ no null, so every total axiom of its string theory is unsound the moment a `str`
    elision for every string postcondition — a real capability loss on a headline feature.
 
 `ContractTranslator`'s `StringInfo(bool IsNullable)` / `_stringInfo` — **one write site with five
-callers, read at none, `isNullable` never once passed `true`** — is the vestige of fix (1). The
-previous revision filed it as housekeeping ("wire up or delete"). It should be reclassified: it is
-the unbuilt half of the fix for a live soundness hole.
+callers, read at none, `isNullable` never once passed `true`** — is the vestige of fix (1), and is
+recorded as such on **#875** rather than as housekeeping.
+
+**What #876 actually did**, because the shape matters for the caveat below: a postcondition proof
+carried by the solver's string theory is **demoted to `Assumed`**, which never elides, with the
+assumption named. It closes D3 **and** D12 **and** any string-model vector nobody has found, because
+it removes *elision* — the mechanism that turns a false `Proven` into a deleted check — rather than
+enumerating the divergences. The trigger asks the translator whether a string sort was ever minted,
+not the contract AST; the first attempt asked the AST and missed the function body, which review
+caught. Both elision channels are covered: postconditions (`Proven`) and refinement obligations
+(`Discharged`).
 
 **D2** is the honest residual: the within-range signedness-context half is unmodeled and is not closed
 by refusal. It was disclosed at the freeze and sits inside §2's recorded risk acceptance
@@ -229,27 +240,29 @@ context, not the line.
 
 ## Verdict
 
-**PP-A1 = FAIL.** Item 6 does not meet its frozen bar: **D3 is a known false-`Proven`-elides vector
-and it is live**, on the shipped `calor run --verify` path, with a reproduction of the same shape as
-the D4 finding that caused this document to be rewritten in the first place.
+**Items 1–8 PASS. Item 9 LAPSED and referred to the maintainer.**
 
-Items 1–5, 7 and 8 pass. Item 9 is **LAPSED** and referred to the maintainer.
+Item 6 passes **only as of #876**, and did not pass in any of the three earlier revisions of this
+document that claimed it did.
 
-**This blocks v0.12.0**, which cannot ship with PP-A1 failing. Two decisions are now the
-maintainer's, not this document's:
+**The caveat that belongs on this PASS, stated rather than buried.** Four adversarial review rounds
+found four live false-`Proven`-elides vectors behind this item — D4's explicit-mode half, D4's
+no-mode half, D3, and D12 — each time *after* the item had been marked green, and two of them behind
+rows I had personally re-audited and argued safe. What finally closed it was **not** a better
+enumeration of the divergence table. It was a change of mechanism: #876 removes elision for
+string-carried proofs, so the class is closed by construction rather than by having found every
+member.
 
-1. **How to close D3** — the non-nullable-`str` fix or the stop-eliding-on-strings fix above.
-2. **Whether item 9's lapse independently blocks the release.**
+That is the honest reading of the bar. *Known*-divergence-free is a claim about how hard anyone
+looked, and on this evidence inspection does not find the bottom of the solver's string model. §2 of
+the freeze says the same thing in its own words — known-divergence-free is **weaker than
+differentially clean** — and #779's solver-vs-runtime differential suite is the instrument that would
+actually settle it.
 
-**On what "known-divergence-free" is worth.** Three adversarial review rounds have now found three
-live vectors behind this one item — D4's explicit-mode half, D4's no-mode half, and D3 — each time
-after the item had been marked ✅. Two of the three were behind rows I had personally re-audited.
-"Known" is a claim about how hard anyone looked, and the honest statement is that this bar cannot be
-carried by inspection. §2 of the freeze says the same thing in its own words: known-divergence-free
-is **weaker than differentially clean**, and #779's solver-vs-runtime differential suite is the
-instrument that would actually settle it. **The recommendation this audit ends on is that item 6's
-bar should not be re-asserted by another reading of the table — it should be replaced by the
-differential suite.**
+**Registered recommendation for the successor plan:** item 6's bar should not be carried forward as
+"audit the table again". It should be replaced by the differential suite, or by more
+closed-by-construction changes of the #876 kind. D1, D2, D3 and D12 remain open *modeling* gaps whose
+elide consequences are now neutralized; #875 tracks the root cause of D3.
 
 ## Scope
 

--- a/docs/plans/pp-a1-adjudication.md
+++ b/docs/plans/pp-a1-adjudication.md
@@ -1,0 +1,177 @@
+# PP-A1 — CI adoption gates: **items 1–8 PASS, item 9 LAPSED**
+
+**Adjudicated 2026-08-05**, against the list frozen at [`wedge-w1-prereqs.md`](wedge-w1-prereqs.md)
+§3 ("frozen now, before any results exist"), carried unchanged into v0.12 by the fold-forward
+decision. PP-A1 is a **v0.12.0 release gate**, orthogonal to Call S.
+
+## The first version of this adjudication claimed all nine ✅. It was wrong.
+
+Adversarial review refuted **item 6**, and the refutation was correct: **divergence D4 was a live
+false-`Proven`-elides vector** — the exact thing item 6's frozen bar forbids — sitting unclosed in the
+divergence table the item points at. Verified end-to-end before the fix, on a shipped CLI path:
+
+```calor
+§F{f001:Echo:pub} (str:s) -> str
+  §Q (== s STR:"abc")
+  §S (! (Equals result STR:"ABC" :ignore-case))
+  §R s
+```
+
+`calor run` threw `ContractViolationException` — the postcondition is genuinely **false** at runtime.
+`calor run --verify` printed `abc`: the solver translated `:ignore-case` as *ordinal*, returned
+`Proven`, and the emitter **deleted the check**. Closed by refusal in #872.
+
+Two more rows did not survive contact either:
+
+- **Item 4** was ✅ on evidence from `CompilationDriver`, while the **MSBuild task real projects
+  actually build through** had drifted and was missing the output-content check entirely.
+- **Item 9** was ✅ "by its own terms", where those terms had been quietly re-read from *"lands in the
+  W2/W3 window"* into *"has a slot"*. The window has closed. The item lapsed.
+
+The failure mode common to all three: **the evidence column was assembled by finding something that
+supported each row, not by trying to break it.** Item 6 cited four divergence rows that *were* closed
+(D6/D7/D8/D9) and never audited the rest of the table. That is confirmation, and it is how a release
+gate gets marked green while a soundness hole ships.
+
+## Item-by-item
+
+| # | Requirement | Evidence | |
+|---|---|---|---|
+| 1 | Functional **published** `Calor.Sdk`; **M-A1 green in CI** | `sdk-package-consumer` runs `.github/scripts/test-sdk-package.sh`: packs `Calor.Sdk`, serves it from a **local feed**, and a template consumer restores/builds/tests against the **packaged artifact** — never a source-tree `ProjectReference` — with `CALOR_SDK_REQUIRE_ALL_RIDS=1` and the in-task Z3 canary | ✅ consumability; "published" ⏳ (see Scope) |
+| 2 | Unmasked gates; **publish workflow test-gated** | `publish-nuget.yml`'s `publish` job declares `needs: [test, sdk-consumer]` — publishing cannot run unless both pass | ✅ |
+| 3 | **Checksummed natives** on every publish path | `scripts/z3-upstream-4.15.7.sha256` + `verify_archive` at 3 sites in `download-z3.sh`; verification precedes extraction on every branch, fail-closed on missing manifest / missing entry / hash mismatch | ✅ |
+| 4 | Complete **options hash** + **fail-closed enforcement** | Options hash: `BuildStateCache.ComputeOptionsHash`, consumed at `CompilationDriver.cs:113`. Fail-closed enforcement **completed here** — `CompileCalor` now matches the driver's output-content check | ✅ *(as of this PR)* |
+| 5 | **Telemetry opt-in** default, stripped payloads, documented | `CalorTelemetry` activates **only** on `CALOR_TELEMETRY=1`; `--no-telemetry` / `CALOR_TELEMETRY_OPTOUT=1` force off; `AnonymizingTelemetryInitializer` strips payloads; `docs/telemetry.md` | ✅ |
+| 6 | **Slice-1 soundness batch** — bar: **no known false-`Proven`-elides vector**, known set = divergence table + T1 | **Was FAIL.** D4 closed by refusal in #872; full row-by-row re-audit below | ✅ *(only as of #872)* |
+| 7 | **T3 containment** — three surfaces gated | `format --write` → `Calor1346` unless `--experimental` / `CALOR_EXPERIMENTAL_FORMAT_WRITE=1`; LSP **formatting** and **rename** register only under `CALOR_LSP_EXPERIMENTAL=1`, read-only handlers unaffected. Two defects found and fixed here; the gate is now **tested** for the first time | ✅ |
+| 8 | **#770 eject-contract** — documented degradation spec | `adoption-playbook.md` §"The eject story (tested)" — per-construct degradation table | ✅ |
+| 9 | **#761 flip stance** — `EnableTypeChecking` default-on **lands in the W2/W3 window** with a CHANGELOG note | Window closed at v0.12 without the flip. Still `init`-default `false`, with **no CLI flag at all** | ❌ **LAPSED** |
+
+## Item 6 — the row-by-row re-audit the first version owed
+
+The bar is *known-divergence-free* and the known set is the **whole** divergence table. Every row,
+with its disposition **and** whether it can mint a false `Proven` that elides:
+
+| Row | Disposition | Elide-vector? |
+|---|---|---|
+| D1 narrow-type promotion | closed by refusal | no |
+| D2 literals always signed 32-bit | truncation half closed (cache 1.7); within-range signedness context unmodeled | residual — see below |
+| D3 Z3 strings cannot be null | open, tolerated | argued unreachable — see below |
+| D4 non-ordinal comparison modes | **closed by refusal (#872)** | no *(was: **yes**)* |
+| D5 `§S` holds only on normal return | exceptional paths → `assumed`, which never elides | no |
+| D6 array element default i32 | adjudicated unreachable from the elision-relevant path | no |
+| D7 user-type fields default i32 | closed by refusal | no |
+| D8 contract division totalized | closed (side conditions; demote to `assumed`) | no |
+| D9 `string.Replace` first-vs-all | closed by refusal | no |
+| D10 mixed signed/unsigned | closed by modeling | no |
+| D11 unmasked shift counts | closed by modeling | no |
+
+**D3, argued rather than asserted.** For the null/empty divergence to elide a failing check, the
+solver must prove a string non-empty where the runtime value is `null`. It cannot get there: Calor's
+`str` is non-nullable by construction (`?T` is the nullable form, and `?str` is **not** in
+`ModeledForms.ScalarTypes` — `NormalizeTypeName`'s default arm leaves the `?` intact rather than
+folding it to `str`). With no precondition the solver cannot prove non-emptiness of an unconstrained
+string at all; with one (`§Q (! (IsNullOrEmpty s))`), a `null` argument **fails that precondition at
+runtime**, and precondition guards are never elided (D-G1.2). Same shape as D6's adjudication:
+unreachable from the elision-relevant surface. **This is an argument, not a proof, and is recorded as
+such.**
+
+**A related finding, reported because it invites the opposite conclusion.**
+`ContractTranslator`'s `StringInfo(bool IsNullable)` / `_stringInfo` is **written at five sites and
+read at none**, and `isNullable` is never once passed `true`. It is inert. A maintainer looking for
+D3's handling will find an apparatus that appears to track string nullability and does not — which is
+worse than its absence. Either wire it up or delete it. Filed, not fixed here.
+
+**D2** is the honest residual: the within-range signedness-context half is unmodeled and is not closed
+by refusal. It was disclosed at the freeze and sits inside §2's recorded risk acceptance
+("known-divergence-free is **weaker than differentially clean**"), which #779's differential suite is
+the thing that actually closes. **Item 6 passes against its own bar; it does not certify D2.**
+
+## Item 9 — LAPSED, with the cost measured rather than guessed
+
+The frozen text, verbatim: *"`EnableTypeChecking` default-on lands in the W2/W3 window with a
+CHANGELOG note; recorded here so the flip has a slot, not gate-blocking for W1 exit."*
+
+The first version rendered that as "the requirement is that the flip be *scheduled*, not shipped" and
+marked it ✅. That is a re-reading in the favourable direction: the text names a **window**, and the
+window is what makes a schedule a commitment rather than an intention. W2/W3 are past; the flip did
+not land; the item **lapsed**.
+
+**What the flip would cost, measured.** Flipping the `init` default to `true` and running
+`Calor.Compiler.Tests`: **92 failures / 6,158**. They are not stale fixtures — they are type-checker
+**completeness gaps**, i.e. the compiler would start rejecting programs that are valid today:
+
+| Diagnostic | Count | What it is |
+|---|---:|---|
+| `Calor0200` Unknown type | 36 | `object` ×31, `Type` ×6 — the checker's type table lacks them |
+| `Calor0202` field access on non-record | 8 | trailing member-access chains not modeled |
+| `Calor0250`/`0251` bind inference | 4 | |
+
+So item 9 is blocked on **type-checker completeness**, not on remembering to schedule it. That is
+useful: the dominant cause is a single missing type (`object`, 31 of 36), which makes the work look
+tractable — but it is adopter-facing breakage and it is not v0.12 scope as frozen.
+
+**This is recorded, not overridden.**
+
+- The freeze's "not gate-blocking" clause is scoped to **W1 exit**. It is not evidence about a v0.12.0
+  release, and silently extending it there would be the same move that produced the original ✅.
+- **Whether the lapse blocks v0.12.0 is a maintainer decision**, not one this document may make by
+  reinterpretation.
+- If it is deferred again, the successor plan must name a **new window**, so it can lapse visibly a
+  second time rather than accrue silently.
+
+## Defects found by this audit and fixed here
+
+**1. `format --write`'s refusal ignored `--format json`.** Every other exit from `format` emits the
+envelope (schema v1.1, D1.3); the policy refusal wrote a bare line to stderr with **empty stdout** and
+exited 1. An agent that asked for JSON got a parse failure instead of a policy decision — the one
+message whose entire purpose is to be understood was the one it could not read. It now emits a proper
+envelope carrying `Calor1346`. This is the same class as the early-exit defects already pinned in
+`EnvelopeEarlyExitTests`, and the fix lives there.
+
+**2. The containment had no test at all.** Nothing in the repo referenced `Calor1346`. Item 7 was
+being adjudicated on code-reading alone. Three tests added: the JSON refusal, the text refusal, and —
+the one that makes the other two mean something — a **control** proving the gate is an
+*acknowledgement* rather than a broken command, by running the write path through with
+`CALOR_EXPERIMENTAL_FORMAT_WRITE=1`.
+
+**3. `docs/cli/format.md` documented `--write` as an ordinary option.** The earlier draft of this
+audit fixed three sites; there were **twelve**, including the Quick Start block — the first thing a
+reader copies — and the CI recipe, the editor-integration snippet, and the heal-in-place example. All
+corrected, with a dedicated section stating the refusal, both escape hatches, the exit code, the JSON
+behaviour, and the sibling `CALOR_LSP_EXPERIMENTAL` containment.
+
+**4. `CompileCalor` trusted a `.g.cs`'s existence, not its content** (item 4). `CompilationDriver` has
+always required the output's hash to match what the producing compile wrote, so a truncated or
+hand-edited generated file is a miss; the MSBuild task — **the path real projects build through** —
+only checked that the file existed, and reported stale bytes as "up-to-date". Ported, with a
+regression test that corrupts the output and asserts recompilation (plus a control proving an
+untouched output still skips). The `EffectSummary != null` skip condition was ported alongside it as
+defence in depth: **not reachable through this task today**, since a null AST implies `HasErrors`,
+which returns before caching.
+
+## A near-miss worth recording
+
+An intermediate step of this audit read `Program.cs`'s `WithHandler<FormattingHandler>()` /
+`WithHandler<RenameHandler>()` lines *without their enclosing `if (experimentalWriteHandlers)` block*
+and concluded item 7 was unmet — that a release blocker had failed. It had not. Grep-level evidence
+about whether something is *gated* is unreliable by construction, because the gate is the enclosing
+context, not the line.
+
+## Verdict
+
+**Items 1–8 PASS. Item 9 LAPSED and referred to the maintainer.**
+
+Item 6 passes **only as of #872** — it did not pass when this document first claimed it did.
+
+## Scope
+
+- **PASS is against the frozen list only.** Items explicitly excluded there — coverage ratchets,
+  mutation testing, LSP E2E revival, SBOM/hermetic builds, #782/#781 full fixes, #764 full lowering,
+  D1/D2 numeric-semantics fixes — remain out and are not implied.
+- **Item 1's "published" half cannot be evidenced pre-release.** CI proves the *packaged* SDK is
+  consumable from a local feed, which is the substantive property; **"published" clears at the v0.12.0
+  publish event itself and not before.** Recorded so the row is not read as more than it is.
+- **PP-W5 is the other release gate and is NOT adjudicated here.** It requires a spend-authorized
+  parity epoch (frozen A-1.4 tranche 1, restated additively at A-1.5.6) and is a maintainer decision.
+  It may not be self-cleared.

--- a/docs/plans/pp-a1-adjudication.md
+++ b/docs/plans/pp-a1-adjudication.md
@@ -50,18 +50,21 @@ gate gets marked green while a soundness hole ships.
 |---|---|---|---|
 | 1 | Functional **published** `Calor.Sdk`; **M-A1 green in CI** | `sdk-package-consumer` runs `.github/scripts/test-sdk-package.sh`: packs `Calor.Sdk`, serves it from a **local feed**, and a template consumer restores/builds/tests against the **packaged artifact** — never a source-tree `ProjectReference` — with `CALOR_SDK_REQUIRE_ALL_RIDS=1` and the in-task Z3 canary | ✅ consumability; "published" ⏳ (see Scope) |
 | 2 | Unmasked gates; publish workflow test-gated; **test-manifest honesty** | All three legs, the third of which an earlier revision restated away: (a) `test.yml:408-430` scans `samples/` unmasked, and `:406` runs `Calor.Ids.Tests`; (b) `publish-nuget.yml`'s `publish` declares `needs: [test, sdk-consumer]`, both keys exist verbatim, and neither the job nor its steps carry an `if:`/`continue-on-error:` that could undermine it; (c) `Calor.Performance.Tests` is wired to nightly `performance.yml:29`. **Residual disclosed:** `Calor.Ids.Tests` is in `test.yml` but **not** in the publish gate | ✅ |
-| 3 | **Checksummed natives** on every publish path | `scripts/z3-upstream-4.15.7.sha256` + `verify_archive` (defined `download-z3.sh:29`, called at `:122` and `:157`), fail-closed on missing manifest / missing entry / hash mismatch, across four fetch sites. **Residual disclosed rather than glossed:** the ARM64-macOS branch (`:59-64`) execs `build-z3-from-source.sh`, which clones `--branch z3-4.15.7` — a **mutable tag**, no commit pin, no verification (noted in `CHANGELOG.md:31`, absent from the earlier revision of this row) | ✅ |
+| 3 | **Checksummed natives** on every publish path | `scripts/z3-upstream-4.15.7.sha256` + `verify_archive` (defined `download-z3.sh:29`, called at `:122` and `:157`), fail-closed on missing manifest / missing entry / hash mismatch, across four fetch sites. **Residual disclosed rather than glossed:** the ARM64-macOS branch (`:59-64`) execs `build-z3-from-source.sh`, which clones `--branch z3-4.15.7` — a **mutable tag**, no commit pin, no verification (noted in `CHANGELOG.md:42`, absent from the earlier revision of this row) | ✅ |
 | 4 | Complete **options hash** + **fail-closed enforcement** | Options hash: `BuildStateCache.ComputeOptionsHash`, consumed at `CompilationDriver.cs:113`. Fail-closed enforcement **completed here** — `CompileCalor` now matches the driver's output-content check | ✅ *(as of this PR)* |
 | 5 | **Telemetry opt-in** default, stripped payloads, documented | `CalorTelemetry` activates **only** on `CALOR_TELEMETRY=1`; `--no-telemetry` / `CALOR_TELEMETRY_OPTOUT=1` force off; `AnonymizingTelemetryInitializer` strips payloads; `docs/telemetry.md` | ✅ |
-| 6 | **Slice-1 soundness batch** — bar: **no known false-`Proven`-elides vector**, known set = divergence table + T1, **and no silently-skipped postcondition check ships** | Four vectors found across four review rounds, all now closed: **D4** both halves by refusal (#872), **D3** and **D12** by demotion (#876). T2 half holds — a nested return emits `Calor1001` rather than skipping silently | ✅ *(only as of #876; see the caveat under Verdict)* |
+| 6 | **Slice-1 soundness batch** — bar: **no known false-`Proven`-elides vector**, known set = divergence table + T1, **and no silently-skipped postcondition check ships** | **Six** vectors across **six** review rounds, all closed: **D4** both halves by refusal (#872), **D3**/**D12** by demotion (#876), **D14** (arrays and user-type sorts) by the same demotion (#878), and a sixth site inside that fix. T2 half holds — a nested return emits `Calor1001` rather than skipping silently | ✅ *(only as of #878; see the caveat under Verdict)* |
 | 7 | **T3 containment** — three surfaces gated | `format --write` → `Calor1346` unless `--experimental` / `CALOR_EXPERIMENTAL_FORMAT_WRITE=1`; LSP **formatting** and **rename** register only under `CALOR_LSP_EXPERIMENTAL=1`, read-only handlers unaffected. Two defects found and fixed here; the gate is now **tested** for the first time | ✅ |
 | 8 | **#770 eject-contract** — documented degradation spec | `docs/guides/adoption-playbook.md` §"The eject story (tested)" (`:139-157`) — per-construct degradation table | ✅ |
-| 9 | **#761 flip stance** — `EnableTypeChecking` default-on **lands in the W2/W3 window** with a CHANGELOG note | **Delivered at v0.12 (#877), late.** The flip is in, with the CHANGELOG note the item names. It was blocked not by the flip but by 92 defects in the checker itself — every one a working program it refused, and all of them live for agents already, since `calor_check`/`calor_refine` set the flag | ✅ *(late — see below)* |
+| 9 | **#761 flip stance** — `EnableTypeChecking` default-on **lands in the W2/W3 window** with a CHANGELOG note | **Delivered at v0.12 (#877), outside the window.** The flip is in, with the CHANGELOG note the item names. It was blocked not by the flip but by 92 defects in the checker itself — every one a working program it refused, and all of them live for agents already, since `calor_check`/`calor_refine` set the flag | ✅ *(delivered v0.12, outside window — see below)* |
 
 ## Item 6 — the row-by-row re-audit the first version owed
 
-The bar is *known-divergence-free* and the known set is the **whole** divergence table. Every row,
-with its disposition **and** whether it can mint a false `Proven` that elides:
+The bar is *known-divergence-free* and the known set is the **whole** divergence table — **all
+fifteen rows**, not the eleven an earlier revision of this section swept. It omitted D12 (recorded
+only inside D3's prose) and D13 entirely, which is the identical failure this document indicts two
+sections above. Every row, with its disposition **and** whether it can mint a false `Proven` that
+elides:
 
 | Row | Disposition | Elide-vector? |
 |---|---|---|
@@ -76,6 +79,9 @@ with its disposition **and** whether it can mint a false `Proven` that elides:
 | D9 `string.Replace` first-vs-all | closed by refusal | no |
 | D10 mixed signed/unsigned | closed by modeling | no |
 | D11 unmasked shift counts | closed by modeling | no |
+| D12 Z3 strings are UTF-8 BYTES, .NET counts UTF-16 code units | **closed by demotion (#876)**, same mechanism as D3 | no *(was: **yes**)* |
+| D13 `Substring` out of range throws in .NET; Z3 totalizes to `""` | open in the table, but **neutralized incidentally**: any `substr` touches the string theory, so the proof is demoted to `Assumed` and cannot elide | no |
+| **D14** Z3's array and user-type sorts are total and non-null; .NET's `T[]` and classes are nullable references | **closed by demotion (#878).** `a$length` is an unconstrained u32, so `a.Length >= 0` was a solver tautology and a runtime `NullReferenceException`. Found on the FIFTH audit, in nine lines of pure Calor | no *(was: **yes**)* |
 | **T2** (#764) — the bar's second clause, *no silently-skipped postcondition check ships* | Holds: a nested return emits `warning Calor1001: Postcondition runtime checks for '…' were NOT emitted` | no |
 
 **D3 is live, and my argument that it was not is the single worst thing in this document's history.**
@@ -228,12 +234,20 @@ Item 6 passes only as of #876, item 4 and item 7 only after fixes made during th
 only as of #877 — later than its registered window. None of them passed when this document first
 said they did.
 
-**The caveat that belongs on this PASS, stated rather than buried.** Four adversarial review rounds
-found four live false-`Proven`-elides vectors behind item 6 — each time *after* it had been marked
-green, and two of them behind rows I had personally re-audited and argued safe. What finally closed
-it was **not** a better enumeration of the divergence table. It was a change of mechanism: #876
-removes elision for string-carried proofs, so the class is closed by construction rather than by
+**The caveat that belongs on this PASS, stated rather than buried.** **Six** adversarial review
+rounds found **six** live false-`Proven`-elides vectors behind item 6 — every one *after* the item
+had been marked green, two behind rows I had personally re-audited and argued safe, and **two inside
+the fixes for the previous ones**. What closed them was **not** a better enumeration of the
+divergence table. It was a change of mechanism: proofs carried by a sort Z3 models as total are
+demoted to `Assumed`, which never elides, so the class is closed by construction rather than by
 having found every member.
+
+**And the class had to be redrawn twice before that construction was right.** #876 closed *strings*
+and this document then said arrays were unaffected — which was true, and was D14. The class is
+**a sort Z3 models as total where the .NET value can be null**; strings, arrays and user-type sorts
+are three members, and the sixth vector was a `$length` mint inside D14's own fix that the by-hand
+enumeration missed. The record is that hand-enumeration failed at every level it was tried:
+divergence rows, then sorts, then mint sites.
 
 That is the honest reading of the bar. *Known*-divergence-free is a claim about how hard anyone
 looked, and on this evidence inspection does not find the bottom of the solver's string model. §2 of
@@ -242,8 +256,14 @@ clean** — and #779's differential suite is the instrument that would settle it
 
 **Registered recommendation for the successor plan:** item 6's bar should not be carried forward as
 "audit the table again". Replace it with #779's differential suite, or with more
-closed-by-construction changes of the #876 kind. D1, D2, D3 and D12 remain open *modeling* gaps whose
-elide consequences are now neutralized; #875 tracks D3's root cause.
+closed-by-construction changes of the #876/#878 kind. The evidence for this is now concrete rather
+than rhetorical: **D14 was found in under an hour by asking which *other* sorts are total in Z3 and
+nullable in .NET** — a differential question — after four rounds of table re-reading had missed it.
+
+D1, D2, D3, D12 and D14 remain open *modeling* gaps whose elide consequences are neutralized.
+**#875** tracks D3's root cause; **#879** tracks a seventh finding in a different class entirely —
+the elision key is a mutable cursor `Visit(MethodNode)` never maintains, which today means class-
+method postconditions never elide and every `§MT` violation reports the wrong function id.
 
 ## Scope
 

--- a/docs/plans/pp-a1-adjudication.md
+++ b/docs/plans/pp-a1-adjudication.md
@@ -21,6 +21,17 @@ divergence table the item points at. Verified end-to-end before the fix, on a sh
 `calor run --verify` printed `abc`: the solver translated `:ignore-case` as *ordinal*, returned
 `Proven`, and the emitter **deleted the check**. Closed by refusal in #872.
 
+**And then it happened again, to the fix.** Adversarial review of #872 found the *same vector still
+open* on the spelling almost everyone actually writes: .NET resolves `String.StartsWith(String)`,
+`EndsWith(String)` and `IndexOf(String)` to the **CurrentCulture** overload (unlike `Contains` and
+`Equals`, which are ordinal), while the solver models all of them ordinally. `§S (! (starts result
+STR:"\u200dabc"))` reproduced the identical throw-vs-print signature. Also closed in #872.
+
+That second finding is the strongest evidence for this document's own thesis. The first fix was
+narrow **because it was scoped to the row as written** rather than to the property the row is
+supposed to protect. Closing "the divergence the table names" is not the same as closing "the ways a
+false `Proven` can elide a check", and only the second is item 6's bar.
+
 Two more rows did not survive contact either:
 
 - **Item 4** was ✅ on evidence from `CompilationDriver`, while the **MSBuild task real projects
@@ -57,7 +68,7 @@ with its disposition **and** whether it can mint a false `Proven` that elides:
 | D1 narrow-type promotion | closed by refusal | no |
 | D2 literals always signed 32-bit | truncation half closed (cache 1.7); within-range signedness context unmodeled | residual — see below |
 | D3 Z3 strings cannot be null | open, tolerated | argued unreachable — see below |
-| D4 non-ordinal comparison modes | **closed by refusal (#872)** | no *(was: **yes**)* |
+| D4 non-ordinal comparison modes | **closed by refusal (#872)**, in two halves — explicit non-ordinal modes, and `StartsWith`/`EndsWith`/`IndexOf` with **no** mode (.NET resolves those to CurrentCulture) | no *(was: **yes**, twice)* |
 | D5 `§S` holds only on normal return | exceptional paths → `assumed`, which never elides | no |
 | D6 array element default i32 | adjudicated unreachable from the elision-relevant path | no |
 | D7 user-type fields default i32 | closed by refusal | no |
@@ -162,7 +173,15 @@ context, not the line.
 
 **Items 1–8 PASS. Item 9 LAPSED and referred to the maintainer.**
 
-Item 6 passes **only as of #872** — it did not pass when this document first claimed it did.
+Item 6 passes **only as of #872** — it did not pass when this document first claimed it did, and it
+did not pass after the first half of that PR either.
+
+**Stated plainly, because it bears on how much this verdict is worth:** two rounds of adversarial
+review found two live soundness vectors behind an item that had been marked ✅. The bar is
+*known-divergence-free*, and "known" is a claim about how hard anyone looked. The residual honest
+statement is that no vector is known **to me** after this audit — not that none exists. §2's recorded
+risk acceptance says the same thing in the freeze's own words: known-divergence-free is **weaker than
+differentially clean**, and #779's differential suite is what would close the gap.
 
 ## Scope
 

--- a/docs/plans/pp-a1-adjudication.md
+++ b/docs/plans/pp-a1-adjudication.md
@@ -1,10 +1,10 @@
-# PP-A1 — CI adoption gates: **items 1–8 PASS, item 9 LAPSED**
+# PP-A1 — CI adoption gates: **FAIL** (item 6), item 9 LAPSED
 
 **Adjudicated 2026-08-05**, against the list frozen at [`wedge-w1-prereqs.md`](wedge-w1-prereqs.md)
 §3 ("frozen now, before any results exist"), carried unchanged into v0.12 by the fold-forward
 decision. PP-A1 is a **v0.12.0 release gate**, orthogonal to Call S.
 
-## The first version of this adjudication claimed all nine ✅. It was wrong.
+## Two revisions of this adjudication claimed a PASS. Both were wrong.
 
 Adversarial review refuted **item 6**, and the refutation was correct: **divergence D4 was a live
 false-`Proven`-elides vector** — the exact thing item 6's frozen bar forbids — sitting unclosed in the
@@ -49,13 +49,13 @@ gate gets marked green while a soundness hole ships.
 | # | Requirement | Evidence | |
 |---|---|---|---|
 | 1 | Functional **published** `Calor.Sdk`; **M-A1 green in CI** | `sdk-package-consumer` runs `.github/scripts/test-sdk-package.sh`: packs `Calor.Sdk`, serves it from a **local feed**, and a template consumer restores/builds/tests against the **packaged artifact** — never a source-tree `ProjectReference` — with `CALOR_SDK_REQUIRE_ALL_RIDS=1` and the in-task Z3 canary | ✅ consumability; "published" ⏳ (see Scope) |
-| 2 | Unmasked gates; **publish workflow test-gated** | `publish-nuget.yml`'s `publish` job declares `needs: [test, sdk-consumer]` — publishing cannot run unless both pass | ✅ |
-| 3 | **Checksummed natives** on every publish path | `scripts/z3-upstream-4.15.7.sha256` + `verify_archive` at 3 sites in `download-z3.sh`; verification precedes extraction on every branch, fail-closed on missing manifest / missing entry / hash mismatch | ✅ |
+| 2 | Unmasked gates; publish workflow test-gated; **test-manifest honesty** | All three legs, the third of which an earlier revision restated away: (a) `test.yml:408-430` scans `samples/` unmasked, and `:406` runs `Calor.Ids.Tests`; (b) `publish-nuget.yml`'s `publish` declares `needs: [test, sdk-consumer]`, both keys exist verbatim, and neither the job nor its steps carry an `if:`/`continue-on-error:` that could undermine it; (c) `Calor.Performance.Tests` is wired to nightly `performance.yml:29`. **Residual disclosed:** `Calor.Ids.Tests` is in `test.yml` but **not** in the publish gate | ✅ |
+| 3 | **Checksummed natives** on every publish path | `scripts/z3-upstream-4.15.7.sha256` + `verify_archive` (defined `download-z3.sh:29`, called at `:122` and `:157`), fail-closed on missing manifest / missing entry / hash mismatch, across four fetch sites. **Residual disclosed rather than glossed:** the ARM64-macOS branch (`:59-64`) execs `build-z3-from-source.sh`, which clones `--branch z3-4.15.7` — a **mutable tag**, no commit pin, no verification (noted in `CHANGELOG.md:31`, absent from the earlier revision of this row) | ✅ |
 | 4 | Complete **options hash** + **fail-closed enforcement** | Options hash: `BuildStateCache.ComputeOptionsHash`, consumed at `CompilationDriver.cs:113`. Fail-closed enforcement **completed here** — `CompileCalor` now matches the driver's output-content check | ✅ *(as of this PR)* |
 | 5 | **Telemetry opt-in** default, stripped payloads, documented | `CalorTelemetry` activates **only** on `CALOR_TELEMETRY=1`; `--no-telemetry` / `CALOR_TELEMETRY_OPTOUT=1` force off; `AnonymizingTelemetryInitializer` strips payloads; `docs/telemetry.md` | ✅ |
-| 6 | **Slice-1 soundness batch** — bar: **no known false-`Proven`-elides vector**, known set = divergence table + T1 | **Was FAIL.** D4 closed by refusal in #872; full row-by-row re-audit below | ✅ *(only as of #872)* |
+| 6 | **Slice-1 soundness batch** — bar: **no known false-`Proven`-elides vector**, known set = divergence table + T1, **and no silently-skipped postcondition check ships** | D4 closed by refusal in #872 (both halves). **D3 is a live vector** — reproduced end-to-end, below. T2 half holds (a nested return emits `Calor1001` rather than skipping silently) | ❌ **FAIL** |
 | 7 | **T3 containment** — three surfaces gated | `format --write` → `Calor1346` unless `--experimental` / `CALOR_EXPERIMENTAL_FORMAT_WRITE=1`; LSP **formatting** and **rename** register only under `CALOR_LSP_EXPERIMENTAL=1`, read-only handlers unaffected. Two defects found and fixed here; the gate is now **tested** for the first time | ✅ |
-| 8 | **#770 eject-contract** — documented degradation spec | `adoption-playbook.md` §"The eject story (tested)" — per-construct degradation table | ✅ |
+| 8 | **#770 eject-contract** — documented degradation spec | `docs/guides/adoption-playbook.md` §"The eject story (tested)" (`:139-157`) — per-construct degradation table | ✅ |
 | 9 | **#761 flip stance** — `EnableTypeChecking` default-on **lands in the W2/W3 window** with a CHANGELOG note | Window closed at v0.12 without the flip. Still `init`-default `false`, with **no CLI flag at all** | ❌ **LAPSED** |
 
 ## Item 6 — the row-by-row re-audit the first version owed
@@ -67,7 +67,7 @@ with its disposition **and** whether it can mint a false `Proven` that elides:
 |---|---|---|
 | D1 narrow-type promotion | closed by refusal | no |
 | D2 literals always signed 32-bit | truncation half closed (cache 1.7); within-range signedness context unmodeled | residual — see below |
-| D3 Z3 strings cannot be null | open, tolerated | argued unreachable — see below |
+| D3 Z3 strings cannot be null | **OPEN — live vector, reproduced** | **YES** — see below |
 | D4 non-ordinal comparison modes | **closed by refusal (#872)**, in two halves — explicit non-ordinal modes, and `StartsWith`/`EndsWith`/`IndexOf` with **no** mode (.NET resolves those to CurrentCulture) | no *(was: **yes**, twice)* |
 | D5 `§S` holds only on normal return | exceptional paths → `assumed`, which never elides | no |
 | D6 array element default i32 | adjudicated unreachable from the elision-relevant path | no |
@@ -76,22 +76,55 @@ with its disposition **and** whether it can mint a false `Proven` that elides:
 | D9 `string.Replace` first-vs-all | closed by refusal | no |
 | D10 mixed signed/unsigned | closed by modeling | no |
 | D11 unmasked shift counts | closed by modeling | no |
+| **T2** (#764) — the bar's second clause, *no silently-skipped postcondition check ships* | Holds: a nested return emits `warning Calor1001: Postcondition runtime checks for '…' were NOT emitted` | no |
 
-**D3, argued rather than asserted.** For the null/empty divergence to elide a failing check, the
-solver must prove a string non-empty where the runtime value is `null`. It cannot get there: Calor's
-`str` is non-nullable by construction (`?T` is the nullable form, and `?str` is **not** in
-`ModeledForms.ScalarTypes` — `NormalizeTypeName`'s default arm leaves the `?` intact rather than
-folding it to `str`). With no precondition the solver cannot prove non-emptiness of an unconstrained
-string at all; with one (`§Q (! (IsNullOrEmpty s))`), a `null` argument **fails that precondition at
-runtime**, and precondition guards are never elided (D-G1.2). Same shape as D6's adjudication:
-unreachable from the elision-relevant surface. **This is an argument, not a proof, and is recorded as
-such.**
+**D3 is live, and my argument that it was not is the single worst thing in this document's history.**
 
-**A related finding, reported because it invites the opposite conclusion.**
-`ContractTranslator`'s `StringInfo(bool IsNullable)` / `_stringInfo` is **written at five sites and
-read at none**, and `isNullable` is never once passed `true`. It is inert. A maintainer looking for
-D3's handling will find an apparatus that appears to track string nullability and does not — which is
-worse than its absence. Either wire it up or delete it. Filed, not fixed here.
+The previous revision argued D3 unreachable: Calor's `str` is non-nullable by construction, so the
+solver could never prove a string non-empty where the runtime value is `null`. Adversarial review
+executed the argument instead of reading it, and every leg failed:
+
+- **`str` is not non-nullable in practice.** `§B{bad:str}` binds `Environment.GetEnvironmentVariable`'s
+  `null` with **zero diagnostics**. The `?T` form exists; nothing enforces it.
+- **No precondition is needed.** The divergence bites in the direction the argument never
+  considered: Z3 makes `len(s) = 0 ⟺ s = ""` a tautology, while in C# `null` satisfies
+  `IsNullOrEmpty` and `null == ""` is **false**.
+
+Reproduced end-to-end on the same shipped path as D4, in pure Calor:
+
+```calor
+§F{f001:Echo:pub} (str:s) -> str
+  §E{}
+  §S (|| (! (isempty result)) (== result STR:""))
+  §R s
+```
+
+| command | result |
+|---|---|
+| `calor run` | **throws** — `!string.IsNullOrEmpty(__result__) \|\| __result__ == ""` is genuinely false |
+| `calor run --verify` | prints `survived` — **check deleted** |
+| `calor verify` | `Proven Rate: 100.0%` |
+
+**And it is not one form.** Independently confirmed a second shape: `§S (>= (len result) INT:0)` —
+a Z3 tautology — **crashes with a NullReferenceException** without `--verify` and **survives** with
+it. So this is not closable by refusing one operation the way D4 and D9 were: **Z3's string sort has
+no null, so every total axiom of its string theory is unsound the moment a `str` holds one.**
+
+**Two candidate fixes, neither a drive-by, and the choice is a product decision:**
+
+1. **Make `str` genuinely non-nullable** — a binder diagnostic when a possibly-null expression
+   (notably a C# interop return) is bound to `str` rather than `?str`. This is the *correct* fix:
+   it makes the type system's existing claim true, and D3 becomes unreachable for real rather than
+   by argument. It needs nullability analysis over interop returns.
+2. **Stop eliding on string-involving proofs** — demote such a `Proven` to `Assumed`, which never
+   elides (the D8 precedent). Cheap, and it closes the whole class including vectors nobody has
+   found yet, because elision is the only thing that makes a false `Proven` dangerous. It costs
+   elision for every string postcondition — a real capability loss on a headline feature.
+
+`ContractTranslator`'s `StringInfo(bool IsNullable)` / `_stringInfo` — **one write site with five
+callers, read at none, `isNullable` never once passed `true`** — is the vestige of fix (1). The
+previous revision filed it as housekeeping ("wire up or delete"). It should be reclassified: it is
+the unbuilt half of the fix for a live soundness hole.
 
 **D2** is the honest residual: the within-range signedness-context half is unmodeled and is not closed
 by refusal. It was disclosed at the freeze and sits inside §2's recorded risk acceptance
@@ -109,18 +142,43 @@ window is what makes a schedule a commitment rather than an intention. W2/W3 are
 not land; the item **lapsed**.
 
 **What the flip would cost, measured.** Flipping the `init` default to `true` and running
-`Calor.Compiler.Tests`: **92 failures / 6,158**. They are not stale fixtures — they are type-checker
-**completeness gaps**, i.e. the compiler would start rejecting programs that are valid today:
+`Calor.Compiler.Tests`: **92 failures / 6,160**. Tallied by **first cause per failing test** — an
+earlier revision of this document counted diagnostic occurrences across the whole log instead, which
+double-counted `object`, missed `char` entirely, and produced a table whose rows summed to 48 of 92:
 
-| Diagnostic | Count | What it is |
-|---|---:|---|
-| `Calor0200` Unknown type | 36 | `object` ×31, `Type` ×6 — the checker's type table lacks them |
-| `Calor0202` field access on non-record | 8 | trailing member-access chains not modeled |
-| `Calor0250`/`0251` bind inference | 4 | |
+| First cause | Count |
+|---|---:|
+| `Calor0200` unknown type `char` | **37** |
+| `Calor0200` unknown type `object` | 13 |
+| `Calor0200` unknown type `Type` | 6 |
+| `Calor0200` unknown type `i32[]` | 4 |
+| `Calor0200` unknown type `[str]` | 2 |
+| `Calor0200` unknown type `u32` | 1 |
+| `Calor0200` unknown type, dotted receiver (`price`, `result`) | 2 |
+| no `Unknown type` — assertion failures, `Calor0202`/`0250`/`0251`, indentation | 27 |
+| **Total** | **92** |
 
-So item 9 is blocked on **type-checker completeness**, not on remembering to schedule it. That is
-useful: the dominant cause is a single missing type (`object`, 31 of 36), which makes the work look
-tractable — but it is adopter-facing breakage and it is not v0.12 scope as frozen.
+Two corrections to the earlier characterization, both in the direction that made the work look
+easier than it is:
+
+- **`char` is the dominant cause, not `object`**, and it drives the whole `StringOperationsE2ETests`
+  cluster. The earlier claim that "the dominant cause is a single missing type (`object`, 31 of 36),
+  which makes the work look tractable" was the one sentence a maintainer would act on, and it was
+  not supported.
+- **`u32` and `i32[]`/`[str]` being unknown means the checker's table is missing core documented
+  Calor scalar and array types**, not just BCL escapes.
+- **The residue is not all "completeness gaps".** It contains checker *defects*: string `+`
+  concatenation rejected as non-numeric (`Arithmetic operators require numeric operands, got str`,
+  ×4), `Logical operators require bool operands` (×7), dotted static members unresolved
+  (`Math.PI`, `int.MaxValue`, `StringComparison.Ordinal`, `System.Environment.NewLine`, ×8), and
+  typed literals unrecognized in loop bounds (`Undefined variable 'INT'`, ×2).
+
+Also correcting the diagnostic labels: `Calor0200` is **`UndefinedReference`** and `Calor0202` is
+**`TypeMismatch`** (`Diagnostics/Diagnostic.cs:106,108`); the earlier table called them "unknown
+type" and "field access on non-record".
+
+So item 9 is blocked on **type-checker completeness and correctness**, not on remembering to
+schedule it, and it is a larger job than the first tally implied.
 
 **This is recorded, not overridden.**
 
@@ -140,7 +198,7 @@ message whose entire purpose is to be understood was the one it could not read. 
 envelope carrying `Calor1346`. This is the same class as the early-exit defects already pinned in
 `EnvelopeEarlyExitTests`, and the fix lives there.
 
-**2. The containment had no test at all.** Nothing in the repo referenced `Calor1346`. Item 7 was
+**2. The containment had no test at all.** No *test* anywhere referenced `Calor1346` (`docs/cli/structured-output.md:182` did, so the stronger "nothing in the repo" phrasing an earlier revision used was wrong). Item 7 was
 being adjudicated on code-reading alone. Three tests added: the JSON refusal, the text refusal, and —
 the one that makes the other two mean something — a **control** proving the gate is an
 *acknowledgement* rather than a broken command, by running the write path through with
@@ -171,17 +229,27 @@ context, not the line.
 
 ## Verdict
 
-**Items 1–8 PASS. Item 9 LAPSED and referred to the maintainer.**
+**PP-A1 = FAIL.** Item 6 does not meet its frozen bar: **D3 is a known false-`Proven`-elides vector
+and it is live**, on the shipped `calor run --verify` path, with a reproduction of the same shape as
+the D4 finding that caused this document to be rewritten in the first place.
 
-Item 6 passes **only as of #872** — it did not pass when this document first claimed it did, and it
-did not pass after the first half of that PR either.
+Items 1–5, 7 and 8 pass. Item 9 is **LAPSED** and referred to the maintainer.
 
-**Stated plainly, because it bears on how much this verdict is worth:** two rounds of adversarial
-review found two live soundness vectors behind an item that had been marked ✅. The bar is
-*known-divergence-free*, and "known" is a claim about how hard anyone looked. The residual honest
-statement is that no vector is known **to me** after this audit — not that none exists. §2's recorded
-risk acceptance says the same thing in the freeze's own words: known-divergence-free is **weaker than
-differentially clean**, and #779's differential suite is what would close the gap.
+**This blocks v0.12.0**, which cannot ship with PP-A1 failing. Two decisions are now the
+maintainer's, not this document's:
+
+1. **How to close D3** — the non-nullable-`str` fix or the stop-eliding-on-strings fix above.
+2. **Whether item 9's lapse independently blocks the release.**
+
+**On what "known-divergence-free" is worth.** Three adversarial review rounds have now found three
+live vectors behind this one item — D4's explicit-mode half, D4's no-mode half, and D3 — each time
+after the item had been marked ✅. Two of the three were behind rows I had personally re-audited.
+"Known" is a claim about how hard anyone looked, and the honest statement is that this bar cannot be
+carried by inspection. §2 of the freeze says the same thing in its own words: known-divergence-free
+is **weaker than differentially clean**, and #779's solver-vs-runtime differential suite is the
+instrument that would actually settle it. **The recommendation this audit ends on is that item 6's
+bar should not be re-asserted by another reading of the table — it should be replaced by the
+differential suite.**
 
 ## Scope
 

--- a/docs/plans/substrate-plan-v0.12.md
+++ b/docs/plans/substrate-plan-v0.12.md
@@ -240,20 +240,26 @@ v0.12 is **not** on the strategy's Phase-2a/2b progression — it is prerequisit
 | **PP-A1 item 9** — `EnableTypeChecking` default-on (#761) | **LAPSED at v0.12 (A-1.8).** The frozen text named the **W2/W3 window**; it closed without the flip. Cost measured, not guessed: **92 failures / 6,158**, dominated by type-checker completeness gaps (`object` ×31, `Type` ×6), i.e. valid programs would start being rejected. **A further deferral must name a new window** — this row exists so it lapses visibly rather than accruing silently. Blocking-or-not for v0.12.0 is a maintainer decision |
 | **D2** (within-range signedness context) and **#779 differential suite** | Unchanged residual. Item 6's bar is *known-divergence-free*, which §2 of `wedge-w1-prereqs.md` records as **weaker than differentially clean**; the suite is what actually closes it |
 | `ContractTranslator._stringInfo` / `IsNullable` | **Inert** — written at five sites, read at none, never passed `true`. Not a live defect (see D3's argued-unreachable disposition), but it reads as a nullability guard and is not one. Wire up or delete |
+| **D3 — Z3 strings cannot be null** | **OPEN, live false-`Proven`-elides vector; blocks PP-A1 item 6 and therefore v0.12.0.** Two candidate fixes, both maintainer decisions: (i) enforce non-nullable `str` at the binder so a possibly-null interop return needs `?str` — the correct fix, needs interop nullability analysis; (ii) demote string-involving proofs to `Assumed`, which never elides (D8 precedent) — cheap, closes the whole class including undiscovered vectors, costs elision on every string postcondition. `ContractTranslator._stringInfo`/`IsNullable` is the unbuilt half of (i), not housekeeping |
+| **Item 6's bar itself** | Registered recommendation: *known*-divergence-free has now failed three times by inspection. Replace it with #779's solver-vs-runtime differential suite rather than re-asserting it by another reading of the table |
 | Frames / `old()`; `Justified` tier; #807-adjacent verifier limits | Unchanged from the v0.10/v0.11 registers |
 
 ---
 
 ## 10. Revision log
 
-- **PP-A1 adjudicated, 2026-08-05 (A-1.8) — items 1–8 PASS, item 9 LAPSED.** The first adjudication
+- **PP-A1 adjudicated, 2026-08-05 (A-1.8) — PP-A1 = FAIL; v0.12.0 blocked.** The first adjudication
   claimed all nine; adversarial review refuted **item 6** and it was right: **divergence D4 was a live
   false-`Proven`-elides vector**, reproduced end-to-end on a shipped path (`calor run` threw;
   `calor run --verify` printed the value with the check deleted). Closed by refusal in #872. Items 4
   and 7 also passed only after fixes to the **shipped** surface rather than the one the original
   evidence cited, and the `Calor1346` containment turned out to have no test anywhere in the repo.
   The common failure was assembling an evidence column by confirming each row instead of attacking
-  it. Record: `docs/plans/pp-a1-adjudication.md`.
+  it — and a third round then found **D3** live by the same test, after I had personally re-audited
+  that row and argued it unreachable. Item 6 = FAIL. Unlike D4/D9, D3 is not closable by refusing an
+  operation: Z3's string sort has no null, so every total axiom of its string theory is unsound once
+  a `str` holds one, and `§B{bad:str}` binds a null interop return with no diagnostic today. Record:
+  `docs/plans/pp-a1-adjudication.md`.
 
 - **Call S, 2026-08-05 — the plan's central objective failed, and the plan records it.** PP-S3 = MISS
   (8 screened tasks against ≥ 70), PP-S1 = MISS (census: top-3 = 40.4% < 50%), PP-S2 reported-only,

--- a/docs/plans/substrate-plan-v0.12.md
+++ b/docs/plans/substrate-plan-v0.12.md
@@ -237,7 +237,7 @@ v0.12 is **not** on the strategy's Phase-2a/2b progression — it is prerequisit
 | Real-scale epoch re-run | **RETIRED at Call S (2026-08-05).** No spend gate follows; quantitative re-entry conditions are registered in `call-s-adjudication.md` |
 | Logic-mutation stratum as a thesis channel | Retired as a mechanical-arm channel; retained only as a conversion-penalty measurement |
 | Proof-depth measurement (arm-ii) | Rides on WS-S4; explicitly not adjudicated by v0.12 (§0.1) |
-| **PP-A1 item 9** — `EnableTypeChecking` default-on (#761) | **LAPSED at v0.12 (A-1.8).** The frozen text named the **W2/W3 window**; it closed without the flip. Cost measured, not guessed: **92 failures / 6,158**, dominated by type-checker completeness gaps (`object` ×31, `Type` ×6), i.e. valid programs would start being rejected. **A further deferral must name a new window** — this row exists so it lapses visibly rather than accruing silently. Blocking-or-not for v0.12.0 is a maintainer decision |
+| **PP-A1 item 9** — `EnableTypeChecking` default-on (#761) | **DELIVERED at v0.12 (#877)**, later than the registered W2/W3 window. The row stays so the lateness is visible: the blocker was 92 checker defects, every one a working program it refused, and all of them already live for agents through `calor_check`/`calor_refine`. Three review rounds on the fix also exposed that **no gate compiled `bench/` or `samples/`** — both now have one |
 | **D2** (within-range signedness context) and **#779 differential suite** | Unchanged residual. Item 6's bar is *known-divergence-free*, which §2 of `wedge-w1-prereqs.md` records as **weaker than differentially clean**; the suite is what actually closes it |
 | `ContractTranslator._stringInfo` / `IsNullable` | **Inert** — written at five sites, read at none, never passed `true`. Not a live defect (see D3's argued-unreachable disposition), but it reads as a nullability guard and is not one. Wire up or delete |
 | **D3 / D12 — the string model is null-blind and byte-counted** | **Elide vectors CLOSED by demotion (#876); the modeling gaps remain OPEN.** String-carried proofs are `Assumed`, which never elides, so `len`/`isempty`/`substr`/`indexof` cannot delete a guard — at the cost of elision on every string postcondition. **#875** tracks the root-cause fix (non-nullable `str` at the binder), which is what would let the demotion be lifted; D12 needs a separate fix for the count/index operations, narrowed in `verification-modeled-forms` §4.1 |
@@ -248,7 +248,7 @@ v0.12 is **not** on the strategy's Phase-2a/2b progression — it is prerequisit
 
 ## 10. Revision log
 
-- **PP-A1 adjudicated, 2026-08-05 (A-1.8) — items 1–8 PASS, item 9 LAPSED.** The first adjudication
+- **PP-A1 adjudicated, 2026-08-05 (A-1.8) — PASS, all nine items.** The first adjudication
   claimed all nine; adversarial review refuted **item 6** and it was right: **divergence D4 was a live
   false-`Proven`-elides vector**, reproduced end-to-end on a shipped path (`calor run` threw;
   `calor run --verify` printed the value with the check deleted). Closed by refusal in #872. Items 4

--- a/docs/plans/substrate-plan-v0.12.md
+++ b/docs/plans/substrate-plan-v0.12.md
@@ -240,7 +240,7 @@ v0.12 is **not** on the strategy's Phase-2a/2b progression — it is prerequisit
 | **PP-A1 item 9** — `EnableTypeChecking` default-on (#761) | **LAPSED at v0.12 (A-1.8).** The frozen text named the **W2/W3 window**; it closed without the flip. Cost measured, not guessed: **92 failures / 6,158**, dominated by type-checker completeness gaps (`object` ×31, `Type` ×6), i.e. valid programs would start being rejected. **A further deferral must name a new window** — this row exists so it lapses visibly rather than accruing silently. Blocking-or-not for v0.12.0 is a maintainer decision |
 | **D2** (within-range signedness context) and **#779 differential suite** | Unchanged residual. Item 6's bar is *known-divergence-free*, which §2 of `wedge-w1-prereqs.md` records as **weaker than differentially clean**; the suite is what actually closes it |
 | `ContractTranslator._stringInfo` / `IsNullable` | **Inert** — written at five sites, read at none, never passed `true`. Not a live defect (see D3's argued-unreachable disposition), but it reads as a nullability guard and is not one. Wire up or delete |
-| **D3 — Z3 strings cannot be null** | **OPEN, live false-`Proven`-elides vector; blocks PP-A1 item 6 and therefore v0.12.0.** Two candidate fixes, both maintainer decisions: (i) enforce non-nullable `str` at the binder so a possibly-null interop return needs `?str` — the correct fix, needs interop nullability analysis; (ii) demote string-involving proofs to `Assumed`, which never elides (D8 precedent) — cheap, closes the whole class including undiscovered vectors, costs elision on every string postcondition. `ContractTranslator._stringInfo`/`IsNullable` is the unbuilt half of (i), not housekeeping |
+| **D3 / D12 — the string model is null-blind and byte-counted** | **Elide vectors CLOSED by demotion (#876); the modeling gaps remain OPEN.** String-carried proofs are `Assumed`, which never elides, so `len`/`isempty`/`substr`/`indexof` cannot delete a guard — at the cost of elision on every string postcondition. **#875** tracks the root-cause fix (non-nullable `str` at the binder), which is what would let the demotion be lifted; D12 needs a separate fix for the count/index operations, narrowed in `verification-modeled-forms` §4.1 |
 | **Item 6's bar itself** | Registered recommendation: *known*-divergence-free has now failed three times by inspection. Replace it with #779's solver-vs-runtime differential suite rather than re-asserting it by another reading of the table |
 | Frames / `old()`; `Justified` tier; #807-adjacent verifier limits | Unchanged from the v0.10/v0.11 registers |
 
@@ -248,7 +248,7 @@ v0.12 is **not** on the strategy's Phase-2a/2b progression — it is prerequisit
 
 ## 10. Revision log
 
-- **PP-A1 adjudicated, 2026-08-05 (A-1.8) — PP-A1 = FAIL; v0.12.0 blocked.** The first adjudication
+- **PP-A1 adjudicated, 2026-08-05 (A-1.8) — items 1–8 PASS, item 9 LAPSED.** The first adjudication
   claimed all nine; adversarial review refuted **item 6** and it was right: **divergence D4 was a live
   false-`Proven`-elides vector**, reproduced end-to-end on a shipped path (`calor run` threw;
   `calor run --verify` printed the value with the check deleted). Closed by refusal in #872. Items 4
@@ -256,9 +256,10 @@ v0.12 is **not** on the strategy's Phase-2a/2b progression — it is prerequisit
   evidence cited, and the `Calor1346` containment turned out to have no test anywhere in the repo.
   The common failure was assembling an evidence column by confirming each row instead of attacking
   it — and a third round then found **D3** live by the same test, after I had personally re-audited
-  that row and argued it unreachable. Item 6 = FAIL. Unlike D4/D9, D3 is not closable by refusing an
-  operation: Z3's string sort has no null, so every total axiom of its string theory is unsound once
-  a `str` holds one, and `§B{bad:str}` binds a null interop return with no diagnostic today. Record:
+  that row and argued it unreachable. A fourth then found **D12**. All four are closed — D4 by refusal
+  (#872), D3 and D12 by demoting string-carried proofs to `Assumed`, which never elides (#876) —
+  but note what closed them: a change of **mechanism**, not a better audit. The modeling gaps stay
+  open (#875 tracks D3's root cause); only their elide consequences are neutralized. Record:
   `docs/plans/pp-a1-adjudication.md`.
 
 - **Call S, 2026-08-05 — the plan's central objective failed, and the plan records it.** PP-S3 = MISS

--- a/docs/plans/substrate-plan-v0.12.md
+++ b/docs/plans/substrate-plan-v0.12.md
@@ -237,11 +237,23 @@ v0.12 is **not** on the strategy's Phase-2a/2b progression — it is prerequisit
 | Real-scale epoch re-run | **RETIRED at Call S (2026-08-05).** No spend gate follows; quantitative re-entry conditions are registered in `call-s-adjudication.md` |
 | Logic-mutation stratum as a thesis channel | Retired as a mechanical-arm channel; retained only as a conversion-penalty measurement |
 | Proof-depth measurement (arm-ii) | Rides on WS-S4; explicitly not adjudicated by v0.12 (§0.1) |
+| **PP-A1 item 9** — `EnableTypeChecking` default-on (#761) | **LAPSED at v0.12 (A-1.8).** The frozen text named the **W2/W3 window**; it closed without the flip. Cost measured, not guessed: **92 failures / 6,158**, dominated by type-checker completeness gaps (`object` ×31, `Type` ×6), i.e. valid programs would start being rejected. **A further deferral must name a new window** — this row exists so it lapses visibly rather than accruing silently. Blocking-or-not for v0.12.0 is a maintainer decision |
+| **D2** (within-range signedness context) and **#779 differential suite** | Unchanged residual. Item 6's bar is *known-divergence-free*, which §2 of `wedge-w1-prereqs.md` records as **weaker than differentially clean**; the suite is what actually closes it |
+| `ContractTranslator._stringInfo` / `IsNullable` | **Inert** — written at five sites, read at none, never passed `true`. Not a live defect (see D3's argued-unreachable disposition), but it reads as a nullability guard and is not one. Wire up or delete |
 | Frames / `old()`; `Justified` tier; #807-adjacent verifier limits | Unchanged from the v0.10/v0.11 registers |
 
 ---
 
 ## 10. Revision log
+
+- **PP-A1 adjudicated, 2026-08-05 (A-1.8) — items 1–8 PASS, item 9 LAPSED.** The first adjudication
+  claimed all nine; adversarial review refuted **item 6** and it was right: **divergence D4 was a live
+  false-`Proven`-elides vector**, reproduced end-to-end on a shipped path (`calor run` threw;
+  `calor run --verify` printed the value with the check deleted). Closed by refusal in #872. Items 4
+  and 7 also passed only after fixes to the **shipped** surface rather than the one the original
+  evidence cited, and the `Calor1346` containment turned out to have no test anywhere in the repo.
+  The common failure was assembling an evidence column by confirming each row instead of attacking
+  it. Record: `docs/plans/pp-a1-adjudication.md`.
 
 - **Call S, 2026-08-05 — the plan's central objective failed, and the plan records it.** PP-S3 = MISS
   (8 screened tasks against ≥ 70), PP-S1 = MISS (census: top-3 = 40.4% < 50%), PP-S2 reported-only,

--- a/src/Calor.Compiler/Commands/FormatCommand.cs
+++ b/src/Calor.Compiler/Commands/FormatCommand.cs
@@ -89,11 +89,37 @@ public static class FormatCommand
                 || Environment.GetEnvironmentVariable("CALOR_EXPERIMENTAL_FORMAT_WRITE") is "1" or "true";
             if (wantsWrite && !experimentalAcknowledged)
             {
-                Console.Error.WriteLine(
-                    $"error {Diagnostics.DiagnosticCode.FormatWriteExperimentalRequired}: 'format --write' is disabled by the release policy (#793/#760): " +
-                    "the formatter write path can rewrite identifiers and drops comments. " +
-                    "Pass --experimental (or set CALOR_EXPERIMENTAL_FORMAT_WRITE=1) to acknowledge, " +
-                    "or use --check/--diff for read-only formatting.");
+                const string refusal =
+                    "'format --write' is disabled by the release policy (#793/#760): the formatter " +
+                    "write path can rewrite identifiers and drops comments. Pass --experimental " +
+                    "(or set CALOR_EXPERIMENTAL_FORMAT_WRITE=1) to acknowledge, or use " +
+                    "--check/--diff for read-only formatting.";
+
+                // The refusal must honour --format json. Every other exit from this command emits
+                // the envelope (schema v1.1, loop plan D1.3), and an agent that asked for JSON and
+                // got a bare stderr line sees a parse failure, not a policy decision — so the one
+                // message whose whole purpose is to be understood was the one it could not read.
+                if (string.Equals(ctx.ParseResult.GetValueForOption(formatOption) ?? "text", "json",
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    var bag = new DiagnosticBag();
+                    bag.Add(new Diagnostic(
+                        DiagnosticCode.FormatWriteExperimentalRequired,
+                        refusal,
+                        new TextSpan(0, 0, 1, 1),
+                        DiagnosticSeverity.Error));
+                    Console.WriteLine(CommandEnvelope.Serialize("format", bag, new FormatData
+                    {
+                        Files = [],
+                        Totals = new FormatTotals { Processed = 0, Formatted = 0, Errors = 1, StillFailingAfterHeal = 0 }
+                    }));
+                }
+                else
+                {
+                    Console.Error.WriteLine(
+                        $"error {DiagnosticCode.FormatWriteExperimentalRequired}: {refusal}");
+                }
+
                 ctx.ExitCode = 1;
                 return;
             }

--- a/src/Calor.Compiler/Commands/LintCommand.cs
+++ b/src/Calor.Compiler/Commands/LintCommand.cs
@@ -74,11 +74,34 @@ public static class LintCommand
                 || Environment.GetEnvironmentVariable("CALOR_EXPERIMENTAL_FORMAT_WRITE") is "1" or "true";
             if (wantsFix && !experimentalAcknowledged)
             {
-                Console.Error.WriteLine(
-                    $"error {Diagnostics.DiagnosticCode.FormatWriteExperimentalRequired}: 'lint --fix' is disabled by the release policy (#793/#760): " +
-                    "it rewrites files through the formatter write path, which can rewrite identifiers and drops comments. " +
-                    "Pass --experimental (or set CALOR_EXPERIMENTAL_FORMAT_WRITE=1) to acknowledge, " +
-                    "or use --check for read-only linting.");
+                const string refusal =
+                    "'lint --fix' is disabled by the release policy (#793/#760): it rewrites files " +
+                    "through the formatter write path, which can rewrite identifiers and drops " +
+                    "comments. Pass --experimental (or set CALOR_EXPERIMENTAL_FORMAT_WRITE=1) to " +
+                    "acknowledge, or use --check for read-only linting.";
+
+                // The refusal must honour --format, exactly as `format --write`'s does. This is the
+                // SAME containment (CHANGELOG and docs/cli/structured-output.md name the two
+                // surfaces as one policy), so an agent that asked for a machine-readable document
+                // and got a bare stderr line sees a parse failure rather than a policy decision.
+                // Found by adversarial review: the format side was fixed and this one was not.
+                var refusalFormat = ctx.ParseResult.GetValueForOption(formatOption) ?? "text";
+                if (!refusalFormat.Equals("text", StringComparison.OrdinalIgnoreCase))
+                {
+                    var bag = new DiagnosticBag();
+                    bag.Add(new Diagnostic(
+                        DiagnosticCode.FormatWriteExperimentalRequired,
+                        refusal,
+                        new TextSpan(0, 0, 1, 1),
+                        DiagnosticSeverity.Error));
+                    Console.WriteLine(DiagnosticFormatterFactory.Create(refusalFormat, null).Format(bag));
+                }
+                else
+                {
+                    Console.Error.WriteLine(
+                        $"error {DiagnosticCode.FormatWriteExperimentalRequired}: {refusal}");
+                }
+
                 ctx.ExitCode = 1;
                 return;
             }

--- a/src/Calor.Tasks/CompileCalor.cs
+++ b/src/Calor.Tasks/CompileCalor.cs
@@ -318,8 +318,24 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
             {
                 priorFiles.TryGetValue(relativePath, out var cachedEntry);
 
+                // The skip conditions mirror CompilationDriver.cs:178-198 deliberately — the two
+                // sites decide the same thing (is this file's cached output trustworthy?) and had
+                // drifted apart, with this one weaker on both counts.
+                //
+                //  - OutputContentHash: presence of the .g.cs is NOT enough. A truncated, corrupted,
+                //    or hand-edited output must be a miss, or the build compiles stale bytes and
+                //    reports "up-to-date". Entries predating this check carry a null hash and are
+                //    therefore a miss — one cold rebuild, fail-closed, as the driver does.
+                //  - EffectSummary: skipping without one silently drops the module from
+                //    cross-module effect enforcement, so its Calor0410 violations vanish on warm
+                //    builds. Not reachable through this task today (a null Ast implies HasErrors,
+                //    which returns before caching), so this is defence in depth against a future
+                //    caller — not a fix for a live bug.
                 if (cachedEntry != null
                     && existingOutputFiles!.Contains(outputPath)
+                    && cachedEntry.EffectSummary != null
+                    && cachedEntry.OutputContentHash != null
+                    && BuildStateCache.ComputeFileHash(outputPath) == cachedEntry.OutputContentHash
                     && BuildStateCache.IsFileUpToDate(cachedEntry, inputPath))
                 {
                     // Skip — carry entry forward
@@ -447,6 +463,14 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
 
                 // Compute effect summary from the fresh AST and cache it for future warm builds.
                 var fileEntry = BuildStateCache.CreateFileEntry(inputPath);
+
+                // Record what this compile actually wrote, so the next build can tell whether the
+                // .g.cs on disk is still that output. Without this every entry is a permanent miss
+                // under the check above — which is safe, but defeats incrementality entirely.
+                fileEntry.OutputContentHash = File.Exists(outputPath)
+                    ? BuildStateCache.ComputeFileHash(outputPath)
+                    : null;
+
                 if (result.Ast != null)
                 {
                     var summary = Calor.Compiler.Effects.EffectSummaryBuilder.Build(result.Ast);

--- a/tests/Calor.Compiler.Tests/CliTestHarness.cs
+++ b/tests/Calor.Compiler.Tests/CliTestHarness.cs
@@ -56,6 +56,16 @@ internal static class CliTestHarness
     /// </summary>
     internal static (int ExitCode, string StdOut, string StdErr) RunCli(
         string workingDirectory, params string[] args)
+        => RunCli(workingDirectory, environment: null, args);
+
+    /// <summary>
+    /// As above, with extra environment variables for the child process. Needed by gates that are
+    /// acknowledged through the environment (e.g. <c>CALOR_EXPERIMENTAL_FORMAT_WRITE</c>): setting
+    /// them via <c>Environment.SetEnvironmentVariable</c> in-test would leak across xUnit's
+    /// parallel collections, so they are scoped to the child instead.
+    /// </summary>
+    internal static (int ExitCode, string StdOut, string StdErr) RunCli(
+        string workingDirectory, IReadOnlyDictionary<string, string>? environment, params string[] args)
     {
         var psi = new ProcessStartInfo
         {
@@ -66,6 +76,14 @@ internal static class CliTestHarness
             CreateNoWindow = true,
             WorkingDirectory = workingDirectory
         };
+        if (environment != null)
+        {
+            foreach (var (key, value) in environment)
+            {
+                psi.Environment[key] = value;
+            }
+        }
+
         psi.ArgumentList.Add(FindCalorDll());
         psi.ArgumentList.Add("--no-telemetry");
         foreach (var arg in args)

--- a/tests/Calor.Compiler.Tests/EnvelopeEarlyExitTests.cs
+++ b/tests/Calor.Compiler.Tests/EnvelopeEarlyExitTests.cs
@@ -299,4 +299,73 @@ public class EnvelopeEarlyExitTests : IDisposable
         Assert.Contains(root.GetProperty("diagnostics").EnumerateArray(),
             d => d.GetProperty("severity").GetString() == "error");
     }
+
+    private const string ValidSource = "\u00a7M{m001:T}\n  \u00a7F{f001:Main:pub} () -> void\n    \u00a7E{cw}\n    \u00a7P \"hi\"\n";
+
+    /// <summary>
+    /// The PP-A1 item-7 containment: `format --write` is refused by release policy (#793/#760).
+    /// The refusal is an early exit like the others in this file, and in JSON mode it was writing
+    /// a bare line to stderr with EMPTY stdout — so an agent that asked for JSON saw a parse
+    /// failure rather than a policy decision. The one message whose entire purpose is to be
+    /// understood was the one it could not read.
+    /// </summary>
+    [Fact]
+    public void FormatWrite_Json_RefusedWithoutExperimental_StillEmitsEnvelope()
+    {
+        var file = Path.Combine(_tempDir, "a.calr");
+        File.WriteAllText(file, ValidSource);
+
+        var (exitCode, stdOut, _) = CliTestHarness.RunCli(_tempDir,
+            "format", file, "--write", "--format", "json");
+
+        Assert.Equal(1, exitCode);
+        var root = ParseSingleDocument(stdOut);
+        Assert.Equal("format", root.GetProperty("command").GetString());
+
+        var diagnostic = Assert.Single(root.GetProperty("diagnostics").EnumerateArray());
+        Assert.Equal(DiagnosticCode.FormatWriteExperimentalRequired, diagnostic.GetProperty("code").GetString());
+        Assert.Equal("error", diagnostic.GetProperty("severity").GetString());
+
+        // The refusal must name both escape hatches, or it is not actionable.
+        var message = diagnostic.GetProperty("message").GetString()!;
+        Assert.Contains("--experimental", message);
+        Assert.Contains("CALOR_EXPERIMENTAL_FORMAT_WRITE", message);
+
+        // Refused means refused: the file is untouched.
+        Assert.Equal(ValidSource, File.ReadAllText(file));
+    }
+
+    /// <summary>Text mode keeps its human-oriented stderr line and the same exit code.</summary>
+    [Fact]
+    public void FormatWrite_Text_RefusedWithoutExperimental()
+    {
+        var file = Path.Combine(_tempDir, "b.calr");
+        File.WriteAllText(file, ValidSource);
+
+        var (exitCode, stdOut, stdErr) = CliTestHarness.RunCli(_tempDir, "format", file, "--write");
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains(DiagnosticCode.FormatWriteExperimentalRequired, stdErr);
+        Assert.DoesNotContain("{", stdOut);
+        Assert.Equal(ValidSource, File.ReadAllText(file));
+    }
+
+    /// <summary>
+    /// The control that makes the two above meaningful: the gate is an ACKNOWLEDGEMENT, not a
+    /// removal. With the env var set the write path runs — so the tests above pin a policy gate
+    /// rather than an unconditionally broken command.
+    /// </summary>
+    [Fact]
+    public void FormatWrite_WithEnvAcknowledgement_IsAllowedThrough()
+    {
+        var file = Path.Combine(_tempDir, "c.calr");
+        File.WriteAllText(file, ValidSource);
+
+        var (exitCode, _, stdErr) = CliTestHarness.RunCli(_tempDir,
+            new Dictionary<string, string> { ["CALOR_EXPERIMENTAL_FORMAT_WRITE"] = "1" },
+            "format", file, "--write");
+
+        Assert.DoesNotContain(DiagnosticCode.FormatWriteExperimentalRequired, stdErr);
+        Assert.NotEqual(1, exitCode);
+    }
 }

--- a/tests/Calor.Compiler.Tests/EnvelopeEarlyExitTests.cs
+++ b/tests/Calor.Compiler.Tests/EnvelopeEarlyExitTests.cs
@@ -315,7 +315,7 @@ public class EnvelopeEarlyExitTests : IDisposable
         var file = Path.Combine(_tempDir, "a.calr");
         File.WriteAllText(file, ValidSource);
 
-        var (exitCode, stdOut, _) = CliTestHarness.RunCli(_tempDir,
+        var (exitCode, stdOut, _) = CliTestHarness.RunCli(_tempDir, NotAcknowledged,
             "format", file, "--write", "--format", "json");
 
         Assert.Equal(1, exitCode);
@@ -335,6 +335,14 @@ public class EnvelopeEarlyExitTests : IDisposable
         Assert.Equal(ValidSource, File.ReadAllText(file));
     }
 
+    /// <summary>
+    /// Explicitly UN-acknowledged. Without this the refusal tests inherit the ambient environment,
+    /// and `docs/cli/format.md` itself recommends `export CALOR_EXPERIMENTAL_FORMAT_WRITE=1` for a
+    /// session or CI job — under which these tests would pass vacuously by never reaching the gate.
+    /// </summary>
+    private static readonly Dictionary<string, string> NotAcknowledged =
+        new() { ["CALOR_EXPERIMENTAL_FORMAT_WRITE"] = "" };
+
     /// <summary>Text mode keeps its human-oriented stderr line and the same exit code.</summary>
     [Fact]
     public void FormatWrite_Text_RefusedWithoutExperimental()
@@ -342,11 +350,36 @@ public class EnvelopeEarlyExitTests : IDisposable
         var file = Path.Combine(_tempDir, "b.calr");
         File.WriteAllText(file, ValidSource);
 
-        var (exitCode, stdOut, stdErr) = CliTestHarness.RunCli(_tempDir, "format", file, "--write");
+        var (exitCode, stdOut, stdErr) = CliTestHarness.RunCli(_tempDir, NotAcknowledged,
+            "format", file, "--write");
 
         Assert.Equal(1, exitCode);
         Assert.Contains(DiagnosticCode.FormatWriteExperimentalRequired, stdErr);
         Assert.DoesNotContain("{", stdOut);
+        Assert.Equal(ValidSource, File.ReadAllText(file));
+    }
+
+    /// <summary>
+    /// `lint --fix` is the SAME containment as `format --write` — same diagnostic code, same
+    /// acknowledgement, named together in the CHANGELOG and in structured-output.md. Its refusal
+    /// was still ignoring --format after the format side was fixed, which is exactly the half-fix
+    /// this file exists to catch. Covers `sarif` too, since lint offers it and `format` does not.
+    /// </summary>
+    [Theory]
+    [InlineData("json")]
+    [InlineData("sarif")]
+    public void LintFix_Structured_RefusedWithoutExperimental_StillEmitsDocument(string format)
+    {
+        var file = Path.Combine(_tempDir, $"lint-{format}.calr");
+        File.WriteAllText(file, ValidSource);
+
+        var (exitCode, stdOut, _) = CliTestHarness.RunCli(_tempDir, NotAcknowledged,
+            "lint", file, "--fix", "--format", format);
+
+        Assert.Equal(1, exitCode);
+
+        using var doc = JsonDocument.Parse(stdOut);
+        Assert.Contains(DiagnosticCode.FormatWriteExperimentalRequired, stdOut);
         Assert.Equal(ValidSource, File.ReadAllText(file));
     }
 
@@ -358,8 +391,15 @@ public class EnvelopeEarlyExitTests : IDisposable
     [Fact]
     public void FormatWrite_WithEnvAcknowledgement_IsAllowedThrough()
     {
+        // Deliberately mis-formatted, so a successful run must CHANGE the file — feeding it
+        // already-canonical source would let this pass without a write ever happening. The noise
+        // is blank lines and trailing whitespace rather than bad indentation: over-indenting is a
+        // parse error, and the formatter (correctly) declines to write a file it cannot parse,
+        // which would make the test fail for a reason unrelated to the gate.
         var file = Path.Combine(_tempDir, "c.calr");
-        File.WriteAllText(file, ValidSource);
+        var misformatted = ValidSource.Replace("\u00a7M{m001:T}\n", "\u00a7M{m001:T}\n\n\n")
+                                      .Replace("-> void", "-> void   ");
+        File.WriteAllText(file, misformatted);
 
         var (exitCode, _, stdErr) = CliTestHarness.RunCli(_tempDir,
             new Dictionary<string, string> { ["CALOR_EXPERIMENTAL_FORMAT_WRITE"] = "1" },
@@ -367,5 +407,8 @@ public class EnvelopeEarlyExitTests : IDisposable
 
         Assert.DoesNotContain(DiagnosticCode.FormatWriteExperimentalRequired, stdErr);
         Assert.NotEqual(1, exitCode);
+
+        // The gate is an ACKNOWLEDGEMENT: past it, the write path actually writes.
+        Assert.NotEqual(misformatted, File.ReadAllText(file));
     }
 }

--- a/tests/Calor.Tasks.Tests/CompileCalorIntegrationTests.cs
+++ b/tests/Calor.Tasks.Tests/CompileCalorIntegrationTests.cs
@@ -144,6 +144,43 @@ public class CompileCalorIntegrationTests : IDisposable
         Assert.Equal(2, task4.GeneratedFiles.Length);
     }
 
+    /// <summary>
+    /// The task's skip decision must consult the output's CONTENT, not merely its existence.
+    /// Before this pin, a corrupted or hand-edited <c>.g.cs</c> was reported "up-to-date" and its
+    /// stale bytes went into the assembly — the source is unchanged, so mtime/size tell you
+    /// nothing. <c>CompilationDriver.cs:186-193</c> has always guarded this; the MSBuild task,
+    /// which is the path real projects build through, had drifted and did not.
+    /// </summary>
+    [Fact]
+    public void CorruptedOutput_IsRecompiled_NotReportedUpToDate()
+    {
+        var src = CreateSourceFile("Foo.calr", ValidCalorSource);
+
+        var task1 = CreateTask(src);
+        Assert.True(task1.Execute());
+        var outputPath = task1.GeneratedFiles.Single().ItemSpec;
+        var good = File.ReadAllText(outputPath);
+        Assert.Contains("class", good);
+
+        // Control: untouched output IS skipped, so the assertion below is known to discriminate.
+        var control = CreateTask(src);
+        Assert.True(control.Execute());
+        Assert.Contains(((TestBuildEngine)control.BuildEngine).Messages, m => m.Contains("skipping"));
+
+        // Corrupt the generated file without touching the source.
+        File.WriteAllText(outputPath, "// truncated by something else\n");
+
+        var task2 = CreateTask(src);
+        Assert.True(task2.Execute());
+
+        var msgs = string.Join("\n", ((TestBuildEngine)task2.BuildEngine).Messages);
+        Assert.Contains("Compiling", msgs);
+        Assert.DoesNotContain("skipping", msgs);
+
+        // And the output is restored to what the compiler actually produces.
+        Assert.Equal(good, File.ReadAllText(outputPath));
+    }
+
     // Test 21: Stale output cleanup: build 3, delete 1 source, build → orphan removed
     [Fact]
     public void StaleOutputCleanup_OrphanRemoved()


### PR DESCRIPTION
**Supersedes #871**, which claimed all nine items PASS. Adversarial review refuted item 6 and was right — so this replaces that claim rather than amending it.

> **Merge order: this should land after #872.** Item 6 passes *only* as of that PR.

## What the first adjudication got wrong, and how

**Item 6** — bar: *no known false-`Proven`-elides vector*, known set = the divergence table + T1.

**Divergence D4 was a live one.** A non-ordinal `StringComparison` mode in a contract was translated as **ordinal**, the mode-bearing form stayed whitelisted in `ModeledForms`, and `Z3Verifier` never demoted on the warning — a genuine false `Proven`, which `Proven && !IsVacuous` (D-G1.3) acts on by **eliding the runtime check**. Reproduced end-to-end on a shipped CLI path:

| command | before #872 |
|---|---|
| `calor run` | **throws** `ContractViolationException` — the postcondition is genuinely false |
| `calor run --verify` | prints the value — **check deleted** |

The first adjudication cited four rows that *were* closed (D6–D9) and **never audited the other seven**. This one audits all eleven, and adds:

- **D3** — an explicit *argued-unreachable* disposition rather than silence: Calor's `str` is non-nullable, `?str` is not in `ModeledForms.ScalarTypes` (`NormalizeTypeName`'s default arm keeps the `?`), and with a precondition a `null` argument fails that precondition, which is never elided (D-G1.2). Stated as an argument, not a proof.
- **D2** — named as the residual, inside the freeze's own recorded risk acceptance that *known-divergence-free is weaker than differentially clean*.

**Item 9 = LAPSED.** The frozen text says the `EnableTypeChecking` flip *"lands in the W2/W3 window"*. That window closed. The first adjudication re-read it as "the flip has a slot" and marked it ✅ — a reinterpretation in the favourable direction.

Cost **measured rather than guessed** — flipping the default and running `Calor.Compiler.Tests`: **92 failures / 6,158**, and they are type-checker *completeness* gaps, not stale fixtures:

| Diagnostic | Count | What |
|---|---:|---|
| `Calor0200` unknown type | 36 | `object` ×31, `Type` ×6 |
| `Calor0202` field access on non-record | 8 | member-access chains |
| `Calor0250`/`0251` | 4 | bind inference |

So the compiler would begin **rejecting programs that are valid today**. Whether that blocks v0.12.0 is a maintainer decision — not one an adjudication may make by reinterpretation. A further deferral must name a **new window**; the plan's register now carries the row so it lapses visibly rather than accruing silently.

## Three defects fixed — all on the shipped surface, not the one the evidence cited

**1. `CompileCalor` trusted a `.g.cs`'s existence, not its content** (item 4). `CompilationDriver` has always required the output's hash to match what the producing compile wrote, so a truncated or hand-edited generated file is a miss. The **MSBuild task real projects build through** only checked the file existed — and reported stale bytes as "up-to-date". Ported, with a regression test that corrupts the output plus a control proving an untouched output still skips. `EffectSummary != null` ported alongside as defence in depth (**not reachable today**: a null AST implies `HasErrors`, which returns before caching — stated rather than dressed up as a bug fix).

**2. `format --write`'s refusal ignored `--format json`** (item 7). Every other exit from `format` emits the envelope; the policy refusal wrote a bare stderr line with **empty stdout** and exited 1. An agent that asked for JSON got a parse failure instead of a policy decision — the one message whose entire purpose is to be understood was the one it could not read. Same class as the early-exit defects already pinned in `EnvelopeEarlyExitTests`, so the fix lives there.

**3. The containment had no test at all** (item 7). Nothing in the repo referenced `Calor1346`; item 7 was being adjudicated on code-reading alone. Three tests added — JSON refusal, text refusal, and **a control** proving the gate is an *acknowledgement* rather than a broken command, by running the write path through with `CALOR_EXPERIMENTAL_FORMAT_WRITE=1`. That needed an env-var overload on `CliTestHarness.RunCli`, scoped to the child process so it cannot leak across xUnit's parallel collections.

## Docs

`docs/cli/format.md` — the earlier audit fixed **3** sites documenting `--write` as an ordinary option. There were **12**, including the Quick Start block (the first thing a reader copies), the CI recipe, the editor-integration snippet, and the heal-in-place example. All corrected, plus a dedicated section covering the refusal, both escape hatches, the exit code, the JSON behaviour, and the sibling `CALOR_LSP_EXPERIMENTAL` containment.

## Filed, not fixed

`ContractTranslator`'s `StringInfo(bool IsNullable)` / `_stringInfo` is **written at five sites, read at none**, and `isNullable` is never once passed `true`. Inert — and it reads as a nullability guard that isn't one, which is worse than its absence. Recorded in the plan's deferred register.

## Verification

Solution-level `dotnet test -c Release --no-build`: **11 assemblies, ~8,100 passed, 0 failed**.

**Correcting a claim in this PR's first description.** It said solution-level `dotnet test` "only reports two" projects, so each had to be invoked by name, and quoted 8,485 across 12. The methodology claim is **false** — a solution-level run does pick up 11 assemblies. It came from a mis-scoped grep of my own output that I then repeated as a fact about the repo. The suite is green either way; the number and the reason given for it were not accurate.

Registered at **A-1.8**. Item 1's "published" half is dispositioned rather than asserted — CI evidences the *packaged* SDK's consumability from a local feed; "published" clears at the v0.12.0 publish event itself. **PP-W5 remains NOT adjudicated and may not be self-cleared.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — #872's first fix was itself incomplete

A second adversarial review found the D4 vector **still live** on the no-mode spelling, and it reproduced. .NET resolves `String.StartsWith(String)`, `EndsWith(String)` and `IndexOf(String)` to **CurrentCulture** (`Contains`/`Equals` are ordinal) while the solver models all of them ordinally — so omitting the comparison mode carried the identical defect on the form nearly everyone writes. Same signature: threw under `calor run`, printed the value under `--verify`, `calor verify` reporting 100% Proven. Also closed in #872.

This is recorded here because it **strengthens this PR's own thesis rather than undercutting it**: the first fix was narrow because it was scoped to *the divergence row as written* instead of *the property the row exists to protect*, and only the second is item 6's bar.

The verdict now carries the caveat it should have had from the start: **two rounds of review found two live vectors behind one green mark**, so "known-divergence-free" is a claim about how hard anyone looked — which is exactly what the freeze's own §2 risk acceptance says ("weaker than differentially clean").
