### PR TITLE
fix(release): repair both publish channels and make the z3 asset chain deterministic

### DIFF
--- a/.github/workflows/build-z3.yml
+++ b/.github/workflows/build-z3.yml
@@ -5,6 +5,14 @@ name: Build Z3 Native Libraries
 #
 # The publish-nuget workflow downloads these pre-built binaries.
 
+# DELIBERATE REPUBLISH ONLY. This workflow used to also run on push to main
+# whenever one of the z3 scripts changed. That is what broke the v0.12.0 NuGet
+# publish: #789 added .github/z3-binaries-4.15.7.sha256 pinning the release
+# assets, and the push of that very commit re-triggered this workflow, which
+# republished all 8 assets a day after the manifest was computed — invalidating
+# the pin with its own introduction. Republishing the shared z3-binaries release
+# retroactively changes what every past tag resolves to, so it must be an
+# explicit act, never a side effect of editing a script.
 on:
   workflow_dispatch:
     inputs:
@@ -13,27 +21,27 @@ on:
         required: true
         default: '4.15.7'
         type: string
-  push:
-    branches: [main]
-    paths:
-      # Only trigger when Z3 version might have changed
-      - 'src/Calor.Compiler/scripts/download-z3.sh'
-      - 'src/Calor.Compiler/scripts/download-z3.ps1'
-      - 'src/Calor.Compiler/scripts/build-z3-from-source.sh'
 
 env:
   Z3_VERSION: ${{ github.event.inputs.z3_version || '4.15.7' }}
+  # Must stay in sync with MANAGED_DLL_ARCHIVE in
+  # src/Calor.Compiler/scripts/download-z3.sh — the managed wrapper we publish
+  # has to be the same bytes developers and CI already build against.
+  MANAGED_DLL_ARCHIVE: x64-win
 
 jobs:
-  # Build Z3 on ARM64 platforms (pre-built binaries have loading issues)
+  # Build Z3 from source on ARM64 macOS ONLY. The upstream arm64-osx archive has
+  # assembly-loading problems on that platform (same exception download-z3.sh
+  # makes at its Darwin/arm64 branch). Every other RID — including linux-arm64,
+  # which download-z3.sh has always taken from the upstream arm64-glibc-2.38
+  # archive — uses the checksum-verified prebuilt path below, because a
+  # from-source C++ build is not reproducible and silently re-drifts the pin on
+  # every run.
   build-z3-arm64:
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-24.04-arm
-            rid: linux-arm64
-            lib: libz3.so
           - os: macos-latest
             rid: osx-arm64
             lib: libz3.dylib
@@ -98,10 +106,16 @@ jobs:
           cp /tmp/z3/build/${{ matrix.lib }} bin/Debug/net10.0/
           dotnet run
 
+      # ONLY the native library. The source-built Microsoft.Z3.dll is a Debug
+      # netstandard1.4 assembly that embeds the builder's absolute obj path, so
+      # it differs on every run — and it used to win the `find | head -1` race in
+      # create-release, which is how a Debug, source-compiled managed wrapper
+      # ended up shipping inside the calor nupkg instead of the official Release
+      # assembly that download-z3.sh gives every developer and every CI test run.
+      # The managed DLL now comes from the canonical upstream archive below.
       - name: Prepare artifacts
         run: |
           mkdir -p artifacts
-          cp /tmp/z3/build/dotnet/bin/Debug/netstandard1.4/Microsoft.Z3.dll artifacts/
           cp /tmp/z3/build/${{ matrix.lib }} artifacts/
 
       - name: Upload artifacts
@@ -110,7 +124,9 @@ jobs:
           name: z3-${{ matrix.rid }}-${{ env.Z3_VERSION }}
           path: artifacts/
 
-  # Download pre-built Z3 for x64 and Windows ARM64 platforms
+  # Download pre-built Z3 for every RID except osx-arm64. These archives are
+  # pinned by src/Calor.Compiler/scripts/z3-upstream-<ver>.sha256, so extraction
+  # is deterministic and the resulting release assets are byte-stable across runs.
   download-z3-prebuilt:
     runs-on: ubuntu-latest
 
@@ -119,6 +135,9 @@ jobs:
         include:
           - rid: linux-x64
             archive: x64-glibc-2.39
+            lib: libz3.so
+          - rid: linux-arm64
+            archive: arm64-glibc-2.38
             lib: libz3.so
           - rid: osx-x64
             archive: x64-osx-15.7.3
@@ -169,8 +188,25 @@ jobs:
           # Copy native library
           find . -name "${{ matrix.lib }}" -path "*/bin/*" -exec cp {} artifacts/ \;
 
-          # Copy managed DLL (only need one copy, they're identical)
-          find . -name "Microsoft.Z3.dll" -exec cp {} artifacts/ \; 2>/dev/null || true
+          # The managed wrapper is emitted by ONE designated archive only.
+          # The old code copied it from whichever archive happened to contain it
+          # and called them "identical" — they are not. Upstream builds the
+          # netstandard1.4 assembly separately per archive, so the hashes differ
+          # (x64-win and x64-glibc-2.39 disagree), and combining that with
+          # `find | head -1` in create-release made the shipped wrapper a
+          # coin flip. x64-win is the canonical source because that is what
+          # download-z3.sh pins as MANAGED_DLL_ARCHIVE — so the DLL we ship is
+          # byte-identical to the one every test run exercises.
+          if [ "${{ matrix.archive }}" = "$MANAGED_DLL_ARCHIVE" ]; then
+            MANAGED="$(find . -name "Microsoft.Z3.dll" -path "*/bin/*" | head -1)"
+            if [ -z "$MANAGED" ]; then
+              echo "::error::canonical archive ${{ matrix.archive }} contains no Microsoft.Z3.dll"
+              exit 1
+            fi
+            cp "$MANAGED" artifacts/Microsoft.Z3.dll
+            echo "Managed wrapper (canonical, from ${{ matrix.archive }}):"
+            sha256sum artifacts/Microsoft.Z3.dll
+          fi
 
           ls -la artifacts/
 
@@ -195,10 +231,30 @@ jobs:
 
       - name: Organize binaries
         run: |
+          set -euo pipefail
           mkdir -p release
 
-          # Get managed DLL (same for all platforms)
-          find artifacts -name "Microsoft.Z3.dll" | head -1 | xargs -I {} cp {} release/Microsoft.Z3.dll
+          # Exactly one artifact carries the managed wrapper now (the canonical
+          # upstream archive). Take it by explicit path and fail closed if it is
+          # absent — the previous `find artifacts -name Microsoft.Z3.dll | head -1`
+          # ranged over every artifact, including the non-reproducible Debug
+          # source builds, so the shipped wrapper depended on artifact download
+          # order rather than on anything anyone chose.
+          MANAGED_ARTIFACT="artifacts/z3-win-x64-${{ env.Z3_VERSION }}/Microsoft.Z3.dll"
+          if [ ! -f "$MANAGED_ARTIFACT" ]; then
+            echo "::error::canonical managed wrapper missing at $MANAGED_ARTIFACT"
+            exit 1
+          fi
+          cp "$MANAGED_ARTIFACT" release/Microsoft.Z3.dll
+
+          # No other artifact may carry a managed wrapper — if one does, the
+          # canonical-source invariant has silently regressed.
+          STRAYS="$(find artifacts -name Microsoft.Z3.dll ! -path "artifacts/z3-win-x64-${{ env.Z3_VERSION }}/*")"
+          if [ -n "$STRAYS" ]; then
+            echo "::error::stray Microsoft.Z3.dll outside the canonical artifact:"
+            echo "$STRAYS"
+            exit 1
+          fi
 
           # Organize native libraries by RID
           for dir in artifacts/z3-*; do
@@ -216,6 +272,17 @@ jobs:
 
           echo "Release contents:"
           ls -la release/
+
+      # The manifest .github/z3-binaries-<ver>.sha256 must be updated in the same
+      # change that republishes these assets, otherwise publish-nuget fails closed
+      # on the next release — which is exactly what happened to v0.12.0. Print the
+      # regenerated manifest body so it can be committed without re-downloading.
+      - name: Emit checksum manifest for the published assets
+        run: |
+          set -euo pipefail
+          cd release
+          echo "::notice::Copy the block below into .github/z3-binaries-${{ env.Z3_VERSION }}.sha256 (keeping its header comment)"
+          sha256sum Microsoft.Z3.dll libz3-*.so libz3-*.dylib libz3-*.dll | tee "$GITHUB_STEP_SUMMARY"
 
       - name: Create or update release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build-z3.yml
+++ b/.github/workflows/build-z3.yml
@@ -222,9 +222,14 @@ jobs:
           print(f"  [arch-neutral] COFF machine 0x{machine:x} (AnyCPU)")
           PY
 
-            cp "$MANAGED" artifacts/Microsoft.Z3.dll
+            # Staged OUTSIDE artifacts/ so it travels as its own fixed-name
+            # artifact. create-release must not have to know which RID happens
+            # to be canonical — encoding that twice is precisely how this broke:
+            # moving the canonical archive left a hardcoded RID path behind.
+            mkdir -p managed
+            cp "$MANAGED" managed/Microsoft.Z3.dll
             echo "Managed wrapper (canonical, from ${{ matrix.archive }}):"
-            sha256sum artifacts/Microsoft.Z3.dll
+            sha256sum managed/Microsoft.Z3.dll
           fi
 
           ls -la artifacts/
@@ -234,6 +239,17 @@ jobs:
         with:
           name: z3-${{ matrix.rid }}-${{ env.Z3_VERSION }}
           path: artifacts/
+
+      # One fixed-name artifact for the managed wrapper, produced by exactly one
+      # matrix leg. create-release addresses it by this name and never needs to
+      # know which archive or RID is canonical.
+      - name: Upload managed wrapper (canonical archive only)
+        if: matrix.archive == env.MANAGED_DLL_ARCHIVE
+        uses: actions/upload-artifact@v4
+        with:
+          name: z3-managed-${{ env.Z3_VERSION }}
+          path: managed/Microsoft.Z3.dll
+          if-no-files-found: error
 
   # Create/update the z3-binaries release with all artifacts
   create-release:
@@ -259,24 +275,26 @@ jobs:
           # ranged over every artifact, including the non-reproducible Debug
           # source builds, so the shipped wrapper depended on artifact download
           # order rather than on anything anyone chose.
-          MANAGED_ARTIFACT="artifacts/z3-win-x64-${{ env.Z3_VERSION }}/Microsoft.Z3.dll"
+          MANAGED_DIR="artifacts/z3-managed-${{ env.Z3_VERSION }}"
+          MANAGED_ARTIFACT="$MANAGED_DIR/Microsoft.Z3.dll"
           if [ ! -f "$MANAGED_ARTIFACT" ]; then
             echo "::error::canonical managed wrapper missing at $MANAGED_ARTIFACT"
             exit 1
           fi
           cp "$MANAGED_ARTIFACT" release/Microsoft.Z3.dll
 
-          # No other artifact may carry a managed wrapper — if one does, the
+          # No RID artifact may carry a managed wrapper — if one does, the
           # canonical-source invariant has silently regressed.
-          STRAYS="$(find artifacts -name Microsoft.Z3.dll ! -path "artifacts/z3-win-x64-${{ env.Z3_VERSION }}/*")"
+          STRAYS="$(find artifacts -name Microsoft.Z3.dll ! -path "$MANAGED_DIR/*")"
           if [ -n "$STRAYS" ]; then
             echo "::error::stray Microsoft.Z3.dll outside the canonical artifact:"
             echo "$STRAYS"
             exit 1
           fi
 
-          # Organize native libraries by RID
+          # Organize native libraries by RID (the managed artifact holds no native)
           for dir in artifacts/z3-*; do
+            [ "$dir" = "$MANAGED_DIR" ] && continue
             rid=$(basename "$dir" | sed "s/z3-//" | sed "s/-${{ env.Z3_VERSION }}//")
 
             # Find and copy native lib with RID prefix

--- a/.github/workflows/build-z3.yml
+++ b/.github/workflows/build-z3.yml
@@ -24,10 +24,16 @@ on:
 
 env:
   Z3_VERSION: ${{ github.event.inputs.z3_version || '4.15.7' }}
-  # Must stay in sync with MANAGED_DLL_ARCHIVE in
-  # src/Calor.Compiler/scripts/download-z3.sh — the managed wrapper we publish
-  # has to be the same bytes developers and CI already build against.
-  MANAGED_DLL_ARCHIVE: x64-win
+  # The archive we take the managed wrapper from. This MUST be an archive whose
+  # Microsoft.Z3.dll is architecture-neutral. Upstream does not build it the same
+  # way everywhere: the x64-win archive ships a PE32+/AMD64 assembly that throws
+  # "assembly architecture is not compatible with the current process
+  # architecture" in an arm64 process, while the glibc archives ship the ordinary
+  # PE32/I386 AnyCPU shape that loads anywhere. The wrapper is pure P/Invoke — the
+  # per-RID native libz3 is what actually differs — so the neutral one is correct
+  # for every RID we publish. Verified by the assertion in the job below.
+  # Keep in sync with MANAGED_DLL_ARCHIVE in download-z3.sh.
+  MANAGED_DLL_ARCHIVE: x64-glibc-2.39
 
 jobs:
   # Build Z3 from source on ARM64 macOS ONLY. The upstream arm64-osx archive has
@@ -191,18 +197,31 @@ jobs:
           # The managed wrapper is emitted by ONE designated archive only.
           # The old code copied it from whichever archive happened to contain it
           # and called them "identical" — they are not. Upstream builds the
-          # netstandard1.4 assembly separately per archive, so the hashes differ
-          # (x64-win and x64-glibc-2.39 disagree), and combining that with
-          # `find | head -1` in create-release made the shipped wrapper a
-          # coin flip. x64-win is the canonical source because that is what
-          # download-z3.sh pins as MANAGED_DLL_ARCHIVE — so the DLL we ship is
-          # byte-identical to the one every test run exercises.
+          # netstandard1.4 assembly separately per archive, so both the bytes AND
+          # the target architecture differ, and combining that with
+          # `find | head -1` in create-release made the shipped wrapper a coin
+          # flip between builds that are not interchangeable.
           if [ "${{ matrix.archive }}" = "$MANAGED_DLL_ARCHIVE" ]; then
             MANAGED="$(find . -name "Microsoft.Z3.dll" -path "*/bin/*" | head -1)"
             if [ -z "$MANAGED" ]; then
               echo "::error::canonical archive ${{ matrix.archive }} contains no Microsoft.Z3.dll"
               exit 1
             fi
+
+            # Fail closed if the canonical archive ever ships an architecture-
+            # specific wrapper. An AMD64-marked assembly builds fine and passes
+            # x64 CI, then fails at load time on every arm64 consumer — a defect
+            # that is invisible on the machines that would publish it.
+            python3 - "$MANAGED" <<'PY'
+          import struct, sys
+          d = open(sys.argv[1], 'rb').read()
+          machine = struct.unpack_from('<H', d, struct.unpack_from('<I', d, 0x3c)[0] + 4)[0]
+          if machine != 0x14c:  # IMAGE_FILE_MACHINE_I386 == the AnyCPU encoding
+              sys.exit(f"::error::managed wrapper is architecture-specific "
+                       f"(COFF machine 0x{machine:x}); it will not load on other architectures")
+          print(f"  [arch-neutral] COFF machine 0x{machine:x} (AnyCPU)")
+          PY
+
             cp "$MANAGED" artifacts/Microsoft.Z3.dll
             echo "Managed wrapper (canonical, from ${{ matrix.archive }}):"
             sha256sum artifacts/Microsoft.Z3.dll

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -564,3 +564,32 @@ jobs:
 
       - name: Run phase-2 gate dry-run smoke
         run: python3 scripts/smoke_phase_2_gate_dryrun.py
+
+  vsix-single-file-publish:
+    # publish-vscode.yml packs the language server with PublishSingleFile=true.
+    # That is the ONLY place the repo builds single-file, and single-file promotes
+    # Assembly.Location uses to IL3000 errors under TreatWarningsAsErrors — so
+    # v0.12.0's VS Code publish died on a compile error that no PR could have
+    # caught. (That channel had in fact been failing since v0.9.0, unnoticed,
+    # because nothing between releases ever ran this build.) One target is
+    # enough; the analyzer verdict is RID-independent.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Publish language server single-file (same script the release uses)
+        run: bash editors/vscode/scripts/build-server.sh linux-x64
+
+      - name: Assert the server binary was produced
+        run: |
+          set -euo pipefail
+          test -f editors/vscode/server/calor-lsp
+          echo "single-file language server built: $(du -h editors/vscode/server/calor-lsp | cut -f1)"

--- a/.github/workflows/z3-pin-check.yml
+++ b/.github/workflows/z3-pin-check.yml
@@ -1,0 +1,103 @@
+name: Z3 Binary Pin Check
+
+# publish-nuget.yml verifies the downloaded z3-binaries release assets against
+# .github/z3-binaries-<ver>.sha256 and refuses to pack on a mismatch. That guard
+# is correct and it did its job — but v0.12.0 is how we found out it only ever
+# fires at release time, after the tag is cut and the GitHub release is public.
+# The pinned z3-binaries release had been republished underneath the manifest a
+# day after the manifest was computed, and nothing noticed for a week.
+#
+# This workflow checks the same invariant continuously, so drift is a red build
+# on an ordinary day rather than a failed publish on release day.
+#
+# Not part of test.yml because verifying the pins means downloading ~350MB of
+# release assets and upstream archives; that is worth a daily run and a run when
+# the pinning machinery itself changes, but not a run on every pull request.
+
+on:
+  schedule:
+    # Daily, 06:15 UTC.
+    - cron: '15 6 * * *'
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/z3-binaries-*.sha256'
+      - '.github/workflows/publish-nuget.yml'
+      - '.github/workflows/build-z3.yml'
+      - '.github/workflows/z3-pin-check.yml'
+      - 'src/Calor.Compiler/scripts/z3-upstream-*.sha256'
+      - 'src/Calor.Compiler/scripts/download-z3.sh'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/z3-binaries-*.sha256'
+      - '.github/workflows/publish-nuget.yml'
+      - '.github/workflows/build-z3.yml'
+      - '.github/workflows/z3-pin-check.yml'
+      - 'src/Calor.Compiler/scripts/z3-upstream-*.sha256'
+      - 'src/Calor.Compiler/scripts/download-z3.sh'
+
+env:
+  Z3_VERSION: "4.15.7"
+
+jobs:
+  verify-pins:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Layer 1: the repo's own z3-binaries release — what publish-nuget packs.
+      - name: Verify committed manifest still matches the live z3-binaries release
+        run: |
+          set -euo pipefail
+          MANIFEST=".github/z3-binaries-${Z3_VERSION}.sha256"
+          RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/z3-binaries-${Z3_VERSION}"
+
+          if [ ! -s "$MANIFEST" ]; then
+            echo "::error::$MANIFEST is missing or empty"
+            exit 1
+          fi
+
+          STAGING="$(mktemp -d)"
+          trap 'rm -rf "$STAGING"' EXIT
+
+          # Fetch exactly the assets the manifest names, so an asset that is in the
+          # manifest but missing from the release fails here too (curl -f).
+          while read -r asset; do
+            curl -fL -sS --retry 5 --retry-delay 3 -o "$STAGING/$asset" "${RELEASE_URL}/${asset}"
+          done < <(grep -v '^#' "$MANIFEST" | awk 'NF {print $2}')
+
+          if ! (cd "$STAGING" && grep -v '^#' "$GITHUB_WORKSPACE/$MANIFEST" | sha256sum --check --strict -); then
+            echo "::error::z3-binaries release no longer matches $MANIFEST — publish-nuget WILL fail on the next release."
+            echo "::error::Do NOT rehash the live assets: that launders whatever is currently published into the pin."
+            echo "::error::Republish deliberately via build-z3.yml (workflow_dispatch) and commit the manifest it prints in its step summary."
+            exit 1
+          fi
+
+      # Layer 2: the upstream Z3Prover archives those assets are derived from.
+      - name: Verify upstream Z3 archives still match their pin
+        run: |
+          set -euo pipefail
+          MANIFEST="src/Calor.Compiler/scripts/z3-upstream-${Z3_VERSION}.sha256"
+          BASE="https://github.com/Z3Prover/z3/releases/download/z3-${Z3_VERSION}"
+
+          if [ ! -s "$MANIFEST" ]; then
+            echo "::error::$MANIFEST is missing or empty"
+            exit 1
+          fi
+
+          STAGING="$(mktemp -d)"
+          trap 'rm -rf "$STAGING"' EXIT
+
+          while read -r zip; do
+            curl -fL -sS --retry 5 --retry-delay 3 -o "$STAGING/$zip" "${BASE}/${zip}"
+          done < <(grep -v '^#' "$MANIFEST" | awk 'NF {print $2}')
+
+          if ! (cd "$STAGING" && grep -v '^#' "$GITHUB_WORKSPACE/$MANIFEST" | sha256sum --check --strict -); then
+            echo "::error::upstream Z3 ${Z3_VERSION} archives no longer match $MANIFEST — investigate before touching anything downstream."
+            exit 1
+          fi

--- a/.github/z3-binaries-4.15.7.sha256
+++ b/.github/z3-binaries-4.15.7.sha256
@@ -2,15 +2,39 @@
 # (W1 Slice 2, #789). publish-nuget.yml verifies every download against
 # this file before packing — a missing or corrupt native fails the release
 # instead of shipping inside the nupkg.
-# Provenance (trust-on-first-use): computed 2026-07-31 by downloading the
-# then-current z3-binaries-4.15.7 release assets and hashing them — the pin
-# guarantees the RELEASE cannot change silently afterward, not that the
-# original upload was audited. Regenerate ONLY when the z3-binaries release
-# is deliberately republished, and only from a build-z3.yml run whose
-# upstream inputs verified against scripts/z3-upstream-4.15.7.sha256:
-#   for a in <assets>; do curl -fL -o "$a" "$RELEASE_URL/$a"; done && shasum -a 256 *
-b9b26761e2da23c38836e65cbc0dd0e50f5bace35293b4be1385265f64cd3124  Microsoft.Z3.dll
-9646bb8e5599a93bc4f26c9c593d6e0261f029eee73a896f15ce8502fc22d55b  libz3-linux-arm64.so
+#
+# Provenance: regenerated 2026-08-07 from build-z3.yml run 31207597466, a
+# deliberate workflow_dispatch republish. Seven of the eight assets are plain
+# extractions from upstream Z3Prover archives that the same run verified against
+# scripts/z3-upstream-4.15.7.sha256, so they are reproducible: all seven were
+# predicted from the pinned archives BEFORE the run and matched byte for byte.
+# The eighth, libz3-osx-arm64.dylib, is still built from source (upstream's
+# arm64-osx archive has assembly-loading problems) and is the only entry not
+# derivable from a pinned input — though it has now reproduced bit-identically
+# across three separate runs.
+#
+# This replaces a 2026-07-31 trust-on-first-use manifest that had drifted. Two
+# entries changed, and neither because upstream changed:
+#
+#   Microsoft.Z3.dll     was a Debug, source-compiled wrapper that a macOS runner
+#                        happened to win a `find | head -1` race with. Now the
+#                        upstream Release build from the x64-glibc-2.39 archive.
+#                        That archive is canonical because its wrapper is
+#                        architecture-NEUTRAL (PE32/I386); upstream's x64-win
+#                        wrapper is PE32+/AMD64 and cannot load in an arm64
+#                        process. build-z3.yml asserts this before publishing.
+#   libz3-linux-arm64.so was built from source for no reason — download-z3.sh has
+#                        always taken linux-arm64 from upstream. Now the upstream
+#                        binary, so a rebuild no longer reshuffles it.
+#
+# Regenerate ONLY when the z3-binaries release is deliberately republished, and
+# only from a build-z3.yml run whose upstream inputs verified against
+# scripts/z3-upstream-4.15.7.sha256. That run prints the replacement block in its
+# step summary; commit it in the same change that republishes. Never rehash the
+# live assets — that launders whatever is currently published into the pin and
+# defeats the entire mechanism. z3-pin-check.yml watches for drift daily.
+59cb6de1d2e855fb44b4698616cc1f452249103989728da3700c4648b4426175  Microsoft.Z3.dll
+7227ad08ae28b731be27a26f68680f627a4e513e2a134b2cbe1fc223a76ce3b5  libz3-linux-arm64.so
 3e70217bc6b05b6204912698becf9f853a7a2f07bb5338dad84aef79aee9bec8  libz3-linux-x64.so
 038f356687ac800c2269ff4d289c7921ec5802dafca3ae6a2a4620defc807f9c  libz3-osx-arm64.dylib
 8d1f54380a32e2c13b03b2e9afa8427908fa480c3f7d1285a1ae034793359ada  libz3-osx-x64.dylib

--- a/src/Calor.Compiler/Commands/ImportCommand.cs
+++ b/src/Calor.Compiler/Commands/ImportCommand.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Calor.Compiler.Diagnostics;
@@ -137,7 +138,12 @@ public static class ImportCommand
 
             var ilOptions = new ILAnalysisOptions
             {
-                RuntimeDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location),
+                // Not typeof(object).Assembly.Location: that is empty under
+                // single-file publish (IL3000), which would silently drop the
+                // framework-assembly probe root in AssemblyIndex. GetRuntimeDirectory
+                // is the single-file-safe equivalent and returns the shared-framework
+                // directory for the framework-dependent `calor` global tool.
+                RuntimeDirectory = RuntimeEnvironment.GetRuntimeDirectory(),
                 NuGetPackageRoot = GetNuGetPackagesRoot(),
                 DepsFilePath = target.DepsFilePath
             };

--- a/src/Calor.Compiler/Verification/Z3/Z3ContextFactory.cs
+++ b/src/Calor.Compiler/Verification/Z3/Z3ContextFactory.cs
@@ -63,6 +63,17 @@ public static class Z3ContextFactory
         return TryLoadZ3Native();
     }
 
+    // IL3000: Assembly.Location is empty under single-file publish (the VS Code
+    // extension packs the language server that way). That is a supported input
+    // here, not a defect: AppContext.BaseDirectory is probe root #1 and covers
+    // the single-file case, while Location is consulted only to reach the
+    // MSBuild-task layout (natives next to calor.dll, where BaseDirectory is the
+    // MSBuild host directory). The empty result is filtered by the
+    // IsNullOrEmpty guard below, so the single-file app simply probes one root.
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
+        "SingleFile", "IL3000",
+        Justification = "Empty Location is expected under single-file and is guarded; " +
+                        "AppContext.BaseDirectory is the primary probe root.")]
     private static IntPtr TryLoadZ3Native()
     {
         // Probe roots, in order:

--- a/src/Calor.Compiler/scripts/download-z3.ps1
+++ b/src/Calor.Compiler/scripts/download-z3.ps1
@@ -44,8 +44,15 @@ $PLATFORMS = @(
     @{ rid = "linux-x64"; archive = "z3-$Z3_VERSION-x64-glibc-2.39"; lib = "libz3.so" }
 )
 
-# Use one platform to get the managed DLL (it's the same across all platforms)
-$MANAGED_DLL_ARCHIVE = "z3-$Z3_VERSION-x64-win"
+# One archive supplies the managed wrapper for every platform. It is NOT "the
+# same across all platforms" as previously assumed: upstream's x64-win archive
+# ships a PE32+/AMD64 Microsoft.Z3.dll that fails to load in an arm64 process,
+# whereas the glibc archives ship the ordinary PE32/I386 AnyCPU shape. The
+# wrapper is pure P/Invoke (the per-RID native libz3 carries the platform
+# difference), so the architecture-neutral one is correct everywhere — and it is
+# the only choice that works on win-arm64. Keep in sync with MANAGED_DLL_ARCHIVE
+# in download-z3.sh and .github/workflows/build-z3.yml.
+$MANAGED_DLL_ARCHIVE = "z3-$Z3_VERSION-x64-glibc-2.39"
 
 $BASE_URL = "https://github.com/Z3Prover/z3/releases/download/z3-$Z3_VERSION"
 

--- a/src/Calor.Compiler/scripts/download-z3.sh
+++ b/src/Calor.Compiler/scripts/download-z3.sh
@@ -74,8 +74,16 @@ PLATFORMS=(
     "linux-x64|z3-${Z3_VERSION}-x64-glibc-2.39|libz3.so|libz3.so"
 )
 
-# Use one platform to get the managed DLL (it's the same across all platforms)
-MANAGED_DLL_ARCHIVE="z3-${Z3_VERSION}-x64-win"
+# One archive supplies the managed wrapper for every platform. It is NOT "the
+# same across all platforms" as previously assumed: upstream's x64-win archive
+# ships a PE32+/AMD64 Microsoft.Z3.dll that throws "assembly architecture is not
+# compatible with the current process architecture" when loaded in an arm64
+# process, whereas the glibc archives ship the ordinary PE32/I386 AnyCPU shape.
+# The wrapper is pure P/Invoke (the per-RID native libz3 carries the platform
+# difference), so the architecture-neutral one is correct everywhere — and it is
+# the only choice that works on linux-arm64 and win-arm64. Keep in sync with
+# MANAGED_DLL_ARCHIVE in .github/workflows/build-z3.yml.
+MANAGED_DLL_ARCHIVE="z3-${Z3_VERSION}-x64-glibc-2.39"
 
 BASE_URL="https://github.com/Z3Prover/z3/releases/download/z3-${Z3_VERSION}"
 


### PR DESCRIPTION
v0.12.0 was tagged but shipped nothing. Both publish workflows failed, nuget.org still serves `0.10.0` and the marketplace still serves `0.3.8`. Neither failure was reachable from any pull request.

## VS Code — `IL3000` (failing since v0.9.0)

`build-server.sh` publishes the language server with `PublishSingleFile=true`, which promotes `Assembly.Location` to `IL3000` — fatal under `TreatWarningsAsErrors`. Two sites:

- **`Z3ContextFactory.TryLoadZ3Native`** — suppressed with justification. The empty `Location` is a *supported input* here: `AppContext.BaseDirectory` is probe root #1 and covers the single-file case, `Location` exists only to reach the MSBuild-task layout, and the result is already filtered by the `IsNullOrEmpty` guard.
- **`ImportCommand`** — switched to `RuntimeEnvironment.GetRuntimeDirectory()`. Verified to resolve to the identical directory (trailing separator only, absorbed by `Path.Combine`). The old expression would have silently emptied `AssemblyIndex`'s framework probe root under single-file.

## NuGet — the checksum guard fired *correctly*

The pinned `z3-binaries-4.15.7` release had been republished underneath its manifest. Root cause is two determinism defects in `build-z3.yml`, not a stale hash:

1. **`create-release` selected the managed wrapper with `find | head -1`** across *all* artifacts, including the from-source ARM64 jobs. The winner was arbitrary — and the one published was a **Debug `netstandard1.4` assembly with the builder's absolute path baked in** (`/private/tmp/z3/build/dotnet/obj/Debug/…`). The `calor` nupkg had been shipping a locally source-compiled Debug Z3 wrapper. The adjacent `only need one copy, they're identical` comment was false.
2. **`linux-arm64` was built from source for no reason.** `download-z3.sh` has always taken it from the upstream `arm64-glibc-2.38` archive; the "prebuilt has loading issues" exception is scoped to ARM64 *macOS*. A from-source C++ build is not reproducible, so it re-drifted the pin every run.

Both now come from checksum-verified upstream archives.

### The wrapper is not architecture-neutral in every archive

The first attempt made `x64-win` canonical, on the reasoning that it is what `download-z3.sh` designates. **That reasoning was wrong — `download-z3.sh`'s own choice is latently broken.** Upstream does not build `Microsoft.Z3.dll` the same way in every archive:

| archive | PE | loads in arm64 process |
|---|---|---|
| `x64-win` | PE32+ / **AMD64** | ❌ |
| `x64-glibc-2.39` | PE32 / I386 (AnyCPU) | ✅ |

Caught by building with it on an arm64 host: `Could not load file or assembly 'Microsoft.Z3' … The assembly architecture is not compatible with the current process architecture.` The wrapper is pure P/Invoke — the per-RID native `libz3` carries the platform difference — so the neutral build is correct for every RID and is the only one that works on `linux-arm64`/`win-arm64`. Fixed in `build-z3.yml`, `download-z3.sh` **and** `download-z3.ps1` (the PowerShell path serves win-arm64 and had the same latent bug).

`build-z3.yml` now **asserts the COFF machine** of the wrapper before publishing and fails closed on an architecture-specific one — otherwise an AMD64 wrapper builds fine, passes x64 CI, and only breaks on consumers whose machines never run the publish.

The canonical leg also now uploads the wrapper as its own fixed-name `z3-managed-<ver>` artifact, so "which leg is canonical" is stated **once** in `MANAGED_DLL_ARCHIVE`. An intermediate run failed closed at exactly the check that caught this duplication — nothing was published.

### Repin

Regenerated from run `31207597466`:

| asset | before | after |
|---|---|---|
| `Microsoft.Z3.dll` | `b9b26761…` Debug source build | `59cb6de1…` upstream Release, AnyCPU |
| `libz3-linux-arm64.so` | `9646bb8e…` source build | `7227ad08…` upstream binary |
| other 6 | — | **unchanged** |

Seven of eight were predicted from the pinned upstream archives *before* the run and matched byte for byte. The eighth (osx-arm64 source build) reproduced bit-identically across three runs. Replaying `publish-nuget`'s verification against the live release passes on all eight.

## The push trigger that started it

`build-z3.yml` also ran on push to main whenever a z3 script changed. That is what invalidated the pin: #789 added the manifest, and pushing *that very commit* re-ran `build-z3` and republished all eight assets a day later. Trigger removed; `workflow_dispatch` only. The job now prints the regenerated manifest to its step summary.

## Why both bugs survived to release day

Nothing between releases exercised either path — `PublishSingleFile` appears *only* in the release workflow, and the pin was only ever verified while publishing. Two guards close that:

- **`vsix-single-file-publish`** in `test.yml` (~1m10s) — runs the same single-file publish the VSIX build uses.
- **`z3-pin-check.yml`** — daily + on changes to the pinning machinery, verifying both the repo's release and the upstream archives. Separate from `test.yml` because it downloads ~350MB.

## Test plan

- [x] Reproduced `IL3000` locally byte-for-byte; single-file publish now succeeds
- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] **`Calor.Verification.Tests` 359/359, zero skips, on arm64 with the new wrapper** — Z3 genuinely loads and solves
- [x] `Calor.ILAnalysis.Tests` 42/42; import-filtered compiler tests 10/10
- [x] `calor import` end-to-end: 76 public methods, 21 effects derived via IL call chains
- [x] Confirmed `GetRuntimeDirectory()` ≡ old expression on a normal build
- [x] Simulated `create-release` against a full artifact tree before each dispatch
- [x] Negative-tested every new guard: stray wrapper, missing canonical wrapper, AMD64 wrapper (rejected with `COFF machine 0x8664`), and pin drift
- [x] All 13 CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)