### PR TITLE
Release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,66 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-08-07
+
+**A packaging release. v0.12.0 was tagged but never installable** — both publish workflows
+failed, so nuget.org continued to serve `0.10.0` and the VS Code marketplace continued to serve
+`0.3.8`. Nothing in the language, compiler, or verifier changed here; if you already build from
+source, this release contains nothing for you.
+
+### Benchmark Results (Statistical: 30 runs)
+- **Overall Advantage**: 1.32 (Calor/C#)
+- **Metrics**: Calor wins 7, C# wins 1
+- **Highlights**:
+  - Comprehension: 1.84x (large effect)
+  - ErrorDetection: 1.49x (large effect)
+  - TokenEconomics: 1.42x (small effect)
+  - InformationDensity: 0.98x (**C# wins**, medium effect)
+- **Programs Tested**: 217
+
+**Identical to v0.12.0 in every digit, and that is the expected result, not a coincidence.** The
+suite was re-run at the documented 30 iterations; the regenerated dashboard JSON differs from
+v0.12.0's by exactly two lines, the timestamp and the commit hash. These metrics are computed by
+deterministic static analysis, and this release changes no analyzed code path. The zero-width
+confidence intervals carry the same defect disclosed in v0.12.0 and are still not fixed.
+
+### Fixed
+- **The VS Code extension can be published again.** It had failed to publish for **three
+  consecutive releases** (v0.9.0, v0.10.0, v0.12.0) without anyone noticing, which is why the
+  marketplace still served `0.3.8`. The language server is packed with `PublishSingleFile=true`,
+  which promotes `Assembly.Location` to an `IL3000` error under `TreatWarningsAsErrors`. Fixed at
+  both sites: `Z3ContextFactory` carries a justified suppression (the empty location is a
+  supported input there and is already guarded), and `ImportCommand` now uses
+  `RuntimeEnvironment.GetRuntimeDirectory()`, the single-file-safe equivalent — the previous
+  expression would have silently emptied the framework probe root used by IL effect analysis.
+- **The NuGet publish no longer fails its own checksum gate.** The gate was right; the pinned
+  `z3-binaries` release had been republished underneath its manifest. Two underlying defects are
+  fixed rather than papered over by rehashing: the managed `Microsoft.Z3.dll` was selected with
+  `find | head -1` across all build artifacts, and `linux-arm64` was built from source despite
+  upstream publishing a binary for it. Both now come from checksum-verified upstream archives, so
+  the published assets are reproducible.
+- **The shipped Z3 managed wrapper is now upstream's Release build.** Because of the selection
+  race above, released packages had been carrying a **Debug** `netstandard1.4` assembly compiled
+  on a CI runner, with that runner's absolute build path embedded in it.
+- **Z3 now loads on ARM64 consumers.** Upstream's `x64-win` archive ships an AMD64-marked wrapper
+  that throws *"the assembly architecture is not compatible with the current process
+  architecture"* in an arm64 process; the glibc archives ship the architecture-neutral build.
+  Both `download-z3.sh` and `download-z3.ps1` had designated the AMD64 one — latent because x64 CI
+  cannot observe it and macOS/arm64 diverts to a source build. This affected `linux-arm64` and
+  `win-arm64`.
+- **Republishing the shared Z3 binaries is now a deliberate act.** `build-z3.yml` no longer runs
+  on push, which is what invalidated the pin originally: the commit that *introduced* the manifest
+  re-triggered the workflow and republished every asset a day later.
+
+### Added
+- **CI now exercises both release-only paths**, which is why neither failure was catchable before
+  release day. `test.yml` runs the same single-file publish the VSIX build uses (~1m10s), and a
+  new scheduled `z3-pin-check` workflow verifies the binary pins daily and on changes to the
+  pinning machinery — against both the repo's release and the upstream Z3Prover archives.
+- `build-z3.yml` asserts that the wrapper it is about to publish is architecture-neutral, and
+  fails closed otherwise. An architecture-specific wrapper builds fine and passes x64 CI, so it
+  would only break on consumers whose machines never run the publish.
+
 ## [0.12.0] - 2026-08-06
 
 ### Benchmark Results (Statistical: 30 runs)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.12.0</Version>
+    <Version>0.12.1</Version>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "calor",
   "displayName": "Calor Language",
   "description": "Language support for the Calor programming language",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "publisher": "calor-dev",
   "license": "Apache-2.0",
   "icon": "icons/calor-icon.png",

--- a/website/content/changelog.mdx
+++ b/website/content/changelog.mdx
@@ -10,6 +10,20 @@ All notable changes to Calor, organized by release.
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-08-07
+
+A packaging release. **v0.12.0 was tagged but never installable** — both publish workflows failed, so nuget.org continued to serve `0.10.0` and the VS Code marketplace continued to serve `0.3.8`. Nothing in the language, compiler, or verifier changed here.
+
+### Fixed
+- **The VS Code extension can be published again.** It had failed to publish for **three consecutive releases** without anyone noticing, which is why the marketplace still served `0.3.8`. The language server is packed as a single file, which promotes `Assembly.Location` to a build error. Fixed at both sites — one justified suppression where the empty location is a supported and already-guarded input, and one switch to the single-file-safe `RuntimeEnvironment.GetRuntimeDirectory()`, since the old expression would have silently emptied the framework probe root used by IL effect analysis.
+- **The NuGet publish no longer fails its own checksum gate.** The gate was right — the pinned Z3 binaries release had been republished underneath its manifest. Two underlying defects are fixed rather than papered over by rehashing the live assets: the managed `Microsoft.Z3.dll` was selected with `find | head -1` across all build artifacts, and `linux-arm64` was built from source despite upstream publishing a binary for it. Both now come from checksum-verified upstream archives, so the published assets are reproducible.
+- **The shipped Z3 managed wrapper is now upstream's Release build.** Because of that selection race, released packages had been carrying a *Debug* assembly compiled on a CI runner, with the runner's absolute build path embedded in it.
+- **Z3 now loads on ARM64.** Upstream's Windows x64 archive ships an AMD64-marked wrapper that cannot load in an arm64 process, and both download scripts had designated it. This affected `linux-arm64` and `win-arm64`; it stayed hidden because x64 CI cannot observe it.
+- **Republishing the shared Z3 binaries is now deliberate.** The build workflow no longer runs on push — which is what invalidated the pin originally, since the commit that *introduced* the manifest re-triggered the workflow and republished every asset a day later.
+
+### Added
+- **CI now exercises both release-only paths.** Neither failure was catchable before release day, because the single-file publish and the binary pins were only ever exercised while publishing. The test suite now runs the same single-file publish the extension build uses, and a scheduled check verifies the binary pins daily against both the project's release and the upstream archives.
+
 ## [0.12.0] - 2026-08-06
 
 The soundness release. **This entry covers the v0.11 range as well** — there is no `v0.11.0` tag; the maintainer folded v0.11 forward, so everything below ships together.

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calor-website",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/website/public/data/benchmark-results.json
+++ b/website/public/data/benchmark-results.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
-  "timestamp": "2026-08-06T19:42:57.207072Z",
-  "commit": "ecb38d99",
+  "timestamp": "2026-08-07T19:28:36.62649Z",
+  "commit": "f7341d81",
   "frameworkVersion": "1.0.0",
   "summary": {
     "overallAdvantage": 1.32,

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -15,9 +15,9 @@ export function WhatsNewBanner() {
         <div className="flex items-center justify-center gap-3 text-sm">
           <Sparkles className="h-4 w-4 text-calor-cerulean flex-shrink-0" />
           <p className="text-center">
-            <span className="font-semibold text-calor-cerulean">v0.12.0</span>
+            <span className="font-semibold text-calor-cerulean">v0.12.1</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">The soundness release: six distinct cases where <code>--verify</code> deleted a runtime check that would have failed are closed — by refusing the divergent forms and by demoting proofs carried by a sort Z3 models as total to <em>Assumed</em>, which never elides. Type checking is on by default, effect enforcement closes five fail-open holes, and <code>calor import</code> plus <code>calor review-packet</code> land the adoption surface. Both release gates pass; the toolchain-parity epoch found no large token tax.</span>
+            <span className="text-foreground">The soundness release of v0.12.0 is now actually installable. Both publish channels were broken — the extension had failed to publish for three consecutive releases — so <code>calor</code> is back on NuGet and the VS Code extension is back on the marketplace. Along the way: the shipped Z3 wrapper is now upstream&apos;s Release build rather than a Debug artifact, it loads on ARM64 again, and CI exercises both release-only paths so neither failure can reach release day unseen.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"


### PR DESCRIPTION
## Summary

Packaging release. **v0.12.0 was tagged but never installable** — both publish workflows failed, so nuget.org still serves `0.10.0` and the VS Code marketplace still serves `0.3.8`. The pipeline repairs landed in #885; this cuts the version that can actually carry them to users.

Nothing in the language, compiler, or verifier changed. If you build from source, this release contains nothing for you.

## Benchmark Results (Statistical: 30 runs)

- **Overall Advantage**: 1.32 (Calor/C#)
- **Metrics**: Calor wins 7, C# wins 1
- **Highlights**: Comprehension 1.84x · ErrorDetection 1.49x · TokenEconomics 1.42x · InformationDensity 0.98x (**C# wins**)
- **Programs Tested**: 217

**Identical to v0.12.0 in every digit — the expected result, not a coincidence.** The suite was re-run at the documented 30 iterations; the regenerated dashboard JSON differs from v0.12.0's by **exactly two lines**, the timestamp and the commit hash. These metrics are deterministic static analysis and this release changes no analyzed code path. The CHANGELOG records them as unchanged rather than presenting them as a fresh measurement. The zero-width confidence intervals carry the same defect disclosed in v0.12.0 and are still not fixed.

## What this release delivers

- The VS Code extension can be published again — it had silently failed for **three consecutive releases** (v0.9.0, v0.10.0, v0.12.0)
- The NuGet publish passes its own checksum gate again
- The shipped Z3 managed wrapper is upstream's **Release** build, not a Debug artifact with a CI runner's absolute path embedded
- Z3 loads on ARM64 consumers again (`linux-arm64`, `win-arm64`)
- CI exercises both release-only paths, so neither failure class can reach release day unseen

## Checklist

- [x] Version updated in `Directory.Build.props`
- [x] Version updated in `editors/vscode/package.json`
- [x] Version updated in `website/package.json`
- [x] `CHANGELOG.md` updated with version, date, and benchmark summary
- [x] `website/content/changelog.mdx` updated with version and changes (no benchmark stats)
- [x] `website/src/components/landing/WhatsNewBanner.tsx` updated with version and headline
- [x] `website/public/data/benchmark-results.json` updated with latest results
- [x] `dotnet build -c Release` clean (0 warnings, 0 errors)
- [x] `npm run build` in `website/` succeeds with the changelog and banner edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)