### PR TITLE
fix(msbuild): complete deterministic fail-closed caching (#788)

### DIFF
--- a/src/Calor.Compiler/Effects/IL/AssemblyIndex.cs
+++ b/src/Calor.Compiler/Effects/IL/AssemblyIndex.cs
@@ -64,7 +64,7 @@ public sealed class MethodLocation
 /// </summary>
 public sealed class AssemblyIndex : IDisposable
 {
-    private readonly ILAnalysisOptions _options;
+    private readonly AssemblyPathResolver _pathResolver;
     private readonly List<LoadedAssembly> _assemblies = [];
 
     // Phase 1: type name → assembly (eager, built on construction)
@@ -81,17 +81,175 @@ public sealed class AssemblyIndex : IDisposable
     // Type → direct subtypes (for abstract class resolution)
     private readonly Dictionary<string, List<string>> _subtypeIndex = new(StringComparer.Ordinal);
 
-    // Deps.json runtime mappings: assembly simple name → implementation path
-    private readonly Dictionary<string, string> _depsRuntimePaths = new(StringComparer.OrdinalIgnoreCase);
-
     private bool _disposed;
 
     public AssemblyIndex(IReadOnlyList<string> assemblyPaths, ILAnalysisOptions? options = null)
     {
-        _options = options ?? new ILAnalysisOptions();
-        LoadDepsJson();
+        _pathResolver = new AssemblyPathResolver(options ?? new ILAnalysisOptions());
         LoadAssemblies(assemblyPaths);
         BuildImplementationIndex();
+    }
+
+    internal sealed class AssemblyPathResolver
+    {
+        private readonly ILAnalysisOptions _options;
+        private readonly Dictionary<string, string> _depsRuntimePaths =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        internal AssemblyPathResolver(ILAnalysisOptions options)
+        {
+            _options = options;
+            LoadDepsJson();
+        }
+
+        internal string? Resolve(string path)
+        {
+            if (!File.Exists(path))
+                return null;
+            if (!IsReferenceAssembly(path))
+                return path;
+
+            var implPath = TryRefToLibSwap(path);
+            if (implPath != null)
+                return implPath;
+
+            var assemblyName = Path.GetFileNameWithoutExtension(path);
+            if (_depsRuntimePaths.TryGetValue(assemblyName, out var depsPath)
+                && File.Exists(depsPath))
+            {
+                return depsPath;
+            }
+
+            if (!string.IsNullOrEmpty(_options.RuntimeDirectory))
+            {
+                var runtimePath = Path.Combine(_options.RuntimeDirectory, Path.GetFileName(path));
+                if (File.Exists(runtimePath))
+                    return runtimePath;
+            }
+
+            return null;
+        }
+
+        private static bool IsReferenceAssembly(string path)
+        {
+            try
+            {
+                using var stream = File.OpenRead(path);
+                using var peReader = new PEReader(stream);
+                if (!peReader.HasMetadata)
+                    return false;
+
+                var reader = peReader.GetMetadataReader();
+                foreach (var attrHandle in reader.GetAssemblyDefinition().GetCustomAttributes())
+                {
+                    var attr = reader.GetCustomAttribute(attrHandle);
+                    var attributeName = attr.Constructor.Kind switch
+                    {
+                        HandleKind.MemberReference => GetMemberReferenceTypeName(
+                            reader,
+                            reader.GetMemberReference((MemberReferenceHandle)attr.Constructor)),
+                        HandleKind.MethodDefinition => GetTypeDefinitionName(
+                            reader,
+                            reader.GetMethodDefinition(
+                                (MethodDefinitionHandle)attr.Constructor).GetDeclaringType()),
+                        _ => null
+                    };
+                    if (attributeName == "ReferenceAssemblyAttribute")
+                        return true;
+                }
+                return false;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static string? GetMemberReferenceTypeName(
+            MetadataReader reader,
+            MemberReference constructor)
+            => constructor.Parent.Kind switch
+            {
+                HandleKind.TypeReference => reader.GetString(
+                    reader.GetTypeReference((TypeReferenceHandle)constructor.Parent).Name),
+                HandleKind.TypeDefinition => GetTypeDefinitionName(
+                    reader,
+                    (TypeDefinitionHandle)constructor.Parent),
+                _ => null
+            };
+
+        private static string GetTypeDefinitionName(
+            MetadataReader reader,
+            TypeDefinitionHandle handle)
+            => reader.GetString(reader.GetTypeDefinition(handle).Name);
+
+        private static string? TryRefToLibSwap(string refPath)
+        {
+            var normalized = refPath.Replace('\\', '/');
+            var refIndex = normalized.LastIndexOf("/ref/", StringComparison.OrdinalIgnoreCase);
+            if (refIndex < 0)
+                return null;
+
+            var libPath = normalized[..refIndex] + "/lib/" + normalized[(refIndex + 5)..];
+            libPath = libPath.Replace('/', Path.DirectorySeparatorChar);
+            return File.Exists(libPath) ? libPath : null;
+        }
+
+        private void LoadDepsJson()
+        {
+            if (string.IsNullOrEmpty(_options.DepsFilePath) || !File.Exists(_options.DepsFilePath))
+                return;
+
+            try
+            {
+                var json = File.ReadAllText(_options.DepsFilePath);
+                using var doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+                if (!root.TryGetProperty("targets", out var targets))
+                    return;
+
+                foreach (var target in targets.EnumerateObject())
+                {
+                    foreach (var package in target.Value.EnumerateObject())
+                    {
+                        if (!package.Value.TryGetProperty("runtime", out var runtime))
+                            continue;
+
+                        foreach (var asset in runtime.EnumerateObject())
+                        {
+                            var assemblyFileName = Path.GetFileNameWithoutExtension(asset.Name);
+                            var packageName = package.Name;
+                            if (root.TryGetProperty("libraries", out var libraries)
+                                && libraries.TryGetProperty(packageName, out var lib)
+                                && lib.TryGetProperty("path", out var pathProp))
+                            {
+                                var packagePath = pathProp.GetString();
+                                if (packagePath != null
+                                    && !string.IsNullOrEmpty(_options.NuGetPackageRoot))
+                                {
+                                    var fullPath = Path.GetFullPath(Path.Combine(
+                                        _options.NuGetPackageRoot, packagePath, asset.Name));
+                                    _depsRuntimePaths.TryAdd(assemblyFileName, fullPath);
+                                }
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+            catch
+            {
+                // Invalid dependency metadata is ignored consistently with IL analysis.
+            }
+        }
+    }
+
+    internal static IReadOnlyList<string?> ResolveImplementationAssemblyPaths(
+        IReadOnlyList<string> assemblyPaths,
+        ILAnalysisOptions? options = null)
+    {
+        var resolver = new AssemblyPathResolver(options ?? new ILAnalysisOptions());
+        return assemblyPaths.Select(resolver.Resolve).ToList();
     }
 
     /// <summary>
@@ -189,7 +347,7 @@ public sealed class AssemblyIndex : IDisposable
         {
             try
             {
-                var resolvedPath = ResolveAssemblyPath(path);
+                var resolvedPath = _pathResolver.Resolve(path);
                 if (resolvedPath == null)
                     continue;
 
@@ -212,135 +370,6 @@ public sealed class AssemblyIndex : IDisposable
             catch (IOException) { /* file access error — skip */ }
             catch (InvalidOperationException) { /* no metadata — skip */ }
         }
-    }
-
-    /// <summary>
-    /// Resolves a reference assembly path to its implementation assembly.
-    /// Returns the original path if it's already an implementation assembly,
-    /// the resolved impl path if found, or null if unresolvable.
-    /// </summary>
-    private string? ResolveAssemblyPath(string path)
-    {
-        if (!File.Exists(path))
-            return null;
-
-        // Quick check: is this a reference assembly?
-        if (!IsReferenceAssembly(path))
-            return path; // Already an implementation assembly
-
-        // Strategy 1: NuGet ref→lib path swap
-        var implPath = TryRefToLibSwap(path);
-        if (implPath != null)
-            return implPath;
-
-        // Strategy 2: deps.json runtime mapping
-        var assemblyName = Path.GetFileNameWithoutExtension(path);
-        if (_depsRuntimePaths.TryGetValue(assemblyName, out var depsPath) && File.Exists(depsPath))
-            return depsPath;
-
-        // Strategy 3: Runtime directory for BCL assemblies
-        if (!string.IsNullOrEmpty(_options.RuntimeDirectory))
-        {
-            var runtimePath = Path.Combine(_options.RuntimeDirectory, Path.GetFileName(path));
-            if (File.Exists(runtimePath))
-                return runtimePath;
-        }
-
-        // Unresolvable — will be skipped
-        return null;
-    }
-
-    private static bool IsReferenceAssembly(string path)
-    {
-        try
-        {
-            using var stream = File.OpenRead(path);
-            using var peReader = new PEReader(stream);
-            if (!peReader.HasMetadata) return false;
-
-            var reader = peReader.GetMetadataReader();
-            foreach (var attrHandle in reader.GetAssemblyDefinition().GetCustomAttributes())
-            {
-                var attr = reader.GetCustomAttribute(attrHandle);
-                if (attr.Constructor.Kind == HandleKind.MemberReference)
-                {
-                    var ctor = reader.GetMemberReference((MemberReferenceHandle)attr.Constructor);
-                    if (ctor.Parent.Kind == HandleKind.TypeReference)
-                    {
-                        var typeRef = reader.GetTypeReference((TypeReferenceHandle)ctor.Parent);
-                        var name = reader.GetString(typeRef.Name);
-                        if (name == "ReferenceAssemblyAttribute")
-                            return true;
-                    }
-                }
-            }
-            return false;
-        }
-        catch { return false; }
-    }
-
-    private static string? TryRefToLibSwap(string refPath)
-    {
-        // NuGet layout: packages/{id}/{version}/ref/{tfm}/Assembly.dll
-        // Implementation: packages/{id}/{version}/lib/{tfm}/Assembly.dll
-        var normalized = refPath.Replace('\\', '/');
-        var refIndex = normalized.LastIndexOf("/ref/", StringComparison.OrdinalIgnoreCase);
-        if (refIndex < 0) return null;
-
-        var libPath = normalized[..refIndex] + "/lib/" + normalized[(refIndex + 5)..];
-        libPath = libPath.Replace('/', Path.DirectorySeparatorChar);
-        return File.Exists(libPath) ? libPath : null;
-    }
-
-    private void LoadDepsJson()
-    {
-        if (string.IsNullOrEmpty(_options.DepsFilePath) || !File.Exists(_options.DepsFilePath))
-            return;
-
-        try
-        {
-            var json = File.ReadAllText(_options.DepsFilePath);
-            using var doc = JsonDocument.Parse(json);
-            var root = doc.RootElement;
-
-            if (!root.TryGetProperty("targets", out var targets))
-                return;
-
-            // Get the first target (e.g., ".NETCoreApp,Version=v10.0")
-            foreach (var target in targets.EnumerateObject())
-            {
-                foreach (var package in target.Value.EnumerateObject())
-                {
-                    if (!package.Value.TryGetProperty("runtime", out var runtime))
-                        continue;
-
-                    foreach (var asset in runtime.EnumerateObject())
-                    {
-                        // asset.Name is like "lib/net10.0/Assembly.dll"
-                        var assemblyFileName = Path.GetFileNameWithoutExtension(asset.Name);
-
-                        // Find the package path in libraries
-                        var packageName = package.Name; // e.g., "Newtonsoft.Json/13.0.3"
-                        if (root.TryGetProperty("libraries", out var libraries)
-                            && libraries.TryGetProperty(packageName, out var lib)
-                            && lib.TryGetProperty("path", out var pathProp))
-                        {
-                            var packagePath = pathProp.GetString();
-                            if (packagePath != null && !string.IsNullOrEmpty(_options.NuGetPackageRoot))
-                            {
-                                var fullPath = Path.Combine(
-                                    _options.NuGetPackageRoot, packagePath, asset.Name);
-                                fullPath = Path.GetFullPath(fullPath);
-                                if (!_depsRuntimePaths.ContainsKey(assemblyFileName))
-                                    _depsRuntimePaths[assemblyFileName] = fullPath;
-                            }
-                        }
-                    }
-                }
-                break; // Only process the first target
-            }
-        }
-        catch { /* deps.json parsing failure — non-fatal */ }
     }
 
     private void IndexTypes(LoadedAssembly assembly)

--- a/src/Calor.Compiler/Effects/IL/AssemblyIndex.cs
+++ b/src/Calor.Compiler/Effects/IL/AssemblyIndex.cs
@@ -154,7 +154,8 @@ public sealed class AssemblyIndex : IDisposable
                                 (MethodDefinitionHandle)attr.Constructor).GetDeclaringType()),
                         _ => null
                     };
-                    if (attributeName == "ReferenceAssemblyAttribute")
+                    if (attributeName
+                        == "System.Runtime.CompilerServices.ReferenceAssemblyAttribute")
                         return true;
                 }
                 return false;
@@ -170,8 +171,9 @@ public sealed class AssemblyIndex : IDisposable
             MemberReference constructor)
             => constructor.Parent.Kind switch
             {
-                HandleKind.TypeReference => reader.GetString(
-                    reader.GetTypeReference((TypeReferenceHandle)constructor.Parent).Name),
+                HandleKind.TypeReference => GetTypeReferenceFullName(
+                    reader,
+                    (TypeReferenceHandle)constructor.Parent),
                 HandleKind.TypeDefinition => GetTypeDefinitionName(
                     reader,
                     (TypeDefinitionHandle)constructor.Parent),
@@ -181,7 +183,27 @@ public sealed class AssemblyIndex : IDisposable
         private static string GetTypeDefinitionName(
             MetadataReader reader,
             TypeDefinitionHandle handle)
-            => reader.GetString(reader.GetTypeDefinition(handle).Name);
+        {
+            var type = reader.GetTypeDefinition(handle);
+            return GetFullTypeName(
+                reader.GetString(type.Namespace),
+                reader.GetString(type.Name));
+        }
+
+        private static string GetTypeReferenceFullName(
+            MetadataReader reader,
+            TypeReferenceHandle handle)
+        {
+            var type = reader.GetTypeReference(handle);
+            return GetFullTypeName(
+                reader.GetString(type.Namespace),
+                reader.GetString(type.Name));
+        }
+
+        private static string GetFullTypeName(string typeNamespace, string typeName)
+            => string.IsNullOrEmpty(typeNamespace)
+                ? typeName
+                : $"{typeNamespace}.{typeName}";
 
         private static string? TryRefToLibSwap(string refPath)
         {

--- a/src/Calor.Compiler/Effects/Manifests/ManifestLoader.cs
+++ b/src/Calor.Compiler/Effects/Manifests/ManifestLoader.cs
@@ -65,7 +65,8 @@ public sealed class ManifestLoader
     {
         var assembly = Assembly.GetExecutingAssembly();
         var resourceNames = assembly.GetManifestResourceNames()
-            .Where(name => name.EndsWith(".calor-effects.json", StringComparison.OrdinalIgnoreCase));
+            .Where(name => name.EndsWith(".calor-effects.json", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(name => name, StringComparer.Ordinal);
 
         foreach (var resourceName in resourceNames)
         {
@@ -134,11 +135,16 @@ public sealed class ManifestLoader
     /// <summary>
     /// Loads all .calor-effects.json files from a directory.
     /// </summary>
-    private void LoadManifestsFromDirectory(string directory, ManifestPriority priority)
+    internal void LoadManifestsFromDirectory(string directory, ManifestPriority priority)
     {
         try
         {
             var files = Directory.GetFiles(directory, "*.calor-effects.json", SearchOption.TopDirectoryOnly);
+            Array.Sort(
+                files,
+                OperatingSystem.IsWindows()
+                    ? StringComparer.OrdinalIgnoreCase
+                    : StringComparer.Ordinal);
             foreach (var file in files)
             {
                 LoadManifestFromFile(file, priority);

--- a/src/Calor.Compiler/Effects/Manifests/ManifestLoader.cs
+++ b/src/Calor.Compiler/Effects/Manifests/ManifestLoader.cs
@@ -305,7 +305,7 @@ public sealed class ManifestLoader
     /// <summary>
     /// Gets the user-level manifests directory (~/.calor/manifests/).
     /// </summary>
-    private static string? GetUserManifestsDirectory()
+    internal static string? GetUserManifestsDirectory()
     {
         try
         {

--- a/src/Calor.Compiler/Effects/Manifests/ManifestLoader.cs
+++ b/src/Calor.Compiler/Effects/Manifests/ManifestLoader.cs
@@ -140,11 +140,7 @@ public sealed class ManifestLoader
         try
         {
             var files = Directory.GetFiles(directory, "*.calor-effects.json", SearchOption.TopDirectoryOnly);
-            Array.Sort(
-                files,
-                OperatingSystem.IsWindows()
-                    ? StringComparer.OrdinalIgnoreCase
-                    : StringComparer.Ordinal);
+            Array.Sort(files, StringComparer.Ordinal);
             foreach (var file in files)
             {
                 LoadManifestFromFile(file, priority);

--- a/src/Calor.Compiler/Incremental/BuildStateCache.cs
+++ b/src/Calor.Compiler/Incremental/BuildStateCache.cs
@@ -120,7 +120,7 @@ internal static class BuildStateCache
     // fingerprinting. Older state is intentionally rebuilt and overwritten.
     public const string CurrentFormatVersion = "3.0";
     public const string CurrentCompilerSemanticsVersion = "calor-compile-semantics-v1";
-    public const string CurrentOptionsSerializerVersion = "compile-inputs-v2";
+    public const string CurrentOptionsSerializerVersion = "compile-inputs-v3";
     private const string CacheFileName = ".calor-build-state.json";
     private const int MaxRetries = 3;
     private const int BaseRetryDelayMs = 50;

--- a/src/Calor.Compiler/Incremental/BuildStateCache.cs
+++ b/src/Calor.Compiler/Incremental/BuildStateCache.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Calor.Compiler.Effects;
+using Calor.Compiler.Effects.Manifests;
 
 namespace Calor.Compiler.Incremental;
 
@@ -276,34 +277,6 @@ internal static class BuildStateCache
     }
 
     /// <summary>
-    /// MSBuild-task compiler hash over the conventional deployed closure. The
-    /// task itself passes explicitly resolved assembly locations when executing.
-    /// </summary>
-    public static string ComputeCompilerHash(string tasksAssemblyPath)
-    {
-        var tasksDir = Path.GetDirectoryName(tasksAssemblyPath)!;
-        // The compiler project deliberately emits calor.dll, not
-        // Calor.Compiler.dll. Hash the deployed task/compiler/runtime/solver
-        // closure by resolved paths; names and missing markers are included so
-        // deleting or replacing one member also changes the fingerprint.
-        var closureNames = new[]
-        {
-            Path.GetFileName(tasksAssemblyPath),
-            "calor.dll",
-            "Calor.Runtime.dll",
-            "Microsoft.Z3.dll",
-            OperatingSystem.IsWindows() ? "libz3.dll"
-                : OperatingSystem.IsMacOS() ? "libz3.dylib" : "libz3.so"
-        };
-        var paths = closureNames
-            .Select(name => Path.Combine(tasksDir, name))
-            .Distinct(GetPathComparer())
-            .OrderBy(path => Path.GetFileName(path), StringComparer.Ordinal)
-            .ToList();
-        return ComputeCompilerHash(paths);
-    }
-
-    /// <summary>
     /// Compiler hash over an explicit set of assembly files. Missing members are
     /// represented explicitly so removing a dependency invalidates the cache.
     /// </summary>
@@ -413,33 +386,58 @@ internal static class BuildStateCache
     /// files from several directories, each with its own effect manifests).
     /// </summary>
     public static string ComputeManifestHash(IReadOnlyList<string> projectDirectories)
+        => ComputeManifestHash(projectDirectories, ManifestLoader.GetUserManifestsDirectory());
+
+    internal static string ComputeManifestHash(
+        IReadOnlyList<string> projectDirectories,
+        string? userManifestsDirectory)
     {
-        var manifestFiles = new List<string>();
-        var seen = new HashSet<string>(GetPathComparer());
-        foreach (var dir in projectDirectories)
+        var roots = projectDirectories
+            .Where(directory => !string.IsNullOrWhiteSpace(directory))
+            .Select((directory, index) => (
+                Scope: $"project-{index}",
+                Directory: Path.GetFullPath(directory)))
+            .ToList();
+        if (!string.IsNullOrEmpty(userManifestsDirectory))
         {
-            if (!Directory.Exists(dir))
+            roots.Add(("user", Path.GetFullPath(userManifestsDirectory)));
+        }
+
+        var manifestFiles = new List<(string Scope, string Path)>();
+        var seen = new HashSet<string>(GetPathComparer());
+        foreach (var root in roots)
+        {
+            if (!Directory.Exists(root.Directory))
                 continue;
-            foreach (var file in Directory.GetFiles(dir, "*.calor-effects.json", SearchOption.TopDirectoryOnly))
+            foreach (var file in Directory.GetFiles(
+                         root.Directory, "*.calor-effects.json", SearchOption.TopDirectoryOnly))
             {
                 if (seen.Add(Path.GetFullPath(file)))
-                    manifestFiles.Add(file);
+                    manifestFiles.Add((root.Scope, file));
             }
         }
 
         if (manifestFiles.Count == 0)
             return "";
 
-        manifestFiles.Sort((left, right) => StringComparer.Ordinal.Compare(
-            NormalizePathForOrdering(left), NormalizePathForOrdering(right)));
+        manifestFiles.Sort((left, right) =>
+        {
+            var scopeComparison = StringComparer.Ordinal.Compare(left.Scope, right.Scope);
+            return scopeComparison != 0
+                ? scopeComparison
+                : StringComparer.Ordinal.Compare(
+                    NormalizePathForOrdering(left.Path),
+                    NormalizePathForOrdering(right.Path));
+        });
 
         using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         foreach (var manifestFile in manifestFiles)
         {
-            AppendLengthPrefixed(sha, Path.GetFileName(manifestFile));
-            AppendLengthPrefixed(sha, new FileInfo(manifestFile).Length.ToString(
+            AppendLengthPrefixed(sha, manifestFile.Scope);
+            AppendLengthPrefixed(sha, Path.GetFileName(manifestFile.Path));
+            AppendLengthPrefixed(sha, new FileInfo(manifestFile.Path).Length.ToString(
                 System.Globalization.CultureInfo.InvariantCulture));
-            HashFileStreaming(sha, manifestFile);
+            HashFileStreaming(sha, manifestFile.Path);
         }
         return Convert.ToHexStringLower(sha.GetHashAndReset());
     }

--- a/src/Calor.Compiler/Incremental/BuildStateCache.cs
+++ b/src/Calor.Compiler/Incremental/BuildStateCache.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -18,8 +19,9 @@ internal sealed partial class BuildStateJsonContext : JsonSerializerContext { }
 /// </summary>
 internal sealed class BuildState
 {
-    // Bump when cache schema changes (e.g., added EffectSummary in 2.0).
-    public string FormatVersion { get; set; } = "2.1";
+    public string FormatVersion { get; set; } = BuildStateCache.CurrentFormatVersion;
+    public string CompilerSemanticsVersion { get; set; } =
+        BuildStateCache.CurrentCompilerSemanticsVersion;
 
     /// <summary>
     /// Fingerprint of the cross-module function map the outputs were emitted
@@ -53,19 +55,71 @@ internal sealed class BuildFileEntry
     /// compile that produced this entry. A warm build only trusts an output whose
     /// current hash matches — a corrupted or manually edited output is a cache
     /// miss, not "Up-to-date". Null (older caches, or the output was never
-    /// observed) is also a miss. Populated by the CLI driver; the MSBuild task
-    /// does not populate it yet and still trusts bare output existence
-    /// (known limitation — follow-up).
+    /// observed) is also a miss.
     /// </summary>
     public string? OutputContentHash { get; set; }
+
+    /// <summary>
+    /// File-local diagnostics replayed by the MSBuild task on a warm hit. Paths
+    /// are intentionally not persisted; the current source path is supplied at
+    /// replay time to keep cache state portable and privacy-aware.
+    /// </summary>
+    public List<CachedDiagnostic>? Diagnostics { get; set; }
+}
+
+internal sealed class CachedDiagnostic
+{
+    public string Code { get; set; } = "";
+    public string Severity { get; set; } = "";
+    public string Message { get; set; } = "";
+    public int Line { get; set; }
+    public int Column { get; set; }
+}
+
+internal enum CacheLoadStatus
+{
+    Loaded,
+    Missing,
+    CorruptOrPartial,
+    Unreadable
+}
+
+internal sealed record CacheLoadResult(BuildState? State, CacheLoadStatus Status);
+
+internal enum GlobalCacheInvalidationReason
+{
+    MissingCache,
+    CorruptOrPartialCache,
+    UnreadableCache,
+    SchemaVersionChanged,
+    CompilerSemanticsChanged,
+    CompilerChanged,
+    OptionsOrInputsChanged,
+    ManifestChanged,
+    OutputDirectoryChanged,
+    CrossModuleMapChanged
+}
+
+internal enum FileCacheMissReason
+{
+    EntryMissing,
+    EffectSummaryMissing,
+    DiagnosticsMissing,
+    OutputMissing,
+    OutputHashMissing,
+    OutputContentChanged,
+    SourceMissing,
+    SourceContentChanged,
+    CacheValidationFailed
 }
 
 internal static class BuildStateCache
 {
-    // 2.1: cross-module call qualification (G3/#809) — outputs emitted before
-    // the qualifier existed carry bare cross-module calls and must not be
-    // trusted by warm builds; the bump invalidates them once.
-    private const string FormatVersion = "2.1";
+    // 3.0 adds an explicit compiler-semantics surface and canonical MSBuild input
+    // fingerprinting. Older state is intentionally rebuilt and overwritten.
+    public const string CurrentFormatVersion = "3.0";
+    public const string CurrentCompilerSemanticsVersion = "calor-compile-semantics-v1";
+    public const string CurrentOptionsSerializerVersion = "compile-inputs-v2";
     private const string CacheFileName = ".calor-build-state.json";
     private const int MaxRetries = 3;
     private const int BaseRetryDelayMs = 50;
@@ -74,17 +128,80 @@ internal static class BuildStateCache
         => Path.Combine(outputDirectory, CacheFileName);
 
     public static BuildState? Load(string outputDirectory)
+        => LoadWithStatus(outputDirectory).State;
+
+    public static CacheLoadResult LoadWithStatus(string outputDirectory)
     {
         var cachePath = GetCachePath(outputDirectory);
-        return RetryOnIOException(() =>
+        for (var attempt = 0; attempt < MaxRetries; attempt++)
         {
-            if (!File.Exists(cachePath))
-                return null;
+            try
+            {
+                if (!File.Exists(cachePath))
+                    return new CacheLoadResult(null, CacheLoadStatus.Missing);
 
-            var json = File.ReadAllText(cachePath);
-            var state = JsonSerializer.Deserialize(json, BuildStateJsonContext.Default.BuildState);
-            return state;
-        });
+                var json = File.ReadAllText(cachePath);
+                using var document = JsonDocument.Parse(json);
+                if (!HasRequiredCacheProperties(document.RootElement))
+                    return new CacheLoadResult(null, CacheLoadStatus.CorruptOrPartial);
+                var state = JsonSerializer.Deserialize(json, BuildStateJsonContext.Default.BuildState);
+                if (state == null
+                    || state.Files == null
+                    || string.IsNullOrEmpty(state.CompilerHash)
+                    || string.IsNullOrEmpty(state.OptionsHash)
+                    || string.IsNullOrEmpty(state.FormatVersion))
+                {
+                    return new CacheLoadResult(null, CacheLoadStatus.CorruptOrPartial);
+                }
+                return new CacheLoadResult(state, CacheLoadStatus.Loaded);
+            }
+            catch (IOException) when (attempt < MaxRetries - 1)
+            {
+                Thread.Sleep(BaseRetryDelayMs * (1 << attempt));
+            }
+            catch (JsonException)
+            {
+                return new CacheLoadResult(null, CacheLoadStatus.CorruptOrPartial);
+            }
+            catch (NotSupportedException)
+            {
+                return new CacheLoadResult(null, CacheLoadStatus.CorruptOrPartial);
+            }
+            catch (IOException)
+            {
+                return new CacheLoadResult(null, CacheLoadStatus.Unreadable);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return new CacheLoadResult(null, CacheLoadStatus.Unreadable);
+            }
+        }
+        return new CacheLoadResult(null, CacheLoadStatus.Unreadable);
+    }
+
+    private static bool HasRequiredCacheProperties(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object
+            || !root.TryGetProperty("formatVersion", out var format)
+            || format.ValueKind != JsonValueKind.String
+            || !root.TryGetProperty("compilerHash", out var compilerHash)
+            || compilerHash.ValueKind != JsonValueKind.String
+            || !root.TryGetProperty("optionsHash", out var optionsHash)
+            || optionsHash.ValueKind != JsonValueKind.String
+            || !root.TryGetProperty("manifestHash", out var manifestHash)
+            || manifestHash.ValueKind != JsonValueKind.String
+            || !root.TryGetProperty("outputDirectory", out var outputDirectory)
+            || outputDirectory.ValueKind != JsonValueKind.String
+            || !root.TryGetProperty("files", out var files)
+            || files.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        return format.GetString() != CurrentFormatVersion
+            || (root.TryGetProperty("compilerSemanticsVersion", out var semantics)
+                && semantics.ValueKind == JsonValueKind.String
+                && !string.IsNullOrEmpty(semantics.GetString()));
     }
 
     public static void Save(BuildState state, string outputDirectory)
@@ -94,36 +211,62 @@ internal static class BuildStateCache
         if (dir != null && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        var tmpPath = cachePath + ".tmp";
-        RetryOnIOException(() =>
+        var tmpPath = cachePath + $".tmp.{Environment.ProcessId}.{Environment.CurrentManagedThreadId}.{Guid.NewGuid():N}";
+        try
         {
-            var json = JsonSerializer.Serialize(state, BuildStateJsonContext.Default.BuildState);
-            File.WriteAllText(tmpPath, json);
-            File.Move(tmpPath, cachePath, overwrite: true);
-        });
+            RetryOnIOException(() =>
+            {
+                if (File.Exists(tmpPath))
+                    File.Delete(tmpPath);
+                var json = JsonSerializer.Serialize(state, BuildStateJsonContext.Default.BuildState);
+                using (var stream = new FileStream(
+                    tmpPath, FileMode.CreateNew, FileAccess.Write, FileShare.None,
+                    bufferSize: 4096, FileOptions.WriteThrough))
+                using (var writer = new StreamWriter(stream, new UTF8Encoding(false)))
+                {
+                    writer.Write(json);
+                    writer.Flush();
+                    stream.Flush(flushToDisk: true);
+                }
+                File.Move(tmpPath, cachePath, overwrite: true);
+            });
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(tmpPath))
+                    File.Delete(tmpPath);
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
     }
 
     /// <summary>
     /// Deletes the state file (best-effort). Used by <c>--clear-cache</c>.
     /// </summary>
-    public static void Delete(string outputDirectory)
+    public static bool Delete(string outputDirectory)
     {
         var cachePath = GetCachePath(outputDirectory);
         try
         {
             if (File.Exists(cachePath))
                 File.Delete(cachePath);
+            return !File.Exists(cachePath);
         }
-        catch (IOException) { /* best-effort */ }
-        catch (UnauthorizedAccessException) { /* best-effort */ }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
     }
 
     public static string ComputeFileHash(string filePath)
     {
         var bytes = File.ReadAllBytes(filePath);
-        var hash = SHA256.HashData(bytes);
-        return Convert.ToHexStringLower(hash);
+        return ComputeContentHash(bytes);
     }
+
+    public static string ComputeContentHash(byte[] bytes)
+        => Convert.ToHexStringLower(SHA256.HashData(bytes));
 
     public static string ComputePathHash(string path)
     {
@@ -133,28 +276,55 @@ internal static class BuildStateCache
     }
 
     /// <summary>
-    /// MSBuild-task compiler hash: the task assembly plus the Calor.Compiler.dll
-    /// deployed next to it.
+    /// MSBuild-task compiler hash over the conventional deployed closure. The
+    /// task itself passes explicitly resolved assembly locations when executing.
     /// </summary>
     public static string ComputeCompilerHash(string tasksAssemblyPath)
     {
         var tasksDir = Path.GetDirectoryName(tasksAssemblyPath)!;
-        var compilerDllPath = Path.Combine(tasksDir, "Calor.Compiler.dll");
-        return ComputeCompilerHash([tasksAssemblyPath, compilerDllPath]);
+        // The compiler project deliberately emits calor.dll, not
+        // Calor.Compiler.dll. Hash the deployed task/compiler/runtime/solver
+        // closure by resolved paths; names and missing markers are included so
+        // deleting or replacing one member also changes the fingerprint.
+        var closureNames = new[]
+        {
+            Path.GetFileName(tasksAssemblyPath),
+            "calor.dll",
+            "Calor.Runtime.dll",
+            "Microsoft.Z3.dll",
+            OperatingSystem.IsWindows() ? "libz3.dll"
+                : OperatingSystem.IsMacOS() ? "libz3.dylib" : "libz3.so"
+        };
+        var paths = closureNames
+            .Select(name => Path.Combine(tasksDir, name))
+            .Distinct(GetPathComparer())
+            .OrderBy(path => Path.GetFileName(path), StringComparer.Ordinal)
+            .ToList();
+        return ComputeCompilerHash(paths);
     }
 
     /// <summary>
-    /// Compiler hash over an explicit set of assembly files (streamed; missing files
-    /// are skipped so the hash degrades gracefully rather than throwing).
+    /// Compiler hash over an explicit set of assembly files. Missing members are
+    /// represented explicitly so removing a dependency invalidates the cache.
     /// </summary>
     public static string ComputeCompilerHash(IReadOnlyList<string> assemblyPaths)
     {
         using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
 
-        // Stream hash to avoid allocating multi-MB arrays
-        foreach (var path in assemblyPaths)
+        foreach (var path in assemblyPaths.OrderBy(
+                     path => Path.GetFileName(path), StringComparer.Ordinal))
         {
-            HashFileStreaming(sha, path);
+            var name = Path.GetFileName(path);
+            AppendLengthPrefixed(sha, name);
+            if (File.Exists(path))
+            {
+                AppendLengthPrefixed(sha, "present");
+                HashFileStreaming(sha, path);
+            }
+            else
+            {
+                AppendLengthPrefixed(sha, "missing");
+            }
         }
 
         return Convert.ToHexStringLower(sha.GetHashAndReset());
@@ -194,8 +364,17 @@ internal static class BuildStateCache
         }
     }
 
+    private static void AppendLengthPrefixed(IncrementalHash hash, string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        Span<byte> length = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32LittleEndian(length, bytes.Length);
+        hash.AppendData(length);
+        hash.AppendData(bytes);
+    }
+
     /// <summary>
-    /// MSBuild-task options hash (kept bit-compatible with the historical format).
+    /// Legacy convenience overload for callers with only effect enforcement.
     /// </summary>
     public static string ComputeOptionsHash(bool enforceEffects = true)
         => ComputeOptionsHash($"enforceEffects:{enforceEffects}");
@@ -204,8 +383,9 @@ internal static class BuildStateCache
     /// Options hash over a caller-supplied canonical token. Diagnostics-affecting
     /// options must be folded into the token: an option flip between builds has to
     /// invalidate cached (skipped) files, otherwise violations that the new option
-    /// set would report are silently missed on warm builds. (Options that only
-    /// affect presentation — verbose, --format — must be excluded.)
+    /// set would report are silently missed on warm builds. Presentation-only
+    /// options are excluded unless they alter diagnostics; the MSBuild task's
+    /// Verbose setting does, so its canonical record includes that value.
     ///
     /// The set of EffectKind enum values is also folded in: cached EffectSummary entries
     /// reference kinds by name, and a kind added/removed/renamed in a compiler upgrade
@@ -214,7 +394,7 @@ internal static class BuildStateCache
     public static string ComputeOptionsHash(string optionsToken)
     {
         using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
-        sha.AppendData(Encoding.UTF8.GetBytes("options:v1"));
+        sha.AppendData(Encoding.UTF8.GetBytes($"options:{CurrentOptionsSerializerVersion}"));
         sha.AppendData(Encoding.UTF8.GetBytes($"|{optionsToken}"));
         sha.AppendData(Encoding.UTF8.GetBytes("|effectkinds:"));
         foreach (var kind in Enum.GetNames(typeof(EffectKind)))
@@ -250,14 +430,24 @@ internal static class BuildStateCache
         if (manifestFiles.Count == 0)
             return "";
 
-        manifestFiles.Sort(StringComparer.OrdinalIgnoreCase);
+        manifestFiles.Sort((left, right) => StringComparer.Ordinal.Compare(
+            NormalizePathForOrdering(left), NormalizePathForOrdering(right)));
 
         using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         foreach (var manifestFile in manifestFiles)
         {
-            sha.AppendData(File.ReadAllBytes(manifestFile));
+            AppendLengthPrefixed(sha, Path.GetFileName(manifestFile));
+            AppendLengthPrefixed(sha, new FileInfo(manifestFile).Length.ToString(
+                System.Globalization.CultureInfo.InvariantCulture));
+            HashFileStreaming(sha, manifestFile);
         }
         return Convert.ToHexStringLower(sha.GetHashAndReset());
+    }
+
+    private static string NormalizePathForOrdering(string path)
+    {
+        var normalized = Path.GetFullPath(path).Replace('\\', '/');
+        return OperatingSystem.IsWindows() ? normalized.ToUpperInvariant() : normalized;
     }
 
     public static bool IsFileUpToDate(BuildFileEntry? cached, string filePath)
@@ -269,14 +459,88 @@ internal static class BuildStateCache
         if (!fileInfo.Exists)
             return false;
 
-        // Level 1: stat gate — (mtime, size)
-        if (fileInfo.LastWriteTimeUtc == cached.LastModified && fileInfo.Length == cached.FileSize)
-            return true;
-
-        // Level 2: content hash
-        var currentHash = ComputeFileHash(filePath);
-        return currentHash == cached.ContentHash;
+        // Always verify bytes. Metadata is retained as the pre-read snapshot for
+        // race safety and observability, but mtime/size alone cannot prove that
+        // content is unchanged (both can be preserved by editors or restored).
+        return ComputeFileHash(filePath) == cached.ContentHash;
     }
+
+    /// <summary>
+    /// Evaluates a warm-cache entry in a fixed order so verbose logs and tests get
+    /// one deterministic, actionable miss reason.
+    /// </summary>
+    public static FileCacheMissReason? GetFileCacheMissReason(
+        BuildFileEntry? cached, string sourcePath, string outputPath)
+    {
+        if (cached == null)
+            return FileCacheMissReason.EntryMissing;
+        if (cached.EffectSummary == null)
+            return FileCacheMissReason.EffectSummaryMissing;
+        if (cached.Diagnostics == null)
+            return FileCacheMissReason.DiagnosticsMissing;
+        if (cached.Diagnostics.Any(diagnostic =>
+                diagnostic.Severity is not ("warning" or "info")
+                || string.IsNullOrEmpty(diagnostic.Code)
+                || diagnostic.Line < 0
+                || diagnostic.Column < 0))
+        {
+            return FileCacheMissReason.CacheValidationFailed;
+        }
+        if (!File.Exists(outputPath))
+            return FileCacheMissReason.OutputMissing;
+        if (cached.OutputContentHash == null)
+            return FileCacheMissReason.OutputHashMissing;
+
+        try
+        {
+            if (ComputeFileHash(outputPath) != cached.OutputContentHash)
+                return FileCacheMissReason.OutputContentChanged;
+
+            var info = new FileInfo(sourcePath);
+            if (!info.Exists)
+                return FileCacheMissReason.SourceMissing;
+            return ComputeFileHash(sourcePath) == cached.ContentHash
+                ? null
+                : FileCacheMissReason.SourceContentChanged;
+        }
+        catch (IOException)
+        {
+            return FileCacheMissReason.CacheValidationFailed;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return FileCacheMissReason.CacheValidationFailed;
+        }
+    }
+
+    public static string GetReasonCode(GlobalCacheInvalidationReason reason) => reason switch
+    {
+        GlobalCacheInvalidationReason.MissingCache => "missing-cache",
+        GlobalCacheInvalidationReason.CorruptOrPartialCache => "corrupt-or-partial-cache",
+        GlobalCacheInvalidationReason.UnreadableCache => "unreadable-cache",
+        GlobalCacheInvalidationReason.SchemaVersionChanged => "schema-version-changed",
+        GlobalCacheInvalidationReason.CompilerSemanticsChanged => "compiler-semantics-changed",
+        GlobalCacheInvalidationReason.CompilerChanged => "compiler-changed",
+        GlobalCacheInvalidationReason.OptionsOrInputsChanged => "options-or-inputs-changed",
+        GlobalCacheInvalidationReason.ManifestChanged => "manifest-changed",
+        GlobalCacheInvalidationReason.OutputDirectoryChanged => "output-directory-changed",
+        GlobalCacheInvalidationReason.CrossModuleMapChanged => "cross-module-map-changed",
+        _ => throw new ArgumentOutOfRangeException(nameof(reason))
+    };
+
+    public static string GetReasonCode(FileCacheMissReason reason) => reason switch
+    {
+        FileCacheMissReason.EntryMissing => "entry-missing",
+        FileCacheMissReason.EffectSummaryMissing => "effect-summary-missing",
+        FileCacheMissReason.DiagnosticsMissing => "diagnostics-missing",
+        FileCacheMissReason.OutputMissing => "output-missing",
+        FileCacheMissReason.OutputHashMissing => "output-hash-missing",
+        FileCacheMissReason.OutputContentChanged => "output-content-changed",
+        FileCacheMissReason.SourceMissing => "source-missing",
+        FileCacheMissReason.SourceContentChanged => "source-content-changed",
+        FileCacheMissReason.CacheValidationFailed => "cache-validation-failed",
+        _ => throw new ArgumentOutOfRangeException(nameof(reason))
+    };
 
     public static BuildFileEntry CreateFileEntry(string filePath)
     {
@@ -308,16 +572,14 @@ internal static class BuildStateCache
     /// here (as <see cref="CreateFileEntry(string)"/> does) races with concurrent
     /// editors: an edit landing mid-compile would be hashed as if it had been
     /// compiled, so the next run would skip it and the new content would never
-    /// be compiled. Stat-before-read matters for the same reason — a stale
-    /// (mtime,size) fails the level-1 gate and falls through to the content hash,
-    /// whereas a too-new (mtime,size) paired with an old hash could level-1-skip
-    /// content that was never compiled.
+    /// be compiled. The snapshot is retained for observability and migration
+    /// even though warm validation hashes bytes unconditionally.
     /// </summary>
     public static BuildFileEntry CreateFileEntry(FileStat statBeforeRead, byte[] compiledContent)
     {
         return new BuildFileEntry
         {
-            ContentHash = Convert.ToHexStringLower(SHA256.HashData(compiledContent)),
+            ContentHash = ComputeContentHash(compiledContent),
             LastModified = statBeforeRead.LastWriteTimeUtc,
             FileSize = statBeforeRead.Length
         };
@@ -403,42 +665,34 @@ internal static class BuildStateCache
 
     public static bool IsGlobalInvalidation(BuildState? cached, string compilerHash,
         string optionsHash, string manifestHash, string outputDirectory)
+        => GetGlobalInvalidationReasons(
+            cached, compilerHash, optionsHash, manifestHash, outputDirectory).Count != 0;
+
+    public static IReadOnlyList<GlobalCacheInvalidationReason> GetGlobalInvalidationReasons(
+        BuildState? cached, string compilerHash, string optionsHash,
+        string manifestHash, string outputDirectory)
     {
+        var reasons = new List<GlobalCacheInvalidationReason>();
         if (cached == null)
-            return true;
-        if (cached.FormatVersion != FormatVersion)
-            return true;
+        {
+            reasons.Add(GlobalCacheInvalidationReason.MissingCache);
+            return reasons;
+        }
+        if (cached.FormatVersion != CurrentFormatVersion)
+            reasons.Add(GlobalCacheInvalidationReason.SchemaVersionChanged);
+        if (cached.CompilerSemanticsVersion != CurrentCompilerSemanticsVersion)
+            reasons.Add(GlobalCacheInvalidationReason.CompilerSemanticsChanged);
         if (cached.CompilerHash != compilerHash)
-            return true;
+            reasons.Add(GlobalCacheInvalidationReason.CompilerChanged);
         if (cached.OptionsHash != optionsHash)
-            return true;
+            reasons.Add(GlobalCacheInvalidationReason.OptionsOrInputsChanged);
         if (cached.ManifestHash != manifestHash)
-            return true;
+            reasons.Add(GlobalCacheInvalidationReason.ManifestChanged);
         if (!GetPathComparer().Equals(
             NormalizeRelativePath(cached.OutputDirectory),
             NormalizeRelativePath(outputDirectory)))
-            return true;
-        return false;
-    }
-
-    private static T? RetryOnIOException<T>(Func<T?> action)
-    {
-        for (var attempt = 0; attempt < MaxRetries; attempt++)
-        {
-            try
-            {
-                return action();
-            }
-            catch (IOException) when (attempt < MaxRetries - 1)
-            {
-                Thread.Sleep(BaseRetryDelayMs * (1 << attempt));
-            }
-            catch
-            {
-                return default;
-            }
-        }
-        return default;
+            reasons.Add(GlobalCacheInvalidationReason.OutputDirectoryChanged);
+        return reasons;
     }
 
     private static void RetryOnIOException(Action action)

--- a/src/Calor.Compiler/Incremental/BuildStateCache.cs
+++ b/src/Calor.Compiler/Incremental/BuildStateCache.cs
@@ -404,7 +404,7 @@ internal static class BuildStateCache
         }
 
         var manifestFiles = new List<(string Scope, string Path)>();
-        var seen = new HashSet<string>(GetPathComparer());
+        var seen = new HashSet<string>(StringComparer.Ordinal);
         foreach (var root in roots)
         {
             if (!Directory.Exists(root.Directory))
@@ -443,10 +443,7 @@ internal static class BuildStateCache
     }
 
     private static string NormalizePathForOrdering(string path)
-    {
-        var normalized = Path.GetFullPath(path).Replace('\\', '/');
-        return OperatingSystem.IsWindows() ? normalized.ToUpperInvariant() : normalized;
-    }
+        => Path.GetFullPath(path).Replace('\\', '/');
 
     public static bool IsFileUpToDate(BuildFileEntry? cached, string filePath)
     {

--- a/src/Calor.Compiler/Verification/Z3/Z3ContextFactory.cs
+++ b/src/Calor.Compiler/Verification/Z3/Z3ContextFactory.cs
@@ -76,6 +76,17 @@ public static class Z3ContextFactory
                         "AppContext.BaseDirectory is the primary probe root.")]
     private static IntPtr TryLoadZ3Native()
     {
+        foreach (var path in GetNativeLibraryProbePaths())
+        {
+            if (File.Exists(path) && NativeLibrary.TryLoad(path, out var handle))
+                return handle;
+        }
+
+        return IntPtr.Zero;
+    }
+
+    internal static IReadOnlyList<string> GetNativeLibraryProbePaths()
+    {
         // Probe roots, in order:
         //  1. AppContext.BaseDirectory — the CLI / test-host case (libz3 copied
         //     to the output root, or under runtimes/<rid>/native).
@@ -116,13 +127,7 @@ public static class Z3ContextFactory
             }
         }
 
-        foreach (var path in libPaths)
-        {
-            if (File.Exists(path) && NativeLibrary.TryLoad(path, out var handle))
-                return handle;
-        }
-
-        return IntPtr.Zero;
+        return libPaths;
     }
 
     /// <summary>

--- a/src/Calor.Compiler/Verification/Z3/Z3ContextFactory.cs
+++ b/src/Calor.Compiler/Verification/Z3/Z3ContextFactory.cs
@@ -107,6 +107,10 @@ public static class Z3ContextFactory
         return IntPtr.Zero;
     }
 
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
+        "SingleFile", "IL3000",
+        Justification = "Empty Location is expected under single-file and is guarded; " +
+                        "AppContext.BaseDirectory is the primary probe root.")]
     internal static IReadOnlyList<string> GetNativeLibraryProbePaths()
     {
         // Probe roots, in order:

--- a/src/Calor.Compiler/Verification/Z3/Z3ContextFactory.cs
+++ b/src/Calor.Compiler/Verification/Z3/Z3ContextFactory.cs
@@ -32,7 +32,15 @@ public static class Z3ContextFactory
             // Pre-load the native library FIRST
             _z3NativeHandle = TryLoadZ3Native();
 
-            // Register resolver for any future P/Invoke calls
+            // Bind Microsoft.Z3 imports only to the explicit, fingerprinted
+            // probe paths. Throwing for an unavailable Z3 handle prevents the
+            // runtime from silently falling back to an ambient system library.
+            NativeLibrary.SetDllImportResolver(
+                typeof(Microsoft.Z3.Context).Assembly,
+                ResolveZ3DllImport);
+
+            // Retain load-context handlers for hosts that raise resolution
+            // events for transitive unmanaged imports.
             AssemblyLoadContext.Default.ResolvingUnmanagedDll += OnResolvingUnmanagedDll;
 
             // When this assembly is loaded by MSBuild (Calor.Sdk package path),
@@ -47,6 +55,20 @@ public static class Z3ContextFactory
 
             _resolverRegistered = true;
         }
+    }
+
+    private static IntPtr ResolveZ3DllImport(
+        string libraryName,
+        Assembly assembly,
+        DllImportSearchPath? searchPath)
+    {
+        if (!libraryName.Contains("z3", StringComparison.OrdinalIgnoreCase))
+            return IntPtr.Zero;
+        if (_z3NativeHandle != IntPtr.Zero)
+            return _z3NativeHandle;
+
+        throw new DllNotFoundException(
+            "Z3 was not found in Calor's explicit native-library probe paths.");
     }
 
     private static IntPtr OnResolvingUnmanagedDll(Assembly assembly, string libraryName)

--- a/src/Calor.Sdk/Sdk/Sdk.targets
+++ b/src/Calor.Sdk/Sdk/Sdk.targets
@@ -34,8 +34,10 @@
   <Target Name="_CalorComputeDefaults" BeforeTargets="CompileCalorFiles;CleanCalorFiles">
     <PropertyGroup>
       <CalorOutputDirectory Condition="'$(CalorOutputDirectory)' == ''">$(IntermediateOutputPath)calor\</CalorOutputDirectory>
-      <!-- IL analysis: resolve runtime directory for BCL implementation assemblies -->
-      <_CalorRuntimeDir Condition="'$(CalorEnableILAnalysis)' == 'true' and '$(_CalorRuntimeDir)' == '' and '$(NetCoreTargetingPackRoot)' != ''">$([System.IO.Path]::GetFullPath('$(NetCoreTargetingPackRoot)\..\..\..\shared\Microsoft.NETCore.App\$(BundledNETCoreAppTargetFrameworkVersion)'))\</_CalorRuntimeDir>
+      <!-- The task runs in the MSBuild host runtime, whose exact patch version
+           contains the BCL implementation assemblies corresponding to ReferencePath. -->
+      <_CalorHostRuntimeVersion Condition="'$(CalorEnableILAnalysis)' == 'true'">$([System.Environment]::Version)</_CalorHostRuntimeVersion>
+      <_CalorRuntimeDir Condition="'$(CalorEnableILAnalysis)' == 'true' and '$(_CalorRuntimeDir)' == '' and '$(NetCoreRoot)' != ''">$([System.IO.Path]::Combine('$(NetCoreRoot)', 'shared', 'Microsoft.NETCore.App', '$(_CalorHostRuntimeVersion)'))</_CalorRuntimeDir>
     </PropertyGroup>
   </Target>
 

--- a/src/Calor.Tasks/BuildStateCache.cs
+++ b/src/Calor.Tasks/BuildStateCache.cs
@@ -3,4 +3,8 @@
 // aliases preserve the historical unqualified names inside Calor.Tasks.
 global using BuildState = Calor.Compiler.Incremental.BuildState;
 global using BuildFileEntry = Calor.Compiler.Incremental.BuildFileEntry;
+global using CachedDiagnostic = Calor.Compiler.Incremental.CachedDiagnostic;
 global using BuildStateCache = Calor.Compiler.Incremental.BuildStateCache;
+global using CacheLoadStatus = Calor.Compiler.Incremental.CacheLoadStatus;
+global using GlobalCacheInvalidationReason =
+    Calor.Compiler.Incremental.GlobalCacheInvalidationReason;

--- a/src/Calor.Tasks/CompileCalor.cs
+++ b/src/Calor.Tasks/CompileCalor.cs
@@ -315,8 +315,7 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
             return string.Empty;
         try
         {
-            var normalized = Path.GetFullPath(path).Replace('\\', '/').TrimEnd('/');
-            return OperatingSystem.IsWindows() ? normalized.ToUpperInvariant() : normalized;
+            return Path.GetFullPath(path).Replace('\\', '/').TrimEnd('/');
         }
         catch (Exception ex) when (ex is ArgumentException or NotSupportedException
                                    or PathTooLongException)

--- a/src/Calor.Tasks/CompileCalor.cs
+++ b/src/Calor.Tasks/CompileCalor.cs
@@ -179,10 +179,18 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
             EnableILAnalysis,
             canonicalExperimentalFlags,
             DescribePath(ProjectDirectory, includeContent: false),
-            referencedAssemblies.Select(reference => reference.Descriptor).ToList(),
-            DescribePath(RuntimeDirectory, includeContent: false),
-            DescribePath(NuGetPackageRoot, includeContent: false),
-            DescribePath(DepsFilePath, includeContent: true));
+            EnableILAnalysis
+                ? referencedAssemblies.Select(reference => reference.Descriptor).ToList()
+                : [],
+            EnableILAnalysis
+                ? DescribePath(RuntimeDirectory, includeContent: false)
+                : "unused",
+            EnableILAnalysis
+                ? DescribePath(NuGetPackageRoot, includeContent: false)
+                : "unused",
+            EnableILAnalysis
+                ? DescribePath(DepsFilePath, includeContent: true)
+                : "unused");
     }
 
     private IReadOnlyList<ResolvedReference> ResolveReferencedAssemblies()
@@ -780,9 +788,9 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
         }
 
         // 5. Orphan cleanup (scoped to prior cache entries only)
-        if (priorFiles != null)
+        if (priorCache?.Files != null)
         {
-            foreach (var kvp in priorFiles)
+            foreach (var kvp in priorCache.Files)
             {
                 if (!currentRelativePaths.Contains(kvp.Key))
                 {
@@ -864,7 +872,7 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
     [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
         "SingleFile", "IL3000",
         Justification = "The MSBuild task is deployed as files; missing locations are represented in the cache fingerprint.")]
-    private static IReadOnlyList<string> ResolveCompilerClosurePaths(string tasksAssemblyPath)
+    internal static IReadOnlyList<string> ResolveCompilerClosurePaths(string tasksAssemblyPath)
     {
         var tasksDirectory = Path.GetDirectoryName(tasksAssemblyPath) ?? string.Empty;
         var compilerPath = typeof(Program).Assembly.Location;

--- a/src/Calor.Tasks/CompileCalor.cs
+++ b/src/Calor.Tasks/CompileCalor.cs
@@ -27,6 +27,7 @@ internal sealed record CompileCalorCacheInputs(
     string ExperimentalFlags,
     string ProjectDirectory,
     IReadOnlyList<string> ReferencedAssemblies,
+    IReadOnlyList<string> ResolvedImplementationAssemblies,
     string RuntimeDirectory,
     string NuGetPackageRoot,
     string DepsFile)
@@ -46,6 +47,8 @@ internal sealed record CompileCalorCacheInputs(
         Append(builder, "projectDirectory", ProjectDirectory);
         foreach (var reference in ReferencedAssemblies)
             Append(builder, "referencedAssembly", reference);
+        foreach (var implementation in ResolvedImplementationAssemblies)
+            Append(builder, "resolvedImplementationAssembly", implementation);
         Append(builder, "runtimeDirectory", RuntimeDirectory);
         Append(builder, "nuGetPackageRoot", NuGetPackageRoot);
         Append(builder, "depsFile", DepsFile);
@@ -168,6 +171,12 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
                 .Select(flag => flag.ToLowerInvariant())
                 .OrderBy(flag => flag, StringComparer.Ordinal));
 
+        var resolvedImplementations = EnableILAnalysis
+            ? Compiler.Effects.IL.AssemblyIndex.ResolveImplementationAssemblyPaths(
+                referencedAssemblies.Select(reference => reference.Path).ToList(),
+                CreateILAnalysisOptions())
+            : [];
+
         return new CompileCalorCacheInputs(
             BuildStateCache.CurrentOptionsSerializerVersion,
             BuildStateCache.CurrentFormatVersion,
@@ -182,6 +191,10 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
             EnableILAnalysis
                 ? referencedAssemblies.Select(reference => reference.Descriptor).ToList()
                 : [],
+            resolvedImplementations.Select((path, index) =>
+                path == null
+                    ? $"unresolved:{referencedAssemblies[index].Descriptor}"
+                    : DescribeAssembly(path, File.Exists(path))).ToList(),
             EnableILAnalysis
                 ? DescribePath(RuntimeDirectory, includeContent: false)
                 : "unused",
@@ -192,6 +205,14 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
                 ? DescribePath(DepsFilePath, includeContent: true)
                 : "unused");
     }
+
+    private Compiler.Effects.IL.ILAnalysisOptions CreateILAnalysisOptions()
+        => new()
+        {
+            RuntimeDirectory = !string.IsNullOrEmpty(RuntimeDirectory) ? RuntimeDirectory : null,
+            NuGetPackageRoot = !string.IsNullOrEmpty(NuGetPackageRoot) ? NuGetPackageRoot : null,
+            DepsFilePath = !string.IsNullOrEmpty(DepsFilePath) ? DepsFilePath : null
+        };
 
     private IReadOnlyList<ResolvedReference> ResolveReferencedAssemblies()
     {
@@ -391,12 +412,7 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
 
                 if (assemblyPaths.Count > 0)
                 {
-                    var ilOptions = new Compiler.Effects.IL.ILAnalysisOptions
-                    {
-                        RuntimeDirectory = !string.IsNullOrEmpty(RuntimeDirectory) ? RuntimeDirectory : null,
-                        NuGetPackageRoot = !string.IsNullOrEmpty(NuGetPackageRoot) ? NuGetPackageRoot : null,
-                        DepsFilePath = !string.IsNullOrEmpty(DepsFilePath) ? DepsFilePath : null
-                    };
+                    var ilOptions = CreateILAnalysisOptions();
 
                     var resolver = new Compiler.Effects.EffectResolver();
                     resolver.Initialize(ProjectDirectory);
@@ -415,6 +431,7 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
                             "Calor: IL analysis enabled with {0} referenced assemblies ({1} loaded).",
                             assemblyPaths.Count, ilAnalyzer.LoadedAssemblyCount);
                     }
+
                 }
             }
             catch (Exception ex)

--- a/src/Calor.Tasks/CompileCalor.cs
+++ b/src/Calor.Tasks/CompileCalor.cs
@@ -413,12 +413,30 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
                 if (assemblyPaths.Count > 0)
                 {
                     var ilOptions = CreateILAnalysisOptions();
+                    var resolvedImplementationPaths =
+                        Compiler.Effects.IL.AssemblyIndex.ResolveImplementationAssemblyPaths(
+                            assemblyPaths,
+                            ilOptions);
+                    var unresolvedReferenceCount = resolvedImplementationPaths.Count(
+                        path => path == null);
+                    if (unresolvedReferenceCount != 0)
+                    {
+                        throw new InvalidOperationException(
+                            $"{unresolvedReferenceCount} managed reference assembly input(s) "
+                            + "could not be resolved to implementation assemblies");
+                    }
 
                     var resolver = new Compiler.Effects.EffectResolver();
                     resolver.Initialize(ProjectDirectory);
 
                     ilAnalyzer = new Compiler.Effects.IL.ILEffectAnalyzer(
                         assemblyPaths, resolver, ilOptions);
+                    if (ilAnalyzer.LoadedAssemblyCount != assemblyPaths.Count)
+                    {
+                        throw new InvalidOperationException(
+                            $"IL analysis loaded {ilAnalyzer.LoadedAssemblyCount} of "
+                            + $"{assemblyPaths.Count} referenced assembly input(s)");
+                    }
 
                     var sharedResolver = new Compiler.Effects.EffectResolver(ilAnalyzer: ilAnalyzer);
                     sharedResolver.Initialize(ProjectDirectory);
@@ -903,7 +921,12 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
             typeof(Calor.Runtime.Option<int>).Assembly.Location,
             Path.Combine(compilerDirectory, "Microsoft.Z3.dll"),
             Path.Combine(compilerDirectory, nativeZ3Name)
-        };
+        }
+        .Concat(Compiler.Verification.Z3.Z3ContextFactory.GetNativeLibraryProbePaths())
+        .Distinct(OperatingSystem.IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal)
+        .ToList();
     }
 
     private static string DecodeSource(byte[] bytes)

--- a/src/Calor.Tasks/CompileCalor.cs
+++ b/src/Calor.Tasks/CompileCalor.cs
@@ -1,9 +1,63 @@
+using System.Reflection;
+using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Calor.Compiler;
 using Calor.Compiler.Effects;
 
 namespace Calor.Tasks;
+
+internal enum CompileCalorTestPhase
+{
+    BeforeILAnalysisInitialization,
+    AfterSourceRead,
+    BeforeCacheEntrySaved,
+    BeforeCrossModuleEnforcement
+}
+
+internal sealed record CompileCalorCacheInputs(
+    string SerializerVersion,
+    string CacheSchemaVersion,
+    string CompilerSemanticsVersion,
+    bool Verbose,
+    bool EnforceEffects,
+    bool EnableTypeChecking,
+    bool VerifyContracts,
+    bool EnableILAnalysis,
+    string ExperimentalFlags,
+    string ProjectDirectory,
+    IReadOnlyList<string> ReferencedAssemblies,
+    string RuntimeDirectory,
+    string NuGetPackageRoot,
+    string DepsFile)
+{
+    internal string Serialize()
+    {
+        var builder = new StringBuilder();
+        Append(builder, "serializerVersion", SerializerVersion);
+        Append(builder, "cacheSchemaVersion", CacheSchemaVersion);
+        Append(builder, "compilerSemanticsVersion", CompilerSemanticsVersion);
+        Append(builder, "verbose", Verbose ? "true" : "false");
+        Append(builder, "enforceEffects", EnforceEffects ? "true" : "false");
+        Append(builder, "enableTypeChecking", EnableTypeChecking ? "true" : "false");
+        Append(builder, "verifyContracts", VerifyContracts ? "true" : "false");
+        Append(builder, "enableILAnalysis", EnableILAnalysis ? "true" : "false");
+        Append(builder, "experimentalFlags", ExperimentalFlags);
+        Append(builder, "projectDirectory", ProjectDirectory);
+        foreach (var reference in ReferencedAssemblies)
+            Append(builder, "referencedAssembly", reference);
+        Append(builder, "runtimeDirectory", RuntimeDirectory);
+        Append(builder, "nuGetPackageRoot", NuGetPackageRoot);
+        Append(builder, "depsFile", DepsFile);
+        return builder.ToString();
+    }
+
+    private static void Append(StringBuilder builder, string name, string value)
+    {
+        builder.Append(name.Length).Append(':').Append(name)
+            .Append('=').Append(value.Length).Append(':').Append(value).Append(';');
+    }
+}
 
 /// <summary>
 /// MSBuild task that compiles Calor source files to C#.
@@ -83,37 +137,6 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
     public bool TypeCheck { get; set; } = true;
 
     /// <summary>
-    /// This task's options token, from its own properties. The call site goes through here so a
-    /// test can observe the composition — an earlier pin passed literal booleans to
-    /// <see cref="OptionsToken"/> and therefore could not tell whether the call site still folded
-    /// in <see cref="CompilationOptions.TypeCheckingDefault"/>. Reverting the fix left it green,
-    /// which is the same non-discriminating-pin failure this release already shipped twice.
-    /// </summary>
-    internal string ComputeOptionsToken(string canonicalExperimentalFlags)
-        => OptionsToken(
-            EnforceEffects,
-            TypeCheck && CompilationOptions.TypeCheckingDefault,
-            Verify,
-            EnableILAnalysis,
-            canonicalExperimentalFlags);
-
-    /// <summary>
-    /// The options token, extracted so it can be pinned directly. Note the type-check parameter is
-    /// the EFFECTIVE value (<c>TypeCheck &amp;&amp; CompilationOptions.TypeCheckingDefault</c>), not the
-    /// task property: the first cut hashed the property, so flipping <c>CALOR_NO_TYPE_CHECK</c>
-    /// against a warm cache changed what was reported without invalidating anything, and every
-    /// unchanged file was silently skipped — the #788 defect described at the call site.
-    /// </summary>
-    internal static string OptionsToken(
-        bool enforceEffects,
-        bool effectiveTypeCheck,
-        bool verify,
-        bool ilAnalysis,
-        string canonicalExperimentalFlags)
-        => $"enforceEffects:{enforceEffects}|typeCheck:{effectiveTypeCheck}|verify:{verify}"
-           + $"|ilAnalysis:{ilAnalysis}|experimental:{canonicalExperimentalFlags}";
-
-    /// <summary>
     /// Run static contract verification during compilation (Annex A-1.3
     /// instrumentation item 1): refutations surface as Calor0712-band build
     /// diagnostics (Warning severity — the build still succeeds). Off by
@@ -128,6 +151,159 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
     /// Unknown flags are accepted silently — see <see cref="Calor.Compiler.ExperimentalFlags"/>.
     /// </summary>
     public string ExperimentalFlags { get; set; } = string.Empty;
+
+    internal Action<string, CompileCalorTestPhase>? CacheTestHook { get; set; }
+
+    internal CompileCalorCacheInputs ComputeCacheInputs()
+        => ComputeCacheInputs(ResolveReferencedAssemblies());
+
+    private sealed record ResolvedReference(
+        string Path, string Descriptor, bool Exists, bool IsUsable);
+
+    private CompileCalorCacheInputs ComputeCacheInputs(
+        IReadOnlyList<ResolvedReference> referencedAssemblies)
+    {
+        var canonicalExperimentalFlags = string.Join(",",
+            Calor.Compiler.ExperimentalFlags.Parse(ExperimentalFlags).EnabledFlags
+                .Select(flag => flag.ToLowerInvariant())
+                .OrderBy(flag => flag, StringComparer.Ordinal));
+
+        return new CompileCalorCacheInputs(
+            BuildStateCache.CurrentOptionsSerializerVersion,
+            BuildStateCache.CurrentFormatVersion,
+            BuildStateCache.CurrentCompilerSemanticsVersion,
+            Verbose,
+            EnforceEffects,
+            TypeCheck && CompilationOptions.TypeCheckingDefault,
+            Verify,
+            EnableILAnalysis,
+            canonicalExperimentalFlags,
+            DescribePath(ProjectDirectory, includeContent: false),
+            referencedAssemblies.Select(reference => reference.Descriptor).ToList(),
+            DescribePath(RuntimeDirectory, includeContent: false),
+            DescribePath(NuGetPackageRoot, includeContent: false),
+            DescribePath(DepsFilePath, includeContent: true));
+    }
+
+    private IReadOnlyList<ResolvedReference> ResolveReferencedAssemblies()
+    {
+        return ReferencedAssemblies
+            .Select(item =>
+            {
+                var path = item.GetMetadata("FullPath");
+                if (string.IsNullOrEmpty(path))
+                    path = item.ItemSpec;
+                var fullPath = NormalizeFullPath(path);
+                var exists = !string.IsNullOrEmpty(fullPath) && File.Exists(fullPath);
+                var descriptor = DescribeAssembly(fullPath, exists);
+                return new ResolvedReference(
+                    fullPath,
+                    descriptor,
+                    exists,
+                    exists
+                    && !descriptor.Contains("non-managed:", StringComparison.Ordinal)
+                    && !descriptor.Contains("unreadable", StringComparison.Ordinal));
+            })
+            .OrderBy(reference => reference.Descriptor, StringComparer.Ordinal)
+            .ThenBy(reference => PrivacySafePathFingerprint(reference.Path), StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static string DescribeAssembly(string path, bool exists)
+    {
+        if (!exists)
+            return $"missing:{PrivacySafePathFingerprint(path)}";
+
+        string identity;
+        try
+        {
+            identity = AssemblyName.GetAssemblyName(path).FullName
+                ?? Path.GetFileName(path);
+        }
+        catch (BadImageFormatException)
+        {
+            identity = $"non-managed:{CanonicalFileName(path)}";
+        }
+        catch (FileLoadException)
+        {
+            identity = $"unreadable:{CanonicalFileName(path)}";
+        }
+        catch (IOException)
+        {
+            identity = $"unreadable:{CanonicalFileName(path)}";
+        }
+        catch (UnauthorizedAccessException)
+        {
+            identity = $"unreadable:{CanonicalFileName(path)}";
+        }
+
+        string contentHash;
+        try
+        {
+            contentHash = BuildStateCache.ComputeFileHash(path);
+        }
+        catch (IOException)
+        {
+            contentHash = "unreadable";
+        }
+        catch (UnauthorizedAccessException)
+        {
+            contentHash = "unreadable";
+        }
+        return $"identity:{identity}|content:{contentHash}";
+    }
+
+    private static string DescribePath(string path, bool includeContent)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return "unset";
+
+        var fullPath = NormalizeFullPath(path);
+        var kind = File.Exists(fullPath) ? "file"
+            : Directory.Exists(fullPath) ? "directory"
+            : "missing";
+        var descriptor = $"{kind}:{PrivacySafePathFingerprint(fullPath)}";
+        if (!includeContent || kind != "file")
+            return descriptor;
+
+        try
+        {
+            return $"{descriptor}|content:{BuildStateCache.ComputeFileHash(fullPath)}";
+        }
+        catch (IOException)
+        {
+            return $"{descriptor}|content:unreadable";
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return $"{descriptor}|content:unreadable";
+        }
+    }
+
+    private static string NormalizeFullPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return string.Empty;
+        try
+        {
+            var normalized = Path.GetFullPath(path).Replace('\\', '/').TrimEnd('/');
+            return OperatingSystem.IsWindows() ? normalized.ToUpperInvariant() : normalized;
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException
+                                   or PathTooLongException)
+        {
+            return path.Replace('\\', '/').TrimEnd('/');
+        }
+    }
+
+    private static string PrivacySafePathFingerprint(string path)
+        => string.IsNullOrEmpty(path) ? "unset" : BuildStateCache.ComputePathHash(path);
+
+    private static string CanonicalFileName(string path)
+    {
+        var name = Path.GetFileName(path);
+        return OperatingSystem.IsWindows() ? name.ToUpperInvariant() : name;
+    }
 
     public override bool Execute()
     {
@@ -144,31 +320,16 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
         }
 
         // 1. Load cache
-        BuildState? priorCache;
-        try
-        {
-            priorCache = BuildStateCache.Load(OutputDirectory);
-        }
-        catch
-        {
-            priorCache = null;
-        }
+        var cacheLoad = BuildStateCache.LoadWithStatus(OutputDirectory);
+        var priorCache = cacheLoad.State;
 
         // 2. Compute global hashes
         var tasksAssemblyPath = typeof(CompileCalor).Assembly.Location;
-        var compilerHash = BuildStateCache.ComputeCompilerHash(tasksAssemblyPath);
-        // Every diagnostics-affecting task option must be in the options token:
-        // flipping one with a warm cache has to force a recompile, or findings
-        // the new option set would report on unchanged files are silently
-        // missed (#788: ExperimentalFlags and EnableILAnalysis were omitted).
-        // Experimental flags are canonicalized (parsed, sorted, case-folded) so
-        // "a;b" and "B,a" hash identically.
-        var canonicalExperimentalFlags = string.Join(",",
-            Calor.Compiler.ExperimentalFlags.Parse(ExperimentalFlags).EnabledFlags
-                .Select(f => f.ToLowerInvariant())
-                .OrderBy(f => f, StringComparer.Ordinal));
+        var compilerHash = BuildStateCache.ComputeCompilerHash(
+            ResolveCompilerClosurePaths(tasksAssemblyPath));
+        var referencedAssemblyInputs = ResolveReferencedAssemblies();
         var optionsHash = BuildStateCache.ComputeOptionsHash(
-            ComputeOptionsToken(canonicalExperimentalFlags));
+            ComputeCacheInputs(referencedAssemblyInputs).Serialize());
         var manifestHash = BuildStateCache.ComputeManifestHash(ProjectDirectory);
 
         // 3. Global invalidation check
@@ -177,14 +338,19 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
         // Store output directory relative to project for cache portability across machines
         var relativeOutputDir = BuildStateCache.NormalizeRelativePath(
             Path.GetRelativePath(fullProjectDir, Path.GetFullPath(OutputDirectory)));
-        var globalInvalidation = BuildStateCache.IsGlobalInvalidation(
-            priorCache, compilerHash, optionsHash, manifestHash, relativeOutputDir);
-
-        if (globalInvalidation && Verbose)
+        var globalReasons = BuildStateCache.GetGlobalInvalidationReasons(
+            priorCache, compilerHash, optionsHash, manifestHash, relativeOutputDir).ToList();
+        if (cacheLoad.Status == CacheLoadStatus.CorruptOrPartial)
         {
-            Log.LogMessage(MessageImportance.High, "Calor: global invalidation — recompiling all files.");
+            globalReasons.Clear();
+            globalReasons.Add(GlobalCacheInvalidationReason.CorruptOrPartialCache);
+            BuildStateCache.Delete(OutputDirectory);
         }
-
+        else if (cacheLoad.Status == CacheLoadStatus.Unreadable)
+        {
+            globalReasons.Clear();
+            globalReasons.Add(GlobalCacheInvalidationReason.UnreadableCache);
+        }
         var newState = new BuildState
         {
             CompilerHash = compilerHash,
@@ -200,9 +366,19 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
         {
             try
             {
-                var assemblyPaths = ReferencedAssemblies
-                    .Select(item => item.GetMetadata("FullPath"))
-                    .Where(p => !string.IsNullOrEmpty(p) && File.Exists(p))
+                CacheTestHook?.Invoke(
+                    ProjectDirectory, CompileCalorTestPhase.BeforeILAnalysisInitialization);
+                var unusableReferenceCount = referencedAssemblyInputs.Count(
+                    input => !input.IsUsable);
+                if (unusableReferenceCount != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"{unusableReferenceCount} referenced assembly input(s) were missing, "
+                        + "unreadable, or not managed assemblies");
+                }
+                var assemblyPaths = referencedAssemblyInputs
+                    .Where(input => input.Exists)
+                    .Select(input => input.Path)
                     .ToList();
 
                 if (assemblyPaths.Count > 0)
@@ -284,19 +460,6 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
         // Track output paths to detect collisions from out-of-project file sanitization
         var outputPaths = new Dictionary<string, string>(pathComparer);
 
-        // On warm path: build lookup dictionary + pre-scan outputs to avoid per-file stat calls
-        Dictionary<string, BuildFileEntry>? priorFiles = null;
-        HashSet<string>? existingOutputFiles = null;
-        if (!globalInvalidation && priorCache?.Files != null)
-        {
-            priorFiles = new Dictionary<string, BuildFileEntry>(priorCache.Files, pathComparer);
-            existingOutputFiles = new HashSet<string>(
-                Directory.Exists(OutputDirectory)
-                    ? Directory.GetFiles(OutputDirectory, "*.g.cs", SearchOption.AllDirectories)
-                    : [],
-                pathComparer);
-        }
-
         // Cross-module call qualification map (G3/#809, #823 review M2): MSBuild is
         // the surface where csc actually consumes the outputs, so it needs the same
         // map the CLI driver builds. Warm-skip validity: a changed map invalidates
@@ -316,9 +479,27 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
             crossModuleMapHash = Calor.Compiler.CompilationDriver.ComputeCrossModuleMapHash(crossModuleMap);
         }
         newState.CrossModuleMapHash = crossModuleMapHash;
-        if (priorFiles != null && priorCache?.CrossModuleMapHash != crossModuleMapHash)
+        if (priorCache != null && priorCache.CrossModuleMapHash != crossModuleMapHash)
         {
-            priorFiles = null;
+            globalReasons.Add(GlobalCacheInvalidationReason.CrossModuleMapChanged);
+        }
+
+        var globalInvalidation = globalReasons.Count != 0;
+        if (Verbose)
+        {
+            foreach (var reason in globalReasons.Distinct())
+            {
+                Log.LogMessage(
+                    MessageImportance.High,
+                    "Calor: global invalidation [{0}] — recompiling all files.",
+                    BuildStateCache.GetReasonCode(reason));
+            }
+        }
+
+        Dictionary<string, BuildFileEntry>? priorFiles = null;
+        if (!globalInvalidation && priorCache?.Files != null)
+        {
+            priorFiles = new Dictionary<string, BuildFileEntry>(priorCache.Files, pathComparer);
         }
 
         // 4. Process each source file
@@ -356,38 +537,32 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
             if (!globalInvalidation && priorFiles != null)
             {
                 priorFiles.TryGetValue(relativePath, out var cachedEntry);
-
-                // The skip conditions mirror CompilationDriver.cs:178-198 deliberately — the two
-                // sites decide the same thing (is this file's cached output trustworthy?) and had
-                // drifted apart, with this one weaker on both counts.
-                //
-                //  - OutputContentHash: presence of the .g.cs is NOT enough. A truncated, corrupted,
-                //    or hand-edited output must be a miss, or the build compiles stale bytes and
-                //    reports "up-to-date". Entries predating this check carry a null hash and are
-                //    therefore a miss — one cold rebuild, fail-closed, as the driver does.
-                //  - EffectSummary: skipping without one silently drops the module from
-                //    cross-module effect enforcement, so its Calor0410 violations vanish on warm
-                //    builds. Not reachable through this task today (a null Ast implies HasErrors,
-                //    which returns before caching), so this is defence in depth against a future
-                //    caller — not a fix for a live bug.
-                if (cachedEntry != null
-                    && existingOutputFiles!.Contains(outputPath)
-                    && cachedEntry.EffectSummary != null
-                    && cachedEntry.OutputContentHash != null
-                    && BuildStateCache.ComputeFileHash(outputPath) == cachedEntry.OutputContentHash
-                    && BuildStateCache.IsFileUpToDate(cachedEntry, inputPath))
+                var missReason = BuildStateCache.GetFileCacheMissReason(
+                    cachedEntry, inputPath, outputPath);
+                if (missReason == null)
                 {
+                    var trustedEntry = cachedEntry!;
                     // Skip — carry entry forward
-                    newState.Files[relativePath] = cachedEntry;
+                    newState.Files[relativePath] = trustedEntry;
                     var outputItem = new TaskItem(outputPath);
                     outputItem.SetMetadata("SourceFile", inputPath);
                     generatedFiles.Add(outputItem);
 
                     // Carry forward cached effect summary so cross-module enforcement
                     // still sees this module on warm builds.
-                    if (cachedEntry.EffectSummary != null)
+                    if (trustedEntry.EffectSummary != null)
                     {
-                        moduleSummaries.Add((cachedEntry.EffectSummary, inputPath));
+                        moduleSummaries.Add((trustedEntry.EffectSummary, inputPath));
+                    }
+                    foreach (var diagnostic in trustedEntry.Diagnostics ?? [])
+                    {
+                        LogDiagnostic(
+                            diagnostic.Code,
+                            diagnostic.Severity,
+                            diagnostic.Message,
+                            inputPath,
+                            diagnostic.Line,
+                            diagnostic.Column);
                     }
 
                     if (Verbose)
@@ -396,6 +571,15 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
                             "Calor: skipping (up-to-date): {0}", inputPath);
                     }
                     continue;
+                }
+
+                if (Verbose)
+                {
+                    Log.LogMessage(
+                        MessageImportance.High,
+                        "Calor: file cache miss [{0}]: {1}",
+                        BuildStateCache.GetReasonCode(missReason.Value),
+                        inputPath);
                 }
             }
 
@@ -423,7 +607,10 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
 
             try
             {
-                var source = File.ReadAllText(inputPath);
+                var statBeforeRead = BuildStateCache.StatFile(inputPath);
+                var sourceBytes = File.ReadAllBytes(inputPath);
+                CacheTestHook?.Invoke(inputPath, CompileCalorTestPhase.AfterSourceRead);
+                var source = DecodeSource(sourceBytes);
                 var compileOptions = new CompilationOptions
                 {
                     Verbose = Verbose,
@@ -445,46 +632,14 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
                 // has something to say.
                 foreach (var diagnostic in result.Diagnostics)
                 {
-                    if (diagnostic.IsError)
-                    {
-                        Log.LogError(
-                            subcategory: "Calor",
-                            errorCode: diagnostic.Code,
-                            helpKeyword: null,
-                            file: diagnostic.FilePath ?? inputPath,
-                            lineNumber: diagnostic.Span.Line,
-                            columnNumber: diagnostic.Span.Column,
-                            endLineNumber: 0,
-                            endColumnNumber: 0,
-                            message: diagnostic.Message);
-                    }
-                    else if (diagnostic.IsWarning)
-                    {
-                        Log.LogWarning(
-                            subcategory: "Calor",
-                            warningCode: diagnostic.Code,
-                            helpKeyword: null,
-                            file: diagnostic.FilePath ?? inputPath,
-                            lineNumber: diagnostic.Span.Line,
-                            columnNumber: diagnostic.Span.Column,
-                            endLineNumber: 0,
-                            endColumnNumber: 0,
-                            message: diagnostic.Message);
-                    }
-                    else
-                    {
-                        Log.LogMessage(
-                            subcategory: "Calor",
-                            code: diagnostic.Code,
-                            helpKeyword: null,
-                            file: diagnostic.FilePath ?? inputPath,
-                            lineNumber: diagnostic.Span.Line,
-                            columnNumber: diagnostic.Span.Column,
-                            endLineNumber: 0,
-                            endColumnNumber: 0,
-                            importance: MessageImportance.Normal,
-                            message: diagnostic.Message);
-                    }
+                    LogDiagnostic(
+                        diagnostic.Code,
+                        diagnostic.IsError ? "error"
+                            : diagnostic.IsWarning ? "warning" : "info",
+                        diagnostic.Message,
+                        diagnostic.FilePath ?? inputPath,
+                        diagnostic.Span.Line,
+                        diagnostic.Span.Column);
                 }
 
                 if (result.HasErrors)
@@ -499,24 +654,29 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
                     continue;
                 }
 
-                File.WriteAllText(outputPath, result.GeneratedCode);
+                var generatedBytes = new UTF8Encoding(false).GetBytes(result.GeneratedCode);
+                File.WriteAllBytes(outputPath, generatedBytes);
+                CacheTestHook?.Invoke(inputPath, CompileCalorTestPhase.BeforeCacheEntrySaved);
 
-                // Compute effect summary from the fresh AST and cache it for future warm builds.
-                var fileEntry = BuildStateCache.CreateFileEntry(inputPath);
-
-                // Record what this compile actually wrote, so the next build can tell whether the
-                // .g.cs on disk is still that output. Without this every entry is a permanent miss
-                // under the check above — which is safe, but defeats incrementality entirely.
-                fileEntry.OutputContentHash = File.Exists(outputPath)
-                    ? BuildStateCache.ComputeFileHash(outputPath)
-                    : null;
-
+                EffectSummary? summary = null;
                 if (result.Ast != null)
                 {
-                    var summary = Calor.Compiler.Effects.EffectSummaryBuilder.Build(result.Ast);
-                    fileEntry.EffectSummary = summary;
+                    summary = Calor.Compiler.Effects.EffectSummaryBuilder.Build(result.Ast);
                     moduleSummaries.Add((summary, inputPath));
                 }
+
+                var fileEntry = BuildStateCache.CreateFileEntry(statBeforeRead, sourceBytes);
+                fileEntry.OutputContentHash = BuildStateCache.ComputeContentHash(generatedBytes);
+                fileEntry.EffectSummary = summary;
+                fileEntry.Diagnostics = result.Diagnostics.Select(diagnostic => new CachedDiagnostic
+                {
+                    Code = diagnostic.Code,
+                    Severity = diagnostic.IsError ? "error"
+                        : diagnostic.IsWarning ? "warning" : "info",
+                    Message = diagnostic.Message,
+                    Line = diagnostic.Span.Line,
+                    Column = diagnostic.Span.Column
+                }).ToList();
                 newState.Files[relativePath] = fileEntry;
 
                 var item = new TaskItem(outputPath);
@@ -548,6 +708,8 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
         {
             try
             {
+                CacheTestHook?.Invoke(
+                    ProjectDirectory, CompileCalorTestPhase.BeforeCrossModuleEnforcement);
                 Log.LogMessage(MessageImportance.Normal,
                     "Calor: running cross-module effect enforcement over {0} modules",
                     moduleSummaries.Count);
@@ -652,7 +814,19 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
         }
         catch (Exception ex)
         {
-            Log.LogWarning("Calor: failed to save build state cache: {0}", ex.Message);
+            if (BuildStateCache.Delete(OutputDirectory))
+            {
+                Log.LogWarning(
+                    "Calor: failed to save build state cache; the cache was purged and the next build "
+                    + "will run cold: {0}", ex.Message);
+            }
+            else
+            {
+                Log.LogError(
+                    "Calor: failed to save or purge build state cache. Incremental state cannot be "
+                    + "trusted, so the build fails closed: {0}", ex.Message);
+                success = false;
+            }
         }
 
         GeneratedFiles = generatedFiles.ToArray();
@@ -663,5 +837,54 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
             ilAnalyzer?.Dispose();
             compilationContext?.Dispose();
         }
+    }
+
+    private void LogDiagnostic(
+        string code, string severity, string message,
+        string filePath, int line, int column)
+    {
+        if (severity == "error")
+        {
+            Log.LogError(
+                "Calor", code, null, filePath, line, column, 0, 0, message);
+        }
+        else if (severity == "warning")
+        {
+            Log.LogWarning(
+                "Calor", code, null, filePath, line, column, 0, 0, message);
+        }
+        else
+        {
+            Log.LogMessage(
+                "Calor", code, null, filePath, line, column, 0, 0,
+                MessageImportance.Normal, message);
+        }
+    }
+
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
+        "SingleFile", "IL3000",
+        Justification = "The MSBuild task is deployed as files; missing locations are represented in the cache fingerprint.")]
+    private static IReadOnlyList<string> ResolveCompilerClosurePaths(string tasksAssemblyPath)
+    {
+        var tasksDirectory = Path.GetDirectoryName(tasksAssemblyPath) ?? string.Empty;
+        var compilerPath = typeof(Program).Assembly.Location;
+        var compilerDirectory = Path.GetDirectoryName(compilerPath) ?? tasksDirectory;
+        var nativeZ3Name = OperatingSystem.IsWindows() ? "libz3.dll"
+            : OperatingSystem.IsMacOS() ? "libz3.dylib" : "libz3.so";
+        return new[]
+        {
+            tasksAssemblyPath,
+            compilerPath,
+            typeof(Calor.Runtime.Option<int>).Assembly.Location,
+            Path.Combine(compilerDirectory, "Microsoft.Z3.dll"),
+            Path.Combine(compilerDirectory, nativeZ3Name)
+        };
+    }
+
+    private static string DecodeSource(byte[] bytes)
+    {
+        using var reader = new StreamReader(
+            new MemoryStream(bytes), Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        return reader.ReadToEnd();
     }
 }

--- a/tests/Calor.Tasks.Tests/BuildStateCacheTests.cs
+++ b/tests/Calor.Tasks.Tests/BuildStateCacheTests.cs
@@ -601,17 +601,27 @@ public class BuildStateCacheTests : IDisposable
         Assert.Contains(typeof(Calor.Compiler.Program).Assembly.Location, resolved);
         Assert.Contains(typeof(Calor.Runtime.Option<int>).Assembly.Location, resolved);
 
-        var copied = resolved.Select(path =>
+        Assert.Contains(resolved, path =>
+            path.Contains(
+                $"{Path.DirectorySeparatorChar}runtimes{Path.DirectorySeparatorChar}",
+                StringComparison.Ordinal)
+            && path.EndsWith(
+                OperatingSystem.IsWindows() ? "libz3.dll"
+                    : OperatingSystem.IsMacOS() ? "libz3.dylib" : "libz3.so",
+                StringComparison.Ordinal));
+
+        var copied = resolved.Select((path, index) =>
         {
-            var destination = Path.Combine(dir, Path.GetFileName(path));
+            var destination = Path.Combine(dir, $"{index:D2}-{Path.GetFileName(path)}");
             if (File.Exists(path))
                 File.Copy(path, destination);
             return destination;
         }).ToList();
         var compiler = copied.Single(path =>
-            Path.GetFileName(path).Equals("calor.dll", StringComparison.OrdinalIgnoreCase));
+            Path.GetFileName(path).EndsWith("-calor.dll", StringComparison.OrdinalIgnoreCase));
         var runtime = copied.Single(path =>
-            Path.GetFileName(path).Equals("Calor.Runtime.dll", StringComparison.OrdinalIgnoreCase));
+            Path.GetFileName(path).EndsWith(
+                "-Calor.Runtime.dll", StringComparison.OrdinalIgnoreCase));
 
         var baseline = BuildStateCache.ComputeCompilerHash(copied);
         File.AppendAllText(compiler, "compiler-change");

--- a/tests/Calor.Tasks.Tests/BuildStateCacheTests.cs
+++ b/tests/Calor.Tasks.Tests/BuildStateCacheTests.cs
@@ -898,14 +898,20 @@ public class BuildStateCacheTests : IDisposable
         File.WriteAllText(
             Path.Combine(directory, "a.calor-effects.json"),
             """{"version":"1.0","mappings":[]}""");
+        File.WriteAllText(
+            Path.Combine(directory, "A.calor-effects.json"),
+            """{"version":"1.0","mappings":[]}""");
 
         var loader = new Calor.Compiler.Effects.Manifests.ManifestLoader();
         loader.LoadManifestsFromDirectory(
             directory,
             Calor.Compiler.Effects.Manifests.ManifestPriority.UserLevel);
 
+        var expected = Directory.GetFiles(directory, "*.calor-effects.json")
+            .Select(Path.GetFileName)
+            .OrderBy(name => name, StringComparer.Ordinal);
         Assert.Equal(
-            ["a.calor-effects.json", "z.calor-effects.json"],
+            expected,
             loader.LoadedManifests.Select(item => Path.GetFileName(item.Source.FilePath)));
     }
 

--- a/tests/Calor.Tasks.Tests/BuildStateCacheTests.cs
+++ b/tests/Calor.Tasks.Tests/BuildStateCacheTests.cs
@@ -1,6 +1,7 @@
 using Xunit;
 using Calor.Tasks;
 using Calor.Compiler.Effects;
+using Microsoft.Build.Utilities;
 
 namespace Calor.Tasks.Tests;
 
@@ -55,9 +56,9 @@ public class BuildStateCacheTests : IDisposable
         Assert.NotEqual(hash1, hash2);
     }
 
-    // Test 3: Stat gate hit — matching (mtime, size) → skip without hashing
+    // Test 3: Matching metadata never overrides a byte mismatch.
     [Fact]
-    public void IsFileUpToDate_MatchingStatFields_ReturnsTrue()
+    public void IsFileUpToDate_MatchingStatFieldsButDifferentBytes_ReturnsFalse()
     {
         var filePath = CreateTempFile("test.calr", "content");
         var fileInfo = new FileInfo(filePath);
@@ -69,10 +70,10 @@ public class BuildStateCacheTests : IDisposable
             FileSize = fileInfo.Length
         };
 
-        Assert.True(BuildStateCache.IsFileUpToDate(entry, filePath));
+        Assert.False(BuildStateCache.IsFileUpToDate(entry, filePath));
     }
 
-    // Test 4: Stat gate miss, hash match — mtime changed, content same → skip
+    // Test 4: Metadata changed, content same → skip
     [Fact]
     public void IsFileUpToDate_MtimeChanged_ContentSame_ReturnsTrue()
     {
@@ -86,7 +87,6 @@ public class BuildStateCacheTests : IDisposable
             FileSize = new FileInfo(filePath).Length
         };
 
-        // Stat gate misses (mtime differs), falls through to hash check, hash matches → skip
         Assert.True(BuildStateCache.IsFileUpToDate(entry, filePath));
     }
 
@@ -134,7 +134,8 @@ public class BuildStateCacheTests : IDisposable
         var loaded = BuildStateCache.Load(outputDir);
 
         Assert.NotNull(loaded);
-        Assert.Equal("2.1", loaded.FormatVersion);
+        Assert.Equal(BuildStateCache.CurrentFormatVersion, loaded.FormatVersion);
+        Assert.Equal(BuildStateCache.CurrentCompilerSemanticsVersion, loaded.CompilerSemanticsVersion);
         Assert.Equal("abc123", loaded.CompilerHash);
         Assert.Equal("def456", loaded.OptionsHash);
         Assert.Equal("ghi789", loaded.ManifestHash);
@@ -341,6 +342,33 @@ public class BuildStateCacheTests : IDisposable
             cached, "compiler", "opts", "manifest", "out/"));
     }
 
+    [Fact]
+    public void GlobalInvalidationReasons_AreDeterministic_AndTrackCompilerSemantics()
+    {
+        var cached = new BuildState
+        {
+            FormatVersion = "old-schema",
+            CompilerSemanticsVersion = "old-semantics",
+            CompilerHash = "old-compiler",
+            OptionsHash = "old-options",
+            ManifestHash = "old-manifest",
+            OutputDirectory = "old-output"
+        };
+
+        var reasons = BuildStateCache.GetGlobalInvalidationReasons(
+            cached, "compiler", "options", "manifest", "output");
+
+        Assert.Equal(new[]
+        {
+            Calor.Compiler.Incremental.GlobalCacheInvalidationReason.SchemaVersionChanged,
+            Calor.Compiler.Incremental.GlobalCacheInvalidationReason.CompilerSemanticsChanged,
+            Calor.Compiler.Incremental.GlobalCacheInvalidationReason.CompilerChanged,
+            Calor.Compiler.Incremental.GlobalCacheInvalidationReason.OptionsOrInputsChanged,
+            Calor.Compiler.Incremental.GlobalCacheInvalidationReason.ManifestChanged,
+            Calor.Compiler.Incremental.GlobalCacheInvalidationReason.OutputDirectoryChanged
+        }, reasons);
+    }
+
     // Test 12: Corrupt cache → recompile all, no exception
     [Fact]
     public void Load_CorruptCache_ReturnsNull()
@@ -352,6 +380,30 @@ public class BuildStateCacheTests : IDisposable
         var result = BuildStateCache.Load(outputDir);
 
         Assert.Null(result);
+    }
+
+    [Fact]
+    public void Load_CurrentSchemaMissingSemanticVersion_IsRejectedAsPartial()
+    {
+        var outputDir = Path.Combine(_tempDir, "partial-current");
+        Directory.CreateDirectory(outputDir);
+        File.WriteAllText(
+            BuildStateCache.GetCachePath(outputDir),
+            $$"""
+              {
+                "formatVersion": "{{BuildStateCache.CurrentFormatVersion}}",
+                "compilerHash": "compiler",
+                "optionsHash": "options",
+                "manifestHash": "",
+                "outputDirectory": ".",
+                "files": {}
+              }
+              """);
+
+        var result = BuildStateCache.LoadWithStatus(outputDir);
+
+        Assert.Equal(CacheLoadStatus.CorruptOrPartial, result.Status);
+        Assert.Null(result.State);
     }
 
     // Test 13: Missing cache → all compile
@@ -540,6 +592,28 @@ public class BuildStateCacheTests : IDisposable
     }
 
     [Fact]
+    public void ComputeCompilerHash_TracksDeployedCompilerAndRuntimeClosure()
+    {
+        var dir = Path.Combine(_tempDir, "compiler-closure");
+        Directory.CreateDirectory(dir);
+        var tasks = Path.Combine(dir, "Calor.Tasks.dll");
+        var compiler = Path.Combine(dir, "calor.dll");
+        var runtime = Path.Combine(dir, "Calor.Runtime.dll");
+        File.WriteAllText(tasks, "tasks");
+        File.WriteAllText(compiler, "compiler-v1");
+        File.WriteAllText(runtime, "runtime-v1");
+
+        var baseline = BuildStateCache.ComputeCompilerHash(tasks);
+        File.WriteAllText(compiler, "compiler-v2");
+        var compilerChanged = BuildStateCache.ComputeCompilerHash(tasks);
+        File.WriteAllText(runtime, "runtime-v2");
+        var runtimeChanged = BuildStateCache.ComputeCompilerHash(tasks);
+
+        Assert.NotEqual(baseline, compilerChanged);
+        Assert.NotEqual(compilerChanged, runtimeChanged);
+    }
+
+    [Fact]
     public void Save_AtomicWrite_NoCorruptionOnRead()
     {
         var outputDir = Path.Combine(_tempDir, "atomic-test");
@@ -630,7 +704,7 @@ public class BuildStateCacheTests : IDisposable
             cached, "compiler", "opts", "manifest", "obj\\Debug\\net10.0\\calor"));
     }
     /// <summary>
-    /// The options token must carry the EFFECTIVE type-check setting, not the task property.
+    /// The canonical input record must carry the EFFECTIVE type-check setting, not the task property.
     /// v0.12 added a CALOR_NO_TYPE_CHECK escape hatch read at the CompilationOptions default; the
     /// first cut hashed `TypeCheck` alone, so flipping the variable against a warm cache changed
     /// what would be reported without invalidating anything and every unchanged file was silently
@@ -647,18 +721,20 @@ public class BuildStateCacheTests : IDisposable
         // below is the guard that fails. Two earlier revisions of this comment claimed otherwise;
         // a pin's docstring asserting a discrimination it does not have is how the first two
         // versions of this test survived review.
-        var on = new Calor.Tasks.CompileCalor { TypeCheck = true }.ComputeOptionsToken("");
-        var off = new Calor.Tasks.CompileCalor { TypeCheck = false }.ComputeOptionsToken("");
+        var on = new Calor.Tasks.CompileCalor { TypeCheck = true }.ComputeCacheInputs();
+        var off = new Calor.Tasks.CompileCalor { TypeCheck = false }.ComputeCacheInputs();
 
-        Assert.NotEqual(on, off);
-        Assert.NotEqual(BuildStateCache.ComputeOptionsHash(on), BuildStateCache.ComputeOptionsHash(off));
-        Assert.Contains("typeCheck:True", on);
-        Assert.Contains("typeCheck:False", off);
+        Assert.NotEqual(on.Serialize(), off.Serialize());
+        Assert.NotEqual(
+            BuildStateCache.ComputeOptionsHash(on.Serialize()),
+            BuildStateCache.ComputeOptionsHash(off.Serialize()));
+        Assert.True(on.EnableTypeChecking);
+        Assert.False(off.EnableTypeChecking);
     }
 
     /// <summary>
     /// The half that actually caught the defect. `CALOR_NO_TYPE_CHECK` changes what the task will
-    /// report, so it MUST move the options token — otherwise a warm cache serves the other
+    /// report, so it MUST move the canonical fingerprint — otherwise a warm cache serves the other
     /// setting's findings and every unchanged file is silently skipped (#788). Two earlier
     /// revisions of this pin passed with the fix reverted: the first fed literal booleans straight
     /// to the token function, the second drove the task but never set the variable, so the value it
@@ -671,16 +747,16 @@ public class BuildStateCacheTests : IDisposable
         try
         {
             Environment.SetEnvironmentVariable("CALOR_NO_TYPE_CHECK", null);
-            var checking = new Calor.Tasks.CompileCalor { TypeCheck = true }.ComputeOptionsToken("");
+            var checking = new Calor.Tasks.CompileCalor { TypeCheck = true }.ComputeCacheInputs();
 
             Environment.SetEnvironmentVariable("CALOR_NO_TYPE_CHECK", "1");
-            var optedOut = new Calor.Tasks.CompileCalor { TypeCheck = true }.ComputeOptionsToken("");
+            var optedOut = new Calor.Tasks.CompileCalor { TypeCheck = true }.ComputeCacheInputs();
 
-            Assert.Contains("typeCheck:True", checking);
-            Assert.Contains("typeCheck:False", optedOut);
+            Assert.True(checking.EnableTypeChecking);
+            Assert.False(optedOut.EnableTypeChecking);
             Assert.NotEqual(
-                BuildStateCache.ComputeOptionsHash(checking),
-                BuildStateCache.ComputeOptionsHash(optedOut));
+                BuildStateCache.ComputeOptionsHash(checking.Serialize()),
+                BuildStateCache.ComputeOptionsHash(optedOut.Serialize()));
         }
         finally
         {
@@ -692,18 +768,65 @@ public class BuildStateCacheTests : IDisposable
     /// And the guard that keeps that honest: every other diagnostics-affecting option must still
     /// move the token, so the parameter above was not simply added to a token nobody consults.
     /// </summary>
-    [Theory]
-    [InlineData(false, true, true, true, "")]
-    [InlineData(true, true, false, true, "")]
-    [InlineData(true, true, true, false, "")]
-    [InlineData(true, true, true, true, "flag-a")]
-    public void OptionsToken_DistinguishesEveryOption(
-        bool enforceEffects, bool typeCheck, bool verify, bool il, string flags)
+    [Fact]
+    public void CanonicalInputs_DistinguishEveryTaskInput_AndDoNotPersistPaths()
     {
-        var baseline = Calor.Tasks.CompileCalor.OptionsToken(true, true, true, true, "");
-        var varied = Calor.Tasks.CompileCalor.OptionsToken(enforceEffects, typeCheck, verify, il, flags);
+        var reference = CreateTempFile("refs/Fake.dll", "reference-v1");
+        var deps = CreateTempFile("project.deps.json", """{"runtimeTarget":{"name":"x"}}""");
+        var baselineTask = new Calor.Tasks.CompileCalor { ProjectDirectory = _tempDir };
+        var baseline = baselineTask.ComputeCacheInputs().Serialize();
 
-        Assert.NotEqual(baseline, varied);
+        var variants = new[]
+        {
+            new Calor.Tasks.CompileCalor
+            {
+                ProjectDirectory = Path.Combine(_tempDir, "other-project")
+            },
+            new Calor.Tasks.CompileCalor { ProjectDirectory = _tempDir, Verbose = true },
+            new Calor.Tasks.CompileCalor { ProjectDirectory = _tempDir, EnforceEffects = false },
+            new Calor.Tasks.CompileCalor { ProjectDirectory = _tempDir, TypeCheck = false },
+            new Calor.Tasks.CompileCalor { ProjectDirectory = _tempDir, Verify = true },
+            new Calor.Tasks.CompileCalor { ProjectDirectory = _tempDir, EnableILAnalysis = true },
+            new Calor.Tasks.CompileCalor { ProjectDirectory = _tempDir, ExperimentalFlags = "flag-a" },
+            new Calor.Tasks.CompileCalor
+            {
+                ProjectDirectory = _tempDir,
+                ReferencedAssemblies = [new TaskItem(reference)]
+            },
+            new Calor.Tasks.CompileCalor { ProjectDirectory = _tempDir, RuntimeDirectory = _tempDir },
+            new Calor.Tasks.CompileCalor { ProjectDirectory = _tempDir, NuGetPackageRoot = _tempDir },
+            new Calor.Tasks.CompileCalor { ProjectDirectory = _tempDir, DepsFilePath = deps }
+        };
+
+        Assert.All(variants, task => Assert.NotEqual(baseline, task.ComputeCacheInputs().Serialize()));
+        Assert.DoesNotContain(_tempDir, variants[^1].ComputeCacheInputs().Serialize());
+        var record = baselineTask.ComputeCacheInputs();
+        Assert.Equal(BuildStateCache.CurrentOptionsSerializerVersion, record.SerializerVersion);
+        Assert.Equal(BuildStateCache.CurrentFormatVersion, record.CacheSchemaVersion);
+        Assert.Equal(BuildStateCache.CurrentCompilerSemanticsVersion, record.CompilerSemanticsVersion);
+    }
+
+    [Fact]
+    public void CanonicalInputs_ReferenceOrderIsStable_AndContentChangesFingerprint()
+    {
+        var referenceA = CreateTempFile("refs/A.dll", "a-v1");
+        var referenceB = CreateTempFile("refs/B.dll", "b-v1");
+        var first = new Calor.Tasks.CompileCalor
+        {
+            ProjectDirectory = _tempDir,
+            ReferencedAssemblies = [new TaskItem(referenceA), new TaskItem(referenceB)]
+        };
+        var reordered = new Calor.Tasks.CompileCalor
+        {
+            ProjectDirectory = _tempDir,
+            ReferencedAssemblies = [new TaskItem(referenceB), new TaskItem(referenceA)]
+        };
+
+        var baseline = first.ComputeCacheInputs().Serialize();
+        Assert.Equal(baseline, reordered.ComputeCacheInputs().Serialize());
+
+        File.WriteAllText(referenceA, "a-v2");
+        Assert.NotEqual(baseline, first.ComputeCacheInputs().Serialize());
     }
 
 }

--- a/tests/Calor.Tasks.Tests/BuildStateCacheTests.cs
+++ b/tests/Calor.Tasks.Tests/BuildStateCacheTests.cs
@@ -592,22 +592,32 @@ public class BuildStateCacheTests : IDisposable
     }
 
     [Fact]
-    public void ComputeCompilerHash_TracksDeployedCompilerAndRuntimeClosure()
+    public void ComputeCompilerHash_TracksResolvedCompilerAndRuntimeClosure()
     {
         var dir = Path.Combine(_tempDir, "compiler-closure");
         Directory.CreateDirectory(dir);
-        var tasks = Path.Combine(dir, "Calor.Tasks.dll");
-        var compiler = Path.Combine(dir, "calor.dll");
-        var runtime = Path.Combine(dir, "Calor.Runtime.dll");
-        File.WriteAllText(tasks, "tasks");
-        File.WriteAllText(compiler, "compiler-v1");
-        File.WriteAllText(runtime, "runtime-v1");
+        var resolved = Calor.Tasks.CompileCalor.ResolveCompilerClosurePaths(
+            typeof(Calor.Tasks.CompileCalor).Assembly.Location);
+        Assert.Contains(typeof(Calor.Compiler.Program).Assembly.Location, resolved);
+        Assert.Contains(typeof(Calor.Runtime.Option<int>).Assembly.Location, resolved);
 
-        var baseline = BuildStateCache.ComputeCompilerHash(tasks);
-        File.WriteAllText(compiler, "compiler-v2");
-        var compilerChanged = BuildStateCache.ComputeCompilerHash(tasks);
-        File.WriteAllText(runtime, "runtime-v2");
-        var runtimeChanged = BuildStateCache.ComputeCompilerHash(tasks);
+        var copied = resolved.Select(path =>
+        {
+            var destination = Path.Combine(dir, Path.GetFileName(path));
+            if (File.Exists(path))
+                File.Copy(path, destination);
+            return destination;
+        }).ToList();
+        var compiler = copied.Single(path =>
+            Path.GetFileName(path).Equals("calor.dll", StringComparison.OrdinalIgnoreCase));
+        var runtime = copied.Single(path =>
+            Path.GetFileName(path).Equals("Calor.Runtime.dll", StringComparison.OrdinalIgnoreCase));
+
+        var baseline = BuildStateCache.ComputeCompilerHash(copied);
+        File.AppendAllText(compiler, "compiler-change");
+        var compilerChanged = BuildStateCache.ComputeCompilerHash(copied);
+        File.AppendAllText(runtime, "runtime-change");
+        var runtimeChanged = BuildStateCache.ComputeCompilerHash(copied);
 
         Assert.NotEqual(baseline, compilerChanged);
         Assert.NotEqual(compilerChanged, runtimeChanged);
@@ -791,11 +801,27 @@ public class BuildStateCacheTests : IDisposable
             new Calor.Tasks.CompileCalor
             {
                 ProjectDirectory = _tempDir,
+                EnableILAnalysis = true,
                 ReferencedAssemblies = [new TaskItem(reference)]
             },
-            new Calor.Tasks.CompileCalor { ProjectDirectory = _tempDir, RuntimeDirectory = _tempDir },
-            new Calor.Tasks.CompileCalor { ProjectDirectory = _tempDir, NuGetPackageRoot = _tempDir },
-            new Calor.Tasks.CompileCalor { ProjectDirectory = _tempDir, DepsFilePath = deps }
+            new Calor.Tasks.CompileCalor
+            {
+                ProjectDirectory = _tempDir,
+                EnableILAnalysis = true,
+                RuntimeDirectory = _tempDir
+            },
+            new Calor.Tasks.CompileCalor
+            {
+                ProjectDirectory = _tempDir,
+                EnableILAnalysis = true,
+                NuGetPackageRoot = _tempDir
+            },
+            new Calor.Tasks.CompileCalor
+            {
+                ProjectDirectory = _tempDir,
+                EnableILAnalysis = true,
+                DepsFilePath = deps
+            }
         };
 
         Assert.All(variants, task => Assert.NotEqual(baseline, task.ComputeCacheInputs().Serialize()));
@@ -814,11 +840,13 @@ public class BuildStateCacheTests : IDisposable
         var first = new Calor.Tasks.CompileCalor
         {
             ProjectDirectory = _tempDir,
+            EnableILAnalysis = true,
             ReferencedAssemblies = [new TaskItem(referenceA), new TaskItem(referenceB)]
         };
         var reordered = new Calor.Tasks.CompileCalor
         {
             ProjectDirectory = _tempDir,
+            EnableILAnalysis = true,
             ReferencedAssemblies = [new TaskItem(referenceB), new TaskItem(referenceA)]
         };
 
@@ -827,6 +855,26 @@ public class BuildStateCacheTests : IDisposable
 
         File.WriteAllText(referenceA, "a-v2");
         Assert.NotEqual(baseline, first.ComputeCacheInputs().Serialize());
+    }
+
+    [Fact]
+    public void ManifestHash_IncludesUserLevelManifests_AndDistinguishesScopes()
+    {
+        var project = Path.Combine(_tempDir, "manifest-project");
+        var user = Path.Combine(_tempDir, "manifest-user");
+        Directory.CreateDirectory(project);
+        Directory.CreateDirectory(user);
+        File.WriteAllText(Path.Combine(project, "same.calor-effects.json"), "project-v1");
+        File.WriteAllText(Path.Combine(user, "same.calor-effects.json"), "user-v1");
+
+        var baseline = BuildStateCache.ComputeManifestHash([project], user);
+        File.WriteAllText(Path.Combine(user, "same.calor-effects.json"), "user-v2");
+        var userChanged = BuildStateCache.ComputeManifestHash([project], user);
+        File.WriteAllText(Path.Combine(project, "same.calor-effects.json"), "project-v2");
+        var projectChanged = BuildStateCache.ComputeManifestHash([project], user);
+
+        Assert.NotEqual(baseline, userChanged);
+        Assert.NotEqual(userChanged, projectChanged);
     }
 
 }

--- a/tests/Calor.Tasks.Tests/BuildStateCacheTests.cs
+++ b/tests/Calor.Tasks.Tests/BuildStateCacheTests.cs
@@ -877,4 +877,77 @@ public class BuildStateCacheTests : IDisposable
         Assert.NotEqual(userChanged, projectChanged);
     }
 
+    [Fact]
+    public void ManifestLoader_LoadsSamePriorityManifestsInCanonicalPathOrder()
+    {
+        var directory = Path.Combine(_tempDir, "ordered-manifests");
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(
+            Path.Combine(directory, "z.calor-effects.json"),
+            """{"version":"1.0","mappings":[]}""");
+        File.WriteAllText(
+            Path.Combine(directory, "a.calor-effects.json"),
+            """{"version":"1.0","mappings":[]}""");
+
+        var loader = new Calor.Compiler.Effects.Manifests.ManifestLoader();
+        loader.LoadManifestsFromDirectory(
+            directory,
+            Calor.Compiler.Effects.Manifests.ManifestPriority.UserLevel);
+
+        Assert.Equal(
+            ["a.calor-effects.json", "z.calor-effects.json"],
+            loader.LoadedManifests.Select(item => Path.GetFileName(item.Source.FilePath)));
+    }
+
+    [Fact]
+    public void CanonicalInputs_HashResolvedRuntimeImplementationContent()
+    {
+        var runtimeSourceDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var runtimeAssembly = Path.Combine(runtimeSourceDirectory, "System.Runtime.dll");
+        var referenceAssembly = FindFrameworkReferenceAssembly("System.Runtime.dll");
+        Assert.True(File.Exists(runtimeAssembly));
+
+        var runtimeDirectory = Path.Combine(_tempDir, "runtime-implementations");
+        Directory.CreateDirectory(runtimeDirectory);
+        var copiedRuntimeAssembly = Path.Combine(runtimeDirectory, "System.Runtime.dll");
+        File.Copy(runtimeAssembly, copiedRuntimeAssembly);
+        var resolved = Calor.Compiler.Effects.IL.AssemblyIndex
+            .ResolveImplementationAssemblyPaths(
+                [referenceAssembly],
+                new Calor.Compiler.Effects.IL.ILAnalysisOptions
+                {
+                    RuntimeDirectory = runtimeDirectory
+                });
+        Assert.Equal(copiedRuntimeAssembly, Assert.Single(resolved));
+
+        var task = new Calor.Tasks.CompileCalor
+        {
+            ProjectDirectory = _tempDir,
+            EnableILAnalysis = true,
+            RuntimeDirectory = runtimeDirectory,
+            ReferencedAssemblies = [new TaskItem(referenceAssembly)]
+        };
+        var baseline = task.ComputeCacheInputs().Serialize();
+
+        File.AppendAllText(copiedRuntimeAssembly, "runtime-implementation-change");
+
+        Assert.NotEqual(baseline, task.ComputeCacheInputs().Serialize());
+    }
+
+    private static string FindFrameworkReferenceAssembly(string fileName)
+    {
+        var runtimeDirectory = new DirectoryInfo(
+            Path.GetDirectoryName(typeof(object).Assembly.Location)!);
+        var dotnetRoot = runtimeDirectory.Parent?.Parent?.Parent
+            ?? throw new DirectoryNotFoundException("Could not locate the dotnet root.");
+        var referencePackRoot = Path.Combine(
+            dotnetRoot.FullName, "packs", "Microsoft.NETCore.App.Ref");
+        var referenceAssembly = Directory.GetDirectories(referencePackRoot)
+            .OrderByDescending(path => path, StringComparer.Ordinal)
+            .Select(path => Path.Combine(path, "ref", "net10.0", fileName))
+            .FirstOrDefault(File.Exists);
+        return referenceAssembly
+            ?? throw new FileNotFoundException($"Could not locate framework reference {fileName}.");
+    }
+
 }

--- a/tests/Calor.Tasks.Tests/CompileCalorIntegrationTests.cs
+++ b/tests/Calor.Tasks.Tests/CompileCalorIntegrationTests.cs
@@ -1048,6 +1048,30 @@ public class CompileCalorIntegrationTests : IDisposable
     }
 
     [Fact]
+    public void ILAnalysis_UnresolvableManagedReference_FailsClosed()
+    {
+        var runtimeDirectory = new DirectoryInfo(
+            Path.GetDirectoryName(typeof(object).Assembly.Location)!);
+        var dotnetRoot = runtimeDirectory.Parent?.Parent?.Parent
+            ?? throw new DirectoryNotFoundException("Could not locate the dotnet root.");
+        var referenceAssembly = Directory.GetDirectories(Path.Combine(
+                dotnetRoot.FullName, "packs", "Microsoft.NETCore.App.Ref"))
+            .OrderByDescending(path => path, StringComparer.Ordinal)
+            .Select(path => Path.Combine(path, "ref", "net10.0", "System.Runtime.dll"))
+            .First(File.Exists);
+
+        var src = CreateSourceFile("UnresolvedIl.calr", ValidCalorSource);
+        var task = CreateTask(src);
+        task.EnableILAnalysis = true;
+        task.ReferencedAssemblies = [new TaskItem(referenceAssembly)];
+
+        Assert.False(task.Execute());
+        Assert.Contains(
+            ((TestBuildEngine)task.BuildEngine).Errors,
+            error => error.Contains("could not be resolved to implementation assemblies"));
+    }
+
+    [Fact]
     public void CrossModuleEnforcementException_FailsClosed()
     {
         var src1 = CreateSourceFile("StrictCrossA.calr", ValidCalorSource);
@@ -1067,14 +1091,6 @@ public class CompileCalorIntegrationTests : IDisposable
             error => error.Contains("fails rather than silently skipping")
                      && error.Contains("injected cross-module failure"));
     }
-
-    // #788 fail-closed note: the IL-analysis init and cross-module enforcement
-    // catch blocks in CompileCalor now FAIL the build instead of warning and
-    // continuing. Neither failure is cheaply reachable with real components
-    // (AssemblyIndex and ManifestLoader are internally defensive and skip
-    // malformed inputs), so the fail-closed branches are covered by review,
-    // not by a fixture — a garbage referenced assembly is deliberately
-    // tolerated (skipped) by design and does not trip them.
 
     [Fact]
     public void CrossModuleCall_TasksPath_EmitsQualifiedTarget()

--- a/tests/Calor.Tasks.Tests/CompileCalorIntegrationTests.cs
+++ b/tests/Calor.Tasks.Tests/CompileCalorIntegrationTests.cs
@@ -176,6 +176,7 @@ public class CompileCalorIntegrationTests : IDisposable
         var msgs = string.Join("\n", ((TestBuildEngine)task2.BuildEngine).Messages);
         Assert.Contains("Compiling", msgs);
         Assert.DoesNotContain("skipping", msgs);
+        Assert.Contains("[output-content-changed]", msgs);
 
         // And the output is restored to what the compiler actually produces.
         Assert.Equal(good, File.ReadAllText(outputPath));
@@ -315,6 +316,7 @@ public class CompileCalorIntegrationTests : IDisposable
         var engine2 = (TestBuildEngine)task2.BuildEngine;
         // Should see "global invalidation" log and compilation, not skip
         Assert.Contains(engine2.Messages, m => m.Contains("global invalidation"));
+        Assert.Contains(engine2.Messages, m => m.Contains("[compiler-changed]"));
     }
 
     // Test 24: Nested outputs: A/foo.calr + B/foo.calr → separate .g.cs, both compiled
@@ -378,19 +380,25 @@ public class CompileCalorIntegrationTests : IDisposable
     [Fact]
     public void ConcurrentBuild_BothCompleteWithoutException()
     {
-        var src1 = CreateSourceFile("Concurrent1.calr", ValidCalorSource);
-        var src2 = CreateSourceFile("Concurrent2.calr", ValidCalorSource.Replace("TestModule", "Mod2")
-            .Replace("m001", "m005").Replace("f001", "f005"));
+        var src = CreateSourceFile("Concurrent.calr", ValidCalorSource);
+        using var barrier = new Barrier(2);
 
         Exception? exception1 = null;
         Exception? exception2 = null;
+        bool? result1 = null;
+        bool? result2 = null;
 
         var thread1 = new Thread(() =>
         {
             try
             {
-                var task = CreateTask(src1);
-                task.Execute();
+                var task = CreateTask(src);
+                task.CacheTestHook = (_, phase) =>
+                {
+                    if (phase == CompileCalorTestPhase.AfterSourceRead)
+                        barrier.SignalAndWait(TimeSpan.FromSeconds(10));
+                };
+                result1 = task.Execute();
             }
             catch (Exception ex) { exception1 = ex; }
         });
@@ -399,8 +407,13 @@ public class CompileCalorIntegrationTests : IDisposable
         {
             try
             {
-                var task = CreateTask(src2);
-                task.Execute();
+                var task = CreateTask(src);
+                task.CacheTestHook = (_, phase) =>
+                {
+                    if (phase == CompileCalorTestPhase.AfterSourceRead)
+                        barrier.SignalAndWait(TimeSpan.FromSeconds(10));
+                };
+                result2 = task.Execute();
             }
             catch (Exception ex) { exception2 = ex; }
         });
@@ -412,6 +425,8 @@ public class CompileCalorIntegrationTests : IDisposable
 
         Assert.Null(exception1);
         Assert.Null(exception2);
+        Assert.True(result1);
+        Assert.True(result2);
 
         // Cache file should be valid JSON
         var cachePath = BuildStateCache.GetCachePath(_outputDir);
@@ -419,6 +434,10 @@ public class CompileCalorIntegrationTests : IDisposable
         var json = File.ReadAllText(cachePath);
         var state = System.Text.Json.JsonSerializer.Deserialize(json, BuildStateJsonContext.Default.BuildState);
         Assert.NotNull(state);
+
+        var warm = CreateTask(src);
+        Assert.True(warm.Execute());
+        Assert.Contains(((TestBuildEngine)warm.BuildEngine).Messages, m => m.Contains("skipping"));
     }
 
     // Cross-module effect enforcement — caller is missing a declared effect the callee requires.
@@ -601,11 +620,12 @@ public class CompileCalorIntegrationTests : IDisposable
         var engine = (TestBuildEngine)task.BuildEngine;
         // Global invalidation should kick in because format version doesn't match.
         Assert.Contains(engine.Messages, m => m.Contains("global invalidation"));
+        Assert.Contains(engine.Messages, m => m.Contains("[schema-version-changed]"));
 
-        // After this build, the cache should be v2.0 and the file should have a summary.
+        // After this build, the cache should use the current schema and have a summary.
         var loaded = BuildStateCache.Load(_outputDir);
         Assert.NotNull(loaded);
-        Assert.Equal("2.1", loaded.FormatVersion);
+        Assert.Equal(BuildStateCache.CurrentFormatVersion, loaded.FormatVersion);
         var entry = Assert.Single(loaded.Files).Value;
         Assert.NotNull(entry.EffectSummary);
         Assert.Equal("TestModule", entry.EffectSummary!.ModuleName);
@@ -613,9 +633,7 @@ public class CompileCalorIntegrationTests : IDisposable
 
     // Phase 0a — verifies the ExperimentalFlags MSBuild property plumbs into the
     // CompileCalor task and compiles cleanly. Per-diagnostic verification (pilot
-    // info diagnostic emitted) lives in Calor.Compiler.Tests.ExperimentalFlagPilotTests;
-    // the task currently drops info diagnostics on successful compile (pre-existing
-    // behavior, out of scope for Phase 0a).
+    // info diagnostic emitted) lives in Calor.Compiler.Tests.ExperimentalFlagPilotTests.
     [Fact]
     public void ExperimentalFlags_PilotFlag_CompilesCleanly()
     {
@@ -689,7 +707,9 @@ public class CompileCalorIntegrationTests : IDisposable
     // every skip — a cached output was produced under a different option set and
     // its (absent) diagnostics would be silently stale.
     [Theory]
+    [InlineData("verbose")]
     [InlineData("enforceEffects")]
+    [InlineData("typeCheck")]
     [InlineData("verify")]
     [InlineData("ilAnalysis")]
     [InlineData("experimental")]
@@ -706,17 +726,29 @@ public class CompileCalorIntegrationTests : IDisposable
 
         // Third build with one option flipped: nothing may skip.
         var flipped = CreateTask(src);
+        var compiled = false;
+        flipped.CacheTestHook = (_, phase) =>
+        {
+            if (phase == CompileCalorTestPhase.AfterSourceRead)
+                compiled = true;
+        };
         switch (option)
         {
+            case "verbose": flipped.Verbose = false; break;
             case "enforceEffects": flipped.EnforceEffects = false; break;
+            case "typeCheck": flipped.TypeCheck = false; break;
             case "verify": flipped.Verify = true; break;
             case "ilAnalysis": flipped.EnableILAnalysis = true; break;
             case "experimental": flipped.ExperimentalFlags = "pilot-hello-world"; break;
         }
         Assert.True(flipped.Execute());
+        Assert.True(compiled);
         var msgs = string.Join("\n", ((TestBuildEngine)flipped.BuildEngine).Messages);
         Assert.DoesNotContain("skipping", msgs);
-        Assert.Contains("Compiling", msgs);
+        if (option != "verbose")
+            Assert.Contains("Compiling", msgs);
+        var cache = BuildStateCache.Load(_outputDir);
+        Assert.NotNull(cache);
     }
 
     [Fact]
@@ -735,6 +767,260 @@ public class CompileCalorIntegrationTests : IDisposable
         Assert.True(task2.Execute());
         Assert.Contains(((TestBuildEngine)task2.BuildEngine).Messages,
             m => m.Contains("skipping"));
+    }
+
+    [Theory]
+    [InlineData("referencedAssembly")]
+    [InlineData("runtimeDirectory")]
+    [InlineData("nuGetPackageRoot")]
+    [InlineData("depsFile")]
+    public void CanonicalInputs_MutatingAnalysisInput_InvalidatesWarmCache(string input)
+    {
+        var src = CreateSourceFile("AnalysisInput.calr", ValidCalorSource);
+        Assert.True(CreateTask(src).Execute());
+        var warm = CreateTask(src);
+        Assert.True(warm.Execute());
+        Assert.Contains(((TestBuildEngine)warm.BuildEngine).Messages, m => m.Contains("skipping"));
+
+        var changed = CreateTask(src);
+        switch (input)
+        {
+            case "referencedAssembly":
+                var reference = CreateSourceFile("inputs/FakeReference.dll", "fake-reference");
+                changed.ReferencedAssemblies = [new TaskItem(reference)];
+                break;
+            case "runtimeDirectory":
+                var runtime = Path.Combine(_tempDir, "runtime");
+                Directory.CreateDirectory(runtime);
+                changed.RuntimeDirectory = runtime;
+                break;
+            case "nuGetPackageRoot":
+                var packages = Path.Combine(_tempDir, "packages");
+                Directory.CreateDirectory(packages);
+                changed.NuGetPackageRoot = packages;
+                break;
+            case "depsFile":
+                changed.DepsFilePath = CreateSourceFile(
+                    "inputs/project.deps.json", """{"runtimeTarget":{"name":"test"}}""");
+                break;
+        }
+
+        Assert.True(changed.Execute());
+        var messages = string.Join("\n", ((TestBuildEngine)changed.BuildEngine).Messages);
+        Assert.Contains("[options-or-inputs-changed]", messages);
+        Assert.DoesNotContain("skipping", messages);
+    }
+
+    [Fact]
+    public void CanonicalInputs_ReferencedAssemblyContentMutation_InvalidatesWarmCache()
+    {
+        var src = CreateSourceFile("ReferenceContent.calr", ValidCalorSource);
+        var reference = CreateSourceFile("inputs/MutableReference.dll", "reference-v1");
+
+        CompileCalor Task()
+        {
+            var task = CreateTask(src);
+            task.ReferencedAssemblies = [new TaskItem(reference)];
+            return task;
+        }
+
+        Assert.True(Task().Execute());
+        var warm = Task();
+        Assert.True(warm.Execute());
+        Assert.Contains(((TestBuildEngine)warm.BuildEngine).Messages, m => m.Contains("skipping"));
+
+        File.WriteAllText(reference, "reference-v2");
+        var changed = Task();
+        Assert.True(changed.Execute());
+        Assert.Contains(((TestBuildEngine)changed.BuildEngine).Messages,
+            m => m.Contains("[options-or-inputs-changed]"));
+    }
+
+    [Fact]
+    public void CanonicalInputs_DepsFileContentMutation_InvalidatesWarmCache()
+    {
+        var src = CreateSourceFile("DepsContent.calr", ValidCalorSource);
+        var deps = CreateSourceFile(
+            "inputs/mutable.deps.json", """{"runtimeTarget":{"name":"v1"}}""");
+
+        CompileCalor Task()
+        {
+            var task = CreateTask(src);
+            task.DepsFilePath = deps;
+            return task;
+        }
+
+        Assert.True(Task().Execute());
+        var warm = Task();
+        Assert.True(warm.Execute());
+        Assert.Contains(((TestBuildEngine)warm.BuildEngine).Messages, m => m.Contains("skipping"));
+
+        File.WriteAllText(deps, """{"runtimeTarget":{"name":"v2"}}""");
+        var changed = Task();
+        Assert.True(changed.Execute());
+        Assert.Contains(((TestBuildEngine)changed.BuildEngine).Messages,
+            m => m.Contains("[options-or-inputs-changed]"));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void SourceEditRace_CacheHashesExactCompiledBytes_AndNextBuildRecompiles(
+        int editPhaseValue)
+    {
+        var editPhase = (CompileCalorTestPhase)editPhaseValue;
+        var original = ValidCalorSource;
+        var edited = ValidCalorSource.Replace("(+ a b)", "(- a b)");
+        var src = CreateSourceFile("Race.calr", original);
+        var task = CreateTask(src);
+        var editedOnce = false;
+        task.CacheTestHook = (_, phase) =>
+        {
+            if (!editedOnce && phase == editPhase)
+            {
+                editedOnce = true;
+                File.WriteAllText(src, edited);
+            }
+        };
+
+        Assert.True(task.Execute());
+        var firstOutput = File.ReadAllText(task.GeneratedFiles.Single().ItemSpec);
+        Assert.Contains("a + b", firstOutput);
+        var racedState = BuildStateCache.Load(_outputDir);
+        Assert.NotNull(racedState);
+        var racedEntry = Assert.Single(racedState.Files).Value;
+        Assert.Equal(
+            BuildStateCache.ComputeContentHash(System.Text.Encoding.UTF8.GetBytes(original)),
+            racedEntry.ContentHash);
+        Assert.NotEqual(BuildStateCache.ComputeFileHash(src), racedEntry.ContentHash);
+
+        var next = CreateTask(src);
+        Assert.True(next.Execute());
+        var messages = string.Join("\n", ((TestBuildEngine)next.BuildEngine).Messages);
+        Assert.Contains("[source-content-changed]", messages);
+        Assert.DoesNotContain("skipping", messages);
+        Assert.Contains("a - b", File.ReadAllText(next.GeneratedFiles.Single().ItemSpec));
+    }
+
+    [Theory]
+    [InlineData("not json")]
+    [InlineData("{}")]
+    public void CorruptOrPartialCache_IsPurged_ColdBuildLogsReason(string cacheContents)
+    {
+        var src = CreateSourceFile("CorruptCache.calr", ValidCalorSource);
+        File.WriteAllText(BuildStateCache.GetCachePath(_outputDir), cacheContents);
+
+        var task = CreateTask(src);
+        Assert.True(task.Execute());
+        var messages = string.Join("\n", ((TestBuildEngine)task.BuildEngine).Messages);
+        Assert.Contains("[corrupt-or-partial-cache]", messages);
+
+        var loaded = BuildStateCache.LoadWithStatus(_outputDir);
+        Assert.Equal(CacheLoadStatus.Loaded, loaded.Status);
+        Assert.NotNull(loaded.State);
+    }
+
+    [Fact]
+    public void StructurallyInvalidCachedDiagnostics_AreNotTrusted()
+    {
+        var src = CreateSourceFile("InvalidDiagnostics.calr", ValidCalorSource);
+        Assert.True(CreateTask(src).Execute());
+        var state = BuildStateCache.Load(_outputDir);
+        Assert.NotNull(state);
+        var entry = Assert.Single(state.Files).Value;
+        entry.Diagnostics =
+        [
+            new Calor.Compiler.Incremental.CachedDiagnostic
+            {
+                Code = "Calor9999",
+                Severity = "error",
+                Message = "must not be replayed as a trusted successful compile"
+            }
+        ];
+        BuildStateCache.Save(state, _outputDir);
+
+        var task = CreateTask(src);
+        Assert.True(task.Execute());
+        var engine = (TestBuildEngine)task.BuildEngine;
+        Assert.Contains(engine.Messages, message => message.Contains("[cache-validation-failed]"));
+        Assert.DoesNotContain(engine.Errors,
+            error => error.Contains("must not be replayed as a trusted successful compile"));
+    }
+
+    [Fact]
+    public void WarningInfoDiagnostics_WarmAndColdOutputsAndDiagnosticsAreIdentical()
+    {
+        var src = CreateSourceFile("Diagnostics.calr", ValidCalorSource);
+
+        CompileCalor Task()
+        {
+            var task = CreateTask(src);
+            task.ExperimentalFlags = "pilot-hello-world";
+            return task;
+        }
+
+        var cold = Task();
+        Assert.True(cold.Execute());
+        var coldBytes = File.ReadAllBytes(cold.GeneratedFiles.Single().ItemSpec);
+        var coldDiagnostics = ((TestBuildEngine)cold.BuildEngine).Messages
+            .Where(message => message.Contains("pilot-hello-world"))
+            .ToList();
+        Assert.NotEmpty(coldDiagnostics);
+
+        var warm = Task();
+        Assert.True(warm.Execute());
+        var warmBytes = File.ReadAllBytes(warm.GeneratedFiles.Single().ItemSpec);
+        var warmEngine = (TestBuildEngine)warm.BuildEngine;
+        var warmDiagnostics = warmEngine.Messages
+            .Where(message => message.Contains("pilot-hello-world"))
+            .ToList();
+
+        Assert.Equal(coldBytes, warmBytes);
+        Assert.Equal(coldDiagnostics, warmDiagnostics);
+        Assert.Contains(warmEngine.Messages, message => message.Contains("skipping"));
+    }
+
+    [Fact]
+    public void ILAnalysisInitializationException_FailsClosed()
+    {
+        var src = CreateSourceFile("StrictIl.calr", ValidCalorSource);
+        var task = CreateTask(src);
+        task.EnableILAnalysis = true;
+        task.ReferencedAssemblies =
+        [
+            new TaskItem(typeof(object).Assembly.Location)
+        ];
+        task.CacheTestHook = (_, phase) =>
+        {
+            if (phase == CompileCalorTestPhase.BeforeILAnalysisInitialization)
+                throw new InvalidOperationException("injected IL initialization failure");
+        };
+
+        Assert.False(task.Execute());
+        Assert.Contains(((TestBuildEngine)task.BuildEngine).Errors,
+            error => error.Contains("fails rather than silently skipping")
+                     && error.Contains("injected IL initialization failure"));
+    }
+
+    [Fact]
+    public void CrossModuleEnforcementException_FailsClosed()
+    {
+        var src1 = CreateSourceFile("StrictCrossA.calr", ValidCalorSource);
+        var src2 = CreateSourceFile(
+            "StrictCrossB.calr",
+            ValidCalorSource.Replace("TestModule", "OtherModule")
+                .Replace("m001", "m002").Replace("f001", "f002"));
+        var task = CreateTask(src1, src2);
+        task.CacheTestHook = (_, phase) =>
+        {
+            if (phase == CompileCalorTestPhase.BeforeCrossModuleEnforcement)
+                throw new InvalidOperationException("injected cross-module failure");
+        };
+
+        Assert.False(task.Execute());
+        Assert.Contains(((TestBuildEngine)task.BuildEngine).Errors,
+            error => error.Contains("fails rather than silently skipping")
+                     && error.Contains("injected cross-module failure"));
     }
 
     // #788 fail-closed note: the IL-analysis init and cross-module enforcement

--- a/tests/Calor.Tasks.Tests/CompileCalorIntegrationTests.cs
+++ b/tests/Calor.Tasks.Tests/CompileCalorIntegrationTests.cs
@@ -777,17 +777,30 @@ public class CompileCalorIntegrationTests : IDisposable
     public void CanonicalInputs_MutatingAnalysisInput_InvalidatesWarmCache(string input)
     {
         var src = CreateSourceFile("AnalysisInput.calr", ValidCalorSource);
-        Assert.True(CreateTask(src).Execute());
-        var warm = CreateTask(src);
+        CompileCalor BaseTask()
+        {
+            var task = CreateTask(src);
+            task.EnableILAnalysis = true;
+            task.ReferencedAssemblies =
+            [
+                new TaskItem(typeof(object).Assembly.Location)
+            ];
+            return task;
+        }
+
+        Assert.True(BaseTask().Execute());
+        var warm = BaseTask();
         Assert.True(warm.Execute());
         Assert.Contains(((TestBuildEngine)warm.BuildEngine).Messages, m => m.Contains("skipping"));
 
-        var changed = CreateTask(src);
+        var changed = BaseTask();
         switch (input)
         {
             case "referencedAssembly":
-                var reference = CreateSourceFile("inputs/FakeReference.dll", "fake-reference");
-                changed.ReferencedAssemblies = [new TaskItem(reference)];
+                changed.ReferencedAssemblies =
+                [
+                    new TaskItem(typeof(CompileCalor).Assembly.Location)
+                ];
                 break;
             case "runtimeDirectory":
                 var runtime = Path.Combine(_tempDir, "runtime");
@@ -812,14 +825,44 @@ public class CompileCalorIntegrationTests : IDisposable
     }
 
     [Fact]
+    public void GlobalInvalidation_RemovesOutputsForDeletedSources()
+    {
+        var kept = CreateSourceFile("Kept.calr", ValidCalorSource);
+        var removed = CreateSourceFile(
+            "Removed.calr",
+            ValidCalorSource.Replace("TestModule", "RemovedModule")
+                .Replace("m001", "m002")
+                .Replace("f001", "f002"));
+
+        var cold = CreateTask(kept, removed);
+        Assert.True(cold.Execute());
+        var removedOutput = cold.GeneratedFiles.Single(item =>
+            item.ItemSpec.EndsWith("Removed.g.cs", StringComparison.Ordinal)).ItemSpec;
+        Assert.True(File.Exists(removedOutput));
+
+        File.Delete(removed);
+        var invalidated = CreateTask(kept);
+        invalidated.ExperimentalFlags = "pilot-hello-world";
+        Assert.True(invalidated.Execute());
+
+        Assert.False(File.Exists(removedOutput));
+        Assert.Contains(
+            ((TestBuildEngine)invalidated.BuildEngine).Messages,
+            message => message.Contains("removed orphan output"));
+    }
+
+    [Fact]
     public void CanonicalInputs_ReferencedAssemblyContentMutation_InvalidatesWarmCache()
     {
         var src = CreateSourceFile("ReferenceContent.calr", ValidCalorSource);
-        var reference = CreateSourceFile("inputs/MutableReference.dll", "reference-v1");
+        var reference = Path.Combine(_tempDir, "inputs", "MutableReference.dll");
+        Directory.CreateDirectory(Path.GetDirectoryName(reference)!);
+        File.Copy(typeof(object).Assembly.Location, reference);
 
         CompileCalor Task()
         {
             var task = CreateTask(src);
+            task.EnableILAnalysis = true;
             task.ReferencedAssemblies = [new TaskItem(reference)];
             return task;
         }
@@ -829,7 +872,7 @@ public class CompileCalorIntegrationTests : IDisposable
         Assert.True(warm.Execute());
         Assert.Contains(((TestBuildEngine)warm.BuildEngine).Messages, m => m.Contains("skipping"));
 
-        File.WriteAllText(reference, "reference-v2");
+        File.AppendAllText(reference, "reference-v2");
         var changed = Task();
         Assert.True(changed.Execute());
         Assert.Contains(((TestBuildEngine)changed.BuildEngine).Messages,
@@ -846,6 +889,8 @@ public class CompileCalorIntegrationTests : IDisposable
         CompileCalor Task()
         {
             var task = CreateTask(src);
+            task.EnableILAnalysis = true;
+            task.ReferencedAssemblies = [new TaskItem(typeof(object).Assembly.Location)];
             task.DepsFilePath = deps;
             return task;
         }

--- a/tests/Calor.Tasks.Tests/GlobalUsings.cs
+++ b/tests/Calor.Tasks.Tests/GlobalUsings.cs
@@ -4,8 +4,9 @@ global using BuildState = Calor.Compiler.Incremental.BuildState;
 global using BuildFileEntry = Calor.Compiler.Incremental.BuildFileEntry;
 global using BuildStateCache = Calor.Compiler.Incremental.BuildStateCache;
 global using BuildStateJsonContext = Calor.Compiler.Incremental.BuildStateJsonContext;
+global using CacheLoadStatus = Calor.Compiler.Incremental.CacheLoadStatus;
 
-// Calor.Tasks.Tests manipulates CALOR_NO_TYPE_CHECK to pin the MSBuild task's options token
+// Calor.Tasks.Tests manipulates CALOR_NO_TYPE_CHECK to pin the MSBuild task's canonical inputs
 // against the environment escape hatch. Environment variables are process-wide, so in-assembly
 // parallelism has to be off for that to be sound. It costs nothing here (under a
 // second for 66 tests) and cannot affect other test projects, which run in their own testhost processes.


### PR DESCRIPTION
## Summary
- fingerprint the resolved compiler/runtime closure and all diagnostics-affecting MSBuild inputs with an explicit versioned format
- cache the exact source bytes used for compilation, verify generated output bytes, replay diagnostics, and report deterministic miss reasons
- harden schema migration, corrupt-cache recovery, atomic concurrent persistence, and fail-closed cache-save behavior
- add deterministic race hooks and regression coverage for option/input mutation, output tampering, concurrent builds, and warm/cold equivalence

## Validation
- `dotnet test tests/Calor.Tasks.Tests/Calor.Tasks.Tests.csproj --no-restore`
- `dotnet build --no-restore`

Closes #788