### PR TITLE
v0.13: freeze registrations F-1..F-4 — gate denominators frozen before work

### DIFF
--- a/docs/plans/v0.13-freeze-registrations.md
+++ b/docs/plans/v0.13-freeze-registrations.md
@@ -1,0 +1,127 @@
+# v0.13 freeze registrations (F-1 … F-4)
+
+**Date:** 2026-08-10
+**Status:** Registered — frozen at the merge commit of this document
+**Owning plan:** `roadmap-v0.13-v0.15.md` (§2.1, §2.5). That plan requires every release gate to
+name its instrument, denominator, and freeze point, and requires these four registrations to land
+**before** the work they gate merges. The freeze event for each registration below is the merge
+commit of this document; the ordering is checkable from git history (ordering control, per the
+A-1.5 lesson: an ordering control cannot be defeated by arithmetic).
+
+**Amendment rules (apply to all four):**
+- **Additive amendments** (new corpus files, new edit scripts, residual→registered promotions) are
+  allowed by PR at any time — additions can only make the gates harder.
+- **Subtractive or weakening amendments** (removing corpus files, registered→residual demotions,
+  loosening generator bounds) require an explicit supersession entry in this file stating what was
+  weakened and why, and may not merge in the same PR as work that benefits from the weakening.
+
+---
+
+## F-1 — Binding-totality construct-class list (denominator of roadmap §2.5 gate 1)
+
+#762's definition-of-done is universal (100% of accepted expression kinds); this registration is
+the gate-precision sharpening the roadmap requires. The compiler has exactly **61 concrete
+`ExpressionNode` subclasses** (all direct; verified by grep over `src/Calor.Compiler/Ast/*.cs` at
+registration time). Every one is assigned to exactly one tier — the assignment is exhaustive, so a
+new node class added later without a tier assignment fails the completeness check by construction.
+
+### Tier A — registered (55 classes; the gate prohibits silent `<unsupported:...>` fallback)
+
+Grouped by #762 "Required implementation" item 1's families, plus the core set:
+
+| Family (#762 item 1) | Classes |
+|---|---|
+| conversion | TypeOperationNode |
+| type/pattern tests | IsPatternNode, TypeOfExpressionNode |
+| arrays/indexes | ArrayAccessNode, ArrayCreationNode, ArrayLengthNode, MultiDimArrayAccessNode, MultiDimArrayCreationNode, IndexFromEndNode, RangeExpressionNode |
+| collections | ListCreationNode, SetCreationNode, DictionaryCreationNode, CollectionContainsNode, CollectionCountNode, TupleLiteralNode |
+| lambdas | LambdaExpressionNode |
+| await | AwaitExpressionNode |
+| coalesce | NullCoalesceNode, NullConditionalNode |
+| match | MatchExpressionNode |
+| quantifiers | ForallExpressionNode, ExistsExpressionNode, ImplicationExpressionNode |
+| string operations | StringOperationNode, InterpolatedStringNode, StringBuilderOperationNode, CharOperationNode |
+| interop | RawCSharpExpressionNode, FallbackExpressionNode |
+| core (already-binding set, registered for regression protection) | IntLiteralNode, FloatLiteralNode, DecimalLiteralNode, BoolLiteralNode, StringLiteralNode, BinaryOperationNode, UnaryOperationNode, CallExpressionNode, ExpressionCallNode, ReferenceNode, FieldAccessNode, ConditionalExpressionNode, NewExpressionNode, AnonymousObjectCreationNode, RecordCreationNode, WithExpressionNode, ThisExpressionNode, BaseExpressionNode, SelfRefNode, ThrowExpressionNode, NameOfExpressionNode, OkExpressionNode, ErrExpressionNode, SomeExpressionNode, NoneExpressionNode |
+
+For interop classes, "structurally bind" means: explicit stable type + verbatim content retained +
+an explicit interop marker — never a zero-child erasure. (#762 item 3.)
+
+### Tier B — residual (6 classes; incomplete-fraction published per release, reported-not-adjudicated)
+
+| Class | Reason it is residual |
+|---|---|
+| AddressOfNode, PointerDereferenceNode, StackAllocNode, SizeOfNode | Unsafe/pointer family — flows through `§UNSAFE` interop; a binding-analysis story for raw pointers is out of 0.13 scope |
+| GenericTypeNode, KeywordArgNode | Helper/value-object candidates under #762 item 8 (reclassify so they are not expression nodes, or bind them) — the item-8 decision moves each to Tier A or out of the denominator entirely; until then they are residual, not silently absent |
+
+**Gate restated with this denominator:** on the F-2 corpus, zero `<unsupported:...>` fallbacks for
+Tier A classes; Tier B incidence is published per release. Tier A→B moves are subtractive (see
+amendment rules).
+
+## F-2 — Binding-totality measurement corpus (corpus of roadmap §2.5 gate 1)
+
+Two legs, both required:
+
+1. **In-repo leg:** every git-tracked `.calr` file under `samples/`, `tests/`, `benchmarks/`, and
+   `src/Calor.Compiler/Resources/SelfTest/` at the gate-evaluation commit. Gitignored epoch
+   fixtures are excluded (untracked by definition). Files may be added freely; removing a file from
+   these trees is a subtractive amendment.
+2. **Conversion leg:** the `.calr` output of `calor import` over the three A-1.5.3-pinned
+   conversion subjects at their frozen commits — **MediatR `fb309026`, Serilog `0597ddfb`,
+   FluentValidation `71b3c60c`** (`agent-native-gates.md` A-1.5.3; synthetic subjects excluded
+   there, excluded here). This leg exercises exactly the C#-shaped expression forms the in-repo
+   leg under-represents.
+
+Instrument: a CI job that compiles both legs and greps the bound trees for `<unsupported:` — with a
+**discriminating pin**: a fixture containing a known Tier A construct temporarily reverted to the
+fallback path must turn the job red (revert-the-fix test, per `pins-must-discriminate`).
+
+## F-3 — Edit-script corpus (denominator of roadmap §2.5 gate 2, full-vs-incremental identity)
+
+**Location:** `tests/TestData/EditScripts/` (committed with the identity-gate harness).
+**Schema:** each script is a directory with `steps.jsonl` (ordered file edits: path, old, new) and
+`expect.md` (the identity invariant it pins). Registered members — scripts are immutable once
+landed; supersede-with-disclosure only:
+
+| Script | Edit | Invariant pinned |
+|---|---|---|
+| ES-01 | Timestamp-only touch, no content change | Full and incremental outputs byte-identical; incremental does no re-analysis (incrementality witness leg) |
+| ES-02 | Whitespace/comment-only edit | Identical diagnostics, index contents, review packet |
+| ES-03 | Body edit in one function | Diagnostics/index/packet deltas confined to affected declarations; unaffected index entries byte-identical |
+| ES-04 | **#883 reproduction**: change an IL-analysis input (referenced assembly / runtime directory / deps file) with **no source edit** | Incremental re-analysis fires; incremental ≡ full afterward. This script must FAIL on the pre-#883-fix compiler (discriminating pin) |
+| ES-05 | Contract edit (`§S` change) | Proof invalidation propagates through the semantics-versioned cache keys (#778); stale `Proven` never survives |
+| ES-06 | SymbolId-addressed rename, including a shadowing case | Gate 4's apply-recompile-and-test behavior oracle; shared corpus with the rename gate |
+
+## F-4 — Differential-generator registration (roadmap §2.5 gate 5 / #779 program)
+
+- **Denominator:** the modeled-forms whitelist `docs/verification-modeled-forms.md`, pinned at
+  content hash `ce25c3f9f61cf094e6686727eaf4796c7b6af7958da65d6e7424ae1a74506572` (sha256,
+  registration time). Editing that file re-pins by an additive amendment entry here naming the new
+  hash — the denominator never tracks the file silently.
+- **Generator (parameters frozen now, before any suite code merges):** every whitelisted form ×
+  contract positions {`§S` postcondition, `§PROOF` obligation} (the two elision legs) plus `§Q`
+  precondition (diagnostic leg — preconditions never elide by design) × nesting depth ≤ 3 ×
+  both polarity variants (a provable instance and a refutable instance per form).
+- **Oracle:** solver verdict vs runtime execution of the generated C# with guards forced on. A
+  mismatch is any case where the solver reports `Proven` (contracts) or `Discharged` (obligations)
+  and the runtime guard fires, or the inverse.
+- **Explicitly in scope:** the D15 emitter-lowering class (mismatches originating in emitter
+  lowering, not solver ops — the class the demotion mechanism is structurally blind to), and the
+  **`§PROOF` obligation-elision path** (`ObligationStatus.Discharged`, `CSharpEmitter.cs` ~5709 —
+  a third elide route outside the contract-guard path).
+- **Published metric:** elision-coverage fraction = forms eliding ÷ forms whitelisted, per release,
+  so demotion-shrinkage is visible rather than silent.
+- **Bar:** zero mismatches is the **0.14 elision-re-enable bar** (roadmap §3.5 gate 6). In 0.13
+  elision is opt-in and this program's gate is existence + CI integration + published coverage
+  (roadmap §2.5 gate 5).
+
+---
+
+## Registration inventory
+
+| ID | Freezes | Gates |
+|---|---|---|
+| F-1 | 61-class tier assignment (55 registered / 6 residual) | §2.5 gate 1 denominator |
+| F-2 | Two-leg corpus + discriminating pin | §2.5 gate 1 corpus |
+| F-3 | Edit-script location, schema, 6 members | §2.5 gates 2 and 4 |
+| F-4 | Modeled-forms hash + generator parameters + oracle + scope | §2.5 gate 5, §3.5 gate 6 |

--- a/docs/plans/v0.13-freeze-registrations.md
+++ b/docs/plans/v0.13-freeze-registrations.md
@@ -4,9 +4,10 @@
 **Status:** Registered — frozen at the merge commit of this document
 **Owning plan:** `roadmap-v0.13-v0.15.md` (§2.1, §2.5). That plan requires every release gate to
 name its instrument, denominator, and freeze point, and requires these four registrations to land
-**before** the work they gate merges. The freeze event for each registration below is the merge
-commit of this document; the ordering is checkable from git history (ordering control, per the
-A-1.5 lesson: an ordering control cannot be defeated by arithmetic).
+**before** the work they gate merges. The freeze event for each registration below is **the commit
+that lands this document on main** (squash merges produce no merge commit; the linear-history
+ordering is what carries the control — checkable from git history, per the A-1.5 lesson: an
+ordering control cannot be defeated by arithmetic).
 
 **Amendment rules (apply to all four):**
 - **Additive amendments** (new corpus files, new edit scripts, residual→registered promotions) are
@@ -14,6 +15,12 @@ A-1.5 lesson: an ordering control cannot be defeated by arithmetic).
 - **Subtractive or weakening amendments** (removing corpus files, registered→residual demotions,
   loosening generator bounds) require an explicit supersession entry in this file stating what was
   weakened and why, and may not merge in the same PR as work that benefits from the weakening.
+- **The completeness check is bidirectional.** The 61-name list below is frozen by name, not by
+  "whatever subclasses `ExpressionNode` at check time": a class that is re-parented out of the
+  hierarchy, deleted, or reclassified as a helper/value object (#762 item 8) without a supersession
+  entry here is a red CI failure — the item-8 maneuver applied to **any** listed class (not just
+  the two Tier B candidates) is a subtractive amendment. Otherwise a code-only PR could shrink the
+  frozen denominator without ever touching this file.
 
 ---
 
@@ -25,9 +32,18 @@ the gate-precision sharpening the roadmap requires. The compiler has exactly **6
 registration time). Every one is assigned to exactly one tier — the assignment is exhaustive, so a
 new node class added later without a tier assignment fails the completeness check by construction.
 
-### Tier A — registered (55 classes; the gate prohibits silent `<unsupported:...>` fallback)
+### Tier A — registered (55 classes: 53 live, 2 dormant; the gate prohibits silent `<unsupported:...>` fallback)
 
-Grouped by #762 "Required implementation" item 1's families, plus the core set:
+Grouped by #762 "Required implementation" item 1's families, plus the core set. **Registered does
+not mean already-binding**: of the core row's 25 classes, 9 do not bind today
+(`ExpressionCallNode`, `AnonymousObjectCreationNode`, `RecordCreationNode`, `WithExpressionNode`,
+`SelfRefNode`, `ThrowExpressionNode`, `OkExpressionNode`, `ErrExpressionNode`,
+`SomeExpressionNode` — zero occurrences in `Binder.cs`, all hit the fallback; note `Ok`/`Err`/
+`Some` back `Result`/`Option`, which are mainstream) — closing them **is** the #762 work the gate
+measures. **Dormant (2)**: `FallbackExpressionNode` is constructed nowhere since W1 Slice 3
+(`fa0b5347`/#836) and `SelfRefNode` cannot reach a binder-visible position (the parser rejects `#`
+outside refinement predicates), so their registrations are vacuously green today; if a
+construction path returns, each promotes to live **with a corpus obligation** in the same PR.
 
 | Family (#762 item 1) | Classes |
 |---|---|
@@ -63,14 +79,18 @@ amendment rules).
 Two legs, both required:
 
 1. **In-repo leg:** every git-tracked `.calr` file under `samples/`, `tests/`, `benchmarks/`, and
-   `src/Calor.Compiler/Resources/SelfTest/` at the gate-evaluation commit. Gitignored epoch
-   fixtures are excluded (untracked by definition). Files may be added freely; removing a file from
-   these trees is a subtractive amendment.
-2. **Conversion leg:** the `.calr` output of `calor import` over the three A-1.5.3-pinned
-   conversion subjects at their frozen commits — **MediatR `fb309026`, Serilog `0597ddfb`,
-   FluentValidation `71b3c60c`** (`agent-native-gates.md` A-1.5.3; synthetic subjects excluded
-   there, excluded here). This leg exercises exactly the C#-shaped expression forms the in-repo
-   leg under-represents.
+   `src/Calor.Compiler/Resources/SelfTest/` at the gate-evaluation commit (452 files at
+   registration). **Deliberately excluded**: `bench/**` (contains intentionally-broken and
+   generated fixtures, incl. `bench/mcp/tasks/*` invalid-by-design files and the 10k-latency
+   fixture) and `scripts/**` — exclusion stated here so it is a decision, not an omission. A
+   corpus file that fails to parse is a **gate failure, not a skip** (a file with no bound tree
+   would otherwise pass vacuously).
+2. **Conversion leg:** the `.calr` output of **`calor migrate --direction cs-to-calor`** over the
+   three A-1.5.3-pinned conversion subjects at their frozen commits — **MediatR `fb309026`,
+   Serilog `0597ddfb`, FluentValidation `71b3c60c`** (`agent-native-gates.md` A-1.5.3; synthetic
+   subjects excluded there, excluded here). (Not `calor import`, which consumes IL and emits
+   effect manifests, never `.calr`.) This leg exercises exactly the C#-shaped expression forms
+   the in-repo leg under-represents.
 
 Instrument: a CI job that compiles both legs and greps the bound trees for `<unsupported:` — with a
 **discriminating pin**: a fixture containing a known Tier A construct temporarily reverted to the
@@ -79,8 +99,10 @@ fallback path must turn the job red (revert-the-fix test, per `pins-must-discrim
 ## F-3 — Edit-script corpus (denominator of roadmap §2.5 gate 2, full-vs-incremental identity)
 
 **Location:** `tests/TestData/EditScripts/` (committed with the identity-gate harness).
-**Schema:** each script is a directory with `steps.jsonl` (ordered file edits: path, old, new) and
-`expect.md` (the identity invariant it pins). Registered members — scripts are immutable once
+**Schema:** each script is a directory with `steps.jsonl` (ordered steps, each with a `kind`:
+`touch` (timestamp-only, no old/new), `edit` (path, old, new), or `set-property` (an MSBuild
+property routed through a csproj/deps-file text edit — how ES-04 expresses `RuntimeDirectory`-class
+inputs)) and `expect.md` (the identity invariant it pins). Registered members — scripts are immutable once
 landed; supersede-with-disclosure only:
 
 | Script | Edit | Invariant pinned |
@@ -95,8 +117,8 @@ landed; supersede-with-disclosure only:
 ## F-4 — Differential-generator registration (roadmap §2.5 gate 5 / #779 program)
 
 - **Denominator:** the modeled-forms whitelist `docs/verification-modeled-forms.md`, pinned at
-  content hash `ce25c3f9f61cf094e6686727eaf4796c7b6af7958da65d6e7424ae1a74506572` (sha256,
-  registration time). Editing that file re-pins by an additive amendment entry here naming the new
+  content hash `ce25c3f9f61cf094e6686727eaf4796c7b6af7958da65d6e7424ae1a74506572` (sha256; file
+  unchanged since `04c8b697`, re-verified against `origin/main` at review time). Editing that file re-pins by an additive amendment entry here naming the new
   hash — the denominator never tracks the file silently.
 - **Generator (parameters frozen now, before any suite code merges):** every whitelisted form ×
   contract positions {`§S` postcondition, `§PROOF` obligation} (the two elision legs) plus `§Q`


### PR DESCRIPTION
## Summary

First v0.13 execution PR under the merged roadmap (#889). Lands `docs/plans/v0.13-freeze-registrations.md` — the four freeze artifacts the roadmap requires **before** any gated work merges, so every 0.13 release-gate denominator is pinned by git-history ordering rather than set after values are visible:

- **F-1 — construct-class tiers** (§2.5 gate 1 denominator): all **61** concrete `ExpressionNode` subclasses exhaustively assigned — 55 registered (the #762 item-1 families mapped to named classes, plus the core always-bind set for regression protection), 6 residual with stated reasons (unsafe/pointer family; two #762-item-8 helper-node candidates). Tier A→B moves are subtractive and require disclosed supersession.
- **F-2 — measurement corpus** (gate 1 corpus): in-repo tracked `.calr` leg + the `calor import` output of the three A-1.5.3-pinned subjects (MediatR `fb309026`, Serilog `0597ddfb`, FluentValidation `71b3c60c`), with a revert-the-fix discriminating pin required of the CI instrument.
- **F-3 — edit-script corpus** (gates 2/4): location, schema, and six immutable members — including the #883 reproduction (must fail on the pre-fix compiler) and the SymbolId-rename behavior oracle with shadowing.
- **F-4 — differential generator** (gate 5 / #779 program): `verification-modeled-forms.md` pinned at sha256 `ce25c3f9…`, generator parameters frozen (forms × {§S, §PROOF, §Q} × depth ≤ 3 × polarity), the D15 emitter-lowering class and the third elide route (`§PROOF` → `ObligationStatus.Discharged`) explicitly in scope, elision-coverage fraction published per release.

## Verification

- 61-class count and the full class list produced by grep over `src/Calor.Compiler/Ast/*.cs` at registration time (all direct subclasses; no indirect ones).
- `FallbackExpressionNode` verified as unconverted-C# interop (registered tier); `GenericTypeNode`/`KeywordArgNode` verified as helper-node candidates (residual tier, pending the #762 item-8 decision).
- Modeled-forms hash computed from the working tree at `9df631ae`.
- Corpus subject pins quoted from `agent-native-gates.md` A-1.5.3 (line 654).

Docs-only; no behavior change. Next PRs in the roadmap order: PP-S4 registry + elision opt-in flip + #874/#879 (quick wins), then the #762 scoping doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)