### PR TITLE
fix(emitter): maintain the elision cursor in Visit(MethodNode) (#879)

### DIFF
--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -2738,6 +2738,16 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(MethodNode node)
     {
+        // #879: the postcondition-elision key is a mutable cursor
+        // (_currentFunctionId, _currentPostconditionIndex) that every emission path
+        // visiting contracts MUST maintain. Before this was set here, class-method
+        // postconditions never elided even when Proven, §MT contract violations
+        // reported "unknown" (or a foreign id) as the failing function, and — had
+        // §EEXT contracts ever been verified — a method's check could have been
+        // deleted on an unrelated function's proof.
+        _currentFunctionId = node.Id;
+        _currentPostconditionIndex = 0;
+
         // Clear declared variables tracking for new method scope
         ResetDeclScopes(node.Parameters);
 
@@ -5712,6 +5722,12 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                     case Verification.Obligations.ObligationStatus.Boundary:
                     case Verification.Obligations.ObligationStatus.Failed:
                     case Verification.Obligations.ObligationStatus.Timeout:
+                    // #879 ride-along: Unsupported keeps its runtime guard by design.
+                    // Previously it fell through to the no-guard TODO comment — and
+                    // Assumed's guard survived only because ToObligationStatus maps it
+                    // onto Timeout. An obligation the solver cannot model must keep its
+                    // check (#779 posture: guards stay until verification proves).
+                    case Verification.Obligations.ObligationStatus.Unsupported:
                         // Emit runtime guard
                         var condition = node.Condition.Accept(this);
                         AppendLine($"if (!({condition})) throw new InvalidOperationException(" +

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -3322,6 +3322,14 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(PropertyAccessorNode node)
     {
+        // #879: property accessors are never verified (EnumerateContractBearers covers
+        // functions and class methods only), and this node carries no id. A stale cursor
+        // here would attribute an accessor precondition failure to a foreign method — or,
+        // worse, elide on a foreign proof. Null is the honest key: lookup misses, guard
+        // kept, id reported as "unknown".
+        _currentFunctionId = null;
+        _currentPostconditionIndex = 0;
+
         var accessorKeyword = node.Kind switch
         {
             PropertyAccessorNode.AccessorKind.Get => "get",
@@ -3371,6 +3379,12 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(ConstructorNode node)
     {
+        // #879: constructors are never verified, so their own id is the honest cursor
+        // key — the results lookup misses (guard kept) and violations report this
+        // constructor, not whatever method the cursor last pointed at.
+        _currentFunctionId = node.Id;
+        _currentPostconditionIndex = 0;
+
         // Clear declared variables tracking for new constructor scope
         ResetDeclScopes(node.Parameters);
 
@@ -3427,6 +3441,14 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(OperatorOverloadNode node)
     {
+        // #879: operators are never verified, and they emit AFTER methods — without
+        // this, an operator inherits the last method's verified id, and a Proven result
+        // there deletes the operator's own, never-verified postcondition (the foreign-
+        // proof elision the issue described as latent; review of this fix reproduced it
+        // live). The operator's own id makes the lookup miss: guard kept, right id.
+        _currentFunctionId = node.Id;
+        _currentPostconditionIndex = 0;
+
         ResetDeclScopes(node.Parameters);
 
         EmitCSharpAttributes(node.CSharpAttributes);
@@ -5722,12 +5744,16 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                     case Verification.Obligations.ObligationStatus.Boundary:
                     case Verification.Obligations.ObligationStatus.Failed:
                     case Verification.Obligations.ObligationStatus.Timeout:
-                    // #879 ride-along: Unsupported keeps its runtime guard by design.
-                    // Previously it fell through to the no-guard TODO comment — and
-                    // Assumed's guard survived only because ToObligationStatus maps it
-                    // onto Timeout. An obligation the solver cannot model must keep its
-                    // check (#779 posture: guards stay until verification proves).
+                    // #879 ride-along: Unsupported and Pending keep their runtime guards
+                    // by design. Previously both fell through to the no-guard TODO
+                    // comment — and Assumed's guard survived only because
+                    // ToObligationStatus maps it onto Timeout. Pending-with-tracker is
+                    // reachable (--verify-refinements with Z3 unavailable attaches the
+                    // tracker without solving). An obligation not proven must keep its
+                    // check (#779 posture: guards stay until verification proves); the
+                    // no-guard TODO now means exactly "no tracker ran".
                     case Verification.Obligations.ObligationStatus.Unsupported:
+                    case Verification.Obligations.ObligationStatus.Pending:
                         // Emit runtime guard
                         var condition = node.Condition.Accept(this);
                         AppendLine($"if (!({condition})) throw new InvalidOperationException(" +

--- a/src/Calor.Compiler/Resources/SelfTest/08_contract_inheritance_z3.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/08_contract_inheritance_z3.g.cs
@@ -19,12 +19,12 @@ namespace ContractZ3Test
     {
         public int Process(int value)
         {
-            if (!(value >= -10)) throw new Calor.Runtime.ContractViolationException("Precondition failed: value >= -10", "unknown", Calor.Runtime.ContractKind.Requires, startOffset: 192, length: 17, sourceFile: null, line: 9, column: 7, condition: "value >= -10");
+            if (!(value >= -10)) throw new Calor.Runtime.ContractViolationException("Precondition failed: value >= -10", "mt001", Calor.Runtime.ContractKind.Requires, startOffset: 192, length: 17, sourceFile: null, line: 9, column: 7, condition: "value >= -10");
             int __result__ = default;
 
             __result__ = value + 1;
 
-            if (!(__result__ >= 1)) throw new Calor.Runtime.ContractViolationException("Postcondition failed: __result__ >= 1", "unknown", Calor.Runtime.ContractKind.Ensures, startOffset: 216, length: 16, sourceFile: null, line: 10, column: 7, condition: "__result__ >= 1");
+            if (!(__result__ >= 1)) throw new Calor.Runtime.ContractViolationException("Postcondition failed: __result__ >= 1", "mt001", Calor.Runtime.ContractKind.Ensures, startOffset: 216, length: 16, sourceFile: null, line: 10, column: 7, condition: "__result__ >= 1");
             return __result__;
         }
 
@@ -34,12 +34,12 @@ namespace ContractZ3Test
     {
         public int Process(int value)
         {
-            if (!(value >= 0)) throw new Calor.Runtime.ContractViolationException("Precondition failed: value >= 0", "unknown", Calor.Runtime.ContractKind.Requires, startOffset: 365, length: 15, sourceFile: null, line: 18, column: 7, condition: "value >= 0");
+            if (!(value >= 0)) throw new Calor.Runtime.ContractViolationException("Precondition failed: value >= 0", "mt002", Calor.Runtime.ContractKind.Requires, startOffset: 365, length: 15, sourceFile: null, line: 18, column: 7, condition: "value >= 0");
             int __result__ = default;
 
             __result__ = value + 10;
 
-            if (!(__result__ >= 10)) throw new Calor.Runtime.ContractViolationException("Postcondition failed: __result__ >= 10", "unknown", Calor.Runtime.ContractKind.Ensures, startOffset: 387, length: 17, sourceFile: null, line: 19, column: 7, condition: "__result__ >= 10");
+            if (!(__result__ >= 10)) throw new Calor.Runtime.ContractViolationException("Postcondition failed: __result__ >= 10", "mt002", Calor.Runtime.ContractKind.Ensures, startOffset: 387, length: 17, sourceFile: null, line: 19, column: 7, condition: "__result__ >= 10");
             return __result__;
         }
 

--- a/tests/Calor.Compiler.Tests/ObligationTests.cs
+++ b/tests/Calor.Compiler.Tests/ObligationTests.cs
@@ -527,6 +527,69 @@ public sealed class ObligationTests
     }
 
     [Fact]
+    public void CSharpEmit_UnsupportedProofObligation_EmitsRuntimeGuard()
+    {
+        // #879 ride-along: an obligation the solver cannot model keeps its runtime
+        // check. Pre-fix, Unsupported fell through to the no-guard TODO comment.
+        var source = """
+            §M{m001:Test}
+              §F{f001:Main:pub}
+                  §I{i32:x}
+                  §O{void}
+                  §PROOF{p1:check} (>= x INT:0)
+            """;
+
+        var module = Parse(source, out var diagnostics);
+        Assert.False(diagnostics.HasErrors);
+
+        var tracker = new ObligationTracker();
+        var genr = new ObligationGenerator(tracker);
+        genr.Generate(module);
+
+        foreach (var obl in tracker.Obligations)
+        {
+            if (obl.Kind == ObligationKind.ProofObligation)
+                obl.Status = ObligationStatus.Unsupported;
+        }
+
+        var emitter = new CSharpEmitter(ContractMode.Debug, null, null, tracker);
+        var csharp = emitter.Emit(module);
+
+        Assert.Contains("throw new InvalidOperationException", csharp);
+        Assert.DoesNotContain("// TODO:", csharp);
+        Assert.DoesNotContain("// PROVEN:", csharp);
+    }
+
+    [Fact]
+    public void CSharpEmit_PendingProofObligation_EmitsRuntimeGuard()
+    {
+        // #879 ride-along: Pending-with-tracker is reachable (--verify-refinements with
+        // Z3 unavailable attaches the tracker without solving) and must keep its guard.
+        // The no-guard TODO now means exactly "no tracker ran".
+        var source = """
+            §M{m001:Test}
+              §F{f001:Main:pub}
+                  §I{i32:x}
+                  §O{void}
+                  §PROOF{p1:check} (>= x INT:0)
+            """;
+
+        var module = Parse(source, out var diagnostics);
+        Assert.False(diagnostics.HasErrors);
+
+        var tracker = new ObligationTracker();
+        var genr = new ObligationGenerator(tracker);
+        genr.Generate(module);
+        // Generate leaves ProofObligation status at Pending — no override needed.
+
+        var emitter = new CSharpEmitter(ContractMode.Debug, null, null, tracker);
+        var csharp = emitter.Emit(module);
+
+        Assert.Contains("throw new InvalidOperationException", csharp);
+        Assert.DoesNotContain("// TODO:", csharp);
+    }
+
+    [Fact]
     public void CSharpEmit_NoTracker_EmitsTodoComment()
     {
         var source = """

--- a/tests/Calor.Verification.Tests/MethodElisionCursorTests.cs
+++ b/tests/Calor.Verification.Tests/MethodElisionCursorTests.cs
@@ -58,8 +58,73 @@ public class MethodElisionCursorTests
         var result = Program.Compile(source, "test.calr", new CompilationOptions());
 
         Assert.False(result.HasErrors);
-        Assert.Contains("mt001", result.GeneratedCode);
+        // Anchored to the exception's function-id argument position, not any occurrence.
+        Assert.Contains("\"mt001\", Calor.Runtime.ContractKind", result.GeneratedCode);
         Assert.DoesNotContain("\"unknown\"", result.GeneratedCode);
+    }
+
+    [SkippableFact]
+    public void OperatorPostcondition_NeverElidesOnForeignMethodProof()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        // The review-of-the-fix repro: operators emit AFTER methods and are never
+        // verified. Pick's §S is Proven but non-lowerable (nested returns), leaving the
+        // postcondition index at 0 — without the operator's own cursor reset, the
+        // operator's FALSE §S elides on Pick's proof. It must keep its guard.
+        const string source = @"
+§M{m001:Test}
+  §CL{c001:Calc:pub}
+    §MT{mt001:Pick:pub}
+      §I{i32:x}
+      §O{i32}
+      §Q (>= x 0)
+      §S (>= result 0)
+      §IF{if1} (>= x 5)
+        §R x
+      §EL
+        §R INT:0
+    §OP{op001:+:pub}
+      §I{i32:left}
+      §I{i32:right}
+      §O{i32}
+      §S (>= result 100)
+      §R INT:0";
+
+        var result = Program.Compile(source, "test.calr", NoCache());
+
+        Assert.False(result.HasErrors);
+        Assert.Contains("__result__ >= 100)) throw", result.GeneratedCode);
+        Assert.DoesNotContain(
+            "// PROVEN: Postcondition statically verified: __result__ >= 100",
+            result.GeneratedCode);
+    }
+
+    [Fact]
+    public void ConstructorPrecondition_ReportsOwnId_NotForeignMethodId()
+    {
+        // Cross-class misattribution: pre-fix the cursor carried First.Inc's id into
+        // Second's constructor guard (pre-#879 it was "unknown"; the first fix upgraded
+        // it to a confidently WRONG id). The constructor's own id is the honest key.
+        const string source = @"
+§M{m001:Test}
+  §CL{c001:First:pub}
+    §MT{mt001:Inc:pub}
+      §I{i32:x}
+      §O{i32}
+      §Q (>= x 0)
+      §S (>= result 1)
+      §R (+ x 1)
+  §CL{c002:Second:pub}
+    §CTOR{ct001:pub}
+      §I{i32:size}
+      §Q (> size 0)";
+
+        var result = Program.Compile(source, "test.calr", new CompilationOptions());
+
+        Assert.False(result.HasErrors);
+        Assert.Contains("\"ct001\", Calor.Runtime.ContractKind", result.GeneratedCode);
+        Assert.DoesNotContain("size > 0\", \"mt001\"", result.GeneratedCode);
     }
 
     [SkippableFact]
@@ -84,6 +149,9 @@ public class MethodElisionCursorTests
 
         Assert.False(result.HasErrors);
         Assert.DoesNotContain("// PROVEN: Postcondition", result.GeneratedCode);
+        // The guard must be PRESENT — a regression through the not-lowered path (guard
+        // silently dropped, Calor1001 only warns) would otherwise pass this test.
+        Assert.Contains("ContractViolationException", result.GeneratedCode);
         Assert.Contains(result.Diagnostics,
             d => d.Code == DiagnosticCode.ContractVerificationUnsupported);
     }
@@ -111,6 +179,8 @@ public class MethodElisionCursorTests
 
         Assert.False(result.HasErrors);
         Assert.DoesNotContain("// PROVEN: Postcondition", result.GeneratedCode);
+        // Guard presence pinned for the same reason as the array test above.
+        Assert.Contains("ContractViolationException", result.GeneratedCode);
         Assert.Contains(result.Diagnostics, d => d.Code == DiagnosticCode.ContractVerificationAssumed);
     }
 

--- a/tests/Calor.Verification.Tests/MethodElisionCursorTests.cs
+++ b/tests/Calor.Verification.Tests/MethodElisionCursorTests.cs
@@ -1,0 +1,122 @@
+using Calor.Compiler;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Verification.Z3;
+using Calor.Compiler.Verification.Z3.Cache;
+using Xunit;
+
+namespace Calor.Verification.Tests;
+
+/// <summary>
+/// Issue #879: postcondition elision is keyed by a mutable cursor
+/// (_currentFunctionId, _currentPostconditionIndex) that Visit(MethodNode) never
+/// maintained. Consequences pinned here: class-method postconditions never elided even
+/// when Proven, and §MT contract violations reported "unknown" as the failing function.
+/// The fix enables a NEW elision surface (class methods), so this file also pins that the
+/// D14 demotion governs it — an array-carried method proof must stay Assumed, guard kept.
+/// </summary>
+public class MethodElisionCursorTests
+{
+    [SkippableFact]
+    public void MethodPostcondition_Proven_Elides()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        // Same contract shape the §F form has always elided (VerifierTests square
+        // pattern); pre-fix the §MT form emitted a runtime guard with id "unknown".
+        const string source = @"
+§M{m001:Test}
+  §CL{c001:Calc:pub}
+    §MT{mt001:Square:pub}
+      §I{i32:x}
+      §O{i32}
+      §Q (>= x 0)
+      §Q (<= x 46340)
+      §S (>= result 0)
+      §R (* x x)";
+
+        var result = Program.Compile(source, "test.calr", NoCache());
+
+        Assert.False(result.HasErrors);
+        Assert.Contains("// PROVEN: Postcondition", result.GeneratedCode);
+        Assert.DoesNotContain("\"unknown\"", result.GeneratedCode);
+    }
+
+    [Fact]
+    public void MethodPostconditionGuard_CarriesOwnFunctionId_NotUnknown()
+    {
+        // No Z3 needed: with no verification result the guard is always kept, and its
+        // reported function id comes straight from the cursor — pre-fix, "unknown".
+        const string source = @"
+§M{m001:Test}
+  §CL{c001:Calc:pub}
+    §MT{mt001:Half:pub}
+      §I{i32:x}
+      §O{i32}
+      §S (> result 10)
+      §R (/ x 2)";
+
+        var result = Program.Compile(source, "test.calr", new CompilationOptions());
+
+        Assert.False(result.HasErrors);
+        Assert.Contains("mt001", result.GeneratedCode);
+        Assert.DoesNotContain("\"unknown\"", result.GeneratedCode);
+    }
+
+    [SkippableFact]
+    public void MethodPostcondition_ArrayTakingMethod_NeverElides_GuardKept()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        // The #879 landing requirement: the fix opens elision to class methods, so the
+        // demotion/refusal machinery must govern the new surface. This array shape is
+        // REFUSED at translation (Calor0718 — `(len x)` models string length, not array
+        // length), which keeps the guard: the new surface must not over-elide it.
+        const string source = @"
+§M{m001:Test}
+  §CL{c001:Calc:pub}
+    §MT{mt001:Count:pub}
+      §I{i32[]:arr}
+      §O{i32}
+      §S (>= result 0)
+      §R (len arr)";
+
+        var result = Program.Compile(source, "test.calr", NoCache());
+
+        Assert.False(result.HasErrors);
+        Assert.DoesNotContain("// PROVEN: Postcondition", result.GeneratedCode);
+        Assert.Contains(result.Diagnostics,
+            d => d.Code == DiagnosticCode.ContractVerificationUnsupported);
+    }
+
+    [SkippableFact]
+    public void MethodPostcondition_StringModelCarried_StaysAssumed_GuardKept()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        // The D3/D12 demotion on the new surface: the same string-ordinal shape that is
+        // Assumed (never Proven-elided) on the §F form (IntegrationTests) must be
+        // Assumed on the §MT form too — the cursor fix must not turn a demoted proof
+        // into an elision on class methods.
+        const string source = @"
+§M{m001:Test}
+  §CL{c001:Fmt:pub}
+    §MT{mt001:Chk:pub}
+      §I{str:s}
+      §O{str}
+      §Q (== s STR:""abc"")
+      §S (! (starts result STR:""zzz"" :ordinal))
+      §R s";
+
+        var result = Program.Compile(source, "test.calr", NoCache());
+
+        Assert.False(result.HasErrors);
+        Assert.DoesNotContain("// PROVEN: Postcondition", result.GeneratedCode);
+        Assert.Contains(result.Diagnostics, d => d.Code == DiagnosticCode.ContractVerificationAssumed);
+    }
+
+    private static CompilationOptions NoCache() => new()
+    {
+        VerifyContracts = true,
+        VerificationCacheOptions = new VerificationCacheOptions { Enabled = false }
+    };
+}

--- a/tests/E2E/scenarios/08_contract_inheritance_z3/output.g.cs
+++ b/tests/E2E/scenarios/08_contract_inheritance_z3/output.g.cs
@@ -19,12 +19,12 @@ namespace ContractZ3Test
     {
         public int Process(int value)
         {
-            if (!(value >= -10)) throw new Calor.Runtime.ContractViolationException("Precondition failed: value >= -10", "unknown", Calor.Runtime.ContractKind.Requires, startOffset: 192, length: 17, sourceFile: null, line: 9, column: 7, condition: "value >= -10");
+            if (!(value >= -10)) throw new Calor.Runtime.ContractViolationException("Precondition failed: value >= -10", "mt001", Calor.Runtime.ContractKind.Requires, startOffset: 192, length: 17, sourceFile: null, line: 9, column: 7, condition: "value >= -10");
             int __result__ = default;
 
             __result__ = value + 1;
 
-            if (!(__result__ >= 1)) throw new Calor.Runtime.ContractViolationException("Postcondition failed: __result__ >= 1", "unknown", Calor.Runtime.ContractKind.Ensures, startOffset: 216, length: 16, sourceFile: null, line: 10, column: 7, condition: "__result__ >= 1");
+            if (!(__result__ >= 1)) throw new Calor.Runtime.ContractViolationException("Postcondition failed: __result__ >= 1", "mt001", Calor.Runtime.ContractKind.Ensures, startOffset: 216, length: 16, sourceFile: null, line: 10, column: 7, condition: "__result__ >= 1");
             return __result__;
         }
 
@@ -34,12 +34,12 @@ namespace ContractZ3Test
     {
         public int Process(int value)
         {
-            if (!(value >= 0)) throw new Calor.Runtime.ContractViolationException("Precondition failed: value >= 0", "unknown", Calor.Runtime.ContractKind.Requires, startOffset: 365, length: 15, sourceFile: null, line: 18, column: 7, condition: "value >= 0");
+            if (!(value >= 0)) throw new Calor.Runtime.ContractViolationException("Precondition failed: value >= 0", "mt002", Calor.Runtime.ContractKind.Requires, startOffset: 365, length: 15, sourceFile: null, line: 18, column: 7, condition: "value >= 0");
             int __result__ = default;
 
             __result__ = value + 10;
 
-            if (!(__result__ >= 10)) throw new Calor.Runtime.ContractViolationException("Postcondition failed: __result__ >= 10", "unknown", Calor.Runtime.ContractKind.Ensures, startOffset: 387, length: 17, sourceFile: null, line: 19, column: 7, condition: "__result__ >= 10");
+            if (!(__result__ >= 10)) throw new Calor.Runtime.ContractViolationException("Postcondition failed: __result__ >= 10", "mt002", Calor.Runtime.ContractKind.Ensures, startOffset: 387, length: 17, sourceFile: null, line: 19, column: 7, condition: "__result__ >= 10");
             return __result__;
         }
 


### PR DESCRIPTION
## Summary

v0.13 quick-wins batch, item 2 (roadmap §2.1 truth floor). Fixes #879: the postcondition-elision key is a mutable cursor that `Visit(MethodNode)` never maintained — class-method postconditions never elided even when `Proven`, and `§MT` contract violations reported `"unknown"` (or a foreign id) as the failing function. The near-miss soundness route (a method's check deleted on an unrelated function's proof, live the moment `§EEXT` contracts get verified) is closed by the same two lines.

## Changes

- `Visit(MethodNode)` sets `_currentFunctionId`/`_currentPostconditionIndex`, with a comment stating the invariant every contract-visiting emission path must maintain.
- **Ride-along from the issue**: `ObligationStatus.Unsupported` joins the guard-emitting arms — previously it fell through to a `// TODO` comment with **no guard**, and `Assumed` kept its guard only by coincidence of its `Timeout` mapping. An obligation the solver cannot model keeps its check (#779 posture).
- **Golden pinning the defect** (the D15 lesson recurring): `08_contract_inheritance_z3` asserted the `"unknown"` ids. Corrected at the E2E scenario source — the build's `SyncSelfTestFiles` target overwrites `Resources/SelfTest` from `tests/E2E/scenarios/`, which is why regenerating the resource copy alone silently reverted (a live demonstration of the #789 sync finding).

## Verification

- Four pinning tests (`MethodElisionCursorTests`): the two cursor pins **fail without the fix** (revert-verified); the two new-surface pins hold the opened elision surface to the demotion/refusal machinery.
- **Honest deviation from the issue's landing requirement**: it asked for "array-taking method comes out `Assumed`" — at the e2e surface that shape is *refused* at translation (`Calor0718`, guard kept) because lisp `(len x)` models string length only; the demotion family is instead pinned via the string-`:ordinal` form (`Calor0720` `Assumed` on `§MT` exactly as on `§F`, mirroring the IntegrationTests precedent).
- Golden diff verified line-by-line: exactly the four id corrections (`"unknown"` → `mt001`/`mt002` — the fix also corrects **pre**condition attribution) plus trailing-newline normalization.
- Full suite: **8,284 tests, 0 failed, 17 skipped** (known profile).

Fixes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)