### PR TITLE
feat(verify): proof-based guard elision is now opt-in (roadmap v0.13 §2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Proof-based guard elision is now opt-in** (`--elide-proven-guards` on the CLI,
+  `ElideProvenGuards` on `CompilationOptions` and the MSBuild task). By default a `Proven`
+  postcondition or `Discharged` `§PROOF` obligation keeps its runtime check — verification
+  verdicts are diagnostic. This executes roadmap v0.13 §2.1: the elide surface has produced
+  seven false-`Proven` vectors to date and its differential gate (freeze registration F-4) is
+  not yet built; elision re-enables by default only when that gate is green (roadmap §3.5
+  gate 6). The `run`/`test` execution paths always keep guards regardless of the flag.
+
 ### Corrected
 - **The v0.12.1 notes below understated the VS Code outage by about six times, and implied a
   publish that did not happen.** They said the extension "can be published again" after "three

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
   seven false-`Proven` vectors to date and its differential gate (freeze registration F-4) is
   not yet built; elision re-enables by default only when that gate is green (roadmap §3.5
   gate 6). The `run`/`test` execution paths always keep guards regardless of the flag.
+  Note: `§PROOF` obligation guards have always ignored `--contract-mode` (pre-existing for
+  Failed/Timeout); with the flip, a Discharged obligation under `--contract-mode off` now
+  also emits its guard unless the opt-in is set — Off-mode output is guard-free by mode
+  only for `§Q`/`§S` contracts, not obligations.
 
 ### Corrected
 - **The v0.12.1 notes below understated the VS Code outage by about six times, and implied a

--- a/docs/plans/v0.13-freeze-registrations.md
+++ b/docs/plans/v0.13-freeze-registrations.md
@@ -118,7 +118,11 @@ landed; supersede-with-disclosure only:
 
 - **Denominator:** the modeled-forms whitelist `docs/verification-modeled-forms.md`, pinned at
   content hash `ce25c3f9f61cf094e6686727eaf4796c7b6af7958da65d6e7424ae1a74506572` (sha256; file
-  unchanged since `04c8b697`, re-verified against `origin/main` at review time). Editing that file re-pins by an additive amendment entry here naming the new
+  unchanged since `04c8b697`, re-verified against `origin/main` at review time).
+  - **Amendment (2026-08-10, additive re-pin):** new hash
+    `6dbdc9c0e1ec122ec1110013cb023ac51109ae5452b55ad00a0b782b471ec463` — §4.1 prose updated to
+    state the v0.13 elision opt-in (`--elide-proven-guards`); the whitelist's *content* (which
+    forms are modeled) is unchanged, so the generator's form enumeration is unaffected. Editing that file re-pins by an additive amendment entry here naming the new
   hash — the denominator never tracks the file silently.
 - **Generator (parameters frozen now, before any suite code merges):** every whitelisted form ×
   contract positions {`§S` postcondition, `§PROOF` obligation} (the two elision legs) plus `§Q`

--- a/docs/syntax-reference/refinement-types.md
+++ b/docs/syntax-reference/refinement-types.md
@@ -154,7 +154,7 @@ Z3 proves this: given `balance >= amount` and `amount > 0`, then `balance - amou
 
 | Status | Meaning | C# Output |
 |:-------|:--------|:----------|
-| Discharged | Z3 proved the condition | `// PROVEN: proof obligation [p1]` |
+| Discharged | Z3 proved the condition | Runtime guard kept (default); `// PROVEN: proof obligation [p1]` with `--elide-proven-guards` (elision is opt-in as of v0.13) |
 | Failed | Z3 found a counterexample | Runtime guard (throws on violation) |
 | Timeout | Z3 couldn't decide in time | Runtime guard (configurable by policy) |
 | Boundary | Public API — can't verify callers | Runtime guard (always emitted) |
@@ -225,7 +225,7 @@ Refinement types are a **compile-time construct**. In the emitted C#, they are e
 | `§RTYPE{r1:NatInt:i32} (>= # INT:0)` | *(nothing — erased)* |
 | `§I{NatInt:count}` | `int count` |
 | `§I{i32:x} \| (>= # INT:0)` | `int x` |
-| `§PROOF{p1:check} (cond)` (Discharged) | `// PROVEN: proof obligation [p1: check]` |
+| `§PROOF{p1:check} (cond)` (Discharged) | Runtime guard (default); `// PROVEN: proof obligation [p1: check]` with `--elide-proven-guards` |
 | `§PROOF{p1:check} (cond)` (Failed) | `if (!(cond)) throw new InvalidOperationException(...)` |
 
 The refinement constrains what values are valid. The obligation engine verifies those constraints and emits runtime guards only where verification fails.
@@ -268,7 +268,7 @@ The obligation policy controls what happens for each obligation status. Three bu
 
 | Status | Action |
 |:-------|:-------|
-| Discharged | Ignore (proven, no guard needed) |
+| Discharged | Ignore in diagnostics; the runtime guard stays unless `--elide-proven-guards` is set |
 | Failed | Error (compilation fails) |
 | Timeout | WarnAndGuard |
 | Boundary | AlwaysGuard |
@@ -310,7 +310,8 @@ The obligation engine:
 1. Creates `Boundary` obligations for `balance` and `amount` (public function)
 2. Creates a `ProofObligation` for `p1`
 3. Z3 proves `p1`: given `balance >= 0`, `amount > 0`, and `balance >= amount`, then `balance - amount >= 0`
-4. Emitted C#: runtime guards for the public boundary parameters, proven comment for `p1`
+4. Emitted C#: runtime guards for the public boundary parameters and for `p1` (the proven
+   comment replaces `p1`'s guard only with `--elide-proven-guards` — elision is opt-in)
 
 ---
 

--- a/docs/verification-modeled-forms.md
+++ b/docs/verification-modeled-forms.md
@@ -94,7 +94,8 @@ A postcondition proof **carried by the solver's string theory** is reported as *
 > nullable and UTF-16-code-unit-counted (D3/D12); a proof touching string semantics is conditional on
 > the value being non-null and ASCII
 
-`Assumed` **never elides** the runtime check (only `Proven && !IsVacuous` does), so a false string
+`Assumed` **never elides** the runtime check (only `Proven && !IsVacuous` does — and as of
+v0.13 only under the `--elide-proven-guards` opt-in; elision is off by default), so a false string
 proof can no longer delete a check that would have failed. This is the D8 precedent — name the
 assumption rather than silently strengthen the claim.
 

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -154,6 +154,12 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     {
     }
 
+    /// <summary>
+    /// Opt-in to deleting runtime guards on Proven/Discharged verdicts (roadmap v0.13
+    /// §2.1). Default false: verification verdicts are diagnostic; every guard stays.
+    /// </summary>
+    public bool ElideProvenGuards { get; set; }
+
     public CSharpEmitter(ContractMode contractMode, ModuleVerificationResult? verificationResults, ModuleInheritanceResult? inheritanceResult,
         Verification.Obligations.ObligationTracker? obligationTracker = null,
         Diagnostics.DiagnosticBag? diagnostics = null)
@@ -2030,11 +2036,13 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var verificationResult = GetPostconditionVerificationResult();
         _currentPostconditionIndex++;
 
-        // Proven postconditions elide the runtime check — a postcondition Proven is a
-        // genuine ∀-proof (UNSAT on negation). A VACUOUS proof does not qualify
-        // (guarantees plan D-G1.3): it holds only because the precondition set is
-        // unsatisfiable, so the check is kept.
-        if (verificationResult is { Status: ContractVerificationStatus.Proven }
+        // Proven postconditions elide the runtime check ONLY when the caller opted in
+        // (roadmap v0.13 §2.1: elision is opt-in; verification is diagnostic by
+        // default). A Proven verdict is a genuine ∀-proof (UNSAT on negation); a
+        // VACUOUS proof never qualifies (guarantees plan D-G1.3): it holds only
+        // because the precondition set is unsatisfiable, so the check is kept.
+        if (ElideProvenGuards
+            && verificationResult is { Status: ContractVerificationStatus.Proven }
             && !verificationResult.EffectiveOutcome.IsVacuous)
         {
             return $"// PROVEN: Postcondition statically verified: {condition}";
@@ -5737,10 +5745,15 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             {
                 switch (matching.Status)
                 {
-                    case Verification.Obligations.ObligationStatus.Discharged:
+                    // Elision is opt-in (roadmap v0.13 §2.1): a Discharged obligation
+                    // drops its guard only when the caller asked for it; otherwise the
+                    // verdict is diagnostic and the check stays.
+                    case Verification.Obligations.ObligationStatus.Discharged
+                        when ElideProvenGuards:
                         AppendLine($"// PROVEN: proof obligation [{node.Id}{desc}]");
                         return "";
 
+                    case Verification.Obligations.ObligationStatus.Discharged:
                     case Verification.Obligations.ObligationStatus.Boundary:
                     case Verification.Obligations.ObligationStatus.Failed:
                     case Verification.Obligations.ObligationStatus.Timeout:

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -324,6 +324,13 @@ public class Program
         var structuredOutput = !format.Equals("text", StringComparison.OrdinalIgnoreCase);
         var diagnosticSink = structuredOutput ? new DiagnosticBag() : null;
         var declarationIds = structuredOutput ? new Ids.DeclarationIdResolver() : null;
+
+        if (elideProvenGuards && !verify)
+        {
+            Console.Error.WriteLine(
+                "warning: --elide-proven-guards has no effect without --verify " +
+                "(there are no verification verdicts to elide on).");
+        }
         var structuredEmitted = false;
 
         // In structured mode a JSON/SARIF document is ALWAYS emitted to stdout,
@@ -883,6 +890,7 @@ public class Program
             var verificationOptions = new VerificationOptions
             {
                 Verbose = options.Verbose,
+                ElideProvenGuards = options.ElideProvenGuards,
                 TimeoutMs = options.VerificationTimeoutMs,
                 CacheOptions = options.VerificationCacheOptions ?? VerificationCacheOptions.Default,
                 CancellationToken = options.CancellationToken

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -80,6 +80,11 @@ public class Program
             aliases: ["--verify"],
             description: "Enable static contract verification with Z3 SMT solver");
 
+        var elideProvenGuardsOption = new Option<bool>(
+            aliases: ["--elide-proven-guards"],
+            description: "Opt in to deleting runtime contract guards on Proven verdicts (v0.13 flips the old default: verification is diagnostic unless this is set)",
+            getDefaultValue: () => false);
+
         var cacheOption = new Option<bool>(
             aliases: ["--cache"],
             description: "Enable the incremental-build cache (.calor-build-state.json next to the outputs): unchanged files are skipped and report 'Up-to-date (cached)'. Opt-in for plain compiles; 'calor watch' always caches.");
@@ -157,6 +162,7 @@ public class Program
             permissiveEffectsOption,
             contractModeOption,
             verifyOption,
+            elideProvenGuardsOption,
             cacheOption,
             noCacheOption,
             clearCacheOption,
@@ -199,6 +205,7 @@ public class Program
             var permissiveEffects = ctx.ParseResult.GetValueForOption(permissiveEffectsOption);
             var contractMode = ctx.ParseResult.GetValueForOption(contractModeOption) ?? "debug";
             var verify = ctx.ParseResult.GetValueForOption(verifyOption);
+            var elideProvenGuards = ctx.ParseResult.GetValueForOption(elideProvenGuardsOption);
             var cache = ctx.ParseResult.GetValueForOption(cacheOption);
             var noCache = ctx.ParseResult.GetValueForOption(noCacheOption);
             var clearCache = ctx.ParseResult.GetValueForOption(clearCacheOption);
@@ -230,7 +237,7 @@ public class Program
 
             try
             {
-                ctx.ExitCode = await CompileAsync(input, output, verbose, strictApi, requireDocs, enforceEffects, noTypeCheck, strictEffects, permissiveEffects, contractMode, verify, cache, noCache, clearCache, verificationTimeout, analyze, allFindings, experimental, strictBindInference, format);
+                ctx.ExitCode = await CompileAsync(input, output, verbose, strictApi, requireDocs, enforceEffects, noTypeCheck, strictEffects, permissiveEffects, contractMode, verify, cache, noCache, clearCache, verificationTimeout, analyze, allFindings, experimental, strictBindInference, format, elideProvenGuards);
             }
             catch (Exception ex)
             {
@@ -305,10 +312,10 @@ public class Program
         return result;
     }
 
-    private static Task<int> CompileAsync(FileInfo[]? input, FileInfo? output, bool verbose, bool strictApi, bool requireDocs, bool enforceEffects, bool noTypeCheck, bool strictEffects, bool permissiveEffects, string contractMode, bool verify, bool cache, bool noCache, bool clearCache, int verificationTimeout, bool analyze, bool allFindings = false, string[]? experimentalFlags = null, bool strictBindInference = true, string format = "text")
-        => Task.FromResult(CompileCore(input, output, verbose, strictApi, requireDocs, enforceEffects, noTypeCheck, strictEffects, permissiveEffects, contractMode, verify, cache, noCache, clearCache, verificationTimeout, analyze, allFindings, experimentalFlags, strictBindInference, format));
+    private static Task<int> CompileAsync(FileInfo[]? input, FileInfo? output, bool verbose, bool strictApi, bool requireDocs, bool enforceEffects, bool noTypeCheck, bool strictEffects, bool permissiveEffects, string contractMode, bool verify, bool cache, bool noCache, bool clearCache, int verificationTimeout, bool analyze, bool allFindings = false, string[]? experimentalFlags = null, bool strictBindInference = true, string format = "text", bool elideProvenGuards = false)
+        => Task.FromResult(CompileCore(input, output, verbose, strictApi, requireDocs, enforceEffects, noTypeCheck, strictEffects, permissiveEffects, contractMode, verify, cache, noCache, clearCache, verificationTimeout, analyze, allFindings, experimentalFlags, strictBindInference, format, elideProvenGuards));
 
-    private static int CompileCore(FileInfo[]? input, FileInfo? output, bool verbose, bool strictApi, bool requireDocs, bool enforceEffects, bool noTypeCheck, bool strictEffects, bool permissiveEffects, string contractMode, bool verify, bool cache, bool noCache, bool clearCache, int verificationTimeout, bool analyze, bool allFindings, string[]? experimentalFlags, bool strictBindInference, string format = "text")
+    private static int CompileCore(FileInfo[]? input, FileInfo? output, bool verbose, bool strictApi, bool requireDocs, bool enforceEffects, bool noTypeCheck, bool strictEffects, bool permissiveEffects, string contractMode, bool verify, bool cache, bool noCache, bool clearCache, int verificationTimeout, bool analyze, bool allFindings, string[]? experimentalFlags, bool strictBindInference, string format = "text", bool elideProvenGuards = false)
     {
         // Structured diagnostic output (--format json|sarif): diagnostics are
         // aggregated across files and serialized once through the shared
@@ -428,6 +435,7 @@ public class Program
                         UnknownCallPolicy = permissiveEffects ? UnknownCallPolicy.Permissive : UnknownCallPolicy.Strict,
                         ContractMode = parsedContractMode,
                         VerifyContracts = verify,
+                        ElideProvenGuards = elideProvenGuards,
                         ProjectDirectory = Path.GetDirectoryName(file.FullName),
                         VerificationCacheOptions = cacheOptions,
                         VerificationTimeoutMs = (uint)verificationTimeout,
@@ -917,7 +925,10 @@ public class Program
 
         // Code generation
         phaseSw.Restart();
-        var emitter = new CSharpEmitter(options.ContractMode, options.VerificationResults, inheritanceResult, options.ObligationResults, diagnostics);
+        var emitter = new CSharpEmitter(options.ContractMode, options.VerificationResults, inheritanceResult, options.ObligationResults, diagnostics)
+        {
+            ElideProvenGuards = options.ElideProvenGuards
+        };
         emitter.CrossModuleFunctionModules = options.CrossModuleFunctionModules;
         if (options.EmitLineDirectives && !string.IsNullOrEmpty(filePath))
         {
@@ -1066,6 +1077,15 @@ public sealed class CompilationOptions
     /// Enable static contract verification with Z3 SMT solver.
     /// </summary>
     public bool VerifyContracts { get; init; }
+
+    /// <summary>
+    /// Opt IN to deleting runtime contract guards on a Proven verdict (roadmap v0.13
+    /// §2.1: elision is opt-in; verification is diagnostic by default). Off, a Proven
+    /// postcondition or Discharged §PROOF obligation keeps its runtime check — the
+    /// verdict is reported, never silently acted on. The zero-mismatch differential
+    /// gate (freeze registration F-4) is the bar for flipping this default back on.
+    /// </summary>
+    public bool ElideProvenGuards { get; init; }
 
     /// <summary>
     /// Options for verification result caching.

--- a/src/Calor.Compiler/Verification/ContractVerificationPass.cs
+++ b/src/Calor.Compiler/Verification/ContractVerificationPass.cs
@@ -211,10 +211,16 @@ public sealed class ContractVerificationPass
                 }
                 else if (!isPrecondition && _options.Verbose)
                 {
+                    // v0.13: elision is opt-in, so the message must state what actually
+                    // happens to the check — claiming "elided" when the guard stays
+                    // would misreport the emitted code.
+                    var checkDisposition = _options.ElideProvenGuards
+                        ? "Runtime check elided."
+                        : "Runtime check kept (elision opt-in not set).";
                     _diagnostics.ReportVerification(
                         span,
                         DiagnosticCode.PostconditionProven,
-                        $"Postcondition statically verified in function '{function.Name}'. Runtime check elided.",
+                        $"Postcondition statically verified in function '{function.Name}'. {checkDisposition}",
                         DiagnosticSeverity.Info,
                         outcome);
                 }

--- a/src/Calor.Compiler/Verification/VerificationOptions.cs
+++ b/src/Calor.Compiler/Verification/VerificationOptions.cs
@@ -24,6 +24,13 @@ public sealed class VerificationOptions
     public bool Verbose { get; init; }
 
     /// <summary>
+    /// Mirrors <see cref="Calor.Compiler.CompilationOptions"/>' elision opt-in so verbose
+    /// diagnostics can state the check's actual disposition (kept vs elided) truthfully.
+    /// Verification itself never acts on this — only the emitter does.
+    /// </summary>
+    public bool ElideProvenGuards { get; init; }
+
+    /// <summary>
     /// Cache options for verification results.
     /// Default: caching enabled.
     /// </summary>

--- a/src/Calor.Sdk/Sdk/Sdk.targets
+++ b/src/Calor.Sdk/Sdk/Sdk.targets
@@ -72,6 +72,7 @@
         EnforceEffects="$(CalorEnforceEffects)"
         TypeCheck="$(CalorTypeCheck)"
         Verify="$(CalorVerify)"
+        ElideProvenGuards="$(CalorElideProvenGuards)"
         EnableILAnalysis="$(CalorEnableILAnalysis)"
         ReferencedAssemblies="@(ReferencePath)"
         RuntimeDirectory="$(_CalorRuntimeDir)"

--- a/src/Calor.Tasks/CompileCalor.cs
+++ b/src/Calor.Tasks/CompileCalor.cs
@@ -123,6 +123,12 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
     public bool Verify { get; set; }
 
     /// <summary>
+    /// Opt in to deleting runtime contract guards on Proven verdicts (MSBuild property
+    /// <c>CalorElideProvenGuards</c>). v0.13 default: off — verification is diagnostic.
+    /// </summary>
+    public bool ElideProvenGuards { get; set; }
+
+    /// <summary>
     /// Semicolon- or comma-separated list of experimental feature flag names to enable.
     /// Plumbed through to <see cref="Calor.Compiler.CompilationOptions.ExperimentalFlags"/>.
     /// Unknown flags are accepted silently — see <see cref="Calor.Compiler.ExperimentalFlags"/>.
@@ -433,7 +439,8 @@ public sealed class CompileCalor : Microsoft.Build.Utilities.Task
                     Context = compilationContext,
                     EnableILAnalysis = EnableILAnalysis,
                     ExperimentalFlags = Calor.Compiler.ExperimentalFlags.Parse(ExperimentalFlags),
-                    VerifyContracts = Verify
+                    VerifyContracts = Verify,
+                    ElideProvenGuards = ElideProvenGuards
                 };
                 compileOptions.CrossModuleFunctionModules = crossModuleMap;
                 var result = Program.Compile(source, inputPath, compileOptions);

--- a/tests/Calor.Compiler.Tests/ObligationTests.cs
+++ b/tests/Calor.Compiler.Tests/ObligationTests.cs
@@ -488,11 +488,47 @@ public sealed class ObligationTests
                 obl.Status = ObligationStatus.Discharged;
         }
 
-        var emitter = new CSharpEmitter(ContractMode.Debug, null, null, tracker);
+        // Elision is opt-in as of v0.13 (roadmap §2.1); this test pins the machinery.
+        var emitter = new CSharpEmitter(ContractMode.Debug, null, null, tracker)
+        {
+            ElideProvenGuards = true
+        };
         var csharp = emitter.Emit(module);
 
         Assert.Contains("// PROVEN:", csharp);
         Assert.DoesNotContain("// TODO:", csharp);
+    }
+
+    [Fact]
+    public void CSharpEmit_DischargedObligation_DefaultKeepsGuard()
+    {
+        // v0.13 default: verification is diagnostic. Without the opt-in, a Discharged
+        // obligation keeps its runtime check.
+        var source = """
+            §M{m001:Test}
+              §F{f001:Main:pub}
+                  §I{i32:x}
+                  §O{void}
+                  §PROOF{p1:check} (>= x INT:0)
+            """;
+
+        var module = Parse(source, out var diagnostics);
+        Assert.False(diagnostics.HasErrors);
+
+        var tracker = new ObligationTracker();
+        var genr = new ObligationGenerator(tracker);
+        genr.Generate(module);
+        foreach (var obl in tracker.Obligations)
+        {
+            if (obl.Kind == ObligationKind.ProofObligation)
+                obl.Status = ObligationStatus.Discharged;
+        }
+
+        var emitter = new CSharpEmitter(ContractMode.Debug, null, null, tracker);
+        var csharp = emitter.Emit(module);
+
+        Assert.Contains("throw new InvalidOperationException", csharp);
+        Assert.DoesNotContain("// PROVEN:", csharp);
     }
 
     [Fact]

--- a/tests/Calor.Verification.Tests/IntegrationTests.cs
+++ b/tests/Calor.Verification.Tests/IntegrationTests.cs
@@ -33,7 +33,7 @@ public class IntegrationTests
         var options = new CompilationOptions
         {
             VerifyContracts = true,
-        ElideProvenGuards = true
+            ElideProvenGuards = true
         };
 
         var result = Program.Compile(source, "test.calr", options);
@@ -211,7 +211,7 @@ public class IntegrationTests
         var options = new CompilationOptions
         {
             VerifyContracts = true,
-        ElideProvenGuards = true
+            ElideProvenGuards = true
         };
 
         var result = Program.Compile(source, "test.calr", options);
@@ -241,7 +241,7 @@ public class IntegrationTests
         var options = new CompilationOptions
         {
             VerifyContracts = true,
-        ElideProvenGuards = true
+            ElideProvenGuards = true
         };
 
         var result = Program.Compile(source, "test.calr", options);
@@ -268,7 +268,7 @@ public class IntegrationTests
         var options = new CompilationOptions
         {
             VerifyContracts = true,
-        ElideProvenGuards = true
+            ElideProvenGuards = true
         };
 
         var result = Program.Compile(source, "test.calr", options);
@@ -323,7 +323,7 @@ public class IntegrationTests
         var options = new CompilationOptions
         {
             VerifyContracts = true,
-        ElideProvenGuards = true
+            ElideProvenGuards = true
         };
 
         var result = Program.Compile(source, "test.calr", options);

--- a/tests/Calor.Verification.Tests/IntegrationTests.cs
+++ b/tests/Calor.Verification.Tests/IntegrationTests.cs
@@ -32,7 +32,8 @@ public class IntegrationTests
 
         var options = new CompilationOptions
         {
-            VerifyContracts = true
+            VerifyContracts = true,
+        ElideProvenGuards = true
         };
 
         var result = Program.Compile(source, "test.calr", options);
@@ -187,6 +188,7 @@ public class IntegrationTests
     private static CompilationOptions NoCache() => new()
     {
         VerifyContracts = true,
+        ElideProvenGuards = true,
         VerificationCacheOptions = new VerificationCacheOptions { Enabled = false }
     };
 
@@ -208,7 +210,8 @@ public class IntegrationTests
 
         var options = new CompilationOptions
         {
-            VerifyContracts = true
+            VerifyContracts = true,
+        ElideProvenGuards = true
         };
 
         var result = Program.Compile(source, "test.calr", options);
@@ -237,7 +240,8 @@ public class IntegrationTests
 
         var options = new CompilationOptions
         {
-            VerifyContracts = true
+            VerifyContracts = true,
+        ElideProvenGuards = true
         };
 
         var result = Program.Compile(source, "test.calr", options);
@@ -263,7 +267,8 @@ public class IntegrationTests
 
         var options = new CompilationOptions
         {
-            VerifyContracts = true
+            VerifyContracts = true,
+        ElideProvenGuards = true
         };
 
         var result = Program.Compile(source, "test.calr", options);
@@ -317,7 +322,8 @@ public class IntegrationTests
 
         var options = new CompilationOptions
         {
-            VerifyContracts = true
+            VerifyContracts = true,
+        ElideProvenGuards = true
         };
 
         var result = Program.Compile(source, "test.calr", options);
@@ -398,7 +404,7 @@ public class IntegrationTests
       §S (>= result LONG:0)
       §R x";
 
-        var options = new CompilationOptions { VerifyContracts = true };
+        var options = new CompilationOptions { VerifyContracts = true, ElideProvenGuards = true };
         var result = Program.Compile(source, "test.calr", options);
 
         // Verification runs to completion — the width markers neither crash the

--- a/tests/Calor.Verification.Tests/MethodElisionCursorTests.cs
+++ b/tests/Calor.Verification.Tests/MethodElisionCursorTests.cs
@@ -184,9 +184,40 @@ public class MethodElisionCursorTests
         Assert.Contains(result.Diagnostics, d => d.Code == DiagnosticCode.ContractVerificationAssumed);
     }
 
+    [SkippableFact]
+    public void ProvenPostcondition_WithoutOptIn_KeepsGuard()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+
+        // The v0.13 default (roadmap §2.1): a Proven verdict is diagnostic; the guard
+        // stays unless ElideProvenGuards is set. Same source as the elide test above,
+        // compiled WITHOUT the opt-in.
+        const string source = @"
+§M{m001:Test}
+  §CL{c001:Calc:pub}
+    §MT{mt001:Square:pub}
+      §I{i32:x}
+      §O{i32}
+      §Q (>= x 0)
+      §Q (<= x 46340)
+      §S (>= result 0)
+      §R (* x x)";
+
+        var result = Program.Compile(source, "test.calr", new CompilationOptions
+        {
+            VerifyContracts = true,
+            VerificationCacheOptions = new VerificationCacheOptions { Enabled = false }
+        });
+
+        Assert.False(result.HasErrors);
+        Assert.DoesNotContain("// PROVEN: Postcondition", result.GeneratedCode);
+        Assert.Contains("ContractViolationException", result.GeneratedCode);
+    }
+
     private static CompilationOptions NoCache() => new()
     {
         VerifyContracts = true,
+        ElideProvenGuards = true,
         VerificationCacheOptions = new VerificationCacheOptions { Enabled = false }
     };
 }

--- a/tests/Calor.Verification.Tests/MethodElisionCursorTests.cs
+++ b/tests/Calor.Verification.Tests/MethodElisionCursorTests.cs
@@ -206,12 +206,21 @@ public class MethodElisionCursorTests
         var result = Program.Compile(source, "test.calr", new CompilationOptions
         {
             VerifyContracts = true,
-            VerificationCacheOptions = new VerificationCacheOptions { Enabled = false }
+            VerificationCacheOptions = new VerificationCacheOptions { Enabled = false },
+            // Verbose surfaces the Calor0713 Proven diagnostic the vacuity check needs.
+            Verbose = true,
+            StatusWriter = TextWriter.Null
         });
 
         Assert.False(result.HasErrors);
         Assert.DoesNotContain("// PROVEN: Postcondition", result.GeneratedCode);
         Assert.Contains("ContractViolationException", result.GeneratedCode);
+        // The verdict must actually be Proven — otherwise this test passes vacuously
+        // for a source whose verification degraded to Assumed/Timeout. The message must
+        // also say the check was KEPT: the verbose diagnostic used to claim "elided"
+        // unconditionally, which is false without the opt-in.
+        Assert.Contains(result.Diagnostics,
+            d => d.Code == DiagnosticCode.PostconditionProven && d.Message.Contains("kept"));
     }
 
     private static CompilationOptions NoCache() => new()

--- a/tests/Calor.Verification.Tests/OutcomeCorpusTests.cs
+++ b/tests/Calor.Verification.Tests/OutcomeCorpusTests.cs
@@ -30,6 +30,7 @@ public class OutcomeCorpusTests
         var options = new CompilationOptions
         {
             VerifyContracts = true,
+        ElideProvenGuards = true,
             Verbose = verbose,
             StatusWriter = TextWriter.Null,
             VerificationTimeoutMs = timeoutMs,

--- a/tests/Calor.Verification.Tests/OutcomeCorpusTests.cs
+++ b/tests/Calor.Verification.Tests/OutcomeCorpusTests.cs
@@ -30,7 +30,7 @@ public class OutcomeCorpusTests
         var options = new CompilationOptions
         {
             VerifyContracts = true,
-        ElideProvenGuards = true,
+            ElideProvenGuards = true,
             Verbose = verbose,
             StatusWriter = TextWriter.Null,
             VerificationTimeoutMs = timeoutMs,

--- a/website/content/cli/compile.mdx
+++ b/website/content/cli/compile.mdx
@@ -105,7 +105,7 @@ Use `--verify` to enable Z3 static contract verification:
 calor -i MyModule.calr -o MyModule.g.cs --verify
 ```
 
-When enabled, the compiler uses the Z3 SMT solver to attempt proving contracts at compile time. Proven contracts may have their runtime checks elided.
+When enabled, the compiler uses the Z3 SMT solver to attempt proving contracts at compile time. Verdicts are diagnostic by default: proven contracts keep their runtime checks unless you also pass `--elide-proven-guards` (elision is opt-in as of v0.13).
 
 Example output:
 

--- a/website/content/syntax-reference/refinement-types.mdx
+++ b/website/content/syntax-reference/refinement-types.mdx
@@ -150,7 +150,7 @@ Z3 proves this: given `balance >= amount` and `amount > 0`, then `balance - amou
 
 | Status | Meaning | C# Output |
 |:-------|:--------|:----------|
-| Discharged | Z3 proved the condition | `// PROVEN: proof obligation [p1]` |
+| Discharged | Z3 proved the condition | Runtime guard kept (default); `// PROVEN: proof obligation [p1]` with `--elide-proven-guards` (elision is opt-in as of v0.13) |
 | Failed | Z3 found a counterexample | Runtime guard (throws on violation) |
 | Timeout | Z3 couldn't decide in time | Runtime guard (configurable by policy) |
 | Boundary | Public API — can't verify callers | Runtime guard (always emitted) |
@@ -166,7 +166,7 @@ Refinement types are a **compile-time construct**. In the emitted C#, they are e
 | `§RTYPE{r1:NatInt:i32} (>= # INT:0)` | *(nothing — erased)* |
 | `§I{NatInt:count}` | `int count` |
 | `§I{i32:x} \| (>= # INT:0)` | `int x` |
-| `§PROOF{p1:check} (cond)` (Discharged) | `// PROVEN: proof obligation [p1: check]` |
+| `§PROOF{p1:check} (cond)` (Discharged) | Runtime guard (default); `// PROVEN: proof obligation [p1: check]` with `--elide-proven-guards` |
 | `§PROOF{p1:check} (cond)` (Failed) | `if (!(cond)) throw new InvalidOperationException(...)` |
 
 The refinement constrains what values are valid. The obligation engine verifies those constraints and emits runtime guards only where verification fails.


### PR DESCRIPTION
## Summary

v0.13 quick-wins batch, item 3 — the elision policy decision the roadmap takes by design rather than by gate (§2.1): **proof-based guard elision becomes explicitly opt-in; verification is diagnostic by default.**

- Default: a `Proven` postcondition or `Discharged` `§PROOF` obligation **keeps its runtime check**; the verdict is reported, never silently acted on.
- Opt-in: `--elide-proven-guards` (CLI, threaded through `CompileAsync`/`CompileCore`), `CompilationOptions.ElideProvenGuards`, MSBuild task property `ElideProvenGuards`.
- The `run`/`test` execution paths (`ExecutionWorkspace`) deliberately have no flag — execution always keeps guards.
- Both elide sites gated: the postcondition `Proven` branch and the obligation `Discharged` arm (`Discharged` without opt-in now joins the guard-emitting group alongside the #893 ride-along statuses).

## Why

Seven false-`Proven` elide vectors closed across v0.10–v0.12; D15 proved the demotion mechanism is structurally blind to emitter-side vectors; the #893 review demonstrated a *new* foreign-proof elision route two days after the class was thought understood. The differential gate that would justify default-on (freeze registration F-4: zero mismatches over the pinned `verification-modeled-forms.md` denominator, coverage fraction published) is registered but not yet built — roadmap §3.5 gate 6 is the re-enable bar.

## Verification

- Existing elision pins (IntegrationTests, OutcomeCorpusTests, MethodElisionCursorTests, ObligationTests) opt in explicitly — they pin the elision machinery, which is unchanged behind the flag.
- New default-off pins: `ProvenPostcondition_WithoutOptIn_KeepsGuard` and `CSharpEmit_DischargedObligation_DefaultKeepsGuard`.
- Full suite: **8,290 tests, 0 failed, 17 skipped** — nothing outside the explicitly opted-in pins depended on the old default, which is itself evidence the flip's blast radius is as narrow as intended.
- CHANGELOG Unreleased entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)