### PR TITLE
feat(ci): PP-S4 fixture registry + d-s1.5-fixtures gate (A-1.5.7, roadmap gate 6)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,6 @@
 **/*.cs @juanmicrosoft
 /scripts/check-calor-first-diff.sh @juanmicrosoft
 /scripts/check-calor-first-diff-tests.sh @juanmicrosoft
+/scripts/check-d-s1.5-fixtures.sh @juanmicrosoft
+/bench/phase0-agent-native/fixtures/d-s1.5/ @juanmicrosoft
 /.github/workflows/test.yml @juanmicrosoft

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,54 @@ jobs:
             exit 1
           fi
 
+  d-s1.5-fixtures:
+    # PP-S4's instrument (A-1.5.7; roadmap v0.13 §2.5 gate 6): every SupportLevel
+    # promotion toward Full and every net ConversionLossKind removal must carry a
+    # registered fixture. The script's --self-test runs FIRST on every invocation,
+    # so the gate is demonstrated to fail on a fixture-less promotion continuously,
+    # not once (the discriminating pin, per pins-must-discriminate).
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Self-test (discriminating pin)
+        run: bash scripts/check-d-s1.5-fixtures.sh --self-test
+
+      - name: Check promotions and loss-kind removals against the registry
+        env:
+          CALOR_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          BASE="${CALOR_BASE_SHA:-}"
+          if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
+            BASE=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
+          fi
+          bash scripts/check-d-s1.5-fixtures.sh "$BASE" HEAD
+
+      - name: Detect registered fixtures
+        id: fixtures
+        run: |
+          if ls bench/phase0-agent-native/fixtures/d-s1.5/*/fixture.json >/dev/null 2>&1; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.fixtures.outputs.present == 'true'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Validate registered fixtures (indeterminate = failing)
+        if: steps.fixtures.outputs.present == 'true'
+        run: |
+          dotnet test tests/Calor.Conversion.Tests -c Release \
+            --filter "FullyQualifiedName~DS15FixtureRegistry" --verbosity detailed
+
   semantics-tests:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,12 +132,16 @@ jobs:
             exit 1
           fi
 
-  d-s1.5-fixtures:
+  ds15-fixtures:
     # PP-S4's instrument (A-1.5.7; roadmap v0.13 §2.5 gate 6): every SupportLevel
     # promotion toward Full and every net ConversionLossKind removal must carry a
     # registered fixture. The script's --self-test runs FIRST on every invocation,
     # so the gate is demonstrated to fail on a fixture-less promotion continuously,
     # not once (the discriminating pin, per pins-must-discriminate).
+    # Job ID cannot contain dots (GitHub Actions rejects the whole workflow file);
+    # the display name below carries the A-1.5.7 frozen entry-point name and is what
+    # status contexts show.
+    name: d-s1.5-fixtures
     runs-on: ubuntu-latest
 
     steps:
@@ -157,6 +161,9 @@ jobs:
           if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
             BASE=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
           fi
+          # merge-base: the precise span for PR events (payload base.sha is the base
+          # branch at PR creation and can span unrelated main commits).
+          BASE=$(git merge-base "$BASE" HEAD 2>/dev/null || echo "$BASE")
           bash scripts/check-d-s1.5-fixtures.sh "$BASE" HEAD
 
       - name: Detect registered fixtures

--- a/bench/phase0-agent-native/fixtures/d-s1.5/README.md
+++ b/bench/phase0-agent-native/fixtures/d-s1.5/README.md
@@ -12,14 +12,20 @@ only mergeable when a fixture demonstrates the claimed fidelity on real values.
 ## Schema (frozen at A-1.5.7 — one directory per registered feature)
 
 ```
-d-s1.5/<feature-key>/
-  fixture.json     { "featureKey": "<FeatureSupport key>",
+d-s1.5/<sanitized-key>/
+  fixture.json     { "featureKey": "<exact FeatureSupport key>",
                      "lossKindCertifiedAbsent": "<ConversionLossKind name or null>" }
   input.cs         the C# input exercising the feature
   expected.calr    the expected converted Calor (exact match against `calor migrate` output)
   test.calr        the value-asserting test: a Calor program using the converted construct
                    whose contracts/assertions fail if the conversion is value-wrong
 ```
+
+**Directory naming:** feature keys may contain spaces, parentheses, and slashes (two such keys
+exist today: `binary pattern (and/or)`, `unary pattern (not)`), which cannot be directory names.
+The directory name is the key with every character outside `[a-z0-9-]` replaced by `-` (runs
+collapsed); the **exact** key lives in `fixture.json`'s `featureKey`, which is what the checker
+matches on — never the directory name.
 
 ## CI entry point (frozen at A-1.5.7): the `d-s1.5-fixtures` job
 
@@ -42,6 +48,32 @@ discriminating pin, executed continuously rather than demonstrated once.
 
 Empty, per the registration: frozen by location, schema, and entry point — not by content. The
 first fixtures are expected from roadmap §3.2's nullable-idiom migration work, which is blocked
-on this gate being green (roadmap §3.2 sequencing constraint). Value-assertion *execution* of
-`test.calr` (beyond compile validation) lands with the first fixture; the disclosure exists so
-the gap is a decision on record, not an omission.
+on this gate being green (roadmap §3.2 sequencing constraint).
+
+## Disclosed limits (decisions on record, not omissions)
+
+- **Value-assertion execution of `test.calr`** (beyond compile validation) lands with the first
+  fixture.
+- **Fixture-to-feature linkage is nominal**: nothing yet asserts `input.cs` actually exercises
+  the promoted feature (a converter-ledger-touch check is the registered follow-up). Until it
+  lands, a review of the fixture's content is part of reviewing the promotion PR.
+- **Loss-kind certification is registry-global**: a fixture naming a kind certifies it for any
+  removal site, not the specific one in the diff.
+- **Behavioral suppression is out of reach**: wrapping a `RecordLoss` call in a never-true
+  condition keeps the reference count intact. The gate detects reclassification-by-deletion,
+  not reclassification-by-dead-code — the latter is what adversarial review of promotion PRs
+  is for.
+- **De-facto promotion via call sites**: converter code that branches on
+  `GetSupportLevel(...) != Full` can change behavior without touching the table; outside this
+  gate's reach (the round-trip and conformance suites cover behavior).
+- **The checker runs from the PR's own checkout.** CODEOWNERS protects the script, the
+  registry, and `test.yml` from unreviewed weakening; the residual (owner-approved changes)
+  is accepted.
+- **Direct pushes to main** bypass PR gating entirely (a known repo footgun) and multi-commit
+  direct pushes are scanned only from `HEAD~1`.
+
+## Enforcement note (CRITICAL-2 from the introducing PR's review)
+
+The job blocks merges only once its context (`d-s1.5-fixtures`) is added to the branch's
+required status checks — an admin action to perform immediately after the introducing PR
+merges, recorded here so the gap between "job exists" and "job gates" is on the record.

--- a/bench/phase0-agent-native/fixtures/d-s1.5/README.md
+++ b/bench/phase0-agent-native/fixtures/d-s1.5/README.md
@@ -1,0 +1,47 @@
+# D-S1.5 fixture registry — PP-S4's instrument
+
+Registered at **A-1.5.7** (`docs/plans/agent-native-gates.md`): *"a blocker with no measurement
+path is unfalsifiable."* Carried out of Call S as explicit debt ("the first `SupportLevel`
+promotion re-arms PP-S4 with no CI to enforce it") and discharged by roadmap v0.13 §2.5 gate 6.
+
+**What PP-S4 guards:** M-S4 = 0 — no converter or harness change may raise a support or fidelity
+metric *by making converted code less faithful* (reclassification instead of implementation).
+The registry is the measurement path: a `SupportLevel` promotion or a loss-ledger removal is
+only mergeable when a fixture demonstrates the claimed fidelity on real values.
+
+## Schema (frozen at A-1.5.7 — one directory per registered feature)
+
+```
+d-s1.5/<feature-key>/
+  fixture.json     { "featureKey": "<FeatureSupport key>",
+                     "lossKindCertifiedAbsent": "<ConversionLossKind name or null>" }
+  input.cs         the C# input exercising the feature
+  expected.calr    the expected converted Calor (exact match against `calor migrate` output)
+  test.calr        the value-asserting test: a Calor program using the converted construct
+                   whose contracts/assertions fail if the conversion is value-wrong
+```
+
+## CI entry point (frozen at A-1.5.7): the `d-s1.5-fixtures` job
+
+`scripts/check-d-s1.5-fixtures.sh` runs on every PR and asserts, for the diff under test:
+
+1. **Every `SupportLevel` promotion toward `Full`** in `Migration/FeatureSupport.cs` (including
+   a new entry born above `NotSupported` — the same maneuver in one step) has a registry
+   directory whose `fixture.json` names that feature key.
+2. **Every net loss-kind removal** (a `ConversionLossKind.<Kind>` reference removed from
+   `Migration/` sources) has a registry fixture naming that kind as certified-absent.
+3. Registered fixtures are **green** (`DS15FixtureRegistryTests` — structure, conversion match,
+   Calor compilation). **Indeterminate (a fixture that will not build) counts as failing**,
+   conservatively, per the registration.
+
+The job runs the script's **`--self-test` first on every invocation**: a synthetic fixture-less
+promotion must make the check fail, and a no-change diff must pass. This is the roadmap gate 6
+discriminating pin, executed continuously rather than demonstrated once.
+
+## Initial contents
+
+Empty, per the registration: frozen by location, schema, and entry point — not by content. The
+first fixtures are expected from roadmap §3.2's nullable-idiom migration work, which is blocked
+on this gate being green (roadmap §3.2 sequencing constraint). Value-assertion *execution* of
+`test.calr` (beyond compile validation) lands with the first fixture; the disclosure exists so
+the gap is a decision on record, not an omission.

--- a/scripts/check-d-s1.5-fixtures.sh
+++ b/scripts/check-d-s1.5-fixtures.sh
@@ -3,27 +3,34 @@
 #
 # For the diff BASE..HEAD, asserts:
 #   1. every SupportLevel promotion toward Full in Migration/FeatureSupport.cs (including a
-#      new entry born above NotSupported) has a fixture at
-#      bench/phase0-agent-native/fixtures/d-s1.5/<key>/fixture.json naming that featureKey;
-#   2. every NET removal of a ConversionLossKind.<Kind> reference from Migration/ sources has
-#      a fixture naming that kind as lossKindCertifiedAbsent.
-# Fixture GREENNESS (build/conversion match) is asserted by DS15FixtureRegistryTests, run by
-# the same CI job after this script. Indeterminate counts as failing there.
+#      new entry born above NotSupported) has a registered fixture naming that featureKey;
+#   2. every NET removal of a ConversionLossKind.<Kind> reference from Migration/ sources
+#      (counted tree-wide at each ref, comments stripped — not per diff line, so file moves
+#      and same-line refactors cannot false-fire) has a fixture certifying that kind absent;
+#   3. FAIL-CLOSED: every key present at BASE must be extractable at HEAD. A key that
+#      vanishes or becomes unparseable (e.g. `Support = SomeConst` instead of the literal)
+#      fails the check — evading the parser is indistinguishable from a hidden promotion.
+#      The extractor must also account for every FeatureInfo entry at HEAD (count check).
+#
+# Fixture GREENNESS is asserted by DS15FixtureRegistryTests, run by the same CI job.
+# Indeterminate counts as failing there.
 #
 # Usage:
 #   check-d-s1.5-fixtures.sh <BASE_SHA> [HEAD_SHA]      # real check (HEAD default: HEAD)
-#   check-d-s1.5-fixtures.sh --self-test                # discriminating pin, run every CI pass
+#   check-d-s1.5-fixtures.sh --self-test                # discriminating pins, every CI run
 set -euo pipefail
 
 REGISTRY="bench/phase0-agent-native/fixtures/d-s1.5"
 FEATURE_FILE="src/Calor.Compiler/Migration/FeatureSupport.cs"
+MIGRATION_DIR="src/Calor.Compiler/Migration"
 
-# Extract "key level-rank" pairs from a FeatureSupport.cs content stream.
-# Rank: NotSupported=0, Partial=1, Full=2. Pairing rule: the most recent ["key"] =
-# line owns the next Support = SupportLevel.<X> line. POSIX awk only (no gawk
-# extensions — CI runners default to mawk, macOS to BSD awk).
+# Extract "rank<TAB>key" pairs from FeatureSupport.cs content on stdin. Keys may contain
+# spaces and parentheses (two such keys exist today), so TAB is the only safe separator.
+# Line comments are stripped first, so commented-out entries neither fire nor parse.
+# Rank: NotSupported=0, Partial=1, Full=2. POSIX awk only (CI runners default to mawk).
 extract_levels() {
   awk '
+    { sub(/\/\/.*/, "") }
     /\["[^"]+"\] = new FeatureInfo/ {
       line = $0
       sub(/^[^"]*"/, "", line); sub(/".*/, "", line)
@@ -34,55 +41,109 @@ extract_levels() {
         rank = 0
         if ($0 ~ /SupportLevel\.Full/) rank = 2
         else if ($0 ~ /SupportLevel\.Partial/) rank = 1
-        print key, rank
+        printf "%d\t%s\n", rank, key
         key = ""
       }
     }'
 }
 
-# Compare two level maps (files of "key rank"); print promoted keys (rank increased,
-# or new key born above NotSupported — treated as promotion from rank 0).
+# Count FeatureInfo entries in content on stdin (comments stripped) — the extractor's
+# fail-closed denominator: every entry must yield an extracted pair.
+count_entries() {
+  awk '{ sub(/\/\/.*/, "") } /= new FeatureInfo/ { n++ } END { print n + 0 }'
+}
+
+# Promoted keys: rank increased, or key born above NotSupported (base rank 0).
 find_promotions() {
   local base_map="$1" head_map="$2"
-  awk 'NR == FNR { b[$1] = $2; next }
-       { base = ($1 in b) ? b[$1] : 0; if ($2 + 0 > base + 0) print $1 }' \
+  awk -F'\t' 'NR == FNR { b[$2] = $1; next }
+       { base = ($2 in b) ? b[$2] : 0; if ($1 + 0 > base + 0) print $2 }' \
     "$base_map" "$head_map"
 }
 
+# FAIL-CLOSED leg: keys present at BASE but absent from the HEAD map. A legitimate
+# feature-entry removal is a denominator change and needs a supersession note plus a
+# temporary allowlist entry here — never a silent disappearance.
+find_vanished() {
+  local base_map="$1" head_map="$2"
+  awk -F'\t' 'NR == FNR { h[$2] = 1; next } !($2 in h) { print $2 }' \
+    "$head_map" "$base_map"
+}
+
+# The fixture is located by exact featureKey match across ALL fixture.json files (grep -F:
+# keys contain parens), not by directory name — dirnames are sanitized (see README).
 fixture_has_key() {
-  local key="$1"
-  [ -f "$REGISTRY/$key/fixture.json" ] \
-    && grep -q "\"featureKey\"[[:space:]]*:[[:space:]]*\"$key\"" "$REGISTRY/$key/fixture.json"
+  local key="$1" f
+  for f in "$REGISTRY"/*/fixture.json; do
+    [ -f "$f" ] || continue
+    grep -qF "\"featureKey\": \"$key\"" "$f" && return 0
+  done
+  return 1
 }
 
 fixture_certifies_loss_kind() {
   local kind="$1" f
   for f in "$REGISTRY"/*/fixture.json; do
     [ -f "$f" ] || continue
-    grep -q "\"lossKindCertifiedAbsent\"[[:space:]]*:[[:space:]]*\"$kind\"" "$f" && return 0
+    grep -qF "\"lossKindCertifiedAbsent\": \"$kind\"" "$f" && return 0
   done
   return 1
 }
 
-check_maps() {
-  # Args: base-map-file head-map-file removed-loss-kinds-file(one per line, may be empty)
-  local base_map="$1" head_map="$2" removed_kinds="$3" fail=0
+# Count ConversionLossKind.<Kind> references tree-wide under Migration/ at a ref,
+# comments stripped. Output: "count<TAB>kind" lines.
+count_loss_kinds_at_ref() {
+  local ref="$1" f
+  git ls-tree -r --name-only "$ref" -- "$MIGRATION_DIR" 2>/dev/null \
+    | grep '\.cs$' \
+    | while read -r f; do git show "$ref:$f" 2>/dev/null || true; done \
+    | awk '
+        { sub(/\/\/.*/, "")
+          s = $0
+          while (match(s, /ConversionLossKind\.[A-Za-z0-9]+/)) {
+            n[substr(s, RSTART + 19, RLENGTH - 19)]++
+            s = substr(s, RSTART + RLENGTH)
+          } }
+        END { for (k in n) printf "%d\t%s\n", n[k], k }'
+}
 
-  while read -r key; do
+check_maps() {
+  # Args: base-map head-map removed-kinds-file head-entry-count
+  local base_map="$1" head_map="$2" removed_kinds="$3" head_entries="${4:-}" fail=0
+
+  if [ -n "$head_entries" ]; then
+    local extracted; extracted=$(wc -l < "$head_map" | tr -d ' ')
+    if [ "$extracted" -ne "$head_entries" ]; then
+      echo "FAIL (fail-closed): extracted $extracted level pairs but HEAD has" \
+           "$head_entries FeatureInfo entries — an entry's Support is not the plain" \
+           "SupportLevel literal, which is indistinguishable from a hidden promotion." >&2
+      fail=1
+    fi
+  fi
+
+  while IFS= read -r key; do
+    [ -n "$key" ] || continue
+    echo "FAIL (fail-closed): key '$key' present at BASE is missing/unparseable at HEAD." \
+         "Removing or rewriting a FeatureSupport entry is a denominator change that" \
+         "needs an explicit supersession, never a silent disappearance." >&2
+    fail=1
+  done < <(find_vanished "$base_map" "$head_map")
+
+  while IFS= read -r key; do
     [ -n "$key" ] || continue
     if ! fixture_has_key "$key"; then
       echo "FAIL: SupportLevel promotion for '$key' has no registered fixture" \
-           "($REGISTRY/$key/fixture.json with featureKey '$key'). PP-S4: a promotion" \
+           "(no $REGISTRY/*/fixture.json with featureKey '$key'). PP-S4: a promotion" \
            "toward Full must be demonstrated on values, not declared." >&2
       fail=1
     fi
   done < <(find_promotions "$base_map" "$head_map")
 
-  while read -r kind; do
+  while IFS= read -r kind; do
     [ -n "$kind" ] || continue
     if ! fixture_certifies_loss_kind "$kind"; then
-      echo "FAIL: net removal of ConversionLossKind.$kind has no fixture certifying that" \
-           "loss absent (no fixture.json with lossKindCertifiedAbsent '$kind')." >&2
+      echo "FAIL: net removal of ConversionLossKind.$kind references under Migration/" \
+           "has no fixture certifying that loss absent." >&2
       fail=1
     fi
   done < "$removed_kinds"
@@ -100,6 +161,11 @@ self_test() {
             Name = "record",
             Support = SupportLevel.Partial,
         },
+        ["binary pattern (and/or)"] = new FeatureInfo
+        {
+            Name = "binary pattern",
+            Support = SupportLevel.Partial,
+        },
         ["class"] = new FeatureInfo
         {
             Name = "class",
@@ -107,28 +173,48 @@ self_test() {
         },
 EOF
   sed 's/SupportLevel.Partial/SupportLevel.Full/' "$tmp/base.cs" > "$tmp/head.cs"
+  # Evasion variant: rewrite one entry's level as a non-literal.
+  sed 's/Support = SupportLevel.Partial,/Support = PromotedConst,/' "$tmp/base.cs" > "$tmp/evade.cs"
+  # Comment variant: the base plus a commented-out Full entry (must NOT fire).
+  { cat "$tmp/base.cs"; echo '        // ["ghost"] = new FeatureInfo { Support = SupportLevel.Full },'; } > "$tmp/comment.cs"
 
-  extract_levels < "$tmp/base.cs" > "$tmp/base.map"
-  extract_levels < "$tmp/head.cs" > "$tmp/head.map"
+  extract_levels < "$tmp/base.cs"    > "$tmp/base.map"
+  extract_levels < "$tmp/head.cs"    > "$tmp/head.map"
+  extract_levels < "$tmp/evade.cs"   > "$tmp/evade.map"
+  extract_levels < "$tmp/comment.cs" > "$tmp/comment.map"
   : > "$tmp/no-kinds"
 
-  # Pin 1 (discriminating): a fixture-less promotion MUST fail.
+  # Pin 1: a fixture-less promotion MUST fail — including the space-bearing key.
   if check_maps "$tmp/base.map" "$tmp/head.map" "$tmp/no-kinds" 2>/dev/null; then
-    echo "SELF-TEST FAILED: fixture-less promotion did not fail the check" >&2
-    return 1
+    echo "SELF-TEST FAILED: fixture-less promotion did not fail" >&2; return 1
   fi
-  # Pin 2 (negative control): an unchanged map MUST pass.
-  if ! check_maps "$tmp/base.map" "$tmp/base.map" "$tmp/no-kinds" 2>/dev/null; then
-    echo "SELF-TEST FAILED: no-change diff did not pass the check" >&2
-    return 1
+  # Capture rather than pipe: with pipefail, check_maps' (correct) exit 1 would fail
+  # the pipeline even when grep matches.
+  local pin1_out
+  pin1_out=$(check_maps "$tmp/base.map" "$tmp/head.map" "$tmp/no-kinds" 2>&1 || true)
+  if ! grep -qF "binary pattern (and/or)" <<< "$pin1_out"; then
+    echo "SELF-TEST FAILED: space-bearing key's promotion was not detected" >&2; return 1
   fi
-  # Pin 3 (discriminating, loss leg): an uncertified loss-kind removal MUST fail.
+  # Pin 2: no change MUST pass (incl. entry-count leg).
+  if ! check_maps "$tmp/base.map" "$tmp/base.map" "$tmp/no-kinds" "$(count_entries < "$tmp/base.cs")" 2>/dev/null; then
+    echo "SELF-TEST FAILED: no-change diff did not pass" >&2; return 1
+  fi
+  # Pin 3: an uncertified loss-kind removal MUST fail.
   echo "InteropPreserved" > "$tmp/kinds"
   if check_maps "$tmp/base.map" "$tmp/base.map" "$tmp/kinds" 2>/dev/null; then
-    echo "SELF-TEST FAILED: uncertified loss-kind removal did not fail the check" >&2
-    return 1
+    echo "SELF-TEST FAILED: uncertified loss-kind removal did not fail" >&2; return 1
   fi
-  echo "self-test: all three pins hold (promotion fails, no-change passes, loss-removal fails)"
+  # Pin 4 (fail-closed): a key rewritten to a non-literal level MUST fail, two ways —
+  # vanished-key leg and entry-count leg.
+  if check_maps "$tmp/base.map" "$tmp/evade.map" "$tmp/no-kinds" "$(count_entries < "$tmp/evade.cs")" 2>/dev/null; then
+    echo "SELF-TEST FAILED: non-literal Support rewrite did not fail closed" >&2; return 1
+  fi
+  # Pin 5 (negative control): a commented-out entry neither fires nor counts.
+  if ! check_maps "$tmp/base.map" "$tmp/comment.map" "$tmp/no-kinds" "$(count_entries < "$tmp/comment.cs")" 2>/dev/null; then
+    echo "SELF-TEST FAILED: commented-out entry false-fired" >&2; return 1
+  fi
+  echo "self-test: all five pins hold (promotion incl. space-key fails, no-change passes," \
+       "loss-removal fails, non-literal rewrite fails closed, comment does not fire)"
 }
 
 if [ "${1:-}" = "--self-test" ]; then
@@ -143,21 +229,18 @@ tmpd=$(mktemp -d); trap 'rm -rf "$tmpd"' EXIT
 
 git show "$BASE:$FEATURE_FILE" 2>/dev/null | extract_levels > "$tmpd/base.map" || : > "$tmpd/base.map"
 git show "$HEAD_REF:$FEATURE_FILE" | extract_levels > "$tmpd/head.map"
+head_entries=$(git show "$HEAD_REF:$FEATURE_FILE" | count_entries)
 
-# Net loss-kind removals across Migration/ sources: kinds whose removed-line count
-# exceeds their added-line count in the diff.
-git diff "$BASE".."$HEAD_REF" -- 'src/Calor.Compiler/Migration/*.cs' \
-  | awk '
-      # "ConversionLossKind." is 19 characters; the kind name follows it.
-      /^-[^-]/ { s = $0; while (match(s, /ConversionLossKind\.[A-Za-z]+/)) {
-                   rem[substr(s, RSTART + 19, RLENGTH - 19)]++; s = substr(s, RSTART + RLENGTH) } }
-      /^\+[^+]/ { s = $0; while (match(s, /ConversionLossKind\.[A-Za-z]+/)) {
-                   add[substr(s, RSTART + 19, RLENGTH - 19)]++; s = substr(s, RSTART + RLENGTH) } }
-      END { for (k in rem) if (rem[k] > add[k] + 0) print k }
-    ' > "$tmpd/removed-kinds"
+# Net loss-kind removals: tree-wide counts at each ref (comments stripped), not diff
+# lines — a file moved out of Migration/ or a same-line refactor cannot false-fire.
+count_loss_kinds_at_ref "$BASE"     > "$tmpd/base.kinds"
+count_loss_kinds_at_ref "$HEAD_REF" > "$tmpd/head.kinds"
+awk -F'\t' 'NR == FNR { h[$2] = $1; next }
+     { if (($2 in h ? h[$2] : 0) + 0 < $1 + 0) print $2 }' \
+  "$tmpd/head.kinds" "$tmpd/base.kinds" > "$tmpd/removed-kinds"
 
-if check_maps "$tmpd/base.map" "$tmpd/head.map" "$tmpd/removed-kinds"; then
-  echo "d-s1.5 check: no unregistered promotions or loss-kind removals in $BASE..$HEAD_REF"
+if check_maps "$tmpd/base.map" "$tmpd/head.map" "$tmpd/removed-kinds" "$head_entries"; then
+  echo "d-s1.5 check: no unregistered promotions, vanished keys, or loss-kind removals in $BASE..$HEAD_REF"
 else
   exit 1
 fi

--- a/scripts/check-d-s1.5-fixtures.sh
+++ b/scripts/check-d-s1.5-fixtures.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# D-S1.5 fixture-registry check (PP-S4's instrument; A-1.5.7, roadmap v0.13 §2.5 gate 6).
+#
+# For the diff BASE..HEAD, asserts:
+#   1. every SupportLevel promotion toward Full in Migration/FeatureSupport.cs (including a
+#      new entry born above NotSupported) has a fixture at
+#      bench/phase0-agent-native/fixtures/d-s1.5/<key>/fixture.json naming that featureKey;
+#   2. every NET removal of a ConversionLossKind.<Kind> reference from Migration/ sources has
+#      a fixture naming that kind as lossKindCertifiedAbsent.
+# Fixture GREENNESS (build/conversion match) is asserted by DS15FixtureRegistryTests, run by
+# the same CI job after this script. Indeterminate counts as failing there.
+#
+# Usage:
+#   check-d-s1.5-fixtures.sh <BASE_SHA> [HEAD_SHA]      # real check (HEAD default: HEAD)
+#   check-d-s1.5-fixtures.sh --self-test                # discriminating pin, run every CI pass
+set -euo pipefail
+
+REGISTRY="bench/phase0-agent-native/fixtures/d-s1.5"
+FEATURE_FILE="src/Calor.Compiler/Migration/FeatureSupport.cs"
+
+# Extract "key level-rank" pairs from a FeatureSupport.cs content stream.
+# Rank: NotSupported=0, Partial=1, Full=2. Pairing rule: the most recent ["key"] =
+# line owns the next Support = SupportLevel.<X> line. POSIX awk only (no gawk
+# extensions — CI runners default to mawk, macOS to BSD awk).
+extract_levels() {
+  awk '
+    /\["[^"]+"\] = new FeatureInfo/ {
+      line = $0
+      sub(/^[^"]*"/, "", line); sub(/".*/, "", line)
+      key = line
+    }
+    /Support = SupportLevel\.(NotSupported|Partial|Full)/ {
+      if (key != "") {
+        rank = 0
+        if ($0 ~ /SupportLevel\.Full/) rank = 2
+        else if ($0 ~ /SupportLevel\.Partial/) rank = 1
+        print key, rank
+        key = ""
+      }
+    }'
+}
+
+# Compare two level maps (files of "key rank"); print promoted keys (rank increased,
+# or new key born above NotSupported — treated as promotion from rank 0).
+find_promotions() {
+  local base_map="$1" head_map="$2"
+  awk 'NR == FNR { b[$1] = $2; next }
+       { base = ($1 in b) ? b[$1] : 0; if ($2 + 0 > base + 0) print $1 }' \
+    "$base_map" "$head_map"
+}
+
+fixture_has_key() {
+  local key="$1"
+  [ -f "$REGISTRY/$key/fixture.json" ] \
+    && grep -q "\"featureKey\"[[:space:]]*:[[:space:]]*\"$key\"" "$REGISTRY/$key/fixture.json"
+}
+
+fixture_certifies_loss_kind() {
+  local kind="$1" f
+  for f in "$REGISTRY"/*/fixture.json; do
+    [ -f "$f" ] || continue
+    grep -q "\"lossKindCertifiedAbsent\"[[:space:]]*:[[:space:]]*\"$kind\"" "$f" && return 0
+  done
+  return 1
+}
+
+check_maps() {
+  # Args: base-map-file head-map-file removed-loss-kinds-file(one per line, may be empty)
+  local base_map="$1" head_map="$2" removed_kinds="$3" fail=0
+
+  while read -r key; do
+    [ -n "$key" ] || continue
+    if ! fixture_has_key "$key"; then
+      echo "FAIL: SupportLevel promotion for '$key' has no registered fixture" \
+           "($REGISTRY/$key/fixture.json with featureKey '$key'). PP-S4: a promotion" \
+           "toward Full must be demonstrated on values, not declared." >&2
+      fail=1
+    fi
+  done < <(find_promotions "$base_map" "$head_map")
+
+  while read -r kind; do
+    [ -n "$kind" ] || continue
+    if ! fixture_certifies_loss_kind "$kind"; then
+      echo "FAIL: net removal of ConversionLossKind.$kind has no fixture certifying that" \
+           "loss absent (no fixture.json with lossKindCertifiedAbsent '$kind')." >&2
+      fail=1
+    fi
+  done < "$removed_kinds"
+
+  return "$fail"
+}
+
+self_test() {
+  local tmp; tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' RETURN
+
+  cat > "$tmp/base.cs" <<'EOF'
+        ["record"] = new FeatureInfo
+        {
+            Name = "record",
+            Support = SupportLevel.Partial,
+        },
+        ["class"] = new FeatureInfo
+        {
+            Name = "class",
+            Support = SupportLevel.Full,
+        },
+EOF
+  sed 's/SupportLevel.Partial/SupportLevel.Full/' "$tmp/base.cs" > "$tmp/head.cs"
+
+  extract_levels < "$tmp/base.cs" > "$tmp/base.map"
+  extract_levels < "$tmp/head.cs" > "$tmp/head.map"
+  : > "$tmp/no-kinds"
+
+  # Pin 1 (discriminating): a fixture-less promotion MUST fail.
+  if check_maps "$tmp/base.map" "$tmp/head.map" "$tmp/no-kinds" 2>/dev/null; then
+    echo "SELF-TEST FAILED: fixture-less promotion did not fail the check" >&2
+    return 1
+  fi
+  # Pin 2 (negative control): an unchanged map MUST pass.
+  if ! check_maps "$tmp/base.map" "$tmp/base.map" "$tmp/no-kinds" 2>/dev/null; then
+    echo "SELF-TEST FAILED: no-change diff did not pass the check" >&2
+    return 1
+  fi
+  # Pin 3 (discriminating, loss leg): an uncertified loss-kind removal MUST fail.
+  echo "InteropPreserved" > "$tmp/kinds"
+  if check_maps "$tmp/base.map" "$tmp/base.map" "$tmp/kinds" 2>/dev/null; then
+    echo "SELF-TEST FAILED: uncertified loss-kind removal did not fail the check" >&2
+    return 1
+  fi
+  echo "self-test: all three pins hold (promotion fails, no-change passes, loss-removal fails)"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  self_test
+  exit $?
+fi
+
+BASE="${1:?usage: $0 <BASE_SHA>|--self-test}"
+HEAD_REF="${2:-HEAD}"
+
+tmpd=$(mktemp -d); trap 'rm -rf "$tmpd"' EXIT
+
+git show "$BASE:$FEATURE_FILE" 2>/dev/null | extract_levels > "$tmpd/base.map" || : > "$tmpd/base.map"
+git show "$HEAD_REF:$FEATURE_FILE" | extract_levels > "$tmpd/head.map"
+
+# Net loss-kind removals across Migration/ sources: kinds whose removed-line count
+# exceeds their added-line count in the diff.
+git diff "$BASE".."$HEAD_REF" -- 'src/Calor.Compiler/Migration/*.cs' \
+  | awk '
+      # "ConversionLossKind." is 19 characters; the kind name follows it.
+      /^-[^-]/ { s = $0; while (match(s, /ConversionLossKind\.[A-Za-z]+/)) {
+                   rem[substr(s, RSTART + 19, RLENGTH - 19)]++; s = substr(s, RSTART + RLENGTH) } }
+      /^\+[^+]/ { s = $0; while (match(s, /ConversionLossKind\.[A-Za-z]+/)) {
+                   add[substr(s, RSTART + 19, RLENGTH - 19)]++; s = substr(s, RSTART + RLENGTH) } }
+      END { for (k in rem) if (rem[k] > add[k] + 0) print k }
+    ' > "$tmpd/removed-kinds"
+
+if check_maps "$tmpd/base.map" "$tmpd/head.map" "$tmpd/removed-kinds"; then
+  echo "d-s1.5 check: no unregistered promotions or loss-kind removals in $BASE..$HEAD_REF"
+else
+  exit 1
+fi

--- a/tests/Calor.Conversion.Tests/DS15FixtureRegistryTests.cs
+++ b/tests/Calor.Conversion.Tests/DS15FixtureRegistryTests.cs
@@ -41,11 +41,25 @@ public class DS15FixtureRegistryTests
     {
         // A single fact rather than a MemberData theory: the registry is legitimately
         // empty until the first SupportLevel promotion, and xUnit fails a theory with
-        // zero data rows. Every assertion message names the fixture.
+        // zero data rows. Errors are COLLECTED across all fixtures (not fail-fast), so
+        // one bad fixture does not hide the others' defects.
         var root = RegistryPath();
         if (!Directory.Exists(root)) return;
+
+        var failures = new List<string>();
         foreach (var dir in Directory.GetDirectories(root))
-            ValidateFixture(dir, Path.GetFileName(dir));
+        {
+            try
+            {
+                ValidateFixture(dir, Path.GetFileName(dir));
+            }
+            catch (Exception ex)
+            {
+                failures.Add($"{Path.GetFileName(dir)}: {ex.Message}");
+            }
+        }
+        Assert.True(failures.Count == 0,
+            "Fixture defects (indeterminate = failing):\n" + string.Join("\n", failures));
     }
 
     private static void ValidateFixture(string dir, string name)
@@ -61,11 +75,12 @@ public class DS15FixtureRegistryTests
         var testPath = Path.Combine(dir, "test.calr");
         Assert.True(File.Exists(testPath), $"{name}: test.calr missing");
 
-        // 2. Manifest: featureKey named and directory-consistent.
+        // 2. Manifest: featureKey named; the DIRECTORY is the sanitized form of the key
+        // (keys may contain spaces/parens/slashes — see README) and must match it.
         using var doc = JsonDocument.Parse(File.ReadAllText(manifestPath));
         var featureKey = doc.RootElement.GetProperty("featureKey").GetString();
         Assert.False(string.IsNullOrWhiteSpace(featureKey), $"{name}: featureKey empty");
-        Assert.Equal(name, featureKey);
+        Assert.Equal(SanitizeKey(featureKey!), name);
 
         // 3. Conversion match: input.cs converts to exactly expected.calr.
         var converter = new CSharpToCalorConverter(new ConversionOptions
@@ -93,4 +108,18 @@ public class DS15FixtureRegistryTests
 
     private static string Normalize(string s) =>
         s.Replace("\r\n", "\n").TrimEnd('\n');
+
+    /// <summary>README rule: every char outside [a-z0-9-] becomes '-', runs collapsed.</summary>
+    private static string SanitizeKey(string key)
+    {
+        var chars = key.ToLowerInvariant()
+            .Select(c => (char.IsAsciiLetterLower(c) || char.IsAsciiDigit(c) || c == '-') ? c : '-');
+        var collapsed = new System.Text.StringBuilder();
+        foreach (var c in chars)
+        {
+            if (c == '-' && collapsed.Length > 0 && collapsed[^1] == '-') continue;
+            collapsed.Append(c);
+        }
+        return collapsed.ToString().Trim('-');
+    }
 }

--- a/tests/Calor.Conversion.Tests/DS15FixtureRegistryTests.cs
+++ b/tests/Calor.Conversion.Tests/DS15FixtureRegistryTests.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using Calor.Compiler;
+using Calor.Compiler.Migration;
+using Xunit;
+
+namespace Calor.Conversion.Tests;
+
+/// <summary>
+/// PP-S4's fixture registry (A-1.5.7; roadmap v0.13 §2.5 gate 6). Every entry under
+/// bench/phase0-agent-native/fixtures/d-s1.5/ must be structurally complete, its C# input
+/// must convert to exactly the expected Calor, and both Calor files must compile.
+/// Indeterminate (a fixture that will not build) counts as FAILING, per the registration —
+/// which these tests implement by failing on any defect rather than skipping.
+/// The registry is legitimately empty until the first SupportLevel promotion; the
+/// enumeration test pins the location exists either way.
+/// </summary>
+public class DS15FixtureRegistryTests
+{
+    private static string RegistryPath()
+    {
+        // Walk up from the test bin dir to the repo root (marker: Directory.Build.props).
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "Directory.Build.props")))
+            dir = Path.GetDirectoryName(dir);
+        Assert.NotNull(dir);
+        return Path.Combine(dir!, "bench", "phase0-agent-native", "fixtures", "d-s1.5");
+    }
+
+    [Fact]
+    public void Registry_ExistsAtRegisteredLocation()
+    {
+        var root = RegistryPath();
+        Assert.True(Directory.Exists(root),
+            $"A-1.5.7 registry location missing: {root}");
+        Assert.True(File.Exists(Path.Combine(root, "README.md")),
+            "Registry schema doc (README.md) missing");
+    }
+
+    [Fact]
+    public void AllFixtures_AreCompleteConvertExactlyAndCompile()
+    {
+        // A single fact rather than a MemberData theory: the registry is legitimately
+        // empty until the first SupportLevel promotion, and xUnit fails a theory with
+        // zero data rows. Every assertion message names the fixture.
+        var root = RegistryPath();
+        if (!Directory.Exists(root)) return;
+        foreach (var dir in Directory.GetDirectories(root))
+            ValidateFixture(dir, Path.GetFileName(dir));
+    }
+
+    private static void ValidateFixture(string dir, string name)
+    {
+
+        // 1. Structure: all four schema components present.
+        var manifestPath = Path.Combine(dir, "fixture.json");
+        Assert.True(File.Exists(manifestPath), $"{name}: fixture.json missing");
+        var inputPath = Path.Combine(dir, "input.cs");
+        Assert.True(File.Exists(inputPath), $"{name}: input.cs missing");
+        var expectedPath = Path.Combine(dir, "expected.calr");
+        Assert.True(File.Exists(expectedPath), $"{name}: expected.calr missing");
+        var testPath = Path.Combine(dir, "test.calr");
+        Assert.True(File.Exists(testPath), $"{name}: test.calr missing");
+
+        // 2. Manifest: featureKey named and directory-consistent.
+        using var doc = JsonDocument.Parse(File.ReadAllText(manifestPath));
+        var featureKey = doc.RootElement.GetProperty("featureKey").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(featureKey), $"{name}: featureKey empty");
+        Assert.Equal(name, featureKey);
+
+        // 3. Conversion match: input.cs converts to exactly expected.calr.
+        var converter = new CSharpToCalorConverter(new ConversionOptions
+        {
+            ModuleName = "Fixture",
+            GracefulFallback = true,
+            AutoGenerateIds = true
+        });
+        var converted = converter.Convert(File.ReadAllText(inputPath), $"{name}.cs");
+        Assert.NotNull(converted.CalorSource);
+        Assert.Equal(
+            Normalize(File.ReadAllText(expectedPath)),
+            Normalize(converted.CalorSource!));
+
+        // 4. Both Calor files compile with zero errors (indeterminate = failing).
+        foreach (var calr in new[] { expectedPath, testPath })
+        {
+            var result = Program.Compile(File.ReadAllText(calr),
+                Path.GetFileName(calr), new CompilationOptions());
+            Assert.False(result.HasErrors,
+                $"{name}/{Path.GetFileName(calr)} does not compile: " +
+                string.Join("; ", result.Diagnostics.Where(d => d.IsError).Select(d => d.Message)));
+        }
+    }
+
+    private static string Normalize(string s) =>
+        s.Replace("\r\n", "\n").TrimEnd('\n');
+}


### PR DESCRIPTION
## Summary

v0.13 quick-wins batch, final item — discharges the Call S debt (*"the first `SupportLevel` promotion re-arms PP-S4 with no CI to enforce it"*, `call-s-adjudication.md:100-103`) by building PP-S4's registered instrument at **all three frozen parts of A-1.5.7**: location, schema, and CI entry point.

- **Registry**: `bench/phase0-agent-native/fixtures/d-s1.5/` + schema README. Initial contents empty, per the registration ("frozen by location, schema, and entry point, not by content").
- **Detection** (`scripts/check-d-s1.5-fixtures.sh`): `SupportLevel` promotions toward `Full` — including a new entry born above `NotSupported`, the one-step form of the same maneuver — and **net** `ConversionLossKind` removals aggregated across the whole Migration diff (moving a `RecordLoss` between files nets zero; no false fire).
- **The discriminating pin runs continuously**: the CI job executes the script's three-pin `--self-test` before every real check — a synthetic fixture-less promotion must fail, a no-change diff must pass, an uncertified loss-kind removal must fail. Roadmap §2.5 gate 6 asks for the pin to be "demonstrated"; this executes it every run.
- **Greenness** (`DS15FixtureRegistryTests`): per-fixture structure, exact conversion match against `expected.calr`, and compilation of both Calor files — **indeterminate (won't build) fails rather than skips**, implementing the registration's conservative rule.

## Consequence

Roadmap §3.2's sequencing constraint — no `FeatureSupport` promotion or loss-ledger removal merges before this gate is green — is now mechanically enforceable, closing the silent-roll-forward risk the substrate plan flags (§7 item 4: "fidelity bought by relabelling corrupts the evidence base").

## Known evasion surfaces for review

Named so the reviewer verifies rather than rediscovers: key-rename-while-promoting (caught: rename = new key born at `Full`), two-PR delete-then-readd (each PR gated independently; the re-add is a birth above `NotSupported` → gated), force-push base-SHA on push events (falls back to `HEAD~1`), awk extractor's coupling to `FeatureSupport.cs` formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)