### PR TITLE
docs: #762 binder rebuild scoping — the v0.13 spine (Draft v1)

### DIFF
--- a/docs/plans/binder-rebuild-762-scoping.md
+++ b/docs/plans/binder-rebuild-762-scoping.md
@@ -1,33 +1,42 @@
 # #762 binder rebuild — scoping (v0.13 spine)
 
 **Date:** 2026-08-10
-**Status:** Draft v1 — for adversarial review before any binder code merges
+**Status:** Draft v2 — adversarial review round 1 applied (verdict 65%; both CRITICALs and all
+Majors/minors addressed; dispositions in §8)
 **Governing inputs:** issue #762 (DoD: 100% of accepted expression kinds structurally bind),
 `v0.13-freeze-registrations.md` F-1 (the 61-class tier assignment — 55 registered / 6 residual —
 frozen before this work; the denominator of roadmap §2.5 gate 1) and F-2 (the measurement corpus),
 `roadmap-v0.13-v0.15.md` §2.1/§2.5. Per the freeze discipline, this doc merges before the work it
 scopes.
 
-## 1. Current state (measured, this branch)
+## 1. Current state (measured; corrected by review round 1)
 
-- `Binder.BindExpression` (`Binding/Binder.cs:297`) has **19 arms** over **61** concrete
-  `ExpressionNode` classes; everything else reaches `BindFallbackExpression` (`Binder.cs:515`),
-  a **zero-child** `BoundCallExpression` named `<unsupported:TypeName>` typed `"OBJECT"` — the
-  exact shape #762's evidence section describes (nested calls, division, indexing invisible to
-  every analysis). The fallback's own comment records the class of harm: an earlier fallback
-  (`BoundIntLiteral(0)`) made the div-by-zero checker false-positive on every unhandled divisor.
-- **Types are strings** (`"INT"`, `"OBJECT"`, …) throughout `BoundNodes.cs` (~25 bound classes);
-  `DecimalLiteralNode` binds as `BoundFloatLiteral((double)value)` — #762 item 4's defect,
-  visible in the switch.
-- **Consumers of the bound tree are the analysis layer only**: dataflow/CFG, the five bug-pattern
-  checkers, taint, contract inference, verification analysis, k-induction
-  (`Analysis/**`, `Verification/Z3/KInduction`). The emitters are `IAstVisitor` over the AST —
-  codegen is NOT in this rebuild's blast radius.
-- Top-level function registration ignores `TryDeclare` failures and bypasses the overload-set
-  machinery class members already use (#762 items 5–6).
-- Five AST classes still carry no-op `default!` `Accept`s (the #874 null-injection hazard class);
-  two expression-node members (`GenericTypeNode`, `KeywordArgNode`) are F-1 Tier B pending the
-  item-8 disposition.
+- `Binder.BindExpression` (`Binding/Binder.cs:299`) has **18 class-matched arms** over **61**
+  concrete `ExpressionNode` classes — and two of the 18 fall back *conditionally*
+  (`ThisExpressionNode` in static context; `TypeOperationNode` for non-Cast/Is/As ops). Everything
+  else reaches `BindFallbackExpression` (`Binder.cs:514`), a **zero-child** `BoundCallExpression`
+  named `<unsupported:TypeName>` typed `"OBJECT"`, and — important — **silent**: the fallback
+  reports no diagnostic. The fallback's comment records the class of harm an earlier
+  `BoundIntLiteral(0)` fallback caused (div-by-zero false positives on every unhandled divisor).
+- **Types are strings** (`"INT"`, `"OBJECT"`, …); `BoundNodes.cs` holds **43 bound classes**
+  (40 concrete + 3 abstract; 14 are `BoundExpression` subclasses). `DecimalLiteralNode` binds as
+  `BoundFloatLiteral((double)value)` — #762 item 4's defect, visible in the switch.
+- **Where binding runs — the load-bearing correction from review:** `new Binder(` has exactly
+  three production sites. (a) `Analysis/VerificationAnalysisPass.cs:155` — analyze-mode only
+  (`EnableVerificationAnalyses`, i.e. `--analyze`/MCP), and it binds into a **throwaway
+  DiagnosticBag**: binder diagnostics never reach the user there today. (b)
+  **`Calor.LanguageServer/State/DocumentState.cs:105` — the LSP binds every open document with
+  the LIVE diagnostics bag.** (c) Tests. Binding does **not** run in a normal compile.
+  Consequences: the analysis layer AND the LSP are the blast radius; any new binder diagnostic is
+  editor-visible immediately; and the incomplete-fraction instrument cannot be read from the
+  analyze path until the discarded-bag defect is fixed (§5).
+- Top-level function registration ignores `TryDeclare` failures (`Binder.cs:65`) while class
+  members use `DeclareOverload` (`:742`) — #762 items 5–6.
+- **Eight** AST classes carry no-op `default!` `Accept`s (the #874 null-injection hazard class):
+  `ElseIfClauseNode`, `OutputNode`, `EffectsNode`, `KeywordArgNode`, `FieldDefinitionNode`,
+  `VariantDefinitionNode`, `TypeReferenceNode`, `FieldAssignmentNode` — **only one of which
+  (`KeywordArgNode`) is an `ExpressionNode`**. #762 item 8 therefore has an expression half
+  (F-1's Tier B pair) and a larger non-expression half; both are scheduled (§3, B8).
 
 ## 2. Design decisions
 
@@ -35,96 +44,150 @@ scopes.
 `IReadOnlyDictionary<Type, Func<Binder, ExpressionNode, BoundExpression>>` built once. A
 **reflection completeness test** asserts every concrete `ExpressionNode` subclass has exactly one
 entry — Tier A classes map to real binders, Tier B classes map to an *explicit*
-`BindIncomplete` with a stated reason. A new class with no entry fails CI by construction (the
-F-1 bidirectional completeness check's code-side half). Parser expression-start classification
-(#762 item 7) derives from the same source of truth in the final PR — one table, two projections.
+`BindIncomplete` with a stated reason. Why a Type-keyed table rather than a new
+`IAstVisitor<BoundExpression>` implementation, recorded so B1's reviewer doesn't relitigate it:
+`IAstVisitor` carries ~236 methods across 4+ implementers (the roadmap's change-amplification
+complaint, #791), and eight classes have broken `Accept` dispatch — visitor traversal is exactly
+the mechanism that cannot be trusted here until item 8 lands. Parser expression-start
+classification (#762 item 7) derives from the same source of truth in B8 — one table, two
+projections.
 
-**D2 — `BoundIncompleteExpression` replaces the fallback.** A dedicated bound node that (a)
-**binds and retains all child expressions** (the subtree stays analyzable — #762 item 3's "never
-silently erase"), (b) carries the node-type name and an explicit stable type, and (c) reports an
-*analysis incomplete* diagnostic (new code in the 0200 semantic band) at Warning severity.
-Checkers treat it as an opaque non-constant value — preserving the div-by-zero lesson — but can
-now traverse *through* it to the children they previously lost. The `<unsupported:` string
-disappears from the tree; the F-2 instrument greps for the new node's marker instead (one
-instrument update, in the same PR).
+**D2 — `BoundIncompleteExpression` replaces the fallback, in two phases.** The node carries the
+node-type name, an explicit stable type, and an *analysis incomplete* diagnostic (new code in the
+0200 band). **Phase semantics, stated precisely (review M2):**
+- **B1 ships it zero-child** — traversal-identical to today's fallback, which is what makes B1's
+  "zero checker behavior change" exit criterion true by construction rather than aspiration.
+- **Children arrive with each family's real binder** (a family PR replaces the incomplete node
+  with a real bound node — children come from the real arm, not from a generic extractor).
+- **Classes that remain incomplete at B8** (Tier B residuals) get explicit per-class child
+  extractors there, with children **marked non-evaluated** (`IsDeferredContext`) so dataflow/
+  taint/uninitialized checkers do not treat lambda bodies or `?.`/`??` right-sides inside an
+  unsupported wrapper as evaluated in-line — the residual false-positive route review M2 named.
+  #762 item 3 ("retain children") is thus satisfied at end state, with the interim disclosed.
+  There is no generic child-enumeration mechanism and none is assumed.
+- Opacity-at-the-node is preserved throughout (the div-by-zero lesson): the node itself is an
+  opaque non-constant value to every checker.
 
-**D3 — Types stay strings in 0.13; they become explicit and non-null.** The 0.14 typed semantic
-representation (roadmap §3.2) replaces the *representation*; this rebuild fixes the *structure*.
-Every bound expression gets a non-null type string assigned through a single constructor choke
-point (no more implicit `"INT"` defaults scattered through binders). Widening this into
-metadata-backed typing is the 0.14 entry spike's job — an explicit non-goal here (§4).
+**D3 — Types stay strings in 0.13; they become explicit and non-null.** The single constructor
+choke point is the base `BoundExpression` constructor (verified viable by review). The 0.14 typed
+representation (roadmap §3.2) replaces the *representation*; widening into metadata-backed typing
+here is a fenced non-goal (§4).
 
-**D4 — SymbolIds and exact spans (#762 item 9).** Declarations already carry validated syntax ids
-(`§F{f001}`, `§MT{mt001}`, …); `SymbolId` = `<module-id>/<declaration-id>` for declarations,
-`<module-id>/<function-id>/<name>#<ordinal>` for locals and parameters. `VariableSymbol` /
-`FunctionSymbol` gain `SymbolId` + the **exact identifier token span** (not the whole
-declaration). This is the substrate roadmap gates 3 (index correctness) and 4 (SymbolId-addressed
-rename) instrument against, and what retires the #879/#893 mutable-cursor class properly: contract
-emission can key on the symbol in hand instead of a cursor the emitter must remember to maintain
-(the emitter change itself is follow-up, not this rebuild).
+**D4 — SymbolIds and exact spans (#762 item 9), corrected for the review's two defects.**
+- **Module ids are not unique** (nothing enforces it; nine sample files all use `§M{m001`), so a
+  bare `<module-id>/<declaration-id>` collides corpus-wide. `SymbolId` therefore =
+  `<project-relative-file-path>::<module-id>/<declaration-id>` for declarations. (Enforcing
+  module-id uniqueness instead would break existing corpora; the path component is
+  collision-free by construction and what the index needs anyway.)
+- **Locals/parameters are keyed by declaration order, not per-name ordinal**:
+  `…/<function-id>/local#<declaration-index>` (name carried as display metadata). A per-name
+  ordinal renumbers the *surviving* symbol when a same-named shadowing local is renamed — an
+  untouched symbol changing identity under exactly the rename-gate oracle (F-3 ES-06) that
+  consumes these ids. Declaration order is invariant under rename.
+- `VariableSymbol`/`FunctionSymbol` gain `SymbolId` + the **exact identifier token span**. This is
+  the substrate roadmap gates 3/4 instrument against, and what retires the #879/#893
+  mutable-cursor class properly (the emitter follow-up is separate work).
+- **Scheduled in B1** (plumbing on symbols, no consumers yet) — review C1's unassigned-item fix.
 
 **D5 — Overload sets for top-level functions (#762 items 5–6).** Reuse the class-member
-overload-set machinery for module-level functions; `TryDeclare` failures become diagnostics
-(duplicate signature, ambiguity, no-match at call sites). Diagnosed, never silently first-wins.
+machinery; `TryDeclare` failures become diagnostics. **Pass-interaction note (review m2):** this
+changes *pass 1* (symbol registration, `Binder.cs:57–66`) while bodies bind in pass 2 — the
+overload-set switch must land with a test that pass-2 call resolution sees the full set
+regardless of declaration order, which is the property two-pass binding exists to provide.
 
 **D6 — Decimal and conversion fidelity (#762 item 4).** `BoundDecimalLiteral` (no double
 downcast); `BoundConversionExpression` preserving the target type; `is`/pattern tests bind
 structurally instead of folding to `true`.
 
-**D7 — Item-8 disposition lands in the final PR** with its F-1 amendment: `GenericTypeNode` and
-`KeywordArgNode` either become non-`ExpressionNode` helper types (subtractive amendment with
-supersession entry) or get real binders (additive promotion to Tier A). Until then they stay
-residual and explicitly incomplete — never silently absent.
+**D7 — Item-8 disposition lands in B8, full scope.** The expression half (`GenericTypeNode`,
+`KeywordArgNode`) resolves with its F-1 amendment (additive promotion or subtractive
+reclassification with supersession). The **seven non-expression no-op-Accept classes** get real
+dispatch or a reclassification out of `AstNode`, plus the **AstNode-wide** reflection test #762's
+regression list requires (the ExpressionNode-only test ships in B1; B8 widens it).
 
-## 3. PR slicing (each PR: suite green, adversarial review, merge; family-by-family)
+## 3. PR slicing (each PR: suite green, adversarial review, merge)
 
 | PR | Scope | Exit criterion |
 |---|---|---|
-| **B1 — rails** | Dispatch table + reflection completeness test; `BoundIncompleteExpression` + diagnostic; Tier B explicit-incomplete; **the F-2 instrument** (CI leg over the pinned corpus publishing the incomplete-fraction, with the revert-the-fix discriminating pin) | All 61 classes flow through the table; baseline fraction measured and published; zero checker behavior change (fallback semantics preserved for not-yet-bound classes) |
+| **B1 — rails** | Dispatch table + ExpressionNode reflection completeness test; `BoundIncompleteExpression` (zero-child phase) + 0200-band diagnostic; **diagnostic routing** (§5: analyze path stops discarding the binder bag; LSP severity decision applied); **D4 SymbolId + span plumbing** on symbols; **the F-2 instrument** (§5) with its discriminating pin; **F-2/roadmap marker amendments** (§5); baseline checker-verdict snapshot + direct-Binder test audit (22 files instantiate `Binder` directly) | All 61 classes flow through the table; baseline incomplete-fraction measured and published; checker verdicts byte-identical to the snapshot; LSP noise decision in effect |
 | **B2 — core 9** | `Ok/Err/Some`, `ExpressionCallNode`, `AnonymousObjectCreationNode`, `RecordCreationNode`, `WithExpressionNode`, `ThrowExpressionNode` (+`SelfRefNode` per its F-1 dormant rule) | F-1 core row fully live |
-| **B3 — arrays/indexes + collections** | 13 classes; the biggest checker payoff (index-OOB, off-by-one see real structure) | Family binds; checker deltas disclosed |
+| **B3 — arrays/indexes + collections** | 13 classes; biggest checker payoff | Family binds; checker deltas disclosed |
 | **B4 — string family** | `StringOperationNode`, `InterpolatedStringNode`, `StringBuilderOperationNode`, `CharOperationNode` | Family binds |
-| **B5 — conversion + type/pattern + decimals** | `TypeOperationNode`, `IsPatternNode`, `TypeOfExpressionNode`, D6 | Casts keep operand+target; patterns stop folding to `true` |
-| **B6 — control-value forms** | `NullCoalesceNode`, `NullConditionalNode`, `MatchExpressionNode`, `LambdaExpressionNode`, `AwaitExpressionNode` | Family binds |
-| **B7 — quantifiers** | `ForallExpressionNode`, `ExistsExpressionNode`, `ImplicationExpressionNode` (contract-adjacent; verify no interaction with the verification pipeline's own AST path) | Family binds |
-| **B8 — interop + overloads + closure** | `RawCSharpExpressionNode`/`FallbackExpressionNode` structural binding; D5 overload sets; expression-start unification (#762 item 7); D7 item-8 disposition + F-1 amendment; **gate 1 evaluation** | Zero Tier A `incomplete` on the F-2 corpus; DoD met |
+| **B5 — conversion + type/pattern + decimals** | `TypeOperationNode` full ops, `IsPatternNode`, `TypeOfExpressionNode`, D6 | Casts keep operand+target; patterns stop folding to `true` |
+| **B6 — control-value forms** | `NullCoalesceNode`, `NullConditionalNode`, `MatchExpressionNode`, `LambdaExpressionNode`, `AwaitExpressionNode` | Family binds; deferred-evaluation marking exercised |
+| **B7 — quantifiers** | `ForallExpressionNode`, `ExistsExpressionNode`, `ImplicationExpressionNode` | Family binds; no verification-pipeline interaction |
+| **B8 — closure** | Interop structural binding; D5 overload sets; expression-start unification + **the token-context test matrix** (#762: every expression-start token in return/bind/argument/nested contexts); **diagnostic-seed suite** (a seed nested inside every expression wrapper, proven reachable); D7 full item-8 scope (all 8 no-op Accepts + AstNode-wide reflection test) + F-1 amendment; Tier-B child extractors with `IsDeferredContext`; **gate 1 evaluation** | Zero Tier A `incomplete` on the F-2 corpus; every #762 DoD bullet green |
 
-Ordering rationale: B1 makes the gap *visible and measured* before any of it closes (the freeze
-discipline applied to code); B2–B7 order by checker payoff and risk; B8 carries the items that
-touch the parser and the frozen registration.
+Every #762 "Required implementation" item and regression-coverage bullet now maps to a row:
+items 1–3 (B1–B8 families), 4 (B5), 5–6 (B8), 7 (B8), 8 (B1 expression-half test + B8 full),
+9 (B1); regression list: AstNode reflection test (B8), diagnostic seed (B8), cast/type/decimal
+(B5), overloads (B8), token contexts (B8), unsupported-node diagnostics (B1).
 
 ## 4. Explicitly out of scope
 
-- **Metadata-backed .NET typing, overload resolution against BCL signatures, nullable
-  annotations** — the 0.14 entry spike (roadmap §3.1). This rebuild must not grow into it.
-- **Effect-resolution changes**: `BoundCallExpression.Target`-string consumers
-  (`MapShortTypeNameToFullName`, `NullDereferenceChecker`'s `.unwrap` suffix convention) keep
-  their contracts until 0.14/0.15; new bound nodes must not break the string surface they read.
-- **Emitter/codegen changes** (AST-based; unaffected), except the follow-up noted in D4.
-- **Rebuilding checkers on the richer tree** (#786, scheduled 0.15) — checkers get *more* input,
-  their logic is not rewritten here.
+- **Metadata-backed .NET typing** — the 0.14 entry spike. This rebuild must not grow into it.
+- **Effect-resolution contracts**: `BoundCallExpression.Target`-string consumers keep their
+  string surface until 0.14/0.15.
+- **Emitter/codegen changes** (verified: neither emitter consumes bound nodes).
+- **Checker rewrites** (#786, 0.15) — checkers get more input; their logic is untouched.
 
-## 5. Instrumentation and gates
+## 5. Instrumentation, diagnostics routing, and the frozen marker
 
-- **Incomplete-fraction**, published per release from B1 on: incomplete-marked bound nodes ÷
-  total bound expressions over the F-2 corpus (both legs). Reported-not-adjudicated, per the
-  registration; the *gate* (roadmap §2.5.1) is zero Tier A fallbacks at release.
+- **Diagnostic routing (new, from review C2):** `VerificationAnalysisPass` binds into a throwaway
+  bag today — B1 routes binder diagnostics into the real bag (or the instrument cannot see them),
+  and decides LSP presentation: the incomplete diagnostic ships at **Info severity until B8**
+  (37 Tier A classes are incomplete at B1 — Warning would flood every editor; the severity
+  promotion to Warning is B8's, when the count is ~0 and a warning means something).
+- **Instrument mechanism (named, from review M3):** diagnostic-count based — the CI leg runs the
+  analyze pipeline over both F-2 corpus legs and counts the 0200-band incomplete code per file;
+  fraction = incomplete diagnostics ÷ bound expressions (a counter the binder emits). No
+  bound-tree serialization exists and none is invented for this.
+- **The `<unsupported:` marker is frozen in three places** (`v0.13-freeze-registrations.md`
+  Tier A header, gate restatement, F-2 instrument; `roadmap-v0.13-v0.15.md` gate 1). B1 carries
+  **additive amendment entries** in the freeze doc (and the roadmap wording) naming the new
+  marker/diagnostic code, argued as an additive rename — the denominator (Tier A classes must not
+  silently degrade) is unchanged and the instrument strictly improves (silent fallback → counted
+  diagnostic); it is not a weakening, and the argument appears in B1's PR description per the
+  amendment rules.
 - **Discriminating pin** (F-2's requirement): a fixture whose Tier A construct is temporarily
-  routed to `BindIncomplete` must turn the CI leg red; pinned as a test the same way the PP-S4
-  self-test pins run continuously.
-- **Checker-delta disclosure**: each family PR states which checker verdicts changed on the
-  corpus and why (structure became visible), with the D-S2.3 negative-corpus precedent applied —
-  new findings must be real, not fallback-shape artifacts.
+  routed to `BindIncomplete` must turn the CI leg red; runs as a test, continuously.
+- **Checker-delta disclosure** per family PR, diffed against B1's frozen baseline snapshot.
+- **CI cost budget (review m2):** the corpus leg must stay under **5 minutes**; B1 measures and
+  publishes the actual cost; the conversion leg's migrate outputs are cached per pinned subject
+  commit (they are deterministic at a frozen commit).
 
 ## 6. Risks
 
-1. **Checker behavior movement** is the big one: five checkers currently key on the fallback's
-   opaque shape; every family PR changes their input distribution. Mitigation: B1 freezes a
-   baseline checker-verdict snapshot over the F-2 corpus; family PRs diff against it and
-   disclose.
-2. **Parser coupling** (`IsExpressionStart` vs dispatch) — deferred to B8 deliberately; touching
-   it early risks destabilizing the whole expression grammar while binding is mid-flight.
-3. **Golden/E2E churn**: bound-tree changes shouldn't move emitted C#, but diagnostics counts
-   will move (new incomplete warnings). E2E goldens are diagnostics-blind; lint/analyze
-   snapshots may not be — audited in B1.
-4. **Scope creep toward 0.14** — §4 is the fence; reviews should police it.
+1. **Checker behavior movement** — five checkers key on the fallback shape; family PRs change
+   their input distribution. Mitigation: B1's frozen baseline snapshot + per-family disclosure +
+   the D-S2.3 negative-corpus precedent.
+2. **LSP visibility** — the binder runs live in editors (review C2); the Info-until-B8 severity
+   decision is the mitigation, and LSP snapshot tests are part of B1's audit.
+3. **Parser coupling** — deferred to B8 deliberately.
+4. **Direct-Binder tests** — 22 test files instantiate `Binder` and assert diagnostic sets; B1
+   audits and updates them alongside the routing change (not just goldens, which are
+   diagnostics-blind).
+5. **Scope creep toward 0.14** — §4 is the fence; reviews police it.
+
+## 7. What "zero checker behavior change" means in B1 (review C2/M2)
+
+Binding runs only under analyze and in the LSP. B1's criterion is therefore: (a) analyze-mode
+checker verdicts over the F-2 corpus are byte-identical to the pre-B1 snapshot; (b) LSP
+diagnostics gain only the new Info-severity incomplete code; (c) normal compiles are bit-identical
+(binding still doesn't run there). The incomplete-fraction is measured in analyze mode — stated so
+the instrument's scope is honest about where binding executes.
+
+## 8. Review record — round 1 (2026-08-10)
+
+Verdict 65%, NEEDS-FIXES. Applied: **C1** (SymbolIds scheduled in B1; item 8's non-expression
+half — 7 classes — plus the AstNode-wide reflection test, diagnostic-seed suite, and
+token-context matrix all assigned to B8; full DoD→row map added) · **C2** (consumer map corrected:
+LSP binds with the live bag, analyze discards its bag; diagnostic routing + Info-severity decision
+added to B1; §7 defines the exit criterion against where binding actually runs) · **M1** (SymbolId
+gains a file-path component — module ids demonstrably collide — and locals key by declaration
+order, rename-invariant) · **M2** (two-phase D2 semantics: B1 zero-child, children with real
+binders, Tier-B extractors with `IsDeferredContext` at B8; no generic child enumeration assumed) ·
+**M3** (marker frozen in three places; B1 carries the additive amendments with the classification
+argued; instrument mechanism named as diagnostic-count based) · **M4** (counts corrected: 18 arms
+with 2 conditional, 43 bound classes, 8 no-op Accepts) · **m1** (D1 justification recorded) ·
+**m2** (CI budget, two-pass note on D5, direct-Binder test audit). Declined: none.

--- a/docs/plans/binder-rebuild-762-scoping.md
+++ b/docs/plans/binder-rebuild-762-scoping.md
@@ -1,0 +1,130 @@
+# #762 binder rebuild — scoping (v0.13 spine)
+
+**Date:** 2026-08-10
+**Status:** Draft v1 — for adversarial review before any binder code merges
+**Governing inputs:** issue #762 (DoD: 100% of accepted expression kinds structurally bind),
+`v0.13-freeze-registrations.md` F-1 (the 61-class tier assignment — 55 registered / 6 residual —
+frozen before this work; the denominator of roadmap §2.5 gate 1) and F-2 (the measurement corpus),
+`roadmap-v0.13-v0.15.md` §2.1/§2.5. Per the freeze discipline, this doc merges before the work it
+scopes.
+
+## 1. Current state (measured, this branch)
+
+- `Binder.BindExpression` (`Binding/Binder.cs:297`) has **19 arms** over **61** concrete
+  `ExpressionNode` classes; everything else reaches `BindFallbackExpression` (`Binder.cs:515`),
+  a **zero-child** `BoundCallExpression` named `<unsupported:TypeName>` typed `"OBJECT"` — the
+  exact shape #762's evidence section describes (nested calls, division, indexing invisible to
+  every analysis). The fallback's own comment records the class of harm: an earlier fallback
+  (`BoundIntLiteral(0)`) made the div-by-zero checker false-positive on every unhandled divisor.
+- **Types are strings** (`"INT"`, `"OBJECT"`, …) throughout `BoundNodes.cs` (~25 bound classes);
+  `DecimalLiteralNode` binds as `BoundFloatLiteral((double)value)` — #762 item 4's defect,
+  visible in the switch.
+- **Consumers of the bound tree are the analysis layer only**: dataflow/CFG, the five bug-pattern
+  checkers, taint, contract inference, verification analysis, k-induction
+  (`Analysis/**`, `Verification/Z3/KInduction`). The emitters are `IAstVisitor` over the AST —
+  codegen is NOT in this rebuild's blast radius.
+- Top-level function registration ignores `TryDeclare` failures and bypasses the overload-set
+  machinery class members already use (#762 items 5–6).
+- Five AST classes still carry no-op `default!` `Accept`s (the #874 null-injection hazard class);
+  two expression-node members (`GenericTypeNode`, `KeywordArgNode`) are F-1 Tier B pending the
+  item-8 disposition.
+
+## 2. Design decisions
+
+**D1 — One authoritative dispatch table.** The `switch` becomes a
+`IReadOnlyDictionary<Type, Func<Binder, ExpressionNode, BoundExpression>>` built once. A
+**reflection completeness test** asserts every concrete `ExpressionNode` subclass has exactly one
+entry — Tier A classes map to real binders, Tier B classes map to an *explicit*
+`BindIncomplete` with a stated reason. A new class with no entry fails CI by construction (the
+F-1 bidirectional completeness check's code-side half). Parser expression-start classification
+(#762 item 7) derives from the same source of truth in the final PR — one table, two projections.
+
+**D2 — `BoundIncompleteExpression` replaces the fallback.** A dedicated bound node that (a)
+**binds and retains all child expressions** (the subtree stays analyzable — #762 item 3's "never
+silently erase"), (b) carries the node-type name and an explicit stable type, and (c) reports an
+*analysis incomplete* diagnostic (new code in the 0200 semantic band) at Warning severity.
+Checkers treat it as an opaque non-constant value — preserving the div-by-zero lesson — but can
+now traverse *through* it to the children they previously lost. The `<unsupported:` string
+disappears from the tree; the F-2 instrument greps for the new node's marker instead (one
+instrument update, in the same PR).
+
+**D3 — Types stay strings in 0.13; they become explicit and non-null.** The 0.14 typed semantic
+representation (roadmap §3.2) replaces the *representation*; this rebuild fixes the *structure*.
+Every bound expression gets a non-null type string assigned through a single constructor choke
+point (no more implicit `"INT"` defaults scattered through binders). Widening this into
+metadata-backed typing is the 0.14 entry spike's job — an explicit non-goal here (§4).
+
+**D4 — SymbolIds and exact spans (#762 item 9).** Declarations already carry validated syntax ids
+(`§F{f001}`, `§MT{mt001}`, …); `SymbolId` = `<module-id>/<declaration-id>` for declarations,
+`<module-id>/<function-id>/<name>#<ordinal>` for locals and parameters. `VariableSymbol` /
+`FunctionSymbol` gain `SymbolId` + the **exact identifier token span** (not the whole
+declaration). This is the substrate roadmap gates 3 (index correctness) and 4 (SymbolId-addressed
+rename) instrument against, and what retires the #879/#893 mutable-cursor class properly: contract
+emission can key on the symbol in hand instead of a cursor the emitter must remember to maintain
+(the emitter change itself is follow-up, not this rebuild).
+
+**D5 — Overload sets for top-level functions (#762 items 5–6).** Reuse the class-member
+overload-set machinery for module-level functions; `TryDeclare` failures become diagnostics
+(duplicate signature, ambiguity, no-match at call sites). Diagnosed, never silently first-wins.
+
+**D6 — Decimal and conversion fidelity (#762 item 4).** `BoundDecimalLiteral` (no double
+downcast); `BoundConversionExpression` preserving the target type; `is`/pattern tests bind
+structurally instead of folding to `true`.
+
+**D7 — Item-8 disposition lands in the final PR** with its F-1 amendment: `GenericTypeNode` and
+`KeywordArgNode` either become non-`ExpressionNode` helper types (subtractive amendment with
+supersession entry) or get real binders (additive promotion to Tier A). Until then they stay
+residual and explicitly incomplete — never silently absent.
+
+## 3. PR slicing (each PR: suite green, adversarial review, merge; family-by-family)
+
+| PR | Scope | Exit criterion |
+|---|---|---|
+| **B1 — rails** | Dispatch table + reflection completeness test; `BoundIncompleteExpression` + diagnostic; Tier B explicit-incomplete; **the F-2 instrument** (CI leg over the pinned corpus publishing the incomplete-fraction, with the revert-the-fix discriminating pin) | All 61 classes flow through the table; baseline fraction measured and published; zero checker behavior change (fallback semantics preserved for not-yet-bound classes) |
+| **B2 — core 9** | `Ok/Err/Some`, `ExpressionCallNode`, `AnonymousObjectCreationNode`, `RecordCreationNode`, `WithExpressionNode`, `ThrowExpressionNode` (+`SelfRefNode` per its F-1 dormant rule) | F-1 core row fully live |
+| **B3 — arrays/indexes + collections** | 13 classes; the biggest checker payoff (index-OOB, off-by-one see real structure) | Family binds; checker deltas disclosed |
+| **B4 — string family** | `StringOperationNode`, `InterpolatedStringNode`, `StringBuilderOperationNode`, `CharOperationNode` | Family binds |
+| **B5 — conversion + type/pattern + decimals** | `TypeOperationNode`, `IsPatternNode`, `TypeOfExpressionNode`, D6 | Casts keep operand+target; patterns stop folding to `true` |
+| **B6 — control-value forms** | `NullCoalesceNode`, `NullConditionalNode`, `MatchExpressionNode`, `LambdaExpressionNode`, `AwaitExpressionNode` | Family binds |
+| **B7 — quantifiers** | `ForallExpressionNode`, `ExistsExpressionNode`, `ImplicationExpressionNode` (contract-adjacent; verify no interaction with the verification pipeline's own AST path) | Family binds |
+| **B8 — interop + overloads + closure** | `RawCSharpExpressionNode`/`FallbackExpressionNode` structural binding; D5 overload sets; expression-start unification (#762 item 7); D7 item-8 disposition + F-1 amendment; **gate 1 evaluation** | Zero Tier A `incomplete` on the F-2 corpus; DoD met |
+
+Ordering rationale: B1 makes the gap *visible and measured* before any of it closes (the freeze
+discipline applied to code); B2–B7 order by checker payoff and risk; B8 carries the items that
+touch the parser and the frozen registration.
+
+## 4. Explicitly out of scope
+
+- **Metadata-backed .NET typing, overload resolution against BCL signatures, nullable
+  annotations** — the 0.14 entry spike (roadmap §3.1). This rebuild must not grow into it.
+- **Effect-resolution changes**: `BoundCallExpression.Target`-string consumers
+  (`MapShortTypeNameToFullName`, `NullDereferenceChecker`'s `.unwrap` suffix convention) keep
+  their contracts until 0.14/0.15; new bound nodes must not break the string surface they read.
+- **Emitter/codegen changes** (AST-based; unaffected), except the follow-up noted in D4.
+- **Rebuilding checkers on the richer tree** (#786, scheduled 0.15) — checkers get *more* input,
+  their logic is not rewritten here.
+
+## 5. Instrumentation and gates
+
+- **Incomplete-fraction**, published per release from B1 on: incomplete-marked bound nodes ÷
+  total bound expressions over the F-2 corpus (both legs). Reported-not-adjudicated, per the
+  registration; the *gate* (roadmap §2.5.1) is zero Tier A fallbacks at release.
+- **Discriminating pin** (F-2's requirement): a fixture whose Tier A construct is temporarily
+  routed to `BindIncomplete` must turn the CI leg red; pinned as a test the same way the PP-S4
+  self-test pins run continuously.
+- **Checker-delta disclosure**: each family PR states which checker verdicts changed on the
+  corpus and why (structure became visible), with the D-S2.3 negative-corpus precedent applied —
+  new findings must be real, not fallback-shape artifacts.
+
+## 6. Risks
+
+1. **Checker behavior movement** is the big one: five checkers currently key on the fallback's
+   opaque shape; every family PR changes their input distribution. Mitigation: B1 freezes a
+   baseline checker-verdict snapshot over the F-2 corpus; family PRs diff against it and
+   disclose.
+2. **Parser coupling** (`IsExpressionStart` vs dispatch) — deferred to B8 deliberately; touching
+   it early risks destabilizing the whole expression grammar while binding is mid-flight.
+3. **Golden/E2E churn**: bound-tree changes shouldn't move emitted C#, but diagnostics counts
+   will move (new incomplete warnings). E2E goldens are diagnostics-blind; lint/analyze
+   snapshots may not be — audited in B1.
+4. **Scope creep toward 0.14** — §4 is the fence; reviews should police it.


### PR DESCRIPTION
## Summary

Scoping doc for the #762 binder rebuild — the roadmap's load-bearing spine (§2.1 MUST) and the item v0.14/v0.15 cannot proceed without. Per the freeze discipline, this merges **before** any binder code: the F-2 measurement instrument lands in the first implementation PR (B1) so the gap is visible and measured before any of it closes.

Grounded in the code, not the issue text: 19 of 61 expression classes bind today; the decimal→double downcast is visible in the switch; the fallback's own comment records the false-positive class the replacement must preserve opacity against; and the bound tree's consumers are exactly the analysis layer — emitters are AST-based, so codegen is out of blast radius.

Key structural decisions: one authoritative dispatch table with a reflection completeness test (the F-1 bidirectional check's code-side half); `BoundIncompleteExpression` that **retains bound children** instead of erasing subtrees; SymbolIds from the already-validated syntax ids with exact identifier spans (the substrate for the roadmap's index/rename gates, and the proper retirement of the #879/#893 mutable-cursor class); types stay strings in 0.13 with the 0.14 typed-representation boundary explicitly fenced as a non-goal.

Eight-PR slicing with per-PR exit criteria, checker-delta disclosure per family (five checkers key on the fallback shape today — their verdict movement is measured against a B1 baseline snapshot, not discovered), and four named risks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)