### PR TITLE
feat(binder): #762 B3 — arrays/collections bind, retention complete (ratchet 79→51, conv 1450→1257)

### DIFF
--- a/bench/phase0-agent-native/binder-incomplete-baseline.json
+++ b/bench/phase0-agent-native/binder-incomplete-baseline.json
@@ -1,12 +1,12 @@
 {
-  "IncompleteCount": 79,
+  "IncompleteCount": 51,
   "ParsedFiles": 443,
   "ParseFailures": 9,
-  "ExpressionsBound": 4299,
+  "ExpressionsBound": 4385,
   "Scope": "both F-2 legs; conversion leg skips when corpus submodules are absent",
   "Conversion": {
-    "Incomplete": 1450,
-    "ExpressionsBound": 12307,
+    "Incomplete": 1257,
+    "ExpressionsBound": 12766,
     "ConvertedAndBound": 305,
     "ConvertExceptions": 0,
     "EmptyOutput": 0,

--- a/src/Calor.Compiler/Analysis/Dataflow/BoundNodeHelpers.cs
+++ b/src/Calor.Compiler/Analysis/Dataflow/BoundNodeHelpers.cs
@@ -313,6 +313,26 @@ public static class BoundNodeHelpers
     /// </summary>
     public static bool ContainsArrayAccess(BoundExpression? expression, out BoundExpression? arrayExpr, out BoundExpression? indexExpr)
     {
+        // #762 B3: the STRUCTURAL array-access nodes this helper was named for finally
+        // exist — match them first (the B3 review found the old "placeholder for when
+        // it's added" comment left false by the family PR that added them).
+        if (expression is BoundArrayAccess structural)
+        {
+            arrayExpr = structural.Array;
+            indexExpr = structural.Index;
+            return true;
+        }
+        if (expression is BoundMultiDimArrayAccess multi)
+        {
+            arrayExpr = multi.Array;
+            indexExpr = multi.Indices.Count > 0 ? multi.Indices[0] : null;
+            return true;
+        }
+        return ContainsArrayAccessLegacy(expression, out arrayExpr, out indexExpr);
+    }
+
+    private static bool ContainsArrayAccessLegacy(BoundExpression? expression, out BoundExpression? arrayExpr, out BoundExpression? indexExpr)
+    {
         arrayExpr = null;
         indexExpr = null;
 

--- a/src/Calor.Compiler/Binding/Binder.cs
+++ b/src/Calor.Compiler/Binding/Binder.cs
@@ -395,6 +395,66 @@ public sealed class Binder
                 },
             [typeof(ThrowExpressionNode)] = (b, e) =>
                 { var n = (ThrowExpressionNode)e; return new BoundThrowExpression(n.Span, b.BindExpression(n.Exception)); },
+            // #762 B3 — arrays/indexes + collections (13 classes). Every AST property is
+            // retained (the B2 review's children-retention standard).
+            [typeof(ArrayCreationNode)] = (b, e) =>
+                {
+                    var n = (ArrayCreationNode)e;
+                    return new BoundArrayCreation(n.Span, n.Name, n.ElementType,
+                        n.Size is null ? null : b.BindExpression(n.Size),
+                        n.Initializer.Select(b.BindExpression).ToList());
+                },
+            [typeof(ArrayAccessNode)] = (b, e) =>
+                { var n = (ArrayAccessNode)e; return new BoundArrayAccess(n.Span, b.BindExpression(n.Array), b.BindExpression(n.Index)); },
+            [typeof(ArrayLengthNode)] = (b, e) =>
+                { var n = (ArrayLengthNode)e; return new BoundArrayLength(n.Span, b.BindExpression(n.Array)); },
+            [typeof(MultiDimArrayCreationNode)] = (b, e) =>
+                {
+                    var n = (MultiDimArrayCreationNode)e;
+                    return new BoundMultiDimArrayCreation(n.Span, n.Name, n.ElementType, n.Rank,
+                        n.DimensionSizes.Select(b.BindExpression).ToList(),
+                        n.Initializer.SelectMany(row => row).Select(b.BindExpression).ToList());
+                },
+            [typeof(MultiDimArrayAccessNode)] = (b, e) =>
+                {
+                    var n = (MultiDimArrayAccessNode)e;
+                    return new BoundMultiDimArrayAccess(n.Span, b.BindExpression(n.Array),
+                        n.Indices.Select(b.BindExpression).ToList());
+                },
+            [typeof(IndexFromEndNode)] = (b, e) =>
+                { var n = (IndexFromEndNode)e; return new BoundIndexFromEnd(n.Span, b.BindExpression(n.Offset)); },
+            [typeof(RangeExpressionNode)] = (b, e) =>
+                {
+                    var n = (RangeExpressionNode)e;
+                    return new BoundRangeExpression(n.Span,
+                        n.Start is null ? null : b.BindExpression(n.Start),
+                        n.End is null ? null : b.BindExpression(n.End));
+                },
+            [typeof(ListCreationNode)] = (b, e) =>
+                {
+                    var n = (ListCreationNode)e;
+                    return new BoundListCreation(n.Span, n.Name, n.ElementType,
+                        n.Elements.Select(b.BindExpression).ToList());
+                },
+            [typeof(SetCreationNode)] = (b, e) =>
+                {
+                    var n = (SetCreationNode)e;
+                    return new BoundSetCreation(n.Span, n.Name, n.ElementType,
+                        n.Elements.Select(b.BindExpression).ToList());
+                },
+            [typeof(DictionaryCreationNode)] = (b, e) =>
+                {
+                    var n = (DictionaryCreationNode)e;
+                    return new BoundDictionaryCreation(n.Span, n.Name, n.KeyType, n.ValueType,
+                        n.Entries.Select(kv => new BoundPair(
+                            b.BindExpression(kv.Key), b.BindExpression(kv.Value), kv.Span)).ToList());
+                },
+            [typeof(CollectionContainsNode)] = (b, e) =>
+                { var n = (CollectionContainsNode)e; return new BoundCollectionContains(n.Span, n.CollectionName, b.BindExpression(n.KeyOrValue)); },
+            [typeof(CollectionCountNode)] = (b, e) =>
+                { var n = (CollectionCountNode)e; return new BoundCollectionCount(n.Span, b.BindExpression(n.Collection)); },
+            [typeof(TupleLiteralNode)] = (b, e) =>
+                { var n = (TupleLiteralNode)e; return new BoundTupleLiteral(n.Span, n.Elements.Select(b.BindExpression).ToList()); },
         };
 
         // Every remaining concrete ExpressionNode subclass dispatches to BindIncomplete.

--- a/src/Calor.Compiler/Binding/Binder.cs
+++ b/src/Calor.Compiler/Binding/Binder.cs
@@ -400,7 +400,7 @@ public sealed class Binder
             [typeof(ArrayCreationNode)] = (b, e) =>
                 {
                     var n = (ArrayCreationNode)e;
-                    return new BoundArrayCreation(n.Span, n.Name, n.ElementType,
+                    return new BoundArrayCreation(n.Span, n.Id, n.Name, n.ElementType,
                         n.Size is null ? null : b.BindExpression(n.Size),
                         n.Initializer.Select(b.BindExpression).ToList());
                 },
@@ -411,9 +411,10 @@ public sealed class Binder
             [typeof(MultiDimArrayCreationNode)] = (b, e) =>
                 {
                     var n = (MultiDimArrayCreationNode)e;
-                    return new BoundMultiDimArrayCreation(n.Span, n.Name, n.ElementType, n.Rank,
+                    return new BoundMultiDimArrayCreation(n.Span, n.Id, n.Name, n.ElementType, n.Rank,
                         n.DimensionSizes.Select(b.BindExpression).ToList(),
-                        n.Initializer.SelectMany(row => row).Select(b.BindExpression).ToList());
+                        n.Initializer.Select(row =>
+                            (IReadOnlyList<BoundExpression>)row.Select(b.BindExpression).ToList()).ToList());
                 },
             [typeof(MultiDimArrayAccessNode)] = (b, e) =>
                 {
@@ -433,24 +434,24 @@ public sealed class Binder
             [typeof(ListCreationNode)] = (b, e) =>
                 {
                     var n = (ListCreationNode)e;
-                    return new BoundListCreation(n.Span, n.Name, n.ElementType,
+                    return new BoundListCreation(n.Span, n.Id, n.Name, n.ElementType,
                         n.Elements.Select(b.BindExpression).ToList());
                 },
             [typeof(SetCreationNode)] = (b, e) =>
                 {
                     var n = (SetCreationNode)e;
-                    return new BoundSetCreation(n.Span, n.Name, n.ElementType,
+                    return new BoundSetCreation(n.Span, n.Id, n.Name, n.ElementType,
                         n.Elements.Select(b.BindExpression).ToList());
                 },
             [typeof(DictionaryCreationNode)] = (b, e) =>
                 {
                     var n = (DictionaryCreationNode)e;
-                    return new BoundDictionaryCreation(n.Span, n.Name, n.KeyType, n.ValueType,
+                    return new BoundDictionaryCreation(n.Span, n.Id, n.Name, n.KeyType, n.ValueType,
                         n.Entries.Select(kv => new BoundPair(
                             b.BindExpression(kv.Key), b.BindExpression(kv.Value), kv.Span)).ToList());
                 },
             [typeof(CollectionContainsNode)] = (b, e) =>
-                { var n = (CollectionContainsNode)e; return new BoundCollectionContains(n.Span, n.CollectionName, b.BindExpression(n.KeyOrValue)); },
+                { var n = (CollectionContainsNode)e; return new BoundCollectionContains(n.Span, n.CollectionName, b.BindExpression(n.KeyOrValue), n.Mode); },
             [typeof(CollectionCountNode)] = (b, e) =>
                 { var n = (CollectionCountNode)e; return new BoundCollectionCount(n.Span, b.BindExpression(n.Collection)); },
             [typeof(TupleLiteralNode)] = (b, e) =>

--- a/src/Calor.Compiler/Binding/BoundNodes.cs
+++ b/src/Calor.Compiler/Binding/BoundNodes.cs
@@ -476,7 +476,7 @@ public static class BoundChildren
         BoundArrayCreation ac => ac.Size is null ? ac.Initializer : [ac.Size, .. ac.Initializer],
         BoundArrayAccess aa => [aa.Array, aa.Index],
         BoundArrayLength al => [al.Array],
-        BoundMultiDimArrayCreation mc => [.. mc.DimensionSizes, .. mc.Initializer],
+        BoundMultiDimArrayCreation mc => [.. mc.DimensionSizes, .. mc.InitializerRows.SelectMany(r => r)],
         BoundMultiDimArrayAccess ma => [ma.Array, .. ma.Indices],
         BoundIndexFromEnd ie => [ie.Offset],
         BoundRangeExpression r => new[] { r.Start, r.End }.Where(e => e is not null).Cast<BoundExpression>(),
@@ -595,15 +595,16 @@ public sealed record BoundPair(BoundExpression Key, BoundExpression Value, TextS
 /// <summary>#762 B3: array creation — size and initializers are bound children.</summary>
 public sealed class BoundArrayCreation : BoundExpression
 {
+    public string Id { get; }
     public string Name { get; }
     public string ElementType { get; }
     public BoundExpression? Size { get; }
     public IReadOnlyList<BoundExpression> Initializer { get; }
     public override string TypeName { get; }
-    public BoundArrayCreation(TextSpan span, string name, string elementType,
+    public BoundArrayCreation(TextSpan span, string id, string name, string elementType,
         BoundExpression? size, IReadOnlyList<BoundExpression> initializer) : base(span)
     {
-        Name = name; ElementType = elementType; Size = size; Initializer = initializer;
+        Id = id; Name = name; ElementType = elementType; Size = size; Initializer = initializer;
         TypeName = $"{elementType}[]";
     }
 }
@@ -636,18 +637,22 @@ public sealed class BoundArrayLength : BoundExpression
 /// <summary>#762 B3: multi-dimensional array creation.</summary>
 public sealed class BoundMultiDimArrayCreation : BoundExpression
 {
+    public string Id { get; }
     public string Name { get; }
     public string ElementType { get; }
     public int Rank { get; }
     public IReadOnlyList<BoundExpression> DimensionSizes { get; }
-    public IReadOnlyList<BoundExpression> Initializer { get; }
+    /// <summary>Row structure RETAINED (B3 review M2): rectangularity/shape-vs-rank
+    /// validation needs it; flattening happens only in BoundChildren.Of.</summary>
+    public IReadOnlyList<IReadOnlyList<BoundExpression>> InitializerRows { get; }
     public override string TypeName { get; }
-    public BoundMultiDimArrayCreation(TextSpan span, string name, string elementType, int rank,
-        IReadOnlyList<BoundExpression> dimensionSizes, IReadOnlyList<BoundExpression> initializer)
+    public BoundMultiDimArrayCreation(TextSpan span, string id, string name, string elementType,
+        int rank, IReadOnlyList<BoundExpression> dimensionSizes,
+        IReadOnlyList<IReadOnlyList<BoundExpression>> initializerRows)
         : base(span)
     {
-        Name = name; ElementType = elementType; Rank = rank;
-        DimensionSizes = dimensionSizes; Initializer = initializer;
+        Id = id; Name = name; ElementType = elementType; Rank = rank;
+        DimensionSizes = dimensionSizes; InitializerRows = initializerRows;
         TypeName = $"{elementType}[{new string(',', Math.Max(0, rank - 1))}]";
     }
 }
@@ -662,8 +667,10 @@ public sealed class BoundMultiDimArrayAccess : BoundExpression
         IReadOnlyList<BoundExpression> indices) : base(span)
     {
         Array = array; Indices = indices;
+        // LastIndexOf: on jagged shapes like "i32[][,]" the element type is
+        // everything before the TRAILING bracket group ("i32[]"), not "i32" (B3 review m5).
         var t = array.TypeName;
-        var open = t.IndexOf('[');
+        var open = t.LastIndexOf('[');
         TypeName = open > 0 ? t[..open] : "OBJECT";
     }
 }
@@ -690,14 +697,17 @@ public sealed class BoundRangeExpression : BoundExpression
 /// <summary>#762 B3: list creation.</summary>
 public sealed class BoundListCreation : BoundExpression
 {
+    public string Id { get; }
     public string Name { get; }
     public string ElementType { get; }
     public IReadOnlyList<BoundExpression> Elements { get; }
     public override string TypeName { get; }
-    public BoundListCreation(TextSpan span, string name, string elementType,
+    public BoundListCreation(TextSpan span, string id, string name, string elementType,
         IReadOnlyList<BoundExpression> elements) : base(span)
     {
-        Name = name; ElementType = elementType; Elements = elements;
+        Id = id; Name = name; ElementType = elementType; Elements = elements;
+        // Spelling matches the PARSER's own vocabulary for the same construct
+        // (B3 review M3: the bind statement types §SET as "HashSet<T>").
         TypeName = $"List<{elementType}>";
     }
 }
@@ -705,15 +715,18 @@ public sealed class BoundListCreation : BoundExpression
 /// <summary>#762 B3: set creation.</summary>
 public sealed class BoundSetCreation : BoundExpression
 {
+    public string Id { get; }
     public string Name { get; }
     public string ElementType { get; }
     public IReadOnlyList<BoundExpression> Elements { get; }
     public override string TypeName { get; }
-    public BoundSetCreation(TextSpan span, string name, string elementType,
+    public BoundSetCreation(TextSpan span, string id, string name, string elementType,
         IReadOnlyList<BoundExpression> elements) : base(span)
     {
-        Name = name; ElementType = elementType; Elements = elements;
-        TypeName = $"Set<{elementType}>";
+        Id = id; Name = name; ElementType = elementType; Elements = elements;
+        // Spelling matches the PARSER's own vocabulary for the same construct
+        // (B3 review M3: the bind statement types §SET as "HashSet<T>").
+        TypeName = $"HashSet<{elementType}>";
     }
 }
 
@@ -725,11 +738,13 @@ public sealed class BoundDictionaryCreation : BoundExpression
     public string ValueType { get; }
     public IReadOnlyList<BoundPair> Entries { get; }
     public override string TypeName { get; }
-    public BoundDictionaryCreation(TextSpan span, string name, string keyType, string valueType,
-        IReadOnlyList<BoundPair> entries) : base(span)
+    public string Id { get; }
+    public BoundDictionaryCreation(TextSpan span, string id, string name, string keyType,
+        string valueType, IReadOnlyList<BoundPair> entries) : base(span)
     {
-        Name = name; KeyType = keyType; ValueType = valueType; Entries = entries;
-        TypeName = $"Dictionary<{keyType}, {valueType}>";
+        Id = id; Name = name; KeyType = keyType; ValueType = valueType; Entries = entries;
+        // No space: matches Parser.cs/RoslynSyntaxVisitor's "Dictionary<K,V>" (review M3).
+        TypeName = $"Dictionary<{keyType},{valueType}>";
     }
 }
 
@@ -739,10 +754,15 @@ public sealed class BoundCollectionContains : BoundExpression
 {
     public string CollectionName { get; }
     public BoundExpression KeyOrValue { get; }
+    /// <summary>Value vs Key vs DictValue — THREE different operations (.Contains /
+    /// .ContainsKey / .ContainsValue); dropping this was B3 review's CRITICAL.</summary>
+    public Ast.ContainsMode Mode { get; }
+    // NOTE: the collection itself is a NAME (AST shape) — GetUsedVariables cannot
+    // report it as used; liveness blindness tracked with the #786 checker re-platform.
     public override string TypeName => "BOOL";
-    public BoundCollectionContains(TextSpan span, string collectionName, BoundExpression keyOrValue)
-        : base(span)
-    { CollectionName = collectionName; KeyOrValue = keyOrValue; }
+    public BoundCollectionContains(TextSpan span, string collectionName,
+        BoundExpression keyOrValue, Ast.ContainsMode mode) : base(span)
+    { CollectionName = collectionName; KeyOrValue = keyOrValue; Mode = mode; }
 }
 
 /// <summary>#762 B3: collection count — INT.</summary>
@@ -758,9 +778,13 @@ public sealed class BoundCollectionCount : BoundExpression
 public sealed class BoundTupleLiteral : BoundExpression
 {
     public IReadOnlyList<BoundExpression> Elements { get; }
-    public override string TypeName => "TUPLE";
+    public override string TypeName { get; }
     public BoundTupleLiteral(TextSpan span, IReadOnlyList<BoundExpression> elements) : base(span)
-        => Elements = elements;
+    {
+        Elements = elements;
+        // Element types composed rather than discarded (review M3).
+        TypeName = $"Tuple<{string.Join(",", elements.Select(e => e.TypeName))}>";
+    }
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Binding/BoundNodes.cs
+++ b/src/Calor.Compiler/Binding/BoundNodes.cs
@@ -472,6 +472,20 @@ public static class BoundChildren
         BoundRecordCreation rec => rec.Fields.Select(f => f.Value),
         BoundWithExpression with => [with.Target, .. with.Assignments.Select(a => a.Value)],
         BoundThrowExpression thr => [thr.Exception],
+        // #762 B3 — arrays/indexes + collections.
+        BoundArrayCreation ac => ac.Size is null ? ac.Initializer : [ac.Size, .. ac.Initializer],
+        BoundArrayAccess aa => [aa.Array, aa.Index],
+        BoundArrayLength al => [al.Array],
+        BoundMultiDimArrayCreation mc => [.. mc.DimensionSizes, .. mc.Initializer],
+        BoundMultiDimArrayAccess ma => [ma.Array, .. ma.Indices],
+        BoundIndexFromEnd ie => [ie.Offset],
+        BoundRangeExpression r => new[] { r.Start, r.End }.Where(e => e is not null).Cast<BoundExpression>(),
+        BoundListCreation lc => lc.Elements,
+        BoundSetCreation sc => sc.Elements,
+        BoundDictionaryCreation dc => dc.Entries.SelectMany(e => new[] { e.Key, e.Value }),
+        BoundCollectionContains cc => [cc.KeyOrValue],
+        BoundCollectionCount cn => [cn.Collection],
+        BoundTupleLiteral tl => tl.Elements,
         _ => [],
     };
 }
@@ -573,6 +587,180 @@ public sealed class BoundThrowExpression : BoundExpression
     public override string TypeName => "NEVER";
     public BoundThrowExpression(TextSpan span, BoundExpression exception) : base(span)
         => Exception = exception;
+}
+
+/// <summary>A bound key→value expression pair (dictionary entries).</summary>
+public sealed record BoundPair(BoundExpression Key, BoundExpression Value, TextSpan Span);
+
+/// <summary>#762 B3: array creation — size and initializers are bound children.</summary>
+public sealed class BoundArrayCreation : BoundExpression
+{
+    public string Name { get; }
+    public string ElementType { get; }
+    public BoundExpression? Size { get; }
+    public IReadOnlyList<BoundExpression> Initializer { get; }
+    public override string TypeName { get; }
+    public BoundArrayCreation(TextSpan span, string name, string elementType,
+        BoundExpression? size, IReadOnlyList<BoundExpression> initializer) : base(span)
+    {
+        Name = name; ElementType = elementType; Size = size; Initializer = initializer;
+        TypeName = $"{elementType}[]";
+    }
+}
+
+/// <summary>#762 B3: array element access. Element type derives from the array's
+/// composed type string when it has the "T[]" shape; "OBJECT" otherwise (0.13 string
+/// types — 0.14's typed representation replaces the derivation).</summary>
+public sealed class BoundArrayAccess : BoundExpression
+{
+    public BoundExpression Array { get; }
+    public BoundExpression Index { get; }
+    public override string TypeName { get; }
+    public BoundArrayAccess(TextSpan span, BoundExpression array, BoundExpression index) : base(span)
+    {
+        Array = array; Index = index;
+        TypeName = array.TypeName.EndsWith("[]", StringComparison.Ordinal)
+            ? array.TypeName[..^2]
+            : "OBJECT";
+    }
+}
+
+/// <summary>#762 B3: array length — always INT.</summary>
+public sealed class BoundArrayLength : BoundExpression
+{
+    public BoundExpression Array { get; }
+    public override string TypeName => "INT";
+    public BoundArrayLength(TextSpan span, BoundExpression array) : base(span) => Array = array;
+}
+
+/// <summary>#762 B3: multi-dimensional array creation.</summary>
+public sealed class BoundMultiDimArrayCreation : BoundExpression
+{
+    public string Name { get; }
+    public string ElementType { get; }
+    public int Rank { get; }
+    public IReadOnlyList<BoundExpression> DimensionSizes { get; }
+    public IReadOnlyList<BoundExpression> Initializer { get; }
+    public override string TypeName { get; }
+    public BoundMultiDimArrayCreation(TextSpan span, string name, string elementType, int rank,
+        IReadOnlyList<BoundExpression> dimensionSizes, IReadOnlyList<BoundExpression> initializer)
+        : base(span)
+    {
+        Name = name; ElementType = elementType; Rank = rank;
+        DimensionSizes = dimensionSizes; Initializer = initializer;
+        TypeName = $"{elementType}[{new string(',', Math.Max(0, rank - 1))}]";
+    }
+}
+
+/// <summary>#762 B3: multi-dimensional array access.</summary>
+public sealed class BoundMultiDimArrayAccess : BoundExpression
+{
+    public BoundExpression Array { get; }
+    public IReadOnlyList<BoundExpression> Indices { get; }
+    public override string TypeName { get; }
+    public BoundMultiDimArrayAccess(TextSpan span, BoundExpression array,
+        IReadOnlyList<BoundExpression> indices) : base(span)
+    {
+        Array = array; Indices = indices;
+        var t = array.TypeName;
+        var open = t.IndexOf('[');
+        TypeName = open > 0 ? t[..open] : "OBJECT";
+    }
+}
+
+/// <summary>#762 B3: index-from-end (^n).</summary>
+public sealed class BoundIndexFromEnd : BoundExpression
+{
+    public BoundExpression Offset { get; }
+    public override string TypeName => "INDEX";
+    public BoundIndexFromEnd(TextSpan span, BoundExpression offset) : base(span) => Offset = offset;
+}
+
+/// <summary>#762 B3: range (a..b) — either bound may be absent.</summary>
+public sealed class BoundRangeExpression : BoundExpression
+{
+    public BoundExpression? Start { get; }
+    public BoundExpression? End { get; }
+    public override string TypeName => "RANGE";
+    public BoundRangeExpression(TextSpan span, BoundExpression? start, BoundExpression? end)
+        : base(span)
+    { Start = start; End = end; }
+}
+
+/// <summary>#762 B3: list creation.</summary>
+public sealed class BoundListCreation : BoundExpression
+{
+    public string Name { get; }
+    public string ElementType { get; }
+    public IReadOnlyList<BoundExpression> Elements { get; }
+    public override string TypeName { get; }
+    public BoundListCreation(TextSpan span, string name, string elementType,
+        IReadOnlyList<BoundExpression> elements) : base(span)
+    {
+        Name = name; ElementType = elementType; Elements = elements;
+        TypeName = $"List<{elementType}>";
+    }
+}
+
+/// <summary>#762 B3: set creation.</summary>
+public sealed class BoundSetCreation : BoundExpression
+{
+    public string Name { get; }
+    public string ElementType { get; }
+    public IReadOnlyList<BoundExpression> Elements { get; }
+    public override string TypeName { get; }
+    public BoundSetCreation(TextSpan span, string name, string elementType,
+        IReadOnlyList<BoundExpression> elements) : base(span)
+    {
+        Name = name; ElementType = elementType; Elements = elements;
+        TypeName = $"Set<{elementType}>";
+    }
+}
+
+/// <summary>#762 B3: dictionary creation — entries are bound key/value pairs.</summary>
+public sealed class BoundDictionaryCreation : BoundExpression
+{
+    public string Name { get; }
+    public string KeyType { get; }
+    public string ValueType { get; }
+    public IReadOnlyList<BoundPair> Entries { get; }
+    public override string TypeName { get; }
+    public BoundDictionaryCreation(TextSpan span, string name, string keyType, string valueType,
+        IReadOnlyList<BoundPair> entries) : base(span)
+    {
+        Name = name; KeyType = keyType; ValueType = valueType; Entries = entries;
+        TypeName = $"Dictionary<{keyType}, {valueType}>";
+    }
+}
+
+/// <summary>#762 B3: collection membership test — BOOL; the collection itself is a NAME
+/// (metadata, matching the AST shape), the probed key/value is a bound child.</summary>
+public sealed class BoundCollectionContains : BoundExpression
+{
+    public string CollectionName { get; }
+    public BoundExpression KeyOrValue { get; }
+    public override string TypeName => "BOOL";
+    public BoundCollectionContains(TextSpan span, string collectionName, BoundExpression keyOrValue)
+        : base(span)
+    { CollectionName = collectionName; KeyOrValue = keyOrValue; }
+}
+
+/// <summary>#762 B3: collection count — INT.</summary>
+public sealed class BoundCollectionCount : BoundExpression
+{
+    public BoundExpression Collection { get; }
+    public override string TypeName => "INT";
+    public BoundCollectionCount(TextSpan span, BoundExpression collection) : base(span)
+        => Collection = collection;
+}
+
+/// <summary>#762 B3: tuple literal.</summary>
+public sealed class BoundTupleLiteral : BoundExpression
+{
+    public IReadOnlyList<BoundExpression> Elements { get; }
+    public override string TypeName => "TUPLE";
+    public BoundTupleLiteral(TextSpan span, IReadOnlyList<BoundExpression> elements) : base(span)
+        => Elements = elements;
 }
 
 /// <summary>

--- a/tests/Calor.Compiler.Tests/Binding/BinderArrayCollectionFamilyTests.cs
+++ b/tests/Calor.Compiler.Tests/Binding/BinderArrayCollectionFamilyTests.cs
@@ -88,7 +88,9 @@ public class BinderArrayCollectionFamilyTests
         var mc = Assert.IsType<BoundMultiDimArrayCreation>(expr);
         Assert.Equal("i32[,]", mc.TypeName);
         Assert.Equal(2, mc.DimensionSizes.Count);
-        Assert.Equal(2, mc.Initializer.Count);
+        // Row STRUCTURE retained (review M2): one row of two, not a flattened two.
+        Assert.Single(mc.InitializerRows);
+        Assert.Equal(2, mc.InitializerRows[0].Count);
         AssertComplete(diags);
 
         var (acc, d2) = BindReturn(new MultiDimArrayAccessNode(S, creation,
@@ -123,13 +125,13 @@ public class BinderArrayCollectionFamilyTests
 
         var (set, d2) = BindReturn(new SetCreationNode(S, "s1", "ys", "str",
             new ExpressionNode[] { new StringLiteralNode(S, "a") }, new AttributeCollection()));
-        Assert.Equal("Set<str>", Assert.IsType<BoundSetCreation>(set).TypeName);
+        Assert.Equal("HashSet<str>", Assert.IsType<BoundSetCreation>(set).TypeName);
         AssertComplete(d2);
 
         var (dict, d3) = BindReturn(new DictionaryCreationNode(S, "d1", "map", "str", "i32",
             new[] { new KeyValuePairNode(S, new StringLiteralNode(S, "k"), Lit(1)) }, new AttributeCollection()));
         var bd = Assert.IsType<BoundDictionaryCreation>(dict);
-        Assert.Equal("Dictionary<str, i32>", bd.TypeName);
+        Assert.Equal("Dictionary<str,i32>", bd.TypeName);
         Assert.Single(bd.Entries);
         AssertComplete(d3);
     }
@@ -142,11 +144,15 @@ public class BinderArrayCollectionFamilyTests
         var cc = Assert.IsType<BoundCollectionContains>(contains);
         Assert.Equal("BOOL", cc.TypeName);
         Assert.Equal("xs", cc.CollectionName);
+        // The B3 review's CRITICAL: Mode distinguishes three different operations.
+        Assert.Equal(ContainsMode.Value, cc.Mode);
         AssertComplete(d1);
 
         var (tuple, d2) = BindReturn(new TupleLiteralNode(S,
             new ExpressionNode[] { Lit(1), new StringLiteralNode(S, "a") }));
-        Assert.Equal(2, Assert.IsType<BoundTupleLiteral>(tuple).Elements.Count);
+        var tl = Assert.IsType<BoundTupleLiteral>(tuple);
+        Assert.Equal(2, tl.Elements.Count);
+        Assert.Equal("Tuple<INT,STRING>", tl.TypeName);
         AssertComplete(d2);
     }
 
@@ -155,25 +161,50 @@ public class BinderArrayCollectionFamilyTests
     {
         var i = new BoundIntLiteral(S, 1);
         var j = new BoundIntLiteral(S, 2);
-        var arr = new BoundArrayCreation(S, "a", "i32", i, [j]);
+        var arr = new BoundArrayCreation(S, "id1", "a", "i32", i, [j]);
         Assert.Equal([i, j], BoundChildren.Of(arr));
         Assert.Equal(new BoundExpression[] { arr, i },
             BoundChildren.Of(new BoundArrayAccess(S, arr, i)));
         Assert.Equal([arr], BoundChildren.Of(new BoundArrayLength(S, arr)));
         Assert.Equal([i, j], BoundChildren.Of(
-            new BoundMultiDimArrayCreation(S, "m", "i32", 2, [i], [j])));
+            new BoundMultiDimArrayCreation(S, "idm", "m", "i32", 2, [i], [[j]])));
         Assert.Equal(new BoundExpression[] { arr, i, j },
             BoundChildren.Of(new BoundMultiDimArrayAccess(S, arr, [i, j])));
         Assert.Equal([i], BoundChildren.Of(new BoundIndexFromEnd(S, i)));
         Assert.Equal([i], BoundChildren.Of(new BoundRangeExpression(S, i, null)));
         Assert.Equal([i, j], BoundChildren.Of(new BoundRangeExpression(S, i, j)));
-        Assert.Equal([i], BoundChildren.Of(new BoundListCreation(S, "l", "i32", [i])));
-        Assert.Equal([i], BoundChildren.Of(new BoundSetCreation(S, "s", "i32", [i])));
+        Assert.Equal([i], BoundChildren.Of(new BoundListCreation(S, "idl", "l", "i32", [i])));
+        Assert.Equal([i], BoundChildren.Of(new BoundSetCreation(S, "ids", "s", "i32", [i])));
         Assert.Equal([i, j], BoundChildren.Of(
-            new BoundDictionaryCreation(S, "d", "str", "i32", [new BoundPair(i, j, S)])));
-        Assert.Equal([i], BoundChildren.Of(new BoundCollectionContains(S, "xs", i)));
+            new BoundDictionaryCreation(S, "idd", "d", "str", "i32", [new BoundPair(i, j, S)])));
+        Assert.Equal([i], BoundChildren.Of(new BoundCollectionContains(S, "xs", i, ContainsMode.Value)));
         Assert.Equal([i], BoundChildren.Of(new BoundCollectionCount(S, i)));
         Assert.Equal([i, j], BoundChildren.Of(new BoundTupleLiteral(S, [i, j])));
+    }
+
+    [Fact]
+    public void JaggedElementType_DerivesFromTrailingBracketGroup()
+    {
+        // review m5: "i32[][]" element = "i32[]" (EndsWith route) and a multi-dim
+        // access on a jagged-of-multidim type slices at the TRAILING bracket group.
+        var jagged = new BoundArrayCreation(S, "j1", "js", "i32[]", null, []);
+        Assert.Equal("i32[][]", jagged.TypeName);
+        Assert.Equal("i32[]", new BoundArrayAccess(S, jagged, new BoundIntLiteral(S, 0)).TypeName);
+    }
+
+    [Fact]
+    public void ContainsArrayAccess_RecognizesStructuralAccessNodes()
+    {
+        // review M4: the helper NAMED for array access must match the structural nodes
+        // this family added, not only recurse through them.
+        var arr = new BoundArrayCreation(S, "a1", "xs", "i32", null, []);
+        var idx = new BoundIntLiteral(S, 0);
+        Assert.True(Compiler.Analysis.Dataflow.BoundNodeHelpers.ContainsArrayAccess(
+            new BoundArrayAccess(S, arr, idx), out var a, out var i2));
+        Assert.Same(arr, a);
+        Assert.Same(idx, i2);
+        Assert.True(Compiler.Analysis.Dataflow.BoundNodeHelpers.ContainsArrayAccess(
+            new BoundMultiDimArrayAccess(S, arr, [idx]), out _, out _));
     }
 
     [Fact]
@@ -202,7 +233,9 @@ public class BinderArrayCollectionFamilyTests
             }
         });
 
+        // Span-anchored (review m7): the finding must point INSIDE the initializer
+        // (line 6 of the source), not merely exist somewhere in the file.
         Assert.Contains(result.Diagnostics,
-            d => d.Code == DiagnosticCode.DivisionByZero || d.Message.Contains("Division by"));
+            d => d.Code == DiagnosticCode.DivisionByZero && d.Span.Line == 6);
     }
 }

--- a/tests/Calor.Compiler.Tests/Binding/BinderArrayCollectionFamilyTests.cs
+++ b/tests/Calor.Compiler.Tests/Binding/BinderArrayCollectionFamilyTests.cs
@@ -1,0 +1,208 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Binding;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+// Flat test namespace: see BinderDispatchCompletenessTests.
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// #762 B3: arrays/indexes + collections (13 classes) bind structurally — bound node
+/// type, explicit type string, ALL AST properties retained, no Calor0259. Direct-AST
+/// construction (the B2 pattern). Checker-consumption honesty: binding these makes the
+/// subtrees VISIBLE (BoundChildren default arms traverse them — pinned below); the
+/// index-OOB checker still keys on call-target strings until #786 re-platforms it, so
+/// visibility here is not yet an OOB-findings delta, and the family PR says so.
+/// </summary>
+public class BinderArrayCollectionFamilyTests
+{
+    private static readonly TextSpan S = new(0, 0, 1, 1);
+    private static BoundExpression I(long v) => new BoundIntLiteral(S, v);
+
+    private static (BoundExpression Expr, DiagnosticBag Diagnostics) BindReturn(ExpressionNode expr)
+    {
+        var func = new FunctionNode(S, "f001", "Probe", Visibility.Public,
+            Array.Empty<ParameterNode>(), new OutputNode(S, "OBJECT"), null,
+            new StatementNode[] { new ReturnStatementNode(S, expr) },
+            new AttributeCollection());
+        var module = new ModuleNode(S, "m001", "Test",
+            Array.Empty<UsingDirectiveNode>(), new[] { func }, new AttributeCollection());
+        var diagnostics = new DiagnosticBag();
+        var bound = new Binder(diagnostics).Bind(module);
+        var ret = bound.Functions.Single().Body.OfType<BoundReturnStatement>().Single();
+        return (ret.Expression!, diagnostics);
+    }
+
+    private static void AssertComplete(DiagnosticBag d) =>
+        Assert.DoesNotContain(d, x => x.Code == DiagnosticCode.AnalysisIncomplete);
+
+    private static IntLiteralNode Lit(long v) => new(S, v);
+
+    [Fact]
+    public void ArrayCreation_BindsSizeAndInitializers_ComposesType()
+    {
+        var (expr, diags) = BindReturn(new ArrayCreationNode(S, "a1", "nums", "i32",
+            Lit(3), new ExpressionNode[] { Lit(1), Lit(2), Lit(3) }, new AttributeCollection()));
+        var arr = Assert.IsType<BoundArrayCreation>(expr);
+        Assert.Equal("i32[]", arr.TypeName);
+        Assert.NotNull(arr.Size);
+        Assert.Equal(3, arr.Initializer.Count);
+        AssertComplete(diags);
+    }
+
+    [Fact]
+    public void ArrayAccess_DerivesElementType_FromArrayTypeString()
+    {
+        var creation = new ArrayCreationNode(S, "a1", "nums", "i32",
+            null, new ExpressionNode[] { Lit(1) }, new AttributeCollection());
+        var (expr, diags) = BindReturn(new ArrayAccessNode(S, creation, Lit(0)));
+        var access = Assert.IsType<BoundArrayAccess>(expr);
+        Assert.Equal("i32", access.TypeName);
+        Assert.IsType<BoundArrayCreation>(access.Array);
+        AssertComplete(diags);
+    }
+
+    [Fact]
+    public void ArrayLength_And_CollectionCount_AreInt()
+    {
+        var creation = new ArrayCreationNode(S, "a1", "nums", "i32",
+            null, new ExpressionNode[] { Lit(1) }, new AttributeCollection());
+        var (len, d1) = BindReturn(new ArrayLengthNode(S, creation));
+        Assert.Equal("INT", Assert.IsType<BoundArrayLength>(len).TypeName);
+        AssertComplete(d1);
+
+        var list = new ListCreationNode(S, "l1", "xs", "i32", new ExpressionNode[] { Lit(1) }, new AttributeCollection());
+        var (cnt, d2) = BindReturn(new CollectionCountNode(S, list));
+        Assert.Equal("INT", Assert.IsType<BoundCollectionCount>(cnt).TypeName);
+        AssertComplete(d2);
+    }
+
+    [Fact]
+    public void MultiDim_CreationAndAccess_RetainAllChildren()
+    {
+        var creation = new MultiDimArrayCreationNode(S, "m1", "grid", "i32", 2,
+            new ExpressionNode[] { Lit(2), Lit(2) },
+            new IReadOnlyList<ExpressionNode>[] { new ExpressionNode[] { Lit(1), Lit(2) } });
+        var (expr, diags) = BindReturn(creation);
+        var mc = Assert.IsType<BoundMultiDimArrayCreation>(expr);
+        Assert.Equal("i32[,]", mc.TypeName);
+        Assert.Equal(2, mc.DimensionSizes.Count);
+        Assert.Equal(2, mc.Initializer.Count);
+        AssertComplete(diags);
+
+        var (acc, d2) = BindReturn(new MultiDimArrayAccessNode(S, creation,
+            new ExpressionNode[] { Lit(0), Lit(1) }));
+        var ma = Assert.IsType<BoundMultiDimArrayAccess>(acc);
+        Assert.Equal("i32", ma.TypeName);
+        Assert.Equal(2, ma.Indices.Count);
+        AssertComplete(d2);
+    }
+
+    [Fact]
+    public void IndexFromEnd_And_Range_BindWithOptionalBounds()
+    {
+        var (idx, d1) = BindReturn(new IndexFromEndNode(S, Lit(1)));
+        Assert.Equal("INDEX", Assert.IsType<BoundIndexFromEnd>(idx).TypeName);
+        AssertComplete(d1);
+
+        var (openRange, d2) = BindReturn(new RangeExpressionNode(S, Lit(1), null));
+        var r = Assert.IsType<BoundRangeExpression>(openRange);
+        Assert.NotNull(r.Start);
+        Assert.Null(r.End);
+        AssertComplete(d2);
+    }
+
+    [Fact]
+    public void ListSetDictionary_BindElementsAndEntries_ComposeTypes()
+    {
+        var (list, d1) = BindReturn(new ListCreationNode(S, "l1", "xs", "i32",
+            new ExpressionNode[] { Lit(1), Lit(2) }, new AttributeCollection()));
+        Assert.Equal("List<i32>", Assert.IsType<BoundListCreation>(list).TypeName);
+        AssertComplete(d1);
+
+        var (set, d2) = BindReturn(new SetCreationNode(S, "s1", "ys", "str",
+            new ExpressionNode[] { new StringLiteralNode(S, "a") }, new AttributeCollection()));
+        Assert.Equal("Set<str>", Assert.IsType<BoundSetCreation>(set).TypeName);
+        AssertComplete(d2);
+
+        var (dict, d3) = BindReturn(new DictionaryCreationNode(S, "d1", "map", "str", "i32",
+            new[] { new KeyValuePairNode(S, new StringLiteralNode(S, "k"), Lit(1)) }, new AttributeCollection()));
+        var bd = Assert.IsType<BoundDictionaryCreation>(dict);
+        Assert.Equal("Dictionary<str, i32>", bd.TypeName);
+        Assert.Single(bd.Entries);
+        AssertComplete(d3);
+    }
+
+    [Fact]
+    public void Contains_IsBool_TupleComposes()
+    {
+        var (contains, d1) = BindReturn(new CollectionContainsNode(S, "xs", Lit(1),
+            ContainsMode.Value));
+        var cc = Assert.IsType<BoundCollectionContains>(contains);
+        Assert.Equal("BOOL", cc.TypeName);
+        Assert.Equal("xs", cc.CollectionName);
+        AssertComplete(d1);
+
+        var (tuple, d2) = BindReturn(new TupleLiteralNode(S,
+            new ExpressionNode[] { Lit(1), new StringLiteralNode(S, "a") }));
+        Assert.Equal(2, Assert.IsType<BoundTupleLiteral>(tuple).Elements.Count);
+        AssertComplete(d2);
+    }
+
+    [Fact]
+    public void BoundChildren_EnumeratesEveryB3NodeChild()
+    {
+        var i = new BoundIntLiteral(S, 1);
+        var j = new BoundIntLiteral(S, 2);
+        var arr = new BoundArrayCreation(S, "a", "i32", i, [j]);
+        Assert.Equal([i, j], BoundChildren.Of(arr));
+        Assert.Equal(new BoundExpression[] { arr, i },
+            BoundChildren.Of(new BoundArrayAccess(S, arr, i)));
+        Assert.Equal([arr], BoundChildren.Of(new BoundArrayLength(S, arr)));
+        Assert.Equal([i, j], BoundChildren.Of(
+            new BoundMultiDimArrayCreation(S, "m", "i32", 2, [i], [j])));
+        Assert.Equal(new BoundExpression[] { arr, i, j },
+            BoundChildren.Of(new BoundMultiDimArrayAccess(S, arr, [i, j])));
+        Assert.Equal([i], BoundChildren.Of(new BoundIndexFromEnd(S, i)));
+        Assert.Equal([i], BoundChildren.Of(new BoundRangeExpression(S, i, null)));
+        Assert.Equal([i, j], BoundChildren.Of(new BoundRangeExpression(S, i, j)));
+        Assert.Equal([i], BoundChildren.Of(new BoundListCreation(S, "l", "i32", [i])));
+        Assert.Equal([i], BoundChildren.Of(new BoundSetCreation(S, "s", "i32", [i])));
+        Assert.Equal([i, j], BoundChildren.Of(
+            new BoundDictionaryCreation(S, "d", "str", "i32", [new BoundPair(i, j, S)])));
+        Assert.Equal([i], BoundChildren.Of(new BoundCollectionContains(S, "xs", i)));
+        Assert.Equal([i], BoundChildren.Of(new BoundCollectionCount(S, i)));
+        Assert.Equal([i, j], BoundChildren.Of(new BoundTupleLiteral(S, [i, j])));
+    }
+
+    [Fact]
+    public void NestedDivision_InsideArrayIndex_ProducesRealFinding_EndToEnd()
+    {
+        // The B2-review standard applied to B3: a /0 nested in a bound B3 node must
+        // produce the actual Calor0920 through the full pipeline, not merely a subtree.
+        const string source = @"
+§M{m001:Test}
+  §F{f001:Trap:pub} () -> void
+    §E{cw}
+    §LIST{xs:i32}
+      (/ 10 0)
+    §/LIST{xs}
+    §P §CNT{xs}";
+
+        var result = Compiler.Program.Compile(source, "test.calr", new CompilationOptions
+        {
+            EnableVerificationAnalyses = true,
+            VerificationAnalysisOptions = new Compiler.Analysis.VerificationAnalysisOptions
+            {
+                BugPatternOptions = new Compiler.Analysis.BugPatterns.BugPatternOptions
+                {
+                    ReportOnlyVerified = false
+                }
+            }
+        });
+
+        Assert.Contains(result.Diagnostics,
+            d => d.Code == DiagnosticCode.DivisionByZero || d.Message.Contains("Division by"));
+    }
+}


### PR DESCRIPTION
## Summary

B3 of the #762 binder rebuild (scoping doc row 3): the thirteen arrays/indexes + collections classes bind structurally.

- **All AST properties retained** per the B2 review's standard — sizes, initializers, dimension lists, optional range bounds, dictionary entries (as span-carrying `BoundPair` records), collection-name metadata matching the AST shape.
- **Composed type strings**: `T[]`/`T[,]` with element-type derivation on access, `List<T>`/`Set<T>`/`Dictionary<K,V>`, INT/BOOL for counts and membership — 0.13 string types, explicit and non-null per D3.
- **`BoundChildren.Of()` extended** per the family contract (one place; all four traversal switches follow), per-node enumeration locked by unit test, and the **end-to-end pin**: a `/0` nested in a `§LIST` initializer produces the real `Calor0920` through the full pipeline.
- **Ratchet movement, both legs**: in-repo **79 → 51**; conversion leg **1,450 → 1,257** (−193 — matching the B2 review's B3 estimate of ~200 to the digit's neighborhood). Fractions now 1.2% in-repo / 9.8% converted.
- **Checker-delta disclosure**: zero pre-existing tests moved. Visibility-vs-consumption honesty in the test file itself — the index-OOB checker keys on call-target strings until #786, so this PR delivers traversal visibility for the array family, not an OOB-findings delta, and says so.

## Verification

Nine family tests (bound types, composed type strings, children retention, no `Calor0259`, `BoundChildren` coverage, e2e finding). Full suite **8,319/0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)