### PR TITLE
feat(binder): #762 B4 — string family binds, per-op typed results (ratchet 51→28, conv 1257→982)

### DIFF
--- a/bench/phase0-agent-native/binder-incomplete-baseline.json
+++ b/bench/phase0-agent-native/binder-incomplete-baseline.json
@@ -1,12 +1,12 @@
 {
-  "IncompleteCount": 51,
+  "IncompleteCount": 28,
   "ParsedFiles": 443,
   "ParseFailures": 9,
-  "ExpressionsBound": 4385,
+  "ExpressionsBound": 4415,
   "Scope": "both F-2 legs; conversion leg skips when corpus submodules are absent",
   "Conversion": {
-    "Incomplete": 1257,
-    "ExpressionsBound": 12766,
+    "Incomplete": 982,
+    "ExpressionsBound": 13179,
     "ConvertedAndBound": 305,
     "ConvertExceptions": 0,
     "EmptyOutput": 0,

--- a/docs/plans/binder-rebuild-762-scoping.md
+++ b/docs/plans/binder-rebuild-762-scoping.md
@@ -160,6 +160,13 @@ items 1–3 (B1–B8 families), 4 (B5), 5–6 (B8), 7 (B8), 8 (B1 expression-hal
   close in that PR, not a silent delta. (B1's direct-Binder audit, corrected count: **14**
   pre-existing test files instantiate `Binder` directly — not 22 as round-1 review estimated —
   all green post-B1 with one updated pin, `Binder_FallbackExpression_ReturnsOpaqueExpression`.)
+- **Bound-TypeName normalization decision (B4 review Major 1), due BEFORE B6:** the bound
+  vocabulary is bifurcated — scalars use canonical forms ("STRING") while composed types use
+  surface forms ("str[]", "i32[]"), so array-element derivation yields "str" where scalar
+  string expressions say "STRING". Latent (no consumer equality-compares bound TypeNames —
+  verified), but B5/B6 must not mint more derived types on top of it. Candidate: all bound
+  TypeNames pass through AttributeHelper's canonical expansion at construction. Decide and
+  apply in B5.
 - **CI cost budget (review m2):** the corpus leg must stay under **5 minutes**; B1 measures and
   publishes the actual cost; the conversion leg's migrate outputs are cached per pinned subject
   commit (they are deterministic at a frozen commit).

--- a/src/Calor.Compiler/Binding/Binder.cs
+++ b/src/Calor.Compiler/Binding/Binder.cs
@@ -456,6 +456,41 @@ public sealed class Binder
                 { var n = (CollectionCountNode)e; return new BoundCollectionCount(n.Span, b.BindExpression(n.Collection)); },
             [typeof(TupleLiteralNode)] = (b, e) =>
                 { var n = (TupleLiteralNode)e; return new BoundTupleLiteral(n.Span, n.Elements.Select(b.BindExpression).ToList()); },
+            // #762 B4 — string family (4 classes), every AST property retained.
+            [typeof(StringOperationNode)] = (b, e) =>
+                {
+                    var n = (StringOperationNode)e;
+                    return new BoundStringOperation(n.Span, n.Operation,
+                        n.Arguments.Select(b.BindExpression).ToList(), n.ComparisonMode);
+                },
+            [typeof(InterpolatedStringNode)] = (b, e) =>
+                {
+                    var n = (InterpolatedStringNode)e;
+                    // Part subclasses have real Accept dispatch, but binding goes through
+                    // properties for the same reason as FieldAssignmentNode: no
+                    // IAstVisitor<BoundExpression> implementation exists.
+                    return new BoundInterpolatedString(n.Span, n.Parts.Select(p => p switch
+                    {
+                        InterpolatedStringTextNode t =>
+                            new BoundInterpolationPart(t.Text, null, null, null, t.Span),
+                        InterpolatedStringExpressionNode ex => new BoundInterpolationPart(
+                            null, b.BindExpression(ex.Expression),
+                            ex.FormatSpecifier, ex.AlignmentClause, ex.Span),
+                        _ => new BoundInterpolationPart(null, null, null, null, p.Span),
+                    }).ToList());
+                },
+            [typeof(StringBuilderOperationNode)] = (b, e) =>
+                {
+                    var n = (StringBuilderOperationNode)e;
+                    return new BoundStringBuilderOperation(n.Span, n.Operation,
+                        n.Arguments.Select(b.BindExpression).ToList());
+                },
+            [typeof(CharOperationNode)] = (b, e) =>
+                {
+                    var n = (CharOperationNode)e;
+                    return new BoundCharOperation(n.Span, n.Operation,
+                        n.Arguments.Select(b.BindExpression).ToList());
+                },
         };
 
         // Every remaining concrete ExpressionNode subclass dispatches to BindIncomplete.

--- a/src/Calor.Compiler/Binding/Binder.cs
+++ b/src/Calor.Compiler/Binding/Binder.cs
@@ -476,7 +476,10 @@ public sealed class Binder
                         InterpolatedStringExpressionNode ex => new BoundInterpolationPart(
                             null, b.BindExpression(ex.Expression),
                             ex.FormatSpecifier, ex.AlignmentClause, ex.Span),
-                        _ => new BoundInterpolationPart(null, null, null, null, p.Span),
+                        // Fail LOUD if a third part subclass ever appears (B4 review
+                        // minor 3) — a silent empty part would vanish from BoundChildren.
+                        _ => throw new NotSupportedException(
+                            $"Unknown interpolation part: {p.GetType().Name}"),
                     }).ToList());
                 },
             [typeof(StringBuilderOperationNode)] = (b, e) =>

--- a/src/Calor.Compiler/Binding/BoundNodes.cs
+++ b/src/Calor.Compiler/Binding/BoundNodes.cs
@@ -814,6 +814,10 @@ public sealed class BoundStringOperation : BoundExpression
                 or StringOp.IsNullOrEmpty or StringOp.IsNullOrWhiteSpace
                 or StringOp.Equals or StringOp.RegexTest => "BOOL",
             StringOp.Split or StringOp.RegexSplit => "str[]",
+            // Emits Regex.Match (a Match object). Calor has no Match type-string; OBJECT
+            // is the honest placeholder but note it collides with the incomplete-node
+            // spelling (B4 review minor 2) — revisit with the pre-B6 vocabulary
+            // normalization decision (scoping doc §5).
             StringOp.RegexMatch => "OBJECT",
             _ => "STRING",
         };

--- a/src/Calor.Compiler/Binding/BoundNodes.cs
+++ b/src/Calor.Compiler/Binding/BoundNodes.cs
@@ -486,6 +486,12 @@ public static class BoundChildren
         BoundCollectionContains cc => [cc.KeyOrValue],
         BoundCollectionCount cn => [cn.Collection],
         BoundTupleLiteral tl => tl.Elements,
+        // #762 B4 — string family.
+        BoundStringOperation so => so.Arguments,
+        BoundInterpolatedString istr => istr.Parts
+            .Where(p => p.Expression is not null).Select(p => p.Expression!),
+        BoundStringBuilderOperation sb => sb.Arguments,
+        BoundCharOperation co => co.Arguments,
         _ => [],
     };
 }
@@ -784,6 +790,89 @@ public sealed class BoundTupleLiteral : BoundExpression
         Elements = elements;
         // Element types composed rather than discarded (review M3).
         TypeName = $"Tuple<{string.Join(",", elements.Select(e => e.TypeName))}>";
+    }
+}
+
+/// <summary>#762 B4: string operation — result type derived PER OPERATION from the
+/// StringOp enum's own semantics (the first family with genuinely typed results rather
+/// than placeholders). ComparisonMode retained (the B3 ContainsMode lesson).</summary>
+public sealed class BoundStringOperation : BoundExpression
+{
+    public StringOp Operation { get; }
+    public IReadOnlyList<BoundExpression> Arguments { get; }
+    public StringComparisonMode? ComparisonMode { get; }
+    public override string TypeName { get; }
+    public BoundStringOperation(TextSpan span, StringOp operation,
+        IReadOnlyList<BoundExpression> arguments, StringComparisonMode? comparisonMode)
+        : base(span)
+    {
+        Operation = operation; Arguments = arguments; ComparisonMode = comparisonMode;
+        TypeName = operation switch
+        {
+            StringOp.Length or StringOp.IndexOf => "INT",
+            StringOp.Contains or StringOp.StartsWith or StringOp.EndsWith
+                or StringOp.IsNullOrEmpty or StringOp.IsNullOrWhiteSpace
+                or StringOp.Equals or StringOp.RegexTest => "BOOL",
+            StringOp.Split or StringOp.RegexSplit => "str[]",
+            StringOp.RegexMatch => "OBJECT",
+            _ => "STRING",
+        };
+    }
+}
+
+/// <summary>One part of a bound interpolated string: either literal text or a bound
+/// expression with its format/alignment clauses retained (B3 retention standard).</summary>
+public sealed record BoundInterpolationPart(
+    string? Text, BoundExpression? Expression,
+    string? FormatSpecifier, string? AlignmentClause, TextSpan Span);
+
+/// <summary>#762 B4: interpolated string — STRING; parts ordered, expressions bound.</summary>
+public sealed class BoundInterpolatedString : BoundExpression
+{
+    public IReadOnlyList<BoundInterpolationPart> Parts { get; }
+    public override string TypeName => "STRING";
+    public BoundInterpolatedString(TextSpan span, IReadOnlyList<BoundInterpolationPart> parts)
+        : base(span) => Parts = parts;
+}
+
+/// <summary>#762 B4: StringBuilder operation — ToString→STRING, Length→INT, everything
+/// else returns the builder ("StringBuilder", the effect-resolution spelling).</summary>
+public sealed class BoundStringBuilderOperation : BoundExpression
+{
+    public StringBuilderOp Operation { get; }
+    public IReadOnlyList<BoundExpression> Arguments { get; }
+    public override string TypeName { get; }
+    public BoundStringBuilderOperation(TextSpan span, StringBuilderOp operation,
+        IReadOnlyList<BoundExpression> arguments) : base(span)
+    {
+        Operation = operation; Arguments = arguments;
+        TypeName = operation switch
+        {
+            StringBuilderOp.ToString => "STRING",
+            StringBuilderOp.Length => "INT",
+            _ => "StringBuilder",
+        };
+    }
+}
+
+/// <summary>#762 B4: char operation — per-op result ("CHAR" is the canonical spelling,
+/// AttributeHelper maps char↔CHAR).</summary>
+public sealed class BoundCharOperation : BoundExpression
+{
+    public CharOp Operation { get; }
+    public IReadOnlyList<BoundExpression> Arguments { get; }
+    public override string TypeName { get; }
+    public BoundCharOperation(TextSpan span, CharOp operation,
+        IReadOnlyList<BoundExpression> arguments) : base(span)
+    {
+        Operation = operation; Arguments = arguments;
+        TypeName = operation switch
+        {
+            CharOp.CharCode => "INT",
+            CharOp.IsLetter or CharOp.IsDigit or CharOp.IsWhiteSpace
+                or CharOp.IsUpper or CharOp.IsLower => "BOOL",
+            _ => "CHAR",
+        };
     }
 }
 

--- a/tests/Calor.Compiler.Tests/Binding/BinderStringFamilyTests.cs
+++ b/tests/Calor.Compiler.Tests/Binding/BinderStringFamilyTests.cs
@@ -1,0 +1,161 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Binding;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+// Flat test namespace: see BinderDispatchCompletenessTests.
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// #762 B4: the string family (4 classes) binds with PER-OPERATION result types derived
+/// from the op enums' own semantics — the first family with genuinely typed results.
+/// Every AST property retained (ComparisonMode, format/alignment clauses — the B3
+/// ContainsMode lesson applied up front).
+/// </summary>
+public class BinderStringFamilyTests
+{
+    private static readonly TextSpan S = new(0, 0, 1, 1);
+
+    private static (BoundExpression Expr, DiagnosticBag Diagnostics) BindReturn(ExpressionNode expr)
+    {
+        var func = new FunctionNode(S, "f001", "Probe", Visibility.Public,
+            Array.Empty<ParameterNode>(), new OutputNode(S, "OBJECT"), null,
+            new StatementNode[] { new ReturnStatementNode(S, expr) },
+            new AttributeCollection());
+        var module = new ModuleNode(S, "m001", "Test",
+            Array.Empty<UsingDirectiveNode>(), new[] { func }, new AttributeCollection());
+        var diagnostics = new DiagnosticBag();
+        var bound = new Binder(diagnostics).Bind(module);
+        var ret = bound.Functions.Single().Body.OfType<BoundReturnStatement>().Single();
+        return (ret.Expression!, diagnostics);
+    }
+
+    private static void AssertComplete(DiagnosticBag d) =>
+        Assert.DoesNotContain(d, x => x.Code == DiagnosticCode.AnalysisIncomplete);
+
+    private static StringLiteralNode Str(string s) => new(S, s);
+
+    [Theory]
+    [InlineData(StringOp.Length, "INT")]
+    [InlineData(StringOp.IndexOf, "INT")]
+    [InlineData(StringOp.Contains, "BOOL")]
+    [InlineData(StringOp.StartsWith, "BOOL")]
+    [InlineData(StringOp.IsNullOrEmpty, "BOOL")]
+    [InlineData(StringOp.RegexTest, "BOOL")]
+    [InlineData(StringOp.Split, "str[]")]
+    [InlineData(StringOp.RegexSplit, "str[]")]
+    [InlineData(StringOp.RegexMatch, "OBJECT")]
+    [InlineData(StringOp.ToUpper, "STRING")]
+    [InlineData(StringOp.Concat, "STRING")]
+    public void StringOperation_DerivesResultType_PerOp(StringOp op, string expected)
+    {
+        var (expr, diags) = BindReturn(new StringOperationNode(S, op,
+            new ExpressionNode[] { Str("a"), Str("b") }));
+        var bound = Assert.IsType<BoundStringOperation>(expr);
+        Assert.Equal(expected, bound.TypeName);
+        Assert.Equal(2, bound.Arguments.Count);
+        AssertComplete(diags);
+    }
+
+    [Fact]
+    public void StringOperation_RetainsComparisonMode()
+    {
+        // The B3 ContainsMode lesson, applied up front: the mode selects the
+        // StringComparison overload — a different operation, not decoration.
+        var (expr, _) = BindReturn(new StringOperationNode(S, StringOp.Contains,
+            new ExpressionNode[] { Str("a"), Str("b") }, StringComparisonMode.IgnoreCase));
+        Assert.Equal(StringComparisonMode.IgnoreCase,
+            Assert.IsType<BoundStringOperation>(expr).ComparisonMode);
+    }
+
+    [Fact]
+    public void InterpolatedString_RetainsPartOrder_FormatAndAlignment()
+    {
+        var node = new InterpolatedStringNode(S, new InterpolatedStringPartNode[]
+        {
+            new InterpolatedStringTextNode(S, "total: "),
+            new InterpolatedStringExpressionNode(S, new IntLiteralNode(S, 42), "N2", "8"),
+        });
+        var (expr, diags) = BindReturn(node);
+        var bound = Assert.IsType<BoundInterpolatedString>(expr);
+        Assert.Equal("STRING", bound.TypeName);
+        Assert.Equal(2, bound.Parts.Count);
+        Assert.Equal("total: ", bound.Parts[0].Text);
+        Assert.NotNull(bound.Parts[1].Expression);
+        Assert.Equal("N2", bound.Parts[1].FormatSpecifier);
+        Assert.Equal("8", bound.Parts[1].AlignmentClause);
+        AssertComplete(diags);
+    }
+
+    [Theory]
+    [InlineData(StringBuilderOp.New, "StringBuilder")]
+    [InlineData(StringBuilderOp.Append, "StringBuilder")]
+    [InlineData(StringBuilderOp.ToString, "STRING")]
+    [InlineData(StringBuilderOp.Length, "INT")]
+    public void StringBuilderOperation_DerivesResultType_PerOp(StringBuilderOp op, string expected)
+    {
+        var (expr, diags) = BindReturn(new StringBuilderOperationNode(S, op,
+            new ExpressionNode[] { Str("x") }));
+        Assert.Equal(expected, Assert.IsType<BoundStringBuilderOperation>(expr).TypeName);
+        AssertComplete(diags);
+    }
+
+    [Theory]
+    [InlineData(CharOp.CharAt, "CHAR")]
+    [InlineData(CharOp.CharCode, "INT")]
+    [InlineData(CharOp.IsDigit, "BOOL")]
+    [InlineData(CharOp.ToUpperChar, "CHAR")]
+    public void CharOperation_DerivesResultType_PerOp(CharOp op, string expected)
+    {
+        var (expr, diags) = BindReturn(new CharOperationNode(S, op,
+            new ExpressionNode[] { Str("a") }));
+        Assert.Equal(expected, Assert.IsType<BoundCharOperation>(expr).TypeName);
+        AssertComplete(diags);
+    }
+
+    [Fact]
+    public void BoundChildren_EnumeratesEveryB4NodeChild()
+    {
+        var i = new BoundIntLiteral(S, 1);
+        var j = new BoundIntLiteral(S, 2);
+        Assert.Equal([i, j], BoundChildren.Of(
+            new BoundStringOperation(S, StringOp.Contains, [i, j], null)));
+        Assert.Equal([i], BoundChildren.Of(new BoundInterpolatedString(S,
+        [
+            new BoundInterpolationPart("t", null, null, null, S),
+            new BoundInterpolationPart(null, i, null, null, S),
+        ])));
+        Assert.Equal([i], BoundChildren.Of(
+            new BoundStringBuilderOperation(S, StringBuilderOp.Append, [i])));
+        Assert.Equal([i], BoundChildren.Of(
+            new BoundCharOperation(S, CharOp.CharAt, [i])));
+    }
+
+    [Fact]
+    public void NestedDivision_InsideStringOperation_ProducesRealFinding_EndToEnd()
+    {
+        // The family's span-anchored e2e pin: /0 nested in a string-op argument must
+        // produce the real Calor0920 pointing at the right line. ((str x) = ToString.)
+        const string source = @"
+§M{m001:Test}
+  §F{f001:Trap:pub} () -> void
+    §E{cw}
+    §P (contains STR:""ab"" (str (/ 10 0)))";
+
+        var result = Compiler.Program.Compile(source, "test.calr", new CompilationOptions
+        {
+            EnableVerificationAnalyses = true,
+            VerificationAnalysisOptions = new Compiler.Analysis.VerificationAnalysisOptions
+            {
+                BugPatternOptions = new Compiler.Analysis.BugPatterns.BugPatternOptions
+                {
+                    ReportOnlyVerified = false
+                }
+            }
+        });
+
+        Assert.Contains(result.Diagnostics,
+            d => d.Code == DiagnosticCode.DivisionByZero && d.Span.Line == 5);
+    }
+}


### PR DESCRIPTION
## Summary

B4 of the #762 binder rebuild (scoping doc row 4): the four string-family classes bind with **per-operation derived result types** — the first family where the type strings carry real information rather than placeholders.

- `BoundStringOperation`: 11 distinct per-op result mappings (INT/BOOL/`str[]`/OBJECT/STRING) pinned by theory tests; **`ComparisonMode` retained** — the B3 `ContainsMode` lesson applied up front.
- `BoundInterpolatedString`: part order + **format specifiers and alignment clauses retained**; `BoundChildren.Of` enumerates expression holes only.
- `BoundStringBuilderOperation` / `BoundCharOperation`: per-op types using existing vocabulary (`StringBuilder` = the effect-resolution spelling; `CHAR` = AttributeHelper's canonical form) — no invented spellings this round.
- Span-anchored e2e pin: `/0` nested in a string-op argument produces the real `Calor0920` at the right line. (Honest note: the first pin attempt used an interpolation hole and discovered Calor interpolation doesn't parse lisp expressions in holes — the pin nests through `(str …)` instead.)

## Ratchet movement

In-repo **51 → 28**; conversion leg **1,257 → 982** (−275 — the B2 breakdown's B4 estimate was 274). Fractions now **0.63% in-repo / 7.5% converted**. Remaining conversion-leg mass is exactly the B5 (~74) and B6 (~881-minus-newly-exposed) families, as scheduled.

## Verification

23 family tests; zero pre-existing tests moved (checker-delta disclosure); full suite **8,344/0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)