### PR TITLE
feat(binder): #762 B5 — semantic repairs: decimals, casts, type tests (conv 982→904)

### DIFF
--- a/bench/phase0-agent-native/binder-incomplete-baseline.json
+++ b/bench/phase0-agent-native/binder-incomplete-baseline.json
@@ -5,7 +5,7 @@
   "ExpressionsBound": 4415,
   "Scope": "both F-2 legs; conversion leg skips when corpus submodules are absent",
   "Conversion": {
-    "Incomplete": 982,
+    "Incomplete": 904,
     "ExpressionsBound": 13179,
     "ConvertedAndBound": 305,
     "ConvertExceptions": 0,

--- a/docs/plans/binder-rebuild-762-scoping.md
+++ b/docs/plans/binder-rebuild-762-scoping.md
@@ -164,9 +164,12 @@ items 1–3 (B1–B8 families), 4 (B5), 5–6 (B8), 7 (B8), 8 (B1 expression-hal
   vocabulary is bifurcated — scalars use canonical forms ("STRING") while composed types use
   surface forms ("str[]", "i32[]"), so array-element derivation yields "str" where scalar
   string expressions say "STRING". Latent (no consumer equality-compares bound TypeNames —
-  verified), but B5/B6 must not mint more derived types on top of it. Candidate: all bound
-  TypeNames pass through AttributeHelper's canonical expansion at construction. Decide and
-  apply in B5.
+  verified), but B5/B6 must not mint more derived types on top of it. DECIDED IN B5 (#907): **documented deferral** —
+  the two-layer vocabulary (canonical literal families + parser-surface composed forms) is
+  stated on `BoundExpression.TypeName` with the rationale (string unification would break the
+  B3 parser-agreement or churn every family twice); 0.14's typed representation replaces the
+  strings wholesale. Bound TypeNames are informational and never equality-compared; B6+ may
+  not mint spellings outside the two layers (the "Type"→"TYPE" correction enforced this).
 - **CI cost budget (review m2):** the corpus leg must stay under **5 minutes**; B1 measures and
   publishes the actual cost; the conversion leg's migrate outputs are cached per pinned subject
   commit (they are deterministic at a frozen commit).

--- a/src/Calor.Compiler/Analysis/BugPatterns/Patterns/DivisionByZeroChecker.cs
+++ b/src/Calor.Compiler/Analysis/BugPatterns/Patterns/DivisionByZeroChecker.cs
@@ -216,6 +216,13 @@ public sealed class DivisionByZeroChecker : IBugPatternChecker
         DiagnosticBag diagnostics,
         List<BoundExpression> pathConditions)
     {
+        // #762 B5 review C2: numeric casts are zero-preserving — see THROUGH the
+        // conversion wrapper or a cast divisor loses its Z3-verified warning and the
+        // Calor0926 suggester (the old Cast arm returned the operand bare, so this
+        // worked by accident before B5).
+        while (divisor is BoundConversionExpression conv)
+            divisor = conv.Operand;
+
         // Quick check: literal zero is always a bug
         if (BoundNodeHelpers.IsLiteralZero(divisor))
         {

--- a/src/Calor.Compiler/Analysis/Dataflow/BoundNodeHelpers.cs
+++ b/src/Calor.Compiler/Analysis/Dataflow/BoundNodeHelpers.cs
@@ -386,6 +386,9 @@ public static class BoundNodeHelpers
         {
             BoundIntLiteral intLit => intLit.Value == 0,
             BoundFloatLiteral floatLit => floatLit.Value == 0.0,
+            // #762 B5 review C1: DEC:0 divisors bound as BoundDecimalLiteral post-B5;
+            // without this arm a hard Calor0920 ERROR silently became nothing.
+            BoundDecimalLiteral d => d.Value == 0m,
             _ => false
         };
     }
@@ -395,7 +398,9 @@ public static class BoundNodeHelpers
     /// </summary>
     public static bool IsConstant(BoundExpression? expression)
     {
-        return expression is BoundIntLiteral or BoundFloatLiteral or BoundBoolLiteral or BoundStringLiteral;
+        // BoundDecimalLiteral added with the B5 decimal repair (review C1's sibling gap:
+        // known-safe DEC divisors lost their constant suppression).
+        return expression is BoundIntLiteral or BoundFloatLiteral or BoundBoolLiteral or BoundStringLiteral or BoundDecimalLiteral;
     }
 
     /// <summary>

--- a/src/Calor.Compiler/Binding/Binder.cs
+++ b/src/Calor.Compiler/Binding/Binder.cs
@@ -339,8 +339,8 @@ public sealed class Binder
             [typeof(StringLiteralNode)] = (b, e) => { var n = (StringLiteralNode)e; return new BoundStringLiteral(n.Span, n.Value); },
             [typeof(BoolLiteralNode)] = (b, e) => { var n = (BoolLiteralNode)e; return new BoundBoolLiteral(n.Span, n.Value); },
             [typeof(FloatLiteralNode)] = (b, e) => { var n = (FloatLiteralNode)e; return new BoundFloatLiteral(n.Span, n.Value); },
-            // Known defect, preserved verbatim until B5 (#762 item 4): decimals downcast.
-            [typeof(DecimalLiteralNode)] = (b, e) => { var n = (DecimalLiteralNode)e; return new BoundFloatLiteral(n.Span, (double)n.Value); },
+            // B5 (#762 item 4): full-precision decimal — the downcast is gone.
+            [typeof(DecimalLiteralNode)] = (b, e) => { var n = (DecimalLiteralNode)e; return new BoundDecimalLiteral(n.Span, n.Value); },
             [typeof(ReferenceNode)] = (b, e) => b.BindReferenceExpression((ReferenceNode)e),
             [typeof(BinaryOperationNode)] = (b, e) => b.BindBinaryOperation((BinaryOperationNode)e),
             [typeof(UnaryOperationNode)] = (b, e) => b.BindUnaryOperation((UnaryOperationNode)e),
@@ -359,7 +359,15 @@ public sealed class Binder
             [typeof(FieldAccessNode)] = (b, e) => b.BindFieldAccess((FieldAccessNode)e),
             [typeof(NewExpressionNode)] = (b, e) => b.BindNewExpression((NewExpressionNode)e),
             [typeof(TypeOperationNode)] = (b, e) => b.BindTypeOperation((TypeOperationNode)e),
-            [typeof(IsPatternNode)] = (b, e) => b.BindIsPattern((IsPatternNode)e),
+            [typeof(IsPatternNode)] = (b, e) =>
+                {
+                    // B5: pattern tests no longer fold to literal true (#762 evidence).
+                    var n = (IsPatternNode)e;
+                    return new BoundTypeTest(n.Span, b.BindExpression(n.Operand),
+                        n.TargetType, n.VariableName);
+                },
+            [typeof(TypeOfExpressionNode)] = (b, e) =>
+                { var n = (TypeOfExpressionNode)e; return new BoundTypeOfExpression(n.Span, n.TypeName); },
             // #762 B2 — the core-9 family (SelfRefNode excepted: dormant, see s_tierBReasons).
             [typeof(SomeExpressionNode)] = (b, e) =>
                 { var n = (SomeExpressionNode)e; return new BoundSomeExpression(n.Span, b.BindExpression(n.Value)); },
@@ -544,25 +552,19 @@ public sealed class Binder
 
     private BoundExpression BindTypeOperation(TypeOperationNode typeOp)
     {
+        // B5 (#762 items 1/4): casts and `as` produce a real conversion node carrying
+        // the TARGET type (the old arm returned the operand — a cast's static type was
+        // whatever the operand claimed); `is` produces a real BOOL type test (the old
+        // arm returned LITERAL TRUE, which constant-aware checkers could fold on).
         var operand = BindExpression(typeOp.Operand);
         return typeOp.Operation switch
         {
-            // Cast: bind inner expression and return it — the value is preserved,
-            // type changes to TargetType. This prevents (cast f64 nonZeroExpr)
-            // from becoming BoundIntLiteral(0) via the fallback path.
-            TypeOp.Cast => operand,
-            // Is: result is always BOOL
-            TypeOp.Is => new BoundBoolLiteral(typeOp.Span, true),
-            // As: result has the target type (nullable), bind inner
-            TypeOp.As => operand,
-            _ => BindFallbackExpression(typeOp)
+            TypeOp.Cast or TypeOp.As => new BoundConversionExpression(
+                typeOp.Span, typeOp.Operation, operand, typeOp.TargetType),
+            TypeOp.Is => new BoundTypeTest(typeOp.Span, operand, typeOp.TargetType, null),
+            // TypeOp is enum-complete above; fail loud if a member is ever added.
+            _ => throw new NotSupportedException($"Unknown TypeOp: {typeOp.Operation}"),
         };
-    }
-
-    private BoundExpression BindIsPattern(IsPatternNode isPattern)
-    {
-        BindExpression(isPattern.Operand); // bind for side effects
-        return new BoundBoolLiteral(isPattern.Span, true);
     }
 
     private BoundExpression BindNewExpression(NewExpressionNode newExpr)

--- a/src/Calor.Compiler/Binding/Binder.cs
+++ b/src/Calor.Compiler/Binding/Binder.cs
@@ -363,8 +363,15 @@ public sealed class Binder
                 {
                     // B5: pattern tests no longer fold to literal true (#762 evidence).
                     var n = (IsPatternNode)e;
-                    return new BoundTypeTest(n.Span, b.BindExpression(n.Operand),
+                    var bound = new BoundTypeTest(n.Span, b.BindExpression(n.Operand),
                         n.TargetType, n.VariableName);
+                    // Review M3: the pattern VARIABLE (`x is Foo f`) is a declaration —
+                    // without this, `f` was "retained" into a node nothing consumes while
+                    // every later use was a hard Undefined-variable error. Scoped to the
+                    // enclosing bind scope (approximates C#'s definite-assignment scope).
+                    if (n.VariableName is not null)
+                        b._scope.TryDeclare(new VariableSymbol(n.VariableName, n.TargetType, isMutable: false));
+                    return bound;
                 },
             [typeof(TypeOfExpressionNode)] = (b, e) =>
                 { var n = (TypeOfExpressionNode)e; return new BoundTypeOfExpression(n.Span, n.TypeName); },

--- a/src/Calor.Compiler/Binding/BoundNodes.cs
+++ b/src/Calor.Compiler/Binding/BoundNodes.cs
@@ -29,6 +29,17 @@ public abstract class BoundStatement : BoundNode
 /// </summary>
 public abstract class BoundExpression : BoundNode
 {
+    /// <summary>
+    /// INFORMATIONAL type string — never compare for equality. The vocabulary is
+    /// deliberately two-layer (a pre-B-series reality): literal-family names are
+    /// canonical ("INT", "STRING", "DECIMAL"), while composed/derived forms use the
+    /// PARSER's surface spellings ("i32[]", "HashSet<i32>") so a bind statement's
+    /// variable and its initializer agree (the B3 alignment decision). Full
+    /// normalization is deferred BY DECISION (B5, resolving B4 review Major 1) to
+    /// 0.14's typed semantic representation, which replaces these strings wholesale
+    /// (roadmap §3.2) — a string-level unification now would either break parser
+    /// agreement or churn every family twice.
+    /// </summary>
     public abstract string TypeName { get; }
 
     protected BoundExpression(TextSpan span) : base(span) { }
@@ -486,6 +497,10 @@ public static class BoundChildren
         BoundCollectionContains cc => [cc.KeyOrValue],
         BoundCollectionCount cn => [cn.Collection],
         BoundTupleLiteral tl => tl.Elements,
+        // #762 B5 — conversion/pattern family.
+        BoundConversionExpression conv => [conv.Operand],
+        BoundTypeTest tt => [tt.Operand],
+        // (BoundTypeOfExpression and BoundDecimalLiteral have no expression children.)
         // #762 B4 — string family.
         BoundStringOperation so => so.Arguments,
         BoundInterpolatedString istr => istr.Parts
@@ -878,6 +893,54 @@ public sealed class BoundCharOperation : BoundExpression
             _ => "CHAR",
         };
     }
+}
+
+/// <summary>#762 B5 (item 4): decimal literal WITHOUT the double downcast the old
+/// switch applied ((double)value lost precision — the defect was visible in the arm).</summary>
+public sealed class BoundDecimalLiteral : BoundExpression
+{
+    public decimal Value { get; }
+    public override string TypeName => "DECIMAL";
+    public BoundDecimalLiteral(TextSpan span, decimal value) : base(span) => Value = value;
+}
+
+/// <summary>#762 B5: cast/as conversion — the operand is RETAINED as a child and the
+/// TypeName is the conversion TARGET (the old arm returned the operand itself, so a
+/// cast's static type was whatever the operand claimed — #762's evidence bullet).</summary>
+public sealed class BoundConversionExpression : BoundExpression
+{
+    public TypeOp Operation { get; }
+    public BoundExpression Operand { get; }
+    public string TargetType { get; }
+    public override string TypeName => TargetType;
+    public BoundConversionExpression(TextSpan span, TypeOp operation,
+        BoundExpression operand, string targetType) : base(span)
+    { Operation = operation; Operand = operand; TargetType = targetType; }
+}
+
+/// <summary>#762 B5: type test (both the `is` operator and is-pattern forms) — BOOL,
+/// with the operand retained and the pattern variable name carried. The old arms
+/// returned LITERAL TRUE, which a constant-aware checker could fold branches on.</summary>
+public sealed class BoundTypeTest : BoundExpression
+{
+    public BoundExpression Operand { get; }
+    public string TargetType { get; }
+    /// <summary>The is-pattern's declared variable (e.g. `x is Foo f`), if any.</summary>
+    public string? VariableName { get; }
+    public override string TypeName => "BOOL";
+    public BoundTypeTest(TextSpan span, BoundExpression operand, string targetType,
+        string? variableName) : base(span)
+    { Operand = operand; TargetType = targetType; VariableName = variableName; }
+}
+
+/// <summary>#762 B5: typeof — emits typeof(T) (System.Type); "Type" is the
+/// effect-resolution-style short spelling.</summary>
+public sealed class BoundTypeOfExpression : BoundExpression
+{
+    public string TargetTypeName { get; }
+    public override string TypeName => "Type";
+    public BoundTypeOfExpression(TextSpan span, string targetTypeName) : base(span)
+        => TargetTypeName = targetTypeName;
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Binding/BoundNodes.cs
+++ b/src/Calor.Compiler/Binding/BoundNodes.cs
@@ -933,12 +933,12 @@ public sealed class BoundTypeTest : BoundExpression
     { Operand = operand; TargetType = targetType; VariableName = variableName; }
 }
 
-/// <summary>#762 B5: typeof — emits typeof(T) (System.Type); "Type" is the
-/// effect-resolution-style short spelling.</summary>
+/// <summary>#762 B5: typeof — emits typeof(T) (System.Type). "TYPE" per the
+/// canonical-caps literal-family convention (review M2: no third spelling family).</summary>
 public sealed class BoundTypeOfExpression : BoundExpression
 {
     public string TargetTypeName { get; }
-    public override string TypeName => "Type";
+    public override string TypeName => "TYPE";
     public BoundTypeOfExpression(TextSpan span, string targetTypeName) : base(span)
         => TargetTypeName = targetTypeName;
 }

--- a/tests/Calor.Compiler.Tests/Analysis/ClassMemberBindingTests.cs
+++ b/tests/Calor.Compiler.Tests/Analysis/ClassMemberBindingTests.cs
@@ -672,9 +672,11 @@ public class ClassMemberBindingTests
         // The return expression should be a binary division
         Assert.IsType<BoundBinaryExpression>(ret.Expression);
         var div = (BoundBinaryExpression)ret.Expression!;
-        // The RHS (DEC:100) should NOT be zero
-        Assert.IsType<BoundFloatLiteral>(div.Right);
-        Assert.NotEqual(0.0, ((BoundFloatLiteral)div.Right).Value);
+        // The RHS (DEC:100) should NOT be zero. #762 B5: decimals now bind as
+        // BoundDecimalLiteral at FULL precision (the old BoundFloatLiteral shape this
+        // pin asserted was itself the item-4 downcast defect).
+        Assert.IsType<BoundDecimalLiteral>(div.Right);
+        Assert.NotEqual(0m, ((BoundDecimalLiteral)div.Right).Value);
     }
 
     #endregion

--- a/tests/Calor.Compiler.Tests/Binding/BinderConversionPatternFamilyTests.cs
+++ b/tests/Calor.Compiler.Tests/Binding/BinderConversionPatternFamilyTests.cs
@@ -99,7 +99,7 @@ public class BinderConversionPatternFamilyTests
     {
         var (expr, diags) = BindReturn(new TypeOfExpressionNode(S, "MyClass"));
         var t = Assert.IsType<BoundTypeOfExpression>(expr);
-        Assert.Equal("Type", t.TypeName);
+        Assert.Equal("TYPE", t.TypeName);
         Assert.Equal("MyClass", t.TargetTypeName);
         AssertComplete(diags);
     }
@@ -113,6 +113,87 @@ public class BinderConversionPatternFamilyTests
         Assert.Equal([i], BoundChildren.Of(new BoundTypeTest(S, i, "str", null)));
         Assert.Empty(BoundChildren.Of(new BoundTypeOfExpression(S, "T")));
         Assert.Empty(BoundChildren.Of(new BoundDecimalLiteral(S, 1m)));
+    }
+
+    [Fact]
+    public void DecimalZeroDivisor_ProducesHardError_UnderDefaultOptions()
+    {
+        // Review C1's regression pin: pre-B5 DEC:0 bound as BoundFloatLiteral(0.0) and
+        // IsLiteralZero caught it; the B5 BoundDecimalLiteral fell through to false and
+        // a hard ERROR silently became nothing. DEFAULT options (ReportOnlyVerified) —
+        // the literal-zero case must not need --all-findings.
+        const string source = @"
+§M{m001:Test}
+  §F{f001:Trap:pub} (i32:x) -> dec
+    §R (/ x DEC:0)";
+
+        // ReportOnlyVerified=true IS the CLI default (--analyze without --all-findings);
+        // BugPatternOptions' own default is false, so it must be set explicitly or this
+        // pin silently tests all-findings mode (the first draft's non-discrimination bug).
+        var result = Compiler.Program.Compile(source, "test.calr", new CompilationOptions
+        {
+            EnableVerificationAnalyses = true,
+            VerificationAnalysisOptions = new Compiler.Analysis.VerificationAnalysisOptions
+            {
+                BugPatternOptions = new Compiler.Analysis.BugPatterns.BugPatternOptions
+                {
+                    ReportOnlyVerified = true
+                }
+            }
+        });
+
+        Assert.Contains(result.Diagnostics,
+            d => d.Code == DiagnosticCode.DivisionByZero
+                 && d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void CastDivisor_KeepsVerifiedWarning_UnderDefaultOptions()
+    {
+        // Review C2's regression pin: the old Cast arm returned the operand bare, so a
+        // cast divisor reached Z3 as a variable; the B5 conversion wrapper made it
+        // untranslatable and the verified Warning vanished. CheckDivisor now unwraps
+        // conversions (numeric casts are zero-preserving).
+        const string source = @"
+§M{m001:Test}
+  §F{f001:Trap:pub} (i32:y) -> i64
+    §R (/ 100 (cast i64 y))";
+
+        var result = Compiler.Program.Compile(source, "test.calr", new CompilationOptions
+        {
+            EnableVerificationAnalyses = true,
+            VerificationAnalysisOptions = new Compiler.Analysis.VerificationAnalysisOptions
+            {
+                BugPatternOptions = new Compiler.Analysis.BugPatterns.BugPatternOptions
+                {
+                    ReportOnlyVerified = true
+                }
+            }
+        });
+
+        // The VERIFIED warning, not an inconclusive Info — severity is the discriminator.
+        Assert.Contains(result.Diagnostics,
+            d => d.Code == DiagnosticCode.DivisionByZero
+                 && d.Severity != DiagnosticSeverity.Info);
+    }
+
+    [Fact]
+    public void PatternVariable_IsDeclaredInScope_UsableAfterTest()
+    {
+        // Review M3: `x is str s` DECLARES s. Pre-fix, s was retained into the bound
+        // node while every later use was a hard Undefined-variable error.
+        var test = new IsPatternNode(S, new ReferenceNode(S, "x"), "str", "s");
+        var use = new ReturnStatementNode(S, new ReferenceNode(S, "s"));
+        var func = new FunctionNode(S, "f001", "Probe", Visibility.Public,
+            new[] { new ParameterNode(S, "x", "OBJECT", new AttributeCollection()) }, new OutputNode(S, "str"), null,
+            new StatementNode[] { new ExpressionStatementNode(S, test), use },
+            new AttributeCollection());
+        var module = new ModuleNode(S, "m001", "Test",
+            Array.Empty<UsingDirectiveNode>(), new[] { func }, new AttributeCollection());
+        var diagnostics = new DiagnosticBag();
+        new Binder(diagnostics).Bind(module);
+        Assert.DoesNotContain(diagnostics,
+            d => d.Code == DiagnosticCode.UndefinedReference && d.Message.Contains("'s'"));
     }
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/Binding/BinderConversionPatternFamilyTests.cs
+++ b/tests/Calor.Compiler.Tests/Binding/BinderConversionPatternFamilyTests.cs
@@ -1,0 +1,145 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Binding;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+// Flat test namespace: see BinderDispatchCompletenessTests.
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// #762 B5: conversion + type/pattern + decimals — the SEMANTIC-REPAIR family. These
+/// tests pin the three #762 evidence bullets dead: decimals no longer downcast through
+/// double, casts carry their TARGET type instead of the operand's, and `is`/pattern
+/// tests are real BOOL type tests instead of literal true.
+/// </summary>
+public class BinderConversionPatternFamilyTests
+{
+    private static readonly TextSpan S = new(0, 0, 1, 1);
+
+    private static (BoundExpression Expr, DiagnosticBag Diagnostics) BindReturn(ExpressionNode expr)
+    {
+        var func = new FunctionNode(S, "f001", "Probe", Visibility.Public,
+            Array.Empty<ParameterNode>(), new OutputNode(S, "OBJECT"), null,
+            new StatementNode[] { new ReturnStatementNode(S, expr) },
+            new AttributeCollection());
+        var module = new ModuleNode(S, "m001", "Test",
+            Array.Empty<UsingDirectiveNode>(), new[] { func }, new AttributeCollection());
+        var diagnostics = new DiagnosticBag();
+        var bound = new Binder(diagnostics).Bind(module);
+        var ret = bound.Functions.Single().Body.OfType<BoundReturnStatement>().Single();
+        return (ret.Expression!, diagnostics);
+    }
+
+    private static void AssertComplete(DiagnosticBag d) =>
+        Assert.DoesNotContain(d, x => x.Code == DiagnosticCode.AnalysisIncomplete);
+
+    [Fact]
+    public void DecimalLiteral_KeepsFullPrecision_NoDoubleDowncast()
+    {
+        // 0.1m + a 28-digit tail: provably not double-representable. The old arm bound
+        // this as BoundFloatLiteral((double)value) — #762 item 4's defect.
+        const decimal precise = 0.1234567890123456789012345678m;
+        Assert.NotEqual(precise, (decimal)(double)precise); // the downcast WOULD lose it
+
+        var (expr, diags) = BindReturn(new DecimalLiteralNode(S, precise));
+        var bound = Assert.IsType<BoundDecimalLiteral>(expr);
+        Assert.Equal(precise, bound.Value);
+        Assert.Equal("DECIMAL", bound.TypeName);
+        AssertComplete(diags);
+    }
+
+    [Fact]
+    public void Cast_CarriesTargetType_RetainsOperand()
+    {
+        var (expr, diags) = BindReturn(new TypeOperationNode(S, TypeOp.Cast,
+            new IntLiteralNode(S, 42), "f64"));
+        var conv = Assert.IsType<BoundConversionExpression>(expr);
+        Assert.Equal("f64", conv.TypeName); // the TARGET, not the operand's INT
+        Assert.IsType<BoundIntLiteral>(conv.Operand);
+        Assert.Equal(TypeOp.Cast, conv.Operation);
+        AssertComplete(diags);
+    }
+
+    [Fact]
+    public void As_CarriesTargetType()
+    {
+        var (expr, _) = BindReturn(new TypeOperationNode(S, TypeOp.As,
+            new ReferenceNode(S, "obj"), "MyClass"));
+        Assert.Equal("MyClass", Assert.IsType<BoundConversionExpression>(expr).TypeName);
+    }
+
+    [Fact]
+    public void Is_IsARealTypeTest_NotLiteralTrue()
+    {
+        var (expr, _) = BindReturn(new TypeOperationNode(S, TypeOp.Is,
+            new ReferenceNode(S, "x"), "str"));
+        var test = Assert.IsType<BoundTypeTest>(expr);
+        Assert.Equal("BOOL", test.TypeName);
+        Assert.Equal("str", test.TargetType);
+        Assert.Null(test.VariableName);
+        // The defect shape: any checker seeing BoundBoolLiteral(true) here could fold.
+        Assert.IsNotType<BoundBoolLiteral>(expr);
+    }
+
+    [Fact]
+    public void IsPattern_RetainsOperandAndVariable()
+    {
+        var (expr, diags) = BindReturn(new IsPatternNode(S,
+            new ReferenceNode(S, "x"), "Circle", "c"));
+        var test = Assert.IsType<BoundTypeTest>(expr);
+        Assert.Equal("Circle", test.TargetType);
+        Assert.Equal("c", test.VariableName);
+        Assert.IsType<BoundVariableExpression>(test.Operand);
+        AssertComplete(diags);
+    }
+
+    [Fact]
+    public void TypeOf_BindsWithTypeResult()
+    {
+        var (expr, diags) = BindReturn(new TypeOfExpressionNode(S, "MyClass"));
+        var t = Assert.IsType<BoundTypeOfExpression>(expr);
+        Assert.Equal("Type", t.TypeName);
+        Assert.Equal("MyClass", t.TargetTypeName);
+        AssertComplete(diags);
+    }
+
+    [Fact]
+    public void BoundChildren_EnumeratesEveryB5NodeChild()
+    {
+        var i = new BoundIntLiteral(S, 1);
+        Assert.Equal([i], BoundChildren.Of(
+            new BoundConversionExpression(S, TypeOp.Cast, i, "f64")));
+        Assert.Equal([i], BoundChildren.Of(new BoundTypeTest(S, i, "str", null)));
+        Assert.Empty(BoundChildren.Of(new BoundTypeOfExpression(S, "T")));
+        Assert.Empty(BoundChildren.Of(new BoundDecimalLiteral(S, 1m)));
+    }
+
+    [Fact]
+    public void NestedDivision_InsideCastOperand_ProducesRealFinding_EndToEnd()
+    {
+        // The family's span-anchored e2e pin: /0 inside a cast operand must produce
+        // the real Calor0920 — the old Cast arm returned the operand so this already
+        // worked; the pin guards the new conversion node against regressing it.
+        const string source = @"
+§M{m001:Test}
+  §F{f001:Trap:pub} () -> void
+    §E{cw}
+    §P (cast f64 (/ 10 0))";
+
+        var result = Compiler.Program.Compile(source, "test.calr", new CompilationOptions
+        {
+            EnableVerificationAnalyses = true,
+            VerificationAnalysisOptions = new Compiler.Analysis.VerificationAnalysisOptions
+            {
+                BugPatternOptions = new Compiler.Analysis.BugPatterns.BugPatternOptions
+                {
+                    ReportOnlyVerified = false
+                }
+            }
+        });
+
+        Assert.Contains(result.Diagnostics,
+            d => d.Code == DiagnosticCode.DivisionByZero && d.Span.Line == 5);
+    }
+}


### PR DESCRIPTION
## Summary

B5 of the #762 binder rebuild (scoping doc row 5) — the semantic-repair family. The three #762 evidence bullets die here:

- **Decimals keep full precision** (`BoundDecimalLiteral`): the pin uses a 28-digit value and asserts the old `(double)` downcast *would* have lost it — proving the defect existed, not merely that the fix works.
- **Casts carry their target type** (`BoundConversionExpression`, Cast + As): the old arm returned the operand, so a cast's static type was whatever the operand claimed.
- **`is`/patterns are real type tests** (`BoundTypeTest`, operand + pattern variable retained): the old arms returned **literal `true`** — a branch-folding hazard for constant-aware checkers.
- `typeof` binds; `TypeOp`'s fallback arm fails loud (enum-complete).

**The vocabulary-normalization decision (B4 review Major 1, due here) is resolved as documented deferral**: the two-layer TypeName reality is stated on `BoundExpression.TypeName` itself — canonical literal families, parser-surface composed forms, never equality-compared — with unification owned by 0.14's typed representation (roadmap §3.2), because a string-level fix now would either break the B3 parser-agreement or churn every family twice.

## Ratchet & disclosure

In-repo **unchanged at 28** — this family was bound-but-*wrong*, not incomplete; repairs don't move `Calor0259` counts, and saying so is the honest reading of the instrument. Conversion **982 → 904** (−78 = exactly the `TypeOf` clearance). Checker-delta: **one** pre-existing test moved — `DecimalLiteral_NotMisparsedAsZero`, which had pinned the downcast defect's implementation shape (the golden-pins-the-defect pattern, again).

## Verification

Eight family tests incl. the span-anchored e2e pin (`/0` inside a cast operand → real `Calor0920`). Full suite **8,352/0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)