### PR TITLE
#762 B6: bind the control-value family (null-coalesce, null-conditional, match, lambda, await)

### DIFF
--- a/bench/phase0-agent-native/binder-incomplete-baseline.json
+++ b/bench/phase0-agent-native/binder-incomplete-baseline.json
@@ -1,12 +1,12 @@
 {
-  "IncompleteCount": 28,
+  "IncompleteCount": 1,
   "ParsedFiles": 443,
   "ParseFailures": 9,
-  "ExpressionsBound": 4415,
+  "ExpressionsBound": 4567,
   "Scope": "both F-2 legs; conversion leg skips when corpus submodules are absent",
   "Conversion": {
-    "Incomplete": 904,
-    "ExpressionsBound": 13179,
+    "Incomplete": 21,
+    "ExpressionsBound": 17661,
     "ConvertedAndBound": 305,
     "ConvertExceptions": 0,
     "EmptyOutput": 0,

--- a/src/Calor.Compiler/Analysis/Dataflow/Analyses/UninitializedVariables.cs
+++ b/src/Calor.Compiler/Analysis/Dataflow/Analyses/UninitializedVariables.cs
@@ -94,6 +94,12 @@ public sealed class UninitializedVariablesAnalysis
             {
                 foreach (var v in BoundNodeHelpers.GetUsedVariables(block.BranchCondition))
                 {
+                    // Parameters are initialized by their caller: function parameters
+                    // are seeded Initialized at entry, and a LAMBDA parameter (a scope
+                    // this name-keyed analysis cannot see) is always initialized when
+                    // its body runs — flagging it is wrong on any execution (#908 F2).
+                    if (v.IsParameter)
+                        continue;
                     var state = currentFacts.GetState(v.Name);
                     if (state != InitializationState.Initialized)
                     {
@@ -108,6 +114,8 @@ public sealed class UninitializedVariablesAnalysis
                 // Check uses first
                 foreach (var v in BoundNodeHelpers.GetUsedVariables(stmt))
                 {
+                    if (v.IsParameter)
+                        continue;
                     var state = currentFacts.GetState(v.Name);
                     if (state != InitializationState.Initialized)
                     {

--- a/src/Calor.Compiler/Binding/Binder.cs
+++ b/src/Calor.Compiler/Binding/Binder.cs
@@ -509,6 +509,24 @@ public sealed class Binder
                     return new BoundCharOperation(n.Span, n.Operation,
                         n.Arguments.Select(b.BindExpression).ToList());
                 },
+            // #762 B6 — control-value family (5 classes; the conversion-leg payload).
+            [typeof(NullCoalesceNode)] = (b, e) =>
+                { var n = (NullCoalesceNode)e; return new BoundNullCoalesce(n.Span, b.BindExpression(n.Left), b.BindExpression(n.Right)); },
+            [typeof(NullConditionalNode)] = (b, e) =>
+                { var n = (NullConditionalNode)e; return new BoundNullConditional(n.Span, b.BindExpression(n.Target), n.MemberName); },
+            [typeof(MatchExpressionNode)] = (b, e) =>
+                {
+                    var n = (MatchExpressionNode)e;
+                    return new BoundMatchExpression(n.Span, n.Id, b.BindExpression(n.Target),
+                        n.Cases.Select(c => new BoundMatchExpressionCase(
+                            c.Pattern,
+                            c.Guard is null ? null : b.BindExpression(c.Guard),
+                            b.BindStatements(c.Body),
+                            c.Span)).ToList());
+                },
+            [typeof(LambdaExpressionNode)] = (b, e) => b.BindLambda((LambdaExpressionNode)e),
+            [typeof(AwaitExpressionNode)] = (b, e) =>
+                { var n = (AwaitExpressionNode)e; return new BoundAwaitExpression(n.Span, b.BindExpression(n.Awaited), n.ConfigureAwait); },
         };
 
         // Every remaining concrete ExpressionNode subclass dispatches to BindIncomplete.
@@ -748,6 +766,26 @@ public sealed class Binder
     /// errors on constructs that HAVE a binder (e.g. static 'this'). Counting those as
     /// "incomplete" would pollute the instrument, and the pre-B1 behavior was silent.
     /// </summary>
+    /// <summary>#762 B6: lambda parameters live in a child scope; both body forms bind
+    /// there. Bodies are DEFERRED (BoundChildren.DeferredOf) — bound for visibility,
+    /// marked conditionally-executed.</summary>
+    private BoundExpression BindLambda(LambdaExpressionNode lambda)
+    {
+        var lambdaScope = _scope.CreateChild();
+        using var _ = PushScope(lambdaScope);
+        var parameters = new List<VariableSymbol>();
+        foreach (var p in lambda.Parameters)
+        {
+            var sym = new VariableSymbol(p.Name, p.TypeName ?? "OBJECT", isMutable: false, isParameter: true);
+            lambdaScope.TryDeclare(sym);
+            parameters.Add(sym);
+        }
+        var exprBody = lambda.ExpressionBody is null ? null : BindExpression(lambda.ExpressionBody);
+        var stmtBody = lambda.StatementBody is null ? null : BindStatements(lambda.StatementBody);
+        return new BoundLambda(lambda.Span, lambda.Id, parameters,
+            lambda.IsAsync, lambda.IsStatic, exprBody, stmtBody);
+    }
+
     private BoundExpression BindIncompleteQuiet(ExpressionNode expr, string reason)
         => new BoundIncompleteExpression(expr.Span, expr.GetType().Name, reason);
 

--- a/src/Calor.Compiler/Binding/Binder.cs
+++ b/src/Calor.Compiler/Binding/Binder.cs
@@ -514,16 +514,7 @@ public sealed class Binder
                 { var n = (NullCoalesceNode)e; return new BoundNullCoalesce(n.Span, b.BindExpression(n.Left), b.BindExpression(n.Right)); },
             [typeof(NullConditionalNode)] = (b, e) =>
                 { var n = (NullConditionalNode)e; return new BoundNullConditional(n.Span, b.BindExpression(n.Target), n.MemberName); },
-            [typeof(MatchExpressionNode)] = (b, e) =>
-                {
-                    var n = (MatchExpressionNode)e;
-                    return new BoundMatchExpression(n.Span, n.Id, b.BindExpression(n.Target),
-                        n.Cases.Select(c => new BoundMatchExpressionCase(
-                            c.Pattern,
-                            c.Guard is null ? null : b.BindExpression(c.Guard),
-                            b.BindStatements(c.Body),
-                            c.Span)).ToList());
-                },
+            [typeof(MatchExpressionNode)] = (b, e) => b.BindMatchExpression((MatchExpressionNode)e),
             [typeof(LambdaExpressionNode)] = (b, e) => b.BindLambda((LambdaExpressionNode)e),
             [typeof(AwaitExpressionNode)] = (b, e) =>
                 { var n = (AwaitExpressionNode)e; return new BoundAwaitExpression(n.Span, b.BindExpression(n.Awaited), n.ConfigureAwait); },
@@ -766,6 +757,26 @@ public sealed class Binder
     /// errors on constructs that HAVE a binder (e.g. static 'this'). Counting those as
     /// "incomplete" would pollute the instrument, and the pre-B1 behavior was silent.
     /// </summary>
+    /// <summary>#762 B6: each arm gets its own child scope — at most one arm executes,
+    /// so same-named locals across arms are legal and arm locals must not leak outward
+    /// (mirrors BindMatchStatement). A variable pattern declares its capture in the arm
+    /// scope, typed by the scrutinee.</summary>
+    private BoundExpression BindMatchExpression(MatchExpressionNode match)
+    {
+        var target = BindExpression(match.Target);
+        var cases = new List<BoundMatchExpressionCase>();
+        foreach (var c in match.Cases)
+        {
+            using var _caseScope = PushScope(_scope.CreateChild());
+            if (c.Pattern is VariablePatternNode varPattern)
+                _scope.TryDeclare(new VariableSymbol(varPattern.Name, target.TypeName, isMutable: false));
+            var guard = c.Guard is null ? null : BindExpression(c.Guard);
+            var body = BindStatements(c.Body);
+            cases.Add(new BoundMatchExpressionCase(c.Pattern, guard, body, c.Span));
+        }
+        return new BoundMatchExpression(match.Span, match.Id, target, cases);
+    }
+
     /// <summary>#762 B6: lambda parameters live in a child scope; both body forms bind
     /// there. Bodies are DEFERRED (BoundChildren.DeferredOf) — bound for visibility,
     /// marked conditionally-executed.</summary>
@@ -777,12 +788,16 @@ public sealed class Binder
         foreach (var p in lambda.Parameters)
         {
             var sym = new VariableSymbol(p.Name, p.TypeName ?? "OBJECT", isMutable: false, isParameter: true);
-            lambdaScope.TryDeclare(sym);
+            if (!lambdaScope.TryDeclare(sym))
+            {
+                var suggestedName = GenerateUniqueName(p.Name);
+                _diagnostics.ReportDuplicateDefinitionWithFix(p.Span, p.Name, suggestedName);
+            }
             parameters.Add(sym);
         }
         var exprBody = lambda.ExpressionBody is null ? null : BindExpression(lambda.ExpressionBody);
         var stmtBody = lambda.StatementBody is null ? null : BindStatements(lambda.StatementBody);
-        return new BoundLambda(lambda.Span, lambda.Id, parameters,
+        return new BoundLambda(lambda.Span, lambda.Id, parameters, lambda.Effects,
             lambda.IsAsync, lambda.IsStatic, exprBody, stmtBody);
     }
 

--- a/src/Calor.Compiler/Binding/BoundNodes.cs
+++ b/src/Calor.Compiler/Binding/BoundNodes.cs
@@ -497,6 +497,16 @@ public static class BoundChildren
         BoundCollectionContains cc => [cc.KeyOrValue],
         BoundCollectionCount cn => [cn.Collection],
         BoundTupleLiteral tl => tl.Elements,
+        // #762 B6 — control-value family. Of() enumerates ALL expression children
+        // (visibility — a /0 in a lambda body is still a bug worth surfacing); analyses
+        // that are OCCURRENCE-sensitive (dataflow/liveness/taint) must additionally
+        // consult DeferredOf() to avoid treating conditionally-executed subtrees as
+        // inline code (scoping doc D2's IsDeferredContext, realized as an enumeration).
+        BoundNullCoalesce nc => [nc.Left, nc.Right],
+        BoundNullConditional ncond => [ncond.Target],
+        BoundMatchExpression me => [me.Target, .. me.Cases.Where(c => c.Guard is not null).Select(c => c.Guard!)],
+        BoundLambda lam => lam.ExpressionBody is null ? [] : [lam.ExpressionBody],
+        BoundAwaitExpression aw => [aw.Awaited],
         // #762 B5 — conversion/pattern family.
         BoundConversionExpression conv => [conv.Operand],
         BoundTypeTest tt => [tt.Operand],
@@ -507,6 +517,20 @@ public static class BoundChildren
             .Where(p => p.Expression is not null).Select(p => p.Expression!),
         BoundStringBuilderOperation sb => sb.Arguments,
         BoundCharOperation co => co.Arguments,
+        _ => [],
+    };
+
+    /// <summary>
+    /// The subset of Of() whose evaluation is CONDITIONAL at runtime (lambda bodies,
+    /// coalesce fallbacks, match guards): occurrence-sensitive analyses treat these as
+    /// not-necessarily-executed. Value-safety traversals (e.g. division-by-literal-zero)
+    /// deliberately still walk them via Of().
+    /// </summary>
+    public static IEnumerable<BoundExpression> DeferredOf(BoundExpression expression) => expression switch
+    {
+        BoundNullCoalesce nc => [nc.Right],
+        BoundMatchExpression me => me.Cases.Where(c => c.Guard is not null).Select(c => c.Guard!),
+        BoundLambda lam => lam.ExpressionBody is null ? [] : [lam.ExpressionBody],
         _ => [],
     };
 }
@@ -941,6 +965,91 @@ public sealed class BoundTypeOfExpression : BoundExpression
     public override string TypeName => "TYPE";
     public BoundTypeOfExpression(TextSpan span, string targetTypeName) : base(span)
         => TargetTypeName = targetTypeName;
+}
+
+/// <summary>#762 B6: null-coalesce — the fallback is a DEFERRED child (evaluates only
+/// when the left is null); type follows the left operand.</summary>
+public sealed class BoundNullCoalesce : BoundExpression
+{
+    public BoundExpression Left { get; }
+    public BoundExpression Right { get; }
+    public override string TypeName { get; }
+    public BoundNullCoalesce(TextSpan span, BoundExpression left, BoundExpression right)
+        : base(span)
+    { Left = left; Right = right; TypeName = left.TypeName; }
+}
+
+/// <summary>#762 B6: null-conditional member access (x?.M) — the member's type is
+/// unknowable under string types; OBJECT placeholder until 0.14.</summary>
+public sealed class BoundNullConditional : BoundExpression
+{
+    public BoundExpression Target { get; }
+    public string MemberName { get; }
+    public override string TypeName => "OBJECT";
+    public BoundNullConditional(TextSpan span, BoundExpression target, string memberName)
+        : base(span)
+    { Target = target; MemberName = memberName; }
+}
+
+/// <summary>One bound match arm: the PATTERN is retained as its AST node (pattern
+/// binding is its own design, deferred with #786's checker re-platform — several
+/// PatternNode subclasses carry the broken-Accept hazard, so consumers use properties);
+/// guard and body are DEFERRED (at most one arm executes).</summary>
+public sealed record BoundMatchExpressionCase(
+    PatternNode Pattern, BoundExpression? Guard,
+    IReadOnlyList<BoundStatement> Body, TextSpan Span);
+
+/// <summary>#762 B6: match expression — scrutinee immediate, arms deferred.</summary>
+public sealed class BoundMatchExpression : BoundExpression
+{
+    public string Id { get; }
+    public BoundExpression Target { get; }
+    public IReadOnlyList<BoundMatchExpressionCase> Cases { get; }
+    public override string TypeName => "OBJECT";
+    public BoundMatchExpression(TextSpan span, string id, BoundExpression target,
+        IReadOnlyList<BoundMatchExpressionCase> cases) : base(span)
+    { Id = id; Target = target; Cases = cases; }
+}
+
+/// <summary>#762 B6: lambda — parameters declared in a child scope, bodies bound and
+/// DEFERRED. Expression bodies are expression children (visible to traversals via
+/// DeferredOf); STATEMENT bodies are bound statements reachable only through this node
+/// (expression-level traversals do not walk them — a consumer gap owned by #786).
+/// Function types are 0.15 (effect rows); OBJECT placeholder until then.</summary>
+public sealed class BoundLambda : BoundExpression
+{
+    public string Id { get; }
+    public IReadOnlyList<VariableSymbol> Parameters { get; }
+    public bool IsAsync { get; }
+    public bool IsStatic { get; }
+    public BoundExpression? ExpressionBody { get; }
+    public IReadOnlyList<BoundStatement>? StatementBody { get; }
+    public override string TypeName => "OBJECT";
+    public BoundLambda(TextSpan span, string id, IReadOnlyList<VariableSymbol> parameters,
+        bool isAsync, bool isStatic, BoundExpression? expressionBody,
+        IReadOnlyList<BoundStatement>? statementBody) : base(span)
+    {
+        Id = id; Parameters = parameters; IsAsync = isAsync; IsStatic = isStatic;
+        ExpressionBody = expressionBody; StatementBody = statementBody;
+    }
+}
+
+/// <summary>#762 B6: await — unwraps "Task&lt;T&gt;" → T / "Task" → VOID at the string level
+/// where the shape allows; ConfigureAwait retained.</summary>
+public sealed class BoundAwaitExpression : BoundExpression
+{
+    public BoundExpression Awaited { get; }
+    public bool? ConfigureAwait { get; }
+    public override string TypeName { get; }
+    public BoundAwaitExpression(TextSpan span, BoundExpression awaited, bool? configureAwait)
+        : base(span)
+    {
+        Awaited = awaited; ConfigureAwait = configureAwait;
+        var t = awaited.TypeName;
+        TypeName = t.StartsWith("Task<", StringComparison.Ordinal) && t.EndsWith(">", StringComparison.Ordinal)
+            ? t[5..^1]
+            : t is "Task" or "TASK" ? "VOID" : "OBJECT";
+    }
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Binding/BoundNodes.cs
+++ b/src/Calor.Compiler/Binding/BoundNodes.cs
@@ -993,13 +993,16 @@ public sealed class BoundNullConditional : BoundExpression
 
 /// <summary>One bound match arm: the PATTERN is retained as its AST node (pattern
 /// binding is its own design, deferred with #786's checker re-platform — several
-/// PatternNode subclasses carry the broken-Accept hazard, so consumers use properties);
-/// guard and body are DEFERRED (at most one arm executes).</summary>
+/// PatternNode subclasses carry the broken-Accept hazard, so consumers use properties).
+/// The GUARD is a deferred expression child (BoundChildren.DeferredOf); the BODY is
+/// bound STATEMENTS reachable only through this node — expression-level traversals do
+/// not walk them, a consumer gap owned by #786 (same gap as BoundLambda.StatementBody).</summary>
 public sealed record BoundMatchExpressionCase(
     PatternNode Pattern, BoundExpression? Guard,
     IReadOnlyList<BoundStatement> Body, TextSpan Span);
 
-/// <summary>#762 B6: match expression — scrutinee immediate, arms deferred.</summary>
+/// <summary>#762 B6: match expression — scrutinee immediate, guards deferred, arm
+/// bodies statement-level (see BoundMatchExpressionCase for the visibility gap).</summary>
 public sealed class BoundMatchExpression : BoundExpression
 {
     public string Id { get; }
@@ -1020,17 +1023,21 @@ public sealed class BoundLambda : BoundExpression
 {
     public string Id { get; }
     public IReadOnlyList<VariableSymbol> Parameters { get; }
+    /// <summary>Retained as AST (like BoundMatchExpressionCase.Pattern) — effect
+    /// CHECKING of lambda bodies is 0.15 effect-rows work; retention keeps the
+    /// declared row visible to consumers until then.</summary>
+    public EffectsNode? Effects { get; }
     public bool IsAsync { get; }
     public bool IsStatic { get; }
     public BoundExpression? ExpressionBody { get; }
     public IReadOnlyList<BoundStatement>? StatementBody { get; }
     public override string TypeName => "OBJECT";
     public BoundLambda(TextSpan span, string id, IReadOnlyList<VariableSymbol> parameters,
-        bool isAsync, bool isStatic, BoundExpression? expressionBody,
+        EffectsNode? effects, bool isAsync, bool isStatic, BoundExpression? expressionBody,
         IReadOnlyList<BoundStatement>? statementBody) : base(span)
     {
-        Id = id; Parameters = parameters; IsAsync = isAsync; IsStatic = isStatic;
-        ExpressionBody = expressionBody; StatementBody = statementBody;
+        Id = id; Parameters = parameters; Effects = effects; IsAsync = isAsync;
+        IsStatic = isStatic; ExpressionBody = expressionBody; StatementBody = statementBody;
     }
 }
 

--- a/tests/Calor.Compiler.Tests/Binding/BinderControlValueFamilyTests.cs
+++ b/tests/Calor.Compiler.Tests/Binding/BinderControlValueFamilyTests.cs
@@ -1,0 +1,179 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Binding;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+// Flat test namespace: see BinderDispatchCompletenessTests.
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// #762 B6: the control-value family (5 classes — the conversion-leg payload; lambda
+/// alone was 46% of the original incomplete mass). The family introduces DEFERRED
+/// evaluation semantics: BoundChildren.Of() sees everything (value-safety traversals
+/// deliberately walk conditionally-executed subtrees), and DeferredOf() identifies
+/// which children are not-necessarily-executed (for occurrence-sensitive analyses).
+/// </summary>
+public class BinderControlValueFamilyTests
+{
+    private static readonly TextSpan S = new(0, 0, 1, 1);
+
+    private static (BoundExpression Expr, DiagnosticBag Diagnostics) BindReturn(ExpressionNode expr)
+    {
+        var func = new FunctionNode(S, "f001", "Probe", Visibility.Public,
+            Array.Empty<ParameterNode>(), new OutputNode(S, "OBJECT"), null,
+            new StatementNode[] { new ReturnStatementNode(S, expr) },
+            new AttributeCollection());
+        var module = new ModuleNode(S, "m001", "Test",
+            Array.Empty<UsingDirectiveNode>(), new[] { func }, new AttributeCollection());
+        var diagnostics = new DiagnosticBag();
+        var bound = new Binder(diagnostics).Bind(module);
+        var ret = bound.Functions.Single().Body.OfType<BoundReturnStatement>().Single();
+        return (ret.Expression!, diagnostics);
+    }
+
+    private static void AssertComplete(DiagnosticBag d) =>
+        Assert.DoesNotContain(d, x => x.Code == DiagnosticCode.AnalysisIncomplete);
+
+    [Fact]
+    public void NullCoalesce_TypeFollowsLeft_RightIsDeferred()
+    {
+        var (expr, diags) = BindReturn(new NullCoalesceNode(S,
+            new IntLiteralNode(S, 1), new IntLiteralNode(S, 2)));
+        var nc = Assert.IsType<BoundNullCoalesce>(expr);
+        Assert.Equal("INT", nc.TypeName);
+        Assert.Equal(2, BoundChildren.Of(nc).Count());
+        Assert.Equal([nc.Right], BoundChildren.DeferredOf(nc));
+        AssertComplete(diags);
+    }
+
+    [Fact]
+    public void NullConditional_BindsTarget_MemberRetained()
+    {
+        var (expr, diags) = BindReturn(new NullConditionalNode(S,
+            new ReferenceNode(S, "obj"), "Length"));
+        var ncond = Assert.IsType<BoundNullConditional>(expr);
+        Assert.Equal("Length", ncond.MemberName);
+        Assert.Empty(BoundChildren.DeferredOf(ncond)); // target itself always evaluates
+        AssertComplete(diags);
+    }
+
+    [Fact]
+    public void Match_BindsScrutineeGuardsAndBodies_ArmsDeferred()
+    {
+        var node = new MatchExpressionNode(S, "mx1", new ReferenceNode(S, "x"),
+            new[]
+            {
+                new MatchCaseNode(S,
+                    new ConstantPatternNode(S, new IntLiteralNode(S, 0)),
+                    new BinaryOperationNode(S, BinaryOperator.GreaterThan,
+                        new ReferenceNode(S, "x"), new IntLiteralNode(S, 5)),
+                    new StatementNode[] { new ReturnStatementNode(S, new IntLiteralNode(S, 1)) }),
+            }, new AttributeCollection());
+        var (expr, diags) = BindReturn(node);
+        var match = Assert.IsType<BoundMatchExpression>(expr);
+        Assert.Equal("mx1", match.Id);
+        Assert.Single(match.Cases);
+        Assert.NotNull(match.Cases[0].Guard);
+        Assert.Single(match.Cases[0].Body);
+        Assert.IsType<ConstantPatternNode>(match.Cases[0].Pattern); // AST-retained
+        Assert.Single(BoundChildren.DeferredOf(match)); // the guard
+        AssertComplete(diags);
+    }
+
+    [Fact]
+    public void Lambda_ParametersScoped_BodyDeferred_OuterScopeClean()
+    {
+        // Lambda parameter `y` binds inside the body but must NOT leak to the outer
+        // scope — the lambda after-use of `y` is the leak probe.
+        var lambda = new LambdaExpressionNode(S, "lam1",
+            new[] { new LambdaParameterNode(S, "y", "i32") }, null,
+            isAsync: false,
+            new BinaryOperationNode(S, BinaryOperator.Add,
+                new ReferenceNode(S, "y"), new IntLiteralNode(S, 1)),
+            null, new AttributeCollection());
+        var use = new ReturnStatementNode(S, new ReferenceNode(S, "y"));
+        var func = new FunctionNode(S, "f001", "Probe", Visibility.Public,
+            Array.Empty<ParameterNode>(), new OutputNode(S, "OBJECT"), null,
+            new StatementNode[] { new ExpressionStatementNode(S, lambda), use },
+            new AttributeCollection());
+        var module = new ModuleNode(S, "m001", "Test",
+            Array.Empty<UsingDirectiveNode>(), new[] { func }, new AttributeCollection());
+        var diagnostics = new DiagnosticBag();
+        var bound = new Binder(diagnostics).Bind(module);
+
+        var boundLambda = bound.Functions.Single().Body
+            .OfType<BoundExpressionStatement>().Select(s => s.Expression)
+            .OfType<BoundLambda>().Single();
+        Assert.Single(boundLambda.Parameters);
+        Assert.NotNull(boundLambda.ExpressionBody);
+        Assert.Equal([boundLambda.ExpressionBody!], BoundChildren.DeferredOf(boundLambda));
+        // `y` inside the body bound cleanly; `y` OUTSIDE did not:
+        Assert.Contains(diagnostics,
+            d => d.Code == DiagnosticCode.UndefinedReference && d.Message.Contains("'y'"));
+    }
+
+    [Fact]
+    public void Await_UnwrapsTaskTypeString_ConfigureAwaitRetained()
+    {
+        var (expr, diags) = BindReturn(new AwaitExpressionNode(S,
+            new ReferenceNode(S, "t"), configureAwait: false));
+        var aw = Assert.IsType<BoundAwaitExpression>(expr);
+        Assert.False(aw.ConfigureAwait);
+        AssertComplete(diags);
+
+        // String-level unwrap pins (constructed directly — variable types are surface).
+        Assert.Equal("i32",
+            new BoundAwaitExpression(S,
+                new BoundVariableExpression(S, new VariableSymbol("t", "Task<i32>", false)),
+                null).TypeName);
+        Assert.Equal("VOID",
+            new BoundAwaitExpression(S,
+                new BoundVariableExpression(S, new VariableSymbol("t", "Task", false)),
+                null).TypeName);
+    }
+
+    [Fact]
+    public void BoundChildren_EnumeratesEveryB6NodeChild()
+    {
+        var i = new BoundIntLiteral(S, 1);
+        var j = new BoundIntLiteral(S, 2);
+        Assert.Equal([i, j], BoundChildren.Of(new BoundNullCoalesce(S, i, j)));
+        Assert.Equal([i], BoundChildren.Of(new BoundNullConditional(S, i, "M")));
+        var guard = new BoundBoolLiteral(S, true);
+        var match = new BoundMatchExpression(S, "m", i,
+            [new BoundMatchExpressionCase(new ConstantPatternNode(S, new IntLiteralNode(S, 0)),
+                guard, [], S)]);
+        Assert.Equal(new BoundExpression[] { i, guard }, BoundChildren.Of(match));
+        var lam = new BoundLambda(S, "l", [], false, false, j, null);
+        Assert.Equal([j], BoundChildren.Of(lam));
+        Assert.Equal([i], BoundChildren.Of(new BoundAwaitExpression(S, i, null)));
+    }
+
+    [Fact]
+    public void NestedDivision_InsideCoalesceFallback_ProducesRealFinding_EndToEnd()
+    {
+        // Value-safety traversals deliberately walk DEFERRED children: a /0 in the ??
+        // fallback is a real latent bug (it is about WHEN it executes, not WHETHER the
+        // expression is wrong) — Of() includes it, and the finding fires.
+        const string source = @"
+§M{m001:Test}
+  §F{f001:Trap:pub} (i32:x) -> i32
+    §R (?? x (/ 10 0))";
+
+        var result = Compiler.Program.Compile(source, "test.calr", new CompilationOptions
+        {
+            EnableVerificationAnalyses = true,
+            VerificationAnalysisOptions = new Compiler.Analysis.VerificationAnalysisOptions
+            {
+                BugPatternOptions = new Compiler.Analysis.BugPatterns.BugPatternOptions
+                {
+                    ReportOnlyVerified = true
+                }
+            }
+        });
+
+        Assert.Contains(result.Diagnostics,
+            d => d.Code == DiagnosticCode.DivisionByZero && d.Span.Line == 4);
+    }
+}

--- a/tests/Calor.Compiler.Tests/Binding/BinderControlValueFamilyTests.cs
+++ b/tests/Calor.Compiler.Tests/Binding/BinderControlValueFamilyTests.cs
@@ -145,7 +145,7 @@ public class BinderControlValueFamilyTests
             [new BoundMatchExpressionCase(new ConstantPatternNode(S, new IntLiteralNode(S, 0)),
                 guard, [], S)]);
         Assert.Equal(new BoundExpression[] { i, guard }, BoundChildren.Of(match));
-        var lam = new BoundLambda(S, "l", [], false, false, j, null);
+        var lam = new BoundLambda(S, "l", [], null, false, false, j, null);
         Assert.Equal([j], BoundChildren.Of(lam));
         Assert.Equal([i], BoundChildren.Of(new BoundAwaitExpression(S, i, null)));
     }
@@ -175,5 +175,136 @@ public class BinderControlValueFamilyTests
 
         Assert.Contains(result.Diagnostics,
             d => d.Code == DiagnosticCode.DivisionByZero && d.Span.Line == 4);
+    }
+
+    // ---- #908 adversarial-review pins (F1, F2, F4, F5, F3) ----
+
+    private static MatchCaseNode Arm(PatternNode pattern, ExpressionNode? guard, params StatementNode[] body)
+        => new(S, pattern, guard, body);
+
+    [Fact]
+    public void Match_ArmsHaveIndependentScopes_SameLocalNameLegal_NoOutwardLeak()
+    {
+        // #908 F1: at most one arm executes — two arms declaring the same local is
+        // valid (statement-match parity), and arm locals must not resolve after the
+        // match. Pre-fix: false Calor0201 on arm 2 and the leaked `tmp` bound cleanly.
+        StatementNode DeclareTmp() => new BindStatementNode(S, "tmp", "i32",
+            false, new IntLiteralNode(S, 7), new AttributeCollection());
+        var match = new MatchExpressionNode(S, "mx1", new ReferenceNode(S, "x"),
+            new[]
+            {
+                Arm(new ConstantPatternNode(S, new IntLiteralNode(S, 0)), null, DeclareTmp()),
+                Arm(new WildcardPatternNode(S), null, DeclareTmp()),
+            }, new AttributeCollection());
+        var func = new FunctionNode(S, "f001", "Probe", Visibility.Public,
+            new[] { new ParameterNode(S, "x", "i32", new AttributeCollection()) },
+            new OutputNode(S, "OBJECT"), null,
+            new StatementNode[]
+            {
+                new ExpressionStatementNode(S, match),
+                new ReturnStatementNode(S, new ReferenceNode(S, "tmp")), // leak probe
+            },
+            new AttributeCollection());
+        var module = new ModuleNode(S, "m001", "Test",
+            Array.Empty<UsingDirectiveNode>(), new[] { func }, new AttributeCollection());
+        var diagnostics = new DiagnosticBag();
+        new Binder(diagnostics).Bind(module);
+
+        Assert.DoesNotContain(diagnostics, d => d.Code == DiagnosticCode.DuplicateDefinition);
+        Assert.Contains(diagnostics,
+            d => d.Code == DiagnosticCode.UndefinedReference && d.Message.Contains("'tmp'"));
+    }
+
+    [Fact]
+    public void Match_VariablePattern_CaptureResolvesInGuardAndBody()
+    {
+        // #908 F1: a variable pattern declares its capture in the arm scope (typed by
+        // the scrutinee). Pre-fix: hard Calor0200 Errors on every use of the capture.
+        var match = new MatchExpressionNode(S, "mx1", new IntLiteralNode(S, 42),
+            new[]
+            {
+                Arm(new VariablePatternNode(S, "captured"),
+                    new BinaryOperationNode(S, BinaryOperator.GreaterThan,
+                        new ReferenceNode(S, "captured"), new IntLiteralNode(S, 0)),
+                    new ReturnStatementNode(S, new ReferenceNode(S, "captured"))),
+            }, new AttributeCollection());
+        var (expr, diags) = BindReturn(match);
+        Assert.IsType<BoundMatchExpression>(expr);
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.UndefinedReference);
+    }
+
+    [Fact]
+    public void Lambda_DuplicateParameterNames_ReportDuplicateDefinition()
+    {
+        // #908 F5: function parameters report Calor0201 on duplicates; lambda
+        // parameters must match (pre-fix: silent, body resolved to the first).
+        var lambda = new LambdaExpressionNode(S, "lam1",
+            new[]
+            {
+                new LambdaParameterNode(S, "y", "i32"),
+                new LambdaParameterNode(S, "y", "str"),
+            }, null,
+            isAsync: false, new ReferenceNode(S, "y"), null, new AttributeCollection());
+        var (_, diags) = BindReturn(lambda);
+        Assert.Contains(diags, d => d.Code == DiagnosticCode.DuplicateDefinition);
+    }
+
+    [Fact]
+    public void Lambda_EffectsRetained()
+    {
+        // #908 F4: per-family contract — every AST property retained. Effects ride
+        // along as AST until 0.15 effect-rows gives them checking semantics.
+        var effects = new EffectsNode(S, new Dictionary<string, string> { ["cw"] = "cw" });
+        var lambda = new LambdaExpressionNode(S, "lam1",
+            new[] { new LambdaParameterNode(S, "y", "i32") }, effects,
+            isAsync: false, new ReferenceNode(S, "y"), null, new AttributeCollection());
+        var (expr, _) = BindReturn(lambda);
+        var bound = Assert.IsType<BoundLambda>(expr);
+        Assert.Same(effects, bound.Effects);
+    }
+
+    [Fact]
+    public void Lambda_OwnParameterUse_NoUninitializedFalsePositive_EndToEnd()
+    {
+        // #908 F2: a lambda's own parameter is always initialized when its body runs.
+        // Binding lambda bodies made their parameter uses visible to the name-keyed
+        // uninitialized-variables analysis, which defaulted unknown names to
+        // Uninitialized — an Error-severity Calor0900 on EVERY expression-body lambda.
+        // The fix skips IsParameter symbols in use detection (function parameters are
+        // seeded Initialized at entry, so this drops no true finding).
+        const string source = """
+            §M{m001:Test}
+              §F{f001:Probe:pub} (List<i32>:items) -> i32
+                §B{n:i32} §C{items.Count} §A §LAM{lam001:y:i32} (> y 0) §/LAM{lam001} §/C
+                §R n
+            """;
+
+        var result = Compiler.Program.Compile(source, "test.calr", new CompilationOptions
+        {
+            EnableVerificationAnalyses = true,
+        });
+
+        Assert.DoesNotContain(result.Diagnostics,
+            d => d.Code == DiagnosticCode.UninitializedVariable);
+    }
+
+    [Fact]
+    public void Match_ArmBodyDivision_NotYetVisibleToCheckers_CurrentStatePin()
+    {
+        // #908 F3 (current-state pin, NOT desired behavior): match-arm BODIES are
+        // bound statements reachable only through BoundMatchExpression — no checker
+        // traversal walks them yet (statement-match parity; consumer gap owned by
+        // #786). This pin documents the blindness so closing the gap flips a test.
+        var match = new MatchExpressionNode(S, "mx1", new ReferenceNode(S, "x"),
+            new[]
+            {
+                Arm(new WildcardPatternNode(S), null,
+                    new ReturnStatementNode(S,
+                        new BinaryOperationNode(S, BinaryOperator.Divide,
+                            new IntLiteralNode(S, 10), new IntLiteralNode(S, 0)))),
+            }, new AttributeCollection());
+        var (expr, diags) = BindReturn(match);
+        Assert.IsType<BoundMatchExpression>(expr);
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.DivisionByZero);
     }
 }

--- a/tests/Calor.LanguageServer.Tests/State/DocumentStateTests.cs
+++ b/tests/Calor.LanguageServer.Tests/State/DocumentStateTests.cs
@@ -51,12 +51,15 @@ public class DocumentStateTests
         // #762 B1: the LSP binds every open document with the LIVE diagnostics bag, so
         // the Calor0259 incomplete-fraction instrument is editor-visible. This pins the
         // severity decision (scoping doc §5): Info until B8 — a document using a
-        // not-yet-bound construct (null-coalesce, family B6) must gain the instrument
+        // not-yet-bound construct (quantifier, family B7) must gain the instrument
         // diagnostic WITHOUT errors, or every editor floods while the family PRs land.
+        // (Fixture has moved down the family sequence as each family binds: B6 retired
+        // the null-coalesce version; when B7 lands this must move to a Tier B construct
+        // or, post-B8, be re-pointed at whatever the closure decision leaves incomplete.)
         var source = """
             §M{m001:TestModule}
-              §F{f001:Pick:pub} (i32:x) -> i32
-                §R (?? x 5)
+              §F{f001:Pick:pub} (i32:x) -> bool
+                §R (forall ((i i32)) (> i 0))
             """;
 
         var state = LspTestHarness.CreateDocument(source);


### PR DESCRIPTION
## Summary

Sixth family PR of the #762 binder rebuild (B6 of B1–B8, per the [scoping doc](../blob/main/docs/plans/binder-rebuild-762-scoping.md)). Binds the five control-value classes — the conversion-leg payload; lambda alone accounted for 46% of the original conversion-leg incomplete mass.

## The deferred-evaluation decision

This family is the first whose children are **conditionally executed** (`??` fallback, match guards, lambda bodies). Two-part decision, pinned by tests:

- `BoundChildren.Of()` **keeps seeing everything** — value-safety traversals deliberately walk deferred subtrees, because a `/ 10 0` in a `??` fallback is a real latent bug (the question is *when* it executes, not *whether* it's wrong). E2E pin: `§R (?? x (/ 10 0))` produces Calor0920 at the right span with `ReportOnlyVerified = true`.
- New `BoundChildren.DeferredOf()` identifies the not-necessarily-executed subset for future occurrence-sensitive analyses (nothing consumes it yet; each family test pins its contents).

## Nodes

| Bound node | Shape retained | TypeName |
|---|---|---|
| `BoundNullCoalesce` | left, right | left's |
| `BoundNullConditional` | target, member name | `OBJECT` |
| `BoundMatchExpression` | scrutinee, cases (Pattern AST + Guard + Body), Id | `OBJECT` |
| `BoundLambda` | Id, params, IsAsync, IsStatic, expr/statement body | `OBJECT` |
| `BoundAwaitExpression` | awaited, ConfigureAwait | unwraps `Task<T>`→`T`, `Task`→`VOID`, else `OBJECT` |

`BoundMatchExpressionCase` is named to avoid colliding with the existing match-*statement* case class.

## Scoping

`BindLambda` opens a child scope and declares the lambda parameters — bodies now bind for real (conversion-leg ExpressionsBound 13,179 → 17,661) and parameter names do not leak outward (leak-probe test: `y` binds inside, Calor0201 outside).

## Ratchet movement

| Leg | Before | After |
|---|---|---|
| In-repo incomplete | 28 | **1** |
| Conversion incomplete | 904 | **21** |

Remaining mass is B7 (quantifiers) + Tier B.

The LSP Info-severity instrument test used `??` as its unbound fixture — re-pointed to a B7 quantifier per its own fixture-migration note.

Part of #762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)