### PR TITLE
#762 B7: bind the quantifier family (forall, exists, implication)

### DIFF
--- a/src/Calor.Compiler/Binding/Binder.cs
+++ b/src/Calor.Compiler/Binding/Binder.cs
@@ -515,9 +515,30 @@ public sealed class Binder
             [typeof(NullConditionalNode)] = (b, e) =>
                 { var n = (NullConditionalNode)e; return new BoundNullConditional(n.Span, b.BindExpression(n.Target), n.MemberName); },
             [typeof(MatchExpressionNode)] = (b, e) => b.BindMatchExpression((MatchExpressionNode)e),
-            [typeof(LambdaExpressionNode)] = (b, e) => b.BindLambda((LambdaExpressionNode)e),
+            [typeof(LambdaExpressionNode)] = (b, e) =>
+                b.BindLambda((LambdaExpressionNode)e),
             [typeof(AwaitExpressionNode)] = (b, e) =>
                 { var n = (AwaitExpressionNode)e; return new BoundAwaitExpression(n.Span, b.BindExpression(n.Awaited), n.ConfigureAwait); },
+            // #762 B7 — quantifier family (spec expressions; Z3 consumes their AST,
+            // not these bound nodes — binding is for value-safety visibility only).
+            [typeof(ForallExpressionNode)] = (b, e) =>
+                {
+                    var n = (ForallExpressionNode)e;
+                    var (vars, body) = b.BindQuantifier(n.BoundVariables, n.Body);
+                    return new BoundForallExpression(n.Span, vars, body);
+                },
+            [typeof(ExistsExpressionNode)] = (b, e) =>
+                {
+                    var n = (ExistsExpressionNode)e;
+                    var (vars, body) = b.BindQuantifier(n.BoundVariables, n.Body);
+                    return new BoundExistsExpression(n.Span, vars, body);
+                },
+            [typeof(ImplicationExpressionNode)] = (b, e) =>
+                {
+                    var n = (ImplicationExpressionNode)e;
+                    return new BoundImplicationExpression(n.Span,
+                        b.BindExpression(n.Antecedent), b.BindExpression(n.Consequent));
+                },
         };
 
         // Every remaining concrete ExpressionNode subclass dispatches to BindIncomplete.
@@ -775,6 +796,30 @@ public sealed class Binder
             cases.Add(new BoundMatchExpressionCase(c.Pattern, guard, body, c.Span));
         }
         return new BoundMatchExpression(match.Span, match.Id, target, cases);
+    }
+
+    /// <summary>#762 B7: quantifier variables are declared in a child scope, marked
+    /// isParameter — they are bound BY the quantifier (never "uninitialized"), exactly
+    /// like a lambda parameter. The scope pops on all paths, so they never leak into
+    /// the enclosing spec or body. Duplicate names report Calor0201 (function-parameter
+    /// parity).</summary>
+    private (IReadOnlyList<VariableSymbol> Vars, BoundExpression Body) BindQuantifier(
+        IReadOnlyList<QuantifierVariableNode> boundVariables, ExpressionNode body)
+    {
+        var quantifierScope = _scope.CreateChild();
+        using var _ = PushScope(quantifierScope);
+        var vars = new List<VariableSymbol>();
+        foreach (var v in boundVariables)
+        {
+            var sym = new VariableSymbol(v.Name, v.TypeName, isMutable: false, isParameter: true);
+            if (!quantifierScope.TryDeclare(sym))
+            {
+                var suggestedName = GenerateUniqueName(v.Name);
+                _diagnostics.ReportDuplicateDefinitionWithFix(v.Span, v.Name, suggestedName);
+            }
+            vars.Add(sym);
+        }
+        return (vars, BindExpression(body));
     }
 
     /// <summary>#762 B6: lambda parameters live in a child scope; both body forms bind

--- a/src/Calor.Compiler/Binding/BoundNodes.cs
+++ b/src/Calor.Compiler/Binding/BoundNodes.cs
@@ -507,6 +507,12 @@ public static class BoundChildren
         BoundMatchExpression me => [me.Target, .. me.Cases.Where(c => c.Guard is not null).Select(c => c.Guard!)],
         BoundLambda lam => lam.ExpressionBody is null ? [] : [lam.ExpressionBody],
         BoundAwaitExpression aw => [aw.Awaited],
+        // #762 B7 — quantifiers. Bodies are visible (a /0 inside a forall body is a
+        // bug in the SPEC worth surfacing); quantifier variables are declared symbols,
+        // so body references resolve rather than tripping name-keyed analyses.
+        BoundForallExpression fa => [fa.Body],
+        BoundExistsExpression ex => [ex.Body],
+        BoundImplicationExpression imp => [imp.Antecedent, imp.Consequent],
         // #762 B5 — conversion/pattern family.
         BoundConversionExpression conv => [conv.Operand],
         BoundTypeTest tt => [tt.Operand],
@@ -530,6 +536,11 @@ public static class BoundChildren
     {
         BoundNullCoalesce nc => [nc.Right],
         BoundMatchExpression me => me.Cases.Where(c => c.Guard is not null).Select(c => c.Guard!),
+        // #762 B7: a quantifier body evaluates zero-or-more times (empty domain → not
+        // at all); the implication consequent short-circuits on a false antecedent.
+        BoundForallExpression fa => [fa.Body],
+        BoundExistsExpression ex => [ex.Body],
+        BoundImplicationExpression imp => [imp.Consequent],
         BoundLambda lam => lam.ExpressionBody is null ? [] : [lam.ExpressionBody],
         _ => [],
     };
@@ -1057,6 +1068,45 @@ public sealed class BoundAwaitExpression : BoundExpression
             ? t[5..^1]
             : t is "Task" or "TASK" ? "VOID" : "OBJECT";
     }
+}
+
+/// <summary>#762 B7: universal quantification — the body binds in a child scope where
+/// the quantifier variables are declared (as parameter-like symbols: bound by the
+/// quantifier, never "uninitialized"). Quantifiers are SPEC expressions: the Z3
+/// verification pipeline consumes their AST (ExpressionSimplifier), never these bound
+/// nodes — binding them only gives value-safety analyses visibility into the body.</summary>
+public sealed class BoundForallExpression : BoundExpression
+{
+    public IReadOnlyList<VariableSymbol> BoundVariables { get; }
+    public BoundExpression Body { get; }
+    public override string TypeName => "BOOL";
+    public BoundForallExpression(TextSpan span, IReadOnlyList<VariableSymbol> boundVariables,
+        BoundExpression body) : base(span)
+    { BoundVariables = boundVariables; Body = body; }
+}
+
+/// <summary>#762 B7: existential quantification — see BoundForallExpression.</summary>
+public sealed class BoundExistsExpression : BoundExpression
+{
+    public IReadOnlyList<VariableSymbol> BoundVariables { get; }
+    public BoundExpression Body { get; }
+    public override string TypeName => "BOOL";
+    public BoundExistsExpression(TextSpan span, IReadOnlyList<VariableSymbol> boundVariables,
+        BoundExpression body) : base(span)
+    { BoundVariables = boundVariables; Body = body; }
+}
+
+/// <summary>#762 B7: logical implication (-> a b) ≡ !a || b. The consequent is
+/// DEFERRED: any executable lowering short-circuits it when the antecedent is false
+/// (same shape as BoundNullCoalesce.Right).</summary>
+public sealed class BoundImplicationExpression : BoundExpression
+{
+    public BoundExpression Antecedent { get; }
+    public BoundExpression Consequent { get; }
+    public override string TypeName => "BOOL";
+    public BoundImplicationExpression(TextSpan span, BoundExpression antecedent,
+        BoundExpression consequent) : base(span)
+    { Antecedent = antecedent; Consequent = consequent; }
 }
 
 /// <summary>

--- a/tests/Calor.Compiler.Tests/Binding/BinderQuantifierFamilyTests.cs
+++ b/tests/Calor.Compiler.Tests/Binding/BinderQuantifierFamilyTests.cs
@@ -9,11 +9,16 @@ namespace Calor.Compiler.Tests;
 
 /// <summary>
 /// #762 B7: the quantifier family (3 classes). Quantifiers are SPEC expressions — the
-/// Z3 verification pipeline consumes their AST (ExpressionSimplifier), never these
-/// bound nodes ("no verification-pipeline interaction" is the family's checker
-/// contract; the Verification.Tests suite is its baseline). Binding gives value-safety
-/// analyses visibility into bodies, with quantifier variables declared as
-/// parameter-like symbols in a child scope.
+/// CONTRACT verification pipeline (Z3 over §Q/§S/§IV) consumes their AST
+/// (ExpressionSimplifier), never these bound nodes; contracts are never bound at all
+/// (BindFunction binds parameters and body statements only), so a contract quantifier
+/// cannot produce different diagnostics post-B7. The Verification.Tests suite is that
+/// contract's baseline. Scope note (#910 review): the bug-pattern Z3 path DOES consume
+/// bound quantifier bodies — that is the point of binding them (the division pin below
+/// proves it) — and §PROOF is a bound spec position, so quantifiers there now surface
+/// real scope diagnostics on the LSP live bag. Binding gives value-safety analyses
+/// visibility into bodies, with quantifier variables declared as parameter-like
+/// symbols in a child scope.
 /// </summary>
 public class BinderQuantifierFamilyTests
 {
@@ -124,6 +129,9 @@ public class BinderQuantifierFamilyTests
         // Parser-surface e2e: the quantifier variable is a declared, parameter-like
         // symbol — no Calor0200 (undefined), no Calor0900 (uninitialized), and no
         // Calor0259 (the family now binds).
+        // Routing caveat (#910 review): Program.Compile routes ONLY Calor0259 from the
+        // binder's bag, so the 0200 assertion here cannot fail via binder scoping —
+        // the real scope guards are the live-bag unit tests above.
         const string source = """
             §M{m001:Test}
               §F{f001:Probe:pub} () -> bool
@@ -144,8 +152,10 @@ public class BinderQuantifierFamilyTests
     public void DivisionInQuantifierBody_ProducesRealFinding_EndToEnd()
     {
         // A /0 inside a forall body is a bug in the SPEC — Of() exposes it and the
-        // checker fires at the division's span (line 4). Same options discipline as
+        // checker fires at the division's span (line 3). Same options discipline as
         // the B6 pin: ReportOnlyVerified set explicitly (CLI default true, API false).
+        // This is the bug-pattern Z3 path consuming a BOUND quantifier body — the one
+        // Z3-involving verdict B7 deliberately changes (contract Z3 is untouched).
         const string source = """
             §M{m001:Test}
               §F{f001:Trap:pub} (i32:x) -> bool
@@ -166,5 +176,45 @@ public class BinderQuantifierFamilyTests
 
         Assert.Contains(result.Diagnostics,
             d => d.Code == DiagnosticCode.DivisionByZero && d.Span.Line == 3);
+    }
+
+    [Fact]
+    public void Exists_ParsedSource_BindsClean_EndToEnd()
+    {
+        // #910 review: parser→binder reachability pinned for all three spellings, not
+        // just forall — `(exists ((v T)) body)` from real source.
+        const string source = """
+            §M{m001:Test}
+              §F{f001:Probe:pub} (i32:x) -> bool
+                §R (exists ((j i32)) (> j x))
+            """;
+
+        var result = Compiler.Program.Compile(source, "test.calr", new CompilationOptions
+        {
+            EnableVerificationAnalyses = true,
+        });
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Code == DiagnosticCode.AnalysisIncomplete);
+        Assert.False(result.Diagnostics.HasErrors);
+    }
+
+    [Fact]
+    public void Implication_ParsedSource_BindsClean_EndToEnd()
+    {
+        // `(-> a b)` is the ONLY implication spelling (==>/implies are parse errors);
+        // `->` in Lisp operator position cannot collide with the return arrow.
+        const string source = """
+            §M{m001:Test}
+              §F{f001:Probe:pub} (i32:x) -> bool
+                §R (-> (> x 0) (> x -1))
+            """;
+
+        var result = Compiler.Program.Compile(source, "test.calr", new CompilationOptions
+        {
+            EnableVerificationAnalyses = true,
+        });
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Code == DiagnosticCode.AnalysisIncomplete);
+        Assert.False(result.Diagnostics.HasErrors);
     }
 }

--- a/tests/Calor.Compiler.Tests/Binding/BinderQuantifierFamilyTests.cs
+++ b/tests/Calor.Compiler.Tests/Binding/BinderQuantifierFamilyTests.cs
@@ -1,0 +1,170 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Binding;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+// Flat test namespace: see BinderDispatchCompletenessTests.
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// #762 B7: the quantifier family (3 classes). Quantifiers are SPEC expressions — the
+/// Z3 verification pipeline consumes their AST (ExpressionSimplifier), never these
+/// bound nodes ("no verification-pipeline interaction" is the family's checker
+/// contract; the Verification.Tests suite is its baseline). Binding gives value-safety
+/// analyses visibility into bodies, with quantifier variables declared as
+/// parameter-like symbols in a child scope.
+/// </summary>
+public class BinderQuantifierFamilyTests
+{
+    private static readonly TextSpan S = new(0, 0, 1, 1);
+
+    private static (BoundExpression Expr, DiagnosticBag Diagnostics) BindReturn(ExpressionNode expr)
+    {
+        var func = new FunctionNode(S, "f001", "Probe", Visibility.Public,
+            Array.Empty<ParameterNode>(), new OutputNode(S, "BOOL"), null,
+            new StatementNode[] { new ReturnStatementNode(S, expr) },
+            new AttributeCollection());
+        var module = new ModuleNode(S, "m001", "Test",
+            Array.Empty<UsingDirectiveNode>(), new[] { func }, new AttributeCollection());
+        var diagnostics = new DiagnosticBag();
+        var bound = new Binder(diagnostics).Bind(module);
+        var ret = bound.Functions.Single().Body.OfType<BoundReturnStatement>().Single();
+        return (ret.Expression!, diagnostics);
+    }
+
+    private static ForallExpressionNode Forall(string var, string type, ExpressionNode body)
+        => new(S, new[] { new QuantifierVariableNode(S, var, type) }, body);
+
+    private static ExpressionNode GreaterThanZero(string var)
+        => new BinaryOperationNode(S, BinaryOperator.GreaterThan,
+            new ReferenceNode(S, var), new IntLiteralNode(S, 0));
+
+    [Fact]
+    public void Forall_BodyBindsInChildScope_TypeBool_BodyVisibleAndDeferred()
+    {
+        var (expr, diags) = BindReturn(Forall("i", "i32", GreaterThanZero("i")));
+        var fa = Assert.IsType<BoundForallExpression>(expr);
+        Assert.Equal("BOOL", fa.TypeName);
+        Assert.Single(fa.BoundVariables);
+        Assert.Equal("i", fa.BoundVariables[0].Name);
+        Assert.Equal("i32", fa.BoundVariables[0].TypeName);
+        Assert.True(fa.BoundVariables[0].IsParameter); // bound BY the quantifier
+        Assert.Equal([fa.Body], BoundChildren.Of(fa));
+        Assert.Equal([fa.Body], BoundChildren.DeferredOf(fa)); // empty domain → 0 evals
+        // `i` resolved inside the body:
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.UndefinedReference);
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.AnalysisIncomplete);
+    }
+
+    [Fact]
+    public void Exists_SameContractAsForall()
+    {
+        var node = new ExistsExpressionNode(S,
+            new[] { new QuantifierVariableNode(S, "j", "i32") }, GreaterThanZero("j"));
+        var (expr, diags) = BindReturn(node);
+        var ex = Assert.IsType<BoundExistsExpression>(expr);
+        Assert.Equal("BOOL", ex.TypeName);
+        Assert.Equal([ex.Body], BoundChildren.Of(ex));
+        Assert.Equal([ex.Body], BoundChildren.DeferredOf(ex));
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.UndefinedReference);
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.AnalysisIncomplete);
+    }
+
+    [Fact]
+    public void QuantifierVariable_DoesNotLeakToEnclosingScope()
+    {
+        // Same leak-probe shape as the B6 lambda test: `i` after the quantifier is an
+        // UndefinedReference; `i` inside was not.
+        var func = new FunctionNode(S, "f001", "Probe", Visibility.Public,
+            Array.Empty<ParameterNode>(), new OutputNode(S, "BOOL"), null,
+            new StatementNode[]
+            {
+                new ExpressionStatementNode(S, Forall("i", "i32", GreaterThanZero("i"))),
+                new ReturnStatementNode(S, new ReferenceNode(S, "i")), // leak probe
+            },
+            new AttributeCollection());
+        var module = new ModuleNode(S, "m001", "Test",
+            Array.Empty<UsingDirectiveNode>(), new[] { func }, new AttributeCollection());
+        var diagnostics = new DiagnosticBag();
+        new Binder(diagnostics).Bind(module);
+        Assert.Contains(diagnostics,
+            d => d.Code == DiagnosticCode.UndefinedReference && d.Message.Contains("'i'"));
+    }
+
+    [Fact]
+    public void Quantifier_DuplicateBoundVariableNames_ReportDuplicateDefinition()
+    {
+        var node = new ForallExpressionNode(S,
+            new[]
+            {
+                new QuantifierVariableNode(S, "i", "i32"),
+                new QuantifierVariableNode(S, "i", "i64"),
+            }, GreaterThanZero("i"));
+        var (_, diags) = BindReturn(node);
+        Assert.Contains(diags, d => d.Code == DiagnosticCode.DuplicateDefinition);
+    }
+
+    [Fact]
+    public void Implication_BothChildrenVisible_ConsequentDeferred_TypeBool()
+    {
+        var node = new ImplicationExpressionNode(S,
+            new BoolLiteralNode(S, true), new BoolLiteralNode(S, false));
+        var (expr, diags) = BindReturn(node);
+        var imp = Assert.IsType<BoundImplicationExpression>(expr);
+        Assert.Equal("BOOL", imp.TypeName);
+        Assert.Equal([imp.Antecedent, imp.Consequent], BoundChildren.Of(imp));
+        Assert.Equal([imp.Consequent], BoundChildren.DeferredOf(imp)); // !a || b short-circuits
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.AnalysisIncomplete);
+    }
+
+    [Fact]
+    public void QuantifierVariableUse_NoUninitializedOrUndefinedFalsePositive_EndToEnd()
+    {
+        // Parser-surface e2e: the quantifier variable is a declared, parameter-like
+        // symbol — no Calor0200 (undefined), no Calor0900 (uninitialized), and no
+        // Calor0259 (the family now binds).
+        const string source = """
+            §M{m001:Test}
+              §F{f001:Probe:pub} () -> bool
+                §R (forall ((i i32)) (> i 0))
+            """;
+
+        var result = Compiler.Program.Compile(source, "test.calr", new CompilationOptions
+        {
+            EnableVerificationAnalyses = true,
+        });
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Code == DiagnosticCode.UndefinedReference);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Code == DiagnosticCode.UninitializedVariable);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Code == DiagnosticCode.AnalysisIncomplete);
+    }
+
+    [Fact]
+    public void DivisionInQuantifierBody_ProducesRealFinding_EndToEnd()
+    {
+        // A /0 inside a forall body is a bug in the SPEC — Of() exposes it and the
+        // checker fires at the division's span (line 4). Same options discipline as
+        // the B6 pin: ReportOnlyVerified set explicitly (CLI default true, API false).
+        const string source = """
+            §M{m001:Test}
+              §F{f001:Trap:pub} (i32:x) -> bool
+                §R (forall ((i i32)) (> (/ 10 0) i))
+            """;
+
+        var result = Compiler.Program.Compile(source, "test.calr", new CompilationOptions
+        {
+            EnableVerificationAnalyses = true,
+            VerificationAnalysisOptions = new Compiler.Analysis.VerificationAnalysisOptions
+            {
+                BugPatternOptions = new Compiler.Analysis.BugPatterns.BugPatternOptions
+                {
+                    ReportOnlyVerified = true
+                }
+            }
+        });
+
+        Assert.Contains(result.Diagnostics,
+            d => d.Code == DiagnosticCode.DivisionByZero && d.Span.Line == 3);
+    }
+}

--- a/tests/Calor.LanguageServer.Tests/State/DocumentStateTests.cs
+++ b/tests/Calor.LanguageServer.Tests/State/DocumentStateTests.cs
@@ -51,15 +51,16 @@ public class DocumentStateTests
         // #762 B1: the LSP binds every open document with the LIVE diagnostics bag, so
         // the Calor0259 incomplete-fraction instrument is editor-visible. This pins the
         // severity decision (scoping doc §5): Info until B8 — a document using a
-        // not-yet-bound construct (quantifier, family B7) must gain the instrument
-        // diagnostic WITHOUT errors, or every editor floods while the family PRs land.
+        // not-yet-bound construct must gain the instrument diagnostic WITHOUT errors,
+        // or every editor floods while the family PRs land.
         // (Fixture has moved down the family sequence as each family binds: B6 retired
-        // the null-coalesce version; when B7 lands this must move to a Tier B construct
-        // or, post-B8, be re-pointed at whatever the closure decision leaves incomplete.)
+        // null-coalesce, B7 retired the quantifier. Now a Tier B construct — §SIZEOF,
+        // unsafe/pointer family, out of 0.13 binding scope — so this holds until B8's
+        // closure decision, which owns re-pointing or retiring it.)
         var source = """
             §M{m001:TestModule}
-              §F{f001:Pick:pub} (i32:x) -> bool
-                §R (forall ((i i32)) (> i 0))
+              §F{f001:Pick:pub} (i32:x) -> i32
+                §R §SIZEOF{i32}
             """;
 
         var state = LspTestHarness.CreateDocument(source);


### PR DESCRIPTION
## Summary

Seventh family PR of the #762 binder rebuild (B7 of B1–B8, per the [scoping doc](../blob/main/docs/plans/binder-rebuild-762-scoping.md)). Binds the three quantifier classes: `ForallExpressionNode`, `ExistsExpressionNode`, `ImplicationExpressionNode`.

## The family's checker contract, scoped precisely (review round applied)

Quantifiers are SPEC expressions. **Contract verification is untouched**: contracts (§Q/§S/§IV) are never bound at all — `BindFunction` binds parameters and body statements only — and the contract Z3 pipeline consumes quantifier **AST** (`ExpressionSimplifier`). A contract quantifier cannot produce different diagnostics post-B7 (review-confirmed by experiment, including a §Q with duplicate bound vars + undefined ref + /0: zero binder diagnostics on both analyze and LSP paths). The untouched 375-test `Calor.Verification.Tests` suite is that contract's baseline.

Two deliberate interactions, disclosed: the **bug-pattern Z3 path** now consumes bound quantifier bodies — that's the point of binding them, and the division pin proves it — and **§PROOF** (a bound spec position) now surfaces real scope diagnostics (e.g. Calor0201 for duplicate bound vars) on the LSP live bag instead of Info Calor0259.

## Nodes

| Bound node | Shape | TypeName |
|---|---|---|
| `BoundForallExpression` | bound variables (as symbols), body | `BOOL` |
| `BoundExistsExpression` | same | `BOOL` |
| `BoundImplicationExpression` | antecedent, consequent | `BOOL` |

## Scoping (applies the B6 review lessons up front)

- Quantifier variables are declared in a **child scope**, marked `isParameter` — bound *by* the quantifier, so the name-keyed uninitialized-variables analysis can never flag them (the B6 F2 rule covers them with zero new analysis code). Review confirmed all three repo-wide `IsParameter` consumers are safe for these symbols.
- No leak outward (leak-probe pin); duplicate bound-variable names report Calor0201 (function-parameter parity).
- `Of()`: bodies visible — a `/ 10 0` inside a forall body is a bug in the spec; e2e pin proves Calor0920 fires at the right span. `DeferredOf()`: quantifier bodies (empty domain → zero evaluations) and the implication consequent (`!a || b` short-circuits).
- Parsed-source e2e pins for **all three** spellings: `(forall …)`, `(exists …)`, `(-> …)` — review confirmed `(-> a b)` is the only implication spelling and cannot collide with the return arrow.

## Ratchet: zero movement — because contracts are never bound

Corrected per review: quantifiers **do** occur in the in-repo corpus (`07_quantifiers.calr` under two roots) — but exclusively in §Q positions, and contracts are never bound. So B7's binding is exercised by expression-position and §PROOF-position quantifiers only, which outside this PR's tests occur nowhere in the repo today. The "family binds" exit criterion is met; the practical payload arrives when quantifiers appear in executable positions (and when B8's routing/closure work broadens what analyze surfaces).

Remainder-by-class (review-reproduced byte-for-byte):

| Leg | Remaining incomplete | Classes |
|---|---|---|
| In-repo | 1 | `SizeOfNode` (Tier B, unsafe family) |
| Conversion | 21 | 17× `StackAllocNode` (Tier B, unsafe), 4× `RawCSharpExpressionNode` (B8 interop structural binding) |

**Post-B7, every remaining incomplete on both legs is Tier B or B8-owned** — the B8 "zero Tier A incomplete" gate-1 criterion is now within B8's own scope.

The LSP Info-instrument fixture moves to its third construct (`??` → `forall` → `§SIZEOF{i32}`), which holds until B8's closure decision owns re-pointing or retiring it.

Part of #762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)