### PR TITLE
#762 B8: closure — interop, item-8, overload sets, expression-start unification, seed suite, gate 1

### DIFF
--- a/bench/phase0-agent-native/binder-incomplete-baseline.json
+++ b/bench/phase0-agent-native/binder-incomplete-baseline.json
@@ -5,8 +5,8 @@
   "ExpressionsBound": 4567,
   "Scope": "both F-2 legs; conversion leg skips when corpus submodules are absent",
   "Conversion": {
-    "Incomplete": 21,
-    "ExpressionsBound": 17661,
+    "Incomplete": 17,
+    "ExpressionsBound": 17678,
     "ConvertedAndBound": 305,
     "ConvertExceptions": 0,
     "EmptyOutput": 0,

--- a/docs/plans/roadmap-v0.13-v0.15.md
+++ b/docs/plans/roadmap-v0.13-v0.15.md
@@ -167,7 +167,9 @@ gates 1, 4, 5, 6, 7, and gate 2's diagnostics leg.
    strictly better instrument); the residual incomplete-fraction outside those classes is
    **published per release, reported-not-adjudicated** (the M-S2/PP-L4 route). The escape
    category is thereby bounded: the gate cannot be passed by marking registered constructs
-   "incomplete".
+   "incomplete". **Status: measured green by the B8 closure PR (2026-08-10)** — zero Tier A
+   `Calor0259` on both F-2 legs; residuals published in the F-1 B8 amendment (in-repo 1
+   `SizeOfNode`, conversion 17 `StackAllocNode`, all Tier B).
 2. **Full-vs-incremental identity**: byte-identical diagnostics, index contents, and review packets
    (after canonical ordering) across a **registered edit-script corpus** that includes the #883
    reproduction — plus an **incrementality witness** (the incremental path demonstrably reuses the

--- a/docs/plans/v0.13-freeze-registrations.md
+++ b/docs/plans/v0.13-freeze-registrations.md
@@ -76,9 +76,13 @@ amendment rules).
 
 ### F-1 amendment — B8 item-8 dispositions, interop closure, and gate-1 evaluation (2026-08-10)
 
-- **GenericTypeNode → Tier A (additive promotion).** It is a real expression-position type
-  reference with real Accept dispatch; it now binds structurally
-  (`BoundGenericTypeExpression`, composed parser-surface TypeName).
+- **GenericTypeNode → Tier A (additive promotion), DORMANT** (disclosure per the
+  SelfRefNode precedent, added by the #911 review): the binder is real
+  (`BoundGenericTypeExpression`, composed parser-surface TypeName) but the class is
+  currently **unreachable from source text** — the legacy `§G` lexer keyword was removed,
+  so the only producer (`Parser.ParseGenericType`) has no live token route, and the
+  matrix test's Generic row runs on hand-built tokens (labeled "synthetic"). If a
+  construction path returns, the promotion carries F-1's dormant-rule corpus obligation.
 - **KeywordArgNode → out of the denominator (subtractive, with supersession).** #762 item 8's
   reclassify option, ported from PR #900's design: the class no longer derives from
   `ExpressionNode`/`AstNode` at all — it is a parser-internal value object (producer

--- a/docs/plans/v0.13-freeze-registrations.md
+++ b/docs/plans/v0.13-freeze-registrations.md
@@ -68,11 +68,41 @@ an explicit interop marker — never a zero-child erasure. (#762 item 3.)
 | Class | Reason it is residual |
 |---|---|
 | AddressOfNode, PointerDereferenceNode, StackAllocNode, SizeOfNode | Unsafe/pointer family — flows through `§UNSAFE` interop; a binding-analysis story for raw pointers is out of 0.13 scope |
-| GenericTypeNode, KeywordArgNode | Helper/value-object candidates under #762 item 8 (reclassify so they are not expression nodes, or bind them) — the item-8 decision moves each to Tier A or out of the denominator entirely; until then they are residual, not silently absent |
+| GenericTypeNode, KeywordArgNode | Helper/value-object candidates under #762 item 8 (reclassify so they are not expression nodes, or bind them) — the item-8 decision moves each to Tier A or out of the denominator entirely; until then they are residual, not silently absent. **Resolved by the B8 amendment below.** |
 
 **Gate restated with this denominator:** on the F-2 corpus, zero `<unsupported:...>` fallbacks for
 Tier A classes; Tier B incidence is published per release. Tier A→B moves are subtractive (see
 amendment rules).
+
+### F-1 amendment — B8 item-8 dispositions, interop closure, and gate-1 evaluation (2026-08-10)
+
+- **GenericTypeNode → Tier A (additive promotion).** It is a real expression-position type
+  reference with real Accept dispatch; it now binds structurally
+  (`BoundGenericTypeExpression`, composed parser-surface TypeName).
+- **KeywordArgNode → out of the denominator (subtractive, with supersession).** #762 item 8's
+  reclassify option, ported from PR #900's design: the class no longer derives from
+  `ExpressionNode`/`AstNode` at all — it is a parser-internal value object (producer
+  `Parser.ParseLispArgumentOrKeyword`, consumer `Parser.FilterKeywordArgs`, #874 choke point
+  retained). **Supersession argument:** the freeze rule exists to prevent silent denominator
+  shrink; this exit is the opposite of silent — the class becomes *unrepresentable* in
+  expression position (a compile-time property), and two pins enforce it
+  (`ArchitectureTests.ParserOnlyKeywordArgument_IsNotAnAstNode`; the dispatch-completeness
+  count moving 61 → 60 with the amendment named in the test comment). Denominator after
+  amendment: **60 concrete classes = 56 Tier A / 4 Tier B**.
+- **Interop row landed** (`RawCSharpExpressionNode`, `FallbackExpressionNode` bind with
+  verbatim content + stable type + `IsInterop` marker, per this registration's interop
+  clause).
+- **Tier-B residuals now retain children** (scoping doc D2): the four unsafe classes still
+  count as incomplete (`Calor0259` unchanged, so this amendment does not move the gate bar)
+  but their subtrees bind and remain traversal-visible, deferred-marked
+  (`BoundIncompleteExpression.RetainedChildren`); seed-reachability rows pin `§ADDR`/`§DEREF`.
+- **Calor0259 severity promoted Info → Warning** (the scoping doc §5 decision scheduled for
+  B8): Tier A incomplete is zero, so a warning now genuinely means "analysis does not cover
+  this construct" (only Tier B unsafe residuals emit it).
+- **Gate-1 evaluation (measured on this PR):** zero Tier A `Calor0259` on BOTH F-2 legs.
+  Residual (published, reported-not-adjudicated): in-repo 1 (`SizeOfNode`, conversion
+  snapshot fixture); conversion leg 17 (all `StackAllocNode`). Baseline:
+  `bench/phase0-agent-native/binder-incomplete-baseline.json`.
 
 ## F-2 — Binding-totality measurement corpus (corpus of roadmap §2.5 gate 1)
 
@@ -185,7 +215,7 @@ landed; supersede-with-disclosure only:
 
 | ID | Freezes | Gates |
 |---|---|---|
-| F-1 | 61-class tier assignment (55 registered / 6 residual) | §2.5 gate 1 denominator |
+| F-1 | 61-class tier assignment (55 registered / 6 residual); B8 amendment: 60 (56 registered / 4 residual) | §2.5 gate 1 denominator |
 | F-2 | Two-leg corpus + discriminating pin | §2.5 gate 1 corpus |
 | F-3 | Edit-script location, schema, 6 members | §2.5 gates 2 and 4 |
 | F-4 | Modeled-forms hash + generator parameters + oracle + scope | §2.5 gate 5, §3.5 gate 6 |

--- a/src/Calor.Compiler/Analysis/BugPatterns/Patterns/DivisionByZeroChecker.cs
+++ b/src/Calor.Compiler/Analysis/BugPatterns/Patterns/DivisionByZeroChecker.cs
@@ -188,6 +188,15 @@ public sealed class DivisionByZeroChecker : IBugPatternChecker
                 CheckExpression(unaryExpr.Operand, function, diagnostics, pathConditions);
                 break;
 
+            // #762 B8: Tier-B residuals are BoundCallExpression-shaped but carry
+            // RetainedChildren — walk those, or the case below erases the subtree.
+            case BoundIncompleteExpression incomplete:
+                foreach (var child in incomplete.RetainedChildren)
+                {
+                    CheckExpression(child, function, diagnostics, pathConditions);
+                }
+                break;
+
             case BoundCallExpression callExpr:
                 foreach (var arg in callExpr.Arguments)
                 {

--- a/src/Calor.Compiler/Analysis/Dataflow/BoundNodeHelpers.cs
+++ b/src/Calor.Compiler/Analysis/Dataflow/BoundNodeHelpers.cs
@@ -41,6 +41,14 @@ public static class BoundNodeHelpers
                     yield return v;
                 break;
 
+            // #762 B8: Tier-B residuals carry RetainedChildren on a
+            // BoundCallExpression-shaped node — walk those first.
+            case BoundIncompleteExpression incomplete:
+                foreach (var child in incomplete.RetainedChildren)
+                    foreach (var v in GetUsedVariables(child))
+                        yield return v;
+                break;
+
             case BoundCallExpression callExpr:
                 foreach (var arg in callExpr.Arguments)
                     foreach (var v in GetUsedVariables(arg))
@@ -291,6 +299,12 @@ public static class BoundNodeHelpers
             case BoundUnaryExpression unaryExpr:
                 return ContainsDivision(unaryExpr.Operand, out divisionExpr);
 
+            case BoundIncompleteExpression incomplete:
+                foreach (var child in incomplete.RetainedChildren)
+                    if (ContainsDivision(child, out divisionExpr))
+                        return true;
+                break;
+
             case BoundCallExpression callExpr:
                 foreach (var arg in callExpr.Arguments)
                     if (ContainsDivision(arg, out divisionExpr))
@@ -353,6 +367,12 @@ public static class BoundNodeHelpers
 
             default:
                 foreach (var child in BoundChildren.Of(expression))
+                    if (ContainsArrayAccess(child, out arrayExpr, out indexExpr))
+                        return true;
+                break;
+
+            case BoundIncompleteExpression incomplete:
+                foreach (var child in incomplete.RetainedChildren)
                     if (ContainsArrayAccess(child, out arrayExpr, out indexExpr))
                         return true;
                 break;

--- a/src/Calor.Compiler/Analysis/VerificationAnalysisPass.cs
+++ b/src/Calor.Compiler/Analysis/VerificationAnalysisPass.cs
@@ -160,9 +160,13 @@ public sealed class VerificationAnalysisPass
         // ONLY the analysis-incomplete instrument code into the real bag — wholesale
         // routing would double-report binder diagnostics that AST-based passes (e.g.
         // BindValidationPass) already surface through their own channels.
+        // #911 review F1: propagate the binder's ORIGINAL severity — B8 promoted the
+        // instrument to Warning (scoping doc §5), and a hardcoded ReportInfo here made
+        // the promotion silently inert on the CLI/analyze/MCP surface (the LSP live-bag
+        // path was the only one that saw it).
         foreach (var d in bindingDiagnostics.Where(d => d.Code == DiagnosticCode.AnalysisIncomplete))
         {
-            _diagnostics.ReportInfo(d.Span, d.Code, d.Message);
+            _diagnostics.Report(d.Span, d.Code, d.Message, d.Severity);
         }
 
         // Run analyses on the bound module with contract info

--- a/src/Calor.Compiler/Ast/AstNode.cs
+++ b/src/Calor.Compiler/Ast/AstNode.cs
@@ -31,6 +31,8 @@ public interface IAstVisitor
 {
     void Visit(ModuleNode node);
     void Visit(FunctionNode node);
+    void Visit(OutputNode node);
+    void Visit(EffectsNode node);
     void Visit(ParameterNode node);
     void Visit(CallStatementNode node);
     void Visit(ReturnStatementNode node);
@@ -46,6 +48,7 @@ public interface IAstVisitor
     void Visit(WhileStatementNode node);
     void Visit(DoWhileStatementNode node);
     void Visit(IfStatementNode node);
+    void Visit(ElseIfClauseNode node);
     void Visit(BindStatementNode node);
     void Visit(BinaryOperationNode node);
     void Visit(UnaryOperationNode node);
@@ -57,11 +60,15 @@ public interface IAstVisitor
     void Visit(PrintStatementNode node);
     // Phase 3: Type System
     void Visit(RecordDefinitionNode node);
+    void Visit(FieldDefinitionNode node);
     void Visit(UnionTypeDefinitionNode node);
+    void Visit(VariantDefinitionNode node);
+    void Visit(TypeReferenceNode node);
     void Visit(EnumDefinitionNode node);
     void Visit(EnumMemberNode node);
     void Visit(EnumExtensionNode node);
     void Visit(RecordCreationNode node);
+    void Visit(FieldAssignmentNode node);
     void Visit(FieldAccessNode node);
     void Visit(SomeExpressionNode node);
     void Visit(NoneExpressionNode node);
@@ -256,6 +263,8 @@ public interface IAstVisitor<T>
 {
     T Visit(ModuleNode node);
     T Visit(FunctionNode node);
+    T Visit(OutputNode node);
+    T Visit(EffectsNode node);
     T Visit(ParameterNode node);
     T Visit(CallStatementNode node);
     T Visit(ReturnStatementNode node);
@@ -271,6 +280,7 @@ public interface IAstVisitor<T>
     T Visit(WhileStatementNode node);
     T Visit(DoWhileStatementNode node);
     T Visit(IfStatementNode node);
+    T Visit(ElseIfClauseNode node);
     T Visit(BindStatementNode node);
     T Visit(BinaryOperationNode node);
     T Visit(UnaryOperationNode node);
@@ -282,11 +292,15 @@ public interface IAstVisitor<T>
     T Visit(PrintStatementNode node);
     // Phase 3: Type System
     T Visit(RecordDefinitionNode node);
+    T Visit(FieldDefinitionNode node);
     T Visit(UnionTypeDefinitionNode node);
+    T Visit(VariantDefinitionNode node);
+    T Visit(TypeReferenceNode node);
     T Visit(EnumDefinitionNode node);
     T Visit(EnumMemberNode node);
     T Visit(EnumExtensionNode node);
     T Visit(RecordCreationNode node);
+    T Visit(FieldAssignmentNode node);
     T Visit(FieldAccessNode node);
     T Visit(SomeExpressionNode node);
     T Visit(NoneExpressionNode node);

--- a/src/Calor.Compiler/Ast/ControlFlowNodes.cs
+++ b/src/Calor.Compiler/Ast/ControlFlowNodes.cs
@@ -152,8 +152,8 @@ public sealed class ElseIfClauseNode : AstNode
         Body = body ?? throw new ArgumentNullException(nameof(body));
     }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Ast/FunctionNode.cs
+++ b/src/Calor.Compiler/Ast/FunctionNode.cs
@@ -26,8 +26,8 @@ public sealed class OutputNode : AstNode
         TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
     }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
 
 /// <summary>
@@ -42,8 +42,8 @@ public sealed class EffectsNode : AstNode
         Effects = effects ?? throw new ArgumentNullException(nameof(effects));
     }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Ast/StringOperationNode.cs
+++ b/src/Calor.Compiler/Ast/StringOperationNode.cs
@@ -74,24 +74,21 @@ public static class StringComparisonModeExtensions
 /// Only valid as arguments to operations that support them.
 /// This is an internal node type used during parsing and is not visitable.
 /// </summary>
-public sealed class KeywordArgNode : ExpressionNode
+public sealed class KeywordArgNode
 {
+    // #762 item 8 (B8): reclassified OUT of the AST — a keyword argument is a
+    // parser-internal value object (produced by Parser.ParseLispArgumentOrKeyword,
+    // consumed by Parser.FilterKeywordArgs, #874), not an expression. As a plain
+    // class it cannot appear in expression position, so the old no-op-Accept
+    // null-injection hazard is unrepresentable rather than merely guarded.
+    public TextSpan Span { get; }
     public string Name { get; }
 
-    public KeywordArgNode(TextSpan span, string name) : base(span)
+    public KeywordArgNode(TextSpan span, string name)
     {
+        Span = span;
         Name = name ?? throw new ArgumentNullException(nameof(name));
     }
-
-    // KeywordArgNode is internal to parsing - it should be consumed by the parser
-    // and not appear in the final AST. The parser enforces this at a single choke
-    // point (Parser.FilterKeywordArgs, #874): a trailing keyword on a recognized
-    // string operation is consumed as the comparison mode; every other occurrence
-    // is rejected with a diagnostic and dropped. These methods should therefore
-    // never be called; default! here means any escape becomes a null child in a
-    // visitor rebuild, so the choke point is load-bearing.
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Ast/TypeNodes.cs
+++ b/src/Calor.Compiler/Ast/TypeNodes.cs
@@ -71,8 +71,8 @@ public sealed class FieldDefinitionNode : AstNode
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
     }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
 
 /// <summary>
@@ -123,8 +123,8 @@ public sealed class VariantDefinitionNode : AstNode
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
     }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
 
 /// <summary>
@@ -143,8 +143,8 @@ public sealed class TypeReferenceNode : AstNode
         TypeArguments = typeArguments ?? Array.Empty<TypeReferenceNode>();
     }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 
     public override string ToString()
     {
@@ -192,8 +192,8 @@ public sealed class FieldAssignmentNode : AstNode
         Value = value ?? throw new ArgumentNullException(nameof(value));
     }
 
-    public override void Accept(IAstVisitor visitor) { }
-    public override T Accept<T>(IAstVisitor<T> visitor) => default!;
+    public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
+    public override T Accept<T>(IAstVisitor<T> visitor) => visitor.Visit(this);
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Binding/Binder.cs
+++ b/src/Calor.Compiler/Binding/Binder.cs
@@ -845,7 +845,7 @@ public sealed class Binder
     /// </summary>
     private BoundExpression BindIncomplete(ExpressionNode expr, string reason)
     {
-        _diagnostics.ReportInfo(expr.Span, DiagnosticCode.AnalysisIncomplete,
+        _diagnostics.ReportWarning(expr.Span, DiagnosticCode.AnalysisIncomplete,
             $"Analysis incomplete: '{expr.GetType().Name}' has no structural binding yet " +
             $"({reason}). Analyses treat this expression as an opaque value; its sub-expressions " +
             "are not yet visible to them.");
@@ -859,7 +859,7 @@ public sealed class Binder
     private BoundExpression BindIncompleteWithChildren(
         ExpressionNode expr, string reason, IReadOnlyList<BoundExpression> children)
     {
-        _diagnostics.ReportInfo(expr.Span, DiagnosticCode.AnalysisIncomplete,
+        _diagnostics.ReportWarning(expr.Span, DiagnosticCode.AnalysisIncomplete,
             $"Analysis incomplete: '{expr.GetType().Name}' has no structural binding yet " +
             $"({reason}). Analyses treat this expression as an opaque value; its sub-expressions " +
             "are retained and visible to traversals, deferred-marked.");

--- a/src/Calor.Compiler/Binding/Binder.cs
+++ b/src/Calor.Compiler/Binding/Binder.cs
@@ -315,12 +315,14 @@ public sealed class Binder
     /// and the dispatch builder reads this table.</summary>
     private static readonly IReadOnlyDictionary<string, string> s_tierBReasons = new Dictionary<string, string>
     {
+        // B8: the four unsafe classes keep Tier B residual status (a binding-analysis
+        // story for raw pointers is out of 0.13 scope) but now RETAIN their bound
+        // children on the incomplete node (scoping doc D2's Tier-B extractors) — the
+        // reasons below feed the child-retaining arms, not the default loop.
         ["AddressOfNode"] = "unsafe/pointer family — F-1 Tier B, out of 0.13 binding scope",
         ["PointerDereferenceNode"] = "unsafe/pointer family — F-1 Tier B, out of 0.13 binding scope",
         ["StackAllocNode"] = "unsafe/pointer family — F-1 Tier B, out of 0.13 binding scope",
         ["SizeOfNode"] = "unsafe/pointer family — F-1 Tier B, out of 0.13 binding scope",
-        ["GenericTypeNode"] = "helper-node candidate — #762 item 8 disposition lands in B8",
-        ["KeywordArgNode"] = "helper-node candidate — #762 item 8 disposition lands in B8",
         // B2: dormant per F-1 — the parser rejects '#' outside refinement predicates, so no
         // legal program places a SelfRefNode in a binder-visible position; a binder for it
         // would be vacuously green. Promoted to live WITH a corpus obligation if a
@@ -539,6 +541,43 @@ public sealed class Binder
                     return new BoundImplicationExpression(n.Span,
                         b.BindExpression(n.Antecedent), b.BindExpression(n.Consequent));
                 },
+            // #762 B8 — interop closure (F-1 Tier A interop row: verbatim content +
+            // stable type + explicit marker, never a zero-child erasure).
+            [typeof(RawCSharpExpressionNode)] = (b, e) =>
+                { var n = (RawCSharpExpressionNode)e; return new BoundRawCSharpExpression(n.Span, n.CSharpCode); },
+            [typeof(FallbackExpressionNode)] = (b, e) =>
+                { var n = (FallbackExpressionNode)e; return new BoundFallbackExpression(n.Span, n.OriginalCSharp, n.FeatureName, n.Suggestion); },
+            // #762 B8 — item-8 disposition: GenericTypeNode promoted to Tier A (it is a
+            // real expression-position type reference with real Accept dispatch; the
+            // F-1 amendment records the additive promotion).
+            [typeof(GenericTypeNode)] = (b, e) =>
+                { var n = (GenericTypeNode)e; return new BoundGenericTypeExpression(n.Span, n.TypeName, n.TypeArguments); },
+            // #762 B8 — Tier-B child extractors (scoping doc D2): the unsafe family
+            // stays incomplete (Calor0259 still fires; the analysis story is out of
+            // 0.13 scope) but its subtrees are no longer erased — children bind and
+            // ride on the incomplete node, deferred-marked (#762 item 3 end state).
+            [typeof(AddressOfNode)] = (b, e) =>
+                {
+                    var n = (AddressOfNode)e;
+                    return b.BindIncompleteWithChildren(e, s_tierBReasons["AddressOfNode"],
+                        new[] { b.BindExpression(n.Operand) });
+                },
+            [typeof(PointerDereferenceNode)] = (b, e) =>
+                {
+                    var n = (PointerDereferenceNode)e;
+                    return b.BindIncompleteWithChildren(e, s_tierBReasons["PointerDereferenceNode"],
+                        new[] { b.BindExpression(n.Operand) });
+                },
+            [typeof(StackAllocNode)] = (b, e) =>
+                {
+                    var n = (StackAllocNode)e;
+                    var children = new List<BoundExpression>();
+                    if (n.Size is not null) children.Add(b.BindExpression(n.Size));
+                    children.AddRange(n.Initializer.Select(b.BindExpression));
+                    return b.BindIncompleteWithChildren(e, s_tierBReasons["StackAllocNode"], children);
+                },
+            // (SizeOfNode has no expression children — it stays on the default
+            // BindIncomplete path via s_tierBReasons.)
         };
 
         // Every remaining concrete ExpressionNode subclass dispatches to BindIncomplete.
@@ -771,6 +810,20 @@ public sealed class Binder
             $"({reason}). Analyses treat this expression as an opaque value; its sub-expressions " +
             "are not yet visible to them.");
         return new BoundIncompleteExpression(expr.Span, expr.GetType().Name, reason);
+    }
+
+    /// <summary>#762 B8 (scoping doc D2): the Tier-B path that RETAINS bound children on
+    /// the incomplete node instead of erasing the subtree. Still incomplete — Calor0259
+    /// still fires (message without the "not visible" clause, which is no longer true) —
+    /// but the children are enumerable via BoundChildren.Of/DeferredOf.</summary>
+    private BoundExpression BindIncompleteWithChildren(
+        ExpressionNode expr, string reason, IReadOnlyList<BoundExpression> children)
+    {
+        _diagnostics.ReportInfo(expr.Span, DiagnosticCode.AnalysisIncomplete,
+            $"Analysis incomplete: '{expr.GetType().Name}' has no structural binding yet " +
+            $"({reason}). Analyses treat this expression as an opaque value; its sub-expressions " +
+            "are retained and visible to traversals, deferred-marked.");
+        return new BoundIncompleteExpression(expr.Span, expr.GetType().Name, reason, children);
     }
 
     /// <summary>

--- a/src/Calor.Compiler/Binding/Binder.cs
+++ b/src/Calor.Compiler/Binding/Binder.cs
@@ -54,7 +54,12 @@ public sealed class Binder
     {
         var functions = new List<BoundFunction>();
 
-        // First pass: register all function symbols in module scope
+        // First pass: register all function symbols in module scope. #762 items 5–6
+        // (B8, scoping doc D5): top-level functions use the same overload-set
+        // machinery as class members — a second declaration with a DIFFERENT
+        // signature is a legal overload (previously its TryDeclare silently failed
+        // and every call resolved to the first declaration); an IDENTICAL ordered
+        // parameter-type list is unresolvable and diagnosed at the declaration.
         foreach (var func in module.Functions)
         {
             var parameters = func.Parameters
@@ -62,7 +67,17 @@ public sealed class Binder
                 .ToList();
             var returnType = func.Output?.TypeName ?? "VOID";
             var funcSymbol = new FunctionSymbol(func.Name, returnType, parameters);
-            _scope.TryDeclare(funcSymbol);
+            var existing = _scope.LookupOverloadSet(func.Name);
+            if (existing.Any(f => f.Parameters.Select(p => p.TypeName)
+                    .SequenceEqual(funcSymbol.Parameters.Select(p => p.TypeName), StringComparer.Ordinal)))
+            {
+                _diagnostics.ReportError(func.Span, DiagnosticCode.DuplicateFunctionSignature,
+                    $"Function '{func.Name}' is already declared with the same parameter types " +
+                    $"({string.Join(", ", parameters.Select(p => p.TypeName))}). Overloads must " +
+                    "differ in their parameter list.");
+                continue;
+            }
+            _scope.DeclareOverload(funcSymbol);
         }
 
         // Second pass: bind function bodies
@@ -753,12 +768,37 @@ public sealed class Binder
             args.Add(BindExpression(arg));
         }
 
-        // Try arity-aware lookup first (resolves overloaded sibling methods)
+        // #762 items 5–6 (B8): resolve against the full overload set, never silently.
+        // Exact-arity single match resolves; an arity tie is Calor0207 (bound types
+        // are informational strings in 0.13 and cannot discriminate — B5 decision);
+        // a declared name with no arity match is Calor0208. Both proceed with the
+        // first declaration for bound-tree continuity — flagged, not silent.
         string returnType;
-        var funcSymbol = _scope.LookupByArity(callExpr.Target, args.Count);
-        if (funcSymbol != null)
+        var overloads = _scope.LookupOverloadSet(callExpr.Target);
+        if (overloads.Count > 0)
         {
-            returnType = funcSymbol.ReturnType;
+            var atArity = overloads.Where(f => f.Parameters.Count == args.Count).ToList();
+            FunctionSymbol resolved;
+            if (atArity.Count == 1)
+            {
+                resolved = atArity[0];
+            }
+            else if (atArity.Count > 1)
+            {
+                _diagnostics.ReportWarning(callExpr.Span, DiagnosticCode.AmbiguousOverload,
+                    $"Call to '{callExpr.Target}' with {args.Count} argument(s) matches " +
+                    $"{atArity.Count} overloads; argument types cannot discriminate between " +
+                    "them. Resolving to the first declaration.");
+                resolved = atArity[0];
+            }
+            else
+            {
+                _diagnostics.ReportWarning(callExpr.Span, DiagnosticCode.NoMatchingOverload,
+                    $"No overload of '{callExpr.Target}' accepts {args.Count} argument(s) " +
+                    $"(declared arities: {string.Join(", ", overloads.Select(f => f.Parameters.Count).Distinct().OrderBy(c => c))}).");
+                resolved = overloads[0];
+            }
+            returnType = resolved.ReturnType;
         }
         else
         {

--- a/src/Calor.Compiler/Binding/Binder.cs
+++ b/src/Calor.Compiler/Binding/Binder.cs
@@ -862,7 +862,9 @@ public sealed class Binder
         _diagnostics.ReportWarning(expr.Span, DiagnosticCode.AnalysisIncomplete,
             $"Analysis incomplete: '{expr.GetType().Name}' has no structural binding yet " +
             $"({reason}). Analyses treat this expression as an opaque value; its sub-expressions " +
-            "are retained and visible to traversals, deferred-marked.");
+            "are retained and visible to the shared traversals (BoundChildren and the " +
+            "patched checker walks), deferred-marked — checkers with their own unpatched " +
+            "walks still treat the subtree as opaque (#911 follow-up).");
         return new BoundIncompleteExpression(expr.Span, expr.GetType().Name, reason, children);
     }
 

--- a/src/Calor.Compiler/Binding/BoundNodes.cs
+++ b/src/Calor.Compiler/Binding/BoundNodes.cs
@@ -450,11 +450,40 @@ public sealed class BoundIncompleteExpression : BoundCallExpression
     /// <summary>Why this class is incomplete (F-1 tier reason or "family PR pending").</summary>
     public string Reason { get; }
 
-    public BoundIncompleteExpression(TextSpan span, string nodeTypeName, string reason)
+    /// <summary>#762 B8 (D2 Tier-B extractors): bound children of a residual class,
+    /// retained instead of erased. Deliberately NOT in Arguments — the node's
+    /// checker-visible BoundCallExpression shape stays zero-arg opaque; traversals see
+    /// these via BoundChildren.Of, deferred-marked via DeferredOf (the analysis story
+    /// for the wrapping construct is still out of scope).</summary>
+    public IReadOnlyList<BoundExpression> RetainedChildren { get; }
+
+    public BoundIncompleteExpression(TextSpan span, string nodeTypeName, string reason,
+        IReadOnlyList<BoundExpression>? retainedChildren = null)
         : base(span, $"<unsupported:{nodeTypeName}>", Array.Empty<BoundExpression>(), "OBJECT")
     {
         NodeTypeName = nodeTypeName;
         Reason = reason;
+        RetainedChildren = retainedChildren ?? Array.Empty<BoundExpression>();
+    }
+}
+
+/// <summary>#762 B8 (item-8 disposition): a generic-type reference in expression
+/// position (legacy §G / inline generic syntax), promoted to Tier A. TypeName is the
+/// composed parser-surface form ("List&lt;i32&gt;" — the two-layer vocabulary's second
+/// layer, no-space commas per the B5 decision record). No expression children.</summary>
+public sealed class BoundGenericTypeExpression : BoundExpression
+{
+    public string GenericTypeName { get; }
+    public IReadOnlyList<string> TypeArguments { get; }
+    public override string TypeName { get; }
+    public BoundGenericTypeExpression(TextSpan span, string genericTypeName,
+        IReadOnlyList<string> typeArguments) : base(span)
+    {
+        GenericTypeName = genericTypeName;
+        TypeArguments = typeArguments;
+        TypeName = typeArguments.Count == 0
+            ? genericTypeName
+            : $"{genericTypeName}<{string.Join(",", typeArguments)}>";
     }
 }
 
@@ -513,6 +542,11 @@ public static class BoundChildren
         BoundForallExpression fa => [fa.Body],
         BoundExistsExpression ex => [ex.Body],
         BoundImplicationExpression imp => [imp.Antecedent, imp.Consequent],
+        // #762 B8 — Tier-B residuals retain children (never erase the subtree); the
+        // wrapping construct's own analysis story is out of scope, so the same list is
+        // deferred-marked below. (Interop and BoundGenericTypeExpression have no
+        // expression children — verbatim C# text and type strings respectively.)
+        BoundIncompleteExpression inc => inc.RetainedChildren,
         // #762 B5 — conversion/pattern family.
         BoundConversionExpression conv => [conv.Operand],
         BoundTypeTest tt => [tt.Operand],
@@ -542,6 +576,9 @@ public static class BoundChildren
         BoundExistsExpression ex => [ex.Body],
         BoundImplicationExpression imp => [imp.Consequent],
         BoundLambda lam => lam.ExpressionBody is null ? [] : [lam.ExpressionBody],
+        // #762 B8: Tier-B retained children are visible but never treated as inline
+        // code — the wrapping construct's evaluation semantics are out of scope.
+        BoundIncompleteExpression inc => inc.RetainedChildren,
         _ => [],
     };
 }
@@ -1094,6 +1131,35 @@ public sealed class BoundExistsExpression : BoundExpression
     public BoundExistsExpression(TextSpan span, IReadOnlyList<VariableSymbol> boundVariables,
         BoundExpression body) : base(span)
     { BoundVariables = boundVariables; Body = body; }
+}
+
+/// <summary>#762 B8: interop — a verbatim C# expression (F-1 Tier A interop row:
+/// "explicit stable type + verbatim content retained + an explicit interop marker —
+/// never a zero-child erasure"). The content is C# text, not Calor AST, so there are
+/// no expression children to retain; the node is an opaque OBJECT value that names
+/// itself, and IsInterop is the explicit marker analyses key on.</summary>
+public sealed class BoundRawCSharpExpression : BoundExpression
+{
+    public string CSharpCode { get; }
+    public bool IsInterop => true;
+    public override string TypeName => "OBJECT";
+    public BoundRawCSharpExpression(TextSpan span, string csharpCode) : base(span)
+    { CSharpCode = csharpCode; }
+}
+
+/// <summary>#762 B8: interop — the C#→Calor converter's unconverted-feature fallback.
+/// Same Tier A interop contract as BoundRawCSharpExpression; FeatureName/Suggestion
+/// retained for diagnostics and tooling.</summary>
+public sealed class BoundFallbackExpression : BoundExpression
+{
+    public string OriginalCSharp { get; }
+    public string FeatureName { get; }
+    public string? Suggestion { get; }
+    public bool IsInterop => true;
+    public override string TypeName => "OBJECT";
+    public BoundFallbackExpression(TextSpan span, string originalCSharp, string featureName,
+        string? suggestion) : base(span)
+    { OriginalCSharp = originalCSharp; FeatureName = featureName; Suggestion = suggestion; }
 }
 
 /// <summary>#762 B7: logical implication (-> a b) ≡ !a || b. The consequent is

--- a/src/Calor.Compiler/Binding/Scope.cs
+++ b/src/Calor.Compiler/Binding/Scope.cs
@@ -134,6 +134,16 @@ public sealed class Scope
         return Parent?.LookupByArity(name, argCount);
     }
 
+    /// <summary>#762 items 5–6 (B8): the full overload set for a name, nearest scope
+    /// wins — the binder resolves against the SET and diagnoses ambiguity/no-match
+    /// itself rather than relying on LookupByArity's silent first-overload fallback.</summary>
+    public IReadOnlyList<FunctionSymbol> LookupOverloadSet(string name)
+    {
+        if (_overloadSets.TryGetValue(name, out var list))
+            return list;
+        return Parent?.LookupOverloadSet(name) ?? Array.Empty<FunctionSymbol>();
+    }
+
     public bool TryLookup(string name, out Symbol? symbol)
     {
         symbol = Lookup(name);

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -5780,6 +5780,53 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         AppendLine($"// TODO: proof obligation [{node.Id}{desc}]");
         return "";
     }
+
+    // #762 item 8 (B8): real dispatch for the seven former no-op-Accept classes.
+    // Bodies ported from PR #900's implementations (same projections the parent
+    // nodes' inline handling produces).
+    public string Visit(OutputNode node) => MapTypeName(node.TypeName);
+
+    public string Visit(EffectsNode node) => "";
+
+    public string Visit(ElseIfClauseNode node)
+    {
+        var condition = node.Condition.Accept(this);
+        AppendLine($"else if ({condition})");
+        AppendLine("{");
+        Indent();
+        PushDeclScope();
+        foreach (var stmt in node.Body)
+        {
+            EmitStatement(stmt);
+        }
+        PopDeclScope();
+        Dedent();
+        AppendLine("}");
+        return "";
+    }
+
+    public string Visit(FieldDefinitionNode node)
+    {
+        var defaultValue = node.DefaultValue is null ? "" : $" = {node.DefaultValue.Accept(this)}";
+        return $"{MapTypeName(node.TypeName)} {SanitizeIdentifier(node.Name)}{defaultValue}";
+    }
+
+    public string Visit(VariantDefinitionNode node)
+    {
+        var fields = string.Join(", ", node.Fields.Select(Visit));
+        return $"{SanitizeIdentifier(node.Name)}({fields})";
+    }
+
+    public string Visit(TypeReferenceNode node)
+    {
+        var typeName = MapTypeName(node.Name);
+        return node.TypeArguments.Count == 0
+            ? typeName
+            : $"{typeName}<{string.Join(", ", node.TypeArguments.Select(Visit))}>";
+    }
+
+    public string Visit(FieldAssignmentNode node) => node.Value.Accept(this);
+
 }
 
 /// <summary>
@@ -5925,4 +5972,5 @@ public static class GeneratedCSharpCompiler
 
         return new GeneratedCSharpValidation(syntaxErrors, compilationErrors);
     }
+
 }

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -5782,8 +5782,10 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     }
 
     // #762 item 8 (B8): real dispatch for the seven former no-op-Accept classes.
-    // Bodies ported from PR #900's implementations (same projections the parent
-    // nodes' inline handling produces).
+    // Bodies ported from PR #900's implementations. REFERENCE PROJECTIONS: the parent
+    // nodes' emission paths still inline-handle these nodes (routing them through
+    // Accept is follow-up work) — keep each body matching its live inline path, or
+    // the day something dispatches Accept the output silently diverges (#911 F5).
     public string Visit(OutputNode node) => MapTypeName(node.TypeName);
 
     public string Visit(EffectsNode node) => "";

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -124,6 +124,28 @@ public static class DiagnosticCode
     /// </summary>
     public const string ReturnValueInVoidOwner = "Calor0205";
 
+    /// <summary>
+    /// Error: two top-level functions declare the same name AND the same ordered
+    /// parameter-type list (#762 items 5–6, B8). Distinct signatures under one name
+    /// are a legal overload set; an identical signature is unresolvable.
+    /// </summary>
+    public const string DuplicateFunctionSignature = "Calor0206";
+
+    /// <summary>
+    /// Warning: an internal call matches more than one overload at its arity and the
+    /// argument types cannot discriminate (bound types are informational strings in
+    /// 0.13 — B5 decision record). Resolution proceeds with the first declaration,
+    /// NON-silently (#762 DoD: no silent incompatible fallback).
+    /// </summary>
+    public const string AmbiguousOverload = "Calor0207";
+
+    /// <summary>
+    /// Warning: an internal call names a declared function but no overload accepts
+    /// the given argument count. Resolution proceeds with the first declaration for
+    /// bound-tree continuity, NON-silently (#762 DoD).
+    /// </summary>
+    public const string NoMatchingOverload = "Calor0208";
+
     // Bind inference diagnostics (Calor0250-0259) — RFC v0.6 bind-inference-formalization
 
     /// <summary>

--- a/src/Calor.Compiler/Effects/EffectEnforcementPass.cs
+++ b/src/Calor.Compiler/Effects/EffectEnforcementPass.cs
@@ -1788,7 +1788,7 @@ public sealed class EffectEnforcementPass
                     or DecimalLiteralNode or ReferenceNode or NoneExpressionNode
                     or ThisExpressionNode or BaseExpressionNode or SelfRefNode
                     or GenericTypeNode or TypeOfExpressionNode or NameOfExpressionNode
-                    or SizeOfNode or KeywordArgNode => EffectSet.Empty,
+                    or SizeOfNode => EffectSet.Empty,
                 // Contract-form quantifiers evaluate over pure predicates
                 ForallExpressionNode or ExistsExpressionNode or ImplicationExpressionNode => EffectSet.Empty,
                 // D-W2.3: interop / unconverted content — assumed, not silently pure

--- a/src/Calor.Compiler/Ids/IdScanner.cs
+++ b/src/Calor.Compiler/Ids/IdScanner.cs
@@ -343,4 +343,15 @@ public sealed class IdScanner : IAstVisitor
         if (!string.IsNullOrEmpty(node.Id))
             AddEntry(node.Id, IdKind.IndexedType, node.Name, node.Span);
     }
+
+    // #762 item 8 (B8): real dispatch for the former no-op-Accept classes — no IDs
+    // to scan on any of them (IdScanner convention: empty visit).
+    public void Visit(OutputNode node) { }
+    public void Visit(EffectsNode node) { }
+    public void Visit(ElseIfClauseNode node) { }
+    public void Visit(FieldDefinitionNode node) { }
+    public void Visit(VariantDefinitionNode node) { }
+    public void Visit(TypeReferenceNode node) { }
+    public void Visit(FieldAssignmentNode node) { }
+
 }

--- a/src/Calor.Compiler/Mcp/Tools/AnalyzeTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/AnalyzeTool.cs
@@ -261,12 +261,15 @@ public sealed class AnalyzeTool : McpToolBase
                 var result = Program.Compile(source, Path.GetFileName(filePath), compileOptions);
                 var analysisResult = compileOptions.VerificationAnalysisResult;
 
-                // Info-severity diagnostics (e.g. the Calor0259 incomplete-fraction
-                // instrument, #762 B1) are measurements, not issues — counting them
-                // would flip filesWithIssues on clean files that merely use constructs
-                // the binder has not reached yet.
+                // Info-severity diagnostics are measurements, not issues — counting
+                // them would flip filesWithIssues on clean files. The Calor0259
+                // incomplete-fraction instrument (#762 B1) is additionally excluded BY
+                // CODE: B8 promoted it to Warning (a per-construct "analysis does not
+                // cover this" signal worth showing), but at the aggregate level it
+                // remains an instrument — an unsafe-family file is not an "issue".
                 var issueCount = result.Diagnostics.Count(
-                    d => d.Severity != DiagnosticSeverity.Info);
+                    d => d.Severity != DiagnosticSeverity.Info
+                        && d.Code != DiagnosticCode.AnalysisIncomplete);
                 totalIssues += issueCount;
                 if (issueCount > 0) filesWithIssues++;
 

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -4191,4 +4191,53 @@ public sealed class CalorEmitter : IAstVisitor<string>
         AppendLine(sb.ToString());
         return "";
     }
+
+    // #762 item 8 (B8): real dispatch for the seven former no-op-Accept classes
+    // (bodies ported from PR #900).
+    public string Visit(OutputNode node) => $"§O{{{TypeMapper.CSharpToCalor(node.TypeName)}}}";
+
+    public string Visit(EffectsNode node)
+    {
+        var effectCodes = node.Effects
+            .SelectMany(kvp => kvp.Value.Split(',').Select(v => EffectCodes.ToCompact(kvp.Key, v.Trim())))
+            .Distinct();
+        return $"§E{{{string.Join(",", effectCodes)}}}";
+    }
+
+    public string Visit(ElseIfClauseNode node)
+    {
+        AppendLine($"§EI {node.Condition.Accept(this)}");
+        Indent();
+        foreach (var stmt in node.Body)
+        {
+            stmt.Accept(this);
+        }
+        Dedent();
+        return "";
+    }
+
+    public string Visit(FieldDefinitionNode node)
+    {
+        var defaultValue = node.DefaultValue is null ? "" : $" = {node.DefaultValue.Accept(this)}";
+        return $"{TypeMapper.CSharpToCalor(node.TypeName)}:{node.Name}{defaultValue}";
+    }
+
+    public string Visit(VariantDefinitionNode node)
+    {
+        var fields = node.Fields.Count == 0
+            ? ""
+            : $"({string.Join(", ", node.Fields.Select(Visit))})";
+        return $"§V{{{node.Name}}}{fields}";
+    }
+
+    public string Visit(TypeReferenceNode node)
+    {
+        var typeName = TypeMapper.CSharpToCalor(node.Name);
+        return node.TypeArguments.Count == 0
+            ? typeName
+            : $"{typeName}<{string.Join(",", node.TypeArguments.Select(Visit))}>";
+    }
+
+    public string Visit(FieldAssignmentNode node) => node.Value.Accept(this);
+
 }

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -4193,11 +4193,18 @@ public sealed class CalorEmitter : IAstVisitor<string>
     }
 
     // #762 item 8 (B8): real dispatch for the seven former no-op-Accept classes
-    // (bodies ported from PR #900).
+    // (bodies ported from PR #900). REFERENCE PROJECTIONS: the parent nodes'
+    // emission paths still inline-handle these nodes (routing them through Accept is
+    // follow-up work) — keep each body matching its live inline path, or the day
+    // something dispatches Accept the output silently diverges (#911 review F5).
     public string Visit(OutputNode node) => $"§O{{{TypeMapper.CSharpToCalor(node.TypeName)}}}";
 
     public string Visit(EffectsNode node)
     {
+        // Live-path parity (#911 F5): EmitEffects omits the line entirely for an empty
+        // effects map — an emitted `§E{}` would MEAN pure, which is a different claim.
+        if (node.Effects.Count == 0)
+            return "";
         var effectCodes = node.Effects
             .SelectMany(kvp => kvp.Value.Split(',').Select(v => EffectCodes.ToCompact(kvp.Key, v.Trim())))
             .Distinct();

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -1662,7 +1662,9 @@ public sealed class Parser
     private CallStatementNode ParseCallStatement()
     {
         var startToken = Expect(TokenKind.Call);
-        var attrs = ParseAttributes();
+        // #911 review F6: exactly one header group — a following brace group is a
+        // collection-initializer expression, not more header attributes.
+        var attrs = ParseAttributes(maxGroups: 1);
 
         // Interpret call attributes
         var (target, fallible) = AttributeHelper.InterpretCallAttributes(attrs);
@@ -3854,7 +3856,9 @@ public sealed class Parser
     private MatchExpressionNode ParseMatchExpression()
     {
         var startToken = Expect(TokenKind.Match);
-        var attrs = ParseAttributes();
+        // #911 review F6: exactly one header group — a following brace group is a
+        // collection-initializer expression, not more header attributes.
+        var attrs = ParseAttributes(maxGroups: 1);
         var id = AttributeHelper.InterpretMatchAttributes(attrs);
         if (string.IsNullOrEmpty(id))
         {
@@ -3881,7 +3885,9 @@ public sealed class Parser
     private StatementNode ParseMatchStatement()
     {
         var startToken = Expect(TokenKind.Match);
-        var attrs = ParseAttributes();
+        // #911 review F6: exactly one header group — a following brace group is a
+        // collection-initializer expression, not more header attributes.
+        var attrs = ParseAttributes(maxGroups: 1);
         var id = AttributeHelper.InterpretMatchAttributes(attrs);
         if (string.IsNullOrEmpty(id))
         {
@@ -8276,7 +8282,9 @@ public sealed class Parser
     private ExpressionNode ParseCallExpression()
     {
         var startToken = Expect(TokenKind.Call);
-        var attrs = ParseAttributes();
+        // #911 review F6: exactly one header group — a following brace group is a
+        // collection-initializer expression, not more header attributes.
+        var attrs = ParseAttributes(maxGroups: 1);
 
         // Positional: [target]
         var target = attrs["_pos0"] ?? "";
@@ -9740,7 +9748,9 @@ public sealed class Parser
     private LambdaExpressionNode ParseLambdaExpression()
     {
         var startToken = Expect(TokenKind.Lambda);
-        var attrs = ParseAttributes();
+        // #911 review F6: exactly one header group — a following brace group is a
+        // collection-initializer expression, not more header attributes.
+        var attrs = ParseAttributes(maxGroups: 1);
 
         // Positional: [id:param1:type1:param2:type2:...] or [id:async:param1:type1:...]
         var id = attrs["_pos0"] ?? "";

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -2355,24 +2355,29 @@ public sealed class Parser
             return ParseLispCastExpression(startToken);
         }
 
-        // Parse arguments until we hit CloseParen
-        var args = new List<ExpressionNode>();
+        // Parse arguments until we hit CloseParen. The raw list is object-typed because
+        // a keyword argument is NOT an expression (#762 item 8, B8): KeywordArgNode is a
+        // parser-internal value object produced only here and consumed only by
+        // FilterKeywordArgs below.
+        var rawArgs = new List<object>();
         while (!Check(TokenKind.CloseParen) && !IsAtEnd)
         {
-            args.Add(ParseLispArgument(allowKeyword: true));
+            rawArgs.Add(ParseLispArgumentOrKeyword());
         }
 
         var endToken = Expect(TokenKind.CloseParen);
         var span = startToken.Span.Union(endToken.Span);
 
-        // #874: KeywordArgNode is produced only by ParseLispArgument, and the only legal
-        // position for one is as the FINAL argument of a recognized string operation (its
-        // comparison mode, consumed by the string-op branch below). Enforce that here, at
-        // the single point where every operator branch receives its arguments. Per-branch
-        // handling leaves escape routes (binary/ternary/unary operands, mid-position or
-        // doubled keywords, CALL targets), each ending in a null child from the node's
-        // no-op Accept and an unlocatable NRE — or silently invalid emitted C#.
-        args = FilterKeywordArgs(opText, args);
+        // #874: the only legal position for a keyword is as the FINAL argument of a
+        // recognized string operation (its comparison mode, consumed by the string-op
+        // branch below). Enforce that here, at the single point where every operator
+        // branch receives its arguments. Per-branch handling leaves escape routes
+        // (binary/ternary/unary operands, mid-position or doubled keywords, CALL
+        // targets) that previously ended in a null child from the node's no-op Accept
+        // and an unlocatable NRE — or silently invalid emitted C#. Post-item-8, a
+        // keyword cannot even TYPE as an expression, so escape is a compile error here
+        // rather than a runtime hazard downstream.
+        var (args, trailingKeyword) = FilterKeywordArgs(opText, rawArgs);
 
         // Handle ternary conditional: (? cond then else)
         if (opText == "?" && args.Count == 3)
@@ -2496,11 +2501,12 @@ public sealed class Parser
         var stringOp = StringOpExtensions.FromString(opText);
         if (stringOp.HasValue)
         {
-            // Extract keyword arguments (comparison modes) from the end of the args list
+            // The trailing comparison-mode keyword arrives pre-split by
+            // FilterKeywordArgs (args never contains keywords post-item-8).
             StringComparisonMode? comparisonMode = null;
             var nonKeywordArgs = args;
 
-            if (args.Count > 0 && args[^1] is KeywordArgNode keywordArg)
+            if (trailingKeyword is { } keywordArg)
             {
                 comparisonMode = StringComparisonModeExtensions.FromKeyword(keywordArg.Name);
                 if (comparisonMode == null)
@@ -2514,7 +2520,6 @@ public sealed class Parser
                         $"Operation '{opText}' does not support comparison modes");
                     comparisonMode = null;
                 }
-                nonKeywordArgs = args.Take(args.Count - 1).ToList();
             }
 
             // Handle substr disambiguation: 2 args = SubstringFrom, 3 args = Substring
@@ -2734,34 +2739,41 @@ public sealed class Parser
     /// unlocatable NullReferenceException, or silently invalid emitted C# (#874).
     /// Called once, at the single choke point where the lisp argument list is complete.
     /// </summary>
-    private List<ExpressionNode> FilterKeywordArgs(string opText, List<ExpressionNode> args)
+    private (List<ExpressionNode> Arguments, KeywordArgNode? TrailingKeyword) FilterKeywordArgs(
+        string opText, List<object> rawArgs)
     {
-        if (!args.Any(a => a is KeywordArgNode))
-            return args;
-
         // A single trailing keyword on a recognized string operation is legal; the
         // string-op branch consumes it and validates the mode name and operation support.
         var lastLegalIndex =
-            StringOpExtensions.FromString(opText).HasValue && args[^1] is KeywordArgNode
-                ? args.Count - 1
+            StringOpExtensions.FromString(opText).HasValue && rawArgs.Count > 0
+                && rawArgs[^1] is KeywordArgNode
+                ? rawArgs.Count - 1
                 : -1;
 
-        var kept = new List<ExpressionNode>(args.Count);
-        for (int i = 0; i < args.Count; i++)
+        var kept = new List<ExpressionNode>(rawArgs.Count);
+        KeywordArgNode? trailingKeyword = null;
+        for (int i = 0; i < rawArgs.Count; i++)
         {
-            if (args[i] is KeywordArgNode kw && i != lastLegalIndex)
+            if (rawArgs[i] is KeywordArgNode kw)
             {
-                _diagnostics.ReportError(kw.Span, DiagnosticCode.InvalidLispExpression,
-                    $"Keyword argument ':{kw.Name}' is not valid here. A comparison-mode " +
-                    "keyword is only allowed as the final argument of a built-in string " +
-                    "operation (e.g. starts, contains, equals — the lowercase forms).");
+                if (i == lastLegalIndex)
+                {
+                    trailingKeyword = kw;
+                }
+                else
+                {
+                    _diagnostics.ReportError(kw.Span, DiagnosticCode.InvalidLispExpression,
+                        $"Keyword argument ':{kw.Name}' is not valid here. A comparison-mode " +
+                        "keyword is only allowed as the final argument of a built-in string " +
+                        "operation (e.g. starts, contains, equals — the lowercase forms).");
+                }
             }
             else
             {
-                kept.Add(args[i]);
+                kept.Add((ExpressionNode)rawArgs[i]);
             }
         }
-        return kept;
+        return (kept, trailingKeyword);
     }
 
     private (TokenKind kind, string text, TextSpan span) ParseLispOperator()
@@ -2986,42 +2998,65 @@ public sealed class Parser
     /// operands — gets a diagnostic and a recovery node instead, so the keyword node can
     /// never leak into the AST through a side entrance (#874).
     /// </summary>
-    private ExpressionNode ParseLispArgument(bool allowKeyword = false)
+    /// <summary>Parses ':name' / ':hyphen-ated-name' with the colon current. Returns
+    /// null (after reporting) for a standalone colon.</summary>
+    private (string Name, TextSpan Span)? ParseKeywordSyntax()
     {
-        // Handle keyword argument syntax: :keyword or :hyphenated-keyword
-        if (Check(TokenKind.Colon))
+        var colonToken = Advance();
+        if (!Check(TokenKind.Identifier))
         {
-            var colonToken = Advance();
-            if (Check(TokenKind.Identifier))
-            {
-                var identToken = Advance();
-                var keywordName = identToken.Text;
-                var endSpan = identToken.Span;
-
-                // Handle hyphenated keywords (e.g., :ignore-case, :invariant-ignore-case)
-                while (Check(TokenKind.Minus) && Peek(1).Kind == TokenKind.Identifier)
-                {
-                    Advance(); // consume '-'
-                    var nextIdent = Advance();
-                    keywordName += "-" + nextIdent.Text;
-                    endSpan = nextIdent.Span;
-                }
-
-                var span = colonToken.Span.Union(endSpan);
-                if (!allowKeyword)
-                {
-                    _diagnostics.ReportError(span, DiagnosticCode.InvalidLispExpression,
-                        $"Keyword argument ':{keywordName}' is not valid here. A comparison-mode " +
-                        "keyword is only allowed as the final argument of a built-in string " +
-                        "operation (e.g. starts, contains, equals — the lowercase forms).");
-                    return new IntLiteralNode(span, 0);
-                }
-                return new KeywordArgNode(span, keywordName);
-            }
-            // Standalone colon - error
             _diagnostics.ReportError(colonToken.Span, DiagnosticCode.InvalidLispExpression,
                 "Expected identifier after ':' for keyword argument");
-            return new IntLiteralNode(colonToken.Span, 0);
+            return null;
+        }
+        var identToken = Advance();
+        var keywordName = identToken.Text;
+        var endSpan = identToken.Span;
+
+        // Handle hyphenated keywords (e.g., :ignore-case, :invariant-ignore-case)
+        while (Check(TokenKind.Minus) && Peek(1).Kind == TokenKind.Identifier)
+        {
+            Advance(); // consume '-'
+            var nextIdent = Advance();
+            keywordName += "-" + nextIdent.Text;
+            endSpan = nextIdent.Span;
+        }
+        return (keywordName, colonToken.Span.Union(endSpan));
+    }
+
+    /// <summary>#762 item 8 (B8): a keyword argument is a parser-internal VALUE OBJECT,
+    /// not an expression — this is its only producer, the lisp operator-argument loop
+    /// its only route, and FilterKeywordArgs its only consumer. Everywhere else a colon
+    /// keyword is a diagnostic (ParseLispArgument's colon path).</summary>
+    private object ParseLispArgumentOrKeyword()
+    {
+        if (Check(TokenKind.Colon))
+        {
+            var start = Current.Span;
+            var kw = ParseKeywordSyntax();
+            return kw is { } k
+                ? new KeywordArgNode(k.Span, k.Name)
+                : new IntLiteralNode(start, 0);
+        }
+        return ParseLispArgument();
+    }
+
+    private ExpressionNode ParseLispArgument()
+    {
+        // A keyword argument is not an expression; in expression position it is always
+        // a diagnostic (the operator-argument loop uses ParseLispArgumentOrKeyword).
+        if (Check(TokenKind.Colon))
+        {
+            var start = Current.Span;
+            var kw = ParseKeywordSyntax();
+            if (kw is { } k)
+            {
+                _diagnostics.ReportError(k.Span, DiagnosticCode.InvalidLispExpression,
+                    $"Keyword argument ':{k.Name}' is not valid here. A comparison-mode " +
+                    "keyword is only allowed as the final argument of a built-in string " +
+                    "operation (e.g. starts, contains, equals — the lowercase forms).");
+            }
+            return new IntLiteralNode(kw?.Span ?? start, 0);
         }
 
         ExpressionNode expr;

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -8,6 +8,70 @@ namespace Calor.Compiler.Parsing;
 /// </summary>
 public sealed class Parser
 {
+    private delegate ExpressionNode ExpressionParser(Parser parser);
+
+    /// <summary>#762 item 7 (B8, design ported from PR #900): THE authoritative
+    /// expression-start table — one source of truth, two projections. Membership IS
+    /// expression-start classification (IsExpressionStart) and the value IS primary
+    /// dispatch (ParseExpressionCore). The pre-B8 defect class this retires: the two
+    /// hand-maintained lists disagreed in BOTH directions (see the B8 PR for the
+    /// diff). The token-context matrix test (ExpressionRegistrationTests) pins
+    /// every entry in return/bind/argument/nested positions.</summary>
+    private static readonly IReadOnlyDictionary<TokenKind, ExpressionParser> ExpressionParsers =
+        new Dictionary<TokenKind, ExpressionParser>
+        {
+            [TokenKind.IntLiteral] = static parser => parser.ParseIntLiteral(),
+            [TokenKind.StrLiteral] = static parser => parser.ParseStringLiteral(),
+            [TokenKind.BoolLiteral] = static parser => parser.ParseBoolLiteral(),
+            [TokenKind.FloatLiteral] = static parser => parser.ParseFloatLiteral(),
+            [TokenKind.DecimalLiteral] = static parser => parser.ParseDecimalLiteral(),
+            [TokenKind.Identifier] = static parser => parser.ParseReference(),
+            [TokenKind.OpenParen] = static parser => parser.ParseParenExpressionOrInlineLambda(),
+            [TokenKind.OpenBrace] = static parser => parser.ParseCollectionInitializer(),
+            [TokenKind.If] = static parser => parser.ParseIfExpression(),
+            [TokenKind.Some] = static parser => parser.ParseSomeExpression(),
+            [TokenKind.None] = static parser => parser.ParseNoneExpression(),
+            [TokenKind.Ok] = static parser => parser.ParseOkExpression(),
+            [TokenKind.Err] = static parser => parser.ParseErrExpression(),
+            [TokenKind.Match] = static parser => parser.ParseMatchExpression(),
+            [TokenKind.Record] = static parser => parser.ParseRecordCreation(),
+            [TokenKind.Array] = static parser => parser.ParseArrayCreation(),
+            [TokenKind.Index] = static parser => parser.ParseArrayAccess(),
+            [TokenKind.Length] = static parser => parser.ParseArrayLength(),
+            [TokenKind.List] = static parser => parser.ParseListCreation(),
+            [TokenKind.Dict] = static parser => parser.ParseDictionaryCreation(),
+            [TokenKind.HashSet] = static parser => parser.ParseSetCreation(),
+            [TokenKind.Has] = static parser => parser.ParseCollectionContains(),
+            [TokenKind.Count] = static parser => parser.ParseCollectionCount(),
+            [TokenKind.Generic] = static parser => parser.ParseGenericType(),
+            [TokenKind.New] = static parser => parser.ParseNewExpression(),
+            [TokenKind.AnonymousObject] = static parser => parser.ParseAnonymousObjectCreation(),
+            [TokenKind.This] = static parser => parser.ParseThisExpression(),
+            [TokenKind.Base] = static parser => parser.ParseBaseExpression(),
+            [TokenKind.Call] = static parser => parser.ParseCallExpression(),
+            [TokenKind.Lambda] = static parser => parser.ParseLambdaExpression(),
+            [TokenKind.Await] = static parser => parser.ParseAwaitExpression(),
+            [TokenKind.Interpolate] = static parser => parser.ParseInterpolatedString(),
+            [TokenKind.NullCoalesce] = static parser => parser.ParseNullCoalesce(),
+            [TokenKind.NullConditional] = static parser => parser.ParseNullConditional(),
+            [TokenKind.RangeOp] = static parser => parser.ParseRangeExpression(),
+            [TokenKind.IndexEnd] = static parser => parser.ParseIndexFromEnd(),
+            [TokenKind.With] = static parser => parser.ParseWithExpression(),
+            [TokenKind.StackAlloc] = static parser => parser.ParseStackAlloc(),
+            [TokenKind.AddressOf] = static parser => parser.ParseAddressOf(),
+            [TokenKind.Deref] = static parser => parser.ParsePointerDereference(),
+            [TokenKind.SizeOf] = static parser => parser.ParseSizeOf(),
+            [TokenKind.Array2D] = static parser => parser.ParseMultiDimArrayCreation(),
+            [TokenKind.Index2D] = static parser => parser.ParseMultiDimArrayAccess(),
+            [TokenKind.Throw] = static parser => parser.ParseThrowExpression(),
+            [TokenKind.RawCSharpExpression] = static parser => parser.ParseRawCSharpExpression(),
+            [TokenKind.Hash] = static parser => parser.ParseSelfRef(),
+            [TokenKind.At] = static parser => parser.ParseVerbatimIdentifier(),
+        };
+
+    internal static IReadOnlyCollection<TokenKind> RegisteredExpressionStartTokens
+        => ExpressionParsers.Keys.ToArray();
+
     private readonly List<Token> _tokens;
     private readonly DiagnosticBag _diagnostics;
     private int _position;
@@ -1766,69 +1830,7 @@ public sealed class Parser
     }
 
     private bool IsExpressionStart()
-    {
-        return Current.Kind is TokenKind.IntLiteral
-            or TokenKind.StrLiteral
-            or TokenKind.BoolLiteral
-            or TokenKind.FloatLiteral
-            or TokenKind.DecimalLiteral
-            or TokenKind.Identifier
-            // Lisp-style expression
-            or TokenKind.OpenParen
-            // Phase 2: Control Flow - IF as conditional expression
-            or TokenKind.If
-            // Phase 3: Type System
-            or TokenKind.Some
-            or TokenKind.None
-            or TokenKind.Ok
-            or TokenKind.Err
-            or TokenKind.Match
-            or TokenKind.Record
-            // Phase 6: Arrays
-            or TokenKind.Array
-            or TokenKind.Index
-            or TokenKind.Length
-            // Phase 6 Extended: Collections
-            or TokenKind.List
-            or TokenKind.Dict
-            or TokenKind.HashSet
-            or TokenKind.Has
-            or TokenKind.Count
-            // Phase 7: Generics
-            or TokenKind.Generic
-            // Phase 8: Classes
-            or TokenKind.New
-            or TokenKind.AnonymousObject
-            or TokenKind.This
-            or TokenKind.Base
-            or TokenKind.Call  // Call expressions (§C[...])
-            // Phase 11: Lambdas
-            or TokenKind.Lambda
-            // Phase 12: Async/Await
-            or TokenKind.Await
-            // Phase 9: String Interpolation and Modern Operators
-            or TokenKind.Interpolate
-            or TokenKind.NullCoalesce
-            or TokenKind.NullConditional
-            or TokenKind.RangeOp
-            or TokenKind.IndexEnd
-            // Phase 10: Advanced Patterns
-            or TokenKind.With
-            // Unsafe/Low-Level
-            or TokenKind.StackAlloc
-            or TokenKind.AddressOf
-            or TokenKind.Deref
-            or TokenKind.SizeOf
-            or TokenKind.Array2D
-            or TokenKind.Index2D
-            or TokenKind.Throw
-            // Inline raw C# expression
-            or TokenKind.RawCSharpExpression
-            // Dependent Types: Self-reference in refinement predicates
-            or TokenKind.Hash
-            // Verbatim identifiers: @keyword
-            or TokenKind.At;
-    }
+        => ExpressionParsers.ContainsKey(Current.Kind);
 
     // Deterministic guard against stack exhaustion on adversarially nested
     // expressions: StackOverflowException is uncatchable in .NET, so without
@@ -1900,75 +1902,9 @@ public sealed class Parser
 
     private ExpressionNode ParseExpressionCore()
     {
-        var expr = Current.Kind switch
-        {
-            TokenKind.IntLiteral => ParseIntLiteral(),
-            TokenKind.StrLiteral => ParseStringLiteral(),
-            TokenKind.BoolLiteral => ParseBoolLiteral(),
-            TokenKind.FloatLiteral => ParseFloatLiteral(),
-            TokenKind.DecimalLiteral => ParseDecimalLiteral(),
-            TokenKind.Identifier => ParseReference(),
-            // Lisp-style expression: (op args...) or inline lambda: () → body
-            TokenKind.OpenParen => ParseParenExpressionOrInlineLambda(),
-            // Collection/array initializer: {elem1, elem2, ...}
-            TokenKind.OpenBrace => ParseCollectionInitializer(),
-            // Phase 2: Control Flow - IF as conditional expression
-            TokenKind.If => ParseIfExpression(),
-            // Phase 3: Type System
-            TokenKind.Some => ParseSomeExpression(),
-            TokenKind.None => ParseNoneExpression(),
-            TokenKind.Ok => ParseOkExpression(),
-            TokenKind.Err => ParseErrExpression(),
-            TokenKind.Match => ParseMatchExpression(),
-            TokenKind.Record => ParseRecordCreation(),
-            // Phase 6: Arrays
-            TokenKind.Array => ParseArrayCreation(),
-            TokenKind.Index => ParseArrayAccess(),
-            TokenKind.Length => ParseArrayLength(),
-            // Phase 6 Extended: Collections
-            TokenKind.List => ParseListCreation(),
-            TokenKind.Dict => ParseDictionaryCreation(),
-            TokenKind.HashSet => ParseSetCreation(),
-            TokenKind.Has => ParseCollectionContains(),
-            TokenKind.Count => ParseCollectionCount(),
-            // Phase 7: Generics
-            TokenKind.Generic => ParseGenericType(),
-            // Phase 8: Classes
-            TokenKind.New => ParseNewExpression(),
-            TokenKind.AnonymousObject => ParseAnonymousObjectCreation(),
-            TokenKind.This => ParseThisExpression(),
-            TokenKind.Base => ParseBaseExpression(),
-            TokenKind.Call => ParseCallExpression(),
-            // Phase 11: Lambdas
-            TokenKind.Lambda => ParseLambdaExpression(),
-            // Phase 12: Async/Await
-            TokenKind.Await => ParseAwaitExpression(),
-            // Phase 9: String Interpolation and Modern Operators
-            TokenKind.Interpolate => ParseInterpolatedString(),
-            TokenKind.NullCoalesce => ParseNullCoalesce(),
-            TokenKind.NullConditional => ParseNullConditional(),
-            TokenKind.RangeOp => ParseRangeExpression(),
-            TokenKind.IndexEnd => ParseIndexFromEnd(),
-            // Phase 10: Advanced Patterns
-            TokenKind.With => ParseWithExpression(),
-            // Unsafe/Low-Level
-            TokenKind.StackAlloc => ParseStackAlloc(),
-            TokenKind.AddressOf => ParseAddressOf(),
-            TokenKind.Deref => ParsePointerDereference(),
-            TokenKind.SizeOf => ParseSizeOf(),
-            // Multidimensional Arrays
-            TokenKind.Array2D => ParseMultiDimArrayCreation(),
-            TokenKind.Index2D => ParseMultiDimArrayAccess(),
-            // Throw expression
-            TokenKind.Throw => ParseThrowExpression(),
-            // Inline raw C# expression
-            TokenKind.RawCSharpExpression => ParseRawCSharpExpression(),
-            // Dependent Types: Self-reference in refinement predicates
-            TokenKind.Hash => ParseSelfRef(),
-            // Verbatim identifiers: @keyword (strip @ and treat as identifier)
-            TokenKind.At => ParseVerbatimIdentifier(),
-            _ => RecoverFromUnexpectedToken()
-        };
+        var expr = ExpressionParsers.TryGetValue(Current.Kind, out var parser)
+            ? parser(this)
+            : RecoverFromUnexpectedToken();
 
         // Handle trailing member access (e.g., (typeof X).Name, result.Property)
         expr = ParseTrailingMemberAccess(expr);
@@ -4843,7 +4779,10 @@ public sealed class Parser
     private BindStatementNode ParseBindStatement()
     {
         var startToken = Expect(TokenKind.Bind);
-        var attrs = ParseAttributes();
+        // A bind has exactly one header group. A following brace group is a
+        // collection initializer expression, not another header group (#762 item 7 —
+        // the OpenBrace start-classification fix makes it reachable; port of #900).
+        var attrs = ParseAttributes(maxGroups: 1);
 
         // Interpret bind attributes - now includes type as third return value
         var (name, isMutable, typeName) = AttributeHelper.InterpretBindAttributes(attrs);
@@ -4952,13 +4891,14 @@ public sealed class Parser
         return statements;
     }
 
-    private AttributeCollection ParseAttributes()
+    private AttributeCollection ParseAttributes(int maxGroups = int.MaxValue)
     {
         var attrs = new AttributeCollection();
+        var groupsParsed = 0;
 
         // Parse structural braces {} for tag attributes
         // Note: [] is now reserved for array types to align with LLM training
-        while (Check(TokenKind.OpenBrace))
+        while (groupsParsed < maxGroups && Check(TokenKind.OpenBrace))
         {
             Advance(); // consume {
 
@@ -4966,6 +4906,7 @@ public sealed class Parser
             ParsePositionalAttributes(attrs);
 
             Expect(TokenKind.CloseBrace);
+            groupsParsed++;
         }
 
         return attrs;

--- a/src/Calor.Compiler/Verification/ExpressionSimplifier.cs
+++ b/src/Calor.Compiler/Verification/ExpressionSimplifier.cs
@@ -1447,4 +1447,15 @@ public sealed class ExpressionSimplifier : IAstVisitor<ExpressionNode>
     public ExpressionNode Visit(IndexedTypeNode node) => throw new InvalidOperationException();
 
     #endregion
+
+    // #762 item 8 (B8): real dispatch for the former no-op-Accept classes — none is
+    // an expression, so reaching one here is a caller bug (class convention).
+    public ExpressionNode Visit(OutputNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(EffectsNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(ElseIfClauseNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(FieldDefinitionNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(VariantDefinitionNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(TypeReferenceNode node) => throw new InvalidOperationException();
+    public ExpressionNode Visit(FieldAssignmentNode node) => throw new InvalidOperationException();
+
 }

--- a/src/Calor.LanguageServer/Utilities/AstPositionVisitor.cs
+++ b/src/Calor.LanguageServer/Utilities/AstPositionVisitor.cs
@@ -263,4 +263,14 @@ public abstract class AstPositionVisitor<T> : IAstVisitor<T> where T : class?
     public virtual T Visit(ProofObligationNode node) => DefaultVisit(node)!;
     // Dependent Types: Indexed Types (size-parameterized)
     public virtual T Visit(IndexedTypeNode node) => DefaultVisit(node)!;
+
+    // #762 item 8 (B8): real dispatch for the former no-op-Accept classes.
+    public virtual T Visit(OutputNode node) => DefaultVisit(node)!;
+    public virtual T Visit(EffectsNode node) => DefaultVisit(node)!;
+    public virtual T Visit(ElseIfClauseNode node) => DefaultVisit(node)!;
+    public virtual T Visit(FieldDefinitionNode node) => DefaultVisit(node)!;
+    public virtual T Visit(VariantDefinitionNode node) => DefaultVisit(node)!;
+    public virtual T Visit(TypeReferenceNode node) => DefaultVisit(node)!;
+    public virtual T Visit(FieldAssignmentNode node) => DefaultVisit(node)!;
+
 }

--- a/tests/Calor.Compiler.Tests/ArchitectureTests.cs
+++ b/tests/Calor.Compiler.Tests/ArchitectureTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Calor.Compiler.Ast;
 using Xunit;
 
@@ -161,6 +162,76 @@ public class ArchitectureTests
         Assert.True(issues.Count == 0,
             $"Visitor documentation is out of sync:\n{string.Join("\n", issues)}\n\n" +
             $"Current visitors: {string.Join(", ", actualVisitors.OrderBy(x => x))}");
+    }
+
+
+    /// <summary>
+    /// #762 item 8 / B8 (mechanism ported from PR #900): every concrete AstNode,
+    /// instantiated WITHOUT running constructors, must route Accept to exactly one
+    /// matching Visit overload on both visitor interfaces. A no-op or default!
+    /// Accept fails with zero recorded calls; a wrong overload fails the parameter
+    /// match. This is the AstNode-wide widening of the ExpressionNode-only test
+    /// that shipped in B1.
+    /// </summary>
+    [Fact]
+    public void EveryConcreteAstNode_DispatchesExactlyOnceToMatchingVisitorMethod()
+    {
+        var nodeTypes = typeof(AstNode).Assembly
+            .GetTypes()
+            .Where(type => !type.IsAbstract && typeof(AstNode).IsAssignableFrom(type))
+            .OrderBy(type => type.Name)
+            .ToList();
+
+        var nonGenericVisitor = DispatchProxy.Create<IAstVisitor, RecordingVisitorProxy>();
+        var nonGenericRecorder = (RecordingVisitorProxy)(object)nonGenericVisitor;
+        var genericVisitor = DispatchProxy.Create<IAstVisitor<object?>, RecordingVisitorProxy>();
+        var genericRecorder = (RecordingVisitorProxy)(object)genericVisitor;
+
+        foreach (var nodeType in nodeTypes)
+        {
+            var node = (AstNode)RuntimeHelpers.GetUninitializedObject(nodeType);
+
+            nonGenericRecorder.Reset();
+            node.Accept(nonGenericVisitor);
+            AssertSingleMatchingDispatch(nodeType, node, nonGenericRecorder.Calls);
+
+            genericRecorder.Reset();
+            node.Accept(genericVisitor);
+            AssertSingleMatchingDispatch(nodeType, node, genericRecorder.Calls);
+        }
+    }
+
+    /// <summary>#762 item 8 (B8): the keyword-argument disposition — reclassified out
+    /// of the AST entirely, so it can never re-enter the expression denominator.</summary>
+    [Fact]
+    public void ParserOnlyKeywordArgument_IsNotAnAstNode()
+    {
+        Assert.False(typeof(AstNode).IsAssignableFrom(typeof(Calor.Compiler.Ast.KeywordArgNode)));
+    }
+
+    private static void AssertSingleMatchingDispatch(
+        Type nodeType,
+        AstNode node,
+        IReadOnlyList<(MethodInfo Method, object? Argument)> calls)
+    {
+        var call = Assert.Single(calls);
+        Assert.Equal("Visit", call.Method.Name);
+        Assert.Equal(nodeType, Assert.Single(call.Method.GetParameters()).ParameterType);
+        Assert.Same(node, call.Argument);
+    }
+
+    public class RecordingVisitorProxy : DispatchProxy
+    {
+        public List<(MethodInfo Method, object? Argument)> Calls { get; } = new();
+
+        public void Reset() => Calls.Clear();
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            Assert.NotNull(targetMethod);
+            Calls.Add((targetMethod, args is { Length: > 0 } ? args[0] : null));
+            return null;
+        }
     }
 
 }

--- a/tests/Calor.Compiler.Tests/Binding/BinderDispatchCompletenessTests.cs
+++ b/tests/Calor.Compiler.Tests/Binding/BinderDispatchCompletenessTests.cs
@@ -43,6 +43,10 @@ public class BinderDispatchCompletenessTests
         // F-1 (v0.13-freeze-registrations.md) froze the denominator at 61 classes,
         // exhaustively tiered. A count change here without an F-1 amendment is exactly
         // the silent-denominator-drift the registration's bidirectional rule forbids.
-        Assert.Equal(61, ConcreteExpressionTypes().Count);
+        // B8 amendment (#762 item 8, subtractive-with-supersession recorded in F-1):
+        // KeywordArgNode reclassified out of the AST entirely — it is a parser-internal
+        // value object that can no longer TYPE as an expression, so it leaves the
+        // denominator by becoming unrepresentable, not by being silently skipped.
+        Assert.Equal(60, ConcreteExpressionTypes().Count);
     }
 }

--- a/tests/Calor.Compiler.Tests/Binding/BinderOverloadSetTests.cs
+++ b/tests/Calor.Compiler.Tests/Binding/BinderOverloadSetTests.cs
@@ -1,0 +1,111 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Binding;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+// Flat test namespace: see BinderDispatchCompletenessTests.
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// #762 items 5–6 (B8, scoping doc D5): top-level functions register in overload sets
+/// (previously a same-name second declaration's TryDeclare silently failed and every
+/// call resolved to the first declaration); duplicate signatures, arity ties, and
+/// no-arity-match calls are explicit diagnostics; resolution is order-independent
+/// (the property two-pass binding exists to provide).
+/// </summary>
+public class BinderOverloadSetTests
+{
+    private static readonly TextSpan S = new(0, 0, 1, 1);
+
+    private static FunctionNode Func(string id, string name, string returnType,
+        (string Type, string Name)[] parameters, params StatementNode[] body)
+        => new(S, id, name, Visibility.Public,
+            parameters.Select(p => new ParameterNode(S, p.Name, p.Type, new AttributeCollection())).ToArray(),
+            new OutputNode(S, returnType), null, body, new AttributeCollection());
+
+    private static (BoundModule Bound, DiagnosticBag Diagnostics) Bind(params FunctionNode[] funcs)
+    {
+        var module = new ModuleNode(S, "m001", "Test",
+            Array.Empty<UsingDirectiveNode>(), funcs, new AttributeCollection());
+        var diagnostics = new DiagnosticBag();
+        var bound = new Binder(diagnostics).Bind(module);
+        return (bound, diagnostics);
+    }
+
+    private static FunctionNode Caller(string id, int argCount)
+        => Func(id, "Caller", "OBJECT", Array.Empty<(string, string)>(),
+            new ReturnStatementNode(S, new CallExpressionNode(S, "Pick",
+                Enumerable.Range(0, argCount).Select(i => (ExpressionNode)new IntLiteralNode(S, i)).ToArray())));
+
+    private static string CallerResolvedType(BoundModule bound)
+        => bound.Functions.Single(f => f.Symbol.Name == "Caller")
+            .Body.OfType<BoundReturnStatement>().Single().Expression!.TypeName;
+
+    [Fact]
+    public void Overloads_ResolveByArity_RegardlessOfDeclarationOrder()
+    {
+        var oneArg = Func("f001", "Pick", "i32", new[] { ("i32", "x") });
+        var twoArg = Func("f002", "Pick", "str", new[] { ("i32", "x"), ("i32", "y") });
+
+        // Caller FIRST (pass-2 resolution must see overloads declared after it),
+        // then the same module with the overload order reversed.
+        var (boundA, diagsA) = Bind(Caller("f003", 2), oneArg, twoArg);
+        var (boundB, diagsB) = Bind(twoArg, oneArg, Caller("f003", 2));
+
+        Assert.Equal("str", CallerResolvedType(boundA));
+        Assert.Equal("str", CallerResolvedType(boundB));
+        foreach (var d in new[] { diagsA, diagsB })
+        {
+            Assert.DoesNotContain(d, x => x.Code == DiagnosticCode.DuplicateDefinition);
+            Assert.DoesNotContain(d, x => x.Code == DiagnosticCode.DuplicateFunctionSignature);
+            Assert.DoesNotContain(d, x => x.Code == DiagnosticCode.AmbiguousOverload);
+            Assert.DoesNotContain(d, x => x.Code == DiagnosticCode.NoMatchingOverload);
+        }
+    }
+
+    [Fact]
+    public void DuplicateSignature_IsAnError()
+    {
+        var (_, diags) = Bind(
+            Func("f001", "Pick", "i32", new[] { ("i32", "x") }),
+            Func("f002", "Pick", "str", new[] { ("i32", "y") })); // same ordered types
+        Assert.Contains(diags, d => d.Code == DiagnosticCode.DuplicateFunctionSignature
+            && d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void ArityTie_IsANonSilentAmbiguityWarning()
+    {
+        // (i32) vs (str) — same arity, different types; string-typed bound arguments
+        // cannot discriminate in 0.13 (B5 decision record), so the tie is flagged.
+        var (bound, diags) = Bind(
+            Func("f001", "Pick", "i32", new[] { ("i32", "x") }),
+            Func("f002", "Pick", "str", new[] { ("str", "s") }),
+            Caller("f003", 1));
+        Assert.Contains(diags, d => d.Code == DiagnosticCode.AmbiguousOverload);
+        Assert.Equal("i32", CallerResolvedType(bound)); // first declaration, flagged
+    }
+
+    [Fact]
+    public void NoArityMatch_IsANonSilentWarning()
+    {
+        var (_, diags) = Bind(
+            Func("f001", "Pick", "i32", new[] { ("i32", "x") }),
+            Caller("f002", 3));
+        Assert.Contains(diags, d => d.Code == DiagnosticCode.NoMatchingOverload);
+    }
+
+    [Fact]
+    public void SecondOverload_NoLongerSilentlyDropped()
+    {
+        // Pre-B8 pin of the item-5 defect: the second declaration's TryDeclare failed
+        // silently and a 2-arg call resolved to the FIRST declaration's return type.
+        var (bound, diags) = Bind(
+            Func("f001", "Pick", "i32", new[] { ("i32", "x") }),
+            Func("f002", "Pick", "str", new[] { ("i32", "x"), ("i32", "y") }),
+            Caller("f003", 2));
+        Assert.Equal("str", CallerResolvedType(bound));
+        Assert.DoesNotContain(diags, d => d.Code == DiagnosticCode.DuplicateFunctionSignature);
+    }
+}

--- a/tests/Calor.Compiler.Tests/Binding/DiagnosticSeedReachabilityTests.cs
+++ b/tests/Calor.Compiler.Tests/Binding/DiagnosticSeedReachabilityTests.cs
@@ -1,0 +1,73 @@
+using Calor.Compiler.Diagnostics;
+using Xunit;
+
+// Flat test namespace: see BinderDispatchCompletenessTests.
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// #762 required regression coverage (B8): "a diagnostic seed nested inside every
+/// expression wrapper and proof that it remains reachable." The seed is a literal
+/// division by zero; the proof is Calor0920 firing through the analyze pipeline with
+/// ReportOnlyVerified — i.e., the wrapper's bound node exposes the seed to traversals
+/// (BoundChildren.Of) and Z3 confirms it. A wrapper reverting to a zero-child opaque
+/// binding turns its row red.
+///
+/// Wrappers NOT here, each with its reason (the honest exclusion list):
+/// - Match-arm BODIES and lambda STATEMENT bodies: statement-level, reachable only
+///   through their nodes — the #786 consumer gap, pinned as current-state in the B6
+///   family tests.
+/// - SizeOf: no expression children (type-name only).
+/// - Interop (§CS / fallback): content is verbatim C# text, not Calor AST.
+/// - NullConditional: its single child is the target (member access has no
+///   expression argument to seed).
+/// </summary>
+public class DiagnosticSeedReachabilityTests
+{
+    public static IEnumerable<object[]> Wrappers()
+    {
+        yield return new object[] { "binary-operand", "§R (+ 1 (/ 10 0))" };
+        yield return new object[] { "coalesce-fallback", "§R (?? x (/ 10 0))" };
+        yield return new object[] { "implication-consequent", "§R (-> (> x 0) (== (/ 10 0) 1))" };
+        yield return new object[] { "forall-body", "§R (forall ((i i32)) (> (/ 10 0) i))" };
+        yield return new object[] { "exists-body", "§R (exists ((i i32)) (> (/ 10 0) i))" };
+        yield return new object[] { "some-payload", "§R §SM (/ 10 0)" };
+        yield return new object[] { "ok-payload", "§R §OK (/ 10 0)" };
+        yield return new object[] { "conversion-operand", "§R (as (/ 10 0) i64)" };
+        yield return new object[] { "await-operand", "§R §AWAIT (/ 10 0)" };
+        yield return new object[] { "lambda-expression-body", "§R §LAM{l1:y:i32} (/ 10 0) §/LAM{l1}" };
+        yield return new object[] { "bind-initializer", "§B{y:i32} (/ 10 0)\n    §R y" };
+        // Tier-B retained children (B8's D2 extractors): the wrapper stays incomplete
+        // (Calor0259) but the seed inside it must STILL reach the checker.
+        yield return new object[] { "addressof-operand", "§R §ADDR (/ 10 0)" };
+        yield return new object[] { "deref-operand", "§R §DEREF (/ 10 0)" };
+    }
+
+    [Theory]
+    [MemberData(nameof(Wrappers))]
+    public void SeedInsideWrapper_ReachesTheDivisionChecker(string wrapper, string statement)
+    {
+        var source = $$"""
+            §M{m001:Test}
+              §F{f001:Probe:pub} (i32:x) -> OBJECT
+                {{statement}}
+            """;
+
+        var result = Compiler.Program.Compile(source, "test.calr", new CompilationOptions
+        {
+            EnableVerificationAnalyses = true,
+            VerificationAnalysisOptions = new Compiler.Analysis.VerificationAnalysisOptions
+            {
+                BugPatternOptions = new Compiler.Analysis.BugPatterns.BugPatternOptions
+                {
+                    ReportOnlyVerified = true
+                }
+            }
+        });
+
+        Assert.True(
+            result.Diagnostics.Any(d => d.Code == DiagnosticCode.DivisionByZero),
+            $"Seed inside '{wrapper}' did not reach the division checker — its wrapper " +
+            "no longer exposes children to traversals. Diagnostics: " +
+            string.Join("; ", result.Diagnostics.Select(d => $"{d.Code}:{d.Message}")));
+    }
+}

--- a/tests/Calor.Compiler.Tests/Binding/DiagnosticSeedReachabilityTests.cs
+++ b/tests/Calor.Compiler.Tests/Binding/DiagnosticSeedReachabilityTests.cs
@@ -42,6 +42,35 @@ public class DiagnosticSeedReachabilityTests
         yield return new object[] { "deref-operand", "§R §DEREF (/ 10 0)" };
     }
 
+    [Fact]
+    public void UninitializedUseInsideTierBWrapper_ReachesTheDataflowAnalysis()
+    {
+        // #911 review F2: the division seed rows pin the CheckExpression +
+        // ContainsDivision arms only as a PAIR; the GetUsedVariables RetainedChildren
+        // arm needs its own discriminating consumer. An uninitialized local read
+        // inside §ADDR fires Calor0900 only if GetUsedVariables walks the retained
+        // children (revert that arm and this fails).
+        const string source = """
+            §M{m001:Test}
+              §F{f001:Probe:pub} () -> OBJECT
+                §B{~y:i32}
+                §R §ADDR y
+            """;
+
+        var result = Compiler.Program.Compile(source, "test.calr", new CompilationOptions
+        {
+            EnableVerificationAnalyses = true,
+        });
+
+        Assert.Contains(result.Diagnostics,
+            d => d.Code == DiagnosticCode.UninitializedVariable && d.Message.Contains("'y'"));
+        // #911 review F1 pin: the B8 severity promotion must reach THIS surface too —
+        // the analyze path re-reports the binder's 0259 with its original severity.
+        Assert.Contains(result.Diagnostics,
+            d => d.Code == DiagnosticCode.AnalysisIncomplete
+                && d.Severity == DiagnosticSeverity.Warning);
+    }
+
     [Theory]
     [MemberData(nameof(Wrappers))]
     public void SeedInsideWrapper_ReachesTheDivisionChecker(string wrapper, string statement)

--- a/tests/Calor.Compiler.Tests/CompilerBugFixTests.cs
+++ b/tests/Calor.Compiler.Tests/CompilerBugFixTests.cs
@@ -345,12 +345,14 @@ public class CompilerBugFixTests
         Assert.IsType<BoundIncompleteExpression>(ret.Expression);
         // The opaque call should NOT be mistaken for a zero literal
         Assert.False(BoundNodeHelpers.IsLiteralZero(ret.Expression));
-        // The fallback must not report ERRORS (the original noise complaint) — but it now
-        // reports exactly one Info-severity Calor0259, which IS the incomplete-fraction
-        // instrument. Both properties pinned.
+        // The fallback must not report ERRORS (the original noise complaint) — but it
+        // reports exactly one Calor0259, which IS the incomplete-fraction instrument.
+        // B1 shipped it at Info; B8 promoted it to Warning (scoping doc §5: Tier A
+        // incomplete is zero, so a warning finally means something). Both properties
+        // pinned.
         Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
         Assert.Contains(diagnostics,
-            d => d.Code == DiagnosticCode.AnalysisIncomplete && d.Severity == DiagnosticSeverity.Info);
+            d => d.Code == DiagnosticCode.AnalysisIncomplete && d.Severity == DiagnosticSeverity.Warning);
     }
 
     #endregion

--- a/tests/Calor.Compiler.Tests/ExpressionRegistrationTests.cs
+++ b/tests/Calor.Compiler.Tests/ExpressionRegistrationTests.cs
@@ -80,6 +80,28 @@ public class ExpressionRegistrationTests
     }
 
     [Fact]
+    public void CallHeader_DoesNotEatAFollowingBraceInitializerAsAttributes()
+    {
+        // #911 review F6: pre-fix, `§C{Sink} {1, 2} §/C` SILENTLY merged the brace
+        // group into the call header — Target became "Sink" + "1, 2" garbage with zero
+        // diagnostics. With maxGroups: 1 on the §C header, the brace group parses as a
+        // collection-initializer argument. (§B got the same fix with the OpenBrace
+        // unification; §W and §LAM headers are covered by the same one-group rule.)
+        const string source = """
+            §M{m:Test}
+              §F{f:Test:pub}
+                §O{object}
+                §C{Sink} {1, 2} §/C
+            """;
+        var diagnostics = new Calor.Compiler.Diagnostics.DiagnosticBag();
+        var tokens = new Lexer(source, diagnostics).TokenizeAllForParser().ToList();
+        var module = new Parser(tokens, diagnostics).Parse();
+        var call = Assert.IsType<CallStatementNode>(Assert.Single(Assert.Single(module.Functions).Body));
+        Assert.Equal("Sink", call.Target);
+        Assert.Single(call.Arguments);
+    }
+
+    [Fact]
     public void TestCasesCoverEveryRegisteredExpressionStartToken()
     {
         var property = typeof(Parser).GetProperty(

--- a/tests/Calor.Compiler.Tests/ExpressionRegistrationTests.cs
+++ b/tests/Calor.Compiler.Tests/ExpressionRegistrationTests.cs
@@ -1,0 +1,176 @@
+using System.Reflection;
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+public class ExpressionRegistrationTests
+{
+    public enum ExpressionContext
+    {
+        Return,
+        Binding,
+        CallArgument,
+        Nested,
+    }
+
+    private static readonly IReadOnlyDictionary<TokenKind, (string Source, string ExpectedType)> Cases =
+        new Dictionary<TokenKind, (string, string)>
+        {
+            [TokenKind.IntLiteral] = ("1", nameof(IntLiteralNode)),
+            [TokenKind.StrLiteral] = ("\"x\"", nameof(StringLiteralNode)),
+            [TokenKind.BoolLiteral] = ("true", nameof(BoolLiteralNode)),
+            [TokenKind.FloatLiteral] = ("1.5", nameof(FloatLiteralNode)),
+            [TokenKind.DecimalLiteral] = ("DEC:1.5", nameof(DecimalLiteralNode)),
+            [TokenKind.Identifier] = ("value", nameof(ReferenceNode)),
+            [TokenKind.OpenParen] = ("(+ 1 2)", nameof(BinaryOperationNode)),
+            [TokenKind.OpenBrace] = ("{1, 2}", nameof(ArrayCreationNode)),
+            [TokenKind.If] = ("§IF{i} true → 1 §EL → 2 §/I{i}", nameof(ConditionalExpressionNode)),
+            [TokenKind.Some] = ("§SM 1", nameof(SomeExpressionNode)),
+            [TokenKind.None] = ("§NN{i32}", nameof(NoneExpressionNode)),
+            [TokenKind.Ok] = ("§OK 1", nameof(OkExpressionNode)),
+            [TokenKind.Err] = ("§ERR \"error\"", nameof(ErrExpressionNode)),
+            [TokenKind.Match] = ("§W{w} value §K _ → 1 §/W{w}", nameof(MatchExpressionNode)),
+            [TokenKind.Record] = ("§D{Person} §FL{Name} \"Ada\"", nameof(RecordCreationNode)),
+            [TokenKind.Array] = ("§ARR{a:i32} §/ARR{a}", nameof(ArrayCreationNode)),
+            [TokenKind.Index] = ("§IDX values 0", nameof(ArrayAccessNode)),
+            [TokenKind.Length] = ("§LEN values", nameof(ArrayLengthNode)),
+            [TokenKind.List] = ("§LIST{l:i32} §/LIST{l}", nameof(ListCreationNode)),
+            [TokenKind.Dict] = ("§DICT{d:str:i32} §/DICT{d}", nameof(DictionaryCreationNode)),
+            [TokenKind.HashSet] = ("§HSET{s:i32} §/HSET{s}", nameof(SetCreationNode)),
+            [TokenKind.Has] = ("§HAS{values} 1", nameof(CollectionContainsNode)),
+            [TokenKind.Count] = ("§CNT{values}", nameof(CollectionCountNode)),
+            [TokenKind.Generic] = ("synthetic", nameof(GenericTypeNode)),
+            [TokenKind.New] = ("§NEW{object} §/NEW", nameof(NewExpressionNode)),
+            [TokenKind.AnonymousObject] = ("§ANON Name = \"Ada\" §/ANON", nameof(AnonymousObjectCreationNode)),
+            [TokenKind.This] = ("§THIS", nameof(ThisExpressionNode)),
+            [TokenKind.Base] = ("§BASE", nameof(BaseExpressionNode)),
+            [TokenKind.Call] = ("§C{GetValue} §/C", nameof(CallExpressionNode)),
+            [TokenKind.Lambda] = ("§LAM{l:x:i32} x §/LAM{l}", nameof(LambdaExpressionNode)),
+            [TokenKind.Await] = ("§AWAIT §C{GetValueAsync} §/C", nameof(AwaitExpressionNode)),
+            [TokenKind.Interpolate] = ("§INTERP \"x\" §/INTERP", nameof(InterpolatedStringNode)),
+            [TokenKind.NullCoalesce] = ("§?? value 0", nameof(NullCoalesceNode)),
+            [TokenKind.NullConditional] = ("§?. value Length", nameof(NullConditionalNode)),
+            [TokenKind.RangeOp] = ("§RANGE 1 2", nameof(RangeExpressionNode)),
+            [TokenKind.IndexEnd] = ("§^ 1", nameof(IndexFromEndNode)),
+            [TokenKind.With] = ("§WITH value §SET{Name} \"Ada\" §/WITH", nameof(WithExpressionNode)),
+            [TokenKind.StackAlloc] = ("§SALLOC{i32:4}", nameof(StackAllocNode)),
+            [TokenKind.AddressOf] = ("§ADDR value", nameof(AddressOfNode)),
+            [TokenKind.Deref] = ("§DEREF pointer", nameof(PointerDereferenceNode)),
+            [TokenKind.SizeOf] = ("§SIZEOF{i32}", nameof(SizeOfNode)),
+            [TokenKind.Array2D] = ("§ARR2D{a:grid:i32:2:2}", nameof(MultiDimArrayCreationNode)),
+            [TokenKind.Index2D] = ("§IDX2D grid 0 1", nameof(MultiDimArrayAccessNode)),
+            [TokenKind.Throw] = ("§TH §NEW{Exception} §/NEW", nameof(ThrowExpressionNode)),
+            [TokenKind.RawCSharpExpression] = ("§CS{DateTime.Now}", nameof(RawCSharpExpressionNode)),
+            [TokenKind.Hash] = ("#", nameof(SelfRefNode)),
+            [TokenKind.At] = ("@value", nameof(ReferenceNode)),
+        };
+
+    public static IEnumerable<object[]> RegisteredCases()
+    {
+        foreach (var (kind, expressionCase) in Cases.OrderBy(pair => pair.Key))
+        {
+            foreach (var context in Enum.GetValues<ExpressionContext>())
+            {
+                yield return new object[] { kind, expressionCase.Source, expressionCase.ExpectedType, context };
+            }
+        }
+    }
+
+    [Fact]
+    public void TestCasesCoverEveryRegisteredExpressionStartToken()
+    {
+        var property = typeof(Parser).GetProperty(
+            "RegisteredExpressionStartTokens",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        var registered = Assert.IsAssignableFrom<IEnumerable<TokenKind>>(property?.GetValue(null)).ToHashSet();
+
+        Assert.Equal(
+            registered.OrderBy(kind => kind),
+            Cases.Keys.OrderBy(kind => kind));
+    }
+
+    [Theory]
+    [MemberData(nameof(RegisteredCases))]
+    public void RegisteredExpressionStart_ParsesInEveryExpressionContext(
+        TokenKind kind,
+        string source,
+        string expectedType,
+        ExpressionContext context)
+    {
+        var expressionTokens = GetExpressionTokens(kind, source);
+        var module = ParseWithExpression(expressionTokens, context);
+        var expression = ExtractExpression(module, context);
+
+        Assert.Equal(expectedType, expression.GetType().Name);
+    }
+
+    private static IReadOnlyList<Token> GetExpressionTokens(TokenKind kind, string source)
+    {
+        if (kind == TokenKind.Generic)
+        {
+            return
+            [
+                new Token(TokenKind.Generic, "§G", TextSpan.Empty),
+                new Token(TokenKind.OpenBrace, "{", TextSpan.Empty),
+                new Token(TokenKind.Identifier, "List", TextSpan.Empty),
+                new Token(TokenKind.Colon, ":", TextSpan.Empty),
+                new Token(TokenKind.Identifier, "i32", TextSpan.Empty),
+                new Token(TokenKind.CloseBrace, "}", TextSpan.Empty),
+            ];
+        }
+
+        var diagnostics = new DiagnosticBag();
+        return new Lexer(source, diagnostics)
+            .TokenizeAllForParser()
+            .Where(token => token.Kind is not TokenKind.Eof and not TokenKind.Dedent)
+            .ToList();
+    }
+
+    private static ModuleNode ParseWithExpression(
+        IReadOnlyList<Token> expressionTokens,
+        ExpressionContext context)
+    {
+        var statement = context switch
+        {
+            ExpressionContext.Return => "§R __expression__",
+            ExpressionContext.Binding => "§B{x} __expression__",
+            ExpressionContext.CallArgument => "§C{Sink} §A __expression__ §/C",
+            ExpressionContext.Nested => "§R §SM __expression__",
+            _ => throw new ArgumentOutOfRangeException(nameof(context), context, null),
+        };
+        var source = $$"""
+            §M{m:Test}
+              §F{f:Test:pub}
+                §O{object}
+                {{statement}}
+            """;
+
+        var diagnostics = new DiagnosticBag();
+        var tokens = new Lexer(source, diagnostics).TokenizeAllForParser().ToList();
+        var marker = tokens.FindIndex(token =>
+            token.Kind == TokenKind.Identifier && token.Text == "__expression__");
+        Assert.True(marker >= 0);
+        tokens.RemoveAt(marker);
+        tokens.InsertRange(marker, expressionTokens);
+
+        return new Parser(tokens, diagnostics).Parse();
+    }
+
+    private static ExpressionNode ExtractExpression(ModuleNode module, ExpressionContext context)
+    {
+        var function = Assert.Single(module.Functions);
+        return context switch
+        {
+            ExpressionContext.Return => Assert.IsType<ReturnStatementNode>(Assert.Single(function.Body)).Expression!,
+            ExpressionContext.Binding => Assert.IsType<BindStatementNode>(Assert.Single(function.Body)).Initializer!,
+            ExpressionContext.CallArgument => Assert.Single(
+                Assert.IsType<CallStatementNode>(Assert.Single(function.Body)).Arguments),
+            ExpressionContext.Nested => Assert.IsType<SomeExpressionNode>(
+                Assert.IsType<ReturnStatementNode>(Assert.Single(function.Body)).Expression).Value,
+            _ => throw new ArgumentOutOfRangeException(nameof(context), context, null),
+        };
+    }
+}

--- a/tests/Calor.Compiler.Tests/Mcp/McpSerialCollection.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/McpSerialCollection.cs
@@ -8,6 +8,25 @@ namespace Calor.Compiler.Tests.Mcp;
 /// mitigation is running them serialized. Remove only with #897's root cause fixed.
 /// </summary>
 [CollectionDefinition("McpSerial", DisableParallelization = true)]
-public class McpSerialCollection
+public class McpSerialCollection : ICollectionFixture<McpMemoryHeadroomFixture>
 {
+}
+
+/// <summary>
+/// #897 second failure mode (first seen on the B8 CI run): the MCP server's
+/// memory-pressure breaker trips when the test HOST process is already holding the
+/// rest of the suite's garbage (observed: 8.5 GB used vs the ~8 GB threshold — the
+/// breaker measures the whole process, and thousands of preceding tests leave
+/// collectable heap behind). Forcing a full compacting collection before the MCP
+/// collection starts removes that inherited pressure deterministically instead of
+/// hoping the GC ran recently.
+/// </summary>
+public sealed class McpMemoryHeadroomFixture
+{
+    public McpMemoryHeadroomFixture()
+    {
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, blocking: true, compacting: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, blocking: true, compacting: true);
+    }
 }

--- a/tests/Calor.LanguageServer.Tests/State/DocumentStateTests.cs
+++ b/tests/Calor.LanguageServer.Tests/State/DocumentStateTests.cs
@@ -46,17 +46,17 @@ public class DocumentStateTests
     }
 
     [Fact]
-    public void Reanalyze_UnboundConstruct_PublishesInfoSeverityIncomplete_NotError()
+    public void Reanalyze_UnboundConstruct_PublishesWarningSeverityIncomplete_NotError()
     {
-        // #762 B1: the LSP binds every open document with the LIVE diagnostics bag, so
-        // the Calor0259 incomplete-fraction instrument is editor-visible. This pins the
-        // severity decision (scoping doc §5): Info until B8 — a document using a
-        // not-yet-bound construct must gain the instrument diagnostic WITHOUT errors,
-        // or every editor floods while the family PRs land.
-        // (Fixture has moved down the family sequence as each family binds: B6 retired
-        // null-coalesce, B7 retired the quantifier. Now a Tier B construct — §SIZEOF,
-        // unsafe/pointer family, out of 0.13 binding scope — so this holds until B8's
-        // closure decision, which owns re-pointing or retiring it.)
+        // #762 B1→B8: the LSP binds every open document with the LIVE diagnostics bag,
+        // so the Calor0259 incomplete-fraction instrument is editor-visible. B1 shipped
+        // it at Info (37 Tier A classes were incomplete — Warning would flood); B8
+        // promoted it to WARNING per the scoping-doc §5 decision: Tier A incomplete is
+        // zero on both F-2 legs, the only remaining emitters are Tier B unsafe
+        // residuals, and a warning on those genuinely means "analysis does not cover
+        // this construct". Still never an Error.
+        // (Fixture history: ?? → forall → §SIZEOF as each family bound; §SIZEOF is
+        // Tier B residual, so this holds unless a 0.14+ unsafe story binds it.)
         var source = """
             §M{m001:TestModule}
               §F{f001:Pick:pub} (i32:x) -> i32
@@ -70,7 +70,7 @@ public class DocumentStateTests
             d => d.Code == Compiler.Diagnostics.DiagnosticCode.AnalysisIncomplete).ToList();
         Assert.NotEmpty(incomplete);
         Assert.All(incomplete,
-            d => Assert.Equal(Compiler.Diagnostics.DiagnosticSeverity.Info, d.Severity));
+            d => Assert.Equal(Compiler.Diagnostics.DiagnosticSeverity.Warning, d.Severity));
     }
 
     [Fact(Skip = "Phase 4d: mismatched-ID diagnostic is obsolete under indent-only (no closing tags)")]


### PR DESCRIPTION
## Summary

Final PR of the #762 binder rebuild (B8 of B1–B8, per the [scoping doc](../blob/main/docs/plans/binder-rebuild-762-scoping.md)). Four commits, one per workstream cluster. Several designs are deliberately ported from PR #900 (the parallel full implementation) with attribution — the ExpressionParsers table, the `ParseAttributes(maxGroups)` companion fix, the item-8 visitor implementations, the DispatchProxy architecture test, and the token-context matrix test.

## What closes here

**Interop (Tier A closure).** `RawCSharpExpressionNode` / `FallbackExpressionNode` bind with verbatim content + stable `OBJECT` type + `IsInterop` marker (F-1's interop clause). Conversion-leg incomplete 21 → 17; **Tier A incomplete is now ZERO on both F-2 legs** — §2.5 **gate 1 measured green** (annotated in the roadmap; residuals published: 1 `SizeOfNode` in-repo, 17 `StackAllocNode` conversion, all Tier B).

**Item 8, full scope.** The seven non-expression no-op-Accept classes get real Visit dispatch in both interfaces and all five implementers; `GenericTypeNode` promotes to Tier A (binds structurally); `KeywordArgNode` is **reclassified out of the AST** (parser-internal value object — the no-op-Accept null-injection hazard is now unrepresentable, not merely guarded). The AstNode-wide architecture test (DispatchProxy + `GetUninitializedObject`) makes any future no-op Accept a CI failure. F-1 amendment recorded: denominator 61 → 60 (56 Tier A / 4 Tier B), subtractive-with-supersession argument in the freeze doc.

**D5 overload sets (items 5–6).** Top-level functions register in overload sets (previously a same-name second declaration *silently vanished* and every call resolved to the first). New: Calor0206 duplicate-signature Error at the declaration; Calor0207 arity-tie / Calor0208 no-arity-match Warnings at the call — resolution proceeds with the first declaration for bound-tree continuity, flagged, never silent. Order-independence pinned.

**Item 7 expression-start unification.** `ParseExpressionCore`'s 47-arm switch and `IsExpressionStart`'s hand-maintained list are now two projections of ONE static table. The measured pre-B8 disagreement: exactly `OpenBrace` (dispatchable, not start-classified) — brace collection initializers silently failed to parse in start-gated contexts; fixing it required the `ParseAttributes(maxGroups: 1)` companion so `§B{x} {1, 2}` doesn't eat the initializer as a header group. Token-context matrix: every registered token × return/bind/argument/nested (188 cases) + a completeness fact tying the case table to the registry.

**Diagnostic-seed suite (#762 required coverage).** A `/ 10 0` seed inside 13 wrappers proven to reach the division checker — including the Tier-B retained-children rows, which caught a real bug in this PR's own first draft: `BoundIncompleteExpression` matched checkers' `BoundCallExpression` arms before any `BoundChildren` default, so retained children were invisible. Four traversals now walk `RetainedChildren` explicitly. Honest exclusions documented (match-arm bodies / lambda statement bodies = #786 gap).

**Tier-B child extractors (D2).** The four unsafe classes stay incomplete (Calor0259 unchanged — the gate bar does not move) but their subtrees bind and ride on `BoundIncompleteExpression.RetainedChildren`, deferred-marked.

**Severity promotion (scoping doc §5's B8 decision).** Calor0259: Info → **Warning**. Tier A incomplete is zero, so a warning now genuinely means "analysis does not cover this construct" — only Tier B unsafe residuals emit it.

## #762 DoD checklist

| DoD bullet | Status |
|---|---|
| 100% of accepted expression kinds structurally bind | 56/56 Tier A bind; 4 Tier B residuals retain children + diagnostic (item-3 end state) |
| No silent zero-child `<unsupported:...>` | Calor0259 Warning + RetainedChildren; ratchet enforces |
| Stable type + retained evaluated children | Per-family bound nodes B2–B8 |
| Every concrete visitable AstNode dispatches exactly once | ArchitectureTests (AstNode-wide, this PR) |
| Overload resolution never silently falls back | Calor0206/0207/0208 (this PR) |
| Binder completeness measured in CI, cannot regress | Two-leg ratchet + dispatch completeness + matrix tests |

SymbolId population (item 9) was plumbed in B1; population-at-scale and consumers remain the roadmap's gates 3/4 work, not B8's.

Full suite: 7,607 tests green.

Part of #762 — closes the B1–B8 execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)