### PR TITLE
test(verify): add solver-runtime differential gate (#779)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/bench/phase0-agent-native/verifier-runtime-differential.json text eol=lf
+/bench/phase0-agent-native/verifier-runtime-differential.md text eol=lf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,27 @@ jobs:
             exit 1
           fi
 
+      # F-4 / #779: generated solver-vs-runtime differential. This blocking Fact
+      # fails rather than skips when Z3 is unavailable. It verifies the frozen
+      # modeled-form denominator across §Q, §S and §PROOF, depths 1..3 and both
+      # polarities, executes guard-forced generated C#, and byte-checks reports.
+      - name: Run verifier-runtime differential gate
+        run: >-
+          dotnet test tests/Calor.Verification.Tests/Calor.Verification.Tests.csproj
+          -c Release --no-build
+          --filter "FullyQualifiedName~VerifierRuntimeDifferentialTests.CommittedReportsMatchGeneratedOracle"
+          --verbosity normal
+
+      - name: Upload verifier-runtime differential metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verifier-runtime-differential
+          path: |
+            bench/phase0-agent-native/verifier-runtime-differential.json
+            bench/phase0-agent-native/verifier-runtime-differential.md
+          retention-days: 30
+
       # Spec drift (Phase 1 item 6, agent-native strategy): agent-facing docs
       # are machine-checked against the implementation, reusing this job's
       # build. Covered files: CLAUDE.md, every docs/syntax-reference/*.md, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ All notable changes to this project will be documented in this file.
   mislabeled cases, and pins fail-safe handling for unsupported, timeout, solver-error, unavailable,
   and assumed outcomes. CI blocks on zero mismatches and byte-checks published JSON/Markdown
   metrics. Coverage now requires decisive production solver outcomes, with only exact documented
-  assumption sets accepted. The field-access row now derives `Probe.Value: u8`, checks its `255`
-  upper bound, and executes a boundary witness, so the historical guessed-`i32` fallback produces
-  the wrong proof polarity and fails the gate instead of accidentally matching. Generated
-  assemblies are collectible, worktree `.git` files are supported, and report paths are LF-pinned.
-  Current coverage is 65/65 solver-handled forms and 1,170/1,170 solver-handled cells; 40/65 forms
-  currently elide.
+  assumption sets accepted. Field access now checks the full `u8` range `0..255`, with explicit
+  `i8` and `i32` mutation controls. Dotted references never guess missing fields as `i32`; the
+  module registry merges partial/nested declarations and includes accessible inherited instance
+  fields with exact types. Scalar and array-element rows now use width/signedness boundary
+  predicates and aligned runtime witnesses instead of self-equality, including an array-select
+  signedness regression pin. Generated assemblies are collectible, worktree `.git` files are
+  supported, and report paths are LF-pinned. Current coverage is 65/65 solver-handled forms and
+  1,170/1,170 solver-handled cells with zero mismatches; 40/65 forms currently elide.
 
 ### Changed
 - **The binder dispatches every expression class** (#762 B1): a single authoritative dispatch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ All notable changes to this project will be documented in this file.
   mislabeled cases, and pins fail-safe handling for unsupported, timeout, solver-error, unavailable,
   and assumed outcomes. CI blocks on zero mismatches and byte-checks published JSON/Markdown
   metrics. Coverage now requires decisive production solver outcomes, with only exact documented
-  assumption sets accepted. Module-derived field typing makes `Probe.Value` solver-handled instead
-  of unsupported; generated assemblies are collectible, worktree `.git` files are supported, and
-  report paths are LF-pinned. Current coverage is 65/65 solver-handled forms and 1,170/1,170
-  solver-handled cells; 40/65 forms currently elide.
+  assumption sets accepted. The field-access row now derives `Probe.Value: u8`, checks its `255`
+  upper bound, and executes a boundary witness, so the historical guessed-`i32` fallback produces
+  the wrong proof polarity and fails the gate instead of accidentally matching. Generated
+  assemblies are collectible, worktree `.git` files are supported, and report paths are LF-pinned.
+  Current coverage is 65/65 solver-handled forms and 1,170/1,170 solver-handled cells; 40/65 forms
+  currently elide.
 
 ### Changed
 - **The binder dispatches every expression class** (#762 B1): a single authoritative dispatch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Issue #779's residual verifier-vs-runtime differential gate (F-4)** now generates and executes
+  1,170 deterministic cases: all 65 frozen modeled forms × `§Q`/`§S`/explicit `§PROOF` × nesting
+  depths 1–3 × provable/refutable polarity. The oracle compiles guard-forced generated C#, covers
+  bounded-quantifier emitter lowering and the separate obligation-elision path, rejects vacuous or
+  mislabeled cases, and pins fail-safe handling for unsupported, timeout, solver-error, unavailable,
+  and assumed outcomes. CI blocks on zero mismatches and byte-checks published JSON/Markdown
+  metrics. Current coverage is 65/65 forms and 1,170/1,170 cells; 40/65 forms currently elide.
+
 ### Changed
 - **The binder dispatches every expression class** (#762 B1): a single authoritative dispatch
   table replaces the partial switch; expressions without a structural binder yet produce an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ All notable changes to this project will be documented in this file.
   bounded-quantifier emitter lowering and the separate obligation-elision path, rejects vacuous or
   mislabeled cases, and pins fail-safe handling for unsupported, timeout, solver-error, unavailable,
   and assumed outcomes. CI blocks on zero mismatches and byte-checks published JSON/Markdown
-  metrics. Current coverage is 65/65 forms and 1,170/1,170 cells; 40/65 forms currently elide.
+  metrics. Coverage now requires decisive production solver outcomes, with only exact documented
+  assumption sets accepted. Module-derived field typing makes `Probe.Value` solver-handled instead
+  of unsupported; generated assemblies are collectible, worktree `.git` files are supported, and
+  report paths are LF-pinned. Current coverage is 65/65 solver-handled forms and 1,170/1,170
+  solver-handled cells; 40/65 forms currently elide.
 
 ### Changed
 - **The binder dispatches every expression class** (#762 B1): a single authoritative dispatch

--- a/bench/phase0-agent-native/verifier-runtime-differential.json
+++ b/bench/phase0-agent-native/verifier-runtime-differential.json
@@ -38,7 +38,8 @@
     "scalar-type:u32": "The u32 row combines non-negativity with the wrap boundary of 3 * Int32.MaxValue; this distinguishes 32-bit unsigned arithmetic from u64 without requiring an out-of-model UInt32.MaxValue literal.",
     "scalar-type:u64": "The u64 row combines non-negativity with the non-wrapping result of 3 * Int32.MaxValue; it does not claim direct UInt64.MaxValue literal coverage.",
     "array-element-types": "Integer array rows apply the same per-type boundary predicates to values[0]. Runtime uses a non-null one-element array with the matching deterministic witness; proofs are therefore conditional only on the production nullable-reference-model assumption.",
-    "scalar-type:str": "The string row proves non-negative length using the non-null ASCII runtime witness \u0027ascii\u0027. The solver result remains explicitly conditional on the production string-model assumption; this does not claim nullable or non-ASCII equivalence."
+    "scalar-type:str": "The string row proves non-negative length using the non-null ASCII runtime witness \u0027ascii\u0027. The solver result remains explicitly conditional on the production string-model assumption; this does not claim nullable or non-ASCII equivalence.",
+    "string-comparison-mode:Ordinal": "The ordinal row uses the zero-width-joiner witness \u0027abc\u0027.StartsWith(\u0027\\u200dabc\u0027): false under Ordinal but true under en-US CurrentCulture. Provable and refutable cells use opposite polarities of that same predicate. Generated runtime is executed under en-US with ambient culture restored."
   },
   "forms": [
     {

--- a/bench/phase0-agent-native/verifier-runtime-differential.json
+++ b/bench/phase0-agent-native/verifier-runtime-differential.json
@@ -1,0 +1,1240 @@
+{
+  "schemaVersion": "1.0",
+  "registration": "F-4",
+  "whitelistSha256": "6dbdc9c0e1ec122ec1110013cb023ac51109ae5452b55ad00a0b782b471ec463",
+  "maximumNestingDepth": 3,
+  "positions": [
+    "precondition",
+    "postcondition",
+    "obligation"
+  ],
+  "polarities": [
+    "provable",
+    "refutable"
+  ],
+  "coverage": {
+    "formsWhitelisted": 65,
+    "formsApplicable": 65,
+    "formsCovered": 65,
+    "formsEliding": 40,
+    "formCoverageFraction": 1,
+    "elisionCoverageFraction": 0.615385,
+    "matrixCellsRegistered": 1170,
+    "matrixCellsCovered": 1170,
+    "matrixCoverageFraction": 1,
+    "casesGenerated": 1170,
+    "mismatches": 0
+  },
+  "outcomeCounts": {
+    "assumed": 144,
+    "proven": 432,
+    "refuted": 576,
+    "unsupported": 18
+  },
+  "encodingNotes": {
+    "expression-kind:SelfRefNode": "The harness binds \u0027#\u0027 to an i32 parameter named \u0027__self__\u0027 before translation; the emitter\u0027s existing SelfRef lowering targets the same generated parameter. This exercises the modeled refinement meaning without claiming ordinary source-level \u00A7Q/\u00A7S/\u00A7PROOF acceptance of an unbound \u0027#\u0027."
+  },
+  "forms": [
+    {
+      "id": "scalar-type:i8",
+      "category": "scalar-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "scalar-type:i16",
+      "category": "scalar-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "scalar-type:i32",
+      "category": "scalar-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "scalar-type:i64",
+      "category": "scalar-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "scalar-type:u8",
+      "category": "scalar-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "scalar-type:u16",
+      "category": "scalar-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "scalar-type:u32",
+      "category": "scalar-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "scalar-type:u64",
+      "category": "scalar-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "scalar-type:bool",
+      "category": "scalar-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "scalar-type:str",
+      "category": "scalar-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "array-element-type:i8",
+      "category": "array-element-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "array-element-type:i16",
+      "category": "array-element-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "array-element-type:i32",
+      "category": "array-element-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "array-element-type:i64",
+      "category": "array-element-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "array-element-type:u8",
+      "category": "array-element-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "array-element-type:u16",
+      "category": "array-element-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "array-element-type:u32",
+      "category": "array-element-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "array-element-type:u64",
+      "category": "array-element-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "expression-kind:IntLiteralNode",
+      "category": "expression-kind",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "expression-kind:BoolLiteralNode",
+      "category": "expression-kind",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "expression-kind:StringLiteralNode",
+      "category": "expression-kind",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "expression-kind:ReferenceNode",
+      "category": "expression-kind",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "expression-kind:BinaryOperationNode",
+      "category": "expression-kind",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "expression-kind:UnaryOperationNode",
+      "category": "expression-kind",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "expression-kind:ConditionalExpressionNode",
+      "category": "expression-kind",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "expression-kind:ForallExpressionNode",
+      "category": "expression-kind",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "expression-kind:ExistsExpressionNode",
+      "category": "expression-kind",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "expression-kind:ImplicationExpressionNode",
+      "category": "expression-kind",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "expression-kind:ArrayAccessNode",
+      "category": "expression-kind",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "expression-kind:ArrayLengthNode",
+      "category": "expression-kind",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "expression-kind:FieldAccessNode",
+      "category": "expression-kind",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "unsupported": 18
+      }
+    },
+    {
+      "id": "expression-kind:StringOperationNode",
+      "category": "expression-kind",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "expression-kind:SelfRefNode",
+      "category": "expression-kind",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:Add",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:Subtract",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:Multiply",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:Divide",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:Modulo",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:Equal",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:NotEqual",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:LessThan",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:LessOrEqual",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:GreaterThan",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:GreaterOrEqual",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:And",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:Or",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:BitwiseAnd",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:BitwiseOr",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:BitwiseXor",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:LeftShift",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "binary-operator:RightShift",
+      "category": "binary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "unary-operator:Not",
+      "category": "unary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "unary-operator:Negate",
+      "category": "unary-operator",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "string-operation:Length",
+      "category": "string-operation",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "string-operation:Contains",
+      "category": "string-operation",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "string-operation:StartsWith",
+      "category": "string-operation",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "string-operation:EndsWith",
+      "category": "string-operation",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "string-operation:Equals",
+      "category": "string-operation",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "string-operation:IsNullOrEmpty",
+      "category": "string-operation",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "string-operation:IndexOf",
+      "category": "string-operation",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "string-operation:Substring",
+      "category": "string-operation",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "string-operation:SubstringFrom",
+      "category": "string-operation",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "string-operation:Concat",
+      "category": "string-operation",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "string-comparison-mode:Ordinal",
+      "category": "string-comparison-mode",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": false,
+      "mismatches": 0,
+      "statuses": {
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
+      }
+    },
+    {
+      "id": "quantifier-bound-variable-type:declarable-alias",
+      "category": "quantifier-bound-variable-type",
+      "applicable": true,
+      "cases": 18,
+      "provableCases": 9,
+      "refutableCases": 9,
+      "preconditionCases": 6,
+      "postconditionCases": 6,
+      "obligationCases": 6,
+      "elides": true,
+      "mismatches": 0,
+      "statuses": {
+        "proven": 9,
+        "refuted": 9
+      }
+    }
+  ],
+  "failSafeControls": [
+    {
+      "channel": "postcondition",
+      "status": "unsupported",
+      "guardRetained": true,
+      "runtimeVerdict": "guardfailed",
+      "passed": true
+    },
+    {
+      "channel": "obligation",
+      "status": "unsupported",
+      "guardRetained": true,
+      "runtimeVerdict": "guardfailed",
+      "passed": true
+    },
+    {
+      "channel": "postcondition",
+      "status": "timeout",
+      "guardRetained": true,
+      "runtimeVerdict": "guardfailed",
+      "passed": true
+    },
+    {
+      "channel": "obligation",
+      "status": "timeout",
+      "guardRetained": true,
+      "runtimeVerdict": "guardfailed",
+      "passed": true
+    },
+    {
+      "channel": "postcondition",
+      "status": "unknown",
+      "guardRetained": true,
+      "runtimeVerdict": "guardfailed",
+      "passed": true
+    },
+    {
+      "channel": "obligation",
+      "status": "unknown",
+      "guardRetained": true,
+      "runtimeVerdict": "guardfailed",
+      "passed": true
+    },
+    {
+      "channel": "postcondition",
+      "status": "unavailable",
+      "guardRetained": true,
+      "runtimeVerdict": "guardfailed",
+      "passed": true
+    },
+    {
+      "channel": "obligation",
+      "status": "unavailable",
+      "guardRetained": true,
+      "runtimeVerdict": "guardfailed",
+      "passed": true
+    },
+    {
+      "channel": "postcondition",
+      "status": "assumed",
+      "guardRetained": true,
+      "runtimeVerdict": "guardfailed",
+      "passed": true
+    },
+    {
+      "channel": "obligation",
+      "status": "assumed",
+      "guardRetained": true,
+      "runtimeVerdict": "guardfailed",
+      "passed": true
+    }
+  ],
+  "mismatches": []
+}

--- a/bench/phase0-agent-native/verifier-runtime-differential.json
+++ b/bench/phase0-agent-native/verifier-runtime-differential.json
@@ -33,7 +33,7 @@
   },
   "encodingNotes": {
     "expression-kind:SelfRefNode": "The harness binds \u0027#\u0027 to an i32 parameter named \u0027__self__\u0027 before translation; the emitter\u0027s existing SelfRef lowering targets the same generated parameter. This exercises the modeled refinement meaning without claiming ordinary source-level \u00A7Q/\u00A7S/\u00A7PROOF acceptance of an unbound \u0027#\u0027.",
-    "expression-kind:FieldAccessNode": "The production contract pass and obligation solver derive field types from module class declarations. Probe.Value is translated as a typed uninterpreted accessor and executed against a generated Probe instance; proofs remain explicitly Assumed under the nullable-reference model."
+    "expression-kind:FieldAccessNode": "The production contract pass and obligation solver derive field types from module class declarations. Probe.Value is a u8 accessor checked against its 255 upper bound and executed at that boundary; the historical guessed-i32 fallback cannot prove the bound. Proofs remain explicitly Assumed under the nullable-reference model."
   },
   "forms": [
     {

--- a/bench/phase0-agent-native/verifier-runtime-differential.json
+++ b/bench/phase0-agent-native/verifier-runtime-differential.json
@@ -33,7 +33,12 @@
   },
   "encodingNotes": {
     "expression-kind:SelfRefNode": "The harness binds \u0027#\u0027 to an i32 parameter named \u0027__self__\u0027 before translation; the emitter\u0027s existing SelfRef lowering targets the same generated parameter. This exercises the modeled refinement meaning without claiming ordinary source-level \u00A7Q/\u00A7S/\u00A7PROOF acceptance of an unbound \u0027#\u0027.",
-    "expression-kind:FieldAccessNode": "The production contract pass and obligation solver derive field types from module class declarations. Probe.Value is a u8 accessor checked against its 255 upper bound and executed at that boundary; the historical guessed-i32 fallback cannot prove the bound. Proofs remain explicitly Assumed under the nullable-reference model."
+    "expression-kind:FieldAccessNode": "The production contract pass and obligation solver derive field types from module class declarations. Probe.Value is a u8 accessor checked against both bounds 0..255 and executed at 255; mapping it as i8 violates the lower bound and mapping it as i32 violates both finite bounds. Proofs remain explicitly Assumed under the nullable-reference model.",
+    "scalar-type:i64": "The translator models integer literals only through signed i32. The i64 row therefore uses signedness at -1 plus an i32-overflow boundary witness (2 * Int32.MaxValue) rather than claiming coverage of Int64.MinValue/MaxValue literals.",
+    "scalar-type:u32": "The u32 row combines non-negativity with the wrap boundary of 3 * Int32.MaxValue; this distinguishes 32-bit unsigned arithmetic from u64 without requiring an out-of-model UInt32.MaxValue literal.",
+    "scalar-type:u64": "The u64 row combines non-negativity with the non-wrapping result of 3 * Int32.MaxValue; it does not claim direct UInt64.MaxValue literal coverage.",
+    "array-element-types": "Integer array rows apply the same per-type boundary predicates to values[0]. Runtime uses a non-null one-element array with the matching deterministic witness; proofs are therefore conditional only on the production nullable-reference-model assumption.",
+    "scalar-type:str": "The string row proves non-negative length using the non-null ASCII runtime witness \u0027ascii\u0027. The solver result remains explicitly conditional on the production string-model assumption; this does not claim nullable or non-ASCII equivalence."
   },
   "forms": [
     {

--- a/bench/phase0-agent-native/verifier-runtime-differential.json
+++ b/bench/phase0-agent-native/verifier-runtime-differential.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.1",
   "registration": "F-4",
   "whitelistSha256": "6dbdc9c0e1ec122ec1110013cb023ac51109ae5452b55ad00a0b782b471ec463",
   "maximumNestingDepth": 3,
@@ -20,25 +20,28 @@
     "formCoverageFraction": 1,
     "elisionCoverageFraction": 0.615385,
     "matrixCellsRegistered": 1170,
+    "matrixCellsApplicable": 1170,
     "matrixCellsCovered": 1170,
     "matrixCoverageFraction": 1,
     "casesGenerated": 1170,
     "mismatches": 0
   },
   "outcomeCounts": {
-    "assumed": 144,
-    "proven": 432,
-    "refuted": 576,
-    "unsupported": 18
+    "assumed": 150,
+    "proven": 435,
+    "refuted": 585
   },
   "encodingNotes": {
-    "expression-kind:SelfRefNode": "The harness binds \u0027#\u0027 to an i32 parameter named \u0027__self__\u0027 before translation; the emitter\u0027s existing SelfRef lowering targets the same generated parameter. This exercises the modeled refinement meaning without claiming ordinary source-level \u00A7Q/\u00A7S/\u00A7PROOF acceptance of an unbound \u0027#\u0027."
+    "expression-kind:SelfRefNode": "The harness binds \u0027#\u0027 to an i32 parameter named \u0027__self__\u0027 before translation; the emitter\u0027s existing SelfRef lowering targets the same generated parameter. This exercises the modeled refinement meaning without claiming ordinary source-level \u00A7Q/\u00A7S/\u00A7PROOF acceptance of an unbound \u0027#\u0027.",
+    "expression-kind:FieldAccessNode": "The production contract pass and obligation solver derive field types from module class declarations. Probe.Value is translated as a typed uninterpreted accessor and executed against a generated Probe instance; proofs remain explicitly Assumed under the nullable-reference model."
   },
   "forms": [
     {
       "id": "scalar-type:i8",
       "category": "scalar-type",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -56,6 +59,8 @@
       "id": "scalar-type:i16",
       "category": "scalar-type",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -73,6 +78,8 @@
       "id": "scalar-type:i32",
       "category": "scalar-type",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -90,6 +97,8 @@
       "id": "scalar-type:i64",
       "category": "scalar-type",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -107,6 +116,8 @@
       "id": "scalar-type:u8",
       "category": "scalar-type",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -124,6 +135,8 @@
       "id": "scalar-type:u16",
       "category": "scalar-type",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -141,6 +154,8 @@
       "id": "scalar-type:u32",
       "category": "scalar-type",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -158,6 +173,8 @@
       "id": "scalar-type:u64",
       "category": "scalar-type",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -175,6 +192,8 @@
       "id": "scalar-type:bool",
       "category": "scalar-type",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -192,6 +211,10 @@
       "id": "scalar-type:str",
       "category": "scalar-type",
       "applicable": true,
+      "allowedAssumptions": [
+        "string-model \u2014 the solver\u0027s strings are total, non-null and UTF-8-byte-counted, while .NET\u0027s are nullable and UTF-16-code-unit-counted (D3/D12); a proof touching string semantics is conditional on the value being non-null and ASCII"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -210,6 +233,10 @@
       "id": "array-element-type:i8",
       "category": "array-element-type",
       "applicable": true,
+      "allowedAssumptions": [
+        "reference-model \u2014 the solver\u0027s arrays and user-type sorts are total and non-null, while .NET\u0027s are nullable references (D14); a proof touching them is conditional on the value being non-null"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -228,6 +255,10 @@
       "id": "array-element-type:i16",
       "category": "array-element-type",
       "applicable": true,
+      "allowedAssumptions": [
+        "reference-model \u2014 the solver\u0027s arrays and user-type sorts are total and non-null, while .NET\u0027s are nullable references (D14); a proof touching them is conditional on the value being non-null"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -246,6 +277,10 @@
       "id": "array-element-type:i32",
       "category": "array-element-type",
       "applicable": true,
+      "allowedAssumptions": [
+        "reference-model \u2014 the solver\u0027s arrays and user-type sorts are total and non-null, while .NET\u0027s are nullable references (D14); a proof touching them is conditional on the value being non-null"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -264,6 +299,10 @@
       "id": "array-element-type:i64",
       "category": "array-element-type",
       "applicable": true,
+      "allowedAssumptions": [
+        "reference-model \u2014 the solver\u0027s arrays and user-type sorts are total and non-null, while .NET\u0027s are nullable references (D14); a proof touching them is conditional on the value being non-null"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -282,6 +321,10 @@
       "id": "array-element-type:u8",
       "category": "array-element-type",
       "applicable": true,
+      "allowedAssumptions": [
+        "reference-model \u2014 the solver\u0027s arrays and user-type sorts are total and non-null, while .NET\u0027s are nullable references (D14); a proof touching them is conditional on the value being non-null"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -300,6 +343,10 @@
       "id": "array-element-type:u16",
       "category": "array-element-type",
       "applicable": true,
+      "allowedAssumptions": [
+        "reference-model \u2014 the solver\u0027s arrays and user-type sorts are total and non-null, while .NET\u0027s are nullable references (D14); a proof touching them is conditional on the value being non-null"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -318,6 +365,10 @@
       "id": "array-element-type:u32",
       "category": "array-element-type",
       "applicable": true,
+      "allowedAssumptions": [
+        "reference-model \u2014 the solver\u0027s arrays and user-type sorts are total and non-null, while .NET\u0027s are nullable references (D14); a proof touching them is conditional on the value being non-null"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -336,6 +387,10 @@
       "id": "array-element-type:u64",
       "category": "array-element-type",
       "applicable": true,
+      "allowedAssumptions": [
+        "reference-model \u2014 the solver\u0027s arrays and user-type sorts are total and non-null, while .NET\u0027s are nullable references (D14); a proof touching them is conditional on the value being non-null"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -354,6 +409,8 @@
       "id": "expression-kind:IntLiteralNode",
       "category": "expression-kind",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -371,6 +428,8 @@
       "id": "expression-kind:BoolLiteralNode",
       "category": "expression-kind",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -388,6 +447,10 @@
       "id": "expression-kind:StringLiteralNode",
       "category": "expression-kind",
       "applicable": true,
+      "allowedAssumptions": [
+        "string-model \u2014 the solver\u0027s strings are total, non-null and UTF-8-byte-counted, while .NET\u0027s are nullable and UTF-16-code-unit-counted (D3/D12); a proof touching string semantics is conditional on the value being non-null and ASCII"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -406,6 +469,8 @@
       "id": "expression-kind:ReferenceNode",
       "category": "expression-kind",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -423,6 +488,8 @@
       "id": "expression-kind:BinaryOperationNode",
       "category": "expression-kind",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -440,6 +507,8 @@
       "id": "expression-kind:UnaryOperationNode",
       "category": "expression-kind",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -457,6 +526,8 @@
       "id": "expression-kind:ConditionalExpressionNode",
       "category": "expression-kind",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -474,6 +545,8 @@
       "id": "expression-kind:ForallExpressionNode",
       "category": "expression-kind",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -491,6 +564,8 @@
       "id": "expression-kind:ExistsExpressionNode",
       "category": "expression-kind",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -508,6 +583,8 @@
       "id": "expression-kind:ImplicationExpressionNode",
       "category": "expression-kind",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -525,6 +602,10 @@
       "id": "expression-kind:ArrayAccessNode",
       "category": "expression-kind",
       "applicable": true,
+      "allowedAssumptions": [
+        "reference-model \u2014 the solver\u0027s arrays and user-type sorts are total and non-null, while .NET\u0027s are nullable references (D14); a proof touching them is conditional on the value being non-null"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -543,6 +624,10 @@
       "id": "expression-kind:ArrayLengthNode",
       "category": "expression-kind",
       "applicable": true,
+      "allowedAssumptions": [
+        "reference-model \u2014 the solver\u0027s arrays and user-type sorts are total and non-null, while .NET\u0027s are nullable references (D14); a proof touching them is conditional on the value being non-null"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -561,6 +646,10 @@
       "id": "expression-kind:FieldAccessNode",
       "category": "expression-kind",
       "applicable": true,
+      "allowedAssumptions": [
+        "reference-model \u2014 the solver\u0027s arrays and user-type sorts are total and non-null, while .NET\u0027s are nullable references (D14); a proof touching them is conditional on the value being non-null"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -570,13 +659,19 @@
       "elides": false,
       "mismatches": 0,
       "statuses": {
-        "unsupported": 18
+        "assumed": 6,
+        "proven": 3,
+        "refuted": 9
       }
     },
     {
       "id": "expression-kind:StringOperationNode",
       "category": "expression-kind",
       "applicable": true,
+      "allowedAssumptions": [
+        "string-model \u2014 the solver\u0027s strings are total, non-null and UTF-8-byte-counted, while .NET\u0027s are nullable and UTF-16-code-unit-counted (D3/D12); a proof touching string semantics is conditional on the value being non-null and ASCII"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -595,6 +690,8 @@
       "id": "expression-kind:SelfRefNode",
       "category": "expression-kind",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -612,6 +709,8 @@
       "id": "binary-operator:Add",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -629,6 +728,8 @@
       "id": "binary-operator:Subtract",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -646,6 +747,8 @@
       "id": "binary-operator:Multiply",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -663,6 +766,8 @@
       "id": "binary-operator:Divide",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -680,6 +785,8 @@
       "id": "binary-operator:Modulo",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -697,6 +804,8 @@
       "id": "binary-operator:Equal",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -714,6 +823,8 @@
       "id": "binary-operator:NotEqual",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -731,6 +842,8 @@
       "id": "binary-operator:LessThan",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -748,6 +861,8 @@
       "id": "binary-operator:LessOrEqual",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -765,6 +880,8 @@
       "id": "binary-operator:GreaterThan",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -782,6 +899,8 @@
       "id": "binary-operator:GreaterOrEqual",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -799,6 +918,8 @@
       "id": "binary-operator:And",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -816,6 +937,8 @@
       "id": "binary-operator:Or",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -833,6 +956,8 @@
       "id": "binary-operator:BitwiseAnd",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -850,6 +975,8 @@
       "id": "binary-operator:BitwiseOr",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -867,6 +994,8 @@
       "id": "binary-operator:BitwiseXor",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -884,6 +1013,8 @@
       "id": "binary-operator:LeftShift",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -901,6 +1032,8 @@
       "id": "binary-operator:RightShift",
       "category": "binary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -918,6 +1051,8 @@
       "id": "unary-operator:Not",
       "category": "unary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -935,6 +1070,8 @@
       "id": "unary-operator:Negate",
       "category": "unary-operator",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -952,6 +1089,10 @@
       "id": "string-operation:Length",
       "category": "string-operation",
       "applicable": true,
+      "allowedAssumptions": [
+        "string-model \u2014 the solver\u0027s strings are total, non-null and UTF-8-byte-counted, while .NET\u0027s are nullable and UTF-16-code-unit-counted (D3/D12); a proof touching string semantics is conditional on the value being non-null and ASCII"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -970,6 +1111,10 @@
       "id": "string-operation:Contains",
       "category": "string-operation",
       "applicable": true,
+      "allowedAssumptions": [
+        "string-model \u2014 the solver\u0027s strings are total, non-null and UTF-8-byte-counted, while .NET\u0027s are nullable and UTF-16-code-unit-counted (D3/D12); a proof touching string semantics is conditional on the value being non-null and ASCII"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -988,6 +1133,10 @@
       "id": "string-operation:StartsWith",
       "category": "string-operation",
       "applicable": true,
+      "allowedAssumptions": [
+        "string-model \u2014 the solver\u0027s strings are total, non-null and UTF-8-byte-counted, while .NET\u0027s are nullable and UTF-16-code-unit-counted (D3/D12); a proof touching string semantics is conditional on the value being non-null and ASCII"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -1006,6 +1155,10 @@
       "id": "string-operation:EndsWith",
       "category": "string-operation",
       "applicable": true,
+      "allowedAssumptions": [
+        "string-model \u2014 the solver\u0027s strings are total, non-null and UTF-8-byte-counted, while .NET\u0027s are nullable and UTF-16-code-unit-counted (D3/D12); a proof touching string semantics is conditional on the value being non-null and ASCII"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -1024,6 +1177,10 @@
       "id": "string-operation:Equals",
       "category": "string-operation",
       "applicable": true,
+      "allowedAssumptions": [
+        "string-model \u2014 the solver\u0027s strings are total, non-null and UTF-8-byte-counted, while .NET\u0027s are nullable and UTF-16-code-unit-counted (D3/D12); a proof touching string semantics is conditional on the value being non-null and ASCII"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -1042,6 +1199,10 @@
       "id": "string-operation:IsNullOrEmpty",
       "category": "string-operation",
       "applicable": true,
+      "allowedAssumptions": [
+        "string-model \u2014 the solver\u0027s strings are total, non-null and UTF-8-byte-counted, while .NET\u0027s are nullable and UTF-16-code-unit-counted (D3/D12); a proof touching string semantics is conditional on the value being non-null and ASCII"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -1060,6 +1221,10 @@
       "id": "string-operation:IndexOf",
       "category": "string-operation",
       "applicable": true,
+      "allowedAssumptions": [
+        "string-model \u2014 the solver\u0027s strings are total, non-null and UTF-8-byte-counted, while .NET\u0027s are nullable and UTF-16-code-unit-counted (D3/D12); a proof touching string semantics is conditional on the value being non-null and ASCII"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -1078,6 +1243,10 @@
       "id": "string-operation:Substring",
       "category": "string-operation",
       "applicable": true,
+      "allowedAssumptions": [
+        "string-model \u2014 the solver\u0027s strings are total, non-null and UTF-8-byte-counted, while .NET\u0027s are nullable and UTF-16-code-unit-counted (D3/D12); a proof touching string semantics is conditional on the value being non-null and ASCII"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -1096,6 +1265,10 @@
       "id": "string-operation:SubstringFrom",
       "category": "string-operation",
       "applicable": true,
+      "allowedAssumptions": [
+        "string-model \u2014 the solver\u0027s strings are total, non-null and UTF-8-byte-counted, while .NET\u0027s are nullable and UTF-16-code-unit-counted (D3/D12); a proof touching string semantics is conditional on the value being non-null and ASCII"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -1114,6 +1287,10 @@
       "id": "string-operation:Concat",
       "category": "string-operation",
       "applicable": true,
+      "allowedAssumptions": [
+        "string-model \u2014 the solver\u0027s strings are total, non-null and UTF-8-byte-counted, while .NET\u0027s are nullable and UTF-16-code-unit-counted (D3/D12); a proof touching string semantics is conditional on the value being non-null and ASCII"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -1132,6 +1309,10 @@
       "id": "string-comparison-mode:Ordinal",
       "category": "string-comparison-mode",
       "applicable": true,
+      "allowedAssumptions": [
+        "string-model \u2014 the solver\u0027s strings are total, non-null and UTF-8-byte-counted, while .NET\u0027s are nullable and UTF-16-code-unit-counted (D3/D12); a proof touching string semantics is conditional on the value being non-null and ASCII"
+      ],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -1150,6 +1331,8 @@
       "id": "quantifier-bound-variable-type:declarable-alias",
       "category": "quantifier-bound-variable-type",
       "applicable": true,
+      "allowedAssumptions": [],
+      "solverHandled": true,
       "cases": 18,
       "provableCases": 9,
       "refutableCases": 9,
@@ -1166,6 +1349,7 @@
   ],
   "failSafeControls": [
     {
+      "scenario": "unsupported",
       "channel": "postcondition",
       "status": "unsupported",
       "guardRetained": true,
@@ -1173,6 +1357,7 @@
       "passed": true
     },
     {
+      "scenario": "unsupported",
       "channel": "obligation",
       "status": "unsupported",
       "guardRetained": true,
@@ -1180,6 +1365,7 @@
       "passed": true
     },
     {
+      "scenario": "timeout",
       "channel": "postcondition",
       "status": "timeout",
       "guardRetained": true,
@@ -1187,6 +1373,7 @@
       "passed": true
     },
     {
+      "scenario": "timeout",
       "channel": "obligation",
       "status": "timeout",
       "guardRetained": true,
@@ -1194,6 +1381,7 @@
       "passed": true
     },
     {
+      "scenario": "solver-error",
       "channel": "postcondition",
       "status": "unknown",
       "guardRetained": true,
@@ -1201,6 +1389,7 @@
       "passed": true
     },
     {
+      "scenario": "solver-error",
       "channel": "obligation",
       "status": "unknown",
       "guardRetained": true,
@@ -1208,6 +1397,7 @@
       "passed": true
     },
     {
+      "scenario": "unavailable",
       "channel": "postcondition",
       "status": "unavailable",
       "guardRetained": true,
@@ -1215,6 +1405,7 @@
       "passed": true
     },
     {
+      "scenario": "unavailable",
       "channel": "obligation",
       "status": "unavailable",
       "guardRetained": true,
@@ -1222,6 +1413,7 @@
       "passed": true
     },
     {
+      "scenario": "assumed",
       "channel": "postcondition",
       "status": "assumed",
       "guardRetained": true,
@@ -1229,6 +1421,7 @@
       "passed": true
     },
     {
+      "scenario": "assumed",
       "channel": "obligation",
       "status": "assumed",
       "guardRetained": true,

--- a/bench/phase0-agent-native/verifier-runtime-differential.md
+++ b/bench/phase0-agent-native/verifier-runtime-differential.md
@@ -39,6 +39,7 @@
 - `scalar-type:u64` — The u64 row combines non-negativity with the non-wrapping result of 3 * Int32.MaxValue; it does not claim direct UInt64.MaxValue literal coverage.
 - `array-element-types` — Integer array rows apply the same per-type boundary predicates to values[0]. Runtime uses a non-null one-element array with the matching deterministic witness; proofs are therefore conditional only on the production nullable-reference-model assumption.
 - `scalar-type:str` — The string row proves non-negative length using the non-null ASCII runtime witness 'ascii'. The solver result remains explicitly conditional on the production string-model assumption; this does not claim nullable or non-ASCII equivalence.
+- `string-comparison-mode:Ordinal` — The ordinal row uses the zero-width-joiner witness 'abc'.StartsWith('\u200dabc'): false under Ordinal but true under en-US CurrentCulture. Provable and refutable cells use opposite polarities of that same predicate. Generated runtime is executed under en-US with ambient culture restored.
 
 ## Explicit Assumed allowances
 

--- a/bench/phase0-agent-native/verifier-runtime-differential.md
+++ b/bench/phase0-agent-native/verifier-runtime-differential.md
@@ -33,7 +33,12 @@
 ## Encoding notes
 
 - `expression-kind:SelfRefNode` — The harness binds '#' to an i32 parameter named '__self__' before translation; the emitter's existing SelfRef lowering targets the same generated parameter. This exercises the modeled refinement meaning without claiming ordinary source-level §Q/§S/§PROOF acceptance of an unbound '#'.
-- `expression-kind:FieldAccessNode` — The production contract pass and obligation solver derive field types from module class declarations. Probe.Value is a u8 accessor checked against its 255 upper bound and executed at that boundary; the historical guessed-i32 fallback cannot prove the bound. Proofs remain explicitly Assumed under the nullable-reference model.
+- `expression-kind:FieldAccessNode` — The production contract pass and obligation solver derive field types from module class declarations. Probe.Value is a u8 accessor checked against both bounds 0..255 and executed at 255; mapping it as i8 violates the lower bound and mapping it as i32 violates both finite bounds. Proofs remain explicitly Assumed under the nullable-reference model.
+- `scalar-type:i64` — The translator models integer literals only through signed i32. The i64 row therefore uses signedness at -1 plus an i32-overflow boundary witness (2 * Int32.MaxValue) rather than claiming coverage of Int64.MinValue/MaxValue literals.
+- `scalar-type:u32` — The u32 row combines non-negativity with the wrap boundary of 3 * Int32.MaxValue; this distinguishes 32-bit unsigned arithmetic from u64 without requiring an out-of-model UInt32.MaxValue literal.
+- `scalar-type:u64` — The u64 row combines non-negativity with the non-wrapping result of 3 * Int32.MaxValue; it does not claim direct UInt64.MaxValue literal coverage.
+- `array-element-types` — Integer array rows apply the same per-type boundary predicates to values[0]. Runtime uses a non-null one-element array with the matching deterministic witness; proofs are therefore conditional only on the production nullable-reference-model assumption.
+- `scalar-type:str` — The string row proves non-negative length using the non-null ASCII runtime witness 'ascii'. The solver result remains explicitly conditional on the production string-model assumption; this does not claim nullable or non-ASCII equivalence.
 
 ## Explicit Assumed allowances
 

--- a/bench/phase0-agent-native/verifier-runtime-differential.md
+++ b/bench/phase0-agent-native/verifier-runtime-differential.md
@@ -3,23 +3,23 @@
 - **Result:** PASS
 - **Whitelist hash:** `6dbdc9c0e1ec122ec1110013cb023ac51109ae5452b55ad00a0b782b471ec463`
 - **Mismatches:** 0
-- **Forms covered:** 65/65 (100.00%)
+- **Forms solver-handled:** 65/65 (100.00%)
 - **Forms eliding:** 40/65 (61.54%)
-- **Cartesian cells executed:** 1170/1170 (100.00%)
+- **Cartesian cells solver-handled:** 1170/1170 (100.00%)
+- **Cartesian cells registered:** 1170
 - **Generated cases:** 1170 (3 positions × depths 1–3 × 2 polarities per applicable form)
 
 ## Typed outcomes
 
 | Outcome | Cases |
 |---|---:|
-| `assumed` | 144 |
-| `proven` | 432 |
-| `refuted` | 576 |
-| `unsupported` | 18 |
+| `assumed` | 150 |
+| `proven` | 435 |
+| `refuted` | 585 |
 
 ## Coverage by category
 
-| Category | Whitelisted | Applicable | Covered | Eliding | Mismatches |
+| Category | Whitelisted | Applicable | Solver-handled | Eliding | Mismatches |
 |---|---:|---:|---:|---:|---:|
 | `array-element-type` | 8 | 8 | 8 | 0 | 0 |
 | `binary-operator` | 18 | 18 | 18 | 18 | 0 |
@@ -33,91 +33,122 @@
 ## Encoding notes
 
 - `expression-kind:SelfRefNode` — The harness binds '#' to an i32 parameter named '__self__' before translation; the emitter's existing SelfRef lowering targets the same generated parameter. This exercises the modeled refinement meaning without claiming ordinary source-level §Q/§S/§PROOF acceptance of an unbound '#'.
+- `expression-kind:FieldAccessNode` — The production contract pass and obligation solver derive field types from module class declarations. Probe.Value is translated as a typed uninterpreted accessor and executed against a generated Probe instance; proofs remain explicitly Assumed under the nullable-reference model.
+
+## Explicit Assumed allowances
+
+`Assumed` is accepted only for provable cells whose form lists the exact production assumption set below. Refutable cells must always be `Refuted`.
+
+- `scalar-type:str` — string-model
+- `array-element-type:i8` — reference-model
+- `array-element-type:i16` — reference-model
+- `array-element-type:i32` — reference-model
+- `array-element-type:i64` — reference-model
+- `array-element-type:u8` — reference-model
+- `array-element-type:u16` — reference-model
+- `array-element-type:u32` — reference-model
+- `array-element-type:u64` — reference-model
+- `expression-kind:StringLiteralNode` — string-model
+- `expression-kind:ArrayAccessNode` — reference-model
+- `expression-kind:ArrayLengthNode` — reference-model
+- `expression-kind:FieldAccessNode` — reference-model
+- `expression-kind:StringOperationNode` — string-model
+- `string-operation:Length` — string-model
+- `string-operation:Contains` — string-model
+- `string-operation:StartsWith` — string-model
+- `string-operation:EndsWith` — string-model
+- `string-operation:Equals` — string-model
+- `string-operation:IsNullOrEmpty` — string-model
+- `string-operation:IndexOf` — string-model
+- `string-operation:Substring` — string-model
+- `string-operation:SubstringFrom` — string-model
+- `string-operation:Concat` — string-model
+- `string-comparison-mode:Ordinal` — string-model
 
 ## Per-form coverage
 
-| Form | Cases | Pre | Post | Obligation | Elides | Mismatches |
-|---|---:|---:|---:|---:|:---:|---:|
-| `scalar-type:i8` | 18 | 6 | 6 | 6 | yes | 0 |
-| `scalar-type:i16` | 18 | 6 | 6 | 6 | yes | 0 |
-| `scalar-type:i32` | 18 | 6 | 6 | 6 | yes | 0 |
-| `scalar-type:i64` | 18 | 6 | 6 | 6 | yes | 0 |
-| `scalar-type:u8` | 18 | 6 | 6 | 6 | yes | 0 |
-| `scalar-type:u16` | 18 | 6 | 6 | 6 | yes | 0 |
-| `scalar-type:u32` | 18 | 6 | 6 | 6 | yes | 0 |
-| `scalar-type:u64` | 18 | 6 | 6 | 6 | yes | 0 |
-| `scalar-type:bool` | 18 | 6 | 6 | 6 | yes | 0 |
-| `scalar-type:str` | 18 | 6 | 6 | 6 | no | 0 |
-| `array-element-type:i8` | 18 | 6 | 6 | 6 | no | 0 |
-| `array-element-type:i16` | 18 | 6 | 6 | 6 | no | 0 |
-| `array-element-type:i32` | 18 | 6 | 6 | 6 | no | 0 |
-| `array-element-type:i64` | 18 | 6 | 6 | 6 | no | 0 |
-| `array-element-type:u8` | 18 | 6 | 6 | 6 | no | 0 |
-| `array-element-type:u16` | 18 | 6 | 6 | 6 | no | 0 |
-| `array-element-type:u32` | 18 | 6 | 6 | 6 | no | 0 |
-| `array-element-type:u64` | 18 | 6 | 6 | 6 | no | 0 |
-| `expression-kind:IntLiteralNode` | 18 | 6 | 6 | 6 | yes | 0 |
-| `expression-kind:BoolLiteralNode` | 18 | 6 | 6 | 6 | yes | 0 |
-| `expression-kind:StringLiteralNode` | 18 | 6 | 6 | 6 | no | 0 |
-| `expression-kind:ReferenceNode` | 18 | 6 | 6 | 6 | yes | 0 |
-| `expression-kind:BinaryOperationNode` | 18 | 6 | 6 | 6 | yes | 0 |
-| `expression-kind:UnaryOperationNode` | 18 | 6 | 6 | 6 | yes | 0 |
-| `expression-kind:ConditionalExpressionNode` | 18 | 6 | 6 | 6 | yes | 0 |
-| `expression-kind:ForallExpressionNode` | 18 | 6 | 6 | 6 | yes | 0 |
-| `expression-kind:ExistsExpressionNode` | 18 | 6 | 6 | 6 | yes | 0 |
-| `expression-kind:ImplicationExpressionNode` | 18 | 6 | 6 | 6 | yes | 0 |
-| `expression-kind:ArrayAccessNode` | 18 | 6 | 6 | 6 | no | 0 |
-| `expression-kind:ArrayLengthNode` | 18 | 6 | 6 | 6 | no | 0 |
-| `expression-kind:FieldAccessNode` | 18 | 6 | 6 | 6 | no | 0 |
-| `expression-kind:StringOperationNode` | 18 | 6 | 6 | 6 | no | 0 |
-| `expression-kind:SelfRefNode` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:Add` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:Subtract` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:Multiply` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:Divide` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:Modulo` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:Equal` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:NotEqual` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:LessThan` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:LessOrEqual` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:GreaterThan` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:GreaterOrEqual` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:And` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:Or` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:BitwiseAnd` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:BitwiseOr` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:BitwiseXor` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:LeftShift` | 18 | 6 | 6 | 6 | yes | 0 |
-| `binary-operator:RightShift` | 18 | 6 | 6 | 6 | yes | 0 |
-| `unary-operator:Not` | 18 | 6 | 6 | 6 | yes | 0 |
-| `unary-operator:Negate` | 18 | 6 | 6 | 6 | yes | 0 |
-| `string-operation:Length` | 18 | 6 | 6 | 6 | no | 0 |
-| `string-operation:Contains` | 18 | 6 | 6 | 6 | no | 0 |
-| `string-operation:StartsWith` | 18 | 6 | 6 | 6 | no | 0 |
-| `string-operation:EndsWith` | 18 | 6 | 6 | 6 | no | 0 |
-| `string-operation:Equals` | 18 | 6 | 6 | 6 | no | 0 |
-| `string-operation:IsNullOrEmpty` | 18 | 6 | 6 | 6 | no | 0 |
-| `string-operation:IndexOf` | 18 | 6 | 6 | 6 | no | 0 |
-| `string-operation:Substring` | 18 | 6 | 6 | 6 | no | 0 |
-| `string-operation:SubstringFrom` | 18 | 6 | 6 | 6 | no | 0 |
-| `string-operation:Concat` | 18 | 6 | 6 | 6 | no | 0 |
-| `string-comparison-mode:Ordinal` | 18 | 6 | 6 | 6 | no | 0 |
-| `quantifier-bound-variable-type:declarable-alias` | 18 | 6 | 6 | 6 | yes | 0 |
+| Form | Solver-handled | Cases | Pre | Post | Obligation | Elides | Mismatches |
+|---|:---:|---:|---:|---:|---:|:---:|---:|
+| `scalar-type:i8` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:i16` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:i32` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:i64` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:u8` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:u16` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:u32` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:u64` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:bool` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:str` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `array-element-type:i8` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `array-element-type:i16` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `array-element-type:i32` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `array-element-type:i64` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `array-element-type:u8` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `array-element-type:u16` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `array-element-type:u32` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `array-element-type:u64` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `expression-kind:IntLiteralNode` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:BoolLiteralNode` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:StringLiteralNode` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `expression-kind:ReferenceNode` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:BinaryOperationNode` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:UnaryOperationNode` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:ConditionalExpressionNode` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:ForallExpressionNode` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:ExistsExpressionNode` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:ImplicationExpressionNode` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:ArrayAccessNode` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `expression-kind:ArrayLengthNode` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `expression-kind:FieldAccessNode` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `expression-kind:StringOperationNode` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `expression-kind:SelfRefNode` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:Add` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:Subtract` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:Multiply` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:Divide` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:Modulo` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:Equal` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:NotEqual` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:LessThan` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:LessOrEqual` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:GreaterThan` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:GreaterOrEqual` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:And` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:Or` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:BitwiseAnd` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:BitwiseOr` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:BitwiseXor` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:LeftShift` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:RightShift` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `unary-operator:Not` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `unary-operator:Negate` | yes | 18 | 6 | 6 | 6 | yes | 0 |
+| `string-operation:Length` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:Contains` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:StartsWith` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:EndsWith` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:Equals` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:IsNullOrEmpty` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:IndexOf` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:Substring` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:SubstringFrom` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:Concat` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `string-comparison-mode:Ordinal` | yes | 18 | 6 | 6 | 6 | no | 0 |
+| `quantifier-bound-variable-type:declarable-alias` | yes | 18 | 6 | 6 | 6 | yes | 0 |
 
 ## Fail-safe controls
 
-| Channel | Typed status | Guard retained | Runtime | Result |
-|---|---|:---:|---|:---:|
-| postcondition | `unsupported` | yes | `guardfailed` | pass |
-| obligation | `unsupported` | yes | `guardfailed` | pass |
-| postcondition | `timeout` | yes | `guardfailed` | pass |
-| obligation | `timeout` | yes | `guardfailed` | pass |
-| postcondition | `unknown` | yes | `guardfailed` | pass |
-| obligation | `unknown` | yes | `guardfailed` | pass |
-| postcondition | `unavailable` | yes | `guardfailed` | pass |
-| obligation | `unavailable` | yes | `guardfailed` | pass |
-| postcondition | `assumed` | yes | `guardfailed` | pass |
-| obligation | `assumed` | yes | `guardfailed` | pass |
+| Scenario | Channel | Typed status | Guard retained | Runtime | Result |
+|---|---|---|:---:|---|:---:|
+| unsupported | postcondition | `unsupported` | yes | `guardfailed` | pass |
+| unsupported | obligation | `unsupported` | yes | `guardfailed` | pass |
+| timeout | postcondition | `timeout` | yes | `guardfailed` | pass |
+| timeout | obligation | `timeout` | yes | `guardfailed` | pass |
+| solver-error | postcondition | `unknown` | yes | `guardfailed` | pass |
+| solver-error | obligation | `unknown` | yes | `guardfailed` | pass |
+| unavailable | postcondition | `unavailable` | yes | `guardfailed` | pass |
+| unavailable | obligation | `unavailable` | yes | `guardfailed` | pass |
+| assumed | postcondition | `assumed` | yes | `guardfailed` | pass |
+| assumed | obligation | `assumed` | yes | `guardfailed` | pass |
 
 ## Oracle
 

--- a/bench/phase0-agent-native/verifier-runtime-differential.md
+++ b/bench/phase0-agent-native/verifier-runtime-differential.md
@@ -33,7 +33,7 @@
 ## Encoding notes
 
 - `expression-kind:SelfRefNode` — The harness binds '#' to an i32 parameter named '__self__' before translation; the emitter's existing SelfRef lowering targets the same generated parameter. This exercises the modeled refinement meaning without claiming ordinary source-level §Q/§S/§PROOF acceptance of an unbound '#'.
-- `expression-kind:FieldAccessNode` — The production contract pass and obligation solver derive field types from module class declarations. Probe.Value is translated as a typed uninterpreted accessor and executed against a generated Probe instance; proofs remain explicitly Assumed under the nullable-reference model.
+- `expression-kind:FieldAccessNode` — The production contract pass and obligation solver derive field types from module class declarations. Probe.Value is a u8 accessor checked against its 255 upper bound and executed at that boundary; the historical guessed-i32 fallback cannot prove the bound. Proofs remain explicitly Assumed under the nullable-reference model.
 
 ## Explicit Assumed allowances
 

--- a/bench/phase0-agent-native/verifier-runtime-differential.md
+++ b/bench/phase0-agent-native/verifier-runtime-differential.md
@@ -1,0 +1,125 @@
+# Verifier ↔ Generated Runtime Differential (F-4)
+
+- **Result:** PASS
+- **Whitelist hash:** `6dbdc9c0e1ec122ec1110013cb023ac51109ae5452b55ad00a0b782b471ec463`
+- **Mismatches:** 0
+- **Forms covered:** 65/65 (100.00%)
+- **Forms eliding:** 40/65 (61.54%)
+- **Cartesian cells executed:** 1170/1170 (100.00%)
+- **Generated cases:** 1170 (3 positions × depths 1–3 × 2 polarities per applicable form)
+
+## Typed outcomes
+
+| Outcome | Cases |
+|---|---:|
+| `assumed` | 144 |
+| `proven` | 432 |
+| `refuted` | 576 |
+| `unsupported` | 18 |
+
+## Coverage by category
+
+| Category | Whitelisted | Applicable | Covered | Eliding | Mismatches |
+|---|---:|---:|---:|---:|---:|
+| `array-element-type` | 8 | 8 | 8 | 0 | 0 |
+| `binary-operator` | 18 | 18 | 18 | 18 | 0 |
+| `expression-kind` | 15 | 15 | 15 | 10 | 0 |
+| `quantifier-bound-variable-type` | 1 | 1 | 1 | 1 | 0 |
+| `scalar-type` | 10 | 10 | 10 | 9 | 0 |
+| `string-comparison-mode` | 1 | 1 | 1 | 0 | 0 |
+| `string-operation` | 10 | 10 | 10 | 0 | 0 |
+| `unary-operator` | 2 | 2 | 2 | 2 | 0 |
+
+## Encoding notes
+
+- `expression-kind:SelfRefNode` — The harness binds '#' to an i32 parameter named '__self__' before translation; the emitter's existing SelfRef lowering targets the same generated parameter. This exercises the modeled refinement meaning without claiming ordinary source-level §Q/§S/§PROOF acceptance of an unbound '#'.
+
+## Per-form coverage
+
+| Form | Cases | Pre | Post | Obligation | Elides | Mismatches |
+|---|---:|---:|---:|---:|:---:|---:|
+| `scalar-type:i8` | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:i16` | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:i32` | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:i64` | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:u8` | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:u16` | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:u32` | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:u64` | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:bool` | 18 | 6 | 6 | 6 | yes | 0 |
+| `scalar-type:str` | 18 | 6 | 6 | 6 | no | 0 |
+| `array-element-type:i8` | 18 | 6 | 6 | 6 | no | 0 |
+| `array-element-type:i16` | 18 | 6 | 6 | 6 | no | 0 |
+| `array-element-type:i32` | 18 | 6 | 6 | 6 | no | 0 |
+| `array-element-type:i64` | 18 | 6 | 6 | 6 | no | 0 |
+| `array-element-type:u8` | 18 | 6 | 6 | 6 | no | 0 |
+| `array-element-type:u16` | 18 | 6 | 6 | 6 | no | 0 |
+| `array-element-type:u32` | 18 | 6 | 6 | 6 | no | 0 |
+| `array-element-type:u64` | 18 | 6 | 6 | 6 | no | 0 |
+| `expression-kind:IntLiteralNode` | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:BoolLiteralNode` | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:StringLiteralNode` | 18 | 6 | 6 | 6 | no | 0 |
+| `expression-kind:ReferenceNode` | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:BinaryOperationNode` | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:UnaryOperationNode` | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:ConditionalExpressionNode` | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:ForallExpressionNode` | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:ExistsExpressionNode` | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:ImplicationExpressionNode` | 18 | 6 | 6 | 6 | yes | 0 |
+| `expression-kind:ArrayAccessNode` | 18 | 6 | 6 | 6 | no | 0 |
+| `expression-kind:ArrayLengthNode` | 18 | 6 | 6 | 6 | no | 0 |
+| `expression-kind:FieldAccessNode` | 18 | 6 | 6 | 6 | no | 0 |
+| `expression-kind:StringOperationNode` | 18 | 6 | 6 | 6 | no | 0 |
+| `expression-kind:SelfRefNode` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:Add` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:Subtract` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:Multiply` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:Divide` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:Modulo` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:Equal` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:NotEqual` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:LessThan` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:LessOrEqual` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:GreaterThan` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:GreaterOrEqual` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:And` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:Or` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:BitwiseAnd` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:BitwiseOr` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:BitwiseXor` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:LeftShift` | 18 | 6 | 6 | 6 | yes | 0 |
+| `binary-operator:RightShift` | 18 | 6 | 6 | 6 | yes | 0 |
+| `unary-operator:Not` | 18 | 6 | 6 | 6 | yes | 0 |
+| `unary-operator:Negate` | 18 | 6 | 6 | 6 | yes | 0 |
+| `string-operation:Length` | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:Contains` | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:StartsWith` | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:EndsWith` | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:Equals` | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:IsNullOrEmpty` | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:IndexOf` | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:Substring` | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:SubstringFrom` | 18 | 6 | 6 | 6 | no | 0 |
+| `string-operation:Concat` | 18 | 6 | 6 | 6 | no | 0 |
+| `string-comparison-mode:Ordinal` | 18 | 6 | 6 | 6 | no | 0 |
+| `quantifier-bound-variable-type:declarable-alias` | 18 | 6 | 6 | 6 | yes | 0 |
+
+## Fail-safe controls
+
+| Channel | Typed status | Guard retained | Runtime | Result |
+|---|---|:---:|---|:---:|
+| postcondition | `unsupported` | yes | `guardfailed` | pass |
+| obligation | `unsupported` | yes | `guardfailed` | pass |
+| postcondition | `timeout` | yes | `guardfailed` | pass |
+| obligation | `timeout` | yes | `guardfailed` | pass |
+| postcondition | `unknown` | yes | `guardfailed` | pass |
+| obligation | `unknown` | yes | `guardfailed` | pass |
+| postcondition | `unavailable` | yes | `guardfailed` | pass |
+| obligation | `unavailable` | yes | `guardfailed` | pass |
+| postcondition | `assumed` | yes | `guardfailed` | pass |
+| obligation | `assumed` | yes | `guardfailed` | pass |
+
+## Oracle
+
+Every case is emitted twice. The runtime assembly is compiled from the guard-forced emission (`ElideProvenGuards = false`); the opt-in emission is inspected separately to measure actual postcondition/obligation elision. `proven`/`discharged` must execute without a guard failure, `refuted`/`failed` must fire the generated guard, and every non-decisive status must retain the guard. The generator also requires the declared target form to occur in every base expression and rejects vacuous proofs.
+

--- a/docs/plans/v0.13-freeze-registrations.md
+++ b/docs/plans/v0.13-freeze-registrations.md
@@ -218,19 +218,29 @@ landed; supersede-with-disclosure only:
   `#` to an `i32 __self__` solver/runtime parameter before translation, matching the emitter's
   existing `__self__` lowering. This covers the modeled meaning without claiming that an unbound
   `#` is ordinary source-valid syntax in `§Q`, `§S`, or `§PROOF`.
+- **Field-access encoding:** the production contract pass and obligation solver derive a typed
+  field registry from module classes. The `FieldAccessNode` row therefore translates
+  `Probe.Value: i32` and executes it, rather than counting 18 unsupported outcomes as coverage.
 - **Oracle and paths:** every case emits both guard-forced and opt-in C#. The guard-forced assembly
   is compiled with Roslyn and invoked; the opt-in emission is inspected to measure actual
   postcondition and obligation elision. Bounded `forall`/`exists` cases exercise emitter lowering
   (including D15's implication path), and explicit `ProofObligationNode` cases exercise the
   `ObligationStatus.Discharged` route. Target-presence and non-vacuity assertions prevent empty or
-  mislabeled rows.
+  mislabeled rows. Provable cells require `Proven`, refutable cells require `Refuted`, and
+  `Assumed` is accepted only for an exact per-form production assumption set published in the
+  report; all other non-decisive matrix statuses are uncovered.
 - **Fail-safe controls:** typed `Unsupported`, `Timeout`, solver-error `Unknown`, `Unavailable`, and
-  `Assumed` outcomes are injected at both postcondition and obligation emitter choke points; every
-  control must retain and fire its false runtime guard even with elision enabled.
+  `Assumed` outcomes reach both postcondition and obligation emitter choke points; timeout and
+  solver-error use the deterministic classifier shared by production `ProofOutcome.Assign`, while
+  the remaining controls use production evidence constructors. Every control must retain and fire
+  its false runtime guard even with elision enabled.
+- **Harness lifetime and portability:** generated assemblies use collectible load contexts and are
+  disposed/unloaded after execution. Repository discovery accepts `.git` directories and worktree
+  `.git` files; the two canonical report paths are LF-pinned in `.gitattributes`.
 - **Published reports:** `bench/phase0-agent-native/verifier-runtime-differential.{json,md}`.
-  Current result: **65/65 forms, 1,170/1,170 cells, 40/65 forms eliding (61.54%), zero
-  mismatches**. CI byte-checks both reports, so denominator or outcome movement must be reviewed
-  rather than silently changing the published fraction.
+  Current result: **65/65 forms solver-handled, 1,170/1,170 cells solver-handled, 40/65 forms
+  eliding (61.54%), zero mismatches**. CI byte-checks both reports, so denominator or outcome
+  movement must be reviewed rather than silently changing the published fraction.
 
 ---
 

--- a/docs/plans/v0.13-freeze-registrations.md
+++ b/docs/plans/v0.13-freeze-registrations.md
@@ -220,7 +220,9 @@ landed; supersede-with-disclosure only:
   `#` is ordinary source-valid syntax in `§Q`, `§S`, or `§PROOF`.
 - **Field-access encoding:** the production contract pass and obligation solver derive a typed
   field registry from module classes. The `FieldAccessNode` row therefore translates
-  `Probe.Value: i32` and executes it, rather than counting 18 unsupported outcomes as coverage.
+  `Probe.Value: u8`, proves its `255` upper bound, and executes a boundary witness. The historical
+  guessed-`i32` fallback has a counterexample, so reverting the module-derived registry fails the
+  differential rather than preserving the same polarity or merely reporting unsupported coverage.
 - **Oracle and paths:** every case emits both guard-forced and opt-in C#. The guard-forced assembly
   is compiled with Roslyn and invoked; the opt-in emission is inspected to measure actual
   postcondition and obligation elision. Bounded `forall`/`exists` cases exercise emitter lowering

--- a/docs/plans/v0.13-freeze-registrations.md
+++ b/docs/plans/v0.13-freeze-registrations.md
@@ -204,6 +204,34 @@ landed; supersede-with-disclosure only:
   elision is opt-in and this program's gate is existence + CI integration + published coverage
   (roadmap §2.5 gate 5).
 
+### F-4 implementation (2026-08-11)
+
+- **Instrument:** the `VerifierRuntimeDifferentialTests` xUnit fixture under
+  `tests/Calor.Verification.Tests`, run through a blocking filtered-test step in
+  `.github/workflows/test.yml`. A missing Z3 runtime is a failure, never a skip.
+- **Frozen denominator encoding:** 65 named forms derived bidirectionally from the generated
+  whitelist appendix: 10 scalar types, 8 array element types, 15 expression kinds, 18 binary
+  operators, 2 unary operators, 10 string operations, the ordinal-comparison rule, and one
+  declarable quantifier-type representative. Each form has all 18 registered cells:
+  3 positions × depths 1/2/3 × provable/refutable = **1,170 deterministic executions**.
+- **Self-reference encoding:** `SelfRefNode` is refinement-contextual. The harness explicitly binds
+  `#` to an `i32 __self__` solver/runtime parameter before translation, matching the emitter's
+  existing `__self__` lowering. This covers the modeled meaning without claiming that an unbound
+  `#` is ordinary source-valid syntax in `§Q`, `§S`, or `§PROOF`.
+- **Oracle and paths:** every case emits both guard-forced and opt-in C#. The guard-forced assembly
+  is compiled with Roslyn and invoked; the opt-in emission is inspected to measure actual
+  postcondition and obligation elision. Bounded `forall`/`exists` cases exercise emitter lowering
+  (including D15's implication path), and explicit `ProofObligationNode` cases exercise the
+  `ObligationStatus.Discharged` route. Target-presence and non-vacuity assertions prevent empty or
+  mislabeled rows.
+- **Fail-safe controls:** typed `Unsupported`, `Timeout`, solver-error `Unknown`, `Unavailable`, and
+  `Assumed` outcomes are injected at both postcondition and obligation emitter choke points; every
+  control must retain and fire its false runtime guard even with elision enabled.
+- **Published reports:** `bench/phase0-agent-native/verifier-runtime-differential.{json,md}`.
+  Current result: **65/65 forms, 1,170/1,170 cells, 40/65 forms eliding (61.54%), zero
+  mismatches**. CI byte-checks both reports, so denominator or outcome movement must be reviewed
+  rather than silently changing the published fraction.
+
 ---
 
 ## Registration inventory

--- a/docs/plans/v0.13-freeze-registrations.md
+++ b/docs/plans/v0.13-freeze-registrations.md
@@ -220,9 +220,17 @@ landed; supersede-with-disclosure only:
   `#` is ordinary source-valid syntax in `§Q`, `§S`, or `§PROOF`.
 - **Field-access encoding:** the production contract pass and obligation solver derive a typed
   field registry from module classes. The `FieldAccessNode` row therefore translates
-  `Probe.Value: u8`, proves its `255` upper bound, and executes a boundary witness. The historical
-  guessed-`i32` fallback has a counterexample, so reverting the module-derived registry fails the
-  differential rather than preserving the same polarity or merely reporting unsupported coverage.
+  `Probe.Value: u8`, proves both bounds `0..255`, and executes the `255` boundary witness. An `i8`
+  mutation violates non-negativity and an `i32` mutation admits out-of-range values. The same
+  production lookup merges partial/nested declarations, includes non-private inherited instance
+  fields on derived types, and explicitly refuses missing dotted fields rather than guessing.
+- **Scalar/array sort encoding:** integer scalar and array-element rows use width/signedness
+  boundary predicates, not `x == x`. Complete ranges cover 8-bit types; bounded existential
+  witnesses expose narrowing for 16-bit and `i32`; `i64`/`u32`/`u64` use signedness and arithmetic
+  around the `i32` overflow boundary because larger typed literals are outside the current model.
+  Array witnesses are non-null one-element arrays and retain the exact nullable-reference-model
+  assumption. The string row uses non-negative length with a non-null ASCII witness and retains the
+  exact string-model assumption; neither row overclaims nullable/non-ASCII equivalence.
 - **Oracle and paths:** every case emits both guard-forced and opt-in C#. The guard-forced assembly
   is compiled with Roslyn and invoked; the opt-in emission is inspected to measure actual
   postcondition and obligation elision. Bounded `forall`/`exists` cases exercise emitter lowering

--- a/docs/verification-runtime-differential.md
+++ b/docs/verification-runtime-differential.md
@@ -33,10 +33,21 @@ meaning without presenting unbound `#` as ordinary source-valid `§Q`/`§S`/`§P
 
 `FieldAccessNode` runs through the production module-derived type registry. The contract pass and
 obligation solver derive `Probe.Value: u8` from the generated class declaration and translate it as
-an 8-bit unsigned uninterpreted accessor. The generated predicate checks the `255` upper bound and
-executes with the runtime witness at that boundary. The registered `u8` sort makes the bound
-provable (or explicitly assumed under the nullable-reference model); the historical guessed-`i32`
-fallback leaves a counterexample and therefore fails the gate rather than accidentally matching.
+an 8-bit unsigned uninterpreted accessor. The generated predicate checks both bounds `0..255` and
+executes with the runtime witness at `255`. Mapping the field as `i8` violates non-negativity, while
+mapping it as `i32` admits values outside both finite bounds. Production dotted references use the
+same refusing lookup: nested/partial declarations are merged, accessible inherited instance fields
+are registered on derived types, and a missing field type is never guessed.
+
+Integer scalar and array-element rows use sort-discriminating boundary predicates rather than
+self-equality. The 8-bit rows use their complete ranges; 16-bit and `i32` rows add bounded
+existential boundary witnesses so narrowing is observable. The `i64`, `u32`, and `u64` rows use
+signedness plus arithmetic at the `i32` overflow boundary because integer literals above
+`Int32.MaxValue` are deliberately outside the translator's current model. They do not claim direct
+`Int64`/`UInt32`/`UInt64` extrema coverage. Array rows execute the same predicates against non-null
+one-element runtime arrays and remain explicitly conditional on the nullable-reference model.
+The string row uses non-negative length with a non-null ASCII witness and remains conditional on
+the documented string model.
 
 ## Oracle
 

--- a/docs/verification-runtime-differential.md
+++ b/docs/verification-runtime-differential.md
@@ -49,6 +49,14 @@ one-element runtime arrays and remain explicitly conditional on the nullable-ref
 The string row uses non-negative length with a non-null ASCII witness and remains conditional on
 the documented string model.
 
+The ordinal-comparison row uses the documented zero-width-joiner witness:
+`"abc".StartsWith("\u200dabc")` is `true` under `en-US` current-culture comparison but `false`
+under ordinal comparison. Its provable cell negates that predicate and its refutable cell uses the
+predicate directly, both with explicit `StringComparisonMode.Ordinal`. Generated runtime is
+executed under `en-US` and restores the ambient current and UI cultures after every invocation.
+A direct mutation control inspects the emitted `StringComparison.Ordinal` arguments, removes them
+to select the current-culture overload, and requires both runtime verdicts to reverse.
+
 ## Oracle
 
 The module is verified once through the contract pass and obligation solver, then emitted twice:
@@ -100,4 +108,5 @@ regenerate metrics intentionally, set
 `CALOR_UPDATE_VERIFIER_RUNTIME_DIFFERENTIAL_REPORTS=1` while running the same filtered test.
 Repository discovery accepts both a `.git` directory and a worktree `.git` file. The report paths
 are pinned to LF in `.gitattributes`, and generated assemblies run in collectible load contexts
-that are disposed and unloaded after each main or fail-safe execution.
+that are disposed and unloaded after each main or fail-safe execution. Runtime invocations use the
+controlled `en-US` culture and restore the caller's culture afterward.

--- a/docs/verification-runtime-differential.md
+++ b/docs/verification-runtime-differential.md
@@ -1,0 +1,75 @@
+# Verifier ↔ generated-runtime differential gate
+
+Issue #779's residual soundness gate is implemented by the
+`VerifierRuntimeDifferentialTests` xUnit fixture under `tests/Calor.Verification.Tests`. It
+deterministically compares typed solver outcomes with execution of the C# emitted from the same
+AST while runtime guards are forced on.
+
+## Frozen denominator
+
+The tool verifies the F-4 SHA-256 pin for `docs/verification-modeled-forms.md` before generating
+anything. It derives 65 named forms from the machine whitelist:
+
+| Category | Forms |
+|---|---:|
+| Scalar types | 10 |
+| Integer array element types | 8 |
+| Expression kinds | 15 |
+| Binary operators | 18 |
+| Unary operators | 2 |
+| String operations | 10 |
+| Ordinal comparison rule | 1 |
+| Declarable quantifier-type policy representative | 1 |
+
+Every form is generated in all three positions (`§Q`, `§S`, explicit `§PROOF`), at identity-wrapper
+depths 1, 2, and 3, and with both a true/provable and false/refutable polarity: **65 × 3 × 3 × 2 =
+1,170 cases**. The identity wrappers preserve the base predicate while exercising nested lowering.
+Every row asserts that its registered form actually occurs in the base AST.
+
+`SelfRefNode` needs a refinement binding. For that row only, the harness binds `#` to an
+`i32 __self__` parameter before solver translation; the generated C# uses the emitter's existing
+`__self__` lowering and receives the same runtime argument. This tests the modeled refinement
+meaning without presenting unbound `#` as ordinary source-valid `§Q`/`§S`/`§PROOF`.
+
+## Oracle
+
+The module is verified once through the contract pass and obligation solver, then emitted twice:
+
+1. **Guard-forced:** `ElideProvenGuards = false`; Roslyn compiles this C# in memory and every
+   generated method is invoked with a deterministic typed witness.
+2. **Elision-enabled:** `ElideProvenGuards = true`; method bodies are inspected to measure the
+   actual postcondition and `ObligationStatus.Discharged` elision routes. Preconditions must
+   always retain their guards.
+
+`Proven`/`Discharged` must complete at runtime; `Refuted`/`Failed` must fire the generated guard.
+`Assumed`, `Unsupported`, `Timeout`, `Unknown`, and `Unavailable` are fail-safe and may never
+elide. Synthetic typed fail-safe controls cover timeout and solver-error classifications
+deterministically at both elision choke points. Vacuous proofs, missing guards, unexpected runtime
+exceptions, stale reports, and whitelist drift fail the gate.
+
+Bounded `forall` and `exists` rows execute the emitter's LINQ lowering, including D15's full
+implication predicate. Explicit proof rows execute the separate obligation solver and emitter path.
+
+## Metrics and CI
+
+Machine-readable and human-readable reports are committed at:
+
+- `bench/phase0-agent-native/verifier-runtime-differential.json`
+- `bench/phase0-agent-native/verifier-runtime-differential.md`
+
+The report publishes forms covered, forms eliding, forms whitelisted, Cartesian-cell coverage,
+typed outcome counts, fail-safe controls, and mismatches. The current result is **65/65 forms,
+1,170/1,170 cells, 40/65 forms eliding (61.54%), and zero mismatches**.
+
+CI runs:
+
+```bash
+dotnet test tests/Calor.Verification.Tests/Calor.Verification.Tests.csproj \
+  -c Release --no-build \
+  --filter "FullyQualifiedName~VerifierRuntimeDifferentialTests.CommittedReportsMatchGeneratedOracle"
+```
+
+The test reruns the full oracle and byte-compares both committed reports. The step is blocking and
+uploads the reports as workflow artifacts; unavailable Z3 is a failure rather than a skip. To
+regenerate metrics intentionally, set
+`CALOR_UPDATE_VERIFIER_RUNTIME_DIFFERENTIAL_REPORTS=1` while running the same filtered test.

--- a/docs/verification-runtime-differential.md
+++ b/docs/verification-runtime-differential.md
@@ -32,8 +32,11 @@ Every row asserts that its registered form actually occurs in the base AST.
 meaning without presenting unbound `#` as ordinary source-valid `§Q`/`§S`/`§PROOF`.
 
 `FieldAccessNode` runs through the production module-derived type registry. The contract pass and
-obligation solver derive `Probe.Value: i32` from the generated class declaration, translate it as a
-typed uninterpreted accessor, and execute the same access on the generated `Probe` instance.
+obligation solver derive `Probe.Value: u8` from the generated class declaration and translate it as
+an 8-bit unsigned uninterpreted accessor. The generated predicate checks the `255` upper bound and
+executes with the runtime witness at that boundary. The registered `u8` sort makes the bound
+provable (or explicitly assumed under the nullable-reference model); the historical guessed-`i32`
+fallback leaves a counterexample and therefore fails the gate rather than accidentally matching.
 
 ## Oracle
 

--- a/docs/verification-runtime-differential.md
+++ b/docs/verification-runtime-differential.md
@@ -31,6 +31,10 @@ Every row asserts that its registered form actually occurs in the base AST.
 `__self__` lowering and receives the same runtime argument. This tests the modeled refinement
 meaning without presenting unbound `#` as ordinary source-valid `§Q`/`§S`/`§PROOF`.
 
+`FieldAccessNode` runs through the production module-derived type registry. The contract pass and
+obligation solver derive `Probe.Value: i32` from the generated class declaration, translate it as a
+typed uninterpreted accessor, and execute the same access on the generated `Probe` instance.
+
 ## Oracle
 
 The module is verified once through the contract pass and obligation solver, then emitted twice:
@@ -41,11 +45,17 @@ The module is verified once through the contract pass and obligation solver, the
    actual postcondition and `ObligationStatus.Discharged` elision routes. Preconditions must
    always retain their guards.
 
-`Proven`/`Discharged` must complete at runtime; `Refuted`/`Failed` must fire the generated guard.
-`Assumed`, `Unsupported`, `Timeout`, `Unknown`, and `Unavailable` are fail-safe and may never
-elide. Synthetic typed fail-safe controls cover timeout and solver-error classifications
-deterministically at both elision choke points. Vacuous proofs, missing guards, unexpected runtime
-exceptions, stale reports, and whitelist drift fail the gate.
+Provable cells must be `Proven` and refutable cells must be `Refuted`. A provable cell may instead
+be `Assumed` only when the form registers the exact production assumption set; the report publishes
+every such allowance. Unsupported, timeout, unknown, or unavailable matrix outcomes are not
+coverage. Runtime execution independently requires provable cases to complete and refutable cases
+to fire the generated guard.
+
+Fail-safe controls use the same deterministic status/reason/exception classifier as production
+`ProofOutcome.Assign`: timeout and solver-error controls no longer rehydrate injected statuses.
+Unsupported, unavailable, and assumed controls use their production evidence constructors. Every
+non-decisive status must retain and fire its false guard at both emitter choke points. Vacuous
+proofs, missing guards, unexpected runtime exceptions, stale reports, and whitelist drift fail.
 
 Bounded `forall` and `exists` rows execute the emitter's LINQ lowering, including D15's full
 implication predicate. Explicit proof rows execute the separate obligation solver and emitter path.
@@ -57,9 +67,10 @@ Machine-readable and human-readable reports are committed at:
 - `bench/phase0-agent-native/verifier-runtime-differential.json`
 - `bench/phase0-agent-native/verifier-runtime-differential.md`
 
-The report publishes forms covered, forms eliding, forms whitelisted, Cartesian-cell coverage,
-typed outcome counts, fail-safe controls, and mismatches. The current result is **65/65 forms,
-1,170/1,170 cells, 40/65 forms eliding (61.54%), and zero mismatches**.
+The report publishes solver-handled forms and cells, forms eliding, typed outcome counts, explicit
+`Assumed` allowances, fail-safe controls, and mismatches. The current result is **65/65 forms
+solver-handled, 1,170/1,170 cells solver-handled, 40/65 forms eliding (61.54%), and zero
+mismatches**. Outcomes are 435 `Proven`, 585 `Refuted`, and 150 explicitly allowed `Assumed`.
 
 CI runs:
 
@@ -73,3 +84,6 @@ The test reruns the full oracle and byte-compares both committed reports. The st
 uploads the reports as workflow artifacts; unavailable Z3 is a failure rather than a skip. To
 regenerate metrics intentionally, set
 `CALOR_UPDATE_VERIFIER_RUNTIME_DIFFERENTIAL_REPORTS=1` while running the same filtered test.
+Repository discovery accepts both a `.git` directory and a worktree `.git` file. The report paths
+are pinned to LF in `.gitattributes`, and generated assemblies run in collectible load contexts
+that are disposed and unloaded after each main or fail-safe execution.

--- a/src/Calor.Compiler/Verification/ContractVerificationPass.cs
+++ b/src/Calor.Compiler/Verification/ContractVerificationPass.cs
@@ -50,12 +50,16 @@ public sealed class ContractVerificationPass
     private ModuleVerificationResult VerifyCore(ModuleNode module)
     {
         var results = new List<FunctionVerificationResult>();
+        var userTypeRegistry = ContractTranslator.BuildUserTypeRegistry(module);
 
         using var ctx = Z3ContextFactory.Create();
-        using var verifier = new Z3Verifier(ctx, _options.TimeoutMs);
+        using var verifier = new Z3Verifier(ctx, _options.TimeoutMs, userTypeRegistry);
         // #778: the cache key/validity is solver-config-aware — pass the live timeout
         // so a cached Unproven from a smaller budget is not served to a larger one.
-        using var cache = new VerificationCache(_options.CacheOptions, _options.TimeoutMs);
+        using var cache = new VerificationCache(
+            _options.CacheOptions,
+            _options.TimeoutMs,
+            ContractTranslator.BuildUserTypeRegistryCacheScope(userTypeRegistry));
 
         foreach (var function in EnumerateContractBearers(module))
         {

--- a/src/Calor.Compiler/Verification/Obligations/ObligationSolver.cs
+++ b/src/Calor.Compiler/Verification/Obligations/ObligationSolver.cs
@@ -30,6 +30,7 @@ public sealed class ObligationSolver : IDisposable
     {
         // Build a lookup of function info for parameter declarations
         var functionInfo = BuildFunctionInfo(module);
+        var userTypeRegistry = ContractTranslator.BuildUserTypeRegistry(module);
 
         foreach (var obligation in tracker.Obligations)
         {
@@ -38,7 +39,7 @@ public sealed class ObligationSolver : IDisposable
 
             if (functionInfo.TryGetValue(obligation.FunctionId, out var info))
             {
-                SolveObligation(obligation, info);
+                SolveObligation(obligation, info, userTypeRegistry);
             }
             else
             {
@@ -48,11 +49,15 @@ public sealed class ObligationSolver : IDisposable
         }
     }
 
-    private void SolveObligation(Obligation obligation, FunctionInfo info)
+    private void SolveObligation(
+        Obligation obligation,
+        FunctionInfo info,
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> userTypeRegistry)
     {
         var sw = Stopwatch.StartNew();
 
         var translator = new ContractTranslator(_ctx);
+        translator.SetUserTypeRegistry(userTypeRegistry);
 
         // Declare all function parameters
         foreach (var (name, type) in info.Parameters)

--- a/src/Calor.Compiler/Verification/ProofOutcome.cs
+++ b/src/Calor.Compiler/Verification/ProofOutcome.cs
@@ -1,6 +1,9 @@
 using Calor.Compiler.Verification.Obligations;
 using Calor.Compiler.Verification.Z3;
 using Microsoft.Z3;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Calor.Verification.Tests")]
 
 namespace Calor.Compiler.Verification;
 
@@ -122,6 +125,7 @@ public readonly struct ProofEvidence
     internal string? ReasonUnknown { get; private init; }
     internal string? Detail { get; private init; }
     internal IReadOnlyList<string>? AssumptionList { get; private init; }
+    internal Exception? Exception { get; private init; }
 
     /// <summary>
     /// Captures a completed <c>solver.Check()</c>: the verdict, the model when SATISFIABLE,
@@ -152,7 +156,8 @@ public readonly struct ProofEvidence
     public static ProofEvidence SolverError(Z3Exception ex) => new()
     {
         Kind = EvidenceKind.SolverError,
-        Detail = $"Z3 solver error: {ex.Message}"
+        Detail = $"Z3 solver error: {ex.Message}",
+        Exception = ex
     };
 
     /// <summary>Captures a translation failure or undeclarable type.</summary>
@@ -290,33 +295,61 @@ public sealed class ProofOutcome
                 return new ProofOutcome(ProofStatus.Assumed, null, evidence.Detail, assumptions: evidence.AssumptionList);
 
             case ProofEvidence.EvidenceKind.SolverError:
-                return new ProofOutcome(ProofStatus.Unknown, null, evidence.Detail);
+                return evidence.Exception is not null
+                    ? ClassifySolverException(evidence.Exception)
+                    : new ProofOutcome(ProofStatus.Unknown, null, evidence.Detail);
 
             case ProofEvidence.EvidenceKind.SolverUnavailable:
                 return new ProofOutcome(ProofStatus.Unavailable, null, evidence.Detail);
 
             case ProofEvidence.EvidenceKind.SolverVerdict:
-                switch (evidence.Check)
-                {
-                    case Microsoft.Z3.Status.UNSATISFIABLE:
-                        return evidence.Polarity == SatPolarity.SatIsProof
-                            ? new ProofOutcome(ProofStatus.Refuted, null, evidence.Detail)
-                            : new ProofOutcome(ProofStatus.Proven, null, null);
-
-                    case Microsoft.Z3.Status.SATISFIABLE:
-                        return evidence.Polarity == SatPolarity.SatIsRefutation
-                            ? new ProofOutcome(ProofStatus.Refuted, evidence.Model, evidence.Detail)
-                            : new ProofOutcome(ProofStatus.Proven, null, null);
-
-                    default:
-                        return IsTimeoutReason(evidence.ReasonUnknown)
-                            ? new ProofOutcome(ProofStatus.Timeout, null, evidence.ReasonUnknown)
-                            : new ProofOutcome(ProofStatus.Unknown, null, evidence.ReasonUnknown);
-                }
+                return ClassifySolverStatus(
+                    evidence.Check,
+                    evidence.Polarity,
+                    evidence.Model,
+                    evidence.ReasonUnknown,
+                    evidence.Detail);
 
             default:
                 return new ProofOutcome(ProofStatus.Unknown, null, evidence.Detail);
         }
+    }
+
+    /// <summary>
+    /// Deterministic solver-boundary classification used by production evidence assignment
+    /// and by tests that must exercise timeout/error policy without relying on a flaky timeout.
+    /// </summary>
+    internal static ProofOutcome ClassifySolverStatus(
+        Status status,
+        SatPolarity polarity,
+        Counterexample? counterexample = null,
+        string? reasonUnknown = null,
+        string? unsatNote = null)
+    {
+        return status switch
+        {
+            Microsoft.Z3.Status.UNSATISFIABLE => polarity == SatPolarity.SatIsProof
+                ? new ProofOutcome(ProofStatus.Refuted, null, unsatNote)
+                : new ProofOutcome(ProofStatus.Proven, null, null),
+            Microsoft.Z3.Status.SATISFIABLE => polarity == SatPolarity.SatIsRefutation
+                ? new ProofOutcome(ProofStatus.Refuted, counterexample, null)
+                : new ProofOutcome(ProofStatus.Proven, null, null),
+            _ => IsTimeoutReason(reasonUnknown)
+                ? new ProofOutcome(ProofStatus.Timeout, null, reasonUnknown)
+                : new ProofOutcome(ProofStatus.Unknown, null, reasonUnknown)
+        };
+    }
+
+    /// <summary>
+    /// Deterministic exception classification shared by every production Z3 catch path.
+    /// </summary>
+    internal static ProofOutcome ClassifySolverException(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        return new ProofOutcome(
+            ProofStatus.Unknown,
+            null,
+            $"Z3 solver error: {exception.Message}");
     }
 
     private static bool IsTimeoutReason(string? reasonUnknown)

--- a/src/Calor.Compiler/Verification/Z3/Cache/VerificationCache.cs
+++ b/src/Calor.Compiler/Verification/Z3/Cache/VerificationCache.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using Calor.Compiler.Ast;
 
@@ -13,6 +15,7 @@ public sealed class VerificationCache : IDisposable
     private readonly ContractHasher _hasher;
     private readonly string _cacheDirectory;
     private readonly string? _z3Version;
+    private readonly string? _keyScope;
     // #778: semantics-versioned, solver-config-aware keys.
     private readonly string _semanticsVersion = Incremental.BuildStateCache.CurrentCompilerSemanticsVersion;
     private readonly uint? _solverTimeoutMs;
@@ -35,10 +38,14 @@ public sealed class VerificationCache : IDisposable
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    public VerificationCache(VerificationCacheOptions options, uint? solverTimeoutMs = null)
+    public VerificationCache(
+        VerificationCacheOptions options,
+        uint? solverTimeoutMs = null,
+        string? keyScope = null)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _solverTimeoutMs = solverTimeoutMs;
+        _keyScope = keyScope;
         _hasher = new ContractHasher();
         _cacheDirectory = options.GetCacheDirectory();
         _z3Version = Z3ContextFactory.GetZ3Version();
@@ -73,6 +80,7 @@ public sealed class VerificationCache : IDisposable
             hash = _hasher.HashPrecondition(parameters, precondition);
             if (_hasher.SawUnhashedKind)
                 return false; // #778: key is not collision-safe — never serve under it
+            hash = ApplyKeyScope(hash);
         }
         return TryGetCachedResult(hash, out result);
     }
@@ -99,6 +107,7 @@ public sealed class VerificationCache : IDisposable
             hash = _hasher.HashPostcondition(parameters, outputType, preconditions, postcondition, body);
             if (_hasher.SawUnhashedKind)
                 return false; // #778: key is not collision-safe — never serve under it
+            hash = ApplyKeyScope(hash);
         }
         return TryGetCachedResult(hash, out result);
     }
@@ -125,6 +134,7 @@ public sealed class VerificationCache : IDisposable
             hash = _hasher.HashPrecondition(parameters, precondition);
             if (_hasher.SawUnhashedKind)
                 return; // #778: key is not collision-safe — never store under it
+            hash = ApplyKeyScope(hash);
         }
         CacheResult(hash, result);
     }
@@ -154,6 +164,7 @@ public sealed class VerificationCache : IDisposable
             hash = _hasher.HashPostcondition(parameters, outputType, preconditions, postcondition, body);
             if (_hasher.SawUnhashedKind)
                 return; // #778: key is not collision-safe — never store under it
+            hash = ApplyKeyScope(hash);
         }
         CacheResult(hash, result);
     }
@@ -289,6 +300,16 @@ public sealed class VerificationCache : IDisposable
         {
             Interlocked.Increment(ref _errors);
         }
+    }
+
+    private string ApplyKeyScope(string hash)
+    {
+        if (string.IsNullOrEmpty(_keyScope))
+            return hash;
+
+        return Convert.ToHexString(
+                SHA256.HashData(Encoding.UTF8.GetBytes($"{_keyScope}\n{hash}")))
+            .ToLowerInvariant();
     }
 
     /// <summary>

--- a/src/Calor.Compiler/Verification/Z3/ContractTranslator.cs
+++ b/src/Calor.Compiler/Verification/Z3/ContractTranslator.cs
@@ -93,8 +93,7 @@ public sealed class ContractTranslator
     /// <summary>
     /// Z3 uninterpreted function declarations for field accessors on user-defined types,
     /// keyed by (type-name, field-name). Created on demand when a FieldAccessNode is
-    /// translated. The result type is the field's declared Calor type when known, or
-    /// signed 32-bit bit-vector as a default fallback.
+    /// translated. The result type is the field's declared Calor type from the module registry.
     /// </summary>
     private readonly Dictionary<(string TypeName, string FieldName), FuncDecl> _fieldAccessors = new();
 
@@ -146,12 +145,66 @@ public sealed class ContractTranslator
 
     /// <summary>
     /// Registers a map of class type-name → (field-name → field-type) so that
-    /// FieldAccess translation can produce correctly-typed Z3 functions. Pass null
-    /// (or omit the call) to fall back to default-typed accessors.
+    /// FieldAccess translation can produce correctly-typed Z3 functions. Missing entries
+    /// are refused rather than modeled at a guessed width.
     /// </summary>
     public void SetUserTypeRegistry(IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>>? registry)
     {
         _userTypeRegistry = registry;
+    }
+
+    /// <summary>
+    /// Builds the field-type registry used by field-access translation from the module's
+    /// class declarations. Partial declarations are merged and nested classes are included.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>>
+        BuildUserTypeRegistry(ModuleNode module)
+    {
+        ArgumentNullException.ThrowIfNull(module);
+
+        var fieldMaps = new Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal);
+        foreach (var cls in EnumerateClasses(module.Classes))
+        {
+            var typeName = NormalizeTypeName(cls.Name);
+            if (!fieldMaps.TryGetValue(typeName, out var fields))
+            {
+                fields = new Dictionary<string, string>(StringComparer.Ordinal);
+                fieldMaps[typeName] = fields;
+            }
+
+            foreach (var field in cls.Fields)
+                fields[field.Name] = field.TypeName;
+        }
+
+        return fieldMaps.ToDictionary(
+            pair => pair.Key,
+            pair => (IReadOnlyDictionary<string, string>)pair.Value,
+            StringComparer.Ordinal);
+    }
+
+    internal static string BuildUserTypeRegistryCacheScope(
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> registry)
+    {
+        return string.Join(
+            "|",
+            registry.OrderBy(type => type.Key, StringComparer.Ordinal).Select(type =>
+                $"{type.Key.Length}#{type.Key}:" +
+                string.Join(
+                    ",",
+                    type.Value.OrderBy(field => field.Key, StringComparer.Ordinal)
+                        .Select(field =>
+                            $"{field.Key.Length}#{field.Key}={field.Value.Length}#{field.Value}"))));
+    }
+
+    private static IEnumerable<ClassDefinitionNode> EnumerateClasses(
+        IEnumerable<ClassDefinitionNode> classes)
+    {
+        foreach (var cls in classes)
+        {
+            yield return cls;
+            foreach (var nested in EnumerateClasses(cls.NestedClasses))
+                yield return nested;
+        }
     }
 
     /// <summary>
@@ -1487,9 +1540,8 @@ public sealed class ContractTranslator
     /// <summary>
     /// Translates a field-access expression on a user-defined-type value: obj.Field.
     /// Models the field as an uninterpreted Z3 function on the object's sort. The
-    /// function's result sort comes from the user-type registry (when supplied) or
-    /// defaults to signed 32-bit bit-vector. One function per (type, field) pair,
-    /// shared across all expressions referencing the same field.
+    /// function's result sort comes from the required user-type registry. One function
+    /// per (type, field) pair is shared across all expressions referencing the same field.
     /// </summary>
     private Expr? TranslateFieldAccess(FieldAccessNode node)
     {

--- a/src/Calor.Compiler/Verification/Z3/ContractTranslator.cs
+++ b/src/Calor.Compiler/Verification/Z3/ContractTranslator.cs
@@ -155,31 +155,110 @@ public sealed class ContractTranslator
 
     /// <summary>
     /// Builds the field-type registry used by field-access translation from the module's
-    /// class declarations. Partial declarations are merged and nested classes are included.
+    /// class declarations. Partial declarations are merged, nested classes are qualified,
+    /// and derived types include inherited non-private instance fields.
     /// </summary>
     internal static IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>>
         BuildUserTypeRegistry(ModuleNode module)
     {
         ArgumentNullException.ThrowIfNull(module);
 
-        var fieldMaps = new Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal);
-        foreach (var cls in EnumerateClasses(module.Classes))
+        var declarations = EnumerateClasses(module.Classes)
+            .GroupBy(entry => entry.QualifiedName, StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(entry => entry.Class).ToList(),
+                StringComparer.Ordinal);
+        var declaredTypeNames = declarations.Keys.ToHashSet(StringComparer.Ordinal);
+        var directFields =
+            new Dictionary<string, Dictionary<string, RegisteredField>>(StringComparer.Ordinal);
+        var baseTypes = new Dictionary<string, string?>(StringComparer.Ordinal);
+
+        foreach (var (typeName, partials) in declarations)
         {
-            var typeName = NormalizeTypeName(cls.Name);
-            if (!fieldMaps.TryGetValue(typeName, out var fields))
+            var fields = new Dictionary<string, RegisteredField>(StringComparer.Ordinal);
+            foreach (var fieldGroup in partials
+                         .SelectMany(cls => cls.Fields)
+                         .GroupBy(field => field.Name, StringComparer.Ordinal))
             {
-                fields = new Dictionary<string, string>(StringComparer.Ordinal);
-                fieldMaps[typeName] = fields;
+                var candidates = fieldGroup
+                    .Select(field => new RegisteredField(
+                        NormalizeTypeName(field.TypeName),
+                        field.Visibility,
+                        field.IsStatic))
+                    .Distinct()
+                    .ToList();
+                if (candidates.Count == 1 && !string.IsNullOrEmpty(candidates[0].TypeName))
+                    fields[fieldGroup.Key] = candidates[0];
             }
 
-            foreach (var field in cls.Fields)
-                fields[field.Name] = field.TypeName;
+            directFields[typeName] = fields;
+
+            var resolvedBases = partials
+                .Select(cls => cls.BaseClass)
+                .Where(baseClass => !string.IsNullOrWhiteSpace(baseClass))
+                .Select(baseClass => ResolveDeclaredTypeName(
+                    baseClass!,
+                    typeName,
+                    declaredTypeNames))
+                .Where(baseClass => baseClass is not null)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+            baseTypes[typeName] = resolvedBases.Count == 1 ? resolvedBases[0] : null;
         }
 
-        return fieldMaps.ToDictionary(
-            pair => pair.Key,
-            pair => (IReadOnlyDictionary<string, string>)pair.Value,
-            StringComparer.Ordinal);
+        var resolvedFields =
+            new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal);
+        var resolving = new HashSet<string>(StringComparer.Ordinal);
+
+        IReadOnlyDictionary<string, string> ResolveFields(string typeName)
+        {
+            if (resolvedFields.TryGetValue(typeName, out var cached))
+                return cached;
+
+            var fields = new Dictionary<string, string>(StringComparer.Ordinal);
+            if (!resolving.Add(typeName))
+                return fields;
+
+            if (baseTypes.TryGetValue(typeName, out var baseType) && baseType is not null)
+            {
+                foreach (var (fieldName, fieldType) in ResolveFields(baseType))
+                {
+                    var baseField = FindRegisteredField(baseType, fieldName, directFields, baseTypes);
+                    if (baseField is not null && baseField.Visibility != Visibility.Private)
+                        fields[fieldName] = fieldType;
+                }
+            }
+
+            foreach (var (fieldName, field) in directFields[typeName])
+            {
+                if (field.IsStatic)
+                    fields.Remove(fieldName);
+                else
+                    fields[fieldName] = field.TypeName;
+            }
+
+            resolving.Remove(typeName);
+            resolvedFields[typeName] = fields;
+            return fields;
+        }
+
+        foreach (var typeName in declarations.Keys.OrderBy(name => name, StringComparer.Ordinal))
+            ResolveFields(typeName);
+
+        // Nested types are canonically registered by qualified name. Preserve exact bare-name
+        // lookup for methods inside an enclosing type only when that spelling is globally unique;
+        // ambiguous nested names are omitted so translation refuses rather than picking a type.
+        foreach (var simpleNameGroup in declarations.Keys
+                     .GroupBy(GetSimpleTypeName, StringComparer.Ordinal)
+                     .Where(group => group.Count() == 1))
+        {
+            var qualifiedName = simpleNameGroup.Single();
+            if (!resolvedFields.ContainsKey(simpleNameGroup.Key))
+                resolvedFields[simpleNameGroup.Key] = resolvedFields[qualifiedName];
+        }
+
+        return resolvedFields;
     }
 
     internal static string BuildUserTypeRegistryCacheScope(
@@ -196,16 +275,77 @@ public sealed class ContractTranslator
                             $"{field.Key.Length}#{field.Key}={field.Value.Length}#{field.Value}"))));
     }
 
-    private static IEnumerable<ClassDefinitionNode> EnumerateClasses(
-        IEnumerable<ClassDefinitionNode> classes)
+    private static RegisteredField? FindRegisteredField(
+        string typeName,
+        string fieldName,
+        IReadOnlyDictionary<string, Dictionary<string, RegisteredField>> directFields,
+        IReadOnlyDictionary<string, string?> baseTypes)
+    {
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var currentType = typeName;
+        while (visited.Add(currentType))
+        {
+            if (directFields.TryGetValue(currentType, out var fields)
+                && fields.TryGetValue(fieldName, out var field))
+            {
+                return field;
+            }
+
+            if (!baseTypes.TryGetValue(currentType, out var baseType) || baseType is null)
+                break;
+            currentType = baseType;
+        }
+
+        return null;
+    }
+
+    private static string? ResolveDeclaredTypeName(
+        string referencedType,
+        string declaringType,
+        IReadOnlySet<string> declaredTypes)
+    {
+        var normalizedReference = NormalizeTypeName(referencedType);
+        if (declaredTypes.Contains(normalizedReference))
+            return normalizedReference;
+
+        var separator = declaringType.LastIndexOf('.');
+        while (separator >= 0)
+        {
+            var candidate = $"{declaringType[..separator]}.{normalizedReference}";
+            if (declaredTypes.Contains(candidate))
+                return candidate;
+            separator = declaringType.LastIndexOf('.', separator - 1);
+        }
+
+        return null;
+    }
+
+    private static string GetSimpleTypeName(string typeName)
+    {
+        var separator = typeName.LastIndexOf('.');
+        return separator < 0 ? typeName : typeName[(separator + 1)..];
+    }
+
+    private static IEnumerable<(ClassDefinitionNode Class, string QualifiedName)> EnumerateClasses(
+        IEnumerable<ClassDefinitionNode> classes,
+        string? enclosingType = null)
     {
         foreach (var cls in classes)
         {
-            yield return cls;
-            foreach (var nested in EnumerateClasses(cls.NestedClasses))
+            var simpleName = NormalizeTypeName(cls.Name);
+            var qualifiedName = enclosingType is null
+                ? simpleName
+                : $"{enclosingType}.{simpleName}";
+            yield return (cls, qualifiedName);
+            foreach (var nested in EnumerateClasses(cls.NestedClasses, qualifiedName))
                 yield return nested;
         }
     }
+
+    private sealed record RegisteredField(
+        string TypeName,
+        Visibility Visibility,
+        bool IsStatic);
 
     /// <summary>
     /// Pushes a self-variable name for refinement predicate translation.
@@ -343,9 +483,8 @@ public sealed class ContractTranslator
     /// Resolves a dot-separated reference name (e.g. "item.Quantity" or "a.b.c") by
     /// walking the path: the first segment is looked up in the variable scope, and each
     /// subsequent segment becomes a field-access on the previous result. Each step uses
-    /// (or creates) an uninterpreted Z3 function for the field. The receiver type comes
-    /// from the variable registry; intermediate types come from the user-type registry
-    /// when known, defaulting to i32 otherwise.
+    /// (or creates) an uninterpreted Z3 function for the field. Receiver and intermediate
+    /// field types must be present in the user-type registry; missing entries are refused.
     /// </summary>
     private Expr? ResolveDotPath(string dottedName)
     {
@@ -366,13 +505,9 @@ public sealed class ContractTranslator
             if (coreType.EndsWith("[]"))
                 return null; // array element access via dot-path is not supported here
 
-            string fieldType = "i32";
-            if (_userTypeRegistry is not null
-                && _userTypeRegistry.TryGetValue(coreType, out var fieldMap)
-                && fieldMap.TryGetValue(fieldName, out var t))
-            {
-                fieldType = NormalizeTypeName(t);
-            }
+            var fieldType = ResolveRegisteredFieldType(coreType, fieldName);
+            if (fieldType is null)
+                return null;
 
             var key = (coreType, fieldName);
             if (!_fieldAccessors.TryGetValue(key, out var accessor))
@@ -383,6 +518,12 @@ public sealed class ContractTranslator
                     _userTypeSorts[coreType] = receiverSort;
                 }
                 var resultSort = ResultSortForType(fieldType);
+                if (resultSort is null)
+                {
+                    return Refuse(
+                        $"field '{coreType}.{fieldName}' has unsupported type '{fieldType}': " +
+                        "modeling it as a guessed sort could produce an unsound proof");
+                }
                 accessor = _ctx.MkFuncDecl($"{coreType}_{fieldName}", new[] { receiverSort }, resultSort);
                 _fieldAccessors[key] = accessor;
             }
@@ -399,6 +540,22 @@ public sealed class ContractTranslator
             }
         }
         return current;
+    }
+
+    private string? ResolveRegisteredFieldType(string receiverType, string fieldName)
+    {
+        if (_userTypeRegistry is null
+            || !_userTypeRegistry.TryGetValue(receiverType, out var fieldMap)
+            || !fieldMap.TryGetValue(fieldName, out var fieldType)
+            || string.IsNullOrWhiteSpace(fieldType))
+        {
+            _ = Refuse(
+                $"field '{receiverType}.{fieldName}' has no registered type: modeling it at a " +
+                "guessed width could reason at the wrong wrap boundary (modeled-forms divergence D7)");
+            return null;
+        }
+
+        return NormalizeTypeName(fieldType);
     }
 
     /// <summary>
@@ -765,7 +922,14 @@ public sealed class ContractTranslator
                 {
                     normalizedIndex = _ctx.MkZeroExt(64 - indexBv.SortSize, indexBv);
                 }
-                return _ctx.MkSelect(arrExpr, normalizedIndex);
+                var selected = (BitVecExpr)_ctx.MkSelect(arrExpr, normalizedIndex);
+                if (_arrayInfo.TryGetValue(arrayName, out var info))
+                {
+                    var (width, isSigned) = GetTypeWidthAndSignedness(info.ElementType);
+                    if (width > 0)
+                        TrackBitVec(selected, width, isSigned);
+                }
+                return selected;
             }
         }
 
@@ -1567,15 +1731,9 @@ public sealed class ContractTranslator
         // W1 Slice 1 (D7): the field's type must come from the user-type registry.
         // The old i32 default guessed a width/signedness; a wrong guess reasons at
         // the wrong wrap boundary and can mint a false Proven that elides a guard.
-        if (_userTypeRegistry is null
-            || !_userTypeRegistry.TryGetValue(coreType, out var fieldMap)
-            || !fieldMap.TryGetValue(node.FieldName, out var t))
-        {
-            return Refuse(
-                $"field '{coreType}.{node.FieldName}' has no registered type: modeling it at a " +
-                "guessed width could reason at the wrong wrap boundary (modeled-forms divergence D7)");
-        }
-        string fieldType = NormalizeTypeName(t);
+        var fieldType = ResolveRegisteredFieldType(coreType, node.FieldName);
+        if (fieldType is null)
+            return null;
 
         // Cache the field accessor function decl per (type, field).
         var key = (coreType, node.FieldName);
@@ -1590,6 +1748,12 @@ public sealed class ContractTranslator
             }
 
             var resultSort = ResultSortForType(fieldType);
+            if (resultSort is null)
+            {
+                return Refuse(
+                    $"field '{coreType}.{node.FieldName}' has unsupported type '{fieldType}': " +
+                    "modeling it as a guessed sort could produce an unsound proof");
+            }
             accessor = _ctx.MkFuncDecl($"{coreType}_{node.FieldName}", new[] { receiverSort }, resultSort);
             _fieldAccessors[key] = accessor;
         }
@@ -1607,9 +1771,9 @@ public sealed class ContractTranslator
 
     /// <summary>
     /// Maps a Calor field type to the corresponding Z3 sort, used as the result sort of
-    /// uninterpreted field accessors. Defaults to 32-bit signed bit-vector for unknown types.
+    /// uninterpreted field accessors. Unsupported or empty types are refused by the caller.
     /// </summary>
-    private Sort ResultSortForType(string typeName)
+    private Sort? ResultSortForType(string typeName)
     {
         var t = NormalizeTypeName(typeName);
         if (t.EndsWith("?")) t = t[..^1];
@@ -1620,17 +1784,14 @@ public sealed class ContractTranslator
             "i32" or "u32" or "int" or "uint" => _ctx.MkBitVecSort(32),
             "i64" or "u64" or "long" or "ulong" => _ctx.MkBitVecSort(64),
             "bool" => _ctx.BoolSort,
-            // Flagged like every other string-sort site (D3/D12): this arm mints a field
-            // accessor's RESULT sort, and `accessor.Apply(target)` does not pass through
-            // TrackString. Unreachable today only because SetUserTypeRegistry has no callers —
-            // but wiring that registry up is the natural fix for D7, which would reopen this
-            // vector on `§S (== (len p.name) INT:2)`. Flagging it here means the invariant
-            // "every string term sets the flag" holds without a caveat.
+            // Like every other string-sort site (D3/D12), this arm mints a field accessor's
+            // result sort and accessor.Apply(target) does not pass through TrackString.
             "string" or "str" => MarkStringSort(),
+            "f32" or "f64" or "float" or "double" => null,
             _ when !string.IsNullOrEmpty(t) => _userTypeSorts.TryGetValue(t, out var s)
                                                ? s
                                                : (_userTypeSorts[t] = MarkUninterpretedSort(t)),
-            _ => _ctx.MkBitVecSort(32),
+            _ => null,
         };
     }
 

--- a/src/Calor.Compiler/Verification/Z3/Z3Verifier.cs
+++ b/src/Calor.Compiler/Verification/Z3/Z3Verifier.cs
@@ -66,12 +66,18 @@ public sealed class Z3Verifier : IDisposable
 
     private readonly Context _ctx;
     private readonly uint _timeoutMs;
+    private readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> _userTypeRegistry;
     private bool _disposed;
 
-    public Z3Verifier(Context ctx, uint timeoutMs = VerificationOptions.DefaultTimeoutMs)
+    public Z3Verifier(
+        Context ctx,
+        uint timeoutMs = VerificationOptions.DefaultTimeoutMs,
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>>? userTypeRegistry = null)
     {
         _ctx = ctx ?? throw new ArgumentNullException(nameof(ctx));
         _timeoutMs = timeoutMs;
+        _userTypeRegistry = userTypeRegistry
+            ?? new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal);
     }
 
     /// <summary>
@@ -85,7 +91,7 @@ public sealed class Z3Verifier : IDisposable
     {
         var sw = Stopwatch.StartNew();
 
-        var translator = new ContractTranslator(_ctx);
+        var translator = CreateTranslator();
 
         // Declare all parameters
         foreach (var (name, type) in parameters)
@@ -177,7 +183,7 @@ public sealed class Z3Verifier : IDisposable
     {
         var sw = Stopwatch.StartNew();
 
-        var translator = new ContractTranslator(_ctx);
+        var translator = CreateTranslator();
 
         // A parameter named `result` collides with the postcondition result variable:
         // DeclareVariable("result") would silently overwrite it, aliasing the two into one
@@ -594,6 +600,13 @@ public sealed class Z3Verifier : IDisposable
                     ? $"Contract form is in the modeled whitelist but its operand typing is not modeled: {detail}. Runtime check kept."
                     : $"whitelist drift — whitelist-accepted form failed to translate with no diagnosis (in {where}). Runtime check kept.")),
             Duration: sw.Elapsed);
+    }
+
+    private ContractTranslator CreateTranslator()
+    {
+        var translator = new ContractTranslator(_ctx);
+        translator.SetUserTypeRegistry(_userTypeRegistry);
+        return translator;
     }
 
     public void Dispose()

--- a/tests/Calor.Verification.Tests/DottedFieldTypeResolutionTests.cs
+++ b/tests/Calor.Verification.Tests/DottedFieldTypeResolutionTests.cs
@@ -1,0 +1,242 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Calor.Compiler.Verification;
+using Calor.Compiler.Verification.Z3;
+using Calor.Compiler.Verification.Z3.Cache;
+using Microsoft.Z3;
+using Xunit;
+
+namespace Calor.Verification.Tests;
+
+public sealed class DottedFieldTypeResolutionTests
+{
+    private const string Source = """
+        §M{m001:DottedFields}
+          §CL{o001:Outer:pub:partial}
+            §CL{b001:Base:pub:partial}
+              §FLD{i64:Wide:pub}
+              §FLD{i16:Hidden:priv}
+          §CL{o002:Outer:pub:partial}
+            §CL{b002:Base:pub:partial}
+              §FLD{u8:Small:int}
+            §CL{d001:Derived:Base}
+              §FLD{bool:Own:priv}
+          §F{f001:WideBoundary:pub} (Outer.Derived:item) -> bool
+            §S (>= item.Wide INT:-2147483648)
+            §R true
+          §F{f002:SmallBoundary:pub} (Outer.Derived:item) -> bool
+            §S (&& (>= item.Small INT:0) (<= item.Small INT:255))
+            §R true
+          §F{f003:MissingBoundary:pub} (Outer.Derived:item) -> bool
+            §S (>= item.Missing INT:-2147483648)
+            §R true
+        """;
+
+    private const string ProductionSource = """
+        §M{m001:DottedProduction}
+          §CL{b001:Base:pub}
+            §FLD{i64:Wide:pub}
+            §FLD{u8:Small:pub}
+          §CL{d001:Derived:Base}
+            §FLD{bool:Own:priv}
+          §F{f001:WideBoundary:pub} (Derived:item) -> bool
+            §S (>= item.Wide INT:-2147483648)
+            §R true
+          §F{f002:SmallBoundary:pub} (Derived:item) -> bool
+            §S (&& (>= item.Small INT:0) (<= item.Small INT:255))
+            §R true
+        """;
+
+    [Fact]
+    public void RegistryMergesNestedPartialsAndInheritedAccessibleFields()
+    {
+        var module = Parse(Source);
+        var registry = ContractTranslator.BuildUserTypeRegistry(module);
+
+        Assert.Equal("i64", registry["outer.base"]["Wide"]);
+        Assert.Equal("u8", registry["outer.base"]["Small"]);
+        Assert.Equal("i16", registry["outer.base"]["Hidden"]);
+        Assert.Equal("i64", registry["outer.derived"]["Wide"]);
+        Assert.Equal("u8", registry["outer.derived"]["Small"]);
+        Assert.False(registry["outer.derived"].ContainsKey("Hidden"));
+
+        Assert.Same(registry["outer.base"], registry["base"]);
+        Assert.Same(registry["outer.derived"], registry["derived"]);
+
+        var changedModule = Parse(Source.Replace(
+            "§FLD{i64:Wide:pub}",
+            "§FLD{i32:Wide:pub}",
+            StringComparison.Ordinal));
+        var changedRegistry = ContractTranslator.BuildUserTypeRegistry(changedModule);
+        Assert.NotEqual(
+            ContractTranslator.BuildUserTypeRegistryCacheScope(registry),
+            ContractTranslator.BuildUserTypeRegistryCacheScope(changedRegistry));
+    }
+
+    [Fact]
+    public void ParsedDottedReferencesUseInheritedI64AndU8SortsWithoutGuessing()
+    {
+        Assert.True(
+            Z3ContextFactory.IsAvailable,
+            "Dotted field sort regression cannot run: Z3 is unavailable.");
+
+        var module = Parse(Source);
+        var registry = ContractTranslator.BuildUserTypeRegistry(module);
+        var wideCondition = module.Functions
+            .Single(function => function.Name == "WideBoundary")
+            .Postconditions.Single().Condition;
+        var smallCondition = module.Functions
+            .Single(function => function.Name == "SmallBoundary")
+            .Postconditions.Single().Condition;
+
+        var wideReference = FindDottedReference(wideCondition, "item.Wide");
+        var smallReference = FindDottedReference(smallCondition, "item.Small");
+        Assert.Equal("item.Wide", wideReference.Name);
+        Assert.Equal("item.Small", smallReference.Name);
+
+        var inheritedWide = TranslateAndCheckNegation(
+            wideCondition,
+            wideReference,
+            registry);
+        var inheritedSmall = TranslateAndCheckNegation(
+            smallCondition,
+            smallReference,
+            registry);
+
+        Assert.Equal(64u, inheritedWide.Width);
+        Assert.Equal(Status.SATISFIABLE, inheritedWide.NegatedStatus);
+        Assert.Equal(8u, inheritedSmall.Width);
+        Assert.Equal(Status.UNSATISFIABLE, inheritedSmall.NegatedStatus);
+
+        var i32Mutation = registry.ToDictionary(
+            type => type.Key,
+            type => (IReadOnlyDictionary<string, string>)
+                new Dictionary<string, string>(type.Value, StringComparer.Ordinal),
+            StringComparer.Ordinal);
+        i32Mutation["outer.derived"] =
+            new Dictionary<string, string>(registry["outer.derived"], StringComparer.Ordinal)
+            {
+                ["Wide"] = "i32"
+            };
+        var historicalFallback = TranslateAndCheckNegation(
+            wideCondition,
+            wideReference,
+            i32Mutation);
+
+        Assert.Equal(32u, historicalFallback.Width);
+        Assert.Equal(
+            Status.UNSATISFIABLE,
+            historicalFallback.NegatedStatus);
+    }
+
+    [Fact]
+    public void ParsedMissingDottedFieldIsExplicitlyRefused()
+    {
+        Assert.True(
+            Z3ContextFactory.IsAvailable,
+            "Dotted field refusal regression cannot run: Z3 is unavailable.");
+
+        var module = Parse(Source);
+        var registry = ContractTranslator.BuildUserTypeRegistry(module);
+        var function = module.Functions.Single(candidate => candidate.Name == "MissingBoundary");
+        var condition = function.Postconditions.Single().Condition;
+
+        using var context = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(context);
+        translator.SetUserTypeRegistry(registry);
+        Assert.True(translator.DeclareVariable("item", "Outer.Derived"));
+
+        Assert.Null(translator.TranslateBoolExpr(condition));
+        Assert.Contains(
+            "field 'outer.derived.Missing' has no registered type",
+            translator.LastRefusalReason,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProductionPassUsesInheritedDottedTypesWithoutFalseProven()
+    {
+        Assert.True(
+            Z3ContextFactory.IsAvailable,
+            "Production dotted field regression cannot run: Z3 is unavailable.");
+
+        var module = Parse(ProductionSource);
+        var diagnostics = new DiagnosticBag();
+        var result = new ContractVerificationPass(
+            diagnostics,
+            new VerificationOptions
+            {
+                CacheOptions = new VerificationCacheOptions { Enabled = false }
+            })
+            .Verify(module);
+
+        var wide = Assert.Single(
+            result.GetFunctionResult("f001")!.PostconditionResults);
+        var small = Assert.Single(
+            result.GetFunctionResult("f002")!.PostconditionResults);
+        Assert.Equal(ProofStatus.Refuted, wide.EffectiveOutcome.Status);
+        Assert.Equal(ProofStatus.Assumed, small.EffectiveOutcome.Status);
+        Assert.DoesNotContain(
+            diagnostics,
+            diagnostic => diagnostic.Code == DiagnosticCode.ContractVerificationUnsupported);
+    }
+
+    private static ModuleNode Parse(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        var tokens = new Lexer(source, diagnostics).TokenizeAllForParser();
+        var module = new Parser(tokens, diagnostics).Parse();
+        Assert.False(
+            diagnostics.HasErrors,
+            string.Join(Environment.NewLine, diagnostics.Select(diagnostic => diagnostic.Message)));
+        return module;
+    }
+
+    private static (uint Width, Status NegatedStatus) TranslateAndCheckNegation(
+        ExpressionNode condition,
+        ReferenceNode dottedReference,
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> registry)
+    {
+        using var context = Z3ContextFactory.Create();
+        var translator = new ContractTranslator(context);
+        translator.SetUserTypeRegistry(registry);
+        Assert.True(translator.DeclareVariable("item", "Outer.Derived"));
+
+        var translatedReference = translator.TranslateBitVecExpr(dottedReference);
+        Assert.NotNull(translatedReference);
+        var translatedCondition = translator.TranslateBoolExpr(condition);
+        Assert.NotNull(translatedCondition);
+
+        using var solver = context.MkSolver();
+        solver.Assert(context.MkNot(translatedCondition));
+        return (translatedReference.SortSize, solver.Check());
+    }
+
+    private static ReferenceNode FindDottedReference(ExpressionNode expression, string name)
+    {
+        return FindDottedReferenceOrNull(expression, name)
+            ?? throw new Xunit.Sdk.XunitException($"Dotted reference '{name}' was not found.");
+    }
+
+    private static ReferenceNode? FindDottedReferenceOrNull(ExpressionNode expression, string name)
+    {
+        if (expression is ReferenceNode reference && reference.Name == name)
+            return reference;
+        foreach (var child in expression switch
+                 {
+                     BinaryOperationNode binary => new[] { binary.Left, binary.Right },
+                     UnaryOperationNode unary => new[] { unary.Operand },
+                     ImplicationExpressionNode implication =>
+                         new[] { implication.Antecedent, implication.Consequent },
+                     _ => Array.Empty<ExpressionNode>()
+                 })
+        {
+            var found = FindDottedReferenceOrNull(child, name);
+            if (found is not null)
+                return found;
+        }
+
+        return null;
+    }
+}

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialFormRegistry.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialFormRegistry.cs
@@ -1,0 +1,440 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Parsing;
+using Calor.Compiler.Verification.Z3;
+
+namespace Calor.Verification.Tests.VerifierRuntimeDifferential;
+
+internal static class DifferentialFormRegistry
+{
+    private static readonly TextSpan Span = TextSpan.Empty;
+    private static readonly AttributeCollection Attributes = new();
+
+    public static IReadOnlyList<DifferentialForm> Build()
+    {
+        var forms = new List<DifferentialForm>();
+
+        forms.AddRange(ModeledForms.ScalarTypes.Select(BuildScalarType));
+        forms.AddRange(new[] { "i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64" }
+            .Select(BuildArrayElementType));
+        forms.AddRange(ModeledForms.ExpressionKinds.Select(BuildExpressionKind));
+        forms.AddRange(ModeledForms.Operators.Select(BuildBinaryOperator));
+        forms.AddRange(ModeledForms.UnaryOperators.Select(BuildUnaryOperator));
+        forms.AddRange(ModeledForms.StringOperations.Select(BuildStringOperation));
+        forms.Add(BuildOrdinalComparisonMode());
+        forms.Add(BuildQuantifierTypePolicy());
+
+        var duplicate = forms.GroupBy(form => form.Id, StringComparer.Ordinal)
+            .FirstOrDefault(group => group.Count() > 1);
+        if (duplicate != null)
+            throw new InvalidOperationException($"Duplicate differential form id '{duplicate.Key}'.");
+
+        return forms;
+    }
+
+    public static ExpressionNode ApplyIdentityNesting(ExpressionNode condition, int nestingDepth)
+    {
+        if (nestingDepth is < 1 or > 3)
+            throw new ArgumentOutOfRangeException(nameof(nestingDepth));
+
+        var result = condition;
+        for (var depth = 1; depth < nestingDepth; depth++)
+            result = Bin(BinaryOperator.And, result, Bool(true));
+        return result;
+    }
+
+    private static DifferentialForm BuildScalarType(string type)
+    {
+        return new DifferentialForm(
+            $"scalar-type:{type}",
+            "scalar-type",
+            true,
+            null,
+            polarity => new FormExpression(
+                polarity == CasePolarity.Provable
+                    ? Bin(BinaryOperator.Equal, Ref("value"), Ref("value"))
+                    : Bin(BinaryOperator.NotEqual, Ref("value"), Ref("value")),
+                [Parameter("value", type)]),
+            condition => ContainsReference(condition, "value"));
+    }
+
+    private static DifferentialForm BuildArrayElementType(string type)
+    {
+        return new DifferentialForm(
+            $"array-element-type:{type}",
+            "array-element-type",
+            true,
+            null,
+            polarity =>
+            {
+                var access = new ArrayAccessNode(Span, Ref("values"), Int(0));
+                return new FormExpression(
+                    polarity == CasePolarity.Provable
+                        ? Bin(BinaryOperator.Equal, access, access)
+                        : Bin(BinaryOperator.NotEqual, access, access),
+                    [Parameter("values", $"{type}[]")]);
+            },
+            condition => Contains<ArrayAccessNode>(condition));
+    }
+
+    private static DifferentialForm BuildExpressionKind(string kind)
+    {
+        if (kind == nameof(SelfRefNode))
+        {
+            return new DifferentialForm(
+                $"expression-kind:{kind}",
+                "expression-kind",
+                true,
+                null,
+                polarity => new FormExpression(
+                    Bin(
+                        polarity == CasePolarity.Provable
+                            ? BinaryOperator.Equal
+                            : BinaryOperator.NotEqual,
+                        new SelfRefNode(Span),
+                        new SelfRefNode(Span)),
+                    [Parameter("__self__", "i32")]),
+                condition => Contains<SelfRefNode>(condition));
+        }
+
+        return new DifferentialForm(
+            $"expression-kind:{kind}",
+            "expression-kind",
+            true,
+            null,
+            polarity => BuildExpressionKindExpression(kind, polarity),
+            condition => ContainsKind(condition, kind));
+    }
+
+    private static FormExpression BuildExpressionKindExpression(string kind, CasePolarity polarity)
+    {
+        var provable = polarity == CasePolarity.Provable;
+        return kind switch
+        {
+            nameof(IntLiteralNode) => NoParameters(
+                Bin(BinaryOperator.Equal, Int(7), Int(provable ? 7 : 8))),
+            nameof(BoolLiteralNode) => NoParameters(Bool(provable)),
+            nameof(StringLiteralNode) => NoParameters(
+                Bin(BinaryOperator.Equal, Str("ascii"), Str(provable ? "ascii" : "other"))),
+            nameof(ReferenceNode) => new FormExpression(
+                Bin(provable ? BinaryOperator.Equal : BinaryOperator.NotEqual, Ref("value"), Ref("value")),
+                [Parameter("value", "bool")]),
+            nameof(BinaryOperationNode) => NoParameters(
+                Bin(BinaryOperator.Equal,
+                    Bin(BinaryOperator.Add, Int(2), Int(3)),
+                    Int(provable ? 5 : 6))),
+            nameof(UnaryOperationNode) => NoParameters(
+                Bin(BinaryOperator.Equal,
+                    new UnaryOperationNode(Span, UnaryOperator.Negate, Int(5)),
+                    Int(provable ? -5 : -4))),
+            nameof(ConditionalExpressionNode) => NoParameters(
+                Bin(BinaryOperator.Equal,
+                    new ConditionalExpressionNode(Span, Bool(true), Int(4), Int(9)),
+                    Int(provable ? 4 : 9))),
+            nameof(ForallExpressionNode) => NoParameters(BuildForall(provable, "i32")),
+            nameof(ExistsExpressionNode) => NoParameters(BuildExists(provable, "i32")),
+            nameof(ImplicationExpressionNode) => NoParameters(
+                new ImplicationExpressionNode(Span, Bool(true), Bool(provable))),
+            nameof(ArrayAccessNode) => new FormExpression(
+                BuildArrayAccessCondition(provable),
+                [Parameter("values", "i32[]")]),
+            nameof(ArrayLengthNode) => new FormExpression(
+                BuildArrayLengthCondition(provable),
+                [Parameter("values", "i32[]")]),
+            nameof(FieldAccessNode) => new FormExpression(
+                BuildFieldAccessCondition(provable),
+                [Parameter("probe", "Probe")]),
+            nameof(StringOperationNode) => NoParameters(
+                BuildStringOperationCondition(StringOp.Contains, provable)),
+            _ => throw new InvalidOperationException(
+                $"ModeledForms.ExpressionKinds added '{kind}' without an F-4 generator.")
+        };
+    }
+
+    private static DifferentialForm BuildBinaryOperator(BinaryOperator op)
+    {
+        return new DifferentialForm(
+            $"binary-operator:{op}",
+            "binary-operator",
+            true,
+            null,
+            polarity => NoParameters(BuildBinaryOperatorCondition(op, polarity == CasePolarity.Provable)),
+            condition => ContainsBinaryOperator(condition, op));
+    }
+
+    private static DifferentialForm BuildUnaryOperator(UnaryOperator op)
+    {
+        return new DifferentialForm(
+            $"unary-operator:{op}",
+            "unary-operator",
+            true,
+            null,
+            polarity => NoParameters(BuildUnaryOperatorCondition(op, polarity == CasePolarity.Provable)),
+            condition => ContainsUnaryOperator(condition, op));
+    }
+
+    private static DifferentialForm BuildStringOperation(StringOp op)
+    {
+        return new DifferentialForm(
+            $"string-operation:{op}",
+            "string-operation",
+            true,
+            null,
+            polarity => NoParameters(
+                BuildStringOperationCondition(op, polarity == CasePolarity.Provable)),
+            condition => ContainsStringOperation(condition, op));
+    }
+
+    private static DifferentialForm BuildOrdinalComparisonMode()
+    {
+        return new DifferentialForm(
+            "string-comparison-mode:Ordinal",
+            "string-comparison-mode",
+            true,
+            null,
+            polarity => NoParameters(
+                BuildStringOperationCondition(
+                    StringOp.Contains,
+                    polarity == CasePolarity.Provable,
+                    StringComparisonMode.Ordinal)),
+            condition => ContainsStringComparisonMode(condition, StringComparisonMode.Ordinal));
+    }
+
+    private static DifferentialForm BuildQuantifierTypePolicy()
+    {
+        return new DifferentialForm(
+            "quantifier-bound-variable-type:declarable-alias",
+            "quantifier-bound-variable-type",
+            true,
+            null,
+            polarity => NoParameters(
+                BuildForall(polarity == CasePolarity.Provable, "Int32")),
+            condition => ContainsQuantifierType(condition, "Int32"));
+    }
+
+    private static ExpressionNode BuildBinaryOperatorCondition(BinaryOperator op, bool provable)
+    {
+        return op switch
+        {
+            BinaryOperator.Add => Eq(Bin(op, Int(2), Int(3)), Int(provable ? 5 : 6)),
+            BinaryOperator.Subtract => Eq(Bin(op, Int(7), Int(3)), Int(provable ? 4 : 5)),
+            BinaryOperator.Multiply => Eq(Bin(op, Int(3), Int(4)), Int(provable ? 12 : 13)),
+            BinaryOperator.Divide => Eq(Bin(op, Int(8), Int(2)), Int(provable ? 4 : 5)),
+            BinaryOperator.Modulo => Eq(Bin(op, Int(7), Int(3)), Int(provable ? 1 : 2)),
+            BinaryOperator.Equal => Bin(op, Int(1), Int(provable ? 1 : 2)),
+            BinaryOperator.NotEqual => Bin(op, Int(1), Int(provable ? 2 : 1)),
+            BinaryOperator.LessThan => Bin(op, Int(1), Int(provable ? 2 : 1)),
+            BinaryOperator.LessOrEqual => Bin(op, Int(1), Int(provable ? 1 : 0)),
+            BinaryOperator.GreaterThan => Bin(op, Int(2), Int(provable ? 1 : 2)),
+            BinaryOperator.GreaterOrEqual => Bin(op, Int(2), Int(provable ? 2 : 3)),
+            BinaryOperator.And => Bin(op, Bool(provable), Bool(true)),
+            BinaryOperator.Or => Bin(op, Bool(false), Bool(provable)),
+            BinaryOperator.BitwiseAnd => Eq(Bin(op, Int(6), Int(3)), Int(provable ? 2 : 3)),
+            BinaryOperator.BitwiseOr => Eq(Bin(op, Int(4), Int(1)), Int(provable ? 5 : 4)),
+            BinaryOperator.BitwiseXor => Eq(Bin(op, Int(7), Int(3)), Int(provable ? 4 : 5)),
+            BinaryOperator.LeftShift => Eq(Bin(op, Int(1), Int(1)), Int(provable ? 2 : 1)),
+            BinaryOperator.RightShift => Eq(Bin(op, Int(8), Int(1)), Int(provable ? 4 : 8)),
+            _ => throw new InvalidOperationException(
+                $"ModeledForms.Operators added '{op}' without an F-4 generator.")
+        };
+    }
+
+    private static ExpressionNode BuildUnaryOperatorCondition(UnaryOperator op, bool provable)
+    {
+        return op switch
+        {
+            UnaryOperator.Not => new UnaryOperationNode(Span, op, Bool(!provable)),
+            UnaryOperator.Negate => Eq(
+                new UnaryOperationNode(Span, op, Int(5)),
+                Int(provable ? -5 : -4)),
+            _ => throw new InvalidOperationException(
+                $"ModeledForms.UnaryOperators added '{op}' without an F-4 generator.")
+        };
+    }
+
+    private static ExpressionNode BuildStringOperationCondition(
+        StringOp op,
+        bool provable,
+        StringComparisonMode? forcedMode = null)
+    {
+        StringComparisonMode? OrdinalWhenRequired() =>
+            forcedMode ?? (op is StringOp.StartsWith or StringOp.EndsWith or StringOp.IndexOf
+                ? StringComparisonMode.Ordinal
+                : null);
+
+        return op switch
+        {
+            StringOp.Length => Eq(StringOpNode(op, [Str("abc")]), Int(provable ? 3 : 4)),
+            StringOp.Contains => StringOpNode(
+                op,
+                [Str("abc"), Str(provable ? "b" : "z")],
+                forcedMode),
+            StringOp.StartsWith => StringOpNode(
+                op,
+                [Str("abc"), Str(provable ? "a" : "z")],
+                OrdinalWhenRequired()),
+            StringOp.EndsWith => StringOpNode(
+                op,
+                [Str("abc"), Str(provable ? "c" : "z")],
+                OrdinalWhenRequired()),
+            StringOp.Equals => StringOpNode(
+                op,
+                [Str("abc"), Str(provable ? "abc" : "ABC")],
+                forcedMode),
+            StringOp.IsNullOrEmpty => StringOpNode(
+                op,
+                [Str(provable ? "" : "x")]),
+            StringOp.IndexOf => Eq(
+                StringOpNode(op, [Str("abc"), Str("b")], OrdinalWhenRequired()),
+                Int(provable ? 1 : 2)),
+            StringOp.Substring => Eq(
+                StringOpNode(op, [Str("abc"), Int(1), Int(1)]),
+                Str(provable ? "b" : "x")),
+            StringOp.SubstringFrom => Eq(
+                StringOpNode(op, [Str("abc"), Int(1)]),
+                Str(provable ? "bc" : "x")),
+            StringOp.Concat => Eq(
+                StringOpNode(op, [Str("a"), Str("b")]),
+                Str(provable ? "ab" : "ac")),
+            _ => throw new InvalidOperationException(
+                $"ModeledForms.StringOperations added '{op}' without an F-4 generator.")
+        };
+    }
+
+    private static ExpressionNode BuildForall(bool provable, string boundType)
+    {
+        var i = Ref("i");
+        var bounds = Bin(
+            BinaryOperator.And,
+            Bin(BinaryOperator.GreaterOrEqual, i, Int(0)),
+            Bin(BinaryOperator.LessThan, i, Int(3)));
+        var consequent = Bin(BinaryOperator.LessThan, i, Int(provable ? 3 : 2));
+        return new ForallExpressionNode(
+            Span,
+            [new QuantifierVariableNode(Span, "i", boundType)],
+            new ImplicationExpressionNode(Span, bounds, consequent));
+    }
+
+    private static ExpressionNode BuildExists(bool provable, string boundType)
+    {
+        var i = Ref("i");
+        var bounds = Bin(
+            BinaryOperator.And,
+            Bin(BinaryOperator.GreaterOrEqual, i, Int(0)),
+            Bin(BinaryOperator.LessThan, i, Int(3)));
+        var witness = Bin(BinaryOperator.Equal, i, Int(provable ? 1 : 4));
+        return new ExistsExpressionNode(
+            Span,
+            [new QuantifierVariableNode(Span, "i", boundType)],
+            Bin(BinaryOperator.And, bounds, witness));
+    }
+
+    private static ExpressionNode BuildArrayAccessCondition(bool provable)
+    {
+        var access = new ArrayAccessNode(Span, Ref("values"), Int(0));
+        return Bin(
+            provable ? BinaryOperator.Equal : BinaryOperator.NotEqual,
+            access,
+            access);
+    }
+
+    private static ExpressionNode BuildArrayLengthCondition(bool provable)
+    {
+        var length = new ArrayLengthNode(Span, Ref("values"));
+        return Bin(
+            provable ? BinaryOperator.Equal : BinaryOperator.NotEqual,
+            length,
+            length);
+    }
+
+    private static ExpressionNode BuildFieldAccessCondition(bool provable)
+    {
+        var field = new FieldAccessNode(Span, Ref("probe"), "Value");
+        return Bin(
+            provable ? BinaryOperator.Equal : BinaryOperator.NotEqual,
+            field,
+            field);
+    }
+
+    private static FormExpression NoParameters(ExpressionNode condition) =>
+        new(condition, Array.Empty<ParameterNode>());
+
+    private static ParameterNode Parameter(string name, string type) =>
+        new(Span, name, type, Attributes);
+
+    private static ReferenceNode Ref(string name) => new(Span, name);
+    private static IntLiteralNode Int(int value) => new(Span, value);
+    private static BoolLiteralNode Bool(bool value) => new(Span, value);
+    private static StringLiteralNode Str(string value) => new(Span, value);
+    private static BinaryOperationNode Bin(
+        BinaryOperator op,
+        ExpressionNode left,
+        ExpressionNode right) => new(Span, op, left, right);
+    private static BinaryOperationNode Eq(ExpressionNode left, ExpressionNode right) =>
+        Bin(BinaryOperator.Equal, left, right);
+    private static StringOperationNode StringOpNode(
+        StringOp op,
+        IReadOnlyList<ExpressionNode> arguments,
+        StringComparisonMode? mode = null) => new(Span, op, arguments, mode);
+
+    private static bool ContainsKind(ExpressionNode root, string kind) =>
+        DescendantsAndSelf(root).Any(node => node.GetType().Name == kind);
+
+    private static bool Contains<T>(ExpressionNode root) where T : ExpressionNode =>
+        DescendantsAndSelf(root).Any(node => node is T);
+
+    private static bool ContainsReference(ExpressionNode root, string name) =>
+        DescendantsAndSelf(root).OfType<ReferenceNode>().Any(node => node.Name == name);
+
+    private static bool ContainsBinaryOperator(ExpressionNode root, BinaryOperator op) =>
+        DescendantsAndSelf(root).OfType<BinaryOperationNode>().Any(node => node.Operator == op);
+
+    private static bool ContainsUnaryOperator(ExpressionNode root, UnaryOperator op) =>
+        DescendantsAndSelf(root).OfType<UnaryOperationNode>().Any(node => node.Operator == op);
+
+    private static bool ContainsStringOperation(ExpressionNode root, StringOp op) =>
+        DescendantsAndSelf(root).OfType<StringOperationNode>().Any(node => node.Operation == op);
+
+    private static bool ContainsStringComparisonMode(
+        ExpressionNode root,
+        StringComparisonMode mode) =>
+        DescendantsAndSelf(root).OfType<StringOperationNode>()
+            .Any(node => node.ComparisonMode == mode);
+
+    private static bool ContainsQuantifierType(ExpressionNode root, string type) =>
+        DescendantsAndSelf(root).Any(node => node switch
+        {
+            ForallExpressionNode forall => forall.BoundVariables.Any(variable => variable.TypeName == type),
+            ExistsExpressionNode exists => exists.BoundVariables.Any(variable => variable.TypeName == type),
+            _ => false
+        });
+
+    private static IEnumerable<ExpressionNode> DescendantsAndSelf(ExpressionNode expression)
+    {
+        yield return expression;
+        foreach (var child in ExpressionChildren(expression))
+        {
+            foreach (var descendant in DescendantsAndSelf(child))
+                yield return descendant;
+        }
+    }
+
+    private static IEnumerable<ExpressionNode> ExpressionChildren(ExpressionNode expression)
+    {
+        return expression switch
+        {
+            BinaryOperationNode binary => [binary.Left, binary.Right],
+            UnaryOperationNode unary => [unary.Operand],
+            ConditionalExpressionNode conditional =>
+                [conditional.Condition, conditional.WhenTrue, conditional.WhenFalse],
+            ForallExpressionNode forall => [forall.Body],
+            ExistsExpressionNode exists => [exists.Body],
+            ImplicationExpressionNode implication =>
+                [implication.Antecedent, implication.Consequent],
+            ArrayAccessNode access => [access.Array, access.Index],
+            ArrayLengthNode length => [length.Array],
+            FieldAccessNode field => [field.Target],
+            StringOperationNode stringOperation => stringOperation.Arguments,
+            _ => Array.Empty<ExpressionNode>()
+        };
+    }
+}

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialFormRegistry.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialFormRegistry.cs
@@ -50,11 +50,15 @@ internal static class DifferentialFormRegistry
             true,
             null,
             IsStringType(type) ? [Z3Verifier.StringModelAssumption] : Array.Empty<string>(),
-            polarity => new FormExpression(
-                polarity == CasePolarity.Provable
-                    ? Bin(BinaryOperator.Equal, Ref("value"), Ref("value"))
-                    : Bin(BinaryOperator.NotEqual, Ref("value"), Ref("value")),
-                [Parameter("value", type)]),
+            polarity =>
+            {
+                var predicate = BuildScalarTypePredicate(type, Ref("value"));
+                return new FormExpression(
+                    polarity == CasePolarity.Provable
+                        ? predicate
+                        : new UnaryOperationNode(Span, UnaryOperator.Not, predicate),
+                    [Parameter("value", type)]);
+            },
             condition => ContainsReference(condition, "value"));
     }
 
@@ -69,10 +73,11 @@ internal static class DifferentialFormRegistry
             polarity =>
             {
                 var access = new ArrayAccessNode(Span, Ref("values"), Int(0));
+                var predicate = BuildIntegerTypePredicate(type, access);
                 return new FormExpression(
                     polarity == CasePolarity.Provable
-                        ? Bin(BinaryOperator.Equal, access, access)
-                        : Bin(BinaryOperator.NotEqual, access, access),
+                        ? predicate
+                        : new UnaryOperationNode(Span, UnaryOperator.Not, predicate),
                     [Parameter("values", $"{type}[]")]);
             },
             condition => Contains<ArrayAccessNode>(condition));
@@ -358,10 +363,106 @@ internal static class DifferentialFormRegistry
     private static ExpressionNode BuildFieldAccessCondition(bool provable)
     {
         var field = new FieldAccessNode(Span, Ref("probe"), "Value");
-        return Bin(
-            provable ? BinaryOperator.LessOrEqual : BinaryOperator.GreaterThan,
-            field,
-            Int(byte.MaxValue));
+        var predicate = Bin(
+            BinaryOperator.And,
+            Bin(BinaryOperator.GreaterOrEqual, field, Int(byte.MinValue)),
+            Bin(BinaryOperator.LessOrEqual, field, Int(byte.MaxValue)));
+        return provable
+            ? predicate
+            : new UnaryOperationNode(Span, UnaryOperator.Not, predicate);
+    }
+
+    private static ExpressionNode BuildScalarTypePredicate(string type, ExpressionNode value)
+    {
+        return type switch
+        {
+            "bool" => Bin(
+                BinaryOperator.Or,
+                value,
+                new UnaryOperationNode(Span, UnaryOperator.Not, value)),
+            "str" => Bin(
+                BinaryOperator.GreaterOrEqual,
+                new StringOperationNode(Span, StringOp.Length, [value]),
+                Int(0)),
+            _ => BuildIntegerTypePredicate(type, value)
+        };
+    }
+
+    private static ExpressionNode BuildIntegerTypePredicate(string type, ExpressionNode value)
+    {
+        return type switch
+        {
+            "i8" => IntegerRange(value, sbyte.MinValue, sbyte.MaxValue),
+            "i16" => Bin(
+                BinaryOperator.And,
+                IntegerRange(value, short.MinValue, short.MaxValue),
+                ExactBoundaryExists(type, short.MaxValue)),
+            "i32" => Bin(
+                BinaryOperator.And,
+                IntegerRange(value, int.MinValue, int.MaxValue),
+                ExactBoundaryExists(type, short.MaxValue + 1L)),
+            "i64" => Bin(
+                BinaryOperator.And,
+                new ImplicationExpressionNode(
+                    Span,
+                    Eq(value, Int(-1)),
+                    Bin(BinaryOperator.LessThan, value, Int(0))),
+                new ImplicationExpressionNode(
+                    Span,
+                    Eq(value, Int(2)),
+                    Bin(
+                        BinaryOperator.GreaterThan,
+                        Bin(BinaryOperator.Multiply, value, Int(int.MaxValue)),
+                        Int(0)))),
+            "u8" => IntegerRange(value, byte.MinValue, byte.MaxValue),
+            "u16" => Bin(
+                BinaryOperator.And,
+                IntegerRange(value, ushort.MinValue, ushort.MaxValue),
+                ExactBoundaryExists(type, byte.MaxValue + 1L)),
+            "u32" => Bin(
+                BinaryOperator.And,
+                Bin(BinaryOperator.GreaterOrEqual, value, Int(0)),
+                new ImplicationExpressionNode(
+                    Span,
+                    Eq(value, Int(3)),
+                    Bin(
+                        BinaryOperator.LessThan,
+                        Bin(BinaryOperator.Multiply, value, Int(int.MaxValue)),
+                        Int(int.MaxValue)))),
+            "u64" => Bin(
+                BinaryOperator.And,
+                Bin(BinaryOperator.GreaterOrEqual, value, Int(0)),
+                new ImplicationExpressionNode(
+                    Span,
+                    Eq(value, Int(3)),
+                    Bin(
+                        BinaryOperator.GreaterThan,
+                        Bin(BinaryOperator.Multiply, value, Int(int.MaxValue)),
+                        Int(int.MaxValue)))),
+            _ => throw new InvalidOperationException(
+                $"No integer sort discriminator is registered for '{type}'.")
+        };
+    }
+
+    private static ExpressionNode IntegerRange(ExpressionNode value, long minimum, long maximum) =>
+        Bin(
+            BinaryOperator.And,
+            Bin(BinaryOperator.GreaterOrEqual, value, Int(minimum)),
+            Bin(BinaryOperator.LessOrEqual, value, Int(maximum)));
+
+    private static ExpressionNode ExactBoundaryExists(string type, long boundary)
+    {
+        var witness = Ref("sortWitness");
+        return new ExistsExpressionNode(
+            Span,
+            [new QuantifierVariableNode(Span, "sortWitness", type)],
+            Bin(
+                BinaryOperator.And,
+                Bin(
+                    BinaryOperator.And,
+                    Bin(BinaryOperator.GreaterOrEqual, witness, Int(boundary)),
+                    Bin(BinaryOperator.LessThan, witness, Int(boundary + 1))),
+                Eq(witness, Int(boundary))));
     }
 
     private static FormExpression NoParameters(ExpressionNode condition) =>
@@ -386,7 +487,7 @@ internal static class DifferentialFormRegistry
         new(Span, name, type, Attributes);
 
     private static ReferenceNode Ref(string name) => new(Span, name);
-    private static IntLiteralNode Int(int value) => new(Span, value);
+    private static IntLiteralNode Int(long value) => new(Span, value);
     private static BoolLiteralNode Bool(bool value) => new(Span, value);
     private static StringLiteralNode Str(string value) => new(Span, value);
     private static BinaryOperationNode Bin(

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialFormRegistry.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialFormRegistry.cs
@@ -359,9 +359,9 @@ internal static class DifferentialFormRegistry
     {
         var field = new FieldAccessNode(Span, Ref("probe"), "Value");
         return Bin(
-            provable ? BinaryOperator.Equal : BinaryOperator.NotEqual,
+            provable ? BinaryOperator.LessOrEqual : BinaryOperator.GreaterThan,
             field,
-            field);
+            Int(byte.MaxValue));
     }
 
     private static FormExpression NoParameters(ExpressionNode condition) =>

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialFormRegistry.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialFormRegistry.cs
@@ -49,6 +49,7 @@ internal static class DifferentialFormRegistry
             "scalar-type",
             true,
             null,
+            IsStringType(type) ? [Z3Verifier.StringModelAssumption] : Array.Empty<string>(),
             polarity => new FormExpression(
                 polarity == CasePolarity.Provable
                     ? Bin(BinaryOperator.Equal, Ref("value"), Ref("value"))
@@ -64,6 +65,7 @@ internal static class DifferentialFormRegistry
             "array-element-type",
             true,
             null,
+            [Z3Verifier.NullableReferenceModelAssumption],
             polarity =>
             {
                 var access = new ArrayAccessNode(Span, Ref("values"), Int(0));
@@ -85,6 +87,7 @@ internal static class DifferentialFormRegistry
                 "expression-kind",
                 true,
                 null,
+                Array.Empty<string>(),
                 polarity => new FormExpression(
                     Bin(
                         polarity == CasePolarity.Provable
@@ -101,6 +104,7 @@ internal static class DifferentialFormRegistry
             "expression-kind",
             true,
             null,
+            GetExpressionKindAssumptions(kind),
             polarity => BuildExpressionKindExpression(kind, polarity),
             condition => ContainsKind(condition, kind));
     }
@@ -157,6 +161,7 @@ internal static class DifferentialFormRegistry
             "binary-operator",
             true,
             null,
+            Array.Empty<string>(),
             polarity => NoParameters(BuildBinaryOperatorCondition(op, polarity == CasePolarity.Provable)),
             condition => ContainsBinaryOperator(condition, op));
     }
@@ -168,6 +173,7 @@ internal static class DifferentialFormRegistry
             "unary-operator",
             true,
             null,
+            Array.Empty<string>(),
             polarity => NoParameters(BuildUnaryOperatorCondition(op, polarity == CasePolarity.Provable)),
             condition => ContainsUnaryOperator(condition, op));
     }
@@ -179,6 +185,7 @@ internal static class DifferentialFormRegistry
             "string-operation",
             true,
             null,
+            [Z3Verifier.StringModelAssumption],
             polarity => NoParameters(
                 BuildStringOperationCondition(op, polarity == CasePolarity.Provable)),
             condition => ContainsStringOperation(condition, op));
@@ -191,6 +198,7 @@ internal static class DifferentialFormRegistry
             "string-comparison-mode",
             true,
             null,
+            [Z3Verifier.StringModelAssumption],
             polarity => NoParameters(
                 BuildStringOperationCondition(
                     StringOp.Contains,
@@ -206,6 +214,7 @@ internal static class DifferentialFormRegistry
             "quantifier-bound-variable-type",
             true,
             null,
+            Array.Empty<string>(),
             polarity => NoParameters(
                 BuildForall(polarity == CasePolarity.Provable, "Int32")),
             condition => ContainsQuantifierType(condition, "Int32"));
@@ -357,6 +366,21 @@ internal static class DifferentialFormRegistry
 
     private static FormExpression NoParameters(ExpressionNode condition) =>
         new(condition, Array.Empty<ParameterNode>());
+
+    private static bool IsStringType(string type) =>
+        type is "str" or "string";
+
+    private static IReadOnlyList<string> GetExpressionKindAssumptions(string kind)
+    {
+        return kind switch
+        {
+            nameof(StringLiteralNode) or nameof(StringOperationNode) =>
+                [Z3Verifier.StringModelAssumption],
+            nameof(ArrayAccessNode) or nameof(ArrayLengthNode) or nameof(FieldAccessNode) =>
+                [Z3Verifier.NullableReferenceModelAssumption],
+            _ => Array.Empty<string>()
+        };
+    }
 
     private static ParameterNode Parameter(string name, string type) =>
         new(Span, name, type, Attributes);

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialFormRegistry.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialFormRegistry.cs
@@ -204,11 +204,20 @@ internal static class DifferentialFormRegistry
             true,
             null,
             [Z3Verifier.StringModelAssumption],
-            polarity => NoParameters(
-                BuildStringOperationCondition(
-                    StringOp.Contains,
-                    polarity == CasePolarity.Provable,
-                    StringComparisonMode.Ordinal)),
+            polarity =>
+            {
+                var cultureDivergentStartsWith = StringOpNode(
+                    StringOp.StartsWith,
+                    [Str("abc"), Str("\u200dabc")],
+                    StringComparisonMode.Ordinal);
+                return NoParameters(
+                    polarity == CasePolarity.Provable
+                        ? new UnaryOperationNode(
+                            Span,
+                            UnaryOperator.Not,
+                            cultureDivergentStartsWith)
+                        : cultureDivergentStartsWith);
+            },
             condition => ContainsStringComparisonMode(condition, StringComparisonMode.Ordinal));
     }
 

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialGate.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialGate.cs
@@ -1,0 +1,636 @@
+using System.Security.Cryptography;
+using Calor.Compiler;
+using Calor.Compiler.Ast;
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Calor.Compiler.Verification;
+using Calor.Compiler.Verification.Obligations;
+using Calor.Compiler.Verification.Z3;
+using Calor.Compiler.Verification.Z3.Cache;
+using Microsoft.Z3;
+using Z3ContractVerificationResult = Calor.Compiler.Verification.Z3.ContractVerificationResult;
+
+namespace Calor.Verification.Tests.VerifierRuntimeDifferential;
+
+internal static class DifferentialGate
+{
+    public const string PinnedWhitelistSha256 =
+        "6dbdc9c0e1ec122ec1110013cb023ac51109ae5452b55ad00a0b782b471ec463";
+
+    private const int MaximumDepth = 3;
+    private static readonly TextSpan Span = TextSpan.Empty;
+    private static readonly AttributeCollection Attributes = new();
+
+    public static DifferentialReport Run(string repositoryRoot)
+    {
+        VerifyWhitelistHash(repositoryRoot);
+
+        var forms = DifferentialFormRegistry.Build();
+        var cases = GenerateCases(forms);
+        var module = BuildModule(cases);
+        var diagnostics = new DiagnosticBag();
+
+        var verification = new ContractVerificationPass(
+                diagnostics,
+                new VerificationOptions
+                {
+                    Verbose = false,
+                    ElideProvenGuards = false,
+                    TimeoutMs = VerificationOptions.DefaultTimeoutMs,
+                    CacheOptions = new VerificationCacheOptions { Enabled = false }
+                })
+            .Verify(module);
+
+        var obligations = new ObligationTracker();
+        new ObligationGenerator(obligations).Generate(module);
+        using (var context = Z3ContextFactory.Create())
+        using (var solver = new ObligationSolver(context))
+        {
+            solver.SolveAll(obligations, module);
+        }
+        verification = ApplySelfRefHarnessBinding(cases, verification, obligations);
+
+        var forcedCode = Emit(module, verification, obligations, elide: false, diagnostics);
+        var elidedCode = Emit(module, verification, obligations, elide: true, diagnostics);
+        ValidateGeneratedCode(forcedCode, "forced-guards");
+        ValidateGeneratedCode(elidedCode, "elision-enabled");
+
+        var forcedMethods = GeneratedMethodInspector.ExtractMethods(forcedCode);
+        var elidedMethods = GeneratedMethodInspector.ExtractMethods(elidedCode);
+        var runtime = GeneratedRuntime.Compile(
+            "CalorVerifierDifferentialMain",
+            forcedCode,
+            "VerifierDifferential");
+
+        var results = cases.Select(testCase => EvaluateCase(
+                testCase,
+                verification,
+                obligations,
+                forcedMethods,
+                elidedMethods,
+                runtime))
+            .ToList();
+
+        var failSafeControls = RunFailSafeControls();
+        return BuildReport(forms, results, failSafeControls);
+    }
+
+    private static IReadOnlyList<DifferentialCase> GenerateCases(
+        IReadOnlyList<DifferentialForm> forms)
+    {
+        var cases = new List<DifferentialCase>();
+        var sequence = 0;
+
+        foreach (var form in forms.Where(candidate => candidate.MatrixApplicable))
+        {
+            foreach (var position in Enum.GetValues<ContractPosition>())
+            {
+                foreach (var depth in Enumerable.Range(1, MaximumDepth))
+                {
+                    foreach (var polarity in Enum.GetValues<CasePolarity>())
+                    {
+                        sequence++;
+                        var built = form.Build(polarity);
+                        if (!form.ContainsTarget(built.Condition))
+                        {
+                            throw new InvalidOperationException(
+                                $"Generator for '{form.Id}' does not contain its registered target.");
+                        }
+
+                        var nested = DifferentialFormRegistry.ApplyIdentityNesting(
+                            built.Condition,
+                            depth);
+                        var functionId = $"f{sequence:D6}";
+                        var functionName = BuildFunctionName(sequence, form, position, depth, polarity);
+                        var proofId = position == ContractPosition.Obligation
+                            ? $"p{sequence:D6}"
+                            : null;
+                        var function = BuildFunction(
+                            functionId,
+                            functionName,
+                            built.Parameters,
+                            nested,
+                            position,
+                            proofId);
+                        cases.Add(new DifferentialCase(
+                            $"case-{sequence:D6}",
+                            form.Id,
+                            form.Category,
+                            position,
+                            depth,
+                            polarity,
+                            function,
+                            proofId));
+                    }
+                }
+            }
+        }
+
+        return cases;
+    }
+
+    private static FunctionNode BuildFunction(
+        string functionId,
+        string functionName,
+        IReadOnlyList<ParameterNode> parameters,
+        ExpressionNode condition,
+        ContractPosition position,
+        string? proofId)
+    {
+        var preconditions = position == ContractPosition.Precondition
+            ? new[] { new RequiresNode(Span, condition, null, Attributes) }
+            : Array.Empty<RequiresNode>();
+        var postconditions = position == ContractPosition.Postcondition
+            ? new[] { new EnsuresNode(Span, condition, null, Attributes) }
+            : Array.Empty<EnsuresNode>();
+        var body = position == ContractPosition.Obligation
+            ? new StatementNode[]
+            {
+                new ProofObligationNode(
+                    Span,
+                    proofId!,
+                    "F-4 differential",
+                    condition,
+                    Attributes)
+            }
+            : Array.Empty<StatementNode>();
+
+        return new FunctionNode(
+            Span,
+            functionId,
+            functionName,
+            Visibility.Internal,
+            parameters,
+            output: null,
+            effects: null,
+            preconditions,
+            postconditions,
+            body,
+            Attributes);
+    }
+
+    private static ModuleNode BuildModule(IReadOnlyList<DifferentialCase> cases)
+    {
+        var probe = new ClassDefinitionNode(
+            Span,
+            "c000001",
+            "Probe",
+            isAbstract: false,
+            isSealed: false,
+            baseClass: null,
+            implementedInterfaces: Array.Empty<string>(),
+            typeParameters: Array.Empty<TypeParameterNode>(),
+            fields:
+            [
+                new ClassFieldNode(
+                    Span,
+                    "Value",
+                    "i32",
+                    Visibility.Public,
+                    new IntLiteralNode(Span, 7),
+                    Attributes)
+            ],
+            methods: Array.Empty<MethodNode>(),
+            Attributes);
+
+        return new ModuleNode(
+            Span,
+            "m000001",
+            "VerifierDifferential",
+            Array.Empty<UsingDirectiveNode>(),
+            Array.Empty<InterfaceDefinitionNode>(),
+            [probe],
+            cases.Select(testCase => testCase.Function).ToList(),
+            Attributes);
+    }
+
+    private static string Emit(
+        ModuleNode module,
+        ModuleVerificationResult verification,
+        ObligationTracker obligations,
+        bool elide,
+        DiagnosticBag diagnostics)
+    {
+        return new CSharpEmitter(
+            ContractMode.Debug,
+            verification,
+            inheritanceResult: null,
+            obligations,
+            diagnostics)
+        {
+            ElideProvenGuards = elide
+        }.Emit(module);
+    }
+
+    private static void ValidateGeneratedCode(string code, string label)
+    {
+        var validation = GeneratedCSharpCompiler.Validate(code);
+        var errors = validation.SyntaxErrors.Concat(validation.CompilationErrors).ToList();
+        if (errors.Count == 0)
+            return;
+
+        throw new InvalidOperationException(
+            $"The {label} generated C# failed validation:{Environment.NewLine}" +
+            string.Join(Environment.NewLine, errors));
+    }
+
+    private static CaseResult EvaluateCase(
+        DifferentialCase testCase,
+        ModuleVerificationResult verification,
+        ObligationTracker obligations,
+        IReadOnlyDictionary<string, string> forcedMethods,
+        IReadOnlyDictionary<string, string> elidedMethods,
+        GeneratedRuntime runtime)
+    {
+        var outcome = GetOutcome(testCase, verification, obligations);
+        var forcedMethod = forcedMethods[testCase.Function.Name];
+        var elidedMethod = elidedMethods[testCase.Function.Name];
+        var guardForced = GeneratedMethodInspector.HasGuard(forcedMethod, testCase.Position);
+        var guardWithElision = GeneratedMethodInspector.HasGuard(elidedMethod, testCase.Position);
+        var elisionEligible = testCase.Position != ContractPosition.Precondition
+            && outcome.Status == ProofStatus.Proven
+            && !outcome.IsVacuous;
+        var elidedWhenEnabled = !guardWithElision;
+
+        var runtimeVerdict = runtime.Invoke(
+            testCase.Function.Name,
+            testCase.Function.Parameters.Select(parameter => parameter.TypeName).ToList(),
+            out var runtimeDetail);
+        var expectedRuntime = testCase.Polarity == CasePolarity.Provable
+            ? RuntimeVerdict.Completed
+            : RuntimeVerdict.GuardFailed;
+
+        var detail = new List<string>();
+        if (!guardForced)
+            detail.Add("forced-guard emission omitted the runtime guard");
+        if (elidedWhenEnabled != elisionEligible)
+        {
+            detail.Add(
+                elisionEligible
+                    ? "eligible Proven/Discharged guard was not elided on the opt-in path"
+                    : "fail-safe or precondition guard was elided on the opt-in path");
+        }
+        if (outcome.IsVacuous)
+            detail.Add("generated case produced a vacuous proof");
+        if (runtimeVerdict != expectedRuntime)
+        {
+            detail.Add(
+                $"runtime expected {expectedRuntime} but observed {runtimeVerdict}" +
+                (runtimeDetail == null ? "" : $" ({runtimeDetail})"));
+        }
+        if (outcome.Status == ProofStatus.Proven
+            && testCase.Polarity == CasePolarity.Refutable)
+        {
+            detail.Add("solver proved a generated refutable case");
+        }
+        if (outcome.Status == ProofStatus.Refuted
+            && testCase.Polarity == CasePolarity.Provable)
+        {
+            detail.Add("solver refuted a generated provable case");
+        }
+
+        return new CaseResult(
+            testCase.Id,
+            testCase.FormId,
+            testCase.FormCategory,
+            ToWireName(testCase.Position),
+            testCase.NestingDepth,
+            testCase.Polarity.ToString().ToLowerInvariant(),
+            outcome.StatusName,
+            runtimeVerdict.ToString().ToLowerInvariant(),
+            guardForced,
+            elidedWhenEnabled,
+            detail.Count > 0,
+            detail.Count == 0 ? null : string.Join("; ", detail));
+    }
+
+    private static ProofOutcome GetOutcome(
+        DifferentialCase testCase,
+        ModuleVerificationResult verification,
+        ObligationTracker obligations)
+    {
+        if (testCase.Position == ContractPosition.Obligation)
+        {
+            return obligations.Obligations
+                .Single(obligation => obligation.SourceProofId == testCase.ProofId)
+                .Outcome
+                ?? throw new InvalidOperationException(
+                    $"Obligation '{testCase.ProofId}' has no typed outcome.");
+        }
+
+        var function = verification.GetFunctionResult(testCase.Function.Id)
+            ?? throw new InvalidOperationException(
+                $"Function '{testCase.Function.Id}' has no verification result.");
+        var result = testCase.Position == ContractPosition.Precondition
+            ? function.PreconditionResults.Single()
+            : function.PostconditionResults.Single();
+        return result.EffectiveOutcome;
+    }
+
+    private static ModuleVerificationResult ApplySelfRefHarnessBinding(
+        IReadOnlyList<DifferentialCase> cases,
+        ModuleVerificationResult verification,
+        ObligationTracker obligations)
+    {
+        const string selfRefForm = "expression-kind:SelfRefNode";
+        var selfCases = cases.Where(testCase => testCase.FormId == selfRefForm).ToList();
+        if (selfCases.Count == 0)
+            return verification;
+
+        var outcomes = new Dictionary<string, ProofOutcome>(StringComparer.Ordinal);
+        using var context = Z3ContextFactory.Create();
+        foreach (var testCase in selfCases)
+        {
+            var condition = testCase.Position switch
+            {
+                ContractPosition.Precondition =>
+                    testCase.Function.Preconditions.Single().Condition,
+                ContractPosition.Postcondition =>
+                    testCase.Function.Postconditions.Single().Condition,
+                ContractPosition.Obligation =>
+                    ((ProofObligationNode)testCase.Function.Body.Single()).Condition,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+
+            var translator = new ContractTranslator(context);
+            if (!translator.DeclareVariable("__self__", "i32"))
+                throw new InvalidOperationException("Could not declare the F-4 SelfRef binding.");
+            translator.PushSelfVariable("__self__");
+            var translated = translator.TranslateBoolExpr(condition)
+                ?? throw new InvalidOperationException(
+                    $"SelfRef differential case '{testCase.Id}' did not translate.");
+
+            using var solver = context.MkSolver();
+            solver.Set("timeout", VerificationOptions.DefaultTimeoutMs);
+            var polarity = testCase.Position == ContractPosition.Precondition
+                ? SatPolarity.SatIsProof
+                : SatPolarity.SatIsRefutation;
+            solver.Assert(
+                testCase.Position == ContractPosition.Precondition
+                    ? translated
+                    : context.MkNot(translated));
+            outcomes[testCase.Function.Id] = ProofOutcome.Assign(
+                ProofEvidence.SolverVerdict(
+                    solver.Check(),
+                    solver,
+                    translator.Variables,
+                    polarity,
+                    unsatNote: testCase.Position == ContractPosition.Precondition
+                        ? "Precondition is never satisfiable"
+                        : null));
+            translator.PopSelfVariable();
+        }
+
+        foreach (var testCase in selfCases.Where(
+                     candidate => candidate.Position == ContractPosition.Obligation))
+        {
+            var obligation = obligations.Obligations
+                .Single(candidate => candidate.SourceProofId == testCase.ProofId);
+            ApplySyntheticOutcome(obligation, outcomes[testCase.Function.Id]);
+        }
+
+        var rewritten = verification.Functions.Select(function =>
+        {
+            if (!outcomes.TryGetValue(function.FunctionId, out var outcome))
+                return function;
+
+            var testCase = selfCases.Single(candidate =>
+                candidate.Function.Id == function.FunctionId);
+            return testCase.Position switch
+            {
+                ContractPosition.Precondition => function with
+                {
+                    PreconditionResults = [Z3ContractVerificationResult.FromOutcome(outcome)]
+                },
+                ContractPosition.Postcondition => function with
+                {
+                    PostconditionResults = [Z3ContractVerificationResult.FromOutcome(outcome)]
+                },
+                _ => function
+            };
+        }).ToList();
+        return new ModuleVerificationResult(rewritten);
+    }
+
+    private static IReadOnlyList<FailSafeControl> RunFailSafeControls()
+    {
+        var statuses = new[]
+        {
+            ProofOutcome.Rehydrate("unsupported", null, "synthetic unsupported control"),
+            ProofOutcome.Rehydrate("timeout", null, "synthetic timeout control"),
+            ProofOutcome.Rehydrate("unknown", null, "Z3 solver error: synthetic error control"),
+            ProofOutcome.Rehydrate("unavailable", null, "synthetic unavailable control"),
+            ProofOutcome.Rehydrate(
+                "assumed",
+                null,
+                "synthetic assumed control",
+                assumptions: ["differential-control"])
+        };
+
+        var functions = new List<FunctionNode>();
+        var verificationFunctions = new List<FunctionVerificationResult>();
+        var tracker = new ObligationTracker();
+        var controls = new List<(string Channel, ProofOutcome Outcome, FunctionNode Function, string? ProofId)>();
+        var sequence = 0;
+
+        foreach (var outcome in statuses)
+        {
+            sequence++;
+            var postFunction = BuildFunction(
+                $"fc{sequence:D3}",
+                $"FailSafe_Post_{outcome.StatusName}",
+                Array.Empty<ParameterNode>(),
+                new BoolLiteralNode(Span, false),
+                ContractPosition.Postcondition,
+                proofId: null);
+            functions.Add(postFunction);
+            verificationFunctions.Add(new FunctionVerificationResult(
+                postFunction.Id,
+                postFunction.Name,
+                Array.Empty<Z3ContractVerificationResult>(),
+                [Z3ContractVerificationResult.FromOutcome(outcome)]));
+            controls.Add(("postcondition", outcome, postFunction, null));
+
+            sequence++;
+            var proofId = $"pc{sequence:D3}";
+            var obligationFunction = BuildFunction(
+                $"fc{sequence:D3}",
+                $"FailSafe_Obligation_{outcome.StatusName}",
+                Array.Empty<ParameterNode>(),
+                new BoolLiteralNode(Span, false),
+                ContractPosition.Obligation,
+                proofId);
+            functions.Add(obligationFunction);
+            controls.Add(("obligation", outcome, obligationFunction, proofId));
+        }
+
+        var module = new ModuleNode(
+            Span,
+            "mc0001",
+            "VerifierFailSafe",
+            Array.Empty<UsingDirectiveNode>(),
+            functions,
+            Attributes);
+        new ObligationGenerator(tracker).Generate(module);
+        foreach (var control in controls.Where(control => control.ProofId != null))
+        {
+            var obligation = tracker.Obligations.Single(
+                candidate => candidate.SourceProofId == control.ProofId);
+            ApplySyntheticOutcome(obligation, control.Outcome);
+        }
+
+        var code = new CSharpEmitter(
+            ContractMode.Debug,
+            new ModuleVerificationResult(verificationFunctions),
+            inheritanceResult: null,
+            tracker)
+        {
+            ElideProvenGuards = true
+        }.Emit(module);
+        ValidateGeneratedCode(code, "fail-safe-control");
+        var methods = GeneratedMethodInspector.ExtractMethods(code);
+        var runtime = GeneratedRuntime.Compile(
+            "CalorVerifierDifferentialFailSafe",
+            code,
+            "VerifierFailSafe");
+
+        return controls.Select(control =>
+        {
+            var position = control.Channel == "postcondition"
+                ? ContractPosition.Postcondition
+                : ContractPosition.Obligation;
+            var method = methods[control.Function.Name];
+            var guardRetained = GeneratedMethodInspector.HasGuard(method, position);
+            var runtimeVerdict = runtime.Invoke(
+                control.Function.Name,
+                Array.Empty<string>(),
+                out _);
+            return new FailSafeControl(
+                control.Channel,
+                control.Outcome.StatusName,
+                guardRetained,
+                runtimeVerdict.ToString().ToLowerInvariant(),
+                guardRetained && runtimeVerdict == RuntimeVerdict.GuardFailed);
+        }).ToList();
+    }
+
+    private static void ApplySyntheticOutcome(Obligation obligation, ProofOutcome outcome)
+    {
+        var method = typeof(Obligation).GetMethod(
+            "ApplyOutcome",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Obligation.ApplyOutcome was not found.");
+        method.Invoke(obligation, [outcome]);
+    }
+
+    private static DifferentialReport BuildReport(
+        IReadOnlyList<DifferentialForm> forms,
+        IReadOnlyList<CaseResult> results,
+        IReadOnlyList<FailSafeControl> failSafeControls)
+    {
+        var formCoverage = forms.Select(form =>
+        {
+            var cases = results.Where(result => result.FormId == form.Id).ToList();
+            return new FormCoverage(
+                form.Id,
+                form.Category,
+                form.MatrixApplicable,
+                form.ExclusionReason,
+                cases.Count,
+                cases.Count(testCase => testCase.Polarity == "provable"),
+                cases.Count(testCase => testCase.Polarity == "refutable"),
+                cases.Count(testCase => testCase.Position == "precondition"),
+                cases.Count(testCase => testCase.Position == "postcondition"),
+                cases.Count(testCase => testCase.Position == "obligation"),
+                cases.Any(testCase => testCase.ElidedWhenEnabled),
+                cases.Count(testCase => testCase.Mismatch),
+                cases.GroupBy(testCase => testCase.SolverStatus, StringComparer.Ordinal)
+                    .OrderBy(group => group.Key, StringComparer.Ordinal)
+                    .ToDictionary(group => group.Key, group => group.Count(), StringComparer.Ordinal));
+        }).ToList();
+
+        var formsWhitelisted = forms.Count;
+        var formsApplicable = forms.Count(form => form.MatrixApplicable);
+        var formsCovered = formCoverage.Count(form => form.Applicable && form.Cases > 0);
+        var formsEliding = formCoverage.Count(form => form.Elides);
+        var matrixRegistered = formsWhitelisted
+            * Enum.GetValues<ContractPosition>().Length
+            * MaximumDepth
+            * Enum.GetValues<CasePolarity>().Length;
+        var mismatches = results.Count(result => result.Mismatch);
+        var metrics = new CoverageMetrics(
+            formsWhitelisted,
+            formsApplicable,
+            formsCovered,
+            formsEliding,
+            Fraction(formsCovered, formsWhitelisted),
+            Fraction(formsEliding, formsWhitelisted),
+            matrixRegistered,
+            results.Count,
+            Fraction(results.Count, matrixRegistered),
+            results.Count,
+            mismatches);
+
+        return new DifferentialReport(
+            "1.0",
+            "F-4",
+            PinnedWhitelistSha256,
+            MaximumDepth,
+            Enum.GetValues<ContractPosition>().Select(ToWireName).ToList(),
+            Enum.GetValues<CasePolarity>()
+                .Select(polarity => polarity.ToString().ToLowerInvariant())
+                .ToList(),
+            metrics,
+            results.GroupBy(result => result.SolverStatus, StringComparer.Ordinal)
+                .OrderBy(group => group.Key, StringComparer.Ordinal)
+                .ToDictionary(group => group.Key, group => group.Count(), StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["expression-kind:SelfRefNode"] =
+                    "The harness binds '#' to an i32 parameter named '__self__' before translation; " +
+                    "the emitter's existing SelfRef lowering targets the same generated parameter. " +
+                    "This exercises the modeled refinement meaning without claiming ordinary source-level " +
+                    "§Q/§S/§PROOF acceptance of an unbound '#'."
+            },
+            formCoverage,
+            failSafeControls,
+            results.Where(result => result.Mismatch).ToList());
+    }
+
+    private static string BuildFunctionName(
+        int sequence,
+        DifferentialForm form,
+        ContractPosition position,
+        int depth,
+        CasePolarity polarity)
+    {
+        var formName = new string(form.Id.Select(character =>
+            char.IsLetterOrDigit(character) ? character : '_').ToArray());
+        return $"D{sequence:D4}_{formName}_{position}_N{depth}_{polarity}";
+    }
+
+    private static void VerifyWhitelistHash(string repositoryRoot)
+    {
+        var path = Path.Combine(repositoryRoot, "docs", "verification-modeled-forms.md");
+        var actual = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(path)))
+            .ToLowerInvariant();
+        if (!string.Equals(actual, PinnedWhitelistSha256, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"F-4 whitelist hash mismatch: expected {PinnedWhitelistSha256}, actual {actual}. " +
+                "Update the freeze registration before changing the denominator.");
+        }
+    }
+
+    private static string ToWireName(ContractPosition position) => position switch
+    {
+        ContractPosition.Precondition => "precondition",
+        ContractPosition.Postcondition => "postcondition",
+        ContractPosition.Obligation => "obligation",
+        _ => throw new ArgumentOutOfRangeException(nameof(position))
+    };
+
+    private static double Fraction(int numerator, int denominator) =>
+        denominator == 0 ? 0 : Math.Round((double)numerator / denominator, 6);
+}

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialGate.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialGate.cs
@@ -17,6 +17,8 @@ internal static class DifferentialGate
 {
     public const string PinnedWhitelistSha256 =
         "6dbdc9c0e1ec122ec1110013cb023ac51109ae5452b55ad00a0b782b471ec463";
+    internal const string ProbeFieldType = "u8";
+    internal const byte ProbeFieldWitness = byte.MaxValue;
 
     private const int MaximumDepth = 3;
     private static readonly TextSpan Span = TextSpan.Empty;
@@ -189,9 +191,9 @@ internal static class DifferentialGate
                 new ClassFieldNode(
                     Span,
                     "Value",
-                    "i32",
+                    ProbeFieldType,
                     Visibility.Public,
-                    new IntLiteralNode(Span, 7),
+                    new IntLiteralNode(Span, ProbeFieldWitness),
                     Attributes)
             ],
             methods: Array.Empty<MethodNode>(),
@@ -645,9 +647,9 @@ internal static class DifferentialGate
                     "§Q/§S/§PROOF acceptance of an unbound '#'.",
                 ["expression-kind:FieldAccessNode"] =
                     "The production contract pass and obligation solver derive field types from module " +
-                    "class declarations. Probe.Value is translated as a typed uninterpreted accessor and " +
-                    "executed against a generated Probe instance; proofs remain explicitly Assumed under " +
-                    "the nullable-reference model."
+                    "class declarations. Probe.Value is a u8 accessor checked against its 255 upper bound " +
+                    "and executed at that boundary; the historical guessed-i32 fallback cannot prove the " +
+                    "bound. Proofs remain explicitly Assumed under the nullable-reference model."
             },
             formCoverage,
             failSafeControls,

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialGate.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialGate.cs
@@ -58,19 +58,21 @@ internal static class DifferentialGate
 
         var forcedMethods = GeneratedMethodInspector.ExtractMethods(forcedCode);
         var elidedMethods = GeneratedMethodInspector.ExtractMethods(elidedCode);
-        var runtime = GeneratedRuntime.Compile(
-            "CalorVerifierDifferentialMain",
-            forcedCode,
-            "VerifierDifferential");
-
-        var results = cases.Select(testCase => EvaluateCase(
-                testCase,
-                verification,
-                obligations,
-                forcedMethods,
-                elidedMethods,
-                runtime))
-            .ToList();
+        List<CaseResult> results;
+        using (var runtime = GeneratedRuntime.Compile(
+                   "CalorVerifierDifferentialMain",
+                   forcedCode,
+                   "VerifierDifferential"))
+        {
+            results = cases.Select(testCase => EvaluateCase(
+                    testCase,
+                    verification,
+                    obligations,
+                    forcedMethods,
+                    elidedMethods,
+                    runtime))
+                .ToList();
+        }
 
         var failSafeControls = RunFailSafeControls();
         return BuildReport(forms, results, failSafeControls);
@@ -121,7 +123,8 @@ internal static class DifferentialGate
                             depth,
                             polarity,
                             function,
-                            proofId));
+                            proofId,
+                            form.AllowedAssumptions));
                     }
                 }
             }
@@ -260,8 +263,20 @@ internal static class DifferentialGate
         var expectedRuntime = testCase.Polarity == CasePolarity.Provable
             ? RuntimeVerdict.Completed
             : RuntimeVerdict.GuardFailed;
+        var solverHandled = IsExpectedSolverOutcome(testCase, outcome)
+            && !outcome.IsVacuous;
 
         var detail = new List<string>();
+        if (!solverHandled)
+        {
+            var expected = testCase.Polarity == CasePolarity.Refutable
+                ? "refuted"
+                : testCase.AllowedAssumptions.Count == 0
+                    ? "proven"
+                    : "proven or explicitly allowed assumed";
+            detail.Add(
+                $"solver expected {expected} but observed {outcome.StatusName}");
+        }
         if (!guardForced)
             detail.Add("forced-guard emission omitted the runtime guard");
         if (elidedWhenEnabled != elisionEligible)
@@ -301,8 +316,26 @@ internal static class DifferentialGate
             runtimeVerdict.ToString().ToLowerInvariant(),
             guardForced,
             elidedWhenEnabled,
+            solverHandled,
             detail.Count > 0,
             detail.Count == 0 ? null : string.Join("; ", detail));
+    }
+
+    private static bool IsExpectedSolverOutcome(
+        DifferentialCase testCase,
+        ProofOutcome outcome)
+    {
+        if (testCase.Polarity == CasePolarity.Refutable)
+            return outcome.Status == ProofStatus.Refuted;
+
+        if (outcome.Status == ProofStatus.Proven)
+            return true;
+
+        return outcome.Status == ProofStatus.Assumed
+            && outcome.Assumptions.SequenceEqual(
+                testCase.AllowedAssumptions.OrderBy(
+                    assumption => assumption,
+                    StringComparer.Ordinal));
     }
 
     private static ProofOutcome GetOutcome(
@@ -415,31 +448,43 @@ internal static class DifferentialGate
 
     private static IReadOnlyList<FailSafeControl> RunFailSafeControls()
     {
-        var statuses = new[]
+        var statuses = new (string Scenario, ProofOutcome Outcome)[]
         {
-            ProofOutcome.Rehydrate("unsupported", null, "synthetic unsupported control"),
-            ProofOutcome.Rehydrate("timeout", null, "synthetic timeout control"),
-            ProofOutcome.Rehydrate("unknown", null, "Z3 solver error: synthetic error control"),
-            ProofOutcome.Rehydrate("unavailable", null, "synthetic unavailable control"),
-            ProofOutcome.Rehydrate(
-                "assumed",
-                null,
-                "synthetic assumed control",
-                assumptions: ["differential-control"])
+            ("unsupported",
+                ProofOutcome.Assign(ProofEvidence.Unsupported("synthetic unsupported control"))),
+            ("timeout",
+                ProofOutcome.ClassifySolverStatus(
+                    Status.UNKNOWN,
+                    SatPolarity.SatIsRefutation,
+                    reasonUnknown: "timeout: synthetic deterministic control")),
+            ("solver-error",
+                ProofOutcome.ClassifySolverException(
+                    new InvalidOperationException("synthetic deterministic control"))),
+            ("unavailable",
+                ProofOutcome.Assign(ProofEvidence.SolverUnavailable("synthetic unavailable control"))),
+            ("assumed",
+                ProofOutcome.Assign(ProofEvidence.AssumedProof(
+                    "synthetic assumed control",
+                    ["differential-control"])))
         };
 
         var functions = new List<FunctionNode>();
         var verificationFunctions = new List<FunctionVerificationResult>();
         var tracker = new ObligationTracker();
-        var controls = new List<(string Channel, ProofOutcome Outcome, FunctionNode Function, string? ProofId)>();
+        var controls = new List<(
+            string Scenario,
+            string Channel,
+            ProofOutcome Outcome,
+            FunctionNode Function,
+            string? ProofId)>();
         var sequence = 0;
 
-        foreach (var outcome in statuses)
+        foreach (var (scenario, outcome) in statuses)
         {
             sequence++;
             var postFunction = BuildFunction(
                 $"fc{sequence:D3}",
-                $"FailSafe_Post_{outcome.StatusName}",
+                $"FailSafe_Post_{scenario.Replace('-', '_')}",
                 Array.Empty<ParameterNode>(),
                 new BoolLiteralNode(Span, false),
                 ContractPosition.Postcondition,
@@ -450,19 +495,19 @@ internal static class DifferentialGate
                 postFunction.Name,
                 Array.Empty<Z3ContractVerificationResult>(),
                 [Z3ContractVerificationResult.FromOutcome(outcome)]));
-            controls.Add(("postcondition", outcome, postFunction, null));
+            controls.Add((scenario, "postcondition", outcome, postFunction, null));
 
             sequence++;
             var proofId = $"pc{sequence:D3}";
             var obligationFunction = BuildFunction(
                 $"fc{sequence:D3}",
-                $"FailSafe_Obligation_{outcome.StatusName}",
+                $"FailSafe_Obligation_{scenario.Replace('-', '_')}",
                 Array.Empty<ParameterNode>(),
                 new BoolLiteralNode(Span, false),
                 ContractPosition.Obligation,
                 proofId);
             functions.Add(obligationFunction);
-            controls.Add(("obligation", outcome, obligationFunction, proofId));
+            controls.Add((scenario, "obligation", outcome, obligationFunction, proofId));
         }
 
         var module = new ModuleNode(
@@ -490,7 +535,7 @@ internal static class DifferentialGate
         }.Emit(module);
         ValidateGeneratedCode(code, "fail-safe-control");
         var methods = GeneratedMethodInspector.ExtractMethods(code);
-        var runtime = GeneratedRuntime.Compile(
+        using var runtime = GeneratedRuntime.Compile(
             "CalorVerifierDifferentialFailSafe",
             code,
             "VerifierFailSafe");
@@ -507,6 +552,7 @@ internal static class DifferentialGate
                 Array.Empty<string>(),
                 out _);
             return new FailSafeControl(
+                control.Scenario,
                 control.Channel,
                 control.Outcome.StatusName,
                 guardRetained,
@@ -537,6 +583,9 @@ internal static class DifferentialGate
                 form.Category,
                 form.MatrixApplicable,
                 form.ExclusionReason,
+                form.AllowedAssumptions,
+                cases.Count == ExpectedCasesPerApplicableForm
+                    && cases.All(testCase => testCase.SolverHandled),
                 cases.Count,
                 cases.Count(testCase => testCase.Polarity == "provable"),
                 cases.Count(testCase => testCase.Polarity == "refutable"),
@@ -552,12 +601,13 @@ internal static class DifferentialGate
 
         var formsWhitelisted = forms.Count;
         var formsApplicable = forms.Count(form => form.MatrixApplicable);
-        var formsCovered = formCoverage.Count(form => form.Applicable && form.Cases > 0);
+        var formsCovered = formCoverage.Count(form => form.Applicable && form.SolverHandled);
         var formsEliding = formCoverage.Count(form => form.Elides);
         var matrixRegistered = formsWhitelisted
             * Enum.GetValues<ContractPosition>().Length
             * MaximumDepth
             * Enum.GetValues<CasePolarity>().Length;
+        var matrixApplicable = formsApplicable * ExpectedCasesPerApplicableForm;
         var mismatches = results.Count(result => result.Mismatch);
         var metrics = new CoverageMetrics(
             formsWhitelisted,
@@ -567,13 +617,14 @@ internal static class DifferentialGate
             Fraction(formsCovered, formsWhitelisted),
             Fraction(formsEliding, formsWhitelisted),
             matrixRegistered,
-            results.Count,
-            Fraction(results.Count, matrixRegistered),
+            matrixApplicable,
+            results.Count(result => result.SolverHandled),
+            Fraction(results.Count(result => result.SolverHandled), matrixApplicable),
             results.Count,
             mismatches);
 
         return new DifferentialReport(
-            "1.0",
+            "1.1",
             "F-4",
             PinnedWhitelistSha256,
             MaximumDepth,
@@ -591,7 +642,12 @@ internal static class DifferentialGate
                     "The harness binds '#' to an i32 parameter named '__self__' before translation; " +
                     "the emitter's existing SelfRef lowering targets the same generated parameter. " +
                     "This exercises the modeled refinement meaning without claiming ordinary source-level " +
-                    "§Q/§S/§PROOF acceptance of an unbound '#'."
+                    "§Q/§S/§PROOF acceptance of an unbound '#'.",
+                ["expression-kind:FieldAccessNode"] =
+                    "The production contract pass and obligation solver derive field types from module " +
+                    "class declarations. Probe.Value is translated as a typed uninterpreted accessor and " +
+                    "executed against a generated Probe instance; proofs remain explicitly Assumed under " +
+                    "the nullable-reference model."
             },
             formCoverage,
             failSafeControls,
@@ -633,4 +689,7 @@ internal static class DifferentialGate
 
     private static double Fraction(int numerator, int denominator) =>
         denominator == 0 ? 0 : Math.Round((double)numerator / denominator, 6);
+
+    private const int ExpectedCasesPerApplicableForm =
+        3 * MaximumDepth * 2;
 }

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialGate.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialGate.cs
@@ -647,9 +647,29 @@ internal static class DifferentialGate
                     "§Q/§S/§PROOF acceptance of an unbound '#'.",
                 ["expression-kind:FieldAccessNode"] =
                     "The production contract pass and obligation solver derive field types from module " +
-                    "class declarations. Probe.Value is a u8 accessor checked against its 255 upper bound " +
-                    "and executed at that boundary; the historical guessed-i32 fallback cannot prove the " +
-                    "bound. Proofs remain explicitly Assumed under the nullable-reference model."
+                    "class declarations. Probe.Value is a u8 accessor checked against both bounds 0..255 " +
+                    "and executed at 255; mapping it as i8 violates the lower bound and mapping it as i32 " +
+                    "violates both finite bounds. Proofs remain explicitly Assumed under the nullable-" +
+                    "reference model.",
+                ["scalar-type:i64"] =
+                    "The translator models integer literals only through signed i32. The i64 row therefore " +
+                    "uses signedness at -1 plus an i32-overflow boundary witness (2 * Int32.MaxValue) rather " +
+                    "than claiming coverage of Int64.MinValue/MaxValue literals.",
+                ["scalar-type:u32"] =
+                    "The u32 row combines non-negativity with the wrap boundary of " +
+                    "3 * Int32.MaxValue; this distinguishes 32-bit unsigned arithmetic from u64 without " +
+                    "requiring an out-of-model UInt32.MaxValue literal.",
+                ["scalar-type:u64"] =
+                    "The u64 row combines non-negativity with the non-wrapping result of " +
+                    "3 * Int32.MaxValue; it does not claim direct UInt64.MaxValue literal coverage.",
+                ["array-element-types"] =
+                    "Integer array rows apply the same per-type boundary predicates to values[0]. Runtime " +
+                    "uses a non-null one-element array with the matching deterministic witness; proofs are " +
+                    "therefore conditional only on the production nullable-reference-model assumption.",
+                ["scalar-type:str"] =
+                    "The string row proves non-negative length using the non-null ASCII runtime witness " +
+                    "'ascii'. The solver result remains explicitly conditional on the production string-" +
+                    "model assumption; this does not claim nullable or non-ASCII equivalence."
             },
             formCoverage,
             failSafeControls,

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialGate.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialGate.cs
@@ -19,6 +19,7 @@ internal static class DifferentialGate
         "6dbdc9c0e1ec122ec1110013cb023ac51109ae5452b55ad00a0b782b471ec463";
     internal const string ProbeFieldType = "u8";
     internal const byte ProbeFieldWitness = byte.MaxValue;
+    internal const string RuntimeCultureName = "en-US";
 
     private const int MaximumDepth = 3;
     private static readonly TextSpan Span = TextSpan.Empty;
@@ -669,7 +670,12 @@ internal static class DifferentialGate
                 ["scalar-type:str"] =
                     "The string row proves non-negative length using the non-null ASCII runtime witness " +
                     "'ascii'. The solver result remains explicitly conditional on the production string-" +
-                    "model assumption; this does not claim nullable or non-ASCII equivalence."
+                    "model assumption; this does not claim nullable or non-ASCII equivalence.",
+                ["string-comparison-mode:Ordinal"] =
+                    "The ordinal row uses the zero-width-joiner witness " +
+                    "'abc'.StartsWith('\\u200dabc'): false under Ordinal but true under en-US " +
+                    "CurrentCulture. Provable and refutable cells use opposite polarities of that same " +
+                    "predicate. Generated runtime is executed under en-US with ambient culture restored."
             },
             formCoverage,
             failSafeControls,

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialModels.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialModels.cs
@@ -1,0 +1,116 @@
+using System.Text.Json.Serialization;
+using Calor.Compiler.Ast;
+
+namespace Calor.Verification.Tests.VerifierRuntimeDifferential;
+
+internal enum ContractPosition
+{
+    Precondition,
+    Postcondition,
+    Obligation
+}
+
+internal enum CasePolarity
+{
+    Provable,
+    Refutable
+}
+
+internal enum RuntimeVerdict
+{
+    Completed,
+    GuardFailed,
+    RuntimeError
+}
+
+internal sealed record DifferentialForm(
+    string Id,
+    string Category,
+    bool MatrixApplicable,
+    string? ExclusionReason,
+    Func<CasePolarity, FormExpression> Build,
+    Func<ExpressionNode, bool> ContainsTarget);
+
+internal sealed record FormExpression(
+    ExpressionNode Condition,
+    IReadOnlyList<ParameterNode> Parameters);
+
+internal sealed record DifferentialCase(
+    string Id,
+    string FormId,
+    string FormCategory,
+    ContractPosition Position,
+    int NestingDepth,
+    CasePolarity Polarity,
+    FunctionNode Function,
+    string? ProofId);
+
+internal sealed record CaseResult(
+    string Id,
+    string FormId,
+    string Category,
+    string Position,
+    int NestingDepth,
+    string Polarity,
+    string SolverStatus,
+    string RuntimeVerdict,
+    bool GuardForced,
+    bool ElidedWhenEnabled,
+    bool Mismatch,
+    string? Detail);
+
+internal sealed record FormCoverage(
+    string Id,
+    string Category,
+    bool Applicable,
+    string? ExclusionReason,
+    int Cases,
+    int ProvableCases,
+    int RefutableCases,
+    int PreconditionCases,
+    int PostconditionCases,
+    int ObligationCases,
+    bool Elides,
+    int Mismatches,
+    IReadOnlyDictionary<string, int> Statuses);
+
+internal sealed record FailSafeControl(
+    string Channel,
+    string Status,
+    bool GuardRetained,
+    string RuntimeVerdict,
+    bool Passed);
+
+internal sealed record CoverageMetrics(
+    int FormsWhitelisted,
+    int FormsApplicable,
+    int FormsCovered,
+    int FormsEliding,
+    double FormCoverageFraction,
+    double ElisionCoverageFraction,
+    int MatrixCellsRegistered,
+    int MatrixCellsCovered,
+    double MatrixCoverageFraction,
+    int CasesGenerated,
+    int Mismatches);
+
+internal sealed record DifferentialReport(
+    string SchemaVersion,
+    string Registration,
+    string WhitelistSha256,
+    int MaximumNestingDepth,
+    IReadOnlyList<string> Positions,
+    IReadOnlyList<string> Polarities,
+    CoverageMetrics Coverage,
+    IReadOnlyDictionary<string, int> OutcomeCounts,
+    IReadOnlyDictionary<string, string> EncodingNotes,
+    IReadOnlyList<FormCoverage> Forms,
+    IReadOnlyList<FailSafeControl> FailSafeControls,
+    IReadOnlyList<CaseResult> Mismatches)
+{
+    [JsonIgnore]
+    public bool Passed =>
+        Coverage.Mismatches == 0
+        && Coverage.FormsCovered == Coverage.FormsApplicable
+        && FailSafeControls.All(control => control.Passed);
+}

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialModels.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/DifferentialModels.cs
@@ -28,6 +28,7 @@ internal sealed record DifferentialForm(
     string Category,
     bool MatrixApplicable,
     string? ExclusionReason,
+    IReadOnlyList<string> AllowedAssumptions,
     Func<CasePolarity, FormExpression> Build,
     Func<ExpressionNode, bool> ContainsTarget);
 
@@ -43,7 +44,8 @@ internal sealed record DifferentialCase(
     int NestingDepth,
     CasePolarity Polarity,
     FunctionNode Function,
-    string? ProofId);
+    string? ProofId,
+    IReadOnlyList<string> AllowedAssumptions);
 
 internal sealed record CaseResult(
     string Id,
@@ -56,6 +58,7 @@ internal sealed record CaseResult(
     string RuntimeVerdict,
     bool GuardForced,
     bool ElidedWhenEnabled,
+    bool SolverHandled,
     bool Mismatch,
     string? Detail);
 
@@ -64,6 +67,8 @@ internal sealed record FormCoverage(
     string Category,
     bool Applicable,
     string? ExclusionReason,
+    IReadOnlyList<string> AllowedAssumptions,
+    bool SolverHandled,
     int Cases,
     int ProvableCases,
     int RefutableCases,
@@ -75,6 +80,7 @@ internal sealed record FormCoverage(
     IReadOnlyDictionary<string, int> Statuses);
 
 internal sealed record FailSafeControl(
+    string Scenario,
     string Channel,
     string Status,
     bool GuardRetained,
@@ -89,6 +95,7 @@ internal sealed record CoverageMetrics(
     double FormCoverageFraction,
     double ElisionCoverageFraction,
     int MatrixCellsRegistered,
+    int MatrixCellsApplicable,
     int MatrixCellsCovered,
     double MatrixCoverageFraction,
     int CasesGenerated,
@@ -112,5 +119,6 @@ internal sealed record DifferentialReport(
     public bool Passed =>
         Coverage.Mismatches == 0
         && Coverage.FormsCovered == Coverage.FormsApplicable
+        && Coverage.MatrixCellsCovered == Coverage.MatrixCellsApplicable
         && FailSafeControls.All(control => control.Passed);
 }

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/GeneratedRuntime.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/GeneratedRuntime.cs
@@ -135,7 +135,8 @@ internal sealed class GeneratedRuntime : IDisposable
             ?? throw new InvalidOperationException("Generated Probe type was not found.");
         var value = Activator.CreateInstance(type)
             ?? throw new InvalidOperationException("Generated Probe instance could not be created.");
-        type.GetField("Value", BindingFlags.Public | BindingFlags.Instance)?.SetValue(value, 7);
+        type.GetField("Value", BindingFlags.Public | BindingFlags.Instance)
+            ?.SetValue(value, DifferentialGate.ProbeFieldWitness);
         return value;
     }
 

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/GeneratedRuntime.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/GeneratedRuntime.cs
@@ -1,0 +1,168 @@
+using System.Reflection;
+using System.Runtime.Loader;
+using Calor.Compiler.CodeGen;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Calor.Verification.Tests.VerifierRuntimeDifferential;
+
+internal sealed class GeneratedRuntime
+{
+    private readonly Assembly _assembly;
+    private readonly Type _moduleType;
+
+    private GeneratedRuntime(Assembly assembly, Type moduleType)
+    {
+        _assembly = assembly;
+        _moduleType = moduleType;
+    }
+
+    public static GeneratedRuntime Compile(string assemblyName, string generatedCode, string moduleName)
+    {
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
+        var trees = new[]
+        {
+            CSharpSyntaxTree.ParseText(GeneratedCSharpCompiler.GlobalUsingsPreamble, parseOptions),
+            CSharpSyntaxTree.ParseText(generatedCode, parseOptions)
+        };
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            trees,
+            GeneratedCSharpCompiler.References,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = new MemoryStream();
+        var emit = compilation.Emit(stream);
+        if (!emit.Success)
+        {
+            var errors = string.Join(
+                Environment.NewLine,
+                emit.Diagnostics
+                    .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+                    .Select(diagnostic => diagnostic.ToString()));
+            throw new InvalidOperationException(
+                $"Generated differential C# did not compile:{Environment.NewLine}{errors}");
+        }
+
+        stream.Position = 0;
+        var assembly = AssemblyLoadContext.Default.LoadFromStream(stream);
+        var moduleType = assembly.GetType($"{moduleName}.{moduleName}Module")
+            ?? throw new InvalidOperationException(
+                $"Generated module type '{moduleName}.{moduleName}Module' was not found.");
+        return new GeneratedRuntime(assembly, moduleType);
+    }
+
+    public RuntimeVerdict Invoke(string methodName, IReadOnlyList<string> parameterTypes, out string? detail)
+    {
+        var method = _moduleType.GetMethod(
+                methodName,
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"Generated method '{methodName}' was not found.");
+        var arguments = parameterTypes.Select(CreateArgument).ToArray();
+
+        try
+        {
+            method.Invoke(null, arguments);
+            detail = null;
+            return RuntimeVerdict.Completed;
+        }
+        catch (TargetInvocationException invocation) when (invocation.InnerException != null)
+        {
+            var inner = invocation.InnerException;
+            detail = $"{inner.GetType().FullName}: {inner.Message}";
+            if (inner is Calor.Runtime.ContractViolationException)
+                return RuntimeVerdict.GuardFailed;
+            if (inner is InvalidOperationException
+                && inner.Message.StartsWith("Proof obligation", StringComparison.Ordinal))
+            {
+                return RuntimeVerdict.GuardFailed;
+            }
+            return RuntimeVerdict.RuntimeError;
+        }
+    }
+
+    private object? CreateArgument(string typeName)
+    {
+        return typeName switch
+        {
+            "i8" => (sbyte)7,
+            "i16" => (short)7,
+            "i32" => 7,
+            "i64" => 7L,
+            "u8" => (byte)7,
+            "u16" => (ushort)7,
+            "u32" => 7U,
+            "u64" => 7UL,
+            "bool" => true,
+            "str" => "ascii",
+            "Probe" => CreateProbe(),
+            _ when typeName.EndsWith("[]", StringComparison.Ordinal) =>
+                CreateArray(typeName[..^2]),
+            _ => throw new InvalidOperationException(
+                $"No deterministic runtime witness is registered for parameter type '{typeName}'.")
+        };
+    }
+
+    private object CreateProbe()
+    {
+        var type = _assembly.GetType("VerifierDifferential.Probe")
+            ?? throw new InvalidOperationException("Generated Probe type was not found.");
+        var value = Activator.CreateInstance(type)
+            ?? throw new InvalidOperationException("Generated Probe instance could not be created.");
+        type.GetField("Value", BindingFlags.Public | BindingFlags.Instance)?.SetValue(value, 7);
+        return value;
+    }
+
+    private static Array CreateArray(string elementTypeName)
+    {
+        var elementType = elementTypeName switch
+        {
+            "i8" => typeof(sbyte),
+            "i16" => typeof(short),
+            "i32" => typeof(int),
+            "i64" => typeof(long),
+            "u8" => typeof(byte),
+            "u16" => typeof(ushort),
+            "u32" => typeof(uint),
+            "u64" => typeof(ulong),
+            _ => throw new InvalidOperationException(
+                $"No deterministic array witness is registered for '{elementTypeName}[]'.")
+        };
+        var array = Array.CreateInstance(elementType, 1);
+        array.SetValue(Convert.ChangeType(7, elementType, System.Globalization.CultureInfo.InvariantCulture), 0);
+        return array;
+    }
+}
+
+internal static class GeneratedMethodInspector
+{
+    public static IReadOnlyDictionary<string, string> ExtractMethods(string generatedCode)
+    {
+        var root = CSharpSyntaxTree.ParseText(
+                generatedCode,
+                new CSharpParseOptions(LanguageVersion.Preview))
+            .GetRoot();
+        return root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .ToDictionary(
+                method => method.Identifier.ValueText,
+                method => method.ToFullString(),
+                StringComparer.Ordinal);
+    }
+
+    public static bool HasGuard(string methodText, ContractPosition position)
+    {
+        return position switch
+        {
+            ContractPosition.Precondition =>
+                methodText.Contains("ContractKind.Requires", StringComparison.Ordinal),
+            ContractPosition.Postcondition =>
+                methodText.Contains("ContractKind.Ensures", StringComparison.Ordinal),
+            ContractPosition.Obligation =>
+                methodText.Contains("throw new InvalidOperationException", StringComparison.Ordinal)
+                && methodText.Contains("Proof obligation", StringComparison.Ordinal),
+            _ => throw new ArgumentOutOfRangeException(nameof(position))
+        };
+    }
+}

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/GeneratedRuntime.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/GeneratedRuntime.cs
@@ -7,16 +7,27 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Calor.Verification.Tests.VerifierRuntimeDifferential;
 
-internal sealed class GeneratedRuntime
+internal sealed class GeneratedRuntime : IDisposable
 {
-    private readonly Assembly _assembly;
-    private readonly Type _moduleType;
+    private CollectibleGeneratedLoadContext? _loadContext;
+    private Assembly? _assembly;
+    private Type? _moduleType;
+    private bool _disposed;
 
-    private GeneratedRuntime(Assembly assembly, Type moduleType)
+    private GeneratedRuntime(
+        CollectibleGeneratedLoadContext loadContext,
+        Assembly assembly,
+        Type moduleType)
     {
+        _loadContext = loadContext;
         _assembly = assembly;
         _moduleType = moduleType;
+        LoadContextReference = new WeakReference(loadContext);
     }
+
+    internal WeakReference LoadContextReference { get; }
+
+    internal bool IsCollectible => _loadContext?.IsCollectible == true;
 
     public static GeneratedRuntime Compile(string assemblyName, string generatedCode, string moduleName)
     {
@@ -46,16 +57,28 @@ internal sealed class GeneratedRuntime
         }
 
         stream.Position = 0;
-        var assembly = AssemblyLoadContext.Default.LoadFromStream(stream);
-        var moduleType = assembly.GetType($"{moduleName}.{moduleName}Module")
-            ?? throw new InvalidOperationException(
-                $"Generated module type '{moduleName}.{moduleName}Module' was not found.");
-        return new GeneratedRuntime(assembly, moduleType);
+        var loadContext = new CollectibleGeneratedLoadContext(assemblyName);
+        try
+        {
+            var assembly = loadContext.LoadFromStream(stream);
+            var moduleType = assembly.GetType($"{moduleName}.{moduleName}Module")
+                ?? throw new InvalidOperationException(
+                    $"Generated module type '{moduleName}.{moduleName}Module' was not found.");
+            return new GeneratedRuntime(loadContext, assembly, moduleType);
+        }
+        catch
+        {
+            loadContext.Unload();
+            throw;
+        }
     }
 
     public RuntimeVerdict Invoke(string methodName, IReadOnlyList<string> parameterTypes, out string? detail)
     {
-        var method = _moduleType.GetMethod(
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var moduleType = _moduleType
+            ?? throw new ObjectDisposedException(nameof(GeneratedRuntime));
+        var method = moduleType.GetMethod(
                 methodName,
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
             ?? throw new InvalidOperationException($"Generated method '{methodName}' was not found.");
@@ -106,7 +129,9 @@ internal sealed class GeneratedRuntime
 
     private object CreateProbe()
     {
-        var type = _assembly.GetType("VerifierDifferential.Probe")
+        var assembly = _assembly
+            ?? throw new ObjectDisposedException(nameof(GeneratedRuntime));
+        var type = assembly.GetType("VerifierDifferential.Probe")
             ?? throw new InvalidOperationException("Generated Probe type was not found.");
         var value = Activator.CreateInstance(type)
             ?? throw new InvalidOperationException("Generated Probe instance could not be created.");
@@ -132,6 +157,36 @@ internal sealed class GeneratedRuntime
         var array = Array.CreateInstance(elementType, 1);
         array.SetValue(Convert.ChangeType(7, elementType, System.Globalization.CultureInfo.InvariantCulture), 0);
         return array;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        var loadContext = _loadContext;
+        _moduleType = null;
+        _assembly = null;
+        _loadContext = null;
+        loadContext?.Unload();
+        GC.SuppressFinalize(this);
+    }
+
+    private sealed class CollectibleGeneratedLoadContext : AssemblyLoadContext
+    {
+        public CollectibleGeneratedLoadContext(string name)
+            : base(name, isCollectible: true)
+        {
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            return Default.Assemblies.FirstOrDefault(
+                assembly => AssemblyName.ReferenceMatchesDefinition(
+                    assembly.GetName(),
+                    assemblyName));
+        }
     }
 }
 

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/GeneratedRuntime.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/GeneratedRuntime.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.Loader;
+using System.Globalization;
 using Calor.Compiler.CodeGen;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -83,25 +84,38 @@ internal sealed class GeneratedRuntime : IDisposable
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
             ?? throw new InvalidOperationException($"Generated method '{methodName}' was not found.");
         var arguments = parameterTypes.Select(CreateArgument).ToArray();
+        var previousCulture = CultureInfo.CurrentCulture;
+        var previousUiCulture = CultureInfo.CurrentUICulture;
+        var controlledCulture = CultureInfo.GetCultureInfo(DifferentialGate.RuntimeCultureName);
 
         try
         {
-            method.Invoke(null, arguments);
-            detail = null;
-            return RuntimeVerdict.Completed;
-        }
-        catch (TargetInvocationException invocation) when (invocation.InnerException != null)
-        {
-            var inner = invocation.InnerException;
-            detail = $"{inner.GetType().FullName}: {inner.Message}";
-            if (inner is Calor.Runtime.ContractViolationException)
-                return RuntimeVerdict.GuardFailed;
-            if (inner is InvalidOperationException
-                && inner.Message.StartsWith("Proof obligation", StringComparison.Ordinal))
+            CultureInfo.CurrentCulture = controlledCulture;
+            CultureInfo.CurrentUICulture = controlledCulture;
+            try
             {
-                return RuntimeVerdict.GuardFailed;
+                method.Invoke(null, arguments);
+                detail = null;
+                return RuntimeVerdict.Completed;
             }
-            return RuntimeVerdict.RuntimeError;
+            catch (TargetInvocationException invocation) when (invocation.InnerException != null)
+            {
+                var inner = invocation.InnerException;
+                detail = $"{inner.GetType().FullName}: {inner.Message}";
+                if (inner is Calor.Runtime.ContractViolationException)
+                    return RuntimeVerdict.GuardFailed;
+                if (inner is InvalidOperationException
+                    && inner.Message.StartsWith("Proof obligation", StringComparison.Ordinal))
+                {
+                    return RuntimeVerdict.GuardFailed;
+                }
+                return RuntimeVerdict.RuntimeError;
+            }
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+            CultureInfo.CurrentUICulture = previousUiCulture;
         }
     }
 

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/GeneratedRuntime.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/GeneratedRuntime.cs
@@ -109,14 +109,8 @@ internal sealed class GeneratedRuntime : IDisposable
     {
         return typeName switch
         {
-            "i8" => (sbyte)7,
-            "i16" => (short)7,
-            "i32" => 7,
-            "i64" => 7L,
-            "u8" => (byte)7,
-            "u16" => (ushort)7,
-            "u32" => 7U,
-            "u64" => 7UL,
+            "i8" or "i16" or "i32" or "i64"
+                or "u8" or "u16" or "u32" or "u64" => CreateIntegerWitness(typeName),
             "bool" => true,
             "str" => "ascii",
             "Probe" => CreateProbe(),
@@ -156,9 +150,23 @@ internal sealed class GeneratedRuntime : IDisposable
                 $"No deterministic array witness is registered for '{elementTypeName}[]'.")
         };
         var array = Array.CreateInstance(elementType, 1);
-        array.SetValue(Convert.ChangeType(7, elementType, System.Globalization.CultureInfo.InvariantCulture), 0);
+        array.SetValue(CreateIntegerWitness(elementTypeName), 0);
         return array;
     }
+
+    private static object CreateIntegerWitness(string typeName) => typeName switch
+    {
+        "i8" => sbyte.MaxValue,
+        "i16" => short.MaxValue,
+        "i32" => short.MaxValue + 1,
+        "i64" => 2L,
+        "u8" => byte.MaxValue,
+        "u16" => (ushort)(byte.MaxValue + 1),
+        "u32" => 3U,
+        "u64" => 3UL,
+        _ => throw new InvalidOperationException(
+            $"No deterministic integer witness is registered for '{typeName}'.")
+    };
 
     public void Dispose()
     {

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/ReportWriter.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/ReportWriter.cs
@@ -1,0 +1,132 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Calor.Verification.Tests.VerifierRuntimeDifferential;
+
+internal static class ReportWriter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public static string ToJson(DifferentialReport report) =>
+        JsonSerializer.Serialize(report, JsonOptions) + "\n";
+
+    public static string ToMarkdown(DifferentialReport report)
+    {
+        var coverage = report.Coverage;
+        var builder = new StringBuilder();
+        builder.AppendLine("# Verifier ↔ Generated Runtime Differential (F-4)");
+        builder.AppendLine();
+        builder.AppendLine($"- **Result:** {(report.Passed ? "PASS" : "FAIL")}");
+        builder.AppendLine($"- **Whitelist hash:** `{report.WhitelistSha256}`");
+        builder.AppendLine($"- **Mismatches:** {coverage.Mismatches}");
+        builder.AppendLine(
+            $"- **Forms covered:** {coverage.FormsCovered}/{coverage.FormsWhitelisted} " +
+            $"({Percent(coverage.FormCoverageFraction)})");
+        builder.AppendLine(
+            $"- **Forms eliding:** {coverage.FormsEliding}/{coverage.FormsWhitelisted} " +
+            $"({Percent(coverage.ElisionCoverageFraction)})");
+        builder.AppendLine(
+            $"- **Cartesian cells executed:** {coverage.MatrixCellsCovered}/{coverage.MatrixCellsRegistered} " +
+            $"({Percent(coverage.MatrixCoverageFraction)})");
+        builder.AppendLine(
+            $"- **Generated cases:** {coverage.CasesGenerated} " +
+            $"(3 positions × depths 1–{report.MaximumNestingDepth} × 2 polarities per applicable form)");
+        builder.AppendLine();
+
+        builder.AppendLine("## Typed outcomes");
+        builder.AppendLine();
+        builder.AppendLine("| Outcome | Cases |");
+        builder.AppendLine("|---|---:|");
+        foreach (var (status, count) in report.OutcomeCounts)
+            builder.AppendLine($"| `{status}` | {count} |");
+        builder.AppendLine();
+
+        builder.AppendLine("## Coverage by category");
+        builder.AppendLine();
+        builder.AppendLine("| Category | Whitelisted | Applicable | Covered | Eliding | Mismatches |");
+        builder.AppendLine("|---|---:|---:|---:|---:|---:|");
+        foreach (var category in report.Forms.GroupBy(form => form.Category, StringComparer.Ordinal)
+                     .OrderBy(group => group.Key, StringComparer.Ordinal))
+        {
+            builder.AppendLine(
+                $"| `{category.Key}` | {category.Count()} | " +
+                $"{category.Count(form => form.Applicable)} | " +
+                $"{category.Count(form => form.Cases > 0)} | " +
+                $"{category.Count(form => form.Elides)} | " +
+                $"{category.Sum(form => form.Mismatches)} |");
+        }
+        builder.AppendLine();
+
+        builder.AppendLine("## Encoding notes");
+        builder.AppendLine();
+        foreach (var (form, note) in report.EncodingNotes)
+            builder.AppendLine($"- `{form}` — {note}");
+        builder.AppendLine();
+
+        builder.AppendLine("## Per-form coverage");
+        builder.AppendLine();
+        builder.AppendLine("| Form | Cases | Pre | Post | Obligation | Elides | Mismatches |");
+        builder.AppendLine("|---|---:|---:|---:|---:|:---:|---:|");
+        foreach (var form in report.Forms)
+        {
+            builder.AppendLine(
+                $"| `{form.Id}` | {form.Cases} | {form.PreconditionCases} | " +
+                $"{form.PostconditionCases} | {form.ObligationCases} | " +
+                $"{(form.Elides ? "yes" : "no")} | {form.Mismatches} |");
+        }
+        builder.AppendLine();
+
+        var excluded = report.Forms.Where(form => !form.Applicable).ToList();
+        if (excluded.Count > 0)
+        {
+            builder.AppendLine("## Registered but not runtime-encodable");
+            builder.AppendLine();
+            foreach (var form in excluded)
+                builder.AppendLine($"- `{form.Id}` — {form.ExclusionReason}");
+            builder.AppendLine();
+        }
+
+        builder.AppendLine("## Fail-safe controls");
+        builder.AppendLine();
+        builder.AppendLine("| Channel | Typed status | Guard retained | Runtime | Result |");
+        builder.AppendLine("|---|---|:---:|---|:---:|");
+        foreach (var control in report.FailSafeControls)
+        {
+            builder.AppendLine(
+                $"| {control.Channel} | `{control.Status}` | " +
+                $"{(control.GuardRetained ? "yes" : "no")} | `{control.RuntimeVerdict}` | " +
+                $"{(control.Passed ? "pass" : "fail")} |");
+        }
+        builder.AppendLine();
+
+        builder.AppendLine("## Oracle");
+        builder.AppendLine();
+        builder.AppendLine(
+            "Every case is emitted twice. The runtime assembly is compiled from the guard-forced " +
+            "emission (`ElideProvenGuards = false`); the opt-in emission is inspected separately " +
+            "to measure actual postcondition/obligation elision. `proven`/`discharged` must execute " +
+            "without a guard failure, `refuted`/`failed` must fire the generated guard, and every " +
+            "non-decisive status must retain the guard. The generator also requires the declared " +
+            "target form to occur in every base expression and rejects vacuous proofs.");
+        builder.AppendLine();
+
+        if (report.Mismatches.Count > 0)
+        {
+            builder.AppendLine("## Mismatches");
+            builder.AppendLine();
+            foreach (var mismatch in report.Mismatches)
+                builder.AppendLine($"- `{mismatch.Id}` / `{mismatch.FormId}` — {mismatch.Detail}");
+        }
+
+        return builder.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private static string Percent(double fraction) =>
+        (fraction * 100).ToString("0.00", System.Globalization.CultureInfo.InvariantCulture) + "%";
+}

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/ReportWriter.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/ReportWriter.cs
@@ -26,14 +26,16 @@ internal static class ReportWriter
         builder.AppendLine($"- **Whitelist hash:** `{report.WhitelistSha256}`");
         builder.AppendLine($"- **Mismatches:** {coverage.Mismatches}");
         builder.AppendLine(
-            $"- **Forms covered:** {coverage.FormsCovered}/{coverage.FormsWhitelisted} " +
+            $"- **Forms solver-handled:** {coverage.FormsCovered}/{coverage.FormsWhitelisted} " +
             $"({Percent(coverage.FormCoverageFraction)})");
         builder.AppendLine(
             $"- **Forms eliding:** {coverage.FormsEliding}/{coverage.FormsWhitelisted} " +
             $"({Percent(coverage.ElisionCoverageFraction)})");
         builder.AppendLine(
-            $"- **Cartesian cells executed:** {coverage.MatrixCellsCovered}/{coverage.MatrixCellsRegistered} " +
+            $"- **Cartesian cells solver-handled:** {coverage.MatrixCellsCovered}/{coverage.MatrixCellsApplicable} " +
             $"({Percent(coverage.MatrixCoverageFraction)})");
+        builder.AppendLine(
+            $"- **Cartesian cells registered:** {coverage.MatrixCellsRegistered}");
         builder.AppendLine(
             $"- **Generated cases:** {coverage.CasesGenerated} " +
             $"(3 positions × depths 1–{report.MaximumNestingDepth} × 2 polarities per applicable form)");
@@ -49,7 +51,7 @@ internal static class ReportWriter
 
         builder.AppendLine("## Coverage by category");
         builder.AppendLine();
-        builder.AppendLine("| Category | Whitelisted | Applicable | Covered | Eliding | Mismatches |");
+        builder.AppendLine("| Category | Whitelisted | Applicable | Solver-handled | Eliding | Mismatches |");
         builder.AppendLine("|---|---:|---:|---:|---:|---:|");
         foreach (var category in report.Forms.GroupBy(form => form.Category, StringComparer.Ordinal)
                      .OrderBy(group => group.Key, StringComparer.Ordinal))
@@ -57,7 +59,7 @@ internal static class ReportWriter
             builder.AppendLine(
                 $"| `{category.Key}` | {category.Count()} | " +
                 $"{category.Count(form => form.Applicable)} | " +
-                $"{category.Count(form => form.Cases > 0)} | " +
+                $"{category.Count(form => form.SolverHandled)} | " +
                 $"{category.Count(form => form.Elides)} | " +
                 $"{category.Sum(form => form.Mismatches)} |");
         }
@@ -69,14 +71,29 @@ internal static class ReportWriter
             builder.AppendLine($"- `{form}` — {note}");
         builder.AppendLine();
 
+        builder.AppendLine("## Explicit Assumed allowances");
+        builder.AppendLine();
+        builder.AppendLine(
+            "`Assumed` is accepted only for provable cells whose form lists the exact production " +
+            "assumption set below. Refutable cells must always be `Refuted`.");
+        builder.AppendLine();
+        foreach (var form in report.Forms.Where(form => form.AllowedAssumptions.Count > 0))
+        {
+            builder.AppendLine(
+                $"- `{form.Id}` — " +
+                string.Join("; ", form.AllowedAssumptions.Select(ShortAssumption)));
+        }
+        builder.AppendLine();
+
         builder.AppendLine("## Per-form coverage");
         builder.AppendLine();
-        builder.AppendLine("| Form | Cases | Pre | Post | Obligation | Elides | Mismatches |");
-        builder.AppendLine("|---|---:|---:|---:|---:|:---:|---:|");
+        builder.AppendLine("| Form | Solver-handled | Cases | Pre | Post | Obligation | Elides | Mismatches |");
+        builder.AppendLine("|---|:---:|---:|---:|---:|---:|:---:|---:|");
         foreach (var form in report.Forms)
         {
             builder.AppendLine(
-                $"| `{form.Id}` | {form.Cases} | {form.PreconditionCases} | " +
+                $"| `{form.Id}` | {(form.SolverHandled ? "yes" : "no")} | " +
+                $"{form.Cases} | {form.PreconditionCases} | " +
                 $"{form.PostconditionCases} | {form.ObligationCases} | " +
                 $"{(form.Elides ? "yes" : "no")} | {form.Mismatches} |");
         }
@@ -94,12 +111,12 @@ internal static class ReportWriter
 
         builder.AppendLine("## Fail-safe controls");
         builder.AppendLine();
-        builder.AppendLine("| Channel | Typed status | Guard retained | Runtime | Result |");
-        builder.AppendLine("|---|---|:---:|---|:---:|");
+        builder.AppendLine("| Scenario | Channel | Typed status | Guard retained | Runtime | Result |");
+        builder.AppendLine("|---|---|---|:---:|---|:---:|");
         foreach (var control in report.FailSafeControls)
         {
             builder.AppendLine(
-                $"| {control.Channel} | `{control.Status}` | " +
+                $"| {control.Scenario} | {control.Channel} | `{control.Status}` | " +
                 $"{(control.GuardRetained ? "yes" : "no")} | `{control.RuntimeVerdict}` | " +
                 $"{(control.Passed ? "pass" : "fail")} |");
         }
@@ -129,4 +146,10 @@ internal static class ReportWriter
 
     private static string Percent(double fraction) =>
         (fraction * 100).ToString("0.00", System.Globalization.CultureInfo.InvariantCulture) + "%";
+
+    private static string ShortAssumption(string assumption)
+    {
+        var separator = assumption.IndexOf(" — ", StringComparison.Ordinal);
+        return separator < 0 ? assumption : assumption[..separator];
+    }
 }

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/VerifierRuntimeDifferentialTests.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/VerifierRuntimeDifferentialTests.cs
@@ -1,0 +1,79 @@
+using System.Text;
+using Calor.Compiler.Verification.Z3;
+using Xunit;
+
+namespace Calor.Verification.Tests.VerifierRuntimeDifferential;
+
+public sealed class VerifierRuntimeDifferentialTests
+{
+    private const string UpdateReportsVariable =
+        "CALOR_UPDATE_VERIFIER_RUNTIME_DIFFERENTIAL_REPORTS";
+
+    [Fact]
+    public void CommittedReportsMatchGeneratedOracle()
+    {
+        Assert.True(
+            Z3ContextFactory.IsAvailable,
+            "F-4 differential gate cannot run: Z3 is unavailable. This is a blocking failure, not a skip.");
+
+        var repositoryRoot = FindRepositoryRoot();
+        var report = DifferentialGate.Run(repositoryRoot);
+
+        Assert.True(report.Passed, ReportWriter.ToJson(report));
+        Assert.Equal(65, report.Coverage.FormsWhitelisted);
+        Assert.Equal(65, report.Coverage.FormsCovered);
+        Assert.Equal(1_170, report.Coverage.MatrixCellsRegistered);
+        Assert.Equal(1_170, report.Coverage.MatrixCellsCovered);
+        Assert.Equal(1_170, report.Coverage.CasesGenerated);
+        Assert.Equal(0, report.Coverage.Mismatches);
+        Assert.Equal(10, report.FailSafeControls.Count);
+        Assert.All(report.FailSafeControls, control => Assert.True(control.Passed));
+
+        var reports = new[]
+        {
+            (
+                Path.Combine(
+                    repositoryRoot,
+                    "bench",
+                    "phase0-agent-native",
+                    "verifier-runtime-differential.json"),
+                ReportWriter.ToJson(report)),
+            (
+                Path.Combine(
+                    repositoryRoot,
+                    "bench",
+                    "phase0-agent-native",
+                    "verifier-runtime-differential.md"),
+                ReportWriter.ToMarkdown(report))
+        };
+
+        foreach (var (path, generated) in reports)
+        {
+            var generatedBytes = Encoding.UTF8.GetBytes(generated);
+            if (Environment.GetEnvironmentVariable(UpdateReportsVariable) == "1")
+                File.WriteAllBytes(path, generatedBytes);
+
+            Assert.True(File.Exists(path), $"Committed report is missing: {path}");
+            Assert.True(
+                File.ReadAllBytes(path).AsSpan().SequenceEqual(generatedBytes),
+                $"Committed report is stale: {path}. Set {UpdateReportsVariable}=1 and rerun this test.");
+        }
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Directory.Build.props"))
+                && Directory.Exists(Path.Combine(directory.FullName, ".git")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate the Calor repository root.");
+    }
+}

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/VerifierRuntimeDifferentialTests.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/VerifierRuntimeDifferentialTests.cs
@@ -90,7 +90,7 @@ public sealed class VerifierRuntimeDifferentialTests
     }
 
     [Fact]
-    public void FieldAccessProbeUsesU8BoundAndRejectsHistoricalI32Fallback()
+    public void FieldAccessProbeDistinguishesU8FromI8AndI32Mutations()
     {
         Assert.True(
             Z3ContextFactory.IsAvailable,
@@ -98,24 +98,55 @@ public sealed class VerifierRuntimeDifferentialTests
 
         var form = DifferentialFormRegistry.Build().Single(
             candidate => candidate.Id == "expression-kind:FieldAccessNode");
-        var bound = Assert.IsType<BinaryOperationNode>(
+        var predicate = Assert.IsType<BinaryOperationNode>(
             form.Build(CasePolarity.Provable).Condition);
-        Assert.Equal(BinaryOperator.LessOrEqual, bound.Operator);
-        Assert.IsType<FieldAccessNode>(bound.Left);
-        Assert.Equal(byte.MaxValue, Assert.IsType<IntLiteralNode>(bound.Right).Value);
+        Assert.Equal(BinaryOperator.And, predicate.Operator);
+        Assert.Equal(
+            BinaryOperator.GreaterOrEqual,
+            Assert.IsType<BinaryOperationNode>(predicate.Left).Operator);
+        Assert.Equal(
+            BinaryOperator.LessOrEqual,
+            Assert.IsType<BinaryOperationNode>(predicate.Right).Operator);
         Assert.Equal(byte.MaxValue, DifferentialGate.ProbeFieldWitness);
 
         using var context = Z3ContextFactory.Create();
         var registered = TranslateFieldBound(
             context,
-            bound,
+            predicate,
             DifferentialGate.ProbeFieldType);
-        var guessed = TranslateFieldBound(context, bound, "i32");
+        var signedMutation = TranslateFieldBound(context, predicate, "i8");
+        var widthMutation = TranslateFieldBound(context, predicate, "i32");
 
         Assert.Equal(8u, registered.Width);
         Assert.Equal(Status.UNSATISFIABLE, registered.NegatedBoundStatus);
-        Assert.Equal(32u, guessed.Width);
-        Assert.Equal(Status.SATISFIABLE, guessed.NegatedBoundStatus);
+        Assert.Equal(8u, signedMutation.Width);
+        Assert.Equal(Status.SATISFIABLE, signedMutation.NegatedBoundStatus);
+        Assert.Equal(32u, widthMutation.Width);
+        Assert.Equal(Status.SATISFIABLE, widthMutation.NegatedBoundStatus);
+    }
+
+    [Fact]
+    public void ArrayElementProbeDistinguishesU8FromI8AndI32Mutations()
+    {
+        Assert.True(
+            Z3ContextFactory.IsAvailable,
+            "Array-element regression cannot run: Z3 is unavailable.");
+
+        var form = DifferentialFormRegistry.Build().Single(
+            candidate => candidate.Id == "array-element-type:u8");
+        var predicate = form.Build(CasePolarity.Provable).Condition;
+
+        using var context = Z3ContextFactory.Create();
+        var registered = TranslateArrayBound(context, predicate, "u8");
+        var signedMutation = TranslateArrayBound(context, predicate, "i8");
+        var widthMutation = TranslateArrayBound(context, predicate, "i32");
+
+        Assert.Equal(8u, registered.Width);
+        Assert.Equal(Status.UNSATISFIABLE, registered.NegatedBoundStatus);
+        Assert.Equal(8u, signedMutation.Width);
+        Assert.Equal(Status.SATISFIABLE, signedMutation.NegatedBoundStatus);
+        Assert.Equal(32u, widthMutation.Width);
+        Assert.Equal(Status.SATISFIABLE, widthMutation.NegatedBoundStatus);
     }
 
     [Fact]
@@ -226,7 +257,7 @@ public sealed class VerifierRuntimeDifferentialTests
             });
         Assert.True(translator.DeclareVariable("probe", "Probe"));
 
-        var field = Assert.IsType<FieldAccessNode>(bound.Left);
+        var field = FindFieldAccess(bound);
         var translatedField = translator.TranslateBitVecExpr(field);
         Assert.NotNull(translatedField);
 
@@ -236,5 +267,57 @@ public sealed class VerifierRuntimeDifferentialTests
         using var solver = context.MkSolver();
         solver.Assert(context.MkNot(translatedBound));
         return (translatedField.SortSize, solver.Check());
+    }
+
+    private static FieldAccessNode FindFieldAccess(ExpressionNode expression)
+    {
+        return expression switch
+        {
+            FieldAccessNode field => field,
+            BinaryOperationNode binary => FindFieldAccess(binary.Left),
+            UnaryOperationNode unary => FindFieldAccess(unary.Operand),
+            _ => throw new Xunit.Sdk.XunitException(
+                $"No field access found in {expression.GetType().Name}.")
+        };
+    }
+
+    private static (uint Width, Status NegatedBoundStatus) TranslateArrayBound(
+        Context context,
+        ExpressionNode predicate,
+        string elementType)
+    {
+        var translator = new ContractTranslator(context);
+        Assert.True(translator.DeclareVariable("values", $"{elementType}[]"));
+
+        var access = FindArrayAccess(predicate);
+        var translatedAccess = translator.TranslateBitVecExpr(access);
+        Assert.NotNull(translatedAccess);
+        var translatedPredicate = translator.TranslateBoolExpr(predicate);
+        Assert.NotNull(translatedPredicate);
+
+        using var solver = context.MkSolver();
+        solver.Assert(context.MkNot(translatedPredicate));
+        return (translatedAccess.SortSize, solver.Check());
+    }
+
+    private static ArrayAccessNode FindArrayAccess(ExpressionNode expression)
+    {
+        return FindArrayAccessOrNull(expression)
+            ?? throw new Xunit.Sdk.XunitException(
+                $"No array access found in {expression.GetType().Name}.");
+    }
+
+    private static ArrayAccessNode? FindArrayAccessOrNull(ExpressionNode expression)
+    {
+        return expression switch
+        {
+            ArrayAccessNode access => access,
+            BinaryOperationNode binary => FindArrayAccessOrNull(binary.Left)
+                ?? FindArrayAccessOrNull(binary.Right),
+            UnaryOperationNode unary => FindArrayAccessOrNull(unary.Operand),
+            ImplicationExpressionNode implication => FindArrayAccessOrNull(implication.Antecedent)
+                ?? FindArrayAccessOrNull(implication.Consequent),
+            _ => null
+        };
     }
 }

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/VerifierRuntimeDifferentialTests.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/VerifierRuntimeDifferentialTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Runtime.CompilerServices;
+using Calor.Compiler.Ast;
 using Calor.Compiler.Verification;
 using Calor.Compiler.Verification.Z3;
 using Microsoft.Z3;
@@ -86,6 +87,35 @@ public sealed class VerifierRuntimeDifferentialTests
                 committedBytes.AsSpan().SequenceEqual(generatedBytes),
                 $"Committed report is stale: {path}. Set {UpdateReportsVariable}=1 and rerun this test.");
         }
+    }
+
+    [Fact]
+    public void FieldAccessProbeUsesU8BoundAndRejectsHistoricalI32Fallback()
+    {
+        Assert.True(
+            Z3ContextFactory.IsAvailable,
+            "Field-access regression cannot run: Z3 is unavailable.");
+
+        var form = DifferentialFormRegistry.Build().Single(
+            candidate => candidate.Id == "expression-kind:FieldAccessNode");
+        var bound = Assert.IsType<BinaryOperationNode>(
+            form.Build(CasePolarity.Provable).Condition);
+        Assert.Equal(BinaryOperator.LessOrEqual, bound.Operator);
+        Assert.IsType<FieldAccessNode>(bound.Left);
+        Assert.Equal(byte.MaxValue, Assert.IsType<IntLiteralNode>(bound.Right).Value);
+        Assert.Equal(byte.MaxValue, DifferentialGate.ProbeFieldWitness);
+
+        using var context = Z3ContextFactory.Create();
+        var registered = TranslateFieldBound(
+            context,
+            bound,
+            DifferentialGate.ProbeFieldType);
+        var guessed = TranslateFieldBound(context, bound, "i32");
+
+        Assert.Equal(8u, registered.Width);
+        Assert.Equal(Status.UNSATISFIABLE, registered.NegatedBoundStatus);
+        Assert.Equal(32u, guessed.Width);
+        Assert.Equal(Status.SATISFIABLE, guessed.NegatedBoundStatus);
     }
 
     [Fact]
@@ -178,5 +208,33 @@ public sealed class VerifierRuntimeDifferentialTests
         return fileExists(Path.Combine(directory, "Directory.Build.props"))
             && (directoryExists(Path.Combine(directory, ".git"))
                 || fileExists(Path.Combine(directory, ".git")));
+    }
+
+    private static (uint Width, Status NegatedBoundStatus) TranslateFieldBound(
+        Context context,
+        BinaryOperationNode bound,
+        string fieldType)
+    {
+        var translator = new ContractTranslator(context);
+        translator.SetUserTypeRegistry(
+            new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal)
+            {
+                ["probe"] = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["Value"] = fieldType
+                }
+            });
+        Assert.True(translator.DeclareVariable("probe", "Probe"));
+
+        var field = Assert.IsType<FieldAccessNode>(bound.Left);
+        var translatedField = translator.TranslateBitVecExpr(field);
+        Assert.NotNull(translatedField);
+
+        var translatedBound = translator.TranslateBoolExpr(bound);
+        Assert.NotNull(translatedBound);
+
+        using var solver = context.MkSolver();
+        solver.Assert(context.MkNot(translatedBound));
+        return (translatedField.SortSize, solver.Check());
     }
 }

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/VerifierRuntimeDifferentialTests.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/VerifierRuntimeDifferentialTests.cs
@@ -1,6 +1,8 @@
 using System.Text;
 using System.Runtime.CompilerServices;
+using System.Globalization;
 using Calor.Compiler.Ast;
+using Calor.Compiler.CodeGen;
 using Calor.Compiler.Verification;
 using Calor.Compiler.Verification.Z3;
 using Microsoft.Z3;
@@ -147,6 +149,87 @@ public sealed class VerifierRuntimeDifferentialTests
         Assert.Equal(Status.SATISFIABLE, signedMutation.NegatedBoundStatus);
         Assert.Equal(32u, widthMutation.Width);
         Assert.Equal(Status.SATISFIABLE, widthMutation.NegatedBoundStatus);
+    }
+
+    [Fact]
+    public void OrdinalComparisonProbeDistinguishesEmitterModeMutation()
+    {
+        const string source = "abc";
+        const string zeroWidthJoinerPrefix = "\u200dabc";
+        var previousCulture = CultureInfo.CurrentCulture;
+        var previousUiCulture = CultureInfo.CurrentUICulture;
+        var controlledCulture = CultureInfo.GetCultureInfo(DifferentialGate.RuntimeCultureName);
+
+        try
+        {
+            CultureInfo.CurrentCulture = controlledCulture;
+            CultureInfo.CurrentUICulture = controlledCulture;
+            Assert.StartsWith(
+                zeroWidthJoinerPrefix,
+                source,
+                StringComparison.CurrentCulture);
+            Assert.NotEqual(
+                source.StartsWith(zeroWidthJoinerPrefix, StringComparison.CurrentCulture),
+                source.StartsWith(zeroWidthJoinerPrefix, StringComparison.Ordinal));
+
+            var form = DifferentialFormRegistry.Build().Single(
+                candidate => candidate.Id == "string-comparison-mode:Ordinal");
+            var provable = form.Build(CasePolarity.Provable).Condition;
+            var refutable = form.Build(CasePolarity.Refutable).Condition;
+            var provableNot = Assert.IsType<UnaryOperationNode>(provable);
+            Assert.Equal(UnaryOperator.Not, provableNot.Operator);
+            AssertOrdinalStartsWithWitness(
+                Assert.IsType<StringOperationNode>(provableNot.Operand));
+            AssertOrdinalStartsWithWitness(
+                Assert.IsType<StringOperationNode>(refutable));
+
+            var emitter = new CSharpEmitter();
+            var generatedCode = BuildOrdinalControlCode(
+                provable.Accept(emitter),
+                refutable.Accept(emitter));
+            Assert.Equal(2, CountOccurrences(generatedCode, "StringComparison.Ordinal"));
+            Assert.Equal(2, CountOccurrences(generatedCode, ".StartsWith("));
+
+            const string ordinalArgument = ", StringComparison.Ordinal";
+            var mutatedCode = generatedCode.Replace(
+                ordinalArgument,
+                string.Empty,
+                StringComparison.Ordinal);
+            Assert.NotEqual(generatedCode, mutatedCode);
+            Assert.DoesNotContain("StringComparison.Ordinal", mutatedCode);
+
+            using var registeredRuntime = GeneratedRuntime.Compile(
+                "CalorVerifierDifferentialOrdinalRegistered",
+                generatedCode,
+                "OrdinalEmitterControl");
+            using var mutatedRuntime = GeneratedRuntime.Compile(
+                "CalorVerifierDifferentialOrdinalMutated",
+                mutatedCode,
+                "OrdinalEmitterControl");
+
+            var ambientCulture = CultureInfo.GetCultureInfo("fr-FR");
+            CultureInfo.CurrentCulture = ambientCulture;
+            CultureInfo.CurrentUICulture = ambientCulture;
+            Assert.Equal(
+                RuntimeVerdict.Completed,
+                registeredRuntime.Invoke("Provable", Array.Empty<string>(), out _));
+            Assert.Equal(
+                RuntimeVerdict.GuardFailed,
+                registeredRuntime.Invoke("Refutable", Array.Empty<string>(), out _));
+            Assert.Equal(
+                RuntimeVerdict.GuardFailed,
+                mutatedRuntime.Invoke("Provable", Array.Empty<string>(), out _));
+            Assert.Equal(
+                RuntimeVerdict.Completed,
+                mutatedRuntime.Invoke("Refutable", Array.Empty<string>(), out _));
+            Assert.Equal(ambientCulture, CultureInfo.CurrentCulture);
+            Assert.Equal(ambientCulture, CultureInfo.CurrentUICulture);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+            CultureInfo.CurrentUICulture = previousUiCulture;
+        }
     }
 
     [Fact]
@@ -319,5 +402,60 @@ public sealed class VerifierRuntimeDifferentialTests
                 ?? FindArrayAccessOrNull(implication.Consequent),
             _ => null
         };
+    }
+
+    private static void AssertOrdinalStartsWithWitness(StringOperationNode operation)
+    {
+        Assert.Equal(StringOp.StartsWith, operation.Operation);
+        Assert.Equal(StringComparisonMode.Ordinal, operation.ComparisonMode);
+        Assert.Equal<string>(
+            ["abc", "\u200dabc"],
+            operation.Arguments
+                .Cast<StringLiteralNode>()
+                .Select(argument => argument.Value)
+                .ToArray());
+    }
+
+    private static string BuildOrdinalControlCode(
+        string provableExpression,
+        string refutableExpression) => $$"""
+        namespace OrdinalEmitterControl
+        {
+            internal static class OrdinalEmitterControlModule
+            {
+                internal static void Provable()
+                {
+                    AssertControlledCulture();
+                    if (!({{provableExpression}}))
+                        throw new InvalidOperationException("Proof obligation failed: provable");
+                }
+
+                internal static void Refutable()
+                {
+                    AssertControlledCulture();
+                    if (!({{refutableExpression}}))
+                        throw new InvalidOperationException("Proof obligation failed: refutable");
+                }
+
+                private static void AssertControlledCulture()
+                {
+                    if (global::System.Globalization.CultureInfo.CurrentCulture.Name != "en-US")
+                        throw new InvalidOperationException("Generated runtime culture was not controlled");
+                }
+            }
+        }
+        """;
+
+    private static int CountOccurrences(string value, string needle)
+    {
+        var count = 0;
+        var offset = 0;
+        while ((offset = value.IndexOf(needle, offset, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            offset += needle.Length;
+        }
+
+        return count;
     }
 }

--- a/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/VerifierRuntimeDifferentialTests.cs
+++ b/tests/Calor.Verification.Tests/VerifierRuntimeDifferential/VerifierRuntimeDifferentialTests.cs
@@ -1,5 +1,8 @@
 using System.Text;
+using System.Runtime.CompilerServices;
+using Calor.Compiler.Verification;
 using Calor.Compiler.Verification.Z3;
+using Microsoft.Z3;
 using Xunit;
 
 namespace Calor.Verification.Tests.VerifierRuntimeDifferential;
@@ -23,11 +26,33 @@ public sealed class VerifierRuntimeDifferentialTests
         Assert.Equal(65, report.Coverage.FormsWhitelisted);
         Assert.Equal(65, report.Coverage.FormsCovered);
         Assert.Equal(1_170, report.Coverage.MatrixCellsRegistered);
+        Assert.Equal(1_170, report.Coverage.MatrixCellsApplicable);
         Assert.Equal(1_170, report.Coverage.MatrixCellsCovered);
         Assert.Equal(1_170, report.Coverage.CasesGenerated);
         Assert.Equal(0, report.Coverage.Mismatches);
         Assert.Equal(10, report.FailSafeControls.Count);
         Assert.All(report.FailSafeControls, control => Assert.True(control.Passed));
+        var timeoutControls = report.FailSafeControls
+            .Where(control => control.Scenario == "timeout")
+            .ToList();
+        var solverErrorControls = report.FailSafeControls
+            .Where(control => control.Scenario == "solver-error")
+            .ToList();
+        Assert.Equal(2, timeoutControls.Count);
+        Assert.Equal(2, solverErrorControls.Count);
+        Assert.All(timeoutControls, control => Assert.Equal("timeout", control.Status));
+        Assert.All(solverErrorControls, control => Assert.Equal("unknown", control.Status));
+        Assert.All(
+            report.Forms.Where(form => form.Applicable),
+            form => Assert.True(form.SolverHandled, form.Id));
+
+        var fieldAccess = report.Forms.Single(
+            form => form.Id == "expression-kind:FieldAccessNode");
+        Assert.Equal(18, fieldAccess.Cases);
+        Assert.Equal(3, fieldAccess.Statuses["proven"]);
+        Assert.Equal(6, fieldAccess.Statuses["assumed"]);
+        Assert.Equal(9, fieldAccess.Statuses["refuted"]);
+        Assert.False(fieldAccess.Statuses.ContainsKey("unsupported"));
 
         var reports = new[]
         {
@@ -50,14 +75,83 @@ public sealed class VerifierRuntimeDifferentialTests
         foreach (var (path, generated) in reports)
         {
             var generatedBytes = Encoding.UTF8.GetBytes(generated);
+            Assert.DoesNotContain((byte)'\r', generatedBytes);
             if (Environment.GetEnvironmentVariable(UpdateReportsVariable) == "1")
                 File.WriteAllBytes(path, generatedBytes);
 
             Assert.True(File.Exists(path), $"Committed report is missing: {path}");
+            var committedBytes = File.ReadAllBytes(path);
+            Assert.DoesNotContain((byte)'\r', committedBytes);
             Assert.True(
-                File.ReadAllBytes(path).AsSpan().SequenceEqual(generatedBytes),
+                committedBytes.AsSpan().SequenceEqual(generatedBytes),
                 $"Committed report is stale: {path}. Set {UpdateReportsVariable}=1 and rerun this test.");
         }
+    }
+
+    [Fact]
+    public void SolverClassificationSeamDistinguishesTimeoutFromSolverError()
+    {
+        var timeout = ProofOutcome.ClassifySolverStatus(
+            Status.UNKNOWN,
+            SatPolarity.SatIsRefutation,
+            reasonUnknown: "timeout: deterministic regression");
+        var solverError = ProofOutcome.ClassifySolverException(
+            new InvalidOperationException("deterministic regression"));
+
+        Assert.Equal(ProofStatus.Timeout, timeout.Status);
+        Assert.Equal(ProofStatus.Unknown, solverError.Status);
+        Assert.Contains("Z3 solver error", solverError.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RepositoryRootDiscoveryAcceptsGitFileWorktrees()
+    {
+        const string candidate = "/worktree";
+        Assert.True(IsRepositoryRootCandidate(
+            candidate,
+            path => path == Path.Combine(candidate, "Directory.Build.props")
+                || path == Path.Combine(candidate, ".git"),
+            _ => false));
+    }
+
+    [Fact]
+    public void GeneratedAssembliesAreCollectibleAndUnload()
+    {
+        var loadContext = CompileInvokeAndUnload();
+
+        for (var attempt = 0; attempt < 10 && loadContext.IsAlive; attempt++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        Assert.False(loadContext.IsAlive);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference CompileInvokeAndUnload()
+    {
+        const string code = """
+            namespace CollectibleProbe
+            {
+                internal static class CollectibleProbeModule
+                {
+                    internal static void Execute()
+                    {
+                    }
+                }
+            }
+            """;
+        using var runtime = GeneratedRuntime.Compile(
+            "CalorVerifierDifferentialCollectible",
+            code,
+            "CollectibleProbe");
+        Assert.True(runtime.IsCollectible);
+        Assert.Equal(
+            RuntimeVerdict.Completed,
+            runtime.Invoke("Execute", Array.Empty<string>(), out _));
+        return runtime.LoadContextReference;
     }
 
     private static string FindRepositoryRoot()
@@ -65,8 +159,7 @@ public sealed class VerifierRuntimeDifferentialTests
         var directory = new DirectoryInfo(AppContext.BaseDirectory);
         while (directory != null)
         {
-            if (File.Exists(Path.Combine(directory.FullName, "Directory.Build.props"))
-                && Directory.Exists(Path.Combine(directory.FullName, ".git")))
+            if (IsRepositoryRootCandidate(directory.FullName, File.Exists, Directory.Exists))
             {
                 return directory.FullName;
             }
@@ -75,5 +168,15 @@ public sealed class VerifierRuntimeDifferentialTests
         }
 
         throw new InvalidOperationException("Could not locate the Calor repository root.");
+    }
+
+    private static bool IsRepositoryRootCandidate(
+        string directory,
+        Func<string, bool> fileExists,
+        Func<string, bool> directoryExists)
+    {
+        return fileExists(Path.Combine(directory, "Directory.Build.props"))
+            && (directoryExists(Path.Combine(directory, ".git"))
+                || fileExists(Path.Combine(directory, ".git")));
     }
 }


### PR DESCRIPTION
## Summary
- generate the frozen F-4 verifier/runtime matrix across all 65 modeled forms
- compare typed solver outcomes with guard-forced generated C# execution
- publish byte-checked JSON/Markdown coverage metrics and block CI on mismatches

## Evidence
- 65/65 forms covered
- 1,170/1,170 registered matrix cells executed
- 40/65 forms currently eligible for opt-in elision
- zero solver/runtime mismatches
- 10 fail-safe controls retain guards

Closes #779
