### PR TITLE
Z3 chain closure: drop osx-x64, upstream osx-arm64, arch-vs-RID assertion

### DIFF
--- a/.github/scripts/inspect-sdk-nupkg.sh
+++ b/.github/scripts/inspect-sdk-nupkg.sh
@@ -50,7 +50,7 @@ fi
 if [ "$ALL_RIDS" = "--all-rids" ]; then
   require "tasks/net10.0/runtimes/linux-x64/native/libz3.so"
   require "tasks/net10.0/runtimes/linux-arm64/native/libz3.so"
-  require "tasks/net10.0/runtimes/osx-x64/native/libz3.dylib"
+  # osx-x64 dropped (Z3 chain closure): Intel macOS unsupported for verification.
   require "tasks/net10.0/runtimes/osx-arm64/native/libz3.dylib"
   require "tasks/net10.0/runtimes/win-x64/native/libz3.dll"
   require "tasks/net10.0/runtimes/win-arm64/native/libz3.dll"

--- a/.github/workflows/build-z3.yml
+++ b/.github/workflows/build-z3.yml
@@ -36,115 +36,21 @@ env:
   MANAGED_DLL_ARCHIVE: x64-glibc-2.39
 
 jobs:
-  # Build Z3 from source on ARM64 macOS ONLY.
-  #
-  # ⚠ THE STATED JUSTIFICATION FOR THIS JOB NO LONGER HOLDS. It used to read
-  # "the upstream arm64-osx archive has assembly-loading problems on that
-  # platform (same exception download-z3.sh makes at its Darwin/arm64 branch)".
-  # That branch is gone: download-z3.sh now takes the upstream arm64-osx native
-  # on ARM64 macOS, and it is verified working there (Calor.Verification.Tests
-  # 359/359, zero skips, on a SkippableFact-gated suite). So this job is now the
-  # ONLY producer of a non-reproducible asset, and it makes the shipped
-  # osx-arm64 native differ from the one every ARM64 macOS developer builds
-  # against.
-  #
-  # It is left in place for now only because switching it changes a published
-  # asset and so requires a deliberate republish + repin, which is bundled with
-  # the unresolved osx-x64 decision (upstream's x64-osx archive contains an
-  # arm64 binary — see the note on the prebuilt job below).
-  #
-  # Every other RID — including linux-arm64, which download-z3.sh has always
-  # taken from the upstream arm64-glibc-2.38 archive — uses the
-  # checksum-verified prebuilt path below, because a from-source C++ build is
-  # not reproducible and silently re-drifts the pin on every run.
-  build-z3-arm64:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-latest
-            rid: osx-arm64
-            lib: libz3.dylib
-
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '10.0.x'
-
-      - name: Install build dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential python3 git
-
-      - name: Build Z3 from source
-        run: |
-          git clone --depth 1 --branch "z3-${{ env.Z3_VERSION }}" https://github.com/Z3Prover/z3.git /tmp/z3
-          cd /tmp/z3
-          python3 scripts/mk_make.py --dotnet
-          cd build
-          make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
-          cd dotnet
-          dotnet build -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false
-
-      - name: Verify Z3 works
-        run: |
-          mkdir -p /tmp/z3-test && cd /tmp/z3-test
-
-          cat > test.csproj << 'CSPROJ'
-          <Project Sdk="Microsoft.NET.Sdk">
-            <PropertyGroup>
-              <OutputType>Exe</OutputType>
-              <TargetFramework>net10.0</TargetFramework>
-            </PropertyGroup>
-            <ItemGroup>
-              <Reference Include="Microsoft.Z3">
-                <HintPath>/tmp/z3/build/dotnet/bin/Debug/netstandard1.4/Microsoft.Z3.dll</HintPath>
-              </Reference>
-            </ItemGroup>
-          </Project>
-          CSPROJ
-
-          cat > Program.cs << 'CS'
-          using Microsoft.Z3;
-          using var ctx = new Context();
-          var x = ctx.MkIntConst("x");
-          var solver = ctx.MkSolver();
-          solver.Assert(ctx.MkGt(x, ctx.MkInt(0)));
-          if (solver.Check() != Status.SATISFIABLE) throw new System.Exception("Z3 failed");
-          System.Console.WriteLine("Z3 works!");
-          CS
-
-          # Copy native lib to output
-          dotnet build
-          cp /tmp/z3/build/${{ matrix.lib }} bin/Debug/net10.0/
-          dotnet run
-
-      # ONLY the native library. The source-built Microsoft.Z3.dll is a Debug
-      # netstandard1.4 assembly that embeds the builder's absolute obj path, so
-      # it differs on every run — and it used to win the `find | head -1` race in
-      # create-release, which is how a Debug, source-compiled managed wrapper
-      # ended up shipping inside the calor nupkg instead of the official Release
-      # assembly that download-z3.sh gives every developer and every CI test run.
-      # The managed DLL now comes from the canonical upstream archive below.
-      - name: Prepare artifacts
-        run: |
-          mkdir -p artifacts
-          cp /tmp/z3/build/${{ matrix.lib }} artifacts/
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: z3-${{ matrix.rid }}-${{ env.Z3_VERSION }}
-          path: artifacts/
-
-  # Download pre-built Z3 for every RID except osx-arm64. These archives are
+  # Z3 chain closure (roadmap §2.4, decided 2026-08-11):
+  # - The ARM64-macOS source-build job is GONE. Its stated justification had
+  #   already lapsed (download-z3.sh takes the upstream arm64-osx native on
+  #   ARM64 macOS, verified working); it was the only producer of a
+  #   non-reproducible asset, and it made the shipped osx-arm64 native differ
+  #   from the one every ARM64 macOS developer builds against. osx-arm64 now
+  #   ships the same checksum-verified upstream archive as every other RID.
+  # - osx-x64 is DROPPED: upstream's x64-osx archive contains an arm64 binary
+  #   under the x64 label, so Intel Macs installed successfully and SILENTLY
+  #   lost verification. No honest asset exists to ship; Intel macOS is
+  #   unsupported for verification and documented as such.
+  # - The native arch-vs-RID assertion below (held back until both decisions
+  #   landed) makes any future mislabeled upstream archive fail this job
+  #   instead of shipping.
+  # Download pre-built Z3 for every supported RID. These archives are
   # pinned by src/Calor.Compiler/scripts/z3-upstream-<ver>.sha256, so extraction
   # is deterministic and the resulting release assets are byte-stable across runs.
   download-z3-prebuilt:
@@ -156,21 +62,27 @@ jobs:
           - rid: linux-x64
             archive: x64-glibc-2.39
             lib: libz3.so
+            arch_marker: "x86-64"
           - rid: linux-arm64
             archive: arm64-glibc-2.38
             lib: libz3.so
-          - rid: osx-x64
-            archive: x64-osx-15.7.3
+            arch_marker: "aarch64"
+          - rid: osx-arm64
+            archive: arm64-osx-15.7.3
             lib: libz3.dylib
+            arch_marker: "arm64"
           - rid: win-x64
             archive: x64-win
             lib: libz3.dll
+            arch_marker: "x86-64"
           - rid: win-x86
             archive: x86-win
             lib: libz3.dll
+            arch_marker: "Intel 80386"
           - rid: win-arm64
             archive: arm64-win
             lib: libz3.dll
+            arch_marker: "Aarch64"
 
     steps:
       - uses: actions/checkout@v4
@@ -207,6 +119,19 @@ jobs:
 
           # Copy native library
           find . -name "${{ matrix.lib }}" -path "*/bin/*" -exec cp {} artifacts/ \;
+
+          # Native arch-vs-RID assertion (the check the osx-x64 mislabeling
+          # evaded): the binary's actual architecture must match the RID it is
+          # about to ship under. `file` reads Mach-O/ELF/PE headers directly.
+          DESC="$(file -b "artifacts/${{ matrix.lib }}")"
+          echo "native arch: $DESC"
+          case "$DESC" in
+            *"${{ matrix.arch_marker }}"*) ;;
+            *)
+              echo "::error::${{ matrix.rid }} native is not ${{ matrix.arch_marker }}: $DESC — upstream archive is mislabeled; refusing to ship"
+              exit 1
+              ;;
+          esac
 
           # The managed wrapper is emitted by ONE designated archive only.
           # The old code copied it from whichever archive happened to contain it
@@ -267,7 +192,7 @@ jobs:
 
   # Create/update the z3-binaries release with all artifacts
   create-release:
-    needs: [build-z3-arm64, download-z3-prebuilt]
+    needs: [download-z3-prebuilt]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -341,18 +266,20 @@ jobs:
           tag_name: z3-binaries-${{ env.Z3_VERSION }}
           name: Z3 Binaries v${{ env.Z3_VERSION }}
           body: |
-            Pre-built Z3 ${{ env.Z3_VERSION }} binaries for all supported platforms.
+            Pre-built Z3 ${{ env.Z3_VERSION }} binaries for all supported platforms —
+            every native is the checksum-verified upstream archive for its RID, with
+            the arch-vs-RID assertion enforced at packaging time.
 
-            **Built from source (ARM64):**
+            - linux-x64
             - linux-arm64
             - osx-arm64
-
-            **Downloaded from Z3 releases (x64/Windows):**
-            - linux-x64
-            - osx-x64
             - win-x64
             - win-x86
             - win-arm64
+
+            osx-x64 is deliberately absent: upstream ships an arm64 binary under the
+            x64 label, so Intel Macs would install successfully and silently lose
+            verification. Intel macOS is unsupported for verification.
 
             These binaries are used by the Calor NuGet package.
           files: release/*

--- a/.github/workflows/build-z3.yml
+++ b/.github/workflows/build-z3.yml
@@ -50,6 +50,14 @@ jobs:
   # - The native arch-vs-RID assertion below (held back until both decisions
   #   landed) makes any future mislabeled upstream archive fail this job
   #   instead of shipping.
+  # POST-MERGE PROCEDURE (one repin/republish): dispatch this workflow; then
+  #   `gh release delete-asset z3-binaries-<ver> libz3-osx-x64.dylib` (the
+  #   release action replaces same-named assets but never deletes unlisted
+  #   ones — without this the release claims osx-x64 is absent while the
+  #   mislabeled binary stays attached); then commit the regenerated
+  #   .github/z3-binaries-<ver>.sha256 block from the run's step summary.
+  #   Until that commit, publish-nuget and z3-pin-check fail closed (by
+  #   design) on the changed osx-arm64 asset hash.
   # Download pre-built Z3 for every supported RID. These archives are
   # pinned by src/Calor.Compiler/scripts/z3-upstream-<ver>.sha256, so extraction
   # is deterministic and the resulting release assets are byte-stable across runs.

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -101,7 +101,6 @@ jobs:
           mkdir -p src/Calor.Compiler/z3
           mkdir -p src/Calor.Compiler/runtimes/linux-x64/native
           mkdir -p src/Calor.Compiler/runtimes/linux-arm64/native
-          mkdir -p src/Calor.Compiler/runtimes/osx-x64/native
           mkdir -p src/Calor.Compiler/runtimes/osx-arm64/native
           mkdir -p src/Calor.Compiler/runtimes/win-x64/native
           mkdir -p src/Calor.Compiler/runtimes/win-x86/native
@@ -118,7 +117,7 @@ jobs:
           fi
 
           STAGING="$(mktemp -d)"
-          ASSETS="Microsoft.Z3.dll libz3-linux-x64.so libz3-linux-arm64.so libz3-osx-x64.dylib libz3-osx-arm64.dylib libz3-win-x64.dll libz3-win-x86.dll libz3-win-arm64.dll"
+          ASSETS="Microsoft.Z3.dll libz3-linux-x64.so libz3-linux-arm64.so libz3-osx-arm64.dylib libz3-win-x64.dll libz3-win-x86.dll libz3-win-arm64.dll"
           for asset in $ASSETS; do
             curl -fL -sS --retry 5 --retry-delay 3 -o "$STAGING/$asset" "${RELEASE_URL}/${asset}"
           done
@@ -128,7 +127,6 @@ jobs:
           mv "$STAGING/Microsoft.Z3.dll"      src/Calor.Compiler/z3/Microsoft.Z3.dll
           mv "$STAGING/libz3-linux-x64.so"    src/Calor.Compiler/runtimes/linux-x64/native/libz3.so
           mv "$STAGING/libz3-linux-arm64.so"  src/Calor.Compiler/runtimes/linux-arm64/native/libz3.so
-          mv "$STAGING/libz3-osx-x64.dylib"   src/Calor.Compiler/runtimes/osx-x64/native/libz3.dylib
           mv "$STAGING/libz3-osx-arm64.dylib" src/Calor.Compiler/runtimes/osx-arm64/native/libz3.dylib
           mv "$STAGING/libz3-win-x64.dll"     src/Calor.Compiler/runtimes/win-x64/native/libz3.dll
           mv "$STAGING/libz3-win-x86.dll"     src/Calor.Compiler/runtimes/win-x86/native/libz3.dll

--- a/.github/z3-binaries-4.15.7.sha256
+++ b/.github/z3-binaries-4.15.7.sha256
@@ -8,21 +8,19 @@
 # extractions from upstream Z3Prover archives that the same run verified against
 # scripts/z3-upstream-4.15.7.sha256, so they are reproducible: all seven were
 # predicted from the pinned archives BEFORE the run and matched byte for byte.
-# The eighth, libz3-osx-arm64.dylib, is still built from source and is the only
-# entry not derivable from a pinned input — though it has now reproduced
-# bit-identically across three separate runs. It was previously annotated here
-# as necessary because "upstream's arm64-osx archive has assembly-loading
-# problems"; that justification does not hold — the upstream arm64-osx native is
-# verified working on ARM64 macOS (Calor.Verification.Tests 359/359, zero skips)
-# and download-z3.sh now uses it. Switching build-z3.yml to match is pending a
-# deliberate republish, bundled with the unresolved osx-x64 question below.
+# The eighth, libz3-osx-arm64.dylib, was built from source in that run; the Z3
+# chain closure (2026-08-11) switched build-z3.yml to the checksum-verified
+# upstream arm64-osx archive, so on the NEXT deliberate republish its hash here
+# WILL change (to bytes predictable from scripts/z3-upstream-4.15.7.sha256) and
+# every entry becomes derivable from a pinned input.
 #
-# ⚠ KNOWN DEFECT, NOT FIXED: libz3-osx-x64.dylib is an ARM64 binary. Upstream's
-# z3-4.15.7-x64-osx-15.7.3.zip and z3-4.15.7-arm64-osx-15.7.3.zip ship a
-# byte-identical arm64 libz3.dylib, so the hash below is correct for the bytes
-# we publish but the bytes themselves are mislabeled at the RID. Intel Macs get
-# a native that cannot load and lose verification silently (it fails soft to
-# "Z3 unavailable"). Inherited from upstream; the remedy is an open decision.
+# osx-x64 RESOLVED (2026-08-11, chain closure): upstream's x64-osx archive ships
+# an arm64 binary under the x64 label, so Intel Macs installed successfully and
+# silently lost verification. Decision: the RID is DROPPED — no honest asset
+# exists to ship. Its manifest entry is removed; publish-nuget no longer stages
+# it; build-z3.yml's arch-vs-RID assertion now fails the packaging job if any
+# upstream archive is ever mislabeled again. Intel macOS is unsupported for
+# verification.
 #
 # This replaces a 2026-07-31 trust-on-first-use manifest that had drifted. Two
 # entries changed, and neither because upstream changed:
@@ -48,7 +46,6 @@
 7227ad08ae28b731be27a26f68680f627a4e513e2a134b2cbe1fc223a76ce3b5  libz3-linux-arm64.so
 3e70217bc6b05b6204912698becf9f853a7a2f07bb5338dad84aef79aee9bec8  libz3-linux-x64.so
 038f356687ac800c2269ff4d289c7921ec5802dafca3ae6a2a4620defc807f9c  libz3-osx-arm64.dylib
-8d1f54380a32e2c13b03b2e9afa8427908fa480c3f7d1285a1ae034793359ada  libz3-osx-x64.dylib
 f28f1f6f4795ef82d6dc0fa856145b7ce6dcfee542c236110197ce5f535a7562  libz3-win-arm64.dll
 d301fc1ba4c317d3293fccd784c2c3c0ba06139d21b9fc3a7cae37a244e85a56  libz3-win-x64.dll
 89d584e1e792961a5e5a9a8385f1416cf38251c48446bab8ba64f9a17000ebc9  libz3-win-x86.dll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Removed
+- **The `osx-x64` Z3 native is no longer shipped** (Z3 chain closure). Upstream's
+  x64-osx archive contains an arm64 binary under the x64 label, so Intel Macs
+  installed successfully and silently lost verification — no honest asset exists
+  to ship. Intel macOS is unsupported for verification (Z3-dependent features
+  report "Z3 unavailable"; compilation is unaffected). The osx-arm64 native now
+  ships from the same checksum-verified upstream archive as every other RID
+  (the last source-built, non-reproducible asset is gone), and a native
+  arch-vs-RID assertion in the packaging workflow fails closed if any upstream
+  archive is ever mislabeled again.
+
 ### Changed
 - **The binder dispatches every expression class** (#762 B1): a single authoritative dispatch
   table replaces the partial switch; expressions without a structural binder yet produce an

--- a/docs/plans/roadmap-v0.13-v0.15.md
+++ b/docs/plans/roadmap-v0.13-v0.15.md
@@ -191,10 +191,14 @@ gates 1, 4, 5, 6, 7, and gate 2's diagnostics leg.
    the CI job is **demonstrated to fail on a fixture-less `SupportLevel` promotion** (a
    discriminating pin — revert the fixture, watch it fail).
 7. **Clean-consumer install, per-RID**: on a frozen RID × package matrix (win-x64, linux-x64,
-   osx-x64, osx-arm64; CLI + Sdk + VSIX where unblocked), a clean consumer runs `calor verify` on a
+   osx-arm64: CLI + Sdk + VSIX where unblocked), a clean consumer runs `calor verify` on a
    Z3-requiring fixture and gets a **solver verdict** — exit-0 install is not the bar, because the
-   known osx-x64 state is precisely "installs successfully, silently loses verification". The
-   registries are verified **after** publishing (a workflow firing is not a publish).
+   pre-closure osx-x64 state was precisely "installs successfully, silently loses verification".
+   **Gate amended with the Z3 chain closure (2026-08-11, #916 review F3): the osx-x64 RID is
+   dropped, so its leg's oracle changes rather than disappearing** — a clean Intel-mac consumer
+   must get the *documented degradation* (a loud "Z3 unavailable"/Calor0710 signal, no crash, no
+   silent pass), which turns the drop decision itself into a tested claim. The registries are
+   verified **after** publishing (a workflow firing is not a publish).
 8. **Performance envelope (project scale needs a number)**: index build ≤ 30s and warm `calor query`
    ≤ 500ms on the largest pinned conversion subject, measured in CI. Generous by design; the point
    is that "usable at project scale" is adjudicable at all. Frozen here, before the index exists.

--- a/src/Calor.Compiler/Calor.Compiler.csproj
+++ b/src/Calor.Compiler/Calor.Compiler.csproj
@@ -95,7 +95,6 @@
       <Z3NativeLib Include="$(Z3RuntimesDir)/osx-arm64/native/libz3.dylib" />
     </ItemGroup>
     <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">
-      <Z3NativeLib Include="$(Z3RuntimesDir)/osx-x64/native/libz3.dylib" />
     </ItemGroup>
     <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">
       <Z3NativeLib Include="$(Z3RuntimesDir)/win-x64/native/libz3.dll" />

--- a/src/Calor.Compiler/scripts/download-z3.ps1
+++ b/src/Calor.Compiler/scripts/download-z3.ps1
@@ -6,6 +6,11 @@ $ErrorActionPreference = "Stop"
 $Z3_VERSION = "4.15.7"
 $SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
 $RUNTIMES_DIR = Join-Path $SCRIPT_DIR "..\runtimes"
+
+# Z3 chain closure (#916 review F2): purge the dropped osx-x64 RID unconditionally —
+# the provenance stamp does not invalidate on RID-set changes, and stale natives
+# would be resurrected into local packs by the runtimes/** glob.
+Remove-Item -Recurse -Force (Join-Path $RUNTIMES_DIR "osx-x64") -ErrorAction SilentlyContinue
 $Z3_DIR = Join-Path $SCRIPT_DIR "..\z3"
 $TEMP_DIR = Join-Path $SCRIPT_DIR "..\.z3-temp"
 

--- a/src/Calor.Compiler/scripts/download-z3.ps1
+++ b/src/Calor.Compiler/scripts/download-z3.ps1
@@ -36,7 +36,7 @@ function Test-ArchiveChecksum {
 # Platform mappings
 $PLATFORMS = @(
     @{ rid = "osx-arm64"; archive = "z3-$Z3_VERSION-arm64-osx-15.7.3"; lib = "libz3.dylib" },
-    @{ rid = "osx-x64"; archive = "z3-$Z3_VERSION-x64-osx-15.7.3"; lib = "libz3.dylib" },
+    # osx-x64 removed (Z3 chain closure): upstream x64-osx archive contains an arm64 binary.
     @{ rid = "win-arm64"; archive = "z3-$Z3_VERSION-arm64-win"; lib = "libz3.dll" },
     @{ rid = "win-x64"; archive = "z3-$Z3_VERSION-x64-win"; lib = "libz3.dll" },
     @{ rid = "win-x86"; archive = "z3-$Z3_VERSION-x86-win"; lib = "libz3.dll" },

--- a/src/Calor.Compiler/scripts/download-z3.sh
+++ b/src/Calor.Compiler/scripts/download-z3.sh
@@ -90,7 +90,8 @@ trap 'rm -rf "$TEMP_DIR"' EXIT
 # Platform mappings: "rid|archive_name|lib_name_in_archive|lib_name_output"
 PLATFORMS=(
     "osx-arm64|z3-${Z3_VERSION}-arm64-osx-15.7.3|libz3.dylib|libz3.dylib"
-    "osx-x64|z3-${Z3_VERSION}-x64-osx-15.7.3|libz3.dylib|libz3.dylib"
+    # osx-x64 removed (Z3 chain closure): upstream's x64-osx archive contains an
+    # arm64 binary — Intel macOS is unsupported for verification.
     "win-arm64|z3-${Z3_VERSION}-arm64-win|libz3.dll|libz3.dll"
     "win-x64|z3-${Z3_VERSION}-x64-win|libz3.dll|libz3.dll"
     "win-x86|z3-${Z3_VERSION}-x86-win|libz3.dll|libz3.dll"

--- a/src/Calor.Compiler/scripts/download-z3.sh
+++ b/src/Calor.Compiler/scripts/download-z3.sh
@@ -53,6 +53,12 @@ verify_archive() {
     echo "  [verified] $name"
 }
 RUNTIMES_DIR="$SCRIPT_DIR/../runtimes"
+
+# Z3 chain closure (#916 review F2): the osx-x64 RID is dropped, but the
+# provenance stamp does not invalidate on a RID-set change — an existing
+# checkout keeps the mislabeled dylib forever and local packs resurrect the
+# dropped RID (the csproj packs runtimes/** by glob). Purge unconditionally.
+rm -rf "$RUNTIMES_DIR/osx-x64"
 Z3_DIR="$SCRIPT_DIR/../z3"
 TEMP_DIR="$SCRIPT_DIR/../.z3-temp"
 

--- a/src/Calor.Compiler/scripts/z3-upstream-4.15.7.sha256
+++ b/src/Calor.Compiler/scripts/z3-upstream-4.15.7.sha256
@@ -10,13 +10,13 @@
 # other platform, and build-z3-from-source.sh — the only unverified fetch in the
 # toolchain — has been deleted. Every archive consumed by download-z3.sh,
 # download-z3.ps1 and build-z3.yml is now verified against this manifest.
-# (build-z3.yml still builds osx-arm64 from source for the RELEASE assets; that
-# clone is inside the workflow itself and remains tag-pinned. It is the last
+# (build-z3.yml ships the same checksum-verified upstream archives as this script;
+# osx-x64 is deliberately absent — upstream's x64-osx archive contains an arm64
+# binary, so Intel macOS is unsupported for verification.)
 # unverified input and is tracked separately.)
 dabee41164abf080ae3bc312d80d1d8700ef49fbfc593c8d8fa4f3cdaf7d6551  z3-4.15.7-arm64-glibc-2.38.zip
 1f4aefb345bded8b6cd6a5a92b6bb2e34110b373779bfb38145200ceeb4fa626  z3-4.15.7-arm64-osx-15.7.3.zip
 e6ef5a4f8749c0b3214a1ad72e6c5655bbda2eeebe9177277514df1fa7eed571  z3-4.15.7-arm64-win.zip
 4436ab6381f0b9c68075a267ab13a5f3ad25f7c25f7626dec959c76805c9f2cb  z3-4.15.7-x64-glibc-2.39.zip
-445a851c51701bd044c1d6aa75d024cfa34975045377846161cd1b073cee7796  z3-4.15.7-x64-osx-15.7.3.zip
 7b01f3987bcdab0d0622c417212ad37e7a486ea233e091a59f646e0118316187  z3-4.15.7-x64-win.zip
 40f7cc9e69b51dd77e9131eeea62cf039b560629b76a2e87f27b15f3009f9d9c  z3-4.15.7-x86-win.zip

--- a/src/Calor.Sdk/Calor.Sdk.csproj
+++ b/src/Calor.Sdk/Calor.Sdk.csproj
@@ -89,7 +89,6 @@
          the runtimes flow works at all). -->
     <PropertyGroup>
       <_CalorSdkHasAnyNative Condition="Exists('$(_CalorSdkTasksStageDir)runtimes/osx-arm64/native/libz3.dylib')
-        or Exists('$(_CalorSdkTasksStageDir)runtimes/osx-x64/native/libz3.dylib')
         or Exists('$(_CalorSdkTasksStageDir)runtimes/linux-x64/native/libz3.so')
         or Exists('$(_CalorSdkTasksStageDir)runtimes/linux-arm64/native/libz3.so')
         or Exists('$(_CalorSdkTasksStageDir)runtimes/win-x64/native/libz3.dll')
@@ -100,9 +99,9 @@
 
     <!-- Release publishing must carry every supported RID (set by the publish
          workflow after the checksum-verified Z3 download). -->
+    <!-- osx-x64 deliberately absent (Z3 chain closure): Intel macOS unsupported for verification. -->
     <Error Condition="'$(CalorSdkRequireAllRids)' == 'true' and (!Exists('$(_CalorSdkTasksStageDir)runtimes/linux-x64/native/libz3.so')
         or !Exists('$(_CalorSdkTasksStageDir)runtimes/linux-arm64/native/libz3.so')
-        or !Exists('$(_CalorSdkTasksStageDir)runtimes/osx-x64/native/libz3.dylib')
         or !Exists('$(_CalorSdkTasksStageDir)runtimes/osx-arm64/native/libz3.dylib')
         or !Exists('$(_CalorSdkTasksStageDir)runtimes/win-x64/native/libz3.dll')
         or !Exists('$(_CalorSdkTasksStageDir)runtimes/win-arm64/native/libz3.dll'))"

--- a/src/Calor.Tasks/Calor.Tasks.csproj
+++ b/src/Calor.Tasks/Calor.Tasks.csproj
@@ -42,7 +42,6 @@
       <_CalorZ3NativeLib Include="$(_CalorZ3RuntimesDir)/osx-arm64/native/libz3.dylib" />
     </ItemGroup>
     <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">
-      <_CalorZ3NativeLib Include="$(_CalorZ3RuntimesDir)/osx-x64/native/libz3.dylib" />
     </ItemGroup>
     <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">
       <_CalorZ3NativeLib Include="$(_CalorZ3RuntimesDir)/win-x64/native/libz3.dll" />


### PR DESCRIPTION
## Summary

The final 0.13 MUST (roadmap §2.4 "Z3 asset chain finished"), executing the maintainer decision (2026-08-11): **drop the osx-x64 RID and document**, rather than shipping upstream's mislabeled archive (an arm64 dylib under the x64 label — Intel Macs installed successfully and *silently lost verification*) or paying for a recurring Intel source build.

## Changes

1. **osx-x64 dropped everywhere**: build-z3.yml prebuilt matrix, publish-nuget staging/packing, `Calor.Compiler`/`Calor.Tasks`/`Calor.Sdk` csproj native lists and existence gates, `inspect-sdk-nupkg.sh`, `download-z3.sh`/`.ps1`, both checksum manifests. CHANGELOG documents Intel macOS as unsupported for verification (compilation unaffected; Z3 features report "Z3 unavailable").
2. **The ARM64-macOS source-build job is deleted** — its own comment block admitted the justification had lapsed; it was the only producer of a non-reproducible asset and made the shipped osx-arm64 differ from what every ARM64-macOS developer builds against. osx-arm64 now ships the same checksum-verified upstream archive as every other RID.
3. **The held-back native arch-vs-RID assertion lands**: each prebuilt matrix leg asserts `file` output on the extracted native contains the RID's expected architecture marker (`x86-64`/`aarch64`/`arm64`/`Intel 80386`/`Aarch64`), failing the packaging job if upstream ever mislabels again — the exact check the osx-x64 defect evaded.

## Republish procedure (post-merge, per the manifest's documented rule)

Dispatch build-z3.yml once (the "one repin/republish" the roadmap names); the run prints the regenerated `.github/z3-binaries-4.15.7.sha256` block in its step summary; commit it in the same change-set. The osx-arm64 asset hash will change (source-built → upstream bytes, predictable from the pinned upstream archive); every manifest entry is then derivable from a pinned input for the first time.

Verification.Tests 375/375 and Tasks.Tests 88/88 green; full build clean; actionlint clean (no new findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)