### PR TITLE
Repin z3-binaries manifest after the chain-closure republish

### DIFF
--- a/.github/z3-binaries-4.15.7.sha256
+++ b/.github/z3-binaries-4.15.7.sha256
@@ -8,11 +8,13 @@
 # extractions from upstream Z3Prover archives that the same run verified against
 # scripts/z3-upstream-4.15.7.sha256, so they are reproducible: all seven were
 # predicted from the pinned archives BEFORE the run and matched byte for byte.
-# The eighth, libz3-osx-arm64.dylib, was built from source in that run; the Z3
-# chain closure (2026-08-11) switched build-z3.yml to the checksum-verified
-# upstream arm64-osx archive, so on the NEXT deliberate republish its hash here
-# WILL change (to bytes predictable from scripts/z3-upstream-4.15.7.sha256) and
-# every entry becomes derivable from a pinned input.
+# Repinned 2026-08-11 from build-z3.yml run 31504311157 (the Z3 chain-closure
+# republish): libz3-osx-arm64.dylib is now the checksum-verified upstream
+# arm64-osx archive's dylib — the hash matched the value predicted from
+# scripts/z3-upstream-4.15.7.sha256 BEFORE the run, and every entry below is
+# now derivable from a pinned input. All seven assets were downloaded from the
+# live release and verified directly (hashes + `file` arch-vs-RID) after the
+# run; the stale mislabeled libz3-osx-x64.dylib was deleted from the release.
 #
 # osx-x64 RESOLVED (2026-08-11, chain closure): upstream's x64-osx archive ships
 # an arm64 binary under the x64 label, so Intel Macs installed successfully and
@@ -45,7 +47,7 @@
 59cb6de1d2e855fb44b4698616cc1f452249103989728da3700c4648b4426175  Microsoft.Z3.dll
 7227ad08ae28b731be27a26f68680f627a4e513e2a134b2cbe1fc223a76ce3b5  libz3-linux-arm64.so
 3e70217bc6b05b6204912698becf9f853a7a2f07bb5338dad84aef79aee9bec8  libz3-linux-x64.so
-038f356687ac800c2269ff4d289c7921ec5802dafca3ae6a2a4620defc807f9c  libz3-osx-arm64.dylib
+8d1f54380a32e2c13b03b2e9afa8427908fa480c3f7d1285a1ae034793359ada  libz3-osx-arm64.dylib
 f28f1f6f4795ef82d6dc0fa856145b7ce6dcfee542c236110197ce5f535a7562  libz3-win-arm64.dll
 d301fc1ba4c317d3293fccd784c2c3c0ba06139d21b9fc3a7cae37a244e85a56  libz3-win-x64.dll
 89d584e1e792961a5e5a9a8385f1416cf38251c48446bab8ba64f9a17000ebc9  libz3-win-x86.dll


### PR DESCRIPTION
The documented same-change-set manifest commit for the #916 republish (run 31504311157). One line changes: osx-arm64 moves from the source-built hash to the upstream-archive bytes, which matched the prediction from the pinned upstream manifest before the run. Registry verified directly per policy: all seven assets downloaded from the live release — six byte-identical to the committed pins, osx-arm64 equal to the new value, every native's `file` architecture matching its RID, and the stale mislabeled `libz3-osx-x64.dylib` deleted. Until this merges, publish-nuget and z3-pin-check fail closed by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)