### PR TITLE
Demote VS Code Marketplace to an opportunistic channel

### DIFF
--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -4,8 +4,8 @@ description: >-
     Automate the Calor release process end-to-end: bump version across Directory.Build.props,
     VSCode extension, website, and changelog files; run the statistical benchmark suite
     (30 runs); open and merge a release PR; create the GitHub release with proper pre-release
-    tagging; trigger the website deploy; and verify both packages actually reached nuget.org
-    and the VS Code marketplace. Use when the user asks to "cut a release",
+    tagging; trigger the website deploy; and verify the packages reached nuget.org and the
+    platform VSIX artifacts are attached to the GitHub release. Use when the user asks to "cut a release",
     "create a release", "ship a version", "release vX.Y.Z", or "do a release".
 allowed-tools: Bash, Read, Write, Edit
 user-invocable: true
@@ -13,7 +13,7 @@ user-invocable: true
 
 # /create-release - Create a New Calor Release
 
-This skill automates the release process: bump versions across all components, run benchmarks, create a PR, merge it, create a GitHub release with proper tagging, and **confirm the packages actually published**. Step 8 is not optional — creating the release only *triggers* the publish workflows, and in this repo they have failed silently for long stretches.
+This skill automates the release process: bump versions across all components, run benchmarks, create a PR, merge it, create a GitHub release with proper tagging, and **confirm the NuGet packages and release VSIX artifacts actually published**. Step 8 is not optional — creating the release only *triggers* the workflows, and in this repo they have failed silently for long stretches.
 
 ## Steps to Perform
 
@@ -221,45 +221,44 @@ Trigger the website deploy (the `nextjs-gh-pages` workflow runs on release creat
 gh workflow run nextjs-gh-pages.yml
 ```
 
-### 8. Verify the packages actually published — DO NOT SKIP
+### 8. Verify NuGet and the release VSIX artifacts — DO NOT SKIP
 
-**Creating the release triggers `publish-nuget` and `publish-vscode`; it does not make them
-succeed.** Both have failed silently while the tag and the website went out normally, so the
-release *looks* complete. The VS Code publish failed on **every release from v0.4.0 (2026-03-09)
-through v0.12.1** — the last success was v0.3.8, and the marketplace sat at `0.3.8` for five
-months and roughly nineteen releases before anyone noticed. Verify with
-`gh run list --workflow=publish-vscode.yml --limit 40` before assuming any of this is historical.
+**Creating the release triggers `publish-nuget` and `build-vsix-release`; it does not make either
+succeed.** A tag and website can go live while packages or release assets are absent, so the
+release can look complete when it is not. `publish-vscode` is deliberately absent from the
+release event: Marketplace publishing is opportunistic-only under the roadmap's 2026-08-11
+amendment.
 
-**Wait for the workflows first.** They are not fast: on v0.12.1 `publish-nuget` took ~4 min and
-`publish-vscode` ~23 min. Querying the registries before they finish shows the *previous* version
-and looks like failure.
+**Wait for both release workflows first.** Querying nuget.org or the GitHub release before they
+finish shows the previous version or an empty asset list and looks like failure.
 
 ```bash
 VER=0.12.1   # the version you cut
 
-# Watch both publishes to completion (get the run ids for THIS tag)
+# Watch both release artifact workflows to completion (get the run ids for THIS tag)
 gh run list --event release --limit 10 \
   --json databaseId,workflowName,headBranch,status,conclusion \
-  --jq ".[] | select(.headBranch==\"v$VER\") | \"\(.databaseId)\t\(.workflowName)\t\(.status)\t\(.conclusion)\""
-# then, for each publish run id:
+  --jq ".[] | select(.headBranch==\"v$VER\" and (.workflowName==\"Publish to NuGet\" or .workflowName==\"Build VS Code Release Assets\")) | \"\(.databaseId)\t\(.workflowName)\t\(.status)\t\(.conclusion)\""
+# then, for each run id:
 gh run watch <run-id>
 ```
 
-A green workflow is still not sufficient evidence — check the registries themselves. Note
-nuget.org's flat-container index can lag a successful push by several minutes, so re-check before
-concluding it failed:
+A green workflow is still not sufficient evidence — check nuget.org and the GitHub release
+directly. Note nuget.org's flat-container index can lag a successful push by several minutes, so
+re-check before concluding it failed:
 
 ```bash
 # nuget.org — both packages must list $VER
 curl -s https://api.nuget.org/v3-flatcontainer/calor/index.json     | jq -r '.versions[-3:][]'
 curl -s https://api.nuget.org/v3-flatcontainer/calor.sdk/index.json | jq -r '.versions[-3:][]'
 
-# VS Code marketplace — must report $VER
-curl -s -X POST "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json;api-version=7.2-preview.1" \
-  -d '{"filters":[{"criteria":[{"filterType":7,"value":"calor-dev.calor"}]}],"flags":914}' \
-  | jq -r '.results[0].extensions[0].versions[0].version // "NOT FOUND"'
+# GitHub release — all six platform VSIX files must be attached
+assets="$(gh release view "v$VER" --json assets --jq '.assets[].name')"
+for target in win32-x64 win32-arm64 darwin-x64 darwin-arm64 linux-x64 linux-arm64; do
+  grep -qx "calor-$target-$VER.vsix" <<<"$assets" || {
+    echo "ERROR: missing calor-$target-$VER.vsix"; exit 1;
+  }
+done
 ```
 
 Strongest check for NuGet — install the published tool and exercise Z3, which is the part most
@@ -285,7 +284,10 @@ Known failure modes, so they are recognised rather than re-diagnosed:
 |---|---|---|
 | `sha256sum: WARNING: N computed checksums did NOT match` | The pinned `z3-binaries` release drifted | Republish via `build-z3.yml` (`workflow_dispatch`), commit the manifest it prints, **then re-publish via `workflow_dispatch`, not `gh run rerun`** — see below. **Never rehash the live assets.** |
 | `error IL3000` during the VSIX build | `Assembly.Location` under single-file publish | Code fix. `test.yml`'s `vsix-single-file-publish` job should have caught this on the PR. |
-| `Access Denied: The Personal Access Token used has expired` | `VSCE_PAT` secret expired | **Maintainer only** — mint at https://aka.ms/vscodepat, update the secret, then re-run the `publish` job. The built VSIXes are already uploaded as artifacts, so no rebuild is needed. |
+
+The Marketplace is not part of release verification. Its listing deliberately remains at v0.3.8.
+If a maintainer later mints a publisher token, `publish-vscode.yml` may be dispatched manually;
+success or failure there does not change whether the release shipped.
 
 #### Retrying a failed publish (do NOT re-cut the version)
 
@@ -298,18 +300,22 @@ the failing channel only.
   identically. Use the dispatch path instead, which checks out the default branch and takes a
   version override: `gh workflow run publish-nuget.yml -f version=$VER`. Safe to repeat — the push
   uses `--skip-duplicate`.
-- **VS Code.** Re-run the `publish` job on the existing run once the PAT is valid. The publish
-  step attempts every target and treats an already-published one as success, so a partial publish
-  can be completed by re-running.
-- **Partial release is normal and recoverable.** One channel landing while the other fails is the
-  common case here. Record which channel is live, fix only the broken one, and do not touch the
-  tag.
+- **VSIX release assets.** Re-dispatch the idempotent attachment workflow for the existing tag:
+  `gh workflow run build-vsix-release.yml -f tag=v$VER`. It rebuilds all six targets and replaces
+  same-named release assets with `--clobber`; do not re-cut the tag.
+- **Marketplace (opportunistic only).** If a valid token exists and demand justifies an update,
+  run `gh workflow run publish-vscode.yml -f version=$VER`. A failure is not a partial release and
+  does not block or reopen the release.
+- **Partial release is normal and recoverable.** NuGet or the GitHub release assets may land while
+  the other fails. Record which required artifact is live, fix only the broken workflow, and do
+  not touch the tag.
 
 Note that republishing `z3-binaries` retroactively changes what **every past tag** resolves to, so
 older tags' manifests become invalid. That is a reason to prefer fixing forward.
 
-Report the release as shipped only after the registries confirm it — and if only one channel
-landed, say exactly which one.
+Report the release as shipped only after nuget.org and the GitHub release confirm the required
+artifacts — and if only one landed, say exactly which one. Do not report Marketplace state as a
+release failure.
 
 ## Version Calculation Logic
 

--- a/.github/workflows/build-vsix-release.yml
+++ b/.github/workflows/build-vsix-release.yml
@@ -1,0 +1,125 @@
+name: Build VS Code Release Assets
+
+# The extension and LSP remain supported release artifacts. Marketplace
+# publication is a separate, opportunistic manual workflow; this workflow owns
+# the dependable path by attaching all platform VSIX packages to each release.
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to build and attach (for example v0.13.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            target: win32-x64
+          - os: windows-latest
+            target: win32-arm64
+          - os: macos-latest
+            target: darwin-x64
+          - os: macos-latest
+            target: darwin-arm64
+          - os: ubuntu-latest
+            target: linux-x64
+          - os: ubuntu-latest
+            target: linux-arm64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build Language Server
+        run: |
+          cd editors/vscode
+          chmod +x scripts/build-server.sh
+          ./scripts/build-server.sh ${{ matrix.target }}
+        shell: bash
+
+      - name: Ensure server is executable (Unix)
+        if: runner.os != 'Windows'
+        run: chmod +x editors/vscode/server/calor-lsp
+        shell: bash
+
+      - name: Install dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 15
+          shell: bash
+          command: cd editors/vscode && npm ci
+
+      - name: Compile TypeScript
+        run: |
+          cd editors/vscode
+          npm run compile
+
+      - name: Install vsce
+        run: npm install -g @vscode/vsce
+
+      - name: Package extension
+        run: |
+          cd editors/vscode
+          vsce package --target ${{ matrix.target }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: calor-${{ matrix.target }}
+          path: editors/vscode/*.vsix
+
+  attach:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: vsix-packages
+
+      - name: Upload consolidated Actions artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-extension-all-platforms
+          path: vsix-packages/**/*.vsix
+
+      - name: Attach VSIX packages to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob globstar
+          vsixes=(vsix-packages/**/*.vsix)
+          if [ ${#vsixes[@]} -ne 6 ]; then
+            echo "::error::expected 6 platform VSIX packages, found ${#vsixes[@]}"
+            exit 1
+          fi
+          gh release upload "$RELEASE_TAG" "${vsixes[@]}" --clobber

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -1,8 +1,10 @@
 name: Publish VS Code Extension
 
+# Decision 2026-08-11: Marketplace publishing is opportunistic, not a release
+# commitment. Release-time VSIX assets are built by build-vsix-release.yml;
+# this workflow runs only when a maintainer deliberately attempts Marketplace
+# publication with a valid token.
 on:
-  release:
-    types: [created]
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -666,11 +666,11 @@ jobs:
         run: python3 scripts/smoke_phase_2_gate_dryrun.py
 
   vsix-single-file-publish:
-    # publish-vscode.yml packs the language server with PublishSingleFile=true.
-    # That is the ONLY place the repo builds single-file, and single-file promotes
+    # The VSIX workflows pack the language server with PublishSingleFile=true.
+    # They are the only release paths that build single-file, and single-file promotes
     # Assembly.Location uses to IL3000 errors under TreatWarningsAsErrors — so
     # v0.12.0's VS Code publish died on a compile error that no PR could have
-    # caught. (That channel had in fact been failing since v0.9.0, unnoticed,
+    # caught. (That channel had in fact been failing since v0.4.0, unnoticed,
     # because nothing between releases ever ran this build.) One target is
     # enough; the analyzer verdict is RID-independent.
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to this project will be documented in this file.
   `CALOR_LSP_EXPERIMENTAL` gate and production name-only reference/rename
   collectors were removed after the exact-span gate passed.
 
+- **VS Code Marketplace publishing is no longer a release commitment.** The extension and
+  bundled LSP remain supported as six platform-specific VSIX artifacts attached to each GitHub
+  release, and the PR-only single-file publish check remains a required guard. The Marketplace
+  listing deliberately stays at v0.3.8 unless a publisher token is minted and a maintainer chooses
+  to update it. The channel has been broken since v0.4.0, five months of staleness produced zero
+  complaints, and recurring token/publish-chain maintenance is not justified by demonstrated
+  demand.
+
 ## [0.13.0] - 2026-08-11
 
 ### Benchmark Results (Statistical: 30 runs)

--- a/README.md
+++ b/README.md
@@ -116,6 +116,19 @@ calor init --ai github
 calor --input program.calr --output program.g.cs
 ```
 
+### VS Code Extension
+
+The supported installation path is a platform-specific VSIX attached to the
+[current GitHub release](https://github.com/juanmicrosoft/calor/releases). Download
+the package for your platform, then run **Extensions: Install from VSIX...** in
+VS Code. The extension is a thin client for Calor's first-class language server
+and also includes the `.calr` grammar.
+
+The Marketplace listing deliberately remains at v0.3.8. Marketplace updates
+are opportunistic and happen only if a publishing token is minted; they are not
+a release commitment or gate. The extension, its language server bundle, and
+the release VSIX artifacts remain supported.
+
 ### AI Integration Comparison
 
 | Feature | Claude Code | Gemini CLI | Codex CLI | GitHub Copilot |

--- a/docs/plans/roadmap-v0.13-v0.15.md
+++ b/docs/plans/roadmap-v0.13-v0.15.md
@@ -30,7 +30,8 @@ audit epic and successors — dispositioned exhaustively in §5.2).
   repaired supply story and an arm that actually invokes the Calor compiler.
 - **v0.12.1** — language-equivalent to v0.12.0; packaging remediation. NuGet is live and verified,
   including the **first `Calor.Sdk` publish** (a v0.12.1 event — v0.12.0 was never installable). The
-  VS Code channel is built but blocked on an expired publisher PAT (maintainer action; see §2.4).
+  VS Code extension remains a supported built artifact; the Marketplace listing is historical and
+  updates only opportunistically (decision amendment in §2.4).
 
 The published 1.32× benchmark number remains a **regression indicator, not a roadmap driver** — its
 30 runs are deterministic repetitions and the real-scale comparison never produced a valid Calor arm.
@@ -135,16 +136,19 @@ without renegotiation; DEFERRED items are named now so their absence is a decisi
 - **MCP query surface** → ships with or after the LSP re-platform, same reasoning.
 - **`cli/import.mdx`, `cli/review-packet.mdx`, adoption-playbook mirror** → 0.13.x docs tranche 2.
 
-### 2.4 Delivery chain (with the external dependency named as one)
+### 2.4 Delivery chain
 
-- **VS Code channel — external dependency, not an engineering item.** The one blocker is the
-  expired publisher PAT, a maintainer-only action, for a channel that has failed on **every release
-  since v0.4.0 — 27 releases by the release list; marketplace stuck at 0.3.8**. (The CHANGELOG's
-  corrected entry says "roughly nineteen", itself a ~30% undercount — an erratum to file with this
-  plan.) Per that corrected record (PR #887), the expired token was a second, older blocker masked
-  behind the IL3000 build failure. Escalation rule: if the PAT is not
-  minted by 0.13 freeze, the 0.13 release notes state the channel is down and why — the
-  registry-verification discipline applied to our one unfixable-by-code channel.
+- **Decision amendment — 2026-08-11 (supersedes this section's original VSCE_PAT escalation
+  rule).** Marketplace publishing is demoted from a release commitment to an opportunistic
+  channel. The extension and
+  LSP remain first-class investments: every release builds six platform VSIX packages, attaches
+  them to the GitHub release, and keeps the PR `vsix-single-file-publish` guard. The Marketplace
+  listing deliberately remains at v0.3.8 unless a publisher token is minted and a maintainer
+  chooses to publish. Revisit only on a demand signal: a user issue requesting Marketplace
+  installation or download counts that justify the recurring token and publish-chain maintenance.
+  Rationale recorded rather than inferred: publishing has failed since v0.4.0, five months of a
+  stale listing produced zero complaints, and Calor's premise needs the LSP for agents and human
+  reviewers but does not require Marketplace freshness.
 - **Z3 asset chain finished**: resolve the mislabeled `osx-x64` dylib (upstream ships an arm64
   binary under the x64 label — Intel Macs install successfully and *silently lose verification*),
   switch `build-z3.yml`'s `osx-arm64` leg off the source build, then land the native arch-vs-RID
@@ -189,15 +193,15 @@ gates 1, 4, 5, 6, 7, and gate 2's diagnostics leg.
 6. **PP-S4 registry**: exists at its A-1.5.7-registered location, schema, and CI entry point, and
    the CI job is **demonstrated to fail on a fixture-less `SupportLevel` promotion** (a
    discriminating pin — revert the fixture, watch it fail).
-7. **Clean-consumer install, per-RID**: on a frozen RID × package matrix (win-x64, linux-x64,
-   osx-arm64: CLI + Sdk + VSIX where unblocked), a clean consumer runs `calor verify` on a
+7. **Clean-consumer install, per-RID**: on a frozen RID × artifact matrix (win-x64, linux-x64,
+   osx-arm64: CLI + Sdk + release VSIX), a clean consumer runs `calor verify` on a
    Z3-requiring fixture and gets a **solver verdict** — exit-0 install is not the bar, because the
    pre-closure osx-x64 state was precisely "installs successfully, silently loses verification".
    **Gate amended with the Z3 chain closure (2026-08-11, #916 review F3): the osx-x64 RID is
    dropped, so its leg's oracle changes rather than disappearing** — a clean Intel-mac consumer
    must get the *documented degradation* (a loud "Z3 unavailable"/Calor0710 signal, no crash, no
-   silent pass), which turns the drop decision itself into a tested claim. The registries are
-   verified **after** publishing (a workflow firing is not a publish).
+   silent pass), which turns the drop decision itself into a tested claim. NuGet registries and
+   GitHub release assets are verified **after** publishing (a workflow firing is not a publish).
 8. **Performance envelope (project scale needs a number)**: index build ≤ 30s and warm `calor query`
    ≤ 500ms on the largest pinned conversion subject, measured in CI. Generous by design; the point
    is that "usable at project scale" is adjudicable at all. Frozen here, before the index exists.
@@ -450,7 +454,8 @@ first-order ceiling for the common case. The 0.14 flow checker got exactly this 
 - **Freeze before measurement** — thresholds registered before values are visible; ordering
   controls over concealment controls; freeze *events* named, not implied.
 - **Pins must discriminate** — revert the fix and watch the test fail, or it pins nothing.
-- **Verify registries after every publish** — a workflow firing is not evidence it succeeded.
+- **Verify NuGet registries and GitHub release assets after every publish** — a workflow firing is
+  not evidence it succeeded; Marketplace freshness is not a release criterion.
 - **Claim only what is closed by construction** — "one class closed", never "surface exhausted".
 - **Denominators are pinned artifacts, not implementation-defined sets** — the modeled-forms
   whitelist, the call-site corpus, the RID matrix.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,6 +1,6 @@
 # Calor Language Support for VS Code
 
-Syntax highlighting for the [Calor programming language](https://github.com/juanmicrosoft/calor-2).
+VS Code client and syntax highlighting for the [Calor programming language](https://github.com/juanmicrosoft/calor).
 
 ## Features
 
@@ -59,10 +59,15 @@ Syntax highlighting for the [Calor programming language](https://github.com/juan
 
 ### From VSIX
 
-1. Download the `.vsix` file from the releases
-2. In VS Code, open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`)
-3. Run "Extensions: Install from VSIX..."
-4. Select the downloaded file
+1. Open the [Calor releases page](https://github.com/juanmicrosoft/calor/releases)
+2. Download the platform-specific `.vsix` attached to the current release
+3. In VS Code, open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`)
+4. Run "Extensions: Install from VSIX..."
+5. Select the downloaded file
+
+This is the supported distribution path. The Marketplace listing is
+deliberately stale at v0.3.8; publishing there is opportunistic and will happen
+only if a token is minted. Marketplace freshness is not a release commitment.
 
 ### From Source
 
@@ -83,4 +88,4 @@ vsce package
 
 ## License
 
-Apache-2.0 - See [LICENSE](https://github.com/juanmicrosoft/calor-2/blob/main/LICENSE)
+Apache-2.0 - See [LICENSE](https://github.com/juanmicrosoft/calor/blob/main/LICENSE)

--- a/website/content/changelog.mdx
+++ b/website/content/changelog.mdx
@@ -10,6 +10,10 @@ All notable changes to Calor, organized by release.
 
 ## [Unreleased]
 
+### Changed
+
+- **VS Code Marketplace publishing is opportunistic, not a release commitment.** Current extension builds remain supported as platform-specific VSIX files attached to GitHub releases, and CI continues to exercise the bundled single-file LSP. The Marketplace listing deliberately remains at v0.3.8 unless a publishing token is minted; five months of stale listing produced no demand signal that justifies keeping token rotation in the release path.
+
 ## [0.13.0] - 2026-08-11
 
 The "Trustworthy Project Model" release. Headline: the structural-binding rebuild is complete — all 60 accepted expression classes bind structurally (the analysis-incomplete instrument is retired because nothing is incomplete), with stable symbol identities, full-signature overload resolution, exhaustive checker traversals, a resolved call graph, and LSP rename/references/cross-file resolution on top.

--- a/website/content/getting-started/installation.mdx
+++ b/website/content/getting-started/installation.mdx
@@ -94,20 +94,17 @@ See [`calor init`](/docs/cli/init/) for complete documentation.
 
 ## VS Code Extension
 
-The Marketplace currently carries v0.3.8, not v0.12.1. That old package has a
-known activation defect because its runtime dependency was omitted. The
-v0.12.1 extension builds successfully from the repository, but its Marketplace
-publish is still blocked by an expired token.
+Install the current extension from a platform-specific VSIX attached to the
+[GitHub release](https://github.com/juanmicrosoft/calor/releases):
 
-To use the current extension, follow the build instructions in
-[`editors/vscode`](https://github.com/juanmicrosoft/calor/tree/main/editors/vscode)
-and install the resulting platform-specific VSIX. If you only need to inspect
-the legacy listing:
+1. Download the `.vsix` for your operating system and architecture.
+2. Open the VS Code Command Palette (Cmd+Shift+P / Ctrl+Shift+P).
+3. Run **Extensions: Install from VSIX...** and select the downloaded file.
 
-1. Open VS Code
-2. Go to Extensions (Cmd+Shift+X / Ctrl+Shift+X)
-3. Search for "Calor"
-4. Note that the available version is v0.3.8 and is not the current build
+This release artifact is the supported distribution path. The Marketplace
+listing deliberately remains at v0.3.8, which has a known activation defect.
+Marketplace updates are opportunistic and occur only if a publishing token is
+minted; Marketplace freshness is not a release obligation.
 
 The extension provides:
 
@@ -117,7 +114,8 @@ The extension provides:
 
 ![Calor syntax highlighting in VS Code](/images/calor-vscode.png)
 
-The extension is also available in the `editors/vscode` directory if you want to install it manually or contribute improvements.
+The source is available in [`editors/vscode`](https://github.com/juanmicrosoft/calor/tree/main/editors/vscode)
+for contributors who want to build the extension locally.
 
 ---
 

--- a/website/content/philosophy/tradeoffs.mdx
+++ b/website/content/philosophy/tradeoffs.mdx
@@ -45,7 +45,7 @@ This is a fundamental design choice, not a flaw to be fixed.
 | **Information Density** | 0.98x vs C# | Near parity; C# narrowly leads |
 | **Human Readability** | Unfamiliar syntax | Not the target audience |
 | **Ecosystem** | .NET interop may require manifests or preserved C# | Import, effect manifests, and interop blocks |
-| **Tooling** | Current VS Code build is not on the Marketplace | Build from the repository or use CLI/LSP directly |
+| **Tooling** | Marketplace updates are opportunistic | Install the supported release VSIX, or use the CLI/LSP directly |
 
 ---
 

--- a/website/src/components/landing/VSCodeExtension.tsx
+++ b/website/src/components/landing/VSCodeExtension.tsx
@@ -1,20 +1,18 @@
 'use client';
 
-import { useState } from 'react';
-import { Check, Copy, FileCode, Palette, Settings, ExternalLink } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { FileCode, Palette, Settings, ExternalLink } from 'lucide-react';
 import { trackVSCodeExtensionClick, trackOutboundLink } from '@/lib/analytics';
 
 const features = [
   {
+    name: 'Language Server',
+    description: 'Diagnostics, navigation, references, and rename support through the bundled Calor LSP.',
+    icon: FileCode,
+  },
+  {
     name: 'Syntax Highlighting',
     description: 'Full syntax highlighting for .calr files with support for contracts, effects, and identifiers.',
     icon: Palette,
-  },
-  {
-    name: 'Custom File Icons',
-    description: 'Distinctive file icons in the explorer to easily identify Calor source files.',
-    icon: FileCode,
   },
   {
     name: 'Language Configuration',
@@ -23,19 +21,10 @@ const features = [
   },
 ];
 
+const RELEASES_URL = 'https://github.com/juanmicrosoft/calor/releases';
 const MARKETPLACE_URL = 'https://marketplace.visualstudio.com/items?itemName=calor-dev.calor';
-const INSTALL_COMMAND = 'ext install calor-dev.calor';
 
 export function VSCodeExtension() {
-  const [copied, setCopied] = useState(false);
-
-  const copyToClipboard = async () => {
-    await navigator.clipboard.writeText(INSTALL_COMMAND);
-    trackVSCodeExtensionClick('copy_command');
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
   return (
     <section className="py-24">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
@@ -81,65 +70,31 @@ export function VSCodeExtension() {
 
             <div className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4 text-sm text-muted-foreground">
               <strong className="text-foreground">Release status:</strong> the Marketplace currently carries
-              v0.3.8, which has a known activation defect. v0.12.1 packages build successfully, but publishing
-              is still blocked by an expired Marketplace token. Use the repository build instructions when you
-              need the current extension.
+              v0.3.8, which has a known activation defect. This is deliberate: Marketplace publishing is
+              opportunistic and happens only if a token is minted. Current, supported platform VSIX packages
+              are attached to GitHub releases.
             </div>
 
-            {/* Marketplace Button */}
+            <a
+              href={RELEASES_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => { trackVSCodeExtensionClick('release'); trackOutboundLink(RELEASES_URL); }}
+              className="mt-6 flex items-center justify-center gap-2 rounded-lg bg-calor-navy px-6 py-3 font-medium text-white hover:bg-calor-navy/90 transition-colors"
+            >
+              <ExternalLink className="h-4 w-4" />
+              Download the release VSIX
+            </a>
+
             <a
               href={MARKETPLACE_URL}
               target="_blank"
               rel="noopener noreferrer"
               onClick={() => { trackVSCodeExtensionClick('marketplace'); trackOutboundLink(MARKETPLACE_URL); }}
-              className="mt-6 flex items-center justify-center gap-2 rounded-lg bg-calor-navy px-6 py-3 font-medium text-white hover:bg-calor-navy/90 transition-colors"
-            >
-              <ExternalLink className="h-4 w-4" />
-              View legacy Marketplace listing
-            </a>
-
-            {/* Quick Install Command */}
-            <div className="mt-6">
-              <span className="text-xs text-muted-foreground uppercase tracking-wider">
-                Legacy Marketplace install (v0.3.8)
-              </span>
-              <div className="mt-2 flex items-center justify-between rounded-lg border bg-zinc-950 px-4 py-3">
-                <code className="text-sm text-zinc-100 font-mono">
-                  <span className="text-calor-pink">&gt;</span> {INSTALL_COMMAND}
-                </code>
-                <button
-                  onClick={copyToClipboard}
-                  className={cn(
-                    'shrink-0 flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors',
-                    copied
-                      ? 'text-green-400'
-                      : 'text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800'
-                  )}
-                >
-                  {copied ? (
-                    <>
-                      <Check className="h-3.5 w-3.5" />
-                      Copied
-                    </>
-                  ) : (
-                    <>
-                      <Copy className="h-3.5 w-3.5" />
-                      Copy
-                    </>
-                  )}
-                </button>
-              </div>
-            </div>
-
-            <a
-              href="https://github.com/juanmicrosoft/calor/tree/main/editors/vscode"
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => trackOutboundLink('https://github.com/juanmicrosoft/calor/tree/main/editors/vscode')}
               className="mt-4 flex items-center justify-center gap-2 rounded-lg border px-6 py-3 font-medium hover:bg-muted transition-colors"
             >
               <ExternalLink className="h-4 w-4" />
-              Build the current extension
+              View legacy Marketplace listing
             </a>
           </div>
         </div>

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -17,7 +17,7 @@ export function WhatsNewBanner() {
           <p className="text-center">
             <span className="font-semibold text-calor-cerulean">v0.13.0</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">The v0.12.0 soundness feature set is now installable from NuGet through v0.13.0. The VS Code Marketplace is still at v0.3.8 after the v0.13.0 publish hit an expired token; current extension packages build successfully but have not been published. Z3 packaging and ARM64 loading were also repaired.</span>
+            <span className="text-foreground">The Trustworthy Project Model release is live. Install the current VS Code extension from the release VSIX artifacts; the v0.3.8 Marketplace listing is now an intentionally opportunistic channel, not a release gate.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"

--- a/website/src/lib/analytics.ts
+++ b/website/src/lib/analytics.ts
@@ -51,7 +51,7 @@ export function trackFeatureLearnMore(feature: string) {
   sendEvent({ action: 'feature_learn_more', category: 'engagement', label: feature });
 }
 
-export function trackVSCodeExtensionClick(action: 'marketplace' | 'copy_command') {
+export function trackVSCodeExtensionClick(action: 'release' | 'marketplace') {
   sendEvent({ action: 'vscode_extension_click', category: 'conversion', label: action });
 }
 


### PR DESCRIPTION
## Summary

- make VS Code Marketplace publication manual and opportunistic
- add release-time six-platform VSIX builds and attach them to GitHub releases
- document GitHub release VSIX packages as the supported installation path
- supersede the VSCE_PAT release escalation in the roadmap and release skill
- update the website and changelogs with the recorded rationale

## Why

The Marketplace has remained at v0.3.8 since publishing broke at v0.4.0, with no user complaints during roughly five months of staleness. The extension and LSP remain supported; only Marketplace freshness is removed from the release commitment.

## Validation

- `actionlint .github/workflows/publish-vscode.yml .github/workflows/build-vsix-release.yml .github/workflows/test.yml`
- `npm run build` in `website/` (97 static pages)
- `dotnet run --no-restore --project src/Calor.Compiler -- self-check docs --no-telemetry`
- `git diff --check`
- fresh adversarial review: residual Marketplace assumptions and release-asset reachability

The adversarial review found and we fixed missing `GH_REPO` context in the no-checkout attachment job and one stale CI comment. After merge, `build-vsix-release.yml` will be dispatched for v0.13.0 and all six assets verified before the website deploy.
