### PR TITLE
Fix #765 follow-up: close exact-span refactoring gaps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
         run: >-
           dotnet test tests/Calor.LanguageServer.Tests/Calor.LanguageServer.Tests.csproj
           -c Release --no-build
-          --filter "FullyQualifiedName~ExactSpanRefactoringGateTests"
+          --filter "FullyQualifiedName~ExactSpanRefactoringGateTests|FullyQualifiedName~RenameHandlerTests"
           --verbosity normal
 
       - name: Run full-vs-incremental identity gate

--- a/src/Calor.Compiler/Ast/ArrayNodes.cs
+++ b/src/Calor.Compiler/Ast/ArrayNodes.cs
@@ -23,6 +23,7 @@ public sealed class ArrayCreationNode : ExpressionNode
     /// The element type of the array.
     /// </summary>
     public string ElementType { get; }
+    public TextSpan ElementTypeSpan { get; }
 
     /// <summary>
     /// The size of the array (for sized arrays). Null if using initializer.
@@ -43,12 +44,14 @@ public sealed class ArrayCreationNode : ExpressionNode
         string elementType,
         ExpressionNode? size,
         IReadOnlyList<ExpressionNode> initializer,
-        AttributeCollection attributes)
+        AttributeCollection attributes,
+        TextSpan? elementTypeSpan = null)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
         Name = name ?? throw new ArgumentNullException(nameof(name));
         ElementType = elementType ?? throw new ArgumentNullException(nameof(elementType));
+        ElementTypeSpan = elementTypeSpan ?? TextSpan.Empty;
         Size = size;
         Initializer = initializer ?? throw new ArgumentNullException(nameof(initializer));
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
@@ -129,6 +132,7 @@ public sealed class ForeachStatementNode : StatementNode
     /// The type of the loop variable.
     /// </summary>
     public string VariableType { get; }
+    public TextSpan VariableTypeSpan { get; }
 
     /// <summary>
     /// The collection being iterated.
@@ -158,13 +162,15 @@ public sealed class ForeachStatementNode : StatementNode
         AttributeCollection attributes,
         string? indexVariableName = null,
         TextSpan? variableSpan = null,
-        TextSpan? indexVariableSpan = null)
+        TextSpan? indexVariableSpan = null,
+        TextSpan? variableTypeSpan = null)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
         VariableName = variableName ?? throw new ArgumentNullException(nameof(variableName));
         VariableSpan = variableSpan ?? span;
         VariableType = variableType ?? throw new ArgumentNullException(nameof(variableType));
+        VariableTypeSpan = variableTypeSpan ?? TextSpan.Empty;
         Collection = collection ?? throw new ArgumentNullException(nameof(collection));
         Body = body ?? throw new ArgumentNullException(nameof(body));
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
@@ -186,6 +192,7 @@ public sealed class MultiDimArrayCreationNode : ExpressionNode
     public string Id { get; }
     public string Name { get; }
     public string ElementType { get; }
+    public TextSpan ElementTypeSpan { get; }
 
     /// <summary>
     /// The rank (number of dimensions), e.g., 2 for [,], 3 for [,,].
@@ -210,12 +217,14 @@ public sealed class MultiDimArrayCreationNode : ExpressionNode
         string elementType,
         int rank,
         IReadOnlyList<ExpressionNode> dimensionSizes,
-        IReadOnlyList<IReadOnlyList<ExpressionNode>> initializer)
+        IReadOnlyList<IReadOnlyList<ExpressionNode>> initializer,
+        TextSpan? elementTypeSpan = null)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
         Name = name ?? throw new ArgumentNullException(nameof(name));
         ElementType = elementType ?? throw new ArgumentNullException(nameof(elementType));
+        ElementTypeSpan = elementTypeSpan ?? TextSpan.Empty;
         Rank = rank;
         DimensionSizes = dimensionSizes ?? Array.Empty<ExpressionNode>();
         Initializer = initializer ?? Array.Empty<IReadOnlyList<ExpressionNode>>();

--- a/src/Calor.Compiler/Ast/ClassNodes.cs
+++ b/src/Calor.Compiler/Ast/ClassNodes.cs
@@ -50,6 +50,7 @@ public sealed class InterfaceDefinitionNode : TypeDefinitionNode
     /// Interfaces this interface extends.
     /// </summary>
     public IReadOnlyList<string> BaseInterfaces { get; }
+    public IReadOnlyList<TextSpan> BaseInterfaceSpans { get; }
 
     /// <summary>
     /// Type parameters if this is a generic interface.
@@ -121,10 +122,13 @@ public sealed class InterfaceDefinitionNode : TypeDefinitionNode
         IReadOnlyList<PropertyNode> properties,
         AttributeCollection attributes,
         IReadOnlyList<CalorAttributeNode> csharpAttributes,
-        IReadOnlyList<IndexerNode>? indexers = null)
-        : base(span, id, name, attributes)
+        IReadOnlyList<IndexerNode>? indexers = null,
+        IReadOnlyList<TextSpan>? baseInterfaceSpans = null,
+        TextSpan? identifierSpan = null)
+        : base(span, id, name, attributes, identifierSpan)
     {
         BaseInterfaces = baseInterfaces ?? throw new ArgumentNullException(nameof(baseInterfaces));
+        BaseInterfaceSpans = baseInterfaceSpans ?? Array.Empty<TextSpan>();
         TypeParameters = typeParameters ?? throw new ArgumentNullException(nameof(typeParameters));
         Methods = methods ?? throw new ArgumentNullException(nameof(methods));
         Properties = properties ?? Array.Empty<PropertyNode>();

--- a/src/Calor.Compiler/Ast/CollectionNodes.cs
+++ b/src/Calor.Compiler/Ast/CollectionNodes.cs
@@ -26,6 +26,7 @@ public sealed class ListCreationNode : ExpressionNode
     /// The element type of the list.
     /// </summary>
     public string ElementType { get; }
+    public TextSpan ElementTypeSpan { get; }
 
     /// <summary>
     /// The initial elements of the list.
@@ -40,12 +41,14 @@ public sealed class ListCreationNode : ExpressionNode
         string name,
         string elementType,
         IReadOnlyList<ExpressionNode> elements,
-        AttributeCollection attributes)
+        AttributeCollection attributes,
+        TextSpan? elementTypeSpan = null)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
         Name = name ?? throw new ArgumentNullException(nameof(name));
         ElementType = elementType ?? throw new ArgumentNullException(nameof(elementType));
+        ElementTypeSpan = elementTypeSpan ?? TextSpan.Empty;
         Elements = elements ?? throw new ArgumentNullException(nameof(elements));
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
     }
@@ -104,11 +107,13 @@ public sealed class DictionaryCreationNode : ExpressionNode
     /// The key type of the dictionary.
     /// </summary>
     public string KeyType { get; }
+    public TextSpan KeyTypeSpan { get; }
 
     /// <summary>
     /// The value type of the dictionary.
     /// </summary>
     public string ValueType { get; }
+    public TextSpan ValueTypeSpan { get; }
 
     /// <summary>
     /// The initial key-value pairs.
@@ -124,13 +129,17 @@ public sealed class DictionaryCreationNode : ExpressionNode
         string keyType,
         string valueType,
         IReadOnlyList<KeyValuePairNode> entries,
-        AttributeCollection attributes)
+        AttributeCollection attributes,
+        TextSpan? keyTypeSpan = null,
+        TextSpan? valueTypeSpan = null)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
         Name = name ?? throw new ArgumentNullException(nameof(name));
         KeyType = keyType ?? throw new ArgumentNullException(nameof(keyType));
+        KeyTypeSpan = keyTypeSpan ?? TextSpan.Empty;
         ValueType = valueType ?? throw new ArgumentNullException(nameof(valueType));
+        ValueTypeSpan = valueTypeSpan ?? TextSpan.Empty;
         Entries = entries ?? throw new ArgumentNullException(nameof(entries));
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
     }
@@ -162,6 +171,7 @@ public sealed class SetCreationNode : ExpressionNode
     /// The element type of the set.
     /// </summary>
     public string ElementType { get; }
+    public TextSpan ElementTypeSpan { get; }
 
     /// <summary>
     /// The initial elements of the set.
@@ -176,12 +186,14 @@ public sealed class SetCreationNode : ExpressionNode
         string name,
         string elementType,
         IReadOnlyList<ExpressionNode> elements,
-        AttributeCollection attributes)
+        AttributeCollection attributes,
+        TextSpan? elementTypeSpan = null)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
         Name = name ?? throw new ArgumentNullException(nameof(name));
         ElementType = elementType ?? throw new ArgumentNullException(nameof(elementType));
+        ElementTypeSpan = elementTypeSpan ?? TextSpan.Empty;
         Elements = elements ?? throw new ArgumentNullException(nameof(elements));
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
     }

--- a/src/Calor.Compiler/Ast/ExceptionNodes.cs
+++ b/src/Calor.Compiler/Ast/ExceptionNodes.cs
@@ -53,6 +53,7 @@ public sealed class CatchClauseNode : AstNode
     /// The exception type to catch. Null for catch-all.
     /// </summary>
     public string? ExceptionType { get; }
+    public TextSpan? ExceptionTypeSpan { get; }
 
     /// <summary>
     /// The variable name for the exception. Null if not capturing.
@@ -79,10 +80,12 @@ public sealed class CatchClauseNode : AstNode
         ExpressionNode? filter,
         IReadOnlyList<StatementNode> body,
         AttributeCollection attributes,
-        TextSpan? variableSpan = null)
+        TextSpan? variableSpan = null,
+        TextSpan? exceptionTypeSpan = null)
         : base(span)
     {
         ExceptionType = exceptionType;
+        ExceptionTypeSpan = exceptionType == null ? null : exceptionTypeSpan ?? TextSpan.Empty;
         VariableName = variableName;
         VariableSpan = variableName == null ? null : variableSpan ?? span;
         Filter = filter;

--- a/src/Calor.Compiler/Ast/GenericNodes.cs
+++ b/src/Calor.Compiler/Ast/GenericNodes.cs
@@ -111,16 +111,22 @@ public sealed class GenericTypeNode : ExpressionNode
     /// The name of the generic type (e.g., "List", "Dictionary").
     /// </summary>
     public string TypeName { get; }
+    public TextSpan TypeNameSpan { get; }
 
     /// <summary>
     /// The type arguments.
     /// </summary>
     public IReadOnlyList<string> TypeArguments { get; }
 
-    public GenericTypeNode(TextSpan span, string typeName, IReadOnlyList<string> typeArguments)
+    public GenericTypeNode(
+        TextSpan span,
+        string typeName,
+        IReadOnlyList<string> typeArguments,
+        TextSpan? typeNameSpan = null)
         : base(span)
     {
         TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
+        TypeNameSpan = typeNameSpan ?? TextSpan.Empty;
         TypeArguments = typeArguments ?? throw new ArgumentNullException(nameof(typeArguments));
     }
 

--- a/src/Calor.Compiler/Ast/LambdaNodes.cs
+++ b/src/Calor.Compiler/Ast/LambdaNodes.cs
@@ -10,17 +10,20 @@ public sealed class LambdaParameterNode : AstNode
     public string Name { get; }
     public TextSpan IdentifierSpan { get; }
     public string? TypeName { get; }
+    public TextSpan? TypeNameSpan { get; }
 
     public LambdaParameterNode(
         TextSpan span,
         string name,
         string? typeName,
-        TextSpan? identifierSpan = null)
+        TextSpan? identifierSpan = null,
+        TextSpan? typeNameSpan = null)
         : base(span)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
         IdentifierSpan = identifierSpan ?? span;
         TypeName = typeName;
+        TypeNameSpan = typeName == null ? null : typeNameSpan ?? TextSpan.Empty;
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
@@ -96,8 +99,9 @@ public sealed class DelegateDefinitionNode : TypeDefinitionNode
         IReadOnlyList<ParameterNode> parameters,
         OutputNode? output,
         EffectsNode? effects,
-        AttributeCollection attributes)
-        : base(span, id, name, attributes)
+        AttributeCollection attributes,
+        TextSpan? identifierSpan = null)
+        : base(span, id, name, attributes, identifierSpan)
     {
         Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
         Output = output;
@@ -123,6 +127,7 @@ public sealed class EventDefinitionNode : AstNode
     public string Name { get; }
     public Visibility Visibility { get; }
     public string DelegateType { get; }
+    public TextSpan DelegateTypeSpan { get; }
     public AttributeCollection Attributes { get; }
 
     /// <summary>Optional body for the add accessor.</summary>
@@ -140,8 +145,18 @@ public sealed class EventDefinitionNode : AstNode
         string name,
         Visibility visibility,
         string delegateType,
-        AttributeCollection attributes)
-        : this(span, id, name, visibility, delegateType, attributes, null, null)
+        AttributeCollection attributes,
+        TextSpan? delegateTypeSpan = null)
+        : this(
+            span,
+            id,
+            name,
+            visibility,
+            delegateType,
+            attributes,
+            null,
+            null,
+            delegateTypeSpan)
     {
     }
 
@@ -153,13 +168,15 @@ public sealed class EventDefinitionNode : AstNode
         string delegateType,
         AttributeCollection attributes,
         IReadOnlyList<StatementNode>? addBody,
-        IReadOnlyList<StatementNode>? removeBody)
+        IReadOnlyList<StatementNode>? removeBody,
+        TextSpan? delegateTypeSpan = null)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
         Name = name ?? throw new ArgumentNullException(nameof(name));
         Visibility = visibility;
         DelegateType = delegateType ?? throw new ArgumentNullException(nameof(delegateType));
+        DelegateTypeSpan = delegateTypeSpan ?? TextSpan.Empty;
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
         AddBody = addBody;
         RemoveBody = removeBody;

--- a/src/Calor.Compiler/Ast/ModernOperatorNodes.cs
+++ b/src/Calor.Compiler/Ast/ModernOperatorNodes.cs
@@ -183,11 +183,16 @@ public sealed class IndexFromEndNode : ExpressionNode
 public sealed class TypeOfExpressionNode : ExpressionNode
 {
     public string TypeName { get; }
+    public TextSpan TypeNameSpan { get; }
 
-    public TypeOfExpressionNode(TextSpan span, string typeName)
+    public TypeOfExpressionNode(
+        TextSpan span,
+        string typeName,
+        TextSpan? typeNameSpan = null)
         : base(span)
     {
         TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
+        TypeNameSpan = typeNameSpan ?? TextSpan.Empty;
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);

--- a/src/Calor.Compiler/Ast/PatternNodes.cs
+++ b/src/Calor.Compiler/Ast/PatternNodes.cs
@@ -253,16 +253,22 @@ public sealed class PositionalPatternNode : PatternNode
     /// The type being matched.
     /// </summary>
     public string TypeName { get; }
+    public TextSpan TypeNameSpan { get; }
 
     /// <summary>
     /// The patterns for each position.
     /// </summary>
     public IReadOnlyList<PatternNode> Patterns { get; }
 
-    public PositionalPatternNode(TextSpan span, string typeName, IReadOnlyList<PatternNode> patterns)
+    public PositionalPatternNode(
+        TextSpan span,
+        string typeName,
+        IReadOnlyList<PatternNode> patterns,
+        TextSpan? typeNameSpan = null)
         : base(span)
     {
         TypeName = typeName ?? "";
+        TypeNameSpan = typeNameSpan ?? TextSpan.Empty;
         Patterns = patterns ?? throw new ArgumentNullException(nameof(patterns));
     }
 
@@ -281,16 +287,22 @@ public sealed class PropertyPatternNode : PatternNode
     /// The type being matched (optional).
     /// </summary>
     public string? TypeName { get; }
+    public TextSpan? TypeNameSpan { get; }
 
     /// <summary>
     /// The property matches.
     /// </summary>
     public IReadOnlyList<PropertyMatchNode> Matches { get; }
 
-    public PropertyPatternNode(TextSpan span, string? typeName, IReadOnlyList<PropertyMatchNode> matches)
+    public PropertyPatternNode(
+        TextSpan span,
+        string? typeName,
+        IReadOnlyList<PropertyMatchNode> matches,
+        TextSpan? typeNameSpan = null)
         : base(span)
     {
         TypeName = typeName;
+        TypeNameSpan = typeName == null ? null : typeNameSpan ?? TextSpan.Empty;
         Matches = matches ?? throw new ArgumentNullException(nameof(matches));
     }
 
@@ -492,6 +504,7 @@ public sealed class TypePatternNode : PatternNode
 {
     /// <summary>The type being tested (raw source type name, e.g. "string", "Point").</summary>
     public string TypeName { get; }
+    public TextSpan TypeNameSpan { get; }
 
     /// <summary>The variable bound when the test succeeds, or null for a type-only pattern.</summary>
     public string? BindingName { get; }
@@ -501,10 +514,12 @@ public sealed class TypePatternNode : PatternNode
         TextSpan span,
         string typeName,
         string? bindingName,
-        TextSpan? bindingSpan = null)
+        TextSpan? bindingSpan = null,
+        TextSpan? typeNameSpan = null)
         : base(span)
     {
         TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
+        TypeNameSpan = typeNameSpan ?? TextSpan.Empty;
         BindingName = string.IsNullOrEmpty(bindingName) ? null : bindingName;
         BindingSpan = BindingName == null ? null : bindingSpan ?? span;
     }

--- a/src/Calor.Compiler/Ast/QuantifierNodes.cs
+++ b/src/Calor.Compiler/Ast/QuantifierNodes.cs
@@ -18,17 +18,20 @@ public sealed class QuantifierVariableNode : AstNode
     /// The type name of the variable.
     /// </summary>
     public string TypeName { get; }
+    public TextSpan TypeNameSpan { get; }
 
     public QuantifierVariableNode(
         TextSpan span,
         string name,
         string typeName,
-        TextSpan? identifierSpan = null)
+        TextSpan? identifierSpan = null,
+        TextSpan? typeNameSpan = null)
         : base(span)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
         IdentifierSpan = identifierSpan ?? span;
         TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
+        TypeNameSpan = typeNameSpan ?? TextSpan.Empty;
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);

--- a/src/Calor.Compiler/Ast/RefinementNodes.cs
+++ b/src/Calor.Compiler/Ast/RefinementNodes.cs
@@ -11,6 +11,7 @@ public sealed class RefinementTypeNode : AstNode
     public string Id { get; }
     public string Name { get; }
     public string BaseTypeName { get; }
+    public TextSpan BaseTypeNameSpan { get; }
     public ExpressionNode Predicate { get; }
     public AttributeCollection Attributes { get; }
 
@@ -20,12 +21,14 @@ public sealed class RefinementTypeNode : AstNode
         string name,
         string baseTypeName,
         ExpressionNode predicate,
-        AttributeCollection attributes)
+        AttributeCollection attributes,
+        TextSpan? baseTypeNameSpan = null)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
         Name = name ?? throw new ArgumentNullException(nameof(name));
         BaseTypeName = baseTypeName ?? throw new ArgumentNullException(nameof(baseTypeName));
+        BaseTypeNameSpan = baseTypeNameSpan ?? TextSpan.Empty;
         Predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
     }
@@ -85,6 +88,7 @@ public sealed class IndexedTypeNode : AstNode
     public string Id { get; }
     public string Name { get; }
     public string BaseTypeName { get; }
+    public TextSpan BaseTypeNameSpan { get; }
     public string SizeParam { get; }
     public ExpressionNode? Constraint { get; }
     public AttributeCollection Attributes { get; }
@@ -96,12 +100,14 @@ public sealed class IndexedTypeNode : AstNode
         string baseTypeName,
         string sizeParam,
         ExpressionNode? constraint,
-        AttributeCollection attributes)
+        AttributeCollection attributes,
+        TextSpan? baseTypeNameSpan = null)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
         Name = name ?? throw new ArgumentNullException(nameof(name));
         BaseTypeName = baseTypeName ?? throw new ArgumentNullException(nameof(baseTypeName));
+        BaseTypeNameSpan = baseTypeNameSpan ?? TextSpan.Empty;
         SizeParam = sizeParam ?? throw new ArgumentNullException(nameof(sizeParam));
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
         Constraint = constraint;

--- a/src/Calor.Compiler/Ast/TypeNodes.cs
+++ b/src/Calor.Compiler/Ast/TypeNodes.cs
@@ -61,6 +61,7 @@ public sealed class FieldDefinitionNode : AstNode
 {
     public string Name { get; }
     public string TypeName { get; }
+    public TextSpan TypeNameSpan { get; }
     public ExpressionNode? DefaultValue { get; }
     public AttributeCollection Attributes { get; }
 
@@ -69,11 +70,13 @@ public sealed class FieldDefinitionNode : AstNode
         string name,
         string typeName,
         ExpressionNode? defaultValue,
-        AttributeCollection attributes)
+        AttributeCollection attributes,
+        TextSpan? typeNameSpan = null)
         : base(span)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
         TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
+        TypeNameSpan = typeNameSpan ?? TextSpan.Empty;
         DefaultValue = defaultValue;
         Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
     }
@@ -168,15 +171,18 @@ public sealed class TypeReferenceNode : AstNode
 public sealed class RecordCreationNode : ExpressionNode
 {
     public string TypeName { get; }
+    public TextSpan TypeNameSpan { get; }
     public IReadOnlyList<FieldAssignmentNode> Fields { get; }
 
     public RecordCreationNode(
         TextSpan span,
         string typeName,
-        IReadOnlyList<FieldAssignmentNode> fields)
+        IReadOnlyList<FieldAssignmentNode> fields,
+        TextSpan? typeNameSpan = null)
         : base(span)
     {
         TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
+        TypeNameSpan = typeNameSpan ?? TextSpan.Empty;
         Fields = fields ?? throw new ArgumentNullException(nameof(fields));
     }
 
@@ -254,11 +260,16 @@ public sealed class SomeExpressionNode : ExpressionNode
 public sealed class NoneExpressionNode : ExpressionNode
 {
     public string? TypeName { get; }
+    public TextSpan? TypeNameSpan { get; }
 
-    public NoneExpressionNode(TextSpan span, string? typeName)
+    public NoneExpressionNode(
+        TextSpan span,
+        string? typeName,
+        TextSpan? typeNameSpan = null)
         : base(span)
     {
         TypeName = typeName;
+        TypeNameSpan = typeName == null ? null : typeNameSpan ?? TextSpan.Empty;
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
@@ -378,8 +389,9 @@ public sealed class EnumDefinitionNode : TypeDefinitionNode
         IReadOnlyList<EnumMemberNode> members,
         AttributeCollection attributes,
         IReadOnlyList<CalorAttributeNode> csharpAttributes,
-        Visibility visibility = Visibility.Public)
-        : base(span, id, name, attributes)
+        Visibility visibility = Visibility.Public,
+        TextSpan? identifierSpan = null)
+        : base(span, id, name, attributes, identifierSpan)
     {
         UnderlyingType = underlyingType;
         Members = members ?? throw new ArgumentNullException(nameof(members));

--- a/src/Calor.Compiler/Ast/TypeOperationNode.cs
+++ b/src/Calor.Compiler/Ast/TypeOperationNode.cs
@@ -21,17 +21,20 @@ public sealed class TypeOperationNode : ExpressionNode
     public TypeOp Operation { get; }
     public ExpressionNode Operand { get; }
     public string TargetType { get; }
+    public TextSpan TargetTypeSpan { get; }
 
     public TypeOperationNode(
         TextSpan span,
         TypeOp operation,
         ExpressionNode operand,
-        string targetType)
+        string targetType,
+        TextSpan? targetTypeSpan = null)
         : base(span)
     {
         Operation = operation;
         Operand = operand ?? throw new ArgumentNullException(nameof(operand));
         TargetType = targetType ?? throw new ArgumentNullException(nameof(targetType));
+        TargetTypeSpan = targetTypeSpan ?? TextSpan.Empty;
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);
@@ -46,17 +49,20 @@ public sealed class IsPatternNode : ExpressionNode
 {
     public ExpressionNode Operand { get; }
     public string TargetType { get; }
+    public TextSpan TargetTypeSpan { get; }
     public string? VariableName { get; }
 
     public IsPatternNode(
         TextSpan span,
         ExpressionNode operand,
         string targetType,
-        string? variableName = null)
+        string? variableName = null,
+        TextSpan? targetTypeSpan = null)
         : base(span)
     {
         Operand = operand ?? throw new ArgumentNullException(nameof(operand));
         TargetType = targetType ?? throw new ArgumentNullException(nameof(targetType));
+        TargetTypeSpan = targetTypeSpan ?? TextSpan.Empty;
         VariableName = variableName;
     }
 

--- a/src/Calor.Compiler/Ast/UnsafeNodes.cs
+++ b/src/Calor.Compiler/Ast/UnsafeNodes.cs
@@ -13,6 +13,7 @@ public sealed class StackAllocNode : ExpressionNode
     /// The element type being stack-allocated.
     /// </summary>
     public string ElementType { get; }
+    public TextSpan ElementTypeSpan { get; }
 
     /// <summary>
     /// The size expression (for sized stackalloc). Null if using initializer.
@@ -28,10 +29,12 @@ public sealed class StackAllocNode : ExpressionNode
         TextSpan span,
         string elementType,
         ExpressionNode? size,
-        IReadOnlyList<ExpressionNode> initializer)
+        IReadOnlyList<ExpressionNode> initializer,
+        TextSpan? elementTypeSpan = null)
         : base(span)
     {
         ElementType = elementType ?? throw new ArgumentNullException(nameof(elementType));
+        ElementTypeSpan = elementTypeSpan ?? TextSpan.Empty;
         Size = size;
         Initializer = initializer ?? Array.Empty<ExpressionNode>();
     }
@@ -69,6 +72,7 @@ public sealed class FixedStatementNode : StatementNode
     public string Id { get; }
     public string PointerName { get; }
     public string PointerType { get; }
+    public TextSpan PointerTypeSpan { get; }
     public ExpressionNode Initializer { get; }
     public IReadOnlyList<StatementNode> Body { get; }
 
@@ -78,12 +82,14 @@ public sealed class FixedStatementNode : StatementNode
         string pointerName,
         string pointerType,
         ExpressionNode initializer,
-        IReadOnlyList<StatementNode> body)
+        IReadOnlyList<StatementNode> body,
+        TextSpan? pointerTypeSpan = null)
         : base(span)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
         PointerName = pointerName ?? throw new ArgumentNullException(nameof(pointerName));
         PointerType = pointerType ?? throw new ArgumentNullException(nameof(pointerType));
+        PointerTypeSpan = pointerTypeSpan ?? TextSpan.Empty;
         Initializer = initializer ?? throw new ArgumentNullException(nameof(initializer));
         Body = body ?? throw new ArgumentNullException(nameof(body));
     }
@@ -135,11 +141,13 @@ public sealed class PointerDereferenceNode : ExpressionNode
 public sealed class SizeOfNode : ExpressionNode
 {
     public string TypeName { get; }
+    public TextSpan TypeNameSpan { get; }
 
-    public SizeOfNode(TextSpan span, string typeName)
+    public SizeOfNode(TextSpan span, string typeName, TextSpan? typeNameSpan = null)
         : base(span)
     {
         TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
+        TypeNameSpan = typeNameSpan ?? TextSpan.Empty;
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);

--- a/src/Calor.Compiler/Binding/Binder.cs
+++ b/src/Calor.Compiler/Binding/Binder.cs
@@ -184,6 +184,7 @@ public sealed class Binder
         var functions = new List<BoundFunction>();
 
         RegisterTopLevelFunctions(module);
+        RegisterAdditionalTypes(module);
         foreach (var cls in module.Classes)
             RegisterClassTree(cls, _moduleSymbolId, null);
 
@@ -222,6 +223,67 @@ public sealed class Binder
             if (!_scope.TryDeclareOverload(lookupName, symbol, out var duplicate))
                 ReportDuplicateSignature(function.Span, lookupName, symbol, duplicate);
         }
+    }
+
+    private void RegisterAdditionalTypes(ModuleNode module)
+    {
+        foreach (var @interface in module.Interfaces)
+        {
+            RegisterTypeSymbol(
+                _moduleSymbolId,
+                "interface",
+                @interface.Id,
+                @interface.Name,
+                @interface.Name,
+                Visibility.Public,
+                @interface.IdentifierSpan,
+                @interface.Span);
+        }
+
+        foreach (var @enum in module.Enums)
+        {
+            RegisterTypeSymbol(
+                _moduleSymbolId,
+                "enum",
+                @enum.Id,
+                @enum.Name,
+                @enum.Name,
+                @enum.Visibility,
+                @enum.IdentifierSpan,
+                @enum.Span);
+        }
+
+        foreach (var @delegate in module.Delegates)
+        {
+            RegisterTypeSymbol(
+                _moduleSymbolId,
+                "delegate",
+                @delegate.Id,
+                @delegate.Name,
+                @delegate.Name,
+                Visibility.Public,
+                @delegate.IdentifierSpan,
+                @delegate.Span);
+        }
+    }
+
+    private void RegisterTypeSymbol(
+        SymbolId parentIdentity,
+        string kind,
+        string stableAstId,
+        string name,
+        string qualifiedName,
+        Visibility visibility,
+        Parsing.TextSpan declarationSpan,
+        Parsing.TextSpan definitionSpan)
+    {
+        TrackSymbol(new TypeSymbol(
+            CreateDeclarationId(parentIdentity, kind, stableAstId, name),
+            name,
+            qualifiedName,
+            visibility,
+            declarationSpan,
+            definitionSpan));
     }
 
     private void RegisterClassTree(
@@ -379,6 +441,42 @@ public sealed class Binder
                 nested,
                 classIdentity,
                 qualifiedClassName);
+        }
+        foreach (var nested in cls.NestedInterfaces)
+        {
+            RegisterTypeSymbol(
+                classIdentity,
+                "interface",
+                nested.Id,
+                nested.Name,
+                $"{qualifiedClassName}.{nested.Name}",
+                Visibility.Public,
+                nested.IdentifierSpan,
+                nested.Span);
+        }
+        foreach (var nested in cls.NestedEnums)
+        {
+            RegisterTypeSymbol(
+                classIdentity,
+                "enum",
+                nested.Id,
+                nested.Name,
+                $"{qualifiedClassName}.{nested.Name}",
+                nested.Visibility,
+                nested.IdentifierSpan,
+                nested.Span);
+        }
+        foreach (var nested in cls.NestedDelegates)
+        {
+            RegisterTypeSymbol(
+                classIdentity,
+                "delegate",
+                nested.Id,
+                nested.Name,
+                $"{qualifiedClassName}.{nested.Name}",
+                Visibility.Public,
+                nested.IdentifierSpan,
+                nested.Span);
         }
     }
 
@@ -806,6 +904,9 @@ public sealed class Binder
         var receiverSymbol = ResolveCallReceiver(
             call.Target,
             call.ReceiverSpan ?? call.CalleeSpan);
+        var receiverTypeSymbol = receiverSymbol == null
+            ? ResolveCallReceiverType(call.Target)
+            : null;
         var resolution = ResolveCall(
             call.Span,
             call.Target,
@@ -826,7 +927,8 @@ public sealed class Binder
             call.CalleeSpan,
             call.ReceiverSpan,
             resolution.Kind == OverloadResolutionKind.Inaccessible,
-            call.TypeArguments);
+            call.TypeArguments,
+            receiverTypeSymbol);
     }
 
     private BoundReturnStatement BindReturnStatement(ReturnStatementNode ret)
@@ -2028,6 +2130,9 @@ public sealed class Binder
         var receiverSymbol = ResolveCallReceiver(
             callExpr.Target,
             callExpr.ReceiverSpan ?? callExpr.CalleeSpan);
+        var receiverTypeSymbol = receiverSymbol == null
+            ? ResolveCallReceiverType(callExpr.Target)
+            : null;
         var resolution = ResolveCall(
             callExpr.Span,
             callExpr.Target,
@@ -2048,6 +2153,8 @@ public sealed class Binder
             resolvedTypeName = receiverSymbol != null
                 ? Effects.EffectEnforcementPass.MapShortTypeNameToFullName(
                     GetNominalTypeName(receiverSymbol.TypeName))
+                : receiverTypeSymbol != null
+                    ? receiverTypeSymbol.QualifiedName
                 : !typePart.Contains('.')
                 ? Effects.EffectEnforcementPass.MapShortTypeNameToFullName(typePart)
                 : typePart;
@@ -2071,7 +2178,8 @@ public sealed class Binder
             resolvedSymbols: resolution.Functions,
             calleeSpan: callExpr.CalleeSpan,
             receiverSpan: callExpr.ReceiverSpan,
-            isInaccessibleCall: resolution.Kind == OverloadResolutionKind.Inaccessible);
+            isInaccessibleCall: resolution.Kind == OverloadResolutionKind.Inaccessible,
+            receiverTypeSymbol: receiverTypeSymbol);
     }
 
     private VariableSymbol? ResolveCallReceiver(
@@ -2099,6 +2207,19 @@ public sealed class Binder
         }
 
         return variables[0];
+    }
+
+    private TypeSymbol? ResolveCallReceiverType(string target)
+    {
+        var firstDot = target.IndexOf('.');
+        if (firstDot <= 0)
+            return null;
+
+        var receiverName = target[..firstDot];
+        var genericStart = receiverName.IndexOf('<');
+        if (genericStart > 0)
+            receiverName = receiverName[..genericStart];
+        return ResolveTypeSymbol(receiverName);
     }
 
     private OverloadResolutionResult ResolveCall(

--- a/src/Calor.Compiler/Binding/BoundNodes.cs
+++ b/src/Calor.Compiler/Binding/BoundNodes.cs
@@ -192,6 +192,8 @@ public sealed class BoundCallStatement : BoundStatement
     public IReadOnlyList<FunctionSymbol> ResolvedSymbols { get; }
     public VariableSymbol? ReceiverSymbol { get; }
     public SymbolId? ReceiverSymbolId => ReceiverSymbol?.Id;
+    public TypeSymbol? ReceiverTypeSymbol { get; }
+    public SymbolId? ReceiverTypeSymbolId => ReceiverTypeSymbol?.Id;
     public TextSpan CalleeSpan { get; }
     public TextSpan? ReceiverSpan { get; }
     public bool IsInaccessibleCall { get; }
@@ -212,7 +214,8 @@ public sealed class BoundCallStatement : BoundStatement
         TextSpan? calleeSpan = null,
         TextSpan? receiverSpan = null,
         bool isInaccessibleCall = false,
-        IReadOnlyList<string>? typeArguments = null)
+        IReadOnlyList<string>? typeArguments = null,
+        TypeSymbol? receiverTypeSymbol = null)
         : base(span)
     {
         Target = target;
@@ -224,6 +227,7 @@ public sealed class BoundCallStatement : BoundStatement
         ArgumentModifiers = argumentModifiers;
         TypeArguments = typeArguments;
         ReceiverSymbol = receiverSymbol;
+        ReceiverTypeSymbol = receiverTypeSymbol;
         CalleeSpan = calleeSpan ?? span;
         ReceiverSpan = receiverSpan;
         IsInaccessibleCall = isInaccessibleCall;
@@ -549,6 +553,8 @@ public class BoundCallExpression : BoundExpression
     public IReadOnlyList<FunctionSymbol> ResolvedSymbols { get; }
     public VariableSymbol? ReceiverSymbol { get; }
     public SymbolId? ReceiverSymbolId => ReceiverSymbol?.Id;
+    public TypeSymbol? ReceiverTypeSymbol { get; }
+    public SymbolId? ReceiverTypeSymbolId => ReceiverTypeSymbol?.Id;
     public TextSpan CalleeSpan { get; }
     public TextSpan? ReceiverSpan { get; }
     public bool IsInaccessibleCall { get; }
@@ -597,7 +603,8 @@ public class BoundCallExpression : BoundExpression
         IReadOnlyList<FunctionSymbol>? resolvedSymbols = null,
         TextSpan? calleeSpan = null,
         TextSpan? receiverSpan = null,
-        bool isInaccessibleCall = false)
+        bool isInaccessibleCall = false,
+        TypeSymbol? receiverTypeSymbol = null)
         : base(span)
     {
         Target = target;
@@ -613,6 +620,7 @@ public class BoundCallExpression : BoundExpression
         ArgumentModifiers = argumentModifiers;
         TypeArguments = typeArguments;
         ReceiverSymbol = receiverSymbol;
+        ReceiverTypeSymbol = receiverTypeSymbol;
         CalleeSpan = calleeSpan ?? span;
         ReceiverSpan = receiverSpan;
         IsInaccessibleCall = isInaccessibleCall;

--- a/src/Calor.Compiler/Calor.Compiler.csproj
+++ b/src/Calor.Compiler/Calor.Compiler.csproj
@@ -4,6 +4,8 @@
     <InternalsVisibleTo Include="Calor.Compiler.Tests" />
     <InternalsVisibleTo Include="Calor.Enforcement.Tests" />
     <InternalsVisibleTo Include="Calor.ILAnalysis.Tests" />
+    <InternalsVisibleTo Include="Calor.LanguageServer.Tests" />
+    <InternalsVisibleTo Include="calor-lsp" />
     <InternalsVisibleTo Include="McpBenchHarness" />
     <InternalsVisibleTo Include="Calor.Tasks" />
     <InternalsVisibleTo Include="Calor.Tasks.Tests" />

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -671,7 +671,15 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         var parameters = string.Join(", ", node.Parameters.Select(p => Visit(p)));
 
-        var methodName = SanitizeIdentifier(node.Name);
+        var callableName = node.Name;
+        var genericStart = callableName.LastIndexOf('<');
+        var embeddedTypeParams = "";
+        if (genericStart > 0 && callableName.EndsWith('>'))
+        {
+            embeddedTypeParams = callableName[genericStart..];
+            callableName = callableName[..genericStart];
+        }
+        var methodName = SanitizeIdentifier(callableName);
 
         // Build type parameters if present
         var typeParams = "";
@@ -694,6 +702,10 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             {
                 whereClause = " " + string.Join(" ", whereClauses);
             }
+        }
+        else
+        {
+            typeParams = embeddedTypeParams;
         }
 
         // Check if this is the entry point

--- a/src/Calor.Compiler/CompilationDriver.cs
+++ b/src/Calor.Compiler/CompilationDriver.cs
@@ -329,7 +329,7 @@ internal static class CompilationDriver
     internal static IReadOnlyDictionary<string, string> BuildCrossModuleFunctionMap(
         IReadOnlyList<FileInfo> sources)
     {
-        var byName = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var modules = new List<ModuleNode>();
         foreach (var file in sources)
         {
             try
@@ -343,38 +343,54 @@ internal static class CompilationDriver
                 {
                     continue;
                 }
-                foreach (var fn in module.Functions)
-                {
-                    // Match CrossModuleEffectRegistry's surface exactly (public AND
-                    // internal — #823 review M1): enforcement resolves internal
-                    // cross-module calls, so emission must qualify them too, or the
-                    // front-end passes and csc fails (the exact #809 shape).
-                    if (fn.Visibility is not (Ast.Visibility.Public or Ast.Visibility.Internal))
-                    {
-                        continue;
-                    }
-                    if (!byName.TryGetValue(fn.Name, out var modules))
-                    {
-                        byName[fn.Name] = modules = new List<string>();
-                    }
-                    if (!modules.Contains(module.Name))
-                    {
-                        modules.Add(module.Name);
-                    }
-                }
+                modules.Add(module);
             }
             catch (IOException)
             {
             }
         }
 
-        var map = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (var (name, modules) in byName)
+        return BuildCrossModuleFunctionMap(modules);
+    }
+
+    /// <summary>
+    /// Builds the production cross-module call-qualification map from already
+    /// parsed modules. Editor validation uses this overload so it shares the
+    /// driver's exact visibility and ambiguity rules without reparsing snapshots.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, string> BuildCrossModuleFunctionMap(
+        IReadOnlyList<ModuleNode> modules)
+    {
+        var byName = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var module in modules)
         {
-            if (modules.Count == 1)
+            if (string.IsNullOrEmpty(module.Name) || module.Name == "_global")
+                continue;
+
+            foreach (var fn in module.Functions)
             {
-                map[name] = modules[0];
+                // Match CrossModuleEffectRegistry's surface exactly (public AND
+                // internal — #823 review M1): enforcement resolves internal
+                // cross-module calls, so emission must qualify them too, or the
+                // front-end passes and csc fails (the exact #809 shape).
+                if (fn.Visibility is not (Ast.Visibility.Public or Ast.Visibility.Internal))
+                    continue;
+
+                if (!byName.TryGetValue(fn.Name, out var definingModules))
+                {
+                    definingModules = [];
+                    byName[fn.Name] = definingModules;
+                }
+                if (!definingModules.Contains(module.Name))
+                    definingModules.Add(module.Name);
             }
+        }
+
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (name, definingModules) in byName)
+        {
+            if (definingModules.Count == 1)
+                map[name] = definingModules[0];
         }
         return map;
     }

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -885,6 +885,14 @@ public sealed class CalorEmitter : IAstVisitor<string>
         var typeParams = node.TypeParameters.Count > 0
             ? $"<{string.Join(",", node.TypeParameters.Select(tp => Visit(tp)))}>"
             : "";
+        var functionName = node.Name;
+        var genericStart = functionName.LastIndexOf('<');
+        if (node.TypeParameters.Count > 0
+            && genericStart > 0
+            && functionName.EndsWith('>'))
+        {
+            functionName = functionName[..genericStart];
+        }
 
         var output = node.Output != null ? TypeMapper.CSharpToCalor(node.Output.TypeName) : "void";
 
@@ -895,11 +903,11 @@ public sealed class CalorEmitter : IAstVisitor<string>
         {
             var inlineParams = node.Parameters.Count > 0 || node.Output != null ? $" ({inlineFmt})" : "";
             var inlineReturn = node.Output != null ? $" -> {output}" : "";
-            AppendLine($"§{funcTag}{{{node.Id}:{EscapeCalorIdentifier(node.Name)}{typeParams}:{visibility}}}{inlineParams}{inlineReturn}");
+            AppendLine($"§{funcTag}{{{node.Id}:{EscapeCalorIdentifier(functionName)}{typeParams}:{visibility}}}{inlineParams}{inlineReturn}");
         }
         else
         {
-            AppendLine($"§{funcTag}{{{node.Id}:{EscapeCalorIdentifier(node.Name)}{typeParams}:{visibility}}}");
+            AppendLine($"§{funcTag}{{{node.Id}:{EscapeCalorIdentifier(functionName)}{typeParams}:{visibility}}}");
         }
         Indent();
 

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -1274,7 +1274,14 @@ public sealed class Parser
         }
 
         var span = startToken.Span.Union(predicate.Span);
-        return new RefinementTypeNode(span, id, name, baseTypeName, predicate, attrs);
+        return new RefinementTypeNode(
+            span,
+            id,
+            name,
+            baseTypeName,
+            predicate,
+            attrs,
+            attrs.GetSpan("_pos2"));
     }
 
     /// <summary>
@@ -1321,7 +1328,15 @@ public sealed class Parser
         }
 
         var span = startToken.Span.Union(lastSpan);
-        return new IndexedTypeNode(span, id, name, baseTypeName, sizeParam, constraint, attrs);
+        return new IndexedTypeNode(
+            span,
+            id,
+            name,
+            baseTypeName,
+            sizeParam,
+            constraint,
+            attrs,
+            attrs.GetSpan("_pos2"));
     }
 
     /// <summary>
@@ -2081,7 +2096,8 @@ public sealed class Parser
                         firstToken.Span,
                         paramName,
                         paramType,
-                        parameterSpan);
+                        parameterSpan,
+                        paramType == null ? null : firstToken.Span);
                     return new LambdaExpressionNode(
                         span,
                         "inline",
@@ -2277,9 +2293,12 @@ public sealed class Parser
         // Handle typeof: (typeof TypeName)
         if (opText == "typeof")
         {
-            var typeName = ParseLispTypeName();
+            var typeName = ParseLispTypeName(out var typeNameSpan);
             var typeofEnd = Expect(TokenKind.CloseParen);
-            return new TypeOfExpressionNode(startToken.Span.Union(typeofEnd.Span), typeName);
+            return new TypeOfExpressionNode(
+                startToken.Span.Union(typeofEnd.Span),
+                typeName,
+                typeNameSpan);
         }
 
         // Handle nameof: (nameof name) or (nameof obj.Property)
@@ -2638,7 +2657,12 @@ public sealed class Parser
                 return operandArg;
             }
 
-            return new TypeOperationNode(span, typeOp.Value, operandArg, typeRef.Name);
+            return new TypeOperationNode(
+                span,
+                typeOp.Value,
+                operandArg,
+                typeRef.Name,
+                typeRef.Span);
         }
 
         // Handle function calls: (CALL target arg1 arg2 ...)
@@ -2671,8 +2695,12 @@ public sealed class Parser
                     }
                     var exprName = string.Join(".", exprParts);
                     var typeName = args[i + 1] switch { ReferenceNode r2 => r2.Name, _ => args[i + 1].ToString() ?? "" };
-                    return new TypeOperationNode(span, TypeOp.As,
-                        new ReferenceNode(span, exprName), typeName);
+                    return new TypeOperationNode(
+                        span,
+                        TypeOp.As,
+                        new ReferenceNode(span, exprName),
+                        typeName,
+                        args[i + 1].Span);
                 }
             }
         }
@@ -2943,7 +2971,8 @@ public sealed class Parser
                 bindingSpan,
                 nameToken.Text,
                 typeToken.Text,
-                nameToken.Span));
+                nameToken.Span,
+                typeToken.Span));
         }
 
         Expect(TokenKind.CloseParen);
@@ -3139,7 +3168,20 @@ public sealed class Parser
     /// Examples: int, string, List&lt;string&gt;, Dictionary&lt;string, int&gt;, System.Collections.Generic.List&lt;int&gt;
     /// Used by typeof, is, and as expressions.
     /// </summary>
-    private string ParseLispTypeName()
+    private string ParseLispTypeName() => ParseLispTypeName(out _);
+
+    private string ParseLispTypeName(out TextSpan typeSpan)
+    {
+        var startPosition = _position;
+        var startSpan = Current.Span;
+        var typeName = ParseLispTypeNameCore();
+        typeSpan = _position > startPosition
+            ? startSpan.Union(Peek(-1).Span)
+            : TextSpan.Empty;
+        return typeName;
+    }
+
+    private string ParseLispTypeNameCore()
     {
         // Handle Calor nullable prefix syntax: ?Type → Type?
         bool isNullablePrefix = false;
@@ -3385,7 +3427,7 @@ public sealed class Parser
         var operand = ParseLispArgument();
 
         // Parse the type name using the shared helper
-        var typeName = ParseLispTypeName();
+        var typeName = ParseLispTypeName(out var typeNameSpan);
 
         // Optionally parse a variable name for pattern matching: (is x MyType varName)
         string? variableName = null;
@@ -3398,7 +3440,12 @@ public sealed class Parser
         var endToken = Expect(TokenKind.CloseParen);
         var span = startToken.Span.Union(endToken.Span);
 
-        return new IsPatternNode(span, operand, typeName, variableName);
+        return new IsPatternNode(
+            span,
+            operand,
+            typeName,
+            variableName,
+            typeNameSpan);
     }
 
     /// <summary>
@@ -3411,12 +3458,17 @@ public sealed class Parser
         var operand = ParseLispArgument();
 
         // Parse the type name using the shared helper
-        var typeName = ParseLispTypeName();
+        var typeName = ParseLispTypeName(out var typeNameSpan);
 
         var endToken = Expect(TokenKind.CloseParen);
         var span = startToken.Span.Union(endToken.Span);
 
-        return new TypeOperationNode(span, TypeOp.As, operand, typeName);
+        return new TypeOperationNode(
+            span,
+            TypeOp.As,
+            operand,
+            typeName,
+            typeNameSpan);
     }
 
     /// <summary>
@@ -3426,13 +3478,18 @@ public sealed class Parser
     private ExpressionNode ParseLispCastExpression(Token startToken)
     {
         // cast: type comes first, then expression
-        var typeName = ParseLispTypeName();
+        var typeName = ParseLispTypeName(out var typeNameSpan);
         var operand = ParseLispArgument();
 
         var endToken = Expect(TokenKind.CloseParen);
         var span = startToken.Span.Union(endToken.Span);
 
-        return new TypeOperationNode(span, TypeOp.Cast, operand, typeName);
+        return new TypeOperationNode(
+            span,
+            TypeOp.Cast,
+            operand,
+            typeName,
+            typeNameSpan);
     }
 
     /// <summary>
@@ -3444,7 +3501,7 @@ public sealed class Parser
         var startSpan = left.Span;
         Advance(); // consume 'is'
 
-        var typeName = ParseLispTypeName();
+        var typeName = ParseLispTypeName(out var typeNameSpan);
         string? variableName = null;
 
         // Check for optional variable declaration: is Type variableName
@@ -3456,7 +3513,12 @@ public sealed class Parser
         }
 
         var endSpan = Peek(-1).Span;
-        return new IsPatternNode(startSpan.Union(endSpan), left, typeName, variableName);
+        return new IsPatternNode(
+            startSpan.Union(endSpan),
+            left,
+            typeName,
+            variableName,
+            typeNameSpan);
     }
 
     /// <summary>
@@ -3729,7 +3791,10 @@ public sealed class Parser
         {
             typeName = AttributeHelper.ExpandType(typeName);
         }
-        return new NoneExpressionNode(startToken.Span, typeName);
+        return new NoneExpressionNode(
+            startToken.Span,
+            typeName,
+            typeName == null ? null : attrs.GetSpan("_pos0"));
     }
 
     private OkExpressionNode ParseOkExpression()
@@ -3765,7 +3830,11 @@ public sealed class Parser
         }
 
         var lastSpan = fields.Count > 0 ? fields[^1].Span : startToken.Span;
-        return new RecordCreationNode(startToken.Span.Union(lastSpan), typeName, fields);
+        return new RecordCreationNode(
+            startToken.Span.Union(lastSpan),
+            typeName,
+            fields,
+            attrs.GetSpan("type"));
     }
 
     private MatchExpressionNode ParseMatchExpression()
@@ -4897,7 +4966,9 @@ public sealed class Parser
         if (!attrs.TryGetSpan(key, out var span))
             return TextSpan.Empty;
 
-        var length = Math.Min(identifier.Length, Math.Max(0, span.Length - leadingCharacters));
+        var genericStart = identifier.IndexOf('<');
+        var identifierLength = genericStart > 0 ? genericStart : identifier.Length;
+        var length = Math.Min(identifierLength, Math.Max(0, span.Length - leadingCharacters));
         return new TextSpan(
             span.Start + leadingCharacters,
             length,
@@ -4940,14 +5011,20 @@ public sealed class Parser
             return (null, targetSpan);
 
         var firstDot = target.IndexOf('.');
-        TextSpan? receiver = firstDot > 0
-            ? new TextSpan(targetSpan.Start, firstDot, targetSpan.Line, targetSpan.Column)
+        var receiverGeneric = target.IndexOf('<');
+        var receiverLength = receiverGeneric > 0 && receiverGeneric < firstDot
+            ? receiverGeneric
+            : firstDot;
+        TextSpan? receiver = receiverLength > 0
+            ? new TextSpan(targetSpan.Start, receiverLength, targetSpan.Line, targetSpan.Column)
             : null;
 
         var lastDot = target.LastIndexOf('.');
         var calleeOffset = lastDot >= 0 ? lastDot + 1 : 0;
+        var genericOffset = target.IndexOf('<', calleeOffset);
+        var calleeEnd = genericOffset >= 0 ? genericOffset : target.Length;
         var calleeLength = Math.Min(
-            target.Length - calleeOffset,
+            calleeEnd - calleeOffset,
             Math.Max(0, targetSpan.Length - calleeOffset));
         var callee = new TextSpan(
             targetSpan.Start + calleeOffset,
@@ -6200,7 +6277,18 @@ public sealed class Parser
         }
 
         var span = startToken.Span.Union(endSpan);
-        return new ArrayCreationNode(span, id, id, elementType, size, initializer, attrs);
+        var elementTypeKey = string.Equals(elementType, rawPos0, StringComparison.Ordinal)
+            ? "_pos0"
+            : "_pos1";
+        return new ArrayCreationNode(
+            span,
+            id,
+            id,
+            elementType,
+            size,
+            initializer,
+            attrs,
+            attrs.GetSpan(elementTypeKey));
     }
 
     /// <summary>
@@ -6342,7 +6430,8 @@ public sealed class Parser
             GetIdentifierSpan(attrs, "_pos1", variableName),
             indexVariableName == null
                 ? null
-                : GetIdentifierSpan(attrs, "_pos3", indexVariableName));
+                : GetIdentifierSpan(attrs, "_pos3", indexVariableName),
+            attrs.GetSpan("_pos2"));
     }
 
     // Phase 6 Extended: Collections (List, Dictionary, HashSet)
@@ -6386,7 +6475,14 @@ public sealed class Parser
         }
 
         var span = startToken.Span.Union(endToken.Span);
-        return new ListCreationNode(span, id, id, elementType, elements, attrs);
+        return new ListCreationNode(
+            span,
+            id,
+            id,
+            elementType,
+            elements,
+            attrs,
+            attrs.GetSpan("_pos1"));
     }
 
     /// <summary>
@@ -6461,7 +6557,16 @@ public sealed class Parser
         }
 
         var span = startToken.Span.Union(endToken.Span);
-        return new DictionaryCreationNode(span, id, id, keyType, valueType, entries, attrs);
+        return new DictionaryCreationNode(
+            span,
+            id,
+            id,
+            keyType,
+            valueType,
+            entries,
+            attrs,
+            attrs.GetSpan("_pos1"),
+            attrs.GetSpan("_pos2"));
     }
 
     /// <summary>
@@ -6539,7 +6644,14 @@ public sealed class Parser
         }
 
         var span = startToken.Span.Union(endToken.Span);
-        return new SetCreationNode(span, id, id, elementType, elements, attrs);
+        return new SetCreationNode(
+            span,
+            id,
+            id,
+            elementType,
+            elements,
+            attrs,
+            attrs.GetSpan("_pos1"));
     }
 
     /// <summary>
@@ -7169,7 +7281,11 @@ public sealed class Parser
             }
         }
 
-        return new GenericTypeNode(startToken.Span, typeName, typeArgs);
+        return new GenericTypeNode(
+            startToken.Span,
+            typeName,
+            typeArgs,
+            attrs.GetSpan("_pos0"));
     }
 
     // Phase 8: Classes, Interfaces, Inheritance
@@ -7189,6 +7305,7 @@ public sealed class Parser
         // Positional: [id:name:baseInterface?]
         var id = attrs["_pos0"] ?? "";
         var name = attrs["_pos1"] ?? "";
+        var interfaceNameKey = "_pos1";
         var pos2 = attrs["_pos2"] ?? "";
 
         // --- Compact syntax: optional ID ---
@@ -7199,6 +7316,7 @@ public sealed class Parser
             pos2 = name;
             name = id;
             id = GenerateParserAutoId("i");
+            interfaceNameKey = "_pos0";
         }
 
         if (string.IsNullOrEmpty(id))
@@ -7249,6 +7367,7 @@ public sealed class Parser
         }
 
         var baseInterfaces = new List<string>();
+        var baseInterfaceSpans = new List<TextSpan>();
         if (!string.IsNullOrEmpty(pos2))
         {
             foreach (var baseIface in pos2.Split(','))
@@ -7259,6 +7378,8 @@ public sealed class Parser
                     baseInterfaces.Add(trimmed);
                 }
             }
+            if (attrs.GetSpan("_pos2") is { } baseInterfaceSpan)
+                baseInterfaceSpans.Add(baseInterfaceSpan);
         }
         var methods = new List<MethodSignatureNode>();
         var properties = new List<PropertyNode>();
@@ -7282,6 +7403,8 @@ public sealed class Parser
                 if (!string.IsNullOrEmpty(baseIface))
                 {
                     baseInterfaces.Add(baseIface);
+                    if (extAttrs.GetSpan("_pos0") is { } baseInterfaceSpan)
+                        baseInterfaceSpans.Add(baseInterfaceSpan);
                 }
             }
             else if (Check(TokenKind.Method))
@@ -7314,7 +7437,9 @@ public sealed class Parser
 
         var span = startToken.Span.Union(endToken.Span);
         return new InterfaceDefinitionNode(span, id, name, baseInterfaces, typeParameters, methods, properties, attrs, csharpAttrs,
-            indexers: indexers.Count > 0 ? indexers : null);
+            indexers: indexers.Count > 0 ? indexers : null,
+            baseInterfaceSpans: baseInterfaceSpans,
+            identifierSpan: GetIdentifierSpan(attrs, interfaceNameKey, name));
     }
 
     /// <summary>
@@ -9752,7 +9877,8 @@ public sealed class Parser
             attrs,
             variableName == null
                 ? null
-                : GetIdentifierSpan(attrs, "_pos1", variableName));
+                : GetIdentifierSpan(attrs, "_pos1", variableName),
+            exceptionType == null ? null : attrs.GetSpan("_pos0"));
     }
 
     private ThrowExpressionNode ParseThrowExpression()
@@ -10191,7 +10317,8 @@ public sealed class Parser
                         startToken.Span,
                         paramName,
                         paramType,
-                        GetIdentifierSpan(attrs, $"_pos{i}", paramName)));
+                        GetIdentifierSpan(attrs, $"_pos{i}", paramName),
+                        paramType == null ? null : attrs.GetSpan($"_pos{i + 1}")));
                 }
                 i += 2;
             }
@@ -10400,7 +10527,15 @@ public sealed class Parser
         }
 
         var span = startToken.Span.Union(endToken.Span);
-        return new DelegateDefinitionNode(span, id, name, parameters, output, effects, attrs);
+        return new DelegateDefinitionNode(
+            span,
+            id,
+            name,
+            parameters,
+            output,
+            effects,
+            attrs,
+            GetIdentifierSpan(attrs, "_pos1", name));
     }
 
     /// <summary>
@@ -10436,7 +10571,14 @@ public sealed class Parser
         // Check for accessor bodies (§EADD / §EREM ... §/EVT)
         if (!Check(TokenKind.EventAdd) && !Check(TokenKind.EventRemove))
         {
-            return new EventDefinitionNode(startToken.Span, id, name, visibility, delegateType, attrs);
+            return new EventDefinitionNode(
+                startToken.Span,
+                id,
+                name,
+                visibility,
+                delegateType,
+                attrs,
+                attrs.GetSpan("_pos3"));
         }
 
         List<StatementNode>? addBody = null;
@@ -10474,7 +10616,16 @@ public sealed class Parser
         }
 
         var span = startToken.Span.Union(endToken.Span);
-        return new EventDefinitionNode(span, id, name, visibility, delegateType, attrs, addBody, removeBody);
+        return new EventDefinitionNode(
+            span,
+            id,
+            name,
+            visibility,
+            delegateType,
+            attrs,
+            addBody,
+            removeBody,
+            attrs.GetSpan("_pos3"));
     }
 
     private List<StatementNode> ParseEventAccessorBody(TokenKind startKind, TokenKind endKind)
@@ -10728,7 +10879,11 @@ public sealed class Parser
         var span = patterns.Count > 0
             ? startToken.Span.Union(patterns[^1].Span)
             : startToken.Span;
-        return new PositionalPatternNode(span, typeName, patterns);
+        return new PositionalPatternNode(
+            span,
+            typeName,
+            patterns,
+            attrs.GetSpan("_pos0"));
     }
 
     /// <summary>
@@ -10755,7 +10910,11 @@ public sealed class Parser
         var span = matches.Count > 0
             ? startToken.Span.Union(matches[^1].Span)
             : startToken.Span;
-        return new PropertyPatternNode(span, typeName, matches);
+        return new PropertyPatternNode(
+            span,
+            typeName,
+            matches,
+            typeName == null ? null : attrs.GetSpan("_pos0"));
     }
 
     /// <summary>
@@ -10773,7 +10932,8 @@ public sealed class Parser
             startToken.Span,
             typeName,
             binding,
-            binding == null ? null : GetIdentifierSpan(attrs, "_pos1", binding));
+            binding == null ? null : GetIdentifierSpan(attrs, "_pos1", binding),
+            attrs.GetSpan("_pos0"));
     }
 
     /// <summary>
@@ -11578,6 +11738,7 @@ public sealed class Parser
         // Positional: [id:name] or [id:name:vis] or [id:name:underlyingType] or [id:name:vis:underlyingType]
         var id = attrs["_pos0"] ?? "";
         var name = attrs["_pos1"] ?? "";
+        var enumNameKey = "_pos1";
         var pos2 = attrs["_pos2"];
         var pos3 = attrs["_pos3"];
 
@@ -11587,6 +11748,7 @@ public sealed class Parser
         {
             name = id;
             id = GenerateParserAutoId("e");
+            enumNameKey = "_pos0";
         }
 
         // Disambiguate pos2: visibility keyword vs underlying type
@@ -11670,7 +11832,16 @@ public sealed class Parser
         }
 
         var span = startToken.Span.Union(endToken.Span);
-        return new EnumDefinitionNode(span, id, name, underlyingType, members, attrs, csharpAttrs, visibility);
+        return new EnumDefinitionNode(
+            span,
+            id,
+            name,
+            underlyingType,
+            members,
+            attrs,
+            csharpAttrs,
+            visibility,
+            GetIdentifierSpan(attrs, enumNameKey, name));
     }
 
     /// <summary>
@@ -12733,7 +12904,12 @@ public sealed class Parser
                 ExpectBlockEnd(TokenKind.EndStackAlloc);
         }
 
-        return new StackAllocNode(startToken.Span, elementType, size, initializer);
+        return new StackAllocNode(
+            startToken.Span,
+            elementType,
+            size,
+            initializer,
+            attrs.GetSpan("_pos0"));
     }
 
     /// <summary>
@@ -12764,7 +12940,7 @@ public sealed class Parser
         var startToken = Expect(TokenKind.SizeOf);
         var attrs = ParseAttributes();
         var typeName = attrs["_pos0"] ?? "i32";
-        return new SizeOfNode(startToken.Span, typeName);
+        return new SizeOfNode(startToken.Span, typeName, attrs.GetSpan("_pos0"));
     }
 
     /// <summary>
@@ -12827,7 +13003,15 @@ public sealed class Parser
             rank = initializer.Count > 0 ? 2 : rank;
         }
 
-        return new MultiDimArrayCreationNode(startToken.Span, id, name, elementType, rank, dimensionSizes, initializer);
+        return new MultiDimArrayCreationNode(
+            startToken.Span,
+            id,
+            name,
+            elementType,
+            rank,
+            dimensionSizes,
+            initializer,
+            attrs.GetSpan("_pos2"));
     }
 
     /// <summary>
@@ -12939,7 +13123,14 @@ public sealed class Parser
             ParseAttributes(); // consume optional {id} on closing tag
         }
 
-        return new FixedStatementNode(startToken.Span, id, pointerName, pointerType, initializer, body);
+        return new FixedStatementNode(
+            startToken.Span,
+            id,
+            pointerName,
+            pointerType,
+            initializer,
+            body,
+            attrs.GetSpan("_pos2"));
     }
 
     #endregion

--- a/src/Calor.LanguageServer/Handlers/DefinitionHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/DefinitionHandler.cs
@@ -29,6 +29,7 @@ public sealed class DefinitionHandler : DefinitionHandlerBase
         if (snapshot == null)
             return Task.FromResult<LocationOrLocationLinks?>(null);
 
+        _workspace.RefreshClosedDocuments();
         var offset = PositionConverter.ToOffset(request.Position, snapshot.Source);
         var occurrence = _workspace.ResolveOccurrence(request.TextDocument.Uri, offset);
         if (occurrence == null)

--- a/src/Calor.LanguageServer/Handlers/ReferencesHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/ReferencesHandler.cs
@@ -29,6 +29,7 @@ public sealed class ReferencesHandler : ReferencesHandlerBase
         if (snapshot == null)
             return Task.FromResult<LocationContainer?>(null);
 
+        _workspace.RefreshClosedDocuments();
         var offset = PositionConverter.ToOffset(request.Position, snapshot.Source);
         var occurrence = _workspace.ResolveOccurrence(request.TextDocument.Uri, offset);
         if (occurrence == null)

--- a/src/Calor.LanguageServer/Handlers/RenameHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/RenameHandler.cs
@@ -1,5 +1,7 @@
+using Calor.Compiler.Parsing;
 using Calor.LanguageServer.State;
 using Calor.LanguageServer.Utilities;
+using Microsoft.CodeAnalysis.CSharp;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
@@ -34,9 +36,10 @@ public sealed class RenameHandler : RenameHandlerBase
             return Task.FromResult<WorkspaceEdit?>(null);
         }
 
+        _workspace.RefreshClosedDocuments();
         var offset = PositionConverter.ToOffset(request.Position, snapshot.Source);
         var occurrence = _workspace.ResolveOccurrence(request.TextDocument.Uri, offset);
-        if (occurrence == null)
+        if (occurrence == null || !_workspace.CanRenameSymbol(occurrence.SymbolId))
             return Task.FromResult<WorkspaceEdit?>(null);
 
         var oldName = occurrence.Snapshot.Source.Substring(
@@ -57,7 +60,8 @@ public sealed class RenameHandler : RenameHandlerBase
             || occurrences.Any(item => item.IsSplitDeclaration)
             || occurrences.Any(item =>
                 !IsExactIdentifierSpan(item.Snapshot.Source, item.Span, oldName))
-            || !_workspace.AreOccurrenceSnapshotsCurrent(occurrences))
+            || !_workspace.AreOccurrenceSnapshotsCurrent(occurrences)
+            || !_workspace.ValidateRename(occurrences, request.NewName))
         {
             return Task.FromResult<WorkspaceEdit?>(null);
         }
@@ -117,8 +121,21 @@ public sealed class RenameHandler : RenameHandlerBase
             return false;
         }
 
-        return name.Skip(1).All(character =>
-            char.IsLetterOrDigit(character) || character == '_');
+        if (!name.Skip(1).All(character =>
+                char.IsLetterOrDigit(character) || character == '_')
+            || SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None
+            || SyntaxFacts.GetContextualKeywordKind(name) != SyntaxKind.None)
+        {
+            return false;
+        }
+
+        var diagnostics = new Calor.Compiler.Diagnostics.DiagnosticBag();
+        var tokens = new Lexer(name, diagnostics).TokenizeAll();
+        return !diagnostics.HasErrors
+            && tokens.Count > 0
+            && tokens[0].Kind == TokenKind.Identifier
+            && string.Equals(tokens[0].Text, name, StringComparison.Ordinal)
+            && tokens.Skip(1).All(token => token.Kind == TokenKind.Eof);
     }
 
     protected override RenameRegistrationOptions CreateRegistrationOptions(

--- a/src/Calor.LanguageServer/Handlers/RenameHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/RenameHandler.cs
@@ -69,6 +69,7 @@ public sealed class RenameHandler : RenameHandlerBase
 
         if (!await _workspace.ValidateRenameAsync(
                 occurrences,
+                oldName,
                 request.NewName,
                 cancellationToken).ConfigureAwait(false))
             return null;

--- a/src/Calor.LanguageServer/Handlers/RenameHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/RenameHandler.cs
@@ -23,30 +23,32 @@ public sealed class RenameHandler : RenameHandlerBase
         _workspace = workspace;
     }
 
-    public override Task<WorkspaceEdit?> Handle(
+    public override async Task<WorkspaceEdit?> Handle(
         RenameParams request,
         CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var state = _workspace.Get(request.TextDocument.Uri);
         var snapshot = state?.Snapshot;
         if (snapshot == null
             || string.IsNullOrWhiteSpace(request.NewName)
             || !IsValidIdentifier(request.NewName))
         {
-            return Task.FromResult<WorkspaceEdit?>(null);
+            return null;
         }
 
         _workspace.RefreshClosedDocuments();
+        cancellationToken.ThrowIfCancellationRequested();
         var offset = PositionConverter.ToOffset(request.Position, snapshot.Source);
         var occurrence = _workspace.ResolveOccurrence(request.TextDocument.Uri, offset);
         if (occurrence == null || !_workspace.CanRenameSymbol(occurrence.SymbolId))
-            return Task.FromResult<WorkspaceEdit?>(null);
+            return null;
 
         var oldName = occurrence.Snapshot.Source.Substring(
             occurrence.Span.Start,
             occurrence.Span.Length);
         if (string.Equals(oldName, request.NewName, StringComparison.Ordinal))
-            return Task.FromResult<WorkspaceEdit?>(null);
+            return null;
 
         var occurrences = _workspace.FindSymbolOccurrences(
             occurrence.SymbolId,
@@ -60,11 +62,19 @@ public sealed class RenameHandler : RenameHandlerBase
             || occurrences.Any(item => item.IsSplitDeclaration)
             || occurrences.Any(item =>
                 !IsExactIdentifierSpan(item.Snapshot.Source, item.Span, oldName))
-            || !_workspace.AreOccurrenceSnapshotsCurrent(occurrences)
-            || !_workspace.ValidateRename(occurrences, request.NewName))
+            || !_workspace.AreOccurrenceSnapshotsCurrent(occurrences))
         {
-            return Task.FromResult<WorkspaceEdit?>(null);
+            return null;
         }
+
+        if (!await _workspace.ValidateRenameAsync(
+                occurrences,
+                request.NewName,
+                cancellationToken).ConfigureAwait(false))
+            return null;
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!_workspace.AreOccurrenceSnapshotsCurrent(occurrences))
+            return null;
 
         var documentChanges = occurrences
             .GroupBy(item => DocumentUri.From(item.Doc.Uri))
@@ -94,12 +104,11 @@ public sealed class RenameHandler : RenameHandlerBase
             })
             .ToArray();
 
-        return Task.FromResult<WorkspaceEdit?>(
-            new WorkspaceEdit
-            {
-                DocumentChanges = new Container<WorkspaceEditDocumentChange>(
-                    documentChanges),
-            });
+        return new WorkspaceEdit
+        {
+            DocumentChanges = new Container<WorkspaceEditDocumentChange>(
+                documentChanges),
+        };
     }
 
     private static bool IsExactIdentifierSpan(

--- a/src/Calor.LanguageServer/State/WorkspaceState.cs
+++ b/src/Calor.LanguageServer/State/WorkspaceState.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Text.RegularExpressions;
 using Calor.Compiler;
 using Calor.Compiler.Ast;
 using Calor.Compiler.Binding;
@@ -8,6 +7,7 @@ using Calor.Compiler.Parsing;
 using Calor.LanguageServer.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 
 namespace Calor.LanguageServer.State;
@@ -435,11 +435,24 @@ public sealed class WorkspaceState
             if (replacements.TryGetValue(uri, out var edits))
             {
                 replacedDocuments.Add(uri);
+                var originalLength = source.Length;
+                var previousEnd = 0;
+                foreach (var edit in edits)
+                {
+                    if (edit.Span.Start < 0
+                        || edit.Span.Length < 0
+                        || edit.Span.End < edit.Span.Start
+                        || edit.Span.End > originalLength
+                        || edit.Span.Start < previousEnd)
+                    {
+                        return false;
+                    }
+                    previousEnd = edit.Span.End;
+                }
+
                 var delta = 0;
                 foreach (var edit in edits)
                 {
-                    if (edit.Span.Start < 0 || edit.Span.End > source.Length)
-                        return false;
                     var start = edit.Span.Start + delta;
                     var end = edit.Span.End + delta;
                     source = source[..start] + newName + source[end..];
@@ -1742,22 +1755,27 @@ public sealed class WorkspaceState
 
     private static IEnumerable<string> ExtractPreprocessorSymbols(string source)
     {
-        foreach (var line in source.Split('\n'))
+        var root = CSharpSyntaxTree.ParseText(source).GetRoot();
+        foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
         {
-            var trimmed = line.TrimStart();
-            if (!trimmed.StartsWith("#if ", StringComparison.Ordinal)
-                && !trimmed.StartsWith("#elif ", StringComparison.Ordinal))
+            var condition = trivia.GetStructure() switch
+            {
+                IfDirectiveTriviaSyntax directive => directive.Condition,
+                ElifDirectiveTriviaSyntax directive => directive.Condition,
+                _ => null,
+            };
+            if (condition == null)
             {
                 continue;
             }
 
-            foreach (Match match in Regex.Matches(
-                         trimmed,
-                         @"[A-Za-z_][A-Za-z0-9_]*",
-                         RegexOptions.CultureInvariant))
+            foreach (var token in condition.DescendantTokens(descendIntoTrivia: true))
             {
-                if (match.Value is not ("if" or "elif" or "true" or "false" or "defined"))
-                    yield return match.Value;
+                if (token.IsKind(SyntaxKind.IdentifierToken)
+                    && token.ValueText is not ("true" or "false" or "defined"))
+                {
+                    yield return token.ValueText;
+                }
             }
         }
     }

--- a/src/Calor.LanguageServer/State/WorkspaceState.cs
+++ b/src/Calor.LanguageServer/State/WorkspaceState.cs
@@ -1,7 +1,11 @@
 using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
 using Calor.Compiler.Binding;
+using Calor.Compiler.CodeGen;
 using Calor.Compiler.Parsing;
 using Calor.LanguageServer.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 
 namespace Calor.LanguageServer.State;
@@ -38,6 +42,7 @@ public sealed record ProjectSymbolOccurrence(
     TextSpan Span,
     SymbolOccurrenceKind Kind,
     bool IsOpen,
+    bool IsAmbiguous,
     bool IsSplitDeclaration = false);
 
 /// <summary>
@@ -46,21 +51,36 @@ public sealed record ProjectSymbolOccurrence(
 public sealed class WorkspaceState
 {
     private sealed record WorkspaceRoot(string Path, string Identity);
+    private readonly record struct WorkspaceFileStamp(
+        long Length,
+        DateTime LastWriteTimeUtc);
+    private readonly record struct CompilationError(
+        string Id,
+        string Path,
+        int Line);
     private sealed record DocumentSymbolIndex(
         IReadOnlyDictionary<SymbolId, ProjectSymbolOccurrence[]> BySymbol,
         ProjectSymbolOccurrence[] Occurrences);
     private sealed record WorkspaceSymbolIndex(
         long Generation,
         IReadOnlyDictionary<DocumentUri, DocumentSymbolIndex> ByDocument,
-        IReadOnlyDictionary<SymbolId, ProjectSymbolOccurrence[]> BySymbol);
+        IReadOnlyDictionary<SymbolId, ProjectSymbolOccurrence[]> BySymbol,
+        IReadOnlySet<SymbolId> AmbiguousSymbols,
+        IReadOnlySet<SymbolId> IncompleteTypeSymbols);
 
     private readonly ConcurrentDictionary<DocumentUri, DocumentState> _documents = new();
     private readonly ConcurrentDictionary<DocumentUri, DocumentState> _closedDocuments = new();
+    private readonly ConcurrentDictionary<DocumentUri, WorkspaceFileStamp> _closedDocumentStamps = new();
     private readonly object _workspaceRootsGate = new();
     private readonly object _indexGate = new();
     private WorkspaceRoot[] _workspaceRoots = [];
     private long _workspaceGeneration;
+    private long _workspaceFileReadCount;
     private WorkspaceSymbolIndex? _symbolIndex;
+    private static readonly Lazy<IReadOnlyList<MetadataReference>> PlatformReferences =
+        new(CreatePlatformReferences);
+
+    internal long WorkspaceFileReadCount => Interlocked.Read(ref _workspaceFileReadCount);
 
     public WorkspaceState(string? workspaceRootPath = null)
     {
@@ -122,6 +142,7 @@ public sealed class WorkspaceState
     public DocumentState GetOrCreate(DocumentUri uri, string source, int version = 0)
     {
         _closedDocuments.TryRemove(uri, out _);
+        _closedDocumentStamps.TryRemove(uri, out _);
         if (_documents.TryGetValue(uri, out var existing))
         {
             var before = existing.Snapshot;
@@ -219,7 +240,9 @@ public sealed class WorkspaceState
         var shortest = matches
             .Where(occurrence => occurrence.Span.Length == shortestLength)
             .ToArray();
-        return shortest.Length == 1 ? shortest[0] : null;
+        return shortest.Length == 1 && !shortest[0].IsAmbiguous
+            ? shortest[0]
+            : null;
     }
 
     public ProjectSymbolOccurrence? FindSymbolDefinition(SymbolId symbolId)
@@ -227,10 +250,28 @@ public sealed class WorkspaceState
         if (symbolId.IsNone)
             return null;
 
-        return GetSymbolIndex().BySymbol.TryGetValue(symbolId, out var occurrences)
+        var index = GetSymbolIndex();
+        if (index.AmbiguousSymbols.Contains(symbolId))
+            return null;
+
+        return index.BySymbol.TryGetValue(symbolId, out var occurrences)
             ? occurrences.FirstOrDefault(occurrence =>
                 occurrence.Kind == SymbolOccurrenceKind.Definition)
             : null;
+    }
+
+    public bool CanRenameSymbol(SymbolId symbolId)
+    {
+        if (symbolId.IsNone)
+            return false;
+
+        var index = GetSymbolIndex();
+        return !index.AmbiguousSymbols.Contains(symbolId)
+            && !index.IncompleteTypeSymbols.Contains(symbolId)
+            && index.BySymbol.TryGetValue(symbolId, out var occurrences)
+            && occurrences.Any(occurrence =>
+                occurrence.Kind == SymbolOccurrenceKind.Definition
+                && !occurrence.IsAmbiguous);
     }
 
     public IReadOnlyList<ProjectSymbolOccurrence> FindSymbolOccurrences(
@@ -255,7 +296,7 @@ public sealed class WorkspaceState
         IEnumerable<ProjectSymbolOccurrence> occurrences)
     {
         ArgumentNullException.ThrowIfNull(occurrences);
-        RefreshWorkspaceIndex();
+        var verifiedClosedDocuments = new HashSet<DocumentUri>();
 
         foreach (var occurrence in occurrences)
         {
@@ -277,25 +318,104 @@ public sealed class WorkspaceState
             {
                 return false;
             }
+            if (!verifiedClosedDocuments.Add(uri))
+                continue;
 
             try
             {
+                Interlocked.Increment(ref _workspaceFileReadCount);
                 if (!string.Equals(
                         File.ReadAllText(occurrence.Doc.Uri.LocalPath),
                         occurrence.Snapshot.Source,
                         StringComparison.Ordinal))
                 {
+                    _closedDocumentStamps.TryRemove(uri, out _);
                     return false;
                 }
             }
             catch (IOException)
             {
+                _closedDocumentStamps.TryRemove(uri, out _);
                 return false;
             }
             catch (UnauthorizedAccessException)
             {
+                _closedDocumentStamps.TryRemove(uri, out _);
                 return false;
             }
+        }
+
+        return true;
+    }
+
+    public bool ValidateRename(
+        IReadOnlyList<ProjectSymbolOccurrence> occurrences,
+        string newName)
+    {
+        ArgumentNullException.ThrowIfNull(occurrences);
+        ArgumentException.ThrowIfNullOrWhiteSpace(newName);
+        if (occurrences.Count == 0)
+            return false;
+
+        var replacements = occurrences
+            .GroupBy(occurrence => DocumentUri.From(occurrence.Doc.Uri))
+            .ToDictionary(
+                group => group.Key,
+                group => group.OrderByDescending(occurrence => occurrence.Span.Start)
+                    .ToArray());
+        var syntaxSources = new List<(string Path, string Source)>();
+        foreach (var document in CaptureDocuments())
+        {
+            var uri = DocumentUri.From(document.Document.Uri);
+            var source = document.Analysis.Source;
+            if (replacements.TryGetValue(uri, out var edits))
+            {
+                foreach (var edit in edits)
+                {
+                    if (edit.Span.Start < 0 || edit.Span.End > source.Length)
+                        return false;
+                    source = source[..edit.Span.Start] + newName + source[edit.Span.End..];
+                }
+            }
+
+            var candidate = new DocumentState(
+                document.Document.Uri,
+                source,
+                document.Analysis.Version,
+                GetCanonicalSourceIdentity(document.Document.Uri));
+            candidate.Reanalyze();
+            if (candidate.Ast == null
+                || candidate.BoundModule == null
+                || candidate.Diagnostics.HasErrors)
+            {
+                return false;
+            }
+
+            string generated;
+            try
+            {
+                generated = new CSharpEmitter().Emit(candidate.Ast);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+
+            var path = candidate.Uri.IsFile
+                ? candidate.Uri.LocalPath + ".cs"
+                : candidate.Uri + ".cs";
+            syntaxSources.Add((path, generated));
+        }
+
+        var symbols = syntaxSources
+            .SelectMany(source => ExtractPreprocessorSymbols(source.Source))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(symbol => symbol, StringComparer.Ordinal)
+            .ToArray();
+        foreach (var configuration in EnumeratePreprocessorConfigurations(symbols))
+        {
+            if (GetCompilationErrors(syntaxSources, configuration).Count > 0)
+                return false;
         }
 
         return true;
@@ -530,6 +650,44 @@ public sealed class WorkspaceState
             _ => call.Span,
         };
 
+    private static TypeSymbol? ResolveReceiverType(
+        BoundNode call,
+        IReadOnlyList<TypeSymbol> visibleTypes)
+    {
+        var (target, receiver, resolvedType) = call switch
+        {
+            BoundCallExpression expression => (
+                expression.Target,
+                expression.ReceiverSymbol,
+                expression.ReceiverTypeSymbol),
+            BoundCallStatement statement => (
+                statement.Target,
+                statement.ReceiverSymbol,
+                statement.ReceiverTypeSymbol),
+            _ => (string.Empty, null, null),
+        };
+        if (receiver != null)
+            return null;
+        if (resolvedType != null)
+            return resolvedType;
+
+        var firstDot = target.IndexOf('.');
+        if (firstDot <= 0)
+            return null;
+
+        var receiverName = target[..firstDot];
+        var generic = receiverName.IndexOf('<');
+        if (generic > 0)
+            receiverName = receiverName[..generic];
+        var matches = visibleTypes
+            .Where(type =>
+                string.Equals(type.Name, receiverName, StringComparison.Ordinal)
+                || string.Equals(type.QualifiedName, receiverName, StringComparison.Ordinal))
+            .Take(2)
+            .ToArray();
+        return matches.Length == 1 ? matches[0] : null;
+    }
+
     private static bool TryGetCallShape(
         BoundNode call,
         out string target,
@@ -748,7 +906,6 @@ public sealed class WorkspaceState
     {
         lock (_indexGate)
         {
-            RefreshWorkspaceIndexCore();
             if (_symbolIndex?.Generation == _workspaceGeneration)
                 return _symbolIndex;
 
@@ -767,6 +924,8 @@ public sealed class WorkspaceState
             document => DocumentUri.From(document.Document.Uri),
             _ => new List<ProjectSymbolOccurrence>());
         var bySymbol = new Dictionary<SymbolId, List<ProjectSymbolOccurrence>>();
+        var ambiguousSymbols = new HashSet<SymbolId>();
+        var incompleteTypeSymbols = new HashSet<SymbolId>();
         var seen = new HashSet<(DocumentUri Uri, SymbolId Id, TextSpan Span, SymbolOccurrenceKind Kind)>();
         var typeSymbols = documents
             .SelectMany(document =>
@@ -851,51 +1010,12 @@ public sealed class WorkspaceState
                         symbol.Id,
                         symbol.DeclarationSpan,
                         SymbolOccurrenceKind.Definition,
+                        isAmbiguous: symbol.ConditionalAlternative != null,
                         isSplitDeclaration: symbol is TypeSymbol
                             && declaringDocumentCounts.TryGetValue(
                                 (document.Analysis.Ast!.Name, symbol.Name),
                                 out var declaringDocuments)
                             && declaringDocuments > 1);
-                }
-            }
-
-            foreach (var node in Descendants(boundModule))
-            {
-                switch (node)
-                {
-                    case BoundVariableExpression variable:
-                        foreach (var symbol in variable.ResolvedSymbols.Where(
-                                     symbol => !symbol.Id.IsNone))
-                        {
-                            AddOccurrence(
-                                document,
-                                symbol.Id,
-                                variable.Span,
-                                SymbolOccurrenceKind.Reference);
-                        }
-                        break;
-
-                    case BoundFieldAccessExpression field:
-                        foreach (var symbol in ResolveProjectFields(
-                                     documents,
-                                     document,
-                                     field))
-                        {
-                            AddOccurrence(
-                                document,
-                                symbol.Id,
-                                field.FieldNameSpan,
-                                SymbolOccurrenceKind.Reference);
-                        }
-                        break;
-
-                    case BoundCallExpression call:
-                        AddCallOccurrences(document, call);
-                        break;
-
-                    case BoundCallStatement call:
-                        AddCallOccurrences(document, call);
-                        break;
                 }
             }
 
@@ -906,11 +1026,61 @@ public sealed class WorkspaceState
                         != Calor.Compiler.Ast.Visibility.Private)
                 .Select(candidate => candidate.Symbol)
                 .ToArray();
-            foreach (var reference in TypeReferenceIndex.Build(
-                         document.Analysis.Ast!,
-                         boundModule,
-                         document.Analysis.Source,
-                         visibleTypeSymbols))
+            foreach (var node in Descendants(boundModule))
+            {
+                switch (node)
+                {
+                    case BoundVariableExpression variable:
+                        var variables = variable.ResolvedSymbols
+                            .Where(symbol => !symbol.Id.IsNone)
+                            .DistinctBy(symbol => symbol.Id)
+                            .ToArray();
+                        foreach (var symbol in variables)
+                        {
+                            AddOccurrence(
+                                document,
+                                symbol.Id,
+                                variable.Span,
+                                SymbolOccurrenceKind.Reference,
+                                variables.Length > 1);
+                        }
+                        break;
+
+                    case BoundFieldAccessExpression field:
+                        var fields = ResolveProjectFields(
+                                documents,
+                                document,
+                                field)
+                            .DistinctBy(symbol => symbol.Id)
+                            .ToArray();
+                        foreach (var symbol in fields)
+                        {
+                            AddOccurrence(
+                                document,
+                                symbol.Id,
+                                field.FieldNameSpan,
+                                SymbolOccurrenceKind.Reference,
+                                fields.Length > 1);
+                        }
+                        break;
+
+                    case BoundCallExpression call:
+                        AddCallOccurrences(document, call, visibleTypeSymbols);
+                        break;
+
+                    case BoundCallStatement call:
+                        AddCallOccurrences(document, call, visibleTypeSymbols);
+                        break;
+                }
+            }
+
+            var typeIndex = TypeReferenceIndex.BuildDetailed(
+                document.Analysis.Ast!,
+                boundModule,
+                document.Analysis.Source,
+                visibleTypeSymbols);
+            incompleteTypeSymbols.UnionWith(typeIndex.IncompleteSymbolIds);
+            foreach (var reference in typeIndex.References)
             {
                 AddOccurrence(
                     document,
@@ -947,16 +1117,27 @@ public sealed class WorkspaceState
                     .OrderBy(occurrence => occurrence.Doc.Uri.ToString(), StringComparer.Ordinal)
                     .ThenBy(occurrence => occurrence.Span.Start)
                     .ThenBy(occurrence => occurrence.Kind)
-                    .ToArray()));
+                    .ToArray()),
+            ambiguousSymbols,
+            incompleteTypeSymbols);
 
         void AddCallOccurrences(
             WorkspaceDocumentSnapshot document,
-            BoundNode call)
+            BoundNode call,
+            IReadOnlyList<TypeSymbol> visibleTypes)
         {
             switch (call)
             {
                 case BoundCallExpression expression
                     when expression.ReceiverSymbol is { Id.IsNone: false } receiver:
+                    AddOccurrence(
+                        document,
+                        receiver.Id,
+                        expression.ReceiverSpan ?? expression.Span,
+                        SymbolOccurrenceKind.Reference);
+                    break;
+                case BoundCallExpression expression
+                    when ResolveReceiverType(expression, visibleTypes) is { Id.IsNone: false } receiver:
                     AddOccurrence(
                         document,
                         receiver.Id,
@@ -971,20 +1152,46 @@ public sealed class WorkspaceState
                         statement.ReceiverSpan ?? statement.Span,
                         SymbolOccurrenceKind.Reference);
                     break;
+                case BoundCallStatement statement
+                    when ResolveReceiverType(statement, visibleTypes) is { Id.IsNone: false } receiver:
+                    AddOccurrence(
+                        document,
+                        receiver.Id,
+                        statement.ReceiverSpan ?? statement.Span,
+                        SymbolOccurrenceKind.Reference);
+                    break;
             }
 
-            var resolved = ResolveProjectCall(
-                documents,
-                document.Document,
-                document.Analysis,
-                call);
-            if (resolved.Symbol is { Id.IsNone: false } function)
+            var resolvedFunctions = call switch
+            {
+                BoundCallExpression expression => expression.ResolvedSymbols,
+                BoundCallStatement statement => statement.ResolvedSymbols,
+                _ => Array.Empty<FunctionSymbol>(),
+            };
+            var functions = resolvedFunctions
+                .Where(function => !function.Id.IsNone)
+                .DistinctBy(function => function.Id)
+                .ToArray();
+            if (functions.Length == 0)
+            {
+                var resolved = ResolveProjectCall(
+                    documents,
+                    document.Document,
+                    document.Analysis,
+                    call);
+                functions = resolved.Symbol is { Id.IsNone: false } function
+                    ? [function]
+                    : [];
+            }
+
+            foreach (var function in functions)
             {
                 AddOccurrence(
                     document,
                     function.Id,
                     GetCallReferenceSpan(call),
-                    SymbolOccurrenceKind.Reference);
+                    SymbolOccurrenceKind.Reference,
+                    functions.Length > 1);
             }
         }
 
@@ -993,6 +1200,7 @@ public sealed class WorkspaceState
             SymbolId symbolId,
             TextSpan span,
             SymbolOccurrenceKind kind,
+            bool isAmbiguous = false,
             bool isSplitDeclaration = false)
         {
             if (symbolId.IsNone
@@ -1003,7 +1211,11 @@ public sealed class WorkspaceState
 
             var uri = DocumentUri.From(document.Document.Uri);
             if (!seen.Add((uri, symbolId, span, kind)))
+            {
+                if (isAmbiguous)
+                    ambiguousSymbols.Add(symbolId);
                 return;
+            }
 
             var occurrence = new ProjectSymbolOccurrence(
                 document.Document,
@@ -1012,7 +1224,10 @@ public sealed class WorkspaceState
                 span,
                 kind,
                 _documents.ContainsKey(uri),
+                isAmbiguous,
                 isSplitDeclaration);
+            if (isAmbiguous)
+                ambiguousSymbols.Add(symbolId);
             byDocument[uri].Add(occurrence);
             if (!bySymbol.TryGetValue(symbolId, out var symbolOccurrences))
             {
@@ -1148,10 +1363,7 @@ public sealed class WorkspaceState
     private WorkspaceDocumentSnapshot[] CaptureDocuments()
     {
         lock (_indexGate)
-        {
-            RefreshWorkspaceIndexCore();
             return CaptureDocumentsCore();
-        }
     }
 
     private WorkspaceDocumentSnapshot[] CaptureDocumentsCore()
@@ -1164,11 +1376,13 @@ public sealed class WorkspaceState
             .ToArray();
     }
 
-    private void RefreshWorkspaceIndex()
+    public void RefreshClosedDocuments()
     {
         lock (_indexGate)
             RefreshWorkspaceIndexCore();
     }
+
+    private void RefreshWorkspaceIndex() => RefreshClosedDocuments();
 
     private void RefreshWorkspaceIndexCore()
     {
@@ -1215,12 +1429,38 @@ public sealed class WorkspaceState
                 if (_documents.ContainsKey(uri))
                 {
                     changed |= _closedDocuments.TryRemove(uri, out _);
+                    _closedDocumentStamps.TryRemove(uri, out _);
+                    continue;
+                }
+
+                WorkspaceFileStamp stamp;
+                try
+                {
+                    var info = new FileInfo(fullPath);
+                    stamp = new WorkspaceFileStamp(
+                        info.Length,
+                        info.LastWriteTimeUtc);
+                }
+                catch (IOException)
+                {
+                    continue;
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    continue;
+                }
+
+                if (_closedDocuments.ContainsKey(uri)
+                    && _closedDocumentStamps.TryGetValue(uri, out var existingStamp)
+                    && existingStamp == stamp)
+                {
                     continue;
                 }
 
                 string source;
                 try
                 {
+                    Interlocked.Increment(ref _workspaceFileReadCount);
                     source = File.ReadAllText(fullPath);
                 }
                 catch (IOException)
@@ -1235,10 +1475,12 @@ public sealed class WorkspaceState
                 if (_closedDocuments.TryGetValue(uri, out var existing)
                     && string.Equals(existing.Source, source, StringComparison.Ordinal))
                 {
+                    _closedDocumentStamps[uri] = stamp;
                     continue;
                 }
 
                 _closedDocuments[uri] = CreateAndAnalyze(uri, source, version: 0);
+                _closedDocumentStamps[uri] = stamp;
                 changed = true;
             }
         }
@@ -1246,7 +1488,10 @@ public sealed class WorkspaceState
         foreach (var uri in _closedDocuments.Keys)
         {
             if (!seen.Contains(uri) && _closedDocuments.TryRemove(uri, out _))
+            {
+                _closedDocumentStamps.TryRemove(uri, out _);
                 changed = true;
+            }
         }
 
         if (changed)
@@ -1254,6 +1499,90 @@ public sealed class WorkspaceState
             _workspaceGeneration++;
             _symbolIndex = null;
         }
+    }
+
+    private static IEnumerable<string> ExtractPreprocessorSymbols(string source)
+    {
+        foreach (var line in source.Split('\n'))
+        {
+            var trimmed = line.TrimStart();
+            if (!trimmed.StartsWith("#if ", StringComparison.Ordinal)
+                && !trimmed.StartsWith("#elif ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (Match match in Regex.Matches(
+                         trimmed,
+                         @"[A-Za-z_][A-Za-z0-9_]*",
+                         RegexOptions.CultureInvariant))
+            {
+                if (match.Value is not ("if" or "elif" or "true" or "false" or "defined"))
+                    yield return match.Value;
+            }
+        }
+    }
+
+    private static IReadOnlyList<CompilationError> GetCompilationErrors(
+        IReadOnlyList<(string Path, string Source)> sources,
+        IReadOnlyList<string> configuration)
+    {
+        var parseOptions = CSharpParseOptions.Default.WithPreprocessorSymbols(configuration);
+        var trees = sources
+            .Select(source => CSharpSyntaxTree.ParseText(
+                source.Source,
+                parseOptions,
+                source.Path))
+            .ToArray();
+        var compilation = CSharpCompilation.Create(
+            "CalorRenamePreflight",
+            trees,
+            PlatformReferences.Value,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        return compilation.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .Select(diagnostic =>
+            {
+                var lineSpan = diagnostic.Location.GetLineSpan();
+                return new CompilationError(
+                    diagnostic.Id,
+                    lineSpan.Path ?? string.Empty,
+                    lineSpan.StartLinePosition.Line);
+            })
+            .ToArray();
+    }
+
+    private static IEnumerable<IReadOnlyList<string>> EnumeratePreprocessorConfigurations(
+        IReadOnlyList<string> symbols)
+    {
+        if (symbols.Count <= 8)
+        {
+            var count = 1 << symbols.Count;
+            for (var mask = 0; mask < count; mask++)
+            {
+                yield return symbols
+                    .Where((_, index) => (mask & (1 << index)) != 0)
+                    .ToArray();
+            }
+            yield break;
+        }
+
+        yield return Array.Empty<string>();
+        foreach (var symbol in symbols)
+            yield return [symbol];
+        yield return symbols.ToArray();
+    }
+
+    private static IReadOnlyList<MetadataReference> CreatePlatformReferences()
+    {
+        var trustedAssemblies =
+            (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES");
+        return string.IsNullOrEmpty(trustedAssemblies)
+            ? Array.Empty<MetadataReference>()
+            : trustedAssemblies
+                .Split(Path.PathSeparator)
+                .Select(path => MetadataReference.CreateFromFile(path))
+                .ToArray();
     }
 
     private static bool ShouldIndexPath(string path)

--- a/src/Calor.LanguageServer/State/WorkspaceState.cs
+++ b/src/Calor.LanguageServer/State/WorkspaceState.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
+using Calor.Compiler;
+using Calor.Compiler.Ast;
 using Calor.Compiler.Binding;
 using Calor.Compiler.CodeGen;
 using Calor.Compiler.Parsing;
@@ -58,6 +60,14 @@ public sealed class WorkspaceState
         string Id,
         string Path,
         int Line);
+    private readonly record struct OccurrenceFingerprint(
+        DocumentUri Uri,
+        TextSpan Span,
+        SymbolOccurrenceKind Kind);
+    private sealed record RenameCompilationSource(
+        string Path,
+        string Baseline,
+        string Candidate);
     private sealed record DocumentSymbolIndex(
         IReadOnlyDictionary<SymbolId, ProjectSymbolOccurrence[]> BySymbol,
         ProjectSymbolOccurrence[] Occurrences);
@@ -76,11 +86,17 @@ public sealed class WorkspaceState
     private WorkspaceRoot[] _workspaceRoots = [];
     private long _workspaceGeneration;
     private long _workspaceFileReadCount;
+    private long _renameValidationCompilationCount;
     private WorkspaceSymbolIndex? _symbolIndex;
     private static readonly Lazy<IReadOnlyList<MetadataReference>> PlatformReferences =
         new(CreatePlatformReferences);
+    // Validation is exhaustive through five relevant symbols (2^5 configurations).
+    // Larger relevant condition sets fail closed instead of using an unsound sample.
+    private const int MaxRenamePreprocessorConfigurations = 32;
 
     internal long WorkspaceFileReadCount => Interlocked.Read(ref _workspaceFileReadCount);
+    internal long RenameValidationCompilationCount =>
+        Interlocked.Read(ref _renameValidationCompilationCount);
 
     public WorkspaceState(string? workspaceRootPath = null)
     {
@@ -348,34 +364,88 @@ public sealed class WorkspaceState
         return true;
     }
 
-    public bool ValidateRename(
+    public Task<bool> ValidateRenameAsync(
         IReadOnlyList<ProjectSymbolOccurrence> occurrences,
-        string newName)
+        string newName,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(occurrences);
         ArgumentException.ThrowIfNullOrWhiteSpace(newName);
         if (occurrences.Count == 0)
-            return false;
+            return Task.FromResult(false);
 
+        WorkspaceDocumentSnapshot[] documents;
+        long generation;
+        lock (_indexGate)
+        {
+            documents = CaptureDocumentsCore();
+            generation = _workspaceGeneration;
+        }
+        return Task.Run(
+            () =>
+            {
+                try
+                {
+                    var valid = ValidateRenameCore(
+                        documents,
+                        occurrences,
+                        newName,
+                        cancellationToken);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    lock (_indexGate)
+                        return valid && generation == _workspaceGeneration;
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
+            },
+            cancellationToken);
+    }
+
+    private bool ValidateRenameCore(
+        IReadOnlyList<WorkspaceDocumentSnapshot> documents,
+        IReadOnlyList<ProjectSymbolOccurrence> occurrences,
+        string newName,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
         var replacements = occurrences
             .GroupBy(occurrence => DocumentUri.From(occurrence.Doc.Uri))
             .ToDictionary(
                 group => group.Key,
-                group => group.OrderByDescending(occurrence => occurrence.Span.Start)
+                group => group.OrderBy(occurrence => occurrence.Span.Start)
                     .ToArray());
-        var syntaxSources = new List<(string Path, string Source)>();
-        foreach (var document in CaptureDocuments())
+        var candidateDocuments = new List<WorkspaceDocumentSnapshot>(documents.Count);
+        var replacedDocuments = new HashSet<DocumentUri>();
+        foreach (var document in documents)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var uri = DocumentUri.From(document.Document.Uri);
             var source = document.Analysis.Source;
             if (replacements.TryGetValue(uri, out var edits))
             {
+                replacedDocuments.Add(uri);
+                var delta = 0;
                 foreach (var edit in edits)
                 {
                     if (edit.Span.Start < 0 || edit.Span.End > source.Length)
                         return false;
-                    source = source[..edit.Span.Start] + newName + source[edit.Span.End..];
+                    var start = edit.Span.Start + delta;
+                    var end = edit.Span.End + delta;
+                    source = source[..start] + newName + source[end..];
+                    delta += newName.Length - edit.Span.Length;
                 }
+            }
+
+            if (!replacements.ContainsKey(uri))
+            {
+                candidateDocuments.Add(document);
+                continue;
             }
 
             var candidate = new DocumentState(
@@ -384,37 +454,183 @@ public sealed class WorkspaceState
                 document.Analysis.Version,
                 GetCanonicalSourceIdentity(document.Document.Uri));
             candidate.Reanalyze();
-            if (candidate.Ast == null
-                || candidate.BoundModule == null
-                || candidate.Diagnostics.HasErrors)
+            if (HasNewErrors(
+                    GetAnalysisErrors(document.Analysis, document.Document.Uri),
+                    GetAnalysisErrors(candidate.Snapshot, candidate.Uri))
+                || candidate.Ast == null
+                || candidate.BoundModule == null)
             {
                 return false;
             }
-
-            string generated;
-            try
-            {
-                generated = new CSharpEmitter().Emit(candidate.Ast);
-            }
-            catch (Exception)
-            {
-                return false;
-            }
-
-            var path = candidate.Uri.IsFile
-                ? candidate.Uri.LocalPath + ".cs"
-                : candidate.Uri + ".cs";
-            syntaxSources.Add((path, generated));
+            candidateDocuments.Add(new WorkspaceDocumentSnapshot(
+                candidate,
+                candidate.Snapshot));
         }
 
-        var symbols = syntaxSources
-            .SelectMany(source => ExtractPreprocessorSymbols(source.Source))
+        if (replacedDocuments.Count != replacements.Count)
+            return false;
+
+        var baselineIndex = BuildSymbolIndex(documents, generation: 0);
+        var candidateIndex = BuildSymbolIndex(candidateDocuments, generation: 0);
+        if (!PreservesBindingIdentities(
+                baselineIndex,
+                candidateIndex,
+                replacements,
+                newName,
+                occurrences[0].SymbolId))
+        {
+            return false;
+        }
+
+        var baselineMap = documents.Count > 1
+            ? CompilationDriver.BuildCrossModuleFunctionMap(
+                documents
+                    .Where(document => document.Analysis.Ast != null)
+                    .Select(document => document.Analysis.Ast!)
+                    .ToArray())
+            : null;
+        var candidateMap = candidateDocuments.Count > 1
+            ? CompilationDriver.BuildCrossModuleFunctionMap(
+                candidateDocuments
+                    .Where(document => document.Analysis.Ast != null)
+                    .Select(document => document.Analysis.Ast!)
+                    .ToArray())
+            : null;
+        var mapsEqual = CrossModuleMapsEqual(baselineMap, candidateMap);
+        var syntaxSources = new List<RenameCompilationSource>();
+        for (var index = 0; index < documents.Count; index++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var baselineDocument = documents[index];
+            var candidateDocument = candidateDocuments[index];
+            if (baselineDocument.Analysis.Ast == null
+                || candidateDocument.Analysis.Ast == null)
+            {
+                continue;
+            }
+
+            var sourcePath = baselineDocument.Document.Uri.IsFile
+                ? baselineDocument.Document.Uri.LocalPath
+                : baselineDocument.Document.Uri.ToString();
+            var baselineEmitted = TryEmit(
+                baselineDocument.Analysis.Ast,
+                baselineMap,
+                sourcePath,
+                out var baselineSource);
+            string candidateSource;
+            bool candidateEmitted;
+            if (mapsEqual
+                && ReferenceEquals(
+                    baselineDocument.Analysis,
+                    candidateDocument.Analysis))
+            {
+                candidateEmitted = baselineEmitted;
+                candidateSource = baselineSource;
+            }
+            else
+            {
+                candidateEmitted = TryEmit(
+                    candidateDocument.Analysis.Ast,
+                    candidateMap,
+                    sourcePath,
+                    out candidateSource);
+            }
+
+            if (baselineEmitted != candidateEmitted)
+            {
+                return false;
+            }
+            if (!baselineEmitted)
+                continue;
+
+            syntaxSources.Add(new RenameCompilationSource(
+                sourcePath + ".g.cs",
+                baselineSource,
+                candidateSource));
+        }
+
+        var relevantSymbols = syntaxSources
+            .Where(source => !string.Equals(
+                source.Baseline,
+                source.Candidate,
+                StringComparison.Ordinal))
+            .SelectMany(source =>
+                ExtractPreprocessorSymbols(source.Baseline)
+                    .Concat(ExtractPreprocessorSymbols(source.Candidate)))
             .Distinct(StringComparer.Ordinal)
             .OrderBy(symbol => symbol, StringComparer.Ordinal)
             .ToArray();
-        foreach (var configuration in EnumeratePreprocessorConfigurations(symbols))
+        if (relevantSymbols.Length >= 31
+            || (1L << relevantSymbols.Length) > MaxRenamePreprocessorConfigurations)
         {
-            if (GetCompilationErrors(syntaxSources, configuration).Count > 0)
+            return false;
+        }
+
+        var relevantSymbolSet = relevantSymbols.ToHashSet(StringComparer.Ordinal);
+        var parsedSources = syntaxSources
+            .Select(source =>
+            {
+                var sensitive = ExtractPreprocessorSymbols(source.Baseline)
+                        .Concat(ExtractPreprocessorSymbols(source.Candidate))
+                        .Any(relevantSymbolSet.Contains);
+                SyntaxTree? baselineTree = null;
+                SyntaxTree? candidateTree = null;
+                if (!sensitive)
+                {
+                    baselineTree = ParseGeneratedSource(
+                        source.Baseline,
+                        source.Path,
+                        Array.Empty<string>(),
+                        cancellationToken);
+                    candidateTree = string.Equals(
+                            source.Baseline,
+                            source.Candidate,
+                            StringComparison.Ordinal)
+                        ? baselineTree
+                        : ParseGeneratedSource(
+                            source.Candidate,
+                            source.Path,
+                            Array.Empty<string>(),
+                            cancellationToken);
+                }
+                return (Source: source, BaselineTree: baselineTree, CandidateTree: candidateTree);
+            })
+            .ToArray();
+
+        foreach (var configuration in EnumeratePreprocessorConfigurations(relevantSymbols))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var baselineTrees = new SyntaxTree[parsedSources.Length];
+            var candidateTrees = new SyntaxTree[parsedSources.Length];
+            for (var index = 0; index < parsedSources.Length; index++)
+            {
+                var parsed = parsedSources[index];
+                baselineTrees[index] = parsed.BaselineTree
+                    ?? ParseGeneratedSource(
+                        parsed.Source.Baseline,
+                        parsed.Source.Path,
+                        configuration,
+                        cancellationToken);
+                candidateTrees[index] = parsed.CandidateTree
+                    ?? (string.Equals(
+                            parsed.Source.Baseline,
+                            parsed.Source.Candidate,
+                            StringComparison.Ordinal)
+                        ? baselineTrees[index]
+                        : ParseGeneratedSource(
+                            parsed.Source.Candidate,
+                            parsed.Source.Path,
+                            configuration,
+                            cancellationToken));
+            }
+
+            var baselineErrors = GetCompilationErrors(
+                baselineTrees,
+                cancellationToken);
+            var candidateErrors = GetCompilationErrors(
+                candidateTrees,
+                cancellationToken);
+            if (HasNewErrors(baselineErrors, candidateErrors))
                 return false;
         }
 
@@ -1523,23 +1739,261 @@ public sealed class WorkspaceState
         }
     }
 
-    private static IReadOnlyList<CompilationError> GetCompilationErrors(
-        IReadOnlyList<(string Path, string Source)> sources,
-        IReadOnlyList<string> configuration)
+    private static IReadOnlyList<CompilationError> GetAnalysisErrors(
+        DocumentAnalysisSnapshot analysis,
+        Uri uri)
     {
-        var parseOptions = CSharpParseOptions.Default.WithPreprocessorSymbols(configuration);
-        var trees = sources
-            .Select(source => CSharpSyntaxTree.ParseText(
-                source.Source,
-                parseOptions,
-                source.Path))
+        var path = uri.IsFile ? uri.LocalPath : uri.ToString();
+        return analysis.Diagnostics
+            .Where(diagnostic => diagnostic.IsError)
+            .Select(diagnostic => new CompilationError(
+                diagnostic.Code,
+                path,
+                diagnostic.Span.Line))
             .ToArray();
+    }
+
+    private static bool PreservesBindingIdentities(
+        WorkspaceSymbolIndex baseline,
+        WorkspaceSymbolIndex candidate,
+        IReadOnlyDictionary<DocumentUri, ProjectSymbolOccurrence[]> replacements,
+        string newName,
+        SymbolId renamedSymbol)
+    {
+        var symbolMap = new Dictionary<SymbolId, SymbolId>();
+        var mappedCandidates = new HashSet<SymbolId>();
+        foreach (var (baselineId, baselineOccurrences) in baseline.BySymbol)
+        {
+            var definitions = baselineOccurrences
+                .Where(occurrence =>
+                    occurrence.Kind == SymbolOccurrenceKind.Definition)
+                .ToArray();
+            SymbolId candidateId;
+            if (definitions.Length == 0)
+            {
+                if (!candidate.BySymbol.ContainsKey(baselineId))
+                    return false;
+                candidateId = baselineId;
+            }
+            else
+            {
+                SymbolId? mapped = null;
+                foreach (var definition in definitions)
+                {
+                    var uri = DocumentUri.From(definition.Doc.Uri);
+                    if (!TryTranslateSpan(
+                            definition.Span,
+                            replacements.GetValueOrDefault(uri),
+                            newName.Length,
+                            out var translated)
+                        || !candidate.ByDocument.TryGetValue(
+                            uri,
+                            out var candidateDocument))
+                    {
+                        return false;
+                    }
+
+                    var matchingDefinitions = candidateDocument.Occurrences
+                        .Where(occurrence =>
+                            occurrence.Kind == SymbolOccurrenceKind.Definition
+                            && occurrence.Span == translated)
+                        .Select(occurrence => occurrence.SymbolId)
+                        .Distinct()
+                        .ToArray();
+                    if (matchingDefinitions.Length != 1
+                        || (mapped != null
+                            && mapped.Value != matchingDefinitions[0]))
+                    {
+                        return false;
+                    }
+                    mapped = matchingDefinitions[0];
+                }
+                if (mapped == null)
+                    return false;
+                candidateId = mapped.Value;
+            }
+
+            if (!mappedCandidates.Add(candidateId))
+                return false;
+            symbolMap.Add(baselineId, candidateId);
+
+            if ((!baseline.AmbiguousSymbols.Contains(baselineId)
+                    && candidate.AmbiguousSymbols.Contains(candidateId))
+                || (!baseline.IncompleteTypeSymbols.Contains(baselineId)
+                    && candidate.IncompleteTypeSymbols.Contains(candidateId)))
+            {
+                return false;
+            }
+        }
+
+        if (!symbolMap.TryGetValue(renamedSymbol, out var candidateRenamedSymbol)
+            || candidate.AmbiguousSymbols.Contains(candidateRenamedSymbol)
+            || candidate.IncompleteTypeSymbols.Contains(candidateRenamedSymbol))
+        {
+            return false;
+        }
+
+        foreach (var (baselineId, candidateId) in symbolMap)
+        {
+            var expected = new List<OccurrenceFingerprint>();
+            foreach (var occurrence in baseline.BySymbol[baselineId])
+            {
+                var uri = DocumentUri.From(occurrence.Doc.Uri);
+                if (!TryTranslateSpan(
+                        occurrence.Span,
+                        replacements.GetValueOrDefault(uri),
+                        newName.Length,
+                        out var translated))
+                {
+                    return false;
+                }
+                expected.Add(new OccurrenceFingerprint(
+                    uri,
+                    translated,
+                    occurrence.Kind));
+            }
+
+            if (!candidate.BySymbol.TryGetValue(
+                    candidateId,
+                    out var candidateOccurrences))
+            {
+                return false;
+            }
+            var actual = candidateOccurrences
+                .Select(occurrence => new OccurrenceFingerprint(
+                    DocumentUri.From(occurrence.Doc.Uri),
+                    occurrence.Span,
+                    occurrence.Kind))
+                .ToArray();
+            if (!HaveSameOccurrences(expected, actual))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryTranslateSpan(
+        TextSpan span,
+        IReadOnlyList<ProjectSymbolOccurrence>? edits,
+        int replacementLength,
+        out TextSpan translated)
+    {
+        var delta = 0;
+        if (edits != null)
+        {
+            foreach (var edit in edits)
+            {
+                if (span == edit.Span)
+                {
+                    translated = new TextSpan(
+                        span.Start + delta,
+                        replacementLength,
+                        span.Line,
+                        span.Column);
+                    return true;
+                }
+                if (edit.Span.End <= span.Start)
+                {
+                    delta += replacementLength - edit.Span.Length;
+                    continue;
+                }
+                if (edit.Span.Start >= span.End)
+                    break;
+
+                translated = default;
+                return false;
+            }
+        }
+
+        translated = new TextSpan(
+            span.Start + delta,
+            span.Length,
+            span.Line,
+            span.Column);
+        return true;
+    }
+
+    private static bool HaveSameOccurrences(
+        IEnumerable<OccurrenceFingerprint> baseline,
+        IEnumerable<OccurrenceFingerprint> candidate)
+    {
+        var counts = baseline
+            .GroupBy(fingerprint => fingerprint)
+            .ToDictionary(group => group.Key, group => group.Count());
+        foreach (var fingerprint in candidate)
+        {
+            if (!counts.TryGetValue(fingerprint, out var count) || count == 0)
+                return false;
+            if (count == 1)
+                counts.Remove(fingerprint);
+            else
+                counts[fingerprint] = count - 1;
+        }
+        return counts.Count == 0;
+    }
+
+    private static bool CrossModuleMapsEqual(
+        IReadOnlyDictionary<string, string>? baseline,
+        IReadOnlyDictionary<string, string>? candidate)
+    {
+        if (ReferenceEquals(baseline, candidate))
+            return true;
+        if (baseline == null || candidate == null || baseline.Count != candidate.Count)
+            return false;
+        return baseline.All(pair =>
+            candidate.TryGetValue(pair.Key, out var value)
+            && string.Equals(pair.Value, value, StringComparison.Ordinal));
+    }
+
+    private static bool TryEmit(
+        ModuleNode module,
+        IReadOnlyDictionary<string, string>? crossModuleMap,
+        string sourcePath,
+        out string generated)
+    {
+        try
+        {
+            var emitter = new CSharpEmitter
+            {
+                CrossModuleFunctionModules = crossModuleMap,
+                LineDirectiveFilePath = sourcePath,
+            };
+            generated = emitter.Emit(module);
+            return true;
+        }
+        catch (Exception)
+        {
+            generated = string.Empty;
+            return false;
+        }
+    }
+
+    private static SyntaxTree ParseGeneratedSource(
+        string source,
+        string path,
+        IReadOnlyList<string> configuration,
+        CancellationToken cancellationToken)
+    {
+        var parseOptions = CSharpParseOptions.Default
+            .WithPreprocessorSymbols(configuration);
+        return CSharpSyntaxTree.ParseText(
+            source,
+            parseOptions,
+            path,
+            cancellationToken: cancellationToken);
+    }
+
+    private IReadOnlyList<CompilationError> GetCompilationErrors(
+        IReadOnlyList<SyntaxTree> trees,
+        CancellationToken cancellationToken)
+    {
+        Interlocked.Increment(ref _renameValidationCompilationCount);
         var compilation = CSharpCompilation.Create(
             "CalorRenamePreflight",
             trees,
             PlatformReferences.Value,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
-        return compilation.GetDiagnostics()
+        return compilation.GetDiagnostics(cancellationToken)
             .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
             .Select(diagnostic =>
             {
@@ -1552,25 +2006,35 @@ public sealed class WorkspaceState
             .ToArray();
     }
 
+    private static bool HasNewErrors(
+        IReadOnlyList<CompilationError> baseline,
+        IReadOnlyList<CompilationError> candidate)
+    {
+        var counts = baseline
+            .GroupBy(error => error)
+            .ToDictionary(group => group.Key, group => group.Count());
+        foreach (var error in candidate)
+        {
+            if (!counts.TryGetValue(error, out var count) || count == 0)
+                return true;
+            if (count == 1)
+                counts.Remove(error);
+            else
+                counts[error] = count - 1;
+        }
+        return false;
+    }
+
     private static IEnumerable<IReadOnlyList<string>> EnumeratePreprocessorConfigurations(
         IReadOnlyList<string> symbols)
     {
-        if (symbols.Count <= 8)
+        var count = 1 << symbols.Count;
+        for (var mask = 0; mask < count; mask++)
         {
-            var count = 1 << symbols.Count;
-            for (var mask = 0; mask < count; mask++)
-            {
-                yield return symbols
-                    .Where((_, index) => (mask & (1 << index)) != 0)
-                    .ToArray();
-            }
-            yield break;
+            yield return symbols
+                .Where((_, index) => (mask & (1 << index)) != 0)
+                .ToArray();
         }
-
-        yield return Array.Empty<string>();
-        foreach (var symbol in symbols)
-            yield return [symbol];
-        yield return symbols.ToArray();
     }
 
     private static IReadOnlyList<MetadataReference> CreatePlatformReferences()

--- a/src/Calor.LanguageServer/State/WorkspaceState.cs
+++ b/src/Calor.LanguageServer/State/WorkspaceState.cs
@@ -92,6 +92,7 @@ public sealed class WorkspaceState
         new(CreatePlatformReferences);
     // Validation is exhaustive through five relevant symbols (2^5 configurations).
     // Larger relevant condition sets fail closed instead of using an unsound sample.
+    private const int MaxRenamePreprocessorSymbols = 5;
     private const int MaxRenamePreprocessorConfigurations = 32;
 
     internal long WorkspaceFileReadCount => Interlocked.Read(ref _workspaceFileReadCount);
@@ -366,10 +367,12 @@ public sealed class WorkspaceState
 
     public Task<bool> ValidateRenameAsync(
         IReadOnlyList<ProjectSymbolOccurrence> occurrences,
+        string oldName,
         string newName,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(occurrences);
+        ArgumentException.ThrowIfNullOrWhiteSpace(oldName);
         ArgumentException.ThrowIfNullOrWhiteSpace(newName);
         if (occurrences.Count == 0)
             return Task.FromResult(false);
@@ -389,6 +392,7 @@ public sealed class WorkspaceState
                     var valid = ValidateRenameCore(
                         documents,
                         occurrences,
+                        oldName,
                         newName,
                         cancellationToken);
                     cancellationToken.ThrowIfCancellationRequested();
@@ -410,6 +414,7 @@ public sealed class WorkspaceState
     private bool ValidateRenameCore(
         IReadOnlyList<WorkspaceDocumentSnapshot> documents,
         IReadOnlyList<ProjectSymbolOccurrence> occurrences,
+        string oldName,
         string newName,
         CancellationToken cancellationToken)
     {
@@ -549,30 +554,48 @@ public sealed class WorkspaceState
                 candidateSource));
         }
 
-        var relevantSymbols = syntaxSources
-            .Where(source => !string.Equals(
-                source.Baseline,
-                source.Candidate,
-                StringComparison.Ordinal))
-            .SelectMany(source =>
-                ExtractPreprocessorSymbols(source.Baseline)
-                    .Concat(ExtractPreprocessorSymbols(source.Candidate)))
+        var analyzedSources = syntaxSources
+            .Select(source =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var generatedChanged = !string.Equals(
+                    source.Baseline,
+                    source.Candidate,
+                    StringComparison.Ordinal);
+                var symbols = ExtractPreprocessorSymbols(source.Baseline)
+                    .Concat(ExtractPreprocessorSymbols(source.Candidate))
+                    .Distinct(StringComparer.Ordinal)
+                    .OrderBy(symbol => symbol, StringComparer.Ordinal)
+                    .ToArray();
+                var sensitive = generatedChanged
+                    || (symbols.Length > 0
+                        && ContainsIdentifierToken(
+                            source.Baseline,
+                            oldName,
+                            newName,
+                            cancellationToken));
+                return (Source: source, Symbols: symbols, Sensitive: sensitive);
+            })
+            .ToArray();
+        var relevantSymbols = analyzedSources
+            .Where(source => source.Sensitive)
+            .SelectMany(source => source.Symbols)
             .Distinct(StringComparer.Ordinal)
             .OrderBy(symbol => symbol, StringComparer.Ordinal)
             .ToArray();
-        if (relevantSymbols.Length >= 31
+        if (relevantSymbols.Length > MaxRenamePreprocessorSymbols
             || (1L << relevantSymbols.Length) > MaxRenamePreprocessorConfigurations)
         {
             return false;
         }
 
         var relevantSymbolSet = relevantSymbols.ToHashSet(StringComparer.Ordinal);
-        var parsedSources = syntaxSources
-            .Select(source =>
+        var parsedSources = analyzedSources
+            .Select(analyzed =>
             {
-                var sensitive = ExtractPreprocessorSymbols(source.Baseline)
-                        .Concat(ExtractPreprocessorSymbols(source.Candidate))
-                        .Any(relevantSymbolSet.Contains);
+                var source = analyzed.Source;
+                var sensitive = analyzed.Sensitive
+                    && analyzed.Symbols.Any(relevantSymbolSet.Contains);
                 SyntaxTree? baselineTree = null;
                 SyntaxTree? candidateTree = null;
                 if (!sensitive)
@@ -1737,6 +1760,64 @@ public sealed class WorkspaceState
                     yield return match.Value;
             }
         }
+    }
+
+    private static bool ContainsIdentifierToken(
+        string source,
+        string oldName,
+        string newName,
+        CancellationToken cancellationToken)
+    {
+        var tree = CSharpSyntaxTree.ParseText(
+            source,
+            cancellationToken: cancellationToken);
+        var root = tree.GetRoot(cancellationToken);
+        if (ContainsIdentifierToken(
+                root.DescendantTokens(descendIntoTrivia: true),
+                oldName,
+                newName,
+                cancellationToken))
+        {
+            return true;
+        }
+
+        foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!trivia.IsKind(SyntaxKind.DisabledTextTrivia))
+                continue;
+
+            if (ContainsIdentifierToken(
+                    SyntaxFactory.ParseTokens(trivia.ToFullString()),
+                    oldName,
+                    newName,
+                    cancellationToken))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsIdentifierToken(
+        IEnumerable<SyntaxToken> tokens,
+        string oldName,
+        string newName,
+        CancellationToken cancellationToken)
+    {
+        foreach (var token in tokens)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (token.IsKind(SyntaxKind.IdentifierToken)
+                && (string.Equals(token.ValueText, oldName, StringComparison.Ordinal)
+                    || string.Equals(token.ValueText, newName, StringComparison.Ordinal)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static IReadOnlyList<CompilationError> GetAnalysisErrors(

--- a/src/Calor.LanguageServer/Utilities/SymbolFinder.cs
+++ b/src/Calor.LanguageServer/Utilities/SymbolFinder.cs
@@ -954,12 +954,23 @@ public readonly record struct IndexedTypeReference(
     string Name,
     TextSpan Span);
 
+public sealed record TypeReferenceIndexResult(
+    IReadOnlyList<IndexedTypeReference> References,
+    IReadOnlySet<SymbolId> IncompleteSymbolIds);
+
 /// <summary>
 /// Builds an identity-aware index from parser-recorded type annotation spans.
 /// </summary>
 public static class TypeReferenceIndex
 {
     public static IReadOnlyList<IndexedTypeReference> Build(
+        ModuleNode ast,
+        BoundModule boundModule,
+        string source,
+        IReadOnlyList<TypeSymbol>? workspaceTypeSymbols = null) =>
+        BuildDetailed(ast, boundModule, source, workspaceTypeSymbols).References;
+
+    public static TypeReferenceIndexResult BuildDetailed(
         ModuleNode ast,
         BoundModule boundModule,
         string source,
@@ -975,9 +986,14 @@ public static class TypeReferenceIndex
             .DistinctBy(symbol => symbol.Id)
             .ToArray();
         if (typeSymbols.Length == 0)
-            return Array.Empty<IndexedTypeReference>();
+        {
+            return new TypeReferenceIndexResult(
+                Array.Empty<IndexedTypeReference>(),
+                new HashSet<SymbolId>());
+        }
 
         var references = new List<IndexedTypeReference>();
+        var incompleteSymbolIds = new HashSet<SymbolId>();
         foreach (var creation in Calor.Compiler.Analysis.Dataflow.BoundNodeHelpers
                      .DescendantsAndSelf(boundModule)
                      .OfType<BoundNewExpression>())
@@ -986,7 +1002,8 @@ public static class TypeReferenceIndex
                 creation.TypeReference,
                 source,
                 typeSymbols,
-                references);
+                references,
+                incompleteSymbolIds);
         }
 
         foreach (var node in DescendantsAndSelf(ast))
@@ -994,34 +1011,184 @@ public static class TypeReferenceIndex
             switch (node)
             {
                 case OutputNode output:
-                    AddAnnotation(output.TypeNameSpan, source, typeSymbols, references);
+                    AddTypePosition(output.TypeName, output.TypeNameSpan);
                     break;
                 case ParameterNode parameter:
-                    AddAnnotation(parameter.TypeNameSpan, source, typeSymbols, references);
+                    AddTypePosition(parameter.TypeName, parameter.TypeNameSpan);
                     break;
                 case ClassFieldNode field:
-                    AddAnnotation(field.TypeNameSpan, source, typeSymbols, references);
+                    AddTypePosition(field.TypeName, field.TypeNameSpan);
                     break;
                 case PropertyNode property:
-                    AddAnnotation(property.TypeNameSpan, source, typeSymbols, references);
+                    AddTypePosition(property.TypeName, property.TypeNameSpan);
+                    break;
+                case BindStatementNode bind
+                    when bind.TypeName != null
+                         && bind.TypeNameSpan.Length == 0
+                         && bind.Initializer is ArrayCreationNode
+                             or MultiDimArrayCreationNode
+                             or ListCreationNode
+                             or DictionaryCreationNode
+                             or SetCreationNode:
                     break;
                 case BindStatementNode bind when bind.TypeName != null:
-                    AddAnnotation(bind.TypeNameSpan, source, typeSymbols, references);
+                    AddTypePosition(bind.TypeName, bind.TypeNameSpan);
                     break;
                 case ClassDefinitionNode cls:
                     if (cls.BaseClassSpan is { } baseSpan)
-                        AddAnnotation(baseSpan, source, typeSymbols, references);
+                        AddTypePosition(cls.BaseClass, baseSpan);
+                    else
+                        MarkIncompleteAnnotation(cls.BaseClass);
                     foreach (var interfaceSpan in cls.ImplementedInterfaceSpans)
                         AddAnnotation(interfaceSpan, source, typeSymbols, references);
+                    if (cls.ImplementedInterfaces.Count > 0
+                        && cls.ImplementedInterfaceSpans.Count == 0)
+                    {
+                        foreach (var interfaceName in cls.ImplementedInterfaces)
+                            MarkIncompleteAnnotation(interfaceName);
+                    }
+                    break;
+                case InterfaceDefinitionNode @interface:
+                    foreach (var interfaceBaseSpan in @interface.BaseInterfaceSpans)
+                        AddAnnotation(interfaceBaseSpan, source, typeSymbols, references);
+                    if (@interface.BaseInterfaces.Count > 0
+                        && @interface.BaseInterfaceSpans.Count == 0)
+                    {
+                        foreach (var baseInterface in @interface.BaseInterfaces)
+                            MarkIncompleteAnnotation(baseInterface);
+                    }
+                    break;
+                case CatchClauseNode @catch:
+                    AddTypePosition(@catch.ExceptionType, @catch.ExceptionTypeSpan);
+                    break;
+                case ArrayCreationNode array:
+                    AddTypePosition(array.ElementType, array.ElementTypeSpan);
+                    break;
+                case MultiDimArrayCreationNode array:
+                    AddTypePosition(array.ElementType, array.ElementTypeSpan);
+                    break;
+                case ForeachStatementNode @foreach:
+                    AddTypePosition(@foreach.VariableType, @foreach.VariableTypeSpan);
+                    break;
+                case ListCreationNode list:
+                    AddTypePosition(list.ElementType, list.ElementTypeSpan);
+                    break;
+                case DictionaryCreationNode dictionary:
+                    AddTypePosition(dictionary.KeyType, dictionary.KeyTypeSpan);
+                    AddTypePosition(dictionary.ValueType, dictionary.ValueTypeSpan);
+                    break;
+                case SetCreationNode set:
+                    AddTypePosition(set.ElementType, set.ElementTypeSpan);
+                    break;
+                case TypeOperationNode operation:
+                    AddTypePosition(operation.TargetType, operation.TargetTypeSpan);
+                    break;
+                case IsPatternNode pattern:
+                    AddTypePosition(pattern.TargetType, pattern.TargetTypeSpan);
+                    break;
+                case TypeOfExpressionNode typeOf:
+                    AddTypePosition(typeOf.TypeName, typeOf.TypeNameSpan);
+                    break;
+                case SizeOfNode sizeOf:
+                    AddTypePosition(sizeOf.TypeName, sizeOf.TypeNameSpan);
+                    break;
+                case StackAllocNode stackAlloc:
+                    AddTypePosition(stackAlloc.ElementType, stackAlloc.ElementTypeSpan);
+                    break;
+                case FixedStatementNode fixedStatement:
+                    AddTypePosition(fixedStatement.PointerType, fixedStatement.PointerTypeSpan);
+                    break;
+                case EventDefinitionNode @event:
+                    AddTypePosition(@event.DelegateType, @event.DelegateTypeSpan);
+                    break;
+                case LambdaParameterNode lambdaParameter:
+                    AddTypePosition(lambdaParameter.TypeName, lambdaParameter.TypeNameSpan);
+                    break;
+                case QuantifierVariableNode quantifier:
+                    AddTypePosition(quantifier.TypeName, quantifier.TypeNameSpan);
+                    break;
+                case PositionalPatternNode positionalPattern:
+                    AddTypePosition(
+                        positionalPattern.TypeName,
+                        positionalPattern.TypeNameSpan);
+                    break;
+                case PropertyPatternNode propertyPattern:
+                    AddTypePosition(
+                        propertyPattern.TypeName,
+                        propertyPattern.TypeNameSpan);
+                    break;
+                case TypePatternNode typePattern:
+                    AddTypePosition(typePattern.TypeName, typePattern.TypeNameSpan);
+                    break;
+                case NoneExpressionNode none:
+                    AddTypePosition(none.TypeName, none.TypeNameSpan);
+                    break;
+                case RecordCreationNode recordCreation:
+                    AddTypePosition(
+                        recordCreation.TypeName,
+                        recordCreation.TypeNameSpan);
+                    break;
+                case FieldDefinitionNode fieldDefinition:
+                    AddTypePosition(
+                        fieldDefinition.TypeName,
+                        fieldDefinition.TypeNameSpan);
+                    break;
+                case TypeConstraintNode constraint:
+                    MarkIncompleteAnnotation(constraint.TypeName);
+                    break;
+                case GenericTypeNode genericType:
+                    AddTypePosition(genericType.TypeName, genericType.TypeNameSpan);
+                    foreach (var typeArgument in genericType.TypeArguments)
+                        MarkIncompleteAnnotation(typeArgument);
+                    break;
+                case RefinementTypeNode refinement:
+                    AddTypePosition(
+                        refinement.BaseTypeName,
+                        refinement.BaseTypeNameSpan);
+                    break;
+                case IndexedTypeNode indexed:
+                    AddTypePosition(indexed.BaseTypeName, indexed.BaseTypeNameSpan);
                     break;
             }
         }
 
-        return references
-            .Distinct()
-            .OrderBy(reference => reference.Span.Start)
-            .ThenBy(reference => reference.Span.End)
-            .ToArray();
+        return new TypeReferenceIndexResult(
+            references
+                .Distinct()
+                .OrderBy(reference => reference.Span.Start)
+                .ThenBy(reference => reference.Span.End)
+                .ToArray(),
+            incompleteSymbolIds);
+
+        void AddTypePosition(string? typeName, TextSpan? span)
+        {
+            if (string.IsNullOrWhiteSpace(typeName))
+                return;
+
+            if (span is { Length: > 0 })
+                AddAnnotation(span.Value, source, typeSymbols, references);
+            else
+                MarkIncompleteAnnotation(typeName);
+        }
+
+        void MarkIncompleteAnnotation(string? annotation)
+        {
+            if (string.IsNullOrWhiteSpace(annotation))
+                return;
+
+            var annotationSpan = annotation.AsSpan();
+            var identifiers = ScanIdentifiers(annotationSpan);
+            for (var index = 0; index < identifiers.Count; index++)
+            {
+                var symbol = ResolveTypeSymbol(
+                    annotationSpan,
+                    identifiers,
+                    index,
+                    typeSymbols);
+                if (symbol is { Id.IsNone: false })
+                    incompleteSymbolIds.Add(symbol.Id);
+            }
+        }
     }
 
     private static void AddAnnotation(
@@ -1057,7 +1224,8 @@ public static class TypeReferenceIndex
         BoundTypeReference reference,
         string source,
         IReadOnlyList<TypeSymbol> typeSymbols,
-        ICollection<IndexedTypeReference> references)
+        ICollection<IndexedTypeReference> references,
+        ISet<SymbolId> incompleteSymbolIds)
     {
         var resolvedType = reference.ResolvedType
             ?? ResolveTypeSymbol(reference.Name, typeSymbols);
@@ -1071,9 +1239,20 @@ public static class TypeReferenceIndex
                 source.Substring(reference.Span.Start, reference.Span.Length),
                 reference.Span));
         }
+        else if (resolvedType is { Id.IsNone: false })
+        {
+            incompleteSymbolIds.Add(resolvedType.Id);
+        }
 
         foreach (var typeArgument in reference.TypeArguments)
-            AddBoundTypeReference(typeArgument, source, typeSymbols, references);
+        {
+            AddBoundTypeReference(
+                typeArgument,
+                source,
+                typeSymbols,
+                references,
+                incompleteSymbolIds);
+        }
     }
 
     private static TypeSymbol? ResolveTypeSymbol(

--- a/tests/Calor.LanguageServer.Tests/Handlers/RenameHandlerTests.cs
+++ b/tests/Calor.LanguageServer.Tests/Handlers/RenameHandlerTests.cs
@@ -501,6 +501,463 @@ public class RenameHandlerTests
     }
 
     [Fact]
+    public async Task RenameAcrossDistinctModulesUsesProductionCrossModuleEmissionAsync()
+    {
+        var root = CreateWorkspaceDirectory();
+        try
+        {
+            var sources = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["models.calr"] = """
+                    §M{m001:Models}
+                      §CL{c001:Widget:pub}
+                        §FLD{i32:Value:pub}
+                    """,
+                ["services.calr"] = """
+                    §M{m002:Services}
+                      §U{Models}
+                      §F{f001:Make:pub} () -> Widget
+                        §R §NEW{Widget} §/NEW
+                    """,
+                ["app.calr"] = """
+                    §M{m003:App}
+                      §U{Models}
+                      §F{f002:Run:pub} () -> Widget
+                        §R §C{Make} §/C
+                    """,
+            };
+            foreach (var (fileName, source) in sources)
+                File.WriteAllText(Path.Combine(root, fileName), source);
+
+            var workspace = new WorkspaceState(root);
+            var servicesPath = Path.Combine(root, "services.calr");
+            var servicesUri = DocumentUri.FromFileSystemPath(servicesPath);
+            workspace.GetOrCreate(
+                servicesUri,
+                sources["services.calr"],
+                version: 3);
+
+            var edit = await RenameAtAsync(
+                workspace,
+                servicesUri,
+                sources["services.calr"],
+                "Make:pub",
+                "Create");
+
+            Assert.NotNull(edit);
+            var documentEdits = Assert.IsType<Container<WorkspaceEditDocumentChange>>(
+                    edit.DocumentChanges)
+                .Select(change => Assert.IsType<TextDocumentEdit>(change.TextDocumentEdit))
+                .ToArray();
+            Assert.Equal(2, documentEdits.Length);
+            Assert.Equal(2, documentEdits.Sum(documentEdit => documentEdit.Edits.Count()));
+            Assert.Contains(
+                documentEdits,
+                documentEdit => documentEdit.TextDocument.Uri == servicesUri
+                    && documentEdit.TextDocument.Version == 3);
+            Assert.Contains(
+                documentEdits,
+                documentEdit => documentEdit.TextDocument.Uri.ToUri().LocalPath
+                    == Path.Combine(root, "app.calr"));
+
+            var updated = sources.ToDictionary(
+                pair => Path.Combine(root, pair.Key),
+                pair => pair.Value,
+                StringComparer.Ordinal);
+            ApplyDocumentEdits(updated, documentEdits);
+            var generated = AssertWorkspaceRoslynCleanWithProductionMap(updated);
+            Assert.Contains(
+                "global::Services.ServicesModule.Create",
+                generated[Path.Combine(root, "app.calr")]);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RenameAllowsSplitModuleLocalCallableWithUnrelatedBaselineErrorAsync()
+    {
+        var root = CreateWorkspaceDirectory();
+        try
+        {
+            var sources = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["definition.calr"] = """
+                    §M{m001:Split}
+                      §CL{c001:Worker:pub:partial}
+                        §MT{m001:Pick:pub} (i32:value) -> i32
+                          §R value
+                    """,
+                ["use.calr"] = """
+                    §M{m002:Split}
+                      §CL{c002:Worker:pub:partial}
+                        §MT{m002:Run:pub} () -> i32
+                          §R §C{Pick} §A INT:1 §/C
+                    """,
+                ["broken.calr"] = """
+                    §M{m003:Broken}
+                      §CSHARP{public static class BrokenProbe
+                    {
+                        public static int Value => MissingValue;
+                    }}§/CSHARP
+                    """,
+            };
+            foreach (var (fileName, source) in sources)
+                File.WriteAllText(Path.Combine(root, fileName), source);
+
+            Assert.Single(GetRoslynErrors(sources["broken.calr"]));
+            AssertWorkspaceRoslynCleanWithProductionMap(
+                sources
+                    .Where(pair => pair.Key != "broken.calr")
+                    .ToDictionary(
+                        pair => Path.Combine(root, pair.Key),
+                        pair => pair.Value,
+                        StringComparer.Ordinal));
+            var workspace = new WorkspaceState(root);
+            var definitionPath = Path.Combine(root, "definition.calr");
+            var definitionUri = DocumentUri.FromFileSystemPath(definitionPath);
+            workspace.GetOrCreate(
+                definitionUri,
+                sources["definition.calr"],
+                version: 1);
+
+            var edit = await RenameAtAsync(
+                workspace,
+                definitionUri,
+                sources["definition.calr"],
+                "Pick:pub",
+                "Choose");
+
+            Assert.NotNull(edit);
+            var documentEdits = Assert.IsType<Container<WorkspaceEditDocumentChange>>(
+                    edit.DocumentChanges)
+                .Select(change => Assert.IsType<TextDocumentEdit>(change.TextDocumentEdit))
+                .ToArray();
+            Assert.Equal(2, documentEdits.Length);
+            Assert.DoesNotContain(
+                documentEdits,
+                documentEdit => documentEdit.TextDocument.Uri.ToUri().LocalPath
+                    == Path.Combine(root, "broken.calr"));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RenameRejectsNewCompilationErrorWhenAbsoluteCountIsUnchangedAsync()
+    {
+        const string source = """
+            §M{m001:SwapErrors}
+              §F{f001:Old:pub} () -> i32
+                §R INT:1
+              §CSHARP{public static class Probe
+            {
+                public static int Existing() => SwapErrorsModule.Old();
+                public static int Missing() => SwapErrorsModule.NewName();
+            }}§/CSHARP
+            """;
+        var candidate = source.Replace(
+            "§F{f001:Old:pub}",
+            "§F{f001:NewName:pub}",
+            StringComparison.Ordinal);
+        var baselineErrors = GetRoslynErrors(source);
+        var candidateErrors = GetRoslynErrors(candidate);
+        var baselineError = Assert.Single(baselineErrors);
+        var candidateError = Assert.Single(candidateErrors);
+        Assert.Equal(baselineError.Id, candidateError.Id);
+        Assert.NotEqual(
+            baselineError.Location.GetLineSpan().StartLinePosition.Line,
+            candidateError.Location.GetLineSpan().StartLinePosition.Line);
+
+        var uri = DocumentUri.From("file:///rename-error-identity.calr");
+        var workspace = new WorkspaceState();
+        workspace.GetOrCreate(uri, source);
+
+        Assert.Null(await RenameAtAsync(
+            workspace,
+            uri,
+            source,
+            "Old:pub",
+            "NewName"));
+    }
+
+    [Fact]
+    public async Task RenameRejectsFieldToParameterCaptureThatStillCompilesAsync()
+    {
+        const string source = """
+            §M{m001:Capture}
+              §CL{c001:Box:pub}
+                §FLD{i32:stored:priv}
+                §MT{m001:Read:pub} (i32:value) -> i32
+                  §R stored
+            """;
+        var candidate = source
+            .Replace("stored:priv", "value:priv", StringComparison.Ordinal)
+            .Replace("§R stored", "§R value", StringComparison.Ordinal);
+        AssertRoslynClean(candidate);
+        var uri = DocumentUri.From("file:///field-to-parameter-capture.calr");
+        var workspace = new WorkspaceState();
+        workspace.GetOrCreate(uri, source);
+
+        Assert.Null(await RenameAtAsync(
+            workspace,
+            uri,
+            source,
+            "stored:priv",
+            "value"));
+    }
+
+    [Fact]
+    public async Task RenameRejectsParameterToFieldCaptureThatStillCompilesAsync()
+    {
+        const string source = """
+            §M{m001:Capture}
+              §CL{c001:Box:pub}
+                §FLD{i32:value:priv}
+                §MT{m001:Read:pub} (i32:input) -> i32
+                  §R (+ input value)
+            """;
+        var candidate = source
+            .Replace("i32:input", "i32:value", StringComparison.Ordinal)
+            .Replace("(+ input value)", "(+ value value)", StringComparison.Ordinal);
+        AssertRoslynClean(candidate);
+        var uri = DocumentUri.From("file:///parameter-to-field-capture.calr");
+        var workspace = new WorkspaceState();
+        workspace.GetOrCreate(uri, source);
+
+        Assert.Null(await RenameAtAsync(
+            workspace,
+            uri,
+            source,
+            "input)",
+            "value"));
+    }
+
+    [Fact]
+    public async Task RenameRejectsFieldLocalCaptureInBothDirectionsAsync()
+    {
+        const string fieldToLocal = """
+            §M{m001:Capture}
+              §CL{c001:Box:pub}
+                §FLD{i32:stored:priv}
+                §MT{m001:Read:pub} () -> i32
+                  §B{value:i32} INT:2
+                  §R (+ stored value)
+            """;
+        var fieldToLocalCandidate = fieldToLocal
+            .Replace("stored:priv", "value:priv", StringComparison.Ordinal)
+            .Replace("(+ stored value)", "(+ value value)", StringComparison.Ordinal);
+        AssertRoslynClean(fieldToLocalCandidate);
+        var fieldUri = DocumentUri.From("file:///field-to-local-capture.calr");
+        var fieldWorkspace = new WorkspaceState();
+        fieldWorkspace.GetOrCreate(fieldUri, fieldToLocal);
+        Assert.Null(await RenameAtAsync(
+            fieldWorkspace,
+            fieldUri,
+            fieldToLocal,
+            "stored:priv",
+            "value"));
+
+        const string localToField = """
+            §M{m001:Capture}
+              §CL{c001:Box:pub}
+                §FLD{i32:value:priv}
+                §MT{m001:Read:pub} () -> i32
+                  §B{input:i32} INT:2
+                  §R (+ input value)
+            """;
+        var localToFieldCandidate = localToField
+            .Replace("input:i32", "value:i32", StringComparison.Ordinal)
+            .Replace("(+ input value)", "(+ value value)", StringComparison.Ordinal);
+        AssertRoslynClean(localToFieldCandidate);
+        var localUri = DocumentUri.From("file:///local-to-field-capture.calr");
+        var localWorkspace = new WorkspaceState();
+        localWorkspace.GetOrCreate(localUri, localToField);
+        Assert.Null(await RenameAtAsync(
+            localWorkspace,
+            localUri,
+            localToField,
+            "input:i32",
+            "value"));
+    }
+
+    [Fact]
+    public async Task RenameAllowsExplicitFieldAccessToShadowParameterSafelyAsync()
+    {
+        const string source = """
+            §M{m001:Capture}
+              §CL{c001:Box:pub}
+                §FLD{i32:stored:priv}
+                §MT{m001:Read:pub} (i32:value) -> i32
+                  §R (+ §THIS.stored value)
+            """;
+        var uri = DocumentUri.From("file:///shadow-safe-field-rename.calr");
+        var workspace = new WorkspaceState();
+        workspace.GetOrCreate(uri, source);
+
+        var edit = await RenameAtAsync(
+            workspace,
+            uri,
+            source,
+            "stored:priv",
+            "value");
+
+        Assert.NotNull(edit);
+        var candidate = ApplySingleDocumentEdit(source, edit!);
+        Assert.Contains("§FLD{i32:value:priv}", candidate);
+        Assert.Contains("§THIS.value", candidate);
+        AssertRoslynClean(candidate);
+    }
+
+    [Fact]
+    public async Task UnrelatedPreprocessorSymbolsDoNotExpandRenameValidationAsync()
+    {
+        var root = CreateWorkspaceDirectory();
+        try
+        {
+            var source = CreatePreprocessorRenameSource(
+                "RenameTarget",
+                preprocessorSymbolCount: 0);
+            var unrelated = CreatePreprocessorRenameSource(
+                "UnrelatedFlags",
+                preprocessorSymbolCount: 8,
+                includeRenameTarget: false);
+            var targetPath = Path.Combine(root, "target.calr");
+            File.WriteAllText(targetPath, source);
+            File.WriteAllText(Path.Combine(root, "unrelated.calr"), unrelated);
+            var unrelatedState = LspTestHarness.CreateDocument(unrelated);
+            Assert.Equal(
+                8,
+                new CSharpEmitter().Emit(unrelatedState.Ast!)
+                    .Split("#if FLAG_", StringSplitOptions.None)
+                    .Length - 1);
+
+            var workspace = new WorkspaceState(root);
+            var uri = DocumentUri.FromFileSystemPath(targetPath);
+            workspace.GetOrCreate(uri, source, version: 1);
+            var targetOffset = source.IndexOf("Compute:pub", StringComparison.Ordinal);
+            Assert.NotNull(workspace.ResolveOccurrence(uri, targetOffset));
+            workspace.RefreshClosedDocuments();
+            var target = workspace.ResolveOccurrence(uri, targetOffset);
+            Assert.NotNull(target);
+            Assert.True(workspace.CanRenameSymbol(target!.SymbolId));
+            var targetOccurrences = workspace.FindSymbolOccurrences(
+                target.SymbolId,
+                includeDeclaration: true);
+            Assert.Equal(2, targetOccurrences.Count);
+            Assert.DoesNotContain(
+                targetOccurrences,
+                occurrence => occurrence.IsSplitDeclaration);
+            Assert.True(workspace.AreOccurrenceSnapshotsCurrent(targetOccurrences));
+            var before = workspace.RenameValidationCompilationCount;
+
+            var edit = await RenameAtAsync(
+                workspace,
+                uri,
+                source,
+                "Compute:pub",
+                "Calculate");
+
+            Assert.NotNull(edit);
+            Assert.Equal(
+                2,
+                workspace.RenameValidationCompilationCount - before);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RenameFailsClosedWhenRelevantConfigurationBudgetIsExceededAsync()
+    {
+        var source = CreatePreprocessorRenameSource(
+            "TooManyFlags",
+            preprocessorSymbolCount: 6);
+        var uri = DocumentUri.From("file:///rename-too-many-flags.calr");
+        var workspace = new WorkspaceState();
+        workspace.GetOrCreate(uri, source);
+        var before = workspace.RenameValidationCompilationCount;
+
+        Assert.Null(await RenameAtAsync(
+            workspace,
+            uri,
+            source,
+            "Compute:pub",
+            "Calculate"));
+        Assert.Equal(
+            before,
+            workspace.RenameValidationCompilationCount);
+    }
+
+    [Fact]
+    public async Task RenameValidationHonorsCancellationDuringCompilationAsync()
+    {
+        var root = CreateWorkspaceDirectory();
+        try
+        {
+            var source = CreatePreprocessorRenameSource(
+                "Cancellation",
+                preprocessorSymbolCount: 5);
+            var targetPath = Path.Combine(root, "target.calr");
+            File.WriteAllText(targetPath, source);
+            for (var index = 0; index < 20; index++)
+            {
+                File.WriteAllText(
+                    Path.Combine(root, $"unrelated-{index}.calr"),
+                    $$"""
+                    §M{m100:Unrelated{{index}}}
+                      §CL{c100:Type{{index}}:pub}
+                        §FLD{i32:Value:pub}
+                    """);
+            }
+
+            var workspace = new WorkspaceState(root);
+            var uri = DocumentUri.FromFileSystemPath(targetPath);
+            workspace.GetOrCreate(uri, source);
+            var before = workspace.RenameValidationCompilationCount;
+            using var cancellation = new CancellationTokenSource();
+
+            var rename = RenameAtAsync(
+                workspace,
+                uri,
+                source,
+                "Compute:pub",
+                "Calculate",
+                cancellation.Token);
+            Assert.True(SpinWait.SpinUntil(
+                () => workspace.RenameValidationCompilationCount > before
+                    || rename.IsCompleted,
+                TimeSpan.FromSeconds(5)));
+            Assert.False(rename.IsCompleted);
+            await cancellation.CancelAsync();
+
+            try
+            {
+                await rename;
+                Assert.Fail("Rename validation should have observed cancellation.");
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            Assert.True(workspace.RenameValidationCompilationCount > before);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task TypeRenameRefusesWhenSemanticCompletenessSignalFindsSpanlessConstraintAsync()
     {
         const string source = """
@@ -569,7 +1026,8 @@ public class RenameHandlerTests
         DocumentUri uri,
         string source,
         string cursorText,
-        string newName)
+        string newName,
+        CancellationToken cancellationToken = default)
     {
         var offset = source.IndexOf(cursorText, StringComparison.Ordinal);
         var (line, column) = LspTestHarness.GetLineColumn(source, offset);
@@ -580,7 +1038,7 @@ public class RenameHandlerTests
                 Position = new Position(line - 1, column - 1),
                 NewName = newName,
             },
-            CancellationToken.None);
+            cancellationToken);
     }
 
     private static string TextAt(string source, OmniSharp.Extensions.LanguageServer.Protocol.Models.Range range)
@@ -628,6 +1086,125 @@ public class RenameHandlerTests
             compilation.GetDiagnostics(),
             diagnostic => diagnostic.Severity
                 == Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+    }
+
+    private static Microsoft.CodeAnalysis.Diagnostic[] GetRoslynErrors(string source)
+    {
+        var state = LspTestHarness.CreateDocument(source);
+        Assert.NotNull(state.Ast);
+        Assert.False(
+            state.Diagnostics.HasErrors,
+            string.Join(Environment.NewLine, state.Diagnostics.Select(diagnostic =>
+                $"{diagnostic.Code}: {diagnostic.Message}")));
+        var tree = CSharpSyntaxTree.ParseText(new CSharpEmitter().Emit(state.Ast!));
+        var compilation = CSharpCompilation.Create(
+            "RenameBaselineErrors",
+            [tree],
+            GetPlatformReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        return compilation.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity
+                == Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+            .ToArray();
+    }
+
+    private static Dictionary<string, string> AssertWorkspaceRoslynCleanWithProductionMap(
+        IReadOnlyDictionary<string, string> sources)
+    {
+        var modules = sources
+            .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+            .Select(pair =>
+            {
+                var state = LspTestHarness.CreateDocument(
+                    pair.Value,
+                    new Uri(pair.Key).AbsoluteUri);
+                Assert.NotNull(state.Ast);
+                Assert.NotNull(state.BoundModule);
+                Assert.False(
+                    state.Diagnostics.HasErrors,
+                    string.Join(Environment.NewLine, state.Diagnostics.Select(diagnostic =>
+                        $"{diagnostic.Code}: {diagnostic.Message}")));
+                return (pair.Key, Module: state.Ast!);
+            })
+            .ToArray();
+        var crossModuleMap = modules.Length > 1
+            ? Calor.Compiler.CompilationDriver.BuildCrossModuleFunctionMap(
+                modules.Select(module => module.Module).ToArray())
+            : null;
+        var generated = new Dictionary<string, string>(StringComparer.Ordinal);
+        var trees = modules
+            .Select(module =>
+            {
+                var emitter = new CSharpEmitter
+                {
+                    CrossModuleFunctionModules = crossModuleMap,
+                    LineDirectiveFilePath = module.Key,
+                };
+                var source = emitter.Emit(module.Module);
+                generated[module.Key] = source;
+                return CSharpSyntaxTree.ParseText(
+                    source,
+                    path: module.Key + ".g.cs");
+            })
+            .ToArray();
+        var compilation = CSharpCompilation.Create(
+            "RenameWorkspaceCompile",
+            trees,
+            GetPlatformReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            diagnostic => diagnostic.Severity
+                == Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+        return generated;
+    }
+
+    private static void ApplyDocumentEdits(
+        IDictionary<string, string> sources,
+        IEnumerable<TextDocumentEdit> documentEdits)
+    {
+        foreach (var documentEdit in documentEdits)
+        {
+            var path = documentEdit.TextDocument.Uri.ToUri().LocalPath;
+            var source = sources[path];
+            foreach (var textEdit in documentEdit.Edits.OrderByDescending(textEdit =>
+                         PositionConverter.ToOffset(textEdit.Range.Start, source)))
+            {
+                var start = PositionConverter.ToOffset(textEdit.Range.Start, source);
+                var end = PositionConverter.ToOffset(textEdit.Range.End, source);
+                source = source[..start] + textEdit.NewText + source[end..];
+            }
+            sources[path] = source;
+        }
+    }
+
+    private static string CreatePreprocessorRenameSource(
+        string moduleName,
+        int preprocessorSymbolCount,
+        bool includeRenameTarget = true)
+    {
+        var lines = new List<string>
+        {
+            $"§M{{m001:{moduleName}}}",
+        };
+        if (preprocessorSymbolCount > 0)
+        {
+            lines.Add("  §CL{c001:Flags:pub}");
+            for (var index = 0; index < preprocessorSymbolCount; index++)
+            {
+                lines.Add($"    §PP{{FLAG_{index}}}");
+                lines.Add($"      §FLD{{i32:Field{index}:pub}}");
+                lines.Add($"    §/PP{{FLAG_{index}}}");
+            }
+        }
+        if (includeRenameTarget)
+        {
+            lines.Add("  §F{f001:Compute:pub} () -> i32");
+            lines.Add("    §R INT:1");
+            lines.Add("  §F{f002:Use:pub} () -> i32");
+            lines.Add("    §R §C{Compute} §/C");
+        }
+        return string.Join(Environment.NewLine, lines);
     }
 
     private static IEnumerable<MetadataReference> GetPlatformReferences()

--- a/tests/Calor.LanguageServer.Tests/Handlers/RenameHandlerTests.cs
+++ b/tests/Calor.LanguageServer.Tests/Handlers/RenameHandlerTests.cs
@@ -1026,6 +1026,159 @@ public class RenameHandlerTests
         }
     }
 
+    [Theory]
+    [InlineData("#if(PARENTHESIZED_RAW)")]
+    [InlineData("#if\tTAB_RAW")]
+    public async Task RenameRejectsRawCSharpStaleReferenceWithFlexibleDirectiveSpacingAsync(
+        string directive)
+    {
+        var root = CreateWorkspaceDirectory();
+        try
+        {
+            const string target = """
+                §M{m001:RawSpacing}
+                  §F{f001:Compute:pub} () -> i32
+                    §R INT:1
+                """;
+            var guardedReference = $$$"""
+                §M{m002:RawSpacing}
+                  §CSHARP{public static class RawProbe
+                {
+                {{{directive}}}
+                    public static int Read() => RawSpacingModule.Compute();
+                #endif
+                }}§/CSHARP
+                """;
+            var targetPath = Path.Combine(root, "target.calr");
+            File.WriteAllText(targetPath, target);
+            File.WriteAllText(Path.Combine(root, "guarded-reference.calr"), guardedReference);
+            var emitted = new CSharpEmitter().Emit(
+                LspTestHarness.CreateDocument(guardedReference).Ast!);
+            Assert.Contains(directive, emitted);
+
+            var workspace = new WorkspaceState(root);
+            var uri = DocumentUri.FromFileSystemPath(targetPath);
+            workspace.GetOrCreate(uri, target);
+            var before = workspace.RenameValidationCompilationCount;
+
+            Assert.Null(await RenameAtAsync(
+                workspace,
+                uri,
+                target,
+                "Compute:pub",
+                "Calculate"));
+            Assert.Equal(
+                4,
+                workspace.RenameValidationCompilationCount - before);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RenameRejectsRawCSharpStaleReferenceInNestedDisabledCompoundConditionAsync()
+    {
+        var root = CreateWorkspaceDirectory();
+        try
+        {
+            const string target = """
+                §M{m001:RawCompound}
+                  §F{f001:Compute:pub} () -> i32
+                    §R INT:1
+                """;
+            const string guardedReference = """
+                §M{m002:RawCompound}
+                  §CSHARP{public static class RawProbe
+                {
+                #if OUTER_RAW
+                #if PRIMARY_RAW
+                    public static int ReadPrimary() => 0;
+                #elif INNER_RAW && SECONDARY_RAW
+                    public static int Read() => RawCompoundModule.Compute();
+                #endif
+                #endif
+                }}§/CSHARP
+                """;
+            var targetPath = Path.Combine(root, "target.calr");
+            File.WriteAllText(targetPath, target);
+            File.WriteAllText(Path.Combine(root, "guarded-reference.calr"), guardedReference);
+            var emitted = new CSharpEmitter().Emit(
+                LspTestHarness.CreateDocument(guardedReference).Ast!);
+            Assert.Contains("#if OUTER_RAW", emitted);
+            Assert.Contains("#elif INNER_RAW && SECONDARY_RAW", emitted);
+
+            var workspace = new WorkspaceState(root);
+            var uri = DocumentUri.FromFileSystemPath(targetPath);
+            workspace.GetOrCreate(uri, target);
+            var before = workspace.RenameValidationCompilationCount;
+
+            Assert.Null(await RenameAtAsync(
+                workspace,
+                uri,
+                target,
+                "Compute:pub",
+                "Calculate"));
+            Assert.Equal(
+                24,
+                workspace.RenameValidationCompilationCount - before);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ShorteningRenameNearEndOfFileIsIndependentOfTrailingContextAsync(
+        bool includeTrailingContext)
+    {
+        var source = """
+            §M{m001:ListOps}
+              §F{f001:Sum:pub} (i32:a, i32:b) -> i32
+                §R (+ a b)
+              §F{f002:Count:pub} (i32:n) -> i32
+                §R n
+              §F{f003:FirstOrDefault:pub} (i32:value, i32:defaultVal, bool:hasElements) -> i32
+                §IF{if1} hasElements
+                  §R value
+                §EL
+                  §R defaultVal
+              §F{f004:Use:pub} () -> i32
+                §R §C{FirstOrDefault} §A INT:1 §A INT:0 §A BOOL:true §/C
+            """;
+        if (includeTrailingContext)
+        {
+            source += """
+
+                  §F{f005:TrailingContext:pub} () -> i32
+                    §R INT:0
+                """;
+        }
+
+        var uri = DocumentUri.From("file:///list-ops-shortening-rename.calr");
+        var workspace = new WorkspaceState();
+        workspace.GetOrCreate(uri, source);
+
+        var edit = await RenameAtAsync(
+            workspace,
+            uri,
+            source,
+            "FirstOrDefault:pub",
+            "First");
+
+        Assert.NotNull(edit);
+        var candidate = ApplySingleDocumentEdit(source, edit!);
+        Assert.DoesNotContain("FirstOrDefault", candidate);
+        Assert.Equal(2, candidate.Split("First", StringSplitOptions.None).Length - 1);
+        AssertRoslynClean(candidate);
+    }
+
     [Fact]
     public async Task RenameAllowsNonCollidingMembersInUnchangedPreprocessorFileAsync()
     {

--- a/tests/Calor.LanguageServer.Tests/Handlers/RenameHandlerTests.cs
+++ b/tests/Calor.LanguageServer.Tests/Handlers/RenameHandlerTests.cs
@@ -828,6 +828,14 @@ public class RenameHandlerTests
                 "UnrelatedFlags",
                 preprocessorSymbolCount: 8,
                 includeRenameTarget: false);
+            unrelated += """
+
+                  §CSHARP{public static class IdentifierTextOnly
+                {
+                    public const string Value = "Compute Calculate";
+                    // Compute Calculate
+                }}§/CSHARP
+                """;
             var targetPath = Path.Combine(root, "target.calr");
             File.WriteAllText(targetPath, source);
             File.WriteAllText(Path.Combine(root, "unrelated.calr"), unrelated);
@@ -877,6 +885,207 @@ public class RenameHandlerTests
     }
 
     [Fact]
+    public async Task RenameRejectsMethodCollisionInUnchangedPreprocessorFileAsync()
+    {
+        var root = CreateWorkspaceDirectory();
+        try
+        {
+            const string target = """
+                §M{m001:ConditionalCollision}
+                  §CL{c001:Worker:pub:partial}
+                    §MT{m001:Compute:pub} () -> i32
+                      §R INT:1
+                """;
+            const string conditional = """
+                §M{m002:ConditionalCollision}
+                  §CL{c002:Worker:pub:partial}
+                    §PP{COLLIDING_METHOD}
+                      §MT{m002:Calculate:pub} () -> i32
+                        §R INT:2
+                    §/PP{COLLIDING_METHOD}
+                """;
+            var targetPath = Path.Combine(root, "target.calr");
+            File.WriteAllText(targetPath, target);
+            File.WriteAllText(Path.Combine(root, "conditional.calr"), conditional);
+
+            var workspace = new WorkspaceState(root);
+            var uri = DocumentUri.FromFileSystemPath(targetPath);
+            workspace.GetOrCreate(uri, target);
+            var before = workspace.RenameValidationCompilationCount;
+
+            Assert.Null(await RenameAtAsync(
+                workspace,
+                uri,
+                target,
+                "Compute:pub",
+                "Calculate"));
+            Assert.Equal(
+                4,
+                workspace.RenameValidationCompilationCount - before);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RenameRejectsFieldCollisionInUnchangedPreprocessorFileAsync()
+    {
+        var root = CreateWorkspaceDirectory();
+        try
+        {
+            const string target = """
+                §M{m001:ConditionalCollision}
+                  §CL{c001:Worker:pub:partial}
+                    §FLD{i32:stored:pub}
+                """;
+            const string conditional = """
+                §M{m002:ConditionalCollision}
+                  §CL{c002:Worker:pub:partial}
+                    §PP{COLLIDING_FIELD}
+                      §FLD{i32:value:pub}
+                    §/PP{COLLIDING_FIELD}
+                """;
+            var targetPath = Path.Combine(root, "target.calr");
+            File.WriteAllText(targetPath, target);
+            File.WriteAllText(Path.Combine(root, "conditional.calr"), conditional);
+
+            var workspace = new WorkspaceState(root);
+            var uri = DocumentUri.FromFileSystemPath(targetPath);
+            workspace.GetOrCreate(uri, target);
+            var before = workspace.RenameValidationCompilationCount;
+
+            Assert.Null(await RenameAtAsync(
+                workspace,
+                uri,
+                target,
+                "stored:pub",
+                "value"));
+            Assert.Equal(
+                4,
+                workspace.RenameValidationCompilationCount - before);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RenameRejectsGuardedRawCSharpStaleReferenceInUnchangedFileAsync()
+    {
+        var root = CreateWorkspaceDirectory();
+        try
+        {
+            const string target = """
+                §M{m001:RawGuard}
+                  §F{f001:Compute:pub} () -> i32
+                    §R INT:1
+                """;
+            const string guardedReference = """
+                §M{m002:RawGuard}
+                  §CSHARP{public static class RawProbe
+                {
+                #if PRIMARY_RAW
+                    public static int ReadPrimary() => 0;
+                #elif RAW_REFERENCE
+                    public static int Read() => RawGuardModule.Compute();
+                #endif
+                }}§/CSHARP
+                """;
+            var targetPath = Path.Combine(root, "target.calr");
+            File.WriteAllText(targetPath, target);
+            File.WriteAllText(Path.Combine(root, "guarded-reference.calr"), guardedReference);
+            var guardedState = LspTestHarness.CreateDocument(guardedReference);
+            Assert.Contains(
+                "#elif RAW_REFERENCE",
+                new CSharpEmitter().Emit(guardedState.Ast!));
+
+            var workspace = new WorkspaceState(root);
+            var uri = DocumentUri.FromFileSystemPath(targetPath);
+            workspace.GetOrCreate(uri, target);
+            var before = workspace.RenameValidationCompilationCount;
+
+            Assert.Null(await RenameAtAsync(
+                workspace,
+                uri,
+                target,
+                "Compute:pub",
+                "Calculate"));
+            Assert.Equal(
+                6,
+                workspace.RenameValidationCompilationCount - before);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RenameAllowsNonCollidingMembersInUnchangedPreprocessorFileAsync()
+    {
+        var root = CreateWorkspaceDirectory();
+        try
+        {
+            const string target = """
+                §M{m001:ConditionalControl}
+                  §CL{c001:Worker:pub:partial}
+                    §MT{m001:Compute:pub} () -> i32
+                      §R INT:1
+                    §FLD{i32:stored:pub}
+                """;
+            const string conditional = """
+                §M{m002:ConditionalControl}
+                  §CL{c002:Worker:pub:partial}
+                    §PP{UNRELATED_MEMBERS}
+                      §MT{m002:OtherMethod:pub} () -> i32
+                        §R INT:2
+                      §FLD{i32:otherField:pub}
+                    §/PP{UNRELATED_MEMBERS}
+                """;
+            var targetPath = Path.Combine(root, "target.calr");
+            File.WriteAllText(targetPath, target);
+            File.WriteAllText(Path.Combine(root, "conditional.calr"), conditional);
+
+            var workspace = new WorkspaceState(root);
+            var uri = DocumentUri.FromFileSystemPath(targetPath);
+            workspace.GetOrCreate(uri, target);
+            var before = workspace.RenameValidationCompilationCount;
+
+            Assert.NotNull(await RenameAtAsync(
+                workspace,
+                uri,
+                target,
+                "Compute:pub",
+                "Calculate"));
+            Assert.Equal(
+                2,
+                workspace.RenameValidationCompilationCount - before);
+
+            before = workspace.RenameValidationCompilationCount;
+            Assert.NotNull(await RenameAtAsync(
+                workspace,
+                uri,
+                target,
+                "stored:pub",
+                "value"));
+            Assert.Equal(
+                2,
+                workspace.RenameValidationCompilationCount - before);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task RenameFailsClosedWhenRelevantConfigurationBudgetIsExceededAsync()
     {
         var source = CreatePreprocessorRenameSource(
@@ -896,6 +1105,54 @@ public class RenameHandlerTests
         Assert.Equal(
             before,
             workspace.RenameValidationCompilationCount);
+    }
+
+    [Fact]
+    public async Task RenameFailsClosedWhenAffectedUnchangedFileExceedsCombinedBudgetAsync()
+    {
+        var root = CreateWorkspaceDirectory();
+        try
+        {
+            var target = CreatePreprocessorRenameSource(
+                "CombinedBudget",
+                preprocessorSymbolCount: 3);
+            const string conditional = """
+                §M{m002:CombinedBudget}
+                  §CL{c002:OtherFlags:pub}
+                    §PP{OTHER_FLAG_0}
+                      §FLD{i32:Calculate:pub}
+                    §/PP{OTHER_FLAG_0}
+                    §PP{OTHER_FLAG_1}
+                      §FLD{i32:Field1:pub}
+                    §/PP{OTHER_FLAG_1}
+                    §PP{OTHER_FLAG_2}
+                      §FLD{i32:Field2:pub}
+                    §/PP{OTHER_FLAG_2}
+                """;
+            var targetPath = Path.Combine(root, "target.calr");
+            File.WriteAllText(targetPath, target);
+            File.WriteAllText(Path.Combine(root, "conditional.calr"), conditional);
+
+            var workspace = new WorkspaceState(root);
+            var uri = DocumentUri.FromFileSystemPath(targetPath);
+            workspace.GetOrCreate(uri, target);
+            var before = workspace.RenameValidationCompilationCount;
+
+            Assert.Null(await RenameAtAsync(
+                workspace,
+                uri,
+                target,
+                "Compute:pub",
+                "Calculate"));
+            Assert.Equal(
+                before,
+                workspace.RenameValidationCompilationCount);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
     }
 
     [Fact]

--- a/tests/Calor.LanguageServer.Tests/Handlers/RenameHandlerTests.cs
+++ b/tests/Calor.LanguageServer.Tests/Handlers/RenameHandlerTests.cs
@@ -145,7 +145,7 @@ public class RenameHandlerTests
                   §CL{c001:Widget:pub}
                 """;
             const string use = """
-                §M{m002:App}
+                §M{m002:Models}
                   §F{f001:Make:pub} () -> Widget
                     §R §NEW{Widget} §/NEW
                 """;
@@ -223,6 +223,347 @@ public class RenameHandlerTests
         Assert.Null(edit);
     }
 
+    [Fact]
+    public async Task GenericModuleFunctionRefactoringUsesBaseIdentifierAndCompilesAsync()
+    {
+        const string source = """
+            §M{m001:GenericModule}
+              §F{f001:Identity<T>:pub} (T:value) -> T
+                §R value
+              §F{f002:Use:pub} () -> i32
+                §R §C{Identity<i32>} §A INT:1 §/C
+            """;
+        var uri = DocumentUri.From("file:///generic-refactor.calr");
+        var workspace = new WorkspaceState();
+        var state = workspace.GetOrCreate(uri, source, version: 4);
+        var function = Assert.Single(state.Ast!.Functions, function =>
+            function.Name == "Identity<T>");
+        Assert.Equal("Identity", source[function.IdentifierSpan.Start..function.IdentifierSpan.End]);
+
+        var callOffset = source.IndexOf("Identity<i32>", StringComparison.Ordinal);
+        var (line, column) = LspTestHarness.GetLineColumn(source, callOffset);
+        var definition = await new DefinitionHandler(workspace).Handle(
+            new DefinitionParams
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Position = new Position(line - 1, column - 1),
+            },
+            CancellationToken.None);
+        var definitionLocation = Assert.Single(definition!).Location!;
+        Assert.Equal("Identity", TextAt(source, definitionLocation.Range));
+
+        var references = await new ReferencesHandler(workspace).Handle(
+            new ReferenceParams
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Position = new Position(line - 1, column - 1),
+                Context = new ReferenceContext { IncludeDeclaration = true },
+            },
+            CancellationToken.None);
+        Assert.Equal(2, references!.Count());
+        Assert.All(references!, location => Assert.Equal("Identity", TextAt(source, location.Range)));
+
+        var edit = await RenameAtAsync(workspace, uri, source, "Identity<i32>", "Transform");
+        Assert.NotNull(edit);
+        var updated = ApplySingleDocumentEdit(source, edit!);
+        Assert.Contains("§F{f001:Transform<T>:pub}", updated);
+        Assert.Contains("§C{Transform<i32>}", updated);
+        AssertRoslynClean(updated);
+    }
+
+    [Fact]
+    public async Task TypeRenamesCoverStaticCallsAndTypeBearingPositionsAsync()
+    {
+        const string source = """
+            §M{m001:TypeRefactor}
+              §IFACE{i001:IWidget}
+                §MT{m000:Marker} () -> void
+              §CL{c001:WidgetException:pub}
+                §EXT{System.Exception}
+                §IMPL{IWidget}
+                §MT{m001:Create:pub:static} () -> WidgetException
+                  §R §NEW{WidgetException} §/NEW
+                §MT{m002:Marker:pub} () -> void
+                  §P STR:"marker"
+              §CL{c002:DerivedException:pub}
+                §EXT{WidgetException}
+                §FLD{i32:Code:pub}
+              §F{f001:Use:pub} (object:value) -> WidgetException
+                §ARR{items:WidgetException:1}
+                §LIST{values:WidgetException}
+                  §NEW{WidgetException} §/NEW
+                §/LIST{values}
+                §TR{t001}
+                  §R (cast WidgetException value)
+                §CA{WidgetException:ex}
+                  §R §C{WidgetException.Create} §/C
+                §/TR{t001}
+            """;
+        var uri = DocumentUri.From("file:///type-refactor.calr");
+        var workspace = new WorkspaceState();
+        var state = workspace.GetOrCreate(uri, source, version: 1);
+        Assert.False(
+            state.Diagnostics.HasErrors,
+            string.Join(Environment.NewLine, state.Diagnostics.Select(diagnostic =>
+                $"{diagnostic.Code}: {diagnostic.Message}")));
+        var classOffset = source.IndexOf(
+            "WidgetException:pub",
+            StringComparison.Ordinal);
+        var classOccurrence = workspace.ResolveOccurrence(uri, classOffset);
+        Assert.NotNull(classOccurrence);
+        Assert.NotNull(workspace.FindSymbolDefinition(classOccurrence!.SymbolId));
+        Assert.Contains(
+            workspace.FindSymbolOccurrences(classOccurrence.SymbolId, includeDeclaration: true),
+            occurrence => occurrence.Kind == SymbolOccurrenceKind.Definition);
+        var typeIndex = TypeReferenceIndex.BuildDetailed(
+            state.Ast!,
+            state.BoundModule!,
+            source,
+            state.BoundModule!.SymbolsById.Values.OfType<Calor.Compiler.Binding.TypeSymbol>().ToArray());
+        var spanless = DescendantsAndSelf(state.Ast!)
+            .Select(node => node switch
+            {
+                Calor.Compiler.Ast.EventDefinitionNode value => value.DelegateType,
+                Calor.Compiler.Ast.LambdaParameterNode value => value.TypeName,
+                Calor.Compiler.Ast.QuantifierVariableNode value => value.TypeName,
+                Calor.Compiler.Ast.PositionalPatternNode value => value.TypeName,
+                Calor.Compiler.Ast.PropertyPatternNode value => value.TypeName,
+                Calor.Compiler.Ast.TypePatternNode value => value.TypeName,
+                Calor.Compiler.Ast.NoneExpressionNode value => value.TypeName,
+                Calor.Compiler.Ast.RecordCreationNode value => value.TypeName,
+                Calor.Compiler.Ast.FieldDefinitionNode value => value.TypeName,
+                Calor.Compiler.Ast.TypeConstraintNode value => value.TypeName,
+                Calor.Compiler.Ast.GenericTypeNode value => value.TypeName,
+                Calor.Compiler.Ast.RefinementTypeNode value => value.BaseTypeName,
+                Calor.Compiler.Ast.IndexedTypeNode value => value.BaseTypeName,
+                _ => null,
+            })
+            .Where(typeName => typeName == "WidgetException")
+            .ToArray();
+        Assert.Empty(spanless);
+        var spanlessNewTypes = Calor.Compiler.Analysis.Dataflow.BoundNodeHelpers
+            .DescendantsAndSelf(state.BoundModule!)
+            .OfType<Calor.Compiler.Binding.BoundNewExpression>()
+            .SelectMany(creation => DescendantTypeReferences(creation.TypeReference))
+            .Where(reference => reference.ResolvedTypeSymbolId == classOccurrence.SymbolId)
+            .Where(reference => reference.Span.Length == 0
+                || reference.Span.Start < 0
+                || reference.Span.End > source.Length)
+            .ToArray();
+        Assert.Empty(spanlessNewTypes);
+        var incompleteSpannedPositions = DescendantsAndSelf(state.Ast!)
+            .Select(node => node switch
+            {
+                Calor.Compiler.Ast.OutputNode value when value.TypeName == "WidgetException"
+                    => (Node: node.GetType().Name, Span: value.TypeNameSpan),
+                Calor.Compiler.Ast.ClassDefinitionNode value when value.BaseClass == "WidgetException"
+                    => (Node: node.GetType().Name, Span: value.BaseClassSpan ?? default),
+                Calor.Compiler.Ast.ArrayCreationNode value when value.ElementType == "WidgetException"
+                    => (Node: node.GetType().Name, Span: value.ElementTypeSpan),
+                Calor.Compiler.Ast.ListCreationNode value when value.ElementType == "WidgetException"
+                    => (Node: node.GetType().Name, Span: value.ElementTypeSpan),
+                Calor.Compiler.Ast.TypeOperationNode value when value.TargetType == "WidgetException"
+                    => (Node: node.GetType().Name, Span: value.TargetTypeSpan),
+                Calor.Compiler.Ast.CatchClauseNode value when value.ExceptionType == "WidgetException"
+                    => (Node: node.GetType().Name, Span: value.ExceptionTypeSpan ?? default),
+                _ => default,
+            })
+            .Where(position => position.Node != null && position.Span.Length == 0)
+            .ToArray();
+        Assert.Empty(incompleteSpannedPositions);
+        Assert.DoesNotContain(classOccurrence.SymbolId, typeIndex.IncompleteSymbolIds);
+        Assert.True(workspace.CanRenameSymbol(classOccurrence!.SymbolId));
+        var staticCall = Assert.IsType<Calor.Compiler.Binding.BoundCallExpression>(
+            SymbolFinder.FindBoundCallAtOffset(
+                state.BoundModule,
+                source.IndexOf("WidgetException.Create", StringComparison.Ordinal)));
+        Assert.Equal(classOccurrence.SymbolId, staticCall.ReceiverTypeSymbolId);
+
+        var classEdit = await RenameAtAsync(
+            workspace,
+            uri,
+            source,
+            "WidgetException:pub",
+            "RenamedException");
+        Assert.NotNull(classEdit);
+        var renamedClass = ApplySingleDocumentEdit(source, classEdit!);
+        Assert.DoesNotContain("WidgetException", renamedClass);
+        Assert.Contains("§C{RenamedException.Create}", renamedClass);
+        Assert.Contains("§CA{RenamedException:ex}", renamedClass);
+        Assert.Contains("§ARR{items:RenamedException:1}", renamedClass);
+        Assert.Contains("§LIST{values:RenamedException}", renamedClass);
+        Assert.Contains("(cast RenamedException value)", renamedClass);
+        AssertRoslynClean(renamedClass);
+
+        workspace.Update(uri, renamedClass, version: 2);
+        var interfaceEdit = await RenameAtAsync(
+            workspace,
+            uri,
+            renamedClass,
+            "IWidget}",
+            "IRenamedWidget");
+        Assert.NotNull(interfaceEdit);
+        var renamedInterface = ApplySingleDocumentEdit(
+            renamedClass,
+            interfaceEdit!);
+        Assert.Contains("§IFACE{i001:IRenamedWidget}", renamedInterface);
+        Assert.Contains("§IMPL{IRenamedWidget}", renamedInterface);
+        AssertRoslynClean(renamedInterface);
+    }
+
+    [Fact]
+    public async Task ConditionalAlternativeReferencesRefuseDefinitionReferencesAndRenameAsync()
+    {
+        const string source = """
+            §M{m001:Conditional}
+              §CL{c001:Worker:pub}
+                §PP{FEATURE}
+                  §MT{m001:Pick:pub} () -> i32
+                    §R INT:1
+                §PPE
+                  §MT{m002:Pick:pub} () -> i32
+                    §R INT:2
+                §/PP{FEATURE}
+                §PP{FEATURE}
+                  §FLD{i32:value:pub}
+                §PPE
+                  §FLD{i32:value:pub}
+                §/PP{FEATURE}
+                §MT{m003:Run:pub} () -> i32
+                  §R (+ §C{Pick} §/C §THIS.value)
+            """;
+        var uri = DocumentUri.From("file:///conditional-refactor.calr");
+        var workspace = new WorkspaceState();
+        workspace.GetOrCreate(uri, source);
+        var callOffset = source.LastIndexOf("Pick", StringComparison.Ordinal);
+        var (line, column) = LspTestHarness.GetLineColumn(source, callOffset);
+
+        var definition = await new DefinitionHandler(workspace).Handle(
+            new DefinitionParams
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Position = new Position(line - 1, column - 1),
+            },
+            CancellationToken.None);
+        Assert.Null(definition);
+
+        var references = await new ReferencesHandler(workspace).Handle(
+            new ReferenceParams
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Position = new Position(line - 1, column - 1),
+                Context = new ReferenceContext { IncludeDeclaration = true },
+            },
+            CancellationToken.None);
+        Assert.Null(references);
+
+        Assert.Null(await RenameAtAsync(workspace, uri, source, "§C{Pick}", "Choose"));
+        Assert.Null(await RenameAtAsync(workspace, uri, source, "Pick:pub", "Choose"));
+        Assert.Null(await RenameAtAsync(workspace, uri, source, "§THIS.value", "renamed"));
+    }
+
+    [Theory]
+    [InlineData("if")]
+    [InlineData("class")]
+    [InlineData("return")]
+    [InlineData("async")]
+    public async Task RenameRejectsCalorAndCSharpReservedWordsAsync(string newName)
+    {
+        const string source = """
+            §M{m001:Keywords}
+              §F{f001:Compute:pub} () -> i32
+                §R INT:1
+            """;
+        var uri = DocumentUri.From("file:///rename-keyword.calr");
+        var workspace = new WorkspaceState();
+        workspace.GetOrCreate(uri, source);
+
+        Assert.Null(await RenameAtAsync(workspace, uri, source, "Compute", newName));
+    }
+
+    [Fact]
+    public async Task RenameRejectsDeclarationCollisionWithoutPartialEditsAsync()
+    {
+        const string source = """
+            §M{m001:Collisions}
+              §F{f001:First:pub} () -> i32
+                §R INT:1
+              §F{f002:Second:pub} () -> i32
+                §R INT:2
+              §F{f003:Use:pub} () -> i32
+                §R §C{First} §/C
+            """;
+        var uri = DocumentUri.From("file:///rename-collision.calr");
+        var workspace = new WorkspaceState();
+        workspace.GetOrCreate(uri, source);
+
+        Assert.Null(await RenameAtAsync(workspace, uri, source, "First:pub", "Second"));
+    }
+
+    [Fact]
+    public async Task TypeRenameRefusesWhenSemanticCompletenessSignalFindsSpanlessConstraintAsync()
+    {
+        const string source = """
+            §M{m001:IncompleteTypeSpan}
+              §CL{c001:Widget:pub}
+                §FLD{i32:Value:pub}
+              §F{f001:Use:pub}<T> (T:value) -> T
+                §WHERE T : Widget
+                §R value
+            """;
+        var uri = DocumentUri.From("file:///rename-incomplete-type.calr");
+        var workspace = new WorkspaceState();
+        var state = workspace.GetOrCreate(uri, source);
+        Assert.False(state.Diagnostics.HasErrors);
+
+        var offset = source.IndexOf("Widget:pub", StringComparison.Ordinal);
+        var occurrence = workspace.ResolveOccurrence(uri, offset);
+        Assert.NotNull(occurrence);
+        Assert.False(workspace.CanRenameSymbol(occurrence!.SymbolId));
+        Assert.Null(await RenameAtAsync(workspace, uri, source, "Widget:pub", "RenamedWidget"));
+    }
+
+    [Fact]
+    public void CachedProjectCallResolutionDoesNotRereadWorkspaceFiles()
+    {
+        var root = CreateWorkspaceDirectory();
+        try
+        {
+            const string definitions = """
+                §M{m001:Definitions}
+                  §F{f001:Pick:pub} (i32:value) -> i32
+                    §R value
+                """;
+            const string use = """
+                §M{m002:Use}
+                  §F{f002:Run:pub} () -> i32
+                    §R §C{Pick} §A INT:1 §/C
+                """;
+            File.WriteAllText(Path.Combine(root, "definitions.calr"), definitions);
+            var usePath = Path.Combine(root, "use.calr");
+            File.WriteAllText(usePath, use);
+            var workspace = new WorkspaceState(root);
+            var state = workspace.GetOrCreate(
+                DocumentUri.FromFileSystemPath(usePath),
+                use,
+                version: 1);
+            var call = SymbolFinder.FindBoundCallAtOffset(
+                state.BoundModule,
+                use.IndexOf("Pick", StringComparison.Ordinal));
+            var reads = workspace.WorkspaceFileReadCount;
+
+            for (var iteration = 0; iteration < 10; iteration++)
+                Assert.NotNull(workspace.ResolveProjectCall(state, state.Snapshot, call).Symbol);
+
+            Assert.Equal(reads, workspace.WorkspaceFileReadCount);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
     private static async Task<WorkspaceEdit?> RenameAtAsync(
         WorkspaceState workspace,
         DocumentUri uri,
@@ -247,6 +588,78 @@ public class RenameHandlerTests
         var start = PositionConverter.ToOffset(range.Start, source);
         var end = PositionConverter.ToOffset(range.End, source);
         return source[start..end];
+    }
+
+    private static string ApplySingleDocumentEdit(string source, WorkspaceEdit edit)
+    {
+        var change = Assert.Single(Assert.IsType<Container<WorkspaceEditDocumentChange>>(
+            edit.DocumentChanges));
+        var documentEdit = Assert.IsType<TextDocumentEdit>(change.TextDocumentEdit);
+        foreach (var textEdit in documentEdit.Edits.OrderByDescending(textEdit =>
+                     PositionConverter.ToOffset(textEdit.Range.Start, source)))
+        {
+            var start = PositionConverter.ToOffset(textEdit.Range.Start, source);
+            var end = PositionConverter.ToOffset(textEdit.Range.End, source);
+            source = source[..start] + textEdit.NewText + source[end..];
+        }
+        return source;
+    }
+
+    private static void AssertRoslynClean(string source)
+    {
+        var state = LspTestHarness.CreateDocument(source);
+        Assert.NotNull(state.Ast);
+        Assert.NotNull(state.BoundModule);
+        Assert.False(
+            state.Diagnostics.HasErrors,
+            string.Join(Environment.NewLine, state.Diagnostics.Select(diagnostic =>
+                $"{diagnostic.Code}: {diagnostic.Message}")));
+        var syntaxTree = CSharpSyntaxTree.ParseText(new CSharpEmitter().Emit(state.Ast!));
+        Assert.DoesNotContain(
+            syntaxTree.GetDiagnostics(),
+            diagnostic => diagnostic.Severity
+                == Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+        var compilation = CSharpCompilation.Create(
+            "RenameAppliedCompile",
+            [syntaxTree],
+            GetPlatformReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            diagnostic => diagnostic.Severity
+                == Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+    }
+
+    private static IEnumerable<MetadataReference> GetPlatformReferences()
+    {
+        var trustedAssemblies =
+            (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")
+            ?? throw new InvalidOperationException("Trusted platform assemblies are unavailable.");
+        return trustedAssemblies
+            .Split(Path.PathSeparator)
+            .Select(path => MetadataReference.CreateFromFile(path));
+    }
+
+    private static IEnumerable<Calor.Compiler.Ast.AstNode> DescendantsAndSelf(
+        Calor.Compiler.Ast.AstNode node)
+    {
+        yield return node;
+        foreach (var child in Calor.Compiler.Analysis.RecursiveAstWalker.GetAllChildren(node))
+        {
+            foreach (var descendant in DescendantsAndSelf(child))
+                yield return descendant;
+        }
+    }
+
+    private static IEnumerable<Calor.Compiler.Binding.BoundTypeReference> DescendantTypeReferences(
+        Calor.Compiler.Binding.BoundTypeReference reference)
+    {
+        yield return reference;
+        foreach (var argument in reference.TypeArguments)
+        {
+            foreach (var descendant in DescendantTypeReferences(argument))
+                yield return descendant;
+        }
     }
 
     private static string CreateWorkspaceDirectory()

--- a/tests/TestData/Formatting/formatter-corpus-baseline.json
+++ b/tests/TestData/Formatting/formatter-corpus-baseline.json
@@ -1,6 +1,6 @@
 {
   "trackedFileCount": 861,
-  "successfulTransformationCount": 629,
+  "successfulTransformationCount": 630,
   "parseFailurePaths": [
     "bench/mcp/tasks/01-fix-closing-tag/expected.calr",
     "bench/mcp/tasks/01-fix-closing-tag/input.calr",
@@ -208,7 +208,6 @@
       "bench/phase0-agent-native/latency/fixture-10k/src/l3m33.calr",
       "bench/phase0-agent-native/latency/fixture-10k/src/l3m34.calr",
       "bench/phase0-agent-native/latency/fixture-10k/src/l3m35.calr",
-      "samples/Generics/generics.calr",
       "src/Calor.Compiler/Resources/SelfTest/09_codegen_bugfixes.calr",
       "tests/Calor.Conversion.Tests/Snapshots/08-03.approved.calr",
       "tests/Calor.Conversion.Tests/Snapshots/09-03.approved.calr",


### PR DESCRIPTION
## Summary
- restore fixes produced after PR #921 was merged
- preserve exact spans for generic function declarations and all type-bearing positions
- index static type receivers and refuse incomplete or ambiguous refactors
- reject reserved/conflicting rename targets through semantic preflight
- avoid full workspace disk rescans on signature-help hot paths
- retain split-declaration protections merged in PR #921

## Validation
- Release build: 0 warnings/errors
- Full suite: 8,761 passed, 18 skipped, 0 failed

Follow-up to #765 and PR #921.