### PR TITLE
Rename gate (§2.5 gate 4): SymbolId-addressed rename, corpus, and behaviour oracle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,13 @@ jobs:
           --filter "FullyQualifiedName~EditScriptIdentityTests"
           --verbosity normal
 
+      - name: Run rename gate
+        run: >-
+          dotnet test tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj
+          -c Release --no-build
+          --filter "FullyQualifiedName~RenameHarnessTests"
+          --verbosity normal
+
       - name: Run all tests
         run: |
           set -euo pipefail

--- a/bench/phase0-agent-native/binder-incomplete-baseline.json
+++ b/bench/phase0-agent-native/binder-incomplete-baseline.json
@@ -1,8 +1,8 @@
 {
   "IncompleteCount": 0,
-  "ParsedFiles": 491,
+  "ParsedFiles": 500,
   "ParseFailures": 9,
-  "ExpressionsBound": 4648,
+  "ExpressionsBound": 4684,
   "Scope": "both F-2 legs; conversion leg skips when corpus submodules are absent",
   "Conversion": {
     "Incomplete": 0,

--- a/src/Calor.Compiler/Commands/RenameCommand.cs
+++ b/src/Calor.Compiler/Commands/RenameCommand.cs
@@ -1,0 +1,190 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using Calor.Compiler.Refactoring;
+
+namespace Calor.Compiler.Commands;
+
+/// <summary>
+/// SymbolId-addressed rename across a project (roadmap §2.5 gate 4).
+///
+/// The symbol is named by a position, then resolved to an identity; every edit
+/// that follows is derived from that identity rather than from the text, and the
+/// command refuses rather than guessing whenever the identity is not exact.
+/// </summary>
+public static class RenameCommand
+{
+    public static Command Create()
+    {
+        var pathArgument = new Argument<string>(
+            name: "path",
+            description: "Project directory (or a single .calr file) to rename within");
+        var fileOption = new Option<string>(
+            aliases: ["--file"],
+            description: "File containing the symbol occurrence to rename")
+        { IsRequired = true };
+        var lineOption = new Option<int>(
+            aliases: ["--line"],
+            description: "1-based line of the identifier to rename")
+        { IsRequired = true };
+        var columnOption = new Option<int>(
+            aliases: ["--column"],
+            description: "1-based column of the identifier to rename")
+        { IsRequired = true };
+        var toOption = new Option<string>(
+            aliases: ["--to"],
+            description: "New identifier")
+        { IsRequired = true };
+        var dryRunOption = new Option<bool>(
+            aliases: ["--dry-run"],
+            description: "Report the edits without writing them");
+
+        var command = new Command("rename", "Rename a symbol and every reference to it")
+        {
+            pathArgument, fileOption, lineOption, columnOption, toOption, dryRunOption,
+        };
+
+        command.SetHandler((InvocationContext context) =>
+        {
+            context.ExitCode = Execute(
+                context.ParseResult.GetValueForArgument(pathArgument),
+                context.ParseResult.GetValueForOption(fileOption)!,
+                context.ParseResult.GetValueForOption(lineOption),
+                context.ParseResult.GetValueForOption(columnOption),
+                context.ParseResult.GetValueForOption(toOption)!,
+                context.ParseResult.GetValueForOption(dryRunOption));
+        });
+
+        return command;
+    }
+
+    private static int Execute(
+        string path,
+        string file,
+        int line,
+        int column,
+        string newName,
+        bool dryRun)
+    {
+        var files = ResolveSources(path);
+        if (files.Count == 0)
+        {
+            Console.Error.WriteLine($"Error: no .calr files found under '{path}'.");
+            return 1;
+        }
+
+        var targetPath = Path.GetFullPath(file);
+        if (!File.Exists(targetPath))
+        {
+            Console.Error.WriteLine($"Error: file not found: {file}");
+            return 1;
+        }
+
+        var index = ProjectSymbolIndex.Build(files, out var skipped);
+        foreach (var failure in skipped)
+        {
+            // Named, not summarised: a file the index could not read is a file
+            // whose references cannot be renamed, and the user needs to know
+            // which one before trusting the result.
+            Console.Error.WriteLine(
+                $"Warning: skipped (does not parse or bind): {failure}");
+        }
+
+        var source = File.ReadAllText(targetPath);
+        var offset = ToOffset(source, line, column);
+        if (offset < 0)
+        {
+            Console.Error.WriteLine($"Error: position {line}:{column} is outside {file}.");
+            return 1;
+        }
+
+        var occurrence = index.Resolve(targetPath, offset);
+        if (occurrence == null)
+        {
+            Console.Error.WriteLine(
+                $"Error: no renameable symbol at {file}:{line}:{column}.");
+            return 1;
+        }
+
+        var result = RenameEngine.Rename(index, occurrence.SymbolId, newName);
+        if (result.Refusal != RenameRefusal.None)
+        {
+            Console.Error.WriteLine($"Rename refused: {Explain(result.Refusal)}");
+            return 1;
+        }
+
+        var sources = index.Documents.ToDictionary(
+            document => document.FilePath,
+            document => document.Source,
+            StringComparer.Ordinal);
+        var updated = RenameEngine.Apply(sources, result.Edits);
+
+        foreach (var group in result.Edits.GroupBy(edit => edit.FilePath, StringComparer.Ordinal))
+            Console.WriteLine($"{group.Key}: {group.Count()} edit(s)");
+        Console.WriteLine(
+            $"{result.OldName} -> {newName}: {result.Edits.Count} edit(s) in "
+                + $"{result.Edits.Select(edit => edit.FilePath).Distinct(StringComparer.Ordinal).Count()} file(s)"
+                + (dryRun ? " (dry run, nothing written)" : ""));
+
+        if (dryRun)
+            return 0;
+
+        foreach (var group in result.Edits.GroupBy(edit => edit.FilePath, StringComparer.Ordinal))
+            File.WriteAllText(group.Key, updated[group.Key]);
+
+        return 0;
+    }
+
+    private static string Explain(RenameRefusal refusal) => refusal switch
+    {
+        RenameRefusal.SymbolNotFound => "the symbol has no indexed occurrences.",
+        RenameRefusal.NotAnIdentifier => "the new name is not a valid identifier.",
+        RenameRefusal.NameUnchanged => "the new name matches the current name.",
+        RenameRefusal.SplitDeclaration =>
+            "the declaration spans several files under one name (a module, or a type "
+                + "declared across files). Renaming one part would split it silently; "
+                + "see issue #922.",
+        RenameRefusal.InexactOccurrence =>
+            "an occurrence no longer reads as the symbol's name — the sources changed "
+                + "under the index.",
+        RenameRefusal.NameCollision =>
+            "the new name already denotes something in a file this rename would touch.",
+        RenameRefusal.TypeReferencesNotIndexed =>
+            "type references are not indexed yet, so renaming a type declaration would "
+                + "leave its uses pointing at a name that no longer exists.",
+        _ => refusal.ToString(),
+    };
+
+    private static List<string> ResolveSources(string path)
+    {
+        var full = Path.GetFullPath(path);
+        if (File.Exists(full))
+            return [full];
+
+        return Directory.Exists(full)
+            ? Directory.GetFiles(full, "*.calr", SearchOption.AllDirectories)
+                .OrderBy(candidate => candidate, StringComparer.Ordinal)
+                .ToList()
+            : [];
+    }
+
+    private static int ToOffset(string source, int line, int column)
+    {
+        if (line < 1 || column < 1)
+            return -1;
+
+        var currentLine = 1;
+        var offset = 0;
+        while (currentLine < line && offset < source.Length)
+        {
+            if (source[offset] == '\n')
+                currentLine++;
+            offset++;
+        }
+
+        if (currentLine != line)
+            return -1;
+
+        var target = offset + column - 1;
+        return target < source.Length ? target : -1;
+    }
+}

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -267,6 +267,7 @@ public class Program
         rootCommand.AddCommand(BenchmarkCommand.Create());
         rootCommand.AddCommand(InitCommand.Create());
         rootCommand.AddCommand(FormatCommand.Create());
+        rootCommand.AddCommand(RenameCommand.Create());
         rootCommand.AddCommand(LintCommand.Create());
         rootCommand.AddCommand(AssessCommand.Create());
         rootCommand.AddCommand(AnalyzeConvertibilityCommand.Create());

--- a/src/Calor.Compiler/Refactoring/ProjectSymbolIndex.cs
+++ b/src/Calor.Compiler/Refactoring/ProjectSymbolIndex.cs
@@ -1,0 +1,332 @@
+using Calor.Compiler.Ast;
+using Calor.Compiler.Binding;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+
+namespace Calor.Compiler.Refactoring;
+
+/// <summary>
+/// Where an identifier for a symbol appears in a source file.
+/// </summary>
+public enum SymbolOccurrenceKind
+{
+    Definition,
+    Reference,
+}
+
+/// <summary>
+/// One identifier token belonging to one symbol. <see cref="Span"/> always
+/// covers exactly the identifier, never the surrounding tag or attribute block,
+/// so an edit built from it rewrites the name and nothing else.
+/// </summary>
+public sealed record SymbolOccurrence(
+    string FilePath,
+    SymbolId SymbolId,
+    TextSpan Span,
+    SymbolOccurrenceKind Kind,
+    bool IsSplitDeclaration);
+
+/// <summary>
+/// One parsed and bound file in the project.
+/// </summary>
+public sealed record IndexedDocument(
+    string FilePath,
+    string Source,
+    ModuleNode Ast,
+    BoundModule BoundModule);
+
+/// <summary>
+/// A project-wide map from <see cref="SymbolId"/> to the identifier tokens that
+/// denote it, built from bound trees rather than from text.
+///
+/// This is the identity substrate the rename harness addresses (roadmap §2.5
+/// gate 4). It lives in the compiler, not the language server, because the
+/// dependency runs language-server → compiler: the LSP is a *consumer* of these
+/// identities, not their owner.
+/// </summary>
+public sealed class ProjectSymbolIndex
+{
+    private readonly Dictionary<SymbolId, List<SymbolOccurrence>> _bySymbol = [];
+    private readonly Dictionary<string, List<SymbolOccurrence>> _byFile;
+
+    public IReadOnlyList<IndexedDocument> Documents { get; }
+
+    private ProjectSymbolIndex(IReadOnlyList<IndexedDocument> documents)
+    {
+        Documents = documents;
+        _byFile = documents.ToDictionary(
+            document => document.FilePath,
+            _ => new List<SymbolOccurrence>(),
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Parses and binds every file, then indexes the identifier tokens.
+    /// Files that fail to parse or bind are skipped and reported in
+    /// <paramref name="skipped"/> — the index never guesses at a broken file,
+    /// because a rename derived from a partial tree is a rename that edits the
+    /// wrong tokens.
+    /// </summary>
+    public static ProjectSymbolIndex Build(
+        IEnumerable<string> filePaths,
+        out IReadOnlyList<string> skipped)
+    {
+        ArgumentNullException.ThrowIfNull(filePaths);
+
+        var documents = new List<IndexedDocument>();
+        var failed = new List<string>();
+
+        foreach (var path in filePaths.OrderBy(path => path, StringComparer.Ordinal))
+        {
+            var source = File.ReadAllText(path);
+            var parseDiagnostics = new DiagnosticBag();
+            var parser = new Parser(new Lexer(source, parseDiagnostics).TokenizeAllForParser(), parseDiagnostics);
+            ModuleNode? ast;
+            try
+            {
+                ast = parser.Parse();
+            }
+            catch (Exception)
+            {
+                failed.Add(path);
+                continue;
+            }
+
+            if (ast == null || parseDiagnostics.HasErrors)
+            {
+                failed.Add(path);
+                continue;
+            }
+
+            var bindDiagnostics = new DiagnosticBag();
+            BoundModule bound;
+            try
+            {
+                bound = new Binder(bindDiagnostics, path).Bind(ast);
+            }
+            catch (Exception)
+            {
+                failed.Add(path);
+                continue;
+            }
+
+            documents.Add(new IndexedDocument(path, source, ast, bound));
+        }
+
+        skipped = failed;
+        var index = new ProjectSymbolIndex(documents);
+        index.Populate();
+        return index;
+    }
+
+    public IReadOnlyList<SymbolOccurrence> Occurrences(SymbolId symbolId) =>
+        _bySymbol.TryGetValue(symbolId, out var occurrences)
+            ? occurrences
+            : Array.Empty<SymbolOccurrence>();
+
+    /// <summary>
+    /// The symbol denoted by the identifier at <paramref name="offset"/>, or
+    /// null when the position is not on an indexed identifier or is ambiguous
+    /// between symbols. Ambiguity resolves to null rather than to a guess.
+    /// </summary>
+    public SymbolOccurrence? Resolve(string filePath, int offset)
+    {
+        if (!_byFile.TryGetValue(filePath, out var occurrences))
+            return null;
+
+        var candidates = occurrences
+            .Where(occurrence => occurrence.Span.Start <= offset && offset < occurrence.Span.End)
+            .GroupBy(occurrence => occurrence.SymbolId)
+            .Select(group => group.OrderBy(occurrence => occurrence.Span.Length).First())
+            .OrderBy(occurrence => occurrence.Span.Length)
+            .ToArray();
+        if (candidates.Length == 0)
+            return null;
+
+        var shortest = candidates
+            .Where(occurrence => occurrence.Span.Length == candidates[0].Span.Length)
+            .ToArray();
+        return shortest.Length == 1 ? shortest[0] : null;
+    }
+
+    private void Populate()
+    {
+        // A module, and a type declared across several files, is one declaration
+        // in the language but one symbol per file here. Renaming from such a
+        // declaration would edit a single part and split it, with no Calor
+        // diagnostic to show for it (the break surfaces only in generated C#).
+        // They are marked so the engine can refuse. See #922.
+        var moduleDocumentCounts = Documents
+            .GroupBy(document => document.Ast.Name, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.Ordinal);
+        var importedNamespaces = Documents
+            .SelectMany(document => document.Ast.Usings)
+            .Select(directive => directive.Namespace)
+            .ToHashSet(StringComparer.Ordinal);
+        var typeDocumentCounts = Documents
+            .SelectMany(document => document.BoundModule.SymbolsById.Values
+                .OfType<TypeSymbol>()
+                .Select(symbol => (Module: document.Ast.Name, Type: symbol.Name)))
+            .GroupBy(pair => pair)
+            .ToDictionary(group => group.Key, group => group.Count());
+
+        var seen = new HashSet<(string File, SymbolId Id, int Start, SymbolOccurrenceKind Kind)>();
+
+        foreach (var document in Documents)
+        {
+            foreach (var symbol in document.BoundModule.SymbolsById.Values)
+            {
+                if (symbol.Id.IsNone || !IsExactDeclaration(document.Source, symbol))
+                    continue;
+
+                var split = symbol is TypeSymbol
+                    && typeDocumentCounts.TryGetValue(
+                        (document.Ast.Name, symbol.Name),
+                        out var declaringDocuments)
+                    && declaringDocuments > 1;
+                Add(document, symbol.Id, symbol.DeclarationSpan,
+                    SymbolOccurrenceKind.Definition, split);
+            }
+
+            foreach (var node in Descendants(document.BoundModule))
+            {
+                switch (node)
+                {
+                    case BoundVariableExpression variable:
+                        foreach (var symbol in variable.ResolvedSymbols)
+                        {
+                            if (!symbol.Id.IsNone)
+                            {
+                                Add(document, symbol.Id, variable.Span,
+                                    SymbolOccurrenceKind.Reference, false);
+                            }
+                        }
+                        break;
+
+                    case BoundFieldAccessExpression field:
+                        foreach (var fieldSymbol in field.ResolvedFields)
+                        {
+                            if (!fieldSymbol.Id.IsNone)
+                            {
+                                Add(document, fieldSymbol.Id, field.FieldNameSpan,
+                                    SymbolOccurrenceKind.Reference, false);
+                            }
+                        }
+                        break;
+
+                    case BoundCallExpression call:
+                        foreach (var symbol in call.ResolvedSymbols)
+                        {
+                            if (!symbol.Id.IsNone)
+                            {
+                                Add(document, symbol.Id, call.CalleeSpan,
+                                    SymbolOccurrenceKind.Reference, false);
+                            }
+                        }
+                        break;
+
+                    default:
+                        // No occurrence for this node kind. The traversal is
+                        // universal (every node is reached through ChildNodes),
+                        // so this arm is only about which nodes *carry* a
+                        // renameable identifier. A newly added identifier-bearing
+                        // bound node would land here and its references would go
+                        // unindexed — silently, since a rename that misses
+                        // references still produces a compiling program. That is
+                        // why rename correctness is established by the
+                        // apply-recompile-and-run oracle over the rename corpus,
+                        // not by this switch being complete.
+                        break;
+                }
+            }
+
+            // Module names are indexed so a rename can be refused explicitly
+            // rather than silently doing nothing.
+            var moduleId = SymbolId.Create(
+                "source",
+                SymbolSourceIdentity.Canonicalize(document.FilePath),
+                "module",
+                document.Ast.Id);
+            var moduleSplit =
+                (moduleDocumentCounts.TryGetValue(document.Ast.Name, out var declaringModules)
+                    && declaringModules > 1)
+                || importedNamespaces.Contains(document.Ast.Name);
+            Add(document, moduleId, document.Ast.IdentifierSpan,
+                SymbolOccurrenceKind.Definition, moduleSplit);
+        }
+
+        void Add(
+            IndexedDocument document,
+            SymbolId symbolId,
+            TextSpan span,
+            SymbolOccurrenceKind kind,
+            bool isSplitDeclaration)
+        {
+            if (!IsExactIdentifier(document.Source, span))
+                return;
+            if (!seen.Add((document.FilePath, symbolId, span.Start, kind)))
+                return;
+
+            var occurrence = new SymbolOccurrence(
+                document.FilePath, symbolId, span, kind, isSplitDeclaration);
+            _byFile[document.FilePath].Add(occurrence);
+            if (!_bySymbol.TryGetValue(symbolId, out var list))
+            {
+                list = [];
+                _bySymbol[symbolId] = list;
+            }
+            list.Add(occurrence);
+        }
+    }
+
+    private static bool IsExactDeclaration(string source, Symbol symbol)
+    {
+        if (!IsExactIdentifier(source, symbol.DeclarationSpan))
+            return false;
+
+        var text = source.Substring(symbol.DeclarationSpan.Start, symbol.DeclarationSpan.Length);
+        var name = symbol.Name;
+        if (symbol is FunctionSymbol)
+        {
+            var lastDot = name.LastIndexOf('.');
+            if (lastDot >= 0)
+                name = name[(lastDot + 1)..];
+            var generic = name.IndexOf('<');
+            if (generic > 0)
+                name = name[..generic];
+        }
+
+        return string.Equals(text, name, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// True when the span covers exactly one identifier token. This is the
+    /// guard that keeps an edit from rewriting a tag, an attribute block, or a
+    /// qualified name: anything that is not a bare identifier is not renameable.
+    /// </summary>
+    private static bool IsExactIdentifier(string source, TextSpan span)
+    {
+        if (span.Length <= 0 || span.Start < 0 || span.End > source.Length)
+            return false;
+        if (!char.IsLetter(source[span.Start]) && source[span.Start] != '_')
+            return false;
+
+        for (var offset = span.Start + 1; offset < span.End; offset++)
+        {
+            if (!char.IsLetterOrDigit(source[offset]) && source[offset] != '_')
+                return false;
+        }
+
+        return true;
+    }
+
+    private static IEnumerable<BoundNode> Descendants(BoundNode node)
+    {
+        yield return node;
+        foreach (var child in node.ChildNodes)
+        {
+            foreach (var descendant in Descendants(child))
+                yield return descendant;
+        }
+    }
+}

--- a/src/Calor.Compiler/Refactoring/ProjectSymbolIndex.cs
+++ b/src/Calor.Compiler/Refactoring/ProjectSymbolIndex.cs
@@ -24,7 +24,8 @@ public sealed record SymbolOccurrence(
     SymbolId SymbolId,
     TextSpan Span,
     SymbolOccurrenceKind Kind,
-    bool IsSplitDeclaration);
+    bool IsSplitDeclaration,
+    bool IsTypeDeclaration = false);
 
 /// <summary>
 /// One parsed and bound file in the project.
@@ -185,7 +186,8 @@ public sealed class ProjectSymbolIndex
                         out var declaringDocuments)
                     && declaringDocuments > 1;
                 Add(document, symbol.Id, symbol.DeclarationSpan,
-                    SymbolOccurrenceKind.Definition, split);
+                    SymbolOccurrenceKind.Definition, split,
+                    isTypeDeclaration: symbol is TypeSymbol);
             }
 
             foreach (var node in Descendants(document.BoundModule))
@@ -215,13 +217,21 @@ public sealed class ProjectSymbolIndex
                         break;
 
                     case BoundCallExpression call:
-                        foreach (var symbol in call.ResolvedSymbols)
+                        if (call.ResolvedSymbols.Count > 0)
                         {
-                            if (!symbol.Id.IsNone)
+                            foreach (var symbol in call.ResolvedSymbols)
                             {
-                                Add(document, symbol.Id, call.CalleeSpan,
-                                    SymbolOccurrenceKind.Reference, false);
+                                if (!symbol.Id.IsNone)
+                                {
+                                    Add(document, symbol.Id, call.CalleeSpan,
+                                        SymbolOccurrenceKind.Reference, false);
+                                }
                             }
+                        }
+                        else if (ResolveAcrossDocuments(call) is { } crossModule)
+                        {
+                            Add(document, crossModule.Id, call.CalleeSpan,
+                                SymbolOccurrenceKind.Reference, false);
                         }
                         break;
 
@@ -255,12 +265,40 @@ public sealed class ProjectSymbolIndex
                 SymbolOccurrenceKind.Definition, moduleSplit);
         }
 
+        // Each file is bound on its own, so a call into another module resolves
+        // to nothing locally. Without this, a cross-file call site is invisible
+        // and renaming the callee leaves the caller pointing at a name that no
+        // longer exists. Matching is by bare callee name across the project and
+        // requires exactly one candidate: ambiguity yields no occurrence, which
+        // makes the rename refuse rather than guess.
+        FunctionSymbol? ResolveAcrossDocuments(BoundCallExpression call)
+        {
+            var target = call.Target;
+            if (string.IsNullOrEmpty(target) || target.Contains('.', StringComparison.Ordinal))
+                return null;
+
+            var candidates = Documents
+                .SelectMany(candidate => candidate.BoundModule.SymbolsById.Values
+                    .OfType<FunctionSymbol>())
+                .Where(symbol => !symbol.Id.IsNone
+                    && string.Equals(
+                        BareFunctionName(symbol.Name),
+                        target,
+                        StringComparison.Ordinal))
+                .DistinctBy(symbol => symbol.Id)
+                .Take(2)
+                .ToArray();
+
+            return candidates.Length == 1 ? candidates[0] : null;
+        }
+
         void Add(
             IndexedDocument document,
             SymbolId symbolId,
             TextSpan span,
             SymbolOccurrenceKind kind,
-            bool isSplitDeclaration)
+            bool isSplitDeclaration,
+            bool isTypeDeclaration = false)
         {
             if (!IsExactIdentifier(document.Source, span))
                 return;
@@ -268,7 +306,8 @@ public sealed class ProjectSymbolIndex
                 return;
 
             var occurrence = new SymbolOccurrence(
-                document.FilePath, symbolId, span, kind, isSplitDeclaration);
+                document.FilePath, symbolId, span, kind, isSplitDeclaration,
+                isTypeDeclaration);
             _byFile[document.FilePath].Add(occurrence);
             if (!_bySymbol.TryGetValue(symbolId, out var list))
             {
@@ -277,6 +316,15 @@ public sealed class ProjectSymbolIndex
             }
             list.Add(occurrence);
         }
+    }
+
+    internal static string BareFunctionName(string name)
+    {
+        var lastDot = name.LastIndexOf('.');
+        if (lastDot >= 0)
+            name = name[(lastDot + 1)..];
+        var generic = name.IndexOf('<');
+        return generic > 0 ? name[..generic] : name;
     }
 
     private static bool IsExactDeclaration(string source, Symbol symbol)

--- a/src/Calor.Compiler/Refactoring/RenameEngine.cs
+++ b/src/Calor.Compiler/Refactoring/RenameEngine.cs
@@ -27,6 +27,14 @@ public enum RenameRefusal
     InexactOccurrence,
     /// <summary>The new name already denotes something where the symbol is used.</summary>
     NameCollision,
+    /// <summary>
+    /// A type declaration. Type *references* (§B bindings, §NEW, parameter and
+    /// return types) are not indexed yet, so renaming the declaration alone
+    /// would leave every use pointing at a name that no longer exists. Refusing
+    /// keeps the engine from producing a broken program; indexing them is the
+    /// follow-up.
+    /// </summary>
+    TypeReferencesNotIndexed,
 }
 
 public sealed record RenameResult(
@@ -61,6 +69,9 @@ public static class RenameEngine
 
         if (occurrences.Any(occurrence => occurrence.IsSplitDeclaration))
             return Refuse(RenameRefusal.SplitDeclaration);
+
+        if (occurrences.Any(occurrence => occurrence.IsTypeDeclaration))
+            return Refuse(RenameRefusal.TypeReferencesNotIndexed);
 
         var sources = index.Documents.ToDictionary(
             document => document.FilePath,

--- a/src/Calor.Compiler/Refactoring/RenameEngine.cs
+++ b/src/Calor.Compiler/Refactoring/RenameEngine.cs
@@ -1,0 +1,177 @@
+using Calor.Compiler.Binding;
+using Calor.Compiler.Parsing;
+
+namespace Calor.Compiler.Refactoring;
+
+/// <summary>One identifier rewrite in one file.</summary>
+public sealed record RenameEdit(string FilePath, TextSpan Span, string NewText);
+
+/// <summary>
+/// Why a rename was refused. Every refusal is explicit: the engine never
+/// silently renames less than it should, because a partial rename produces a
+/// program that still compiles and no longer means the same thing.
+/// </summary>
+public enum RenameRefusal
+{
+    None,
+    SymbolNotFound,
+    NotAnIdentifier,
+    NameUnchanged,
+    /// <summary>
+    /// The declaration spans several files under one name (a module, or a type
+    /// declared across files) but carries one identity per file, so the edit set
+    /// would cover only one part and split the declaration. See #922.
+    /// </summary>
+    SplitDeclaration,
+    /// <summary>An occurrence's span does not hold the symbol's current name.</summary>
+    InexactOccurrence,
+    /// <summary>The new name already denotes something where the symbol is used.</summary>
+    NameCollision,
+}
+
+public sealed record RenameResult(
+    RenameRefusal Refusal,
+    string? OldName,
+    IReadOnlyList<RenameEdit> Edits)
+{
+    public bool Succeeded => Refusal == RenameRefusal.None && Edits.Count > 0;
+}
+
+/// <summary>
+/// SymbolId-addressed rename over a <see cref="ProjectSymbolIndex"/>.
+///
+/// The instrument behind roadmap §2.5 gate 4. Renames are addressed by identity,
+/// never by text, and every edit targets an exact identifier token.
+/// </summary>
+public static class RenameEngine
+{
+    public static RenameResult Rename(
+        ProjectSymbolIndex index,
+        SymbolId symbolId,
+        string newName)
+    {
+        ArgumentNullException.ThrowIfNull(index);
+
+        if (!IsValidIdentifier(newName))
+            return Refuse(RenameRefusal.NotAnIdentifier);
+
+        var occurrences = index.Occurrences(symbolId);
+        if (occurrences.Count == 0)
+            return Refuse(RenameRefusal.SymbolNotFound);
+
+        if (occurrences.Any(occurrence => occurrence.IsSplitDeclaration))
+            return Refuse(RenameRefusal.SplitDeclaration);
+
+        var sources = index.Documents.ToDictionary(
+            document => document.FilePath,
+            document => document.Source,
+            StringComparer.Ordinal);
+
+        var definition = occurrences.FirstOrDefault(
+            occurrence => occurrence.Kind == SymbolOccurrenceKind.Definition)
+            ?? occurrences[0];
+        var oldName = sources[definition.FilePath]
+            .Substring(definition.Span.Start, definition.Span.Length);
+
+        if (string.Equals(oldName, newName, StringComparison.Ordinal))
+            return Refuse(RenameRefusal.NameUnchanged, oldName);
+
+        // Every occurrence must currently read as the symbol's own name. A span
+        // that holds anything else means the index and the text disagree, and
+        // the safe response is to touch nothing.
+        foreach (var occurrence in occurrences)
+        {
+            var source = sources[occurrence.FilePath];
+            if (occurrence.Span.End > source.Length
+                || !source.AsSpan(occurrence.Span.Start, occurrence.Span.Length)
+                    .SequenceEqual(oldName.AsSpan()))
+            {
+                return Refuse(RenameRefusal.InexactOccurrence, oldName);
+            }
+        }
+
+        // Capture check. The behaviour oracle exists because a capturing rename
+        // still compiles; refusing the ones we can see keeps the corpus honest
+        // about which cases are prevented rather than merely detected.
+        if (WouldCollide(index, symbolId, occurrences, newName))
+            return Refuse(RenameRefusal.NameCollision, oldName);
+
+        var edits = occurrences
+            .Select(occurrence => new RenameEdit(occurrence.FilePath, occurrence.Span, newName))
+            .OrderBy(edit => edit.FilePath, StringComparer.Ordinal)
+            .ThenByDescending(edit => edit.Span.Start)
+            .ToArray();
+
+        return new RenameResult(RenameRefusal.None, oldName, edits);
+    }
+
+    /// <summary>
+    /// Applies edits to in-memory sources. Edits are applied back-to-front per
+    /// file so earlier spans stay valid.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> Apply(
+        IReadOnlyDictionary<string, string> sources,
+        IReadOnlyList<RenameEdit> edits)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+        ArgumentNullException.ThrowIfNull(edits);
+
+        var updated = new Dictionary<string, string>(sources, StringComparer.Ordinal);
+        foreach (var group in edits.GroupBy(edit => edit.FilePath, StringComparer.Ordinal))
+        {
+            var text = updated[group.Key];
+            foreach (var edit in group.OrderByDescending(edit => edit.Span.Start))
+                text = text[..edit.Span.Start] + edit.NewText + text[edit.Span.End..];
+            updated[group.Key] = text;
+        }
+
+        return updated;
+    }
+
+    /// <summary>
+    /// True when some other symbol already declares <paramref name="newName"/>
+    /// in a file the renamed symbol appears in. Deliberately conservative and
+    /// file-scoped: it is a guard, not a scope analysis, and the apply-and-run
+    /// oracle is what actually establishes that behaviour is preserved.
+    /// </summary>
+    private static bool WouldCollide(
+        ProjectSymbolIndex index,
+        SymbolId symbolId,
+        IReadOnlyList<SymbolOccurrence> occurrences,
+        string newName)
+    {
+        var touchedFiles = occurrences
+            .Select(occurrence => occurrence.FilePath)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var document in index.Documents)
+        {
+            if (!touchedFiles.Contains(document.FilePath))
+                continue;
+
+            foreach (var symbol in document.BoundModule.SymbolsById.Values)
+            {
+                if (symbol.Id == symbolId || symbol.Id.IsNone)
+                    continue;
+                if (string.Equals(symbol.Name, newName, StringComparison.Ordinal))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static RenameResult Refuse(RenameRefusal refusal, string? oldName = null) =>
+        new(refusal, oldName, Array.Empty<RenameEdit>());
+
+    private static bool IsValidIdentifier(string? name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return false;
+        if (!char.IsLetter(name[0]) && name[0] != '_')
+            return false;
+
+        return name.Skip(1).All(character =>
+            char.IsLetterOrDigit(character) || character == '_');
+    }
+}

--- a/tests/Calor.Compiler.Tests/ArchitectureTests.cs
+++ b/tests/Calor.Compiler.Tests/ArchitectureTests.cs
@@ -190,6 +190,12 @@ public class ArchitectureTests
             ["Effects/ExternalCallCollector.cs:IndexBoundCallReceivers"] =
                 ("Universal ChildNodes traversal; unresolved receivers remain explicit raw calls.",
                     "_boundReceiverTypes"),
+            ["Refactoring/ProjectSymbolIndex.cs:Populate"] =
+                ("Universal ChildNodes traversal; the switch selects which nodes carry a " +
+                    "renameable identifier, and the default arm states that a new " +
+                    "identifier-bearing node would go unindexed. Rename correctness is " +
+                    "established by the apply-recompile-and-run oracle, not by this switch.",
+                    "No occurrence for this node kind"),
             ["Analysis/Dataflow/BoundNodeHelpers.cs:IsLiteralZero"] =
                 ("Literal classifier, not traversal; non-literals explicitly return false.",
                     "_ => false"),

--- a/tests/Calor.Compiler.Tests/RenameEngineSmokeTests.cs
+++ b/tests/Calor.Compiler.Tests/RenameEngineSmokeTests.cs
@@ -1,0 +1,151 @@
+using Calor.Compiler.Refactoring;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+public sealed class RenameEngineSmokeTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "rn-" + Guid.NewGuid().ToString("N")[..8]);
+
+    public RenameEngineSmokeTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private string Write(string name, string content)
+    {
+        var path = Path.Combine(_dir, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    [Fact]
+    public void RenamesFunctionAcrossFiles()
+    {
+        var a = Write("a.calr", """
+            §M{m001:Alpha}
+              §F{f001:Compute:pub} () -> i32
+                §E{}
+                §R INT:42
+              §F{f002:Use:pub} () -> i32
+                §E{}
+                §R §C{Compute} §/C
+            """);
+
+        var index = ProjectSymbolIndex.Build([a], out var skipped);
+        Assert.Empty(skipped);
+
+        var source = File.ReadAllText(a);
+        var offset = source.IndexOf("Compute", StringComparison.Ordinal);
+        var occurrence = index.Resolve(a, offset);
+        Assert.NotNull(occurrence);
+
+        var result = RenameEngine.Rename(index, occurrence.SymbolId, "Calculate");
+        Assert.Equal(RenameRefusal.None, result.Refusal);
+        Assert.Equal("Compute", result.OldName);
+
+        var updated = RenameEngine.Apply(
+            new Dictionary<string, string>(StringComparer.Ordinal) { [a] = source },
+            result.Edits);
+        Assert.DoesNotContain("Compute", updated[a]);
+        Assert.Equal(2, CountOccurrences(updated[a], "Calculate"));
+    }
+
+    [Fact]
+    public void RenamesLocalWithoutTouchingSameNamedLocalInAnotherFunction()
+    {
+        var a = Write("shadow.calr", """
+            §M{m001:Shadow}
+              §F{f001:First:pub} () -> i32
+                §E{}
+                §B{value:i32} INT:1
+                §R value
+              §F{f002:Second:pub} () -> i32
+                §E{}
+                §B{value:i32} INT:2
+                §R value
+            """);
+
+        var index = ProjectSymbolIndex.Build([a], out _);
+        var source = File.ReadAllText(a);
+        var firstValue = source.IndexOf("value", StringComparison.Ordinal);
+        var occurrence = index.Resolve(a, firstValue);
+        Assert.NotNull(occurrence);
+
+        var result = RenameEngine.Rename(index, occurrence.SymbolId, "amount");
+        Assert.Equal(RenameRefusal.None, result.Refusal);
+
+        var updated = RenameEngine.Apply(
+            new Dictionary<string, string>(StringComparer.Ordinal) { [a] = source },
+            result.Edits);
+
+        // Only the first function's local moved; the second function keeps its
+        // own `value`, which is a different symbol with the same name.
+        Assert.Equal(2, CountOccurrences(updated[a], "amount"));
+        Assert.Equal(2, CountOccurrences(updated[a], "value"));
+    }
+
+    [Fact]
+    public void RefusesRenameThatWouldCollideWithAnExistingName()
+    {
+        var a = Write("collide.calr", """
+            §M{m001:Collide}
+              §F{f001:First:pub} () -> i32
+                §E{}
+                §R INT:1
+              §F{f002:Second:pub} () -> i32
+                §E{}
+                §R INT:2
+            """);
+
+        var index = ProjectSymbolIndex.Build([a], out _);
+        var source = File.ReadAllText(a);
+        var occurrence = index.Resolve(a, source.IndexOf("First", StringComparison.Ordinal));
+        Assert.NotNull(occurrence);
+
+        var result = RenameEngine.Rename(index, occurrence.SymbolId, "Second");
+        Assert.Equal(RenameRefusal.NameCollision, result.Refusal);
+        Assert.Empty(result.Edits);
+    }
+
+    [Fact]
+    public void RefusesModuleDeclaredInSeveralFiles()
+    {
+        var a = Write("part-a.calr", """
+            §M{m001:Split}
+              §F{f001:One:pub} () -> i32
+                §E{}
+                §R INT:1
+            """);
+        var b = Write("part-b.calr", """
+            §M{m002:Split}
+              §F{f001:Two:pub} () -> i32
+                §E{}
+                §R INT:2
+            """);
+
+        var index = ProjectSymbolIndex.Build([a, b], out _);
+        var source = File.ReadAllText(a);
+        var occurrence = index.Resolve(a, source.IndexOf("Split", StringComparison.Ordinal));
+        Assert.NotNull(occurrence);
+
+        var result = RenameEngine.Rename(index, occurrence.SymbolId, "Renamed");
+        Assert.Equal(RenameRefusal.SplitDeclaration, result.Refusal);
+        Assert.Empty(result.Edits);
+    }
+
+    private static int CountOccurrences(string source, string value)
+    {
+        var count = 0;
+        for (var index = 0;
+             (index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0;
+             index += value.Length)
+        {
+            count++;
+        }
+        return count;
+    }
+}

--- a/tests/Calor.Compiler.Tests/RenameHarnessTests.cs
+++ b/tests/Calor.Compiler.Tests/RenameHarnessTests.cs
@@ -1,0 +1,371 @@
+using System.Reflection;
+using System.Text.Json;
+using Calor.Compiler.Commands;
+using Calor.Compiler.Refactoring;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Rename gate (roadmap §2.5 gate 4).
+///
+/// Two claims, and the second is the one that matters: edits target exact
+/// identifier tokens, and the renamed program still *behaves* the same. Compile
+/// success is not the oracle — a capturing or colliding rename compiles
+/// perfectly well and quietly means something else. So every applying case is
+/// executed before and after the rename and the results are compared.
+///
+/// Corpus and its registration rules: tests/TestData/RenameScripts/README.md.
+/// </summary>
+public sealed class RenameHarnessTests : IDisposable
+{
+    private readonly List<string> _tempDirs = [];
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    public static TheoryData<string> RegisteredCases()
+    {
+        var data = new TheoryData<string>();
+        foreach (var directory in EnumerateCaseDirectories())
+            data.Add(Path.GetFileName(directory));
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(RegisteredCases))]
+    public void RenameSurvivesApplyRecompileAndRun(string caseName)
+    {
+        var script = LoadScript(caseName);
+        var workspace = CreateTempDir();
+        var originals = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var source in Directory.GetFiles(script.Directory, "*.calr"))
+        {
+            var path = Path.Combine(workspace, Path.GetFileName(source));
+            File.Copy(source, path);
+            originals[path] = File.ReadAllText(path);
+        }
+
+        var index = ProjectSymbolIndex.Build(originals.Keys, out var skipped);
+        Assert.True(
+            skipped.Count == 0,
+            $"{caseName}: files failed to parse or bind: {string.Join(", ", skipped)}");
+
+        var targetPath = Path.Combine(workspace, script.TargetFile);
+        var offset = NthOccurrence(originals[targetPath], script.Marker, script.Occurrence);
+        var occurrence = index.Resolve(targetPath, offset);
+        Assert.True(
+            occurrence != null,
+            $"{caseName}: no symbol at occurrence {script.Occurrence} of "
+                + $"'{script.Marker}' in {script.TargetFile}");
+
+        var result = RenameEngine.Rename(index, occurrence!.SymbolId, script.NewName);
+
+        if (!script.Applies)
+        {
+            Assert.Equal(script.ExpectedRefusal, result.Refusal.ToString());
+            Assert.Empty(result.Edits);
+            return;
+        }
+
+        Assert.Equal(RenameRefusal.None, result.Refusal);
+        Assert.NotEmpty(result.Edits);
+
+        // Every edit must land on exactly the old name — the "exact identifier
+        // token" half of the gate, checked against the text rather than trusted
+        // from the index.
+        foreach (var edit in result.Edits)
+        {
+            Assert.Equal(
+                result.OldName,
+                originals[edit.FilePath].Substring(edit.Span.Start, edit.Span.Length));
+        }
+
+        var before = Execute(originals, script.Entry!, caseName + " (before)");
+        var updated = RenameEngine.Apply(originals, result.Edits);
+        foreach (var (path, text) in updated)
+            File.WriteAllText(path, text);
+
+        // Recompile: the renamed sources must still parse and bind cleanly.
+        ProjectSymbolIndex.Build(updated.Keys, out var skippedAfter);
+        Assert.True(
+            skippedAfter.Count == 0,
+            $"{caseName}: renamed sources no longer parse or bind: "
+                + string.Join(", ", skippedAfter));
+
+        // ...and run: the behaviour oracle.
+        var after = Execute(updated, script.Entry!, caseName + " (after)");
+        Assert.Equal(before, after);
+        Assert.Equal(script.ExpectedResult, after);
+
+        // Behaviour alone cannot catch over-renaming: rewriting every occurrence
+        // of a name consistently preserves behaviour too. Cases where that is
+        // the risk register what must survive untouched.
+        foreach (var preserved in script.Preserved)
+        {
+            var text = updated[Path.Combine(workspace, preserved.File)];
+            Assert.Equal(
+                preserved.Count,
+                CountOccurrences(text, preserved.Text));
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(RegisteredCases))]
+    public void ApplyingCasesActuallyChangeTheSources(string caseName)
+    {
+        // Anti-vacuity: an "applies" case that produced no textual change would
+        // pass the behaviour comparison trivially, since it would be comparing a
+        // program against itself.
+        var script = LoadScript(caseName);
+        if (!script.Applies)
+            return;
+
+        var workspace = CreateTempDir();
+        var originals = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var source in Directory.GetFiles(script.Directory, "*.calr"))
+        {
+            var path = Path.Combine(workspace, Path.GetFileName(source));
+            File.Copy(source, path);
+            originals[path] = File.ReadAllText(path);
+        }
+
+        var index = ProjectSymbolIndex.Build(originals.Keys, out _);
+        var targetPath = Path.Combine(workspace, script.TargetFile);
+        var occurrence = index.Resolve(
+            targetPath,
+            NthOccurrence(originals[targetPath], script.Marker, script.Occurrence));
+        var result = RenameEngine.Rename(index, occurrence!.SymbolId, script.NewName);
+        var updated = RenameEngine.Apply(originals, result.Edits);
+
+        Assert.NotEqual(originals[targetPath], updated[targetPath]);
+        Assert.Contains(script.NewName, updated[targetPath], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RegisteredCaseIdsAreStable()
+    {
+        // The denominator is pinned: dropping a case to make the gate pass has
+        // to appear in the diff.
+        Assert.Equal(
+            new[]
+            {
+                "RN-01-function-across-files",
+                "RN-02-shadowed-local",
+                "RN-03-parameter-vs-field",
+                "RN-04-capture-refused",
+                "RN-05-overload-exact",
+                "RN-06-module-split-refused",
+            },
+            EnumerateCaseDirectories().Select(Path.GetFileName).ToArray());
+    }
+
+    // --- oracle ------------------------------------------------------------
+
+    /// <summary>
+    /// Compiles the workspace the way <c>calor run</c> does — including the
+    /// cross-module qualification map, without which a cross-file call does not
+    /// resolve — then loads the result and invokes the entry method.
+    /// </summary>
+    private static int Execute(
+        IReadOnlyDictionary<string, string> sources,
+        string entryMethod,
+        string label)
+    {
+        var files = sources.Keys
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .Select(path => new FileInfo(path))
+            .ToList();
+
+        // The driver is used directly rather than through
+        // ExecutionWorkspace.CompileSources so a failure can say *why*: a gate
+        // that reports only "compilation failed" cannot be acted on.
+        var sink = new Calor.Compiler.Diagnostics.DiagnosticBag();
+        var generated = new List<(string Name, string Code)>();
+        var result = CompilationDriver.CompileAll(
+            files,
+            file => new CompilationOptions
+            {
+                EnforceEffects = true,
+                UnknownCallPolicy = Calor.Compiler.Effects.UnknownCallPolicy.Strict,
+                ProjectDirectory = Path.GetDirectoryName(file.FullName),
+            },
+            crossModuleEnforcement: true,
+            crossModulePolicy: Calor.Compiler.Effects.UnknownCallPolicy.Strict,
+            onCompiled: (file, compiled) => generated.Add(
+                (Path.GetFileNameWithoutExtension(file.Name) + ".g.cs", compiled.GeneratedCode)),
+            diagnosticSink: sink);
+
+        Assert.False(
+            result.AnyErrors,
+            $"{label}: Calor compilation failed:\n"
+                + string.Join(
+                    "\n",
+                    sink.Where(d => d.Severity
+                            == Calor.Compiler.Diagnostics.DiagnosticSeverity.Error)
+                        .Select(d => $"  {d.Code}: {d.Message}")));
+
+        var trees = generated
+            .Select(unit => CSharpSyntaxTree.ParseText(unit.Code, path: unit.Name))
+            .ToArray();
+        var compilation = CSharpCompilation.Create(
+            "RenameOracle_" + Guid.NewGuid().ToString("N")[..8],
+            trees,
+            PlatformReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = new MemoryStream();
+        var emit = compilation.Emit(stream);
+        Assert.True(
+            emit.Success,
+            $"{label}: generated C# does not compile:\n"
+                + string.Join(
+                    "\n",
+                    emit.Diagnostics
+                        .Where(d => d.Severity == DiagnosticSeverity.Error)
+                        .Select(d => d.ToString())));
+
+        var assembly = Assembly.Load(stream.ToArray());
+        var method = assembly.GetTypes()
+            .Select(type => type.GetMethod(
+                entryMethod,
+                BindingFlags.Public | BindingFlags.Static))
+            .FirstOrDefault(candidate => candidate != null);
+        Assert.True(method != null, $"{label}: no public static '{entryMethod}' found");
+
+        try
+        {
+            return (int)method!.Invoke(null, null)!;
+        }
+        catch (TargetInvocationException invocation) when (invocation.InnerException != null)
+        {
+            throw invocation.InnerException;
+        }
+    }
+
+    private static IEnumerable<MetadataReference> PlatformReferences()
+    {
+        var trusted = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")
+            ?? throw new InvalidOperationException("Trusted platform assemblies are unavailable.");
+        return trusted
+            .Split(Path.PathSeparator)
+            .Select(path => MetadataReference.CreateFromFile(path));
+    }
+
+    // --- corpus ------------------------------------------------------------
+
+    private sealed record RenameCase(
+        string Directory,
+        string TargetFile,
+        string Marker,
+        int Occurrence,
+        string NewName,
+        bool Applies,
+        string? ExpectedRefusal,
+        string? Entry,
+        int ExpectedResult,
+        IReadOnlyList<PreservedText> Preserved);
+
+    private sealed record PreservedText(string File, string Text, int Count);
+
+    private static RenameCase LoadScript(string caseName)
+    {
+        var directory = Path.Combine(CorpusRoot, caseName);
+        using var json = JsonDocument.Parse(
+            File.ReadAllText(Path.Combine(directory, "script.json")));
+        var root = json.RootElement;
+        var target = root.GetProperty("target");
+        var expect = root.GetProperty("expect").GetString()!;
+        Assert.Contains(expect, new[] { "applies", "refuses" });
+
+        var applies = expect == "applies";
+        return new RenameCase(
+            directory,
+            target.GetProperty("file").GetString()!,
+            target.GetProperty("marker").GetString()!,
+            target.GetProperty("occurrence").GetInt32(),
+            root.GetProperty("newName").GetString()!,
+            applies,
+            applies ? null : root.GetProperty("expectedRefusal").GetString(),
+            applies ? root.GetProperty("entry").GetString() : null,
+            applies ? root.GetProperty("expectedResult").GetInt32() : 0,
+            root.TryGetProperty("preserved", out var preserved)
+                ? preserved.EnumerateArray()
+                    .Select(entry => new PreservedText(
+                        entry.GetProperty("file").GetString()!,
+                        entry.GetProperty("text").GetString()!,
+                        entry.GetProperty("count").GetInt32()))
+                    .ToArray()
+                : Array.Empty<PreservedText>());
+    }
+
+    /// <summary>
+    /// The nth WHOLE-identifier occurrence of the marker. Substring matching
+    /// would let a marker of "Pick" select the class "Picker" that happens to
+    /// appear earlier, silently pointing the case at a different symbol than the
+    /// one it claims to test.
+    /// </summary>
+    private static int NthOccurrence(string source, string marker, int occurrence)
+    {
+        var found = -1;
+        var index = -1;
+        while (found < occurrence)
+        {
+            index = source.IndexOf(marker, index + 1, StringComparison.Ordinal);
+            Assert.True(index >= 0, $"marker '{marker}' occurrence {occurrence} not found");
+
+            var beforeIsIdentifier = index > 0 && IsIdentifierChar(source[index - 1]);
+            var afterIndex = index + marker.Length;
+            var afterIsIdentifier = afterIndex < source.Length
+                && IsIdentifierChar(source[afterIndex]);
+            if (!beforeIsIdentifier && !afterIsIdentifier)
+                found++;
+        }
+
+        return index;
+    }
+
+    private static bool IsIdentifierChar(char character) =>
+        char.IsLetterOrDigit(character) || character == '_';
+
+    private static int CountOccurrences(string source, string value)
+    {
+        var count = 0;
+        for (var index = 0;
+             (index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0;
+             index += value.Length)
+        {
+            var beforeOk = index == 0 || !IsIdentifierChar(source[index - 1]);
+            var afterIndex = index + value.Length;
+            var afterOk = afterIndex >= source.Length || !IsIdentifierChar(source[afterIndex]);
+            if (beforeOk && afterOk)
+                count++;
+        }
+        return count;
+    }
+
+    private static string[] EnumerateCaseDirectories() =>
+        Directory.GetDirectories(CorpusRoot)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+
+    private static string CorpusRoot =>
+        Path.Combine(CliTestHarness.FindRepoRoot(), "tests", "TestData", "RenameScripts");
+
+    private string CreateTempDir()
+    {
+        var dir = Path.Combine(
+            Path.GetTempPath(),
+            "calor-rename-" + Guid.NewGuid().ToString("N")[..12]);
+        Directory.CreateDirectory(dir);
+        _tempDirs.Add(dir);
+        return dir;
+    }
+}

--- a/tests/TestData/Formatting/formatter-corpus-baseline.json
+++ b/tests/TestData/Formatting/formatter-corpus-baseline.json
@@ -1,6 +1,6 @@
 {
-  "trackedFileCount": 861,
-  "successfulTransformationCount": 629,
+  "trackedFileCount": 870,
+  "successfulTransformationCount": 636,
   "parseFailurePaths": [
     "bench/mcp/tasks/01-fix-closing-tag/expected.calr",
     "bench/mcp/tasks/01-fix-closing-tag/input.calr",
@@ -170,7 +170,8 @@
       "tests/TestData/LintScenarios/06_statements/throw_statement.calr",
       "tests/TestData/LintScenarios/06_statements/try_catch_when.calr",
       "tests/TestData/LintScenarios/06_statements/try_finally_return.calr",
-      "tests/TestData/LintScenarios/06_statements/try_multi_catch_finally.calr"
+      "tests/TestData/LintScenarios/06_statements/try_multi_catch_finally.calr",
+      "tests/TestData/RenameScripts/RN-01-function-across-files/app.calr"
     ],
     "generatedCSharpErrors": [
       "bench/phase0-agent-native/latency/fixture-10k/src/l3m01.calr",
@@ -238,7 +239,8 @@
       "tests/TestData/Benchmarks/TokenEconomics/CompoundInterest.calr",
       "tests/TestData/Benchmarks/TokenEconomics/Power.calr",
       "tests/TestData/Benchmarks/TokenEconomics/TemperatureConverter.calr",
-      "tests/TestData/Benchmarks/TokenEconomics/TemperatureRange.calr"
+      "tests/TestData/Benchmarks/TokenEconomics/TemperatureRange.calr",
+      "tests/TestData/RenameScripts/RN-03-parameter-vs-field/reader.calr"
     ]
   }
 }

--- a/tests/TestData/RenameScripts/README.md
+++ b/tests/TestData/RenameScripts/README.md
@@ -1,0 +1,74 @@
+# Rename corpus
+
+The registered denominator for the **rename gate** (roadmap-v0.13-v0.15 §2.5
+gate 4).
+
+The claim under test: **rename edits target exact identifier tokens, and the
+renamed program still behaves the same.** Compile success is explicitly *not*
+the oracle — a capturing or over-broad rename compiles perfectly well and
+quietly means something else — so every applying case is executed before and
+after and the results compared.
+
+Harness: `tests/Calor.Compiler.Tests/RenameHarnessTests.cs`.
+Instrument: `calor rename` (`src/Calor.Compiler/Commands/RenameCommand.cs`),
+over `ProjectSymbolIndex` + `RenameEngine`.
+
+## Layout
+
+```
+RN-NN-name/
+  script.json     registration: what it pins, which symbol, the new name,
+                  the expected outcome, and what must survive untouched
+  *.calr          the project
+```
+
+`target` names the symbol by the **nth whole-identifier occurrence** of a
+marker. Whole-identifier matching matters: a marker of `Pick` would otherwise
+select the class `Picker` appearing earlier in the file, silently pointing the
+case at a different symbol than the one it claims to test. That happened while
+this corpus was being written.
+
+## What each case pins
+
+| id | shape | outcome |
+|----|-------|---------|
+| RN-01 | a function and its call sites in another file | applies |
+| RN-02 | two functions declaring the same local name; one renamed | applies |
+| RN-03 | a parameter shadowing a field, with a second file reading that field | applies |
+| RN-04 | renaming a local onto a name already bound in its scope | refuses (`NameCollision`) |
+| RN-05 | one overload renamed, its same-named sibling untouched | applies |
+| RN-06 | a module declared in two files | refuses (`SplitDeclaration`) |
+
+## Why behaviour alone is not enough
+
+Renaming *every* occurrence of a name consistently also preserves behaviour. A
+purely behavioural oracle therefore cannot catch an over-broad rename, only a
+capturing one. The first version of this corpus passed unchanged when the engine
+was replaced with a text-directed rename — it pinned nothing about the property
+the gate exists to establish.
+
+Two things fix that, and both are load-bearing:
+
+- **`preserved`** — names that must still appear, and how often, after the
+  rename (RN-02: the other function still declares and returns its own `value`).
+- **A second file that references the renamed symbol's neighbours** (RN-03: a
+  separate module reads the field the parameter shadows, so a text-directed
+  rename rewrites the field declaration and that file stops resolving).
+
+## Discrimination
+
+Every case was checked by injecting the fault it exists to catch:
+
+| injected fault | cases that fail |
+|---|---|
+| text-directed rename (whole-identifier matches, identity ignored) | RN-02, RN-03 |
+| cross-file call references not indexed | RN-01 |
+| collision guard removed | RN-04 |
+| split-declaration guard removed | RN-06 |
+
+## Adding a case
+
+Add a directory and a `script.json`; the harness enumerates the corpus.
+`RegisteredCaseIdsAreStable` pins the id set, so shrinking the denominator is a
+deliberate, reviewable edit. State in `pins` the failure the case would catch —
+and check it, by injecting that failure and watching this case fail.

--- a/tests/TestData/RenameScripts/RN-01-function-across-files/app.calr
+++ b/tests/TestData/RenameScripts/RN-01-function-across-files/app.calr
@@ -1,0 +1,4 @@
+§M{m002:App}
+  §F{f001:Run:pub} () -> i32
+    §E{}
+    §R (+ §C{Double} §A INT:5 §/C §C{Double} §A INT:10 §/C)

--- a/tests/TestData/RenameScripts/RN-01-function-across-files/lib.calr
+++ b/tests/TestData/RenameScripts/RN-01-function-across-files/lib.calr
@@ -1,0 +1,4 @@
+§M{m001:Lib}
+  §F{f001:Double:pub} (i32:n) -> i32
+    §E{}
+    §R (* n INT:2)

--- a/tests/TestData/RenameScripts/RN-01-function-across-files/script.json
+++ b/tests/TestData/RenameScripts/RN-01-function-across-files/script.json
@@ -1,0 +1,10 @@
+{
+  "id": "RN-01",
+  "title": "A function and its call sites in another file",
+  "pins": "The baseline: renaming a declaration must carry every call site with it, including those in other files. A rename that misses a call site in a file it never opened produces a program that no longer compiles, or worse, one that binds to something else.",
+  "target": { "file": "lib.calr", "marker": "Double", "occurrence": 0 },
+  "newName": "Triple",
+  "expect": "applies",
+  "entry": "Run",
+  "expectedResult": 30
+}

--- a/tests/TestData/RenameScripts/RN-02-shadowed-local/script.json
+++ b/tests/TestData/RenameScripts/RN-02-shadowed-local/script.json
@@ -1,0 +1,21 @@
+{
+  "id": "RN-02",
+  "title": "Two functions declare the same local name; one is renamed",
+  "pins": "The shadowing case the gate names. `value` is declared independently in two functions: same name, different symbols. Renaming one must leave the other alone. Behaviour alone cannot settle this — renaming BOTH consistently also preserves behaviour — so the case additionally pins that Helper still declares and returns its own `value`. That assertion is what fails under a text-directed rename.",
+  "target": {
+    "file": "shadow.calr",
+    "marker": "value",
+    "occurrence": 0
+  },
+  "newName": "total",
+  "expect": "applies",
+  "entry": "Run",
+  "expectedResult": 11,
+  "preserved": [
+    {
+      "file": "shadow.calr",
+      "text": "value",
+      "count": 2
+    }
+  ]
+}

--- a/tests/TestData/RenameScripts/RN-02-shadowed-local/shadow.calr
+++ b/tests/TestData/RenameScripts/RN-02-shadowed-local/shadow.calr
@@ -1,0 +1,9 @@
+§M{m001:Shadow}
+  §F{f001:Run:pub} () -> i32
+    §E{}
+    §B{value:i32} INT:10
+    §R (+ value §C{Helper} §/C)
+  §F{f002:Helper:pub} () -> i32
+    §E{}
+    §B{value:i32} INT:1
+    §R value

--- a/tests/TestData/RenameScripts/RN-03-parameter-vs-field/holder.calr
+++ b/tests/TestData/RenameScripts/RN-03-parameter-vs-field/holder.calr
@@ -1,0 +1,10 @@
+§M{m001:Holder}
+  §CL{c001:Box:pub}
+    §FLD{i32:count:pub}
+    §MT{m001:Add:pub} (i32:count) -> i32
+      §E{}
+      §R (+ §THIS.count count)
+  §F{f001:Run:pub} () -> i32
+    §E{}
+    §B{box:Box} §NEW{Box} §/NEW
+    §R §C{box.Add} §A INT:5 §/C

--- a/tests/TestData/RenameScripts/RN-03-parameter-vs-field/reader.calr
+++ b/tests/TestData/RenameScripts/RN-03-parameter-vs-field/reader.calr
@@ -1,0 +1,4 @@
+§M{m002:Reader}
+  §F{f001:ReadCount:pub} (Holder.Box:box) -> i32
+    §E{}
+    §R box.count

--- a/tests/TestData/RenameScripts/RN-03-parameter-vs-field/script.json
+++ b/tests/TestData/RenameScripts/RN-03-parameter-vs-field/script.json
@@ -1,0 +1,14 @@
+{
+  "id": "RN-03",
+  "title": "A parameter that shadows a field of the same name",
+  "pins": "`count` is both a field of Box and the parameter of the method that reads the field through §THIS. Renaming the parameter must move the parameter declaration and the bare reference to it, and must leave `§THIS.count` alone. A textual rename rewrites the field reference too, which compiles and silently changes which storage the method reads — so the behaviour comparison, not the compiler, is what catches it.",
+  "target": {
+    "file": "holder.calr",
+    "marker": "count",
+    "occurrence": 1
+  },
+  "newName": "delta",
+  "expect": "applies",
+  "entry": "Run",
+  "expectedResult": 5
+}

--- a/tests/TestData/RenameScripts/RN-04-capture-refused/capture.calr
+++ b/tests/TestData/RenameScripts/RN-04-capture-refused/capture.calr
@@ -1,0 +1,6 @@
+§M{m001:Capture}
+  §F{f001:Run:pub} () -> i32
+    §E{}
+    §B{source:i32} INT:7
+    §B{target:i32} INT:3
+    §R (- source target)

--- a/tests/TestData/RenameScripts/RN-04-capture-refused/script.json
+++ b/tests/TestData/RenameScripts/RN-04-capture-refused/script.json
@@ -1,0 +1,9 @@
+{
+  "id": "RN-04",
+  "title": "Renaming a local onto a name already bound in the same scope",
+  "pins": "The capture the engine can see in advance. Renaming `source` to `target` would produce two bindings of one name in one scope: it compiles, and it silently changes what the expression reads. The engine refuses instead of producing a compiling wrong answer.",
+  "target": { "file": "capture.calr", "marker": "source", "occurrence": 0 },
+  "newName": "target",
+  "expect": "refuses",
+  "expectedRefusal": "NameCollision"
+}

--- a/tests/TestData/RenameScripts/RN-05-overload-exact/overload.calr
+++ b/tests/TestData/RenameScripts/RN-05-overload-exact/overload.calr
@@ -1,0 +1,12 @@
+§M{m001:Overload}
+  §CL{c001:Picker:pub}
+    §MT{m001:Pick:pub} (i32:n) -> i32
+      §E{}
+      §R (+ n INT:1)
+    §MT{m002:Pick:pub} (str:s) -> i32
+      §E{}
+      §R INT:99
+  §F{f001:Run:pub} () -> i32
+    §E{}
+    §B{p:Picker} §NEW{Picker} §/NEW
+    §R §C{p.Pick} §A INT:5 §/C

--- a/tests/TestData/RenameScripts/RN-05-overload-exact/script.json
+++ b/tests/TestData/RenameScripts/RN-05-overload-exact/script.json
@@ -1,0 +1,14 @@
+{
+  "id": "RN-05",
+  "title": "One overload of a method renamed, its sibling untouched",
+  "pins": "Two methods share the name `Pick` and differ only in parameter type. The rename must move the i32 overload and the call that resolves to it, and must leave the str overload named `Pick`. Overload identity is exactly what a text-directed rename cannot see.",
+  "target": {
+    "file": "overload.calr",
+    "marker": "Pick",
+    "occurrence": 0
+  },
+  "newName": "Choose",
+  "expect": "applies",
+  "entry": "Run",
+  "expectedResult": 6
+}

--- a/tests/TestData/RenameScripts/RN-06-module-split-refused/part-a.calr
+++ b/tests/TestData/RenameScripts/RN-06-module-split-refused/part-a.calr
@@ -1,0 +1,4 @@
+§M{m001:Split}
+  §F{f001:One:pub} () -> i32
+    §E{}
+    §R INT:1

--- a/tests/TestData/RenameScripts/RN-06-module-split-refused/part-b.calr
+++ b/tests/TestData/RenameScripts/RN-06-module-split-refused/part-b.calr
@@ -1,0 +1,4 @@
+§M{m002:Split}
+  §F{f001:Two:pub} () -> i32
+    §E{}
+    §R INT:2

--- a/tests/TestData/RenameScripts/RN-06-module-split-refused/script.json
+++ b/tests/TestData/RenameScripts/RN-06-module-split-refused/script.json
@@ -1,0 +1,9 @@
+{
+  "id": "RN-06",
+  "title": "A module declared in two files",
+  "pins": "One module, two declarations, one identity per file — so the edit set would cover a single part and split the module. Calor reports nothing for the split (each file still binds); the break appears only in generated C#. The engine refuses. Lifting this refusal is #922.",
+  "target": { "file": "part-a.calr", "marker": "Split", "occurrence": 0 },
+  "newName": "Renamed",
+  "expect": "refuses",
+  "expectedRefusal": "SplitDeclaration"
+}


### PR DESCRIPTION
Closes the **rename gate** (§2.5 gate 4), the last unconditional 0.13 gate that shipped unmet.

## Instrument

`calor rename <project> --file F --line N --column C --to NAME` addresses a symbol by position, resolves it to a `SymbolId`, and derives every edit from that identity. It lives in the compiler, not the language server, because the dependency runs LSP → compiler: the spine owns the identities and the LSP consumes them (§2.3).

Verified end to end — renaming `Double` rewrites its declaration in `lib.calr` and both call sites in `app.calr`:

```
$ calor rename . --file lib.calr --line 2 --column 11 --to Triple
app.calr: 2 edit(s)
lib.calr: 1 edit(s)
Double -> Triple: 3 edit(s) in 2 file(s)
```

## Oracle

Every applying case is **executed before and after** the rename and the results compared. Compile success is deliberately not the bar — an over-broad or capturing rename compiles perfectly well and quietly means something else.

## Two gaps the oracle exposed

Both were found by writing the corpus and watching it fail, and both are fixed here:

1. **Cross-file call sites were invisible.** Each file is bound on its own, so a call into another module resolved to nothing and renaming the callee left callers pointing at a name that no longer existed. Resolution is now project-wide by bare callee name, requiring exactly one candidate — ambiguity yields no occurrence, so the rename refuses rather than guesses.
2. **Type references are not indexed at all** (`§B` bindings, `§NEW`, parameter types), so renaming a class silently left every use behind. Type renames now refuse with `TypeReferencesNotIndexed` rather than emitting a broken program.

## The corpus did not discriminate, and that is the interesting part

I injected a text-directed rename (whole-identifier matches, identity ignored) and **the first version of the corpus passed unchanged.** It pinned nothing about the property the gate exists to establish.

The reason is structural and worth recording: renaming *every* occurrence of a name consistently also preserves behaviour, so a purely behavioural oracle catches capture but never over-reach. Two additions fix it, and both now fail under that injection:

- **`preserved`** assertions — RN-02 pins that the *other* function still declares and returns its own `value`.
- **A second file referencing the renamed symbol's neighbours** — RN-03 has a separate module reading the field that the renamed parameter shadows, so a text-directed rename rewrites the field declaration and that file stops resolving.

Discrimination is now tabulated per case in the corpus README:

| injected fault | cases that fail |
|---|---|
| text-directed rename | RN-02, RN-03 |
| cross-file call references not indexed | RN-01 |
| collision guard removed | RN-04 |
| split-declaration guard removed | RN-06 |

Also caught while writing it: substring marker matching had silently pointed RN-05 at the class `Picker` instead of the method `Pick`. Markers now match whole identifiers.

## Baselines

Regenerated for the 9 added `.calr` files, with the change named as both ratchets require: binder 491 → 500 parsed with **`IncompleteCount` still 0**, formatter corpus 861 → 870 tracked, with the two files whose single-file compile is necessarily incomplete registered by path rather than softened.

## Validation

Release build clean (0 warnings, `TreatWarningsAsErrors`); all 11 test projects green locally. Runs as a named CI gate.

Follow-up: indexing type references (which would lift the `TypeReferencesNotIndexed` refusal) pairs naturally with #922's identity groups.