### PR TITLE
chore: allowlist the gate 4 rename harness paths

### DIFF
--- a/.calor-csharp-allowlist
+++ b/.calor-csharp-allowlist
@@ -33,3 +33,14 @@ src/Calor.Compiler/Commands/ReviewPacketCommand.cs
 src/Calor.Compiler/Effects/Manifests/PackageManifestGenerator.cs
 src/Calor.Compiler/Reporting/ReviewPacket.cs
 src/Calor.Compiler/Reporting/ReviewPacketBuilder.cs
+
+# Gate 4 rename harness (roadmap-v0.13-v0.15 §2.5 gate 4) — SymbolId-addressed
+# rename over the parser/binder. Compiler-internal machinery of the same kind
+# as #754: the index reads bound trees and symbol identities, and the engine
+# and command drive them. Calor has no access to its own bound tree, so this
+# cannot be authored in Calor. The gate's plan text places the instrument in
+# the spine deliberately ("shipping with the spine — the deferred LSP later
+# consumes the same identities").
+src/Calor.Compiler/Refactoring/ProjectSymbolIndex.cs
+src/Calor.Compiler/Refactoring/RenameEngine.cs
+src/Calor.Compiler/Commands/RenameCommand.cs


### PR DESCRIPTION
Pre-registration for #927, per the Calor-first guard's own rule: an allowlist entry must land on the protected base branch in its own PR before the PR adding the file can merge — a PR cannot self-exempt.

Three new compiler-internal paths for the §2.5 gate 4 rename harness:

- `src/Calor.Compiler/Refactoring/ProjectSymbolIndex.cs`
- `src/Calor.Compiler/Refactoring/RenameEngine.cs`
- `src/Calor.Compiler/Commands/RenameCommand.cs`

**Rationale**, same shape as the #754 entries: the index reads bound trees and symbol identities, and the engine and command drive them. Calor has no access to its own bound tree, so this is machinery Calor source is compiled *with*, not something authorable in Calor.

The placement is not incidental — gate 4's plan text puts the instrument in the spine deliberately: *"a harness command applying SymbolId-addressed renames, shipping with the spine — the deferred LSP (§2.3) later consumes the same identities"*. The dependency runs language-server → compiler, so the LSP could not host it without inverting that.

No product behaviour changes in this PR; it only registers the paths.