### PR TITLE
Dogfood utility: a real in-repo tool whose only source is Calor (§2.2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Test Calor-first guard behavior
         run: bash scripts/check-calor-first-diff-tests.sh
 
+      # §2.2 dogfood utility: its source must stay Calor-only and its generated
+      # C# must stay untracked. Cheap and dependency-free, so it sits in the
+      # guard job rather than waiting on a build.
+      - name: Check the dogfood utility is Calor-only
+        run: bash scripts/check-dogfood-utility.sh
+
       - name: Reject unapproved C# alongside Calor source
         env:
           CALOR_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
@@ -85,6 +91,17 @@ jobs:
           -c Release --no-build
           --filter "FullyQualifiedName~EditScriptIdentityTests"
           --verbosity normal
+
+      # §2.2 dogfood utility: built from .calr through Calor.Sdk and then RUN,
+      # against this repository's own allowlist. Building it proves the SDK path
+      # works; running it is what makes the repo actually depend on a Calor
+      # program — it exits non-zero when the allowlist has drifted.
+      - name: Build and run the dogfood utility (Calor source, Calor.Sdk)
+        run: |
+          set -euo pipefail
+          dotnet build tools/calor-allowlist-audit/CalorAllowlistAudit.csproj \
+            -c Release --no-restore
+          dotnet tools/calor-allowlist-audit/bin/Release/net10.0/calor-allowlist-audit.dll
 
       - name: Run rename gate
         run: >-

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,10 @@ bench/phase0-agent-native/epochs/**/.smokehash
 # WS2 MCP write-path reject replay payloads (run-internal; recorded in mcp-writes.jsonl)
 bench/phase0-agent-native/epochs/**/rejects/
 .DS_Store
+
+# Dogfood utility (§2.2): its ONLY source is .calr. The generated C# lands in
+# obj/calor/ and must never be committed — scripts/check-dogfood-utility.sh
+# fails the build if it is. Listed explicitly, not left to the global obj/ rule,
+# so the intent survives that rule being loosened.
+tools/calor-allowlist-audit/obj/
+tools/calor-allowlist-audit/bin/

--- a/Calor.sln
+++ b/Calor.sln
@@ -65,6 +65,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "McpBenchHarness", "bench\mc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Calor.Experimental.Tests", "tests\Calor.Experimental.Tests\Calor.Experimental.Tests.csproj", "{DB22515C-58C0-4D3D-9453-C3D279BFDCE3}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "calor-allowlist-audit", "calor-allowlist-audit", "{19C7E56C-9F55-C07B-555E-48B1B5A2505A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CalorAllowlistAudit", "tools\calor-allowlist-audit\CalorAllowlistAudit.csproj", "{D8CE9BF0-300E-4073-AFCA-CF666704FEF2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -363,6 +367,18 @@ Global
 		{DB22515C-58C0-4D3D-9453-C3D279BFDCE3}.Release|x64.Build.0 = Release|Any CPU
 		{DB22515C-58C0-4D3D-9453-C3D279BFDCE3}.Release|x86.ActiveCfg = Release|Any CPU
 		{DB22515C-58C0-4D3D-9453-C3D279BFDCE3}.Release|x86.Build.0 = Release|Any CPU
+		{D8CE9BF0-300E-4073-AFCA-CF666704FEF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8CE9BF0-300E-4073-AFCA-CF666704FEF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8CE9BF0-300E-4073-AFCA-CF666704FEF2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D8CE9BF0-300E-4073-AFCA-CF666704FEF2}.Debug|x64.Build.0 = Debug|Any CPU
+		{D8CE9BF0-300E-4073-AFCA-CF666704FEF2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D8CE9BF0-300E-4073-AFCA-CF666704FEF2}.Debug|x86.Build.0 = Debug|Any CPU
+		{D8CE9BF0-300E-4073-AFCA-CF666704FEF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8CE9BF0-300E-4073-AFCA-CF666704FEF2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8CE9BF0-300E-4073-AFCA-CF666704FEF2}.Release|x64.ActiveCfg = Release|Any CPU
+		{D8CE9BF0-300E-4073-AFCA-CF666704FEF2}.Release|x64.Build.0 = Release|Any CPU
+		{D8CE9BF0-300E-4073-AFCA-CF666704FEF2}.Release|x86.ActiveCfg = Release|Any CPU
+		{D8CE9BF0-300E-4073-AFCA-CF666704FEF2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -394,5 +410,7 @@ Global
 		{4DD2B1E7-8949-04F4-8AA0-8529CA230AA5} = {042EB103-766A-E255-5E43-5B4AC7449960}
 		{CB4E9997-A1F5-45DB-84CC-A5850F32979A} = {4DD2B1E7-8949-04F4-8AA0-8529CA230AA5}
 		{DB22515C-58C0-4D3D-9453-C3D279BFDCE3} = {E5F6A7B8-C9D0-1234-EF01-345678901234}
+		{19C7E56C-9F55-C07B-555E-48B1B5A2505A} = {17DBFA88-FE04-4097-BB7B-A44F76DDA35A}
+		{D8CE9BF0-300E-4073-AFCA-CF666704FEF2} = {19C7E56C-9F55-C07B-555E-48B1B5A2505A}
 	EndGlobalSection
 EndGlobal

--- a/scripts/check-dogfood-utility.sh
+++ b/scripts/check-dogfood-utility.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Dogfood utility guard (roadmap-v0.13-v0.15 §2.2).
+#
+# The utility's claim is that a real in-repo tool is built from Calor and
+# nothing else. That claim decays silently: someone adds a .cs "just for this
+# one thing", or commits the generated output, and the utility keeps building
+# while no longer being dogfood. This enforces the claim mechanically.
+#
+# What is checked:
+#   1. No .cs is tracked under the utility — hand-written or generated.
+#   2. No build output (obj/, bin/) is tracked under the utility.
+#   3. At least one .calr exists, so the utility cannot be emptied and still pass.
+#
+# Note on scope: §2.2 words the rule as "PRs touching the utility touch only
+# .calr". Enforced literally that would reject the commit adding the .csproj
+# itself, so the enforceable form is the one above — no C# and no build output,
+# ever, with the project file and docs allowed to change. The property that
+# matters (the tool's SOURCE is Calor) is fully covered.
+set -euo pipefail
+
+root=$(git rev-parse --show-toplevel)
+cd "$root"
+
+utility="tools/calor-allowlist-audit"
+violations=()
+
+mapfile -t tracked < <(git ls-files "$utility")
+
+if ((${#tracked[@]} == 0)); then
+  echo "Dogfood guard failed: no tracked files under $utility." >&2
+  exit 1
+fi
+
+for path in "${tracked[@]}"; do
+  case "$path" in
+    *.cs)
+      violations+=("$path (C# under the dogfood utility — its source must be .calr only)")
+      ;;
+    "$utility"/obj/*|"$utility"/bin/*)
+      violations+=("$path (committed build output — generated C# must stay untracked)")
+      ;;
+  esac
+done
+
+calr_count=$(git ls-files "$utility/*.calr" | wc -l | tr -d ' ')
+if [[ "$calr_count" -eq 0 ]]; then
+  violations+=("no .calr source under $utility — the utility must be written in Calor")
+fi
+
+if ((${#violations[@]} > 0)); then
+  echo "Dogfood guard failed:" >&2
+  printf '  %s\n' "${violations[@]}" >&2
+  echo "The §2.2 utility is dogfood: its source is Calor, and its generated C# is never committed." >&2
+  exit 1
+fi
+
+echo "Dogfood guard passed ($calr_count .calr source file(s); no C# and no build output tracked)."

--- a/tests/TestData/Formatting/formatter-corpus-baseline.json
+++ b/tests/TestData/Formatting/formatter-corpus-baseline.json
@@ -1,6 +1,6 @@
 {
-  "trackedFileCount": 870,
-  "successfulTransformationCount": 636,
+  "trackedFileCount": 871,
+  "successfulTransformationCount": 637,
   "parseFailurePaths": [
     "bench/mcp/tasks/01-fix-closing-tag/expected.calr",
     "bench/mcp/tasks/01-fix-closing-tag/input.calr",

--- a/tools/calor-allowlist-audit/CalorAllowlistAudit.csproj
+++ b/tools/calor-allowlist-audit/CalorAllowlistAudit.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- The §2.2 dogfood utility: a real in-repo tool whose ONLY source is Calor.
+       There is deliberately no .cs file here — the generated C# lands in
+       obj/calor/ and is gitignored, and scripts/check-dogfood-utility.sh fails
+       the build if any is committed or if a hand-written .cs appears. -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>calor-allowlist-audit</AssemblyName>
+
+    <CalorTasksAssembly>$(MSBuildThisFileDirectory)..\..\src\Calor.Tasks\bin\$(Configuration)\net10.0\Calor.Tasks.dll</CalorTasksAssembly>
+    <CalorOutputDirectory>$(MSBuildThisFileDirectory)obj\calor\</CalorOutputDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Calor.Runtime\Calor.Runtime.csproj" />
+    <!-- Build-order dependency: Sdk.targets compiles through Calor.Tasks.dll. -->
+    <ProjectReference Include="..\..\src\Calor.Tasks\Calor.Tasks.csproj"
+                      ReferenceOutputAssembly="false"
+                      Private="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <CalorCompile Include="**\*.calr" />
+  </ItemGroup>
+
+  <Import Project="..\..\src\Calor.Sdk\Sdk\Sdk.targets" />
+
+</Project>

--- a/tools/calor-allowlist-audit/README.md
+++ b/tools/calor-allowlist-audit/README.md
@@ -1,0 +1,61 @@
+# calor-allowlist-audit
+
+The **dogfood utility** (roadmap-v0.13-v0.15 §2.2): a real in-repo tool whose
+only source is Calor.
+
+## What it does
+
+Audits `.calor-csharp-allowlist` against the rules that file states in prose but
+nothing enforced. The Calor-first guard (`scripts/check-calor-first-diff.sh`)
+*reads* the allowlist; it never validates it. So a deleted or renamed C# file
+leaves a permanent, silent permission behind — the guard keeps honouring an
+entry for a path nothing occupies.
+
+Findings, one per defect:
+
+| check | why it matters |
+|---|---|
+| entry does not exist on disk | a stale entry keeps permission alive for a path nothing occupies |
+| entry listed more than once | duplicates hide which justification comment governs the path |
+| entry contains a wildcard | the allowlist's own rule is "keep entries specific; no directory wildcards" |
+| entry is not a `.cs` path | the guard only inspects `*.cs`, so the entry can never match |
+| entry is under a structurally exempt tree | `tests/`, `bench/`, and `tools/Calor.RoundTrip.Harness/` are already exempt, so the entry grants nothing and misleads a reader into thinking permission was needed |
+
+Existence is only reported for an otherwise well-formed path — a wildcard or
+non-`.cs` entry gets one finding, not two about the same defect.
+
+Exit code is `0` when clean, `1` on findings, `2` if the allowlist is missing.
+Run it from the repository root.
+
+```
+dotnet build tools/calor-allowlist-audit/CalorAllowlistAudit.csproj -c Release
+dotnet tools/calor-allowlist-audit/bin/Release/net10.0/calor-allowlist-audit.dll
+```
+
+## Why it is dogfood, mechanically
+
+- The only source is `allowlist-audit.calr`. There is no `.cs` in this
+  directory and there never may be.
+- Generated C# lands in `obj/calor/` and is gitignored explicitly, not merely by
+  the global rule.
+- `scripts/check-dogfood-utility.sh` fails CI if any `.cs` or any build output
+  becomes tracked here, or if the `.calr` source disappears. Both faults were
+  verified to fail the guard.
+- The project is in `Calor.sln` and CI **builds and runs** it, so a Calor
+  regression that breaks this program breaks the build — the repo genuinely
+  depends on a Calor program.
+
+In 0.14 this utility becomes the first migration subject of the 2.0.0 migrator
+(§3.3).
+
+## Known language friction
+
+Written down because dogfooding exists to surface it:
+
+- **#929** — the module prose belongs in `§CT`, but a module-level `§CT`
+  currently breaks the dedent that closes a later `§IF`, and this program is
+  full of `§IF`. The prose sits in a leading `//` comment instead.
+- Integer-to-string has no dedicated form; the report line relies on `+`
+  concatenation with a string on the left at each step.
+- There is no `continue`, so per-entry checks nest under a single
+  `§IF{...} (! skip)` rather than skipping early.

--- a/tools/calor-allowlist-audit/allowlist-audit.calr
+++ b/tools/calor-allowlist-audit/allowlist-audit.calr
@@ -1,0 +1,99 @@
+// Audits .calor-csharp-allowlist against the rules the file states in prose.
+// The Calor-first guard reads the allowlist but never validates it, so a
+// deleted or renamed C# file leaves a permanent silent permission behind.
+// Run from the repository root.
+//
+// The module prose belongs in §CT, not a comment; §CT currently breaks the
+// dedent that closes a later §IF (#929), which this program is full of.
+§M{m001:AllowlistAudit}
+  §F{f001:StartsWith:pri} (str:text, str:prefix) -> bool
+    §E{}
+    §B{n:i32} (len prefix)
+    §IF{if1} (> n (len text))
+      §R BOOL:false
+    §R (== (substr text 0 n) prefix)
+
+  §F{f002:EndsWith:pri} (str:text, str:suffix) -> bool
+    §E{}
+    §B{n:i32} (len suffix)
+    §B{m:i32} (len text)
+    §IF{if2} (> n m)
+      §R BOOL:false
+    §R (== (substr text (- m n) n) suffix)
+
+  §F{f003:IsSkippable:pri} (str:line) -> bool
+    §E{}
+    §B{t:str} (trim line)
+    §IF{if3} (== (len t) 0)
+      §R BOOL:true
+    §R §C{StartsWith} §A t §A "#" §/C
+
+  §F{f004:IsStructurallyExempt:pri} (str:path) -> bool
+    §E{}
+    §IF{if4} §C{StartsWith} §A path §A "tests/" §/C
+      §R BOOL:true
+    §IF{if5} §C{StartsWith} §A path §A "bench/" §/C
+      §R BOOL:true
+    §IF{if6} §C{StartsWith} §A path §A "tools/Calor.RoundTrip.Harness/" §/C
+      §R BOOL:true
+    §R BOOL:false
+
+  §F{f005:Report:pri} (str:entry, str:problem) -> void
+    §E{cw}
+    §P (+ "  " (+ entry (+ " — " problem)))
+
+  §F{f006:Main:pub} () -> i32
+    §E{fs:r,cw,mut}
+    §B{file:str} ".calor-csharp-allowlist"
+    §B{present:bool} §C{File.Exists} §A file §/C
+    §IF{if7} (! present)
+      §P "allowlist-audit: .calor-csharp-allowlist not found (run from the repository root)."
+      §R INT:2
+
+    §B{lines:[str]} §C{File.ReadAllLines} §A file §/C
+    §LIST{seen:str}
+    §/LIST{seen}
+    §B{~findings:i32} INT:0
+    §B{~entries:i32} INT:0
+
+    §P "allowlist-audit: checking .calor-csharp-allowlist"
+    §EACH{e1:raw} lines
+      §B{skip:bool} §C{IsSkippable} §A raw §/C
+      §IF{if8} (! skip)
+        §B{entry:str} (trim raw)
+        §ASSIGN entries (+ entries INT:1)
+
+        §B{wild:bool} (contains entry "*")
+        §IF{if9} wild
+          §C{Report} §A entry §A "contains a wildcard; the allowlist requires specific paths" §/C
+          §ASSIGN findings (+ findings INT:1)
+
+        §B{isCs:bool} §C{EndsWith} §A entry §A ".cs" §/C
+        §IF{if10} (! isCs)
+          §C{Report} §A entry §A "is not a .cs path, so the guard can never match it" §/C
+          §ASSIGN findings (+ findings INT:1)
+
+        §IF{if11} §HAS{seen} entry
+          §C{Report} §A entry §A "is listed more than once" §/C
+          §ASSIGN findings (+ findings INT:1)
+        §PUSH{seen} entry
+
+        §B{exempt:bool} §C{IsStructurallyExempt} §A entry §/C
+        §IF{if12} exempt
+          §C{Report} §A entry §A "is under a structurally exempt tree, so the entry grants nothing and misleads" §/C
+          §ASSIGN findings (+ findings INT:1)
+
+        // Existence is only meaningful for a well-formed path: reporting it for
+        // a wildcard or a non-.cs entry would be a second finding about the same
+        // defect, and noise is how an auditor gets ignored.
+        §IF{if13} (! wild)
+          §IF{if14} isCs
+            §B{onDisk:bool} §C{File.Exists} §A entry §/C
+            §IF{if15} (! onDisk)
+              §C{Report} §A entry §A "does not exist; a stale entry keeps permission alive for a path nothing occupies" §/C
+              §ASSIGN findings (+ findings INT:1)
+
+    §P (+ (+ (+ (+ "allowlist-audit: " entries) " entries, ") findings) " finding(s)")
+    §IF{if16} (> findings INT:0)
+      §R INT:1
+    §R INT:0


### PR DESCRIPTION
Lands the **dogfood utility**, which §2.2 makes a **0.14-entry precondition** — the 2.0.0 migrator needs a first migration subject.

## What it does, and why it is not a toy

`calor-allowlist-audit` audits `.calor-csharp-allowlist` against the rules that file states in prose and **nothing enforced**. The Calor-first guard *reads* the allowlist; it never validates it. A deleted or renamed C# file therefore leaves a permanent, silent permission behind — the guard keeps honouring an entry for a path nothing occupies.

Five checks: stale entry, duplicate, wildcard, non-`.cs` path, and an entry under a structurally exempt tree (`tests/`, `bench/`, `tools/Calor.RoundTrip.Harness/` — such an entry grants nothing and misleads a reader into thinking permission was needed). Existence is only reported for an otherwise well-formed path, so one defect yields one finding rather than two.

**Verified both directions.** Against a planted corpus — five defects, five findings, exit 1:

```
  src/Gone/Deleted.cs — does not exist; a stale entry keeps permission alive for a path nothing occupies
  src/Real/Exists.cs — is listed more than once
  src/Wild/*.cs — contains a wildcard; the allowlist requires specific paths
  src/NotCode/thing.txt — is not a .cs path, so the guard can never match it
  tests/Foo/Test.cs — is under a structurally exempt tree, so the entry grants nothing and misleads
allowlist-audit: 6 entries, 5 finding(s)
```

Against this repository: `17 entries, 0 finding(s)`, exit 0.

## Dogfood enforced mechanically, not aspirationally

- The only source is `allowlist-audit.calr`. No `.cs` in this directory, ever.
- Generated C# lands in `obj/calor/`, gitignored **explicitly** rather than left to the global `obj/` rule, so the intent survives that rule being loosened.
- `scripts/check-dogfood-utility.sh` fails if any `.cs` or build output becomes tracked, or if the `.calr` source disappears. Both faults were verified to fail it.
- The project is in `Calor.sln` and CI **builds and runs** it — so a Calor regression that breaks this program breaks the build. The repo genuinely depends on a Calor program.

**Scope note, stated plainly:** §2.2 words the rule as "PRs touching the utility touch only `.calr`". Enforced literally, that rejects the commit adding the `.csproj` itself. The guard enforces the property that actually matters — no C# and no build output, ever — and says so in its own header rather than implying it does the literal thing.

## Dogfooding did its job immediately

Writing it surfaced **#929**: a module-level `§CT` breaks the dedent that closes a later `§IF`, and this program is full of `§IF`. Each construct is fine alone; only the combination fails, and the error is a cascade of module-level diagnostics pointing at a return statement twelve lines from the cause. The module prose sits in a leading comment until that is fixed.

The README also records two smaller frictions: no dedicated int-to-string form (the report line leans on `+` with a string on the left at each step), and no `continue` (per-entry checks nest under one `§IF` instead of skipping early).

## Validation

Release build clean (0 warnings); all 11 test projects green; both guards pass. Formatter corpus baseline 870 → 871 tracked, 636 → 637 losslessly formatted — the new file needs no fallback registration, and the binder ratchet was unaffected.