### PR TITLE
docs: scope the persistent index and `calor query` v1

### DIFF
--- a/docs/plans/index-query-v1-scoping.md
+++ b/docs/plans/index-query-v1-scoping.md
@@ -149,14 +149,31 @@ complete it. **`effects` is not a slice.**
 - Any query surface in the LSP or MCP — both are consumers, and §2.3 already
   sequences them after the spine.
 
-## 9. Open questions to settle in S1
+## 9. Decisions and open questions
+
+### 9.1 Semantic hash granularity — DECIDED: per file
+
+**Decision (maintainer, 2026-08-11): per-file semantic hashes.** This is
+coherent with the wholesale-rebuild decision in §3 and is the cheaper build.
+
+**The cost, stated plainly so nobody is surprised by it later:** `impact`
+answers at *file* granularity. Asking "what does this change affect?" returns
+"these files", not "these declarations". If one file holds twenty declarations
+and one changes, `impact` implicates all twenty's dependents.
+
+**This may be too coarse to be useful, and coarse-but-useless is a real
+outcome.** Rather than argue it in the abstract, S3 carries a **checkpoint**:
+the first working `impact` answer on a real project is shown to the maintainer
+before the facet is called done. If the answer is too fuzzy to act on, the
+choice is revisited then, with an actual answer in hand rather than a prediction
+about one. Per-declaration hashing remains a priced follow-up, not a rewrite:
+the storage header is versioned (§4), so granularity is a format revision.
+
+### 9.2 Still open, to settle in S1
 
 1. Does `calor query` build the index on demand when absent, or fail with a
    pointer to `calor index`? (Recommendation: build on demand, with `--no-build`
    for CI timing runs, so gate 8 measures a warm query rather than a build.)
-2. Does the index store the bound tree's semantic hashes per declaration, or per
-   file? Per-declaration is what makes `impact` precise; per-file is what
-   wholesale rebuild makes cheap.
-3. Is the fixture project for gate 3 a new corpus, or an existing one
+2. Is the fixture project for gate 3 a new corpus, or an existing one
    (`tests/TestData/EditScripts` is already registered and small)? Reusing it
    keeps one denominator; a purpose-built one gives better `impact` shapes.

--- a/docs/plans/index-query-v1-scoping.md
+++ b/docs/plans/index-query-v1-scoping.md
@@ -1,0 +1,162 @@
+# Persistent index + `calor query` v1 — scoping
+
+Scopes the §2.2 deliverable that has now been deferred three times and is
+pre-committed against a fourth. Gates 3 and 8 hang off it, as does gate 2's
+index-contents leg and the review-packet integration.
+
+This document fixes boundaries and names the risks. It does not design the
+schema field-by-field; that lands with S1.
+
+## 1. What v1 answers, and what it refuses to
+
+**Facets in v1:** `symbol`, `callers`, `callees`, `impact`, `contract-outcomes`,
+`assumptions`.
+
+**Excluded, by the roadmap and now by evidence: `effects`.** §2.2 excludes it
+because effect resolution string-guesses receiver types. #925 is the measured
+form of that: a qualified `§C{Module.Function}` resolves as an *unknown external
+call*, so the callee's declared effects never reach the answer, and two shipped
+tests could not have failed if propagation were entirely broken. Effects join
+the index in 0.15, derived from 0.14's typed signatures. **A release titled
+"trustworthy" does not ship a facet the same roadmap declares unsound.**
+
+## 2. The soundness posture, stated before anything is built
+
+Calor binds **one file at a time**. Gate 4 established what that costs: a call
+into another module resolves to nothing locally, so cross-file edges come from a
+project-wide match on the bare callee name that requires exactly one candidate
+and otherwise yields nothing. `ReviewPacketBuilder` and
+`CompilationDriver.BuildCrossModuleFunctionMap` already drop ambiguous names the
+same way.
+
+That is a real limit, and v1's job is to **report it, not hide it**:
+
+- Every answer carries a **residual block**: call sites that did not resolve,
+  files that did not parse or bind, and names dropped for ambiguity — with
+  counts, and the paths behind them on request.
+- `callers` is therefore *"the callers we can name"*, never *"the callers"*. The
+  CLI says so in its output, not only in documentation.
+- A query whose residual would change the answer's meaning (e.g. `impact` where
+  an unresolved edge could reach the changed declaration) is reported as
+  **partial**, with the reason.
+
+The alternative — emitting a clean-looking caller list with silent holes — is
+the exact failure shape this repo has paid for repeatedly, most recently in
+#924's ES-05 and in the first rename corpus.
+
+## 3. Staleness is the primary risk, and it has a known shape
+
+An index that answers confidently from stale state is #788/#883 in a new
+component: an input changes, nothing invalidates, and the answer reflects the
+previous world.
+
+**Requirement:** the index's global invalidation inputs are *the same set*
+`BuildStateCache` uses — compiler hash, options token, manifest hash, semantics
+version, plus per-file content hashes — and the index records them in its own
+header. A `calor query` against an index whose inputs no longer match **refuses
+or rebuilds**; it never answers from the mismatch. This is checked by a
+discriminating test (drop one input from the header, watch a query answer
+change) before S2 ships.
+
+Two facts from #924 constrain the design:
+
+- Cache reuse today is **all-or-nothing per build**: any file-set change moves
+  the cross-module map hash, and any options-token change invalidates globally.
+- Only diagnostic-clean files are cached; cross-module diagnostics are
+  recomputed from summaries every run.
+
+**Decision: v1 rebuilds the index wholesale.** Incremental indexing is not in
+v1. Gate 8's budget is 30s on the largest pinned subject, and wholesale is the
+honest starting point; if the measured number fails, incrementality becomes a
+priced follow-up rather than an assumed capability. This also keeps gate 2's
+index-contents leg trivially satisfiable rather than satisfiable-by-accident.
+
+## 4. Storage
+
+- Location `obj/calor/` (alongside `.calor-build-state.json`), single file
+  `.calor-index.json`.
+- Header mirrors `BuildStateCache`: `FormatVersion`, `CompilerSemanticsVersion`,
+  compiler/options/manifest hashes, per-file content hashes.
+- Contents: declarations, occurrences, call edges, contract outcomes,
+  assumptions, semantic hashes — canonically ordered, because gate 2 compares
+  index contents byte-for-byte.
+- Never committed. The dogfood guard's precedent applies: a CI assertion that no
+  index artifact is tracked.
+
+## 5. Reusing what exists
+
+`ProjectSymbolIndex` (shipped in #927 for gate 4) is already the in-memory core:
+it parses and binds a file set, maps `SymbolId` to occurrences, resolves
+cross-file calls with the unique-match rule, and skips-and-reports files it
+cannot read. **S1 persists that model rather than writing a second one.**
+
+Known gaps it carries into this work, both already recorded:
+
+- **Type references are not indexed** (`§B` bindings, `§NEW`, parameter types),
+  which is why gate 4 refuses type renames. The index inherits this: a `symbol`
+  query on a type reports declarations but not uses, and must say so.
+- **Split declarations** (a module or type declared across files) carry one
+  identity per file — #922. `symbol` must group them or label them; it may not
+  silently pick one.
+
+## 6. Gate design
+
+**Gate 3 — index/query correctness.** A golden query-answer corpus, because
+gate 2's identity alone would pass an identically-wrong index.
+
+- Denominator: a purpose-built in-repo fixture project (deterministic,
+  hand-reviewable ground truth) **plus** one pinned conversion subject for
+  scale. Ground truth for the fixture is authored by hand and reviewed; for the
+  subject, spot-audited with the audited fraction published.
+- **Discrimination is part of the gate, not an afterthought:** the corpus must
+  fail when a call edge is dropped, when a caller is attributed to the wrong
+  overload, and when the residual is under-reported. Each injection is recorded
+  in the corpus README, in the shape #924 and #927 now use.
+
+**Gate 8 — performance envelope.** Index build ≤ 30s, warm `calor query`
+≤ 500ms, measured in CI.
+
+- **Denominator: FluentValidation** — 208 non-test `.cs` files, ~25.7k lines,
+  the largest of the three pinned subjects (serilog 112/14.0k, MediatR 76/4.1k).
+  Named here so "largest" is not re-decided later against a smaller subject.
+- Numbers are published per release whether or not they pass.
+
+**Gate 2's index-contents leg** rides along: the ES-01..ES-07 corpus and
+`EditScriptIdentityTests` already exist, so the leg is an added assertion that
+canonically-ordered index contents match between full and incremental runs — not
+a new harness.
+
+## 7. Slices
+
+| slice | contents | gate touched |
+|---|---|---|
+| S1 | index model over `ProjectSymbolIndex`, persistence with invalidation parity, `calor index` build/refresh, no-tracked-artifact assertion | gate 2 index leg |
+| S2 | `calor query symbol\|callers\|callees`, residual reporting, staleness refusal + its discriminating test, gate-3 fixture corpus | gate 3 (fixture) |
+| S3 | `impact` facet; review-packet reads the index (§2.2) | gate 3 (extended) |
+| S4 | `contract-outcomes`, `assumptions` facets | gate 3 (extended) |
+| S5 | perf harness on FluentValidation, numbers published | gate 8 |
+
+S1 and S2 are the ones that must land for the deferral to be honoured; S3–S5
+complete it. **`effects` is not a slice.**
+
+## 8. What this does not include
+
+- Incremental index updates (§3, priced only if gate 8 fails).
+- The effects facet (0.15, after typed signatures).
+- Type-reference indexing (follow-up to #927; would lift the type-rename
+  refusal and complete the `symbol` facet).
+- Cross-repository or package-level indexing.
+- Any query surface in the LSP or MCP — both are consumers, and §2.3 already
+  sequences them after the spine.
+
+## 9. Open questions to settle in S1
+
+1. Does `calor query` build the index on demand when absent, or fail with a
+   pointer to `calor index`? (Recommendation: build on demand, with `--no-build`
+   for CI timing runs, so gate 8 measures a warm query rather than a build.)
+2. Does the index store the bound tree's semantic hashes per declaration, or per
+   file? Per-declaration is what makes `impact` precise; per-file is what
+   wholesale rebuild makes cheap.
+3. Is the fixture project for gate 3 a new corpus, or an existing one
+   (`tests/TestData/EditScripts` is already registered and small)? Reusing it
+   keeps one denominator; a purpose-built one gives better `impact` shapes.


### PR DESCRIPTION
Scopes the §2.2 deliverable deferred three times and pre-committed against a fourth. Gates 3 and 8 hang off it, as does gate 2's index-contents leg and the review-packet integration.

Doc: `docs/plans/index-query-v1-scoping.md`. It fixes boundaries and names risks; it does not design the schema field-by-field, which lands with S1.

## The decisions it fixes

**`effects` is excluded from v1** — as §2.2 requires, and #925 is now the *measured* form of why: a qualified `§C{Module.Function}` resolves as an unknown external call, so the callee's declared effects never reach the answer. A release titled "trustworthy" does not ship a facet the same roadmap declares unsound.

**v1 rebuilds wholesale; incremental indexing is not in v1.** #924 established that cache reuse is already all-or-nothing per build (any file-set change moves the cross-module map hash; any options change invalidates globally). Wholesale is the honest starting point, and incrementality gets *priced* only if gate 8's 30s budget fails — rather than assumed as capability.

**Staleness is the primary risk, with a known shape.** The index's invalidation inputs must be the same set `BuildStateCache` uses, recorded in its own header; a query against a mismatched header refuses or rebuilds, never answers. An index answering confidently from stale state is #788/#883 in a new component, and the discriminating test (drop an input from the header, watch an answer change) ships before S2.

**Every answer carries a residual block.** Calor binds one file at a time, so cross-file edges come from a unique-name match that drops ambiguity — the rule `ReviewPacketBuilder` and the driver's map already use. `callers` is therefore "the callers we can name", said in the CLI output rather than only in docs. Emitting a clean-looking list with silent holes is the failure shape this repo keeps paying for.

**Gate 8's denominator is named now: FluentValidation** — 208 non-test `.cs` files, ~25.7k lines, the largest of the three pinned subjects (serilog 112/14.0k, MediatR 76/4.1k). Named here so "largest pinned conversion subject" cannot be quietly re-decided later against a smaller one.

**Gate 3's corpus must fail under injected faults** — a dropped call edge, a caller attributed to the wrong overload, an under-reported residual — recorded in the same shape #924 and #927 now use. Identity alone (gate 2) would pass an identically-wrong index.

## Slices

S1 (persist the model + invalidation parity) and S2 (`symbol`/`callers`/`callees` + residuals + staleness refusal + gate-3 fixture) are what the deferral requires. S3–S5 add `impact`, the review-packet integration, the contract/assumption facets, and the gate-8 perf harness.

`ProjectSymbolIndex` from #927 is already the in-memory core — it binds a file set, maps `SymbolId` to occurrences, and resolves cross-file calls with the unique-match rule — so **S1 persists a model that exists rather than writing a second one**. Two gaps it carries in are recorded: type references are unindexed (#927's refusal; a `symbol` query on a type must say so), and split declarations carry one identity per file (#922).

## Open questions listed for S1

Build-on-demand vs fail-with-pointer; per-declaration vs per-file semantic hashes; and whether gate 3 reuses the registered `EditScripts` corpus or gets a purpose-built fixture with better `impact` shapes.

Docs-only; no code changes.