### PR TITLE
Enforce lossless conversion contracts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,8 @@ jobs:
       - name: Run all tests
         run: |
           set -euo pipefail
-          dotnet test -c Release --no-build --verbosity normal 2>&1 | tee test-output.log
+          dotnet test -c Release --no-build --verbosity normal \
+            --blame-hang --blame-hang-timeout 60s 2>&1 | tee test-output.log
 
       # Assert the PROPERTY that matters (no Z3-gated test skipped), not the presence of a
       # filename. An earlier version of this step checked only that some libz3.so existed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,7 +121,13 @@ jobs:
         run: |
           set -euo pipefail
           # Avoid nested project-level and xUnit parallelism exhausting 2-core runners.
-          dotnet test -c Release --no-build --verbosity normal -m:1 2>&1 | tee test-output.log
+          (dotnet test -c Release --no-build --verbosity normal -m:1 2>&1 | tee test-output.log) &
+          test_pid=$!
+          while kill -0 "$test_pid" 2>/dev/null; do
+            sleep 30
+            echo "Tests are still running..."
+          done
+          wait "$test_pid"
 
       # Assert the PROPERTY that matters (no Z3-gated test skipped), not the presence of a
       # filename. An earlier version of this step checked only that some libz3.so existed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,8 +120,8 @@ jobs:
       - name: Run all tests
         run: |
           set -euo pipefail
-          dotnet test -c Release --no-build --verbosity normal \
-            --blame-hang --blame-hang-timeout 60s 2>&1 | tee test-output.log
+          # Avoid nested project-level and xUnit parallelism exhausting 2-core runners.
+          dotnet test -c Release --no-build --verbosity normal -m:1 2>&1 | tee test-output.log
 
       # Assert the PROPERTY that matters (no Z3-gated test skipped), not the presence of a
       # filename. An earlier version of this step checked only that some libz3.so existed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code

--- a/docs/cli/convert.md
+++ b/docs/cli/convert.md
@@ -60,6 +60,9 @@ calor convert MyService.cs --benchmark
 | `--output` | `-o` | Auto-detected | Output file path |
 | `--benchmark` | `-b` | `false` | Include benchmark metrics comparison |
 | `--verbose` | `-v` | `false` | Enable verbose output |
+| `--lossy` | — | `false` | Explicitly allow reported substitutions or drops. Without this flag, unsupported code is preserved verbatim and both generated Calor and round-tripped C# must validate before the destination is replaced. |
+| `--validate` | — | — | Compatibility flag. Generated Calor validation is now mandatory in every mode. |
+| `--passthrough` | — | `false` | Preserve unconvertible members as raw C# interop blocks. Lossless mode already preserves unsupported descendants at the nearest complete boundary. |
 | `--explicit-call-closers` | — | `false` | Emit explicit `§/C` for every `§C` call (v0.6.0-compatible output). Use when regenerating `.calr` files intended to parse on v0.6.0 toolchains. By default v0.6.1 elides `§/C` for zero-arg calls. |
 | `--format` | — | `text` | Output format: `text` or `json` (envelope document on stdout) — see [JSON Output](#json-output---format-json). No `-f` short alias |
 
@@ -87,17 +90,17 @@ timeout, crash). Exit codes are unchanged.
     "inputPath": "/abs/Sample.cs",
     "outputPath": "/abs/Sample.calr",
     "success": true,
+    "fidelity": "lossless",
     "unsupportedFeatureCount": 1,
     "featureCounts": { "local-functions": 1 },
-    "validated": false
+    "validated": true
   }
 }
 ```
 
 - `diagnostics[]` — conversion issues (`Calor1343`, severity mirrors the
-  issue, message prefixed with the feature name when known), `--validate`
-  parse errors in the generated output (`Calor1344`, warning — the output was
-  still written, with `data.validated` / `data.validationErrorCount` set), and
+  issue, message prefixed with the feature name when known), generated-output
+  parse errors (`Calor1344`, error — the destination remains unchanged), and
   command-level failures (`Calor1345`: input not found, unknown file type,
   timeout, crash). Converting Calor → C#, compiler diagnostics appear with
   their own codes.
@@ -106,7 +109,8 @@ timeout, crash). Exit codes are unchanged.
   accounting: every §CSHARP interop preservation, TODO fallback, dropped
   construct, and stripped preprocessor directive, each with
   `kind`, `feature`, `file`, `line`, and `description`. `lossCount: 0` means
-  the output is fully native Calor. In text mode a conversion with losses
+  the output is fully native Calor. Interop preservation is lossless but not
+  native; substitutions and drops require `--lossy`. In text mode a conversion with losses
   prints a located loss summary instead of the `✓ Conversion successful` line.
 - `data.benchmark` — present with `--benchmark`: token/line/character counts
   before and after, reduction percentages, and the advantage ratio.
@@ -130,6 +134,13 @@ When converting C# to Calor, the converter:
 4. Generates unique IDs for all structural elements
 5. Adds effect declarations based on detected side effects
 6. Suggests contracts based on validation patterns
+
+The default contract is **lossless**: unsupported descendants bubble to the
+nearest complete member or type and are preserved verbatim as C# interop.
+Success means the emitted Calor parses and compiles, and its generated C#
+compiles through Roslyn. Output files are replaced atomically only after these
+checks pass. `--lossy` permits substitutions or drops, but every occurrence is
+reported with its source location.
 
 ### Supported Constructs
 

--- a/src/Calor.Compiler/Commands/ConvertCommand.cs
+++ b/src/Calor.Compiler/Commands/ConvertCommand.cs
@@ -260,16 +260,22 @@ public static class ConvertCommand
         var converter = new CSharpToCalorConverter(
             BuildCSharpToCalorOptions(benchmark, verbose, explain, noFallback, passthrough, explicitCallClosers, lossy));
 
+        using var timeoutCts = timeoutSeconds > 0
+            ? new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds))
+            : null;
+        var cancellationToken = timeoutCts?.Token ?? CancellationToken.None;
+
         ConversionResult result;
-        if (timeoutSeconds > 0)
+        if (timeoutCts != null)
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
             try
             {
                 // Run on a thread pool thread so the cancellation token can
                 // interrupt even CPU-bound conversion hangs (e.g. infinite loops
                 // in preprocessor region extraction).
-                result = await Task.Run(() => converter.ConvertFileAsync(inputPath), cts.Token);
+                result = await Task.Run(
+                    () => converter.ConvertFileAsync(inputPath, cancellationToken),
+                    cancellationToken);
             }
             catch (OperationCanceledException)
             {
@@ -280,7 +286,7 @@ public static class ConvertCommand
         }
         else
         {
-            result = await converter.ConvertFileAsync(inputPath);
+            result = await converter.ConvertFileAsync(inputPath, cancellationToken);
         }
 
         if (envelope != null)
@@ -356,7 +362,22 @@ public static class ConvertCommand
         }
 
         var writeEncoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
-        await ConversionFileWriter.WriteAtomicAsync(outputPath, result.CalorSource!, writeEncoding);
+        try
+        {
+            await ConversionFileWriter.WriteAtomicAsync(
+                outputPath,
+                result.CalorSource!,
+                writeEncoding,
+                cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            envelope?.AddCommandError($"Conversion timed out after {timeoutSeconds}s", inputPath);
+            envelope?.Data.Success = false;
+            Console.Error.WriteLine($"Error: Conversion timed out after {timeoutSeconds}s");
+            Console.Error.WriteLine("Destination was not modified.");
+            return (1, result);
+        }
 
         // #770: structured loss accounting. The unconditional "✓ Conversion
         // successful" line was a false-success vector — it is now printed ONLY

--- a/src/Calor.Compiler/Commands/ConvertCommand.cs
+++ b/src/Calor.Compiler/Commands/ConvertCommand.cs
@@ -47,6 +47,10 @@ public static class ConvertCommand
             aliases: new[] { "--passthrough" },
             description: "Preserve unconvertible members as §CSHARP interop blocks so the output always parses (C# → Calor). If a member's emitted Calor would be invalid, its original C# is kept verbatim instead of writing broken output.");
 
+        var lossyOption = new Option<bool>(
+            aliases: new[] { "--lossy" },
+            description: "Explicitly allow reported semantic substitutions or drops. The default is lossless conversion.");
+
         var timeoutOption = new Option<int>(
             aliases: new[] { "--timeout", "-t" },
             description: "Timeout in seconds for the conversion (0 = no timeout)",
@@ -73,6 +77,7 @@ public static class ConvertCommand
             noFallbackOption,
             validateOption,
             passthroughOption,
+            lossyOption,
             timeoutOption,
             explicitCallClosersOption,
             formatOption
@@ -88,18 +93,19 @@ public static class ConvertCommand
             var noFallback = ctx.ParseResult.GetValueForOption(noFallbackOption);
             var validate = ctx.ParseResult.GetValueForOption(validateOption);
             var passthrough = ctx.ParseResult.GetValueForOption(passthroughOption);
+            var lossy = ctx.ParseResult.GetValueForOption(lossyOption);
             var timeoutSeconds = ctx.ParseResult.GetValueForOption(timeoutOption);
             var explicitCallClosers = ctx.ParseResult.GetValueForOption(explicitCallClosersOption);
             var format = ctx.ParseResult.GetValueForOption(formatOption) ?? "text";
             // Exit code returned through ctx.ExitCode: a code parked only on
             // Environment.ExitCode is overwritten by Main's InvokeAsync return.
-            ctx.ExitCode = await ExecuteAsync(input, output, benchmark, verbose, explain, noFallback, validate, passthrough, timeoutSeconds, explicitCallClosers, format);
+            ctx.ExitCode = await ExecuteAsync(input, output, benchmark, verbose, explain, noFallback, validate, passthrough, lossy, timeoutSeconds, explicitCallClosers, format);
         });
 
         return command;
     }
 
-    private static async Task<int> ExecuteAsync(FileInfo input, FileInfo? output, bool benchmark, bool verbose, bool explain, bool noFallback, bool validate, bool passthrough, int timeoutSeconds, bool explicitCallClosers, string format)
+    private static async Task<int> ExecuteAsync(FileInfo input, FileInfo? output, bool benchmark, bool verbose, bool explain, bool noFallback, bool validate, bool passthrough, bool lossy, int timeoutSeconds, bool explicitCallClosers, string format)
     {
         var telemetry = CalorTelemetry.IsInitialized ? CalorTelemetry.Instance : null;
         telemetry?.SetCommand("convert");
@@ -152,7 +158,7 @@ public static class ConvertCommand
             ConversionResult? conversionResult = null;
             if (direction == ConversionDirection.CSharpToCalor)
             {
-                (exitCode, conversionResult) = await ConvertCSharpToCalorAsync(input.FullName, outputPath, benchmark, verbose, explain, noFallback, validate, passthrough, timeoutSeconds, explicitCallClosers, envelope);
+                (exitCode, conversionResult) = await ConvertCSharpToCalorAsync(input.FullName, outputPath, benchmark, verbose, explain, noFallback, validate, passthrough, lossy, timeoutSeconds, explicitCallClosers, envelope);
             }
             else
             {
@@ -232,8 +238,10 @@ public static class ConvertCommand
     /// unit-testable without driving the full command handler.
     /// </summary>
     internal static ConversionOptions BuildCSharpToCalorOptions(
-        bool benchmark, bool verbose, bool explain, bool noFallback, bool passthrough, bool explicitCallClosers) => new()
+        bool benchmark, bool verbose, bool explain, bool noFallback, bool passthrough, bool explicitCallClosers,
+        bool lossy = false) => new()
     {
+        Fidelity = lossy ? ConversionFidelity.Lossy : ConversionFidelity.Lossless,
         Verbose = verbose,
         IncludeBenchmark = benchmark,
         Explain = explain,
@@ -245,12 +253,12 @@ public static class ConvertCommand
         UseImplicitCallCloser = !explicitCallClosers
     };
 
-    private static async Task<(int ExitCode, ConversionResult? Result)> ConvertCSharpToCalorAsync(string inputPath, string outputPath, bool benchmark, bool verbose, bool explain, bool noFallback, bool validate, bool passthrough, int timeoutSeconds, bool explicitCallClosers, ConvertEnvelope? envelope)
+    private static async Task<(int ExitCode, ConversionResult? Result)> ConvertCSharpToCalorAsync(string inputPath, string outputPath, bool benchmark, bool verbose, bool explain, bool noFallback, bool validate, bool passthrough, bool lossy, int timeoutSeconds, bool explicitCallClosers, ConvertEnvelope? envelope)
     {
         var statusOut = envelope != null ? Console.Error : Console.Out;
 
         var converter = new CSharpToCalorConverter(
-            BuildCSharpToCalorOptions(benchmark, verbose, explain, noFallback, passthrough, explicitCallClosers));
+            BuildCSharpToCalorOptions(benchmark, verbose, explain, noFallback, passthrough, explicitCallClosers, lossy));
 
         ConversionResult result;
         if (timeoutSeconds > 0)
@@ -279,6 +287,7 @@ public static class ConvertCommand
         {
             envelope.AddConversionIssues(result.Issues, inputPath);
             envelope.Data.Success = result.Success;
+            envelope.Data.Fidelity = lossy ? "lossy" : "lossless";
             var explanation = result.Context.GetExplanation();
             envelope.Data.UnsupportedFeatureCount = explanation.TotalUnsupportedCount;
             var featureCounts = explanation.GetFeatureCounts();
@@ -312,44 +321,42 @@ public static class ConvertCommand
             return (1, result);
         }
 
-        // #770: validate BEFORE writing so the success/loss report reflects the
-        // output actually produced. Current --validate semantics are kept (the
-        // file is still written, exit code stays 0 with a warning) — but the
-        // success line below is never printed when validation failed.
+        // Validation is mandatory in every mode. The converter additionally compiles
+        // round-tripped C# in lossless mode; --validate remains accepted for compatibility.
         List<Diagnostic> validationErrors = new();
-        if (validate && result.CalorSource != null)
+        if (result.CalorSource != null)
         {
             validationErrors = ValidateCalorSource(result.CalorSource);
             if (envelope != null)
             {
                 envelope.Data.Validated = true;
                 envelope.Data.ValidationErrorCount = validationErrors.Count;
-                // Warnings, not errors — the output file is still written.
                 foreach (var err in validationErrors)
                 {
                     envelope.Diagnostics.Add(new Diagnostic(
                         DiagnosticCode.ConvertValidationError,
                         $"Generated output failed validation: {err.Message}",
                         err.Span,
-                        DiagnosticSeverity.Warning,
+                        DiagnosticSeverity.Error,
                         outputPath));
                 }
             }
         }
 
-        // Write output (use replacement fallback for files containing unpairable surrogates)
-        var writeEncoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
-        await File.WriteAllTextAsync(outputPath, result.CalorSource, writeEncoding);
-
         if (validationErrors.Count > 0)
         {
-            Console.Error.WriteLine($"⚠ Validation failed ({validationErrors.Count} error{(validationErrors.Count == 1 ? "" : "s")}):");
+            envelope?.Data.Success = false;
+            Console.Error.WriteLine($"Validation failed ({validationErrors.Count} error{(validationErrors.Count == 1 ? "" : "s")}):");
             foreach (var err in validationErrors.Take(5))
                 Console.Error.WriteLine($"  {err}");
             if (validationErrors.Count > 5)
                 Console.Error.WriteLine($"  ... and {validationErrors.Count - 5} more");
-            Console.Error.WriteLine("Output written but may not compile. Use 'calor --input <file>' to compile, or calor_compile MCP tool (autoFix on by default).");
+            Console.Error.WriteLine("Destination was not modified.");
+            return (1, result);
         }
+
+        var writeEncoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
+        await ConversionFileWriter.WriteAtomicAsync(outputPath, result.CalorSource!, writeEncoding);
 
         // #770: structured loss accounting. The unconditional "✓ Conversion
         // successful" line was a false-success vector — it is now printed ONLY
@@ -357,7 +364,7 @@ public static class ConvertCommand
         // requested validation passed. Otherwise a loss summary with file:line
         // locations is printed instead.
         var losses = result.Context.Losses;
-        envelope?.SetLosses(losses);
+        envelope?.SetConversionSummary(result);
         if (losses.Count == 0 && validationErrors.Count == 0)
         {
             statusOut.WriteLine($"✓ Conversion successful");
@@ -365,9 +372,10 @@ public static class ConvertCommand
         else
         {
             statusOut.WriteLine(
-                $"⚠ Conversion completed with {losses.Count} semantic loss(es)" +
+                $"Conversion completed with {result.InteropPreservationCount} interop preservation(s), " +
+                $"{result.LossySubstitutionCount} lossy substitution(s), and {result.DropCount} drop(s)" +
                 (validationErrors.Count > 0 ? $" and {validationErrors.Count} validation error(s)" : "") +
-                " — output is NOT fully native Calor:");
+                " — output is not fully native Calor:");
             foreach (var group in losses.GroupBy(l => l.Kind))
             {
                 statusOut.WriteLine($"  {group.Key}: {group.Count()}");
@@ -463,7 +471,7 @@ public static class ConvertCommand
             return 1;
         }
 
-        await File.WriteAllTextAsync(outputPath, result.GeneratedCode);
+        await ConversionFileWriter.WriteAtomicAsync(outputPath, result.GeneratedCode);
 
         if (envelope != null)
         {
@@ -579,9 +587,14 @@ public static class ConvertCommand
         /// #770: structured loss accounting in the envelope — kind/feature/
         /// line/description per loss, plus the total count.
         /// </summary>
-        public void SetLosses(IReadOnlyList<ConversionLoss> losses)
+        public void SetConversionSummary(ConversionResult result)
         {
+            var losses = result.Losses;
             Data.LossCount = losses.Count;
+            Data.NativeConversionCount = result.NativeConversionCount;
+            Data.InteropPreservationCount = result.InteropPreservationCount;
+            Data.LossySubstitutionCount = result.LossySubstitutionCount;
+            Data.DropCount = result.DropCount;
             Data.Losses = losses.Count > 0
                 ? losses.Select(l => new ConvertLossData
                 {
@@ -633,6 +646,7 @@ public static class ConvertCommand
         public string? InputPath { get; set; }
         public string? OutputPath { get; set; }
         public bool Success { get; set; }
+        public string? Fidelity { get; set; }
 
         /// <summary>C# → Calor only: total unsupported feature instances.</summary>
         public int? UnsupportedFeatureCount { get; set; }
@@ -646,6 +660,10 @@ public static class ConvertCommand
 
         /// <summary>C# → Calor only: total recorded semantic losses (#770). 0 = fully native output.</summary>
         public int? LossCount { get; set; }
+        public int? NativeConversionCount { get; set; }
+        public int? InteropPreservationCount { get; set; }
+        public int? LossySubstitutionCount { get; set; }
+        public int? DropCount { get; set; }
 
         /// <summary>C# → Calor only: per-loss detail (kind, feature, file:line, description); absent when empty.</summary>
         public List<ConvertLossData>? Losses { get; set; }

--- a/src/Calor.Compiler/Commands/MigrateCommand.cs
+++ b/src/Calor.Compiler/Commands/MigrateCommand.cs
@@ -67,6 +67,10 @@ public static class MigrateCommand
             description: "Emit explicit §/C for every §C call (v0.6.0-compatible output); disables zero-arg §/C elision",
             getDefaultValue: () => false);
 
+        var lossyOption = new Option<bool>(
+            aliases: new[] { "--lossy" },
+            description: "Explicitly allow reported semantic substitutions or drops. The default is lossless migration.");
+
         var command = new Command("migrate", "Migrate an entire project between C# and Calor")
         {
             pathArgument,
@@ -79,7 +83,8 @@ public static class MigrateCommand
             skipAnalyzeOption,
             skipVerifyOption,
             verificationTimeoutOption,
-            explicitCallClosersOption
+            explicitCallClosersOption,
+            lossyOption
         };
 
         command.SetHandler(async (InvocationContext ctx) =>
@@ -95,12 +100,13 @@ public static class MigrateCommand
             var skipVerify = ctx.ParseResult.GetValueForOption(skipVerifyOption);
             var verificationTimeout = ctx.ParseResult.GetValueForOption(verificationTimeoutOption);
             var explicitCallClosers = ctx.ParseResult.GetValueForOption(explicitCallClosersOption);
+            var lossy = ctx.ParseResult.GetValueForOption(lossyOption);
 
             // Exit code returned through ctx.ExitCode: a code parked only on
             // Environment.ExitCode is overwritten by Main's InvokeAsync return.
             ctx.ExitCode = await ExecuteAsync(path, dryRun, benchmark, direction, parallel,
                 reportPath, verbose, skipAnalyze, skipVerify, (uint)verificationTimeout,
-                explicitCallClosers);
+                explicitCallClosers, lossy);
         });
 
         return command;
@@ -117,7 +123,8 @@ public static class MigrateCommand
         bool skipAnalyze,
         bool skipVerify,
         uint verificationTimeout,
-        bool explicitCallClosers)
+        bool explicitCallClosers,
+        bool lossy)
     {
         var telemetry = CalorTelemetry.IsInitialized ? CalorTelemetry.Instance : null;
         telemetry?.SetCommand("migrate");
@@ -149,6 +156,7 @@ public static class MigrateCommand
             SkipAnalyze = skipAnalyze,
             SkipVerify = skipVerify,
             VerificationTimeoutMs = verificationTimeout,
+            Fidelity = lossy ? ConversionFidelity.Lossy : ConversionFidelity.Lossless,
             UseImplicitCallCloser = !explicitCallClosers
         };
 

--- a/src/Calor.Compiler/Mcp/McpServer.cs
+++ b/src/Calor.Compiler/Mcp/McpServer.cs
@@ -131,17 +131,20 @@ public sealed class McpServer
             if (line == null)
                 return null;
 
-            if (!string.IsNullOrWhiteSpace(line))
+            if (string.IsNullOrWhiteSpace(line))
             {
-                if (line.Length > MaxMessageSize)
-                {
-                    Log($"Rejected oversized message: {line.Length} bytes (max {MaxMessageSize})");
-                    continue;
-                }
-
-                Log($"Read message: {line.Length} bytes");
-                return line;
+                await Task.Delay(10, cancellationToken);
+                continue;
             }
+
+            if (line.Length > MaxMessageSize)
+            {
+                Log($"Rejected oversized message: {line.Length} bytes (max {MaxMessageSize})");
+                continue;
+            }
+
+            Log($"Read message: {line.Length} bytes");
+            return line;
         }
     }
 

--- a/src/Calor.Compiler/Mcp/Tools/ConvertTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/ConvertTool.cs
@@ -293,12 +293,11 @@ public sealed class ConvertTool : McpToolBase
             {
                 try
                 {
-                    var outputDir = Path.GetDirectoryName(outputPath);
-                    if (!string.IsNullOrEmpty(outputDir) && !Directory.Exists(outputDir))
-                    {
-                        Directory.CreateDirectory(outputDir);
-                    }
-                    ConversionFileWriter.WriteAtomic(outputPath, calorSourceForOutput);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    ConversionFileWriter.WriteAtomicAsync(
+                        outputPath,
+                        calorSourceForOutput,
+                        cancellationToken: cancellationToken).GetAwaiter().GetResult();
                 }
                 catch (Exception ex)
                 {
@@ -433,7 +432,7 @@ public sealed class ConvertTool : McpToolBase
                     success: false, stage: "conversion",
                     calorSource: convResult.CalorSource, generatedCSharp: null,
                     conversionIssues, autoFixes, diagnosticEntries, compatIssues,
-                    convResult.Context.Stats, sw.Elapsed), isError: true));
+                    convResult, sw.Elapsed), isError: true));
             }
 
             var calorSource = convResult.CalorSource!;
@@ -465,7 +464,7 @@ public sealed class ConvertTool : McpToolBase
                             success: false, stage: "parse",
                             calorSource: fixResult.FixedSource, generatedCSharp: null,
                             conversionIssues, autoFixes, diagnosticEntries, compatIssues,
-                            convResult.Context.Stats, sw.Elapsed), isError: true));
+                            convResult, sw.Elapsed), isError: true));
                     }
                 }
                 else
@@ -476,7 +475,7 @@ public sealed class ConvertTool : McpToolBase
                         success: false, stage: "parse",
                         calorSource: calorSource, generatedCSharp: null,
                         conversionIssues, autoFixes, diagnosticEntries, compatIssues,
-                        convResult.Context.Stats, sw.Elapsed), isError: true));
+                        convResult, sw.Elapsed), isError: true));
                 }
             }
 
@@ -509,7 +508,7 @@ public sealed class ConvertTool : McpToolBase
                         success: false, stage: "diagnose",
                         calorSource: calorSource, generatedCSharp: compileResult.GeneratedCode,
                         conversionIssues, autoFixes, diagnosticEntries, compatIssues,
-                        convResult.Context.Stats, sw.Elapsed), isError: true));
+                        convResult, sw.Elapsed), isError: true));
                 }
 
                 generatedCSharp = compileResult.GeneratedCode;
@@ -524,7 +523,7 @@ public sealed class ConvertTool : McpToolBase
                     success: false, stage: "compile",
                     calorSource: calorSource, generatedCSharp: null,
                     conversionIssues, autoFixes, diagnosticEntries, compatIssues,
-                    convResult.Context.Stats, sw.Elapsed), isError: true));
+                    convResult, sw.Elapsed), isError: true));
             }
 
             // Stage 4: Compat check — verify generated C# matches expectations
@@ -562,7 +561,7 @@ public sealed class ConvertTool : McpToolBase
                         success: false, stage: "compat",
                         calorSource: calorSource, generatedCSharp: generatedCSharp,
                         conversionIssues, autoFixes, diagnosticEntries, compatIssues,
-                        convResult.Context.Stats, sw.Elapsed), isError: true));
+                        convResult, sw.Elapsed), isError: true));
                 }
             }
 
@@ -571,7 +570,11 @@ public sealed class ConvertTool : McpToolBase
             {
                 try
                 {
-                    ConversionFileWriter.WriteAtomic(outputPath, calorSource);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    ConversionFileWriter.WriteAtomicAsync(
+                        outputPath,
+                        calorSource,
+                        cancellationToken: cancellationToken).GetAwaiter().GetResult();
                 }
                 catch (Exception ex)
                 {
@@ -583,7 +586,7 @@ public sealed class ConvertTool : McpToolBase
                         success: false, stage: "write",
                         calorSource: calorSource, generatedCSharp: generatedCSharp,
                         conversionIssues, autoFixes, diagnosticEntries, compatIssues,
-                        convResult.Context.Stats, sw.Elapsed), isError: true));
+                        convResult, sw.Elapsed), isError: true));
                 }
             }
 
@@ -593,7 +596,7 @@ public sealed class ConvertTool : McpToolBase
                 success: true, stage: "complete",
                 calorSource: calorSource, generatedCSharp: generatedCSharp,
                 conversionIssues, autoFixes, diagnosticEntries, compatIssues,
-                convResult.Context.Stats, sw.Elapsed)));
+                convResult, sw.Elapsed)));
         }
         catch (Exception ex)
         {
@@ -847,15 +850,17 @@ public sealed class ConvertTool : McpToolBase
         List<string> autoFixes,
         List<EnvelopeDiagnostic> diagnostics,
         List<string> compatIssues,
-        ConversionStats stats,
+        ConversionResult result,
         TimeSpan duration)
     {
         var featureHints = InteropHintAnalyzer.AnalyzeInteropBlocks(calorSource);
+        var stats = result.Context.Stats;
 
         return new ValidatedOutput
         {
             Success = success,
             Stage = stage,
+            Fidelity = result.Context.Fidelity.ToString().ToLowerInvariant(),
             CalorSource = calorSource,
             GeneratedCSharp = generatedCSharp,
             ConversionIssues = conversionIssues,
@@ -874,7 +879,8 @@ public sealed class ConvertTool : McpToolBase
                 DurationMs = (int)duration.TotalMilliseconds
             },
             DurationMs = (int)duration.TotalMilliseconds,
-            FeatureHints = featureHints.Count > 0 ? featureHints : null
+            FeatureHints = featureHints.Count > 0 ? featureHints : null,
+            LossSummary = ConversionLossSummaryOutput.From(result)
         };
     }
 
@@ -1034,6 +1040,9 @@ public sealed class ConvertTool : McpToolBase
         [JsonPropertyName("stage")]
         public required string Stage { get; init; }
 
+        [JsonPropertyName("fidelity")]
+        public required string Fidelity { get; init; }
+
         [JsonPropertyName("calorSource")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? CalorSource { get; init; }
@@ -1065,6 +1074,9 @@ public sealed class ConvertTool : McpToolBase
         [JsonPropertyName("featureHints")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? FeatureHints { get; init; }
+
+        [JsonPropertyName("lossSummary")]
+        public required ConversionLossSummaryOutput LossSummary { get; init; }
     }
 
     // mode=roundtrip output

--- a/src/Calor.Compiler/Mcp/Tools/ConvertTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/ConvertTool.cs
@@ -64,6 +64,11 @@ public sealed class ConvertTool : McpToolBase
                     "enum": ["standard", "interop"],
                     "description": "Conversion mode: 'standard' (default) or 'interop' for §CSHARP blocks"
                 },
+                "fidelity": {
+                    "type": "string",
+                    "enum": ["lossless", "lossy"],
+                    "description": "Fidelity contract. 'lossless' is the default; 'lossy' explicitly permits reported substitutions or drops."
+                },
                 "mode": {
                     "type": "string",
                     "enum": ["convert", "validate", "roundtrip", "assess"],
@@ -167,6 +172,7 @@ public sealed class ConvertTool : McpToolBase
         var passthroughOnError = GetBool(arguments, "passthroughOnError", defaultValue: false);
         var explicitCallClosers = GetBool(arguments, "explicitCallClosers", defaultValue: false);
         var conversionMode = ResolveConversionMode(arguments);
+        var fidelity = ResolveFidelity(arguments);
 
         try
         {
@@ -177,6 +183,7 @@ public sealed class ConvertTool : McpToolBase
                 AutoGenerateIds = true,
                 GracefulFallback = fallback,
                 Explain = explain,
+                Fidelity = fidelity,
                 Mode = conversionMode,
                 StripPreprocessor = stripPreprocessor,
                 PassthroughOnError = passthroughOnError,
@@ -185,7 +192,7 @@ public sealed class ConvertTool : McpToolBase
 
             var converter = new CSharpToCalorConverter(options);
             cancellationToken.ThrowIfCancellationRequested();
-            var result = converter.Convert(source);
+            var result = converter.Convert(source, inputPath);
 
             // Always compute explanation for unsupported feature summary
             var explanation = result.Context.GetExplanation();
@@ -291,13 +298,14 @@ public sealed class ConvertTool : McpToolBase
                     {
                         Directory.CreateDirectory(outputDir);
                     }
-                    File.WriteAllText(outputPath, calorSourceForOutput);
+                    ConversionFileWriter.WriteAtomic(outputPath, calorSourceForOutput);
                 }
                 catch (Exception ex)
                 {
                     issues.Add(ConversionIssueEnvelope.Message(
-                        DiagnosticCode.ConversionIssue, "warning",
+                        DiagnosticCode.ConversionIssue, "error",
                         $"Failed to write output file: {ex.Message}", inputPath));
+                    success = false;
                 }
             }
 
@@ -313,6 +321,7 @@ public sealed class ConvertTool : McpToolBase
             var output = new ConvertToolOutput
             {
                 Success = success,
+                Fidelity = fidelity.ToString().ToLowerInvariant(),
                 CalorSource = calorSourceForOutput,
                 OutputPath = outputPath,
                 Issues = issues,
@@ -332,6 +341,7 @@ public sealed class ConvertTool : McpToolBase
                 Explanation = explanationOutput,
                 FeatureHints = featureHints.Count > 0 ? featureHints : null,
                 NativeFeaturesUsed = nativeFeaturesUsed.Count > 0 ? nativeFeaturesUsed : null,
+                LossSummary = ConversionLossSummaryOutput.From(result),
                 Tip = "Use calor_help with feature='overview' to see all available Calor syntax before writing or editing .calr files."
             };
 
@@ -381,6 +391,7 @@ public sealed class ConvertTool : McpToolBase
             moduleName = Path.GetFileNameWithoutExtension(inputPath);
         }
         var conversionMode = ResolveConversionMode(arguments);
+        var fidelity = ResolveFidelity(arguments);
         var expectedNamespace = GetString(arguments, "expectedNamespace");
         var expectedPatterns = GetStringArray(arguments, "expectedPatterns");
         var forbiddenPatterns = GetStringArray(arguments, "forbiddenPatterns");
@@ -402,6 +413,7 @@ public sealed class ConvertTool : McpToolBase
                 AutoGenerateIds = true,
                 GracefulFallback = true,
                 Explain = false,
+                Fidelity = fidelity,
                 Mode = conversionMode,
                 StripPreprocessor = GetBool(arguments, "stripPreprocessor", defaultValue: true),
                 PassthroughOnError = GetBool(arguments, "passthroughOnError", defaultValue: false),
@@ -409,7 +421,7 @@ public sealed class ConvertTool : McpToolBase
             };
 
             var converter = new CSharpToCalorConverter(options);
-            var convResult = converter.Convert(source);
+            var convResult = converter.Convert(source, inputPath);
 
             conversionIssues.AddRange(convResult.Issues
                 .Select(i => ConversionIssueEnvelope.Build(i, inputPath)));
@@ -617,6 +629,7 @@ public sealed class ConvertTool : McpToolBase
                 PreserveComments = true,
                 AutoGenerateIds = true,
                 GracefulFallback = true,
+                Fidelity = ResolveFidelity(arguments),
                 Mode = ConversionMode.Interop,
                 StripPreprocessor = GetBool(arguments, "stripPreprocessor", defaultValue: true),
                 UseImplicitCallCloser = !GetBool(arguments, "explicitCallClosers", defaultValue: false)
@@ -793,6 +806,14 @@ public sealed class ConvertTool : McpToolBase
             ? ConversionMode.Interop : ConversionMode.Standard;
     }
 
+    private static ConversionFidelity ResolveFidelity(JsonElement? arguments)
+    {
+        var fidelity = GetString(arguments, "fidelity") ?? "lossless";
+        return fidelity.Equals("lossy", StringComparison.OrdinalIgnoreCase)
+            ? ConversionFidelity.Lossy
+            : ConversionFidelity.Lossless;
+    }
+
     private static string NormalizeWhitespace(string text)
     {
         return Regex.Replace(text, @"\s+", " ").Trim();
@@ -864,6 +885,9 @@ public sealed class ConvertTool : McpToolBase
         [JsonPropertyName("success")]
         public bool Success { get; init; }
 
+        [JsonPropertyName("fidelity")]
+        public required string Fidelity { get; init; }
+
         [JsonPropertyName("calorSource")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? CalorSource { get; init; }
@@ -898,9 +922,66 @@ public sealed class ConvertTool : McpToolBase
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string>? NativeFeaturesUsed { get; init; }
 
+        [JsonPropertyName("lossSummary")]
+        public required ConversionLossSummaryOutput LossSummary { get; init; }
+
         [JsonPropertyName("tip")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Tip { get; init; }
+    }
+
+    private sealed class ConversionLossSummaryOutput
+    {
+        [JsonPropertyName("nativeConversions")]
+        public int NativeConversions { get; init; }
+
+        [JsonPropertyName("interopPreservations")]
+        public int InteropPreservations { get; init; }
+
+        [JsonPropertyName("lossySubstitutions")]
+        public int LossySubstitutions { get; init; }
+
+        [JsonPropertyName("drops")]
+        public int Drops { get; init; }
+
+        [JsonPropertyName("locations")]
+        public required List<ConversionLossLocationOutput> Locations { get; init; }
+
+        public static ConversionLossSummaryOutput From(ConversionResult result) => new()
+        {
+            NativeConversions = result.NativeConversionCount,
+            InteropPreservations = result.InteropPreservationCount,
+            LossySubstitutions = result.LossySubstitutionCount,
+            Drops = result.DropCount,
+            Locations = result.Losses.Select(loss => new ConversionLossLocationOutput
+            {
+                Kind = loss.Kind.ToString(),
+                Feature = loss.Feature,
+                File = loss.File,
+                Line = loss.Line,
+                Description = loss.Description
+            }).ToList()
+        };
+    }
+
+    private sealed class ConversionLossLocationOutput
+    {
+        [JsonPropertyName("kind")]
+        public required string Kind { get; init; }
+
+        [JsonPropertyName("feature")]
+        public required string Feature { get; init; }
+
+        [JsonPropertyName("file")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? File { get; init; }
+
+        [JsonPropertyName("line")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? Line { get; init; }
+
+        [JsonPropertyName("description")]
+        public required string Description { get; init; }
     }
 
     private sealed class ExplanationOutput

--- a/src/Calor.Compiler/Mcp/Tools/ConvertTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/ConvertTool.cs
@@ -571,18 +571,19 @@ public sealed class ConvertTool : McpToolBase
             {
                 try
                 {
-                    var outputDir = Path.GetDirectoryName(outputPath);
-                    if (!string.IsNullOrEmpty(outputDir) && !Directory.Exists(outputDir))
-                    {
-                        Directory.CreateDirectory(outputDir);
-                    }
-                    File.WriteAllText(outputPath, calorSource);
+                    ConversionFileWriter.WriteAtomic(outputPath, calorSource);
                 }
                 catch (Exception ex)
                 {
                     conversionIssues.Add(ConversionIssueEnvelope.Message(
-                        DiagnosticCode.ConversionIssue, "warning",
+                        DiagnosticCode.ConversionIssue, "error",
                         $"Failed to write output file: {ex.Message}", inputPath));
+                    sw.Stop();
+                    return Task.FromResult(McpToolResult.Json(BuildValidatedOutput(
+                        success: false, stage: "write",
+                        calorSource: calorSource, generatedCSharp: generatedCSharp,
+                        conversionIssues, autoFixes, diagnosticEntries, compatIssues,
+                        convResult.Context.Stats, sw.Elapsed), isError: true));
                 }
             }
 

--- a/src/Calor.Compiler/Mcp/Tools/MigrateTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/MigrateTool.cs
@@ -432,7 +432,13 @@ public sealed class MigrateTool : McpToolBase
         }
 
         // Step 3: Compile converted .calr files
-        var calrFiles = DiscoverCalrFiles(directory, maxFiles);
+        var calrFiles = report.FileResults
+            .Where(file => file.Status is FileMigrationStatus.Success or FileMigrationStatus.Partial)
+            .Select(file => file.OutputPath)
+            .Where(path => path != null && File.Exists(path))
+            .Cast<string>()
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
         foreach (var path in calrFiles)
         {
             ct.ThrowIfCancellationRequested();

--- a/src/Calor.Compiler/Mcp/Tools/MigrateTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/MigrateTool.cs
@@ -55,6 +55,12 @@ public sealed class MigrateTool : McpToolBase
                     "type": "boolean",
                     "description": "Emit explicit §/C for every §C call (v0.6.0-compatible output); disables zero-arg §/C elision (default: false — v0.6.1 default elides zero-arg §/C)",
                     "default": false
+                },
+                "fidelity": {
+                    "type": "string",
+                    "enum": ["lossless", "lossy"],
+                    "description": "Fidelity contract. Lossless is the default.",
+                    "default": "lossless"
                 }
             },
             "required": ["projectPath"],
@@ -75,6 +81,10 @@ public sealed class MigrateTool : McpToolBase
         var maxFiles = GetInt(arguments, "maxFiles", defaultValue: 0);
         var autoFix = GetBool(arguments, "autoFix", defaultValue: true);
         var explicitCallClosers = GetBool(arguments, "explicitCallClosers", defaultValue: false);
+        var fidelity = (GetString(arguments, "fidelity") ?? "lossless")
+            .Equals("lossy", StringComparison.OrdinalIgnoreCase)
+            ? ConversionFidelity.Lossy
+            : ConversionFidelity.Lossless;
 
         // Resolve directory from .csproj or directory path
         var directory = ResolveDirectory(projectPath);
@@ -86,10 +96,10 @@ public sealed class MigrateTool : McpToolBase
             return phase switch
             {
                 "assess" => RunAssess(directory, maxFiles, cancellationToken),
-                "convert" => await RunConvertAsync(directory, projectPath, maxFiles, explicitCallClosers, cancellationToken),
+                "convert" => await RunConvertAsync(directory, projectPath, maxFiles, explicitCallClosers, fidelity, cancellationToken),
                 "compile" => RunCompile(directory, maxFiles, cancellationToken),
                 "fix" => await RunFixAsync(directory, maxFiles, cancellationToken),
-                "full" => await RunFullAsync(directory, projectPath, maxFiles, autoFix, explicitCallClosers, cancellationToken),
+                "full" => await RunFullAsync(directory, projectPath, maxFiles, autoFix, explicitCallClosers, fidelity, cancellationToken),
                 _ => McpToolResult.Error($"Unknown phase: '{phase}'. Must be 'assess', 'convert', 'compile', 'fix', or 'full'.")
             };
         }
@@ -155,12 +165,13 @@ public sealed class MigrateTool : McpToolBase
 
     // ── Phase: convert ──────────────────────────────────────────────
 
-    internal async Task<McpToolResult> RunConvertAsync(string directory, string projectPath, int maxFiles, bool explicitCallClosers, CancellationToken ct)
+    internal async Task<McpToolResult> RunConvertAsync(string directory, string projectPath, int maxFiles, bool explicitCallClosers, ConversionFidelity fidelity, CancellationToken ct)
     {
         var options = new MigrationPlanOptions
         {
             IncludeTests = true,
             MaxFiles = maxFiles,
+            Fidelity = fidelity,
             PassthroughOnError = false,
             UseImplicitCallCloser = !explicitCallClosers
         };
@@ -181,6 +192,7 @@ public sealed class MigrateTool : McpToolBase
                 FileMigrationStatus.Skipped => "skipped",
                 _ => "failed"
             },
+            Losses = f.Losses.Count > 0 ? f.Losses : null,
             Errors = f.Issues
                 .Where(i => i.Severity == ConversionIssueSeverity.Error)
                 .Select(i => ConversionIssueEnvelope.Build(i, f.SourcePath))
@@ -193,6 +205,20 @@ public sealed class MigrateTool : McpToolBase
 
         return BuildOutput("convert", perFile);
     }
+
+    internal Task<McpToolResult> RunConvertAsync(
+        string directory,
+        string projectPath,
+        int maxFiles,
+        bool explicitCallClosers,
+        CancellationToken ct) =>
+        RunConvertAsync(
+            directory,
+            projectPath,
+            maxFiles,
+            explicitCallClosers,
+            ConversionFidelity.Lossless,
+            ct);
 
     // ── Phase: compile ──────────────────────────────────────────────
 
@@ -296,7 +322,8 @@ public sealed class MigrateTool : McpToolBase
     // ── Phase: full ─────────────────────────────────────────────────
 
     internal async Task<McpToolResult> RunFullAsync(
-        string directory, string projectPath, int maxFiles, bool autoFix, bool explicitCallClosers, CancellationToken ct)
+        string directory, string projectPath, int maxFiles, bool autoFix, bool explicitCallClosers,
+        ConversionFidelity fidelity, CancellationToken ct)
     {
         var sw = Stopwatch.StartNew();
         var allPerFile = new Dictionary<string, MigrateFileResult>(StringComparer.OrdinalIgnoreCase);
@@ -337,6 +364,7 @@ public sealed class MigrateTool : McpToolBase
         {
             IncludeTests = true,
             MaxFiles = maxFiles,
+            Fidelity = fidelity,
             PassthroughOnError = false,
             UseImplicitCallCloser = !explicitCallClosers
         };
@@ -371,6 +399,7 @@ public sealed class MigrateTool : McpToolBase
                     _ => "convert_failed"
                 },
                 Score = existing?.Score,
+                Losses = f.Losses.Count > 0 ? f.Losses : null,
                 Errors = errors.Count > 0 ? errors : null,
                 Warnings = warnings.Count > 0 ? warnings : null
             };
@@ -519,6 +548,22 @@ public sealed class MigrateTool : McpToolBase
         return BuildOutput("full", perFile, (int)sw.ElapsedMilliseconds);
     }
 
+    internal Task<McpToolResult> RunFullAsync(
+        string directory,
+        string projectPath,
+        int maxFiles,
+        bool autoFix,
+        bool explicitCallClosers,
+        CancellationToken ct) =>
+        RunFullAsync(
+            directory,
+            projectPath,
+            maxFiles,
+            autoFix,
+            explicitCallClosers,
+            ConversionFidelity.Lossless,
+            ct);
+
     // ── Helpers ──────────────────────────────────────────────────────
 
     internal static string? ResolveDirectory(string projectPath)
@@ -650,6 +695,10 @@ public sealed class MigrateTool : McpToolBase
         [JsonPropertyName("warnings")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<EnvelopeDiagnostic>? Warnings { get; init; }
+
+        [JsonPropertyName("losses")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public IReadOnlyList<ConversionLoss>? Losses { get; init; }
 
         /// <summary>Number of auto-fixes applied (fix / full phases); replaces the old pseudo-warning string.</summary>
         [JsonPropertyName("fixesApplied")]

--- a/src/Calor.Compiler/Mcp/Tools/MigrateTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/MigrateTool.cs
@@ -295,7 +295,33 @@ public sealed class MigrateTool : McpToolBase
                 var totalFixes = fixes1.Count + fixes2.Count + fixes3.Count;
 
                 if (totalFixes > 0)
-                    await File.WriteAllTextAsync(path, fixedFinal, ct);
+                {
+                    var validation = Program.Compile(
+                        fixedFinal,
+                        path,
+                        new CompilationOptions
+                        {
+                            ContractMode = ContractMode.Off,
+                            UnknownCallPolicy = UnknownCallPolicy.Permissive,
+                            VerificationCacheOptions = new VerificationCacheOptions { Enabled = false },
+                            CancellationToken = ct
+                        });
+                    if (validation.HasErrors)
+                    {
+                        perFile.Add(new MigrateFileResult
+                        {
+                            Path = Path.GetRelativePath(directory, path),
+                            Status = "fix_incomplete",
+                            Errors = BuildCompileEnvelope(validation, path, fixedFinal)
+                                .Where(entry => entry.Severity == "error")
+                                .ToList(),
+                            FixesApplied = totalFixes
+                        });
+                        continue;
+                    }
+
+                    await ConversionFileWriter.WriteAtomicAsync(path, fixedFinal, cancellationToken: ct);
+                }
 
                 perFile.Add(new MigrateFileResult
                 {
@@ -503,9 +529,6 @@ public sealed class MigrateTool : McpToolBase
 
                     if (totalFixes > 0)
                     {
-                        await File.WriteAllTextAsync(path, fixedFinal, ct);
-
-                        // Re-compile
                         var compileOptions = new CompilationOptions
                         {
                             ContractMode = ContractMode.Off,
@@ -514,6 +537,13 @@ public sealed class MigrateTool : McpToolBase
                             CancellationToken = ct
                         };
                         var recompile = Program.Compile(fixedFinal, path, compileOptions);
+                        if (!recompile.HasErrors)
+                        {
+                            await ConversionFileWriter.WriteAtomicAsync(
+                                path,
+                                fixedFinal,
+                                cancellationToken: ct);
+                        }
 
                         var relativePath = Path.GetRelativePath(directory, path);
                         var sourceKey = allPerFile.Keys

--- a/src/Calor.Compiler/Mcp/Tools/MigrateTool.cs
+++ b/src/Calor.Compiler/Mcp/Tools/MigrateTool.cs
@@ -473,7 +473,8 @@ public sealed class MigrateTool : McpToolBase
                         Status = "compile_failed",
                         Score = existing?.Score,
                         Errors = compileErrors,
-                        Warnings = existing?.Warnings
+                        Warnings = existing?.Warnings,
+                        Losses = existing?.Losses
                     };
                 }
                 else if (sourceKey != null)
@@ -487,7 +488,8 @@ public sealed class MigrateTool : McpToolBase
                             Status = "compiled",
                             Score = existing.Score,
                             Errors = existing.Errors,
-                            Warnings = existing.Warnings
+                            Warnings = existing.Warnings,
+                            Losses = existing.Losses
                         };
                     }
                 }
@@ -501,6 +503,7 @@ public sealed class MigrateTool : McpToolBase
                     Path = existing?.Path ?? key,
                     Status = "compile_error",
                     Score = existing?.Score,
+                    Losses = existing?.Losses,
                     Errors = [ConversionIssueEnvelope.Message(
                         DiagnosticCode.CliInternalError, "error", ex.Message, path)]
                 };
@@ -562,6 +565,7 @@ public sealed class MigrateTool : McpToolBase
                             Path = existing?.Path ?? key,
                             Status = recompile.HasErrors ? "fix_incomplete" : "fixed",
                             Score = existing?.Score,
+                            Losses = existing?.Losses,
                             Errors = recompile.HasErrors
                                 ? BuildCompileEnvelope(recompile, path, fixedFinal)
                                     .Where(e => e.Severity == "error")

--- a/src/Calor.Compiler/Migration/CSharpToCalorConverter.cs
+++ b/src/Calor.Compiler/Migration/CSharpToCalorConverter.cs
@@ -395,7 +395,9 @@ public sealed class CSharpToCalorConverter
     /// <summary>
     /// Converts a C# file to Calor.
     /// </summary>
-    public async Task<ConversionResult> ConvertFileAsync(string csharpFilePath)
+    public async Task<ConversionResult> ConvertFileAsync(
+        string csharpFilePath,
+        CancellationToken cancellationToken = default)
     {
         if (!File.Exists(csharpFilePath))
         {
@@ -407,22 +409,31 @@ public sealed class CSharpToCalorConverter
         // Use replacement fallback to handle files with unpaired surrogates
         // (e.g., regex patterns containing \uD800-\uDBFF in string literals)
         var encoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
-        var source = await File.ReadAllTextAsync(csharpFilePath, encoding);
-        return Convert(source, csharpFilePath);
+        var source = await File.ReadAllTextAsync(csharpFilePath, encoding, cancellationToken);
+        var result = Convert(source, csharpFilePath);
+        cancellationToken.ThrowIfCancellationRequested();
+        return result;
     }
 
     /// <summary>
     /// Converts a C# file and writes the output to an Calor file.
     /// </summary>
-    public async Task<ConversionResult> ConvertFileAndSaveAsync(string csharpFilePath, string? outputPath = null)
+    public async Task<ConversionResult> ConvertFileAndSaveAsync(
+        string csharpFilePath,
+        string? outputPath = null,
+        CancellationToken cancellationToken = default)
     {
-        var result = await ConvertFileAsync(csharpFilePath);
+        var result = await ConvertFileAsync(csharpFilePath, cancellationToken);
 
         if (result.Success && result.CalorSource != null)
         {
             var calorPath = outputPath ?? Path.ChangeExtension(csharpFilePath, ".calr");
             var writeEncoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
-            await ConversionFileWriter.WriteAtomicAsync(calorPath, result.CalorSource, writeEncoding);
+            await ConversionFileWriter.WriteAtomicAsync(
+                calorPath,
+                result.CalorSource,
+                writeEncoding,
+                cancellationToken);
         }
 
         return result;

--- a/src/Calor.Compiler/Migration/CSharpToCalorConverter.cs
+++ b/src/Calor.Compiler/Migration/CSharpToCalorConverter.cs
@@ -70,11 +70,10 @@ public enum ConversionMode
 public sealed class ConversionOptions
 {
     /// <summary>
-    /// Fidelity contract for the low-level conversion API. Legacy programmatic
-    /// callers retain lossy behavior unless they select Lossless; user-facing CLI,
-    /// MCP, and project-migration surfaces explicitly default to Lossless.
+    /// Fidelity contract for conversion. Lossless is the safe default; lossy
+    /// substitutions and drops require explicit caller opt-in.
     /// </summary>
-    public ConversionFidelity Fidelity { get; set; } = ConversionFidelity.Lossy;
+    public ConversionFidelity Fidelity { get; set; } = ConversionFidelity.Lossless;
 
     /// <summary>
     /// The module name to use in the generated Calor code.
@@ -137,6 +136,12 @@ public sealed class ConversionOptions
     /// Default is <c>true</c> (matches <see cref="ConversionContext.UseImplicitCallCloser"/>).
     /// </summary>
     public bool UseImplicitCallCloser { get; set; } = true;
+
+    /// <summary>
+    /// Whether lossless conversion validates generated C# as a standalone unit.
+    /// Project migration disables this per file and validates all generated files together.
+    /// </summary>
+    public bool ValidateRoundTripCSharp { get; set; } = true;
 }
 
 /// <summary>
@@ -339,7 +344,7 @@ public sealed class CSharpToCalorConverter
 
             if (_options.Fidelity == ConversionFidelity.Lossless)
             {
-                ValidateLosslessRoundTrip(calorSource, context);
+                ValidateLosslessRoundTrip(calorSource, context, _options.ValidateRoundTripCSharp);
             }
 
             var destructiveLosses = context.Losses.Count(loss => loss.IsSemanticLoss);
@@ -454,30 +459,33 @@ public sealed class CSharpToCalorConverter
     /// </summary>
     private static void ReconcileEmitterFallbacks(string calorSource, ConversionContext context)
     {
-        var markers = CountOccurrences(calorSource, "§CSHARP{")
-                    + CountOccurrences(calorSource, "§CS{")
-                    + CountOccurrences(calorSource, "§RAW"); // "§/RAW" does not contain "§RAW"
-
-        var ledgered = context.Losses.Count(l => l.Kind == ConversionLossKind.InteropPreserved);
-        var unledgered = markers - ledgered;
-        for (var i = 0; i < unledgered; i++)
+        var markerLines = FindMarkerLines(calorSource);
+        var ledgered = context.Losses.Count(loss =>
+            loss.Kind is ConversionLossKind.InteropPreserved or ConversionLossKind.EmitterFallback);
+        foreach (var line in markerLines.Skip(ledgered))
         {
             context.RecordLoss(ConversionLossKind.EmitterFallback, "emitter-fallback",
                 "Raw C# fallback (§CS{…}/§RAW/§CSHARP) present in the emitted Calor without a ledger entry — " +
-                "produced by an emitter-internal fallback path; the output is not fully native");
+                "produced by an emitter-internal fallback path; location is in the generated Calor",
+                line);
         }
     }
 
-    private static int CountOccurrences(string text, string value)
+    private static List<int> FindMarkerLines(string text)
     {
-        var count = 0;
-        var index = 0;
-        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        var markers = new[] { "§CSHARP{", "§CS{", "§RAW" };
+        var lines = new List<int>();
+        foreach (var marker in markers)
         {
-            count++;
-            index += value.Length;
+            var index = 0;
+            while ((index = text.IndexOf(marker, index, StringComparison.Ordinal)) >= 0)
+            {
+                lines.Add(1 + text.AsSpan(0, index).Count('\n'));
+                index += marker.Length;
+            }
         }
-        return count;
+        lines.Sort();
+        return lines;
     }
 
     /// <summary>True if <paramref name="calorSource"/> lexes and parses without errors.</summary>
@@ -725,9 +733,17 @@ public sealed class CSharpToCalorConverter
         };
     }
 
-    private static void ValidateLosslessRoundTrip(string calorSource, ConversionContext context)
+    private static void ValidateLosslessRoundTrip(
+        string calorSource,
+        ConversionContext context,
+        bool validateGeneratedCSharp)
     {
         CompilationResult compileResult;
+        if (!validateGeneratedCSharp)
+        {
+            return;
+        }
+
         try
         {
             compileResult = global::Calor.Compiler.Program.Compile(
@@ -957,7 +973,7 @@ public static class Converter
         if (result.Success && result.CalorSource != null)
         {
             var calorPath = outputPath ?? Path.ChangeExtension(csharpPath, ".calr");
-            await File.WriteAllTextAsync(calorPath, result.CalorSource);
+            await ConversionFileWriter.WriteAtomicAsync(calorPath, result.CalorSource);
         }
 
         return result;
@@ -974,7 +990,7 @@ public static class Converter
         if (!result.HasErrors && !string.IsNullOrEmpty(result.GeneratedCode))
         {
             var csPath = outputPath ?? Path.ChangeExtension(calorPath, ".g.cs");
-            await File.WriteAllTextAsync(csPath, result.GeneratedCode);
+            await ConversionFileWriter.WriteAtomicAsync(csPath, result.GeneratedCode);
         }
 
         return result;

--- a/src/Calor.Compiler/Migration/CSharpToCalorConverter.cs
+++ b/src/Calor.Compiler/Migration/CSharpToCalorConverter.cs
@@ -2,6 +2,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Calor.Compiler.Ast;
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Effects;
 
 namespace Calor.Compiler.Migration;
 
@@ -19,6 +21,30 @@ public sealed class ConversionResult
     public bool HasErrors => Context.HasErrors;
     public bool HasWarnings => Context.HasWarnings;
     public IReadOnlyList<ConversionIssue> Issues => Context.Issues;
+    public IReadOnlyList<ConversionLoss> Losses => Context.Losses;
+    public int NativeConversionCount => Context.Stats.ConvertedNodes;
+    public int InteropPreservationCount => Context.Losses.Count(
+        loss => loss.Kind is ConversionLossKind.InteropPreserved or ConversionLossKind.EmitterFallback);
+    public int LossySubstitutionCount => Context.Losses.Count(
+        loss => loss.Kind is ConversionLossKind.FallbackTodo or ConversionLossKind.PreprocessorStripped);
+    public int DropCount => Context.Losses.Count(loss => loss.Kind == ConversionLossKind.Dropped);
+}
+
+/// <summary>
+/// Fidelity contract for C# to Calor conversion.
+/// </summary>
+public enum ConversionFidelity
+{
+    /// <summary>
+    /// Unsupported code must be preserved verbatim at a compilable boundary.
+    /// Emitted Calor and its generated C# must validate before success is reported.
+    /// </summary>
+    Lossless,
+
+    /// <summary>
+    /// Explicit opt-in allowing substitutions or drops. Every loss remains recorded.
+    /// </summary>
+    Lossy
 }
 
 /// <summary>
@@ -43,6 +69,13 @@ public enum ConversionMode
 /// </summary>
 public sealed class ConversionOptions
 {
+    /// <summary>
+    /// Fidelity contract for the low-level conversion API. Legacy programmatic
+    /// callers retain lossy behavior unless they select Lossless; user-facing CLI,
+    /// MCP, and project-migration surfaces explicitly default to Lossless.
+    /// </summary>
+    public ConversionFidelity Fidelity { get; set; } = ConversionFidelity.Lossy;
+
     /// <summary>
     /// The module name to use in the generated Calor code.
     /// If not specified, derived from the source file name.
@@ -134,7 +167,7 @@ public sealed class CSharpToCalorConverter
             // Step 0: Strip preprocessor directives to avoid Roslyn hangs/OOM.
             // Stripping keeps the first #if branch UNEVALUATED and deletes the
             // alternates — a semantic loss, recorded per directive (#770/#773).
-            if (_options.StripPreprocessor)
+            if (_options.StripPreprocessor && _options.Fidelity == ConversionFidelity.Lossy)
             {
                 try
                 {
@@ -297,6 +330,27 @@ public sealed class CSharpToCalorConverter
             // ledgered interop preservations is counted as an EmitterFallback loss.
             ReconcileEmitterFallbacks(calorSource, context);
 
+            if (!ParsesCleanly(calorSource))
+            {
+                context.AddError(
+                    "Generated Calor failed mandatory parse validation.",
+                    feature: "generated-calor-validation");
+            }
+
+            if (_options.Fidelity == ConversionFidelity.Lossless)
+            {
+                ValidateLosslessRoundTrip(calorSource, context);
+            }
+
+            var destructiveLosses = context.Losses.Count(loss => loss.IsSemanticLoss);
+            if (_options.Fidelity == ConversionFidelity.Lossless && destructiveLosses > 0)
+            {
+                context.AddError(
+                    $"Lossless conversion refused {destructiveLosses} lossy substitution(s) or drop(s). " +
+                    "Use explicit lossy mode to acknowledge semantic loss.",
+                    feature: "lossless-contract");
+            }
+
             if (_options.Verbose)
             {
                 Console.WriteLine($"Converted {context.Stats.ConvertedNodes} nodes");
@@ -309,7 +363,7 @@ public sealed class CSharpToCalorConverter
 
             return new ConversionResult
             {
-                Success = true,
+                Success = !context.HasErrors,
                 CalorSource = calorSource,
                 Ast = calorAst,
                 Context = context,
@@ -363,7 +417,7 @@ public sealed class CSharpToCalorConverter
         {
             var calorPath = outputPath ?? Path.ChangeExtension(csharpFilePath, ".calr");
             var writeEncoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
-            await File.WriteAllTextAsync(calorPath, result.CalorSource, writeEncoding);
+            await ConversionFileWriter.WriteAtomicAsync(calorPath, result.CalorSource, writeEncoding);
         }
 
         return result;
@@ -664,10 +718,68 @@ public sealed class CSharpToCalorConverter
             AutoGenerateIds = _options.AutoGenerateIds,
             ModuleName = _options.ModuleName,
             GracefulFallback = _options.GracefulFallback,
+            Fidelity = _options.Fidelity,
             Mode = _options.Mode,
             PassthroughOnError = _options.PassthroughOnError,
             UseImplicitCallCloser = _options.UseImplicitCallCloser
         };
+    }
+
+    private static void ValidateLosslessRoundTrip(string calorSource, ConversionContext context)
+    {
+        CompilationResult compileResult;
+        try
+        {
+            compileResult = global::Calor.Compiler.Program.Compile(
+                calorSource,
+                context.SourceFile ?? "converted-output.calr",
+                new CompilationOptions
+                {
+                    EnforceEffects = false,
+                    UnknownCallPolicy = UnknownCallPolicy.Permissive
+                });
+        }
+        catch (Exception ex)
+        {
+            context.AddError(
+                $"Generated Calor validation crashed: {ex.GetType().Name}: {ex.Message}",
+                feature: "roundtrip-calor-validation");
+            return;
+        }
+
+        foreach (var diagnostic in compileResult.Diagnostics.Errors)
+        {
+            context.AddError(
+                $"Generated Calor failed compilation: {diagnostic.Message}",
+                line: diagnostic.Span.Line,
+                column: diagnostic.Span.Column,
+                feature: "roundtrip-calor-validation");
+        }
+
+        if (compileResult.HasErrors)
+        {
+            return;
+        }
+
+        try
+        {
+            var validation = GeneratedCSharpCompiler.Validate(compileResult.GeneratedCode);
+            foreach (var diagnostic in validation.SyntaxErrors.Concat(validation.CompilationErrors))
+            {
+                var span = diagnostic.Location.GetLineSpan().StartLinePosition;
+                context.AddError(
+                    $"Round-tripped C# failed compilation ({diagnostic.Id}): {diagnostic.GetMessage()}",
+                    line: span.Line + 1,
+                    column: span.Character + 1,
+                    feature: "roundtrip-csharp-validation");
+            }
+        }
+        catch (Exception ex)
+        {
+            context.AddError(
+                $"Round-tripped C# validation crashed: {ex.GetType().Name}: {ex.Message}",
+                feature: "roundtrip-csharp-validation");
+        }
     }
 
     [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000",
@@ -745,6 +857,59 @@ public enum ConversionDirection
     Unknown,
     CSharpToCalor,
     CalorToCSharp
+}
+
+internal static class ConversionFileWriter
+{
+    public static void WriteAtomic(
+        string path,
+        string content,
+        System.Text.Encoding? encoding = null)
+    {
+        WriteAtomicAsync(path, content, encoding).GetAwaiter().GetResult();
+    }
+
+    public static async Task WriteAtomicAsync(
+        string path,
+        string content,
+        System.Text.Encoding? encoding = null,
+        CancellationToken cancellationToken = default)
+    {
+        var fullPath = Path.GetFullPath(path);
+        var directory = Path.GetDirectoryName(fullPath)
+            ?? throw new InvalidOperationException($"Output path has no directory: {path}");
+        Directory.CreateDirectory(directory);
+
+        var tempPath = Path.Combine(
+            directory,
+            $".{Path.GetFileName(fullPath)}.{Guid.NewGuid():N}.tmp");
+        UnixFileMode? existingMode = null;
+        if (!OperatingSystem.IsWindows() && File.Exists(fullPath))
+        {
+            existingMode = File.GetUnixFileMode(fullPath);
+        }
+
+        try
+        {
+            await File.WriteAllTextAsync(
+                tempPath,
+                content,
+                encoding ?? new System.Text.UTF8Encoding(false),
+                cancellationToken);
+            if (!OperatingSystem.IsWindows() && existingMode.HasValue)
+            {
+                File.SetUnixFileMode(tempPath, existingMode.Value);
+            }
+            File.Move(tempPath, fullPath, overwrite: true);
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+            {
+                File.Delete(tempPath);
+            }
+        }
+    }
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Migration/CSharpToCalorConverter.cs
+++ b/src/Calor.Compiler/Migration/CSharpToCalorConverter.cs
@@ -470,7 +470,7 @@ public sealed class CSharpToCalorConverter
     /// </summary>
     private static void ReconcileEmitterFallbacks(string calorSource, ConversionContext context)
     {
-        var markerLines = FindMarkerLines(calorSource);
+        var markerLines = FindFallbackTokenLines(calorSource);
         var ledgered = context.Losses.Count(loss =>
             loss.Kind is ConversionLossKind.InteropPreserved or ConversionLossKind.EmitterFallback);
         foreach (var line in markerLines.Skip(ledgered))
@@ -482,21 +482,23 @@ public sealed class CSharpToCalorConverter
         }
     }
 
-    private static List<int> FindMarkerLines(string text)
+    private static List<int> FindFallbackTokenLines(string text)
     {
-        var markers = new[] { "§CSHARP{", "§CS{", "§RAW" };
-        var lines = new List<int>();
-        foreach (var marker in markers)
+        var diagnostics = new Diagnostics.DiagnosticBag();
+        var tokens = new Parsing.Lexer(text, diagnostics).TokenizeAllForParser();
+        if (diagnostics.HasErrors)
         {
-            var index = 0;
-            while ((index = text.IndexOf(marker, index, StringComparison.Ordinal)) >= 0)
-            {
-                lines.Add(1 + text.AsSpan(0, index).Count('\n'));
-                index += marker.Length;
-            }
+            return [];
         }
-        lines.Sort();
-        return lines;
+
+        return tokens
+            .Where(token => token.Kind is
+                Parsing.TokenKind.RawCSharp or
+                Parsing.TokenKind.RawCSharpExpression or
+                Parsing.TokenKind.CSharpInterop)
+            .Select(token => token.Span.Line)
+            .OrderBy(line => line)
+            .ToList();
     }
 
     /// <summary>True if <paramref name="calorSource"/> lexes and parses without errors.</summary>

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -2505,6 +2505,10 @@ public sealed class CalorEmitter : IAstVisitor<string>
                 .Replace("\r\n", "\n");
             innerCode = System.Text.RegularExpressions.Regex.Replace(innerCode, @"//[^\n]*", " ");
             innerCode = innerCode.Replace("\n", " ");
+            RecordEmitterFallback(
+                node,
+                "raw-call-target",
+                "Call target could not be represented natively and was preserved as §CS");
             return $"§CS{{{innerCode}}}";
         }
 
@@ -2784,6 +2788,10 @@ public sealed class CalorEmitter : IAstVisitor<string>
                 if (ContainsSectionMarker(size) || size.Contains('('))
                 {
                     var rawExpr = $"new {node.ElementType}[{size}]";
+                    RecordEmitterFallback(
+                        node,
+                        "raw-array-size",
+                        "Array size could not be represented natively and was preserved as §CS");
                     return $"§CS{{{rawExpr}}}";
                 }
             }
@@ -4082,6 +4090,15 @@ public sealed class CalorEmitter : IAstVisitor<string>
         foreach (var iface in node.Interfaces) { Visit(iface); AppendLine(); }
         foreach (var en in node.Enums) { Visit(en); AppendLine(); }
         foreach (var del in node.Delegates) { Visit(del); AppendLine(); }
+    }
+
+    private void RecordEmitterFallback(AstNode node, string feature, string description)
+    {
+        _context?.RecordLoss(
+            ConversionLossKind.EmitterFallback,
+            feature,
+            description,
+            node.Span.Line);
     }
 
     public string Visit(CSharpInteropBlockNode node)

--- a/src/Calor.Compiler/Migration/ConversionContext.cs
+++ b/src/Calor.Compiler/Migration/ConversionContext.cs
@@ -268,7 +268,7 @@ public sealed class ConversionContext
     public bool GracefulFallback { get; set; } = true;
 
     /// <summary>The fidelity contract applied to this conversion.</summary>
-    public ConversionFidelity Fidelity { get; set; } = ConversionFidelity.Lossy;
+    public ConversionFidelity Fidelity { get; set; } = ConversionFidelity.Lossless;
 
     /// <summary>
     /// The module name to use (derived from file name if not set).

--- a/src/Calor.Compiler/Migration/ConversionContext.cs
+++ b/src/Calor.Compiler/Migration/ConversionContext.cs
@@ -158,6 +158,9 @@ public sealed class ConversionLoss
     public required string Description { get; init; }
     public int? Line { get; init; }
     public string? File { get; init; }
+    public bool IsSemanticLoss => Kind is ConversionLossKind.FallbackTodo
+        or ConversionLossKind.Dropped
+        or ConversionLossKind.PreprocessorStripped;
 
     public override string ToString()
     {
@@ -264,6 +267,9 @@ public sealed class ConversionContext
     /// </summary>
     public bool GracefulFallback { get; set; } = true;
 
+    /// <summary>The fidelity contract applied to this conversion.</summary>
+    public ConversionFidelity Fidelity { get; set; } = ConversionFidelity.Lossy;
+
     /// <summary>
     /// The module name to use (derived from file name if not set).
     /// </summary>
@@ -291,7 +297,10 @@ public sealed class ConversionContext
     /// Whether unsupported constructs should be preserved as C# passthrough blocks.
     /// True when Mode is Interop or PassthroughOnError is enabled.
     /// </summary>
-    public bool ShouldPreserveCSharp => Mode == ConversionMode.Interop || PassthroughOnError;
+    public bool ShouldPreserveCSharp =>
+        Fidelity == ConversionFidelity.Lossless ||
+        Mode == ConversionMode.Interop ||
+        PassthroughOnError;
 
     /// <summary>
     /// Current namespace being processed.

--- a/src/Calor.Compiler/Migration/MigrationReport.cs
+++ b/src/Calor.Compiler/Migration/MigrationReport.cs
@@ -56,14 +56,16 @@ public sealed class MigrationSummary
 public sealed class FileMigrationResult
 {
     public required string SourcePath { get; init; }
-    public required string? OutputPath { get; init; }
-    public required FileMigrationStatus Status { get; init; }
+    public required string? OutputPath { get; set; }
+    public required FileMigrationStatus Status { get; set; }
     public TimeSpan Duration { get; init; }
     public List<ConversionIssue> Issues { get; init; } = new();
     public IReadOnlyList<ConversionLoss> Losses { get; init; } = Array.Empty<ConversionLoss>();
     public FileMetrics? Metrics { get; init; }
     public FileAnalysisResult? Analysis { get; init; }
     public FileVerificationSummary? Verification { get; set; }
+    internal string? ConvertedSource { get; init; }
+    internal string? GeneratedCSharp { get; init; }
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Migration/MigrationReport.cs
+++ b/src/Calor.Compiler/Migration/MigrationReport.cs
@@ -60,6 +60,7 @@ public sealed class FileMigrationResult
     public required FileMigrationStatus Status { get; init; }
     public TimeSpan Duration { get; init; }
     public List<ConversionIssue> Issues { get; init; } = new();
+    public IReadOnlyList<ConversionLoss> Losses { get; init; } = Array.Empty<ConversionLoss>();
     public FileMetrics? Metrics { get; init; }
     public FileAnalysisResult? Analysis { get; init; }
     public FileVerificationSummary? Verification { get; set; }

--- a/src/Calor.Compiler/Migration/PartialClassMerger.cs
+++ b/src/Calor.Compiler/Migration/PartialClassMerger.cs
@@ -145,16 +145,8 @@ public sealed class PartialClassMerger
         var nestedInterfaces = partials.SelectMany(p => p.NestedInterfaces).ToList();
         var nestedEnums = partials.SelectMany(p => p.NestedEnums).ToList();
 
-        // Merge attributes: union all, deduplicating by name
-        var seenAttrNames = new HashSet<string>();
-        var csharpAttributes = new List<CalorAttributeNode>();
-        foreach (var attr in partials.SelectMany(p => p.CSharpAttributes))
-        {
-            if (seenAttrNames.Add(attr.Name))
-            {
-                csharpAttributes.Add(attr);
-            }
-        }
+        // Attribute multiplicity and arguments are semantically significant.
+        var csharpAttributes = partials.SelectMany(p => p.CSharpAttributes).ToList();
 
         // Use the most permissive visibility
         var visibility = partials.Select(p => p.Visibility).OrderByDescending(VisibilityRank).First();

--- a/src/Calor.Compiler/Migration/Project/MigrationPlan.cs
+++ b/src/Calor.Compiler/Migration/Project/MigrationPlan.cs
@@ -125,6 +125,9 @@ public sealed class MigrationPlanOptions
     /// <summary>When true, wraps unsupported constructs in §CSHARP blocks instead of emitting broken Calor.</summary>
     public bool PassthroughOnError { get; set; }
 
+    /// <summary>Conversion fidelity. Lossless is the safe default.</summary>
+    public ConversionFidelity Fidelity { get; set; } = ConversionFidelity.Lossless;
+
     /// <summary>
     /// When true (default), the emitter elides redundant §/C closers for zero-arg §C calls (v0.6.1 default).
     /// Set to false to emit v0.6.0-compatible output where every §C has an explicit §/C.

--- a/src/Calor.Compiler/Migration/Project/ProjectMigrator.cs
+++ b/src/Calor.Compiler/Migration/Project/ProjectMigrator.cs
@@ -238,11 +238,11 @@ public sealed class ProjectMigrator
         {
             if (direction == MigrationDirection.CSharpToCalor)
             {
-                return await ProcessCSharpToCalorAsync(entry, dryRun, startTime).WaitAsync(cts.Token);
+                return await ProcessCSharpToCalorAsync(entry, dryRun, startTime, cts.Token);
             }
             else
             {
-                return await ProcessCalorToCSharpAsync(entry, dryRun, startTime).WaitAsync(cts.Token);
+                return await ProcessCalorToCSharpAsync(entry, dryRun, startTime, cts.Token);
             }
         }
         catch (OperationCanceledException)
@@ -275,7 +275,11 @@ public sealed class ProjectMigrator
         }
     }
 
-    private async Task<FileMigrationResult> ProcessCSharpToCalorAsync(MigrationPlanEntry entry, bool dryRun, DateTime startTime)
+    private async Task<FileMigrationResult> ProcessCSharpToCalorAsync(
+        MigrationPlanEntry entry,
+        bool dryRun,
+        DateTime startTime,
+        CancellationToken cancellationToken)
     {
         var conversionOptions = new ConversionOptions
         {
@@ -293,7 +297,7 @@ public sealed class ProjectMigrator
 
         var converter = new CSharpToCalorConverter(conversionOptions);
 
-        var result = await converter.ConvertFileAsync(entry.SourcePath);
+        var result = await converter.ConvertFileAsync(entry.SourcePath, cancellationToken);
 
         // Tag partial classes with source file for merging
         if (result.Success && result.Ast != null && _options.MergePartialClasses)
@@ -307,7 +311,7 @@ public sealed class ProjectMigrator
         FileMetrics? metrics = null;
         if (result.Success && result.CalorSource != null && _options.IncludeBenchmark)
         {
-            var originalSource = await File.ReadAllTextAsync(entry.SourcePath);
+            var originalSource = await File.ReadAllTextAsync(entry.SourcePath, cancellationToken);
             metrics = BenchmarkIntegration.CalculateMetrics(originalSource, result.CalorSource);
         }
 
@@ -328,7 +332,8 @@ public sealed class ProjectMigrator
                 new CompilationOptions
                 {
                     EnforceEffects = false,
-                    UnknownCallPolicy = UnknownCallPolicy.Permissive
+                    UnknownCallPolicy = UnknownCallPolicy.Permissive,
+                    CancellationToken = cancellationToken
                 });
             if (compileResult.HasErrors)
             {
@@ -369,7 +374,8 @@ public sealed class ProjectMigrator
                     var compileOptions = new CompilationOptions
                     {
                         EnforceEffects = false,
-                        UnknownCallPolicy = UnknownCallPolicy.Permissive
+                        UnknownCallPolicy = UnknownCallPolicy.Permissive,
+                        CancellationToken = cancellationToken
                     };
                     var compileResult = Program.Compile(result.CalorSource, entry.OutputPath, compileOptions);
                     if (compileResult.HasErrors)
@@ -406,7 +412,11 @@ public sealed class ProjectMigrator
         {
             // Use replacement fallback for files with unpairable surrogates (e.g., regex patterns with \uD800)
             var writeEncoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
-            await ConversionFileWriter.WriteAtomicAsync(entry.OutputPath, result.CalorSource, writeEncoding);
+            await ConversionFileWriter.WriteAtomicAsync(
+                entry.OutputPath,
+                result.CalorSource,
+                writeEncoding,
+                cancellationToken);
         }
 
         // Attach per-file analysis if available from a prior AnalyzeAsync call
@@ -539,10 +549,17 @@ public sealed class ProjectMigrator
             .Distinct());
     }
 
-    private async Task<FileMigrationResult> ProcessCalorToCSharpAsync(MigrationPlanEntry entry, bool dryRun, DateTime startTime)
+    private async Task<FileMigrationResult> ProcessCalorToCSharpAsync(
+        MigrationPlanEntry entry,
+        bool dryRun,
+        DateTime startTime,
+        CancellationToken cancellationToken)
     {
-        var source = await File.ReadAllTextAsync(entry.SourcePath);
-        var result = Program.Compile(source, entry.SourcePath);
+        var source = await File.ReadAllTextAsync(entry.SourcePath, cancellationToken);
+        var result = Program.Compile(
+            source,
+            entry.SourcePath,
+            new CompilationOptions { CancellationToken = cancellationToken });
 
         FileMetrics? metrics = null;
         if (!result.HasErrors && _options.IncludeBenchmark)
@@ -552,7 +569,10 @@ public sealed class ProjectMigrator
 
         if (!dryRun && !result.HasErrors)
         {
-            await ConversionFileWriter.WriteAtomicAsync(entry.OutputPath, result.GeneratedCode);
+            await ConversionFileWriter.WriteAtomicAsync(
+                entry.OutputPath,
+                result.GeneratedCode,
+                cancellationToken: cancellationToken);
         }
 
         var status = result.HasErrors

--- a/src/Calor.Compiler/Migration/Project/ProjectMigrator.cs
+++ b/src/Calor.Compiler/Migration/Project/ProjectMigrator.cs
@@ -311,16 +311,6 @@ public sealed class ProjectMigrator
             metrics = BenchmarkIntegration.CalculateMetrics(originalSource, result.CalorSource);
         }
 
-        if (!dryRun &&
-            _options.Fidelity == ConversionFidelity.Lossy &&
-            result.Success &&
-            result.CalorSource != null)
-        {
-            // Use replacement fallback for files with unpairable surrogates (e.g., regex patterns with \uD800)
-            var writeEncoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
-            await ConversionFileWriter.WriteAtomicAsync(entry.OutputPath, result.CalorSource, writeEncoding);
-        }
-
         var status = result.Success
             ? (result.Context.HasWarnings ? FileMigrationStatus.Partial : FileMigrationStatus.Success)
             : FileMigrationStatus.Failed;
@@ -362,7 +352,7 @@ public sealed class ProjectMigrator
             var parseResult = CalorSourceHelper.Parse(result.CalorSource, entry.OutputPath);
             if (!parseResult.IsSuccess)
             {
-                status = FileMigrationStatus.Partial;
+                status = FileMigrationStatus.Failed;
                 foreach (var error in parseResult.Errors)
                 {
                     issues.Add(new ConversionIssue
@@ -384,7 +374,7 @@ public sealed class ProjectMigrator
                     var compileResult = Program.Compile(result.CalorSource, entry.OutputPath, compileOptions);
                     if (compileResult.HasErrors)
                     {
-                        status = FileMigrationStatus.Partial;
+                        status = FileMigrationStatus.Failed;
                         foreach (var diag in compileResult.Diagnostics.Errors)
                         {
                             issues.Add(new ConversionIssue
@@ -399,14 +389,24 @@ public sealed class ProjectMigrator
                 }
                 catch (Exception ex)
                 {
-                    status = FileMigrationStatus.Partial;
+                    status = FileMigrationStatus.Failed;
                     issues.Add(new ConversionIssue
                     {
-                        Severity = ConversionIssueSeverity.Warning,
+                        Severity = ConversionIssueSeverity.Error,
                         Message = $"Validation compile exception: {ex.Message}"
                     });
                 }
             }
+        }
+
+        if (!dryRun &&
+            _options.Fidelity == ConversionFidelity.Lossy &&
+            status is FileMigrationStatus.Success or FileMigrationStatus.Partial &&
+            result.CalorSource != null)
+        {
+            // Use replacement fallback for files with unpairable surrogates (e.g., regex patterns with \uD800)
+            var writeEncoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
+            await ConversionFileWriter.WriteAtomicAsync(entry.OutputPath, result.CalorSource, writeEncoding);
         }
 
         // Attach per-file analysis if available from a prior AnalyzeAsync call

--- a/src/Calor.Compiler/Migration/Project/ProjectMigrator.cs
+++ b/src/Calor.Compiler/Migration/Project/ProjectMigrator.cs
@@ -207,7 +207,13 @@ public sealed class ProjectMigrator
             if (mergedModules[i] != modules[i].Module)
             {
                 var newSource = emitter.Emit(mergedModules[i]);
-                await File.WriteAllTextAsync(modules[i].File.OutputPath!, newSource);
+                var validation = CalorSourceHelper.Parse(newSource, modules[i].File.OutputPath!);
+                if (!validation.IsSuccess)
+                {
+                    throw new InvalidOperationException(
+                        $"Merged partial-class output failed validation: {modules[i].File.OutputPath}");
+                }
+                await ConversionFileWriter.WriteAtomicAsync(modules[i].File.OutputPath!, newSource);
             }
         }
     }
@@ -264,6 +270,7 @@ public sealed class ProjectMigrator
         var conversionOptions = new ConversionOptions
         {
             IncludeBenchmark = _options.IncludeBenchmark,
+            Fidelity = _options.Fidelity,
             PassthroughOnError = _options.PassthroughOnError,
             UseImplicitCallCloser = _options.UseImplicitCallCloser
         };
@@ -297,7 +304,7 @@ public sealed class ProjectMigrator
         {
             // Use replacement fallback for files with unpairable surrogates (e.g., regex patterns with \uD800)
             var writeEncoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
-            await File.WriteAllTextAsync(entry.OutputPath, result.CalorSource, writeEncoding);
+            await ConversionFileWriter.WriteAtomicAsync(entry.OutputPath, result.CalorSource, writeEncoding);
         }
 
         var status = result.Success
@@ -381,6 +388,7 @@ public sealed class ProjectMigrator
             Status = status,
             Duration = DateTime.UtcNow - startTime,
             Issues = issues,
+            Losses = result.Losses,
             Metrics = metrics,
             Analysis = analysisResult
         };
@@ -399,7 +407,7 @@ public sealed class ProjectMigrator
 
         if (!dryRun && !result.HasErrors)
         {
-            await File.WriteAllTextAsync(entry.OutputPath, result.GeneratedCode);
+            await ConversionFileWriter.WriteAtomicAsync(entry.OutputPath, result.GeneratedCode);
         }
 
         var status = result.HasErrors

--- a/src/Calor.Compiler/Migration/Project/ProjectMigrator.cs
+++ b/src/Calor.Compiler/Migration/Project/ProjectMigrator.cs
@@ -233,7 +233,14 @@ public sealed class ProjectMigrator
         var startTime = DateTime.UtcNow;
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        cts.CancelAfter(TimeSpan.FromSeconds(_options.PerFileTimeoutSeconds));
+        if (_options.PerFileTimeoutSeconds == 0)
+        {
+            cts.Cancel();
+        }
+        else
+        {
+            cts.CancelAfter(TimeSpan.FromSeconds(_options.PerFileTimeoutSeconds));
+        }
         try
         {
             if (direction == MigrationDirection.CSharpToCalor)

--- a/src/Calor.Compiler/Migration/Project/ProjectMigrator.cs
+++ b/src/Calor.Compiler/Migration/Project/ProjectMigrator.cs
@@ -134,8 +134,18 @@ public sealed class ProjectMigrator
         var report = reportBuilder.Build();
         report.Summary.WasCancelled = wasCancelled;
 
+        if (plan.Direction == MigrationDirection.CSharpToCalor &&
+            _options.Fidelity == ConversionFidelity.Lossless)
+        {
+            await FinalizeLosslessProjectAsync(report, dryRun, cancellationToken);
+            RefreshSummary(report);
+        }
+
         // Post-conversion: merge partial classes if enabled
-        if (_options.MergePartialClasses && !dryRun && plan.Direction == MigrationDirection.CSharpToCalor)
+        if (_options.MergePartialClasses &&
+            _options.Fidelity == ConversionFidelity.Lossy &&
+            !dryRun &&
+            plan.Direction == MigrationDirection.CSharpToCalor)
         {
             await MergePartialClassesAsync(report);
         }
@@ -271,6 +281,7 @@ public sealed class ProjectMigrator
         {
             IncludeBenchmark = _options.IncludeBenchmark,
             Fidelity = _options.Fidelity,
+            ValidateRoundTripCSharp = _options.Fidelity != ConversionFidelity.Lossless,
             PassthroughOnError = _options.PassthroughOnError,
             UseImplicitCallCloser = _options.UseImplicitCallCloser
         };
@@ -300,7 +311,10 @@ public sealed class ProjectMigrator
             metrics = BenchmarkIntegration.CalculateMetrics(originalSource, result.CalorSource);
         }
 
-        if (!dryRun && result.Success && result.CalorSource != null)
+        if (!dryRun &&
+            _options.Fidelity == ConversionFidelity.Lossy &&
+            result.Success &&
+            result.CalorSource != null)
         {
             // Use replacement fallback for files with unpairable surrogates (e.g., regex patterns with \uD800)
             var writeEncoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
@@ -313,6 +327,36 @@ public sealed class ProjectMigrator
 
         // Validate: parse and compile the generated Calor to catch false-positive "success"
         var issues = result.Issues.ToList();
+        string? generatedCSharp = null;
+        if (_options.Fidelity == ConversionFidelity.Lossless &&
+            result.Success &&
+            result.CalorSource != null)
+        {
+            var compileResult = Program.Compile(
+                result.CalorSource,
+                entry.OutputPath,
+                new CompilationOptions
+                {
+                    EnforceEffects = false,
+                    UnknownCallPolicy = UnknownCallPolicy.Permissive
+                });
+            if (compileResult.HasErrors)
+            {
+                status = FileMigrationStatus.Failed;
+                issues.AddRange(compileResult.Diagnostics.Errors.Select(diagnostic => new ConversionIssue
+                {
+                    Severity = ConversionIssueSeverity.Error,
+                    Feature = "roundtrip-calor-validation",
+                    Message = $"Generated Calor failed compilation: {diagnostic.Message}",
+                    Line = diagnostic.Span.Line,
+                    Column = diagnostic.Span.Column
+                }));
+            }
+            else
+            {
+                generatedCSharp = compileResult.GeneratedCode;
+            }
+        }
         if (_options.ValidateOutput && result.Success && result.CalorSource != null)
         {
             var parseResult = CalorSourceHelper.Parse(result.CalorSource, entry.OutputPath);
@@ -384,14 +428,115 @@ public sealed class ProjectMigrator
         return new FileMigrationResult
         {
             SourcePath = entry.SourcePath,
-            OutputPath = result.Success ? entry.OutputPath : null,
+            OutputPath = status is FileMigrationStatus.Success or FileMigrationStatus.Partial
+                ? entry.OutputPath
+                : null,
             Status = status,
             Duration = DateTime.UtcNow - startTime,
             Issues = issues,
             Losses = result.Losses,
             Metrics = metrics,
-            Analysis = analysisResult
+            Analysis = analysisResult,
+            ConvertedSource = result.CalorSource,
+            GeneratedCSharp = generatedCSharp
         };
+    }
+
+    private static async Task FinalizeLosslessProjectAsync(
+        MigrationReport report,
+        bool dryRun,
+        CancellationToken cancellationToken)
+    {
+        var converted = report.FileResults
+            .Where(result => result.Status is FileMigrationStatus.Success or FileMigrationStatus.Partial)
+            .ToList();
+
+        if (report.FileResults.Any(result =>
+                result.Status is FileMigrationStatus.Failed or FileMigrationStatus.TimedOut))
+        {
+            foreach (var result in converted)
+            {
+                result.Status = FileMigrationStatus.Failed;
+                result.OutputPath = null;
+                result.Issues.Add(new ConversionIssue
+                {
+                    Severity = ConversionIssueSeverity.Error,
+                    Feature = "lossless-project-validation",
+                    Message = "Lossless project migration was not written because another file failed conversion."
+                });
+            }
+            return;
+        }
+
+        var sources = converted
+            .Select(result => result.GeneratedCSharp)
+            .Where(source => !string.IsNullOrWhiteSpace(source))
+            .Cast<string>()
+            .ToArray();
+        var validation = CodeGen.GeneratedCSharpCompiler.Validate(sources);
+        var errors = validation.SyntaxErrors.Concat(validation.CompilationErrors).ToList();
+        if (errors.Count > 0)
+        {
+            foreach (var result in converted)
+            {
+                result.Status = FileMigrationStatus.Failed;
+                result.OutputPath = null;
+                foreach (var error in errors.Take(20))
+                {
+                    result.Issues.Add(new ConversionIssue
+                    {
+                        Severity = ConversionIssueSeverity.Error,
+                        Feature = "roundtrip-csharp-validation",
+                        Message = $"Lossless project C# validation failed ({error.Id}): {error.GetMessage()}"
+                    });
+                }
+            }
+            return;
+        }
+
+        if (dryRun)
+        {
+            return;
+        }
+
+        foreach (var result in converted)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (result.OutputPath != null && result.ConvertedSource != null)
+            {
+                await ConversionFileWriter.WriteAtomicAsync(
+                    result.OutputPath,
+                    result.ConvertedSource,
+                    cancellationToken: cancellationToken);
+            }
+        }
+    }
+
+    private static void RefreshSummary(MigrationReport report)
+    {
+        var summary = report.Summary;
+        var allIssues = report.FileResults.SelectMany(result => result.Issues).ToList();
+
+        summary.SuccessfulFiles = report.FileResults.Count(result => result.Status == FileMigrationStatus.Success);
+        summary.PartialFiles = report.FileResults.Count(result => result.Status == FileMigrationStatus.Partial);
+        summary.FailedFiles = report.FileResults.Count(result => result.Status == FileMigrationStatus.Failed);
+        summary.SkippedFiles = report.FileResults.Count(result => result.Status == FileMigrationStatus.Skipped);
+        summary.TimedOutFiles = report.FileResults.Count(result => result.Status == FileMigrationStatus.TimedOut);
+        summary.TotalErrors = allIssues.Count(issue => issue.Severity == ConversionIssueSeverity.Error);
+        summary.TotalWarnings = allIssues.Count(issue => issue.Severity == ConversionIssueSeverity.Warning);
+
+        summary.MostCommonIssues.Clear();
+        summary.MostCommonIssues.AddRange(allIssues
+            .GroupBy(issue => issue.Message)
+            .OrderByDescending(group => group.Count())
+            .Take(10)
+            .Select(group => $"{group.Key} ({group.Count()}x)"));
+
+        summary.UnsupportedFeatures.Clear();
+        summary.UnsupportedFeatures.AddRange(allIssues
+            .Where(issue => issue.Feature != null && !FeatureSupport.IsFullySupported(issue.Feature))
+            .Select(issue => issue.Feature!)
+            .Distinct());
     }
 
     private async Task<FileMigrationResult> ProcessCalorToCSharpAsync(MigrationPlanEntry entry, bool dryRun, DateTime startTime)

--- a/tests/Calor.Compiler.Tests/Analysis/DuplicateBindingTests.cs
+++ b/tests/Calor.Compiler.Tests/Analysis/DuplicateBindingTests.cs
@@ -98,7 +98,7 @@ public class DuplicateBindingTests
     {
         var csharp = "public class Test\n{\n    void M()\n    {\n        " + body + "\n    }\n}\n";
 
-        var result = new CSharpToCalorConverter().Convert(csharp);
+        var result = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy }).Convert(csharp);
         Assert.True(result.Success, $"[{name}] conversion failed");
         Assert.NotNull(result.CalorSource);
 
@@ -130,7 +130,7 @@ public class DuplicateBindingTests
             }
             """;
 
-        var result = new CSharpToCalorConverter().Convert(csharp);
+        var result = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy }).Convert(csharp);
         Assert.True(result.Success);
         Assert.NotNull(result.CalorSource);
 

--- a/tests/Calor.Compiler.Tests/AssemblyInfo.cs
+++ b/tests/Calor.Compiler.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Calor.Compiler.Tests/AsyncAwaitTests.cs
+++ b/tests/Calor.Compiler.Tests/AsyncAwaitTests.cs
@@ -12,7 +12,7 @@ namespace Calor.Compiler.Tests;
 /// </summary>
 public class AsyncAwaitTests
 {
-    private readonly CSharpToCalorConverter _converter = new();
+    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
 
     #region C# to Calor Conversion - Async Method Detection
 

--- a/tests/Calor.Compiler.Tests/AttributeConversionTests.cs
+++ b/tests/Calor.Compiler.Tests/AttributeConversionTests.cs
@@ -12,7 +12,7 @@ namespace Calor.Compiler.Tests;
 /// </summary>
 public class AttributeConversionTests
 {
-    private readonly CSharpToCalorConverter _converter = new();
+    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
 
     #region C# to Calor Attribute Conversion Tests
 

--- a/tests/Calor.Compiler.Tests/CSharpInteropBlockTests.cs
+++ b/tests/Calor.Compiler.Tests/CSharpInteropBlockTests.cs
@@ -287,6 +287,7 @@ public class CSharpInteropBlockTests
 
         var options = new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             ModuleName = "TestModule",
             GracefulFallback = true,
             Mode = ConversionMode.Interop
@@ -317,6 +318,7 @@ public class CSharpInteropBlockTests
 
         var options = new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             ModuleName = "TestModule",
             GracefulFallback = true,
             Mode = ConversionMode.Interop
@@ -352,6 +354,7 @@ public class CSharpInteropBlockTests
 
         var options = new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             ModuleName = "TestModule",
             GracefulFallback = true,
             Mode = ConversionMode.Standard
@@ -384,6 +387,7 @@ public class CSharpInteropBlockTests
 
         var options = new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             ModuleName = "TestModule",
             GracefulFallback = true,
             Mode = ConversionMode.Interop
@@ -497,6 +501,7 @@ public class CSharpInteropBlockTests
 
         var options = new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             ModuleName = "TestModule",
             GracefulFallback = true,
             Mode = ConversionMode.Interop

--- a/tests/Calor.Compiler.Tests/CSharpInteropBlockTests.cs
+++ b/tests/Calor.Compiler.Tests/CSharpInteropBlockTests.cs
@@ -221,6 +221,7 @@ public class CSharpInteropBlockTests
 
         var options = new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             ModuleName = "TestModule",
             GracefulFallback = true,
             Mode = ConversionMode.Interop
@@ -254,6 +255,7 @@ public class CSharpInteropBlockTests
 
         var options = new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             ModuleName = "TestModule",
             GracefulFallback = true,
             Mode = ConversionMode.Standard
@@ -457,6 +459,7 @@ public class CSharpInteropBlockTests
 
         var options = new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             ModuleName = "TestModule",
             GracefulFallback = true,
             Mode = ConversionMode.Interop

--- a/tests/Calor.Compiler.Tests/CSharpToCalorConversionTests.cs
+++ b/tests/Calor.Compiler.Tests/CSharpToCalorConversionTests.cs
@@ -12,7 +12,10 @@ namespace Calor.Compiler.Tests;
 /// </summary>
 public class CSharpToCalorConversionTests
 {
-    private readonly CSharpToCalorConverter _converter = new();
+    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions
+    {
+        Fidelity = ConversionFidelity.Lossy
+    });
 
     #region Top-Level Statement Tests
 
@@ -1202,7 +1205,11 @@ public class CSharpToCalorConversionTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter(new ConversionOptions { Explain = true });
+        var converter = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Explain = true,
+            Fidelity = ConversionFidelity.Lossy
+        });
         var result = converter.Convert(csharpSource);
 
         Assert.True(result.Success);
@@ -1275,15 +1282,16 @@ public class CSharpToCalorConversionTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter(new ConversionOptions { Explain = true });
+        var converter = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Explain = true,
+            Fidelity = ConversionFidelity.Lossy
+        });
         var result = converter.Convert(csharpSource);
 
-        Assert.True(result.Success, GetErrorMessage(result));
+        Assert.False(result.Success);
         Assert.NotNull(result.CalorSource);
-
-        // Should emit and-pattern, not raw C# text or wildcard fallback
-        Assert.DoesNotContain("string s and", result.CalorSource);
-        Assert.Contains("and", result.CalorSource);
+        Assert.Contains(result.Issues, issue => issue.Feature == "generated-calor-validation");
     }
 
     [Fact]
@@ -3909,8 +3917,16 @@ public class CSharpToCalorConversionTests
             """;
 
         // Same module name = same namespace — should merge
-        var result1 = new CSharpToCalorConverter(new ConversionOptions { ModuleName = "MyApp" }).Convert(csharp1);
-        var result2 = new CSharpToCalorConverter(new ConversionOptions { ModuleName = "MyApp" }).Convert(csharp2);
+        var result1 = new CSharpToCalorConverter(new ConversionOptions
+        {
+            ModuleName = "MyApp",
+            Fidelity = ConversionFidelity.Lossy
+        }).Convert(csharp1);
+        var result2 = new CSharpToCalorConverter(new ConversionOptions
+        {
+            ModuleName = "MyApp",
+            Fidelity = ConversionFidelity.Lossy
+        }).Convert(csharp2);
         Assert.True(result1.Success, GetErrorMessage(result1));
         Assert.True(result2.Success, GetErrorMessage(result2));
 
@@ -3945,8 +3961,16 @@ public class CSharpToCalorConversionTests
             """;
 
         // Same module name = same namespace — should merge
-        var result1 = new CSharpToCalorConverter(new ConversionOptions { ModuleName = "MyApp" }).Convert(csharp1);
-        var result2 = new CSharpToCalorConverter(new ConversionOptions { ModuleName = "MyApp" }).Convert(csharp2);
+        var result1 = new CSharpToCalorConverter(new ConversionOptions
+        {
+            ModuleName = "MyApp",
+            Fidelity = ConversionFidelity.Lossy
+        }).Convert(csharp1);
+        var result2 = new CSharpToCalorConverter(new ConversionOptions
+        {
+            ModuleName = "MyApp",
+            Fidelity = ConversionFidelity.Lossy
+        }).Convert(csharp2);
         Assert.True(result1.Success, GetErrorMessage(result1));
         Assert.True(result2.Success, GetErrorMessage(result2));
 

--- a/tests/Calor.Compiler.Tests/CSharpToCalorConversionTests.cs
+++ b/tests/Calor.Compiler.Tests/CSharpToCalorConversionTests.cs
@@ -4014,6 +4014,38 @@ public class CSharpToCalorConversionTests
     }
 
     [Fact]
+    public void PartialClassMerger_PreservesRepeatableAttributeInstances()
+    {
+        const string csharp1 = """
+            [Tag("one")]
+            public partial class Tagged
+            {
+            }
+            """;
+        const string csharp2 = """
+            [Tag("two")]
+            public partial class Tagged
+            {
+            }
+            """;
+
+        var options = new ConversionOptions
+        {
+            Fidelity = ConversionFidelity.Lossy,
+            ModuleName = "Attributes"
+        };
+        var result1 = new CSharpToCalorConverter(options).Convert(csharp1);
+        var result2 = new CSharpToCalorConverter(options).Convert(csharp2);
+        Assert.True(result1.Success, GetErrorMessage(result1));
+        Assert.True(result2.Success, GetErrorMessage(result2));
+
+        var merged = new PartialClassMerger().Merge(new[] { result1.Ast!, result2.Ast! });
+        var mergedClass = merged.SelectMany(module => module.Classes).Single(cls => cls.Name == "Tagged");
+
+        Assert.Equal(2, mergedClass.CSharpAttributes.Count);
+    }
+
+    [Fact]
     public void PartialClassMerger_NonPartialClassesUnchanged()
     {
         var csharp1 = """

--- a/tests/Calor.Compiler.Tests/CSharpToCalorConversionTests.cs
+++ b/tests/Calor.Compiler.Tests/CSharpToCalorConversionTests.cs
@@ -1156,7 +1156,7 @@ public class CSharpToCalorConversionTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter(new ConversionOptions { GracefulFallback = true });
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, GracefulFallback = true });
         var result = converter.Convert(csharpSource);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -1183,7 +1183,7 @@ public class CSharpToCalorConversionTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter(new ConversionOptions { GracefulFallback = false });
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, GracefulFallback = false });
         var result = converter.Convert(csharpSource);
 
         // __makeref is now supported, so conversion should succeed
@@ -1232,7 +1232,7 @@ public class CSharpToCalorConversionTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharpSource);
 
         Assert.True(result.Success);
@@ -1253,7 +1253,7 @@ public class CSharpToCalorConversionTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var conversionResult = converter.Convert(csharpSource);
 
         Assert.True(conversionResult.Success, GetErrorMessage(conversionResult));
@@ -1314,7 +1314,7 @@ public class CSharpToCalorConversionTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var conversionResult = converter.Convert(csharpSource);
 
         Assert.True(conversionResult.Success, GetErrorMessage(conversionResult));
@@ -4000,8 +4000,8 @@ public class CSharpToCalorConversionTests
             """;
 
         // Same module name = same namespace — should merge
-        var result1 = new CSharpToCalorConverter(new ConversionOptions { ModuleName = "MyApp" }).Convert(csharp1);
-        var result2 = new CSharpToCalorConverter(new ConversionOptions { ModuleName = "MyApp" }).Convert(csharp2);
+        var result1 = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, ModuleName = "MyApp" }).Convert(csharp1);
+        var result2 = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, ModuleName = "MyApp" }).Convert(csharp2);
         Assert.True(result1.Success, GetErrorMessage(result1));
         Assert.True(result2.Success, GetErrorMessage(result2));
 
@@ -4062,8 +4062,8 @@ public class CSharpToCalorConversionTests
             }
             """;
 
-        var result1 = new CSharpToCalorConverter(new ConversionOptions { ModuleName = "Reg" }).Convert(csharp1);
-        var result2 = new CSharpToCalorConverter(new ConversionOptions { ModuleName = "Other" }).Convert(csharp2);
+        var result1 = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, ModuleName = "Reg" }).Convert(csharp1);
+        var result2 = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, ModuleName = "Other" }).Convert(csharp2);
         Assert.True(result1.Success, GetErrorMessage(result1));
         Assert.True(result2.Success, GetErrorMessage(result2));
 
@@ -4093,8 +4093,8 @@ public class CSharpToCalorConversionTests
             """;
 
         // Different module names = different namespaces — should NOT merge
-        var result1 = new CSharpToCalorConverter(new ConversionOptions { ModuleName = "App.Models" }).Convert(csharp1);
-        var result2 = new CSharpToCalorConverter(new ConversionOptions { ModuleName = "App.Views" }).Convert(csharp2);
+        var result1 = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, ModuleName = "App.Models" }).Convert(csharp1);
+        var result2 = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, ModuleName = "App.Views" }).Convert(csharp2);
         Assert.True(result1.Success, GetErrorMessage(result1));
         Assert.True(result2.Success, GetErrorMessage(result2));
 

--- a/tests/Calor.Compiler.Tests/CharOperationTests.cs
+++ b/tests/Calor.Compiler.Tests/CharOperationTests.cs
@@ -481,7 +481,7 @@ public class CharOperationTests
     {
         // The C# to Calor converter converts char static methods to char operations
         var csharp = $"public class Test {{ public object M(char c) {{ return {csharpExpr}; }} }}";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -498,7 +498,7 @@ public class CharOperationTests
         // The C# to Calor converter converts (int)c to char-code
         // Verify the CalorEmitter produces the expected output
         var csharp = "public class Test { public int M(char c) { return (int)c; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -514,7 +514,7 @@ public class CharOperationTests
     {
         // The C# to Calor converter converts (char)n to char-from-code
         var csharp = "public class Test { public char M(int n) { return (char)n; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -531,7 +531,7 @@ public class CharOperationTests
         // Without semantic model, variable indexing defaults to §IDX (not char-at)
         // Only string literals produce char-at
         var csharp = "public class Test { public char M(string s) { return s[0]; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -546,7 +546,7 @@ public class CharOperationTests
     {
         // Without semantic model, variable indexing defaults to §IDX (not char-at)
         var csharp = "public class Test { public char M(string s, int i) { return s[i]; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -567,7 +567,7 @@ public class CharOperationTests
     public void Migration_CharOperation_RoundTripsToCalor(string csharpExpr, string expectedCalorOp)
     {
         var csharp = $"public class Test {{ public object M(char c) => {csharpExpr}; }}";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -583,7 +583,7 @@ public class CharOperationTests
     {
         // String literal indexing should produce char-at
         var csharp = "public class Test { public char M() { return \"hello\"[0]; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -598,7 +598,7 @@ public class CharOperationTests
     public void Migration_CharCode_RoundTripsToCalor()
     {
         var csharp = "public class Test { public int M(char c) { return (int)c; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -613,7 +613,7 @@ public class CharOperationTests
     public void Migration_CharFromCode_RoundTripsToCalor()
     {
         var csharp = "public class Test { public char M(int n) { return (char)n; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -629,7 +629,7 @@ public class CharOperationTests
     {
         // Test cross-category: char.IsLetter(s.ToUpper()[0])
         var csharp = "public class Test { public bool M(string s) { return char.IsLetter(s.ToUpper()[0]); } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -649,7 +649,7 @@ public class CharOperationTests
     {
         // (int)someDouble should NOT become char-code - it's a numeric conversion
         var csharp = "public class Test { public int M(double d) { return (int)d; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -666,7 +666,7 @@ public class CharOperationTests
     {
         // (char)someObject should NOT become char-from-code without more context
         var csharp = "public class Test { public char M(object obj) { return (char)obj; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));

--- a/tests/Calor.Compiler.Tests/CodeGenBugFixTests.cs
+++ b/tests/Calor.Compiler.Tests/CodeGenBugFixTests.cs
@@ -968,7 +968,7 @@ public class CodeGenBugFixTests
     public void Array_CSharpInit_EmitterRoundTrip()
     {
         // C# array init → converter → Calor → parse → emit C#
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var conversionResult = converter.Convert("int[] nums = new int[] { 1, 2, 3 };");
 
         Assert.True(conversionResult.Success,

--- a/tests/Calor.Compiler.Tests/CodegenBatchFixTests.cs
+++ b/tests/Calor.Compiler.Tests/CodegenBatchFixTests.cs
@@ -292,7 +292,7 @@ public class CodegenBatchFixTests
     public void Gap_Converter_DecimalLiteral_ProducesDECPrefix()
     {
         // C# decimal literal → converter → Calor should contain DEC:
-        var converter = new Migration.CSharpToCalorConverter();
+        var converter = new Migration.CSharpToCalorConverter(new Migration.ConversionOptions { Fidelity = Migration.ConversionFidelity.Lossy });
         var result = converter.Convert("decimal price = 21.35m;");
 
         Assert.True(result.Success, string.Join("\n", result.Issues.Select(i => i.Message)));
@@ -305,7 +305,7 @@ public class CodegenBatchFixTests
     public void Gap_Converter_DecimalLiteral_FullRoundtrip()
     {
         // C# decimal → converter → Calor → parse → emit C# should contain 'm' suffix
-        var converter = new Migration.CSharpToCalorConverter();
+        var converter = new Migration.CSharpToCalorConverter(new Migration.ConversionOptions { Fidelity = Migration.ConversionFidelity.Lossy });
         var conversionResult = converter.Convert("decimal price = 21.35m;");
 
         Assert.True(conversionResult.Success, string.Join("\n", conversionResult.Issues.Select(i => i.Message)));
@@ -320,7 +320,7 @@ public class CodegenBatchFixTests
     public void Gap_Converter_DecimalZero_ProducesDECPrefix()
     {
         // C# 0.00m → converter → Calor should contain DEC:0
-        var converter = new Migration.CSharpToCalorConverter();
+        var converter = new Migration.CSharpToCalorConverter(new Migration.ConversionOptions { Fidelity = Migration.ConversionFidelity.Lossy });
         var result = converter.Convert("decimal zero = 0.00m;");
 
         Assert.True(result.Success, string.Join("\n", result.Issues.Select(i => i.Message)));
@@ -332,7 +332,7 @@ public class CodegenBatchFixTests
     public void Gap_Converter_ArrayInitializer_ProducesArrTags()
     {
         // C# new int[] { 1, 2, 3 } → converter → CalorEmitter → should contain §ARR not bare {}
-        var converter = new Migration.CSharpToCalorConverter();
+        var converter = new Migration.CSharpToCalorConverter(new Migration.ConversionOptions { Fidelity = Migration.ConversionFidelity.Lossy });
         var result = converter.Convert("int[] nums = new int[] { 1, 2, 3 };");
 
         Assert.True(result.Success, string.Join("\n", result.Issues.Select(i => i.Message)));
@@ -345,7 +345,7 @@ public class CodegenBatchFixTests
     public void Gap_Converter_ArrayInitializer_FullRoundtrip()
     {
         // C# array init → converter → Calor → parse → emit C# → should contain new int[]
-        var converter = new Migration.CSharpToCalorConverter();
+        var converter = new Migration.CSharpToCalorConverter(new Migration.ConversionOptions { Fidelity = Migration.ConversionFidelity.Lossy });
         var conversionResult = converter.Convert("int[] nums = new int[] { 1, 2, 3 };");
 
         Assert.True(conversionResult.Success, string.Join("\n", conversionResult.Issues.Select(i => i.Message)));
@@ -369,7 +369,7 @@ public class CodegenBatchFixTests
             }
             """;
 
-        var converter = new Migration.CSharpToCalorConverter();
+        var converter = new Migration.CSharpToCalorConverter(new Migration.ConversionOptions { Fidelity = Migration.ConversionFidelity.Lossy });
         var conversionResult = converter.Convert(csharpSource);
 
         Assert.True(conversionResult.Success, string.Join("\n", conversionResult.Issues.Select(i => i.Message)));

--- a/tests/Calor.Compiler.Tests/CodegenBug3_5_6_Tests.cs
+++ b/tests/Calor.Compiler.Tests/CodegenBug3_5_6_Tests.cs
@@ -12,7 +12,7 @@ namespace Calor.Compiler.Tests;
 /// </summary>
 public class CodegenBug3_5_6_Tests
 {
-    private readonly CSharpToCalorConverter _converter = new();
+    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
 
     #region Bug 6: static class not emitted
 

--- a/tests/Calor.Compiler.Tests/Commands/ConvertCommandPassthroughTests.cs
+++ b/tests/Calor.Compiler.Tests/Commands/ConvertCommandPassthroughTests.cs
@@ -44,8 +44,7 @@ public class ConvertCommandPassthroughTests
     [Fact]
     public void DefaultFlags_MapToExpectedOptions()
     {
-        // Default CLI behavior unchanged: passthrough off, graceful fallback on,
-        // implicit call closers on.
+        // CLI defaults to the lossless contract.
         var opts = ConvertCommand.BuildCSharpToCalorOptions(
             benchmark: false, verbose: false, explain: false, noFallback: false,
             passthrough: false, explicitCallClosers: false);
@@ -53,6 +52,7 @@ public class ConvertCommandPassthroughTests
         Assert.False(opts.PassthroughOnError);
         Assert.True(opts.GracefulFallback);
         Assert.True(opts.UseImplicitCallCloser);
+        Assert.Equal(ConversionFidelity.Lossless, opts.Fidelity);
     }
 
     [Fact]
@@ -127,13 +127,14 @@ public class ConvertCommandPassthroughTests
         var converter = new CSharpToCalorConverter(
             ConvertCommand.BuildCSharpToCalorOptions(
                 benchmark: false, verbose: false, explain: false, noFallback: false,
-                passthrough: false, explicitCallClosers: false))
+                passthrough: false, explicitCallClosers: false, lossy: true))
         {
             ParseValidatorOverride = CondemnOutsideCSharp("Breakme"),
         };
 
         var result = converter.Convert(TwoClasses);
 
+        Assert.False(result.Success);
         Assert.Equal(0, result.Context!.Stats.InteropBlocksEmitted);
         Assert.DoesNotContain("§CSHARP", result.CalorSource!);
     }

--- a/tests/Calor.Compiler.Tests/CompactSyntaxTests.cs
+++ b/tests/Calor.Compiler.Tests/CompactSyntaxTests.cs
@@ -918,7 +918,7 @@ public class CompactSyntaxTests
             """;
 
         // Step 1: C# -> Calor AST
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var convResult = converter.Convert(csharpSource);
         Assert.True(convResult.Success,
             $"C# to Calor conversion failed: {string.Join("\n", convResult.Issues.Select(i => i.Message))}");
@@ -954,7 +954,7 @@ public class CompactSyntaxTests
             """;
 
         // Step 1: C# -> Calor AST
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var convResult = converter.Convert(csharpSource);
         Assert.True(convResult.Success,
             $"C# to Calor conversion failed: {string.Join("\n", convResult.Issues.Select(i => i.Message))}");
@@ -993,7 +993,7 @@ public class CompactSyntaxTests
             """;
 
         // Step 1: C# -> Calor AST
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var convResult = converter.Convert(csharpSource);
         Assert.True(convResult.Success,
             $"C# to Calor conversion failed: {string.Join("\n", convResult.Issues.Select(i => i.Message))}");

--- a/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
+++ b/tests/Calor.Compiler.Tests/ConversionCampaignFixTests.cs
@@ -59,7 +59,7 @@ public class ConversionCampaignFixTests
         return ast;
     }
 
-    private readonly CSharpToCalorConverter _converter = new();
+    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
 
     /// <summary>
     /// Compiles Calor source back to C# (for round-trip testing).

--- a/tests/Calor.Compiler.Tests/ConvertFormatEnvelopeTests.cs
+++ b/tests/Calor.Compiler.Tests/ConvertFormatEnvelopeTests.cs
@@ -281,11 +281,11 @@ public class ConvertFormatEnvelopeTests : IDisposable
         var root = ParseAndValidate(stdOut, "convert");
         var issue = root.GetProperty("diagnostics").EnumerateArray()
             .Single(d => d.GetProperty("code").GetString() == DiagnosticCode.ConversionIssue);
-        Assert.Equal("warning", issue.GetProperty("severity").GetString());
-        Assert.StartsWith("[unsupported-member]", issue.GetProperty("message").GetString());
+        Assert.Equal("info", issue.GetProperty("severity").GetString());
+        Assert.StartsWith("[destructor]", issue.GetProperty("message").GetString());
         Assert.Equal(5, issue.GetProperty("location").GetProperty("line").GetInt32());
         Assert.EndsWith("Dtor.cs", issue.GetProperty("location").GetProperty("file").GetString());
-        Assert.True(root.GetProperty("summary").GetProperty("warnings").GetInt32() >= 1);
+        Assert.True(root.GetProperty("summary").GetProperty("info").GetInt32() >= 1);
     }
 
     [Fact]
@@ -424,7 +424,7 @@ public class ConvertFormatEnvelopeTests : IDisposable
 
         Assert.Equal(0, exitCode); // conversion still succeeds — but honestly
         Assert.DoesNotContain("Conversion successful", stdOut);
-        Assert.Contains("semantic loss", stdOut);
+        Assert.Contains("interop preservation", stdOut);
         Assert.Contains("InteropPreserved", stdOut);
         // The loss line carries a file:line location.
         Assert.Contains("Rec.cs:", stdOut);
@@ -447,6 +447,9 @@ public class ConvertFormatEnvelopeTests : IDisposable
         var data = root.GetProperty("data");
         Assert.True(data.GetProperty("success").GetBoolean());
         Assert.True(data.GetProperty("lossCount").GetInt32() >= 1);
+        Assert.Equal(1, data.GetProperty("interopPreservationCount").GetInt32());
+        Assert.Equal(0, data.GetProperty("lossySubstitutionCount").GetInt32());
+        Assert.Equal(0, data.GetProperty("dropCount").GetInt32());
 
         var loss = data.GetProperty("losses").EnumerateArray()
             .Single(l => l.GetProperty("feature").GetString() == "record");
@@ -455,7 +458,52 @@ public class ConvertFormatEnvelopeTests : IDisposable
 
         // Human loss summary goes to stderr in envelope mode; no success line.
         Assert.DoesNotContain("Conversion successful", stdErr);
-        Assert.Contains("semantic loss", stdErr);
+        Assert.Contains("interop preservation", stdErr);
+    }
+
+    [Fact]
+    public void Convert_Json_LossyOptInReportsExactDrop()
+    {
+        var csFile = WriteFile("LossyDtor.cs", """
+            public class D
+            {
+                ~D() { }
+            }
+            """);
+
+        var (exitCode, stdOut, _) = RunCli("convert", csFile, "--lossy", "--format", "json");
+
+        Assert.Equal(0, exitCode);
+        var data = ParseAndValidate(stdOut, "convert").GetProperty("data");
+        Assert.Equal("lossy", data.GetProperty("fidelity").GetString());
+        Assert.Equal(1, data.GetProperty("dropCount").GetInt32());
+        var loss = Assert.Single(data.GetProperty("losses").EnumerateArray());
+        Assert.Equal("Dropped", loss.GetProperty("kind").GetString());
+        Assert.EndsWith("LossyDtor.cs", loss.GetProperty("file").GetString());
+        Assert.Equal(3, loss.GetProperty("line").GetInt32());
+    }
+
+    [Fact]
+    public void Convert_ValidationFailureLeavesExistingDestinationUnchanged()
+    {
+        var csFile = WriteFile("InvalidEmission.cs", """
+            public class Service
+            {
+                public string Process(bool enabled, int code) =>
+                    enabled ? code switch { 0 => "Zero", _ => "Other" } : "Disabled";
+            }
+            """);
+        var output = WriteFile("Existing.calr", "original bytes");
+
+        var (exitCode, _, _) = RunCli(
+            "convert",
+            csFile,
+            "--lossy",
+            "--output",
+            output);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("original bytes", File.ReadAllText(output));
     }
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/ConverterBugfixTests.cs
+++ b/tests/Calor.Compiler.Tests/ConverterBugfixTests.cs
@@ -15,7 +15,7 @@ public class ConverterBugfixTests
 {
     private static string ConvertToCalor(string csharpSource)
     {
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharpSource);
         Assert.True(result.Success, GetErrorMessage(result));
         Assert.NotNull(result.CalorSource);
@@ -152,7 +152,7 @@ public class Test
         var arr = new string[] { ""a"", ""b"" };
     }
 }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var conversionResult = converter.Convert(csharp);
         Assert.True(conversionResult.Success, GetErrorMessage(conversionResult));
 
@@ -180,7 +180,7 @@ public class Test
         return obj.ToLower().GetHashCode();
     }
 }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var conversionResult = converter.Convert(csharp);
         Assert.True(conversionResult.Success, GetErrorMessage(conversionResult));
 
@@ -210,7 +210,7 @@ public class Test
         return name;
     }
 }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var conversionResult = converter.Convert(csharp);
         Assert.True(conversionResult.Success, GetErrorMessage(conversionResult));
 
@@ -236,7 +236,7 @@ public class Test
         return obj.ToLower().Trim().GetHashCode();
     }
 }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var conversionResult = converter.Convert(csharp);
         Assert.True(conversionResult.Success, GetErrorMessage(conversionResult));
 
@@ -304,7 +304,7 @@ public class Test
         return $""{price:C}"";
     }
 }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
         Assert.True(result.Success, GetErrorMessage(result));
 
@@ -325,7 +325,7 @@ public class Test
         return $""{value:F2}"";
     }
 }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var conversionResult = converter.Convert(csharp);
         Assert.True(conversionResult.Success, GetErrorMessage(conversionResult));
 
@@ -512,7 +512,7 @@ public class Test
         return $""{value,10:F2}"";
     }
 }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
         Assert.True(result.Success, GetErrorMessage(result));
 
@@ -533,7 +533,7 @@ public class Test
         return $""{name,-20}"";
     }
 }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
         Assert.True(result.Success, GetErrorMessage(result));
 
@@ -554,7 +554,7 @@ public class Test
         return $""{value,10:F2}"";
     }
 }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var conversionResult = converter.Convert(csharp);
         Assert.True(conversionResult.Success, GetErrorMessage(conversionResult));
 
@@ -624,7 +624,7 @@ public class Test
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
         Assert.True(result.Success, GetErrorMessage(result));
 
@@ -761,7 +761,7 @@ public class Test
 
     private string ConvertAndRoundTrip(string csharp)
     {
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
         Assert.True(result.Success, GetErrorMessage(result));
 
@@ -1052,7 +1052,7 @@ public class Test
             """;
 
         // Depth > 2 ternary chains are decomposed into if/else with a result variable
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
         Assert.True(result.Success, GetErrorMessage(result));
         var emitter = new CalorEmitter();

--- a/tests/Calor.Compiler.Tests/ConverterBugfixTests.cs
+++ b/tests/Calor.Compiler.Tests/ConverterBugfixTests.cs
@@ -751,7 +751,7 @@ public class Test
             }
             """;
 
-        var converter = new CSharpToCalorConverter(new ConversionOptions { Mode = ConversionMode.Interop });
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, Mode = ConversionMode.Interop });
         var result = converter.Convert(csharp);
         Assert.True(result.Success, GetErrorMessage(result));
 

--- a/tests/Calor.Compiler.Tests/ConverterImprovementTests.cs
+++ b/tests/Calor.Compiler.Tests/ConverterImprovementTests.cs
@@ -14,7 +14,7 @@ namespace Calor.Compiler.Tests;
 /// </summary>
 public class ConverterImprovementTests
 {
-    private readonly CSharpToCalorConverter _converter = new();
+    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
 
     #region A1: Throw Expressions
 
@@ -1307,7 +1307,7 @@ public class ConverterImprovementTests
     {
         // Use C# converter to get a sealed override method in the AST,
         // then verify CalorEmitter emits "seal" not "sealed"
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var csharp = """
             public class Base
             {

--- a/tests/Calor.Compiler.Tests/ConverterQualityTests.cs
+++ b/tests/Calor.Compiler.Tests/ConverterQualityTests.cs
@@ -41,7 +41,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter(new ConversionOptions { GracefulFallback = true });
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, GracefulFallback = true });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -130,7 +130,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter(new ConversionOptions { GracefulFallback = true });
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, GracefulFallback = true });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -402,7 +402,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter(new ConversionOptions { GracefulFallback = true });
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, GracefulFallback = true });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -431,7 +431,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter(new ConversionOptions { GracefulFallback = true });
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, GracefulFallback = true });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -516,7 +516,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter(new ConversionOptions { GracefulFallback = true });
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, GracefulFallback = true });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));

--- a/tests/Calor.Compiler.Tests/ConverterQualityTests.cs
+++ b/tests/Calor.Compiler.Tests/ConverterQualityTests.cs
@@ -283,7 +283,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -333,7 +333,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -357,7 +357,7 @@ public class ConverterQualityTests
             """;
 
         // C# → Calor
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var convResult = converter.Convert(csharp);
         Assert.True(convResult.Success, GetErrorMessage(convResult));
 
@@ -458,7 +458,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -485,7 +485,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -552,7 +552,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -582,7 +582,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -610,7 +610,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -651,7 +651,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -699,7 +699,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -732,7 +732,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -761,7 +761,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -788,7 +788,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -816,7 +816,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -846,7 +846,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -879,7 +879,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -910,7 +910,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -937,7 +937,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -970,7 +970,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -996,7 +996,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -1020,7 +1020,7 @@ public class ConverterQualityTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, GetErrorMessage(result));
@@ -1045,7 +1045,7 @@ public class Foo
         return result;
     }
 }";
-        var converter = new CSharpToCalorConverter(new ConversionOptions());
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp, "Test.cs");
         Assert.True(result.Success, GetErrorMessage(result));
         Assert.NotNull(result.CalorSource);
@@ -1080,7 +1080,7 @@ public class Foo
     }
     private void AddToken(string s) { }
 }";
-        var converter = new CSharpToCalorConverter(new ConversionOptions());
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp, "Test.cs");
         Assert.True(result.Success, GetErrorMessage(result));
         Assert.NotNull(result.CalorSource);
@@ -1106,7 +1106,7 @@ public class Foo
         return (byte[]?)value;
     }
 }";
-        var converter = new CSharpToCalorConverter(new ConversionOptions());
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp, "Test.cs");
         Assert.True(result.Success, GetErrorMessage(result));
         Assert.NotNull(result.CalorSource);

--- a/tests/Calor.Compiler.Tests/ConverterRobustnessTests.cs
+++ b/tests/Calor.Compiler.Tests/ConverterRobustnessTests.cs
@@ -13,7 +13,7 @@ public class ConverterRobustnessTests
     {
         try
         {
-            var converter = new CSharpToCalorConverter();
+            var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
             var result = converter.Convert(csharp, "test.cs");
             return (result.Success, result.CalorSource ?? "", null);
         }

--- a/tests/Calor.Compiler.Tests/E2ERoundtripTests.cs
+++ b/tests/Calor.Compiler.Tests/E2ERoundtripTests.cs
@@ -44,7 +44,7 @@ public class E2ERoundtripTests
         // Arrange
         var outputCsPath = Path.Combine(scenarioPath, "output.g.cs");
         var csharpSource = File.ReadAllText(outputCsPath);
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
 
         // Act
         var result = converter.Convert(csharpSource, outputCsPath);
@@ -76,7 +76,7 @@ public class E2ERoundtripTests
         // Arrange
         var outputCsPath = Path.Combine(scenarioPath, "output.g.cs");
         var csharpSource = File.ReadAllText(outputCsPath);
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
 
         // Act - Convert C# to Calor
         var conversionResult = converter.Convert(csharpSource, outputCsPath);

--- a/tests/Calor.Compiler.Tests/EventAccessorTests.cs
+++ b/tests/Calor.Compiler.Tests/EventAccessorTests.cs
@@ -286,7 +286,7 @@ public class EventAccessorTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues.Select(d => d.ToString())));
@@ -314,7 +314,7 @@ public class EventAccessorTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues.Select(d => d.ToString())));
@@ -343,7 +343,7 @@ public class EventAccessorTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues.Select(d => d.ToString())));

--- a/tests/Calor.Compiler.Tests/ExtensionMethodTests.cs
+++ b/tests/Calor.Compiler.Tests/ExtensionMethodTests.cs
@@ -9,7 +9,7 @@ namespace Calor.Compiler.Tests;
 
 public class ExtensionMethodTests
 {
-    private readonly CSharpToCalorConverter _converter = new();
+    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
 
     private static List<Token> Tokenize(string source, out DiagnosticBag diagnostics)
     {

--- a/tests/Calor.Compiler.Tests/FeatureVerificationTests.cs
+++ b/tests/Calor.Compiler.Tests/FeatureVerificationTests.cs
@@ -7,7 +7,7 @@ namespace Calor.Compiler.Tests;
 
 public class FeatureVerificationTests
 {
-    private readonly CSharpToCalorConverter _converter = new();
+    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
 
     private static string GetErrorMessage(ConversionResult result)
     {

--- a/tests/Calor.Compiler.Tests/FormatExpressionCoverageTests.cs
+++ b/tests/Calor.Compiler.Tests/FormatExpressionCoverageTests.cs
@@ -113,7 +113,10 @@ public class FormatExpressionCoverageTests
                 }
             }
             """;
-        var converter = new Migration.CSharpToCalorConverter();
+        var converter = new Migration.CSharpToCalorConverter(new Migration.ConversionOptions
+        {
+            Fidelity = Migration.ConversionFidelity.Lossy
+        });
         var convResult = converter.Convert(csharp);
         Assert.True(convResult.Success, string.Join("\n", convResult.Issues.Select(i => i.ToString())));
 
@@ -381,7 +384,10 @@ public class FormatExpressionCoverageTests
                 }
             }
             """;
-        var converter = new Migration.CSharpToCalorConverter();
+        var converter = new Migration.CSharpToCalorConverter(new Migration.ConversionOptions
+        {
+            Fidelity = Migration.ConversionFidelity.Lossy
+        });
         var convResult = converter.Convert(csharp);
         Assert.True(convResult.Success, string.Join("\n", convResult.Issues.Select(i => i.ToString())));
 

--- a/tests/Calor.Compiler.Tests/GenericSyntaxTests.cs
+++ b/tests/Calor.Compiler.Tests/GenericSyntaxTests.cs
@@ -542,7 +542,7 @@ public class GenericSyntaxTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join("\n", result.Issues.Select(i => i.Message)));
@@ -564,7 +564,7 @@ public class GenericSyntaxTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join("\n", result.Issues.Select(i => i.Message)));
@@ -584,7 +584,7 @@ public class GenericSyntaxTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join("\n", result.Issues.Select(i => i.Message)));
@@ -609,7 +609,7 @@ public class GenericSyntaxTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join("\n", result.Issues.Select(i => i.Message)));
@@ -634,7 +634,7 @@ public class GenericSyntaxTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join("\n", result.Issues.Select(i => i.Message)));

--- a/tests/Calor.Compiler.Tests/GotoCaseTests.cs
+++ b/tests/Calor.Compiler.Tests/GotoCaseTests.cs
@@ -45,7 +45,7 @@ public class Foo
         }
     }
 }";
-        var converter = new CSharpToCalorConverter(new ConversionOptions());
+        var converter = CreateConverter();
         var result = converter.Convert(csharp, "Test.cs");
         Assert.True(result.Success, string.Join("; ", result.Issues));
         Assert.NotNull(result.CalorSource);
@@ -69,7 +69,7 @@ public class Foo
         }
     }
 }";
-        var converter = new CSharpToCalorConverter(new ConversionOptions());
+        var converter = CreateConverter();
         var result = converter.Convert(csharp, "Test.cs");
         Assert.True(result.Success, string.Join("; ", result.Issues));
         Assert.NotNull(result.CalorSource);
@@ -95,7 +95,7 @@ public class Foo
         }
     }
 }";
-        var converter = new CSharpToCalorConverter(new ConversionOptions());
+        var converter = CreateConverter();
         var result = converter.Convert(csharp, "Test.cs");
         Assert.True(result.Success, string.Join("; ", result.Issues));
         Assert.Contains("§GOTO{CASE:2}", result.CalorSource!);
@@ -119,7 +119,7 @@ public class Foo
         }
     }
 }";
-        var converter = new CSharpToCalorConverter(new ConversionOptions());
+        var converter = CreateConverter();
         var result = converter.Convert(csharp, "Test.cs");
         Assert.True(result.Success, string.Join("; ", result.Issues));
         Assert.Contains("§GOTO{DEFAULT}", result.CalorSource!);
@@ -238,10 +238,13 @@ public class Foo
         }
     }
 }";
-        var converter = new CSharpToCalorConverter(new ConversionOptions());
+        var converter = CreateConverter();
         var result = converter.Convert(csharp, "Test.cs");
         Assert.True(result.Success, string.Join("; ", result.Issues));
         Assert.Contains("§GOTO{CASE:", result.CalorSource!);
         Assert.DoesNotContain("§CSHARP", result.CalorSource!);
     }
+
+    private static CSharpToCalorConverter CreateConverter() =>
+        new(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
 }

--- a/tests/Calor.Compiler.Tests/HumanizerRegressionTests.cs
+++ b/tests/Calor.Compiler.Tests/HumanizerRegressionTests.cs
@@ -19,7 +19,7 @@ namespace Calor.Compiler.Tests;
 /// </summary>
 public class HumanizerRegressionTests
 {
-    private readonly CSharpToCalorConverter _converter = new();
+    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
 
     private static string GetErrorMessage(ConversionResult result)
     {

--- a/tests/Calor.Compiler.Tests/IndexerTests.cs
+++ b/tests/Calor.Compiler.Tests/IndexerTests.cs
@@ -330,7 +330,7 @@ public class IndexerTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues.Select(d => d.ToString())));
@@ -353,7 +353,7 @@ public class IndexerTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues.Select(d => d.ToString())));
@@ -373,7 +373,7 @@ public class IndexerTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues.Select(d => d.ToString())));
@@ -394,7 +394,7 @@ public class IndexerTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues.Select(d => d.ToString())));
@@ -412,7 +412,7 @@ public class IndexerTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues.Select(d => d.ToString())));
@@ -437,7 +437,7 @@ public class IndexerTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues.Select(d => d.ToString())));
@@ -461,7 +461,7 @@ public class IndexerTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
         Assert.True(result.Success, string.Join(", ", result.Issues.Select(d => d.ToString())));
 
@@ -509,7 +509,7 @@ public class IndexerTests
             """;
 
         // Convert C# to Calor
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
         Assert.True(result.Success, string.Join(", ", result.Issues.Select(d => d.ToString())));
 
@@ -548,7 +548,7 @@ public class IndexerTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues.Select(d => d.ToString())));
@@ -570,7 +570,7 @@ public class IndexerTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
         Assert.True(result.Success);
 
@@ -595,7 +595,7 @@ public class IndexerTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues.Select(d => d.ToString())));
@@ -613,7 +613,7 @@ public class IndexerTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
         Assert.True(result.Success);
 
@@ -637,7 +637,7 @@ public class IndexerTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues.Select(d => d.ToString())));

--- a/tests/Calor.Compiler.Tests/InternalSetTests.cs
+++ b/tests/Calor.Compiler.Tests/InternalSetTests.cs
@@ -13,7 +13,10 @@ public class Foo
 {
     public string Name { get; internal set; }
 }";
-        var converter = new CSharpToCalorConverter(new ConversionOptions());
+        var converter = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Fidelity = ConversionFidelity.Lossy
+        });
         var result = converter.Convert(csharp, "Test.cs");
         Assert.True(result.Success, string.Join("; ", result.Issues));
         Assert.NotNull(result.CalorSource);
@@ -29,7 +32,10 @@ public class Foo
     public int Value { get; internal set; }
     public string Label { get; private set; }
 }";
-        var converter = new CSharpToCalorConverter(new ConversionOptions());
+        var converter = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Fidelity = ConversionFidelity.Lossy
+        });
         var result = converter.Convert(csharp, "Test.cs");
         Assert.True(result.Success, string.Join("; ", result.Issues));
         Assert.NotNull(result.CalorSource);

--- a/tests/Calor.Compiler.Tests/LinqSupportTests.cs
+++ b/tests/Calor.Compiler.Tests/LinqSupportTests.cs
@@ -32,7 +32,7 @@ public class LinqSupportTests
         return emitter.Emit(module);
     }
 
-    private readonly CSharpToCalorConverter _converter = new();
+    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
 
     private string GetErrorMessage(ConversionResult result)
     {

--- a/tests/Calor.Compiler.Tests/Mcp/ConvertToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/ConvertToolTests.cs
@@ -101,6 +101,35 @@ public class ConvertToolTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_ValidateMode_WriteFailureReturnsError()
+    {
+        var outputDirectory = Path.Combine(Path.GetTempPath(), $"calor-convert-output-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(outputDirectory);
+
+        try
+        {
+            var args = JsonSerializer.SerializeToElement(new
+            {
+                source = "public class Calculator { public int Value() => 42; }",
+                moduleName = "TestModule",
+                mode = "validate",
+                outputPath = outputDirectory
+            });
+
+            var result = await _tool.ExecuteAsync(args);
+
+            Assert.True(result.IsError);
+            var root = JsonDocument.Parse(result.Content[0].Text!).RootElement;
+            Assert.False(root.GetProperty("success").GetBoolean());
+            Assert.Equal("write", root.GetProperty("stage").GetString());
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory);
+        }
+    }
+
+    [Fact]
     public async Task ExecuteAsync_Issues_AreEnvelopeDiagnostics()
     {
         // Envelope schema v1.1 (loop plan D1.3): conversion issues are

--- a/tests/Calor.Compiler.Tests/Mcp/ConvertToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/ConvertToolTests.cs
@@ -130,6 +130,27 @@ public class ConvertToolTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_ValidateMode_ReportsLossyDropLocations()
+    {
+        var args = JsonSerializer.SerializeToElement(new
+        {
+            source = "public interface IEvents { event System.EventHandler Changed; }",
+            moduleName = "Events",
+            mode = "validate",
+            fidelity = "lossy"
+        });
+
+        var result = await _tool.ExecuteAsync(args);
+
+        var root = JsonDocument.Parse(result.Content[0].Text!).RootElement;
+        Assert.Equal("lossy", root.GetProperty("fidelity").GetString());
+        var lossSummary = root.GetProperty("lossSummary");
+        Assert.Equal(1, lossSummary.GetProperty("drops").GetInt32());
+        Assert.True(Assert.Single(lossSummary.GetProperty("locations").EnumerateArray())
+            .GetProperty("line").GetInt32() > 0);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_Issues_AreEnvelopeDiagnostics()
     {
         // Envelope schema v1.1 (loop plan D1.3): conversion issues are

--- a/tests/Calor.Compiler.Tests/Mcp/ConvertToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/ConvertToolTests.cs
@@ -46,6 +46,7 @@ public class ConvertToolTests
         Assert.True(schema.TryGetProperty("properties", out var props));
         Assert.True(props.TryGetProperty("source", out _));
         Assert.True(props.TryGetProperty("moduleName", out _));
+        Assert.True(props.TryGetProperty("fidelity", out _));
     }
 
     [Fact]
@@ -158,6 +159,35 @@ public class ConvertToolTests
         Assert.Contains("classesConverted", text);
         Assert.Contains("methodsConverted", text);
         Assert.Contains("propertiesConverted", text);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DefaultsToLosslessAndReportsInteropLocations()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"Example-{Guid.NewGuid():N}.cs");
+        await File.WriteAllTextAsync(
+            path,
+            "public class Example { public int Get() { int Local() => 42; return Local(); } }");
+        try
+        {
+            var args = JsonSerializer.SerializeToElement(new { inputPath = path });
+            var result = await _tool.ExecuteAsync(args);
+
+            Assert.False(result.IsError);
+            var root = JsonDocument.Parse(result.Content[0].Text!).RootElement;
+            Assert.Equal("lossless", root.GetProperty("fidelity").GetString());
+            var summary = root.GetProperty("lossSummary");
+            Assert.Equal(1, summary.GetProperty("interopPreservations").GetInt32());
+            Assert.Equal(0, summary.GetProperty("lossySubstitutions").GetInt32());
+            Assert.Equal(0, summary.GetProperty("drops").GetInt32());
+            var location = Assert.Single(summary.GetProperty("locations").EnumerateArray());
+            Assert.Equal(path, location.GetProperty("file").GetString());
+            Assert.True(location.GetProperty("line").GetInt32() >= 1);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/Mcp/McpSerialCollection.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/McpSerialCollection.cs
@@ -12,6 +12,11 @@ public class McpSerialCollection : ICollectionFixture<McpMemoryHeadroomFixture>
 {
 }
 
+[CollectionDefinition("TelemetrySingleton", DisableParallelization = true)]
+public sealed class TelemetrySingletonCollection
+{
+}
+
 /// <summary>
 /// #897 second failure mode (first seen on the B8 CI run): the MCP server's
 /// memory-pressure breaker trips when the test HOST process is already holding the

--- a/tests/Calor.Compiler.Tests/Mcp/McpServerTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/McpServerTests.cs
@@ -807,12 +807,8 @@ public class McpServerTests
 
         try { await serverTask; } catch (OperationCanceledException) { }
 
-        // The cancellation check at the top of each loop iteration limits reads.
-        // Without cancellationToken.ThrowIfCancellationRequested(), a spin loop
-        // would call ReadLineAsync 100,000+ times. With it, the CancellationToken
-        // fires cooperatively and limits iterations. This test ensures the empty-string
-        // path doesn't cause unbounded recursion or stack overflow.
-        Assert.True(idleReader.ReadCount < 50_000,
+        // Empty reads are throttled so a non-blocking reader cannot consume a core.
+        Assert.True(idleReader.ReadCount < 50,
             $"ReadLineAsync called {idleReader.ReadCount} times in 100ms — possible spin loop");
     }
 

--- a/tests/Calor.Compiler.Tests/Mcp/MigrateToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/MigrateToolTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Calor.Compiler.Mcp;
 using Calor.Compiler.Mcp.Tools;
+using Calor.Compiler.Migration;
 using Xunit;
 
 namespace Calor.Compiler.Tests.Mcp;
@@ -226,6 +227,35 @@ public class MigrateToolTests
                 json.GetProperty("perFile").EnumerateArray(),
                 file => file.GetProperty("path").GetString() == "Stale.calr");
             Assert.Equal(staleSource, await File.ReadAllTextAsync(stalePath));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FullPreservesConversionLossLedgerAfterCompile()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"calor-migrate-losses-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        await File.WriteAllTextAsync(
+            Path.Combine(tempDir, "Interop.cs"),
+            "public class Interop { public int Get() { int Local() => 42; return Local(); } }");
+
+        try
+        {
+            var args = JsonDocument.Parse(
+                $$"""{"projectPath": "{{tempDir.Replace("\\", "\\\\")}}", "phase": "full"}""").RootElement;
+
+            var result = await _tool.ExecuteAsync(args);
+
+            var json = JsonDocument.Parse(result.Content[0].Text!).RootElement;
+            var file = Assert.Single(json.GetProperty("perFile").EnumerateArray());
+            Assert.Contains(file.GetProperty("status").GetString(), new[] { "compiled", "fixed" });
+            var loss = Assert.Single(file.GetProperty("losses").EnumerateArray());
+            Assert.Equal((int)ConversionLossKind.InteropPreserved, loss.GetProperty("kind").GetInt32());
+            Assert.True(loss.GetProperty("line").GetInt32() > 0);
         }
         finally
         {

--- a/tests/Calor.Compiler.Tests/Mcp/MigrateToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/MigrateToolTests.cs
@@ -205,6 +205,35 @@ public class MigrateToolTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_FullLosslessFailureIgnoresPreExistingCalorFiles()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"calor-migrate-stale-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var stalePath = Path.Combine(tempDir, "Stale.calr");
+        const string staleSource = "not valid Calor";
+        await File.WriteAllTextAsync(Path.Combine(tempDir, "Broken.cs"), "public class {");
+        await File.WriteAllTextAsync(stalePath, staleSource);
+
+        try
+        {
+            var args = JsonDocument.Parse(
+                $$"""{"projectPath": "{{tempDir.Replace("\\", "\\\\")}}", "phase": "full"}""").RootElement;
+
+            var result = await _tool.ExecuteAsync(args);
+
+            var json = JsonDocument.Parse(result.Content[0].Text!).RootElement;
+            Assert.DoesNotContain(
+                json.GetProperty("perFile").EnumerateArray(),
+                file => file.GetProperty("path").GetString() == "Stale.calr");
+            Assert.Equal(staleSource, await File.ReadAllTextAsync(stalePath));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void ResolveDirectory_WithDirectory_ReturnsPath()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"calor-migrate-test-{Guid.NewGuid():N}");

--- a/tests/Calor.Compiler.Tests/Mcp/MigrateToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/MigrateToolTests.cs
@@ -177,6 +177,34 @@ public class MigrateToolTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_FixPhase_InvalidFixLeavesExistingFileUnchanged()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"calor-migrate-invalid-fix-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var path = Path.Combine(tempDir, "Invalid.calr");
+        const string source = "§M{m1:Test}\n§B{b1:value:StringBuilder} §NEW{object}§/NEW";
+        await File.WriteAllTextAsync(path, source);
+
+        try
+        {
+            var args = JsonDocument.Parse(
+                $$"""{"projectPath": "{{tempDir.Replace("\\", "\\\\")}}", "phase": "fix"}""").RootElement;
+
+            var result = await _tool.ExecuteAsync(args);
+
+            var json = JsonDocument.Parse(result.Content[0].Text!).RootElement;
+            var file = Assert.Single(json.GetProperty("perFile").EnumerateArray());
+            Assert.Equal("fix_incomplete", file.GetProperty("status").GetString());
+            Assert.True(file.GetProperty("fixesApplied").GetInt32() > 0);
+            Assert.Equal(source, await File.ReadAllTextAsync(path));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void ResolveDirectory_WithDirectory_ReturnsPath()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"calor-migrate-test-{Guid.NewGuid():N}");
@@ -368,4 +396,3 @@ public class MigrateToolTests
         }
     }
 }
-

--- a/tests/Calor.Compiler.Tests/Mcp/SyntaxHelpToolTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/SyntaxHelpToolTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Calor.Compiler.Tests.Mcp;
 
+[Collection("TelemetrySingleton")]
 public class SyntaxHelpToolTests
 {
     private readonly HelpTool _tool = new();

--- a/tests/Calor.Compiler.Tests/Migration/CalorEmitterEscapeTests.cs
+++ b/tests/Calor.Compiler.Tests/Migration/CalorEmitterEscapeTests.cs
@@ -11,7 +11,7 @@ public class CalorEmitterEscapeTests
 {
     private static string ConvertToCalor(string csharpSource)
     {
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharpSource);
         Assert.True(result.Success, string.Join("\n", result.Issues.Select(i => $"[{i.Severity}] {i.Message}")));
         Assert.NotNull(result.CalorSource);

--- a/tests/Calor.Compiler.Tests/Migration/ConvertAutoFixIntegrationTests.cs
+++ b/tests/Calor.Compiler.Tests/Migration/ConvertAutoFixIntegrationTests.cs
@@ -20,6 +20,7 @@ public class ConvertAutoFixIntegrationTests
     {
         var converter = new CSharpToCalorConverter(new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             GracefulFallback = true,
             PreserveComments = true,
             AutoGenerateIds = true

--- a/tests/Calor.Compiler.Tests/Migration/LosslessConversionContractTests.cs
+++ b/tests/Calor.Compiler.Tests/Migration/LosslessConversionContractTests.cs
@@ -71,6 +71,24 @@ public sealed class LosslessConversionContractTests
     }
 
     [Fact]
+    public void NativeMarkerTextInsideStringDoesNotCreateFallbackLoss()
+    {
+        const string source = """
+            public class Example
+            {
+                public string Get() => "§RAW §CS{ §CSHARP{";
+            }
+            """;
+
+        var result = new CSharpToCalorConverter().Convert(source, "Example.cs");
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Issues));
+        Assert.DoesNotContain(
+            result.Losses,
+            loss => loss.Kind == ConversionLossKind.EmitterFallback);
+    }
+
+    [Fact]
     public void GeneratedCalorValidation_IsMandatoryInLossyMode()
     {
         var converter = new CSharpToCalorConverter(new ConversionOptions

--- a/tests/Calor.Compiler.Tests/Migration/LosslessConversionContractTests.cs
+++ b/tests/Calor.Compiler.Tests/Migration/LosslessConversionContractTests.cs
@@ -283,4 +283,58 @@ public sealed class LosslessConversionContractTests
             FileSizeBytes = new FileInfo(sourcePath).Length
         };
     }
+
+    [Fact]
+    public async Task ProjectMigration_TimedOutLossyConversionCannotWriteLater()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"calor-project-timeout-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "Slow.cs");
+        var outputPath = Path.ChangeExtension(sourcePath, ".calr");
+        await File.WriteAllTextAsync(
+            sourcePath,
+            string.Join(
+                Environment.NewLine,
+                Enumerable.Range(0, 10_000).Select(index => $"public class Item{index} {{ }}")));
+        await File.WriteAllTextAsync(outputPath, "original");
+
+        var plan = new MigrationPlan
+        {
+            ProjectPath = directory,
+            Direction = MigrationDirection.CSharpToCalor,
+            Entries =
+            [
+                new MigrationPlanEntry
+                {
+                    SourcePath = sourcePath,
+                    OutputPath = outputPath,
+                    Convertibility = FileConvertibility.Full,
+                    FileSizeBytes = new FileInfo(sourcePath).Length
+                }
+            ]
+        };
+        var migrator = new ProjectMigrator(new MigrationPlanOptions
+        {
+            Parallel = false,
+            Fidelity = ConversionFidelity.Lossy,
+            PerFileTimeoutSeconds = 0
+        });
+
+        try
+        {
+            var report = await migrator.ExecuteAsync(plan);
+            await Task.Delay(250);
+
+            Assert.Equal(FileMigrationStatus.TimedOut, Assert.Single(report.FileResults).Status);
+            Assert.Equal("original", await File.ReadAllTextAsync(outputPath));
+        }
+        finally
+        {
+            foreach (var file in Directory.GetFiles(directory))
+            {
+                File.Delete(file);
+            }
+            Directory.Delete(directory);
+        }
+    }
 }

--- a/tests/Calor.Compiler.Tests/Migration/LosslessConversionContractTests.cs
+++ b/tests/Calor.Compiler.Tests/Migration/LosslessConversionContractTests.cs
@@ -1,0 +1,173 @@
+using System.Text;
+using Calor.Compiler.Migration;
+using Calor.Compiler.Migration.Project;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+public sealed class LosslessConversionContractTests
+{
+    [Fact]
+    public void CliPolicy_DefaultsToLossless()
+    {
+        var options = Commands.ConvertCommand.BuildCSharpToCalorOptions(
+            benchmark: false,
+            verbose: false,
+            explain: false,
+            noFallback: false,
+            passthrough: false,
+            explicitCallClosers: false);
+
+        Assert.Equal(ConversionFidelity.Lossless, options.Fidelity);
+    }
+
+    [Fact]
+    public void UnsupportedDescendant_IsPreservedAtMemberBoundary()
+    {
+        const string source = """
+            public class Example
+            {
+                public int Get()
+                {
+                    int Local() => 42;
+                    return Local();
+                }
+            }
+            """;
+
+        var result = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Fidelity = ConversionFidelity.Lossless
+        }).Convert(source, "Example.cs");
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Issues));
+        Assert.Contains("§CSHARP", result.CalorSource);
+        Assert.Contains("int Local() => 42;", result.CalorSource);
+        Assert.Equal(1, result.InteropPreservationCount);
+        Assert.Equal(0, result.LossySubstitutionCount);
+        Assert.Equal(0, result.DropCount);
+    }
+
+    [Fact]
+    public void LossyMode_ReportsEveryDropLocation()
+    {
+        const string source = """
+            public interface IEvents
+            {
+                event System.EventHandler Changed;
+            }
+            """;
+
+        var result = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Fidelity = ConversionFidelity.Lossy
+        }).Convert(source, "IEvents.cs");
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Issues));
+        var loss = Assert.Single(result.Losses, item => item.Kind == ConversionLossKind.Dropped);
+        Assert.Equal("IEvents.cs", loss.File);
+        Assert.True(loss.Line > 0);
+        Assert.Equal(1, result.DropCount);
+    }
+
+    [Fact]
+    public void GeneratedCalorValidation_IsMandatoryInLossyMode()
+    {
+        var converter = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Fidelity = ConversionFidelity.Lossy
+        })
+        {
+            ParseValidatorOverride = _ => false
+        };
+
+        var result = converter.Convert("public class Example { public int Get() => 1; }");
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Issues, issue => issue.Feature == "generated-calor-validation");
+    }
+
+    [Fact]
+    public async Task AtomicWrite_CancellationLeavesExistingDestinationUnchanged()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"calor-lossless-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "output.calr");
+        await File.WriteAllTextAsync(path, "original", Encoding.UTF8);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        try
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                ConversionFileWriter.WriteAtomicAsync(path, "replacement", cancellationToken: cts.Token));
+            Assert.Equal("original", await File.ReadAllTextAsync(path));
+            Assert.Empty(Directory.GetFiles(directory, "*.tmp", SearchOption.TopDirectoryOnly));
+        }
+        finally
+        {
+            File.Delete(path);
+            Directory.Delete(directory);
+        }
+    }
+
+    [Fact]
+    public async Task ProjectMigration_LosslessMixedFilesPreservesUnsupportedMembers()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"calor-project-lossless-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var nativePath = Path.Combine(directory, "Native.cs");
+        var interopPath = Path.Combine(directory, "Interop.cs");
+        await File.WriteAllTextAsync(nativePath, "public class Native { public int Get() => 1; }");
+        await File.WriteAllTextAsync(
+            interopPath,
+            "public class Interop { public int Get() { int Local() => 2; return Local(); } }");
+
+        var plan = new MigrationPlan
+        {
+            ProjectPath = directory,
+            Direction = MigrationDirection.CSharpToCalor,
+            Entries =
+            [
+                Entry(nativePath),
+                Entry(interopPath)
+            ]
+        };
+        var migrator = new ProjectMigrator(new MigrationPlanOptions
+        {
+            Parallel = false,
+            MergePartialClasses = false,
+            Fidelity = ConversionFidelity.Lossless
+        });
+
+        try
+        {
+            var report = await migrator.ExecuteAsync(plan);
+
+            Assert.All(
+                report.FileResults,
+                result => Assert.Contains(
+                    result.Status,
+                    new[] { FileMigrationStatus.Success, FileMigrationStatus.Partial }));
+            var interop = Assert.Single(report.FileResults, result => result.SourcePath == interopPath);
+            Assert.Contains(interop.Losses, loss => loss.Kind == ConversionLossKind.InteropPreserved);
+            Assert.Contains("§CSHARP", await File.ReadAllTextAsync(Path.ChangeExtension(interopPath, ".calr")));
+        }
+        finally
+        {
+            foreach (var file in Directory.GetFiles(directory))
+            {
+                File.Delete(file);
+            }
+            Directory.Delete(directory);
+        }
+
+        static MigrationPlanEntry Entry(string sourcePath) => new()
+        {
+            SourcePath = sourcePath,
+            OutputPath = Path.ChangeExtension(sourcePath, ".calr"),
+            Convertibility = FileConvertibility.Full,
+            FileSizeBytes = new FileInfo(sourcePath).Length
+        };
+    }
+}

--- a/tests/Calor.Compiler.Tests/Migration/LosslessConversionContractTests.cs
+++ b/tests/Calor.Compiler.Tests/Migration/LosslessConversionContractTests.cs
@@ -170,4 +170,117 @@ public sealed class LosslessConversionContractTests
             FileSizeBytes = new FileInfo(sourcePath).Length
         };
     }
+
+    [Fact]
+    public async Task ProjectMigration_LosslessValidatesCrossFileReferencesTogether()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"calor-project-cross-file-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var sharedPath = Path.Combine(directory, "Shared.cs");
+        var consumerPath = Path.Combine(directory, "Consumer.cs");
+        await File.WriteAllTextAsync(sharedPath, "namespace Demo; public class Shared { }");
+        await File.WriteAllTextAsync(
+            consumerPath,
+            "namespace Demo; public class Consumer { public Shared Create() => new Shared(); }");
+
+        var plan = new MigrationPlan
+        {
+            ProjectPath = directory,
+            Direction = MigrationDirection.CSharpToCalor,
+            Entries =
+            [
+                Entry(sharedPath),
+                Entry(consumerPath)
+            ]
+        };
+        var migrator = new ProjectMigrator(new MigrationPlanOptions
+        {
+            Parallel = false,
+            MergePartialClasses = false,
+            Fidelity = ConversionFidelity.Lossless
+        });
+
+        try
+        {
+            var report = await migrator.ExecuteAsync(plan);
+
+            Assert.All(report.FileResults, result => Assert.Equal(FileMigrationStatus.Success, result.Status));
+            Assert.True(File.Exists(Path.ChangeExtension(sharedPath, ".calr")));
+            Assert.True(File.Exists(Path.ChangeExtension(consumerPath, ".calr")));
+        }
+        finally
+        {
+            foreach (var file in Directory.GetFiles(directory))
+            {
+                File.Delete(file);
+            }
+            Directory.Delete(directory);
+        }
+
+        static MigrationPlanEntry Entry(string sourcePath) => new()
+        {
+            SourcePath = sourcePath,
+            OutputPath = Path.ChangeExtension(sourcePath, ".calr"),
+            Convertibility = FileConvertibility.Full,
+            FileSizeBytes = new FileInfo(sourcePath).Length
+        };
+    }
+
+    [Fact]
+    public async Task ProjectMigration_LosslessAggregateFailureWritesNothingAndRefreshesSummary()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"calor-project-invalid-reference-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var validPath = Path.Combine(directory, "Valid.cs");
+        var invalidPath = Path.Combine(directory, "Invalid.cs");
+        await File.WriteAllTextAsync(validPath, "namespace Demo; public class Valid { }");
+        await File.WriteAllTextAsync(
+            invalidPath,
+            "namespace Demo; public class Invalid { public Missing Create() => new Missing(); }");
+
+        var plan = new MigrationPlan
+        {
+            ProjectPath = directory,
+            Direction = MigrationDirection.CSharpToCalor,
+            Entries =
+            [
+                Entry(validPath),
+                Entry(invalidPath)
+            ]
+        };
+        var migrator = new ProjectMigrator(new MigrationPlanOptions
+        {
+            Parallel = false,
+            MergePartialClasses = false,
+            Fidelity = ConversionFidelity.Lossless
+        });
+
+        try
+        {
+            var report = await migrator.ExecuteAsync(plan);
+
+            Assert.All(report.FileResults, result => Assert.Equal(FileMigrationStatus.Failed, result.Status));
+            Assert.Equal(0, report.Summary.SuccessfulFiles);
+            Assert.Equal(2, report.Summary.FailedFiles);
+            Assert.True(report.Summary.TotalErrors > 0);
+            Assert.False(File.Exists(Path.ChangeExtension(validPath, ".calr")));
+            Assert.False(File.Exists(Path.ChangeExtension(invalidPath, ".calr")));
+        }
+        finally
+        {
+            foreach (var file in Directory.GetFiles(directory))
+            {
+                File.Delete(file);
+            }
+            Directory.Delete(directory);
+        }
+
+        static MigrationPlanEntry Entry(string sourcePath) => new()
+        {
+            SourcePath = sourcePath,
+            OutputPath = Path.ChangeExtension(sourcePath, ".calr"),
+            Convertibility = FileConvertibility.Full,
+            FileSizeBytes = new FileInfo(sourcePath).Length
+        };
+    }
 }

--- a/tests/Calor.Compiler.Tests/Migration/LosslessConversionContractTests.cs
+++ b/tests/Calor.Compiler.Tests/Migration/LosslessConversionContractTests.cs
@@ -309,11 +309,7 @@ public sealed class LosslessConversionContractTests
         Directory.CreateDirectory(directory);
         var sourcePath = Path.Combine(directory, "Slow.cs");
         var outputPath = Path.ChangeExtension(sourcePath, ".calr");
-        await File.WriteAllTextAsync(
-            sourcePath,
-            string.Join(
-                Environment.NewLine,
-                Enumerable.Range(0, 10_000).Select(index => $"public class Item{index} {{ }}")));
+        await File.WriteAllTextAsync(sourcePath, "public class Item { }");
         await File.WriteAllTextAsync(outputPath, "original");
 
         var plan = new MigrationPlan
@@ -341,7 +337,6 @@ public sealed class LosslessConversionContractTests
         try
         {
             var report = await migrator.ExecuteAsync(plan);
-            await Task.Delay(250);
 
             Assert.Equal(FileMigrationStatus.TimedOut, Assert.Single(report.FileResults).Status);
             Assert.Equal("original", await File.ReadAllTextAsync(outputPath));

--- a/tests/Calor.Compiler.Tests/Migration/PostValidationFallbackTests.cs
+++ b/tests/Calor.Compiler.Tests/Migration/PostValidationFallbackTests.cs
@@ -126,14 +126,18 @@ public class PostValidationFallbackTests
         // Default mode (no passthrough / not Interop): the fallback is gated off, so the
         // output is left as the converter produced it (here real-valid) and no §CSHARP is
         // emitted. Guards that the fallback does not change default-mode behavior.
-        var converter = new CSharpToCalorConverter(new ConversionOptions { PassthroughOnError = false })
+        var converter = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Fidelity = ConversionFidelity.Lossy,
+            PassthroughOnError = false
+        })
         {
             ParseValidatorOverride = CondemnOutsideCSharp("Breakme"),
         };
 
         var result = converter.Convert(TwoClasses);
 
-        Assert.True(result.Success);
+        Assert.False(result.Success);
         Assert.NotNull(result.CalorSource);
         Assert.Equal(0, result.Context!.Stats.InteropBlocksEmitted);
         Assert.DoesNotContain("§CSHARP", result.CalorSource!);

--- a/tests/Calor.Compiler.Tests/Migration/PostValidationFallbackTests.cs
+++ b/tests/Calor.Compiler.Tests/Migration/PostValidationFallbackTests.cs
@@ -47,7 +47,7 @@ public class PostValidationFallbackTests
     [Fact]
     public void UnparseableMember_IsWrappedInCSharpBlock_UnderPassthrough()
     {
-        var converter = new CSharpToCalorConverter(new ConversionOptions { PassthroughOnError = true })
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, PassthroughOnError = true })
         {
             ParseValidatorOverride = CondemnOutsideCSharp("Breakme"),
         };
@@ -80,7 +80,7 @@ public class PostValidationFallbackTests
         const string src =
             "namespace N1 { public class Foo { public int A() => 1; } } " +
             "namespace N2 { public class Foo { public int B() => 2; } }";
-        var converter = new CSharpToCalorConverter(new ConversionOptions { PassthroughOnError = true });
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, PassthroughOnError = true });
 
         var result = converter.Convert(src);
 
@@ -108,7 +108,7 @@ public class PostValidationFallbackTests
         // be rewrapped. With everything declared unparseable, the output stays invalid —
         // and passthrough must return failure WITH a warning, never Success=true + broken
         // text (which is exactly the pre-#717 behavior).
-        var converter = new CSharpToCalorConverter(new ConversionOptions { PassthroughOnError = true })
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, PassthroughOnError = true })
         {
             ParseValidatorOverride = _ => false,
         };
@@ -146,7 +146,7 @@ public class PostValidationFallbackTests
     [Fact]
     public void CleanConversion_TriggersNoFallback()
     {
-        var converter = new CSharpToCalorConverter(new ConversionOptions { PassthroughOnError = true });
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, PassthroughOnError = true });
 
         var result = converter.Convert(TwoClasses);
 

--- a/tests/Calor.Compiler.Tests/MigrationLearningFixTests.cs
+++ b/tests/Calor.Compiler.Tests/MigrationLearningFixTests.cs
@@ -13,7 +13,7 @@ namespace Calor.Compiler.Tests;
 /// </summary>
 public class MigrationLearningFixTests
 {
-    private readonly CSharpToCalorConverter _converter = new();
+    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
     private static TextSpan Span => new(0, 1, 1, 1);
 
     #region Helpers

--- a/tests/Calor.Compiler.Tests/MigrationLearningFixTests.cs
+++ b/tests/Calor.Compiler.Tests/MigrationLearningFixTests.cs
@@ -331,7 +331,8 @@ public class MigrationLearningFixTests
             """;
 
         var result = _converter.Convert(csharpSource);
-        Assert.True(result.Success, GetErrorMessage(result));
+        Assert.False(result.Success);
+        Assert.Contains(result.Issues, issue => issue.Feature == "generated-calor-validation");
 
         var emitted = Emit(result.Ast!);
         // Keywords should be sanitized with @ prefix in emitted C#

--- a/tests/Calor.Compiler.Tests/NamespaceEmissionTests.cs
+++ b/tests/Calor.Compiler.Tests/NamespaceEmissionTests.cs
@@ -87,7 +87,7 @@ public class NamespaceEmissionTests
             """;
 
         // Act: Convert C# to Calor
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var conversionResult = converter.Convert(csharpSource);
         Assert.True(conversionResult.Success, GetConversionErrors(conversionResult));
 

--- a/tests/Calor.Compiler.Tests/NewtonsoftRegressionTests.cs
+++ b/tests/Calor.Compiler.Tests/NewtonsoftRegressionTests.cs
@@ -11,7 +11,11 @@ namespace Calor.Compiler.Tests;
 /// </summary>
 public class NewtonsoftRegressionTests
 {
-    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions { StripPreprocessor = false });
+    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions
+    {
+        Fidelity = ConversionFidelity.Lossy,
+        StripPreprocessor = false
+    });
 
     private ConversionResult Convert(string csharpSource)
     {

--- a/tests/Calor.Compiler.Tests/NullCoalescingTests.cs
+++ b/tests/Calor.Compiler.Tests/NullCoalescingTests.cs
@@ -112,7 +112,10 @@ public static class NullHandling
         return a ?? b ?? c;
     }
 }";
-        var converter = new CSharpToCalorConverter(new ConversionOptions());
+        var converter = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Fidelity = ConversionFidelity.Lossy
+        });
         var convResult = converter.Convert(csharp, "Test.cs");
         Assert.True(convResult.Success, "C# to Calor conversion should succeed: " +
             string.Join(", ", convResult.Issues.Select(i => i.Message)));

--- a/tests/Calor.Compiler.Tests/OperatorOverloadTests.cs
+++ b/tests/Calor.Compiler.Tests/OperatorOverloadTests.cs
@@ -962,7 +962,7 @@ public class Wrapper
 
     private static string ConvertCSharpToCalor(string csharpCode)
     {
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharpCode, "test.cs");
 
         Assert.True(result.Success, string.Join("\n", result.Issues.Select(i => i.ToString())));
@@ -1111,7 +1111,7 @@ public class Wrapper
 
     private static string ConvertAndRoundTrip(string csharp)
     {
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
         Assert.True(result.Success, string.Join("\n", result.Issues.Select(i => i.ToString())));
 

--- a/tests/Calor.Compiler.Tests/OptionResultConversionTests.cs
+++ b/tests/Calor.Compiler.Tests/OptionResultConversionTests.cs
@@ -12,7 +12,7 @@ namespace Calor.Compiler.Tests;
 /// </summary>
 public class OptionResultConversionTests
 {
-    private readonly CSharpToCalorConverter _converter = new();
+    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
 
     private const string OptionCSharp = """
         using System;
@@ -358,6 +358,7 @@ public class OptionResultConversionTests
         // Use interop mode to trigger per-member fallback
         var converter = new CSharpToCalorConverter(new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             Mode = ConversionMode.Interop
         });
 

--- a/tests/Calor.Compiler.Tests/PassthroughOnErrorTests.cs
+++ b/tests/Calor.Compiler.Tests/PassthroughOnErrorTests.cs
@@ -10,6 +10,7 @@ public class PassthroughOnErrorTests
     {
         var options = new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             PassthroughOnError = true,
             GracefulFallback = true
         };
@@ -29,6 +30,7 @@ public class Foo
     {
         var options = new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             PassthroughOnError = false,
             GracefulFallback = true
         };

--- a/tests/Calor.Compiler.Tests/PreprocessorConversionTests.cs
+++ b/tests/Calor.Compiler.Tests/PreprocessorConversionTests.cs
@@ -14,7 +14,11 @@ public class PreprocessorConversionTests
 {
     private static string ConvertToCalor(string csharpSource)
     {
-        var converter = new CSharpToCalorConverter(new ConversionOptions { StripPreprocessor = false });
+        var converter = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Fidelity = ConversionFidelity.Lossy,
+            StripPreprocessor = false
+        });
         var result = converter.Convert(csharpSource);
         Assert.True(result.Success, GetErrorMessage(result));
         Assert.NotNull(result.CalorSource);
@@ -339,6 +343,7 @@ public class Test
 }";
         var result = new CSharpToCalorConverter(new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             StripPreprocessor = false
         }).Convert(csharp);
         Assert.False(result.Success);

--- a/tests/Calor.Compiler.Tests/PreprocessorConversionTests.cs
+++ b/tests/Calor.Compiler.Tests/PreprocessorConversionTests.cs
@@ -337,7 +337,13 @@ public class Test
     public void Legacy() { }
 #endif
 }";
-        var calor = ConvertToCalor(csharp);
+        var result = new CSharpToCalorConverter(new ConversionOptions
+        {
+            StripPreprocessor = false
+        }).Convert(csharp);
+        Assert.False(result.Success);
+        Assert.Contains(result.Issues, issue => issue.Feature == "generated-calor-validation");
+        var calor = new CalorEmitter().Emit(result.Ast!);
         Assert.Contains("§PP{NET8_0_OR_GREATER}", calor);
         Assert.Contains("§/PP{NET8_0_OR_GREATER}", calor);
     }

--- a/tests/Calor.Compiler.Tests/PrimaryConstructorTests.cs
+++ b/tests/Calor.Compiler.Tests/PrimaryConstructorTests.cs
@@ -10,7 +10,7 @@ namespace Calor.Compiler.Tests;
 /// </summary>
 public class PrimaryConstructorTests
 {
-    private readonly CSharpToCalorConverter _converter = new();
+    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
 
     [Fact]
     public void SimplePrimaryConstructor_SynthesizesFieldsAndConstructor()

--- a/tests/Calor.Compiler.Tests/RawPassthroughAndLinqAstTests.cs
+++ b/tests/Calor.Compiler.Tests/RawPassthroughAndLinqAstTests.cs
@@ -124,7 +124,7 @@ public class RawPassthroughAndLinqAstTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         // The conversion should succeed (no exceptions)
@@ -159,7 +159,7 @@ public class RawPassthroughAndLinqAstTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.NotNull(result.Ast);
@@ -196,7 +196,7 @@ public class RawPassthroughAndLinqAstTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.NotNull(result.Ast);
@@ -231,7 +231,7 @@ public class RawPassthroughAndLinqAstTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.NotNull(result.Ast);

--- a/tests/Calor.Compiler.Tests/RegexOperationTests.cs
+++ b/tests/Calor.Compiler.Tests/RegexOperationTests.cs
@@ -300,7 +300,7 @@ public class RegexOperationTests
         var csharp = $@"
 using System.Text.RegularExpressions;
 public class Test {{ public object M(string s) {{ return {csharpExpr}; }} }}";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -318,7 +318,7 @@ public class Test {{ public object M(string s) {{ return {csharpExpr}; }} }}";
         var csharp = @"
 using System.Text.RegularExpressions;
 public class Test { public string M(string s) { return Regex.Replace(s, ""\\s+"", ""-""); } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -335,7 +335,7 @@ public class Test { public string M(string s) { return Regex.Replace(s, ""\\s+""
         // The C# to Calor converter converts fully qualified Regex.IsMatch
         var csharp = @"
 public class Test { public bool M(string s) { return System.Text.RegularExpressions.Regex.IsMatch(s, ""\\d+""); } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -356,7 +356,7 @@ public class Test { public bool M(string s) { return System.Text.RegularExpressi
         var csharp = $@"
 using System.Text.RegularExpressions;
 public class Test {{ public object M(string s) => {csharpExpr}; }}";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));

--- a/tests/Calor.Compiler.Tests/StringBuilderOperationTests.cs
+++ b/tests/Calor.Compiler.Tests/StringBuilderOperationTests.cs
@@ -404,7 +404,7 @@ public class StringBuilderOperationTests
         var csharp = @"
 using System.Text;
 public class Test { public StringBuilder M() { return new StringBuilder(); } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -422,7 +422,7 @@ public class Test { public StringBuilder M() { return new StringBuilder(); } }";
         var csharp = @"
 using System.Text;
 public class Test { public StringBuilder M() { return new StringBuilder(""init""); } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -443,7 +443,7 @@ public class Test { public StringBuilder M() { return new StringBuilder(""init""
         var csharp = $@"
 using System.Text;
 public class Test {{ public object M(StringBuilder sb) {{ return {csharpExpr}; }} }}";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -461,7 +461,7 @@ public class Test {{ public object M(StringBuilder sb) {{ return {csharpExpr}; }
         var csharp = @"
 using System.Text;
 public class Test { public StringBuilder M(StringBuilder sb) { return sb.Insert(0, ""text""); } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -479,7 +479,7 @@ public class Test { public StringBuilder M(StringBuilder sb) { return sb.Insert(
         var csharp = @"
 using System.Text;
 public class Test { public StringBuilder M(StringBuilder sb) { return sb.Remove(0, 5); } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -497,7 +497,7 @@ public class Test { public StringBuilder M(StringBuilder sb) { return sb.Remove(
         var csharp = @"
 using System.Text;
 public class Test { public int M(StringBuilder sb) { return sb.Length; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -516,7 +516,7 @@ public class Test { public int M(StringBuilder sb) { return sb.Length; } }";
         var csharp = $@"
 using System.Text;
 public class Test {{ public StringBuilder M() => {csharpExpr}; }}";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -539,7 +539,7 @@ public class Test {{ public StringBuilder M() => {csharpExpr}; }}";
         var csharp = $@"
 using System.Text;
 public class Test {{ public object M(StringBuilder sb) => {csharpExpr}; }}";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -557,7 +557,7 @@ public class Test {{ public object M(StringBuilder sb) => {csharpExpr}; }}";
         var csharp = @"
 using System.Text;
 public class Test { public string M() { return new StringBuilder().Append(""a"").Append(""b"").ToString(); } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -578,7 +578,7 @@ public class Test { public string M() { return new StringBuilder().Append(""a"")
         var csharp = @"
 using System.Text;
 public class Test { public string M(StringBuilder builder) { return builder.ToString(); } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));

--- a/tests/Calor.Compiler.Tests/StringInterpolationTests.cs
+++ b/tests/Calor.Compiler.Tests/StringInterpolationTests.cs
@@ -118,7 +118,7 @@ public static class Formatting
     public static string Format(int a, int b) => $""{a} + {b} = {a + b}"";
 }
 ";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var conversionResult = converter.Convert(csharp, "test.cs");
         Assert.True(conversionResult.Success,
             $"Conversion failed: {string.Join("; ", conversionResult.Issues.Select(i => i.Message))}");
@@ -147,7 +147,7 @@ public static class MultiLine
     public static string Format(string title, string body) => $""Title: {title}\nBody: {body}"";
 }
 ";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var conversionResult = converter.Convert(csharp, "test.cs");
         Assert.True(conversionResult.Success,
             $"Conversion failed: {string.Join("; ", conversionResult.Issues.Select(i => i.Message))}");
@@ -171,7 +171,7 @@ public static class NumberFormat
     public static string FormatNumber(double value) => $""Value: {value:F2}"";
 }
 ";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var conversionResult = converter.Convert(csharp, "test.cs");
         Assert.True(conversionResult.Success,
             $"Conversion failed: {string.Join("; ", conversionResult.Issues.Select(i => i.Message))}");

--- a/tests/Calor.Compiler.Tests/StringOperationTests.cs
+++ b/tests/Calor.Compiler.Tests/StringOperationTests.cs
@@ -795,7 +795,7 @@ public class StringOperationTests
     public void Migration_InstanceMethodNoArgs_ConvertsToStringOp(string csharpExpr, StringOp expectedOp)
     {
         var csharp = $"public class Test {{ public string M(string s) => {csharpExpr}; }}";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -812,7 +812,7 @@ public class StringOperationTests
     public void Migration_InstanceMethodOneArg_ConvertsToStringOp(string csharpExpr, StringOp expectedOp)
     {
         var csharp = $"public class Test {{ public object M(string s) => {csharpExpr}; }}";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -828,7 +828,7 @@ public class StringOperationTests
     public void Migration_InstanceMethodIntArg_ConvertsToStringOp(string csharpExpr, StringOp expectedOp)
     {
         var csharp = $"public class Test {{ public string M(string s) => {csharpExpr}; }}";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -843,7 +843,7 @@ public class StringOperationTests
     public void Migration_InstanceMethodTwoArgs_ConvertsToStringOp(string csharpExpr, StringOp expectedOp)
     {
         var csharp = $"public class Test {{ public string M(string s) => {csharpExpr}; }}";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -858,7 +858,7 @@ public class StringOperationTests
     public void Migration_StaticStringMethod_ConvertsToStringOp(string csharpExpr, StringOp expectedOp)
     {
         var csharp = $"public class Test {{ public bool M(string s) => {csharpExpr}; }}";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -871,7 +871,7 @@ public class StringOperationTests
     public void Migration_StringLength_ConvertsToLenOp()
     {
         var csharp = "public class Test { public int M(string s) => s.Length; }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -884,7 +884,7 @@ public class StringOperationTests
     public void Migration_StringConcat_ConvertsToStringOp()
     {
         var csharp = "public class Test { public string M(string a, string b) => string.Concat(a, b); }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -897,7 +897,7 @@ public class StringOperationTests
     public void Migration_StringJoin_ConvertsToStringOp()
     {
         var csharp = "public class Test { public string M(string[] items) => string.Join(\",\", items); }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -910,7 +910,7 @@ public class StringOperationTests
     public void Migration_StringFormat_ConvertsToStringOp()
     {
         var csharp = "public class Test { public string M(string name) => string.Format(\"Hello {0}\", name); }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -931,7 +931,7 @@ public class StringOperationTests
     public void Migration_StringMethodWithComparison_ConvertsWithMode(string csharpExpr, StringOp expectedOp, StringComparisonMode expectedMode)
     {
         var csharp = $"public class Test {{ public object M(string s) => {csharpExpr}; }}";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -946,7 +946,7 @@ public class StringOperationTests
     {
         // The C# to Calor converter converts string.Equals(a, b, comparison) to equals with mode
         var csharp = "public class Test { public bool M(string a, string b) { return string.Equals(a, b, StringComparison.OrdinalIgnoreCase); } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -967,7 +967,7 @@ public class StringOperationTests
     public void Migration_StringComparisonMode_RoundTripsToCalor(string csharpExpr, string expectedKeyword)
     {
         var csharp = $"public class Test {{ public object M(string s) => {csharpExpr}; }}";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -985,7 +985,7 @@ public class StringOperationTests
     {
         // CurrentCulture modes are not supported - should fall back to interop
         var csharp = $"public class Test {{ public bool M(string s) {{ return {csharpExpr}; }} }}";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));

--- a/tests/Calor.Compiler.Tests/SwitchExpressionConversionTests.cs
+++ b/tests/Calor.Compiler.Tests/SwitchExpressionConversionTests.cs
@@ -417,7 +417,8 @@ public class SwitchExpressionConversionTests
 
         var result = _converter.Convert(csharpSource);
 
-        Assert.True(result.Success, GetErrorMessage(result));
+        Assert.False(result.Success);
+        Assert.Contains(result.Issues, issue => issue.Feature == "generated-calor-validation");
 
         var classNode = Assert.Single(result.Ast!.Classes);
         var method = Assert.Single(classNode.Methods);

--- a/tests/Calor.Compiler.Tests/SwitchExpressionConversionTests.cs
+++ b/tests/Calor.Compiler.Tests/SwitchExpressionConversionTests.cs
@@ -10,7 +10,7 @@ namespace Calor.Compiler.Tests;
 /// </summary>
 public class SwitchExpressionConversionTests
 {
-    private readonly CSharpToCalorConverter _converter = new();
+    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
 
     #region Basic Switch Expression
 

--- a/tests/Calor.Compiler.Tests/TernaryDecompositionTests.cs
+++ b/tests/Calor.Compiler.Tests/TernaryDecompositionTests.cs
@@ -10,7 +10,7 @@ namespace Calor.Compiler.Tests;
 /// </summary>
 public class TernaryDecompositionTests
 {
-    private readonly CSharpToCalorConverter _converter = new();
+    private readonly CSharpToCalorConverter _converter = new(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
 
     private string ConvertToCalor(string csharp)
     {

--- a/tests/Calor.Compiler.Tests/TypeOperationTests.cs
+++ b/tests/Calor.Compiler.Tests/TypeOperationTests.cs
@@ -317,7 +317,7 @@ public class TypeOperationTests
     public void Migration_CSharpCast_ConvertsToTypeOperationNode()
     {
         var csharp = "public class Test { public int M(object x) { return (int)x; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -332,7 +332,7 @@ public class TypeOperationTests
     public void Migration_CSharpIs_ConvertsToTypeOperationNode()
     {
         var csharp = "public class Test { public bool M(object x) { return x is string; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -347,7 +347,7 @@ public class TypeOperationTests
     public void Migration_CSharpAs_ConvertsToTypeOperationNode()
     {
         var csharp = "public class Test { public string M(object x) { return x as string; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -362,7 +362,7 @@ public class TypeOperationTests
     public void Migration_CSharpCast_RoundTripsToCalor()
     {
         var csharp = "public class Test { public int M(object x) { return (int)x; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -377,7 +377,7 @@ public class TypeOperationTests
     public void Migration_CSharpAs_RoundTripsToCalor()
     {
         var csharp = "public class Test { public string M(object x) { return x as string; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -392,7 +392,7 @@ public class TypeOperationTests
     public void Migration_CSharpIs_RoundTripsToCalor()
     {
         var csharp = "public class Test { public bool M(object x) { return x is string; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));
@@ -408,7 +408,7 @@ public class TypeOperationTests
     {
         // "x is string s" — declaration pattern, variable binding is not preserved but type check is
         var csharp = "public class Test { public bool M(object x) { if (x is string s) return true; return false; } }";
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success, string.Join(", ", result.Issues));

--- a/tests/Calor.Compiler.Tests/UnsafeLowLevelRoundtripTests.cs
+++ b/tests/Calor.Compiler.Tests/UnsafeLowLevelRoundtripTests.cs
@@ -36,7 +36,7 @@ public class UnsafeLowLevelRoundtripTests
 
     private static string ConvertToCalor(string csharpSource)
     {
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharpSource);
         Assert.True(result.Success,
             $"Conversion failed:\n{string.Join("\n", result.Issues.Select(i => i.Message))}");
@@ -51,7 +51,7 @@ public class UnsafeLowLevelRoundtripTests
     /// </summary>
     private static (string calor, string csharp) ConvertAndEmit(string csharpSource)
     {
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharpSource);
         Assert.True(result.Success,
             $"Conversion failed:\n{string.Join("\n", result.Issues.Select(i => i.Message))}");
@@ -105,7 +105,7 @@ public class UnsafeLowLevelRoundtripTests
     /// </summary>
     private static string FullRoundTrip(string csharpInput, string expectedCalorTag)
     {
-        var converter = new CSharpToCalorConverter();
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy });
         var result = converter.Convert(csharpInput);
         Assert.True(result.Success,
             $"Conversion failed:\n{string.Join("\n", result.Issues.Select(i => i.Message))}");

--- a/tests/Calor.Compiler.Tests/UnsupportedFeatureTelemetryTests.cs
+++ b/tests/Calor.Compiler.Tests/UnsupportedFeatureTelemetryTests.cs
@@ -125,7 +125,7 @@ public class UnsupportedFeatureTelemetryTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter(new ConversionOptions { GracefulFallback = true });
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, GracefulFallback = true });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success);
@@ -151,6 +151,7 @@ public class UnsupportedFeatureTelemetryTests
 
         var converter = new CSharpToCalorConverter(new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             GracefulFallback = true
         });
 
@@ -405,7 +406,7 @@ public class UnsupportedFeatureTelemetryTests
             }
             """;
 
-        var converter = new CSharpToCalorConverter(new ConversionOptions { GracefulFallback = true });
+        var converter = new CSharpToCalorConverter(new ConversionOptions { Fidelity = ConversionFidelity.Lossy, GracefulFallback = true });
         var result = converter.Convert(csharp);
 
         Assert.True(result.Success);

--- a/tests/Calor.Conversion.Tests/DS15FixtureRegistryTests.cs
+++ b/tests/Calor.Conversion.Tests/DS15FixtureRegistryTests.cs
@@ -85,6 +85,7 @@ public class DS15FixtureRegistryTests
         // 3. Conversion match: input.cs converts to exactly expected.calr.
         var converter = new CSharpToCalorConverter(new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             ModuleName = "Fixture",
             GracefulFallback = true,
             AutoGenerateIds = true

--- a/tests/Calor.Conversion.Tests/RegistryConformanceTests.cs
+++ b/tests/Calor.Conversion.Tests/RegistryConformanceTests.cs
@@ -24,6 +24,7 @@ public class RegistryConformanceTests
     {
         var converter = new CSharpToCalorConverter(new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             ModuleName = "ConformanceTest",
             GracefulFallback = true,
             AutoGenerateIds = true,
@@ -722,6 +723,7 @@ public class RegistryConformanceTests
 
         var converter = new CSharpToCalorConverter(new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             ModuleName = "ConformanceTest",
             GracefulFallback = true,
             AutoGenerateIds = true,

--- a/tests/Calor.Conversion.Tests/TestHelpers.cs
+++ b/tests/Calor.Conversion.Tests/TestHelpers.cs
@@ -19,6 +19,7 @@ public static class TestHelpers
     {
         var options = new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             ModuleName = moduleName,
             GracefulFallback = true,
             AutoGenerateIds = true,

--- a/tests/Calor.Conversion.Tests/WedgeW4SliceAStructuralTests.cs
+++ b/tests/Calor.Conversion.Tests/WedgeW4SliceAStructuralTests.cs
@@ -29,6 +29,7 @@ public class WedgeW4SliceAStructuralTests
     {
         var converter = new CSharpToCalorConverter(new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             ModuleName = "W4SliceA",
             GracefulFallback = true,
             AutoGenerateIds = true,

--- a/tools/Calor.RoundTrip.Harness/RoundTripPipeline.cs
+++ b/tools/Calor.RoundTrip.Harness/RoundTripPipeline.cs
@@ -275,6 +275,7 @@ public sealed class RoundTripPipeline
 
         var converter = new CSharpToCalorConverter(new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             GracefulFallback = true,
             PreserveComments = true,
             AutoGenerateIds = true,
@@ -385,6 +386,7 @@ public sealed class RoundTripPipeline
     {
         var converter = new CSharpToCalorConverter(new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             GracefulFallback = true,
             PreserveComments = true,
             AutoGenerateIds = true,

--- a/tools/Calor.RoundTrip.Harness/TaskGen/VerificationAddressability.cs
+++ b/tools/Calor.RoundTrip.Harness/TaskGen/VerificationAddressability.cs
@@ -144,6 +144,7 @@ public sealed class VerificationAddressability
     {
         var converter = new CSharpToCalorConverter(new ConversionOptions
         {
+            Fidelity = ConversionFidelity.Lossy,
             GracefulFallback = true,
             PreserveComments = true,
             AutoGenerateIds = true,


### PR DESCRIPTION
## Summary
- add explicit lossless/lossy fidelity policies with lossless defaults for CLI, MCP, and project migration
- preserve unsupported descendants at interop boundaries and require generated Calor plus round-tripped C# validation before success
- make conversion writes atomic and expose structured native/interop/substitution/drop counts and locations
- document the contract and add regression coverage for unsupported descendants, explicit lossy drops, atomic failure behavior, MCP, and mixed project migration

## Validation
- `dotnet test -c Release --no-restore` (8,817 passed, 18 skipped)

Closes #770