### PR TITLE
fix(dogfood): resolve the allowlist pre-registration deadlock

### DIFF
--- a/.calor-csharp-allowlist
+++ b/.calor-csharp-allowlist
@@ -44,3 +44,16 @@ src/Calor.Compiler/Reporting/ReviewPacketBuilder.cs
 src/Calor.Compiler/Refactoring/ProjectSymbolIndex.cs
 src/Calor.Compiler/Refactoring/RenameEngine.cs
 src/Calor.Compiler/Commands/RenameCommand.cs
+
+# Index + query v1, slice S1 (docs/plans/index-query-v1-scoping.md §7) —
+# persistent project index over the bound tree and its CLI. Compiler-internal
+# machinery of the same kind as #754: it reads symbols, occurrences and call
+# edges out of the binder, which Calor has no access to. The "# pending" markers
+# below are required by the guard's own pre-registration rule and are removed by
+# the PR that lands the files.
+# pending: lands with the S1 index PR
+src/Calor.Compiler/Indexing/ProjectIndex.cs
+# pending: lands with the S1 index PR
+src/Calor.Compiler/Indexing/ProjectIndexBuilder.cs
+# pending: lands with the S1 index PR
+src/Calor.Compiler/Commands/IndexCommand.cs

--- a/tools/calor-allowlist-audit/README.md
+++ b/tools/calor-allowlist-audit/README.md
@@ -24,6 +24,31 @@ Findings, one per defect:
 Existence is only reported for an otherwise well-formed path — a wildcard or
 non-`.cs` entry gets one finding, not two about the same defect.
 
+## Pending entries
+
+The Calor-first guard requires an allowlist entry to land **before** the PR that
+adds the C# file. Taken together with the staleness check above, that deadlocks:
+the guard demands the entry first, and this audit fails it for not existing yet.
+The deadlock was real — it blocked the first new `src/` file after this utility
+became blocking.
+
+A `# pending` comment on the line immediately above an entry marks it as
+pre-registered:
+
+```
+# pending: lands with the S1 index PR
+src/Calor.Compiler/Indexing/ProjectIndex.cs
+```
+
+The guard is unaffected (it skips comments, and the entry still grants
+permission). This audit reports the entry informationally instead of failing.
+
+**Pending is a temporary state and clears itself:** once the file exists, a
+still-marked entry is a *finding* — remove the marker. Otherwise the entry would
+keep its exemption from the staleness check forever, reopening the very hole
+this audit exists to close. The marker applies to exactly one entry; a blank
+line or any other comment clears it.
+
 Exit code is `0` when clean, `1` on findings, `2` if the allowlist is missing.
 Run it from the repository root.
 

--- a/tools/calor-allowlist-audit/allowlist-audit.calr
+++ b/tools/calor-allowlist-audit/allowlist-audit.calr
@@ -28,6 +28,11 @@
       §R BOOL:true
     §R §C{StartsWith} §A t §A "#" §/C
 
+  §F{f007:IsPendingMarker:pri} (str:line) -> bool
+    §E{}
+    §B{t:str} (trim line)
+    §R §C{StartsWith} §A t §A "# pending" §/C
+
   §F{f004:IsStructurallyExempt:pri} (str:path) -> bool
     §E{}
     §IF{if4} §C{StartsWith} §A path §A "tests/" §/C
@@ -56,9 +61,18 @@
     §B{~findings:i32} INT:0
     §B{~entries:i32} INT:0
 
+    §B{~pending:bool} BOOL:false
     §P "allowlist-audit: checking .calor-csharp-allowlist"
     §EACH{e1:raw} lines
       §B{skip:bool} §C{IsSkippable} §A raw §/C
+      §IF{if17} skip
+        // A "# pending" comment marks the entry on the NEXT line as
+        // pre-registered for code that has not merged yet. The Calor-first
+        // guard requires the entry to land before the file, so without this the
+        // two controls deadlock: the guard demands the entry first, and this
+        // audit fails it for not existing. Any other comment, or a blank line,
+        // clears the mark — the marker must sit immediately above its entry.
+        §ASSIGN pending §C{IsPendingMarker} §A raw §/C
       §IF{if8} (! skip)
         §B{entry:str} (trim raw)
         §ASSIGN entries (+ entries INT:1)
@@ -89,9 +103,23 @@
         §IF{if13} (! wild)
           §IF{if14} isCs
             §B{onDisk:bool} §C{File.Exists} §A entry §/C
+            // Pending is a temporary state and clears itself: once the file
+            // exists the marker must go, or the entry would keep its exemption
+            // from the staleness check forever — which is the hole this audit
+            // exists to close, reopened by the workaround for it.
+            §IF{if18} onDisk
+              §IF{if19} pending
+                §C{Report} §A entry §A "is marked pending but now exists; remove the pending marker" §/C
+                §ASSIGN findings (+ findings INT:1)
             §IF{if15} (! onDisk)
-              §C{Report} §A entry §A "does not exist; a stale entry keeps permission alive for a path nothing occupies" §/C
-              §ASSIGN findings (+ findings INT:1)
+              §IF{if20} pending
+                §P (+ "  " (+ entry " — pending: pre-registered, file not merged yet"))
+              §IF{if21} (! pending)
+                §C{Report} §A entry §A "does not exist; a stale entry keeps permission alive for a path nothing occupies" §/C
+                §ASSIGN findings (+ findings INT:1)
+
+        // The mark applies to exactly one entry, never to the rest of the file.
+        §ASSIGN pending BOOL:false
 
     §P (+ (+ (+ (+ "allowlist-audit: " entries) " entries, ") findings) " finding(s)")
     §IF{if16} (> findings INT:0)


### PR DESCRIPTION
The dogfood utility's **first real use** found a contradiction between two of this repository's own controls — and it currently blocks all new C# under `src/`.

## The deadlock

- The **Calor-first guard** requires an allowlist entry to land on main *before* the PR that adds the file, and explicitly forbids a PR from self-exempting.
- The **allowlist audit** (#930) fails any entry whose file does not exist.

So the pre-registration PR the guard demands is exactly the PR the audit fails. I hit this trying to start slice S1 of the index work.

Verified rather than reasoned — adding one unwritten path:

```
  src/Calor.Compiler/Indexing/ProjectIndex.cs — does not exist; a stale entry keeps permission alive for a path nothing occupies
allowlist-audit: 18 entries, 1 finding(s)
EXIT=1
```

## The fix

A `# pending` comment immediately above an entry marks it pre-registered:

```
# pending: lands with the S1 index PR
src/Calor.Compiler/Indexing/ProjectIndex.cs
```

The guard is unaffected — it skips comments, and the entry still grants permission. The audit reports it informationally instead of failing.

**Pending is temporary and clears itself.** Once the file exists, a still-marked entry is a *finding*: remove the marker. Without that rule, a pending marker would exempt an entry from the staleness check permanently — reopening the exact hole this audit exists to close, via the workaround for it.

## Verified, all four cases

| case | result |
|---|---|
| pending + file absent | informational, exit 0 |
| pending + file **exists** | **fails** — "remove the pending marker" |
| unmarked + file absent | still fails as stale (original check intact) |
| marker followed by two entries | applies to the first only, does not leak |

## Also

Pre-registers the three S1 index paths (`docs/plans/index-query-v1-scoping.md` §7) under the new convention, so the code PR is unblocked. This PR adds no C#, so it does not self-exempt.

Release build clean; all 11 test projects green; both guards pass; the audit reports `20 entries, 0 finding(s)`.