### PR TITLE
Persistent project index + `calor index` (index/query S1)

### DIFF
--- a/.calor-csharp-allowlist
+++ b/.calor-csharp-allowlist
@@ -51,9 +51,6 @@ src/Calor.Compiler/Commands/RenameCommand.cs
 # edges out of the binder, which Calor has no access to. The "# pending" markers
 # below are required by the guard's own pre-registration rule and are removed by
 # the PR that lands the files.
-# pending: lands with the S1 index PR
 src/Calor.Compiler/Indexing/ProjectIndex.cs
-# pending: lands with the S1 index PR
 src/Calor.Compiler/Indexing/ProjectIndexBuilder.cs
-# pending: lands with the S1 index PR
 src/Calor.Compiler/Commands/IndexCommand.cs

--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,8 @@ bench/phase0-agent-native/epochs/**/rejects/
 # so the intent survives that rule being loosened.
 tools/calor-allowlist-audit/obj/
 tools/calor-allowlist-audit/bin/
+
+# Project index (§2.2): build output derived from sources, carrying
+# machine-specific hashes. scripts/check-dogfood-utility.sh fails if one is
+# committed.
+.calor-index.json

--- a/scripts/check-dogfood-utility.sh
+++ b/scripts/check-dogfood-utility.sh
@@ -47,6 +47,14 @@ if [[ "$calr_count" -eq 0 ]]; then
   violations+=("no .calr source under $utility — the utility must be written in Calor")
 fi
 
+# The project index is build output: it is derived from sources, carries
+# machine-specific hashes, and would conflict on every merge. Same rule as the
+# generated C# above, checked repository-wide rather than only under the utility.
+mapfile -t tracked_indexes < <(git ls-files '*.calor-index.json')
+for path in "${tracked_indexes[@]}"; do
+  violations+=("$path (committed project index — it is build output, not source)")
+done
+
 if ((${#violations[@]} > 0)); then
   echo "Dogfood guard failed:" >&2
   printf '  %s\n' "${violations[@]}" >&2

--- a/src/Calor.Compiler/Commands/IndexCommand.cs
+++ b/src/Calor.Compiler/Commands/IndexCommand.cs
@@ -1,0 +1,163 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using Calor.Compiler.Indexing;
+
+namespace Calor.Compiler.Commands;
+
+/// <summary>
+/// Builds and inspects the persistent project index (§2.2; scoping doc §7 S1).
+///
+/// <c>calor index build</c> writes it; <c>calor index status</c> says whether it
+/// may still be trusted. Status exists because the interesting failure is not a
+/// missing index but a stale one that answers anyway.
+/// </summary>
+public static class IndexCommand
+{
+    private const string DefaultOptionsToken = "index-v1";
+
+    public static Command Create()
+    {
+        var command = new Command("index", "Build and inspect the project index")
+        {
+            CreateBuildCommand(),
+            CreateStatusCommand(),
+        };
+        return command;
+    }
+
+    private static Command CreateBuildCommand()
+    {
+        var pathArgument = new Argument<string>(
+            name: "path",
+            description: "Project directory to index",
+            getDefaultValue: () => ".");
+        var outputOption = new Option<string?>(
+            aliases: ["--output"],
+            description: "Where to write the index (default: <path>/obj/calor)");
+
+        var command = new Command("build", "Build the project index")
+        {
+            pathArgument, outputOption,
+        };
+
+        command.SetHandler((InvocationContext context) =>
+        {
+            var path = context.ParseResult.GetValueForArgument(pathArgument);
+            var output = context.ParseResult.GetValueForOption(outputOption);
+            context.ExitCode = Build(path, output);
+        });
+
+        return command;
+    }
+
+    private static Command CreateStatusCommand()
+    {
+        var pathArgument = new Argument<string>(
+            name: "path",
+            description: "Project directory",
+            getDefaultValue: () => ".");
+        var outputOption = new Option<string?>(
+            aliases: ["--output"],
+            description: "Where the index lives (default: <path>/obj/calor)");
+
+        var command = new Command("status", "Report whether the index is current")
+        {
+            pathArgument, outputOption,
+        };
+
+        command.SetHandler((InvocationContext context) =>
+        {
+            var path = context.ParseResult.GetValueForArgument(pathArgument);
+            var output = context.ParseResult.GetValueForOption(outputOption);
+            context.ExitCode = Status(path, output);
+        });
+
+        return command;
+    }
+
+    internal static string DefaultOutputDirectory(string projectDirectory) =>
+        Path.Combine(Path.GetFullPath(projectDirectory), "obj", "calor");
+
+    private static int Build(string projectDirectory, string? outputDirectory)
+    {
+        if (!Directory.Exists(projectDirectory))
+        {
+            Console.Error.WriteLine($"Error: directory not found: {projectDirectory}");
+            return 1;
+        }
+
+        var sources = ProjectIndexBuilder.DiscoverSources(projectDirectory);
+        if (sources.Count == 0)
+        {
+            Console.Error.WriteLine($"Error: no .calr files under {projectDirectory}");
+            return 1;
+        }
+
+        var options = new ProjectIndexBuilder.Options(
+            projectDirectory, DefaultOptionsToken, sources);
+        var index = ProjectIndexBuilder.Build(options);
+        var target = outputDirectory ?? DefaultOutputDirectory(projectDirectory);
+        index.Save(target);
+
+        Console.WriteLine(
+            $"index: {index.Declarations.Count} declarations, "
+                + $"{index.Occurrences.Count} occurrences, "
+                + $"{index.CallEdges.Count} call edges "
+                + $"from {sources.Count} file(s)");
+        ReportResidual(index);
+        Console.WriteLine($"index: written to {ProjectIndex.PathFor(target)}");
+        return 0;
+    }
+
+    private static int Status(string projectDirectory, string? outputDirectory)
+    {
+        var target = outputDirectory ?? DefaultOutputDirectory(projectDirectory);
+        var (index, status) = ProjectIndex.Load(target);
+        if (index == null)
+        {
+            Console.WriteLine($"index: not usable — {ProjectIndex.Explain(status)}");
+            return 1;
+        }
+
+        var sources = ProjectIndexBuilder.DiscoverSources(projectDirectory);
+        var inputs = ProjectIndexBuilder.CurrentInputs(
+            new ProjectIndexBuilder.Options(projectDirectory, DefaultOptionsToken, sources));
+        var freshness = index.CheckFreshness(
+            inputs.CompilerHash, inputs.OptionsHash, inputs.ManifestHash, inputs.Files);
+
+        if (freshness != ProjectIndex.Freshness.Fresh)
+        {
+            Console.WriteLine(
+                $"index: STALE — {ProjectIndex.Explain(freshness)}. Run `calor index build`.");
+            return 1;
+        }
+
+        Console.WriteLine(
+            $"index: current — {index.Declarations.Count} declarations, "
+                + $"{index.CallEdges.Count} call edges from {index.Files.Count} file(s)");
+        ReportResidual(index);
+        return 0;
+    }
+
+    /// <summary>
+    /// The residual is printed with the answer, never on request only. An index
+    /// that reports 400 call edges and stays silent about the 40 it could not
+    /// resolve is the shape this project keeps paying for.
+    /// </summary>
+    private static void ReportResidual(ProjectIndex index)
+    {
+        if (index.Residual.IsEmpty)
+        {
+            Console.WriteLine("index: no residual — every call site resolved, every file read");
+            return;
+        }
+
+        Console.WriteLine($"index: residual — {index.Residual.Total} item(s) not accounted for:");
+        foreach (var file in index.Residual.UnreadableFiles)
+            Console.WriteLine($"  unreadable: {file}");
+        foreach (var call in index.Residual.UnresolvedCalls)
+            Console.WriteLine($"  unresolved call: {call}");
+        foreach (var name in index.Residual.AmbiguousCallees)
+            Console.WriteLine($"  ambiguous callee: {name} (several declarations share the name)");
+    }
+}

--- a/src/Calor.Compiler/Indexing/ProjectIndex.cs
+++ b/src/Calor.Compiler/Indexing/ProjectIndex.cs
@@ -1,0 +1,243 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Calor.Compiler.Incremental;
+
+namespace Calor.Compiler.Indexing;
+
+/// <summary>
+/// A declaration the index can answer about.
+/// </summary>
+public sealed class IndexedDeclaration
+{
+    public string SymbolId { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string Kind { get; set; } = "";
+    public string File { get; set; } = "";
+    public int Line { get; set; }
+    public int Column { get; set; }
+}
+
+/// <summary>
+/// One identifier token that denotes a symbol.
+/// </summary>
+public sealed class IndexedOccurrence
+{
+    public string SymbolId { get; set; } = "";
+    public string File { get; set; } = "";
+    public int Line { get; set; }
+    public int Column { get; set; }
+    public string Kind { get; set; } = "";
+}
+
+/// <summary>
+/// A resolved call from one function to another.
+/// </summary>
+public sealed class IndexedCallEdge
+{
+    public string CallerSymbolId { get; set; } = "";
+    public string CalleeSymbolId { get; set; } = "";
+    public string File { get; set; } = "";
+    public int Line { get; set; }
+    public int Column { get; set; }
+}
+
+/// <summary>
+/// What the index could NOT account for. Every query reports this alongside its
+/// answer, because Calor binds one file at a time: cross-file edges come from a
+/// unique-name match that drops ambiguity, so an answer is "what we can name",
+/// never "everything". Reporting a clean-looking answer over silent holes is the
+/// failure shape this project has paid for repeatedly.
+/// </summary>
+public sealed class IndexResidual
+{
+    /// <summary>Files that did not parse or bind, so nothing in them is indexed.</summary>
+    public List<string> UnreadableFiles { get; set; } = [];
+
+    /// <summary>Call sites whose callee could not be resolved to a declaration.</summary>
+    public List<string> UnresolvedCalls { get; set; } = [];
+
+    /// <summary>Callee names matching more than one declaration, so the edge was dropped.</summary>
+    public List<string> AmbiguousCallees { get; set; } = [];
+
+    [JsonIgnore]
+    public bool IsEmpty =>
+        UnreadableFiles.Count == 0
+        && UnresolvedCalls.Count == 0
+        && AmbiguousCallees.Count == 0;
+
+    [JsonIgnore]
+    public int Total =>
+        UnreadableFiles.Count + UnresolvedCalls.Count + AmbiguousCallees.Count;
+}
+
+/// <summary>
+/// The persisted project index (§2.2; scoping doc §4).
+///
+/// The header carries the SAME invalidation inputs <see cref="BuildStateCache"/>
+/// uses. That is the point, not a convenience: an index that answers from stale
+/// state is #788/#883 in a new component — an input changes, nothing
+/// invalidates, and the answer reflects the previous world. A query against a
+/// header that no longer matches must rebuild or refuse; it may never answer.
+///
+/// Semantic hashes are per FILE, not per declaration (scoping doc §9.1, decided
+/// with the maintainer). `impact` therefore answers at file granularity.
+/// </summary>
+public sealed class ProjectIndex
+{
+    public const string CurrentFormatVersion = "1.0";
+
+    public string FormatVersion { get; set; } = CurrentFormatVersion;
+    public string CompilerSemanticsVersion { get; set; } =
+        BuildStateCache.CurrentCompilerSemanticsVersion;
+    public string CompilerHash { get; set; } = "";
+    public string OptionsHash { get; set; } = "";
+    public string ManifestHash { get; set; } = "";
+
+    /// <summary>
+    /// Repository-relative path → content hash. Doubles as the per-file semantic
+    /// hash: v1 rebuilds wholesale, so one hash per file serves both roles.
+    /// </summary>
+    public Dictionary<string, string> Files { get; set; } = [];
+
+    public List<IndexedDeclaration> Declarations { get; set; } = [];
+    public List<IndexedOccurrence> Occurrences { get; set; } = [];
+    public List<IndexedCallEdge> CallEdges { get; set; } = [];
+    public IndexResidual Residual { get; set; } = new();
+
+    public static string PathFor(string outputDirectory) =>
+        Path.Combine(outputDirectory, ".calor-index.json");
+
+    /// <summary>
+    /// Why an index cannot be used as-is. <see cref="Fresh"/> is the only value
+    /// that permits answering a query.
+    /// </summary>
+    public enum Freshness
+    {
+        Fresh,
+        Missing,
+        Unreadable,
+        FormatChanged,
+        SemanticsChanged,
+        CompilerChanged,
+        OptionsChanged,
+        ManifestChanged,
+        SourcesChanged,
+    }
+
+    /// <summary>
+    /// Compares a loaded index against the inputs that would build it now.
+    /// Every field the builder records is compared — a field recorded but not
+    /// compared is a silent staleness hole, which is exactly the defect class
+    /// #788 and #883 were.
+    /// </summary>
+    public Freshness CheckFreshness(
+        string compilerHash,
+        string optionsHash,
+        string manifestHash,
+        IReadOnlyDictionary<string, string> currentFiles)
+    {
+        ArgumentNullException.ThrowIfNull(currentFiles);
+
+        if (FormatVersion != CurrentFormatVersion)
+            return Freshness.FormatChanged;
+        if (CompilerSemanticsVersion != BuildStateCache.CurrentCompilerSemanticsVersion)
+            return Freshness.SemanticsChanged;
+        if (CompilerHash != compilerHash)
+            return Freshness.CompilerChanged;
+        if (OptionsHash != optionsHash)
+            return Freshness.OptionsChanged;
+        if (ManifestHash != manifestHash)
+            return Freshness.ManifestChanged;
+
+        if (Files.Count != currentFiles.Count)
+            return Freshness.SourcesChanged;
+        foreach (var (path, hash) in currentFiles)
+        {
+            if (!Files.TryGetValue(path, out var recorded) || recorded != hash)
+                return Freshness.SourcesChanged;
+        }
+
+        return Freshness.Fresh;
+    }
+
+    public static string Explain(Freshness freshness) => freshness switch
+    {
+        Freshness.Fresh => "up to date",
+        Freshness.Missing => "no index has been built",
+        Freshness.Unreadable => "the index file could not be read",
+        Freshness.FormatChanged => "the index format version changed",
+        Freshness.SemanticsChanged => "the compiler's semantics version changed",
+        Freshness.CompilerChanged => "the compiler changed",
+        Freshness.OptionsChanged => "the compilation options changed",
+        Freshness.ManifestChanged => "an effect manifest changed",
+        Freshness.SourcesChanged => "the source files changed",
+        _ => freshness.ToString(),
+    };
+
+    /// <summary>
+    /// Writes canonically: gate 2 compares index contents byte-for-byte between
+    /// full and incremental runs, so ordering may not depend on enumeration
+    /// order of the build.
+    /// </summary>
+    public void Save(string outputDirectory)
+    {
+        Directory.CreateDirectory(outputDirectory);
+        Canonicalize();
+        var json = JsonSerializer.Serialize(this, ProjectIndexJsonContext.Default.ProjectIndex);
+        File.WriteAllText(PathFor(outputDirectory), json + "\n");
+    }
+
+    public static (ProjectIndex? Index, Freshness Status) Load(string outputDirectory)
+    {
+        var path = PathFor(outputDirectory);
+        if (!File.Exists(path))
+            return (null, Freshness.Missing);
+
+        try
+        {
+            var index = JsonSerializer.Deserialize(
+                File.ReadAllText(path),
+                ProjectIndexJsonContext.Default.ProjectIndex);
+            return index == null
+                ? (null, Freshness.Unreadable)
+                : (index, Freshness.Fresh);
+        }
+        catch (JsonException)
+        {
+            return (null, Freshness.Unreadable);
+        }
+        catch (IOException)
+        {
+            return (null, Freshness.Unreadable);
+        }
+    }
+
+    public void Canonicalize()
+    {
+        Files = Files
+            .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+            .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal);
+        Declarations = [.. Declarations
+            .OrderBy(item => item.File, StringComparer.Ordinal)
+            .ThenBy(item => item.Line)
+            .ThenBy(item => item.Column)
+            .ThenBy(item => item.SymbolId, StringComparer.Ordinal)];
+        Occurrences = [.. Occurrences
+            .OrderBy(item => item.File, StringComparer.Ordinal)
+            .ThenBy(item => item.Line)
+            .ThenBy(item => item.Column)
+            .ThenBy(item => item.SymbolId, StringComparer.Ordinal)];
+        CallEdges = [.. CallEdges
+            .OrderBy(item => item.File, StringComparer.Ordinal)
+            .ThenBy(item => item.Line)
+            .ThenBy(item => item.Column)
+            .ThenBy(item => item.CalleeSymbolId, StringComparer.Ordinal)];
+        Residual.UnreadableFiles.Sort(StringComparer.Ordinal);
+        Residual.UnresolvedCalls.Sort(StringComparer.Ordinal);
+        Residual.AmbiguousCallees.Sort(StringComparer.Ordinal);
+    }
+}
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(ProjectIndex))]
+internal sealed partial class ProjectIndexJsonContext : JsonSerializerContext { }

--- a/src/Calor.Compiler/Indexing/ProjectIndexBuilder.cs
+++ b/src/Calor.Compiler/Indexing/ProjectIndexBuilder.cs
@@ -1,0 +1,208 @@
+using Calor.Compiler.Binding;
+using Calor.Compiler.Incremental;
+using Calor.Compiler.Parsing;
+using Calor.Compiler.Refactoring;
+
+namespace Calor.Compiler.Indexing;
+
+/// <summary>
+/// Builds a <see cref="ProjectIndex"/> from a set of Calor sources.
+///
+/// The in-memory model is <see cref="ProjectSymbolIndex"/> — the same one the
+/// rename harness addresses (§2.5 gate 4). This builder persists that model
+/// rather than growing a second one, so identity, cross-file resolution, and the
+/// exact-identifier rule cannot drift between the two consumers.
+///
+/// v1 rebuilds wholesale (scoping doc §3): there is no incremental path, and the
+/// header's inputs are what make a stale index detectable rather than silent.
+/// </summary>
+public static class ProjectIndexBuilder
+{
+    public sealed record Options(
+        string ProjectDirectory,
+        string OptionsToken,
+        IReadOnlyList<string> Files);
+
+    /// <summary>
+    /// Collects the .calr sources under a directory, in a deterministic order.
+    /// </summary>
+    public static IReadOnlyList<string> DiscoverSources(string projectDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(projectDirectory);
+        if (!Directory.Exists(projectDirectory))
+            return [];
+
+        return Directory
+            .GetFiles(projectDirectory, "*.calr", SearchOption.AllDirectories)
+            .Where(path => !IsExcluded(path))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static bool IsExcluded(string path)
+    {
+        var normalized = path.Replace('\\', '/');
+        return normalized.Contains("/obj/", StringComparison.Ordinal)
+            || normalized.Contains("/bin/", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The invalidation inputs as they stand right now, in the same shape the
+    /// index header records them. Callers compare these against a loaded index
+    /// to decide whether it may answer.
+    /// </summary>
+    public static (string CompilerHash, string OptionsHash, string ManifestHash,
+        Dictionary<string, string> Files) CurrentInputs(Options options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var manifestDirectories = options.Files
+            .Select(file => Path.GetDirectoryName(Path.GetFullPath(file))!)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        if (manifestDirectories.Count == 0)
+            manifestDirectories.Add(Path.GetFullPath(options.ProjectDirectory));
+
+        var files = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var file in options.Files)
+        {
+            files[Relative(options.ProjectDirectory, file)] =
+                BuildStateCache.ComputeFileHash(file);
+        }
+
+        return (
+            BuildStateCache.ComputeCliCompilerHash(),
+            BuildStateCache.ComputeOptionsHash(options.OptionsToken),
+            BuildStateCache.ComputeManifestHash(manifestDirectories),
+            files);
+    }
+
+    public static ProjectIndex Build(Options options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var inputs = CurrentInputs(options);
+        var index = new ProjectIndex
+        {
+            CompilerHash = inputs.CompilerHash,
+            OptionsHash = inputs.OptionsHash,
+            ManifestHash = inputs.ManifestHash,
+            Files = inputs.Files,
+        };
+
+        var symbols = ProjectSymbolIndex.Build(options.Files, out var skipped);
+        foreach (var unreadable in skipped)
+            index.Residual.UnreadableFiles.Add(Relative(options.ProjectDirectory, unreadable));
+
+        var declarationIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var document in symbols.Documents)
+        {
+            var relative = Relative(options.ProjectDirectory, document.FilePath);
+
+            foreach (var symbol in document.BoundModule.SymbolsById.Values)
+            {
+                if (symbol.Id.IsNone || !declarationIds.Add(symbol.Id.Value))
+                    continue;
+
+                var (line, column) = LineColumn(document.Source, symbol.DeclarationSpan.Start);
+                index.Declarations.Add(new IndexedDeclaration
+                {
+                    SymbolId = symbol.Id.Value,
+                    Name = symbol.Name,
+                    Kind = KindOf(symbol),
+                    File = relative,
+                    Line = line,
+                    Column = column,
+                });
+            }
+        }
+
+        foreach (var document in symbols.Documents)
+        {
+            var relative = Relative(options.ProjectDirectory, document.FilePath);
+            foreach (var occurrence in symbols.OccurrencesIn(document.FilePath))
+            {
+                var (line, column) = LineColumn(document.Source, occurrence.Span.Start);
+                index.Occurrences.Add(new IndexedOccurrence
+                {
+                    SymbolId = occurrence.SymbolId.Value,
+                    File = relative,
+                    Line = line,
+                    Column = column,
+                    Kind = occurrence.Kind.ToString(),
+                });
+            }
+        }
+
+        var sourcesByPath = symbols.Documents.ToDictionary(
+            document => document.FilePath,
+            document => document.Source,
+            StringComparer.Ordinal);
+        foreach (var edge in symbols.CallEdges)
+        {
+            var (line, column) = LineColumn(sourcesByPath[edge.FilePath], edge.Span.Start);
+            index.CallEdges.Add(new IndexedCallEdge
+            {
+                CallerSymbolId = edge.CallerSymbolId.Value,
+                CalleeSymbolId = edge.CalleeSymbolId.Value,
+                File = Relative(options.ProjectDirectory, edge.FilePath),
+                Line = line,
+                Column = column,
+            });
+        }
+
+        foreach (var unresolved in symbols.Residual.UnresolvedCalls)
+            index.Residual.UnresolvedCalls.Add(RelativePrefix(options.ProjectDirectory, unresolved));
+        foreach (var ambiguous in symbols.Residual.AmbiguousCallees)
+            index.Residual.AmbiguousCallees.Add(ambiguous);
+
+        index.Canonicalize();
+        return index;
+    }
+
+    private static string KindOf(Symbol symbol) => symbol switch
+    {
+        FunctionSymbol => "function",
+        TypeSymbol => "type",
+        VariableSymbol { IsParameter: true } => "parameter",
+        VariableSymbol { IsField: true } => "field",
+        VariableSymbol { IsProperty: true } => "property",
+        VariableSymbol => "local",
+        _ => "symbol",
+    };
+
+    private static string Relative(string projectDirectory, string path)
+    {
+        var full = Path.GetFullPath(path);
+        var root = Path.GetFullPath(projectDirectory);
+        return Path.GetRelativePath(root, full).Replace('\\', '/');
+    }
+
+    private static string RelativePrefix(string projectDirectory, string entry)
+    {
+        var separator = entry.IndexOf(": ", StringComparison.Ordinal);
+        return separator < 0
+            ? entry
+            : Relative(projectDirectory, entry[..separator]) + entry[separator..];
+    }
+
+    private static (int Line, int Column) LineColumn(string source, int offset)
+    {
+        var line = 1;
+        var column = 1;
+        for (var index = 0; index < offset && index < source.Length; index++)
+        {
+            if (source[index] == '\n')
+            {
+                line++;
+                column = 1;
+            }
+            else
+            {
+                column++;
+            }
+        }
+
+        return (line, column);
+    }
+}

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -268,6 +268,7 @@ public class Program
         rootCommand.AddCommand(InitCommand.Create());
         rootCommand.AddCommand(FormatCommand.Create());
         rootCommand.AddCommand(RenameCommand.Create());
+        rootCommand.AddCommand(IndexCommand.Create());
         rootCommand.AddCommand(LintCommand.Create());
         rootCommand.AddCommand(AssessCommand.Create());
         rootCommand.AddCommand(AnalyzeConvertibilityCommand.Create());

--- a/src/Calor.Compiler/Refactoring/ProjectSymbolIndex.cs
+++ b/src/Calor.Compiler/Refactoring/ProjectSymbolIndex.cs
@@ -37,6 +37,24 @@ public sealed record IndexedDocument(
     BoundModule BoundModule);
 
 /// <summary>
+/// A call resolved to a declaration, attributed to the function containing it.
+/// </summary>
+public sealed record ProjectCallEdge(
+    SymbolId CallerSymbolId,
+    SymbolId CalleeSymbolId,
+    string FilePath,
+    TextSpan Span);
+
+/// <summary>
+/// What resolution could not account for. Kept beside the edges rather than
+/// discarded: a caller list computed from partial resolution is only honest if
+/// the part it could not resolve travels with it.
+/// </summary>
+public sealed record ProjectResolutionResidual(
+    IReadOnlyList<string> UnresolvedCalls,
+    IReadOnlyList<string> AmbiguousCallees);
+
+/// <summary>
 /// A project-wide map from <see cref="SymbolId"/> to the identifier tokens that
 /// denote it, built from bound trees rather than from text.
 ///
@@ -49,8 +67,18 @@ public sealed class ProjectSymbolIndex
 {
     private readonly Dictionary<SymbolId, List<SymbolOccurrence>> _bySymbol = [];
     private readonly Dictionary<string, List<SymbolOccurrence>> _byFile;
+    private readonly List<ProjectCallEdge> _callEdges = [];
+    private readonly List<string> _unresolvedCalls = [];
+    private readonly SortedSet<string> _ambiguousCallees = new(StringComparer.Ordinal);
 
     public IReadOnlyList<IndexedDocument> Documents { get; }
+
+    /// <summary>Calls resolved to a declaration, attributed to their containing function.</summary>
+    public IReadOnlyList<ProjectCallEdge> CallEdges => _callEdges;
+
+    /// <summary>What resolution could not account for; travels with the edges.</summary>
+    public ProjectResolutionResidual Residual =>
+        new(_unresolvedCalls, [.. _ambiguousCallees]);
 
     private ProjectSymbolIndex(IReadOnlyList<IndexedDocument> documents)
     {
@@ -119,6 +147,12 @@ public sealed class ProjectSymbolIndex
         index.Populate();
         return index;
     }
+
+    /// <summary>Every indexed occurrence in one file, in document order.</summary>
+    public IReadOnlyList<SymbolOccurrence> OccurrencesIn(string filePath) =>
+        _byFile.TryGetValue(filePath, out var occurrences)
+            ? occurrences
+            : Array.Empty<SymbolOccurrence>();
 
     public IReadOnlyList<SymbolOccurrence> Occurrences(SymbolId symbolId) =>
         _bySymbol.TryGetValue(symbolId, out var occurrences)
@@ -250,6 +284,36 @@ public sealed class ProjectSymbolIndex
                 }
             }
 
+            // Call edges are collected per function rather than from a flat walk,
+            // because an edge needs the function that CONTAINS the call, and a
+            // flat walk of the module has no notion of "containing".
+            foreach (var function in document.BoundModule.Functions)
+            {
+                foreach (var node in Descendants(function))
+                {
+                    if (node is not BoundCallExpression call)
+                        continue;
+
+                    var callee = call.ResolvedSymbols.Count > 0
+                        ? call.ResolvedSymbols[0]
+                        : ResolveAcrossDocuments(call);
+                    if (callee is { Id.IsNone: false })
+                    {
+                        _callEdges.Add(new ProjectCallEdge(
+                            function.Symbol.Id, callee.Id, document.FilePath, call.CalleeSpan));
+                    }
+                    else
+                    {
+                        // Named, not counted: "3 unresolved" tells a reader
+                        // nothing they can act on.
+                        _unresolvedCalls.Add(
+                            $"{document.FilePath}: {call.Target}");
+                        if (IsAmbiguousAcrossDocuments(call))
+                            _ambiguousCallees.Add(call.Target);
+                    }
+                }
+            }
+
             // Module names are indexed so a rename can be refused explicitly
             // rather than silently doing nothing.
             var moduleId = SymbolId.Create(
@@ -290,6 +354,26 @@ public sealed class ProjectSymbolIndex
                 .ToArray();
 
             return candidates.Length == 1 ? candidates[0] : null;
+        }
+
+        // Distinguishes "no such name" from "several declarations share it".
+        // Both drop the edge, but only the second is a resolution *limit* worth
+        // reporting separately — it is what 0.14's typed signatures fix.
+        bool IsAmbiguousAcrossDocuments(BoundCallExpression call)
+        {
+            var target = call.Target;
+            if (string.IsNullOrEmpty(target) || target.Contains('.', StringComparison.Ordinal))
+                return false;
+
+            return Documents
+                .SelectMany(candidate => candidate.BoundModule.SymbolsById.Values
+                    .OfType<FunctionSymbol>())
+                .Where(symbol => !symbol.Id.IsNone
+                    && string.Equals(
+                        BareFunctionName(symbol.Name), target, StringComparison.Ordinal))
+                .DistinctBy(symbol => symbol.Id)
+                .Take(2)
+                .Count() > 1;
         }
 
         void Add(

--- a/tests/Calor.Compiler.Tests/EditScriptIdentityTests.cs
+++ b/tests/Calor.Compiler.Tests/EditScriptIdentityTests.cs
@@ -75,6 +75,79 @@ public sealed class EditScriptIdentityTests : IDisposable
 
     [Theory]
     [MemberData(nameof(RegisteredScripts))]
+    public void IndexContentsAreIdenticalToAFullRebuild(string scriptName)
+    {
+        // Gate 2's index-contents leg (roadmap §2.5 gate 2), which became live
+        // when the index shipped. It rides the corpus that already exists rather
+        // than adding a second one.
+        //
+        // v1 rebuilds the index wholesale, so this leg is not yet load-bearing
+        // against an incremental index — it pins the *canonical form*: the index
+        // built for a given workspace state must serialise byte-identically no
+        // matter what states preceded it. That is what makes the comparison
+        // meaningful the day an incremental path exists.
+        var script = LoadScript(scriptName);
+
+        var fresh = new List<string>();
+        foreach (var step in script.Steps)
+        {
+            var workspace = CreateTempDir();
+            SyncWorkspace(workspace, step.SourceDirectory);
+            fresh.Add(SerializeIndex(workspace, step));
+        }
+
+        var sequential = new List<string>();
+        var reused = CreateTempDir();
+        foreach (var step in script.Steps)
+        {
+            SyncWorkspace(reused, step.SourceDirectory);
+            sequential.Add(SerializeIndex(reused, step));
+        }
+
+        for (var index = 0; index < script.Steps.Count; index++)
+            Assert.Equal(fresh[index], sequential[index]);
+    }
+
+    /// <summary>
+    /// The index for a workspace, serialised canonically with the volatile
+    /// header stripped. Compiler and manifest hashes depend on the machine and
+    /// the temp path, not on the workspace's contents, so comparing them would
+    /// make the test fail for reasons that have nothing to do with the index.
+    /// </summary>
+    private static string SerializeIndex(string workspace, ScriptStep step)
+    {
+        var sources = Directory.GetFiles(workspace, "*.calr")
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+        var index = Indexing.ProjectIndexBuilder.Build(
+            new Indexing.ProjectIndexBuilder.Options(workspace, step.Options, sources));
+
+        var lines = new List<string>();
+        foreach (var declaration in index.Declarations)
+        {
+            lines.Add(
+                $"decl|{declaration.File}|{declaration.Line}|{declaration.Column}"
+                    + $"|{declaration.Kind}|{declaration.Name}");
+        }
+        foreach (var edge in index.CallEdges)
+            lines.Add($"edge|{edge.File}|{edge.Line}|{edge.Column}");
+        foreach (var occurrence in index.Occurrences)
+        {
+            lines.Add(
+                $"occ|{occurrence.File}|{occurrence.Line}|{occurrence.Column}|{occurrence.Kind}");
+        }
+        foreach (var unreadable in index.Residual.UnreadableFiles)
+            lines.Add($"residual-unreadable|{unreadable}");
+        foreach (var unresolved in index.Residual.UnresolvedCalls)
+            lines.Add($"residual-unresolved|{unresolved}");
+        foreach (var ambiguous in index.Residual.AmbiguousCallees)
+            lines.Add($"residual-ambiguous|{ambiguous}");
+
+        return string.Join("\n", lines);
+    }
+
+    [Theory]
+    [MemberData(nameof(RegisteredScripts))]
     public void CacheReuseMatchesTheScriptsRegisteredExpectation(string scriptName)
     {
         // The anti-vacuity leg. Byte-identical diagnostics are free if the

--- a/tests/Calor.Compiler.Tests/ProjectIndexTests.cs
+++ b/tests/Calor.Compiler.Tests/ProjectIndexTests.cs
@@ -1,0 +1,283 @@
+using Calor.Compiler.Indexing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Index persistence and — the part that matters — staleness.
+///
+/// A missing index is harmless: you notice. A STALE index that answers anyway
+/// is #788/#883 in a new component, and it is the failure this suite exists to
+/// make impossible.
+/// </summary>
+public sealed class ProjectIndexTests : IDisposable
+{
+    private readonly List<string> _dirs = [];
+
+    public void Dispose()
+    {
+        foreach (var dir in _dirs)
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    private string NewProject(params (string Name, string Source)[] files)
+    {
+        var dir = Path.Combine(
+            Path.GetTempPath(), "calor-index-" + Guid.NewGuid().ToString("N")[..12]);
+        Directory.CreateDirectory(dir);
+        _dirs.Add(dir);
+        foreach (var (name, source) in files)
+            File.WriteAllText(Path.Combine(dir, name), source);
+        return dir;
+    }
+
+    private static ProjectIndexBuilder.Options OptionsFor(string dir, string token = "t") =>
+        new(dir, token, ProjectIndexBuilder.DiscoverSources(dir));
+
+    private const string Library = """
+        §M{m001:Lib}
+          §F{f001:Double:pub} (i32:n) -> i32
+            §E{}
+            §R (* n INT:2)
+        """;
+
+    private const string App = """
+        §M{m002:App}
+          §F{f001:Run:pub} () -> i32
+            §E{}
+            §R §C{Double} §A INT:5 §/C
+        """;
+
+    // --- staleness: every recorded input must be compared -------------------
+
+    public static TheoryData<string> HeaderInputs()
+    {
+        var data = new TheoryData<string>();
+        foreach (var input in new[]
+                 { "compiler", "options", "manifest", "sources", "format", "semantics" })
+        {
+            data.Add(input);
+        }
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(HeaderInputs))]
+    public void EveryRecordedHeaderInputIsCompared(string input)
+    {
+        // The discriminating test the scoping doc requires: mutate one recorded
+        // input and the index must refuse to be considered fresh. An input the
+        // builder records but the check ignores is a silent staleness hole —
+        // precisely the defect #788 and #883 were.
+        var dir = NewProject(("lib.calr", Library), ("app.calr", App));
+        var options = OptionsFor(dir);
+        var index = ProjectIndexBuilder.Build(options);
+        var inputs = ProjectIndexBuilder.CurrentInputs(options);
+
+        Assert.Equal(
+            ProjectIndex.Freshness.Fresh,
+            index.CheckFreshness(
+                inputs.CompilerHash, inputs.OptionsHash, inputs.ManifestHash, inputs.Files));
+
+        var compiler = inputs.CompilerHash;
+        var optionsHash = inputs.OptionsHash;
+        var manifest = inputs.ManifestHash;
+        var files = new Dictionary<string, string>(inputs.Files, StringComparer.Ordinal);
+        var expected = ProjectIndex.Freshness.Fresh;
+
+        switch (input)
+        {
+            case "compiler":
+                compiler = "different";
+                expected = ProjectIndex.Freshness.CompilerChanged;
+                break;
+            case "options":
+                optionsHash = "different";
+                expected = ProjectIndex.Freshness.OptionsChanged;
+                break;
+            case "manifest":
+                manifest = "different";
+                expected = ProjectIndex.Freshness.ManifestChanged;
+                break;
+            case "sources":
+                files["lib.calr"] = "different";
+                expected = ProjectIndex.Freshness.SourcesChanged;
+                break;
+            case "format":
+                index.FormatVersion = "0.0-old";
+                expected = ProjectIndex.Freshness.FormatChanged;
+                break;
+            case "semantics":
+                index.CompilerSemanticsVersion = "calor-semantics-from-another-era";
+                expected = ProjectIndex.Freshness.SemanticsChanged;
+                break;
+        }
+
+        Assert.Equal(
+            expected,
+            index.CheckFreshness(compiler, optionsHash, manifest, files));
+    }
+
+    [Fact]
+    public void AddingOrRemovingAFileIsStale()
+    {
+        var dir = NewProject(("lib.calr", Library), ("app.calr", App));
+        var index = ProjectIndexBuilder.Build(OptionsFor(dir));
+
+        File.WriteAllText(Path.Combine(dir, "extra.calr"), """
+            §M{m003:Extra}
+              §F{f001:Nothing:pub} () -> i32
+                §E{}
+                §R INT:0
+            """);
+        var afterAdd = ProjectIndexBuilder.CurrentInputs(OptionsFor(dir));
+        Assert.Equal(
+            ProjectIndex.Freshness.SourcesChanged,
+            index.CheckFreshness(
+                afterAdd.CompilerHash, afterAdd.OptionsHash, afterAdd.ManifestHash, afterAdd.Files));
+
+        File.Delete(Path.Combine(dir, "extra.calr"));
+        File.Delete(Path.Combine(dir, "app.calr"));
+        var afterDelete = ProjectIndexBuilder.CurrentInputs(OptionsFor(dir));
+        Assert.Equal(
+            ProjectIndex.Freshness.SourcesChanged,
+            index.CheckFreshness(
+                afterDelete.CompilerHash, afterDelete.OptionsHash,
+                afterDelete.ManifestHash, afterDelete.Files));
+    }
+
+    // --- persistence -------------------------------------------------------
+
+    [Fact]
+    public void SaveAndLoadRoundTripsContents()
+    {
+        var dir = NewProject(("lib.calr", Library), ("app.calr", App));
+        var built = ProjectIndexBuilder.Build(OptionsFor(dir));
+        var output = Path.Combine(dir, "obj", "calor");
+        built.Save(output);
+
+        var (loaded, status) = ProjectIndex.Load(output);
+        Assert.Equal(ProjectIndex.Freshness.Fresh, status);
+        Assert.NotNull(loaded);
+        Assert.Equal(built.Declarations.Count, loaded!.Declarations.Count);
+        Assert.Equal(built.CallEdges.Count, loaded.CallEdges.Count);
+        Assert.Equal(built.Files, loaded.Files);
+
+        var inputs = ProjectIndexBuilder.CurrentInputs(OptionsFor(dir));
+        Assert.Equal(
+            ProjectIndex.Freshness.Fresh,
+            loaded.CheckFreshness(
+                inputs.CompilerHash, inputs.OptionsHash, inputs.ManifestHash, inputs.Files));
+    }
+
+    [Fact]
+    public void CorruptIndexIsUnreadableRatherThanTrusted()
+    {
+        var dir = NewProject(("lib.calr", Library));
+        var output = Path.Combine(dir, "obj", "calor");
+        Directory.CreateDirectory(output);
+        File.WriteAllText(ProjectIndex.PathFor(output), "{ this is not json");
+
+        var (index, status) = ProjectIndex.Load(output);
+        Assert.Null(index);
+        Assert.Equal(ProjectIndex.Freshness.Unreadable, status);
+    }
+
+    [Fact]
+    public void BuildIsDeterministicRegardlessOfInputOrder()
+    {
+        // Gate 2 compares index contents byte-for-byte, so ordering may not
+        // follow the order files happened to be enumerated in.
+        var dir = NewProject(("lib.calr", Library), ("app.calr", App));
+        var sources = ProjectIndexBuilder.DiscoverSources(dir);
+
+        var forward = ProjectIndexBuilder.Build(
+            new ProjectIndexBuilder.Options(dir, "t", sources));
+        var reversed = ProjectIndexBuilder.Build(
+            new ProjectIndexBuilder.Options(dir, "t", sources.Reverse().ToArray()));
+
+        var a = Path.Combine(dir, "a");
+        var b = Path.Combine(dir, "b");
+        forward.Save(a);
+        reversed.Save(b);
+        Assert.Equal(
+            File.ReadAllText(ProjectIndex.PathFor(a)),
+            File.ReadAllText(ProjectIndex.PathFor(b)));
+    }
+
+    // --- residual ----------------------------------------------------------
+
+    [Fact]
+    public void UnresolvedAndAmbiguousCallsAreNamedNotDropped()
+    {
+        // An index that reports its edges and stays silent about what it could
+        // not resolve is the shape this project keeps paying for.
+        var dir = NewProject(
+            ("a.calr", """
+                §M{m001:A}
+                  §F{f001:Shared:pub} () -> i32
+                    §E{}
+                    §R INT:1
+                  §F{f002:Caller:pub} () -> i32
+                    §E{}
+                    §R §C{Missing} §/C
+                """),
+            ("b.calr", """
+                §M{m002:B}
+                  §F{f001:Shared:pub} () -> i32
+                    §E{}
+                    §R INT:2
+                """),
+            ("c.calr", """
+                §M{m003:C}
+                  §F{f001:Ask:pub} () -> i32
+                    §E{}
+                    §R §C{Shared} §/C
+                """));
+
+        var index = ProjectIndexBuilder.Build(OptionsFor(dir));
+
+        Assert.False(index.Residual.IsEmpty);
+        Assert.Contains(index.Residual.UnresolvedCalls, entry => entry.Contains("Missing"));
+        // `Shared` is declared twice, so the cross-file call from c.calr cannot
+        // be attributed — and the ambiguity is named, not merely counted.
+        Assert.Contains("Shared", index.Residual.AmbiguousCallees);
+        Assert.DoesNotContain(
+            index.CallEdges,
+            edge => edge.File == "c.calr");
+    }
+
+    [Fact]
+    public void UnreadableFilesAreReportedNotSilentlySkipped()
+    {
+        var dir = NewProject(
+            ("good.calr", Library),
+            ("broken.calr", "§M{m009:Broken}\n  this is not Calor\n"));
+
+        var index = ProjectIndexBuilder.Build(OptionsFor(dir));
+        Assert.Contains("broken.calr", index.Residual.UnreadableFiles);
+        Assert.Contains(index.Declarations, declaration => declaration.Name == "Double");
+    }
+
+    // --- contents ----------------------------------------------------------
+
+    [Fact]
+    public void CrossFileCallProducesAnEdgeWithItsCaller()
+    {
+        var dir = NewProject(("lib.calr", Library), ("app.calr", App));
+        var index = ProjectIndexBuilder.Build(OptionsFor(dir));
+
+        var callee = Assert.Single(
+            index.Declarations.Where(declaration => declaration.Name == "Double"));
+        var caller = Assert.Single(
+            index.Declarations.Where(declaration => declaration.Name == "Run"));
+        var edge = Assert.Single(index.CallEdges);
+
+        Assert.Equal(caller.SymbolId, edge.CallerSymbolId);
+        Assert.Equal(callee.SymbolId, edge.CalleeSymbolId);
+        Assert.Equal("app.calr", edge.File);
+        Assert.True(index.Residual.IsEmpty);
+    }
+}


### PR DESCRIPTION
First slice of the §2.2 deliverable, per `docs/plans/index-query-v1-scoping.md` §7.

## Built on what exists

The in-memory model is `ProjectSymbolIndex` — the same one the rename harness addresses — extended with **call edges** and a **resolution residual**. Persisting that rather than growing a second model keeps identity, cross-file resolution, and the exact-identifier rule from drifting between two consumers.

## Staleness is the point, not persistence

The header records the *same* invalidation inputs `BuildStateCache` uses: format version, semantics version, compiler hash, options token, manifest hash, and per-file content hashes. `calor index status` **refuses** a mismatched index rather than answering from it.

```
$ calor index status .
index: STALE — the source files changed. Run `calor index build`.
```

Pinned by a test that mutates **each recorded input in turn** and requires the matching refusal — an input the builder records but the check ignores is a silent staleness hole, which is exactly what #788 and #883 were. **Verified discriminating:** deleting the options-hash comparison fails precisely the `options` case and nothing else.

## Residuals travel with the answer

Calor binds one file at a time, so a cross-file call resolves only when exactly one declaration bears the name. Unresolved calls, ambiguous callees, and unreadable files are **named**, not counted or silently dropped:

```
index: 5 declarations, 9 occurrences, 1 call edges from 3 file(s)
index: residual — 3 item(s) not accounted for:
  unresolved call: a.calr: Missing
  unresolved call: c.calr: Shared
  ambiguous callee: Shared (several declarations share the name)
```

Ambiguity is reported *separately* from "no such name", because only the former is a resolution limit — and it is what 0.14's typed signatures fix.

## Decisions carried from the scoping doc

- **Per-file semantic hashes** (§9.1, maintainer decision). `impact` will answer at file granularity; the S3 checkpoint revisits it with a real answer in hand rather than a prediction.
- **Wholesale rebuild** (§3). No incremental path in v1.

## Gate 2's index-contents leg is now live

It rides the existing edit-script corpus rather than adding a second one: the index for a workspace state must serialise identically regardless of which states preceded it. With a wholesale rebuild that pins the *canonical form* — which is what makes the comparison meaningful the day an incremental path exists. The test says so rather than implying it is already load-bearing.

## Housekeeping

The index is build output: gitignored, and the dogfood guard now fails if one is committed anywhere in the repo (verified by planting one). The three `# pending` allowlist markers were removed now that the files exist — the self-clearing rule from #933 working as designed.

Release build clean (0 warnings); all 11 test projects green; both guards pass; the allowlist audit reports `20 entries, 0 finding(s)`.

Next: S2 — `calor query symbol|callers|callees` over this index, with the gate-3 golden corpus.