### PR TITLE
chore: pre-register the S2 query command path

### DIFF
--- a/.calor-csharp-allowlist
+++ b/.calor-csharp-allowlist
@@ -54,3 +54,9 @@ src/Calor.Compiler/Commands/RenameCommand.cs
 src/Calor.Compiler/Indexing/ProjectIndex.cs
 src/Calor.Compiler/Indexing/ProjectIndexBuilder.cs
 src/Calor.Compiler/Commands/IndexCommand.cs
+
+# Index + query v1, slice S2 (docs/plans/index-query-v1-scoping.md §7) — the
+# query surface over the persisted index. Compiler-internal, same rationale as
+# the S1 entries above.
+# pending: lands with the S2 query PR
+src/Calor.Compiler/Commands/QueryCommand.cs


### PR DESCRIPTION
Pre-registration for the index/query S2 slice, using the `# pending` convention from #933.

Adds one entry:

- `src/Calor.Compiler/Commands/QueryCommand.cs` — the query surface over the persisted index (`docs/plans/index-query-v1-scoping.md` §7 S2). Compiler-internal, same rationale as the S1 entries: it reads symbols, occurrences and call edges out of the binder's output, which Calor has no access to.

The audit reports it as pending rather than stale, and the marker is removed by the PR that lands the file — verified by S1, where the same loop closed itself.

No C# in this PR, so it does not self-exempt.