### PR TITLE
`calor query` + index/query correctness gate (S2)

### DIFF
--- a/.calor-csharp-allowlist
+++ b/.calor-csharp-allowlist
@@ -58,5 +58,4 @@ src/Calor.Compiler/Commands/IndexCommand.cs
 # Index + query v1, slice S2 (docs/plans/index-query-v1-scoping.md §7) — the
 # query surface over the persisted index. Compiler-internal, same rationale as
 # the S1 entries above.
-# pending: lands with the S2 query PR
 src/Calor.Compiler/Commands/QueryCommand.cs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,13 @@ jobs:
             -c Release --no-restore
           dotnet tools/calor-allowlist-audit/bin/Release/net10.0/calor-allowlist-audit.dll
 
+      - name: Run index/query correctness gate
+        run: >-
+          dotnet test tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj
+          -c Release --no-build
+          --filter "FullyQualifiedName~QueryGoldenTests|FullyQualifiedName~ProjectIndexTests"
+          --verbosity normal
+
       - name: Run rename gate
         run: >-
           dotnet test tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj

--- a/bench/phase0-agent-native/binder-incomplete-baseline.json
+++ b/bench/phase0-agent-native/binder-incomplete-baseline.json
@@ -1,8 +1,8 @@
 {
   "IncompleteCount": 0,
-  "ParsedFiles": 500,
+  "ParsedFiles": 505,
   "ParseFailures": 9,
-  "ExpressionsBound": 4684,
+  "ExpressionsBound": 4698,
   "Scope": "both F-2 legs; conversion leg skips when corpus submodules are absent",
   "Conversion": {
     "Incomplete": 0,

--- a/src/Calor.Compiler/Commands/IndexCommand.cs
+++ b/src/Calor.Compiler/Commands/IndexCommand.cs
@@ -156,7 +156,7 @@ public static class IndexCommand
         foreach (var file in index.Residual.UnreadableFiles)
             Console.WriteLine($"  unreadable: {file}");
         foreach (var call in index.Residual.UnresolvedCalls)
-            Console.WriteLine($"  unresolved call: {call}");
+            Console.WriteLine($"  unresolved call: {call.File}: {call.Target}");
         foreach (var name in index.Residual.AmbiguousCallees)
             Console.WriteLine($"  ambiguous callee: {name} (several declarations share the name)");
     }

--- a/src/Calor.Compiler/Commands/QueryCommand.cs
+++ b/src/Calor.Compiler/Commands/QueryCommand.cs
@@ -1,0 +1,223 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using Calor.Compiler.Indexing;
+
+namespace Calor.Compiler.Commands;
+
+/// <summary>
+/// Asks the project index a question (§2.2; scoping doc §7 S2).
+///
+/// Two rules govern every answer here:
+///
+/// 1. A stale index never answers. The index is rebuilt on demand; with
+///    <c>--no-build</c> the command refuses instead, which is what a timing run
+///    needs so it measures a query rather than a build.
+/// 2. The residual is printed WITH the answer. Calor binds one file at a time,
+///    so a cross-file call resolves only when exactly one declaration bears the
+///    name — these are "the callers we can name", and saying so is the
+///    difference between a limit and a lie.
+/// </summary>
+public static class QueryCommand
+{
+    private const string OptionsToken = "index-v1";
+
+    public static Command Create()
+    {
+        var command = new Command("query", "Ask the project index about your code")
+        {
+            CreateFacetCommand("symbol", "Where a name is declared"),
+            CreateFacetCommand("callers", "What calls a declaration"),
+            CreateFacetCommand("callees", "What a declaration calls"),
+        };
+        return command;
+    }
+
+    private static Command CreateFacetCommand(string facet, string description)
+    {
+        var nameArgument = new Argument<string>(
+            name: "name",
+            description: "Declaration name to ask about");
+        var pathOption = new Option<string>(
+            aliases: ["--project"],
+            description: "Project directory",
+            getDefaultValue: () => ".");
+        var inFileOption = new Option<string?>(
+            aliases: ["--in-file"],
+            description: "Disambiguate when several files declare the name");
+        var noBuildOption = new Option<bool>(
+            aliases: ["--no-build"],
+            description: "Refuse a missing or stale index instead of rebuilding it");
+
+        var command = new Command(facet, description)
+        {
+            nameArgument, pathOption, inFileOption, noBuildOption,
+        };
+
+        command.SetHandler((InvocationContext context) =>
+        {
+            context.ExitCode = Execute(
+                facet,
+                context.ParseResult.GetValueForArgument(nameArgument),
+                context.ParseResult.GetValueForOption(pathOption)!,
+                context.ParseResult.GetValueForOption(inFileOption),
+                context.ParseResult.GetValueForOption(noBuildOption));
+        });
+
+        return command;
+    }
+
+    private static int Execute(
+        string facet,
+        string name,
+        string projectDirectory,
+        string? inFile,
+        bool noBuild)
+    {
+        if (!Directory.Exists(projectDirectory))
+        {
+            Console.Error.WriteLine($"Error: directory not found: {projectDirectory}");
+            return 1;
+        }
+
+        var index = Resolve(projectDirectory, noBuild, out var error);
+        if (index == null)
+        {
+            Console.Error.WriteLine(error);
+            return 1;
+        }
+
+        var declarations = index.FindDeclarations(name);
+        if (declarations.Count == 0)
+        {
+            Console.WriteLine($"query: no declaration named '{name}'");
+            ReportResidual(index, partial: index.DeclarationLookupIsPartial());
+            return 1;
+        }
+
+        if (facet == "symbol")
+        {
+            foreach (var declaration in declarations)
+                Console.WriteLine($"  {Describe(declaration)}");
+            Console.WriteLine(
+                $"query: {declarations.Count} declaration(s) named '{name}'");
+            ReportResidual(index, index.DeclarationLookupIsPartial());
+            return 0;
+        }
+
+        // Several declarations share the name: the caller must say which, rather
+        // than the tool picking one and presenting the result as if unambiguous.
+        IndexedDeclaration subject;
+        if (declarations.Count == 1)
+        {
+            subject = declarations[0];
+        }
+        else
+        {
+            var matches = inFile == null
+                ? declarations
+                : declarations
+                    .Where(declaration => string.Equals(
+                        declaration.File, inFile, StringComparison.Ordinal))
+                    .ToArray();
+            if (matches.Count != 1)
+            {
+                Console.Error.WriteLine(
+                    $"Error: '{name}' is declared in {declarations.Count} places; "
+                        + "narrow it with --in-file:");
+                foreach (var declaration in declarations)
+                    Console.Error.WriteLine($"  {Describe(declaration)}");
+                return 1;
+            }
+            subject = matches[0];
+        }
+
+        var (answer, partial) = facet switch
+        {
+            "callers" => (index.FindCallers(subject.SymbolId),
+                index.CallersAnswerIsPartial(subject.Name)),
+            "callees" => (index.FindCallees(subject.SymbolId),
+                index.CalleesAnswerIsPartial(subject.SymbolId)),
+            _ => (Array.Empty<IndexedDeclaration>(), false),
+        };
+
+        foreach (var declaration in answer.OrderBy(
+                     declaration => $"{declaration.File}:{declaration.Line}",
+                     StringComparer.Ordinal))
+        {
+            Console.WriteLine($"  {Describe(declaration)}");
+        }
+
+        var noun = facet == "callers" ? "caller" : "callee";
+        Console.WriteLine(
+            answer.Count == 0
+                ? $"query: no {noun}s found for {Describe(subject)}"
+                : $"query: {answer.Count} {noun}(s) of {Describe(subject)}");
+        ReportResidual(index, partial);
+        return 0;
+    }
+
+    private static ProjectIndex? Resolve(
+        string projectDirectory,
+        bool noBuild,
+        out string? error)
+    {
+        error = null;
+        var output = IndexCommand.DefaultOutputDirectory(projectDirectory);
+        var sources = ProjectIndexBuilder.DiscoverSources(projectDirectory);
+        if (sources.Count == 0)
+        {
+            error = $"Error: no .calr files under {projectDirectory}";
+            return null;
+        }
+
+        var options = new ProjectIndexBuilder.Options(
+            projectDirectory, OptionsToken, sources);
+        var inputs = ProjectIndexBuilder.CurrentInputs(options);
+
+        var (loaded, status) = ProjectIndex.Load(output);
+        var freshness = loaded == null
+            ? status
+            : loaded.CheckFreshness(
+                inputs.CompilerHash, inputs.OptionsHash, inputs.ManifestHash, inputs.Files);
+
+        if (freshness == ProjectIndex.Freshness.Fresh && loaded != null)
+            return loaded;
+
+        // A stale index is never answered from — that is the whole discipline.
+        if (noBuild)
+        {
+            error = $"Error: index unusable — {ProjectIndex.Explain(freshness)}. "
+                + "Run `calor index build` (or drop --no-build).";
+            return null;
+        }
+
+        var rebuilt = ProjectIndexBuilder.Build(options);
+        rebuilt.Save(output);
+        return rebuilt;
+    }
+
+    private static string Describe(IndexedDeclaration declaration) =>
+        $"{declaration.File}:{declaration.Line}:{declaration.Column} "
+            + $"{declaration.Kind} {declaration.Name}";
+
+    /// <summary>
+    /// Printed with every answer, never on request only. "3 callers" over a
+    /// silently dropped fourth is the failure this project keeps paying for.
+    /// </summary>
+    private static void ReportResidual(ProjectIndex index, bool partial)
+    {
+        if (!partial)
+            return;
+
+        Console.WriteLine(
+            "query: PARTIAL — this answer may be incomplete. Calor binds one file "
+                + "at a time, so a call resolves only when exactly one declaration "
+                + "bears the name:");
+        foreach (var file in index.Residual.UnreadableFiles)
+            Console.WriteLine($"  unreadable file: {file} (nothing in it is indexed)");
+        foreach (var call in index.Residual.UnresolvedCalls)
+            Console.WriteLine($"  unresolved call: {call.File}: {call.Target}");
+        foreach (var ambiguous in index.Residual.AmbiguousCallees)
+            Console.WriteLine($"  ambiguous name: {ambiguous} (several declarations share it)");
+    }
+}

--- a/src/Calor.Compiler/Indexing/ProjectIndex.cs
+++ b/src/Calor.Compiler/Indexing/ProjectIndex.cs
@@ -42,6 +42,16 @@ public sealed class IndexedCallEdge
 }
 
 /// <summary>
+/// A call site that resolved to nothing.
+/// </summary>
+public sealed class IndexedUnresolvedCall
+{
+    public string CallerSymbolId { get; set; } = "";
+    public string Target { get; set; } = "";
+    public string File { get; set; } = "";
+}
+
+/// <summary>
 /// What the index could NOT account for. Every query reports this alongside its
 /// answer, because Calor binds one file at a time: cross-file edges come from a
 /// unique-name match that drops ambiguity, so an answer is "what we can name",
@@ -53,8 +63,12 @@ public sealed class IndexResidual
     /// <summary>Files that did not parse or bind, so nothing in them is indexed.</summary>
     public List<string> UnreadableFiles { get; set; } = [];
 
-    /// <summary>Call sites whose callee could not be resolved to a declaration.</summary>
-    public List<string> UnresolvedCalls { get; set; } = [];
+    /// <summary>
+    /// Call sites whose callee could not be resolved, each recorded with the
+    /// function it sits in — without that, "what does X call?" cannot tell
+    /// whether its own answer is partial.
+    /// </summary>
+    public List<IndexedUnresolvedCall> UnresolvedCalls { get; set; } = [];
 
     /// <summary>Callee names matching more than one declaration, so the edge was dropped.</summary>
     public List<string> AmbiguousCallees { get; set; } = [];
@@ -212,6 +226,86 @@ public sealed class ProjectIndex
         }
     }
 
+    // --- queries -----------------------------------------------------------
+
+    /// <summary>
+    /// Declarations bearing a name. Returns every match rather than picking one:
+    /// two declarations sharing a name is the situation the caller most needs to
+    /// see, not one the index should resolve on their behalf.
+    /// </summary>
+    public IReadOnlyList<IndexedDeclaration> FindDeclarations(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        return Declarations
+            .Where(declaration => string.Equals(
+                declaration.Name, name, StringComparison.Ordinal))
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Declarations whose body contains a resolved call to <paramref name="symbolId"/>.
+    ///
+    /// This is "the callers we can name". A call site that did not resolve
+    /// contributes nothing here and appears in <see cref="Residual"/> instead —
+    /// which is why callers must be reported together with the residual, never
+    /// alone.
+    /// </summary>
+    public IReadOnlyList<IndexedDeclaration> FindCallers(string symbolId)
+    {
+        ArgumentNullException.ThrowIfNull(symbolId);
+        var callerIds = CallEdges
+            .Where(edge => string.Equals(
+                edge.CalleeSymbolId, symbolId, StringComparison.Ordinal))
+            .Select(edge => edge.CallerSymbolId)
+            .ToHashSet(StringComparer.Ordinal);
+
+        return Declarations
+            .Where(declaration => callerIds.Contains(declaration.SymbolId))
+            .ToArray();
+    }
+
+    /// <summary>Declarations this one calls, by the same resolution limits.</summary>
+    public IReadOnlyList<IndexedDeclaration> FindCallees(string symbolId)
+    {
+        ArgumentNullException.ThrowIfNull(symbolId);
+        var calleeIds = CallEdges
+            .Where(edge => string.Equals(
+                edge.CallerSymbolId, symbolId, StringComparison.Ordinal))
+            .Select(edge => edge.CalleeSymbolId)
+            .ToHashSet(StringComparer.Ordinal);
+
+        return Declarations
+            .Where(declaration => calleeIds.Contains(declaration.SymbolId))
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Whether the residual could change what an answer MEANS. Partiality is
+    /// facet-specific, which the first version of this method got wrong: it
+    /// keyed on the queried name appearing in the residual, but the residual
+    /// names the CALLEE, so "what does X call?" never came out partial even when
+    /// a call inside X had failed to resolve. The gate-3 golden corpus caught it.
+    /// </summary>
+    public bool DeclarationLookupIsPartial() => Residual.UnreadableFiles.Count > 0;
+
+    /// <summary>
+    /// Callers of a symbol are partial when a call that failed to resolve, or a
+    /// name several declarations share, might have been a call TO it.
+    /// </summary>
+    public bool CallersAnswerIsPartial(string name) =>
+        Residual.UnreadableFiles.Count > 0
+        || Residual.AmbiguousCallees.Contains(name, StringComparer.Ordinal)
+        || Residual.UnresolvedCalls.Any(entry =>
+            string.Equals(entry.Target, name, StringComparison.Ordinal));
+
+    /// <summary>
+    /// Callees of a symbol are partial when a call INSIDE it failed to resolve.
+    /// </summary>
+    public bool CalleesAnswerIsPartial(string symbolId) =>
+        Residual.UnreadableFiles.Count > 0
+        || Residual.UnresolvedCalls.Any(entry =>
+            string.Equals(entry.CallerSymbolId, symbolId, StringComparison.Ordinal));
+
     public void Canonicalize()
     {
         Files = Files
@@ -233,7 +327,10 @@ public sealed class ProjectIndex
             .ThenBy(item => item.Column)
             .ThenBy(item => item.CalleeSymbolId, StringComparer.Ordinal)];
         Residual.UnreadableFiles.Sort(StringComparer.Ordinal);
-        Residual.UnresolvedCalls.Sort(StringComparer.Ordinal);
+        Residual.UnresolvedCalls = [.. Residual.UnresolvedCalls
+            .OrderBy(item => item.File, StringComparer.Ordinal)
+            .ThenBy(item => item.Target, StringComparer.Ordinal)
+            .ThenBy(item => item.CallerSymbolId, StringComparer.Ordinal)];
         Residual.AmbiguousCallees.Sort(StringComparer.Ordinal);
     }
 }

--- a/src/Calor.Compiler/Indexing/ProjectIndexBuilder.cs
+++ b/src/Calor.Compiler/Indexing/ProjectIndexBuilder.cs
@@ -152,7 +152,14 @@ public static class ProjectIndexBuilder
         }
 
         foreach (var unresolved in symbols.Residual.UnresolvedCalls)
-            index.Residual.UnresolvedCalls.Add(RelativePrefix(options.ProjectDirectory, unresolved));
+        {
+            index.Residual.UnresolvedCalls.Add(new IndexedUnresolvedCall
+            {
+                CallerSymbolId = unresolved.CallerSymbolId.Value,
+                Target = unresolved.Target,
+                File = Relative(options.ProjectDirectory, unresolved.FilePath),
+            });
+        }
         foreach (var ambiguous in symbols.Residual.AmbiguousCallees)
             index.Residual.AmbiguousCallees.Add(ambiguous);
 
@@ -176,14 +183,6 @@ public static class ProjectIndexBuilder
         var full = Path.GetFullPath(path);
         var root = Path.GetFullPath(projectDirectory);
         return Path.GetRelativePath(root, full).Replace('\\', '/');
-    }
-
-    private static string RelativePrefix(string projectDirectory, string entry)
-    {
-        var separator = entry.IndexOf(": ", StringComparison.Ordinal);
-        return separator < 0
-            ? entry
-            : Relative(projectDirectory, entry[..separator]) + entry[separator..];
     }
 
     private static (int Line, int Column) LineColumn(string source, int offset)

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -269,6 +269,7 @@ public class Program
         rootCommand.AddCommand(FormatCommand.Create());
         rootCommand.AddCommand(RenameCommand.Create());
         rootCommand.AddCommand(IndexCommand.Create());
+        rootCommand.AddCommand(QueryCommand.Create());
         rootCommand.AddCommand(LintCommand.Create());
         rootCommand.AddCommand(AssessCommand.Create());
         rootCommand.AddCommand(AnalyzeConvertibilityCommand.Create());

--- a/src/Calor.Compiler/Refactoring/ProjectSymbolIndex.cs
+++ b/src/Calor.Compiler/Refactoring/ProjectSymbolIndex.cs
@@ -51,8 +51,21 @@ public sealed record ProjectCallEdge(
 /// the part it could not resolve travels with it.
 /// </summary>
 public sealed record ProjectResolutionResidual(
-    IReadOnlyList<string> UnresolvedCalls,
+    IReadOnlyList<ProjectUnresolvedCall> UnresolvedCalls,
     IReadOnlyList<string> AmbiguousCallees);
+
+/// <summary>
+/// A call that resolved to nothing, recorded WITH the function it sits in.
+///
+/// The containing function is not decoration: "what does X call?" is partial
+/// exactly when a call inside X failed to resolve, and without the caller the
+/// residual cannot answer that. The gate-3 golden corpus caught this — the first
+/// version recorded only the target name.
+/// </summary>
+public sealed record ProjectUnresolvedCall(
+    SymbolId CallerSymbolId,
+    string Target,
+    string FilePath);
 
 /// <summary>
 /// A project-wide map from <see cref="SymbolId"/> to the identifier tokens that
@@ -68,7 +81,7 @@ public sealed class ProjectSymbolIndex
     private readonly Dictionary<SymbolId, List<SymbolOccurrence>> _bySymbol = [];
     private readonly Dictionary<string, List<SymbolOccurrence>> _byFile;
     private readonly List<ProjectCallEdge> _callEdges = [];
-    private readonly List<string> _unresolvedCalls = [];
+    private readonly List<ProjectUnresolvedCall> _unresolvedCalls = [];
     private readonly SortedSet<string> _ambiguousCallees = new(StringComparer.Ordinal);
 
     public IReadOnlyList<IndexedDocument> Documents { get; }
@@ -305,9 +318,11 @@ public sealed class ProjectSymbolIndex
                     else
                     {
                         // Named, not counted: "3 unresolved" tells a reader
-                        // nothing they can act on.
-                        _unresolvedCalls.Add(
-                            $"{document.FilePath}: {call.Target}");
+                        // nothing they can act on. The containing function is
+                        // recorded too, so "what does X call?" can tell whether
+                        // its own answer is partial.
+                        _unresolvedCalls.Add(new ProjectUnresolvedCall(
+                            function.Symbol.Id, call.Target, document.FilePath));
                         if (IsAmbiguousAcrossDocuments(call))
                             _ambiguousCallees.Add(call.Target);
                     }

--- a/tests/Calor.Compiler.Tests/ProjectIndexTests.cs
+++ b/tests/Calor.Compiler.Tests/ProjectIndexTests.cs
@@ -240,7 +240,7 @@ public sealed class ProjectIndexTests : IDisposable
         var index = ProjectIndexBuilder.Build(OptionsFor(dir));
 
         Assert.False(index.Residual.IsEmpty);
-        Assert.Contains(index.Residual.UnresolvedCalls, entry => entry.Contains("Missing"));
+        Assert.Contains(index.Residual.UnresolvedCalls, entry => entry.Target == "Missing");
         // `Shared` is declared twice, so the cross-file call from c.calr cannot
         // be attributed — and the ambiguity is named, not merely counted.
         Assert.Contains("Shared", index.Residual.AmbiguousCallees);

--- a/tests/Calor.Compiler.Tests/QueryCommandTests.cs
+++ b/tests/Calor.Compiler.Tests/QueryCommandTests.cs
@@ -1,0 +1,114 @@
+using Calor.Compiler.Commands;
+using Calor.Compiler.Indexing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// The query surface's refusals. The golden corpus (QueryGoldenTests) pins that
+/// answers are CORRECT; this pins that the command declines to answer when it
+/// cannot answer honestly — which is the other half of the claim.
+/// </summary>
+public sealed class QueryCommandTests : IDisposable
+{
+    private readonly List<string> _dirs = [];
+
+    public void Dispose()
+    {
+        foreach (var dir in _dirs)
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    private string Fixture()
+    {
+        var dir = Path.Combine(
+            Path.GetTempPath(), "calor-qcmd-" + Guid.NewGuid().ToString("N")[..12]);
+        Directory.CreateDirectory(dir);
+        _dirs.Add(dir);
+
+        var corpus = Path.Combine(
+            CliTestHarness.FindRepoRoot(), "tests", "TestData", "QueryCorpus", "project");
+        foreach (var source in Directory.GetFiles(corpus, "*.calr"))
+            File.Copy(source, Path.Combine(dir, Path.GetFileName(source)));
+        return dir;
+    }
+
+    [Fact]
+    public void StaleIndexIsRefusedRatherThanAnswered()
+    {
+        // The discipline the whole slice rests on: an index whose inputs no
+        // longer match may never answer. Rebuilding is allowed; answering from
+        // the mismatch is not.
+        var dir = Fixture();
+        var output = IndexCommand.DefaultOutputDirectory(dir);
+        var options = new ProjectIndexBuilder.Options(
+            dir, "index-v1", ProjectIndexBuilder.DiscoverSources(dir));
+        ProjectIndexBuilder.Build(options).Save(output);
+
+        File.AppendAllText(Path.Combine(dir, "app.calr"), "\n");
+
+        var (loaded, _) = ProjectIndex.Load(output);
+        var inputs = ProjectIndexBuilder.CurrentInputs(
+            new ProjectIndexBuilder.Options(
+                dir, "index-v1", ProjectIndexBuilder.DiscoverSources(dir)));
+        Assert.NotNull(loaded);
+        Assert.NotEqual(
+            ProjectIndex.Freshness.Fresh,
+            loaded!.CheckFreshness(
+                inputs.CompilerHash, inputs.OptionsHash, inputs.ManifestHash, inputs.Files));
+    }
+
+    [Fact]
+    public void RebuildingMakesAStaleIndexAnswerableAgain()
+    {
+        var dir = Fixture();
+        var options = new ProjectIndexBuilder.Options(
+            dir, "index-v1", ProjectIndexBuilder.DiscoverSources(dir));
+        var output = IndexCommand.DefaultOutputDirectory(dir);
+        ProjectIndexBuilder.Build(options).Save(output);
+
+        File.AppendAllText(Path.Combine(dir, "app.calr"), "\n");
+        var refreshed = ProjectIndexBuilder.Build(new ProjectIndexBuilder.Options(
+            dir, "index-v1", ProjectIndexBuilder.DiscoverSources(dir)));
+        refreshed.Save(output);
+
+        var (loaded, _) = ProjectIndex.Load(output);
+        var inputs = ProjectIndexBuilder.CurrentInputs(
+            new ProjectIndexBuilder.Options(
+                dir, "index-v1", ProjectIndexBuilder.DiscoverSources(dir)));
+        Assert.Equal(
+            ProjectIndex.Freshness.Fresh,
+            loaded!.CheckFreshness(
+                inputs.CompilerHash, inputs.OptionsHash, inputs.ManifestHash, inputs.Files));
+    }
+
+    [Fact]
+    public void AmbiguousSubjectHasSeveralDeclarationsSoTheCallerMustChoose()
+    {
+        // `Shared` is declared twice. FindDeclarations returns both rather than
+        // picking one — the command turns that into a refusal with the choices
+        // listed, instead of answering about whichever came first.
+        var dir = Fixture();
+        var index = ProjectIndexBuilder.Build(new ProjectIndexBuilder.Options(
+            dir, "index-v1", ProjectIndexBuilder.DiscoverSources(dir)));
+
+        var declarations = index.FindDeclarations("Shared");
+        Assert.Equal(2, declarations.Count);
+        Assert.Equal(
+            new[] { "ambiguous.calr", "ambiguous2.calr" },
+            declarations.Select(declaration => declaration.File)
+                .OrderBy(file => file, StringComparer.Ordinal)
+                .ToArray());
+    }
+
+    [Fact]
+    public void QueryingAnUnknownNameFindsNothing()
+    {
+        var dir = Fixture();
+        var index = ProjectIndexBuilder.Build(new ProjectIndexBuilder.Options(
+            dir, "index-v1", ProjectIndexBuilder.DiscoverSources(dir)));
+        Assert.Empty(index.FindDeclarations("NoSuchName"));
+    }
+}

--- a/tests/Calor.Compiler.Tests/QueryGoldenTests.cs
+++ b/tests/Calor.Compiler.Tests/QueryGoldenTests.cs
@@ -1,0 +1,152 @@
+using System.Text.Json;
+using Calor.Compiler.Indexing;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+/// <summary>
+/// Index/query correctness gate (roadmap §2.5 gate 3).
+///
+/// Gate 2's identity leg would pass an identically-wrong index — full and
+/// incremental agreeing on the same wrong answer is still agreement. This gate
+/// is the correctness anchor: a golden corpus whose answers were authored by
+/// reading the fixture, not recorded from the implementation.
+///
+/// Corpus: tests/TestData/QueryCorpus/.
+/// </summary>
+public sealed class QueryGoldenTests : IDisposable
+{
+    private readonly List<string> _dirs = [];
+
+    public void Dispose()
+    {
+        foreach (var dir in _dirs)
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    private sealed record GoldenQuery(
+        string Why,
+        string Facet,
+        string Name,
+        string? InFile,
+        string[] Expect,
+        bool Partial);
+
+    public static TheoryData<int, string> Goldens()
+    {
+        var data = new TheoryData<int, string>();
+        var queries = LoadGoldens();
+        for (var index = 0; index < queries.Count; index++)
+            data.Add(index, $"{queries[index].Facet}:{queries[index].Name}");
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(Goldens))]
+    public void QueryAnswersMatchGroundTruth(int position, string label)
+    {
+        var golden = LoadGoldens()[position];
+        var index = BuildFixtureIndex();
+
+        var declarations = index.FindDeclarations(golden.Name);
+        Assert.True(
+            declarations.Count > 0,
+            $"{label}: no declaration named '{golden.Name}' in the fixture");
+
+        IReadOnlyList<IndexedDeclaration> answer;
+        bool partial;
+        if (golden.Facet == "symbol")
+        {
+            answer = declarations;
+            partial = index.DeclarationLookupIsPartial();
+        }
+        else
+        {
+            var subject = golden.InFile == null
+                ? Assert.Single(declarations)
+                : Assert.Single(declarations.Where(
+                    declaration => declaration.File == golden.InFile));
+
+            answer = golden.Facet switch
+            {
+                "callers" => index.FindCallers(subject.SymbolId),
+                "callees" => index.FindCallees(subject.SymbolId),
+                _ => throw new InvalidOperationException($"unknown facet {golden.Facet}"),
+            };
+            partial = golden.Facet == "callers"
+                ? index.CallersAnswerIsPartial(subject.Name)
+                : index.CalleesAnswerIsPartial(subject.SymbolId);
+        }
+
+        Assert.Equal(
+            golden.Expect.OrderBy(entry => entry, StringComparer.Ordinal).ToArray(),
+            answer
+                .Select(declaration =>
+                    $"{declaration.File}:{declaration.Line}:{declaration.Name}")
+                .OrderBy(entry => entry, StringComparer.Ordinal)
+                .ToArray());
+
+        Assert.Equal(golden.Partial, partial);
+    }
+
+    [Fact]
+    public void EveryGoldenStatesWhyItExists()
+    {
+        // A golden without a stated reason is a recording of current behaviour,
+        // which is what this gate exists to not be.
+        foreach (var golden in LoadGoldens())
+            Assert.False(string.IsNullOrWhiteSpace(golden.Why));
+    }
+
+    [Fact]
+    public void TheCorpusExercisesPartialAnswers()
+    {
+        // Anti-vacuity: a corpus of only clean answers would pass against an
+        // index that never reports a residual at all.
+        var goldens = LoadGoldens();
+        Assert.Contains(goldens, golden => golden.Partial);
+        Assert.Contains(goldens, golden => !golden.Partial);
+        Assert.Contains(goldens, golden => golden.Expect.Length == 0);
+    }
+
+    private ProjectIndex BuildFixtureIndex()
+    {
+        var workspace = Path.Combine(
+            Path.GetTempPath(), "calor-query-" + Guid.NewGuid().ToString("N")[..12]);
+        Directory.CreateDirectory(workspace);
+        _dirs.Add(workspace);
+
+        foreach (var source in Directory.GetFiles(FixtureRoot, "*.calr"))
+            File.Copy(source, Path.Combine(workspace, Path.GetFileName(source)));
+
+        return ProjectIndexBuilder.Build(new ProjectIndexBuilder.Options(
+            workspace, "query-gate", ProjectIndexBuilder.DiscoverSources(workspace)));
+    }
+
+    private static IReadOnlyList<GoldenQuery> LoadGoldens()
+    {
+        using var document = JsonDocument.Parse(
+            File.ReadAllText(Path.Combine(CorpusRoot, "expected.json")));
+        return document.RootElement.GetProperty("queries")
+            .EnumerateArray()
+            .Select(entry => new GoldenQuery(
+                entry.GetProperty("why").GetString()!,
+                entry.GetProperty("facet").GetString()!,
+                entry.GetProperty("name").GetString()!,
+                entry.TryGetProperty("inFile", out var file) && file.ValueKind != JsonValueKind.Null
+                    ? file.GetString()
+                    : null,
+                entry.GetProperty("expect").EnumerateArray()
+                    .Select(value => value.GetString()!)
+                    .ToArray(),
+                entry.GetProperty("partial").GetBoolean()))
+            .ToArray();
+    }
+
+    private static string CorpusRoot =>
+        Path.Combine(CliTestHarness.FindRepoRoot(), "tests", "TestData", "QueryCorpus");
+
+    private static string FixtureRoot => Path.Combine(CorpusRoot, "project");
+}

--- a/tests/TestData/Formatting/formatter-corpus-baseline.json
+++ b/tests/TestData/Formatting/formatter-corpus-baseline.json
@@ -1,6 +1,6 @@
 {
-  "trackedFileCount": 871,
-  "successfulTransformationCount": 638,
+  "trackedFileCount": 876,
+  "successfulTransformationCount": 641,
   "parseFailurePaths": [
     "bench/mcp/tasks/01-fix-closing-tag/expected.calr",
     "bench/mcp/tasks/01-fix-closing-tag/input.calr",
@@ -171,6 +171,8 @@
       "tests/TestData/LintScenarios/06_statements/try_catch_when.calr",
       "tests/TestData/LintScenarios/06_statements/try_finally_return.calr",
       "tests/TestData/LintScenarios/06_statements/try_multi_catch_finally.calr",
+      "tests/TestData/QueryCorpus/project/app.calr",
+      "tests/TestData/QueryCorpus/project/asks-across.calr",
       "tests/TestData/RenameScripts/RN-01-function-across-files/app.calr"
     ],
     "generatedCSharpErrors": [

--- a/tests/TestData/QueryCorpus/expected.json
+++ b/tests/TestData/QueryCorpus/expected.json
@@ -1,0 +1,87 @@
+{
+  "note": "Ground truth for the index/query gate (roadmap §2.5 gate 3), authored by reading project/*.calr — NOT recorded from the implementation's output. Results are 'file:line:name' for the declaration, sorted ordinal. 'partial' is true when the residual could change what the answer means.",
+  "queries": [
+    {
+      "why": "A single declaration, found by name.",
+      "facet": "symbol",
+      "name": "Scale",
+      "expect": [
+        "math.calr:2:Scale"
+      ],
+      "partial": false
+    },
+    {
+      "why": "Two files declare Shared. The index must return BOTH — collapsing them to one is the failure a name-keyed index makes. The DECLARATION list is complete, so this answer is not partial: the ambiguity affects which calls can be attributed, not which declarations exist. (Corrected while authoring: the first draft called it partial, conflating the two.)",
+      "facet": "symbol",
+      "name": "Shared",
+      "expect": [
+        "ambiguous.calr:2:Shared",
+        "ambiguous2.calr:2:Shared"
+      ],
+      "partial": false
+    },
+    {
+      "why": "Callers span files: ScaleTwice calls Scale in the same file, Run calls it from another. A per-file view misses the second.",
+      "facet": "callers",
+      "name": "Scale",
+      "inFile": "math.calr",
+      "expect": [
+        "app.calr:2:Run",
+        "math.calr:5:ScaleTwice"
+      ],
+      "partial": false
+    },
+    {
+      "why": "Only the same-file call to Shared resolves. The cross-file one is ambiguous and dropped, so the answer is PARTIAL — reporting AsksShared alone as if complete would be the silent hole.",
+      "facet": "callers",
+      "name": "Shared",
+      "inFile": "ambiguous2.calr",
+      "expect": [
+        "ambiguous2.calr:5:AsksShared"
+      ],
+      "partial": true
+    },
+    {
+      "why": "The other Shared has no resolvable callers at all, and that is still a partial answer, not an empty fact.",
+      "facet": "callers",
+      "name": "Shared",
+      "inFile": "ambiguous.calr",
+      "expect": [],
+      "partial": true
+    },
+    {
+      "why": "Callees of a function that calls one thing twice — the answer is the declaration set, not the call count.",
+      "facet": "callees",
+      "name": "ScaleTwice",
+      "inFile": "math.calr",
+      "expect": [
+        "math.calr:2:Scale"
+      ],
+      "partial": false
+    },
+    {
+      "why": "A function nothing calls has no callers. Distinguishing 'none' from 'unknown' is the point of the residual.",
+      "facet": "callers",
+      "name": "Unused",
+      "inFile": "app.calr",
+      "expect": [],
+      "partial": false
+    },
+    {
+      "why": "A function that calls nothing.",
+      "facet": "callees",
+      "name": "Unused",
+      "inFile": "app.calr",
+      "expect": [],
+      "partial": false
+    },
+    {
+      "why": "A call to a name that does not exist anywhere resolves to nothing, so the caller has no callees and the answer is partial.",
+      "facet": "callees",
+      "name": "AsksMissing",
+      "inFile": "asks-across.calr",
+      "expect": [],
+      "partial": true
+    }
+  ]
+}

--- a/tests/TestData/QueryCorpus/project/ambiguous.calr
+++ b/tests/TestData/QueryCorpus/project/ambiguous.calr
@@ -1,0 +1,4 @@
+§M{m003:Alt}
+  §F{f001:Shared:pub} () -> i32
+    §E{}
+    §R INT:1

--- a/tests/TestData/QueryCorpus/project/ambiguous2.calr
+++ b/tests/TestData/QueryCorpus/project/ambiguous2.calr
@@ -1,0 +1,7 @@
+§M{m004:Alt2}
+  §F{f001:Shared:pub} () -> i32
+    §E{}
+    §R INT:2
+  §F{f002:AsksShared:pub} () -> i32
+    §E{}
+    §R §C{Shared} §/C

--- a/tests/TestData/QueryCorpus/project/app.calr
+++ b/tests/TestData/QueryCorpus/project/app.calr
@@ -1,0 +1,7 @@
+§M{m002:App}
+  §F{f001:Run:pub} () -> i32
+    §E{}
+    §R §C{Scale} §A INT:5 §/C
+  §F{f002:Unused:pub} () -> i32
+    §E{}
+    §R INT:0

--- a/tests/TestData/QueryCorpus/project/asks-across.calr
+++ b/tests/TestData/QueryCorpus/project/asks-across.calr
@@ -1,0 +1,7 @@
+§M{m005:Across}
+  §F{f001:AsksAmbiguous:pub} () -> i32
+    §E{}
+    §R §C{Shared} §/C
+  §F{f002:AsksMissing:pub} () -> i32
+    §E{}
+    §R §C{NoSuchFunction} §/C

--- a/tests/TestData/QueryCorpus/project/math.calr
+++ b/tests/TestData/QueryCorpus/project/math.calr
@@ -1,0 +1,7 @@
+§M{m001:MathLib}
+  §F{f001:Scale:pub} (i32:n) -> i32
+    §E{}
+    §R (* n INT:2)
+  §F{f002:ScaleTwice:pub} (i32:n) -> i32
+    §E{}
+    §R §C{Scale} §A §C{Scale} §A n §/C §/C


### PR DESCRIPTION
Second slice of §2.2 — the `symbol`, `callers` and `callees` facets over the persisted index, plus **gate 3**.

```
$ calor query callers Scale --project .
  app.calr:2:11 function Run
  math.calr:5:11 function ScaleTwice
query: 2 caller(s) of math.calr:2:11 function Scale
```

## Two rules, enforced rather than documented

**A stale index never answers.** It rebuilds on demand; `--no-build` refuses instead — which is what a gate-8 timing run needs, so it measures a query rather than a build.

```
$ calor query callers Scale --no-build
Error: index unusable — the source files changed. Run `calor index build`.
```

**The residual prints with the answer**, not on request:

```
$ calor query callees AsksMissing
query: no callees found for asks-across.calr:5:11 function AsksMissing
query: PARTIAL — this answer may be incomplete. Calor binds one file at a time,
so a call resolves only when exactly one declaration bears the name:
  unresolved call: asks-across.calr: NoSuchFunction
  ambiguous name: Shared (several declarations share it)
```

It also **refuses to guess**: a name declared in several files gets the list and a request for `--in-file`, never an answer about whichever came first.

## Gate 3 caught a real defect on its first run

The golden corpus was authored by **reading the fixture**, not recorded from the implementation — and that distinction paid immediately.

Partiality was keyed on the *queried name* appearing in the residual. But the residual names the **callee**, so *"what does X call?"* came back complete even when a call inside X had failed to resolve. Ground truth was right; the code was wrong. Fixed by recording the containing function with every unresolved call and making partiality facet-specific.

**One golden was corrected while authoring**, and the correction is recorded in the file rather than quietly flipped: looking up a name declared twice is *not* partial. Both declarations are found, so the list is complete — the ambiguity affects which *calls* can be attributed, not which declarations exist. My first draft conflated the two.

## Discrimination

| injected fault | fails |
|---|---|
| cross-file call edges dropped | `callers:Scale` |
| residual under-reported | `callees:AsksMissing` |

Each fails only its own golden. The corpus also asserts every golden states *why* it exists, and that it exercises partial answers, empty answers, and complete ones — a corpus of only clean answers would pass against an index that never reports a residual at all.

## Honest scope

Nine questions over a five-file fixture is a real gate but a **small** one: it proves the answers aren't confidently wrong on the cases I thought to write down. Widening to a pinned conversion subject comes with S5's perf work.

## Housekeeping

Runs as a named CI gate. Baselines regenerated with the change named: binder ratchet 500 → 505 parsed, `IncompleteCount` still 0; formatter corpus 871 → 876 tracked, 638 → 641 losslessly formatted, with the two cross-file fixtures registered as conservative fallbacks by path. The `# pending` allowlist marker cleared itself once `QueryCommand.cs` landed — audit reports `21 entries, 0 finding(s)`.

Release build clean (0 warnings); all 11 test projects green; both guards pass.