### PR TITLE
Declaration-precise `impact` (S3)

### DIFF
--- a/docs/plans/index-query-v1-scoping.md
+++ b/docs/plans/index-query-v1-scoping.md
@@ -151,23 +151,38 @@ complete it. **`effects` is not a slice.**
 
 ## 9. Decisions and open questions
 
-### 9.1 Semantic hash granularity — DECIDED: per file
+### 9.1 Semantic hash granularity — REVISED to per declaration
 
-**Decision (maintainer, 2026-08-11): per-file semantic hashes.** This is
-coherent with the wholesale-rebuild decision in §3 and is the cheaper build.
+**First decision (2026-08-11): per file.** Coherent with the wholesale rebuild in
+§3 and the cheaper build. Recorded with its cost stated — `impact` would answer
+at file granularity — and with an S3 checkpoint to show a real answer before
+calling the facet done.
 
-**The cost, stated plainly so nobody is surprised by it later:** `impact`
-answers at *file* granularity. Asking "what does this change affect?" returns
-"these files", not "these declarations". If one file holds twenty declarations
-and one changes, `impact` implicates all twenty's dependents.
+**The checkpoint fired, and the decision was reversed (2026-08-12).** Measured on
+the 106-file / 11k-line `fixture-10k` corpus (1,366 functions, 587 call edges,
+zero residual), file granularity gave:
 
-**This may be too coarse to be useful, and coarse-but-useless is a real
-outcome.** Rather than argue it in the abstract, S3 carries a **checkpoint**:
-the first working `impact` answer on a real project is shown to the maintainer
-before the facet is called done. If the answer is too fuzzy to act on, the
-choice is revisited then, with an actual answer in hand rather than a prediction
-about one. Per-declaration hashing remains a priced follow-up, not a rewrite:
-the storage header is versioned (§4), so granularity is a format revision.
+| | file-grained | declaration-grained |
+|---|---|---|
+| answer exactly right | **10/988 functions (1%)** | 988/988 (100%) |
+| mean reported impact | 13.17 declarations | 1.04 |
+| true impact empty, answer non-empty | **683/988 (69%)** | 0 |
+
+For roughly two functions in three, the honest answer was "nothing is affected"
+and the tool said otherwise — a ~13x over-report. That is not a blurry answer,
+it is one that trains its reader to ignore it, while still looking like it
+works.
+
+**What this cost, and why the checkpoint was worth having:** the reversal was a
+format revision, not a rewrite. `IndexedDeclaration` gained a `SemanticHash` over
+the declaration's own definition text, `Files` was narrowed to its invalidation
+role, and the format version went 1.0 → 2.0 — which the versioned header (§4)
+existed to permit. The argument would not have been settled by discussion: the
+small fixture made file granularity look tight (6 declarations), and only real
+code exposed the 1%.
+
+**Whole-file impact is retained** as `--file`, because "I rewrote this file" is a
+real question. It is no longer how a change to one declaration is answered.
 
 ### 9.2 Still open, to settle in S1
 

--- a/eng/test-manifest.json
+++ b/eng/test-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "projects": [
-    { "path": "tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 6776, "expectedSkipped": 2 },
+    { "path": "tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 6780, "expectedSkipped": 2 },
     { "path": "tests/Calor.Conversion.Tests/Calor.Conversion.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 370, "expectedSkipped": 0 },
     { "path": "tests/Calor.Enforcement.Tests/Calor.Enforcement.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 309, "expectedSkipped": 0 },
     { "path": "tests/Calor.Evaluation/Calor.Evaluation.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 198, "expectedSkipped": 0 },

--- a/src/Calor.Compiler/Commands/QueryCommand.cs
+++ b/src/Calor.Compiler/Commands/QueryCommand.cs
@@ -35,34 +35,47 @@ public static class QueryCommand
 
     private static Command CreateImpactCommand()
     {
-        var fileArgument = new Argument<string>(
-            name: "file",
-            description: "Changed file (project-relative), e.g. lib.calr");
+        var subjectArgument = new Argument<string>(
+            name: "subject",
+            description: "Declaration name to treat as changed (or a file with --file)");
         var pathOption = new Option<string>(
             aliases: ["--project"],
             description: "Project directory",
             getDefaultValue: () => ".");
+        var inFileOption = new Option<string?>(
+            aliases: ["--in-file"],
+            description: "Disambiguate when several files declare the name");
+        var fileOption = new Option<bool>(
+            aliases: ["--file"],
+            description: "Treat the subject as a whole changed FILE rather than one declaration");
         var noBuildOption = new Option<bool>(
             aliases: ["--no-build"],
             description: "Refuse a missing or stale index instead of rebuilding it");
 
-        var command = new Command("impact", "What a change to a file could affect")
+        var command = new Command("impact", "What a change could affect")
         {
-            fileArgument, pathOption, noBuildOption,
+            subjectArgument, pathOption, inFileOption, fileOption, noBuildOption,
         };
 
         command.SetHandler((InvocationContext context) =>
         {
             context.ExitCode = ExecuteImpact(
-                context.ParseResult.GetValueForArgument(fileArgument),
+                context.ParseResult.GetValueForArgument(subjectArgument),
                 context.ParseResult.GetValueForOption(pathOption)!,
+                context.ParseResult.GetValueForOption(inFileOption),
+                context.ParseResult.GetValueForOption(fileOption),
                 context.ParseResult.GetValueForOption(noBuildOption));
         });
 
         return command;
     }
 
-    private static int ExecuteImpact(string file, string projectDirectory, bool noBuild)
+    private static int ExecuteImpact(
+        string subject,
+        string projectDirectory,
+        string? inFile,
+        bool wholeFile,
+        bool noBuild)
     {
         if (!Directory.Exists(projectDirectory))
         {
@@ -77,22 +90,55 @@ public static class QueryCommand
             return 1;
         }
 
-        var normalized = file.Replace('\\', '/');
-        if (!index.Files.ContainsKey(normalized))
+        IReadOnlyList<IndexedDeclaration> affected;
+        string described;
+        if (wholeFile)
         {
-            Console.Error.WriteLine(
-                $"Error: '{file}' is not an indexed source file. Indexed files:");
-            foreach (var indexed in index.Files.Keys.Take(20))
-                Console.Error.WriteLine($"  {indexed}");
-            return 1;
+            var normalized = subject.Replace('\\', '/');
+            if (!index.Files.ContainsKey(normalized))
+            {
+                Console.Error.WriteLine($"Error: '{subject}' is not an indexed source file.");
+                return 1;
+            }
+            affected = index.FindImpactOfFile(normalized);
+            described = $"the whole file {normalized}";
         }
+        else
+        {
+            var declarations = index.FindDeclarations(subject);
+            if (declarations.Count == 0)
+            {
+                Console.Error.WriteLine(
+                    $"Error: no declaration named '{subject}'. Use --file to ask about a file.");
+                return 1;
+            }
 
-        var affected = index.FindImpactOfFile(normalized);
-        var affectedFiles = affected
-            .Select(declaration => declaration.File)
-            .Distinct(StringComparer.Ordinal)
-            .OrderBy(name => name, StringComparer.Ordinal)
-            .ToArray();
+            IndexedDeclaration target;
+            if (declarations.Count == 1)
+            {
+                target = declarations[0];
+            }
+            else
+            {
+                var matches = inFile == null
+                    ? declarations
+                    : declarations.Where(declaration => string.Equals(
+                        declaration.File, inFile, StringComparison.Ordinal)).ToArray();
+                if (matches.Count != 1)
+                {
+                    Console.Error.WriteLine(
+                        $"Error: '{subject}' is declared in {declarations.Count} places; "
+                            + "narrow it with --in-file:");
+                    foreach (var declaration in declarations)
+                        Console.Error.WriteLine($"  {Describe(declaration)}");
+                    return 1;
+                }
+                target = matches[0];
+            }
+
+            affected = index.FindImpactOfDeclarations([target.SymbolId]);
+            described = Describe(target);
+        }
 
         foreach (var declaration in affected.OrderBy(
                      declaration => $"{declaration.File}:{declaration.Line}",
@@ -101,17 +147,23 @@ public static class QueryCommand
             Console.WriteLine($"  {Describe(declaration)}");
         }
 
+        var affectedFiles = affected
+            .Select(declaration => declaration.File)
+            .Distinct(StringComparer.Ordinal)
+            .Count();
         Console.WriteLine(
             affected.Count == 0
-                ? $"impact: nothing else calls into {normalized}"
-                : $"impact: {affected.Count} declaration(s) in {affectedFiles.Length} file(s) "
-                    + $"could be affected by a change to {normalized}");
+                ? $"impact: nothing calls into {described}"
+                : $"impact: {affected.Count} declaration(s) in {affectedFiles} file(s) "
+                    + $"affected by a change to {described}");
 
-        // Said every time, not only when it bites: the answer is file-grained by
-        // construction, so a reader must not take it for declaration-grained.
-        Console.WriteLine(
-            "impact: file-grained — a change to ANY declaration in "
-                + $"{normalized} implicates all of these (scoping doc §9.1)");
+        if (wholeFile)
+        {
+            Console.WriteLine(
+                "impact: file-grained — a change to ANY declaration in this file "
+                    + "implicates all of these. Ask about a declaration for a precise answer.");
+        }
+
         ReportResidual(index, index.ImpactAnswerIsPartial());
         return 0;
     }

--- a/src/Calor.Compiler/Commands/QueryCommand.cs
+++ b/src/Calor.Compiler/Commands/QueryCommand.cs
@@ -28,8 +28,92 @@ public static class QueryCommand
             CreateFacetCommand("symbol", "Where a name is declared"),
             CreateFacetCommand("callers", "What calls a declaration"),
             CreateFacetCommand("callees", "What a declaration calls"),
+            CreateImpactCommand(),
         };
         return command;
+    }
+
+    private static Command CreateImpactCommand()
+    {
+        var fileArgument = new Argument<string>(
+            name: "file",
+            description: "Changed file (project-relative), e.g. lib.calr");
+        var pathOption = new Option<string>(
+            aliases: ["--project"],
+            description: "Project directory",
+            getDefaultValue: () => ".");
+        var noBuildOption = new Option<bool>(
+            aliases: ["--no-build"],
+            description: "Refuse a missing or stale index instead of rebuilding it");
+
+        var command = new Command("impact", "What a change to a file could affect")
+        {
+            fileArgument, pathOption, noBuildOption,
+        };
+
+        command.SetHandler((InvocationContext context) =>
+        {
+            context.ExitCode = ExecuteImpact(
+                context.ParseResult.GetValueForArgument(fileArgument),
+                context.ParseResult.GetValueForOption(pathOption)!,
+                context.ParseResult.GetValueForOption(noBuildOption));
+        });
+
+        return command;
+    }
+
+    private static int ExecuteImpact(string file, string projectDirectory, bool noBuild)
+    {
+        if (!Directory.Exists(projectDirectory))
+        {
+            Console.Error.WriteLine($"Error: directory not found: {projectDirectory}");
+            return 1;
+        }
+
+        var index = Resolve(projectDirectory, noBuild, out var error);
+        if (index == null)
+        {
+            Console.Error.WriteLine(error);
+            return 1;
+        }
+
+        var normalized = file.Replace('\\', '/');
+        if (!index.Files.ContainsKey(normalized))
+        {
+            Console.Error.WriteLine(
+                $"Error: '{file}' is not an indexed source file. Indexed files:");
+            foreach (var indexed in index.Files.Keys.Take(20))
+                Console.Error.WriteLine($"  {indexed}");
+            return 1;
+        }
+
+        var affected = index.FindImpactOfFile(normalized);
+        var affectedFiles = affected
+            .Select(declaration => declaration.File)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        foreach (var declaration in affected.OrderBy(
+                     declaration => $"{declaration.File}:{declaration.Line}",
+                     StringComparer.Ordinal))
+        {
+            Console.WriteLine($"  {Describe(declaration)}");
+        }
+
+        Console.WriteLine(
+            affected.Count == 0
+                ? $"impact: nothing else calls into {normalized}"
+                : $"impact: {affected.Count} declaration(s) in {affectedFiles.Length} file(s) "
+                    + $"could be affected by a change to {normalized}");
+
+        // Said every time, not only when it bites: the answer is file-grained by
+        // construction, so a reader must not take it for declaration-grained.
+        Console.WriteLine(
+            "impact: file-grained — a change to ANY declaration in "
+                + $"{normalized} implicates all of these (scoping doc §9.1)");
+        ReportResidual(index, index.ImpactAnswerIsPartial());
+        return 0;
     }
 
     private static Command CreateFacetCommand(string facet, string description)

--- a/src/Calor.Compiler/Indexing/ProjectIndex.cs
+++ b/src/Calor.Compiler/Indexing/ProjectIndex.cs
@@ -280,6 +280,72 @@ public sealed class ProjectIndex
     }
 
     /// <summary>
+    /// What a change to <paramref name="file"/> could affect: every declaration
+    /// reachable by following call edges INTO the declarations that file holds,
+    /// transitively.
+    ///
+    /// Granularity is the file, not the declaration (scoping doc §9.1). The
+    /// per-file semantic hash cannot say WHICH declaration in a file changed, so
+    /// this treats a change to any part of a file as a change to all of it. The
+    /// result is sound in the direction that matters — it never omits an
+    /// affected caller — but it over-reports: a file holding twenty
+    /// declarations implicates all twenty's callers when one changed.
+    ///
+    /// The cycle guard is not defensive coding: mutually recursive functions are
+    /// ordinary, and following their edges without one does not terminate.
+    /// </summary>
+    public IReadOnlyList<IndexedDeclaration> FindImpactOfFile(string file)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+
+        var seedIds = Declarations
+            .Where(declaration => string.Equals(
+                declaration.File, file, StringComparison.Ordinal))
+            .Select(declaration => declaration.SymbolId)
+            .ToHashSet(StringComparer.Ordinal);
+        if (seedIds.Count == 0)
+            return [];
+
+        var callersByCallee = CallEdges
+            .GroupBy(edge => edge.CalleeSymbolId, StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(edge => edge.CallerSymbolId)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray(),
+                StringComparer.Ordinal);
+
+        var affected = new HashSet<string>(StringComparer.Ordinal);
+        var queue = new Queue<string>(seedIds);
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (!callersByCallee.TryGetValue(current, out var callers))
+                continue;
+
+            foreach (var caller in callers)
+            {
+                // Seeds are the change itself, not something the change affects.
+                if (seedIds.Contains(caller) || !affected.Add(caller))
+                    continue;
+                queue.Enqueue(caller);
+            }
+        }
+
+        return Declarations
+            .Where(declaration => affected.Contains(declaration.SymbolId))
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Impact is partial whenever ANY call failed to resolve anywhere in the
+    /// project: an unresolved edge might have been the one that reached this
+    /// change. Unlike callers/callees this cannot be narrowed to the subject —
+    /// the missing edge is by definition one we cannot attribute.
+    /// </summary>
+    public bool ImpactAnswerIsPartial() => !Residual.IsEmpty;
+
+    /// <summary>
     /// Whether the residual could change what an answer MEANS. Partiality is
     /// facet-specific, which the first version of this method got wrong: it
     /// keyed on the queried name appearing in the residual, but the residual

--- a/src/Calor.Compiler/Indexing/ProjectIndex.cs
+++ b/src/Calor.Compiler/Indexing/ProjectIndex.cs
@@ -15,6 +15,18 @@ public sealed class IndexedDeclaration
     public string File { get; set; } = "";
     public int Line { get; set; }
     public int Column { get; set; }
+
+    /// <summary>
+    /// Hash of this declaration's own definition text, so "what changed?" can be
+    /// answered per declaration rather than per file.
+    ///
+    /// The file-grained alternative was measured before being rejected: on a
+    /// 106-file corpus it gave the exactly-right impact answer for 1% of
+    /// functions and claimed non-empty impact for 69% of functions whose true
+    /// impact was empty — a ~13x over-report. Precision here is what makes the
+    /// impact facet worth having.
+    /// </summary>
+    public string SemanticHash { get; set; } = "";
 }
 
 /// <summary>
@@ -98,7 +110,7 @@ public sealed class IndexResidual
 /// </summary>
 public sealed class ProjectIndex
 {
-    public const string CurrentFormatVersion = "1.0";
+    public const string CurrentFormatVersion = "2.0";
 
     public string FormatVersion { get; set; } = CurrentFormatVersion;
     public string CompilerSemanticsVersion { get; set; } =
@@ -108,8 +120,11 @@ public sealed class ProjectIndex
     public string ManifestHash { get; set; } = "";
 
     /// <summary>
-    /// Repository-relative path → content hash. Doubles as the per-file semantic
-    /// hash: v1 rebuilds wholesale, so one hash per file serves both roles.
+    /// Repository-relative path → content hash. Used for INVALIDATION only:
+    /// deciding whether the index may still answer. Semantic hashes live per
+    /// declaration (<see cref="IndexedDeclaration.SemanticHash"/>) because
+    /// file granularity made the impact facet useless — see the measurement
+    /// recorded there.
     /// </summary>
     public Dictionary<string, string> Files { get; set; } = [];
 
@@ -293,6 +308,49 @@ public sealed class ProjectIndex
     ///
     /// The cycle guard is not defensive coding: mutually recursive functions are
     /// ordinary, and following their edges without one does not terminate.
+    /// </summary>
+    public IReadOnlyList<IndexedDeclaration> FindImpactOfDeclarations(
+        IReadOnlyCollection<string> seedSymbolIds)
+    {
+        ArgumentNullException.ThrowIfNull(seedSymbolIds);
+        var seedIds = seedSymbolIds.ToHashSet(StringComparer.Ordinal);
+        if (seedIds.Count == 0)
+            return [];
+
+        var callersByCallee = CallEdges
+            .GroupBy(edge => edge.CalleeSymbolId, StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(edge => edge.CallerSymbolId)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray(),
+                StringComparer.Ordinal);
+
+        var affected = new HashSet<string>(StringComparer.Ordinal);
+        var queue = new Queue<string>(seedIds);
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (!callersByCallee.TryGetValue(current, out var callers))
+                continue;
+
+            foreach (var caller in callers)
+            {
+                if (seedIds.Contains(caller) || !affected.Add(caller))
+                    continue;
+                queue.Enqueue(caller);
+            }
+        }
+
+        return Declarations
+            .Where(declaration => affected.Contains(declaration.SymbolId))
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Impact of changing an entire file. Retained because "I rewrote this file"
+    /// is a real question — but it is no longer how a change to one declaration
+    /// is answered.
     /// </summary>
     public IReadOnlyList<IndexedDeclaration> FindImpactOfFile(string file)
     {

--- a/src/Calor.Compiler/Indexing/ProjectIndexBuilder.cs
+++ b/src/Calor.Compiler/Indexing/ProjectIndexBuilder.cs
@@ -113,6 +113,7 @@ public static class ProjectIndexBuilder
                     File = relative,
                     Line = line,
                     Column = column,
+                    SemanticHash = HashDefinition(document.Source, symbol),
                 });
             }
         }
@@ -165,6 +166,25 @@ public static class ProjectIndexBuilder
 
         index.Canonicalize();
         return index;
+    }
+
+    /// <summary>
+    /// Hashes a declaration's own definition text. Per declaration, not per
+    /// file: file granularity was measured and rejected (see
+    /// IndexedDeclaration.SemanticHash).
+    /// </summary>
+    private static string HashDefinition(string source, Symbol symbol)
+    {
+        var span = symbol.DefinitionSpan;
+        if (span.Start < 0 || span.Length <= 0 || span.End > source.Length)
+            span = symbol.DeclarationSpan;
+        if (span.Start < 0 || span.Length <= 0 || span.End > source.Length)
+            return "";
+
+        var text = source.Substring(span.Start, span.Length);
+        return Convert.ToHexStringLower(
+            System.Security.Cryptography.SHA256.HashData(
+                System.Text.Encoding.UTF8.GetBytes(text)))[..16];
     }
 
     private static string KindOf(Symbol symbol) => symbol switch

--- a/tests/Calor.Compiler.Tests/QueryGoldenTests.cs
+++ b/tests/Calor.Compiler.Tests/QueryGoldenTests.cs
@@ -50,6 +50,21 @@ public sealed class QueryGoldenTests : IDisposable
         var golden = LoadGoldens()[position];
         var index = BuildFixtureIndex();
 
+        if (golden.Facet == "impact")
+        {
+            // The subject is a FILE, not a declaration name.
+            var impacted = index.FindImpactOfFile(golden.Name);
+            Assert.Equal(
+                golden.Expect.OrderBy(entry => entry, StringComparer.Ordinal).ToArray(),
+                impacted
+                    .Select(declaration =>
+                        $"{declaration.File}:{declaration.Line}:{declaration.Name}")
+                    .OrderBy(entry => entry, StringComparer.Ordinal)
+                    .ToArray());
+            Assert.Equal(golden.Partial, index.ImpactAnswerIsPartial());
+            return;
+        }
+
         var declarations = index.FindDeclarations(golden.Name);
         Assert.True(
             declarations.Count > 0,

--- a/tests/Calor.Compiler.Tests/QueryGoldenTests.cs
+++ b/tests/Calor.Compiler.Tests/QueryGoldenTests.cs
@@ -50,10 +50,32 @@ public sealed class QueryGoldenTests : IDisposable
         var golden = LoadGoldens()[position];
         var index = BuildFixtureIndex();
 
+        if (golden.Facet == "impact-file")
+        {
+            // Whole-file impact: the subject is a file, kept for "I rewrote this".
+            var impacted = index.FindImpactOfFile(golden.Name);
+            Assert.Equal(
+                golden.Expect.OrderBy(entry => entry, StringComparer.Ordinal).ToArray(),
+                impacted
+                    .Select(declaration =>
+                        $"{declaration.File}:{declaration.Line}:{declaration.Name}")
+                    .OrderBy(entry => entry, StringComparer.Ordinal)
+                    .ToArray());
+            Assert.Equal(golden.Partial, index.ImpactAnswerIsPartial());
+            return;
+        }
+
         if (golden.Facet == "impact")
         {
-            // The subject is a FILE, not a declaration name.
-            var impacted = index.FindImpactOfFile(golden.Name);
+            // Declaration-seeded impact — the default, and the reason the
+            // granularity was changed: file seeding answered exactly right for
+            // 1% of functions on a real corpus.
+            var subjectDeclarations = index.FindDeclarations(golden.Name);
+            var target = golden.InFile == null
+                ? Assert.Single(subjectDeclarations)
+                : Assert.Single(subjectDeclarations.Where(
+                    declaration => declaration.File == golden.InFile));
+            var impacted = index.FindImpactOfDeclarations([target.SymbolId]);
             Assert.Equal(
                 golden.Expect.OrderBy(entry => entry, StringComparer.Ordinal).ToArray(),
                 impacted

--- a/tests/TestData/QueryCorpus/expected.json
+++ b/tests/TestData/QueryCorpus/expected.json
@@ -84,26 +84,41 @@
       "partial": true
     },
     {
-      "why": "math.calr declares Scale. ScaleTwice calls it but lives in the same file, so it is part of the change rather than affected by it; Run in app.calr is the genuine downstream. This is the case a naive impact answer gets wrong by including the seed file's own declarations.",
+      "why": "Declaration-seeded impact, the default. Changing Scale affects ScaleTwice (same file, but a DIFFERENT declaration, so genuinely affected) and Run in another file. Under the rejected file-grained scheme ScaleTwice was wrongly excluded as part of the seed.",
       "facet": "impact",
-      "name": "math.calr",
+      "name": "Scale",
+      "inFile": "math.calr",
       "expect": [
-        "app.calr:2:Run"
+        "app.calr:2:Run",
+        "math.calr:5:ScaleTwice"
       ],
       "partial": true
     },
     {
-      "why": "Nothing calls into app.calr, so a change there affects nothing else. Distinguishing 'affects nothing' from 'we could not tell' is why the residual is printed either way.",
+      "why": "Nothing calls ScaleTwice, so changing it affects nothing. Under file granularity this same question returned Run — the over-report that made the facet useless.",
       "facet": "impact",
-      "name": "app.calr",
+      "name": "ScaleTwice",
+      "inFile": "math.calr",
       "expect": [],
       "partial": true
     },
     {
-      "why": "ambiguous2.calr's only caller of its own Shared is AsksShared, in that same file — a seed, not an impact. The cross-file call from asks-across.calr is ambiguous and unattributed, which is exactly why this answer is partial rather than empty-and-complete.",
+      "why": "Only the same-file caller resolves; the cross-file call to Shared is ambiguous, which is why this is partial rather than complete.",
       "facet": "impact",
-      "name": "ambiguous2.calr",
-      "expect": [],
+      "name": "Shared",
+      "inFile": "ambiguous2.calr",
+      "expect": [
+        "ambiguous2.calr:5:AsksShared"
+      ],
+      "partial": true
+    },
+    {
+      "why": "Whole-file impact is still offered for 'I rewrote this file'. math.calr holds Scale and ScaleTwice, so only Run is downstream of the file as a unit.",
+      "facet": "impact-file",
+      "name": "math.calr",
+      "expect": [
+        "app.calr:2:Run"
+      ],
       "partial": true
     }
   ]

--- a/tests/TestData/QueryCorpus/expected.json
+++ b/tests/TestData/QueryCorpus/expected.json
@@ -82,6 +82,29 @@
       "inFile": "asks-across.calr",
       "expect": [],
       "partial": true
+    },
+    {
+      "why": "math.calr declares Scale. ScaleTwice calls it but lives in the same file, so it is part of the change rather than affected by it; Run in app.calr is the genuine downstream. This is the case a naive impact answer gets wrong by including the seed file's own declarations.",
+      "facet": "impact",
+      "name": "math.calr",
+      "expect": [
+        "app.calr:2:Run"
+      ],
+      "partial": true
+    },
+    {
+      "why": "Nothing calls into app.calr, so a change there affects nothing else. Distinguishing 'affects nothing' from 'we could not tell' is why the residual is printed either way.",
+      "facet": "impact",
+      "name": "app.calr",
+      "expect": [],
+      "partial": true
+    },
+    {
+      "why": "ambiguous2.calr's only caller of its own Shared is AsksShared, in that same file — a seed, not an impact. The cross-file call from asks-across.calr is ambiguous and unattributed, which is exactly why this answer is partial rather than empty-and-complete.",
+      "facet": "impact",
+      "name": "ambiguous2.calr",
+      "expect": [],
+      "partial": true
     }
   ]
 }


### PR DESCRIPTION
S3's impact facet — and the §9.1 checkpoint firing, which reversed the granularity decision.

## The checkpoint did its job

The maintainer chose file granularity (fast/cheap) with the cost recorded and a checkpoint to show a real answer before calling the facet done. Measured on the 106-file / 11k-line `fixture-10k` corpus — 1,366 functions, 587 call edges, zero residual:

| | file-grained | declaration-grained |
|---|---|---|
| answer exactly right | **10/988 functions (1%)** | 988/988 (100%) |
| mean reported impact | 13.17 declarations | 1.04 |
| true impact empty, answer non-empty | **683/988 (69%)** | 0 |

For roughly two functions in three, the honest answer was *"nothing is affected"* and the tool said otherwise — a ~13x over-report. Not blurry-but-useful; useless in a way that still looks like it works. Decision reversed.

**The argument could not have been settled by discussion.** On the five-file fixture, file granularity looked tight (6 declarations). Only real code exposed the 1%.

## What changed

`impact` is now seeded on a **declaration**. `IndexedDeclaration` carries a `SemanticHash` over its own definition text, and the per-file hashes are narrowed to the invalidation role they were always doing. **Format version 1.0 → 2.0** — a format revision, not a rewrite, which is exactly what the versioned header (§4) existed to permit. That is why honouring the checkpoint was cheap.

```
$ calor query impact l2m25_fn05
  l1m01.calr:3:11 function l1m01_fn01
  l1m14.calr:77:11 function l1m14_fn12
impact: 2 declaration(s) in 2 file(s) affected by a change to l2m25.calr:35:11 function l2m25_fn05
```

Whole-file impact stays behind `--file` — "I rewrote this file" is a real question — and prints its own granularity caveat.

## Ground truth changed too, and it is worth reading

Under file seeding, `ScaleTwice` was excluded from `Scale`'s impact as part of the seed file. Under declaration seeding it is correctly **included**: a different declaration that calls the changed one. The goldens were re-authored accordingly, with one retained for the `--file` variant.

Earlier discrimination check still holds for the file variant (removing seed-exclusion fails its goldens).

Release build clean (0 warnings); all 11 test projects green; both guards pass; scoping doc §9.1 records the reversal with both numbers.