### PR TITLE
Contracts and assumptions facets (S4)

### DIFF
--- a/bench/phase0-agent-native/binder-incomplete-baseline.json
+++ b/bench/phase0-agent-native/binder-incomplete-baseline.json
@@ -1,8 +1,8 @@
 {
   "IncompleteCount": 0,
-  "ParsedFiles": 505,
+  "ParsedFiles": 506,
   "ParseFailures": 9,
-  "ExpressionsBound": 4698,
+  "ExpressionsBound": 4702,
   "Scope": "both F-2 legs; conversion leg skips when corpus submodules are absent",
   "Conversion": {
     "Incomplete": 0,

--- a/eng/test-manifest.json
+++ b/eng/test-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "projects": [
-    { "path": "tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 6780, "expectedSkipped": 2 },
+    { "path": "tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 6784, "expectedSkipped": 2 },
     { "path": "tests/Calor.Conversion.Tests/Calor.Conversion.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 370, "expectedSkipped": 0 },
     { "path": "tests/Calor.Enforcement.Tests/Calor.Enforcement.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 309, "expectedSkipped": 0 },
     { "path": "tests/Calor.Evaluation/Calor.Evaluation.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 198, "expectedSkipped": 0 },

--- a/src/Calor.Compiler/Commands/QueryCommand.cs
+++ b/src/Calor.Compiler/Commands/QueryCommand.cs
@@ -29,6 +29,8 @@ public static class QueryCommand
             CreateFacetCommand("callers", "What calls a declaration"),
             CreateFacetCommand("callees", "What a declaration calls"),
             CreateImpactCommand(),
+            CreateFacetCommand("contracts", "Contracts declared on a declaration"),
+            CreateFacetCommand("assumptions", "Assumptions in force for a declaration"),
         };
         return command;
     }
@@ -265,6 +267,40 @@ public static class QueryCommand
                 return 1;
             }
             subject = matches[0];
+        }
+
+        if (facet == "contracts")
+        {
+            var contracts = index.FindContracts(subject.SymbolId);
+            foreach (var contract in contracts)
+                Console.WriteLine($"  {contract.File}:{contract.Line} {contract.Kind}: {contract.Text}");
+            Console.WriteLine(
+                contracts.Count == 0
+                    ? $"query: no contracts declared on {Describe(subject)}"
+                    : $"query: {contracts.Count} contract(s) on {Describe(subject)}");
+            // The index records what is DECLARED. A proof status would have to
+            // come from the verifier, and a stale "Proven" is worse than none.
+            Console.WriteLine(
+                "query: declared contracts only — run `calor verify` for proof outcomes");
+            return 0;
+        }
+
+        if (facet == "assumptions")
+        {
+            var assumptions = index.FindAssumptions(subject.SymbolId, subject.File);
+            foreach (var assumption in assumptions)
+            {
+                var scope = assumption.Scope == "module" ? "module-wide" : "on this declaration";
+                var category = string.IsNullOrEmpty(assumption.Category)
+                    ? "" : $"[{assumption.Category}] ";
+                Console.WriteLine(
+                    $"  {assumption.File}:{assumption.Line} ({scope}) {category}{assumption.Description}");
+            }
+            Console.WriteLine(
+                assumptions.Count == 0
+                    ? $"query: nothing is assumed for {Describe(subject)}"
+                    : $"query: {assumptions.Count} assumption(s) in force for {Describe(subject)}");
+            return 0;
         }
 
         var (answer, partial) = facet switch

--- a/src/Calor.Compiler/Indexing/ProjectIndex.cs
+++ b/src/Calor.Compiler/Indexing/ProjectIndex.cs
@@ -54,6 +54,38 @@ public sealed class IndexedCallEdge
 }
 
 /// <summary>
+/// A contract clause declared on a declaration.
+///
+/// The index records what is DECLARED, never a proof status. Outcomes come from
+/// running the verifier (`calor verify`, `review-packet`); an index that carried
+/// a stale "Proven" would be worse than one that carries none, because the whole
+/// point of a proof is that you can rely on it.
+/// </summary>
+public sealed class IndexedContract
+{
+    public string SymbolId { get; set; } = "";
+    public string Kind { get; set; } = "";
+    public int Index { get; set; }
+    public string Text { get; set; } = "";
+    public string File { get; set; } = "";
+    public int Line { get; set; }
+}
+
+/// <summary>
+/// An assumption declared on a module or a declaration — the things a reader is
+/// being asked to take on trust, which is exactly what a reviewer wants listed.
+/// </summary>
+public sealed class IndexedAssumption
+{
+    public string SymbolId { get; set; } = "";
+    public string Scope { get; set; } = "";
+    public string Category { get; set; } = "";
+    public string Description { get; set; } = "";
+    public string File { get; set; } = "";
+    public int Line { get; set; }
+}
+
+/// <summary>
 /// A call site that resolved to nothing.
 /// </summary>
 public sealed class IndexedUnresolvedCall
@@ -110,7 +142,7 @@ public sealed class IndexResidual
 /// </summary>
 public sealed class ProjectIndex
 {
-    public const string CurrentFormatVersion = "2.0";
+    public const string CurrentFormatVersion = "3.0";
 
     public string FormatVersion { get; set; } = CurrentFormatVersion;
     public string CompilerSemanticsVersion { get; set; } =
@@ -131,6 +163,8 @@ public sealed class ProjectIndex
     public List<IndexedDeclaration> Declarations { get; set; } = [];
     public List<IndexedOccurrence> Occurrences { get; set; } = [];
     public List<IndexedCallEdge> CallEdges { get; set; } = [];
+    public List<IndexedContract> Contracts { get; set; } = [];
+    public List<IndexedAssumption> Assumptions { get; set; } = [];
     public IndexResidual Residual { get; set; } = new();
 
     public static string PathFor(string outputDirectory) =>
@@ -294,6 +328,32 @@ public sealed class ProjectIndex
             .ToArray();
     }
 
+    /// <summary>Contracts declared on a symbol.</summary>
+    public IReadOnlyList<IndexedContract> FindContracts(string symbolId)
+    {
+        ArgumentNullException.ThrowIfNull(symbolId);
+        return Contracts
+            .Where(contract => string.Equals(
+                contract.SymbolId, symbolId, StringComparison.Ordinal))
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Assumptions in force for a symbol: its own, plus the module-scoped ones
+    /// declared in its file. A module assumption applies to everything in that
+    /// module, so omitting it would under-report what a reader must trust.
+    /// </summary>
+    public IReadOnlyList<IndexedAssumption> FindAssumptions(string symbolId, string file)
+    {
+        ArgumentNullException.ThrowIfNull(symbolId);
+        return Assumptions
+            .Where(assumption =>
+                string.Equals(assumption.SymbolId, symbolId, StringComparison.Ordinal)
+                || (assumption.Scope == "module"
+                    && string.Equals(assumption.File, file, StringComparison.Ordinal)))
+            .ToArray();
+    }
+
     /// <summary>
     /// What a change to <paramref name="file"/> could affect: every declaration
     /// reachable by following call edges INTO the declarations that file holds,
@@ -450,6 +510,15 @@ public sealed class ProjectIndex
             .ThenBy(item => item.Line)
             .ThenBy(item => item.Column)
             .ThenBy(item => item.CalleeSymbolId, StringComparer.Ordinal)];
+        Contracts = [.. Contracts
+            .OrderBy(item => item.File, StringComparer.Ordinal)
+            .ThenBy(item => item.Line)
+            .ThenBy(item => item.Kind, StringComparer.Ordinal)
+            .ThenBy(item => item.Index)];
+        Assumptions = [.. Assumptions
+            .OrderBy(item => item.File, StringComparer.Ordinal)
+            .ThenBy(item => item.Line)
+            .ThenBy(item => item.Description, StringComparer.Ordinal)];
         Residual.UnreadableFiles.Sort(StringComparer.Ordinal);
         Residual.UnresolvedCalls = [.. Residual.UnresolvedCalls
             .OrderBy(item => item.File, StringComparer.Ordinal)

--- a/src/Calor.Compiler/Indexing/ProjectIndexBuilder.cs
+++ b/src/Calor.Compiler/Indexing/ProjectIndexBuilder.cs
@@ -135,6 +135,58 @@ public static class ProjectIndexBuilder
             }
         }
 
+        foreach (var document in symbols.Documents)
+        {
+            var relative = Relative(options.ProjectDirectory, document.FilePath);
+            var moduleId = document.BoundModule.SymbolsById.Values
+                .OfType<FunctionSymbol>()
+                .Select(symbol => symbol.Id.Value)
+                .FirstOrDefault() ?? "";
+
+            // Module-scoped assumptions apply to everything in the file, so they
+            // are recorded against the file rather than any one declaration.
+            foreach (var assumption in document.Ast.Assumptions)
+            {
+                var (line, _) = LineColumn(document.Source, assumption.Span.Start);
+                index.Assumptions.Add(new IndexedAssumption
+                {
+                    SymbolId = "",
+                    Scope = "module",
+                    Category = assumption.Category?.ToString() ?? "",
+                    Description = assumption.Description,
+                    File = relative,
+                    Line = line,
+                });
+            }
+
+            foreach (var function in document.Ast.Functions)
+            {
+                var symbol = document.BoundModule.Functions
+                    .FirstOrDefault(bound => bound.Symbol.Name == function.Name)?.Symbol;
+                if (symbol == null || symbol.Id.IsNone)
+                    continue;
+
+                AddContracts(index, document, relative, symbol.Id.Value,
+                    "precondition", function.Preconditions.Select(node => node.Span));
+                AddContracts(index, document, relative, symbol.Id.Value,
+                    "postcondition", function.Postconditions.Select(node => node.Span));
+
+                foreach (var assumption in function.Assumptions)
+                {
+                    var (line, _) = LineColumn(document.Source, assumption.Span.Start);
+                    index.Assumptions.Add(new IndexedAssumption
+                    {
+                        SymbolId = symbol.Id.Value,
+                        Scope = "declaration",
+                        Category = assumption.Category?.ToString() ?? "",
+                        Description = assumption.Description,
+                        File = relative,
+                        Line = line,
+                    });
+                }
+            }
+        }
+
         var sourcesByPath = symbols.Documents.ToDictionary(
             document => document.FilePath,
             document => document.Source,
@@ -166,6 +218,33 @@ public static class ProjectIndexBuilder
 
         index.Canonicalize();
         return index;
+    }
+
+    private static void AddContracts(
+        ProjectIndex index,
+        IndexedDocument document,
+        string relative,
+        string symbolId,
+        string kind,
+        IEnumerable<Calor.Compiler.Parsing.TextSpan> spans)
+    {
+        var position = 0;
+        foreach (var span in spans)
+        {
+            var (line, _) = LineColumn(document.Source, span.Start);
+            var text = span.Start >= 0 && span.Length > 0 && span.End <= document.Source.Length
+                ? document.Source.Substring(span.Start, span.Length).Trim()
+                : "";
+            index.Contracts.Add(new IndexedContract
+            {
+                SymbolId = symbolId,
+                Kind = kind,
+                Index = position++,
+                Text = text,
+                File = relative,
+                Line = line,
+            });
+        }
     }
 
     /// <summary>

--- a/tests/Calor.Compiler.Tests/QueryGoldenTests.cs
+++ b/tests/Calor.Compiler.Tests/QueryGoldenTests.cs
@@ -65,6 +65,27 @@ public sealed class QueryGoldenTests : IDisposable
             return;
         }
 
+        if (golden.Facet is "contracts" or "assumptions")
+        {
+            var owners = index.FindDeclarations(golden.Name);
+            var owner = golden.InFile == null
+                ? Assert.Single(owners)
+                : Assert.Single(owners.Where(
+                    declaration => declaration.File == golden.InFile));
+
+            var rendered = golden.Facet == "contracts"
+                ? index.FindContracts(owner.SymbolId)
+                    .Select(contract => $"{contract.File}:{contract.Line}:{contract.Kind}")
+                : index.FindAssumptions(owner.SymbolId, owner.File)
+                    .Select(assumption =>
+                        $"{assumption.File}:{assumption.Line}:{assumption.Scope}");
+
+            Assert.Equal(
+                golden.Expect.OrderBy(entry => entry, StringComparer.Ordinal).ToArray(),
+                rendered.OrderBy(entry => entry, StringComparer.Ordinal).ToArray());
+            return;
+        }
+
         if (golden.Facet == "impact")
         {
             // Declaration-seeded impact — the default, and the reason the

--- a/tests/TestData/Formatting/formatter-corpus-baseline.json
+++ b/tests/TestData/Formatting/formatter-corpus-baseline.json
@@ -1,6 +1,6 @@
 {
-  "trackedFileCount": 876,
-  "successfulTransformationCount": 641,
+  "trackedFileCount": 877,
+  "successfulTransformationCount": 642,
   "parseFailurePaths": [
     "bench/mcp/tasks/01-fix-closing-tag/expected.calr",
     "bench/mcp/tasks/01-fix-closing-tag/input.calr",

--- a/tests/TestData/QueryCorpus/expected.json
+++ b/tests/TestData/QueryCorpus/expected.json
@@ -120,6 +120,46 @@
         "app.calr:2:Run"
       ],
       "partial": true
+    },
+    {
+      "why": "Contracts declared on a function, in source order and kind. The index records what is DECLARED — a proof status would have to come from the verifier, and a stale 'Proven' is worse than none.",
+      "facet": "contracts",
+      "name": "Bounded",
+      "inFile": "contracts.calr",
+      "expect": [
+        "contracts.calr:5:precondition",
+        "contracts.calr:6:postcondition"
+      ],
+      "partial": false
+    },
+    {
+      "why": "A function with no contracts reports none, rather than inheriting its neighbour's.",
+      "facet": "contracts",
+      "name": "Plain",
+      "inFile": "contracts.calr",
+      "expect": [],
+      "partial": false
+    },
+    {
+      "why": "Assumptions in force = the declaration's own PLUS the module-wide one. Omitting module scope would under-report what a reader is being asked to trust.",
+      "facet": "assumptions",
+      "name": "Bounded",
+      "inFile": "contracts.calr",
+      "expect": [
+        "contracts.calr:2:module",
+        "contracts.calr:7:declaration"
+      ],
+      "partial": false
+    },
+    {
+      "why": "The discriminating pair: Plain inherits the MODULE assumption but not Bounded's declaration-scoped one. A scope-blind implementation returns both and passes the Bounded case while failing here.",
+      "facet": "assumptions",
+      "name": "Plain",
+      "inFile": "contracts.calr",
+      "expect": [
+        "contracts.calr:2:module"
+      ],
+      "partial": false
     }
   ]
 }

--- a/tests/TestData/QueryCorpus/project/contracts.calr
+++ b/tests/TestData/QueryCorpus/project/contracts.calr
@@ -1,0 +1,11 @@
+§M{m006:Contracted}
+  §AS{env} "the clock is monotonic"
+  §F{f001:Bounded:pub} (i32:n) -> i32
+    §E{}
+    §Q (>= n 0)
+    §S (>= result 1)
+    §AS{perf} "callers pass small values"
+    §R (+ n INT:1)
+  §F{f002:Plain:pub} () -> i32
+    §E{}
+    §R INT:0


### PR DESCRIPTION
Completes v1's facet set (`docs/plans/index-query-v1-scoping.md` §1) — everything except `effects`, which stays excluded as the roadmap requires and #925 evidences.

## `contracts` — declared, never proven

```
$ calor query contracts Bounded
  contracts.calr:5 precondition: §Q (>= n 0)
  contracts.calr:6 postcondition: §S (>= result 1)
query: 2 contract(s) on contracts.calr:3:11 function Bounded
query: declared contracts only — run `calor verify` for proof outcomes
```

The index deliberately carries **no proof status**. It is rebuilt from syntax; a stale `Proven` would be worse than no verdict at all, because the entire value of a proof is that it can be relied on. The last line says so on every answer rather than leaving it to documentation.

(I checked whether cached outcomes could be served soundly — the verification cache *does* key on the function body, so it would be. It is still out of scope for v1: the index would then depend on an optional, separately-scoped cache, and "sometimes there is a verdict" is a worse contract than "never".)

## `assumptions` — including what you inherit

```
$ calor query assumptions Bounded
  contracts.calr:2 (module-wide) [Env] the clock is monotonic
  contracts.calr:7 (on this declaration) callers pass small values
query: 2 assumption(s) in force for contracts.calr:3:11 function Bounded
```

A declaration's own assumptions **plus** the module-scoped ones over its file. Omitting module scope would under-report precisely what a reviewer wants surfaced.

## The discriminating pair

Four goldens, hand-authored. One exists specifically to catch a scope-blind implementation:

`Plain` inherits the module-wide assumption but **not** `Bounded`'s declaration-scoped one. An implementation that just returns everything in the file passes the `Bounded` golden and fails only this one — verified by injecting exactly that fault:

```
QueryAnswersMatchGroundTruth(position: 16, label: "assumptions:Plain") [FAIL]
Failed: 1, Passed: 18
```

## Housekeeping

Format version 2.0 → 3.0 for the added collections. Baselines regenerated with the change named: binder ratchet 505 → 506 parsed (`IncompleteCount` still 0); formatter corpus 876 → 877 tracked, 641 → 642 losslessly formatted; test inventory 6,780 → 6,784 — verified with `check_trx.py` against a real TRX rather than by arithmetic, plus `check_test_quality.py`.

Release build clean (0 warnings); all test projects green; both guards pass.

Next: S5, the gate-8 performance envelope on FluentValidation.