### PR TITLE
Gate 8 performance envelope (S5)

### DIFF
--- a/docs/plans/index-query-v1-scoping.md
+++ b/docs/plans/index-query-v1-scoping.md
@@ -116,10 +116,23 @@ gate 2's identity alone would pass an identically-wrong index.
 **Gate 8 — performance envelope.** Index build ≤ 30s, warm `calor query`
 ≤ 500ms, measured in CI.
 
-- **Denominator: FluentValidation** — 208 non-test `.cs` files, ~25.7k lines,
-  the largest of the three pinned subjects (serilog 112/14.0k, MediatR 76/4.1k).
-  Named here so "largest" is not re-decided later against a smaller subject.
-- Numbers are published per release whether or not they pass.
+- **Denominator: CORRECTED (2026-08-12).** This doc originally named
+  FluentValidation, chosen as the largest pinned subject by **C# size** (208
+  files / 25.7k lines). That was the wrong measure: what the index consumes is
+  the **converted Calor**, and FluentValidation converts to 62 files / 2.2k
+  lines — 45% of its files, the converter's fidelity-over-coverage posture
+  working as designed. Measured against the C# line count, the gate would have
+  claimed a scale the index never sees.
+
+  The subject is therefore the in-repo **`fixture-10k`** corpus (106 files /
+  11.1k lines, 5,445 declarations, 587 call edges, zero residual), with
+  converted FluentValidation retained as a smaller second data point.
+- Numbers are published per release whether or not they pass. **First
+  measurement (2026-08-12), in-process on `fixture-10k`:** index build
+  **0.40s** against a 30s budget; warm queries **0.0–0.3ms** across all six
+  facets against a 500ms budget. End-to-end through the published binary,
+  which is what a user feels: **0.74s** build, **0.12s** query — the remainder
+  is process startup (~80ms floor), not query work.
 
 **Gate 2's index-contents leg** rides along: the ES-01..ES-07 corpus and
 `EditScriptIdentityTests` already exist, so the leg is an added assertion that

--- a/eng/performance-baselines.json
+++ b/eng/performance-baselines.json
@@ -2,11 +2,11 @@
   "schemaVersion": 1,
   "warmupRuns": 1,
   "measuredRuns": 3,
-  "expectedTestCount": 19,
+  "expectedTestCount": 21,
   "metrics": {
     "performance-suite-seconds": {
-      "maximumMedian": 20.0,
-      "noisePolicy": "One warmup is discarded; three isolated runs are measured; the median must remain at or below the ratcheted maximum."
+      "maximumMedian": 21.0,
+      "noisePolicy": "One warmup is discarded; three isolated runs are measured; the median must remain at or below the ratcheted maximum. Raised 20.0 -> 21.0 on 2026-08-12 for the gate-8 index/query coverage (IndexPerformanceTests): the suite measured ~19.8s against a 20.0s ceiling, i.e. ~1% headroom, so any added coverage breached it. Observed run-to-run spread is ~0.5s, so the new ceiling sits ~0.9s above the measured median rather than hugging it. The added tests were first made cheaper — one shared index build via a class fixture instead of three — before the ceiling moved at all."
     }
   }
 }

--- a/tests/Calor.Performance.Tests/AssemblyInfo.cs
+++ b/tests/Calor.Performance.Tests/AssemblyInfo.cs
@@ -1,0 +1,16 @@
+using Xunit;
+
+// Performance tests measure time and memory, and both measurements are only
+// meaningful in a quiet process. xUnit parallelises across test CLASSES by
+// default, so a second class in this assembly runs concurrently with the first
+// and its allocations land between another test's before/after memory samples.
+//
+// That is not hypothetical: adding IndexPerformanceTests made
+// VerificationPerformanceTests.Memory_SmallModule_Under10MB fail, while it
+// passed when run alone. The measurement was contaminated, not the code
+// regressed.
+//
+// Disabling parallelisation assembly-wide is the fix that keeps every
+// measurement here honest, rather than making one test tolerant of noise it
+// should never have seen.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Calor.Performance.Tests/IndexPerformanceTests.cs
+++ b/tests/Calor.Performance.Tests/IndexPerformanceTests.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+using Calor.Compiler.Indexing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Calor.Performance.Tests;
+
+/// <summary>
+/// Performance envelope for the project index (roadmap §2.5 gate 8): index build
+/// ≤ 30s and a warm query ≤ 500ms at project scale.
+///
+/// The bars are generous by design — the point is that "usable at project scale"
+/// is adjudicable at all, and that the number is published whether or not it
+/// passes.
+///
+/// **Denominator, and a correction.** The scoping doc named FluentValidation as
+/// the subject, chosen as the largest of the three pinned conversion subjects by
+/// C# size (208 files / 25.7k lines). That was the wrong measure: what gets
+/// indexed is the CONVERTED Calor, and FluentValidation converts to 62 files /
+/// 2.2k lines — 45% of its files, the converter's fidelity-over-coverage posture
+/// working as intended. The in-repo `fixture-10k` corpus (106 files / 11.1k
+/// lines, 1,366 functions, 587 call edges) is therefore the larger real Calor
+/// subject and is measured here, with the conversion subject retained as a
+/// second, smaller data point. Measuring the C# line count would have reported a
+/// scale the index never sees.
+/// </summary>
+public sealed class IndexPerformanceFixture
+{
+    // Built once and shared. Each build costs ~0.4s on the project-scale corpus,
+    // and the suite carries a ratcheted total-duration ceiling — rebuilding per
+    // test would spend that budget on setup rather than on coverage.
+    public IndexPerformanceFixture()
+    {
+        Root = FindFixtureRoot();
+        Sources = ProjectIndexBuilder.DiscoverSources(Root);
+        Options = new ProjectIndexBuilder.Options(Root, "perf-gate", Sources);
+        Index = ProjectIndexBuilder.Build(Options);
+    }
+
+    public string Root { get; }
+    public IReadOnlyList<string> Sources { get; }
+    public ProjectIndexBuilder.Options Options { get; }
+    public ProjectIndex Index { get; }
+
+    private static string FindFixtureRoot()
+    {
+        var directory = AppContext.BaseDirectory;
+        while (!File.Exists(Path.Combine(directory, "Calor.sln")))
+            directory = Directory.GetParent(directory)!.FullName;
+        return Path.Combine(
+            directory, "bench", "phase0-agent-native", "latency", "fixture-10k", "src");
+    }
+}
+
+public class IndexPerformanceTests : IClassFixture<IndexPerformanceFixture>
+{
+    private const double IndexBuildBudgetSeconds = 30.0;
+    private const double WarmQueryBudgetMilliseconds = 500.0;
+
+    private readonly ITestOutputHelper _output;
+    private readonly IndexPerformanceFixture _fixture;
+
+    public IndexPerformanceTests(ITestOutputHelper output, IndexPerformanceFixture fixture)
+    {
+        _output = output;
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void IndexBuildStaysWithinItsBudget()
+    {
+        var sources = _fixture.Sources;
+        Assert.True(
+            sources.Count >= 100,
+            $"expected the project-scale fixture, found {sources.Count} files — "
+                + "a shrunken corpus would make this budget meaningless");
+
+        // The fixture's construction already warmed the file cache and the JIT.
+        var stopwatch = Stopwatch.StartNew();
+        var index = ProjectIndexBuilder.Build(_fixture.Options);
+        stopwatch.Stop();
+
+        var seconds = stopwatch.Elapsed.TotalSeconds;
+        _output.WriteLine(
+            $"index build: {seconds:F2}s over {sources.Count} files, "
+                + $"{index.Declarations.Count} declarations, {index.CallEdges.Count} call edges "
+                + $"(budget {IndexBuildBudgetSeconds}s)");
+
+        Assert.True(
+            seconds <= IndexBuildBudgetSeconds,
+            $"index build took {seconds:F2}s, over the {IndexBuildBudgetSeconds}s budget");
+    }
+
+    [Fact]
+    public void WarmQueriesStayWithinTheirBudget()
+    {
+        var index = _fixture.Index;
+        var subject = index.Declarations.First(
+            declaration => declaration.Kind == "function");
+
+        // Every facet, not just the cheapest: callers and impact walk the call
+        // graph, and impact walks it transitively, so measuring only `symbol`
+        // would report a budget the expensive facets never had to meet.
+        var facets = new (string Name, Action Run)[]
+        {
+            ("symbol", () => index.FindDeclarations(subject.Name)),
+            ("callers", () => index.FindCallers(subject.SymbolId)),
+            ("callees", () => index.FindCallees(subject.SymbolId)),
+            ("impact", () => index.FindImpactOfDeclarations([subject.SymbolId])),
+            ("contracts", () => index.FindContracts(subject.SymbolId)),
+            ("assumptions", () => index.FindAssumptions(subject.SymbolId, subject.File)),
+        };
+
+        foreach (var (name, run) in facets)
+        {
+            run(); // warm
+
+            var stopwatch = Stopwatch.StartNew();
+            run();
+            stopwatch.Stop();
+
+            var milliseconds = stopwatch.Elapsed.TotalMilliseconds;
+            _output.WriteLine(
+                $"warm query {name}: {milliseconds:F1}ms "
+                    + $"(budget {WarmQueryBudgetMilliseconds}ms)");
+            Assert.True(
+                milliseconds <= WarmQueryBudgetMilliseconds,
+                $"warm '{name}' query took {milliseconds:F1}ms, over the "
+                    + $"{WarmQueryBudgetMilliseconds}ms budget");
+        }
+    }
+}


### PR DESCRIPTION
Closes gate 8 (roadmap §2.5): index build ≤ 30s, warm query ≤ 500ms at project scale — and two corrections the work forced.

## The numbers, published

Measured in-process on `fixture-10k` (106 files / 11.1k lines, 5,445 declarations, 587 call edges, zero residual):

| | measured | budget |
|---|---|---|
| index build | **0.40s** | 30s |
| warm query (all six facets) | **0.0–0.3ms** | 500ms |

End-to-end through the published binary — what a user actually feels — **0.74s** build, **0.12s** query. The remainder is ~80ms of process startup, not query work.

**All six facets are timed**, not just the cheapest: `callers` and `impact` walk the call graph and `impact` walks it transitively, so measuring `symbol` alone would report a budget the expensive facets never had to meet.

## Correction 1 — the denominator was wrong, and it was mine

The scoping doc named FluentValidation, which I picked as the largest pinned subject by **C# size** (208 files / 25.7k lines). But the index consumes **converted Calor**, and FluentValidation converts to **62 files / 2.2k lines** — 45% of its files, the converter's fidelity-over-coverage posture working exactly as designed.

So the subject I named is one of the *smaller* real Calor corpora. Measuring against its C# line count would have let the gate claim a scale the index never sees. Subject corrected to `fixture-10k`, with converted FluentValidation retained as a second, smaller data point. The doc records the error and the correction.

## Correction 2 — my new tests silently corrupted an existing measurement

`VerificationPerformanceTests.Memory_SmallModule_Under10MB` started failing — and passed when run alone.

Cause: xUnit parallelises across test **classes**. Adding a second class to this project meant my index tests ran concurrently with the memory tests, and my allocations landed between that test's before/after `GC.GetTotalMemory` samples. The measurement was contaminated; the code had not regressed.

Fixed by disabling parallelisation assembly-wide, which is simply correct for a project where every test measures time or memory — rather than making the victim test tolerant of noise it should never have seen.

## The ratchet moved, and only after the tests got cheaper

The suite carries a ratcheted total-duration ceiling. It measured ~19.8s against 20.0s — about 1% headroom — so *any* added coverage breached it.

I first cut my tests' cost: one shared index build via a class fixture instead of three. Median came to 20.07s, still over. Then the ceiling moved 20.0 → 21.0s, with the reason, the measured median, and the observed ~0.5s run-to-run spread recorded in `eng/performance-baselines.json` itself. The new ceiling sits ~0.9s above the median rather than hugging it.

Order matters here: cheaper tests first, ceiling second.

## Validation

Release build clean (0 warnings); all test projects green; performance gate passes (median 20.0s / max 21.0s); test-quality, dogfood, and Calor-first guards pass.

**This completes index/query v1** (S1–S5) and gate 8. Remaining before 0.14 entry: nothing — next is the §3.1 metadata-backed binding spike, which is 0.14 proper.