### PR TITLE
Pre-register the §3.1 metadata-binding entry spike

### DIFF
--- a/bench/phase0-agent-native/binder-incomplete-baseline.json
+++ b/bench/phase0-agent-native/binder-incomplete-baseline.json
@@ -1,8 +1,8 @@
 {
   "IncompleteCount": 0,
-  "ParsedFiles": 506,
-  "ParseFailures": 9,
-  "ExpressionsBound": 4702,
+  "ParsedFiles": 511,
+  "ParseFailures": 10,
+  "ExpressionsBound": 4721,
   "Scope": "both F-2 legs; conversion leg skips when corpus submodules are absent",
   "Conversion": {
     "Incomplete": 0,

--- a/docs/plans/spike-3-1-bcl-binding-registration.md
+++ b/docs/plans/spike-3-1-bcl-binding-registration.md
@@ -1,0 +1,112 @@
+# §3.1 entry spike — pre-registration
+
+**Status: registered, not yet measured.** This document exists to be committed
+*before* any binding is attempted, so the denominator and the adjudication rule
+cannot be chosen after seeing results. Nothing in §2 or §3 may be edited once
+measurement begins; §5 is filled in afterwards.
+
+## 1. Why this spike gates 0.14
+
+The roadmap (§3.1) names metadata-backed .NET binding as the component that can
+sink 0.14 — not the flow checker, which has TIER1A. It is a slice of Roslyn's
+binder: exact receiver type, overload resolution, parameter and return types,
+generic substitution, nullable annotations.
+
+This repo's own postmortem records systematic underestimation in exactly this
+area (`tier1a-postmortem.md` §7.1 V4: overload resolution — 18 overloads on
+`Console.WriteLine` — absent from the original estimate; V3's "3–5 days, not
+1–2" correction on the adjacent TIER2D spike). The spike is sized on that
+record, not on optimism.
+
+**What the compiler does today**, for contrast: call resolution is string-based.
+#925 is the measured form of the consequence — a qualified `§C{Module.Function}`
+resolves as an *unknown external call*, so the callee's declared effects never
+reach the answer. The index built in 0.13.x inherits the same limit and reports
+it as residual rather than hiding it.
+
+## 2. The registered shapes
+
+Six families. Each is a `.calr` fixture under
+`tests/TestData/BclCallShapes/`, calling real BCL surface, with the **expected
+exact signature** recorded alongside it. The expected signature is written by
+reading the BCL, not by running the binder.
+
+| id | family | why it is in the set |
+|----|--------|----------------------|
+| BCL-01 | **overload resolution** | `Console.WriteLine` has 18 overloads; picking by arity alone is indistinguishable from correct on most of them and wrong on the rest. The postmortem names this as the omission that broke the last estimate. |
+| BCL-02 | **generic substitution** | `List<T>.Add`, `Dictionary<K,V>.TryGetValue` — the receiver's type arguments must flow into the parameter types, or `Add(string)` and `Add(int)` are the same call. |
+| BCL-03 | **extension methods** | `IEnumerable<T>.Select`/`Where` — the receiver is the *first parameter* of a static method on another type. A binder that only looks at instance members finds nothing and silently reports unresolved. |
+| BCL-04 | **`params` arrays** | `string.Format(string, params object[])` — arity does not match the declaration, so an arity-keyed lookup fails on a call that is perfectly legal. |
+| BCL-05 | **nullable annotations** | `Dictionary.TryGetValue(K, out V?)`, `string?` returns — 0.14's entire premise is that these annotations survive the boundary, so failing to read them is failing the release. |
+| BCL-06 | **`ref` / `out`** | `int.TryParse(string, out int)` — the modifier is part of the signature; ignoring it resolves to an overload that does not exist. **See §2.1: this one is not currently expressible.** |
+
+### 2.1 Pre-measurement finding: BCL-06 is not expressible today
+
+Recorded here because it was found while writing the fixtures — *before* any
+measurement — and it changes what a BCL-06 failure would mean.
+
+**Calor has no call-site syntax for `ref`/`out` arguments.** `§O` is a
+statement-level output declaration, not an argument form, and the parser passes
+`argumentModifiers: null` at every call-construction site. The converter emits
+`:out` on parameter *declarations* only. So `Int32.TryParse(text, out value)`
+cannot be written in Calor at all.
+
+That is a **language gap, not a binding gap**, and the two adjudicate
+differently: a binder that cannot resolve a call nobody can write has not
+failed. §4 therefore separates them, which it did not in the first draft of this
+document. The fixture is retained as a registered shape so the gap stays
+visible and is re-tested once the syntax exists.
+
+**These six are the denominator** (five expressible, per §2.1). The spike is measured against them and
+nothing else. Shapes discovered later to be hard may not be removed; they may
+only be recorded in §5 as newly-registered follow-ups with their own outcome.
+
+## 3. Method
+
+1. Load real reference assemblies (the same `TRUSTED_PLATFORM_ASSEMBLIES` set
+   the test suite already uses for Roslyn compilation).
+2. For each registered call site, attempt to resolve it to **one exact member**:
+   declaring type, full parameter list with modifiers, return type, and the
+   substituted type arguments where generic.
+3. A shape counts as **resolved** only if the resolved signature matches the
+   pre-recorded expected signature *exactly*. Resolving to the wrong overload
+   counts as **wrong**, not as resolved — that distinction is the whole point,
+   because a plausible wrong answer is what this area produces.
+4. Everything else is **unresolved**.
+
+Resolved / wrong / unresolved are reported per shape, never only as a total: a
+70% total made of five half-working families is a different situation from four
+solid families and two absent ones, and only the per-shape table distinguishes
+them.
+
+## 4. Adjudication — fixed before measuring
+
+| outcome | rule | what 0.14 does |
+|---|---|---|
+| **GREEN** | all five expressible families resolved, zero wrong | metadata binding proceeds as planned; §3.5 gate 2's bar freezes at the measured fraction over the conversion corpus |
+| **AMBER** | ≥4 of the five expressible families resolved, zero wrong | proceed on the **planned exit ramp** (§3.1): ship exact-signature binding for the resolved subset, explicit fail-safe `unresolved` for the rest, and the unsupported families published as a ledger |
+| **RED** | any family resolves **wrong**, or ≤3 *expressible* families resolved | metadata binding is re-scoped before any of it merges. A wrong answer is disqualifying at any count, because unresolved is honest and wrong is not |
+
+**Not-expressible is its own category, and it is excluded from the counts
+above.** A family Calor cannot express (BCL-06 today, per §2.1) is neither
+resolved nor unresolved by the binder — counting it as a binder failure would
+adjudicate a language gap as a binding gap and could push a working mechanism to
+RED. Such families are reported separately, with the missing syntax named, and
+each one is a registered 0.14 work item in its own right.
+
+Expressible families as registered: **five** (BCL-01..05). GREEN/AMBER/RED
+counts are over those five.
+
+**No row is a "try harder and re-measure" row.** If the result is RED, the
+re-scope is the deliverable, and a second measurement requires this document to
+be amended with the reason before it is taken.
+
+The spike's conclusion **freezes §3.5 gate 2's bar**. That bar is a fraction
+over the pinned conversion-subject corpus, not over these six shapes — these
+establish whether the mechanism works at all; the corpus establishes how far it
+reaches.
+
+## 5. Results
+
+*Empty by construction. Filled in after measurement, together with the
+adjudicated row and the date.*

--- a/tests/Calor.Compiler.Tests/Binding/BinderIncompleteRatchetTests.cs
+++ b/tests/Calor.Compiler.Tests/Binding/BinderIncompleteRatchetTests.cs
@@ -45,6 +45,14 @@ public class BinderIncompleteRatchetTests
             ["tests/TestData/LintScenarios/10_error_cases/mismatched_ids.calr"] =
                 "error fixture (NOTE: currently fails on Calor0830 legacy closers, not the " +
                 "mismatched ids it was built for — stale in its own way, see #901's pattern)",
+            // §3.1 entry-spike shape that the LANGUAGE cannot express yet (#943):
+            // Calor can declare an `out` parameter but has no call-site form for
+            // passing one, so Int32.TryParse is unwritable. Registered rather than
+            // deleted so the gap stays visible and is re-tested the moment the
+            // syntax lands — deleting it would quietly shrink the spike's
+            // denominator to the shapes that happen to work.
+            ["tests/TestData/BclCallShapes/BCL-06-ref-out.calr"] =
+                "#943 no call-site ref/out syntax; registered §3.1 spike shape",
             // Known-stale intended-valid benchmark subjects — #901, list shrinks as repaired:
             ["benchmarks/arithmetic/div-by-zero.calr"] = "#901 multi-generation stale",
             ["benchmarks/loops/bounds-violation.calr"] = "#901 multi-generation stale",

--- a/tests/TestData/BclCallShapes/BCL-01-overload-resolution.calr
+++ b/tests/TestData/BclCallShapes/BCL-01-overload-resolution.calr
@@ -1,0 +1,6 @@
+§M{m001:Bcl01}
+  §F{f001:Shapes:pub} () -> void
+    §E{cw}
+    §C{Console.WriteLine} §A STR:"text" §/C
+    §C{Console.WriteLine} §A INT:42 §/C
+    §C{Console.WriteLine} §A BOOL:true §/C

--- a/tests/TestData/BclCallShapes/BCL-02-generic-substitution.calr
+++ b/tests/TestData/BclCallShapes/BCL-02-generic-substitution.calr
@@ -1,0 +1,7 @@
+§M{m002:Bcl02}
+  §F{f001:Shapes:pub} () -> i32
+    §E{mut}
+    §LIST{items:str}
+    §/LIST{items}
+    §PUSH{items} STR:"a"
+    §R §CNT{items}

--- a/tests/TestData/BclCallShapes/BCL-03-extension-methods.calr
+++ b/tests/TestData/BclCallShapes/BCL-03-extension-methods.calr
@@ -1,0 +1,7 @@
+§M{m003:Bcl03}
+  §F{f001:Shapes:pub} () -> i32
+    §E{mut}
+    §LIST{items:i32}
+    §/LIST{items}
+    §PUSH{items} INT:1
+    §R §C{items.Count} §/C

--- a/tests/TestData/BclCallShapes/BCL-04-params-array.calr
+++ b/tests/TestData/BclCallShapes/BCL-04-params-array.calr
@@ -1,0 +1,4 @@
+§M{m004:Bcl04}
+  §F{f001:Shapes:pub} () -> str
+    §E{}
+    §R §C{String.Format} §A STR:"{0}-{1}" §A STR:"a" §A STR:"b" §/C

--- a/tests/TestData/BclCallShapes/BCL-05-nullable-annotations.calr
+++ b/tests/TestData/BclCallShapes/BCL-05-nullable-annotations.calr
@@ -1,0 +1,7 @@
+§M{m005:Bcl05}
+  §F{f001:Shapes:pub} (str:key) -> str
+    §E{}
+    §B{found:?str} §C{Environment.GetEnvironmentVariable} §A key §/C
+    §IF{if1} (== found NULL)
+      §R STR:"missing"
+    §R found

--- a/tests/TestData/BclCallShapes/BCL-06-ref-out.calr
+++ b/tests/TestData/BclCallShapes/BCL-06-ref-out.calr
@@ -1,0 +1,5 @@
+§M{m006:Bcl06}
+  §F{f001:Shapes:pub} (str:text) -> bool
+    §E{}
+    §B{~value:i32} INT:0
+    §R §C{Int32.TryParse} §A text §A §O value §/C

--- a/tests/TestData/Formatting/formatter-corpus-baseline.json
+++ b/tests/TestData/Formatting/formatter-corpus-baseline.json
@@ -1,6 +1,6 @@
 {
-  "trackedFileCount": 877,
-  "successfulTransformationCount": 642,
+  "trackedFileCount": 883,
+  "successfulTransformationCount": 646,
   "parseFailurePaths": [
     "bench/mcp/tasks/01-fix-closing-tag/expected.calr",
     "bench/mcp/tasks/01-fix-closing-tag/input.calr",
@@ -41,6 +41,7 @@
     "benchmarks/security/command-injection.calr",
     "benchmarks/security/path-traversal.calr",
     "benchmarks/security/sql-injection.calr",
+    "tests/TestData/BclCallShapes/BCL-06-ref-out.calr",
     "tests/TestData/LintScenarios/10_error_cases/mismatched_ids.calr",
     "tests/TestData/LintScenarios/10_error_cases/syntax_error.calr",
     "tests/TestData/LintScenarios/10_error_cases/unterminated_string.calr"
@@ -150,6 +151,7 @@
       "tests/E2E/agent-tasks/templates/path-2-gate/task-06-error-handling/expected/Pipeline.calr",
       "tests/E2E/agent-tasks/templates/path-2-gate/task-06-error-handling/setup/Pipeline.calr",
       "tests/E2E/scenarios/07_collections/output.g.calr",
+      "tests/TestData/BclCallShapes/BCL-05-nullable-annotations.calr",
       "tests/TestData/Benchmarks/DesignPatterns/TemplateMethod.calr",
       "tests/TestData/Benchmarks/DesignPatterns/Visitor.calr",
       "tests/TestData/Benchmarks/EffectSoundness/ComposedEffects.calr",


### PR DESCRIPTION
Registers the entry spike that gates 0.14 (roadmap §3.1) **before any binding is attempted**, so neither the denominator nor the adjudication rule can be chosen after seeing results.

## What is registered

Six BCL call-shape families, each with a `.calr` fixture: overload resolution, generic substitution, extension methods, `params` arrays, nullable annotations, `ref`/`out`.

Overload resolution leads because the tier1a postmortem blames exactly that omission — 18 overloads on `Console.WriteLine` — for the last broken estimate in this area.

Adjudication is a **fixed GREEN/AMBER/RED table with no "try harder and re-measure" row**, and resolving to the *wrong* overload counts as **wrong**, not as resolved. That distinction is the point: a plausible wrong answer is what this area produces, and unresolved is honest where wrong is not.

## Writing the fixtures found something, before measuring

**Calor has no call-site syntax for `ref`/`out` arguments** (#943). It can *declare* an `out` parameter — the converter emits `(str:input, i32:result:out)` — but it cannot *pass* one. `§O` is a statement-level output declaration, and every call-construction site in the parser passes `argumentModifiers: null`. `Int32.TryParse(text, out value)` is unwritable.

That is a **language gap, not a binding gap**, and my first draft of the adjudication table would have scored it as a binder failure — potentially pushing a working mechanism to RED over a call nobody can write. The table now separates *not-expressible* from *unresolved*, and the counts run over the five expressible families.

Catching that while still pre-measurement is precisely what the registration discipline is for. Had I measured first, the correction would have looked like moving the goalposts.

## BCL-06 is kept, not deleted

Registered on the binder ratchet's allowed-parse-failure list against #943, so the gap stays visible and is re-tested automatically once the syntax lands. Deleting it would have quietly shrunk the spike's denominator to the shapes that happen to work — which is the failure mode the whole document exists to prevent.

## Baselines

Binder ratchet 506 → 511 parsed, 9 → 10 registered parse failures, `IncompleteCount` still 0. Formatter corpus 877 → 883 tracked, 642 → 646 losslessly formatted, with BCL-05 registered as a semantic fallback and BCL-06 as a parse failure.

Release build clean; all test projects green; test-quality, dogfood, and Calor-first guards pass.

**§5 (Results) is deliberately empty.** Measurement is the next PR.