### PR TITLE
Require semantic validity for round-trip gates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -381,6 +381,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -453,15 +455,26 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const { execFileSync } = require('child_process');
             const current = JSON.parse(fs.readFileSync('conversion-scorecard.json', 'utf8'));
 
-            // Load committed baseline
             const baselinePath = 'tests/Calor.Evaluation/Scorecard/baseline.json';
-            if (!fs.existsSync(baselinePath)) {
-              core.warning('No baseline.json found — skipping regression check');
-              return;
+            let baselineJson;
+            if (context.eventName === 'pull_request') {
+              const baseSha = context.payload.pull_request.base.sha;
+              baselineJson = execFileSync(
+                'git',
+                ['show', `${baseSha}:${baselinePath}`],
+                { encoding: 'utf8' });
+              core.info(`Comparing against baseline from PR base ${baseSha}`);
+            } else {
+              if (!fs.existsSync(baselinePath)) {
+                core.setFailed(`Committed scorecard baseline is missing: ${baselinePath}`);
+                return;
+              }
+              baselineJson = fs.readFileSync(baselinePath, 'utf8');
             }
-            const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+            const baseline = JSON.parse(baselineJson);
 
             // Compare round-trip counts
             const baselineRt = baseline.roundTripPassing;
@@ -473,19 +486,33 @@ jobs:
             core.info(`Delta: ${delta >= 0 ? '+' : ''}${delta}`);
 
             // Detect per-snippet regressions
-            const baselineById = {};
-            for (const r of baseline.results) baselineById[r.id] = r;
+            const currentById = {};
+            for (const r of current.results) currentById[r.id] = r;
 
             const regressions = [];
-            for (const r of current.results) {
-              const b = baselineById[r.id];
-              if (!b) continue;
-              // W1 Slice 3: roslynParseSuccess split into cSharpSyntaxSuccess +
-              // cSharpCompilationSuccess — reading the old field would be
-              // undefined and silently fail-open (no regression ever flagged).
-              const bPass = b.conversionSuccess && b.compilationSuccess && b.cSharpSyntaxSuccess && b.cSharpCompilationSuccess;
-              const cPass = r.conversionSuccess && r.compilationSuccess && r.cSharpSyntaxSuccess && r.cSharpCompilationSuccess;
-              if (bPass && !cPass) regressions.push(r.id);
+            const statusRank = {
+              Crashed: 0,
+              Blocked: 1,
+              PartiallyConverted: 2,
+              FullyConverted: 3,
+            };
+            for (const b of baseline.results) {
+              const r = currentById[b.id];
+              if (!r) {
+                regressions.push(b.id);
+                continue;
+              }
+              const bPass = b.conversionSuccess &&
+                b.compilationSuccess &&
+                b.cSharpCompilationSuccess &&
+                (b.semanticLossCount ?? 0) === 0;
+              const cPass = r.conversionSuccess &&
+                r.compilationSuccess &&
+                r.cSharpCompilationSuccess &&
+                (r.semanticLossCount ?? 0) === 0;
+              if (statusRank[r.status] < statusRank[b.status] || (bPass && !cPass)) {
+                regressions.push(b.id);
+              }
             }
 
             if (regressions.length > 0) {

--- a/eng/test-manifest.json
+++ b/eng/test-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "projects": [
     { "path": "tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 6806, "expectedSkipped": 2 },
-    { "path": "tests/Calor.Conversion.Tests/Calor.Conversion.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 373, "expectedSkipped": 0 },
+    { "path": "tests/Calor.Conversion.Tests/Calor.Conversion.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 374, "expectedSkipped": 0 },
     { "path": "tests/Calor.Enforcement.Tests/Calor.Enforcement.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 309, "expectedSkipped": 0 },
     { "path": "tests/Calor.Evaluation/Calor.Evaluation.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 202, "expectedSkipped": 0 },
     { "path": "tests/Calor.Experimental.Tests/Calor.Experimental.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 21, "expectedSkipped": 0 },

--- a/eng/test-manifest.json
+++ b/eng/test-manifest.json
@@ -2,9 +2,9 @@
   "schemaVersion": 1,
   "projects": [
     { "path": "tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 6806, "expectedSkipped": 2 },
-    { "path": "tests/Calor.Conversion.Tests/Calor.Conversion.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 370, "expectedSkipped": 0 },
+    { "path": "tests/Calor.Conversion.Tests/Calor.Conversion.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 373, "expectedSkipped": 0 },
     { "path": "tests/Calor.Enforcement.Tests/Calor.Enforcement.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 309, "expectedSkipped": 0 },
-    { "path": "tests/Calor.Evaluation/Calor.Evaluation.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 198, "expectedSkipped": 0 },
+    { "path": "tests/Calor.Evaluation/Calor.Evaluation.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 202, "expectedSkipped": 0 },
     { "path": "tests/Calor.Experimental.Tests/Calor.Experimental.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 21, "expectedSkipped": 0 },
     { "path": "tests/Calor.Ids.Tests/Calor.Ids.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 389, "expectedSkipped": 0 },
     { "path": "tests/Calor.ILAnalysis.Tests/Calor.ILAnalysis.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 42, "expectedSkipped": 0 },

--- a/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
+++ b/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
@@ -6900,7 +6900,8 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                     _context.RecordFeatureUsage("collection-spread");
                     var spreadTarget = spread.Expression.ToString();
                     return new CallExpressionNode(GetTextSpan(collection),
-                        $"{spreadTarget}.ToList", Array.Empty<ExpressionNode>());
+                        $"{spreadTarget}.{GetCollectionMaterializer(collection)}",
+                        Array.Empty<ExpressionNode>());
                 }
                 // Mixed spread [..a, ..b] or [1, ..a] — convert to Concat chain
                 _context.RecordFeatureUsage("collection-spread");
@@ -6976,12 +6977,18 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                 new ExpressionNode[] { result, chunks[i] });
         }
 
-        // .ToList() at the end — wrap the Concat chain in a member access
-        result = new CallExpressionNode(span, "Enumerable.ToList",
+        // Materialize to the target collection shape. Array targets must not
+        // silently become List<T>, which is syntax-valid but type-invalid C#.
+        result = new CallExpressionNode(span, $"Enumerable.{GetCollectionMaterializer(collection)}",
             new ExpressionNode[] { result });
 
         return result;
     }
+
+    private string GetCollectionMaterializer(CollectionExpressionSyntax collection)
+        => _semanticModel?.GetTypeInfo(collection).ConvertedType is IArrayTypeSymbol
+            ? "ToArray"
+            : "ToList";
 
     private string? InferTypeFromExpression(ExpressionSyntax expr)
     {

--- a/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
+++ b/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
@@ -4263,6 +4263,11 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             result.Add(new RawCSharpNode(GetTextSpan(node), node.ToFullString()));
             return result;
         }
+        _context.RecordLoss(
+            ConversionLossKind.Dropped,
+            "checked-block",
+            $"{keyword} overflow semantics were stripped",
+            node.GetLocation().GetLineSpan().StartLinePosition.Line + 1);
         result.Add(new FallbackCommentNode(GetTextSpan(node), keyword, "checked-block",
             "Checked/unchecked semantics stripped; handle overflow manually if needed"));
 
@@ -6154,7 +6159,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                 SizeOfExpressionSyntax sizeOf => ConvertSizeOfExpression(sizeOf),
                 RangeExpressionSyntax rangeExpr => ConvertRangeExpression(rangeExpr),
                 WithExpressionSyntax withExpr => ConvertWithExpression(withExpr),
-                CheckedExpressionSyntax checkedExpr => ConvertExpression(checkedExpr.Expression),
+                CheckedExpressionSyntax checkedExpr => ConvertCheckedExpression(checkedExpr),
                 AnonymousMethodExpressionSyntax anonMethod => ConvertAnonymousMethodExpression(anonMethod),
                 RefExpressionSyntax refExpr => ConvertExpression(refExpr.Expression),
                 AliasQualifiedNameSyntax aliasName => new ReferenceNode(GetTextSpan(aliasName), aliasName.Name.ToString()),
@@ -6989,6 +6994,20 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         => _semanticModel?.GetTypeInfo(collection).ConvertedType is IArrayTypeSymbol
             ? "ToArray"
             : "ToList";
+
+    private ExpressionNode ConvertCheckedExpression(CheckedExpressionSyntax expression)
+    {
+        var keyword = expression.IsKind(SyntaxKind.CheckedExpression)
+            ? "checked"
+            : "unchecked";
+        _context.RecordFeatureUsage($"{keyword}-expression");
+        _context.RecordLoss(
+            ConversionLossKind.Dropped,
+            $"{keyword}-expression",
+            $"{keyword} overflow semantics were stripped",
+            expression.GetLocation().GetLineSpan().StartLinePosition.Line + 1);
+        return ConvertExpression(expression.Expression);
+    }
 
     private string? InferTypeFromExpression(ExpressionSyntax expr)
     {

--- a/tests/Calor.Conversion.Tests/KnownGapDiagnosticTests.cs
+++ b/tests/Calor.Conversion.Tests/KnownGapDiagnosticTests.cs
@@ -36,26 +36,33 @@ public class KnownGapDiagnosticTests
 
     [Theory]
     [MemberData(nameof(KnownGapData))]
-    public void KnownGap_ProducesOutputOrDiagnostic(string id, string description, string csharpSource)
+    public void KnownGap_OutputCompilesOrConversionFailsExplicitly(
+        string id,
+        string description,
+        string csharpSource)
     {
         _output.WriteLine($"[{id}] {description}");
 
-        var result = TestHelpers.ConvertCSharp(csharpSource, $"Gap_{id.Replace("-", "_")}");
+        var conversion = TestHelpers.ConvertCSharp(
+            csharpSource, $"Gap_{id.Replace("-", "_")}");
+        var result = TestHelpers.FullRoundTrip(
+            csharpSource, $"Gap_{id.Replace("-", "_")}");
 
-        // Must produce EITHER:
-        // 1. CalorSource output (with graceful fallback/TODO comments), OR
-        // 2. Clear diagnostic issues in the result
-        var hasOutput = result.CalorSource != null && result.CalorSource.Length > 0;
-        var hasDiagnostics = result.Issues.Count > 0;
+        if (!result.ConversionSuccess)
+        {
+            Assert.NotEmpty(result.ConversionIssues);
+            return;
+        }
 
-        _output.WriteLine($"  Success: {result.Success}");
-        _output.WriteLine($"  Has output: {hasOutput}");
-        _output.WriteLine($"  Diagnostics: {result.Issues.Count}");
-        foreach (var issue in result.Issues)
-            _output.WriteLine($"    - {issue.Message}");
-
-        Assert.True(hasOutput || hasDiagnostics,
-            $"[{id}] {description}: Expected either Calor output or diagnostics, got neither.");
+        Assert.True(
+            result.CalorParseSuccess,
+            $"[{id}] fallback Calor failed to compile: " +
+            string.Join("; ", result.CalorDiagnostics));
+        if (!result.CSharpCompilationSuccess)
+        {
+            Assert.Contains(conversion.Losses, loss => loss.IsSemanticLoss);
+            Assert.NotEmpty(result.RoslynErrors);
+        }
     }
 
     [Theory]

--- a/tests/Calor.Conversion.Tests/RoundTripTests.cs
+++ b/tests/Calor.Conversion.Tests/RoundTripTests.cs
@@ -142,4 +142,30 @@ public class RoundTripTests
         Assert.All(results, r => Assert.True(r.RoslynOk,
             $"[{r.Id}] {r.Desc}: emitted C# does not compile"));
     }
+
+    [Fact]
+    public void RoslynGate_RejectsSyntaxValidTypeInvalidOutput()
+    {
+        var validation = TestHelpers.RoslynCompile(
+            "public static class Invalid { public static int Read() => \"wrong\"; }");
+
+        Assert.True(validation.SyntaxSuccess);
+        Assert.False(validation.CompilationSuccess);
+        Assert.Contains(
+            validation.FormattedCompilationErrors,
+            error => error.Contains("CS0029", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void RoslynGate_ClassifiesMissingProjectReferenceAsCompilationFailure()
+    {
+        var validation = TestHelpers.RoslynCompile(
+            "public sealed class Consumer { public External.Library.Api Read() => new(); }");
+
+        Assert.True(validation.SyntaxSuccess);
+        Assert.False(validation.CompilationSuccess);
+        Assert.Contains(
+            validation.FormattedCompilationErrors,
+            error => error.Contains("CS0246", StringComparison.Ordinal));
+    }
 }

--- a/tests/Calor.Conversion.Tests/RoundTripTests.cs
+++ b/tests/Calor.Conversion.Tests/RoundTripTests.cs
@@ -104,18 +104,20 @@ public class RoundTripTests
             $"[{id}] Emitted C# has syntax errors: {string.Join("; ", result.RoslynErrors)}");
         Assert.True(result.RoslynSuccess,
             $"[{id}] Emitted C# does not compile: {string.Join("; ", result.RoslynErrors)}");
+        Assert.Empty(result.SemanticLosses);
     }
 
     [Fact]
     public void RoundTrip_AllRoundTripSnippets_Summary()
     {
-        var results = new List<(string Id, string Desc, bool ConvOk, bool ParseOk, bool RoslynOk)>();
+        var results = new List<(string Id, string Desc, bool ConvOk, bool ParseOk, bool RoslynOk, bool Lossless)>();
 
         foreach (var snippet in ConversionCatalog.RoundTripSnippets)
         {
             var result = TestHelpers.FullRoundTrip(snippet.CSharpSource, $"Test_{snippet.Id.Replace("-", "_")}");
             results.Add((snippet.Id, snippet.Description,
-                result.ConversionSuccess, result.CalorParseSuccess, result.RoslynSuccess));
+                result.ConversionSuccess, result.CalorParseSuccess, result.RoslynSuccess,
+                result.SemanticLosses.Count == 0));
         }
 
         _output.WriteLine("=== Round-Trip Summary ===");
@@ -123,12 +125,12 @@ public class RoundTripTests
         _output.WriteLine($"Conversion OK: {results.Count(r => r.ConvOk)}/{results.Count}");
         _output.WriteLine($"Calor Parse OK: {results.Count(r => r.ParseOk)}/{results.Count}");
         _output.WriteLine($"Roslyn Compile OK: {results.Count(r => r.RoslynOk)}/{results.Count}");
-        _output.WriteLine($"Full Round-Trip OK: {results.Count(r => r.ConvOk && r.ParseOk && r.RoslynOk)}/{results.Count}");
+        _output.WriteLine($"Full Round-Trip OK: {results.Count(r => r.ConvOk && r.ParseOk && r.RoslynOk && r.Lossless)}/{results.Count}");
         _output.WriteLine("");
 
-        foreach (var (id, desc, convOk, parseOk, roslynOk) in results)
+        foreach (var (id, desc, convOk, parseOk, roslynOk, lossless) in results)
         {
-            var status = convOk && parseOk && roslynOk ? "PASS" :
+            var status = convOk && parseOk && roslynOk && lossless ? "PASS" :
                          convOk && parseOk ? "PARTIAL" : "FAIL";
             _output.WriteLine($"  [{status}] {id}: {desc}");
         }
@@ -141,6 +143,25 @@ public class RoundTripTests
             $"[{r.Id}] {r.Desc}: Calor parse failed"));
         Assert.All(results, r => Assert.True(r.RoslynOk,
             $"[{r.Id}] {r.Desc}: emitted C# does not compile"));
+        Assert.All(results, r => Assert.True(r.Lossless,
+            $"[{r.Id}] {r.Desc}: semantic loss was recorded"));
+    }
+
+    [Fact]
+    public void FullRoundTrip_RejectsCheckedExpressionSemanticLoss()
+    {
+        const string source = """
+            public static class Overflow
+            {
+                public static int Add(int value) => checked(value + 1);
+            }
+            """;
+
+        var result = TestHelpers.FullRoundTrip(source, "Overflow");
+
+        Assert.True(result.RoslynSuccess);
+        Assert.NotEmpty(result.SemanticLosses);
+        Assert.False(result.FullSuccess);
     }
 
     [Fact]

--- a/tests/Calor.Conversion.Tests/SnapshotConversionTests.cs
+++ b/tests/Calor.Conversion.Tests/SnapshotConversionTests.cs
@@ -56,27 +56,12 @@ public class SnapshotConversionTests
             string.Join("; ", result.Issues.Select(i => i.Message)));
         Assert.NotNull(result.CalorSource);
 
-        // If running in update mode, write the snapshot
-        if (Environment.GetEnvironmentVariable("CALOR_UPDATE_SNAPSHOTS") == "1")
-        {
-            WriteSnapshot(snapshotName, result.CalorSource!);
-            _output.WriteLine($"[{id}] Snapshot updated: {snapshotName}");
-            return;
-        }
-
-        if (approved == null)
-        {
-            // No snapshot exists yet — generate it and skip
-            WriteSnapshot(snapshotName, result.CalorSource!);
-            _output.WriteLine($"[{id}] Initial snapshot generated: {snapshotName}");
-            return;
-        }
-
-        // Normalize line endings for comparison
-        var normalizedApproved = approved.Replace("\r\n", "\n").Trim();
-        var normalizedActual = result.CalorSource!.Replace("\r\n", "\n").Trim();
-
-        Assert.Equal(normalizedApproved, normalizedActual);
+        VerifySnapshot(
+            snapshotName,
+            approved,
+            result.CalorSource!,
+            Environment.GetEnvironmentVariable("CALOR_UPDATE_SNAPSHOTS") == "1",
+            WriteSnapshot);
     }
 
     [Fact]
@@ -112,6 +97,44 @@ public class SnapshotConversionTests
         var snapshotDir = Path.Combine(projectDir, "Snapshots");
         Directory.CreateDirectory(snapshotDir);
         File.WriteAllText(Path.Combine(snapshotDir, snapshotName), content);
+    }
+
+    internal static void VerifySnapshot(
+        string snapshotName,
+        string? approved,
+        string actual,
+        bool updateMode,
+        Action<string, string> writeSnapshot)
+    {
+        if (updateMode)
+        {
+            writeSnapshot(snapshotName, actual);
+            return;
+        }
+
+        Assert.True(
+            approved != null,
+            $"Missing approved snapshot '{snapshotName}'. " +
+            "Set CALOR_UPDATE_SNAPSHOTS=1 explicitly to create it.");
+        Assert.Equal(
+            approved!.Replace("\r\n", "\n").Trim(),
+            actual.Replace("\r\n", "\n").Trim());
+    }
+
+    [Fact]
+    public void MissingSnapshot_FailsWithoutWriting()
+    {
+        var writeAttempted = false;
+
+        var exception = Record.Exception(() => VerifySnapshot(
+            "missing.approved.calr",
+            approved: null,
+            actual: "§M{m001:Missing}",
+            updateMode: false,
+            (_, _) => writeAttempted = true));
+
+        Assert.NotNull(exception);
+        Assert.False(writeAttempted);
     }
 
     private static string? FindProjectDirectory()

--- a/tests/Calor.Conversion.Tests/TestHelpers.cs
+++ b/tests/Calor.Conversion.Tests/TestHelpers.cs
@@ -87,6 +87,10 @@ public static class TestHelpers
     public static RoundTripResult FullRoundTrip(string csharpSource, string? moduleName = null)
     {
         var conversionResult = ConvertCSharp(csharpSource, moduleName);
+        var semanticLosses = conversionResult.Losses
+            .Where(loss => loss.IsSemanticLoss)
+            .Select(loss => loss.ToString())
+            .ToList();
 
         if (!conversionResult.Success || conversionResult.CalorSource == null)
         {
@@ -94,6 +98,7 @@ public static class TestHelpers
             {
                 ConversionSuccess = false,
                 ConversionIssues = conversionResult.Issues.Select(i => i.Message).ToList(),
+                SemanticLosses = semanticLosses,
             };
         }
 
@@ -109,6 +114,7 @@ public static class TestHelpers
                 CalorSource = conversionResult.CalorSource,
                 CalorParseSuccess = false,
                 CalorDiagnostics = calorCompilation.Diagnostics.ToList(),
+                SemanticLosses = semanticLosses,
             };
         }
 
@@ -124,6 +130,7 @@ public static class TestHelpers
             RoslynErrors = validation.FormattedCompilationErrors.ToList(),
             CSharpSyntaxSuccess = validation.SyntaxSuccess,
             RoslynSuccess = validation.CompilationSuccess,
+            SemanticLosses = semanticLosses,
         };
     }
 
@@ -146,6 +153,7 @@ public sealed class RoundTripResult
     public List<string> CalorDiagnostics { get; init; } = new();
     public string? EmittedCSharp { get; init; }
     public List<string> RoslynErrors { get; init; } = new();
+    public List<string> SemanticLosses { get; init; } = new();
 
     /// <summary>The emitted C# parses with zero syntax errors (#771 split status).</summary>
     public bool CSharpSyntaxSuccess { get; init; }
@@ -155,7 +163,10 @@ public sealed class RoundTripResult
 
     public bool CSharpCompilationSuccess => RoslynSuccess;
 
-    public bool FullSuccess => ConversionSuccess && CalorParseSuccess && RoslynSuccess;
+    public bool FullSuccess => ConversionSuccess &&
+        CalorParseSuccess &&
+        RoslynSuccess &&
+        SemanticLosses.Count == 0;
 }
 
 public sealed record CalorCompilationAttempt(

--- a/tests/Calor.Conversion.Tests/TestHelpers.cs
+++ b/tests/Calor.Conversion.Tests/TestHelpers.cs
@@ -34,6 +34,10 @@ public static class TestHelpers
     /// Returns null if there are parse errors or parser throws.
     /// </summary>
     public static string? CompileCalorToCSharp(string calorSource)
+        => CompileCalorToCSharpWithDiagnostics(calorSource).GeneratedCode;
+
+    public static CalorCompilationAttempt CompileCalorToCSharpWithDiagnostics(
+        string calorSource)
     {
         try
         {
@@ -42,20 +46,28 @@ public static class TestHelpers
 
             var lexer = new Lexer(calorSource, diagnostics);
             var tokens = lexer.TokenizeAllForParser();
-            if (diagnostics.HasErrors) return null;
+            if (diagnostics.HasErrors)
+                return new CalorCompilationAttempt(null, FormatDiagnostics(diagnostics));
 
             var parser = new Parser(tokens, diagnostics);
             var module = parser.Parse();
-            if (diagnostics.HasErrors) return null;
+            if (diagnostics.HasErrors)
+                return new CalorCompilationAttempt(null, FormatDiagnostics(diagnostics));
 
             var emitter = new CSharpEmitter();
-            return emitter.Emit(module);
+            return new CalorCompilationAttempt(
+                emitter.Emit(module),
+                FormatDiagnostics(diagnostics));
         }
-        catch
+        catch (Exception ex)
         {
-            // Parser may throw for unsupported Calor syntax
-            return null;
+            return new CalorCompilationAttempt(
+                null,
+                [$"Compiler exception: {ex.GetType().Name}: {ex.Message}"]);
         }
+
+        static IReadOnlyList<string> FormatDiagnostics(DiagnosticBag diagnostics)
+            => diagnostics.Select(diagnostic => diagnostic.ToString()).ToList();
     }
 
     /// <summary>
@@ -85,7 +97,9 @@ public static class TestHelpers
             };
         }
 
-        var emittedCSharp = CompileCalorToCSharp(conversionResult.CalorSource);
+        var calorCompilation = CompileCalorToCSharpWithDiagnostics(
+            conversionResult.CalorSource);
+        var emittedCSharp = calorCompilation.GeneratedCode;
 
         if (emittedCSharp == null)
         {
@@ -94,6 +108,7 @@ public static class TestHelpers
                 ConversionSuccess = true,
                 CalorSource = conversionResult.CalorSource,
                 CalorParseSuccess = false,
+                CalorDiagnostics = calorCompilation.Diagnostics.ToList(),
             };
         }
 
@@ -104,6 +119,7 @@ public static class TestHelpers
             ConversionSuccess = true,
             CalorSource = conversionResult.CalorSource,
             CalorParseSuccess = true,
+            CalorDiagnostics = calorCompilation.Diagnostics.ToList(),
             EmittedCSharp = emittedCSharp,
             RoslynErrors = validation.FormattedCompilationErrors.ToList(),
             CSharpSyntaxSuccess = validation.SyntaxSuccess,
@@ -127,6 +143,7 @@ public sealed class RoundTripResult
     public List<string> ConversionIssues { get; init; } = new();
     public string? CalorSource { get; init; }
     public bool CalorParseSuccess { get; init; }
+    public List<string> CalorDiagnostics { get; init; } = new();
     public string? EmittedCSharp { get; init; }
     public List<string> RoslynErrors { get; init; } = new();
 
@@ -136,5 +153,11 @@ public sealed class RoundTripResult
     /// <summary>The emitted C# compiles with zero Roslyn errors (full semantic compilation).</summary>
     public bool RoslynSuccess { get; init; }
 
+    public bool CSharpCompilationSuccess => RoslynSuccess;
+
     public bool FullSuccess => ConversionSuccess && CalorParseSuccess && RoslynSuccess;
 }
+
+public sealed record CalorCompilationAttempt(
+    string? GeneratedCode,
+    IReadOnlyList<string> Diagnostics);

--- a/tests/Calor.Evaluation/Scorecard/ConversionScorecard.cs
+++ b/tests/Calor.Evaluation/Scorecard/ConversionScorecard.cs
@@ -28,10 +28,16 @@ public record SnippetResult(
     TimeSpan ConversionDuration,
     TimeSpan CompilationDuration)
 {
+    public int SemanticLossCount { get; init; }
+    public string[] SemanticLossDiagnostics { get; init; } = Array.Empty<string>();
+
     // #771: round-trip success requires the generated C# to COMPILE (full
     // Roslyn semantic compilation), not merely parse — syntax-valid but
     // type-invalid output no longer counts.
-    public bool RoundTripSuccess => ConversionSuccess && CompilationSuccess && CSharpCompilationSuccess;
+    public bool RoundTripSuccess => ConversionSuccess &&
+        CompilationSuccess &&
+        CSharpCompilationSuccess &&
+        SemanticLossCount == 0;
 }
 
 public record ConversionScorecard(

--- a/tests/Calor.Evaluation/Scorecard/ConversionScorecardRunner.cs
+++ b/tests/Calor.Evaluation/Scorecard/ConversionScorecardRunner.cs
@@ -97,6 +97,10 @@ public class ConversionScorecardRunner
         var conversionIssues = conversionResult.Issues
             .Select(i => i.ToString())
             .ToArray();
+        var semanticLosses = conversionResult.Losses
+            .Where(loss => loss.IsSemanticLoss)
+            .Select(loss => loss.ToString())
+            .ToArray();
         var conversionErrors = conversionResult.Issues.Count(i => i.Severity == ConversionIssueSeverity.Error);
         var conversionWarnings = conversionResult.Issues.Count(i => i.Severity == ConversionIssueSeverity.Warning);
 
@@ -118,7 +122,11 @@ public class ConversionScorecardRunner
                 CSharpSyntaxSuccess: false,
                 CSharpCompilationSuccess: false,
                 ConversionDuration: conversionDuration,
-                CompilationDuration: TimeSpan.Zero);
+                CompilationDuration: TimeSpan.Zero)
+            {
+                SemanticLossCount = semanticLosses.Length,
+                SemanticLossDiagnostics = semanticLosses
+            };
         }
 
         // Stage 2: Calor → C#
@@ -155,7 +163,11 @@ public class ConversionScorecardRunner
                 CSharpSyntaxSuccess: false,
                 CSharpCompilationSuccess: false,
                 ConversionDuration: conversionDuration,
-                CompilationDuration: TimeSpan.Zero);
+                CompilationDuration: TimeSpan.Zero)
+            {
+                SemanticLossCount = semanticLosses.Length,
+                SemanticLossDiagnostics = semanticLosses
+            };
         }
 
         var compilationDiagnostics = compilationResult.Diagnostics.Errors
@@ -180,7 +192,11 @@ public class ConversionScorecardRunner
                 CSharpSyntaxSuccess: false,
                 CSharpCompilationSuccess: false,
                 ConversionDuration: conversionDuration,
-                CompilationDuration: compilationDuration);
+                CompilationDuration: compilationDuration)
+            {
+                SemanticLossCount = semanticLosses.Length,
+                SemanticLossDiagnostics = semanticLosses
+            };
         }
 
         // Stage 3: Roslyn validation of the generated C# — a full semantic
@@ -204,7 +220,7 @@ public class ConversionScorecardRunner
         }
 
         // FullyConverted = conversion + Calor compilation + C# COMPILATION.
-        var status = csharpCompilationSuccess
+        var status = csharpCompilationSuccess && semanticLosses.Length == 0
             ? SnippetStatus.FullyConverted
             : SnippetStatus.PartiallyConverted;
 
@@ -224,7 +240,11 @@ public class ConversionScorecardRunner
             CSharpSyntaxSuccess: csharpSyntaxSuccess,
             CSharpCompilationSuccess: csharpCompilationSuccess,
             ConversionDuration: conversionDuration,
-            CompilationDuration: compilationDuration);
+            CompilationDuration: compilationDuration)
+        {
+            SemanticLossCount = semanticLosses.Length,
+            SemanticLossDiagnostics = semanticLosses
+        };
     }
 
     private static ConversionScorecard Aggregate(List<SnippetResult> results, string? commitHash)

--- a/tests/Calor.Evaluation/Scorecard/ConversionScorecardRunner.cs
+++ b/tests/Calor.Evaluation/Scorecard/ConversionScorecardRunner.cs
@@ -106,12 +106,15 @@ public class ConversionScorecardRunner
 
         if (!conversionResult.Success || string.IsNullOrWhiteSpace(conversionResult.CalorSource))
         {
+            var producedCalor = !string.IsNullOrWhiteSpace(conversionResult.CalorSource);
             return new SnippetResult(
                 Id: entry.Id,
                 FileName: entry.File,
                 Level: entry.Level,
                 Features: entry.Features,
-                Status: SnippetStatus.Blocked,
+                Status: producedCalor
+                    ? SnippetStatus.PartiallyConverted
+                    : SnippetStatus.Blocked,
                 ConversionSuccess: false,
                 ConversionErrors: conversionErrors,
                 ConversionWarnings: conversionWarnings,

--- a/tests/Calor.Evaluation/Scorecard/ConversionScorecardTests.cs
+++ b/tests/Calor.Evaluation/Scorecard/ConversionScorecardTests.cs
@@ -26,8 +26,8 @@ public class ConversionScorecardTests
     // Baselines are exact (no slack): the corpus and converter are
     // deterministic, and per-fixture zero-regression is enforced against
     // baseline.json by NoRegressionsVsCommittedBaseline.
-    private const int BASELINE_FULLY_CONVERTED = 93;
-    private const int BASELINE_ROUNDTRIP = 93;
+    private const int BASELINE_FULLY_CONVERTED = 95;
+    private const int BASELINE_ROUNDTRIP = 95;
 
     private static readonly Lazy<ConversionScorecard> _scorecard = new(() =>
     {
@@ -61,8 +61,7 @@ public class ConversionScorecardTests
     public void ConversionRate_AboveBaseline()
     {
         _output.WriteLine($"Fully converted: {Scorecard.FullyConverted}/{Scorecard.Total} (baseline: {BASELINE_FULLY_CONVERTED})");
-        Assert.True(Scorecard.FullyConverted >= BASELINE_FULLY_CONVERTED,
-            $"Fully converted {Scorecard.FullyConverted} < baseline {BASELINE_FULLY_CONVERTED}");
+        Assert.Equal(BASELINE_FULLY_CONVERTED, Scorecard.FullyConverted);
     }
 
     [Fact]
@@ -82,8 +81,7 @@ public class ConversionScorecardTests
     public void RoundTrip_AboveBaseline()
     {
         _output.WriteLine($"Round-trip: {Scorecard.RoundTripPassing}/{Scorecard.Total} (baseline: {BASELINE_ROUNDTRIP})");
-        Assert.True(Scorecard.RoundTripPassing >= BASELINE_ROUNDTRIP,
-            $"Round-trip {Scorecard.RoundTripPassing} < baseline {BASELINE_ROUNDTRIP}");
+        Assert.Equal(BASELINE_ROUNDTRIP, Scorecard.RoundTripPassing);
     }
 
     [Fact]
@@ -119,14 +117,15 @@ public class ConversionScorecardTests
     public async Task NoRegressionsVsCommittedBaseline()
     {
         var baselinePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Scorecard", "baseline.json");
-        if (!File.Exists(baselinePath))
-        {
-            _output.WriteLine($"Baseline not found at {baselinePath} — skipping regression check");
-            return;
-        }
+        Assert.True(File.Exists(baselinePath),
+            $"Committed scorecard baseline is missing: {baselinePath}");
 
         var baseline = await ScorecardComparison.LoadBaselineAsync(baselinePath);
         var diff = ScorecardComparison.Compare(baseline, Scorecard);
+
+        Assert.Equal(
+            baseline.Results.Select(result => result.Id).OrderBy(id => id),
+            Scorecard.Results.Select(result => result.Id).OrderBy(id => id));
 
         _output.WriteLine($"Baseline: {baseline.RoundTripPassing}/{baseline.Total}");
         _output.WriteLine($"Current:  {Scorecard.RoundTripPassing}/{Scorecard.Total}");

--- a/tests/Calor.Evaluation/Scorecard/ScorecardComparison.cs
+++ b/tests/Calor.Evaluation/Scorecard/ScorecardComparison.cs
@@ -30,12 +30,16 @@ public static class ScorecardComparison
         var regressions = new List<string>();
         var improvements = new List<string>();
 
-        foreach (var (id, currentResult) in currentById)
+        foreach (var (id, baselineResult) in baselineById)
         {
-            if (!baselineById.TryGetValue(id, out var baselineResult))
+            if (!currentById.TryGetValue(id, out var currentResult))
+            {
+                regressions.Add(id);
                 continue;
+            }
 
-            if (baselineResult.RoundTripSuccess && !currentResult.RoundTripSuccess)
+            if (StatusRank(currentResult.Status) < StatusRank(baselineResult.Status) ||
+                baselineResult.RoundTripSuccess && !currentResult.RoundTripSuccess)
                 regressions.Add(id);
             else if (!baselineResult.RoundTripSuccess && currentResult.RoundTripSuccess)
                 improvements.Add(id);
@@ -48,6 +52,16 @@ public static class ScorecardComparison
             RoundTripDelta: current.RoundTripPassing - baseline.RoundTripPassing,
             Baseline: baseline,
             Current: current);
+
+        static int StatusRank(SnippetStatus status)
+            => status switch
+            {
+                SnippetStatus.Crashed => 0,
+                SnippetStatus.Blocked => 1,
+                SnippetStatus.PartiallyConverted => 2,
+                SnippetStatus.FullyConverted => 3,
+                _ => throw new ArgumentOutOfRangeException(nameof(status))
+            };
     }
 
     public static async Task<ConversionScorecard> LoadBaselineAsync(string path)

--- a/tests/Calor.Evaluation/Scorecard/ScorecardComparisonTests.cs
+++ b/tests/Calor.Evaluation/Scorecard/ScorecardComparisonTests.cs
@@ -185,6 +185,72 @@ public class ScorecardComparisonTests
         Assert.Equal(0, diff.ConversionDelta);
     }
 
+    [Fact]
+    public void Compare_FailsWhenFixtureDropsFromPartialToBlocked()
+    {
+        var baseline = MakeScorecard(("001", false));
+        var currentResult = MakeScorecard(("001", false)).Results[0] with
+        {
+            Status = SnippetStatus.Blocked,
+            CompilationSuccess = false
+        };
+        var current = MakeScorecard(("001", false)) with
+        {
+            Results = [currentResult],
+            PartiallyConverted = 0,
+            Blocked = 1
+        };
+
+        var diff = ScorecardComparison.Compare(baseline, current);
+
+        Assert.Equal(["001"], diff.Regressions);
+    }
+
+    [Fact]
+    public void Compare_FailsWhenBaselineFixtureIsMissing()
+    {
+        var baseline = MakeScorecard(("001", true), ("002", true));
+        var current = MakeScorecard(("001", true));
+
+        var diff = ScorecardComparison.Compare(baseline, current);
+
+        Assert.Equal(["002"], diff.Regressions);
+    }
+
+    [Fact]
+    public void RoundTripSuccess_RejectsSemanticLossEvenWhenCompilationPasses()
+    {
+        var result = MakeScorecard(("001", true)).Results[0] with
+        {
+            SemanticLossCount = 1,
+            SemanticLossDiagnostics = ["Dropped checked-overflow semantics"]
+        };
+
+        Assert.False(result.RoundTripSuccess);
+    }
+
+    [Fact]
+    public void MarkdownReport_SurfacesSemanticLossDiagnostic()
+    {
+        var result = MakeScorecard(("001", true)).Results[0] with
+        {
+            Status = SnippetStatus.PartiallyConverted,
+            SemanticLossCount = 1,
+            SemanticLossDiagnostics = ["Dropped checked-overflow semantics"]
+        };
+        var scorecard = MakeScorecard(("001", true)) with
+        {
+            FullyConverted = 0,
+            PartiallyConverted = 1,
+            RoundTripPassing = 0,
+            Results = [result]
+        };
+
+        var markdown = ScorecardReportGenerator.GenerateMarkdown(scorecard);
+
+        Assert.Contains("Dropped checked-overflow semantics", markdown);
+    }
+
     private static ConversionScorecard MakeScorecard(params (string id, bool roundTripSuccess)[] snippets)
     {
         var results = snippets.Select(s =>

--- a/tests/Calor.Evaluation/Scorecard/ScorecardReportGenerator.cs
+++ b/tests/Calor.Evaluation/Scorecard/ScorecardReportGenerator.cs
@@ -81,7 +81,8 @@ public static class ScorecardReportGenerator
             sb.AppendLine("|----|------|--------|-----------|");
             foreach (var r in failed)
             {
-                var topIssue = r.ConversionIssues.FirstOrDefault()
+                var topIssue = r.SemanticLossDiagnostics.FirstOrDefault()
+                    ?? r.ConversionIssues.FirstOrDefault()
                     ?? r.CompilationDiagnostics.FirstOrDefault()
                     ?? "-";
                 // Truncate long issues for table readability

--- a/tests/Calor.Evaluation/Scorecard/baseline.json
+++ b/tests/Calor.Evaluation/Scorecard/baseline.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-08-01T04:32:05.993661Z",
-  "commitHash": "08341e44",
+  "timestamp": "2026-08-12T15:23:13.880748Z",
+  "commitHash": "713a9532",
   "version": "1.0",
   "total": 100,
-  "fullyConverted": 93,
-  "partiallyConverted": 7,
-  "blocked": 0,
+  "fullyConverted": 95,
+  "partiallyConverted": 0,
+  "blocked": 5,
   "crashed": 0,
-  "roundTripPassing": 93,
+  "roundTripPassing": 95,
   "byLevel": {
     "1": {
       "total": 20,
@@ -26,13 +26,13 @@
     },
     "4": {
       "total": 20,
-      "passed": 18,
-      "rate": 0.9
+      "passed": 19,
+      "rate": 0.95
     },
     "5": {
       "total": 20,
-      "passed": 15,
-      "rate": 0.75
+      "passed": 16,
+      "rate": 0.8
     }
   },
   "byFeature": {
@@ -348,13 +348,13 @@
     },
     "switch_expression": {
       "total": 2,
-      "passed": 1,
-      "rate": 0.5
+      "passed": 2,
+      "rate": 1
     },
     "pattern_matching": {
       "total": 2,
-      "passed": 1,
-      "rate": 0.5
+      "passed": 2,
+      "rate": 1
     },
     "break": {
       "total": 1,
@@ -743,8 +743,8 @@
     },
     "local_function": {
       "total": 1,
-      "passed": 0,
-      "rate": 0
+      "passed": 1,
+      "rate": 1
     },
     "extension_method": {
       "total": 1,
@@ -958,8 +958,8 @@
     },
     "is_expression": {
       "total": 1,
-      "passed": 0,
-      "rate": 0
+      "passed": 1,
+      "rate": 1
     },
     "null_coalescing": {
       "total": 1,
@@ -1053,8 +1053,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.1118867",
-      "compilationDuration": "00:00:00.0523710",
+      "conversionDuration": "00:00:00.4557705",
+      "compilationDuration": "00:00:00.0043671",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1077,8 +1079,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0051217",
-      "compilationDuration": "00:00:00.0041791",
+      "conversionDuration": "00:00:00.0164311",
+      "compilationDuration": "00:00:00.0033282",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1099,8 +1103,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035421",
-      "compilationDuration": "00:00:00.0017052",
+      "conversionDuration": "00:00:00.0090451",
+      "compilationDuration": "00:00:00.0032271",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1122,8 +1128,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0040708",
-      "compilationDuration": "00:00:00.0061930",
+      "conversionDuration": "00:00:00.0139713",
+      "compilationDuration": "00:00:00.0034877",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1145,8 +1153,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035860",
-      "compilationDuration": "00:00:00.0009281",
+      "conversionDuration": "00:00:00.0078365",
+      "compilationDuration": "00:00:00.0030974",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1167,8 +1177,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0062983",
-      "compilationDuration": "00:00:00.0012787",
+      "conversionDuration": "00:00:00.0229927",
+      "compilationDuration": "00:00:00.0028719",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1190,8 +1202,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0065264",
-      "compilationDuration": "00:00:00.0021472",
+      "conversionDuration": "00:00:00.0247392",
+      "compilationDuration": "00:00:00.0028528",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1213,8 +1227,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0028697",
-      "compilationDuration": "00:00:00.0017430",
+      "conversionDuration": "00:00:00.0065791",
+      "compilationDuration": "00:00:00.0027578",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1236,8 +1252,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0028918",
-      "compilationDuration": "00:00:00.0018517",
+      "conversionDuration": "00:00:00.0064154",
+      "compilationDuration": "00:00:00.0059406",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1259,8 +1277,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0028734",
-      "compilationDuration": "00:00:00.0019022",
+      "conversionDuration": "00:00:00.0059701",
+      "compilationDuration": "00:00:00.0022660",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1281,8 +1301,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0028607",
-      "compilationDuration": "00:00:00.0018017",
+      "conversionDuration": "00:00:00.0054725",
+      "compilationDuration": "00:00:00.0021136",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1303,8 +1325,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0028462",
-      "compilationDuration": "00:00:00.0017100",
+      "conversionDuration": "00:00:00.0063682",
+      "compilationDuration": "00:00:00.0022331",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1326,8 +1350,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0285078",
-      "compilationDuration": "00:00:00.0033553",
+      "conversionDuration": "00:00:00.0314665",
+      "compilationDuration": "00:00:00.0037021",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1348,8 +1374,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0138357",
-      "compilationDuration": "00:00:00.0013839",
+      "conversionDuration": "00:00:00.0161821",
+      "compilationDuration": "00:00:00.0052159",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1373,8 +1401,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0038178",
-      "compilationDuration": "00:00:00.0010734",
+      "conversionDuration": "00:00:00.0076260",
+      "compilationDuration": "00:00:00.0024699",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1396,8 +1426,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035199",
-      "compilationDuration": "00:00:00.0011971",
+      "conversionDuration": "00:00:00.0071131",
+      "compilationDuration": "00:00:00.0024003",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1411,15 +1443,19 @@
       "status": "FullyConverted",
       "conversionSuccess": true,
       "conversionErrors": 0,
-      "conversionWarnings": 0,
-      "conversionIssues": [],
+      "conversionWarnings": 1,
+      "conversionIssues": [
+        "Warning [unsupported-prefix-operator] (line 12): Unsupported feature [unsupported-prefix-operator] escalated to \u00A7CSHARP interop preservation: \u002Bx"
+      ],
       "compilationSuccess": true,
       "compilationErrors": 0,
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0032463",
-      "compilationDuration": "00:00:00.0007624",
+      "conversionDuration": "00:00:00.0076385",
+      "compilationDuration": "00:00:00.0022753",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1440,8 +1476,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0048271",
-      "compilationDuration": "00:00:00.0010625",
+      "conversionDuration": "00:00:00.0075033",
+      "compilationDuration": "00:00:00.0023112",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1462,8 +1500,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0065532",
-      "compilationDuration": "00:00:00.0007547",
+      "conversionDuration": "00:00:00.0250910",
+      "compilationDuration": "00:00:00.0027417",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1484,8 +1524,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035046",
-      "compilationDuration": "00:00:00.0008580",
+      "conversionDuration": "00:00:00.0064116",
+      "compilationDuration": "00:00:00.0024775",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1506,8 +1548,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0063835",
-      "compilationDuration": "00:00:00.0021458",
+      "conversionDuration": "00:00:00.0126613",
+      "compilationDuration": "00:00:00.0025040",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1528,8 +1572,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035629",
-      "compilationDuration": "00:00:00.0007494",
+      "conversionDuration": "00:00:00.0057911",
+      "compilationDuration": "00:00:00.0043201",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1550,8 +1596,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0036396",
-      "compilationDuration": "00:00:00.0008814",
+      "conversionDuration": "00:00:00.0065742",
+      "compilationDuration": "00:00:00.0022091",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1573,8 +1621,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0107805",
-      "compilationDuration": "00:00:00.0026991",
+      "conversionDuration": "00:00:00.0189872",
+      "compilationDuration": "00:00:00.0027411",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1594,8 +1644,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0072573",
-      "compilationDuration": "00:00:00.0039066",
+      "conversionDuration": "00:00:00.0104881",
+      "compilationDuration": "00:00:00.0024705",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1615,8 +1667,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0091918",
-      "compilationDuration": "00:00:00.0021513",
+      "conversionDuration": "00:00:00.0111045",
+      "compilationDuration": "00:00:00.0032855",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1637,8 +1691,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0066283",
-      "compilationDuration": "00:00:00.0008921",
+      "conversionDuration": "00:00:00.0103048",
+      "compilationDuration": "00:00:00.0026382",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1660,8 +1716,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0061113",
-      "compilationDuration": "00:00:00.0020297",
+      "conversionDuration": "00:00:00.0110390",
+      "compilationDuration": "00:00:00.0025351",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1682,8 +1740,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0064575",
-      "compilationDuration": "00:00:00.0007619",
+      "conversionDuration": "00:00:00.0088942",
+      "compilationDuration": "00:00:00.0025778",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1704,8 +1764,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0061825",
-      "compilationDuration": "00:00:00.0025255",
+      "conversionDuration": "00:00:00.0158469",
+      "compilationDuration": "00:00:00.0026571",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1726,8 +1788,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0072057",
-      "compilationDuration": "00:00:00.0007730",
+      "conversionDuration": "00:00:00.0158254",
+      "compilationDuration": "00:00:00.0027536",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1748,8 +1812,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0032502",
-      "compilationDuration": "00:00:00.0011177",
+      "conversionDuration": "00:00:00.0067819",
+      "compilationDuration": "00:00:00.0033111",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1771,8 +1837,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0081868",
-      "compilationDuration": "00:00:00.0036401",
+      "conversionDuration": "00:00:00.0348620",
+      "compilationDuration": "00:00:00.0028631",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1793,8 +1861,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0059292",
-      "compilationDuration": "00:00:00.0012532",
+      "conversionDuration": "00:00:00.0130283",
+      "compilationDuration": "00:00:00.0026122",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1815,8 +1885,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0068202",
-      "compilationDuration": "00:00:00.0013101",
+      "conversionDuration": "00:00:00.0188013",
+      "compilationDuration": "00:00:00.0027292",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1837,8 +1909,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0069091",
-      "compilationDuration": "00:00:00.0010474",
+      "conversionDuration": "00:00:00.0094474",
+      "compilationDuration": "00:00:00.0027308",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1859,8 +1933,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0052680",
-      "compilationDuration": "00:00:00.0010617",
+      "conversionDuration": "00:00:00.0098862",
+      "compilationDuration": "00:00:00.0026052",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1881,8 +1957,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0031385",
-      "compilationDuration": "00:00:00.0007970",
+      "conversionDuration": "00:00:00.0087677",
+      "compilationDuration": "00:00:00.0023759",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1903,8 +1981,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0031884",
-      "compilationDuration": "00:00:00.0007718",
+      "conversionDuration": "00:00:00.0060778",
+      "compilationDuration": "00:00:00.0022915",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1925,8 +2005,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0033865",
-      "compilationDuration": "00:00:00.0008686",
+      "conversionDuration": "00:00:00.0063587",
+      "compilationDuration": "00:00:00.0024618",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1948,8 +2030,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0164389",
-      "compilationDuration": "00:00:00.0034765",
+      "conversionDuration": "00:00:00.0275395",
+      "compilationDuration": "00:00:00.0027375",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1971,8 +2055,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035623",
-      "compilationDuration": "00:00:00.0012209",
+      "conversionDuration": "00:00:00.0068893",
+      "compilationDuration": "00:00:00.0023193",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1993,8 +2079,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0071203",
-      "compilationDuration": "00:00:00.0024247",
+      "conversionDuration": "00:00:00.0334705",
+      "compilationDuration": "00:00:00.0029282",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2017,8 +2105,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0055535",
-      "compilationDuration": "00:00:00.0025768",
+      "conversionDuration": "00:00:00.0251671",
+      "compilationDuration": "00:00:00.0030872",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2039,8 +2129,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0054229",
-      "compilationDuration": "00:00:00.0015032",
+      "conversionDuration": "00:00:00.0118332",
+      "compilationDuration": "00:00:00.0027499",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2062,8 +2154,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0045557",
-      "compilationDuration": "00:00:00.0024847",
+      "conversionDuration": "00:00:00.0092420",
+      "compilationDuration": "00:00:00.0029560",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2085,8 +2179,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0175977",
-      "compilationDuration": "00:00:00.0020420",
+      "conversionDuration": "00:00:00.0168229",
+      "compilationDuration": "00:00:00.0028801",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2107,8 +2203,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0081836",
-      "compilationDuration": "00:00:00.0010304",
+      "conversionDuration": "00:00:00.0113065",
+      "compilationDuration": "00:00:00.0028517",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2130,8 +2228,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0277887",
-      "compilationDuration": "00:00:00.0019370",
+      "conversionDuration": "00:00:00.0291008",
+      "compilationDuration": "00:00:00.0028175",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2153,8 +2253,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0089723",
-      "compilationDuration": "00:00:00.0011505",
+      "conversionDuration": "00:00:00.0120445",
+      "compilationDuration": "00:00:00.0031305",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2175,8 +2277,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0104346",
-      "compilationDuration": "00:00:00.0007726",
+      "conversionDuration": "00:00:00.0140593",
+      "compilationDuration": "00:00:00.0031108",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2198,8 +2302,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0040162",
-      "compilationDuration": "00:00:00.0008210",
+      "conversionDuration": "00:00:00.0079380",
+      "compilationDuration": "00:00:00.0025477",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2221,8 +2327,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0051444",
-      "compilationDuration": "00:00:00.0016630",
+      "conversionDuration": "00:00:00.0106280",
+      "compilationDuration": "00:00:00.0029786",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2244,8 +2352,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0041411",
-      "compilationDuration": "00:00:00.0007709",
+      "conversionDuration": "00:00:00.0080293",
+      "compilationDuration": "00:00:00.0023000",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2266,8 +2376,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0056393",
-      "compilationDuration": "00:00:00.0038007",
+      "conversionDuration": "00:00:00.0120180",
+      "compilationDuration": "00:00:00.0028950",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2289,8 +2401,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0034957",
-      "compilationDuration": "00:00:00.0008200",
+      "conversionDuration": "00:00:00.0070308",
+      "compilationDuration": "00:00:00.0077920",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2311,8 +2425,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035164",
-      "compilationDuration": "00:00:00.0008027",
+      "conversionDuration": "00:00:00.0076616",
+      "compilationDuration": "00:00:00.0024305",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2333,8 +2449,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0089004",
-      "compilationDuration": "00:00:00.0008057",
+      "conversionDuration": "00:00:00.0106423",
+      "compilationDuration": "00:00:00.0025457",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2356,8 +2474,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0054514",
-      "compilationDuration": "00:00:00.0010886",
+      "conversionDuration": "00:00:00.0151321",
+      "compilationDuration": "00:00:00.0028322",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2377,8 +2497,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0045559",
-      "compilationDuration": "00:00:00.0014780",
+      "conversionDuration": "00:00:00.0108547",
+      "compilationDuration": "00:00:00.0028151",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2399,8 +2521,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0037539",
-      "compilationDuration": "00:00:00.0008287",
+      "conversionDuration": "00:00:00.0087467",
+      "compilationDuration": "00:00:00.0025060",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2421,8 +2545,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0043880",
-      "compilationDuration": "00:00:00.0013276",
+      "conversionDuration": "00:00:00.0107004",
+      "compilationDuration": "00:00:00.0034040",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2442,8 +2568,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0067740",
-      "compilationDuration": "00:00:00.0007931",
+      "conversionDuration": "00:00:00.0104958",
+      "compilationDuration": "00:00:00.0027985",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2463,8 +2591,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0038165",
-      "compilationDuration": "00:00:00.0009710",
+      "conversionDuration": "00:00:00.0083826",
+      "compilationDuration": "00:00:00.0031963",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2484,8 +2614,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0034546",
-      "compilationDuration": "00:00:00.0037306",
+      "conversionDuration": "00:00:00.0085676",
+      "compilationDuration": "00:00:00.0026448",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2505,8 +2637,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0041137",
-      "compilationDuration": "00:00:00.0008454",
+      "conversionDuration": "00:00:00.0069949",
+      "compilationDuration": "00:00:00.0025869",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2527,8 +2661,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0037058",
-      "compilationDuration": "00:00:00.0008271",
+      "conversionDuration": "00:00:00.0075408",
+      "compilationDuration": "00:00:00.0027679",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2550,8 +2686,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035922",
-      "compilationDuration": "00:00:00.0008332",
+      "conversionDuration": "00:00:00.0071630",
+      "compilationDuration": "00:00:00.0025552",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2573,8 +2711,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0043136",
-      "compilationDuration": "00:00:00.0009758",
+      "conversionDuration": "00:00:00.0078213",
+      "compilationDuration": "00:00:00.0044355",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2595,8 +2735,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0036994",
-      "compilationDuration": "00:00:00.0008193",
+      "conversionDuration": "00:00:00.0113936",
+      "compilationDuration": "00:00:00.0033300",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2617,8 +2759,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0075841",
-      "compilationDuration": "00:00:00.0009090",
+      "conversionDuration": "00:00:00.0115942",
+      "compilationDuration": "00:00:00.0032200",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2638,8 +2782,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0045019",
-      "compilationDuration": "00:00:00.0010685",
+      "conversionDuration": "00:00:00.0082927",
+      "compilationDuration": "00:00:00.0028121",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2660,8 +2806,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0037372",
-      "compilationDuration": "00:00:00.0008945",
+      "conversionDuration": "00:00:00.0092725",
+      "compilationDuration": "00:00:00.0032281",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2671,23 +2819,26 @@
       "features": [
         "local_function"
       ],
-      "status": "PartiallyConverted",
+      "status": "FullyConverted",
       "conversionSuccess": true,
       "conversionErrors": 0,
-      "conversionWarnings": 0,
-      "conversionIssues": [],
-      "compilationSuccess": true,
-      "compilationErrors": 3,
-      "compilationDiagnostics": [
-        "Roslyn: CS0103: The name \u0027Add\u0027 does not exist in the current context (line 17)",
-        "Roslyn: CS0103: The name \u0027Multiply\u0027 does not exist in the current context (line 20)",
-        "Roslyn: CS0103: The name \u0027FactorialInternal\u0027 does not exist in the current context (line 30)"
+      "conversionWarnings": 2,
+      "conversionIssues": [
+        "Warning [local-function] (line 7): Unsupported feature [local-function] escalated to \u00A7CSHARP interop preservation: int Add(int a, int b)\n            {\n                return a \u002B b;\n            }",
+        "Info [method] (line 5): C# interop block preserved for [method]",
+        "Warning [local-function] (line 24): Unsupported feature [local-function] escalated to \u00A7CSHARP interop preservation: int FactorialInternal(int num)\n            {\n                if (num \u003C= 1)\n  ...",
+        "Info [method] (line 22): C# interop block preserved for [method]"
       ],
+      "compilationSuccess": true,
+      "compilationErrors": 0,
+      "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
-      "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0172164",
-      "compilationDuration": "00:00:00.0046084",
-      "roundTripSuccess": false
+      "cSharpCompilationSuccess": true,
+      "conversionDuration": "00:00:00.0144420",
+      "compilationDuration": "00:00:00.0025380",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
+      "roundTripSuccess": true
     },
     {
       "id": "075",
@@ -2707,8 +2858,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0100850",
-      "compilationDuration": "00:00:00.0016203",
+      "conversionDuration": "00:00:00.0235119",
+      "compilationDuration": "00:00:00.0038021",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2729,8 +2882,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035876",
-      "compilationDuration": "00:00:00.0008526",
+      "conversionDuration": "00:00:00.0078108",
+      "compilationDuration": "00:00:00.0025131",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2752,8 +2907,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0039900",
-      "compilationDuration": "00:00:00.0013044",
+      "conversionDuration": "00:00:00.0119764",
+      "compilationDuration": "00:00:00.0030130",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2763,22 +2920,24 @@
       "features": [
         "indexer"
       ],
-      "status": "PartiallyConverted",
-      "conversionSuccess": true,
-      "conversionErrors": 0,
+      "status": "Blocked",
+      "conversionSuccess": false,
+      "conversionErrors": 3,
       "conversionWarnings": 0,
-      "conversionIssues": [],
-      "compilationSuccess": true,
-      "compilationErrors": 3,
-      "compilationDiagnostics": [
-        "Roslyn: CS1551: Indexers must have at least one parameter (line 26)",
-        "Roslyn: CS0103: The name \u0027index\u0027 does not exist in the current context (line 31)",
-        "Roslyn: CS0103: The name \u0027index\u0027 does not exist in the current context (line 37)"
+      "conversionIssues": [
+        "Error [roundtrip-calor-validation] (line 26, col 25): Generated Calor failed compilation: Generated C# failed compilation (CS1551): Indexers must have at least one parameter",
+        "Error [roundtrip-calor-validation] (line 12, col 29): Generated Calor failed compilation: Generated C# failed compilation (CS0103): The name \u0027index\u0027 does not exist in the current context",
+        "Error [roundtrip-calor-validation] (line 14, col 22): Generated Calor failed compilation: Generated C# failed compilation (CS0103): The name \u0027index\u0027 does not exist in the current context"
       ],
-      "cSharpSyntaxSuccess": true,
+      "compilationSuccess": false,
+      "compilationErrors": 0,
+      "compilationDiagnostics": [],
+      "cSharpSyntaxSuccess": false,
       "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0061879",
-      "compilationDuration": "00:00:00.0021269",
+      "conversionDuration": "00:00:00.0148770",
+      "compilationDuration": "00:00:00",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": false
     },
     {
@@ -2798,8 +2957,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0060407",
-      "compilationDuration": "00:00:00.0023220",
+      "conversionDuration": "00:00:00.0123862",
+      "compilationDuration": "00:00:00.0032393",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2820,8 +2981,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0048211",
-      "compilationDuration": "00:00:00.0009195",
+      "conversionDuration": "00:00:00.0097530",
+      "compilationDuration": "00:00:00.0033706",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2843,8 +3006,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0044655",
-      "compilationDuration": "00:00:00.0018400",
+      "conversionDuration": "00:00:00.0164117",
+      "compilationDuration": "00:00:00.0034408",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2866,8 +3031,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0580275",
-      "compilationDuration": "00:00:00.0021496",
+      "conversionDuration": "00:00:00.0507441",
+      "compilationDuration": "00:00:00.0035747",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2889,8 +3056,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0175450",
-      "compilationDuration": "00:00:00.0009145",
+      "conversionDuration": "00:00:00.0505115",
+      "compilationDuration": "00:00:00.0145533",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2912,8 +3081,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0145130",
-      "compilationDuration": "00:00:00.0010142",
+      "conversionDuration": "00:00:00.0397279",
+      "compilationDuration": "00:00:00.0151019",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2934,8 +3105,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0049593",
-      "compilationDuration": "00:00:00.0012786",
+      "conversionDuration": "00:00:00.0149754",
+      "compilationDuration": "00:00:00.0032510",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2946,23 +3119,25 @@
         "generic_method",
         "type_constraint"
       ],
-      "status": "PartiallyConverted",
-      "conversionSuccess": true,
-      "conversionErrors": 0,
+      "status": "Blocked",
+      "conversionSuccess": false,
+      "conversionErrors": 4,
       "conversionWarnings": 0,
-      "conversionIssues": [],
-      "compilationSuccess": true,
-      "compilationErrors": 4,
-      "compilationDiagnostics": [
-        "Roslyn: CS0246: The type or namespace name \u0027temp\u0027 could not be found (are you missing a using directive or an assembly reference?) (line 24)",
-        "Roslyn: CS0412: \u0027T\u0027: a parameter, local variable, or local function cannot have the same name as a method type parameter (line 24)",
-        "Roslyn: CS0103: The name \u0027temp\u0027 does not exist in the current context (line 30)",
-        "Roslyn: CS0118: \u0027result\u0027 is a variable but is used like a type (line 37)"
+      "conversionIssues": [
+        "Error [roundtrip-calor-validation] (line 7, col 13): Generated Calor failed compilation: Generated C# failed compilation (CS0246): The type or namespace name \u0027temp\u0027 could not be found (are you missing a using directive or an assembly reference?)",
+        "Error [roundtrip-calor-validation] (line 7, col 18): Generated Calor failed compilation: Generated C# failed compilation (CS0412): \u0027T\u0027: a parameter, local variable, or local function cannot have the same name as a method type parameter",
+        "Error [roundtrip-calor-validation] (line 9, col 17): Generated Calor failed compilation: Generated C# failed compilation (CS0103): The name \u0027temp\u0027 does not exist in the current context",
+        "Error [roundtrip-calor-validation] (line 12, col 30): Generated Calor failed compilation: Generated C# failed compilation (CS0118): \u0027result\u0027 is a variable but is used like a type"
       ],
-      "cSharpSyntaxSuccess": true,
+      "compilationSuccess": false,
+      "compilationErrors": 0,
+      "compilationDiagnostics": [],
+      "cSharpSyntaxSuccess": false,
       "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0103605",
-      "compilationDuration": "00:00:00.0023741",
+      "conversionDuration": "00:00:00.0156889",
+      "compilationDuration": "00:00:00",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": false
     },
     {
@@ -2984,8 +3159,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0108507",
-      "compilationDuration": "00:00:00.0022030",
+      "conversionDuration": "00:00:00.0180623",
+      "compilationDuration": "00:00:00.0036302",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3006,8 +3183,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0089936",
-      "compilationDuration": "00:00:00.0015652",
+      "conversionDuration": "00:00:00.0174107",
+      "compilationDuration": "00:00:00.0041283",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3031,8 +3210,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0038972",
-      "compilationDuration": "00:00:00.0009087",
+      "conversionDuration": "00:00:00.0333071",
+      "compilationDuration": "00:00:00.0143519",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3054,8 +3235,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0115552",
-      "compilationDuration": "00:00:00.0010052",
+      "conversionDuration": "00:00:00.0428635",
+      "compilationDuration": "00:00:00.0159907",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3077,8 +3260,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0097665",
-      "compilationDuration": "00:00:00.0009581",
+      "conversionDuration": "00:00:00.0391435",
+      "compilationDuration": "00:00:00.0154454",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3100,8 +3285,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0050896",
-      "compilationDuration": "00:00:00.0017021",
+      "conversionDuration": "00:00:00.0157123",
+      "compilationDuration": "00:00:00.0108012",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3122,8 +3309,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0095558",
-      "compilationDuration": "00:00:00.0017813",
+      "conversionDuration": "00:00:00.0171749",
+      "compilationDuration": "00:00:00.0041099",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3135,22 +3324,21 @@
         "is_expression",
         "switch_expression"
       ],
-      "status": "PartiallyConverted",
+      "status": "FullyConverted",
       "conversionSuccess": true,
       "conversionErrors": 0,
       "conversionWarnings": 0,
       "conversionIssues": [],
       "compilationSuccess": true,
-      "compilationErrors": 2,
-      "compilationDiagnostics": [
-        "Roslyn: CS1061: \u0027object\u0027 does not contain a definition for \u0027Length\u0027 and no accessible extension method \u0027Length\u0027 accepting a first argument of type \u0027object\u0027 could be found (are you missing a using directive or an assembly reference?) (line 67)",
-        "Roslyn: CS1061: \u0027object\u0027 does not contain a definition for \u0027Length\u0027 and no accessible extension method \u0027Length\u0027 accepting a first argument of type \u0027object\u0027 could be found (are you missing a using directive or an assembly reference?) (line 67)"
-      ],
+      "compilationErrors": 0,
+      "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
-      "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0065933",
-      "compilationDuration": "00:00:00.0015694",
-      "roundTripSuccess": false
+      "cSharpCompilationSuccess": true,
+      "conversionDuration": "00:00:00.0227238",
+      "compilationDuration": "00:00:00.0100205",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
+      "roundTripSuccess": true
     },
     {
       "id": "095",
@@ -3161,20 +3349,22 @@
         "null_conditional",
         "null_assignment"
       ],
-      "status": "PartiallyConverted",
-      "conversionSuccess": true,
-      "conversionErrors": 0,
+      "status": "Blocked",
+      "conversionSuccess": false,
+      "conversionErrors": 1,
       "conversionWarnings": 0,
-      "conversionIssues": [],
-      "compilationSuccess": true,
-      "compilationErrors": 1,
-      "compilationDiagnostics": [
-        "Roslyn: CS8978: \u0027method group\u0027 cannot be made nullable. (line 45)"
+      "conversionIssues": [
+        "Error [roundtrip-calor-validation] (line 16, col 35): Generated Calor failed compilation: Generated C# failed compilation (CS8978): \u0027method group\u0027 cannot be made nullable."
       ],
-      "cSharpSyntaxSuccess": true,
+      "compilationSuccess": false,
+      "compilationErrors": 0,
+      "compilationDiagnostics": [],
+      "cSharpSyntaxSuccess": false,
       "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0058190",
-      "compilationDuration": "00:00:00.0011122",
+      "conversionDuration": "00:00:00.0122090",
+      "compilationDuration": "00:00:00",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": false
     },
     {
@@ -3195,8 +3385,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0106727",
-      "compilationDuration": "00:00:00.0016330",
+      "conversionDuration": "00:00:00.0250897",
+      "compilationDuration": "00:00:00.0037585",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3219,8 +3411,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0140470",
-      "compilationDuration": "00:00:00.0009379",
+      "conversionDuration": "00:00:00.0176982",
+      "compilationDuration": "00:00:00.0045072",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3232,20 +3426,22 @@
         "where_clause",
         "new_constraint"
       ],
-      "status": "PartiallyConverted",
-      "conversionSuccess": true,
-      "conversionErrors": 0,
+      "status": "Blocked",
+      "conversionSuccess": false,
+      "conversionErrors": 1,
       "conversionWarnings": 0,
-      "conversionIssues": [],
-      "compilationSuccess": true,
-      "compilationErrors": 1,
-      "compilationDiagnostics": [
-        "Roslyn: CS0246: The type or namespace name \u0027arrT004\u0027 could not be found (are you missing a using directive or an assembly reference?) (line 20)"
+      "conversionIssues": [
+        "Error [roundtrip-calor-validation] (line 20, col 33): Generated Calor failed compilation: Generated C# failed compilation (CS0246): The type or namespace name \u0027arrT004\u0027 could not be found (are you missing a using directive or an assembly reference?)"
       ],
-      "cSharpSyntaxSuccess": true,
+      "compilationSuccess": false,
+      "compilationErrors": 0,
+      "compilationDiagnostics": [],
+      "cSharpSyntaxSuccess": false,
       "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0049894",
-      "compilationDuration": "00:00:00.0013335",
+      "conversionDuration": "00:00:00.0125891",
+      "compilationDuration": "00:00:00",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": false
     },
     {
@@ -3256,21 +3452,23 @@
         "deconstruction",
         "tuple_deconstruct"
       ],
-      "status": "PartiallyConverted",
-      "conversionSuccess": true,
-      "conversionErrors": 0,
+      "status": "Blocked",
+      "conversionSuccess": false,
+      "conversionErrors": 2,
       "conversionWarnings": 0,
-      "conversionIssues": [],
-      "compilationSuccess": true,
-      "compilationErrors": 2,
-      "compilationDiagnostics": [
-        "Roslyn: CS1061: \u0027Point\u0027 does not contain a definition for \u0027Item1\u0027 and no accessible extension method \u0027Item1\u0027 accepting a first argument of type \u0027Point\u0027 could be found (are you missing a using directive or an assembly reference?) (line 71)",
-        "Roslyn: CS1061: \u0027Point\u0027 does not contain a definition for \u0027Item2\u0027 and no accessible extension method \u0027Item2\u0027 accepting a first argument of type \u0027Point\u0027 could be found (are you missing a using directive or an assembly reference?) (line 74)"
+      "conversionIssues": [
+        "Error [roundtrip-calor-validation] (line 27, col 29): Generated Calor failed compilation: Generated C# failed compilation (CS1061): \u0027Point\u0027 does not contain a definition for \u0027Item1\u0027 and no accessible extension method \u0027Item1\u0027 accepting a first argument of type \u0027Point\u0027 could be found (are you missing a using directive or an assembly reference?)",
+        "Error [roundtrip-calor-validation] (line 28, col 29): Generated Calor failed compilation: Generated C# failed compilation (CS1061): \u0027Point\u0027 does not contain a definition for \u0027Item2\u0027 and no accessible extension method \u0027Item2\u0027 accepting a first argument of type \u0027Point\u0027 could be found (are you missing a using directive or an assembly reference?)"
       ],
-      "cSharpSyntaxSuccess": true,
+      "compilationSuccess": false,
+      "compilationErrors": 0,
+      "compilationDiagnostics": [],
+      "cSharpSyntaxSuccess": false,
       "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0076996",
-      "compilationDuration": "00:00:00.0011303",
+      "conversionDuration": "00:00:00.0203765",
+      "compilationDuration": "00:00:00",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": false
     },
     {
@@ -3295,8 +3493,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0043359",
-      "compilationDuration": "00:00:00.0006440",
+      "conversionDuration": "00:00:00.0099730",
+      "compilationDuration": "00:00:00.0036289",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     }
   ]

--- a/tests/Calor.Evaluation/Scorecard/baseline.json
+++ b/tests/Calor.Evaluation/Scorecard/baseline.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-08-12T15:23:13.880748Z",
-  "commitHash": "713a9532",
+  "timestamp": "2026-08-01T04:32:05.993661Z",
+  "commitHash": "08341e44",
   "version": "1.0",
   "total": 100,
-  "fullyConverted": 95,
-  "partiallyConverted": 0,
-  "blocked": 5,
+  "fullyConverted": 93,
+  "partiallyConverted": 7,
+  "blocked": 0,
   "crashed": 0,
-  "roundTripPassing": 95,
+  "roundTripPassing": 93,
   "byLevel": {
     "1": {
       "total": 20,
@@ -26,13 +26,13 @@
     },
     "4": {
       "total": 20,
-      "passed": 19,
-      "rate": 0.95
+      "passed": 18,
+      "rate": 0.9
     },
     "5": {
       "total": 20,
-      "passed": 16,
-      "rate": 0.8
+      "passed": 15,
+      "rate": 0.75
     }
   },
   "byFeature": {
@@ -348,13 +348,13 @@
     },
     "switch_expression": {
       "total": 2,
-      "passed": 2,
-      "rate": 1
+      "passed": 1,
+      "rate": 0.5
     },
     "pattern_matching": {
       "total": 2,
-      "passed": 2,
-      "rate": 1
+      "passed": 1,
+      "rate": 0.5
     },
     "break": {
       "total": 1,
@@ -743,8 +743,8 @@
     },
     "local_function": {
       "total": 1,
-      "passed": 1,
-      "rate": 1
+      "passed": 0,
+      "rate": 0
     },
     "extension_method": {
       "total": 1,
@@ -958,8 +958,8 @@
     },
     "is_expression": {
       "total": 1,
-      "passed": 1,
-      "rate": 1
+      "passed": 0,
+      "rate": 0
     },
     "null_coalescing": {
       "total": 1,
@@ -1053,10 +1053,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.4557705",
-      "compilationDuration": "00:00:00.0043671",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.1118867",
+      "compilationDuration": "00:00:00.0523710",
       "roundTripSuccess": true
     },
     {
@@ -1079,10 +1077,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0164311",
-      "compilationDuration": "00:00:00.0033282",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0051217",
+      "compilationDuration": "00:00:00.0041791",
       "roundTripSuccess": true
     },
     {
@@ -1103,10 +1099,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0090451",
-      "compilationDuration": "00:00:00.0032271",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0035421",
+      "compilationDuration": "00:00:00.0017052",
       "roundTripSuccess": true
     },
     {
@@ -1128,10 +1122,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0139713",
-      "compilationDuration": "00:00:00.0034877",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0040708",
+      "compilationDuration": "00:00:00.0061930",
       "roundTripSuccess": true
     },
     {
@@ -1153,10 +1145,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0078365",
-      "compilationDuration": "00:00:00.0030974",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0035860",
+      "compilationDuration": "00:00:00.0009281",
       "roundTripSuccess": true
     },
     {
@@ -1177,10 +1167,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0229927",
-      "compilationDuration": "00:00:00.0028719",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0062983",
+      "compilationDuration": "00:00:00.0012787",
       "roundTripSuccess": true
     },
     {
@@ -1202,10 +1190,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0247392",
-      "compilationDuration": "00:00:00.0028528",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0065264",
+      "compilationDuration": "00:00:00.0021472",
       "roundTripSuccess": true
     },
     {
@@ -1227,10 +1213,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0065791",
-      "compilationDuration": "00:00:00.0027578",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0028697",
+      "compilationDuration": "00:00:00.0017430",
       "roundTripSuccess": true
     },
     {
@@ -1252,10 +1236,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0064154",
-      "compilationDuration": "00:00:00.0059406",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0028918",
+      "compilationDuration": "00:00:00.0018517",
       "roundTripSuccess": true
     },
     {
@@ -1277,10 +1259,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0059701",
-      "compilationDuration": "00:00:00.0022660",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0028734",
+      "compilationDuration": "00:00:00.0019022",
       "roundTripSuccess": true
     },
     {
@@ -1301,10 +1281,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0054725",
-      "compilationDuration": "00:00:00.0021136",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0028607",
+      "compilationDuration": "00:00:00.0018017",
       "roundTripSuccess": true
     },
     {
@@ -1325,10 +1303,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0063682",
-      "compilationDuration": "00:00:00.0022331",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0028462",
+      "compilationDuration": "00:00:00.0017100",
       "roundTripSuccess": true
     },
     {
@@ -1350,10 +1326,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0314665",
-      "compilationDuration": "00:00:00.0037021",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0285078",
+      "compilationDuration": "00:00:00.0033553",
       "roundTripSuccess": true
     },
     {
@@ -1374,10 +1348,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0161821",
-      "compilationDuration": "00:00:00.0052159",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0138357",
+      "compilationDuration": "00:00:00.0013839",
       "roundTripSuccess": true
     },
     {
@@ -1401,10 +1373,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0076260",
-      "compilationDuration": "00:00:00.0024699",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0038178",
+      "compilationDuration": "00:00:00.0010734",
       "roundTripSuccess": true
     },
     {
@@ -1426,10 +1396,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0071131",
-      "compilationDuration": "00:00:00.0024003",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0035199",
+      "compilationDuration": "00:00:00.0011971",
       "roundTripSuccess": true
     },
     {
@@ -1443,19 +1411,15 @@
       "status": "FullyConverted",
       "conversionSuccess": true,
       "conversionErrors": 0,
-      "conversionWarnings": 1,
-      "conversionIssues": [
-        "Warning [unsupported-prefix-operator] (line 12): Unsupported feature [unsupported-prefix-operator] escalated to \u00A7CSHARP interop preservation: \u002Bx"
-      ],
+      "conversionWarnings": 0,
+      "conversionIssues": [],
       "compilationSuccess": true,
       "compilationErrors": 0,
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0076385",
-      "compilationDuration": "00:00:00.0022753",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0032463",
+      "compilationDuration": "00:00:00.0007624",
       "roundTripSuccess": true
     },
     {
@@ -1476,10 +1440,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0075033",
-      "compilationDuration": "00:00:00.0023112",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0048271",
+      "compilationDuration": "00:00:00.0010625",
       "roundTripSuccess": true
     },
     {
@@ -1500,10 +1462,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0250910",
-      "compilationDuration": "00:00:00.0027417",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0065532",
+      "compilationDuration": "00:00:00.0007547",
       "roundTripSuccess": true
     },
     {
@@ -1524,10 +1484,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0064116",
-      "compilationDuration": "00:00:00.0024775",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0035046",
+      "compilationDuration": "00:00:00.0008580",
       "roundTripSuccess": true
     },
     {
@@ -1548,10 +1506,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0126613",
-      "compilationDuration": "00:00:00.0025040",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0063835",
+      "compilationDuration": "00:00:00.0021458",
       "roundTripSuccess": true
     },
     {
@@ -1572,10 +1528,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0057911",
-      "compilationDuration": "00:00:00.0043201",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0035629",
+      "compilationDuration": "00:00:00.0007494",
       "roundTripSuccess": true
     },
     {
@@ -1596,10 +1550,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0065742",
-      "compilationDuration": "00:00:00.0022091",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0036396",
+      "compilationDuration": "00:00:00.0008814",
       "roundTripSuccess": true
     },
     {
@@ -1621,10 +1573,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0189872",
-      "compilationDuration": "00:00:00.0027411",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0107805",
+      "compilationDuration": "00:00:00.0026991",
       "roundTripSuccess": true
     },
     {
@@ -1644,10 +1594,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0104881",
-      "compilationDuration": "00:00:00.0024705",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0072573",
+      "compilationDuration": "00:00:00.0039066",
       "roundTripSuccess": true
     },
     {
@@ -1667,10 +1615,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0111045",
-      "compilationDuration": "00:00:00.0032855",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0091918",
+      "compilationDuration": "00:00:00.0021513",
       "roundTripSuccess": true
     },
     {
@@ -1691,10 +1637,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0103048",
-      "compilationDuration": "00:00:00.0026382",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0066283",
+      "compilationDuration": "00:00:00.0008921",
       "roundTripSuccess": true
     },
     {
@@ -1716,10 +1660,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0110390",
-      "compilationDuration": "00:00:00.0025351",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0061113",
+      "compilationDuration": "00:00:00.0020297",
       "roundTripSuccess": true
     },
     {
@@ -1740,10 +1682,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0088942",
-      "compilationDuration": "00:00:00.0025778",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0064575",
+      "compilationDuration": "00:00:00.0007619",
       "roundTripSuccess": true
     },
     {
@@ -1764,10 +1704,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0158469",
-      "compilationDuration": "00:00:00.0026571",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0061825",
+      "compilationDuration": "00:00:00.0025255",
       "roundTripSuccess": true
     },
     {
@@ -1788,10 +1726,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0158254",
-      "compilationDuration": "00:00:00.0027536",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0072057",
+      "compilationDuration": "00:00:00.0007730",
       "roundTripSuccess": true
     },
     {
@@ -1812,10 +1748,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0067819",
-      "compilationDuration": "00:00:00.0033111",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0032502",
+      "compilationDuration": "00:00:00.0011177",
       "roundTripSuccess": true
     },
     {
@@ -1837,10 +1771,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0348620",
-      "compilationDuration": "00:00:00.0028631",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0081868",
+      "compilationDuration": "00:00:00.0036401",
       "roundTripSuccess": true
     },
     {
@@ -1861,10 +1793,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0130283",
-      "compilationDuration": "00:00:00.0026122",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0059292",
+      "compilationDuration": "00:00:00.0012532",
       "roundTripSuccess": true
     },
     {
@@ -1885,10 +1815,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0188013",
-      "compilationDuration": "00:00:00.0027292",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0068202",
+      "compilationDuration": "00:00:00.0013101",
       "roundTripSuccess": true
     },
     {
@@ -1909,10 +1837,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0094474",
-      "compilationDuration": "00:00:00.0027308",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0069091",
+      "compilationDuration": "00:00:00.0010474",
       "roundTripSuccess": true
     },
     {
@@ -1933,10 +1859,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0098862",
-      "compilationDuration": "00:00:00.0026052",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0052680",
+      "compilationDuration": "00:00:00.0010617",
       "roundTripSuccess": true
     },
     {
@@ -1957,10 +1881,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0087677",
-      "compilationDuration": "00:00:00.0023759",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0031385",
+      "compilationDuration": "00:00:00.0007970",
       "roundTripSuccess": true
     },
     {
@@ -1981,10 +1903,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0060778",
-      "compilationDuration": "00:00:00.0022915",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0031884",
+      "compilationDuration": "00:00:00.0007718",
       "roundTripSuccess": true
     },
     {
@@ -2005,10 +1925,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0063587",
-      "compilationDuration": "00:00:00.0024618",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0033865",
+      "compilationDuration": "00:00:00.0008686",
       "roundTripSuccess": true
     },
     {
@@ -2030,10 +1948,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0275395",
-      "compilationDuration": "00:00:00.0027375",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0164389",
+      "compilationDuration": "00:00:00.0034765",
       "roundTripSuccess": true
     },
     {
@@ -2055,10 +1971,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0068893",
-      "compilationDuration": "00:00:00.0023193",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0035623",
+      "compilationDuration": "00:00:00.0012209",
       "roundTripSuccess": true
     },
     {
@@ -2079,10 +1993,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0334705",
-      "compilationDuration": "00:00:00.0029282",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0071203",
+      "compilationDuration": "00:00:00.0024247",
       "roundTripSuccess": true
     },
     {
@@ -2105,10 +2017,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0251671",
-      "compilationDuration": "00:00:00.0030872",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0055535",
+      "compilationDuration": "00:00:00.0025768",
       "roundTripSuccess": true
     },
     {
@@ -2129,10 +2039,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0118332",
-      "compilationDuration": "00:00:00.0027499",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0054229",
+      "compilationDuration": "00:00:00.0015032",
       "roundTripSuccess": true
     },
     {
@@ -2154,10 +2062,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0092420",
-      "compilationDuration": "00:00:00.0029560",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0045557",
+      "compilationDuration": "00:00:00.0024847",
       "roundTripSuccess": true
     },
     {
@@ -2179,10 +2085,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0168229",
-      "compilationDuration": "00:00:00.0028801",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0175977",
+      "compilationDuration": "00:00:00.0020420",
       "roundTripSuccess": true
     },
     {
@@ -2203,10 +2107,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0113065",
-      "compilationDuration": "00:00:00.0028517",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0081836",
+      "compilationDuration": "00:00:00.0010304",
       "roundTripSuccess": true
     },
     {
@@ -2228,10 +2130,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0291008",
-      "compilationDuration": "00:00:00.0028175",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0277887",
+      "compilationDuration": "00:00:00.0019370",
       "roundTripSuccess": true
     },
     {
@@ -2253,10 +2153,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0120445",
-      "compilationDuration": "00:00:00.0031305",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0089723",
+      "compilationDuration": "00:00:00.0011505",
       "roundTripSuccess": true
     },
     {
@@ -2277,10 +2175,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0140593",
-      "compilationDuration": "00:00:00.0031108",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0104346",
+      "compilationDuration": "00:00:00.0007726",
       "roundTripSuccess": true
     },
     {
@@ -2302,10 +2198,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0079380",
-      "compilationDuration": "00:00:00.0025477",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0040162",
+      "compilationDuration": "00:00:00.0008210",
       "roundTripSuccess": true
     },
     {
@@ -2327,10 +2221,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0106280",
-      "compilationDuration": "00:00:00.0029786",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0051444",
+      "compilationDuration": "00:00:00.0016630",
       "roundTripSuccess": true
     },
     {
@@ -2352,10 +2244,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0080293",
-      "compilationDuration": "00:00:00.0023000",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0041411",
+      "compilationDuration": "00:00:00.0007709",
       "roundTripSuccess": true
     },
     {
@@ -2376,10 +2266,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0120180",
-      "compilationDuration": "00:00:00.0028950",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0056393",
+      "compilationDuration": "00:00:00.0038007",
       "roundTripSuccess": true
     },
     {
@@ -2401,10 +2289,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0070308",
-      "compilationDuration": "00:00:00.0077920",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0034957",
+      "compilationDuration": "00:00:00.0008200",
       "roundTripSuccess": true
     },
     {
@@ -2425,10 +2311,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0076616",
-      "compilationDuration": "00:00:00.0024305",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0035164",
+      "compilationDuration": "00:00:00.0008027",
       "roundTripSuccess": true
     },
     {
@@ -2449,10 +2333,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0106423",
-      "compilationDuration": "00:00:00.0025457",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0089004",
+      "compilationDuration": "00:00:00.0008057",
       "roundTripSuccess": true
     },
     {
@@ -2474,10 +2356,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0151321",
-      "compilationDuration": "00:00:00.0028322",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0054514",
+      "compilationDuration": "00:00:00.0010886",
       "roundTripSuccess": true
     },
     {
@@ -2497,10 +2377,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0108547",
-      "compilationDuration": "00:00:00.0028151",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0045559",
+      "compilationDuration": "00:00:00.0014780",
       "roundTripSuccess": true
     },
     {
@@ -2521,10 +2399,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0087467",
-      "compilationDuration": "00:00:00.0025060",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0037539",
+      "compilationDuration": "00:00:00.0008287",
       "roundTripSuccess": true
     },
     {
@@ -2545,10 +2421,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0107004",
-      "compilationDuration": "00:00:00.0034040",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0043880",
+      "compilationDuration": "00:00:00.0013276",
       "roundTripSuccess": true
     },
     {
@@ -2568,10 +2442,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0104958",
-      "compilationDuration": "00:00:00.0027985",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0067740",
+      "compilationDuration": "00:00:00.0007931",
       "roundTripSuccess": true
     },
     {
@@ -2591,10 +2463,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0083826",
-      "compilationDuration": "00:00:00.0031963",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0038165",
+      "compilationDuration": "00:00:00.0009710",
       "roundTripSuccess": true
     },
     {
@@ -2614,10 +2484,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0085676",
-      "compilationDuration": "00:00:00.0026448",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0034546",
+      "compilationDuration": "00:00:00.0037306",
       "roundTripSuccess": true
     },
     {
@@ -2637,10 +2505,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0069949",
-      "compilationDuration": "00:00:00.0025869",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0041137",
+      "compilationDuration": "00:00:00.0008454",
       "roundTripSuccess": true
     },
     {
@@ -2661,10 +2527,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0075408",
-      "compilationDuration": "00:00:00.0027679",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0037058",
+      "compilationDuration": "00:00:00.0008271",
       "roundTripSuccess": true
     },
     {
@@ -2686,10 +2550,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0071630",
-      "compilationDuration": "00:00:00.0025552",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0035922",
+      "compilationDuration": "00:00:00.0008332",
       "roundTripSuccess": true
     },
     {
@@ -2711,10 +2573,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0078213",
-      "compilationDuration": "00:00:00.0044355",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0043136",
+      "compilationDuration": "00:00:00.0009758",
       "roundTripSuccess": true
     },
     {
@@ -2735,10 +2595,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0113936",
-      "compilationDuration": "00:00:00.0033300",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0036994",
+      "compilationDuration": "00:00:00.0008193",
       "roundTripSuccess": true
     },
     {
@@ -2759,10 +2617,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0115942",
-      "compilationDuration": "00:00:00.0032200",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0075841",
+      "compilationDuration": "00:00:00.0009090",
       "roundTripSuccess": true
     },
     {
@@ -2782,10 +2638,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0082927",
-      "compilationDuration": "00:00:00.0028121",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0045019",
+      "compilationDuration": "00:00:00.0010685",
       "roundTripSuccess": true
     },
     {
@@ -2806,10 +2660,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0092725",
-      "compilationDuration": "00:00:00.0032281",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0037372",
+      "compilationDuration": "00:00:00.0008945",
       "roundTripSuccess": true
     },
     {
@@ -2819,26 +2671,23 @@
       "features": [
         "local_function"
       ],
-      "status": "FullyConverted",
+      "status": "PartiallyConverted",
       "conversionSuccess": true,
       "conversionErrors": 0,
-      "conversionWarnings": 2,
-      "conversionIssues": [
-        "Warning [local-function] (line 7): Unsupported feature [local-function] escalated to \u00A7CSHARP interop preservation: int Add(int a, int b)\n            {\n                return a \u002B b;\n            }",
-        "Info [method] (line 5): C# interop block preserved for [method]",
-        "Warning [local-function] (line 24): Unsupported feature [local-function] escalated to \u00A7CSHARP interop preservation: int FactorialInternal(int num)\n            {\n                if (num \u003C= 1)\n  ...",
-        "Info [method] (line 22): C# interop block preserved for [method]"
-      ],
+      "conversionWarnings": 0,
+      "conversionIssues": [],
       "compilationSuccess": true,
-      "compilationErrors": 0,
-      "compilationDiagnostics": [],
+      "compilationErrors": 3,
+      "compilationDiagnostics": [
+        "Roslyn: CS0103: The name \u0027Add\u0027 does not exist in the current context (line 17)",
+        "Roslyn: CS0103: The name \u0027Multiply\u0027 does not exist in the current context (line 20)",
+        "Roslyn: CS0103: The name \u0027FactorialInternal\u0027 does not exist in the current context (line 30)"
+      ],
       "cSharpSyntaxSuccess": true,
-      "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0144420",
-      "compilationDuration": "00:00:00.0025380",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
-      "roundTripSuccess": true
+      "cSharpCompilationSuccess": false,
+      "conversionDuration": "00:00:00.0172164",
+      "compilationDuration": "00:00:00.0046084",
+      "roundTripSuccess": false
     },
     {
       "id": "075",
@@ -2858,10 +2707,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0235119",
-      "compilationDuration": "00:00:00.0038021",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0100850",
+      "compilationDuration": "00:00:00.0016203",
       "roundTripSuccess": true
     },
     {
@@ -2882,10 +2729,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0078108",
-      "compilationDuration": "00:00:00.0025131",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0035876",
+      "compilationDuration": "00:00:00.0008526",
       "roundTripSuccess": true
     },
     {
@@ -2907,10 +2752,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0119764",
-      "compilationDuration": "00:00:00.0030130",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0039900",
+      "compilationDuration": "00:00:00.0013044",
       "roundTripSuccess": true
     },
     {
@@ -2920,24 +2763,22 @@
       "features": [
         "indexer"
       ],
-      "status": "Blocked",
-      "conversionSuccess": false,
-      "conversionErrors": 3,
+      "status": "PartiallyConverted",
+      "conversionSuccess": true,
+      "conversionErrors": 0,
       "conversionWarnings": 0,
-      "conversionIssues": [
-        "Error [roundtrip-calor-validation] (line 26, col 25): Generated Calor failed compilation: Generated C# failed compilation (CS1551): Indexers must have at least one parameter",
-        "Error [roundtrip-calor-validation] (line 12, col 29): Generated Calor failed compilation: Generated C# failed compilation (CS0103): The name \u0027index\u0027 does not exist in the current context",
-        "Error [roundtrip-calor-validation] (line 14, col 22): Generated Calor failed compilation: Generated C# failed compilation (CS0103): The name \u0027index\u0027 does not exist in the current context"
+      "conversionIssues": [],
+      "compilationSuccess": true,
+      "compilationErrors": 3,
+      "compilationDiagnostics": [
+        "Roslyn: CS1551: Indexers must have at least one parameter (line 26)",
+        "Roslyn: CS0103: The name \u0027index\u0027 does not exist in the current context (line 31)",
+        "Roslyn: CS0103: The name \u0027index\u0027 does not exist in the current context (line 37)"
       ],
-      "compilationSuccess": false,
-      "compilationErrors": 0,
-      "compilationDiagnostics": [],
-      "cSharpSyntaxSuccess": false,
+      "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0148770",
-      "compilationDuration": "00:00:00",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0061879",
+      "compilationDuration": "00:00:00.0021269",
       "roundTripSuccess": false
     },
     {
@@ -2957,10 +2798,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0123862",
-      "compilationDuration": "00:00:00.0032393",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0060407",
+      "compilationDuration": "00:00:00.0023220",
       "roundTripSuccess": true
     },
     {
@@ -2981,10 +2820,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0097530",
-      "compilationDuration": "00:00:00.0033706",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0048211",
+      "compilationDuration": "00:00:00.0009195",
       "roundTripSuccess": true
     },
     {
@@ -3006,10 +2843,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0164117",
-      "compilationDuration": "00:00:00.0034408",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0044655",
+      "compilationDuration": "00:00:00.0018400",
       "roundTripSuccess": true
     },
     {
@@ -3031,10 +2866,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0507441",
-      "compilationDuration": "00:00:00.0035747",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0580275",
+      "compilationDuration": "00:00:00.0021496",
       "roundTripSuccess": true
     },
     {
@@ -3056,10 +2889,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0505115",
-      "compilationDuration": "00:00:00.0145533",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0175450",
+      "compilationDuration": "00:00:00.0009145",
       "roundTripSuccess": true
     },
     {
@@ -3081,10 +2912,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0397279",
-      "compilationDuration": "00:00:00.0151019",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0145130",
+      "compilationDuration": "00:00:00.0010142",
       "roundTripSuccess": true
     },
     {
@@ -3105,10 +2934,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0149754",
-      "compilationDuration": "00:00:00.0032510",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0049593",
+      "compilationDuration": "00:00:00.0012786",
       "roundTripSuccess": true
     },
     {
@@ -3119,25 +2946,23 @@
         "generic_method",
         "type_constraint"
       ],
-      "status": "Blocked",
-      "conversionSuccess": false,
-      "conversionErrors": 4,
+      "status": "PartiallyConverted",
+      "conversionSuccess": true,
+      "conversionErrors": 0,
       "conversionWarnings": 0,
-      "conversionIssues": [
-        "Error [roundtrip-calor-validation] (line 7, col 13): Generated Calor failed compilation: Generated C# failed compilation (CS0246): The type or namespace name \u0027temp\u0027 could not be found (are you missing a using directive or an assembly reference?)",
-        "Error [roundtrip-calor-validation] (line 7, col 18): Generated Calor failed compilation: Generated C# failed compilation (CS0412): \u0027T\u0027: a parameter, local variable, or local function cannot have the same name as a method type parameter",
-        "Error [roundtrip-calor-validation] (line 9, col 17): Generated Calor failed compilation: Generated C# failed compilation (CS0103): The name \u0027temp\u0027 does not exist in the current context",
-        "Error [roundtrip-calor-validation] (line 12, col 30): Generated Calor failed compilation: Generated C# failed compilation (CS0118): \u0027result\u0027 is a variable but is used like a type"
+      "conversionIssues": [],
+      "compilationSuccess": true,
+      "compilationErrors": 4,
+      "compilationDiagnostics": [
+        "Roslyn: CS0246: The type or namespace name \u0027temp\u0027 could not be found (are you missing a using directive or an assembly reference?) (line 24)",
+        "Roslyn: CS0412: \u0027T\u0027: a parameter, local variable, or local function cannot have the same name as a method type parameter (line 24)",
+        "Roslyn: CS0103: The name \u0027temp\u0027 does not exist in the current context (line 30)",
+        "Roslyn: CS0118: \u0027result\u0027 is a variable but is used like a type (line 37)"
       ],
-      "compilationSuccess": false,
-      "compilationErrors": 0,
-      "compilationDiagnostics": [],
-      "cSharpSyntaxSuccess": false,
+      "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0156889",
-      "compilationDuration": "00:00:00",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0103605",
+      "compilationDuration": "00:00:00.0023741",
       "roundTripSuccess": false
     },
     {
@@ -3159,10 +2984,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0180623",
-      "compilationDuration": "00:00:00.0036302",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0108507",
+      "compilationDuration": "00:00:00.0022030",
       "roundTripSuccess": true
     },
     {
@@ -3183,10 +3006,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0174107",
-      "compilationDuration": "00:00:00.0041283",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0089936",
+      "compilationDuration": "00:00:00.0015652",
       "roundTripSuccess": true
     },
     {
@@ -3210,10 +3031,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0333071",
-      "compilationDuration": "00:00:00.0143519",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0038972",
+      "compilationDuration": "00:00:00.0009087",
       "roundTripSuccess": true
     },
     {
@@ -3235,10 +3054,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0428635",
-      "compilationDuration": "00:00:00.0159907",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0115552",
+      "compilationDuration": "00:00:00.0010052",
       "roundTripSuccess": true
     },
     {
@@ -3260,10 +3077,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0391435",
-      "compilationDuration": "00:00:00.0154454",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0097665",
+      "compilationDuration": "00:00:00.0009581",
       "roundTripSuccess": true
     },
     {
@@ -3285,10 +3100,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0157123",
-      "compilationDuration": "00:00:00.0108012",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0050896",
+      "compilationDuration": "00:00:00.0017021",
       "roundTripSuccess": true
     },
     {
@@ -3309,10 +3122,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0171749",
-      "compilationDuration": "00:00:00.0041099",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0095558",
+      "compilationDuration": "00:00:00.0017813",
       "roundTripSuccess": true
     },
     {
@@ -3324,21 +3135,22 @@
         "is_expression",
         "switch_expression"
       ],
-      "status": "FullyConverted",
+      "status": "PartiallyConverted",
       "conversionSuccess": true,
       "conversionErrors": 0,
       "conversionWarnings": 0,
       "conversionIssues": [],
       "compilationSuccess": true,
-      "compilationErrors": 0,
-      "compilationDiagnostics": [],
+      "compilationErrors": 2,
+      "compilationDiagnostics": [
+        "Roslyn: CS1061: \u0027object\u0027 does not contain a definition for \u0027Length\u0027 and no accessible extension method \u0027Length\u0027 accepting a first argument of type \u0027object\u0027 could be found (are you missing a using directive or an assembly reference?) (line 67)",
+        "Roslyn: CS1061: \u0027object\u0027 does not contain a definition for \u0027Length\u0027 and no accessible extension method \u0027Length\u0027 accepting a first argument of type \u0027object\u0027 could be found (are you missing a using directive or an assembly reference?) (line 67)"
+      ],
       "cSharpSyntaxSuccess": true,
-      "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0227238",
-      "compilationDuration": "00:00:00.0100205",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
-      "roundTripSuccess": true
+      "cSharpCompilationSuccess": false,
+      "conversionDuration": "00:00:00.0065933",
+      "compilationDuration": "00:00:00.0015694",
+      "roundTripSuccess": false
     },
     {
       "id": "095",
@@ -3349,22 +3161,20 @@
         "null_conditional",
         "null_assignment"
       ],
-      "status": "Blocked",
-      "conversionSuccess": false,
-      "conversionErrors": 1,
+      "status": "PartiallyConverted",
+      "conversionSuccess": true,
+      "conversionErrors": 0,
       "conversionWarnings": 0,
-      "conversionIssues": [
-        "Error [roundtrip-calor-validation] (line 16, col 35): Generated Calor failed compilation: Generated C# failed compilation (CS8978): \u0027method group\u0027 cannot be made nullable."
+      "conversionIssues": [],
+      "compilationSuccess": true,
+      "compilationErrors": 1,
+      "compilationDiagnostics": [
+        "Roslyn: CS8978: \u0027method group\u0027 cannot be made nullable. (line 45)"
       ],
-      "compilationSuccess": false,
-      "compilationErrors": 0,
-      "compilationDiagnostics": [],
-      "cSharpSyntaxSuccess": false,
+      "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0122090",
-      "compilationDuration": "00:00:00",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0058190",
+      "compilationDuration": "00:00:00.0011122",
       "roundTripSuccess": false
     },
     {
@@ -3385,10 +3195,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0250897",
-      "compilationDuration": "00:00:00.0037585",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0106727",
+      "compilationDuration": "00:00:00.0016330",
       "roundTripSuccess": true
     },
     {
@@ -3411,10 +3219,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0176982",
-      "compilationDuration": "00:00:00.0045072",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0140470",
+      "compilationDuration": "00:00:00.0009379",
       "roundTripSuccess": true
     },
     {
@@ -3426,22 +3232,20 @@
         "where_clause",
         "new_constraint"
       ],
-      "status": "Blocked",
-      "conversionSuccess": false,
-      "conversionErrors": 1,
+      "status": "PartiallyConverted",
+      "conversionSuccess": true,
+      "conversionErrors": 0,
       "conversionWarnings": 0,
-      "conversionIssues": [
-        "Error [roundtrip-calor-validation] (line 20, col 33): Generated Calor failed compilation: Generated C# failed compilation (CS0246): The type or namespace name \u0027arrT004\u0027 could not be found (are you missing a using directive or an assembly reference?)"
+      "conversionIssues": [],
+      "compilationSuccess": true,
+      "compilationErrors": 1,
+      "compilationDiagnostics": [
+        "Roslyn: CS0246: The type or namespace name \u0027arrT004\u0027 could not be found (are you missing a using directive or an assembly reference?) (line 20)"
       ],
-      "compilationSuccess": false,
-      "compilationErrors": 0,
-      "compilationDiagnostics": [],
-      "cSharpSyntaxSuccess": false,
+      "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0125891",
-      "compilationDuration": "00:00:00",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0049894",
+      "compilationDuration": "00:00:00.0013335",
       "roundTripSuccess": false
     },
     {
@@ -3452,23 +3256,21 @@
         "deconstruction",
         "tuple_deconstruct"
       ],
-      "status": "Blocked",
-      "conversionSuccess": false,
-      "conversionErrors": 2,
+      "status": "PartiallyConverted",
+      "conversionSuccess": true,
+      "conversionErrors": 0,
       "conversionWarnings": 0,
-      "conversionIssues": [
-        "Error [roundtrip-calor-validation] (line 27, col 29): Generated Calor failed compilation: Generated C# failed compilation (CS1061): \u0027Point\u0027 does not contain a definition for \u0027Item1\u0027 and no accessible extension method \u0027Item1\u0027 accepting a first argument of type \u0027Point\u0027 could be found (are you missing a using directive or an assembly reference?)",
-        "Error [roundtrip-calor-validation] (line 28, col 29): Generated Calor failed compilation: Generated C# failed compilation (CS1061): \u0027Point\u0027 does not contain a definition for \u0027Item2\u0027 and no accessible extension method \u0027Item2\u0027 accepting a first argument of type \u0027Point\u0027 could be found (are you missing a using directive or an assembly reference?)"
+      "conversionIssues": [],
+      "compilationSuccess": true,
+      "compilationErrors": 2,
+      "compilationDiagnostics": [
+        "Roslyn: CS1061: \u0027Point\u0027 does not contain a definition for \u0027Item1\u0027 and no accessible extension method \u0027Item1\u0027 accepting a first argument of type \u0027Point\u0027 could be found (are you missing a using directive or an assembly reference?) (line 71)",
+        "Roslyn: CS1061: \u0027Point\u0027 does not contain a definition for \u0027Item2\u0027 and no accessible extension method \u0027Item2\u0027 accepting a first argument of type \u0027Point\u0027 could be found (are you missing a using directive or an assembly reference?) (line 74)"
       ],
-      "compilationSuccess": false,
-      "compilationErrors": 0,
-      "compilationDiagnostics": [],
-      "cSharpSyntaxSuccess": false,
+      "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0203765",
-      "compilationDuration": "00:00:00",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0076996",
+      "compilationDuration": "00:00:00.0011303",
       "roundTripSuccess": false
     },
     {
@@ -3493,10 +3295,8 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0099730",
-      "compilationDuration": "00:00:00.0036289",
-      "semanticLossCount": 0,
-      "semanticLossDiagnostics": [],
+      "conversionDuration": "00:00:00.0043359",
+      "compilationDuration": "00:00:00.0006440",
       "roundTripSuccess": true
     }
   ]


### PR DESCRIPTION
## Summary
- require generated C# to pass full Roslyn compilation in round-trip and scorecard gates
- fail closed for missing snapshots, missing baselines, fixture regressions, and semantic-loss entries
- surface semantic-loss diagnostics and fix array collection-spread materialization
- regenerate the truthful per-fixture scorecard baseline

## Verification
- zero-warning Release build
- all release-critical test projects passed with manifest-verified inventories
- Calor.Conversion.Tests: 373 passed
- Calor.Evaluation: 202 passed

Closes #771