### PR TITLE
Resolve module-qualified cross-module calls (#925)

### DIFF
--- a/eng/test-manifest.json
+++ b/eng/test-manifest.json
@@ -1,34 +1,139 @@
 {
   "schemaVersion": 1,
   "projects": [
-    { "path": "tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 6806, "expectedSkipped": 2 },
-    { "path": "tests/Calor.Conversion.Tests/Calor.Conversion.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 374, "expectedSkipped": 0 },
-    { "path": "tests/Calor.Enforcement.Tests/Calor.Enforcement.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 309, "expectedSkipped": 0 },
-    { "path": "tests/Calor.Evaluation/Calor.Evaluation.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 202, "expectedSkipped": 0 },
-    { "path": "tests/Calor.Experimental.Tests/Calor.Experimental.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 21, "expectedSkipped": 0 },
-    { "path": "tests/Calor.Ids.Tests/Calor.Ids.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 389, "expectedSkipped": 0 },
-    { "path": "tests/Calor.ILAnalysis.Tests/Calor.ILAnalysis.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 42, "expectedSkipped": 0 },
-    { "path": "tests/Calor.LanguageServer.Tests/Calor.LanguageServer.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 436, "expectedSkipped": 0 },
-    { "path": "tests/Calor.Performance.Tests/Calor.Performance.Tests.csproj", "workflow": ".github/workflows/performance.yml", "releaseCritical": true, "expectedTotal": 19, "expectedSkipped": 0 },
-    { "path": "tests/Calor.RoundTrip.Harness.Tests/Calor.RoundTrip.Harness.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 204, "expectedSkipped": 0 },
-    { "path": "tests/Calor.Semantics.Tests/Calor.Semantics.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 37, "expectedSkipped": 0 },
-    { "path": "tests/Calor.Tasks.Tests/Calor.Tasks.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 94, "expectedSkipped": 0 },
-    { "path": "tests/Calor.Verification.Tests/Calor.Verification.Tests.csproj", "workflow": ".github/workflows/test.yml", "releaseCritical": true, "expectedTotal": 388, "expectedSkipped": 0 }
+    {
+      "path": "tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj",
+      "workflow": ".github/workflows/test.yml",
+      "releaseCritical": true,
+      "expectedTotal": 6810,
+      "expectedSkipped": 2
+    },
+    {
+      "path": "tests/Calor.Conversion.Tests/Calor.Conversion.Tests.csproj",
+      "workflow": ".github/workflows/test.yml",
+      "releaseCritical": true,
+      "expectedTotal": 374,
+      "expectedSkipped": 0
+    },
+    {
+      "path": "tests/Calor.Enforcement.Tests/Calor.Enforcement.Tests.csproj",
+      "workflow": ".github/workflows/test.yml",
+      "releaseCritical": true,
+      "expectedTotal": 309,
+      "expectedSkipped": 0
+    },
+    {
+      "path": "tests/Calor.Evaluation/Calor.Evaluation.csproj",
+      "workflow": ".github/workflows/test.yml",
+      "releaseCritical": true,
+      "expectedTotal": 202,
+      "expectedSkipped": 0
+    },
+    {
+      "path": "tests/Calor.Experimental.Tests/Calor.Experimental.Tests.csproj",
+      "workflow": ".github/workflows/test.yml",
+      "releaseCritical": true,
+      "expectedTotal": 21,
+      "expectedSkipped": 0
+    },
+    {
+      "path": "tests/Calor.Ids.Tests/Calor.Ids.Tests.csproj",
+      "workflow": ".github/workflows/test.yml",
+      "releaseCritical": true,
+      "expectedTotal": 389,
+      "expectedSkipped": 0
+    },
+    {
+      "path": "tests/Calor.ILAnalysis.Tests/Calor.ILAnalysis.Tests.csproj",
+      "workflow": ".github/workflows/test.yml",
+      "releaseCritical": true,
+      "expectedTotal": 42,
+      "expectedSkipped": 0
+    },
+    {
+      "path": "tests/Calor.LanguageServer.Tests/Calor.LanguageServer.Tests.csproj",
+      "workflow": ".github/workflows/test.yml",
+      "releaseCritical": true,
+      "expectedTotal": 436,
+      "expectedSkipped": 0
+    },
+    {
+      "path": "tests/Calor.Performance.Tests/Calor.Performance.Tests.csproj",
+      "workflow": ".github/workflows/performance.yml",
+      "releaseCritical": true,
+      "expectedTotal": 19,
+      "expectedSkipped": 0
+    },
+    {
+      "path": "tests/Calor.RoundTrip.Harness.Tests/Calor.RoundTrip.Harness.Tests.csproj",
+      "workflow": ".github/workflows/test.yml",
+      "releaseCritical": true,
+      "expectedTotal": 204,
+      "expectedSkipped": 0
+    },
+    {
+      "path": "tests/Calor.Semantics.Tests/Calor.Semantics.Tests.csproj",
+      "workflow": ".github/workflows/test.yml",
+      "releaseCritical": true,
+      "expectedTotal": 37,
+      "expectedSkipped": 0
+    },
+    {
+      "path": "tests/Calor.Tasks.Tests/Calor.Tasks.Tests.csproj",
+      "workflow": ".github/workflows/test.yml",
+      "releaseCritical": true,
+      "expectedTotal": 94,
+      "expectedSkipped": 0
+    },
+    {
+      "path": "tests/Calor.Verification.Tests/Calor.Verification.Tests.csproj",
+      "workflow": ".github/workflows/test.yml",
+      "releaseCritical": true,
+      "expectedTotal": 388,
+      "expectedSkipped": 0
+    }
   ],
   "excludedProjects": [
-    { "path": "tests/DebugRT/DebugRT.csproj", "reason": "manual scratch console harness" },
-    { "path": "tests/Calor.RoundTrip.Synthetic/SyntheticLib.Tests/SyntheticLib.Tests.csproj", "reason": "round-trip corpus fixture" },
-    { "path": "tests/Calor.RoundTrip.Synthetic2/GeoLib.Tests/GeoLib.Tests.csproj", "reason": "round-trip corpus fixture" },
-    { "path": "tests/SdkConsumer/CalorLib.Tests/CalorLib.Tests.csproj", "reason": "SDK package consumer executable gate" }
+    {
+      "path": "tests/DebugRT/DebugRT.csproj",
+      "reason": "manual scratch console harness"
+    },
+    {
+      "path": "tests/Calor.RoundTrip.Synthetic/SyntheticLib.Tests/SyntheticLib.Tests.csproj",
+      "reason": "round-trip corpus fixture"
+    },
+    {
+      "path": "tests/Calor.RoundTrip.Synthetic2/GeoLib.Tests/GeoLib.Tests.csproj",
+      "reason": "round-trip corpus fixture"
+    },
+    {
+      "path": "tests/SdkConsumer/CalorLib.Tests/CalorLib.Tests.csproj",
+      "reason": "SDK package consumer executable gate"
+    }
   ],
   "allowedSkippedTests": [
-    { "reason": "Integration test - requires network access", "count": 2 }
+    {
+      "reason": "Integration test - requires network access",
+      "count": 2
+    }
   ],
   "allowedRuntimeSkipSites": [
-    { "reason": "Benchmark file not found", "count": 7 },
-    { "reason": "Calor syntax not supported by parser", "count": 5 },
-    { "reason": "Z3 not available", "count": 376 },
-    { "reason": "corpus submodules not initialized", "count": 1 }
+    {
+      "reason": "Benchmark file not found",
+      "count": 7
+    },
+    {
+      "reason": "Calor syntax not supported by parser",
+      "count": 5
+    },
+    {
+      "reason": "Z3 not available",
+      "count": 376
+    },
+    {
+      "reason": "corpus submodules not initialized",
+      "count": 1
+    }
   ],
   "releaseGates": [
     "test",

--- a/src/Calor.Compiler/Effects/EffectEnforcementPass.cs
+++ b/src/Calor.Compiler/Effects/EffectEnforcementPass.cs
@@ -1296,6 +1296,23 @@ public sealed class EffectEnforcementPass
                 }
             }
 
+            // A MODULE-QUALIFIED call into another module of the same multi-file
+            // compilation (#925). The bare-name path already accepts these; this
+            // path did not, so naming the module explicitly — the clearer thing
+            // to write — produced a WORSE result than leaving it bare: the call
+            // fell through to "unknown external", which then forbade it inside a
+            // pure function even when the callee was itself pure.
+            //
+            // The driver's map holds "Module.Function" keys for every module and
+            // the bare name only when unambiguous, so membership here is already
+            // the exactly-one-match rule the rest of resolution uses. As in the
+            // bare case, this pass contributes nothing: the cross-module pass
+            // charges the callee's declared effects.
+            if (_context.CrossModuleFunctionNames.Contains(target))
+            {
+                return EffectSet.Empty;
+            }
+
             // Permissive mode: assume pure for unknown calls (no diagnostic)
             if (_context.Policy == UnknownCallPolicy.Permissive)
             {

--- a/tests/Calor.Compiler.Tests/Q925VerifyTests.cs
+++ b/tests/Calor.Compiler.Tests/Q925VerifyTests.cs
@@ -1,0 +1,40 @@
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Effects;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+public sealed class Q925VerifyTests
+{
+    [Theory]
+    [InlineData("", "OrderService.SaveOrder", false)]
+    [InlineData("db:w", "OrderService.SaveOrder", true)]
+    [InlineData("", "SaveOrder", false)]
+    [InlineData("db:w", "SaveOrder", true)]
+    public void QualifiedAndBareAgree(string calleeEffects, string callTarget, bool expectViolation)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "q925v-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "callee.calr"),
+            "§M{m001:OrderService}\n  §F{f001:SaveOrder:pub} () -> void\n    §E{" + calleeEffects + "}\n");
+        File.WriteAllText(Path.Combine(dir, "caller.calr"),
+            "§M{m002:App}\n  §F{f001:Main:pub} () -> void\n    §E{}\n    §C{" + callTarget + "} §/C\n");
+
+        var sources = Directory.GetFiles(dir, "*.calr")
+            .OrderBy(p => p, StringComparer.Ordinal).Select(p => new FileInfo(p)).ToList();
+        var sink = new DiagnosticBag();
+        CompilationDriver.CompileAll(
+            sources,
+            _ => new CompilationOptions { EnforceEffects = true, UnknownCallPolicy = UnknownCallPolicy.Strict },
+            crossModuleEnforcement: true,
+            crossModulePolicy: UnknownCallPolicy.Strict,
+            onCompiled: (f, r) => File.WriteAllText(Path.ChangeExtension(f.FullName, ".g.cs"), r.GeneratedCode),
+            diagnosticSink: sink);
+
+        var codes = sink.Select(d => d.Code).Distinct().OrderBy(c => c).ToArray();
+        Directory.Delete(dir, true);
+
+        Assert.DoesNotContain(DiagnosticCode.UnknownExternalCall, codes);
+        Assert.Equal(expectViolation, codes.Contains(DiagnosticCode.ForbiddenEffect));
+    }
+}


### PR DESCRIPTION
Closes #925.

## The bug

Writing `§C{OrderService.SaveOrder}` — explicitly naming the module you are calling — produced a **worse** result than writing `§C{SaveOrder}`. The qualified form fell through to *"unknown external call"* (Calor0411), which then forbade the call inside a pure function (Calor0410) **even when the callee was itself pure**.

Being more explicit was penalised.

| callee declares | call form | before | after |
|---|---|---|---|
| nothing (pure) | `SaveOrder` | clean | clean |
| `db:w` | `SaveOrder` | Calor0410 ✓ | Calor0410 ✓ |
| nothing (pure) | `OrderService.SaveOrder` | **Calor0410 + 0411 — false alarm** | clean ✓ |
| `db:w` | `OrderService.SaveOrder` | Calor0410 + 0411 (right answer, wrong reason) | Calor0410 ✓ |

## Cause and fix

The bare-name path consulted the driver's cross-module map; the dotted path never did. The map already holds `"Module.Function"` keys for every module — and the bare name *only when unambiguous* — so consulting it in both places gives the qualified form the same **exactly-one-match** discipline the rest of resolution uses. The cross-module pass still charges the callee's declared effects, so this pass contributes nothing, exactly as in the bare case.

The emitter already resolved the qualified form this way; only effect enforcement disagreed.

## It repairs the non-discriminating test, rather than satisfying it

#925 flagged `CrossModuleViolation_SurfacesFromCachedSummaries` as unable to fail: it asserted `ForbiddenEffect` on a qualified call, which was reported *whatever* the callee declared. That test now passes because the effect **genuinely propagates**, not because an unknown call happens to be forbidden.

`Q925VerifyTests` pins all four combinations, asserting both that no Calor0411 is raised and that `ForbiddenEffect` appears **if and only if** the callee declares an effect the caller does not — so an over-correction (suppressing real violations) fails it too. Verified discriminating: reverting the fix fails exactly the two qualified cases.

## Note for reviewers

While verifying this I hit four SDK build errors locally and nearly reported main as broken. They were **MSBuild node reuse caching a stale task assembly** — `CompileCalor` does define the parameters, and `-nodeReuse:false` builds clean. Not a repo issue; recording it because it looks alarming and costs time to re-diagnose.

Release build clean (0 warnings); all test projects green; inventory updated to 6,810 and verified with `check_trx.py`.