### PR TITLE
Release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,68 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-08-12
+
+### Benchmark Results (Statistical: 30 runs)
+- **Overall Advantage**: 1.32x (Calor leads)
+- **Categories**: Calor wins 7, C# wins 1
+- **Highlights** (advantage ratio, Cohen's d where reported):
+  - Comprehension: 1.84x (Calor, d=1.80 large)
+  - ErrorDetection: 1.49x (Calor, d=1.21 large)
+  - TokenEconomics: 1.42x (Calor)
+  - RefactoringStability: 1.38x (Calor, d=7.09 large)
+  - EditPrecision: 1.36x (Calor, d=4.90 large)
+  - InformationDensity: 0.98x (C#, d=-0.52 medium)
+- **Programs Tested**: 217 Calor / 216 C# compiled successfully
+
 ### Added
-- **Exact-span LSP refactoring (#765)** now indexes every open and closed
-  workspace `.calr` file by stable `SymbolId`, resolves cursors only through
-  exact identifier-token occurrences, and incrementally reparses changed or
-  deleted closed files. Definition, references, and rename distinguish
-  overloads, shadowed locals and fields, unrelated members, and same-spelled
-  symbols across files. Rename emits versioned `documentChanges` for open
-  documents and validated unversioned edits for unchanged closed files.
+- **Persistent project index and `calor query`** (roadmap §2.2, the fourth-deferral
+  item, now shipped). `calor index build` writes a versioned index under
+  `obj/calor/`; `calor index status` reports whether it may still be trusted.
+  `calor query` answers six facets: `symbol`, `callers`, `callees`, `impact`,
+  `contracts`, `assumptions`. Two disciplines are enforced rather than
+  documented: a stale index never answers — it rebuilds, or refuses under
+  `--no-build` — and every answer carries its residual, because Calor binds one
+  file at a time and a cross-file call resolves only when exactly one
+  declaration bears the name. Answers say `PARTIAL` and name what was dropped.
+- **`calor rename`** — SymbolId-addressed rename across a project, with edits
+  derived from bound-tree identity rather than text. Refuses rather than
+  guessing on ambiguity, stale sources, name collisions, declarations split
+  across files (#922), and type declarations whose references are not yet
+  indexed.
+- **Dogfood utility** (`tools/calor-allowlist-audit/`) — a real in-repo tool
+  whose only source is Calor. It audits `.calor-csharp-allowlist` against rules
+  that file states in prose and nothing enforced, and CI both builds and runs
+  it, so a Calor regression that breaks this program breaks the build.
+- **Release gates closed**: §2.5 gate 2 (full-vs-incremental diagnostic
+  identity, over a registered ES-01..ES-07 edit-script corpus), gate 3
+  (index/query correctness, over a hand-authored golden corpus), gate 4
+  (rename, with an apply-recompile-and-run behaviour oracle), and gate 8
+  (performance envelope: index build 0.40s against a 30s budget, warm queries
+  0.0-0.3ms against 500ms, on a 106-file/11.1k-line corpus).
+- Exact-span LSP refactoring (#765) indexes every open and closed workspace
+  `.calr` file by stable `SymbolId`, resolves cursors only through exact
+  identifier-token occurrences, and incrementally reparses changed or deleted
+  closed files. Definition, references, and rename distinguish overloads,
+  shadowed locals and fields, unrelated members, and same-spelled symbols across
+  files.
 - A CI-visible exact-span refactoring gate applies adversarial multi-file edits,
   reparses and rebinds the workspace, emits C#, and requires a clean Roslyn
   compilation.
+- CI and release quality gates are now truthful (#938): a test-inventory
+  manifest pins per-project test counts, with coverage, mutation, flake and
+  performance ratchets alongside.
+- `Calor.Sdk` package consumers are release-grade (#937), and round-trip gates
+  require semantic validity (#945, #932).
+
+### Fixed
+- **Module-qualified cross-module calls resolve** (#925). Writing
+  `§C{Module.Function}` produced a *worse* result than the bare form: it fell
+  through to "unknown external call" and forbade the call inside a pure function
+  even when the callee was itself pure. The dotted path now consults the same
+  cross-module map the bare path always did.
+- Generated C# is guaranteed Roslyn-valid (#939).
+- Formatting is lossless and atomic (#918).
 
 ### Changed
 - LSP rename is advertised by default. The experimental
@@ -28,6 +79,14 @@ All notable changes to this project will be documented in this file.
   to update it. The channel has been broken since v0.4.0, five months of staleness produced zero
   complaints, and recurring token/publish-chain maintenance is not justified by demonstrated
   demand.
+
+### Note on scope
+This is a 0.13.x release. It completes the 0.13 project-model program and its
+release gates; it is **not** 0.14. The 0.14 "Null-Safe .NET" content —
+metadata-backed .NET binding, the typed semantic representation, the typed CFG
+null-state slice, enforced non-nullable reference types, and the 2.0.0
+self-migration — remains unbuilt, and 0.14 will ship as `§SEMVER{2.0.0}` when
+it does.
 
 ## [0.13.0] - 2026-08-11
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.13.0</Version>
+    <Version>0.13.1</Version>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "calor",
   "displayName": "Calor Language",
   "description": "Language support for the Calor programming language",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "publisher": "calor-dev",
   "license": "Apache-2.0",
   "icon": "icons/calor-icon.png",

--- a/website/content/changelog.mdx
+++ b/website/content/changelog.mdx
@@ -14,6 +14,25 @@ All notable changes to Calor, organized by release.
 
 - **VS Code Marketplace publishing is opportunistic, not a release commitment.** Current extension builds remain supported as platform-specific VSIX files attached to GitHub releases, and CI continues to exercise the bundled single-file LSP. The Marketplace listing deliberately remains at v0.3.8 unless a publishing token is minted; five months of stale listing produced no demand signal that justifies keeping token rotation in the release path.
 
+## [0.13.1] - 2026-08-12
+
+Completes the 0.13 project-model program: the persistent index and `calor query` ship — the item deferred three times in 0.13 — and four release gates close.
+
+**Not 0.14.** The "Null-Safe .NET" content (metadata-backed .NET binding, typed semantics, non-nullable reference types, the 2.0.0 self-migration) remains unbuilt and will ship as `§SEMVER{2.0.0}` when it does.
+
+### Added
+
+- **Persistent project index and `calor query`.** `calor index build` writes a versioned index under `obj/calor/`; `calor index status` says whether it can still be trusted. `calor query` answers six facets: `symbol`, `callers`, `callees`, `impact`, `contracts`, `assumptions`. Two rules are enforced rather than documented — a stale index never answers, and every answer carries its residual, naming what could not be resolved rather than quietly omitting it.
+- **`calor rename`** — rename addressed by symbol identity rather than text, refusing rather than guessing on ambiguity, stale sources, collisions, and declarations split across files.
+- **Dogfood utility** — a real in-repo tool whose only source is Calor, built and run by CI.
+- **Four release gates closed**: full-vs-incremental diagnostic identity, index/query correctness, rename (with an apply-recompile-and-run behaviour oracle), and the performance envelope (index build 0.40s against a 30s budget; warm queries under a millisecond against 500ms).
+- **Exact-span LSP refactoring** — definition, references, and rename distinguish overloads, shadowed locals and fields, and same-spelled symbols across files.
+
+### Fixed
+
+- **Module-qualified cross-module calls resolve.** Writing `§C{Module.Function}` previously gave a *worse* result than the bare form — it was treated as an unknown external call and forbidden inside a pure function even when the callee was pure.
+- Generated C# is guaranteed Roslyn-valid; formatting is lossless and atomic.
+
 ## [0.13.0] - 2026-08-11
 
 The "Trustworthy Project Model" release. Headline: the structural-binding rebuild is complete — all 60 accepted expression classes bind structurally (the analysis-incomplete instrument is retired because nothing is incomplete), with stable symbol identities, full-signature overload resolution, exhaustive checker traversals, a resolved call graph, and LSP rename/references/cross-file resolution on top.

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calor-website",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/website/public/data/benchmark-results.json
+++ b/website/public/data/benchmark-results.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
-  "timestamp": "2026-08-11T17:42:39.964774Z",
-  "commit": "a7122d15",
+  "timestamp": "2026-08-12T16:05:34.942065Z",
+  "commit": "ee7c2bbc",
   "frameworkVersion": "1.0.0",
   "summary": {
     "overallAdvantage": 1.32,

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -15,9 +15,9 @@ export function WhatsNewBanner() {
         <div className="flex items-center justify-center gap-3 text-sm">
           <Sparkles className="h-4 w-4 text-calor-cerulean flex-shrink-0" />
           <p className="text-center">
-            <span className="font-semibold text-calor-cerulean">v0.13.0</span>
+            <span className="font-semibold text-calor-cerulean">v0.13.1</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">The Trustworthy Project Model release is live. Install the current VS Code extension from the release VSIX artifacts; the v0.3.8 Marketplace listing is now an intentionally opportunistic channel, not a release gate.</span>
+            <span className="text-foreground">The project model is now queryable: `calor index` and `calor query` answer who calls what, what a change affects, and what a declaration assumes — and say plainly when an answer is incomplete.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"


### PR DESCRIPTION
## Summary
- Bump version to 0.13.1
- CHANGELOG rewritten to cover the full release (the staged `Unreleased` section described 2 of the 21 merges since v0.13.0)
- Website changelog and WhatsNewBanner updated
- Benchmark results regenerated (statistical, 30 runs)

## What this release is

Completes the 0.13 project-model program: the **persistent index and `calor query`** ship — the item deferred three times during 0.13 — and **four release gates close** (full-vs-incremental identity, index/query correctness, rename with an apply-recompile-and-run oracle, and the performance envelope).

Also: `calor rename`, the dogfood utility, exact-span LSP refactoring, and the #925 fix for module-qualified cross-module calls.

## What this release is NOT

**Not 0.14.** The "Null-Safe .NET" content — metadata-backed .NET binding, the typed semantic representation, the typed CFG null-state slice, enforced non-nullable reference types, and the 2.0.0 self-migration — remains unbuilt. 0.14 will ship as `§SEMVER{2.0.0}` when it does. Both changelogs state this explicitly so no reader infers otherwise.

## Benchmark Results (statistical, 30 runs)
- **Overall advantage**: 1.32x (Calor leads)
- **Categories**: Calor wins 7, C# wins 1
- Comprehension 1.84x (d=1.80), ErrorDetection 1.49x (d=1.21), TokenEconomics 1.42x, RefactoringStability 1.38x (d=7.09), EditPrecision 1.36x (d=4.90); InformationDensity 0.98x to C# (d=-0.52)
- **Programs tested**: 217 Calor / 216 C# compiled successfully

Reported as advantage ratios and Cohen's d because that is what the harness emits; the skill's template asks for `± CI` values the report does not produce, and inventing them to match a template would be worse than reporting the real figures.

## Checklist
- [x] Version updated in Directory.Build.props
- [x] Version updated in editors/vscode/package.json
- [x] Version updated in website/package.json
- [x] CHANGELOG.md updated with version, date, and benchmark summary
- [x] website/content/changelog.mdx updated (no benchmark stats)
- [x] website/src/components/landing/WhatsNewBanner.tsx updated
- [x] website/public/data/benchmark-results.json regenerated
- [x] Cut from a **green** main (`4886ab6f`) — the earlier red was the #897 MCP flake, re-run and confirmed