### PR TITLE
fix(ci): drop --no-build from the publish gate's test legs

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts/test
-          dotnet test "${{ matrix.project }}" -c Release --no-build \
+          dotnet test "${{ matrix.project }}" -c Release \
             --logger "trx;LogFileName=${{ matrix.name }}.trx" \
             --results-directory artifacts/test \
             --verbosity normal 2>&1 | tee test-output.log


### PR DESCRIPTION
Fixes a defect I introduced in #953.

## What I got wrong

When sharding the publish gate, I added `--no-build` to each leg's `dotnet test`, reasoning that the preceding `Build` step had already produced the output. **Neither `test.yml`'s matrix nor the serial loop I replaced used it**, and I had no evidence it was safe — I added it as an optimisation.

Three of thirteen legs then failed:

```
The argument .../Calor.Ids.Tests.dll is invalid. Please use the /help option
MSB4181: The "VSTestTask" task returned false but did not log an error
```

## Why this is worth more than a silent revert

**Eight legs passed with the same flag.** The failure is partial and doesn't reproduce uniformly, so `--no-build` looked fine across most of the matrix and broke a subset — exactly the shape of change that survives a casual glance at a mostly-green run. Had the split gone the other way (11 pass, 2 fail on the 503s), I'd likely have attributed all of it to the outage and shipped the flag.

The leg now matches `test.yml`'s proven form exactly. `dotnet test` re-runs the build incrementally, so the standalone `Build` step still earns its place by surfacing compile errors as a distinct step.

## The other two failures in that run

`test (il-analysis)` and `test (evaluation)` failed on **`Seed Z3 native libraries`** with HTTP 503 — the ongoing upstream degradation tracked in #951, unrelated to this change. That issue remains the durable fix; sharding increases fetch concurrency rather than reducing it.

## Release state

`v0.13.1` remains tagged and unpublished; the tag is untouched. Once this lands, the publish is re-dispatched for the existing tag.