### PR TITLE
fix(mcp): scope memory admission control to the server that owns the process (#897)

### DIFF
--- a/.calor-csharp-allowlist
+++ b/.calor-csharp-allowlist
@@ -66,5 +66,4 @@ src/Calor.Compiler/Commands/QueryCommand.cs
 # Compiler-internal MCP protocol machinery, same class as the rest of
 # src/Calor.Compiler/Mcp/; Calor has no access to Process.WorkingSet64 or the
 # GC memory info this policy is built from.
-# pending
 src/Calor.Compiler/Mcp/McpMemoryAdmissionPolicy.cs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **MCP heavy-tool admission control no longer charges a host process's memory to the next tool
+  call (#897).** `calor_compile`, `calor_convert`, `calor_analyze` and `calor_batch` are gated on
+  process memory before they start, measured with `Process.WorkingSet64` — the *whole* process.
+  Under `calor mcp` that is sound, because the server owns its process. It was applied
+  unconditionally, so in any host the handler does not own it attributed that host's memory to the
+  next MCP tool, waited its full 30s, and refused with *"Server under memory pressure"*.
+
+  This is what six `McpServerTests` had been failing on since 2026-08-10 — only on Linux CI, where
+  the test host (thousands of tests plus Roslyn and Z3 in memory) crossed the 50%-of-RAM threshold
+  that a higher-memory dev machine never reached. It was filed and re-run as a flake for two weeks;
+  it is deterministic given the memory condition.
+
+  The gate is now scoped by an explicit policy: enabled for the stdio server, disabled for direct
+  construction. **Behaviour change for embedders:** code that constructs `McpMessageHandler` (or
+  `McpServer`) itself no longer gates tool calls on process memory. No public signature changed.
+  `CALOR_MCP_MAX_MEMORY_MB` still tunes the server's ceiling, and is now read per construction
+  rather than once per process.
+
 ### Removed
 - **VS Code extension support is withdrawn.** The `editors/vscode` tree, the VSIX release-asset
   workflow, the Marketplace publishing workflow, and the single-file publish guard are all removed.

--- a/eng/test-manifest.json
+++ b/eng/test-manifest.json
@@ -5,7 +5,7 @@
       "path": "tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj",
       "workflow": ".github/workflows/test.yml",
       "releaseCritical": true,
-      "expectedTotal": 6810,
+      "expectedTotal": 6814,
       "expectedSkipped": 2
     },
     {

--- a/src/Calor.Compiler/Mcp/McpMemoryAdmissionPolicy.cs
+++ b/src/Calor.Compiler/Mcp/McpMemoryAdmissionPolicy.cs
@@ -1,0 +1,41 @@
+namespace Calor.Compiler.Mcp;
+
+/// <summary>
+/// Admission control for heavy MCP tools: refuse to start a compile/convert/analyze
+/// when the process is already near its memory ceiling.
+///
+/// The measurement behind it is whole-process (<c>Process.WorkingSet64</c>), so the
+/// policy is only sound where the MCP server owns the process. A handler embedded in
+/// somebody else's process would be charging that process's memory to the next tool
+/// call, so embedding gets <see cref="Disabled"/> and the shipped stdio server opts
+/// in via <see cref="FromEnvironment"/>.
+/// </summary>
+/// <param name="Enabled">Whether to gate heavy tools on process memory at all.</param>
+/// <param name="ThresholdBytes">Process working set above which heavy tools wait, then are refused.</param>
+/// <param name="MaxWait">How long to wait for memory to drop before refusing.</param>
+/// <param name="PollInterval">How often to re-measure while waiting.</param>
+internal sealed record McpMemoryAdmissionPolicy(
+    bool Enabled,
+    long ThresholdBytes,
+    TimeSpan MaxWait,
+    TimeSpan PollInterval)
+{
+    /// <summary>No gating — the correct policy when the handler does not own the process.</summary>
+    public static McpMemoryAdmissionPolicy Disabled { get; } =
+        new(Enabled: false, ThresholdBytes: long.MaxValue, TimeSpan.Zero, TimeSpan.Zero);
+
+    /// <summary>
+    /// The server policy: 50% of available physical memory (minimum 512 MB), or an
+    /// explicit ceiling from <c>CALOR_MCP_MAX_MEMORY_MB</c>.
+    /// </summary>
+    public static McpMemoryAdmissionPolicy FromEnvironment() => new(
+        Enabled: true,
+        ThresholdBytes: long.TryParse(
+            Environment.GetEnvironmentVariable("CALOR_MCP_MAX_MEMORY_MB"), out var megabytes)
+                ? megabytes * 1024L * 1024L
+                : Math.Max(
+                    512L * 1024L * 1024L,
+                    (long)(GC.GetGCMemoryInfo().TotalAvailableMemoryBytes * 0.5)),
+        MaxWait: TimeSpan.FromSeconds(30),
+        PollInterval: TimeSpan.FromSeconds(2));
+}

--- a/src/Calor.Compiler/Mcp/McpMessageHandler.cs
+++ b/src/Calor.Compiler/Mcp/McpMessageHandler.cs
@@ -23,16 +23,21 @@ public sealed class McpMessageHandler
     private static readonly int MaxConcurrentTools = Math.Max(2, Environment.ProcessorCount / 2);
     private readonly SemaphoreSlim _concurrencyLimiter = new(MaxConcurrentTools);
 
-    // Reject new heavy work when the process exceeds this memory threshold.
-    // Defaults to 50% of available physical memory (min 512 MB). Override with CALOR_MCP_MAX_MEMORY_MB.
-    private static readonly long MemoryPressureThresholdBytes =
-        long.TryParse(Environment.GetEnvironmentVariable("CALOR_MCP_MAX_MEMORY_MB"), out var mb)
-            ? mb * 1024L * 1024L
-            : Math.Max(512L * 1024L * 1024L, (long)(GC.GetGCMemoryInfo().TotalAvailableMemoryBytes * 0.5));
+    private readonly McpMemoryAdmissionPolicy _memoryAdmission;
     private CancellationToken _serverCancellation;
 
     public McpMessageHandler(bool verbose = false, TextWriter? log = null, string? rootDirectory = null)
+        : this(McpMemoryAdmissionPolicy.Disabled, verbose, log, rootDirectory)
     {
+    }
+
+    internal McpMessageHandler(
+        McpMemoryAdmissionPolicy memoryAdmission,
+        bool verbose = false,
+        TextWriter? log = null,
+        string? rootDirectory = null)
+    {
+        _memoryAdmission = memoryAdmission;
         _verbose = verbose;
         _log = log;
 
@@ -165,6 +170,9 @@ public sealed class McpMessageHandler
     /// <summary>Sets the server-level cancellation token for propagation to tool calls.</summary>
     internal void SetCancellation(CancellationToken cancellationToken) => _serverCancellation = cancellationToken;
 
+    /// <summary>The memory admission policy in force. Exposed so tests can pin which contexts gate on process memory.</summary>
+    internal McpMemoryAdmissionPolicy MemoryAdmission => _memoryAdmission;
+
     private void RegisterTool(IMcpTool tool)
     {
         _tools[tool.Name] = tool;
@@ -294,24 +302,41 @@ public sealed class McpMessageHandler
         var sw = Stopwatch.StartNew();
         McpToolResult result;
 
-        // Wait for memory pressure to subside before running heavy tools
-        if (tool is BatchTool or ConvertTool or CompileTool or AnalyzeTool)
+        // Wait for memory pressure to subside before running heavy tools.
+        //
+        // This is admission control for a long-lived stdio server: `calor mcp` owns
+        // its process, so process RSS is a fair proxy for "how much the tools I have
+        // been running are costing". It is measured with WorkingSet64, which counts
+        // the WHOLE process — so in any host the handler does not own, it attributes
+        // the host's memory to the next MCP tool and refuses it. Enabled only when a
+        // server opts in (see McpServer); direct/embedded construction gets
+        // McpMemoryAdmissionPolicy.Disabled.
+        //
+        // That distinction is not hypothetical. Six tests here construct the handler
+        // directly and ran inside an xUnit host holding 6,810 tests' worth of heap
+        // plus Roslyn and Z3. The host crossed the 50%-of-RAM threshold on Linux CI
+        // runners but not on higher-memory dev machines, so each of the six spent the
+        // full 30s wait and then failed with "Server under memory pressure" — green
+        // locally, red on CI, and blamed on flakiness (#897) for two weeks. An
+        // embedded host's memory is not the MCP tool's to police.
+        if (_memoryAdmission.Enabled && tool is BatchTool or ConvertTool or CompileTool or AnalyzeTool)
         {
+            var threshold = _memoryAdmission.ThresholdBytes;
             var memoryUsed = GetProcessMemory();
-            if (memoryUsed > MemoryPressureThresholdBytes)
+            if (memoryUsed > threshold)
             {
                 var usedMb = memoryUsed / (1024 * 1024);
                 Log($"Tool {callParams.Name} waiting for memory pressure to subside ({usedMb} MB used)");
 
-                // Try a GC and wait up to 30s for memory to drop
+                // Try a GC and wait for memory to drop
                 GC.Collect(2, GCCollectionMode.Aggressive, blocking: true, compacting: true);
-                const int maxWaitMs = 30_000;
-                const int pollIntervalMs = 2_000;
+                var maxWaitMs = (int)_memoryAdmission.MaxWait.TotalMilliseconds;
+                var pollIntervalMs = (int)_memoryAdmission.PollInterval.TotalMilliseconds;
                 var waited = 0;
                 while (waited < maxWaitMs)
                 {
                     memoryUsed = GetProcessMemory();
-                    if (memoryUsed <= MemoryPressureThresholdBytes)
+                    if (memoryUsed <= threshold)
                         break;
                     var jitter = Random.Shared.Next(0, 500); // 0-500ms random jitter to avoid thundering herd
                     await Task.Delay(pollIntervalMs + jitter, _serverCancellation);
@@ -319,14 +344,15 @@ public sealed class McpMessageHandler
                 }
 
                 memoryUsed = GetProcessMemory();
-                if (memoryUsed > MemoryPressureThresholdBytes)
+                if (memoryUsed > threshold)
                 {
                     usedMb = memoryUsed / (1024 * 1024);
-                    var thresholdMb = MemoryPressureThresholdBytes / (1024 * 1024);
+                    var thresholdMb = threshold / (1024 * 1024);
+                    var waitedSeconds = _memoryAdmission.MaxWait.TotalSeconds;
                     Log($"Tool {callParams.Name} rejected after waiting: memory still at {usedMb} MB");
                     return JsonRpcResponse.Success(request.Id,
                         McpToolResult.Error($"Server under memory pressure ({usedMb} MB used, {thresholdMb} MB threshold) " +
-                            "after waiting 30s. Wait for current operations to finish, then retry. " +
+                            $"after waiting {waitedSeconds:0.#}s. Wait for current operations to finish, then retry. " +
                             "Set CALOR_MCP_MAX_MEMORY_MB to adjust the threshold."));
                 }
 

--- a/src/Calor.Compiler/Mcp/McpServer.cs
+++ b/src/Calor.Compiler/Mcp/McpServer.cs
@@ -9,6 +9,9 @@ namespace Calor.Compiler.Mcp;
 public sealed class McpServer
 {
     private readonly McpMessageHandler _handler;
+
+    /// <summary>The message handler backing this server. Exposed so tests can pin its admission policy.</summary>
+    internal McpMessageHandler Handler => _handler;
     private readonly TextReader _reader;
     private readonly Stream _output;
     private readonly TextWriter? _log;
@@ -30,12 +33,26 @@ public sealed class McpServer
     /// </summary>
     public McpServer(TextReader reader, Stream output, bool verbose = false, TextWriter? log = null,
         string? rootDirectory = null)
+        // The server owns its process, so process-wide memory admission control is
+        // sound here — and only here. See McpMemoryAdmissionPolicy.
+        : this(McpMemoryAdmissionPolicy.FromEnvironment(), reader, output, verbose, log, rootDirectory)
+    {
+    }
+
+    /// <summary>
+    /// Creates an MCP server with an explicit memory admission policy. Internal because
+    /// the only caller that should ever pass something other than
+    /// <see cref="McpMemoryAdmissionPolicy.FromEnvironment"/> is a test host, which — like
+    /// any embedding process — does not own its memory on the server's behalf.
+    /// </summary>
+    internal McpServer(McpMemoryAdmissionPolicy memoryAdmission, TextReader reader, Stream output,
+        bool verbose = false, TextWriter? log = null, string? rootDirectory = null)
     {
         _reader = reader ?? throw new ArgumentNullException(nameof(reader));
         _output = output ?? throw new ArgumentNullException(nameof(output));
         _verbose = verbose;
         _log = log;
-        _handler = new McpMessageHandler(verbose, log, rootDirectory);
+        _handler = new McpMessageHandler(memoryAdmission, verbose, log, rootDirectory);
     }
 
     /// <summary>

--- a/tests/Calor.Compiler.Tests/Mcp/McpMemoryAdmissionTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/McpMemoryAdmissionTests.cs
@@ -1,0 +1,123 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using Calor.Compiler.Mcp;
+using Xunit;
+
+namespace Calor.Compiler.Tests.Mcp;
+
+/// <summary>
+/// Pins for #897 — six MCP tests that failed only on CI, each after ~31s, with
+/// "Server under memory pressure".
+///
+/// The cause was not flakiness. The heavy-tool admission gate measures
+/// <c>Process.WorkingSet64</c>, which is the whole process, and it ran
+/// unconditionally. Under `calor mcp` that is fair — the server owns its process.
+/// Inside the xUnit host it was not: 6,810 tests, Roslyn and Z3 in memory, over the
+/// 50%-of-RAM threshold on a Linux runner and under it on a bigger dev machine. The
+/// gate then charged the test host's heap to the next compile, waited its full 30s,
+/// and refused.
+///
+/// So these pin all three halves of the rule, because any one alone is passable by a
+/// wrong fix: embedded does not gate, server does gate, and the gate still refuses
+/// when it is enabled and the ceiling is genuinely exceeded.
+/// </summary>
+public class McpMemoryAdmissionTests
+{
+    // A compile request — CompileTool is one of the four heavy tools the gate covers.
+    private static JsonRpcRequest CompileRequest() => new()
+    {
+        Id = JsonDocument.Parse("1").RootElement,
+        Method = "tools/call",
+        Params = JsonDocument.Parse("""
+            {
+                "name": "calor_compile",
+                "arguments": {
+                    "source": "§M{m001:Test}\n§F{f001:Add:pub}\n§I{i32:a}\n§I{i32:b}\n§O{i32}\n§R (+ a b)\n\n"
+                }
+            }
+            """).RootElement
+    };
+
+    private static string ResultText(JsonRpcResponse response) =>
+        JsonSerializer.Serialize(response.Result, McpJsonOptions.Default);
+
+    [Fact]
+    public async Task EmbeddedHandler_DoesNotGateHeavyToolsOnProcessMemory()
+    {
+        // The public constructor is the embedded path — the one the six #897 tests
+        // use. A threshold of one byte is exceeded by any process that exists, so if
+        // the gate applied here at all, this call would wait and then be refused.
+        var handler = new McpMessageHandler();
+
+        var stopwatch = Stopwatch.StartNew();
+        var response = await handler.HandleRequestAsync(CompileRequest());
+        stopwatch.Stop();
+
+        Assert.NotNull(response);
+        var text = ResultText(response!);
+        Assert.DoesNotContain("under memory pressure", text);
+        Assert.Contains("success", text);
+
+        // The ~31s signature of #897, asserted directly: a gated call spends the full
+        // wait budget before refusing, an ungated one cannot.
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(10),
+            $"compile took {stopwatch.Elapsed.TotalSeconds:F1}s — the #897 signature is a "
+                + "call that spends the memory-pressure wait budget before returning");
+
+        // Asserted last so the behaviour above is what discriminates, not this.
+        Assert.False(handler.MemoryAdmission.Enabled);
+    }
+
+    [Fact]
+    public void StdioServer_DoesGateHeavyToolsOnProcessMemory()
+    {
+        // Without this, "disable the gate everywhere" would pass the test above and
+        // silently drop the protection `calor mcp` actually relies on.
+        using var output = new MemoryStream();
+        var server = new McpServer(new StringReader(string.Empty), output);
+
+        Assert.True(server.Handler.MemoryAdmission.Enabled);
+        Assert.Equal(TimeSpan.FromSeconds(30), server.Handler.MemoryAdmission.MaxWait);
+    }
+
+    [Fact]
+    public async Task EnabledPolicy_StillRefusesHeavyToolsOverTheCeiling()
+    {
+        // And without this, "make the policy a no-op" would pass both of the above.
+        // One byte is under any real working set, so the ceiling is genuinely
+        // exceeded; the wait is shortened so the pin costs a fraction of a second.
+        var policy = new McpMemoryAdmissionPolicy(
+            Enabled: true,
+            ThresholdBytes: 1,
+            MaxWait: TimeSpan.FromMilliseconds(200),
+            PollInterval: TimeSpan.FromMilliseconds(50));
+        var handler = new McpMessageHandler(policy);
+
+        var response = await handler.HandleRequestAsync(CompileRequest());
+
+        Assert.NotNull(response);
+        Assert.Contains("under memory pressure", ResultText(response!));
+    }
+
+    [Fact]
+    public void EnvironmentPolicy_HonoursAnExplicitCeiling()
+    {
+        // The override advertised in the refusal message has to work, and reading it
+        // per-construction rather than once per process is what makes it testable.
+        var previous = Environment.GetEnvironmentVariable("CALOR_MCP_MAX_MEMORY_MB");
+        try
+        {
+            Environment.SetEnvironmentVariable("CALOR_MCP_MAX_MEMORY_MB", "1234");
+            var policy = McpMemoryAdmissionPolicy.FromEnvironment();
+
+            Assert.True(policy.Enabled);
+            Assert.Equal(1234L * 1024 * 1024, policy.ThresholdBytes);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CALOR_MCP_MAX_MEMORY_MB", previous);
+        }
+    }
+}

--- a/tests/Calor.Compiler.Tests/Mcp/McpServerTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/McpServerTests.cs
@@ -435,7 +435,7 @@ public class McpServerTests
         using var input = new MemoryStream(Encoding.UTF8.GetBytes(inputMessage));
         using var output = new MemoryStream();
 
-        var server = new McpServer(input, output);
+        var server = NewTestServer(input, output);
 
         // Run server (it will stop when input stream ends)
         await server.RunAsync();
@@ -456,7 +456,7 @@ public class McpServerTests
         using var input = new MemoryStream(Encoding.UTF8.GetBytes(inputMessage));
         using var output = new MemoryStream();
 
-        var server = new McpServer(input, output);
+        var server = NewTestServer(input, output);
         await server.RunAsync();
 
         output.Position = 0;
@@ -484,7 +484,7 @@ public class McpServerTests
         using var input = new MemoryStream(Encoding.UTF8.GetBytes(fullInput));
         using var output = new MemoryStream();
 
-        var server = new McpServer(input, output);
+        var server = NewTestServer(input, output);
         await server.RunAsync();
 
         output.Position = 0;
@@ -571,7 +571,7 @@ public class McpServerTests
         using var input = new MemoryStream(Encoding.UTF8.GetBytes(inputMessage));
         using var output = new MemoryStream();
 
-        var server = new McpServer(input, output);
+        var server = NewTestServer(input, output);
         await server.RunAsync();
 
         output.Position = 0;
@@ -586,6 +586,21 @@ public class McpServerTests
 
     /// <summary>#897 observability: on failure, carry the FULL response so the next CI
     /// hit shows the server's actual error instead of a truncated prefix.</summary>
+    /// <summary>
+    /// A server for tests. Memory admission is disabled because the xUnit host does not
+    /// own its process on the server's behalf: it holds thousands of tests' worth of heap
+    /// plus Roslyn and Z3, and the gate measures the whole process. Leaving it on is what
+    /// made these tests fail only on CI, each after the full 30s wait (#897). The real
+    /// `calor mcp` path keeps the gate — pinned by
+    /// McpMemoryAdmissionTests.StdioServer_DoesGateHeavyToolsOnProcessMemory.
+    /// </summary>
+    private static McpServer NewTestServer(Stream input, Stream output) =>
+        new(McpMemoryAdmissionPolicy.Disabled,
+            new StreamReader(input, Encoding.UTF8, leaveOpen: true), output);
+
+    private static McpServer NewTestServer(TextReader reader, Stream output) =>
+        new(McpMemoryAdmissionPolicy.Disabled, reader, output);
+
     private static void AssertResponseContains(string response, string expected) =>
         Assert.True(response.Contains(expected),
             $"Expected substring '{expected}' not found. FULL RESPONSE:\n{response}");
@@ -673,7 +688,7 @@ public class McpServerTests
         using var input = new MemoryStream(Encoding.UTF8.GetBytes(inputMessage));
         using var output = new MemoryStream();
 
-        var server = new McpServer(input, output);
+        var server = NewTestServer(input, output);
         await server.RunAsync();
 
         output.Position = 0;
@@ -764,7 +779,7 @@ public class McpServerTests
         var idleReader = new NonBlockingIdleReader();
         using var output = new MemoryStream();
 
-        var server = new McpServer(idleReader, output);
+        var server = NewTestServer(idleReader, output);
 
         using var cts = new CancellationTokenSource();
         var serverTask = server.RunAsync(cts.Token);
@@ -788,7 +803,7 @@ public class McpServerTests
         var idleStream = new NonBlockingIdleStream();
         using var output = new MemoryStream();
 
-        var server = new McpServer(idleStream, output);
+        var server = NewTestServer(idleStream, output);
         await server.RunAsync();
 
         // StreamReader treats 0-byte read as EOF → ReadLineAsync returns null → server exits

--- a/tests/Calor.Compiler.Tests/Mcp/Tools/SyntaxLookupMcpIntegrationTests.cs
+++ b/tests/Calor.Compiler.Tests/Mcp/Tools/SyntaxLookupMcpIntegrationTests.cs
@@ -91,7 +91,10 @@ public class SyntaxLookupMcpIntegrationTests
         using var input = new MemoryStream(Encoding.UTF8.GetBytes(framedRequest));
         using var output = new MemoryStream();
 
-        var server = new McpServer(input, output);
+        // Memory admission disabled: the test host does not own this process (#897).
+        var server = new McpServer(
+            McpMemoryAdmissionPolicy.Disabled,
+            new StreamReader(input, Encoding.UTF8, leaveOpen: true), output);
         await server.RunAsync();
 
         output.Position = 0;


### PR DESCRIPTION
Closes #897. This is the last thing standing between v0.13.1 and nuget.org — it failed the publish gate on every attempt.

## What #897 actually was

Not flakiness. The heavy-tool admission gate measures `Process.WorkingSet64` — the **whole process** — and ran unconditionally.

Under `calor mcp` that is fair: the server owns its process. Inside the xUnit host it is not. That host holds 6,810 tests' worth of heap plus Roslyn and Z3, so it crossed the `max(512MB, 50% of RAM)` threshold on Linux CI runners while staying under it on higher-memory dev machines. The gate then charged the host's memory to the next compile, spent its full 30s wait, and refused.

Every detail in the issue falls out of that:

| Signature in #897 | Explanation |
|---|---|
| exactly six tests, always together | the four heavy tools (compile/convert/analyze/batch) are the only ones gated |
| ~31s each | the 30s wait loop plus 0–500ms jitter |
| text starts with `"Server` | `"Server under memory pressure (…)"` |
| zero Z3 skips | unrelated to #884/#859 — correctly ruled out in the issue |
| green locally on macOS arm64 | more RAM → higher threshold → never tripped |

It was filed as flaky and re-run past for two weeks. It is deterministic given the memory condition.

## The fix

The gate becomes an explicit `McpMemoryAdmissionPolicy`:

- `FromEnvironment()` — the stdio server, which owns its process
- `Disabled` — direct/embedded construction

An embedded host's memory is not the MCP tool's to police. Reading `CALOR_MCP_MAX_MEMORY_MB` per-construction instead of once per process is also what made any of this testable.

## Pins

Four, each blocking a different wrong fix:

1. **embedded does not gate** — the behavioural assertion (elapsed time + absence of the refusal text) is what fires, with the structural check last so it cannot short-circuit
2. **the stdio server still does** — blocks "disable it everywhere"
3. **an enabled policy over its ceiling still refuses** — blocks "make it a no-op"
4. **`CALOR_MCP_MAX_MEMORY_MB` still honoured**

## Verification

I armed the revert rather than trusting green, per the pins-must-discriminate rule:

- **Revert armed** (public ctor gates unconditionally) + `CALOR_MCP_MAX_MEMORY_MB=1` → pin fails at **30s** with `Server under memory pressure (308 MB used, 1 MB threshold)`. That is the #897 signature reproduced exactly, on demand.
- **Fix restored**, same condition → full MCP suite **672/672 in 4 seconds**, under a ceiling that can never be satisfied.
- Full compiler suite: **6,812 passed / 2 skipped** (the 2 are the pre-existing network-gated init tests).
- `scripts/check-calor-first-diff.sh` passes; `eng/test-manifest.json` updated 6810 → 6814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)