### PR TITLE
chore: pre-register McpMemoryAdmissionPolicy.cs in the Calor-first allowlist (#897)

### DIFF
--- a/.calor-csharp-allowlist
+++ b/.calor-csharp-allowlist
@@ -66,4 +66,5 @@ src/Calor.Compiler/Commands/QueryCommand.cs
 # Compiler-internal MCP protocol machinery, same class as the rest of
 # src/Calor.Compiler/Mcp/; Calor has no access to Process.WorkingSet64 or the
 # GC memory info this policy is built from.
+# pending
 src/Calor.Compiler/Mcp/McpMemoryAdmissionPolicy.cs

--- a/.calor-csharp-allowlist
+++ b/.calor-csharp-allowlist
@@ -59,3 +59,11 @@ src/Calor.Compiler/Commands/IndexCommand.cs
 # query surface over the persisted index. Compiler-internal, same rationale as
 # the S1 entries above.
 src/Calor.Compiler/Commands/QueryCommand.cs
+
+# MCP memory admission policy (#897) — the type that carries the heavy-tool
+# admission rule out of McpMessageHandler so it can differ between the stdio
+# server (which owns its process) and an embedded host (which does not).
+# Compiler-internal MCP protocol machinery, same class as the rest of
+# src/Calor.Compiler/Mcp/; Calor has no access to Process.WorkingSet64 or the
+# GC memory info this policy is built from.
+src/Calor.Compiler/Mcp/McpMemoryAdmissionPolicy.cs


### PR DESCRIPTION
Pre-registration only — no code. The guard reads the **merge-base** allowlist by design ("A PR cannot add an allowlist entry and use it in the same PR"), so this has to land on `main` before #956 can pass `calor-first-guard`.

The entry covers one new file, `src/Calor.Compiler/Mcp/McpMemoryAdmissionPolicy.cs`: it carries the heavy-tool admission rule out of `McpMessageHandler` so the policy can differ between the stdio server (which owns its process) and an embedded host (which does not). That is the fix for #897 — see #956 for the analysis.

Compiler-internal MCP protocol machinery, the same class as the rest of `src/Calor.Compiler/Mcp/`. Calor has no access to `Process.WorkingSet64` or `GC.GetGCMemoryInfo()`, which is what the policy is built from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)