### PR TITLE
fix(ci): give the workflow Z3 fetches the same backoff the bootstrap got

### DIFF
--- a/.github/workflows/build-z3.yml
+++ b/.github/workflows/build-z3.yml
@@ -114,7 +114,7 @@ jobs:
 
           mkdir -p artifacts
 
-          curl -fL -sS --retry 5 --retry-delay 3 -o z3.zip "${BASE_URL}/${ARCHIVE}.zip"
+          curl -fL -sS --retry 10 --retry-all-errors --retry-max-time 300 -o z3.zip "${BASE_URL}/${ARCHIVE}.zip"
 
           EXPECTED="$(grep -v '^#' "$MANIFEST" | awk -v n="${ARCHIVE}.zip" '$2 == n {print $1}')"
           EXPECTED_SIZE="$(grep -v '^#' "$MANIFEST" | awk -v n="${ARCHIVE}.zip" '$2 == n {print $3}')"

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -323,7 +323,7 @@ jobs:
           # into Calor packages.
           ASSETS="Microsoft.Z3.dll libz3-linux-x64.so libz3-linux-arm64.so libz3-osx-arm64.dylib libz3-win-x64.dll libz3-win-x86.dll libz3-win-arm64.dll"
           for asset in $ASSETS; do
-            curl -fL -sS --retry 5 --retry-delay 3 -o "$STAGING/$asset" "${RELEASE_URL}/${asset}"
+            curl -fL -sS --retry 10 --retry-all-errors --retry-max-time 300 -o "$STAGING/$asset" "${RELEASE_URL}/${asset}"
           done
 
           while read -r hash asset size; do

--- a/.github/workflows/z3-pin-check.yml
+++ b/.github/workflows/z3-pin-check.yml
@@ -68,7 +68,7 @@ jobs:
           # Fetch exactly the assets the manifest names, so an asset that is in the
           # manifest but missing from the release fails here too (curl -f).
           while read -r asset; do
-            curl -fL -sS --retry 5 --retry-delay 3 -o "$STAGING/$asset" "${RELEASE_URL}/${asset}"
+            curl -fL -sS --retry 10 --retry-all-errors --retry-max-time 300 -o "$STAGING/$asset" "${RELEASE_URL}/${asset}"
           done < <(grep -v '^#' "$MANIFEST" | awk 'NF {print $2}')
 
           while read -r hash asset size; do
@@ -97,7 +97,7 @@ jobs:
           trap 'rm -rf "$STAGING"' EXIT
 
           while read -r zip; do
-            curl -fL -sS --retry 5 --retry-delay 3 -o "$STAGING/$zip" "${BASE}/${zip}"
+            curl -fL -sS --retry 10 --retry-all-errors --retry-max-time 300 -o "$STAGING/$zip" "${BASE}/${zip}"
           done < <(grep -v '^#' "$MANIFEST" | awk 'NF {print $2}')
 
           while read -r hash asset size; do


### PR DESCRIPTION
Rescoped after #954 landed. That PR fixed the same class of bug in `download-z3.sh` and added a PowerShell retry (which closes the #951 half better than my version did — it also removes the partial file on failure). What it did **not** touch is the four `curl` invocations that live in workflow YAML.

## What's left

Those four are still on `--retry 5 --retry-delay 3`. Per `curl(1)`:

> **By using `--retry-delay` you disable this exponential backoff algorithm.**

So the flag that reads like hardening is what turns the backoff off, pinning every retry to a flat 3s and exhausting all attempts in ~15 seconds.

Measured, same endpoint, `--retry 5`:

| flags | elapsed |
|---|---|
| `--retry 5 --retry-delay 3` | **16s** |
| `--retry 5 --retry-max-time 300` | **32s** (1+2+4+8+16) |

One of the four is `publish-nuget.yml:326` — the publish path itself, and where v0.13.1 kept dying: six consecutive 503s inside a 16-second window, on an endpoint serving 200s a minute later.

`--retry-all-errors` matters separately: without it, failures that aren't an HTTP status never enter the retry loop at all. `verify-pins` died on `curl: (56) Connection died` in **12 seconds** despite `--retry 8`.

The settings now match what #954 chose for the shell script, so the bootstrap and the workflows no longer disagree about how patient to be.

## Dropped from this PR

- **`download-z3.sh` backoff** — #954 did it (`--retry 10`), and `scripts/test_supply_chain.py` now pins it.
- **`download-z3.ps1` retry (#951)** — #954's `Invoke-Download` is better than mine.
- **`IgnoreStandardErrorWarningFormat` on the MSBuild `Exec`** — moot. #954 deleted the `DownloadZ3` target entirely ("normal builds are deliberately network-free"), so the failure mode I hit (`exited with return value 0, but errors were detected during execution`, run 31639499947) can no longer occur: nothing Execs the script from MSBuild any more.

Net diff is four lines.

## Verification

- Backoff measured directly, not inferred from flags.
- All three workflow YAMLs parse.
- `scripts/test_supply_chain.py`'s Z3 retry assertions still hold (they cover the scripts, which this PR doesn't touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)