### PR TITLE
Rebuild CFG and dataflow around explicit semantics

### DIFF
--- a/eng/mutation-baselines.json
+++ b/eng/mutation-baselines.json
@@ -44,7 +44,7 @@
       "file": "src/Calor.Compiler/Analysis/Dataflow/Analyses/LiveVariables.cs",
       "before": "return result;",
       "after": "return ImmutableHashSet<SymbolId>.Empty;",
-      "occurrence": 2,
+      "occurrence": 3,
       "project": "tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj",
       "filter": "FullyQualifiedName~DataflowAnalysisTests.LiveVariables_VariableUsedInCondition_IsLive"
     },

--- a/eng/test-manifest.json
+++ b/eng/test-manifest.json
@@ -5,7 +5,7 @@
       "path": "tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj",
       "workflow": ".github/workflows/test.yml",
       "releaseCritical": true,
-      "expectedTotal": 6810,
+      "expectedTotal": 6828,
       "expectedSkipped": 2
     },
     {

--- a/src/Calor.Compiler/Analysis/Dataflow/Analyses/LiveVariables.cs
+++ b/src/Calor.Compiler/Analysis/Dataflow/Analyses/LiveVariables.cs
@@ -13,8 +13,10 @@ public sealed class LiveVariablesAnalysis
     private readonly ControlFlowGraph _cfg;
     private readonly Dictionary<BasicBlock, BlockDataflowResult<ImmutableHashSet<SymbolId>>> _results;
     private readonly IReadOnlyDictionary<SymbolId, VariableSymbol> _allVariables;
+    private readonly LiveVariablesTransfer _transfer;
     public IReadOnlyList<BoundNode> IncompleteNodes { get; }
     public bool IsComplete => IncompleteNodes.Count == 0;
+    public DataflowAnalysisResult<ImmutableHashSet<SymbolId>> AnalysisResult { get; }
 
     public LiveVariablesAnalysis(ControlFlowGraph cfg)
     {
@@ -23,11 +25,17 @@ public sealed class LiveVariablesAnalysis
         IncompleteNodes = BoundNodeHelpers.GetAnalysisIncompleteNodes(cfg.Function).ToArray();
 
         var lattice = new SetLattice<SymbolId>(_allVariables.Keys);
-        var transfer = new LiveVariablesTransfer();
+        _transfer = new LiveVariablesTransfer();
         var analysis = new DataflowAnalysis<ImmutableHashSet<SymbolId>>(
-            lattice, transfer, DataflowDirection.Backward);
+            lattice,
+            _transfer,
+            DataflowDirection.Backward,
+            ImmutableHashSet<SymbolId>.Empty,
+            ImmutableHashSet<SymbolId>.Empty,
+            ImmutableHashSet<SymbolId>.Empty);
 
-        _results = analysis.Analyze(cfg);
+        AnalysisResult = analysis.AnalyzeWithMetadata(cfg);
+        _results = AnalysisResult.Blocks;
     }
 
     /// <summary>
@@ -92,37 +100,76 @@ public sealed class LiveVariablesAnalysis
 
     public IEnumerable<(BasicBlock Block, BoundStatement Statement, VariableSymbol Variable)> FindDeadAssignmentsWithSymbols()
     {
-        foreach (var block in _cfg.Blocks)
+        var candidates = new Dictionary<
+            BoundStatement,
+            (BasicBlock Block, VariableSymbol Variable, bool IsDead)>(
+            ReferenceEqualityComparer.Instance);
+
+        foreach (var block in _cfg.ReachableBlocks)
         {
             if (!_results.TryGetValue(block, out var result))
                 continue;
 
-            var liveAfter = result.Out;
+            var liveAfter = _transfer.TransferExpression(
+                block.Terminator.Condition,
+                result.Out);
+            for (var index = block.SyntheticOperations.Count - 1; index >= 0; index--)
+            {
+                var operation = block.SyntheticOperations[index];
+                var defined = BoundNodeHelpers.GetDefinedVariable(operation);
+                if (defined != null && operation.SourceStatement != null)
+                {
+                    RecordCandidate(
+                        operation.SourceStatement,
+                        block,
+                        defined,
+                        !liveAfter.Contains(defined.Id));
+                }
+
+                liveAfter = _transfer.TransferSynthetic(
+                    block,
+                    index,
+                    operation,
+                    liveAfter);
+            }
 
             // Process statements in reverse order
             for (var i = block.Statements.Count - 1; i >= 0; i--)
             {
                 var stmt = block.Statements[i];
-                var defined = BoundNodeHelpers.GetDefinedVariable(stmt);
+                var defined = block.IsDefinitionDeferred(i)
+                    ? null
+                    : BoundNodeHelpers.GetDefinedVariable(stmt);
 
-                if (defined != null && !liveAfter.Contains(defined.Id))
-                {
-                    // This definition is not live after - it's dead
-                    yield return (block, stmt, defined);
-                }
-
-                // Update liveAfter for the next iteration (going backwards)
-                // Gen: add used variables
-                foreach (var used in BoundNodeHelpers.GetUsedVariables(stmt))
-                {
-                    liveAfter = liveAfter.Add(used.Id);
-                }
-
-                // Kill: remove defined variables
                 if (defined != null)
-                {
-                    liveAfter = liveAfter.Remove(defined.Id);
-                }
+                    RecordCandidate(stmt, block, defined, !liveAfter.Contains(defined.Id));
+
+                liveAfter = _transfer.Transfer(block, i, stmt, liveAfter);
+            }
+        }
+
+        foreach (var (statement, candidate) in candidates)
+        {
+            if (candidate.IsDead)
+                yield return (candidate.Block, statement, candidate.Variable);
+        }
+
+        void RecordCandidate(
+            BoundStatement statement,
+            BasicBlock block,
+            VariableSymbol variable,
+            bool isDead)
+        {
+            if (candidates.TryGetValue(statement, out var existing))
+            {
+                candidates[statement] = (
+                    existing.Block,
+                    existing.Variable,
+                    existing.IsDead && isDead);
+            }
+            else
+            {
+                candidates.Add(statement, (block, variable, isDead));
             }
         }
     }
@@ -131,7 +178,7 @@ public sealed class LiveVariablesAnalysis
     {
         var variables = new Dictionary<SymbolId, VariableSymbol>();
 
-        foreach (var block in cfg.Blocks)
+        foreach (var block in cfg.ReachableBlocks)
         {
             foreach (var stmt in block.Statements)
             {
@@ -146,9 +193,22 @@ public sealed class LiveVariablesAnalysis
                 }
             }
 
-            if (block.BranchCondition != null)
+            foreach (var operation in block.SyntheticOperations)
             {
-                foreach (var used in BoundNodeHelpers.GetUsedVariables(block.BranchCondition))
+                var defined = BoundNodeHelpers.GetDefinedVariable(operation);
+                if (defined != null && !defined.Id.IsNone)
+                    variables.TryAdd(defined.Id, defined);
+
+                foreach (var used in BoundNodeHelpers.GetUsedVariables(operation))
+                {
+                    if (!used.Id.IsNone)
+                        variables.TryAdd(used.Id, used);
+                }
+            }
+
+            if (block.Terminator.Condition != null)
+            {
+                foreach (var used in BoundNodeHelpers.GetUsedVariables(block.Terminator.Condition))
                 {
                     if (!used.Id.IsNone)
                         variables.TryAdd(used.Id, used);
@@ -162,22 +222,40 @@ public sealed class LiveVariablesAnalysis
 
 internal sealed class LiveVariablesTransfer : ITransferFunction<ImmutableHashSet<SymbolId>>
 {
-    public ImmutableHashSet<SymbolId> Transfer(BoundStatement statement, ImmutableHashSet<SymbolId> input)
+    public ImmutableHashSet<SymbolId> Transfer(
+        BasicBlock block,
+        int statementIndex,
+        BoundStatement statement,
+        ImmutableHashSet<SymbolId> input)
     {
-        var result = input;
+        if (!block.IsDefinitionDeferred(statementIndex))
+            return Transfer(statement, input);
 
-        // Gen: add used variables (they must be live before this statement)
+        var result = input;
         foreach (var used in BoundNodeHelpers.GetUsedVariables(statement))
         {
             if (!used.Id.IsNone)
                 result = result.Add(used.Id);
         }
+        return result;
+    }
+
+    public ImmutableHashSet<SymbolId> Transfer(BoundStatement statement, ImmutableHashSet<SymbolId> input)
+    {
+        var result = input;
 
         // Kill: remove defined variables (they don't need to be live before this definition)
         var defined = BoundNodeHelpers.GetDefinedVariable(statement);
         if (defined != null && !defined.Id.IsNone)
         {
             result = result.Remove(defined.Id);
+        }
+
+        // Gen follows kill so a compound/self assignment remains a use.
+        foreach (var used in BoundNodeHelpers.GetUsedVariables(statement))
+        {
+            if (!used.Id.IsNone)
+                result = result.Add(used.Id);
         }
 
         return result;
@@ -197,4 +275,29 @@ internal sealed class LiveVariablesTransfer : ITransferFunction<ImmutableHashSet
 
         return result;
     }
+
+    public ImmutableHashSet<SymbolId> TransferSynthetic(
+        SyntheticOperation operation,
+        ImmutableHashSet<SymbolId> input)
+    {
+        var result = input;
+        var defined = BoundNodeHelpers.GetDefinedVariable(operation);
+        if (defined != null && !defined.Id.IsNone)
+            result = result.Remove(defined.Id);
+
+        foreach (var used in BoundNodeHelpers.GetUsedVariables(operation))
+        {
+            if (!used.Id.IsNone)
+                result = result.Add(used.Id);
+        }
+
+        return result;
+    }
+
+    public ImmutableHashSet<SymbolId> TransferSynthetic(
+        BasicBlock block,
+        int operationIndex,
+        SyntheticOperation operation,
+        ImmutableHashSet<SymbolId> input) =>
+        TransferSynthetic(operation, input);
 }

--- a/src/Calor.Compiler/Analysis/Dataflow/Analyses/ReachingDefinitions.cs
+++ b/src/Calor.Compiler/Analysis/Dataflow/Analyses/ReachingDefinitions.cs
@@ -9,10 +9,13 @@ public readonly record struct DefinitionSite(
     string VariableName,
     int BlockId,
     int StatementIndex,
-    BoundStatement Statement,
-    SymbolId VariableId = default)
+    BoundStatement? Statement,
+    SymbolId VariableId = default,
+    int DefinitionOrdinal = -1,
+    SyntheticOperation? SyntheticOperation = null)
 {
-    public override string ToString() => $"{VariableName}@BB{BlockId}:{StatementIndex}";
+    public override string ToString() =>
+        $"{VariableName}@BB{BlockId}:{StatementIndex}#{DefinitionOrdinal}";
 }
 
 /// <summary>
@@ -26,6 +29,7 @@ public sealed class ReachingDefinitionsAnalysis
     private readonly List<DefinitionSite> _allDefinitions;
     public IReadOnlyList<BoundNode> IncompleteNodes { get; }
     public bool IsComplete => IncompleteNodes.Count == 0;
+    public DataflowAnalysisResult<ImmutableHashSet<DefinitionSite>> AnalysisResult { get; }
 
     public ReachingDefinitionsAnalysis(ControlFlowGraph cfg)
     {
@@ -36,9 +40,15 @@ public sealed class ReachingDefinitionsAnalysis
         var lattice = new SetLattice<DefinitionSite>(_allDefinitions);
         var transfer = new ReachingDefinitionsTransfer(_allDefinitions);
         var analysis = new DataflowAnalysis<ImmutableHashSet<DefinitionSite>>(
-            lattice, transfer, DataflowDirection.Forward);
+            lattice,
+            transfer,
+            DataflowDirection.Forward,
+            ImmutableHashSet<DefinitionSite>.Empty,
+            ImmutableHashSet<DefinitionSite>.Empty,
+            ImmutableHashSet<DefinitionSite>.Empty);
 
-        _results = analysis.Analyze(cfg);
+        AnalysisResult = analysis.AnalyzeWithMetadata(cfg);
+        _results = AnalysisResult.Blocks;
     }
 
     /// <summary>
@@ -95,21 +105,40 @@ public sealed class ReachingDefinitionsAnalysis
     private static List<DefinitionSite> CollectAllDefinitions(ControlFlowGraph cfg)
     {
         var definitions = new List<DefinitionSite>();
+        var definitionOrdinal = 0;
 
-        foreach (var block in cfg.Blocks)
+        foreach (var block in cfg.ReachableBlocks)
         {
             for (var i = 0; i < block.Statements.Count; i++)
             {
                 var stmt = block.Statements[i];
                 var defined = BoundNodeHelpers.GetDefinedVariable(stmt);
-                if (defined != null)
+                if (defined != null && !block.IsDefinitionDeferred(i))
                 {
                     definitions.Add(new DefinitionSite(
                         defined.Name,
                         block.Id,
                         i,
                         stmt,
-                        defined.Id));
+                        defined.Id,
+                        definitionOrdinal++));
+                }
+            }
+
+            for (var i = 0; i < block.SyntheticOperations.Count; i++)
+            {
+                var operation = block.SyntheticOperations[i];
+                var defined = BoundNodeHelpers.GetDefinedVariable(operation);
+                if (defined != null)
+                {
+                    definitions.Add(new DefinitionSite(
+                        defined.Name,
+                        block.Id,
+                        block.Statements.Count + i,
+                        operation.SourceStatement,
+                        defined.Id,
+                        definitionOrdinal++,
+                        operation));
                 }
             }
         }
@@ -128,8 +157,30 @@ internal sealed class ReachingDefinitionsTransfer : ITransferFunction<ImmutableH
     }
 
     public ImmutableHashSet<DefinitionSite> Transfer(BoundStatement statement, ImmutableHashSet<DefinitionSite> input)
+        => TransferDefinition(
+            BoundNodeHelpers.GetDefinedVariable(statement),
+            input,
+            definition => ReferenceEquals(definition.Statement, statement));
+
+    public ImmutableHashSet<DefinitionSite> Transfer(
+        BasicBlock block,
+        int statementIndex,
+        BoundStatement statement,
+        ImmutableHashSet<DefinitionSite> input)
+        => block.IsDefinitionDeferred(statementIndex)
+            ? input
+            : TransferDefinition(
+                BoundNodeHelpers.GetDefinedVariable(statement),
+                input,
+                definition => definition.BlockId == block.Id
+                    && definition.StatementIndex == statementIndex
+                    && ReferenceEquals(definition.Statement, statement));
+
+    private ImmutableHashSet<DefinitionSite> TransferDefinition(
+        VariableSymbol? defined,
+        ImmutableHashSet<DefinitionSite> input,
+        Func<DefinitionSite, bool> matchesDefinition)
     {
-        var defined = BoundNodeHelpers.GetDefinedVariable(statement);
         if (defined == null)
             return input;
 
@@ -142,15 +193,55 @@ internal sealed class ReachingDefinitionsTransfer : ITransferFunction<ImmutableH
         }
 
         // Gen: add the new definition
-        var newDef = _allDefinitions.FirstOrDefault(d =>
-            d.Statement == statement && SameVariable(d, defined));
+        var newDef = _allDefinitions.FirstOrDefault(definition =>
+            matchesDefinition(definition) && SameVariable(definition, defined));
 
-        if (newDef.Statement != null)
+        if (newDef.DefinitionOrdinal >= 0)
         {
             return afterKill.Add(newDef);
         }
 
         return afterKill;
+    }
+
+    public ImmutableHashSet<DefinitionSite> TransferSynthetic(
+        SyntheticOperation operation,
+        ImmutableHashSet<DefinitionSite> input)
+        => TransferSyntheticCore(operation, input, definition =>
+            ReferenceEquals(definition.SyntheticOperation, operation));
+
+    public ImmutableHashSet<DefinitionSite> TransferSynthetic(
+        BasicBlock block,
+        int operationIndex,
+        SyntheticOperation operation,
+        ImmutableHashSet<DefinitionSite> input)
+        => TransferSyntheticCore(operation, input, definition =>
+            definition.BlockId == block.Id
+            && definition.StatementIndex == block.Statements.Count + operationIndex
+            && ReferenceEquals(definition.SyntheticOperation, operation));
+
+    private ImmutableHashSet<DefinitionSite> TransferSyntheticCore(
+        SyntheticOperation operation,
+        ImmutableHashSet<DefinitionSite> input,
+        Func<DefinitionSite, bool> matchesDefinition)
+    {
+        var defined = BoundNodeHelpers.GetDefinedVariable(operation);
+        if (defined == null)
+            return input;
+
+        var afterKill = input;
+        foreach (var definition in input.AsEnumerable().Where(definition =>
+                     SameVariable(definition, defined)))
+        {
+            afterKill = afterKill.Remove(definition);
+        }
+
+        var generated = _allDefinitions.FirstOrDefault(definition =>
+            matchesDefinition(definition)
+            && SameVariable(definition, defined));
+        return generated.DefinitionOrdinal >= 0
+            ? afterKill.Add(generated)
+            : afterKill;
     }
 
     private static bool SameVariable(DefinitionSite definition, VariableSymbol variable)
@@ -159,7 +250,9 @@ internal sealed class ReachingDefinitionsTransfer : ITransferFunction<ImmutableH
             return definition.VariableId == variable.Id;
 
         return ReferenceEquals(
-            BoundNodeHelpers.GetDefinedVariable(definition.Statement),
+            definition.Statement != null
+                ? BoundNodeHelpers.GetDefinedVariable(definition.Statement)
+                : definition.SyntheticOperation?.DefinedVariable,
             variable);
     }
 

--- a/src/Calor.Compiler/Analysis/Dataflow/Analyses/UninitializedVariables.cs
+++ b/src/Calor.Compiler/Analysis/Dataflow/Analyses/UninitializedVariables.cs
@@ -28,37 +28,57 @@ public sealed class UninitializedVariablesAnalysis
     private readonly IReadOnlyDictionary<SymbolId, VariableSymbol> _allVariables;
     private readonly HashSet<SymbolId> _parameters;
     private readonly List<UninitializedUse> _uninitializedUses = new();
+    private readonly UninitializedVariablesTransfer _transfer;
     public IReadOnlyList<BoundNode> IncompleteNodes { get; }
     public bool IsComplete => IncompleteNodes.Count == 0;
+    public DataflowAnalysisResult<InitializationFacts> AnalysisResult { get; }
 
     public UninitializedVariablesAnalysis(ControlFlowGraph cfg, IEnumerable<string>? parameterNames = null)
+        : this(
+            cfg,
+            cfg.Function.Symbol.Parameters
+                .Where(parameter => parameterNames == null
+                    || parameterNames.Contains(parameter.Name, StringComparer.Ordinal))
+                .Select(parameter => parameter.Id))
     {
-        _cfg = cfg ?? throw new ArgumentNullException(nameof(cfg));
-        _allVariables = CollectAllVariables(cfg);
-        IncompleteNodes = BoundNodeHelpers.GetAnalysisIncompleteNodes(cfg.Function).ToArray();
-        var names = parameterNames?.ToHashSet(StringComparer.Ordinal);
-        _parameters = cfg.Function.Symbol.Parameters
-            .Where(parameter => names == null || names.Contains(parameter.Name))
-            .Where(parameter => !parameter.Id.IsNone)
-            .Select(parameter => parameter.Id)
-            .ToHashSet();
-
-        var lattice = new InitializationLattice(_allVariables.Keys.ToHashSet(), _parameters);
-        var transfer = new UninitializedVariablesTransfer();
-        var analysis = new DataflowAnalysis<InitializationFacts>(
-            lattice, transfer, DataflowDirection.Forward);
-
-        _results = analysis.Analyze(cfg);
-
-        // Detect uninitialized uses
-        DetectUninitializedUses();
     }
 
     public UninitializedVariablesAnalysis(
         ControlFlowGraph cfg,
         IEnumerable<VariableSymbol> parameters)
-        : this(cfg, parameters.Select(parameter => parameter.Name))
+        : this(cfg, parameters.Select(parameter => parameter.Id))
     {
+    }
+
+    private UninitializedVariablesAnalysis(
+        ControlFlowGraph cfg,
+        IEnumerable<SymbolId> parameterIds)
+    {
+        _cfg = cfg ?? throw new ArgumentNullException(nameof(cfg));
+        _allVariables = CollectAllVariables(cfg);
+        IncompleteNodes = BoundNodeHelpers.GetAnalysisIncompleteNodes(cfg.Function).ToArray();
+        _parameters = parameterIds
+            .Where(parameterId => !parameterId.IsNone)
+            .ToHashSet();
+
+        var lattice = new InitializationLattice(_allVariables.Keys.ToHashSet());
+        _transfer = new UninitializedVariablesTransfer();
+        var entryBoundary = InitializationFacts.Create(
+            _allVariables.Keys,
+            _parameters);
+        var analysis = new DataflowAnalysis<InitializationFacts>(
+            lattice,
+            _transfer,
+            DataflowDirection.Forward,
+            entryBoundary,
+            InitializationFacts.Empty,
+            InitializationFacts.Empty);
+
+        AnalysisResult = analysis.AnalyzeWithMetadata(cfg);
+        _results = AnalysisResult.Blocks;
+
+        // Detect uninitialized uses
+        DetectUninitializedUses();
     }
 
     /// <summary>
@@ -113,57 +133,112 @@ public sealed class UninitializedVariablesAnalysis
 
     private void DetectUninitializedUses()
     {
-        foreach (var block in _cfg.Blocks)
+        var usesByProgramPoint = new Dictionary<
+            object,
+            Dictionary<SymbolId, AggregatedUse>>(
+            ReferenceEqualityComparer.Instance);
+
+        foreach (var block in _cfg.ReachableBlocks)
         {
             if (!_results.TryGetValue(block, out var result))
                 continue;
 
             var currentFacts = result.In;
 
-            // Check condition expression
-            if (block.BranchCondition != null)
+            // Check each statement
+            for (var index = 0; index < block.Statements.Count; index++)
             {
-                foreach (var v in BoundNodeHelpers.GetUsedVariables(block.BranchCondition))
-                {
-                    if (v.IsParameter)
-                        continue;
-                    var state = currentFacts.GetState(v.Id);
-                    if (state != InitializationState.Initialized)
-                    {
-                        _uninitializedUses.Add(new UninitializedUse(v.Name, block.Span, state, v.Id));
-                    }
-                }
+                var stmt = block.Statements[index];
+                RecordUses(
+                    stmt,
+                    BoundNodeHelpers.GetUsedVariables(stmt),
+                    stmt.Span,
+                    currentFacts,
+                    usesByProgramPoint);
+                currentFacts = _transfer.Transfer(
+                    block,
+                    index,
+                    stmt,
+                    currentFacts);
             }
 
-            // Check each statement
-            foreach (var stmt in block.Statements)
+            foreach (var operation in block.SyntheticOperations)
             {
-                // Check uses first
-                foreach (var v in BoundNodeHelpers.GetUsedVariables(stmt))
-                {
-                    if (v.IsParameter)
-                        continue;
-                    var state = currentFacts.GetState(v.Id);
-                    if (state != InitializationState.Initialized)
-                    {
-                        _uninitializedUses.Add(new UninitializedUse(v.Name, stmt.Span, state, v.Id));
-                    }
-                }
+                RecordUses(
+                    operation,
+                    BoundNodeHelpers.GetUsedVariables(operation),
+                    operation.Span,
+                    currentFacts,
+                    usesByProgramPoint);
+                currentFacts = _transfer.TransferSynthetic(operation, currentFacts);
+            }
 
-                // Update facts for the next statement
-                var defined = BoundNodeHelpers.GetDefinedVariable(stmt);
-                if (defined != null)
+            if (block.Terminator.Condition != null)
+            {
+                RecordUses(
+                    block.Terminator.Condition,
+                    BoundNodeHelpers.GetUsedVariables(block.Terminator.Condition),
+                    block.Terminator.Condition.Span,
+                    currentFacts,
+                    usesByProgramPoint);
+            }
+        }
+
+        foreach (var uses in usesByProgramPoint.Values)
+        {
+            foreach (var (variableId, use) in uses)
+            {
+                if (use.State != InitializationState.Initialized)
                 {
-                    // Check if the variable has an initializer
-                    var hasInitializer = stmt is BoundBindStatement bind && bind.Initializer != null;
-                    if (hasInitializer)
-                    {
-                        currentFacts = currentFacts.SetInitialized(defined.Id);
-                    }
+                    _uninitializedUses.Add(new UninitializedUse(
+                        use.VariableName,
+                        use.Span,
+                        use.State,
+                        variableId));
                 }
             }
         }
     }
+
+    private void RecordUses(
+        object programPoint,
+        IEnumerable<VariableSymbol> variables,
+        TextSpan span,
+        InitializationFacts facts,
+        Dictionary<object, Dictionary<SymbolId, AggregatedUse>> usesByProgramPoint)
+    {
+        if (!usesByProgramPoint.TryGetValue(programPoint, out var pointUses))
+        {
+            pointUses = new Dictionary<SymbolId, AggregatedUse>();
+            usesByProgramPoint.Add(programPoint, pointUses);
+        }
+
+        foreach (var variable in variables)
+        {
+            var state = facts.GetState(variable.Id);
+            if (pointUses.TryGetValue(variable.Id, out var existing))
+            {
+                pointUses[variable.Id] = existing with
+                {
+                    State = existing.State == state
+                        ? state
+                        : InitializationState.MaybeInitialized,
+                };
+            }
+            else
+            {
+                pointUses.Add(variable.Id, new AggregatedUse(
+                    variable.Name,
+                    span,
+                    state));
+            }
+        }
+    }
+
+    private readonly record struct AggregatedUse(
+        string VariableName,
+        TextSpan Span,
+        InitializationState State);
 
     private static IReadOnlyDictionary<SymbolId, VariableSymbol> CollectAllVariables(ControlFlowGraph cfg)
     {
@@ -175,7 +250,7 @@ public sealed class UninitializedVariablesAnalysis
                 variables.TryAdd(parameter.Id, parameter);
         }
 
-        foreach (var block in cfg.Blocks)
+        foreach (var block in cfg.ReachableBlocks)
         {
             foreach (var stmt in block.Statements)
             {
@@ -190,9 +265,22 @@ public sealed class UninitializedVariablesAnalysis
                 }
             }
 
-            if (block.BranchCondition != null)
+            foreach (var operation in block.SyntheticOperations)
             {
-                foreach (var used in BoundNodeHelpers.GetUsedVariables(block.BranchCondition))
+                var defined = BoundNodeHelpers.GetDefinedVariable(operation);
+                if (defined != null && !defined.Id.IsNone)
+                    variables.TryAdd(defined.Id, defined);
+
+                foreach (var used in BoundNodeHelpers.GetUsedVariables(operation))
+                {
+                    if (!used.Id.IsNone)
+                        variables.TryAdd(used.Id, used);
+                }
+            }
+
+            if (block.Terminator.Condition != null)
+            {
+                foreach (var used in BoundNodeHelpers.GetUsedVariables(block.Terminator.Condition))
                 {
                     if (!used.Id.IsNone)
                         variables.TryAdd(used.Id, used);
@@ -322,20 +410,17 @@ public readonly struct InitializationFacts : IEquatable<InitializationFacts>
 internal sealed class InitializationLattice : IDataflowLattice<InitializationFacts>
 {
     private readonly HashSet<SymbolId> _allVariables;
-    private readonly HashSet<SymbolId> _parameters;
 
-    public InitializationLattice(HashSet<SymbolId> allVariables, HashSet<SymbolId> parameters)
+    public InitializationLattice(HashSet<SymbolId> allVariables)
     {
         _allVariables = allVariables;
-        _parameters = parameters;
     }
 
     // Empty is an explicit join identity; InitializationFacts.Join handles it
     // without interpreting missing entries as uninitialized program variables.
     public InitializationFacts Bottom => InitializationFacts.Empty;
 
-    // Top: all variables are initialized (includes parameters)
-    public InitializationFacts Top => InitializationFacts.Create(_allVariables, _parameters);
+    public InitializationFacts Top => InitializationFacts.Create(_allVariables, _allVariables);
 
     public InitializationFacts Join(InitializationFacts a, InitializationFacts b)
         => a.Join(b, _allVariables);
@@ -347,9 +432,7 @@ internal sealed class InitializationLattice : IDataflowLattice<InitializationFac
             var aState = a.GetState(v);
             var bState = b.GetState(v);
 
-            // a <= b if for all variables, a's state is "less certain" than b's
-            // Uninitialized < MaybeInitialized < Initialized
-            if ((int)aState > (int)bState)
+            if (aState != bState && bState != InitializationState.MaybeInitialized)
                 return false;
         }
         return true;
@@ -358,15 +441,29 @@ internal sealed class InitializationLattice : IDataflowLattice<InitializationFac
 
 internal sealed class UninitializedVariablesTransfer : ITransferFunction<InitializationFacts>
 {
+    public InitializationFacts Transfer(
+        BasicBlock block,
+        int statementIndex,
+        BoundStatement statement,
+        InitializationFacts input) =>
+        block.IsDefinitionDeferred(statementIndex)
+            ? input
+            : Transfer(statement, input);
+
     public InitializationFacts Transfer(BoundStatement statement, InitializationFacts input)
     {
         var defined = BoundNodeHelpers.GetDefinedVariable(statement);
         if (defined == null)
             return input;
 
-        // Check if the variable has an initializer
-        var hasInitializer = statement is BoundBindStatement bind && bind.Initializer != null;
-        if (hasInitializer)
+        var initializes = statement switch
+        {
+            BoundBindStatement bind => bind.Initializer != null,
+            BoundAssignmentStatement => true,
+            BoundCompoundAssignment => true,
+            _ => false,
+        };
+        if (initializes && !defined.Id.IsNone)
         {
             return input.SetInitialized(defined.Id);
         }
@@ -377,5 +474,15 @@ internal sealed class UninitializedVariablesTransfer : ITransferFunction<Initial
     public InitializationFacts TransferExpression(BoundExpression? expression, InitializationFacts input)
     {
         return input;
+    }
+
+    public InitializationFacts TransferSynthetic(
+        SyntheticOperation operation,
+        InitializationFacts input)
+    {
+        var defined = BoundNodeHelpers.GetDefinedVariable(operation);
+        return defined != null && !defined.Id.IsNone
+            ? input.SetInitialized(defined.Id)
+            : input;
     }
 }

--- a/src/Calor.Compiler/Analysis/Dataflow/BoundNodeHelpers.cs
+++ b/src/Calor.Compiler/Analysis/Dataflow/BoundNodeHelpers.cs
@@ -184,6 +184,9 @@ public static class BoundNodeHelpers
         };
     }
 
+    public static VariableSymbol? GetDefinedVariable(SyntheticOperation operation) =>
+        operation.DefinedVariable;
+
     /// <summary>
     /// Gets all variables used in a statement (excluding the defined variable).
     /// </summary>
@@ -216,6 +219,23 @@ public static class BoundNodeHelpers
                 if (seen.Add(variable))
                     yield return variable;
             }
+        }
+    }
+
+    public static IEnumerable<VariableSymbol> GetUsedVariables(SyntheticOperation operation)
+    {
+        var seen = new HashSet<VariableSymbol>(VariableSymbolIdentityComparer.Instance);
+        if (operation.ReadsDefinedVariable
+            && operation.DefinedVariable != null
+            && seen.Add(operation.DefinedVariable))
+        {
+            yield return operation.DefinedVariable;
+        }
+
+        foreach (var variable in GetUsedVariables(operation.Expression))
+        {
+            if (seen.Add(variable))
+                yield return variable;
         }
     }
 

--- a/src/Calor.Compiler/Analysis/Dataflow/ControlFlowGraph.cs
+++ b/src/Calor.Compiler/Analysis/Dataflow/ControlFlowGraph.cs
@@ -3,60 +3,294 @@ using Calor.Compiler.Parsing;
 
 namespace Calor.Compiler.Analysis.Dataflow;
 
+public enum ControlFlowEdgeKind
+{
+    True,
+    False,
+    FallThrough,
+    BackEdge,
+    Break,
+    Continue,
+    Return,
+    Throw,
+    Catch,
+    Finally,
+    Dispatch,
+    Unsupported,
+}
+
+public enum ControlFlowTerminatorKind
+{
+    FallThrough,
+    Conditional,
+    Return,
+    Throw,
+    Break,
+    Continue,
+    Continuation,
+    Dispatch,
+    Unsupported,
+    Exit,
+}
+
+public enum SyntheticOperationKind
+{
+    ForInitialization,
+    ForStep,
+    ForeachCollectionEvaluation,
+    ForeachIteration,
+    CatchInitialization,
+    UsingResourceEvaluation,
+    UsingResourceInitialization,
+    UsingDispose,
+    MatchTargetEvaluation,
+    ExpressionEvaluation,
+    StatementDefinition,
+}
+
+/// <summary>
+/// A CFG-only operation used when the bound tree represents an implicit language operation.
+/// </summary>
+public sealed class SyntheticOperation
+{
+    public int Ordinal { get; internal set; } = -1;
+    public SyntheticOperationKind Kind { get; }
+    public VariableSymbol? DefinedVariable { get; }
+    public BoundExpression? Expression { get; }
+    public bool ReadsDefinedVariable { get; }
+    public bool MayThrow { get; }
+    public BoundStatement? SourceStatement { get; }
+    public TextSpan Span { get; }
+    public bool IsDefinition => DefinedVariable != null;
+
+    public SyntheticOperation(
+        SyntheticOperationKind kind,
+        TextSpan span,
+        VariableSymbol? definedVariable = null,
+        BoundExpression? expression = null,
+        bool readsDefinedVariable = false,
+        bool mayThrow = false,
+        BoundStatement? sourceStatement = null)
+    {
+        Kind = kind;
+        Span = span;
+        DefinedVariable = definedVariable;
+        Expression = expression;
+        ReadsDefinedVariable = readsDefinedVariable;
+        MayThrow = mayThrow;
+        SourceStatement = sourceStatement;
+    }
+}
+
+public sealed class ControlFlowEdge
+{
+    public BasicBlock Source { get; }
+    public BasicBlock Target { get; }
+    public ControlFlowEdgeKind Kind { get; }
+
+    internal ControlFlowEdge(BasicBlock source, BasicBlock target, ControlFlowEdgeKind kind)
+    {
+        Source = source;
+        Target = target;
+        Kind = kind;
+    }
+
+    public override string ToString() => $"BB{Source.Id} -{Kind}-> BB{Target.Id}";
+}
+
+public abstract class ControlFlowTerminator
+{
+    public ControlFlowTerminatorKind Kind { get; }
+    public virtual BoundExpression? Condition => null;
+    public abstract IReadOnlyList<ControlFlowEdge> OutgoingEdges { get; }
+    public virtual bool IsAbrupt => false;
+
+    protected ControlFlowTerminator(ControlFlowTerminatorKind kind)
+    {
+        Kind = kind;
+    }
+}
+
+public sealed class FallThroughTerminator : ControlFlowTerminator
+{
+    public ControlFlowEdge Edge { get; }
+    public override IReadOnlyList<ControlFlowEdge> OutgoingEdges => [Edge];
+
+    internal FallThroughTerminator(ControlFlowEdge edge)
+        : base(ControlFlowTerminatorKind.FallThrough)
+    {
+        Edge = edge;
+    }
+}
+
+public sealed class ConditionalTerminator : ControlFlowTerminator
+{
+    private readonly IReadOnlyList<ControlFlowEdge> _edges;
+
+    public override BoundExpression Condition { get; }
+    public ControlFlowEdge TrueEdge { get; }
+    public ControlFlowEdge FalseEdge { get; }
+    public ControlFlowEdge? ExceptionalEdge { get; }
+    public override IReadOnlyList<ControlFlowEdge> OutgoingEdges => _edges;
+
+    internal ConditionalTerminator(
+        BoundExpression condition,
+        ControlFlowEdge trueEdge,
+        ControlFlowEdge falseEdge,
+        ControlFlowEdge? exceptionalEdge)
+        : base(ControlFlowTerminatorKind.Conditional)
+    {
+        Condition = condition;
+        TrueEdge = trueEdge;
+        FalseEdge = falseEdge;
+        ExceptionalEdge = exceptionalEdge;
+        _edges = exceptionalEdge == null
+            ? [trueEdge, falseEdge]
+            : [trueEdge, falseEdge, exceptionalEdge];
+    }
+}
+
+public sealed class AbruptTerminator : ControlFlowTerminator
+{
+    public ControlFlowEdge Edge { get; }
+    public override IReadOnlyList<ControlFlowEdge> OutgoingEdges => [Edge];
+    public override bool IsAbrupt => true;
+
+    internal AbruptTerminator(ControlFlowTerminatorKind kind, ControlFlowEdge edge)
+        : base(kind)
+    {
+        Edge = edge;
+    }
+}
+
+public sealed class ContinuationTerminator : ControlFlowTerminator
+{
+    public ControlFlowEdge Edge { get; }
+    public override IReadOnlyList<ControlFlowEdge> OutgoingEdges => [Edge];
+
+    internal ContinuationTerminator(ControlFlowEdge edge)
+        : base(ControlFlowTerminatorKind.Continuation)
+    {
+        Edge = edge;
+    }
+}
+
+public class DispatchTerminator : ControlFlowTerminator
+{
+    private readonly IReadOnlyList<ControlFlowEdge> _edges;
+
+    public override BoundExpression? Condition { get; }
+    public override IReadOnlyList<ControlFlowEdge> OutgoingEdges => _edges;
+
+    internal DispatchTerminator(
+        BoundExpression? condition,
+        IReadOnlyList<ControlFlowEdge> edges,
+        ControlFlowTerminatorKind kind = ControlFlowTerminatorKind.Dispatch)
+        : base(kind)
+    {
+        Condition = condition;
+        _edges = edges;
+    }
+}
+
+public sealed class UnsupportedTerminator : DispatchTerminator
+{
+    internal UnsupportedTerminator(IReadOnlyList<ControlFlowEdge> edges)
+        : base(null, edges, ControlFlowTerminatorKind.Unsupported)
+    {
+    }
+}
+
+public sealed class ExitTerminator : ControlFlowTerminator
+{
+    public override IReadOnlyList<ControlFlowEdge> OutgoingEdges => Array.Empty<ControlFlowEdge>();
+
+    internal ExitTerminator()
+        : base(ControlFlowTerminatorKind.Exit)
+    {
+    }
+}
+
 /// <summary>
 /// Represents a basic block in a control flow graph.
-/// A basic block is a sequence of statements with one entry and one exit point.
 /// </summary>
 public sealed class BasicBlock
 {
-    private static int _nextId;
+    private readonly List<ControlFlowEdge> _incomingEdges = new();
+    private readonly List<ControlFlowEdge> _outgoingEdges = new();
+    private readonly HashSet<int> _deferredDefinitionStatementIndices = new();
+    private ControlFlowTerminator? _terminator;
 
-    public int Id { get; }
+    public int Id { get; internal set; }
+    public int Ordinal { get; internal set; }
     public List<BoundStatement> Statements { get; } = new();
-    public List<BasicBlock> Predecessors { get; } = new();
-    public List<BasicBlock> Successors { get; } = new();
+    public List<SyntheticOperation> SyntheticOperations { get; } = new();
+    public IReadOnlyList<ControlFlowEdge> IncomingEdges => _incomingEdges;
+    public IReadOnlyList<ControlFlowEdge> OutgoingEdges => _outgoingEdges;
+    public IReadOnlyList<BasicBlock> Predecessors =>
+        _incomingEdges.Select(edge => edge.Source).Distinct().ToArray();
+    public IReadOnlyList<BasicBlock> Successors =>
+        _outgoingEdges.Select(edge => edge.Target).Distinct().ToArray();
+    public BoundExpression? BranchCondition => _terminator?.Condition;
+    public bool IsExit { get; internal set; }
+    public bool IsEntry { get; internal set; }
+    public bool HasTerminator => _terminator != null;
+    public ControlFlowTerminator Terminator =>
+        _terminator ?? throw new InvalidOperationException($"BB{Id} has no terminator");
 
-    /// <summary>
-    /// The condition expression for conditional branches (null for unconditional).
-    /// </summary>
-    public BoundExpression? BranchCondition { get; set; }
-
-    /// <summary>
-    /// Whether this block ends with a return statement.
-    /// </summary>
-    public bool IsExit { get; set; }
-
-    /// <summary>
-    /// Whether this is the entry block of the function.
-    /// </summary>
-    public bool IsEntry { get; set; }
-
-    /// <summary>
-    /// The text span covering all statements in this block.
-    /// </summary>
-    public TextSpan Span => Statements.Count > 0
-        ? new TextSpan(
-            Statements[0].Span.Start,
-            Statements[^1].Span.End,
-            Statements[0].Span.Line,
-            Statements[0].Span.Column)
-        : default;
-
-    public BasicBlock()
+    public TextSpan Span
     {
-        Id = Interlocked.Increment(ref _nextId);
-    }
-
-    public void AddSuccessor(BasicBlock successor)
-    {
-        if (!Successors.Contains(successor))
+        get
         {
-            Successors.Add(successor);
-            successor.Predecessors.Add(this);
+            if (Statements.Count > 0)
+            {
+                return new TextSpan(
+                    Statements[0].Span.Start,
+                    Statements[^1].Span.End,
+                    Statements[0].Span.Line,
+                    Statements[0].Span.Column);
+            }
+
+            if (SyntheticOperations.Count > 0)
+                return SyntheticOperations[0].Span;
+
+            return BranchCondition?.Span ?? default;
         }
     }
 
+    public BasicBlock()
+    {
+    }
+
+    internal void SetTerminator(ControlFlowTerminator terminator)
+    {
+        if (_terminator != null)
+            throw new InvalidOperationException($"BB{Id} already has a terminator");
+
+        _terminator = terminator;
+    }
+
+    internal void AddOutgoingEdge(ControlFlowEdge edge) => _outgoingEdges.Add(edge);
+    internal void AddIncomingEdge(ControlFlowEdge edge) => _incomingEdges.Add(edge);
+    internal void RemoveOutgoingEdge(ControlFlowEdge edge) => _outgoingEdges.Remove(edge);
+    internal void RemoveIncomingEdge(ControlFlowEdge edge) => _incomingEdges.Remove(edge);
+    internal void DeferDefinition(int statementIndex) =>
+        _deferredDefinitionStatementIndices.Add(statementIndex);
+    public bool IsDefinitionDeferred(int statementIndex) =>
+        _deferredDefinitionStatementIndices.Contains(statementIndex);
+
     public override string ToString() => $"BB{Id} ({Statements.Count} stmts)";
+}
+
+public sealed class ControlFlowGraphValidationException : InvalidOperationException
+{
+    public IReadOnlyList<string> Violations { get; }
+
+    public ControlFlowGraphValidationException(IReadOnlyList<string> violations)
+        : base($"Invalid control-flow graph: {string.Join("; ", violations)}")
+    {
+        Violations = violations;
+    }
 }
 
 /// <summary>
@@ -64,55 +298,40 @@ public sealed class BasicBlock
 /// </summary>
 public sealed class ControlFlowGraph
 {
+    private readonly IReadOnlyList<BasicBlock> _reachableBlocks;
+
     public BasicBlock Entry { get; }
     public BasicBlock Exit { get; }
     public IReadOnlyList<BasicBlock> Blocks { get; }
+    public IReadOnlyList<BasicBlock> ReachableBlocks => _reachableBlocks;
     public BoundFunction Function { get; }
 
-    private ControlFlowGraph(BoundFunction function, BasicBlock entry, BasicBlock exit, IReadOnlyList<BasicBlock> blocks)
+    private ControlFlowGraph(
+        BoundFunction function,
+        BasicBlock entry,
+        BasicBlock exit,
+        IReadOnlyList<BasicBlock> blocks)
     {
         Function = function;
         Entry = entry;
         Exit = exit;
         Blocks = blocks;
+        _reachableBlocks = ComputeReachableBlocks(entry);
     }
 
-    /// <summary>
-    /// Builds a control flow graph from a bound function.
-    /// </summary>
     public static ControlFlowGraph Build(BoundFunction function)
     {
-        var builder = new CfgBuilder();
-        return builder.Build(function);
+        ArgumentNullException.ThrowIfNull(function);
+        return new CfgBuilder().Build(function);
     }
 
-    /// <summary>
-    /// Gets all blocks in reverse post-order (topological order for forward analysis).
-    /// </summary>
     public IReadOnlyList<BasicBlock> GetReversePostOrder()
     {
-        var visited = new HashSet<BasicBlock>();
-        var postOrder = new List<BasicBlock>();
-
-        void Visit(BasicBlock block)
-        {
-            if (!visited.Add(block))
-                return;
-
-            foreach (var succ in block.Successors)
-                Visit(succ);
-
-            postOrder.Add(block);
-        }
-
-        Visit(Entry);
+        var postOrder = GetPostOrder().ToList();
         postOrder.Reverse();
         return postOrder;
     }
 
-    /// <summary>
-    /// Gets all blocks in post-order (for backward analysis).
-    /// </summary>
     public IReadOnlyList<BasicBlock> GetPostOrder()
     {
         var visited = new HashSet<BasicBlock>();
@@ -123,8 +342,8 @@ public sealed class ControlFlowGraph
             if (!visited.Add(block))
                 return;
 
-            foreach (var succ in block.Successors)
-                Visit(succ);
+            foreach (var edge in block.OutgoingEdges.OrderBy(edge => edge.Target.Ordinal))
+                Visit(edge.Target);
 
             postOrder.Add(block);
         }
@@ -133,53 +352,236 @@ public sealed class ControlFlowGraph
         return postOrder;
     }
 
+    public void Validate()
+    {
+        var violations = new List<string>();
+        var blockSet = Blocks.ToHashSet();
+
+        if (!blockSet.Contains(Entry))
+            violations.Add("entry block is not in Blocks");
+        if (!blockSet.Contains(Exit))
+            violations.Add("exit block is not in Blocks");
+        if (!Entry.IsEntry)
+            violations.Add("entry block is not marked as entry");
+        if (!Exit.IsExit)
+            violations.Add("exit block is not marked as exit");
+        if (Entry.IncomingEdges.Count != 0)
+            violations.Add("entry block has predecessors");
+
+        for (var index = 0; index < Blocks.Count; index++)
+        {
+            var block = Blocks[index];
+            if (block.Id != index || block.Ordinal != index)
+                violations.Add($"BB{block.Id} has unstable ordinal {block.Ordinal}, expected {index}");
+            if (!block.HasTerminator)
+            {
+                violations.Add($"BB{block.Id} has no terminator");
+                continue;
+            }
+
+            if (!block.OutgoingEdges.SequenceEqual(block.Terminator.OutgoingEdges))
+                violations.Add($"BB{block.Id} terminator edges do not match block edges");
+
+            foreach (var edge in block.OutgoingEdges)
+            {
+                if (!ReferenceEquals(edge.Source, block))
+                    violations.Add($"BB{block.Id} owns an edge with a different source");
+                if (!blockSet.Contains(edge.Target))
+                    violations.Add($"BB{block.Id} targets a block outside the graph");
+                if (!edge.Target.IncomingEdges.Contains(edge))
+                    violations.Add($"BB{block.Id} edge is missing from target predecessors");
+            }
+
+            foreach (var edge in block.IncomingEdges)
+            {
+                if (!ReferenceEquals(edge.Target, block))
+                    violations.Add($"BB{block.Id} owns an incoming edge with a different target");
+                if (!blockSet.Contains(edge.Source))
+                    violations.Add($"BB{block.Id} has a predecessor outside the graph");
+                if (!edge.Source.OutgoingEdges.Contains(edge))
+                    violations.Add($"BB{block.Id} incoming edge is missing from source successors");
+            }
+
+            ValidateTerminator(block, violations);
+        }
+
+        var reachable = ComputeReachableBlocks(Entry).ToHashSet();
+        foreach (var block in Blocks)
+        {
+            if (!reachable.Contains(block) && !ReferenceEquals(block, Exit))
+                violations.Add($"BB{block.Id} is unreachable");
+        }
+
+        if (violations.Count > 0)
+            throw new ControlFlowGraphValidationException(violations);
+    }
+
+    private static void ValidateTerminator(BasicBlock block, List<string> violations)
+    {
+        var edges = block.OutgoingEdges;
+        switch (block.Terminator)
+        {
+            case ExitTerminator:
+                if (edges.Count != 0)
+                    violations.Add($"BB{block.Id} exit terminator has outgoing edges");
+                break;
+
+            case FallThroughTerminator:
+                if (edges.Count != 1 || edges[0].Kind != ControlFlowEdgeKind.FallThrough)
+                    violations.Add($"BB{block.Id} fallthrough terminator has illegal edges");
+                break;
+
+            case ConditionalTerminator conditional:
+                if (edges.Count is < 2 or > 3
+                    || edges.Count(edge => edge.Kind == ControlFlowEdgeKind.True) != 1
+                    || edges.Count(edge => edge.Kind == ControlFlowEdgeKind.False) != 1)
+                {
+                    violations.Add($"BB{block.Id} conditional terminator has illegal cardinality");
+                }
+
+                if (conditional.ExceptionalEdge != null
+                    && conditional.ExceptionalEdge.Kind
+                        is not (ControlFlowEdgeKind.Catch
+                            or ControlFlowEdgeKind.Throw
+                            or ControlFlowEdgeKind.Finally))
+                {
+                    violations.Add($"BB{block.Id} conditional has an illegal exceptional edge");
+                }
+                break;
+
+            case AbruptTerminator abrupt:
+                if (edges.Count != 1 || !IsLegalAbruptEdge(abrupt.Kind, edges[0].Kind))
+                    violations.Add($"BB{block.Id} abrupt terminator has an ordinary or illegal edge");
+                break;
+
+            case UnsupportedTerminator:
+                if (edges.Count != 2
+                    || edges.Count(edge => edge.Kind == ControlFlowEdgeKind.FallThrough) != 1
+                    || edges.Count(edge => edge.Kind
+                        is ControlFlowEdgeKind.Catch
+                            or ControlFlowEdgeKind.Throw
+                            or ControlFlowEdgeKind.Finally) != 1)
+                {
+                    violations.Add($"BB{block.Id} unsupported terminator has illegal edges");
+                }
+                break;
+
+            case DispatchTerminator:
+                if (edges.Count == 0
+                    || edges.Any(edge => edge.Kind
+                        is ControlFlowEdgeKind.True
+                            or ControlFlowEdgeKind.False
+                            or ControlFlowEdgeKind.BackEdge
+                            or ControlFlowEdgeKind.Break
+                            or ControlFlowEdgeKind.Continue
+                            or ControlFlowEdgeKind.Return))
+                {
+                    violations.Add($"BB{block.Id} dispatch terminator has illegal edges");
+                }
+                break;
+
+            case ContinuationTerminator:
+                if (edges.Count != 1
+                    || edges[0].Kind is ControlFlowEdgeKind.True or ControlFlowEdgeKind.False)
+                {
+                    violations.Add($"BB{block.Id} continuation terminator has illegal edges");
+                }
+                break;
+        }
+    }
+
+    private static bool IsLegalAbruptEdge(
+        ControlFlowTerminatorKind terminatorKind,
+        ControlFlowEdgeKind edgeKind) =>
+        terminatorKind switch
+        {
+            ControlFlowTerminatorKind.Return =>
+                edgeKind is ControlFlowEdgeKind.Return or ControlFlowEdgeKind.Finally,
+            ControlFlowTerminatorKind.Throw =>
+                edgeKind is ControlFlowEdgeKind.Throw
+                    or ControlFlowEdgeKind.Catch
+                    or ControlFlowEdgeKind.Finally,
+            ControlFlowTerminatorKind.Break =>
+                edgeKind is ControlFlowEdgeKind.Break or ControlFlowEdgeKind.Finally,
+            ControlFlowTerminatorKind.Continue =>
+                edgeKind is ControlFlowEdgeKind.Continue or ControlFlowEdgeKind.Finally,
+            _ => false,
+        };
+
+    private static IReadOnlyList<BasicBlock> ComputeReachableBlocks(BasicBlock entry)
+    {
+        var visited = new HashSet<BasicBlock>();
+        var worklist = new Stack<BasicBlock>();
+        worklist.Push(entry);
+
+        while (worklist.Count > 0)
+        {
+            var block = worklist.Pop();
+            if (!visited.Add(block))
+                continue;
+
+            foreach (var edge in block.OutgoingEdges
+                         .OrderByDescending(edge => edge.Target.Ordinal))
+            {
+                worklist.Push(edge.Target);
+            }
+        }
+
+        return visited.OrderBy(block => block.Ordinal).ToArray();
+    }
+
     private sealed class CfgBuilder
     {
         private readonly List<BasicBlock> _blocks = new();
-        private BasicBlock _currentBlock = null!;
+        private readonly Dictionary<string, BasicBlock> _labelTargets =
+            new(StringComparer.Ordinal);
+        private BasicBlock _entryBlock = null!;
         private BasicBlock _exitBlock = null!;
-        private readonly Dictionary<string, BasicBlock> _labelTargets = new();
-        private readonly List<(BasicBlock Block, string Label)> _pendingGotos = new();
-
-        // Loop context stacks for break/continue handling
-        private readonly Stack<BasicBlock> _loopExitStack = new();
-        private readonly Stack<BasicBlock> _loopConditionStack = new();
-        // Try context: when inside a try, throws go to catch blocks instead of exit
-        private readonly Stack<BasicBlock> _exceptionTargetStack = new();
 
         public ControlFlowGraph Build(BoundFunction function)
         {
-            // Create entry and exit blocks
-            var entry = CreateBlock();
-            entry.IsEntry = true;
-
+            _entryBlock = CreateBlock();
+            _entryBlock.IsEntry = true;
             _exitBlock = CreateBlock();
             _exitBlock.IsExit = true;
 
-            _currentBlock = entry;
+            RegisterLabels(function);
 
-            // Process all statements
-            foreach (var stmt in function.Body)
+            var rootContext = new BuildContext(
+                Array.Empty<LoopContext>(),
+                Array.Empty<FinallyRegion>(),
+                new FlowDestination(_exitBlock, ControlFlowEdgeKind.Throw, 0));
+
+            var end = BuildStatements(function.Body, _entryBlock, rootContext);
+            if (end != null)
             {
-                ProcessStatement(stmt);
+                TerminateFallThrough(end, _exitBlock);
             }
 
-            // Connect the last block to exit if it doesn't already have a terminator
-            if (_currentBlock != _exitBlock && _currentBlock.Successors.Count == 0)
-            {
-                _currentBlock.AddSuccessor(_exitBlock);
-            }
+            _exitBlock.SetTerminator(new ExitTerminator());
+            PruneUnreachableBlocks();
+            AssignOrdinals();
 
-            // Resolve pending gotos (for future IR-level CFG construction)
-            foreach (var (block, label) in _pendingGotos)
+            var cfg = new ControlFlowGraph(
+                function,
+                _entryBlock,
+                _exitBlock,
+                _blocks.ToArray());
+            cfg.Validate();
+            return cfg;
+        }
+
+        private void RegisterLabels(BoundFunction function)
+        {
+            foreach (var label in BoundNodeHelpers.DescendantsAndSelf(function)
+                         .OfType<BoundLabelStatement>())
             {
-                if (_labelTargets.TryGetValue(label, out var target))
+                if (!_labelTargets.TryAdd(label.Label, CreateBlock()))
                 {
-                    block.AddSuccessor(target);
+                    throw new ControlFlowGraphValidationException(
+                        [$"duplicate label '{label.Label}'"]);
                 }
             }
-
-            return new ControlFlowGraph(function, entry, _exitBlock, _blocks);
         }
 
         private BasicBlock CreateBlock()
@@ -189,510 +591,982 @@ public sealed class ControlFlowGraph
             return block;
         }
 
-        private void ProcessStatement(BoundStatement stmt)
+        private BasicBlock? BuildStatements(
+            IReadOnlyList<BoundStatement> statements,
+            BasicBlock? current,
+            BuildContext context)
         {
-            switch (stmt)
+            foreach (var statement in statements)
             {
-                case BoundBindStatement bind:
-                    _currentBlock.Statements.Add(bind);
-                    break;
+                if (current == null && statement is not BoundLabelStatement)
+                    continue;
 
-                case BoundCallStatement call:
-                    _currentBlock.Statements.Add(call);
-                    break;
+                current = BuildStatement(statement, current, context);
+            }
 
-                case BoundReturnStatement ret:
-                    _currentBlock.Statements.Add(ret);
-                    _currentBlock.AddSuccessor(_exitBlock);
-                    _currentBlock = CreateBlock(); // Dead block after return
-                    break;
+            return current;
+        }
 
-                case BoundIfStatement ifStmt:
-                    ProcessIfStatement(ifStmt);
-                    break;
+        private BasicBlock? BuildStatement(
+            BoundStatement statement,
+            BasicBlock? current,
+            BuildContext context)
+        {
+            if (statement is BoundLabelStatement label)
+                return BuildLabel(label, current);
 
-                case BoundWhileStatement whileStmt:
-                    ProcessWhileStatement(whileStmt);
-                    break;
+            if (current == null)
+                return null;
 
-                case BoundForStatement forStmt:
-                    ProcessForStatement(forStmt);
-                    break;
-
-                case BoundBreakStatement breakStmt:
-                    ProcessBreakStatement(breakStmt);
-                    break;
-
-                case BoundContinueStatement continueStmt:
-                    ProcessContinueStatement(continueStmt);
-                    break;
-
-                case BoundTryStatement tryStmt:
-                    ProcessTryStatement(tryStmt);
-                    break;
-
-                case BoundMatchStatement matchStmt:
-                    ProcessMatchStatement(matchStmt);
-                    break;
-
-                // New statement types for class member analysis
-                case BoundAssignmentStatement assign:
-                    _currentBlock.Statements.Add(assign);
-                    break;
-
-                case BoundCompoundAssignment compound:
-                    _currentBlock.Statements.Add(compound);
-                    break;
-
-                case BoundExpressionStatement exprStmt:
-                    _currentBlock.Statements.Add(exprStmt);
-                    break;
-
-                case BoundThrowStatement throwStmt:
-                    _currentBlock.Statements.Add(throwStmt);
-                    // If inside a try block, throw goes to catch; otherwise to exit
-                    var throwTarget = _exceptionTargetStack.Count > 0
-                        ? _exceptionTargetStack.Peek()
-                        : _exitBlock;
-                    _currentBlock.AddSuccessor(throwTarget);
-                    _currentBlock = CreateBlock(); // Dead block after throw
-                    break;
-
-                case BoundForeachStatement forEach:
-                    ProcessForeachStatement(forEach);
-                    break;
-
-                case BoundDoWhileStatement doWhile:
-                    ProcessDoWhileStatement(doWhile);
-                    break;
-
-                case BoundUsingStatement usingStmt:
-                    ProcessUsingStatement(usingStmt);
-                    break;
-
+            switch (statement)
+            {
+                case BoundIfStatement ifStatement:
+                    return BuildIf(ifStatement, current, context);
+                case BoundWhileStatement whileStatement:
+                    return BuildWhile(whileStatement, current, context);
+                case BoundForStatement forStatement:
+                    return BuildFor(forStatement, current, context);
+                case BoundForeachStatement foreachStatement:
+                    return BuildForeach(foreachStatement, current, context);
+                case BoundDoWhileStatement doWhileStatement:
+                    return BuildDoWhile(doWhileStatement, current, context);
+                case BoundMatchStatement matchStatement:
+                    return BuildMatch(matchStatement, current, context);
+                case BoundTryStatement tryStatement:
+                    return BuildTry(tryStatement, current, context);
+                case BoundUsingStatement usingStatement:
+                    return BuildUsing(usingStatement, current, context);
+                case BoundReturnStatement returnStatement:
+                    return BuildReturn(returnStatement, current, context);
+                case BoundThrowStatement throwStatement:
+                    return BuildThrow(throwStatement, current, context);
+                case BoundBreakStatement breakStatement:
+                    return BuildBreak(breakStatement, current, context);
+                case BoundContinueStatement continueStatement:
+                    return BuildContinue(continueStatement, current, context);
+                case BoundGotoStatement gotoStatement:
+                    return BuildGoto(gotoStatement, current);
                 case BoundUnsupportedStatement unsupported:
-                    // Best-effort: may throw/return (exit edge) or fall through.
-                    // Split block so later statements don't share the exit edge.
-                    _currentBlock.Statements.Add(unsupported);
-                    _currentBlock.AddSuccessor(_exitBlock);
-                    var afterUnsupported = CreateBlock();
-                    _currentBlock.AddSuccessor(afterUnsupported);
-                    _currentBlock = afterUnsupported;
-                    break;
-
+                    return BuildUnsupported(unsupported, current, context);
                 default:
-                    // Unknown statement type - just add it
-                    _currentBlock.Statements.Add(stmt);
-                    break;
+                    current.Statements.Add(statement);
+                    if (!StatementMayThrow(statement))
+                        return current;
+
+                    if (BoundNodeHelpers.GetDefinedVariable(statement) is { } defined
+                        && statement is BoundBindStatement
+                            or BoundAssignmentStatement
+                            or BoundCompoundAssignment)
+                    {
+                        current.DeferDefinition(current.Statements.Count - 1);
+                        current = SplitExceptionalFlow(current, context);
+                        current.SyntheticOperations.Add(new SyntheticOperation(
+                            SyntheticOperationKind.StatementDefinition,
+                            statement.Span,
+                            defined,
+                            sourceStatement: statement));
+                        var continuation = CreateBlock();
+                        TerminateFallThrough(current, continuation);
+                        return continuation;
+                    }
+
+                    return SplitExceptionalFlow(current, context);
             }
         }
 
-        private void ProcessIfStatement(BoundIfStatement ifStmt)
+        private BasicBlock BuildLabel(BoundLabelStatement label, BasicBlock? current)
         {
-            // Current block ends with the condition
-            _currentBlock.BranchCondition = ifStmt.Condition;
+            var target = _labelTargets[label.Label];
+            if (current != null && !ReferenceEquals(current, target))
+                TerminateFallThrough(current, target);
+            target.Statements.Add(label);
+            return target;
+        }
 
+        private BasicBlock? BuildGoto(BoundGotoStatement statement, BasicBlock current)
+        {
+            current.Statements.Add(statement);
+            if (!_labelTargets.TryGetValue(statement.Label, out var target))
+            {
+                throw new ControlFlowGraphValidationException(
+                    [$"goto target '{statement.Label}' does not exist"]);
+            }
+
+            TerminateContinuation(current, target, ControlFlowEdgeKind.Dispatch);
+            return null;
+        }
+
+        private BasicBlock? BuildReturn(
+            BoundReturnStatement statement,
+            BasicBlock current,
+            BuildContext context)
+        {
+            if (ExpressionMayThrow(statement.Expression))
+            {
+                current.SyntheticOperations.Add(new SyntheticOperation(
+                    SyntheticOperationKind.ExpressionEvaluation,
+                    statement.Span,
+                    expression: statement.Expression));
+                current = SplitExceptionalFlow(current, context);
+            }
+            else
+            {
+                current.Statements.Add(statement);
+            }
+
+            var destination = RouteDestination(
+                new FlowDestination(_exitBlock, ControlFlowEdgeKind.Return, 0),
+                context);
+            TerminateAbrupt(
+                current,
+                ControlFlowTerminatorKind.Return,
+                destination);
+            return null;
+        }
+
+        private BasicBlock? BuildThrow(
+            BoundThrowStatement statement,
+            BasicBlock current,
+            BuildContext context)
+        {
+            if (ExpressionMayThrow(statement.Expression))
+            {
+                current.SyntheticOperations.Add(new SyntheticOperation(
+                    SyntheticOperationKind.ExpressionEvaluation,
+                    statement.Span,
+                    expression: statement.Expression));
+                current = SplitExceptionalFlow(current, context);
+            }
+            else
+            {
+                current.Statements.Add(statement);
+            }
+
+            var destination = RouteDestination(context.ExceptionDestination, context);
+            TerminateAbrupt(
+                current,
+                ControlFlowTerminatorKind.Throw,
+                destination);
+            return null;
+        }
+
+        private BasicBlock? BuildBreak(
+            BoundBreakStatement statement,
+            BasicBlock current,
+            BuildContext context)
+        {
+            current.Statements.Add(statement);
+            var loop = context.Loops.LastOrDefault()
+                ?? throw new ControlFlowGraphValidationException(
+                    ["break statement is not inside a loop"]);
+            var destination = RouteDestination(loop.BreakDestination, context);
+            TerminateAbrupt(
+                current,
+                ControlFlowTerminatorKind.Break,
+                destination);
+            return null;
+        }
+
+        private BasicBlock? BuildContinue(
+            BoundContinueStatement statement,
+            BasicBlock current,
+            BuildContext context)
+        {
+            current.Statements.Add(statement);
+            var loop = context.Loops.LastOrDefault()
+                ?? throw new ControlFlowGraphValidationException(
+                    ["continue statement is not inside a loop"]);
+            var destination = RouteDestination(loop.ContinueDestination, context);
+            TerminateAbrupt(
+                current,
+                ControlFlowTerminatorKind.Continue,
+                destination);
+            return null;
+        }
+
+        private BasicBlock BuildUnsupported(
+            BoundUnsupportedStatement statement,
+            BasicBlock current,
+            BuildContext context)
+        {
+            current.Statements.Add(statement);
+            var normal = CreateBlock();
+            var exceptional = RouteDestination(context.ExceptionDestination, context);
+            var edges = new[]
+            {
+                AddEdge(current, normal, ControlFlowEdgeKind.FallThrough),
+                AddEdge(current, exceptional.Target, exceptional.EdgeKind),
+            };
+            current.SetTerminator(new UnsupportedTerminator(edges));
+            return normal;
+        }
+
+        private BasicBlock? BuildIf(
+            BoundIfStatement statement,
+            BasicBlock conditionBlock,
+            BuildContext context)
+        {
+            var merge = CreateBlock();
             var thenBlock = CreateBlock();
-            var mergeBlock = CreateBlock();
+            var falseTarget = statement.ElseIfClauses.Count > 0 || statement.ElseBody != null
+                ? CreateBlock()
+                : merge;
 
-            // Process then branch
-            _currentBlock.AddSuccessor(thenBlock);
-            _currentBlock = thenBlock;
+            TerminateConditional(
+                conditionBlock,
+                statement.Condition,
+                thenBlock,
+                falseTarget,
+                context);
 
-            foreach (var s in ifStmt.ThenBody)
-                ProcessStatement(s);
+            var thenEnd = BuildStatements(statement.ThenBody, thenBlock, context);
+            if (thenEnd != null)
+                TerminateFallThrough(thenEnd, merge);
 
-            // Connect then branch to merge (if it didn't return)
-            if (_currentBlock.Successors.Count == 0)
-                _currentBlock.AddSuccessor(mergeBlock);
-
-            // Process else-if clauses
-            var prevBlock = _blocks[^3]; // The block that had the original condition
-            foreach (var elseIf in ifStmt.ElseIfClauses)
+            var nextCondition = falseTarget;
+            for (var index = 0; index < statement.ElseIfClauses.Count; index++)
             {
-                var elseIfCondBlock = CreateBlock();
-                prevBlock.AddSuccessor(elseIfCondBlock);
-                elseIfCondBlock.BranchCondition = elseIf.Condition;
+                var clause = statement.ElseIfClauses[index];
+                var body = CreateBlock();
+                var next = index + 1 < statement.ElseIfClauses.Count
+                           || statement.ElseBody != null
+                    ? CreateBlock()
+                    : merge;
 
-                var elseIfBodyBlock = CreateBlock();
-                elseIfCondBlock.AddSuccessor(elseIfBodyBlock);
-                _currentBlock = elseIfBodyBlock;
+                TerminateConditional(
+                    nextCondition,
+                    clause.Condition,
+                    body,
+                    next,
+                    context);
 
-                foreach (var s in elseIf.Body)
-                    ProcessStatement(s);
-
-                if (_currentBlock.Successors.Count == 0)
-                    _currentBlock.AddSuccessor(mergeBlock);
-
-                prevBlock = elseIfCondBlock;
+                var bodyEnd = BuildStatements(clause.Body, body, context);
+                if (bodyEnd != null)
+                    TerminateFallThrough(bodyEnd, merge);
+                nextCondition = next;
             }
 
-            // Process else branch
-            if (ifStmt.ElseBody != null && ifStmt.ElseBody.Count > 0)
+            if (statement.ElseBody != null)
             {
-                var elseBlock = CreateBlock();
-                prevBlock.AddSuccessor(elseBlock);
-                _currentBlock = elseBlock;
+                var elseEnd = BuildStatements(statement.ElseBody, nextCondition, context);
+                if (elseEnd != null)
+                    TerminateFallThrough(elseEnd, merge);
+            }
 
-                foreach (var s in ifStmt.ElseBody)
-                    ProcessStatement(s);
+            return merge.IncomingEdges.Count > 0 ? merge : null;
+        }
 
-                if (_currentBlock.Successors.Count == 0)
-                    _currentBlock.AddSuccessor(mergeBlock);
+        private BasicBlock BuildWhile(
+            BoundWhileStatement statement,
+            BasicBlock current,
+            BuildContext context)
+        {
+            var condition = CreateBlock();
+            var body = CreateBlock();
+            var after = CreateBlock();
+            TerminateFallThrough(current, condition);
+            TerminateConditional(condition, statement.Condition, body, after, context);
+
+            var depth = context.FinallyRegions.Count;
+            var loopContext = context.WithLoop(new LoopContext(
+                new FlowDestination(after, ControlFlowEdgeKind.Break, depth),
+                new FlowDestination(condition, ControlFlowEdgeKind.Continue, depth)));
+            var bodyEnd = BuildStatements(statement.Body, body, loopContext);
+            if (bodyEnd != null)
+                TerminateContinuation(bodyEnd, condition, ControlFlowEdgeKind.BackEdge);
+
+            return after;
+        }
+
+        private BasicBlock BuildFor(
+            BoundForStatement statement,
+            BasicBlock current,
+            BuildContext context)
+        {
+            current = AddSyntheticDefinition(
+                current,
+                SyntheticOperationKind.ForInitialization,
+                statement.LoopVariable,
+                statement.From,
+                statement.Span,
+                readsVariable: false,
+                context);
+
+            var condition = CreateBlock();
+            var body = CreateBlock();
+            var step = CreateBlock();
+            var after = CreateBlock();
+            TerminateFallThrough(current, condition);
+
+            var conditionExpression = new BoundStructuralExpression(
+                statement.Span,
+                "ForCondition",
+                "BOOL",
+                [
+                    new BoundVariableExpression(statement.Span, statement.LoopVariable),
+                    statement.To,
+                ]);
+            TerminateConditional(condition, conditionExpression, body, after, context);
+
+            var depth = context.FinallyRegions.Count;
+            var loopContext = context.WithLoop(new LoopContext(
+                new FlowDestination(after, ControlFlowEdgeKind.Break, depth),
+                new FlowDestination(step, ControlFlowEdgeKind.Continue, depth)));
+            var bodyEnd = BuildStatements(statement.Body, body, loopContext);
+            if (bodyEnd != null)
+                TerminateFallThrough(bodyEnd, step);
+
+            var stepExpression = new BoundStructuralExpression(
+                statement.Span,
+                "ForStep",
+                statement.LoopVariable.TypeName,
+                statement.Step == null
+                    ? [new BoundVariableExpression(statement.Span, statement.LoopVariable)]
+                    : [
+                        new BoundVariableExpression(statement.Span, statement.LoopVariable),
+                        statement.Step,
+                    ]);
+            var stepEnd = AddSyntheticDefinition(
+                step,
+                SyntheticOperationKind.ForStep,
+                statement.LoopVariable,
+                stepExpression,
+                statement.Span,
+                readsVariable: false,
+                context);
+            TerminateContinuation(stepEnd, condition, ControlFlowEdgeKind.BackEdge);
+
+            return after;
+        }
+
+        private BasicBlock BuildForeach(
+            BoundForeachStatement statement,
+            BasicBlock current,
+            BuildContext context)
+        {
+            current = AddSyntheticEvaluation(
+                current,
+                SyntheticOperationKind.ForeachCollectionEvaluation,
+                statement.Collection,
+                statement.Span,
+                context);
+
+            var condition = CreateBlock();
+            var iteration = CreateBlock();
+            var body = CreateBlock();
+            var after = CreateBlock();
+            iteration.SyntheticOperations.Add(new SyntheticOperation(
+                SyntheticOperationKind.ForeachIteration,
+                statement.Span,
+                statement.LoopVariable));
+            TerminateFallThrough(iteration, body);
+
+            TerminateFallThrough(current, condition);
+            var moveNext = new BoundStructuralExpression(
+                statement.Span,
+                "ForeachMoveNext",
+                "BOOL");
+            TerminateConditional(
+                condition,
+                moveNext,
+                iteration,
+                after,
+                context,
+                forceExceptionalEdge: true);
+
+            var depth = context.FinallyRegions.Count;
+            var loopContext = context.WithLoop(new LoopContext(
+                new FlowDestination(after, ControlFlowEdgeKind.Break, depth),
+                new FlowDestination(condition, ControlFlowEdgeKind.Continue, depth)));
+            var bodyEnd = BuildStatements(statement.Body, body, loopContext);
+            if (bodyEnd != null)
+                TerminateContinuation(bodyEnd, condition, ControlFlowEdgeKind.BackEdge);
+
+            return after;
+        }
+
+        private BasicBlock BuildDoWhile(
+            BoundDoWhileStatement statement,
+            BasicBlock current,
+            BuildContext context)
+        {
+            var body = CreateBlock();
+            var condition = CreateBlock();
+            var after = CreateBlock();
+            TerminateFallThrough(current, body);
+
+            var depth = context.FinallyRegions.Count;
+            var loopContext = context.WithLoop(new LoopContext(
+                new FlowDestination(after, ControlFlowEdgeKind.Break, depth),
+                new FlowDestination(condition, ControlFlowEdgeKind.Continue, depth)));
+            var bodyEnd = BuildStatements(statement.Body, body, loopContext);
+            if (bodyEnd != null)
+                TerminateFallThrough(bodyEnd, condition);
+
+            TerminateConditional(condition, statement.Condition, body, after, context);
+            return after;
+        }
+
+        private BasicBlock? BuildMatch(
+            BoundMatchStatement statement,
+            BasicBlock current,
+            BuildContext context)
+        {
+            current = AddSyntheticEvaluation(
+                current,
+                SyntheticOperationKind.MatchTargetEvaluation,
+                statement.Target,
+                statement.Span,
+                context);
+
+            var merge = CreateBlock();
+            var next = CreateBlock();
+            TerminateFallThrough(current, next);
+
+            for (var index = 0; index < statement.Cases.Count; index++)
+            {
+                var matchCase = statement.Cases[index];
+                var body = CreateBlock();
+
+                if (matchCase.IsDefault)
+                {
+                    TerminateFallThrough(next, body);
+                }
+                else
+                {
+                    var falseTarget = index + 1 < statement.Cases.Count
+                        ? CreateBlock()
+                        : merge;
+                    var conditionChildren = matchCase.Pattern.Expressions
+                        .Concat(matchCase.Guard == null
+                            ? Array.Empty<BoundExpression>()
+                            : [matchCase.Guard])
+                        .ToArray();
+                    var condition = new BoundStructuralExpression(
+                        matchCase.Span,
+                        "MatchCaseCondition",
+                        "BOOL",
+                        conditionChildren);
+                    TerminateConditional(
+                        next,
+                        condition,
+                        body,
+                        falseTarget,
+                        context);
+                    next = falseTarget;
+                }
+
+                var bodyEnd = BuildStatements(matchCase.Body, body, context);
+                if (bodyEnd != null)
+                    TerminateFallThrough(bodyEnd, merge);
+
+                if (matchCase.IsDefault)
+                {
+                    next = merge;
+                    break;
+                }
+            }
+
+            if (!next.HasTerminator && !ReferenceEquals(next, merge))
+                TerminateFallThrough(next, merge);
+
+            return merge.IncomingEdges.Count > 0 ? merge : null;
+        }
+
+        private BasicBlock? BuildTry(
+            BoundTryStatement statement,
+            BasicBlock current,
+            BuildContext context)
+        {
+            var tryEntry = CreateBlock();
+            var after = CreateBlock();
+            TerminateFallThrough(current, tryEntry);
+
+            var protectedContext = context;
+            if (statement.FinallyBody is { Count: > 0 })
+            {
+                var region = new FinallyRegion(
+                    statement.FinallyBody,
+                    context,
+                    null);
+                protectedContext = context.WithFinally(region);
+            }
+
+            BasicBlock? catchDispatch = null;
+            if (statement.CatchClauses.Count > 0)
+                catchDispatch = CreateBlock();
+
+            var tryContext = catchDispatch == null
+                ? protectedContext
+                : protectedContext.WithException(new FlowDestination(
+                    catchDispatch,
+                    ControlFlowEdgeKind.Throw,
+                    protectedContext.FinallyRegions.Count));
+
+            var tryEnd = BuildStatements(statement.TryBody, tryEntry, tryContext);
+            if (tryEnd != null)
+            {
+                TerminateRouted(
+                    tryEnd,
+                    new FlowDestination(
+                        after,
+                        ControlFlowEdgeKind.FallThrough,
+                        context.FinallyRegions.Count),
+                    protectedContext);
+            }
+
+            if (catchDispatch != null)
+            {
+                var dispatchEdges = new List<ControlFlowEdge>();
+                var hasCatchAll = false;
+                foreach (var catchClause in statement.CatchClauses)
+                {
+                    var catchEntry = CreateBlock();
+                    dispatchEdges.Add(AddEdge(
+                        catchDispatch,
+                        catchEntry,
+                        ControlFlowEdgeKind.Catch));
+                    hasCatchAll |= catchClause.ExceptionTypeName == null;
+
+                    if (catchClause.ExceptionVariable != null)
+                    {
+                        catchEntry.SyntheticOperations.Add(new SyntheticOperation(
+                            SyntheticOperationKind.CatchInitialization,
+                            catchClause.Span,
+                            catchClause.ExceptionVariable));
+                    }
+
+                    var catchBody = catchClause.ExceptionVariable == null
+                        ? catchEntry
+                        : CreateBlock();
+                    if (!ReferenceEquals(catchBody, catchEntry))
+                        TerminateFallThrough(catchEntry, catchBody);
+
+                    var catchEnd = BuildStatements(
+                        catchClause.Body,
+                        catchBody,
+                        protectedContext.WithException(context.ExceptionDestination));
+                    if (catchEnd != null)
+                    {
+                        TerminateRouted(
+                            catchEnd,
+                            new FlowDestination(
+                                after,
+                                ControlFlowEdgeKind.FallThrough,
+                                context.FinallyRegions.Count),
+                            protectedContext);
+                    }
+                }
+
+                if (!hasCatchAll)
+                {
+                    var uncaught = RouteDestination(
+                        context.ExceptionDestination,
+                        protectedContext);
+                    dispatchEdges.Add(AddEdge(
+                        catchDispatch,
+                        uncaught.Target,
+                        uncaught.EdgeKind));
+                }
+
+                catchDispatch.SetTerminator(new DispatchTerminator(null, dispatchEdges));
+            }
+
+            return after.IncomingEdges.Count > 0 ? after : null;
+        }
+
+        private BasicBlock? BuildUsing(
+            BoundUsingStatement statement,
+            BasicBlock current,
+            BuildContext context)
+        {
+            if (statement.Resource != null)
+            {
+                current = AddSyntheticDefinition(
+                    current,
+                    SyntheticOperationKind.UsingResourceInitialization,
+                    statement.Resource,
+                    statement.ResourceExpression,
+                    statement.Span,
+                    readsVariable: false,
+                    context);
             }
             else
             {
-                // No else branch - fall through to merge
-                prevBlock.AddSuccessor(mergeBlock);
+                current = AddSyntheticEvaluation(
+                    current,
+                    SyntheticOperationKind.UsingResourceEvaluation,
+                    statement.ResourceExpression,
+                    statement.Span,
+                    context);
             }
 
-            _currentBlock = mergeBlock;
-        }
+            var body = CreateBlock();
+            var after = CreateBlock();
+            TerminateFallThrough(current, body);
 
-        private void ProcessWhileStatement(BoundWhileStatement whileStmt)
-        {
-            // Create blocks for the loop structure
-            var conditionBlock = CreateBlock();
-            var bodyBlock = CreateBlock();
-            var afterBlock = CreateBlock();
+            var dispose = new SyntheticOperation(
+                SyntheticOperationKind.UsingDispose,
+                statement.Span,
+                statement.Resource,
+                readsDefinedVariable: statement.Resource != null,
+                mayThrow: true);
+            var region = new FinallyRegion(
+                Array.Empty<BoundStatement>(),
+                context,
+                dispose);
+            var protectedContext = context.WithFinally(region);
 
-            // Push loop context for break/continue
-            _loopConditionStack.Push(conditionBlock);
-            _loopExitStack.Push(afterBlock);
-
-            // Connect current block to condition
-            _currentBlock.AddSuccessor(conditionBlock);
-
-            // Condition block
-            conditionBlock.BranchCondition = whileStmt.Condition;
-            conditionBlock.AddSuccessor(bodyBlock);
-            conditionBlock.AddSuccessor(afterBlock);
-
-            // Process body
-            _currentBlock = bodyBlock;
-            foreach (var s in whileStmt.Body)
-                ProcessStatement(s);
-
-            // Loop back to condition (if we didn't return/break)
-            if (_currentBlock.Successors.Count == 0)
-                _currentBlock.AddSuccessor(conditionBlock);
-
-            // Pop loop context
-            _loopConditionStack.Pop();
-            _loopExitStack.Pop();
-
-            _currentBlock = afterBlock;
-        }
-
-        private void ProcessForStatement(BoundForStatement forStmt)
-        {
-            // Create blocks for the loop structure
-            // For loop: init -> condition -> body -> update -> condition
-            var conditionBlock = CreateBlock();
-            var bodyBlock = CreateBlock();
-            var afterBlock = CreateBlock();
-
-            // Push loop context for break/continue
-            _loopConditionStack.Push(conditionBlock);
-            _loopExitStack.Push(afterBlock);
-
-            // Initialize loop variable (already in forStmt.From)
-            // The loop variable initialization is implicit in the for structure
-
-            // Connect to condition block
-            _currentBlock.AddSuccessor(conditionBlock);
-
-            // Condition block - comparison with To value
-            conditionBlock.AddSuccessor(bodyBlock);
-            conditionBlock.AddSuccessor(afterBlock);
-
-            // Process body
-            _currentBlock = bodyBlock;
-            foreach (var s in forStmt.Body)
-                ProcessStatement(s);
-
-            // Loop back to condition (the step is implicit in for loop semantics)
-            if (_currentBlock.Successors.Count == 0)
-                _currentBlock.AddSuccessor(conditionBlock);
-
-            // Pop loop context
-            _loopConditionStack.Pop();
-            _loopExitStack.Pop();
-
-            _currentBlock = afterBlock;
-        }
-
-        private void ProcessBreakStatement(BoundBreakStatement breakStmt)
-        {
-            _currentBlock.Statements.Add(breakStmt);
-
-            if (_loopExitStack.Count > 0)
+            var bodyEnd = BuildStatements(statement.Body, body, protectedContext);
+            if (bodyEnd != null)
             {
-                // Connect to the loop exit block
-                _currentBlock.AddSuccessor(_loopExitStack.Peek());
+                TerminateRouted(
+                    bodyEnd,
+                    new FlowDestination(
+                        after,
+                        ControlFlowEdgeKind.FallThrough,
+                        context.FinallyRegions.Count),
+                    protectedContext);
             }
 
-            // Create a dead block after break (code after break is unreachable)
-            _currentBlock = CreateBlock();
+            return after.IncomingEdges.Count > 0 ? after : null;
         }
 
-        private void ProcessContinueStatement(BoundContinueStatement continueStmt)
+        private BasicBlock AddSyntheticDefinition(
+            BasicBlock current,
+            SyntheticOperationKind kind,
+            VariableSymbol variable,
+            BoundExpression expression,
+            TextSpan span,
+            bool readsVariable,
+            BuildContext context)
         {
-            _currentBlock.Statements.Add(continueStmt);
-
-            if (_loopConditionStack.Count > 0)
+            if (ExpressionMayThrow(expression))
             {
-                // Connect to the loop condition block
-                _currentBlock.AddSuccessor(_loopConditionStack.Peek());
+                current.SyntheticOperations.Add(new SyntheticOperation(
+                    SyntheticOperationKind.ExpressionEvaluation,
+                    span,
+                    expression: expression));
+                current = SplitExceptionalFlow(current, context);
+                current.SyntheticOperations.Add(new SyntheticOperation(
+                    kind,
+                    span,
+                    variable,
+                    readsDefinedVariable: readsVariable));
+                var continuation = CreateBlock();
+                TerminateFallThrough(current, continuation);
+                return continuation;
             }
 
-            // Create a dead block after continue (code after continue is unreachable)
-            _currentBlock = CreateBlock();
+            current.SyntheticOperations.Add(new SyntheticOperation(
+                kind,
+                span,
+                variable,
+                expression,
+                readsVariable));
+            return current;
         }
 
-        private void ProcessTryStatement(BoundTryStatement tryStmt)
+        private BasicBlock AddSyntheticEvaluation(
+            BasicBlock current,
+            SyntheticOperationKind kind,
+            BoundExpression expression,
+            TextSpan span,
+            BuildContext context)
         {
-            // Create blocks for try-catch-finally structure
-            var tryBlock = CreateBlock();
-            var afterBlock = CreateBlock();
+            current.SyntheticOperations.Add(new SyntheticOperation(
+                kind,
+                span,
+                expression: expression));
+            return ExpressionMayThrow(expression)
+                ? SplitExceptionalFlow(current, context)
+                : current;
+        }
 
-            // Create a landing block for exceptions thrown inside the try body
-            var exceptionLanding = CreateBlock();
-            _exceptionTargetStack.Push(exceptionLanding);
-
-            // Connect current block to try block
-            _currentBlock.AddSuccessor(tryBlock);
-            _currentBlock = tryBlock;
-
-            // Process try body (throws inside will now go to exceptionLanding)
-            foreach (var s in tryStmt.TryBody)
-                ProcessStatement(s);
-
-            _exceptionTargetStack.Pop();
-
-            // Save the block that ends the try body
-            var tryEndBlock = _currentBlock;
-
-            // Create blocks for catch clauses
-            var catchBlocks = new List<BasicBlock>();
-            foreach (var catchClause in tryStmt.CatchClauses)
+        private BasicBlock SplitExceptionalFlow(
+            BasicBlock current,
+            BuildContext context)
+        {
+            var normal = CreateBlock();
+            var exceptional = RouteDestination(context.ExceptionDestination, context);
+            var edges = new[]
             {
-                var catchBlock = CreateBlock();
-                catchBlocks.Add(catchBlock);
+                AddEdge(current, normal, ControlFlowEdgeKind.FallThrough),
+                AddEdge(current, exceptional.Target, exceptional.EdgeKind),
+            };
+            current.SetTerminator(new DispatchTerminator(null, edges));
+            return normal;
+        }
 
-                // Exception edges: try body can jump to catch on exception
-                tryBlock.AddSuccessor(catchBlock);
-                // Throws inside try also land here
-                exceptionLanding.AddSuccessor(catchBlock);
-
-                _currentBlock = catchBlock;
-                foreach (var s in catchClause.Body)
-                    ProcessStatement(s);
-
-                // Connect catch end to after block (if it didn't return/throw)
-                if (_currentBlock.Successors.Count == 0)
-                    _currentBlock.AddSuccessor(afterBlock);
+        private void TerminateConditional(
+            BasicBlock source,
+            BoundExpression condition,
+            BasicBlock trueTarget,
+            BasicBlock falseTarget,
+            BuildContext context,
+            bool forceExceptionalEdge = false)
+        {
+            var trueEdge = AddEdge(source, trueTarget, ControlFlowEdgeKind.True);
+            var falseEdge = AddEdge(source, falseTarget, ControlFlowEdgeKind.False);
+            ControlFlowEdge? exceptionalEdge = null;
+            if (forceExceptionalEdge || ExpressionMayThrow(condition))
+            {
+                var exceptional = RouteDestination(
+                    context.ExceptionDestination,
+                    context);
+                exceptionalEdge = AddEdge(
+                    source,
+                    exceptional.Target,
+                    exceptional.EdgeKind);
             }
 
-            // If no catch blocks, exception landing goes to exit
-            if (catchBlocks.Count == 0 && exceptionLanding.Successors.Count == 0)
-                exceptionLanding.AddSuccessor(_exitBlock);
+            source.SetTerminator(new ConditionalTerminator(
+                condition,
+                trueEdge,
+                falseEdge,
+                exceptionalEdge));
+        }
 
-            // Process finally block if present
-            if (tryStmt.FinallyBody != null && tryStmt.FinallyBody.Count > 0)
+        private void TerminateFallThrough(BasicBlock source, BasicBlock target)
+        {
+            var edge = AddEdge(source, target, ControlFlowEdgeKind.FallThrough);
+            source.SetTerminator(new FallThroughTerminator(edge));
+        }
+
+        private void TerminateContinuation(
+            BasicBlock source,
+            BasicBlock target,
+            ControlFlowEdgeKind edgeKind)
+        {
+            var edge = AddEdge(source, target, edgeKind);
+            source.SetTerminator(new ContinuationTerminator(edge));
+        }
+
+        private void TerminateRouted(
+            BasicBlock source,
+            FlowDestination destination,
+            BuildContext context)
+        {
+            var routed = RouteDestination(destination, context);
+            TerminateContinuation(source, routed.Target, routed.EdgeKind);
+        }
+
+        private void TerminateAbrupt(
+            BasicBlock source,
+            ControlFlowTerminatorKind kind,
+            FlowDestination destination)
+        {
+            var edge = AddEdge(source, destination.Target, destination.EdgeKind);
+            source.SetTerminator(new AbruptTerminator(kind, edge));
+        }
+
+        private ControlFlowEdge AddEdge(
+            BasicBlock source,
+            BasicBlock target,
+            ControlFlowEdgeKind kind)
+        {
+            var edge = new ControlFlowEdge(source, target, kind);
+            source.AddOutgoingEdge(edge);
+            target.AddIncomingEdge(edge);
+            return edge;
+        }
+
+        private FlowDestination RouteDestination(
+            FlowDestination destination,
+            BuildContext context)
+        {
+            if (destination.FinallyDepth > context.FinallyRegions.Count)
             {
-                var finallyBlock = CreateBlock();
+                throw new ControlFlowGraphValidationException(
+                    ["control-flow destination crosses into a protected region"]);
+            }
 
-                // All paths go through finally
-                if (tryEndBlock.Successors.Count == 0)
-                    tryEndBlock.AddSuccessor(finallyBlock);
+            var routed = destination;
+            for (var index = destination.FinallyDepth;
+                 index < context.FinallyRegions.Count;
+                 index++)
+            {
+                var entry = GetOrCreateFinallyEntry(
+                    context.FinallyRegions[index],
+                    routed);
+                routed = new FlowDestination(
+                    entry,
+                    ControlFlowEdgeKind.Finally,
+                    index + 1);
+            }
 
-                foreach (var catchBlock in catchBlocks)
+            return routed;
+        }
+
+        private BasicBlock GetOrCreateFinallyEntry(
+            FinallyRegion region,
+            FlowDestination downstream)
+        {
+            var key = new FinallyContinuationKey(
+                downstream.Target,
+                downstream.EdgeKind);
+            if (region.Entries.TryGetValue(key, out var cached))
+                return cached;
+
+            var entry = CreateBlock();
+            region.Entries.Add(key, entry);
+            var current = entry;
+
+            if (region.SyntheticOperation != null)
+            {
+                var template = region.SyntheticOperation;
+                current.SyntheticOperations.Add(new SyntheticOperation(
+                    template.Kind,
+                    template.Span,
+                    template.DefinedVariable,
+                    template.Expression,
+                    template.ReadsDefinedVariable,
+                    template.MayThrow,
+                    template.SourceStatement));
+                if (template.MayThrow)
+                    current = SplitExceptionalFlow(current, region.OuterContext);
+            }
+
+            var end = BuildStatements(region.Body, current, region.OuterContext);
+            if (end != null)
+            {
+                TerminateContinuation(
+                    end,
+                    downstream.Target,
+                    downstream.EdgeKind);
+            }
+
+            return entry;
+        }
+
+        private static bool StatementMayThrow(BoundStatement statement) =>
+            statement is BoundCallStatement
+            || BoundNodeHelpers.DescendantsAndSelf(statement).Any(node =>
+                node is BoundCallExpression
+                    or BoundThrowExpression
+                    or BoundUnsupportedExpression
+                    or BoundInteropExpression);
+
+        private static bool ExpressionMayThrow(BoundExpression? expression) =>
+            BoundNodeHelpers.DescendantsAndSelf(expression).Any(node =>
+                node is BoundCallExpression
+                    or BoundThrowExpression
+                    or BoundUnsupportedExpression
+                    or BoundInteropExpression);
+
+        private void PruneUnreachableBlocks()
+        {
+            var reachable = ComputeReachableBlocks(_entryBlock).ToHashSet();
+            var removed = _blocks
+                .Where(block =>
+                    !reachable.Contains(block) && !ReferenceEquals(block, _exitBlock))
+                .ToHashSet();
+            foreach (var block in removed)
+            {
+                foreach (var edge in block.OutgoingEdges.ToArray())
                 {
-                    // Also connect catch blocks to finally (already connected to after or exit)
+                    block.RemoveOutgoingEdge(edge);
+                    edge.Target.RemoveIncomingEdge(edge);
                 }
 
-                _currentBlock = finallyBlock;
-                foreach (var s in tryStmt.FinallyBody)
-                    ProcessStatement(s);
-
-                // Finally block continues to after block
-                if (_currentBlock.Successors.Count == 0)
-                    _currentBlock.AddSuccessor(afterBlock);
-            }
-            else
-            {
-                // No finally - try end goes directly to after
-                if (tryEndBlock.Successors.Count == 0)
-                    tryEndBlock.AddSuccessor(afterBlock);
-            }
-
-            _currentBlock = afterBlock;
-        }
-
-        private void ProcessMatchStatement(BoundMatchStatement matchStmt)
-        {
-            // Pattern matching is essentially a multi-way branch
-            var afterBlock = CreateBlock();
-
-            // Current block has the target expression
-            var matchConditionBlock = _currentBlock;
-
-            foreach (var matchCase in matchStmt.Cases)
-            {
-                var caseBlock = CreateBlock();
-                matchConditionBlock.AddSuccessor(caseBlock);
-
-                // If there's a guard, the case block has a branch condition
-                if (matchCase.Guard != null)
+                foreach (var edge in block.IncomingEdges.ToArray())
                 {
-                    caseBlock.BranchCondition = matchCase.Guard;
+                    edge.Source.RemoveOutgoingEdge(edge);
+                    block.RemoveIncomingEdge(edge);
                 }
-
-                _currentBlock = caseBlock;
-
-                foreach (var s in matchCase.Body)
-                    ProcessStatement(s);
-
-                // Connect case end to after block (if it didn't return/break)
-                if (_currentBlock.Successors.Count == 0)
-                    _currentBlock.AddSuccessor(afterBlock);
             }
 
-            // If no default case, the match condition block might also fall through
-            // (though well-formed match should be exhaustive)
-            var hasDefault = matchStmt.Cases.Any(c => c.IsDefault);
-            if (!hasDefault && matchConditionBlock.Successors.All(s => s != afterBlock))
+            _blocks.RemoveAll(removed.Contains);
+        }
+
+        private void AssignOrdinals()
+        {
+            var operationOrdinal = 0;
+            for (var index = 0; index < _blocks.Count; index++)
             {
-                matchConditionBlock.AddSuccessor(afterBlock);
+                var block = _blocks[index];
+                block.Id = index;
+                block.Ordinal = index;
+                foreach (var operation in block.SyntheticOperations)
+                    operation.Ordinal = operationOrdinal++;
             }
-
-            _currentBlock = afterBlock;
         }
 
-        private void ProcessForeachStatement(BoundForeachStatement forEach)
+        private sealed record FlowDestination(
+            BasicBlock Target,
+            ControlFlowEdgeKind EdgeKind,
+            int FinallyDepth);
+
+        private sealed record LoopContext(
+            FlowDestination BreakDestination,
+            FlowDestination ContinueDestination);
+
+        private sealed record FinallyContinuationKey(
+            BasicBlock Target,
+            ControlFlowEdgeKind EdgeKind);
+
+        private sealed class FinallyRegion
         {
-            // Foreach: condition (has next?) -> body -> condition
-            var conditionBlock = CreateBlock();
-            var bodyBlock = CreateBlock();
-            var afterBlock = CreateBlock();
+            public IReadOnlyList<BoundStatement> Body { get; }
+            public BuildContext OuterContext { get; }
+            public SyntheticOperation? SyntheticOperation { get; }
+            public Dictionary<FinallyContinuationKey, BasicBlock> Entries { get; } = new();
 
-            _loopConditionStack.Push(conditionBlock);
-            _loopExitStack.Push(afterBlock);
-
-            _currentBlock.AddSuccessor(conditionBlock);
-
-            conditionBlock.AddSuccessor(bodyBlock);
-            conditionBlock.AddSuccessor(afterBlock);
-
-            _currentBlock = bodyBlock;
-            foreach (var s in forEach.Body)
-                ProcessStatement(s);
-
-            if (_currentBlock.Successors.Count == 0)
-                _currentBlock.AddSuccessor(conditionBlock);
-
-            _loopConditionStack.Pop();
-            _loopExitStack.Pop();
-
-            _currentBlock = afterBlock;
+            public FinallyRegion(
+                IReadOnlyList<BoundStatement> body,
+                BuildContext outerContext,
+                SyntheticOperation? syntheticOperation)
+            {
+                Body = body;
+                OuterContext = outerContext;
+                SyntheticOperation = syntheticOperation;
+            }
         }
 
-        private void ProcessDoWhileStatement(BoundDoWhileStatement doWhile)
+        private sealed record BuildContext(
+            IReadOnlyList<LoopContext> Loops,
+            IReadOnlyList<FinallyRegion> FinallyRegions,
+            FlowDestination ExceptionDestination)
         {
-            // Do-while: body -> condition -> body (back edge) or after
-            var bodyBlock = CreateBlock();
-            var conditionBlock = CreateBlock();
-            var afterBlock = CreateBlock();
+            public BuildContext WithLoop(LoopContext loop) =>
+                this with { Loops = [.. Loops, loop] };
 
-            _loopConditionStack.Push(conditionBlock);
-            _loopExitStack.Push(afterBlock);
+            public BuildContext WithFinally(FinallyRegion region) =>
+                this with { FinallyRegions = [.. FinallyRegions, region] };
 
-            _currentBlock.AddSuccessor(bodyBlock);
-
-            _currentBlock = bodyBlock;
-            foreach (var s in doWhile.Body)
-                ProcessStatement(s);
-
-            if (_currentBlock.Successors.Count == 0)
-                _currentBlock.AddSuccessor(conditionBlock);
-
-            conditionBlock.BranchCondition = doWhile.Condition;
-            conditionBlock.AddSuccessor(bodyBlock);  // loop back
-            conditionBlock.AddSuccessor(afterBlock);  // exit
-
-            _loopConditionStack.Pop();
-            _loopExitStack.Pop();
-
-            _currentBlock = afterBlock;
-        }
-
-        private void ProcessUsingStatement(BoundUsingStatement usingStmt)
-        {
-            // Model as try/finally: body can throw, dispose runs on both normal and exception paths
-            _currentBlock.Statements.Add(usingStmt);
-
-            var bodyBlock = CreateBlock();
-            var disposeBlock = CreateBlock(); // implicit finally (Dispose)
-            var afterBlock = CreateBlock();
-
-            // Exception landing for throws inside the using body
-            var exceptionLanding = CreateBlock();
-            _exceptionTargetStack.Push(exceptionLanding);
-
-            _currentBlock.AddSuccessor(bodyBlock);
-            _currentBlock = bodyBlock;
-
-            foreach (var s in usingStmt.Body)
-                ProcessStatement(s);
-
-            _exceptionTargetStack.Pop();
-
-            // Normal path: body → dispose → after
-            if (_currentBlock.Successors.Count == 0)
-                _currentBlock.AddSuccessor(disposeBlock);
-
-            // Exception path: throw → exception landing → dispose → exit
-            exceptionLanding.AddSuccessor(disposeBlock);
-
-            _currentBlock = disposeBlock;
-            // Dispose block flows to after (normal) or exit (exception re-throw)
-            disposeBlock.AddSuccessor(afterBlock);
-            disposeBlock.AddSuccessor(_exitBlock);
-
-            _currentBlock = afterBlock;
+            public BuildContext WithException(FlowDestination destination) =>
+                this with { ExceptionDestination = destination };
         }
     }
 
-    /// <summary>
-    /// Generates a DOT representation for visualization.
-    /// </summary>
     public string ToDot()
     {
-        var sb = new System.Text.StringBuilder();
-        sb.AppendLine("digraph CFG {");
-        sb.AppendLine("  node [shape=box];");
+        var builder = new System.Text.StringBuilder();
+        builder.AppendLine("digraph CFG {");
+        builder.AppendLine("  node [shape=box];");
 
         foreach (var block in Blocks)
         {
             var label = $"BB{block.Id}";
-            if (block.IsEntry) label += " (entry)";
-            if (block.IsExit) label += " (exit)";
+            if (block.IsEntry)
+                label += " (entry)";
+            if (block.IsExit)
+                label += " (exit)";
+            label += $"\\n{block.Terminator.Kind}";
             if (block.Statements.Count > 0)
-            {
                 label += $"\\n{block.Statements.Count} stmts";
-            }
+            if (block.SyntheticOperations.Count > 0)
+                label += $"\\n{block.SyntheticOperations.Count} synthetic";
 
-            sb.AppendLine($"  BB{block.Id} [label=\"{label}\"];");
-
-            foreach (var succ in block.Successors)
+            builder.AppendLine($"  BB{block.Id} [label=\"{label}\"];");
+            foreach (var edge in block.OutgoingEdges)
             {
-                var edgeLabel = block.BranchCondition != null ? "cond" : "";
-                sb.AppendLine($"  BB{block.Id} -> BB{succ.Id} [label=\"{edgeLabel}\"];");
+                builder.AppendLine(
+                    $"  BB{block.Id} -> BB{edge.Target.Id} [label=\"{edge.Kind}\"];");
             }
         }
 
-        sb.AppendLine("}");
-        return sb.ToString();
+        builder.AppendLine("}");
+        return builder.ToString();
     }
 }

--- a/src/Calor.Compiler/Analysis/Dataflow/DataflowFramework.cs
+++ b/src/Calor.Compiler/Analysis/Dataflow/DataflowFramework.cs
@@ -42,10 +42,27 @@ public interface ITransferFunction<T> where T : IEquatable<T>
     /// </summary>
     T Transfer(BoundStatement statement, T input);
 
+    T Transfer(
+        BasicBlock block,
+        int statementIndex,
+        BoundStatement statement,
+        T input) => Transfer(statement, input);
+
     /// <summary>
     /// Computes the dataflow facts after evaluating an expression (for condition blocks).
     /// </summary>
     T TransferExpression(BoundExpression? expression, T input);
+
+    /// <summary>
+    /// Computes the dataflow facts after an implicit CFG operation.
+    /// </summary>
+    T TransferSynthetic(SyntheticOperation operation, T input) => input;
+
+    T TransferSynthetic(
+        BasicBlock block,
+        int operationIndex,
+        SyntheticOperation operation,
+        T input) => TransferSynthetic(operation, input);
 }
 
 /// <summary>
@@ -73,6 +90,39 @@ public sealed class BlockDataflowResult<T>
     }
 }
 
+public sealed class DataflowAnalysisResult<T> where T : IEquatable<T>
+{
+    public Dictionary<BasicBlock, BlockDataflowResult<T>> Blocks { get; }
+    public int Iterations { get; }
+    public bool IsConverged { get; }
+    public IReadOnlyList<BasicBlock> ReachableBlocks { get; }
+
+    internal DataflowAnalysisResult(
+        Dictionary<BasicBlock, BlockDataflowResult<T>> blocks,
+        int iterations,
+        bool isConverged,
+        IReadOnlyList<BasicBlock> reachableBlocks)
+    {
+        Blocks = blocks;
+        Iterations = iterations;
+        IsConverged = isConverged;
+        ReachableBlocks = reachableBlocks;
+    }
+}
+
+public sealed class DataflowConvergenceException : InvalidOperationException
+{
+    public int Iterations { get; }
+    public int MaximumIterations { get; }
+
+    public DataflowConvergenceException(int iterations, int maximumIterations)
+        : base($"Dataflow analysis did not converge within {maximumIterations} iterations")
+    {
+        Iterations = iterations;
+        MaximumIterations = maximumIterations;
+    }
+}
+
 /// <summary>
 /// Generic dataflow analysis framework using worklist algorithm.
 /// </summary>
@@ -82,17 +132,45 @@ public sealed class DataflowAnalysis<T> where T : IEquatable<T>
     private readonly IDataflowLattice<T> _lattice;
     private readonly ITransferFunction<T> _transfer;
     private readonly DataflowDirection _direction;
+    private readonly T _entryBoundary;
+    private readonly T _exitBoundary;
+    private readonly T _joinIdentity;
     private readonly int _maxIterations;
+    public DataflowAnalysisResult<T>? LastResult { get; private set; }
 
     public DataflowAnalysis(
         IDataflowLattice<T> lattice,
         ITransferFunction<T> transfer,
         DataflowDirection direction = DataflowDirection.Forward,
         int maxIterations = 1000)
+        : this(
+            lattice,
+            transfer,
+            direction,
+            direction == DataflowDirection.Forward ? lattice.Top : lattice.Bottom,
+            direction == DataflowDirection.Backward ? lattice.Top : lattice.Bottom,
+            lattice.Bottom,
+            maxIterations)
+    {
+    }
+
+    public DataflowAnalysis(
+        IDataflowLattice<T> lattice,
+        ITransferFunction<T> transfer,
+        DataflowDirection direction,
+        T entryBoundary,
+        T exitBoundary,
+        T joinIdentity,
+        int maxIterations = 1000)
     {
         _lattice = lattice ?? throw new ArgumentNullException(nameof(lattice));
         _transfer = transfer ?? throw new ArgumentNullException(nameof(transfer));
         _direction = direction;
+        _entryBoundary = entryBoundary;
+        _exitBoundary = exitBoundary;
+        _joinIdentity = joinIdentity;
+        if (maxIterations <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxIterations));
         _maxIterations = maxIterations;
     }
 
@@ -100,138 +178,164 @@ public sealed class DataflowAnalysis<T> where T : IEquatable<T>
     /// Runs the dataflow analysis on a control flow graph.
     /// </summary>
     /// <returns>A dictionary mapping each block to its dataflow results.</returns>
-    public Dictionary<BasicBlock, BlockDataflowResult<T>> Analyze(ControlFlowGraph cfg)
+    public Dictionary<BasicBlock, BlockDataflowResult<T>> Analyze(ControlFlowGraph cfg) =>
+        AnalyzeWithMetadata(cfg).Blocks;
+
+    public DataflowAnalysisResult<T> AnalyzeWithMetadata(ControlFlowGraph cfg)
     {
+        ArgumentNullException.ThrowIfNull(cfg);
+        LastResult = null;
         var results = new Dictionary<BasicBlock, BlockDataflowResult<T>>();
 
-        // Initialize all blocks with bottom
+        // Retain compatibility for callers that query an unreachable Exit block, but
+        // only reachable blocks participate in fixed-point computation.
         foreach (var block in cfg.Blocks)
         {
-            results[block] = new BlockDataflowResult<T>(_lattice.Bottom);
+            results[block] = new BlockDataflowResult<T>(_joinIdentity);
         }
 
-        // Entry/exit block initialization
-        if (_direction == DataflowDirection.Forward)
-        {
-            results[cfg.Entry].In = _lattice.Top;
-        }
-        else
-        {
-            results[cfg.Exit].Out = _lattice.Top;
-        }
+        results[cfg.Entry].In = _entryBoundary;
+        results[cfg.Exit].Out = _exitBoundary;
 
-        // Get blocks in appropriate order
-        var worklist = _direction == DataflowDirection.Forward
-            ? new Queue<BasicBlock>(cfg.GetReversePostOrder())
-            : new Queue<BasicBlock>(cfg.GetPostOrder());
-
-        var inWorklist = new HashSet<BasicBlock>(worklist);
+        var orderedBlocks = _direction == DataflowDirection.Forward
+            ? cfg.GetReversePostOrder()
+            : cfg.GetPostOrder();
+        var reachable = cfg.ReachableBlocks.ToHashSet();
+        var worklist = new Queue<BasicBlock>(orderedBlocks);
+        var inWorklist = new HashSet<BasicBlock>(orderedBlocks);
         var iterations = 0;
 
-        while (worklist.Count > 0 && iterations < _maxIterations)
+        while (worklist.Count > 0)
         {
+            if (iterations >= _maxIterations)
+                throw new DataflowConvergenceException(iterations, _maxIterations);
+
             iterations++;
             var block = worklist.Dequeue();
             inWorklist.Remove(block);
-
             var result = results[block];
-            var changed = false;
 
             if (_direction == DataflowDirection.Forward)
             {
-                // Compute IN as join of all predecessors' OUT
-                var newIn = block.Predecessors.Count == 0
-                    ? result.In
-                    : block.Predecessors
-                        .Select(p => results[p].Out)
-                        .Aggregate(_lattice.Bottom, _lattice.Join);
-
-                if (!newIn.Equals(result.In))
+                var newIn = ReferenceEquals(block, cfg.Entry)
+                    ? _entryBoundary
+                    : JoinFacts(
+                        block.IncomingEdges
+                            .Where(edge => reachable.Contains(edge.Source))
+                            .OrderBy(edge => edge.Source.Ordinal)
+                            .Select(edge => results[edge.Source].Out));
+                var currentFacts = newIn;
+                for (var index = 0; index < block.Statements.Count; index++)
                 {
-                    result.In = newIn;
-                    changed = true;
+                    currentFacts = _transfer.Transfer(
+                        block,
+                        index,
+                        block.Statements[index],
+                        currentFacts);
                 }
-
-                // Compute OUT using transfer function
-                var currentFacts = result.In;
-
-                // Apply transfer for branch condition (if any)
-                currentFacts = _transfer.TransferExpression(block.BranchCondition, currentFacts);
-
-                // Apply transfer for each statement
-                foreach (var stmt in block.Statements)
+                for (var index = 0; index < block.SyntheticOperations.Count; index++)
                 {
-                    currentFacts = _transfer.Transfer(stmt, currentFacts);
+                    currentFacts = _transfer.TransferSynthetic(
+                        block,
+                        index,
+                        block.SyntheticOperations[index],
+                        currentFacts);
                 }
+                currentFacts = _transfer.TransferExpression(
+                    block.Terminator.Condition,
+                    currentFacts);
 
-                if (!currentFacts.Equals(result.Out))
-                {
-                    result.Out = currentFacts;
-                    changed = true;
-                }
+                var changed = !newIn.Equals(result.In)
+                    || !currentFacts.Equals(result.Out);
+                result.In = newIn;
+                result.Out = currentFacts;
 
-                // Add successors to worklist if changed
                 if (changed)
                 {
-                    foreach (var succ in block.Successors)
-                    {
-                        if (!inWorklist.Contains(succ))
-                        {
-                            worklist.Enqueue(succ);
-                            inWorklist.Add(succ);
-                        }
-                    }
+                    Enqueue(
+                        block.OutgoingEdges
+                            .Where(edge => reachable.Contains(edge.Target))
+                            .Select(edge => edge.Target),
+                        worklist,
+                        inWorklist);
                 }
             }
-            else // Backward
+            else
             {
-                // Compute OUT as join of all successors' IN
-                var newOut = block.Successors.Count == 0
-                    ? result.Out
-                    : block.Successors
-                        .Select(s => results[s].In)
-                        .Aggregate(_lattice.Bottom, _lattice.Join);
-
-                if (!newOut.Equals(result.Out))
+                var newOut = ReferenceEquals(block, cfg.Exit)
+                    ? _exitBoundary
+                    : JoinFacts(
+                        block.OutgoingEdges
+                            .Where(edge => reachable.Contains(edge.Target))
+                            .OrderBy(edge => edge.Target.Ordinal)
+                            .Select(edge => results[edge.Target].In));
+                var currentFacts = _transfer.TransferExpression(
+                    block.Terminator.Condition,
+                    newOut);
+                for (var index = block.SyntheticOperations.Count - 1; index >= 0; index--)
                 {
-                    result.Out = newOut;
-                    changed = true;
+                    currentFacts = _transfer.TransferSynthetic(
+                        block,
+                        index,
+                        block.SyntheticOperations[index],
+                        currentFacts);
+                }
+                for (var index = block.Statements.Count - 1; index >= 0; index--)
+                {
+                    currentFacts = _transfer.Transfer(
+                        block,
+                        index,
+                        block.Statements[index],
+                        currentFacts);
                 }
 
-                // Compute IN using transfer function (in reverse order for backward)
-                var currentFacts = result.Out;
+                var changed = !newOut.Equals(result.Out)
+                    || !currentFacts.Equals(result.In);
+                result.Out = newOut;
+                result.In = currentFacts;
 
-                // Apply transfer for each statement in reverse
-                for (var i = block.Statements.Count - 1; i >= 0; i--)
-                {
-                    currentFacts = _transfer.Transfer(block.Statements[i], currentFacts);
-                }
-
-                // Apply transfer for branch condition
-                currentFacts = _transfer.TransferExpression(block.BranchCondition, currentFacts);
-
-                if (!currentFacts.Equals(result.In))
-                {
-                    result.In = currentFacts;
-                    changed = true;
-                }
-
-                // Add predecessors to worklist if changed
                 if (changed)
                 {
-                    foreach (var pred in block.Predecessors)
-                    {
-                        if (!inWorklist.Contains(pred))
-                        {
-                            worklist.Enqueue(pred);
-                            inWorklist.Add(pred);
-                        }
-                    }
+                    Enqueue(
+                        block.IncomingEdges
+                            .Where(edge => reachable.Contains(edge.Source))
+                            .Select(edge => edge.Source),
+                        worklist,
+                        inWorklist);
                 }
             }
         }
 
-        return results;
+        LastResult = new DataflowAnalysisResult<T>(
+            results,
+            iterations,
+            isConverged: true,
+            cfg.ReachableBlocks);
+        return LastResult;
+    }
+
+    private T JoinFacts(IEnumerable<T> facts)
+    {
+        using var enumerator = facts.GetEnumerator();
+        if (!enumerator.MoveNext())
+            return _joinIdentity;
+
+        var result = enumerator.Current;
+        while (enumerator.MoveNext())
+            result = _lattice.Join(result, enumerator.Current);
+        return result;
+    }
+
+    private static void Enqueue(
+        IEnumerable<BasicBlock> blocks,
+        Queue<BasicBlock> worklist,
+        HashSet<BasicBlock> inWorklist)
+    {
+        foreach (var block in blocks.Distinct().OrderBy(block => block.Ordinal))
+        {
+            if (inWorklist.Add(block))
+                worklist.Enqueue(block);
+        }
     }
 }
 

--- a/src/Calor.Compiler/Analysis/VerificationAnalysisPass.cs
+++ b/src/Calor.Compiler/Analysis/VerificationAnalysisPass.cs
@@ -603,10 +603,11 @@ public sealed class VerificationAnalysisPass
         }
         catch (Exception ex)
         {
-            ReportAnalysisIncomplete(
+            _diagnostics.ReportError(
                 function.Span,
-                $"Dataflow analysis of '{function.Symbol.DisplaySignature}' did not complete: " +
-                ex.GetType().Name);
+                DiagnosticCode.AnalysisICE,
+                $"Internal dataflow analysis failure for " +
+                $"'{function.Symbol.DisplaySignature}': {ex.GetType().Name}: {ex.Message}");
         }
 
         return issueCount;

--- a/tests/Calor.Compiler.Tests/Analysis/DataflowAnalysisTests.cs
+++ b/tests/Calor.Compiler.Tests/Analysis/DataflowAnalysisTests.cs
@@ -276,7 +276,7 @@ public class DataflowAnalysisTests
     }
 
     [Fact]
-    public void LiveVariables_GetAtExit_ReturnsSet()
+    public void LiveVariables_ExitBoundary_IsEmpty()
     {
         var source = @"
 §M{m001:Test}
@@ -290,7 +290,7 @@ public class DataflowAnalysisTests
         var analysis = new LiveVariablesAnalysis(cfg);
 
         var exitLive = analysis.GetLiveVariablesAtExit(cfg.Exit).ToList();
-        Assert.Contains("x", exitLive);
+        Assert.Empty(exitLive);
     }
 
     #endregion

--- a/tests/Calor.Compiler.Tests/Analysis/ExplicitDataflowAnalysisTests.cs
+++ b/tests/Calor.Compiler.Tests/Analysis/ExplicitDataflowAnalysisTests.cs
@@ -1,0 +1,804 @@
+using Calor.Compiler.Analysis;
+using Calor.Compiler.Analysis.Dataflow;
+using Calor.Compiler.Analysis.Dataflow.Analyses;
+using Calor.Compiler.Ast;
+using Calor.Compiler.Binding;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using Xunit;
+
+namespace Calor.Compiler.Tests.Analysis;
+
+public sealed class ExplicitDataflowAnalysisTests
+{
+    [Fact]
+    public void Cfg_UsesStablePerGraphIdsExplicitTerminatorsAndTypedEdges()
+    {
+        var condition = Variable("condition", "BOOL", "parameter:condition", isParameter: true);
+        var function = Function(
+            "Stable",
+            [condition],
+            [
+                new BoundIfStatement(
+                    Span(1),
+                    Reference(condition, 2),
+                    [new BoundReturnStatement(Span(3), Integer(1, 4))],
+                    [],
+                    [new BoundReturnStatement(Span(5), Integer(0, 6))]),
+            ]);
+
+        var first = ControlFlowGraph.Build(function);
+        var second = ControlFlowGraph.Build(function);
+
+        Assert.Equal(Enumerable.Range(0, first.Blocks.Count), first.Blocks.Select(block => block.Id));
+        Assert.Equal(first.Blocks.Select(block => block.Id), first.Blocks.Select(block => block.Ordinal));
+        Assert.Equal(first.ToDot(), second.ToDot());
+        Assert.All(first.Blocks, block => Assert.True(block.HasTerminator));
+        Assert.IsType<ConditionalTerminator>(first.Entry.Terminator);
+        Assert.Equal(
+            [ControlFlowEdgeKind.True, ControlFlowEdgeKind.False],
+            first.Entry.OutgoingEdges.Select(edge => edge.Kind));
+
+        var returns = first.Blocks
+            .Where(block => block.Terminator.Kind == ControlFlowTerminatorKind.Return)
+            .ToArray();
+        Assert.Equal(2, returns.Length);
+        Assert.All(returns, block =>
+        {
+            var edge = Assert.Single(block.OutgoingEdges);
+            Assert.Equal(ControlFlowEdgeKind.Return, edge.Kind);
+            Assert.DoesNotContain(
+                block.OutgoingEdges,
+                candidate => candidate.Kind == ControlFlowEdgeKind.FallThrough);
+        });
+        first.Validate();
+    }
+
+    [Fact]
+    public void Cfg_NestedLoopsRouteContinueAndBreakToNearestLegalTargets()
+    {
+        var inner = new BoundDoWhileStatement(
+            Span(10),
+            new BoundBoolLiteral(Span(11), false),
+            [new BoundContinueStatement(Span(12))]);
+        var outer = new BoundWhileStatement(
+            Span(13),
+            new BoundBoolLiteral(Span(14), true),
+            [inner, new BoundBreakStatement(Span(15))]);
+        var function = Function(
+            "NestedLoops",
+            [],
+            [outer, new BoundReturnStatement(Span(16), Integer(0, 17))]);
+
+        var cfg = ControlFlowGraph.Build(function);
+        var continueBlock = Assert.Single(cfg.Blocks.Where(block =>
+            block.Terminator.Kind == ControlFlowTerminatorKind.Continue));
+        var breakBlock = Assert.Single(cfg.Blocks.Where(block =>
+            block.Terminator.Kind == ControlFlowTerminatorKind.Break));
+        var returnBlock = Assert.Single(cfg.Blocks.Where(block =>
+            block.Terminator.Kind == ControlFlowTerminatorKind.Return));
+
+        Assert.Equal(ControlFlowEdgeKind.Continue, Assert.Single(continueBlock.OutgoingEdges).Kind);
+        Assert.IsType<ConditionalTerminator>(Assert.Single(continueBlock.Successors).Terminator);
+        Assert.Equal(ControlFlowEdgeKind.Break, Assert.Single(breakBlock.OutgoingEdges).Kind);
+        Assert.Same(returnBlock, Assert.Single(breakBlock.Successors));
+        Assert.All(
+            new[] { continueBlock, breakBlock, returnBlock },
+            block => Assert.DoesNotContain(
+                block.OutgoingEdges,
+                edge => edge.Kind == ControlFlowEdgeKind.FallThrough));
+    }
+
+    [Fact]
+    public void Cfg_AllAbruptBranchesDoNotReconnectUnreachableStatements()
+    {
+        var condition = Variable("condition", "BOOL", "parameter:abrupt", isParameter: true);
+        var unreachable = Variable("unreachable", "INT", "local:unreachable");
+        var unreachableStatement = new BoundBindStatement(
+            Span(18),
+            unreachable,
+            Integer(1, 19));
+        var function = Function(
+            "AbruptBranches",
+            [condition],
+            [
+                new BoundIfStatement(
+                    Span(20),
+                    Reference(condition, 21),
+                    [new BoundReturnStatement(Span(22), Integer(1, 23))],
+                    [],
+                    [new BoundThrowStatement(Span(24), Integer(2, 25))]),
+                unreachableStatement,
+            ]);
+
+        var cfg = ControlFlowGraph.Build(function);
+
+        Assert.DoesNotContain(
+            cfg.Blocks.SelectMany(block => block.Statements),
+            statement => ReferenceEquals(statement, unreachableStatement));
+        var abruptBlocks = cfg.Blocks.Where(block => block.Terminator.IsAbrupt).ToArray();
+        Assert.Equal(2, abruptBlocks.Length);
+        Assert.All(abruptBlocks, block =>
+            Assert.DoesNotContain(
+                block.OutgoingEdges,
+                edge => edge.Kind == ControlFlowEdgeKind.FallThrough));
+    }
+
+    [Fact]
+    public void Cfg_ForForeachDoWhileAndMatchHaveStructuralShapes()
+    {
+        var collection = Variable("items", "List<INT>", "parameter:items", isParameter: true);
+        var forVariable = Variable("i", "INT", "loop:i");
+        var foreachVariable = Variable("item", "INT", "loop:item");
+        var matchCase = new BoundMatchCase(
+            Span(20),
+            new BoundPattern(
+                Span(21),
+                "constant",
+                expressions: [Integer(1, 22)]),
+            isDefault: false,
+            guard: null,
+            body: [new BoundExpressionStatement(Span(23), Integer(1, 24))]);
+        var defaultCase = new BoundMatchCase(
+            Span(25),
+            new BoundPattern(Span(26), "default"),
+            isDefault: true,
+            guard: null,
+            body: [new BoundExpressionStatement(Span(27), Integer(0, 28))]);
+        var function = Function(
+            "Shapes",
+            [collection],
+            [
+                new BoundForStatement(
+                    Span(29),
+                    forVariable,
+                    Integer(0, 30),
+                    Integer(3, 31),
+                    Integer(1, 32),
+                    []),
+                new BoundForeachStatement(
+                    Span(33),
+                    foreachVariable,
+                    Reference(collection, 34),
+                    []),
+                new BoundDoWhileStatement(
+                    Span(35),
+                    new BoundBoolLiteral(Span(36), false),
+                    []),
+                new BoundMatchStatement(
+                    Span(37),
+                    Reference(collection, 38),
+                    [matchCase, defaultCase]),
+                new BoundReturnStatement(Span(39), Integer(0, 40)),
+            ]);
+
+        var cfg = ControlFlowGraph.Build(function);
+
+        Assert.Contains(cfg.Blocks.SelectMany(block => block.SyntheticOperations), operation =>
+            operation.Kind == SyntheticOperationKind.ForInitialization
+            && operation.DefinedVariable?.Id == forVariable.Id);
+        Assert.Contains(cfg.Blocks.SelectMany(block => block.SyntheticOperations), operation =>
+            operation.Kind == SyntheticOperationKind.ForStep
+            && operation.DefinedVariable?.Id == forVariable.Id);
+        Assert.Contains(cfg.Blocks.SelectMany(block => block.SyntheticOperations), operation =>
+            operation.Kind == SyntheticOperationKind.ForeachIteration
+            && operation.DefinedVariable?.Id == foreachVariable.Id);
+        Assert.Contains(cfg.Blocks.SelectMany(block => block.SyntheticOperations), operation =>
+            operation.Kind == SyntheticOperationKind.MatchTargetEvaluation);
+        Assert.True(cfg.Blocks.Count(block =>
+            block.Terminator is ConditionalTerminator) >= 4);
+        Assert.Contains(cfg.Blocks.SelectMany(block => block.OutgoingEdges), edge =>
+            edge.Kind == ControlFlowEdgeKind.BackEdge);
+    }
+
+    [Fact]
+    public void Cfg_TryCatchFinallyRoutesNormalAndAbruptExitsThroughFinally()
+    {
+        var condition = Variable("condition", "BOOL", "parameter:condition", isParameter: true);
+        var exception = Variable("ex", "Exception", "catch:ex");
+        var local = Variable("value", "INT", "local:value");
+        var cleanup = new BoundExpressionStatement(Span(50), Integer(99, 51));
+        var tryStatement = new BoundTryStatement(
+            Span(52),
+            [
+                new BoundCallStatement(Span(53), "MightThrow", []),
+                new BoundUnsupportedStatement(Span(54), "FutureStatement"),
+                new BoundIfStatement(
+                    Span(55),
+                    Reference(condition, 56),
+                    [new BoundReturnStatement(Span(57), Integer(1, 58))],
+                    [],
+                    [new BoundBindStatement(Span(59), local, Integer(2, 60))]),
+            ],
+            [
+                new BoundCatchClause(
+                    Span(61),
+                    "Exception",
+                    exception,
+                    [new BoundThrowStatement(Span(62), Reference(exception, 63))]),
+            ],
+            [cleanup]);
+        var function = Function(
+            "TryFinally",
+            [condition],
+            [tryStatement, new BoundReturnStatement(Span(64), Integer(0, 65))]);
+
+        var cfg = ControlFlowGraph.Build(function);
+        var callBlock = Assert.Single(cfg.Blocks.Where(block =>
+            block.Statements.Any(statement => statement is BoundCallStatement)));
+        Assert.IsType<DispatchTerminator>(callBlock.Terminator);
+        Assert.Contains(callBlock.OutgoingEdges, edge => edge.Kind == ControlFlowEdgeKind.FallThrough);
+        Assert.Contains(callBlock.OutgoingEdges, edge => edge.Kind == ControlFlowEdgeKind.Throw);
+
+        var unsupportedBlock = Assert.Single(cfg.Blocks.Where(block =>
+            block.Terminator is UnsupportedTerminator));
+        Assert.Contains(unsupportedBlock.OutgoingEdges, edge => edge.Kind == ControlFlowEdgeKind.Throw);
+
+        var catchDispatch = Assert.Single(cfg.Blocks.Where(block =>
+            block.Terminator is DispatchTerminator
+            && block.OutgoingEdges.Any(edge => edge.Kind == ControlFlowEdgeKind.Catch)
+            && block.Statements.Count == 0));
+        Assert.Contains(catchDispatch.OutgoingEdges, edge => edge.Kind == ControlFlowEdgeKind.Catch);
+        Assert.Contains(cfg.Blocks.SelectMany(block => block.SyntheticOperations), operation =>
+            operation.Kind == SyntheticOperationKind.CatchInitialization
+            && operation.DefinedVariable?.Id == exception.Id);
+
+        var protectedReturn = Assert.Single(cfg.Blocks.Where(block =>
+            block.Statements.Any(statement => statement.Span == Span(57))));
+        Assert.Equal(ControlFlowEdgeKind.Finally, Assert.Single(protectedReturn.OutgoingEdges).Kind);
+        var protectedThrow = Assert.Single(cfg.Blocks.Where(block =>
+            block.Statements.Any(statement => statement.Span == Span(62))));
+        Assert.Equal(ControlFlowEdgeKind.Finally, Assert.Single(protectedThrow.OutgoingEdges).Kind);
+
+        var cleanupBlocks = cfg.Blocks.Where(block =>
+            block.Statements.Contains(cleanup)).ToArray();
+        Assert.True(cleanupBlocks.Length >= 3);
+        Assert.Contains(cleanupBlocks, block =>
+            Assert.Single(block.OutgoingEdges).Kind == ControlFlowEdgeKind.FallThrough);
+        Assert.Contains(cleanupBlocks, block =>
+            Assert.Single(block.OutgoingEdges).Kind == ControlFlowEdgeKind.Return);
+        Assert.Contains(cleanupBlocks, block =>
+            Assert.Single(block.OutgoingEdges).Kind == ControlFlowEdgeKind.Throw);
+    }
+
+    [Fact]
+    public void Cfg_UsingRoutesReturnThroughDisposeFinally()
+    {
+        var input = Variable("input", "Resource", "parameter:input", isParameter: true);
+        var resource = Variable("resource", "Resource", "using:resource");
+        var usingStatement = new BoundUsingStatement(
+            Span(70),
+            resource,
+            Reference(input, 71),
+            [new BoundReturnStatement(Span(72), Reference(resource, 73))]);
+        var function = Function("Using", [input], [usingStatement]);
+
+        var cfg = ControlFlowGraph.Build(function);
+        var returnBlock = Assert.Single(cfg.Blocks.Where(block =>
+            block.Terminator.Kind == ControlFlowTerminatorKind.Return));
+        Assert.Equal(ControlFlowEdgeKind.Finally, Assert.Single(returnBlock.OutgoingEdges).Kind);
+        var dispose = Assert.Single(returnBlock.Successors);
+        Assert.Contains(dispose.SyntheticOperations, operation =>
+            operation.Kind == SyntheticOperationKind.UsingDispose
+            && operation.ReadsDefinedVariable);
+        Assert.Contains(dispose.OutgoingEdges, edge => edge.Kind == ControlFlowEdgeKind.FallThrough);
+        Assert.Contains(dispose.OutgoingEdges, edge => edge.Kind == ControlFlowEdgeKind.Throw);
+    }
+
+    [Fact]
+    public void Cfg_FinallyInterceptsBreakAndContinue()
+    {
+        var condition = Variable("condition", "BOOL", "parameter:loop-finally", isParameter: true);
+        var cleanup = new BoundExpressionStatement(Span(74), Integer(1, 75));
+        var protectedLoop = new BoundWhileStatement(
+            Span(76),
+            new BoundBoolLiteral(Span(77), true),
+            [
+                new BoundTryStatement(
+                    Span(78),
+                    [
+                        new BoundIfStatement(
+                            Span(79),
+                            Reference(condition, 80),
+                            [new BoundBreakStatement(Span(81))],
+                            [],
+                            [new BoundContinueStatement(Span(82))]),
+                    ],
+                    [],
+                    [cleanup]),
+            ]);
+        var function = Function(
+            "LoopFinally",
+            [condition],
+            [protectedLoop, new BoundReturnStatement(Span(83), Integer(0, 84))]);
+
+        var cfg = ControlFlowGraph.Build(function);
+        var breakBlock = Assert.Single(cfg.Blocks.Where(block =>
+            block.Terminator.Kind == ControlFlowTerminatorKind.Break));
+        var continueBlock = Assert.Single(cfg.Blocks.Where(block =>
+            block.Terminator.Kind == ControlFlowTerminatorKind.Continue));
+        Assert.Equal(ControlFlowEdgeKind.Finally, Assert.Single(breakBlock.OutgoingEdges).Kind);
+        Assert.Equal(ControlFlowEdgeKind.Finally, Assert.Single(continueBlock.OutgoingEdges).Kind);
+
+        var cleanupBlocks = cfg.Blocks.Where(block => block.Statements.Contains(cleanup)).ToArray();
+        Assert.Contains(cleanupBlocks, block =>
+            Assert.Single(block.OutgoingEdges).Kind == ControlFlowEdgeKind.Break);
+        Assert.Contains(cleanupBlocks, block =>
+            Assert.Single(block.OutgoingEdges).Kind == ControlFlowEdgeKind.Continue);
+    }
+
+    [Fact]
+    public void Initialization_AssignmentAndDiamondJoinsUseSymbolIdentity()
+    {
+        var condition = Variable("condition", "BOOL", "parameter:condition", isParameter: true);
+        var unsafeVariable = Variable("value", "INT", "local:unsafe");
+        var unsafeFunction = Function(
+            "UnsafeDiamond",
+            [condition],
+            [
+                new BoundBindStatement(Span(80), unsafeVariable, null),
+                new BoundIfStatement(
+                    Span(81),
+                    Reference(condition, 82),
+                    [
+                        new BoundAssignmentStatement(
+                            Span(83),
+                            Reference(unsafeVariable, 84),
+                            Integer(1, 85)),
+                    ],
+                    [],
+                    []),
+                new BoundReturnStatement(Span(86), Reference(unsafeVariable, 87)),
+            ]);
+
+        var unsafeAnalysis = new UninitializedVariablesAnalysis(
+            ControlFlowGraph.Build(unsafeFunction),
+            unsafeFunction.Symbol.Parameters);
+        var unsafeUse = Assert.Single(unsafeAnalysis.UninitializedUses.Where(use =>
+            use.VariableId == unsafeVariable.Id));
+        Assert.Equal(InitializationState.MaybeInitialized, unsafeUse.State);
+
+        var safeVariable = Variable("value", "INT", "local:safe");
+        var safeFunction = Function(
+            "SafeDiamond",
+            [condition],
+            [
+                new BoundBindStatement(Span(88), safeVariable, null),
+                new BoundIfStatement(
+                    Span(89),
+                    Reference(condition, 90),
+                    [
+                        new BoundAssignmentStatement(
+                            Span(91),
+                            Reference(safeVariable, 92),
+                            Integer(1, 93)),
+                    ],
+                    [],
+                    [
+                        new BoundAssignmentStatement(
+                            Span(94),
+                            Reference(safeVariable, 95),
+                            Integer(2, 96)),
+                    ]),
+                new BoundReturnStatement(Span(97), Reference(safeVariable, 98)),
+            ]);
+
+        var safeAnalysis = new UninitializedVariablesAnalysis(
+            ControlFlowGraph.Build(safeFunction),
+            safeFunction.Symbol.Parameters);
+        Assert.DoesNotContain(
+            safeAnalysis.UninitializedUses,
+            use => use.VariableId == safeVariable.Id);
+
+        var neverVariable = Variable("value", "INT", "local:never");
+        var neverFunction = Function(
+            "NeverInitializedDiamond",
+            [condition],
+            [
+                new BoundBindStatement(Span(99), neverVariable, null),
+                new BoundIfStatement(
+                    Span(100),
+                    Reference(condition, 101),
+                    [],
+                    [],
+                    []),
+                new BoundReturnStatement(Span(102), Reference(neverVariable, 103)),
+            ]);
+        var neverAnalysis = new UninitializedVariablesAnalysis(
+            ControlFlowGraph.Build(neverFunction),
+            neverFunction.Symbol.Parameters);
+        var neverUse = Assert.Single(neverAnalysis.UninitializedUses.Where(use =>
+            use.VariableId == neverVariable.Id));
+        Assert.Equal(InitializationState.Uninitialized, neverUse.State);
+    }
+
+    [Fact]
+    public void Initialization_ExplicitParameterBoundaryControlsWhichParametersAreInitialized()
+    {
+        var parameter = Variable("value", "INT", "parameter:explicit-boundary", isParameter: true);
+        var function = Function(
+            "ParameterBoundary",
+            [parameter],
+            [new BoundReturnStatement(Span(104), Reference(parameter, 105))]);
+
+        var initialized = new UninitializedVariablesAnalysis(
+            ControlFlowGraph.Build(function),
+            function.Symbol.Parameters);
+        Assert.Empty(initialized.UninitializedUses);
+
+        var excluded = new UninitializedVariablesAnalysis(
+            ControlFlowGraph.Build(function),
+            Array.Empty<VariableSymbol>());
+        var use = Assert.Single(excluded.UninitializedUses);
+        Assert.Equal(parameter.Id, use.VariableId);
+        Assert.Equal(InitializationState.Uninitialized, use.State);
+    }
+
+    [Fact]
+    public void Initialization_ThrowingRhsDefinesOnlyOnNormalContinuation()
+    {
+        var variable = Variable("value", "INT", "local:throwing-rhs");
+        var assignment = new BoundAssignmentStatement(
+            Span(99),
+            Reference(variable, 100),
+            new BoundCallExpression(
+                Span(101),
+                "GetValue",
+                [],
+                "INT"));
+        var catchReturn = new BoundReturnStatement(Span(102), Reference(variable, 103));
+        var function = Function(
+            "ThrowingRhs",
+            [],
+            [
+                new BoundBindStatement(Span(104), variable, null),
+                new BoundTryStatement(
+                    Span(105),
+                    [assignment, new BoundReturnStatement(Span(106), Reference(variable, 107))],
+                    [new BoundCatchClause(Span(108), null, null, [catchReturn])],
+                    null),
+            ]);
+
+        var cfg = ControlFlowGraph.Build(function);
+        var initialization = new UninitializedVariablesAnalysis(cfg);
+        Assert.Contains(initialization.UninitializedUses, use =>
+            use.VariableId == variable.Id
+            && use.Span == catchReturn.Span
+            && use.State == InitializationState.Uninitialized);
+        Assert.DoesNotContain(initialization.UninitializedUses, use =>
+            use.VariableId == variable.Id
+            && use.Span == Span(106));
+
+        var catchBlock = Assert.Single(cfg.Blocks.Where(block =>
+            block.Statements.Contains(catchReturn)));
+        var reaching = new ReachingDefinitionsAnalysis(cfg);
+        Assert.DoesNotContain(
+            reaching.GetReachingDefinitionsAtEntry(catchBlock),
+            definition => ReferenceEquals(definition.Statement, assignment));
+    }
+
+    [Fact]
+    public void Cfg_ReturnExpressionExceptionUsesThrowFlowBeforeReturn()
+    {
+        var function = Function(
+            "ThrowingReturn",
+            [],
+            [
+                new BoundTryStatement(
+                    Span(109),
+                    [
+                        new BoundReturnStatement(
+                            Span(110),
+                            new BoundCallExpression(
+                                Span(111),
+                                "GetValue",
+                                [],
+                                "INT")),
+                    ],
+                    [
+                        new BoundCatchClause(
+                            Span(112),
+                            null,
+                            null,
+                            [new BoundReturnStatement(Span(113), Integer(0, 114))]),
+                    ],
+                    null),
+            ]);
+
+        var cfg = ControlFlowGraph.Build(function);
+        var evaluation = Assert.Single(cfg.Blocks.Where(block =>
+            block.SyntheticOperations.Any(operation =>
+                operation.Kind == SyntheticOperationKind.ExpressionEvaluation)));
+        Assert.Contains(evaluation.OutgoingEdges, edge => edge.Kind == ControlFlowEdgeKind.Throw);
+        Assert.Contains(evaluation.OutgoingEdges, edge => edge.Kind == ControlFlowEdgeKind.FallThrough);
+        var returnContinuation = Assert.Single(evaluation.OutgoingEdges
+            .Where(edge => edge.Kind == ControlFlowEdgeKind.FallThrough)
+            .Select(edge => edge.Target));
+        Assert.Equal(ControlFlowTerminatorKind.Return, returnContinuation.Terminator.Kind);
+    }
+
+    [Fact]
+    public void Initialization_SyntheticForForeachCatchAndUsingDefinitionsAreVisible()
+    {
+        var collection = Variable("items", "List<INT>", "parameter:collection", isParameter: true);
+        var resourceInput = Variable("input", "Resource", "parameter:resource", isParameter: true);
+        var forVariable = Variable("i", "INT", "loop:for");
+        var foreachVariable = Variable("item", "INT", "loop:foreach");
+        var exception = Variable("ex", "Exception", "catch:exception");
+        var resource = Variable("resource", "Resource", "using:resource-safe");
+        var function = Function(
+            "SyntheticInitialization",
+            [collection, resourceInput],
+            [
+                new BoundForStatement(
+                    Span(100),
+                    forVariable,
+                    Integer(0, 101),
+                    Integer(1, 102),
+                    Integer(1, 103),
+                    [new BoundCallStatement(Span(104), "Use", [Reference(forVariable, 105)])]),
+                new BoundForeachStatement(
+                    Span(106),
+                    foreachVariable,
+                    Reference(collection, 107),
+                    [new BoundCallStatement(Span(108), "Use", [Reference(foreachVariable, 109)])]),
+                new BoundTryStatement(
+                    Span(110),
+                    [new BoundCallStatement(Span(111), "MightThrow", [])],
+                    [
+                        new BoundCatchClause(
+                            Span(112),
+                            null,
+                            exception,
+                            [new BoundCallStatement(Span(113), "Use", [Reference(exception, 114)])]),
+                    ],
+                    null),
+                new BoundUsingStatement(
+                    Span(115),
+                    resource,
+                    Reference(resourceInput, 116),
+                    [new BoundCallStatement(Span(117), "Use", [Reference(resource, 118)])]),
+                new BoundReturnStatement(Span(119), Integer(0, 120)),
+            ]);
+
+        var cfg = ControlFlowGraph.Build(function);
+        var initialization = new UninitializedVariablesAnalysis(cfg, function.Symbol.Parameters);
+        Assert.DoesNotContain(
+            initialization.UninitializedUses,
+            use => use.VariableId == forVariable.Id
+                || use.VariableId == foreachVariable.Id
+                || use.VariableId == exception.Id
+                || use.VariableId == resource.Id);
+
+        var reaching = new ReachingDefinitionsAnalysis(cfg);
+        Assert.Contains(reaching.AllDefinitions, definition =>
+            definition.VariableId == forVariable.Id
+            && definition.SyntheticOperation?.Kind == SyntheticOperationKind.ForInitialization);
+        Assert.Contains(reaching.AllDefinitions, definition =>
+            definition.VariableId == foreachVariable.Id
+            && definition.SyntheticOperation?.Kind == SyntheticOperationKind.ForeachIteration);
+        Assert.Contains(reaching.AllDefinitions, definition =>
+            definition.VariableId == exception.Id
+            && definition.SyntheticOperation?.Kind == SyntheticOperationKind.CatchInitialization);
+        Assert.Contains(reaching.AllDefinitions, definition =>
+            definition.VariableId == resource.Id
+            && definition.SyntheticOperation?.Kind == SyntheticOperationKind.UsingResourceInitialization);
+    }
+
+    [Fact]
+    public void Liveness_SelfUpdateReadsOldValueBeforeStrongWrite()
+    {
+        var variable = Variable("value", "INT", "local:self-update");
+        var declaration = new BoundBindStatement(Span(130), variable, Integer(0, 131));
+        var assignment = new BoundCompoundAssignment(
+            Span(132),
+            Reference(variable, 133),
+            CompoundAssignmentOperator.Add,
+            Integer(1, 136));
+        var function = Function(
+            "SelfUpdate",
+            [],
+            [declaration, assignment, new BoundReturnStatement(Span(137), Reference(variable, 138))]);
+
+        var analysis = new LiveVariablesAnalysis(ControlFlowGraph.Build(function));
+        var dead = analysis.FindDeadAssignmentsWithSymbols().ToArray();
+
+        Assert.DoesNotContain(dead, item => ReferenceEquals(item.Statement, declaration));
+        Assert.DoesNotContain(dead, item => ReferenceEquals(item.Statement, assignment));
+    }
+
+    [Fact]
+    public void ReachingDefinitions_StrongUpdateAndOrdinalsAreDeterministic()
+    {
+        var loopVariable = Variable("i", "INT", "loop:reaching");
+        var function = Function(
+            "Reaching",
+            [],
+            [
+                new BoundForStatement(
+                    Span(140),
+                    loopVariable,
+                    Integer(0, 141),
+                    Integer(2, 142),
+                    Integer(1, 143),
+                    []),
+                new BoundReturnStatement(Span(144), Integer(0, 145)),
+            ]);
+
+        var firstCfg = ControlFlowGraph.Build(function);
+        var first = new ReachingDefinitionsAnalysis(firstCfg);
+        var second = new ReachingDefinitionsAnalysis(ControlFlowGraph.Build(function));
+
+        Assert.Equal(
+            Enumerable.Range(0, first.AllDefinitions.Count),
+            first.AllDefinitions.Select(definition => definition.DefinitionOrdinal));
+        Assert.Equal(
+            first.AllDefinitions.Select(definition => (
+                definition.BlockId,
+                definition.StatementIndex,
+                definition.DefinitionOrdinal,
+                definition.SyntheticOperation?.Kind)),
+            second.AllDefinitions.Select(definition => (
+                definition.BlockId,
+                definition.StatementIndex,
+                definition.DefinitionOrdinal,
+                definition.SyntheticOperation?.Kind)));
+
+        var stepBlock = Assert.Single(firstCfg.Blocks.Where(block =>
+            block.SyntheticOperations.Any(operation =>
+                operation.Kind == SyntheticOperationKind.ForStep)));
+        var reachingAtStepExit = first.GetReachingDefinitionsAtExit(stepBlock)
+            .Where(definition => definition.VariableId == loopVariable.Id)
+            .ToArray();
+        var stepDefinition = Assert.Single(reachingAtStepExit);
+        Assert.Equal(SyntheticOperationKind.ForStep, stepDefinition.SyntheticOperation?.Kind);
+    }
+
+    [Fact]
+    public void Dataflow_ReportsReachabilityConvergenceAndBoundedFailure()
+    {
+        var function = Function(
+            "Convergence",
+            [],
+            [new BoundReturnStatement(Span(150), Integer(0, 151))]);
+        var cfg = ControlFlowGraph.Build(function);
+        var lattice = new SetLattice<string>();
+        var transfer = new NoOpTransfer();
+        var analysis = new DataflowAnalysis<ImmutableHashSet<string>>(
+            lattice,
+            transfer,
+            DataflowDirection.Forward,
+            ImmutableHashSet<string>.Empty,
+            ImmutableHashSet<string>.Empty,
+            ImmutableHashSet<string>.Empty);
+
+        var result = analysis.AnalyzeWithMetadata(cfg);
+        Assert.True(result.IsConverged);
+        Assert.True(result.Iterations >= cfg.ReachableBlocks.Count);
+        Assert.Equal(cfg.ReachableBlocks, result.ReachableBlocks);
+        Assert.Same(result, analysis.LastResult);
+
+        var bounded = new DataflowAnalysis<ImmutableHashSet<string>>(
+            lattice,
+            transfer,
+            DataflowDirection.Forward,
+            ImmutableHashSet<string>.Empty,
+            ImmutableHashSet<string>.Empty,
+            ImmutableHashSet<string>.Empty,
+            maxIterations: 1);
+        Assert.Throws<DataflowConvergenceException>(() => bounded.Analyze(cfg));
+        Assert.Null(bounded.LastResult);
+    }
+
+    [Fact]
+    public void InitializationLattice_JoinIsAnUpperBoundInDiamondOrdering()
+    {
+        var variable = SymbolId.Create("lattice:value");
+        var variables = new HashSet<SymbolId> { variable };
+        var lattice = new InitializationLattice(variables);
+        var uninitialized = InitializationFacts.Create(variables, []);
+        var initialized = InitializationFacts.Create(variables, variables);
+        var maybe = lattice.Join(uninitialized, initialized);
+
+        Assert.Equal(InitializationState.MaybeInitialized, maybe.GetState(variable));
+        Assert.True(lattice.LessOrEqual(uninitialized, maybe));
+        Assert.True(lattice.LessOrEqual(initialized, maybe));
+        Assert.False(lattice.LessOrEqual(maybe, initialized));
+        Assert.False(lattice.LessOrEqual(initialized, uninitialized));
+    }
+
+    [Fact]
+    public void Cfg_InvalidBreakFailsExplicitlyInsteadOfProducingPartialGraph()
+    {
+        var function = Function(
+            "InvalidBreak",
+            [],
+            [new BoundBreakStatement(Span(160))]);
+
+        Assert.Throws<ControlFlowGraphValidationException>(() =>
+            ControlFlowGraph.Build(function));
+    }
+
+    [Fact]
+    public void VerificationPass_ReportsCfgFailureAsInternalDiagnostic()
+    {
+        var function = Function(
+            "InvalidBreakDiagnostic",
+            [],
+            [new BoundBreakStatement(Span(161))]);
+        var diagnostics = new DiagnosticBag();
+        var pass = new VerificationAnalysisPass(
+            diagnostics,
+            new VerificationAnalysisOptions
+            {
+                EnableDataflow = true,
+                EnableBugPatterns = false,
+                EnableTaintAnalysis = false,
+                EnableContractInference = false,
+                EnableKInduction = false,
+            });
+
+        pass.AnalyzeBound(Module(function));
+
+        Assert.Contains(diagnostics, diagnostic =>
+            diagnostic.Code == DiagnosticCode.AnalysisICE
+            && diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.DoesNotContain(diagnostics, diagnostic =>
+            diagnostic.Code == DiagnosticCode.AnalysisSkipped
+            && diagnostic.Message.Contains("dataflow", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static TextSpan Span(int start) => new(start, start + 1, 1, start + 1);
+
+    private static BoundIntLiteral Integer(long value, int start) =>
+        new(Span(start), value);
+
+    private static BoundVariableExpression Reference(VariableSymbol variable, int start) =>
+        new(Span(start), variable);
+
+    private static VariableSymbol Variable(
+        string name,
+        string type,
+        string id,
+        bool isParameter = false) =>
+        new(
+            SymbolId.Create(id),
+            name,
+            type,
+            isMutable: true,
+            isParameter,
+            declarationSpan: Span(id.Length));
+
+    private static BoundFunction Function(
+        string name,
+        IReadOnlyList<VariableSymbol> parameters,
+        IReadOnlyList<BoundStatement> body)
+    {
+        var symbol = new FunctionSymbol(
+            SymbolId.Create($"function:{name}"),
+            name,
+            "INT",
+            parameters,
+            declarationSpan: Span(name.Length + 200));
+        return new BoundFunction(symbol.DeclarationSpan, symbol, body, new Scope());
+    }
+
+    private static BoundModule Module(BoundFunction function)
+    {
+        var symbols = new Symbol[] { function.Symbol }
+            .Concat(function.Symbol.Parameters)
+            .ToDictionary(symbol => symbol.Id);
+        return new BoundModule(Span(0), "Module", [function], symbols);
+    }
+
+    private sealed class NoOpTransfer : ITransferFunction<ImmutableHashSet<string>>
+    {
+        public ImmutableHashSet<string> Transfer(
+            BoundStatement statement,
+            ImmutableHashSet<string> input) => input;
+
+        public ImmutableHashSet<string> TransferExpression(
+            BoundExpression? expression,
+            ImmutableHashSet<string> input) => input;
+    }
+}


### PR DESCRIPTION
## Summary
- replace positional CFG construction with explicit terminators and typed edges
- route loop, exception, catch, finally, using, return, throw, break, and continue flow structurally
- separate dataflow boundaries from lattice identities and fail explicitly on non-convergence
- make initialization, liveness, and reaching definitions symbol-keyed and semantically ordered
- surface CFG/dataflow failures as Calor0932 internal diagnostics
- add graph-shape, abrupt-flow, initialization, liveness, determinism, convergence, and lattice regressions

## Validation
- 67 targeted CFG/dataflow tests passed
- full Release suite: 6,825 passed, 2 skipped, 0 failed
- Release build: 0 warnings, 0 errors
- adversarial review completed; lattice-order finding fixed and follow-up review clean

Closes #783