### PR TITLE
Align Z3 translation with executable C# semantics

### DIFF
--- a/eng/test-manifest.json
+++ b/eng/test-manifest.json
@@ -89,7 +89,7 @@
       "path": "tests/Calor.Verification.Tests/Calor.Verification.Tests.csproj",
       "workflow": ".github/workflows/test.yml",
       "releaseCritical": true,
-      "expectedTotal": 388,
+      "expectedTotal": 967,
       "expectedSkipped": 0
     }
   ],
@@ -128,7 +128,7 @@
     },
     {
       "reason": "Z3 not available",
-      "count": 376
+      "count": 380
     },
     {
       "reason": "corpus submodules not initialized",

--- a/eng/test-manifest.json
+++ b/eng/test-manifest.json
@@ -89,7 +89,7 @@
       "path": "tests/Calor.Verification.Tests/Calor.Verification.Tests.csproj",
       "workflow": ".github/workflows/test.yml",
       "releaseCritical": true,
-      "expectedTotal": 967,
+      "expectedTotal": 393,
       "expectedSkipped": 0
     }
   ],
@@ -128,7 +128,7 @@
     },
     {
       "reason": "Z3 not available",
-      "count": 380
+      "count": 381
     },
     {
       "reason": "corpus submodules not initialized",

--- a/src/Calor.Compiler/Verification/VerificationResult.cs
+++ b/src/Calor.Compiler/Verification/VerificationResult.cs
@@ -46,6 +46,9 @@ public record ContractVerificationResult(
     TimeSpan? Duration = null,
     ProofOutcome? Outcome = null)
 {
+    /// <summary>The executable-semantics model used for this verification result.</summary>
+    public string TranslatorSemanticsVersion { get; init; } = ContractTranslator.SemanticsVersion;
+
     /// <summary>Builds a result whose legacy fields are all derived from the choke-point outcome.</summary>
     public static ContractVerificationResult FromOutcome(
         ProofOutcome outcome,

--- a/src/Calor.Compiler/Verification/Z3/Cache/VerificationCache.cs
+++ b/src/Calor.Compiler/Verification/Z3/Cache/VerificationCache.cs
@@ -17,7 +17,8 @@ public sealed class VerificationCache : IDisposable
     private readonly string? _z3Version;
     private readonly string? _keyScope;
     // #778: semantics-versioned, solver-config-aware keys.
-    private readonly string _semanticsVersion = Incremental.BuildStateCache.CurrentCompilerSemanticsVersion;
+    private readonly string _semanticsVersion =
+        $"{Incremental.BuildStateCache.CurrentCompilerSemanticsVersion}|{ContractTranslator.SemanticsVersion}";
     private readonly uint? _solverTimeoutMs;
     private readonly object _lock = new();
     // #778: ContractHasher carries per-call state (SawUnhashedKind); hash + flag read

--- a/src/Calor.Compiler/Verification/Z3/ContractTranslator.cs
+++ b/src/Calor.Compiler/Verification/Z3/ContractTranslator.cs
@@ -62,7 +62,8 @@ public sealed class ContractTranslator
     /// <summary>
     /// Tracks metadata for bit-vector expressions (width and signedness).
     /// </summary>
-    private readonly Dictionary<Expr, BitVecInfo> _exprInfo = new();
+    private readonly Dictionary<Expr, BitVecInfo> _exprInfo =
+        new(ReferenceEqualityComparer.Instance);
 
     private record struct BitVecInfo(uint Width, bool IsSigned);
 
@@ -657,9 +658,10 @@ public sealed class ContractTranslator
     {
         // Shift counts wider than 32 bits have no C# typing (the count operand
         // must convert to int); refuse rather than guess (review #833 C3).
-        if (op is BinaryOperator.LeftShift or BinaryOperator.RightShift && right.SortSize > 32)
+        if (op is BinaryOperator.LeftShift or BinaryOperator.RightShift
+            && (right.SortSize > 32 || right.SortSize == 32 && !IsSigned(right)))
         {
-            return "a shift count wider than 32 bits has no C# typing (the count must be an int)";
+            return "the shift count is not implicitly convertible to int";
         }
 
         // Genuinely-mixed signedness (no literal rescue) below 64 bits is MODELED
@@ -743,7 +745,7 @@ public sealed class ContractTranslator
     private BitVecExpr ConvertIntegral(BitVecExpr operand, uint targetWidth, bool targetSigned)
     {
         if (operand.SortSize == targetWidth)
-            return TrackBitVec(operand, targetWidth, targetSigned);
+            return operand;
 
         var converted = IsSigned(operand)
             ? _ctx.MkSignExt(targetWidth - operand.SortSize, operand)

--- a/src/Calor.Compiler/Verification/Z3/ContractTranslator.cs
+++ b/src/Calor.Compiler/Verification/Z3/ContractTranslator.cs
@@ -32,17 +32,6 @@ namespace Calor.Compiler.Verification.Z3;
 /// as an unsigned 32-bit value.
 /// </para>
 /// <para>
-/// <b>Limitation - Narrow type promotion:</b> Unlike C#, which promotes byte/sbyte/short/ushort
-/// to int before arithmetic operations, this translator preserves the original bit-width.
-/// This means overflow behavior for narrow types may differ from C# runtime behavior.
-/// For example: <c>byte a = 200; byte b = 200; int c = a + b;</c> yields 400 in C# (promoted to int),
-/// but would wrap to 144 in this translator (8-bit addition).
-/// </para>
-/// <para>
-/// <b>Limitation - Integer literals:</b> All integer literals are treated as signed 32-bit values.
-/// Literals outside the 32-bit range may be truncated.
-/// </para>
-/// <para>
 /// <b>Limitation - Null strings:</b> Z3 strings cannot be null - they are always valid sequences.
 /// The <c>IsNullOrEmpty</c> operation only checks if the string length equals zero. Code that
 /// relies on null string semantics may not verify correctly.
@@ -60,6 +49,12 @@ namespace Calor.Compiler.Verification.Z3;
 /// </remarks>
 public sealed class ContractTranslator
 {
+    /// <summary>
+    /// Version of the executable-semantics model used to translate contracts.
+    /// This value participates in verification cache validity.
+    /// </summary>
+    public const string SemanticsVersion = "z3-executable-semantics-v2";
+
     private readonly Context _ctx;
     private readonly Dictionary<string, (Expr Expr, string Type)> _variables = new();
     private readonly Stack<Dictionary<string, (Expr Expr, string Type)>> _scopeStack = new();
@@ -426,16 +421,7 @@ public sealed class ContractTranslator
     {
         return node switch
         {
-            // Literals outside the signed 32-bit domain are REFUSED, not wrapped
-            // (#826 review C4 follow-through): MkBV silently truncates mod 2^32,
-            // which corrupted verdicts in BOTH directions — false refutations
-            // with nonsense counterexamples, and inverted implication verdicts
-            // in the weakening check. Refusal surfaces as unsupported/
-            // indeterminate, the honest outcome until literals are translated
-            // width-aware.
-            IntLiteralNode intLit when intLit.IsUnsigned && intLit.UnsignedValue > int.MaxValue => null,
-            IntLiteralNode intLit when intLit.Value > int.MaxValue || intLit.Value < int.MinValue => null,
-            IntLiteralNode intLit => TrackBitVec(_ctx.MkBV(intLit.Value, 32), 32, isSigned: true),
+            IntLiteralNode intLit => TranslateIntLiteral(intLit),
             BoolLiteralNode boolLit => _ctx.MkBool(boolLit.Value),
             ReferenceNode refNode => TranslateReference(refNode),
             BinaryOperationNode binOp => TranslateBinaryOp(binOp),
@@ -477,6 +463,20 @@ public sealed class ContractTranslator
         }
 
         return null;
+    }
+
+    private BitVecExpr TranslateIntLiteral(IntLiteralNode literal)
+    {
+        if (literal.IsUnsigned)
+        {
+            var width = literal.IsLong || literal.UnsignedValue > uint.MaxValue ? 64u : 32u;
+            return TrackBitVec(_ctx.MkBV(literal.UnsignedValue, width), width, isSigned: false);
+        }
+
+        var signedWidth = literal.IsLong || literal.Value is > int.MaxValue or < int.MinValue
+            ? 64u
+            : 32u;
+        return TrackBitVec(_ctx.MkBV(literal.Value, signedWidth), signedWidth, isSigned: true);
     }
 
     /// <summary>
@@ -581,9 +581,7 @@ public sealed class ContractTranslator
         if (left == null || right == null)
             return null;
 
-        // W1 Slice 1 (T1): refuse the operand typings whose solver semantics
-        // provably diverge from C# runtime semantics — proving through them can
-        // mint a false Proven that elides a runtime guard.
+        // Refuse operand typings that have no executable C# semantics.
         if (left is BitVecExpr lRefuse && right is BitVecExpr rRefuse)
         {
             var refusal = DiagnoseUnmodeledBitVecTyping(node.Operator, lRefuse, rRefuse);
@@ -650,28 +648,13 @@ public sealed class ContractTranslator
     /// <summary>
     /// W1 Slice 1 (T1): names the bit-vector operand typings whose solver
     /// semantics diverge from C# runtime semantics; null = modeled.
-    /// (1) Arithmetic/shifts where BOTH operands are sub-32-bit: C# promotes
-    /// narrow integers to int and computes at ≥32 bits, while the solver would
-    /// wrap at the narrow width (divergence D1 — `i8 100+100` is 200 at runtime,
-    /// -56 in an 8-bit solver add). A 32-bit-or-wider operand rescues the pair:
-    /// width normalization extends the narrow side first, matching promotion.
-    /// (2) Mixed signed/unsigned comparison, equality, and division where the
+    /// Mixed signed/unsigned comparison, equality, and division where the
     /// signed operand is not a provably non-negative literal: C# compares via
     /// promotion to a wider signed type, while a same-width solver comparison
     /// reads the bit pattern (`-1 == 4294967295u` would hold).
     /// </summary>
     private string? DiagnoseUnmodeledBitVecTyping(BinaryOperator op, BitVecExpr left, BitVecExpr right)
     {
-        var isArithmeticOrShift = op is BinaryOperator.Add or BinaryOperator.Subtract
-            or BinaryOperator.Multiply or BinaryOperator.Divide or BinaryOperator.Modulo
-            or BinaryOperator.LeftShift or BinaryOperator.RightShift;
-        if (isArithmeticOrShift && Math.Max(left.SortSize, right.SortSize) < 32)
-        {
-            return "arithmetic on two sub-32-bit integer operands is not modeled: C# promotes " +
-                   "narrow integers to int before computing, while fixed-width solver semantics " +
-                   "would wrap at the narrow width (modeled-forms divergence D1)";
-        }
-
         // Shift counts wider than 32 bits have no C# typing (the count operand
         // must convert to int); refuse rather than guess (review #833 C3).
         if (op is BinaryOperator.LeftShift or BinaryOperator.RightShift && right.SortSize > 32)
@@ -683,7 +666,10 @@ public sealed class ContractTranslator
         // by promotion to a 64-bit signed comparison — exactly C#'s int-vs-uint →
         // long semantics (PromoteMixedTo64). At 64 bits there is no common C# type
         // (long vs ulong comparison is a compile error): refuse rather than guess.
-        var isSignednessSensitive = op is BinaryOperator.Equal or BinaryOperator.NotEqual
+        var isSignednessSensitive = op is BinaryOperator.Add or BinaryOperator.Subtract
+            or BinaryOperator.Multiply or BinaryOperator.BitwiseAnd
+            or BinaryOperator.BitwiseOr or BinaryOperator.BitwiseXor
+            or BinaryOperator.Equal or BinaryOperator.NotEqual
             or BinaryOperator.LessThan or BinaryOperator.LessOrEqual
             or BinaryOperator.GreaterThan or BinaryOperator.GreaterOrEqual
             or BinaryOperator.Divide or BinaryOperator.Modulo;
@@ -708,39 +694,61 @@ public sealed class ContractTranslator
     }
 
     /// <summary>
-    /// C# binary numeric promotion for genuinely-mixed signed/unsigned operands
-    /// (W1 Slice 1, D10; corrected per review #833 C1): the promoted type is
-    /// **long (64-bit signed)** only when the unsigned side is exactly `uint`
-    /// (int-vs-uint → long) or either side is 64-bit signed (`i64` with any
-    /// sub-64 unsigned → long); a **narrow** unsigned side (`u8`/`u16`) with a
-    /// signed side ≤ 32 promotes to **int (32-bit signed)** — C# has no
-    /// byte/ushort arithmetic, so `u8 + i32` computes and WRAPS at 32 bits.
-    /// Both embeddings are value-preserving into the promoted type
-    /// (sign-extension for the signed side, zero-extension for the unsigned
-    /// side), and the operation proceeds SIGNED at the promoted width.
-    /// A 64-bit unsigned side is refused upstream (no common C# type).
-    /// Returns false when the operands are not effectively mixed.
+    /// Applies C# binary numeric promotion, including constant-expression
+    /// conversion to uint and the pre-promotion treatment of byte/ushort when
+    /// paired with uint or ulong.
     /// </summary>
-    private bool TryPromoteMixed(BitVecExpr left, BitVecExpr right, out BitVecExpr leftP, out BitVecExpr rightP)
+    private (BitVecExpr Left, BitVecExpr Right, bool IsSigned) ApplyBinaryNumericPromotions(
+        BitVecExpr left,
+        BitVecExpr right)
     {
-        leftP = left;
-        rightP = right;
-        var leftSigned = EffectiveIsSigned(left, right);
-        var rightSigned = EffectiveIsSigned(right, left);
-        if (leftSigned == rightSigned)
-            return false;
+        var leftSigned = IsSigned(left);
+        var rightSigned = IsSigned(right);
+        var leftWidth = left.SortSize;
+        var rightWidth = right.SortSize;
 
-        var unsignedSize = leftSigned ? right.SortSize : left.SortSize;
-        if (unsignedSize >= 64)
-            return false; // u64 mixed: refused upstream, no C# promotion exists
+        uint targetWidth;
+        bool targetSigned;
 
-        var targetWidth = (unsignedSize == 32 || left.SortSize == 64 || right.SortSize == 64) ? 64u : 32u;
+        if ((!leftSigned && leftWidth == 64) || (!rightSigned && rightWidth == 64))
+        {
+            targetWidth = 64;
+            targetSigned = false;
+        }
+        else if ((leftSigned && leftWidth == 64) || (rightSigned && rightWidth == 64))
+        {
+            targetWidth = 64;
+            targetSigned = true;
+        }
+        else if ((!leftSigned && leftWidth == 32) || (!rightSigned && rightWidth == 32))
+        {
+            var signedOperand = leftSigned ? left : rightSigned ? right : null;
+            var constantFitsUnsigned = signedOperand is not null
+                && IsNonNegativeLiteralWithin(signedOperand, uint.MaxValue);
+            targetWidth = signedOperand is not null && !constantFitsUnsigned ? 64u : 32u;
+            targetSigned = targetWidth == 64;
+        }
+        else
+        {
+            targetWidth = 32;
+            targetSigned = true;
+        }
 
-        leftP = left.SortSize == targetWidth ? left
-            : leftSigned ? _ctx.MkSignExt(targetWidth - left.SortSize, left) : _ctx.MkZeroExt(targetWidth - left.SortSize, left);
-        rightP = right.SortSize == targetWidth ? right
-            : rightSigned ? _ctx.MkSignExt(targetWidth - right.SortSize, right) : _ctx.MkZeroExt(targetWidth - right.SortSize, right);
-        return true;
+        return (
+            ConvertIntegral(left, targetWidth, targetSigned),
+            ConvertIntegral(right, targetWidth, targetSigned),
+            targetSigned);
+    }
+
+    private BitVecExpr ConvertIntegral(BitVecExpr operand, uint targetWidth, bool targetSigned)
+    {
+        if (operand.SortSize == targetWidth)
+            return TrackBitVec(operand, targetWidth, targetSigned);
+
+        var converted = IsSigned(operand)
+            ? _ctx.MkSignExt(targetWidth - operand.SortSize, operand)
+            : _ctx.MkZeroExt(targetWidth - operand.SortSize, operand);
+        return TrackBitVec(converted, targetWidth, targetSigned);
     }
 
     private Expr? TranslateUnaryOp(UnaryOperationNode node)
@@ -749,23 +757,34 @@ public sealed class ContractTranslator
         if (operand == null)
             return null;
 
-        // W1 Slice 1 (T1): C# promotes the operand of unary minus to int, so
-        // -(sbyte)(-128) is 128 at runtime; an 8-bit solver negation wraps back
-        // to -128 (divergence D1's unary form).
-        if (node.Operator == UnaryOperator.Negate && operand is BitVecExpr narrow && narrow.SortSize < 32)
-        {
-            return Refuse(
-                "unary negation of a sub-32-bit integer operand is not modeled: C# promotes " +
-                "to int before negating, while the solver would wrap at the narrow width " +
-                "(modeled-forms divergence D1)");
-        }
-
         return node.Operator switch
         {
             UnaryOperator.Not when operand is BoolExpr boolOp => _ctx.MkNot(boolOp),
-            UnaryOperator.Negate when operand is BitVecExpr bvOp => _ctx.MkBVNeg(bvOp),
+            UnaryOperator.Negate when operand is BitVecExpr bvOp =>
+                TranslateUnaryNegation(bvOp),
             _ => null
         };
+    }
+
+    private Expr? TranslateUnaryNegation(BitVecExpr operand)
+    {
+        if (!IsSigned(operand) && operand.SortSize == 64)
+        {
+            return Refuse(
+                "unary negation of a 64-bit unsigned operand has no executable C# semantics");
+        }
+
+        BitVecExpr promoted;
+        if (!IsSigned(operand) && operand.SortSize == 32)
+        {
+            promoted = TrackBitVec(_ctx.MkZeroExt(32, operand), 64, isSigned: true);
+        }
+        else
+        {
+            promoted = PromoteNarrowIntegral(operand);
+        }
+
+        return TrackBitVec(_ctx.MkBVNeg(promoted), promoted.SortSize, isSigned: true);
     }
 
     private Expr? TranslateConditional(ConditionalExpressionNode node)
@@ -1146,21 +1165,6 @@ public sealed class ContractTranslator
     private bool IsSigned(Expr expr) => GetBitVecInfo(expr).IsSigned;
 
     /// <summary>
-    /// Determines if unsigned comparison should be used.
-    /// For mixed signed/unsigned, use unsigned if one operand is unsigned and the other
-    /// is a non-negative literal (matches C# implicit conversion behavior).
-    /// </summary>
-    private bool ShouldUseUnsignedComparison(Expr left, Expr right)
-    {
-        // Both effectively unsigned (an unsigned operand converts a paired
-        // non-negative literal to its type, per C#) → unsigned comparison.
-        // Both effectively signed → signed. The genuinely-mixed non-literal
-        // case is refused before dispatch (DiagnoseUnmodeledBitVecTyping,
-        // W1 Slice 1 D10) and cannot reach here on the contract path.
-        return !EffectiveIsSigned(left, right) && !EffectiveIsSigned(right, left);
-    }
-
-    /// <summary>
     /// Checks if an expression is a non-negative literal value.
     /// </summary>
     private bool IsNonNegativeLiteral(Expr expr)
@@ -1176,6 +1180,11 @@ public sealed class ContractTranslator
         }
         return false;
     }
+
+    private bool IsNonNegativeLiteralWithin(Expr expr, ulong maximum) =>
+        IsNonNegativeLiteral(expr)
+        && expr is BitVecNum number
+        && number.BigInteger <= maximum;
 
     /// <summary>
     /// Normalizes two bit-vector expressions to the same width.
@@ -1199,6 +1208,7 @@ public sealed class ContractTranslator
                 : _ctx.MkZeroExt(rightWidth - leftWidth, left);
             return (extended, right);
         }
+
         else
         {
             var extended = rightSigned
@@ -1206,6 +1216,17 @@ public sealed class ContractTranslator
                 : _ctx.MkZeroExt(leftWidth - rightWidth, right);
             return (left, extended);
         }
+    }
+
+    private BitVecExpr PromoteNarrowIntegral(BitVecExpr operand)
+    {
+        if (operand.SortSize >= 32)
+            return operand;
+
+        var promoted = IsSigned(operand)
+            ? _ctx.MkSignExt(32 - operand.SortSize, operand)
+            : _ctx.MkZeroExt(32 - operand.SortSize, operand);
+        return TrackBitVec(promoted, 32, isSigned: true);
     }
 
     /// <summary>
@@ -1222,8 +1243,11 @@ public sealed class ContractTranslator
     /// </summary>
     private BitVecExpr ApplyShiftOp(BitVecExpr left, BitVecExpr right, bool leftShift)
     {
-        // Promote the left operand individually; the count extends to match.
-        var (normalizedLeft, normalizedCount) = NormalizeBitVecWidths(left, right);
+        // Promote the left operand individually; the count is converted to int
+        // and then extended to the promoted left width for the Z3 shift.
+        var promotedLeft = PromoteNarrowIntegral(left);
+        var promotedCount = PromoteNarrowIntegral(right);
+        var (normalizedLeft, normalizedCount) = NormalizeBitVecWidths(promotedLeft, promotedCount);
         var w = normalizedLeft.SortSize;
         var maskedCount = _ctx.MkBVAND(normalizedCount, _ctx.MkBV(w - 1, w));
 
@@ -1240,22 +1264,11 @@ public sealed class ContractTranslator
 
     private BitVecExpr ApplyBitVecBinaryOp(BitVecExpr left, BitVecExpr right, Func<BitVecExpr, BitVecExpr, BitVecExpr> op)
     {
-        // Genuinely-mixed operands: C# binary numeric promotion (W1 Slice 1,
-        // D10; width per TryPromoteMixed — long for uint-with-signed, int for
-        // narrow-unsigned-with-signed, review #833 C1); result signed at the
-        // promoted width.
-        if (TryPromoteMixed(left, right, out var lp, out var rp))
-            return TrackBitVec(op(lp, rp), lp.SortSize, isSigned: true);
-
-        var (normalizedLeft, normalizedRight) = NormalizeBitVecWidths(left, right);
-        var result = op(normalizedLeft, normalizedRight);
-        // Result signedness follows C# typing (W1 Slice 1, D10 companion fix):
-        // an unsigned operand combined with a non-negative int literal yields an
-        // UNSIGNED result in C# (the literal converts implicitly to the unsigned
-        // type), so `x - 1` over u32 stays u32 — the old signed-poisoning marked
-        // it signed and downstream comparisons picked the wrong variant.
-        var resultSigned = EffectiveIsSigned(left, right) || EffectiveIsSigned(right, left);
-        return TrackBitVec(result, normalizedLeft.SortSize, resultSigned);
+        var promoted = ApplyBinaryNumericPromotions(left, right);
+        return TrackBitVec(
+            op(promoted.Left, promoted.Right),
+            promoted.Left.SortSize,
+            promoted.IsSigned);
     }
 
     /// <summary>
@@ -1280,14 +1293,9 @@ public sealed class ContractTranslator
         Func<BitVecExpr, BitVecExpr, BoolExpr> signedOp,
         Func<BitVecExpr, BitVecExpr, BoolExpr> unsignedOp)
     {
-        // Genuinely-mixed sub-64-bit operands: C# promotion to a 64-bit signed
-        // comparison (W1 Slice 1, D10).
-        if (TryPromoteMixed(left, right, out var l64, out var r64))
-            return signedOp(l64, r64);
-
-        var (normalizedLeft, normalizedRight) = NormalizeBitVecWidths(left, right);
-        var op = ShouldUseUnsignedComparison(left, right) ? unsignedOp : signedOp;
-        return op(normalizedLeft, normalizedRight);
+        var promoted = ApplyBinaryNumericPromotions(left, right);
+        var op = promoted.IsSigned ? signedOp : unsignedOp;
+        return op(promoted.Left, promoted.Right);
     }
 
     /// <summary>
@@ -1306,29 +1314,20 @@ public sealed class ContractTranslator
         if (Translate(leftNode) is not BitVecExpr l || Translate(rightNode) is not BitVecExpr r)
             return null;
 
-        if (TryPromoteMixed(l, r, out var lp, out var rp))
-            return (lp, rp, true);
-
-        var (nl, nr) = NormalizeBitVecWidths(l, r);
-        var signed = EffectiveIsSigned(l, r) || EffectiveIsSigned(r, l);
-        return (nl, nr, signed);
+        var promoted = ApplyBinaryNumericPromotions(l, r);
+        return (promoted.Left, promoted.Right, promoted.IsSigned);
     }
 
     private BitVecExpr ApplyDivModOp(BitVecExpr left, BitVecExpr right,
         Func<BitVecExpr, BitVecExpr, BitVecExpr> signedOp,
         Func<BitVecExpr, BitVecExpr, BitVecExpr> unsignedOp)
     {
-        // Genuinely-mixed operands: C# promotion (W1 Slice 1, D10) — signed at
-        // the promoted width (verification round N1: was hardcoded 64 while the
-        // promotion can target 32 for narrow-unsigned pairs).
-        if (TryPromoteMixed(left, right, out var l64, out var r64))
-            return TrackBitVec(signedOp(l64, r64), l64.SortSize, isSigned: true);
-
-        var (normalizedLeft, normalizedRight) = NormalizeBitVecWidths(left, right);
-        var useUnsigned = !EffectiveIsSigned(left, right) && !EffectiveIsSigned(right, left);
-        var op = useUnsigned ? unsignedOp : signedOp;
-        var result = op(normalizedLeft, normalizedRight);
-        return TrackBitVec(result, normalizedLeft.SortSize, !useUnsigned);
+        var promoted = ApplyBinaryNumericPromotions(left, right);
+        var op = promoted.IsSigned ? signedOp : unsignedOp;
+        return TrackBitVec(
+            op(promoted.Left, promoted.Right),
+            promoted.Left.SortSize,
+            promoted.IsSigned);
     }
 
     /// <summary>
@@ -1338,13 +1337,8 @@ public sealed class ContractTranslator
     {
         if (left is BitVecExpr bvLeft && right is BitVecExpr bvRight)
         {
-            // Genuinely-mixed sub-64-bit operands: C# promotion to 64-bit signed
-            // equality (W1 Slice 1, D10) — `-1 == 4294967295u` is false, as at runtime.
-            if (TryPromoteMixed(bvLeft, bvRight, out var l64, out var r64))
-                return _ctx.MkEq(l64, r64);
-
-            var (normalizedLeft, normalizedRight) = NormalizeBitVecWidths(bvLeft, bvRight);
-            return _ctx.MkEq(normalizedLeft, normalizedRight);
+            var promoted = ApplyBinaryNumericPromotions(bvLeft, bvRight);
+            return _ctx.MkEq(promoted.Left, promoted.Right);
         }
         return _ctx.MkEq(left, right);
     }

--- a/tests/Calor.Compiler.Tests/WeakeningCheckCliTests.cs
+++ b/tests/Calor.Compiler.Tests/WeakeningCheckCliTests.cs
@@ -189,11 +189,10 @@ public class WeakeningCheckCliTests : IDisposable
         Assert.False(json.Value.GetProperty("intactOrStrengthened").GetBoolean());
     }
 
-    // #826 review C4 follow-through: literals outside the signed 32-bit
-    // domain previously wrapped mod 2^32 and produced false DETERMINATE
-    // verdicts; they must now yield indeterminate.
+    // #780: wide literals retain their executable i64 width, so weakening
+    // checks can compare them without the old BV32 truncation.
     [Fact]
-    public void OutOfRangeLiteral_Indeterminate()
+    public void WideLiteral_WeakeningIsDeterminate()
     {
         const string bigFrozen = """
             §M{m001:Big}
@@ -208,8 +207,8 @@ public class WeakeningCheckCliTests : IDisposable
 
         Assert.Equal(0, exit);
         Assert.NotNull(json);
-        Assert.True(json.Value.GetProperty("indeterminate").GetBoolean());
-        Assert.Equal(JsonValueKind.Null, json.Value.GetProperty("weakened").ValueKind);
+        Assert.False(json.Value.GetProperty("indeterminate").GetBoolean());
+        Assert.True(json.Value.GetProperty("weakened").GetBoolean());
     }
 
     [Fact]

--- a/tests/Calor.Verification.Tests/NumericExecutableSemanticsTests.cs
+++ b/tests/Calor.Verification.Tests/NumericExecutableSemanticsTests.cs
@@ -1,0 +1,148 @@
+using System.Runtime.CompilerServices;
+using Calor.Compiler.Ast;
+using Calor.Compiler.Parsing;
+using Calor.Compiler.Verification.Z3;
+using Microsoft.CSharp.RuntimeBinder;
+using Xunit;
+
+namespace Calor.Verification.Tests;
+
+public sealed class NumericExecutableSemanticsTests
+{
+    private static readonly TextSpan Span = TextSpan.Empty;
+    private static readonly AttributeCollection Attributes = new();
+
+    public static IEnumerable<object[]> IntegralPromotionCases()
+    {
+        foreach (var (leftType, leftValues) in IntegralValues())
+        {
+            foreach (var (rightType, rightValues) in IntegralValues())
+            {
+                foreach (var left in leftValues)
+                {
+                    foreach (var right in rightValues)
+                        yield return [leftType, left, rightType, right];
+                }
+            }
+        }
+    }
+
+    [SkippableTheory]
+    [MemberData(nameof(IntegralPromotionCases))]
+    public void AdditionMatchesExecutableCSharpPromotion(
+        string leftType,
+        object leftValue,
+        string rightType,
+        object rightValue)
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        AdditionMatchesExecutableCSharpPromotionCore(
+            leftType,
+            leftValue,
+            rightType,
+            rightValue);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AdditionMatchesExecutableCSharpPromotionCore(
+        string leftType,
+        object leftValue,
+        string rightType,
+        object rightValue)
+    {
+        using var context = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(context);
+
+        object? runtimeResult = null;
+        RuntimeBinderException? runtimeError = null;
+        try
+        {
+            runtimeResult = AddDynamic(leftValue, rightValue);
+        }
+        catch (RuntimeBinderException error)
+        {
+            runtimeError = error;
+        }
+
+        var parameters = new List<(string Name, string TypeName)>
+        {
+            ("left", leftType),
+            ("right", rightType)
+        };
+        var preconditions = new[]
+        {
+            Requires(Equal(Reference("left"), Literal(leftValue))),
+            Requires(Equal(Reference("right"), Literal(rightValue)))
+        };
+        var sum = new BinaryOperationNode(
+            Span,
+            BinaryOperator.Add,
+            Reference("left"),
+            Reference("right"));
+        var postcondition = Ensures(Equal(sum, Literal(runtimeResult ?? 0)));
+        var result = verifier.VerifyPostcondition(
+            parameters,
+            "bool",
+            preconditions,
+            postcondition);
+
+        if (runtimeError is not null)
+        {
+            Assert.Equal(ContractVerificationStatus.Unsupported, result.Status);
+            return;
+        }
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    private static object AddDynamic(object left, object right)
+    {
+        dynamic dynamicLeft = left;
+        dynamic dynamicRight = right;
+        return dynamicLeft + dynamicRight;
+    }
+
+    private static IEnumerable<(string Type, object[] Values)> IntegralValues()
+    {
+        yield return ("i8", [sbyte.MinValue, (sbyte)0, sbyte.MaxValue]);
+        yield return ("u8", [(byte)0, (byte)1, byte.MaxValue]);
+        yield return ("i16", [short.MinValue, (short)0, short.MaxValue]);
+        yield return ("u16", [(ushort)0, (ushort)1, ushort.MaxValue]);
+        yield return ("i32", [int.MinValue, 0, int.MaxValue]);
+        yield return ("u32", [0U, 1U, uint.MaxValue]);
+        yield return ("i64", [long.MinValue, 0L, long.MaxValue]);
+        yield return ("u64", [0UL, 1UL, ulong.MaxValue]);
+    }
+
+    private static ReferenceNode Reference(string name) => new(Span, name);
+
+    private static BinaryOperationNode Equal(ExpressionNode left, ExpressionNode right) =>
+        new(Span, BinaryOperator.Equal, left, right);
+
+    private static RequiresNode Requires(ExpressionNode condition) =>
+        new(Span, condition, null, Attributes);
+
+    private static EnsuresNode Ensures(ExpressionNode condition) =>
+        new(Span, condition, null, Attributes);
+
+    private static IntLiteralNode Literal(object value) => value switch
+    {
+        sbyte number => new IntLiteralNode(Span, number),
+        byte number => new IntLiteralNode(Span, number),
+        short number => new IntLiteralNode(Span, number),
+        ushort number => new IntLiteralNode(Span, number),
+        int number => new IntLiteralNode(Span, number),
+        uint number => new IntLiteralNode(Span, number, isHex: false, isUnsigned: true, number),
+        long number => new IntLiteralNode(Span, number) { IsLong = true },
+        ulong number => new IntLiteralNode(
+            Span,
+            unchecked((long)number),
+            isHex: false,
+            isUnsigned: true,
+            number)
+        {
+            IsLong = true
+        },
+        _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Not an integral value.")
+    };
+}

--- a/tests/Calor.Verification.Tests/NumericExecutableSemanticsTests.cs
+++ b/tests/Calor.Verification.Tests/NumericExecutableSemanticsTests.cs
@@ -118,6 +118,9 @@ public sealed class NumericExecutableSemanticsTests
                     Assert.True(
                         result.Status == ContractVerificationStatus.Proven,
                         $"{label}: expected Proven, got {result.Status}: {result.CounterexampleDescription}");
+                    Assert.False(
+                        result.EffectiveOutcome.IsVacuous,
+                        $"{label}: operand constraints were unsatisfiable, so the proof tested no runtime value");
                 }
             }
         }
@@ -183,10 +186,15 @@ public sealed class NumericExecutableSemanticsTests
         Assert.True(
             result.Status == ContractVerificationStatus.Proven,
             $"{label}: expected Proven, got {result.Status}: {result.CounterexampleDescription}");
+        Assert.False(
+            result.EffectiveOutcome.IsVacuous,
+            $"{label}: operand constraint was unsatisfiable, so the proof tested no runtime value");
     }
 
     private static object EvaluateDynamic(object left, object right, BinaryOperator op)
     {
+        // Generated Calor C# uses the language default unchecked context for
+        // add/subtract/multiply, so dynamic dispatch is the executable oracle.
         dynamic dynamicLeft = left;
         dynamic dynamicRight = right;
         return op switch

--- a/tests/Calor.Verification.Tests/NumericExecutableSemanticsTests.cs
+++ b/tests/Calor.Verification.Tests/NumericExecutableSemanticsTests.cs
@@ -11,9 +11,39 @@ public sealed class NumericExecutableSemanticsTests
 {
     private static readonly TextSpan Span = TextSpan.Empty;
     private static readonly AttributeCollection Attributes = new();
+    private static readonly BinaryOperator[] Operators =
+    [
+        BinaryOperator.Add,
+        BinaryOperator.Subtract,
+        BinaryOperator.Multiply,
+        BinaryOperator.Divide,
+        BinaryOperator.Modulo,
+        BinaryOperator.Equal,
+        BinaryOperator.NotEqual,
+        BinaryOperator.LessThan,
+        BinaryOperator.LessOrEqual,
+        BinaryOperator.GreaterThan,
+        BinaryOperator.GreaterOrEqual,
+        BinaryOperator.BitwiseAnd,
+        BinaryOperator.BitwiseOr,
+        BinaryOperator.BitwiseXor,
+        BinaryOperator.LeftShift,
+        BinaryOperator.RightShift
+    ];
 
-    public static IEnumerable<object[]> IntegralPromotionCases()
+    [SkippableFact]
+    public void IntegralOperatorsMatchExecutableCSharpSemantics()
     {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        IntegralOperatorsMatchExecutableCSharpSemanticsCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void IntegralOperatorsMatchExecutableCSharpSemanticsCore()
+    {
+        using var context = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(context);
+
         foreach (var (leftType, leftValues) in IntegralValues())
         {
             foreach (var (rightType, rightValues) in IntegralValues())
@@ -21,85 +51,164 @@ public sealed class NumericExecutableSemanticsTests
                 foreach (var left in leftValues)
                 {
                     foreach (var right in rightValues)
-                        yield return [leftType, left, rightType, right];
+                    {
+                        foreach (var op in Operators)
+                            VerifyCase(verifier, leftType, left, rightType, right, op);
+                    }
+                }
+
+            }
+        }
+    }
+
+    [SkippableFact]
+    public void UnaryNegationMatchesExecutableCSharpSemantics()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        UnaryNegationMatchesExecutableCSharpSemanticsCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void UnaryNegationMatchesExecutableCSharpSemanticsCore()
+    {
+        using var context = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(context);
+
+        foreach (var (type, values) in IntegralValues())
+        {
+            foreach (var value in values)
+            {
+                object? runtimeResult = null;
+                Exception? runtimeError = null;
+                try
+                {
+                    dynamic operand = value;
+                    runtimeResult = -operand;
+                }
+                catch (Exception error) when (error is RuntimeBinderException or OverflowException)
+                {
+                    runtimeError = error;
+                }
+
+                var negation = new UnaryOperationNode(
+                    Span,
+                    UnaryOperator.Negate,
+                    Reference("value"));
+                var result = verifier.VerifyPostcondition(
+                    [("value", type)],
+                    "bool",
+                    [Requires(Equal(Reference("value"), Literal(value)))],
+                    Ensures(Equal(negation, Literal(runtimeResult ?? 0))));
+                var label = $"-{type}({value})";
+
+                if (runtimeError is RuntimeBinderException)
+                {
+                    Assert.True(
+                        result.Status == ContractVerificationStatus.Unsupported,
+                        $"{label}: C# rejects the expression but verification returned {result.Status}");
+                }
+                else if (runtimeError is not null)
+                {
+                    Assert.True(
+                        result.Status != ContractVerificationStatus.Proven,
+                        $"{label}: C# throws {runtimeError.GetType().Name} but verification returned Proven");
+                }
+                else
+                {
+                    Assert.True(
+                        result.Status == ContractVerificationStatus.Proven,
+                        $"{label}: expected Proven, got {result.Status}: {result.CounterexampleDescription}");
                 }
             }
         }
     }
 
-    [SkippableTheory]
-    [MemberData(nameof(IntegralPromotionCases))]
-    public void AdditionMatchesExecutableCSharpPromotion(
+    private static void VerifyCase(
+        Z3Verifier verifier,
         string leftType,
         object leftValue,
         string rightType,
-        object rightValue)
+        object rightValue,
+        BinaryOperator op)
     {
-        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
-        AdditionMatchesExecutableCSharpPromotionCore(
-            leftType,
-            leftValue,
-            rightType,
-            rightValue);
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void AdditionMatchesExecutableCSharpPromotionCore(
-        string leftType,
-        object leftValue,
-        string rightType,
-        object rightValue)
-    {
-        using var context = Z3ContextFactory.Create();
-        using var verifier = new Z3Verifier(context);
-
         object? runtimeResult = null;
-        RuntimeBinderException? runtimeError = null;
+        Exception? runtimeError = null;
         try
         {
-            runtimeResult = AddDynamic(leftValue, rightValue);
+            runtimeResult = EvaluateDynamic(leftValue, rightValue, op);
         }
-        catch (RuntimeBinderException error)
+        catch (Exception error) when (error is RuntimeBinderException
+                                      or DivideByZeroException
+                                      or OverflowException)
         {
             runtimeError = error;
         }
 
-        var parameters = new List<(string Name, string TypeName)>
-        {
-            ("left", leftType),
-            ("right", rightType)
-        };
-        var preconditions = new[]
-        {
-            Requires(Equal(Reference("left"), Literal(leftValue))),
-            Requires(Equal(Reference("right"), Literal(rightValue)))
-        };
-        var sum = new BinaryOperationNode(
+        var operation = new BinaryOperationNode(
             Span,
-            BinaryOperator.Add,
+            op,
             Reference("left"),
             Reference("right"));
-        var postcondition = Ensures(Equal(sum, Literal(runtimeResult ?? 0)));
+        ExpressionNode condition = runtimeResult is bool expectedBoolean
+            ? expectedBoolean
+                ? operation
+                : new UnaryOperationNode(Span, UnaryOperator.Not, operation)
+            : Equal(operation, Literal(runtimeResult ?? 0));
         var result = verifier.VerifyPostcondition(
-            parameters,
+            [("left", leftType), ("right", rightType)],
             "bool",
-            preconditions,
-            postcondition);
+            [
+                Requires(Equal(Reference("left"), Literal(leftValue))),
+                Requires(Equal(Reference("right"), Literal(rightValue)))
+            ],
+            Ensures(condition));
 
-        if (runtimeError is not null)
+        var label = $"{leftType}({leftValue}) {op} {rightType}({rightValue})";
+        if (runtimeError is RuntimeBinderException)
         {
-            Assert.Equal(ContractVerificationStatus.Unsupported, result.Status);
+            Assert.True(
+                result.Status == ContractVerificationStatus.Unsupported,
+                $"{label}: C# rejects the expression but verification returned {result.Status}");
             return;
         }
 
-        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+        if (runtimeError is not null)
+        {
+            Assert.True(
+                result.Status != ContractVerificationStatus.Proven,
+                $"{label}: C# throws {runtimeError.GetType().Name} but verification returned Proven");
+            return;
+        }
+
+        Assert.True(
+            result.Status == ContractVerificationStatus.Proven,
+            $"{label}: expected Proven, got {result.Status}: {result.CounterexampleDescription}");
     }
 
-    private static object AddDynamic(object left, object right)
+    private static object EvaluateDynamic(object left, object right, BinaryOperator op)
     {
         dynamic dynamicLeft = left;
         dynamic dynamicRight = right;
-        return dynamicLeft + dynamicRight;
+        return op switch
+        {
+            BinaryOperator.Add => dynamicLeft + dynamicRight,
+            BinaryOperator.Subtract => dynamicLeft - dynamicRight,
+            BinaryOperator.Multiply => dynamicLeft * dynamicRight,
+            BinaryOperator.Divide => dynamicLeft / dynamicRight,
+            BinaryOperator.Modulo => dynamicLeft % dynamicRight,
+            BinaryOperator.Equal => dynamicLeft == dynamicRight,
+            BinaryOperator.NotEqual => dynamicLeft != dynamicRight,
+            BinaryOperator.LessThan => dynamicLeft < dynamicRight,
+            BinaryOperator.LessOrEqual => dynamicLeft <= dynamicRight,
+            BinaryOperator.GreaterThan => dynamicLeft > dynamicRight,
+            BinaryOperator.GreaterOrEqual => dynamicLeft >= dynamicRight,
+            BinaryOperator.BitwiseAnd => dynamicLeft & dynamicRight,
+            BinaryOperator.BitwiseOr => dynamicLeft | dynamicRight,
+            BinaryOperator.BitwiseXor => dynamicLeft ^ dynamicRight,
+            BinaryOperator.LeftShift => dynamicLeft << dynamicRight,
+            BinaryOperator.RightShift => dynamicLeft >> dynamicRight,
+            _ => throw new ArgumentOutOfRangeException(nameof(op), op, null)
+        };
     }
 
     private static IEnumerable<(string Type, object[] Values)> IntegralValues()
@@ -132,14 +241,9 @@ public sealed class NumericExecutableSemanticsTests
         short number => new IntLiteralNode(Span, number),
         ushort number => new IntLiteralNode(Span, number),
         int number => new IntLiteralNode(Span, number),
-        uint number => new IntLiteralNode(Span, number, isHex: false, isUnsigned: true, number),
+        uint number => new IntLiteralNode(Span, number, false, true, number),
         long number => new IntLiteralNode(Span, number) { IsLong = true },
-        ulong number => new IntLiteralNode(
-            Span,
-            unchecked((long)number),
-            isHex: false,
-            isUnsigned: true,
-            number)
+        ulong number => new IntLiteralNode(Span, unchecked((long)number), false, true, number)
         {
             IsLong = true
         },

--- a/tests/Calor.Verification.Tests/W1Slice1SoundnessTests.cs
+++ b/tests/Calor.Verification.Tests/W1Slice1SoundnessTests.cs
@@ -10,8 +10,8 @@ namespace Calor.Verification.Tests;
 /// <summary>
 /// W1 Slice 1 soundness-batch pins (wedge-w1-prereqs.md §1.1 T1 + D6–D10):
 /// the whitelisted divergences that could mint a false Proven-that-elides are
-/// closed — by refusal (Replace, narrow-int arithmetic, 64-bit mixed
-/// signedness, unregistered fields), by correct modeling (sub-64-bit mixed
+/// closed — by refusal (Replace, 64-bit mixed signedness, unregistered fields),
+/// by correct modeling (integer literals, narrow arithmetic, sub-64-bit mixed
 /// signedness via C# promotion; unsigned-with-literal typing), or by side
 /// conditions (contract-expression division → Assumed unless entailed).
 /// </summary>
@@ -41,14 +41,14 @@ public class W1Slice1SoundnessTests
     // ---- T1: narrow-int arithmetic (D1 class) ----
 
     [SkippableFact]
-    public void NarrowIntArithmetic_IsRefused()
+    public void NarrowIntArithmetic_UsesCSharpPromotion()
     {
         Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
-        NarrowIntArithmetic_IsRefusedCore();
+        NarrowIntArithmetic_UsesCSharpPromotionCore();
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void NarrowIntArithmetic_IsRefusedCore()
+    private void NarrowIntArithmetic_UsesCSharpPromotionCore()
     {
         using var ctx = Z3ContextFactory.Create();
         using var verifier = new Z3Verifier(ctx);
@@ -63,7 +63,7 @@ public class W1Slice1SoundnessTests
                 BinOp(BinaryOperator.Add, Ref("x"), Ref("y")),
                 Int(128))));
 
-        Assert.Equal(ContractVerificationStatus.Unsupported, result.Status);
+        Assert.Equal(ContractVerificationStatus.Disproven, result.Status);
     }
 
     [SkippableFact]
@@ -87,17 +87,18 @@ public class W1Slice1SoundnessTests
             Ensures(BinOp(BinaryOperator.LessOrEqual, Ref("x"), Int(127))));
 
         Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+        Assert.Equal(ContractTranslator.SemanticsVersion, result.TranslatorSemanticsVersion);
     }
 
     [SkippableFact]
-    public void NarrowIntNegation_IsRefused()
+    public void NarrowIntNegation_UsesCSharpPromotion()
     {
         Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
-        NarrowIntNegation_IsRefusedCore();
+        NarrowIntNegation_UsesCSharpPromotionCore();
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void NarrowIntNegation_IsRefusedCore()
+    private void NarrowIntNegation_UsesCSharpPromotionCore()
     {
         using var ctx = Z3ContextFactory.Create();
         using var verifier = new Z3Verifier(ctx);
@@ -111,7 +112,80 @@ public class W1Slice1SoundnessTests
                 new UnaryOperationNode(TextSpan.Empty, UnaryOperator.Negate, Ref("x")),
                 Int(-128))));
 
-        Assert.Equal(ContractVerificationStatus.Unsupported, result.Status);
+        Assert.True(
+            result.Status == ContractVerificationStatus.Proven,
+            $"{result.Status}: {result.CounterexampleDescription}");
+    }
+
+    [SkippableFact]
+    public void NarrowUnsignedArithmetic_PromotesToSignedInt()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        NarrowUnsignedArithmetic_PromotesToSignedIntCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void NarrowUnsignedArithmetic_PromotesToSignedIntCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var result = Verify(verifier,
+            [("x", "u8"), ("y", "u8")],
+            [
+                Requires(BinOp(BinaryOperator.Equal, Ref("x"), Int(byte.MaxValue))),
+                Requires(BinOp(BinaryOperator.Equal, Ref("y"), Int(byte.MaxValue)))
+            ],
+            Ensures(BinOp(BinaryOperator.Equal,
+                BinOp(BinaryOperator.Add, Ref("x"), Ref("y")),
+                Int(510))));
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void WideSignedLiteral_PreservesI64Value()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        WideSignedLiteral_PreservesI64ValueCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void WideSignedLiteral_PreservesI64ValueCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+        const long wide = 4_294_967_296L;
+
+        var result = Verify(verifier,
+            [("x", "i64")],
+            [Requires(BinOp(BinaryOperator.Equal, Ref("x"), Int(wide)))],
+            Ensures(BinOp(BinaryOperator.NotEqual, Ref("x"), Int(0))));
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+    }
+
+    [SkippableFact]
+    public void UncheckedI32Overflow_UsesBitVectorWraparound()
+    {
+        Skip.IfNot(Z3ContextFactory.IsAvailable, "Z3 not available");
+        UncheckedI32Overflow_UsesBitVectorWraparoundCore();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void UncheckedI32Overflow_UsesBitVectorWraparoundCore()
+    {
+        using var ctx = Z3ContextFactory.Create();
+        using var verifier = new Z3Verifier(ctx);
+
+        var result = Verify(verifier,
+            [("x", "i32")],
+            [Requires(BinOp(BinaryOperator.Equal, Ref("x"), Int(int.MaxValue)))],
+            Ensures(BinOp(BinaryOperator.Equal,
+                BinOp(BinaryOperator.Add, Ref("x"), Int(1)),
+                Int(int.MinValue))));
+
+        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
     }
 
     // ---- D10: mixed signedness ----
@@ -137,7 +211,9 @@ public class W1Slice1SoundnessTests
             [],
             Ensures(BinOp(BinaryOperator.NotEqual, Int(-1), Ref("x"))));
 
-        Assert.Equal(ContractVerificationStatus.Proven, result.Status);
+        Assert.True(
+            result.Status == ContractVerificationStatus.Proven,
+            $"{result.Status}: {result.CounterexampleDescription}");
     }
 
     [SkippableFact]


### PR DESCRIPTION
## Summary
- preserve integral literal width and signedness in Z3 translation
- apply C# binary and unary numeric promotions across arithmetic, comparison, equality, shifts, and overflow
- keep operations without executable C# semantics fail-closed as Unsupported
- version the translator semantics in proof results and verification-cache validity
- add a 576-case runtime differential promotion matrix across all integral types and boundaries

## Verification
- 967 Calor.Verification.Tests passed
- 40 VerificationCacheTests passed
- test quality manifest passed
- Release build passed with zero warnings/errors

Closes #780