### PR TITLE
Correct contract inheritance and preserve transforms

### DIFF
--- a/eng/test-manifest.json
+++ b/eng/test-manifest.json
@@ -5,7 +5,7 @@
       "path": "tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj",
       "workflow": ".github/workflows/test.yml",
       "releaseCritical": true,
-      "expectedTotal": 6893,
+      "expectedTotal": 6915,
       "expectedSkipped": 2
     },
     {
@@ -128,7 +128,7 @@
     },
     {
       "reason": "Z3 not available",
-      "count": 386
+      "count": 388
     },
     {
       "reason": "corpus submodules not initialized",

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -3515,7 +3515,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         // Check for inherited contracts
         var inheritedContracts = _currentClassName != null && _inheritanceResult != null
-            ? _inheritanceResult.GetInheritedContracts(_currentClassName, node.Name)
+            ? _inheritanceResult.GetInheritedContracts(_currentClassName, node)
             : null;
 
         // Emit explicit preconditions
@@ -3531,7 +3531,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         {
             foreach (var requires in inheritedContracts.Preconditions)
             {
-                AppendLine($"// Inherited from {inheritedContracts.InterfaceName}.{inheritedContracts.MethodName}");
+                AppendLine($"// Inherited from {inheritedContracts.SourceDisplayName}");
                 var check = Visit(requires);
                 AppendLine(check);
             }
@@ -3593,7 +3593,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             {
                 foreach (var ensures in inheritedContracts!.Postconditions)
                 {
-                    AppendLine($"// Inherited from {inheritedContracts.InterfaceName}.{inheritedContracts.MethodName}");
+                    AppendLine($"// Inherited from {inheritedContracts.SourceDisplayName}");
                     var check = SubstituteResultIdentifier(Visit(ensures));
                     AppendLine(check);
                 }
@@ -3631,7 +3631,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 {
                     foreach (var ensures in inheritedContracts!.Postconditions)
                     {
-                        AppendLine($"// Inherited from {inheritedContracts.InterfaceName}.{inheritedContracts.MethodName}");
+                        AppendLine($"// Inherited from {inheritedContracts.SourceDisplayName}");
                         var check = Visit(ensures);
                         AppendLine(check);
                     }

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -513,7 +513,7 @@ public static class DiagnosticCode
     /// </summary>
     public const string ContractInheritanceValid = "Calor0814";
 
-    // Contract inheritance Z3 proving (Calor0815-0817)
+    // Contract inheritance Z3 proving (Calor0815-0818)
 
     /// <summary>
     /// Info: Contract implication proven by Z3 SMT solver.
@@ -529,6 +529,11 @@ public static class DiagnosticCode
     /// Info: Z3 SMT solver is unavailable, using heuristic checking only.
     /// </summary>
     public const string Z3UnavailableForInheritance = "Calor0817";
+
+    /// <summary>
+    /// Error: Inherited postconditions cannot all be satisfied.
+    /// </summary>
+    public const string IncompatibleInheritedContracts = "Calor0818";
 
     // Legacy structural-ID lint (Calor0820-0822) — Phase 1/2 v6 plan
     // (drop structural IDs, then introduce compact 12-char IDs).

--- a/src/Calor.Compiler/Resources/SelfTest/08_contract_inheritance_z3.calr
+++ b/src/Calor.Compiler/Resources/SelfTest/08_contract_inheritance_z3.calr
@@ -1,6 +1,7 @@
 §M{m001:ContractZ3Test}
   §IFACE{i001:IService}
     §MT{m001:Process} (i32:value) -> i32
+      §Q (>= value 0)
 
   §CL{c001:ValidService:pub}
     §IMPL{IService}
@@ -18,5 +19,4 @@
       §Q (>= value 0)
       §S (>= result 10)
       §R (+ value 10)
-
 

--- a/src/Calor.Compiler/Resources/SelfTest/08_contract_inheritance_z3.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/08_contract_inheritance_z3.g.cs
@@ -12,6 +12,10 @@ namespace ContractZ3Test
 {
     public interface IService
     {
+        /// <summary>
+        /// Interface method with contracts.
+        /// </summary>
+        /// <remarks>Requires: value >= 0</remarks>
         int Process(int value);
     }
 
@@ -19,12 +23,12 @@ namespace ContractZ3Test
     {
         public int Process(int value)
         {
-            if (!(value >= -10)) throw new Calor.Runtime.ContractViolationException("Precondition failed: value >= -10", "mt001", Calor.Runtime.ContractKind.Requires, startOffset: 192, length: 17, sourceFile: null, line: 9, column: 7, condition: "value >= -10");
+            if (!(value >= -10)) throw new Calor.Runtime.ContractViolationException("Precondition failed: value >= -10", "mt001", Calor.Runtime.ContractKind.Requires, startOffset: 214, length: 17, sourceFile: null, line: 10, column: 7, condition: "value >= -10");
             int __result__ = default;
 
             __result__ = value + 1;
 
-            if (!(__result__ >= 1)) throw new Calor.Runtime.ContractViolationException("Postcondition failed: __result__ >= 1", "mt001", Calor.Runtime.ContractKind.Ensures, startOffset: 216, length: 16, sourceFile: null, line: 10, column: 7, condition: "__result__ >= 1");
+            if (!(__result__ >= 1)) throw new Calor.Runtime.ContractViolationException("Postcondition failed: __result__ >= 1", "mt001", Calor.Runtime.ContractKind.Ensures, startOffset: 238, length: 16, sourceFile: null, line: 11, column: 7, condition: "__result__ >= 1");
             return __result__;
         }
 
@@ -34,12 +38,12 @@ namespace ContractZ3Test
     {
         public int Process(int value)
         {
-            if (!(value >= 0)) throw new Calor.Runtime.ContractViolationException("Precondition failed: value >= 0", "mt002", Calor.Runtime.ContractKind.Requires, startOffset: 365, length: 15, sourceFile: null, line: 18, column: 7, condition: "value >= 0");
+            if (!(value >= 0)) throw new Calor.Runtime.ContractViolationException("Precondition failed: value >= 0", "mt002", Calor.Runtime.ContractKind.Requires, startOffset: 387, length: 15, sourceFile: null, line: 19, column: 7, condition: "value >= 0");
             int __result__ = default;
 
             __result__ = value + 10;
 
-            if (!(__result__ >= 10)) throw new Calor.Runtime.ContractViolationException("Postcondition failed: __result__ >= 10", "mt002", Calor.Runtime.ContractKind.Ensures, startOffset: 387, length: 17, sourceFile: null, line: 19, column: 7, condition: "__result__ >= 10");
+            if (!(__result__ >= 10)) throw new Calor.Runtime.ContractViolationException("Postcondition failed: __result__ >= 10", "mt002", Calor.Runtime.ContractKind.Ensures, startOffset: 409, length: 17, sourceFile: null, line: 20, column: 7, condition: "__result__ >= 10");
             return __result__;
         }
 

--- a/src/Calor.Compiler/Verification/ContractInheritanceChecker.cs
+++ b/src/Calor.Compiler/Verification/ContractInheritanceChecker.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using Calor.Compiler.Ast;
+using Calor.Compiler.Binding;
 using Calor.Compiler.Diagnostics;
 using Calor.Compiler.Parsing;
 using Calor.Compiler.Verification.Z3;
@@ -56,16 +57,19 @@ public sealed class ContractInheritanceChecker : IDisposable
     public ModuleInheritanceResult Check(ModuleNode module)
     {
         var results = new List<ClassInheritanceResult>();
-        var inheritedContracts = new Dictionary<(string ClassName, string MethodName), InheritedContractInfo>();
+        var inheritedContracts =
+            new Dictionary<MethodContractKey, InheritedContractInfo>();
 
-        // Build a lookup of interfaces by name (use last-wins for generic overloads like IFoo and IFoo<T>)
-        var interfaces = new Dictionary<string, InterfaceDefinitionNode>(StringComparer.Ordinal);
-        foreach (var iface in module.Interfaces)
-            interfaces[iface.Name] = iface;
+        var interfaces = module.Interfaces.ToArray();
+        var classes = module.Classes.ToArray();
 
         foreach (var classNode in module.Classes)
         {
-            var classResult = CheckClass(classNode, interfaces, inheritedContracts);
+            var classResult = CheckClass(
+                classNode,
+                interfaces,
+                classes,
+                inheritedContracts);
             results.Add(classResult);
         }
 
@@ -74,43 +78,60 @@ public sealed class ContractInheritanceChecker : IDisposable
 
     private ClassInheritanceResult CheckClass(
         ClassDefinitionNode classNode,
-        Dictionary<string, InterfaceDefinitionNode> interfaces,
-        Dictionary<(string ClassName, string MethodName), InheritedContractInfo> inheritedContracts)
+        IReadOnlyList<InterfaceDefinitionNode> interfaces,
+        IReadOnlyList<ClassDefinitionNode> classes,
+        Dictionary<MethodContractKey, InheritedContractInfo> inheritedContracts)
     {
         var methodResults = new List<MethodInheritanceResult>();
+        var interfaceMethods = CollectInterfaceMethods(classNode, interfaces);
 
-        foreach (var interfaceName in classNode.ImplementedInterfaces)
+        foreach (var interfaceSource in interfaceMethods)
         {
-            if (!interfaces.TryGetValue(interfaceName, out var interfaceNode))
+            if (!classNode.Methods.Any(method =>
+                    InterfaceMethodMatches(method, interfaceSource))
+                && interfaceSource.Method.HasContracts)
             {
-                // Interface not defined in this module - skip (could be external)
+                _diagnostics.ReportError(
+                    classNode.Span,
+                    DiagnosticCode.InterfaceMethodNotFound,
+                    $"Class '{classNode.Name}' does not implement "
+                    + $"'{interfaceSource.Interface.Name}."
+                    + $"{interfaceSource.Method.Name}' which has contracts");
+            }
+        }
+
+        foreach (var implementingMethod in classNode.Methods)
+        {
+            var sources = new List<ContractSource>();
+            sources.AddRange(interfaceMethods
+                .Where(source => InterfaceMethodMatches(
+                    implementingMethod,
+                    source))
+                .Select(pair => new ContractSource(
+                    pair.Interface.Name,
+                    pair.Method.Name,
+                    pair.Method.Id,
+                    pair.Method.Parameters,
+                    pair.Method.Preconditions,
+                    pair.Method.Postconditions,
+                    pair.Method.TypeParameters
+                        .Select(parameter => parameter.Name)
+                        .ToArray(),
+                    pair.TypeSubstitutions)));
+            sources.AddRange(CollectBaseMethods(
+                classNode,
+                implementingMethod,
+                interfaces,
+                classes));
+
+            if (sources.Count == 0)
                 continue;
-            }
 
-            foreach (var interfaceMethod in interfaceNode.Methods)
-            {
-                // Find the implementing method
-                var implementingMethod = classNode.Methods.FirstOrDefault(m =>
-                    m.Name.Equals(interfaceMethod.Name, StringComparison.Ordinal) &&
-                    ParametersMatch(m.Parameters, interfaceMethod.Parameters));
-
-                if (implementingMethod == null)
-                {
-                    // Method not implemented - warn if interface has contracts
-                    if (interfaceMethod.HasContracts)
-                    {
-                        _diagnostics.ReportWarning(
-                            classNode.Span,
-                            DiagnosticCode.InterfaceMethodNotFound,
-                            $"Class '{classNode.Name}' does not implement '{interfaceName}.{interfaceMethod.Name}' which has contracts");
-                    }
-                    continue;
-                }
-
-                var result = CheckMethodContracts(
-                    classNode, implementingMethod, interfaceNode, interfaceMethod, inheritedContracts);
-                methodResults.Add(result);
-            }
+            methodResults.Add(CheckMethodContracts(
+                classNode,
+                implementingMethod,
+                sources,
+                inheritedContracts));
         }
 
         return new ClassInheritanceResult(classNode.Id, classNode.Name, methodResults);
@@ -119,14 +140,20 @@ public sealed class ContractInheritanceChecker : IDisposable
     private MethodInheritanceResult CheckMethodContracts(
         ClassDefinitionNode classNode,
         MethodNode implementingMethod,
-        InterfaceDefinitionNode interfaceNode,
-        MethodSignatureNode interfaceMethod,
-        Dictionary<(string ClassName, string MethodName), InheritedContractInfo> inheritedContracts)
+        IReadOnlyList<ContractSource> sources,
+        Dictionary<MethodContractKey, InheritedContractInfo> inheritedContracts)
     {
         var violations = new List<ContractViolation>();
-        var key = (classNode.Name, implementingMethod.Name);
+        var key = MethodContractKey.Create(classNode.Name, implementingMethod);
+        var orderedSources = sources
+            .Select(source => RebindSourceParameters(
+                source,
+                implementingMethod))
+            .OrderBy(source => source.TypeName, StringComparer.Ordinal)
+            .ThenBy(source => source.MethodName, StringComparer.Ordinal)
+            .ThenBy(source => source.MethodId, StringComparer.Ordinal)
+            .ToArray();
 
-        // Report Z3 unavailable once per check session
         if (!_useZ3 && !_z3UnavailableReported)
         {
             _z3UnavailableReported = true;
@@ -136,130 +163,967 @@ public sealed class ContractInheritanceChecker : IDisposable
                 "Z3 SMT solver unavailable, using heuristic checking only for contract inheritance");
         }
 
-        // Case 1: Interface has contracts, implementer has none → inherit
-        if (interfaceMethod.HasContracts && !implementingMethod.HasContracts)
+        var combinedInherited = orderedSources.Any(source => source.HasContracts)
+            ? CreateInheritedContractInfo(implementingMethod, orderedSources)
+            : null;
+        if (combinedInherited != null)
         {
-            inheritedContracts[key] = new InheritedContractInfo(
-                interfaceNode.Name,
-                interfaceMethod.Name,
-                interfaceMethod.Preconditions,
-                interfaceMethod.Postconditions);
+            AddInheritedConflictViolation(
+                classNode,
+                implementingMethod,
+                combinedInherited,
+                violations);
+        }
+
+        if (!implementingMethod.HasContracts)
+        {
+            if (!orderedSources.Any(source => source.HasContracts))
+            {
+                return new MethodInheritanceResult(
+                    implementingMethod.Id,
+                    implementingMethod.Name,
+                    ContractInheritanceStatus.NoContracts,
+                    violations);
+            }
+
+            var inherited = combinedInherited!;
+            inheritedContracts[key] = inherited;
 
             _diagnostics.ReportInfo(
                 implementingMethod.Span,
                 DiagnosticCode.InheritedContracts,
-                $"Method '{classNode.Name}.{implementingMethod.Name}' inherits contracts from '{interfaceNode.Name}.{interfaceMethod.Name}'");
+                $"Method '{classNode.Name}.{implementingMethod.Name}' inherits contracts from "
+                + inherited.SourceDisplayName);
 
             return new MethodInheritanceResult(
                 implementingMethod.Id,
                 implementingMethod.Name,
-                ContractInheritanceStatus.Inherited,
+                violations.Count == 0
+                    ? ContractInheritanceStatus.Inherited
+                    : ContractInheritanceStatus.Violation,
                 violations);
         }
 
-        // Case 2: Both have contracts → check LSP compliance
-        if (interfaceMethod.HasContracts && implementingMethod.HasContracts)
+        var parameters = GetParameterList(implementingMethod.Parameters);
+        var implementerPrecondition = Conjoin(
+            implementingMethod.Preconditions.Select(contract => contract.Condition),
+            implementingMethod.Span);
+        var implementerPostcondition = Conjoin(
+            implementingMethod.Postconditions.Select(contract => contract.Condition),
+            implementingMethod.Span);
+        var outputType = implementingMethod.Output?.TypeName;
+
+        foreach (var source in orderedSources)
         {
-            var parameters = GetParameterList(implementingMethod.Parameters);
+            var sourcePrecondition = Conjoin(
+                source.Preconditions.Select(contract => contract.Condition),
+                implementingMethod.Span);
+            var preconditionViolation = CheckPreconditionImplication(
+                parameters,
+                sourcePrecondition,
+                implementerPrecondition,
+                classNode,
+                implementingMethod,
+                source.TypeName,
+                source.MethodName,
+                implementingMethod.Span);
+            if (preconditionViolation != null)
+                violations.Add(preconditionViolation);
 
-            // Check preconditions: interface precondition must imply implementer precondition
-            // (implementer must accept at least what interface accepts)
-            // For each interface precondition, check if ANY implementer precondition satisfies it
-            foreach (var interfacePrecondition in interfaceMethod.Preconditions)
-            {
-                bool hasValidMatch = false;
-                ContractViolation? lastViolation = null;
-
-                foreach (var implPrecondition in implementingMethod.Preconditions)
-                {
-                    var result = CheckPreconditionImplication(
-                        parameters,
-                        interfacePrecondition.Condition,
-                        implPrecondition.Condition,
-                        classNode,
-                        implementingMethod,
-                        interfaceNode,
-                        interfaceMethod,
-                        implPrecondition.Span);
-
-                    if (result == null)  // null means valid (no violation)
-                    {
-                        hasValidMatch = true;
-                        break;  // Found a matching precondition, move to next interface precondition
-                    }
-                    lastViolation = result;
-                }
-
-                // Only report violation if NO implementer precondition matched
-                if (!hasValidMatch && lastViolation != null)
-                {
-                    violations.Add(lastViolation);
-                }
-            }
-
-            // Check postconditions: implementer postcondition must imply interface postcondition
-            // (implementer must guarantee at least what interface guarantees)
-            // For each interface postcondition, check if ANY implementer postcondition satisfies it
-            var outputType = implementingMethod.Output?.TypeName;
-            foreach (var interfacePostcondition in interfaceMethod.Postconditions)
-            {
-                bool hasValidMatch = false;
-                ContractViolation? lastViolation = null;
-
-                foreach (var implPostcondition in implementingMethod.Postconditions)
-                {
-                    var result = CheckPostconditionImplication(
-                        parameters,
-                        outputType,
-                        interfacePostcondition.Condition,
-                        implPostcondition.Condition,
-                        classNode,
-                        implementingMethod,
-                        interfaceNode,
-                        interfaceMethod,
-                        implPostcondition.Span);
-
-                    if (result == null)  // null means valid (no violation)
-                    {
-                        hasValidMatch = true;
-                        break;  // Found a matching postcondition, move to next interface postcondition
-                    }
-                    lastViolation = result;
-                }
-
-                // Only report violation if NO implementer postcondition matched
-                if (!hasValidMatch && lastViolation != null)
-                {
-                    violations.Add(lastViolation);
-                }
-            }
-
-            var status = violations.Count > 0
-                ? ContractInheritanceStatus.Violation
-                : ContractInheritanceStatus.Valid;
-
-            if (status == ContractInheritanceStatus.Valid)
-            {
-                _diagnostics.ReportInfo(
-                    implementingMethod.Span,
-                    DiagnosticCode.ContractInheritanceValid,
-                    $"Contract inheritance valid for '{classNode.Name}.{implementingMethod.Name}'");
-            }
-
-            return new MethodInheritanceResult(
-                implementingMethod.Id,
-                implementingMethod.Name,
-                status,
-                violations);
+            var sourcePostcondition = Conjoin(
+                source.Postconditions.Select(contract => contract.Condition),
+                implementingMethod.Span);
+            sourcePostcondition = QualifyPostcondition(
+                sourcePrecondition,
+                sourcePostcondition,
+                implementingMethod.Span);
+            var postconditionViolation = CheckPostconditionImplication(
+                parameters,
+                outputType,
+                sourcePostcondition,
+                implementerPostcondition,
+                classNode,
+                implementingMethod,
+                source.TypeName,
+                source.MethodName,
+                implementingMethod.Span);
+            if (postconditionViolation != null)
+                violations.Add(postconditionViolation);
         }
 
-        // Case 3: Neither has contracts, or only implementer has contracts → valid
+        var status = violations.Count > 0
+            ? ContractInheritanceStatus.Violation
+            : ContractInheritanceStatus.Valid;
+        if (status == ContractInheritanceStatus.Valid)
+        {
+            _diagnostics.ReportInfo(
+                implementingMethod.Span,
+                DiagnosticCode.ContractInheritanceValid,
+                $"Contract inheritance valid for "
+                + $"'{classNode.Name}.{implementingMethod.Name}'");
+        }
+
         return new MethodInheritanceResult(
             implementingMethod.Id,
             implementingMethod.Name,
-            ContractInheritanceStatus.NoContracts,
+            status,
             violations);
     }
+
+    private static IReadOnlyList<InterfaceMethodSource> CollectInterfaceMethods(
+        ClassDefinitionNode classNode,
+        IReadOnlyList<InterfaceDefinitionNode> interfaces)
+    {
+        var result = new List<InterfaceMethodSource>();
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+
+        void Visit(
+            string interfaceReference,
+            IReadOnlyDictionary<string, string> outerSubstitutions)
+        {
+            var substitutedReference = SubstituteTypeName(
+                interfaceReference,
+                outerSubstitutions);
+            if (!visited.Add(substitutedReference))
+                return;
+
+            var reference = ParseTypeReference(substitutedReference);
+            var interfaceNode = interfaces.FirstOrDefault(candidate =>
+                candidate.Name.Equals(reference.Name, StringComparison.Ordinal)
+                && candidate.TypeParameters.Count == reference.Arguments.Count);
+            if (interfaceNode == null)
+            {
+                return;
+            }
+            var substitutions = interfaceNode.TypeParameters
+                .Select(parameter => parameter.Name)
+                .Zip(reference.Arguments, KeyValuePair.Create)
+                .ToDictionary(
+                    pair => pair.Key,
+                    pair => pair.Value,
+                    StringComparer.Ordinal);
+
+            foreach (var baseInterface in interfaceNode.BaseInterfaces
+                         .OrderBy(name => name, StringComparer.Ordinal))
+            {
+                Visit(baseInterface, substitutions);
+            }
+            foreach (var method in interfaceNode.Methods
+                         .OrderBy(method => method.Name, StringComparer.Ordinal)
+                         .ThenBy(method => method.Id, StringComparer.Ordinal))
+            {
+                result.Add(new InterfaceMethodSource(
+                    interfaceNode,
+                    method,
+                    substitutions));
+            }
+        }
+
+        foreach (var interfaceName in classNode.ImplementedInterfaces
+                     .OrderBy(name => name, StringComparer.Ordinal))
+        {
+            Visit(
+                interfaceName,
+                new Dictionary<string, string>(StringComparer.Ordinal));
+        }
+        return result;
+    }
+
+    private static IEnumerable<ContractSource> CollectBaseMethods(
+        ClassDefinitionNode classNode,
+        MethodNode implementingMethod,
+        IReadOnlyList<InterfaceDefinitionNode> interfaces,
+        IReadOnlyList<ClassDefinitionNode> classes)
+    {
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var baseClassReference = classNode.BaseClass;
+        var substitutions =
+            new Dictionary<string, string>(StringComparer.Ordinal);
+        while (baseClassReference != null)
+        {
+            var substitutedReference = SubstituteTypeName(
+                baseClassReference,
+                substitutions);
+            if (!visited.Add(substitutedReference))
+                yield break;
+            var reference = ParseTypeReference(substitutedReference);
+            var baseClass = classes.FirstOrDefault(candidate =>
+                candidate.Name.Equals(reference.Name, StringComparison.Ordinal)
+                && candidate.TypeParameters.Count == reference.Arguments.Count);
+            if (baseClass == null)
+                yield break;
+            substitutions = baseClass.TypeParameters
+                .Select(parameter => parameter.Name)
+                .Zip(reference.Arguments, KeyValuePair.Create)
+                .ToDictionary(
+                    pair => pair.Key,
+                    pair => pair.Value,
+                    StringComparer.Ordinal);
+            var baseMethod = baseClass.Methods.FirstOrDefault(method =>
+                MethodsMatch(implementingMethod, method, substitutions));
+            if (baseMethod != null)
+            {
+                if (baseMethod.HasContracts)
+                {
+                    yield return new ContractSource(
+                        baseClass.Name,
+                        baseMethod.Name,
+                        baseMethod.Id,
+                        baseMethod.Parameters,
+                        baseMethod.Preconditions,
+                        baseMethod.Postconditions,
+                        baseMethod.TypeParameters
+                            .Select(parameter => parameter.Name)
+                            .ToArray(),
+                        new Dictionary<string, string>(
+                            substitutions,
+                            StringComparer.Ordinal));
+                }
+                else
+                {
+                    foreach (var pair in CollectInterfaceMethods(
+                                 baseClass,
+                                 interfaces)
+                                 .Where(pair => MethodsMatch(
+                                     baseMethod,
+                                     pair.Method,
+                                     pair.TypeSubstitutions)))
+                    {
+                        yield return new ContractSource(
+                            pair.Interface.Name,
+                            pair.Method.Name,
+                            pair.Method.Id,
+                            pair.Method.Parameters,
+                            pair.Method.Preconditions,
+                            pair.Method.Postconditions,
+                            pair.Method.TypeParameters
+                                .Select(parameter => parameter.Name)
+                                .ToArray(),
+                            pair.TypeSubstitutions.ToDictionary(
+                                substitution => substitution.Key,
+                                substitution => SubstituteTypeName(
+                                    substitution.Value,
+                                    substitutions),
+                                StringComparer.Ordinal));
+                    }
+                }
+            }
+            baseClassReference = baseClass.BaseClass;
+        }
+    }
+
+    private static ContractSource RebindSourceParameters(
+        ContractSource source,
+        MethodNode implementation)
+    {
+        var implementationParameters = implementation.Parameters;
+        var replacements = source.Parameters
+            .Zip(
+                implementationParameters,
+                (sourceParameter, implementationParameter) =>
+                    KeyValuePair.Create(
+                        sourceParameter.Name,
+                        implementationParameter.Name))
+            .Where(pair =>
+                !pair.Key.Equals(pair.Value, StringComparison.Ordinal))
+            .ToDictionary(
+                pair => pair.Key,
+                pair => pair.Value,
+                StringComparer.Ordinal);
+        var typeReplacements = new Dictionary<string, string>(
+            source.TypeSubstitutions,
+            StringComparer.Ordinal);
+        foreach (var pair in source.MethodTypeParameters
+                     .Zip(
+                         implementation.TypeParameters,
+                         (sourceParameter, implementationParameter) =>
+                             KeyValuePair.Create(
+                                 sourceParameter,
+                                 implementationParameter.Name)))
+        {
+            typeReplacements[pair.Key] = pair.Value;
+        }
+
+        return source with
+        {
+            Parameters = implementationParameters,
+            Preconditions = source.Preconditions
+                .Select(contract => new RequiresNode(
+                    contract.Span,
+                    RewriteReferences(
+                        AvoidPatternCapture(
+                            contract.Condition,
+                            replacements),
+                        replacements,
+                        typeReplacements),
+                    contract.Message,
+                    contract.Attributes))
+                .ToArray(),
+            Postconditions = source.Postconditions
+                .Select(contract => new EnsuresNode(
+                    contract.Span,
+                    RewriteReferences(
+                        AvoidPatternCapture(
+                            contract.Condition,
+                            replacements),
+                        replacements,
+                        typeReplacements),
+                    contract.Message,
+                    contract.Attributes))
+                .ToArray()
+        };
+    }
+
+    private static ExpressionNode RewriteReferences(
+        ExpressionNode expression,
+        IReadOnlyDictionary<string, string> replacements,
+        IReadOnlyDictionary<string, string>? typeReplacements = null)
+    {
+        if (expression is ReferenceNode reference)
+        {
+            var rewritten = RewriteReferenceName(reference.Name, replacements);
+            return rewritten.Equals(reference.Name, StringComparison.Ordinal)
+                ? reference
+                : new ReferenceNode(reference.Span, rewritten);
+        }
+        if (expression is BinaryOperationNode binary)
+        {
+            return new BinaryOperationNode(
+                binary.Span,
+                binary.Operator,
+                RewriteReferences(binary.Left, replacements, typeReplacements),
+                RewriteReferences(binary.Right, replacements, typeReplacements));
+        }
+        if (expression is UnaryOperationNode unary)
+        {
+            return new UnaryOperationNode(
+                unary.Span,
+                unary.Operator,
+                RewriteReferences(unary.Operand, replacements, typeReplacements));
+        }
+        if (expression is ConditionalExpressionNode conditional)
+        {
+            return new ConditionalExpressionNode(
+                conditional.Span,
+                RewriteReferences(conditional.Condition, replacements, typeReplacements),
+                RewriteReferences(conditional.WhenTrue, replacements, typeReplacements),
+                RewriteReferences(conditional.WhenFalse, replacements, typeReplacements));
+        }
+        if (expression is ArrayAccessNode arrayAccess)
+        {
+            return new ArrayAccessNode(
+                arrayAccess.Span,
+                RewriteReferences(arrayAccess.Array, replacements, typeReplacements),
+                RewriteReferences(arrayAccess.Index, replacements, typeReplacements));
+        }
+        if (expression is ArrayLengthNode arrayLength)
+        {
+            return new ArrayLengthNode(
+                arrayLength.Span,
+                RewriteReferences(arrayLength.Array, replacements, typeReplacements));
+        }
+        if (expression is FieldAccessNode fieldAccess)
+        {
+            return new FieldAccessNode(
+                fieldAccess.Span,
+                RewriteReferences(fieldAccess.Target, replacements, typeReplacements),
+                fieldAccess.FieldName,
+                fieldAccess.FieldNameSpan);
+        }
+        if (expression is StringOperationNode stringOperation)
+        {
+            return new StringOperationNode(
+                stringOperation.Span,
+                stringOperation.Operation,
+                stringOperation.Arguments
+                    .Select(argument => RewriteReferences(
+                        argument,
+                        replacements,
+                        typeReplacements))
+                    .ToArray(),
+                stringOperation.ComparisonMode);
+        }
+        if (expression is ImplicationExpressionNode implication)
+        {
+            return new ImplicationExpressionNode(
+                implication.Span,
+                RewriteReferences(implication.Antecedent, replacements, typeReplacements),
+                RewriteReferences(implication.Consequent, replacements, typeReplacements));
+        }
+        if (expression is NullCoalesceNode coalesce)
+        {
+            return new NullCoalesceNode(
+                coalesce.Span,
+                RewriteReferences(coalesce.Left, replacements, typeReplacements),
+                RewriteReferences(coalesce.Right, replacements, typeReplacements));
+        }
+        if (expression is NullConditionalNode conditionalAccess)
+        {
+            return new NullConditionalNode(
+                conditionalAccess.Span,
+                RewriteReferences(
+                    conditionalAccess.Target,
+                    replacements,
+                    typeReplacements),
+                conditionalAccess.MemberName);
+        }
+        if (expression is RangeExpressionNode range)
+        {
+            return new RangeExpressionNode(
+                range.Span,
+                range.Start == null
+                    ? null
+                    : RewriteReferences(range.Start, replacements, typeReplacements),
+                range.End == null
+                    ? null
+                    : RewriteReferences(range.End, replacements, typeReplacements));
+        }
+        if (expression is IndexFromEndNode indexFromEnd)
+        {
+            return new IndexFromEndNode(
+                indexFromEnd.Span,
+                RewriteReferences(
+                    indexFromEnd.Offset,
+                    replacements,
+                    typeReplacements));
+        }
+        if (expression is TypeOperationNode typeOperation)
+        {
+            return new TypeOperationNode(
+                typeOperation.Span,
+                typeOperation.Operation,
+                RewriteReferences(
+                    typeOperation.Operand,
+                    replacements,
+                    typeReplacements),
+                RewriteTypeName(typeOperation.TargetType, typeReplacements),
+                typeOperation.TargetTypeSpan);
+        }
+        if (expression is IsPatternNode isPattern)
+        {
+            return new IsPatternNode(
+                isPattern.Span,
+                RewriteReferences(
+                    isPattern.Operand,
+                    replacements,
+                    typeReplacements),
+                RewriteTypeName(isPattern.TargetType, typeReplacements),
+                isPattern.VariableName == null
+                    ? null
+                    : RewriteReferenceName(
+                        isPattern.VariableName,
+                        replacements),
+                isPattern.TargetTypeSpan);
+        }
+        if (expression is InterpolatedStringNode interpolated)
+        {
+            return new InterpolatedStringNode(
+                interpolated.Span,
+                interpolated.Parts.Select(part =>
+                    part is InterpolatedStringExpressionNode expressionPart
+                        ? new InterpolatedStringExpressionNode(
+                            expressionPart.Span,
+                            RewriteReferences(
+                                expressionPart.Expression,
+                                replacements,
+                                typeReplacements),
+                            expressionPart.FormatSpecifier,
+                            expressionPart.AlignmentClause)
+                        : part).ToArray());
+        }
+        if (expression is TypeOfExpressionNode typeOf)
+        {
+            return new TypeOfExpressionNode(
+                typeOf.Span,
+                RewriteTypeName(typeOf.TypeName, typeReplacements),
+                typeOf.TypeNameSpan);
+        }
+        if (expression is SizeOfNode sizeOf)
+        {
+            return new SizeOfNode(
+                sizeOf.Span,
+                RewriteTypeName(sizeOf.TypeName, typeReplacements),
+                sizeOf.TypeNameSpan);
+        }
+        if (expression is NameOfExpressionNode nameOf)
+        {
+            return new NameOfExpressionNode(
+                nameOf.Span,
+                RewriteReferenceName(nameOf.Name, replacements));
+        }
+        if (expression is SomeExpressionNode some)
+        {
+            return new SomeExpressionNode(
+                some.Span,
+                RewriteReferences(some.Value, replacements, typeReplacements));
+        }
+        if (expression is OkExpressionNode ok)
+        {
+            return new OkExpressionNode(
+                ok.Span,
+                RewriteReferences(ok.Value, replacements, typeReplacements));
+        }
+        if (expression is ErrExpressionNode err)
+        {
+            return new ErrExpressionNode(
+                err.Span,
+                RewriteReferences(err.Error, replacements, typeReplacements));
+        }
+        if (expression is AwaitExpressionNode awaitExpression)
+        {
+            return new AwaitExpressionNode(
+                awaitExpression.Span,
+                RewriteReferences(
+                    awaitExpression.Awaited,
+                    replacements,
+                    typeReplacements),
+                awaitExpression.ConfigureAwait);
+        }
+        if (expression is ThrowExpressionNode throwExpression)
+        {
+            return new ThrowExpressionNode(
+                throwExpression.Span,
+                RewriteReferences(
+                    throwExpression.Exception,
+                    replacements,
+                    typeReplacements));
+        }
+        if (expression is AddressOfNode addressOf)
+        {
+            return new AddressOfNode(
+                addressOf.Span,
+                RewriteReferences(addressOf.Operand, replacements, typeReplacements));
+        }
+        if (expression is PointerDereferenceNode dereference)
+        {
+            return new PointerDereferenceNode(
+                dereference.Span,
+                RewriteReferences(dereference.Operand, replacements, typeReplacements));
+        }
+        if (expression is CollectionContainsNode contains)
+        {
+            return new CollectionContainsNode(
+                contains.Span,
+                RewriteReferenceName(contains.CollectionName, replacements),
+                RewriteReferences(
+                    contains.KeyOrValue,
+                    replacements,
+                    typeReplacements),
+                contains.Mode);
+        }
+        if (expression is CollectionCountNode count)
+        {
+            return new CollectionCountNode(
+                count.Span,
+                RewriteReferences(count.Collection, replacements, typeReplacements));
+        }
+        if (expression is CharOperationNode charOperation)
+        {
+            return new CharOperationNode(
+                charOperation.Span,
+                charOperation.Operation,
+                charOperation.Arguments
+                    .Select(argument => RewriteReferences(
+                        argument,
+                        replacements,
+                        typeReplacements))
+                    .ToArray());
+        }
+        if (expression is StringBuilderOperationNode stringBuilder)
+        {
+            return new StringBuilderOperationNode(
+                stringBuilder.Span,
+                stringBuilder.Operation,
+                stringBuilder.Arguments
+                    .Select(argument => RewriteReferences(
+                        argument,
+                        replacements,
+                        typeReplacements))
+                    .ToArray());
+        }
+        if (expression is CallExpressionNode call)
+        {
+            return new CallExpressionNode(
+                call.Span,
+                RewriteReferenceName(call.Target, replacements),
+                call.Arguments
+                    .Select(argument => RewriteReferences(
+                        argument,
+                        replacements,
+                        typeReplacements))
+                    .ToArray(),
+                call.ArgumentNames,
+                call.ArgumentModifiers,
+                call.TypeArguments?
+                    .Select(typeArgument => RewriteTypeName(
+                        typeArgument,
+                        typeReplacements))
+                    .ToArray(),
+                call.CalleeSpan,
+                call.ReceiverSpan);
+        }
+        if (expression is NewExpressionNode newExpression)
+        {
+            return new NewExpressionNode(
+                newExpression.Span,
+                RewriteTypeName(newExpression.TypeName, typeReplacements),
+                newExpression.TypeArguments
+                    .Select(typeArgument => RewriteTypeName(
+                        typeArgument,
+                        typeReplacements))
+                    .ToArray(),
+                newExpression.Arguments
+                    .Select(argument => RewriteReferences(
+                        argument,
+                        replacements,
+                        typeReplacements))
+                    .ToArray(),
+                newExpression.Initializers
+                    .Select(initializer => new ObjectInitializerAssignment(
+                        initializer.PropertyName,
+                        RewriteReferences(
+                            initializer.Value,
+                            replacements,
+                            typeReplacements)))
+                    .ToArray(),
+                newExpression.TypeNameSpan);
+        }
+        if (expression is AnonymousObjectCreationNode anonymousObject)
+        {
+            return new AnonymousObjectCreationNode(
+                anonymousObject.Span,
+                anonymousObject.Initializers
+                    .Select(initializer => new ObjectInitializerAssignment(
+                        initializer.PropertyName,
+                        RewriteReferences(
+                            initializer.Value,
+                            replacements,
+                            typeReplacements)))
+                    .ToArray());
+        }
+        if (expression is ExpressionCallNode expressionCall)
+        {
+            return new ExpressionCallNode(
+                expressionCall.Span,
+                RewriteReferences(
+                    expressionCall.TargetExpression,
+                    replacements,
+                    typeReplacements),
+                expressionCall.Arguments
+                    .Select(argument => RewriteReferences(
+                        argument,
+                        replacements,
+                        typeReplacements))
+                    .ToArray());
+        }
+        if (expression is ForallExpressionNode forall)
+        {
+            var (boundVariables, body) = AvoidReplacementCapture(
+                forall.BoundVariables,
+                forall.Body,
+                replacements);
+            var nested = replacements
+                .Where(pair => !boundVariables.Any(variable =>
+                    variable.Name.Equals(pair.Key, StringComparison.Ordinal)))
+                .ToDictionary(
+                    pair => pair.Key,
+                    pair => pair.Value,
+                    StringComparer.Ordinal);
+            return new ForallExpressionNode(
+                forall.Span,
+                RewriteQuantifierTypes(boundVariables, typeReplacements),
+                RewriteReferences(body, nested, typeReplacements));
+        }
+        if (expression is ExistsExpressionNode exists)
+        {
+            var (boundVariables, body) = AvoidReplacementCapture(
+                exists.BoundVariables,
+                exists.Body,
+                replacements);
+            var nested = replacements
+                .Where(pair => !boundVariables.Any(variable =>
+                    variable.Name.Equals(pair.Key, StringComparison.Ordinal)))
+                .ToDictionary(
+                    pair => pair.Key,
+                    pair => pair.Value,
+                    StringComparer.Ordinal);
+            return new ExistsExpressionNode(
+                exists.Span,
+                RewriteQuantifierTypes(boundVariables, typeReplacements),
+                RewriteReferences(body, nested, typeReplacements));
+        }
+        return expression;
+    }
+
+    private static string RewriteReferenceName(
+        string name,
+        IReadOnlyDictionary<string, string> replacements)
+    {
+        foreach (var (oldName, newName) in replacements)
+        {
+            if (name.Equals(oldName, StringComparison.Ordinal))
+                return newName;
+            if (name.StartsWith(oldName + ".", StringComparison.Ordinal))
+                return newName + name[oldName.Length..];
+        }
+        return name;
+    }
+
+    private static ExpressionNode AvoidPatternCapture(
+        ExpressionNode expression,
+        IReadOnlyDictionary<string, string> replacements)
+    {
+        var replacementTargets = replacements.Values
+            .ToHashSet(StringComparer.Ordinal);
+        var patternNames = EnumerateDescendantsAndSelf(expression)
+            .OfType<IsPatternNode>()
+            .Select(pattern => pattern.VariableName)
+            .OfType<string>()
+            .Where(replacementTargets.Contains)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (patternNames.Length == 0)
+            return expression;
+
+        var usedNames = replacements.Keys
+            .Concat(replacements.Values)
+            .Concat(patternNames)
+            .ToHashSet(StringComparer.Ordinal);
+        var renames = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var patternName in patternNames)
+        {
+            var suffix = 0;
+            string freshName;
+            do
+            {
+                freshName = $"__contract_{patternName}_{suffix++}";
+            }
+            while (!usedNames.Add(freshName));
+            renames.Add(patternName, freshName);
+        }
+        return RewriteReferences(expression, renames);
+    }
+
+    private static IEnumerable<AstNode> EnumerateDescendantsAndSelf(
+        AstNode node)
+    {
+        yield return node;
+        foreach (var child in Calor.Compiler.Analysis.RecursiveAstWalker
+                     .GetAllChildren(node))
+        {
+            foreach (var descendant in EnumerateDescendantsAndSelf(child))
+                yield return descendant;
+        }
+    }
+
+    private static string RewriteTypeName(
+        string typeName,
+        IReadOnlyDictionary<string, string>? replacements) =>
+        replacements == null
+            ? typeName
+            : SubstituteTypeName(typeName, replacements);
+
+    private static IReadOnlyList<QuantifierVariableNode> RewriteQuantifierTypes(
+        IReadOnlyList<QuantifierVariableNode> variables,
+        IReadOnlyDictionary<string, string>? replacements) =>
+        replacements == null || replacements.Count == 0
+            ? variables
+            : variables.Select(variable => new QuantifierVariableNode(
+                variable.Span,
+                variable.Name,
+                RewriteTypeName(variable.TypeName, replacements),
+                variable.IdentifierSpan,
+                variable.TypeNameSpan)).ToArray();
+
+    private static (
+        IReadOnlyList<QuantifierVariableNode> Variables,
+        ExpressionNode Body) AvoidReplacementCapture(
+            IReadOnlyList<QuantifierVariableNode> variables,
+            ExpressionNode body,
+            IReadOnlyDictionary<string, string> replacements)
+    {
+        var replacementTargets = replacements.Values
+            .ToHashSet(StringComparer.Ordinal);
+        var usedNames = replacements.Keys
+            .Concat(replacements.Values)
+            .Concat(variables.Select(variable => variable.Name))
+            .ToHashSet(StringComparer.Ordinal);
+        var renames = new Dictionary<string, string>(StringComparer.Ordinal);
+        var rewrittenVariables = variables
+            .Select(variable =>
+            {
+                if (!replacementTargets.Contains(variable.Name))
+                    return variable;
+                var suffix = 0;
+                string freshName;
+                do
+                {
+                    freshName = $"__contract_{variable.Name}_{suffix++}";
+                }
+                while (!usedNames.Add(freshName));
+                renames.Add(variable.Name, freshName);
+                return new QuantifierVariableNode(
+                    variable.Span,
+                    freshName,
+                    variable.TypeName,
+                    variable.IdentifierSpan,
+                    variable.TypeNameSpan);
+            })
+            .ToArray();
+        return renames.Count == 0
+            ? (variables, body)
+            : (rewrittenVariables, RewriteReferences(body, renames));
+    }
+
+    private InheritedContractInfo CreateInheritedContractInfo(
+        MethodNode implementingMethod,
+        IReadOnlyList<ContractSource> sources)
+    {
+        var sourcePreconditions = sources
+            .Select(source => Conjoin(
+                source.Preconditions.Select(contract => contract.Condition),
+                implementingMethod.Span))
+            .ToArray();
+        var effectivePrecondition = Disjoin(
+            sourcePreconditions,
+            implementingMethod.Span);
+        var preconditions = effectivePrecondition is BoolLiteralNode { Value: true }
+            ? Array.Empty<RequiresNode>()
+            : new[]
+            {
+                new RequiresNode(
+                    implementingMethod.Span,
+                    effectivePrecondition,
+                    null,
+                    new AttributeCollection())
+            };
+        var postconditions = sources
+            .Where(source => source.Postconditions.Count > 0)
+            .Select(source =>
+            {
+                var sourcePrecondition = Conjoin(
+                    source.Preconditions.Select(contract => contract.Condition),
+                    implementingMethod.Span);
+                var sourcePostcondition = Conjoin(
+                    source.Postconditions.Select(contract => contract.Condition),
+                    implementingMethod.Span);
+                return new EnsuresNode(
+                    implementingMethod.Span,
+                    QualifyPostcondition(
+                        sourcePrecondition,
+                        sourcePostcondition,
+                        implementingMethod.Span),
+                    null,
+                    new AttributeCollection());
+            })
+            .ToArray();
+        return new InheritedContractInfo(
+            sources.Select(source => new InheritedContractSource(
+                source.TypeName,
+                source.MethodName,
+                source.MethodId)).ToArray(),
+            preconditions,
+            postconditions);
+    }
+
+    private void AddInheritedConflictViolation(
+        ClassDefinitionNode classNode,
+        MethodNode implementingMethod,
+        InheritedContractInfo inherited,
+        List<ContractViolation> violations)
+    {
+        if (_z3Prover == null || inherited.Postconditions.Count < 2)
+            return;
+
+        var combined = Conjoin(
+            inherited.Postconditions.Select(contract => contract.Condition),
+            implementingMethod.Span);
+        var impossible = _z3Prover.CheckPostconditionStrengthening(
+            GetParameterList(implementingMethod.Parameters),
+            implementingMethod.Output?.TypeName,
+            new BoolLiteralNode(implementingMethod.Span, false),
+            combined);
+        if (impossible.Status != ImplicationStatus.Proven)
+            return;
+
+        var violation = new ContractViolation(
+            ContractViolationType.IncompatibleInheritedContracts,
+            inherited.SourceDisplayName,
+            implementingMethod.Name,
+            "Inherited postconditions are mutually incompatible");
+        violations.Add(violation);
+        _diagnostics.ReportError(
+            implementingMethod.Span,
+            DiagnosticCode.IncompatibleInheritedContracts,
+            $"Inherited contracts for '{classNode.Name}.{implementingMethod.Name}' "
+            + $"are incompatible: {inherited.SourceDisplayName}");
+    }
+
+    private static ExpressionNode Conjoin(
+        IEnumerable<ExpressionNode> expressions,
+        TextSpan span) =>
+        Combine(expressions, BinaryOperator.And, true, span);
+
+    private static ExpressionNode Disjoin(
+        IEnumerable<ExpressionNode> expressions,
+        TextSpan span) =>
+        Combine(expressions, BinaryOperator.Or, false, span);
+
+    private static ExpressionNode QualifyPostcondition(
+        ExpressionNode precondition,
+        ExpressionNode postcondition,
+        TextSpan span) =>
+        precondition is BoolLiteralNode { Value: true }
+            ? postcondition
+            : new ImplicationExpressionNode(
+                span,
+                precondition,
+                postcondition);
+
+    private static ExpressionNode Combine(
+        IEnumerable<ExpressionNode> expressions,
+        BinaryOperator operation,
+        bool identity,
+        TextSpan span)
+    {
+        using var enumerator = expressions.GetEnumerator();
+        if (!enumerator.MoveNext())
+            return new BoolLiteralNode(span, identity);
+
+        var combined = enumerator.Current;
+        while (enumerator.MoveNext())
+        {
+            combined = new BinaryOperationNode(
+                span,
+                operation,
+                combined,
+                enumerator.Current);
+        }
+        return combined;
+    }
+
+    private sealed record ContractSource(
+        string TypeName,
+        string MethodName,
+        string MethodId,
+        IReadOnlyList<ParameterNode> Parameters,
+        IReadOnlyList<RequiresNode> Preconditions,
+        IReadOnlyList<EnsuresNode> Postconditions,
+        IReadOnlyList<string> MethodTypeParameters,
+        IReadOnlyDictionary<string, string> TypeSubstitutions)
+    {
+        public bool HasContracts =>
+            Preconditions.Count > 0 || Postconditions.Count > 0;
+    }
+
+    private sealed record InterfaceMethodSource(
+        InterfaceDefinitionNode Interface,
+        MethodSignatureNode Method,
+        IReadOnlyDictionary<string, string> TypeSubstitutions);
+
+    private sealed record TypeReference(
+        string Name,
+        IReadOnlyList<string> Arguments);
 
     private static IReadOnlyList<(string Name, string Type)> GetParameterList(IReadOnlyList<ParameterNode> parameters)
     {
@@ -276,8 +1140,8 @@ public sealed class ContractInheritanceChecker : IDisposable
         ExpressionNode implementerPrecondition,
         ClassDefinitionNode classNode,
         MethodNode implementingMethod,
-        InterfaceDefinitionNode interfaceNode,
-        MethodSignatureNode interfaceMethod,
+        string sourceTypeName,
+        string sourceMethodName,
         TextSpan implSpan)
     {
         // Try Z3 first if available
@@ -302,14 +1166,14 @@ public sealed class ContractInheritanceChecker : IDisposable
                     // Implication disproven - this is a violation
                     var violation = new ContractViolation(
                         ContractViolationType.StrongerPrecondition,
-                        interfaceNode.Name,
-                        interfaceMethod.Name,
+                        sourceTypeName,
+                        sourceMethodName,
                         $"Precondition is stronger than interface contract (LSP violation). {z3Result.CounterexampleDescription}");
 
                     _diagnostics.ReportError(
                         implSpan,
                         DiagnosticCode.StrongerPrecondition,
-                        $"LSP violation: Precondition in '{classNode.Name}.{implementingMethod.Name}' is stronger than '{interfaceNode.Name}.{interfaceMethod.Name}'. {z3Result.CounterexampleDescription}");
+                        $"LSP violation: Precondition in '{classNode.Name}.{implementingMethod.Name}' is stronger than '{sourceTypeName}.{sourceMethodName}'. {z3Result.CounterexampleDescription}");
                     return violation;
 
                 case ImplicationStatus.Unknown:
@@ -332,8 +1196,8 @@ public sealed class ContractInheritanceChecker : IDisposable
             implementerPrecondition,
             classNode,
             implementingMethod,
-            interfaceNode,
-            interfaceMethod,
+            sourceTypeName,
+            sourceMethodName,
             implSpan);
     }
 
@@ -348,8 +1212,8 @@ public sealed class ContractInheritanceChecker : IDisposable
         ExpressionNode implementerPostcondition,
         ClassDefinitionNode classNode,
         MethodNode implementingMethod,
-        InterfaceDefinitionNode interfaceNode,
-        MethodSignatureNode interfaceMethod,
+        string sourceTypeName,
+        string sourceMethodName,
         TextSpan implSpan)
     {
         // Try Z3 first if available
@@ -375,14 +1239,14 @@ public sealed class ContractInheritanceChecker : IDisposable
                     // Implication disproven - this is a violation
                     var violation = new ContractViolation(
                         ContractViolationType.WeakerPostcondition,
-                        interfaceNode.Name,
-                        interfaceMethod.Name,
+                        sourceTypeName,
+                        sourceMethodName,
                         $"Postcondition is weaker than interface contract (LSP violation). {z3Result.CounterexampleDescription}");
 
                     _diagnostics.ReportError(
                         implSpan,
                         DiagnosticCode.WeakerPostcondition,
-                        $"LSP violation: Postcondition in '{classNode.Name}.{implementingMethod.Name}' is weaker than '{interfaceNode.Name}.{interfaceMethod.Name}'. {z3Result.CounterexampleDescription}");
+                        $"LSP violation: Postcondition in '{classNode.Name}.{implementingMethod.Name}' is weaker than '{sourceTypeName}.{sourceMethodName}'. {z3Result.CounterexampleDescription}");
                     return violation;
 
                 case ImplicationStatus.Unknown:
@@ -405,8 +1269,8 @@ public sealed class ContractInheritanceChecker : IDisposable
             implementerPostcondition,
             classNode,
             implementingMethod,
-            interfaceNode,
-            interfaceMethod,
+            sourceTypeName,
+            sourceMethodName,
             implSpan);
     }
 
@@ -418,8 +1282,8 @@ public sealed class ContractInheritanceChecker : IDisposable
         ExpressionNode implementerPrecondition,
         ClassDefinitionNode classNode,
         MethodNode implementingMethod,
-        InterfaceDefinitionNode interfaceNode,
-        MethodSignatureNode interfaceMethod,
+        string sourceTypeName,
+        string sourceMethodName,
         TextSpan implSpan)
     {
         // Check if implementer precondition is weaker or equal (valid)
@@ -433,19 +1297,29 @@ public sealed class ContractInheritanceChecker : IDisposable
         {
             var violation = new ContractViolation(
                 ContractViolationType.StrongerPrecondition,
-                interfaceNode.Name,
-                interfaceMethod.Name,
+                sourceTypeName,
+                sourceMethodName,
                 "Precondition is stronger than interface contract (LSP violation)");
 
             _diagnostics.ReportError(
                 implSpan,
                 DiagnosticCode.StrongerPrecondition,
-                $"LSP violation: Precondition in '{classNode.Name}.{implementingMethod.Name}' is stronger than '{interfaceNode.Name}.{interfaceMethod.Name}'");
+                $"LSP violation: Precondition in '{classNode.Name}.{implementingMethod.Name}' is stronger than '{sourceTypeName}.{sourceMethodName}'");
             return violation;
         }
 
-        // Cannot determine - assume valid (conservative)
-        return null;
+        var unknownViolation = new ContractViolation(
+            ContractViolationType.StrongerPrecondition,
+            sourceTypeName,
+            sourceMethodName,
+            "Precondition weakening could not be proven");
+        _diagnostics.ReportError(
+            implSpan,
+            DiagnosticCode.StrongerPrecondition,
+            $"LSP violation: Could not prove that precondition in "
+            + $"'{classNode.Name}.{implementingMethod.Name}' is no stronger than "
+            + $"'{sourceTypeName}.{sourceMethodName}'");
+        return unknownViolation;
     }
 
     /// <summary>
@@ -456,12 +1330,19 @@ public sealed class ContractInheritanceChecker : IDisposable
         ExpressionNode implementerPostcondition,
         ClassDefinitionNode classNode,
         MethodNode implementingMethod,
-        InterfaceDefinitionNode interfaceNode,
-        MethodSignatureNode interfaceMethod,
+        string sourceTypeName,
+        string sourceMethodName,
         TextSpan implSpan)
     {
         // Check if implementer postcondition is stronger or equal (valid)
         if (IsStrongerOrEqual(implementerPostcondition, interfacePostcondition))
+        {
+            return null;
+        }
+        if (interfacePostcondition is ImplicationExpressionNode implication
+            && IsStrongerOrEqual(
+                implementerPostcondition,
+                implication.Consequent))
         {
             return null;
         }
@@ -471,35 +1352,160 @@ public sealed class ContractInheritanceChecker : IDisposable
         {
             var violation = new ContractViolation(
                 ContractViolationType.WeakerPostcondition,
-                interfaceNode.Name,
-                interfaceMethod.Name,
+                sourceTypeName,
+                sourceMethodName,
                 "Postcondition is weaker than interface contract (LSP violation)");
 
             _diagnostics.ReportError(
                 implSpan,
                 DiagnosticCode.WeakerPostcondition,
-                $"LSP violation: Postcondition in '{classNode.Name}.{implementingMethod.Name}' is weaker than '{interfaceNode.Name}.{interfaceMethod.Name}'");
+                $"LSP violation: Postcondition in '{classNode.Name}.{implementingMethod.Name}' is weaker than '{sourceTypeName}.{sourceMethodName}'");
             return violation;
         }
 
-        // Cannot determine - assume valid (conservative)
-        return null;
+        var unknownViolation = new ContractViolation(
+            ContractViolationType.WeakerPostcondition,
+            sourceTypeName,
+            sourceMethodName,
+            "Postcondition strengthening could not be proven");
+        _diagnostics.ReportError(
+            implSpan,
+            DiagnosticCode.WeakerPostcondition,
+            $"LSP violation: Could not prove that postcondition in "
+            + $"'{classNode.Name}.{implementingMethod.Name}' is no weaker than "
+            + $"'{sourceTypeName}.{sourceMethodName}'");
+        return unknownViolation;
     }
 
     private static bool ParametersMatch(
         IReadOnlyList<ParameterNode> impl,
-        IReadOnlyList<ParameterNode> iface)
+        IReadOnlyList<ParameterNode> contract,
+        IReadOnlyList<TypeParameterNode> implementationTypeParameters,
+        IReadOnlyList<TypeParameterNode> contractTypeParameters,
+        IReadOnlyDictionary<string, string>? typeSubstitutions = null)
     {
-        if (impl.Count != iface.Count)
+        if (impl.Count != contract.Count)
             return false;
 
         for (int i = 0; i < impl.Count; i++)
         {
-            if (!impl[i].TypeName.Equals(iface[i].TypeName, StringComparison.Ordinal))
+            var contractType = typeSubstitutions == null
+                || contractTypeParameters.Any(parameter =>
+                    parameter.Name.Equals(
+                        contract[i].TypeName,
+                        StringComparison.Ordinal))
+                ? contract[i].TypeName
+                : SubstituteTypeName(
+                    contract[i].TypeName,
+                    typeSubstitutions);
+            var implementationSignature = TypeIdentity.CanonicalizeSignature(
+                impl[i].TypeName,
+                implementationTypeParameters.Select(parameter => parameter.Name).ToArray());
+            var contractSignature = TypeIdentity.CanonicalizeSignature(
+                contractType,
+                contractTypeParameters.Select(parameter => parameter.Name).ToArray());
+            if (impl[i].Modifier != contract[i].Modifier
+                || !implementationSignature.Equals(
+                    contractSignature,
+                    StringComparison.Ordinal))
                 return false;
         }
 
         return true;
+    }
+
+    private static bool MethodsMatch(
+        MethodNode implementation,
+        MethodSignatureNode contract,
+        IReadOnlyDictionary<string, string>? typeSubstitutions = null) =>
+        implementation.Name.Equals(contract.Name, StringComparison.Ordinal)
+        && implementation.TypeParameters.Count == contract.TypeParameters.Count
+        && ParametersMatch(
+            implementation.Parameters,
+            contract.Parameters,
+            implementation.TypeParameters,
+            contract.TypeParameters,
+            typeSubstitutions);
+
+    private static bool InterfaceMethodMatches(
+        MethodNode implementation,
+        InterfaceMethodSource source) =>
+        (implementation.Name.Equals(
+             source.Method.Name,
+             StringComparison.Ordinal)
+         || implementation.Name.Equals(
+             $"{source.Interface.Name}.{source.Method.Name}",
+             StringComparison.Ordinal))
+        && implementation.TypeParameters.Count
+            == source.Method.TypeParameters.Count
+        && ParametersMatch(
+            implementation.Parameters,
+            source.Method.Parameters,
+            implementation.TypeParameters,
+            source.Method.TypeParameters,
+            source.TypeSubstitutions);
+
+    private static bool MethodsMatch(
+        MethodNode implementation,
+        MethodNode contract,
+        IReadOnlyDictionary<string, string>? typeSubstitutions = null) =>
+        implementation.Name.Equals(contract.Name, StringComparison.Ordinal)
+        && implementation.TypeParameters.Count == contract.TypeParameters.Count
+        && ParametersMatch(
+            implementation.Parameters,
+            contract.Parameters,
+            implementation.TypeParameters,
+            contract.TypeParameters,
+            typeSubstitutions);
+
+    private static string SubstituteTypeName(
+        string typeName,
+        IReadOnlyDictionary<string, string> substitutions)
+    {
+        if (substitutions.TryGetValue(typeName, out var replacement))
+            return replacement;
+
+        var reference = ParseTypeReference(typeName);
+        if (reference.Arguments.Count == 0)
+            return typeName;
+        return reference.Name
+            + "<"
+            + string.Join(
+                ",",
+                reference.Arguments.Select(argument =>
+                    SubstituteTypeName(argument, substitutions)))
+            + ">";
+    }
+
+    private static TypeReference ParseTypeReference(string typeName)
+    {
+        var genericStart = typeName.IndexOf('<');
+        if (genericStart < 0 || !typeName.EndsWith('>'))
+            return new TypeReference(typeName, Array.Empty<string>());
+
+        var arguments = new List<string>();
+        var argumentStart = genericStart + 1;
+        var depth = 0;
+        for (var index = argumentStart; index < typeName.Length - 1; index++)
+        {
+            switch (typeName[index])
+            {
+                case '<':
+                    depth++;
+                    break;
+                case '>':
+                    depth--;
+                    break;
+                case ',' when depth == 0:
+                    arguments.Add(typeName[argumentStart..index].Trim());
+                    argumentStart = index + 1;
+                    break;
+            }
+        }
+        arguments.Add(typeName[argumentStart..^1].Trim());
+        return new TypeReference(
+            typeName[..genericStart],
+            arguments);
     }
 
     /// <summary>
@@ -705,7 +1711,12 @@ public enum ContractViolationType
     /// <summary>
     /// Implementer has a weaker postcondition than the interface.
     /// </summary>
-    WeakerPostcondition
+    WeakerPostcondition,
+
+    /// <summary>
+    /// Multiple inherited guarantees cannot all hold.
+    /// </summary>
+    IncompatibleInheritedContracts
 }
 
 /// <summary>
@@ -736,22 +1747,52 @@ public sealed class ContractViolation
 /// </summary>
 public sealed class InheritedContractInfo
 {
-    public string InterfaceName { get; }
-    public string MethodName { get; }
+    public IReadOnlyList<InheritedContractSource> Sources { get; }
+    public string InterfaceName => Sources[0].TypeName;
+    public string MethodName => Sources[0].MethodName;
+    public string SourceDisplayName => string.Join(
+        ", ",
+        Sources.Select(source => $"{source.TypeName}.{source.MethodName}"));
     public IReadOnlyList<RequiresNode> Preconditions { get; }
     public IReadOnlyList<EnsuresNode> Postconditions { get; }
 
     public InheritedContractInfo(
-        string interfaceName,
-        string methodName,
+        IReadOnlyList<InheritedContractSource> sources,
         IReadOnlyList<RequiresNode> preconditions,
         IReadOnlyList<EnsuresNode> postconditions)
     {
-        InterfaceName = interfaceName;
-        MethodName = methodName;
+        if (sources == null || sources.Count == 0)
+            throw new ArgumentException(
+                "At least one inherited contract source is required",
+                nameof(sources));
+        Sources = sources;
         Preconditions = preconditions;
         Postconditions = postconditions;
     }
+}
+
+public sealed record InheritedContractSource(
+    string TypeName,
+    string MethodName,
+    string MethodId);
+
+public sealed record MethodContractKey(
+    string ClassName,
+    string MethodName,
+    int GenericArity,
+    string ParameterSignature)
+{
+    public static MethodContractKey Create(
+        string className,
+        MethodNode method) =>
+        new(
+            className,
+            method.Name,
+            method.TypeParameters.Count,
+            string.Join(
+                "\u001f",
+                method.Parameters.Select(parameter =>
+                    $"{(int)parameter.Modifier}:{parameter.TypeName}")));
 }
 
 /// <summary>
@@ -807,14 +1848,14 @@ public sealed class ModuleInheritanceResult
     public IReadOnlyList<ClassInheritanceResult> Classes { get; }
 
     /// <summary>
-    /// Mapping of (ClassName, MethodName) to inherited contracts.
+    /// Mapping of resolved class method signatures to inherited contracts.
     /// Used by the emitter to emit inherited contract checks.
     /// </summary>
-    public IReadOnlyDictionary<(string ClassName, string MethodName), InheritedContractInfo> InheritedContracts { get; }
+    public IReadOnlyDictionary<MethodContractKey, InheritedContractInfo> InheritedContracts { get; }
 
     public ModuleInheritanceResult(
         IReadOnlyList<ClassInheritanceResult> classes,
-        IReadOnlyDictionary<(string ClassName, string MethodName), InheritedContractInfo> inheritedContracts)
+        IReadOnlyDictionary<MethodContractKey, InheritedContractInfo> inheritedContracts)
     {
         Classes = classes;
         InheritedContracts = inheritedContracts;
@@ -827,6 +1868,22 @@ public sealed class ModuleInheritanceResult
     /// </summary>
     public InheritedContractInfo? GetInheritedContracts(string className, string methodName)
     {
-        return InheritedContracts.TryGetValue((className, methodName), out var info) ? info : null;
+        var matches = InheritedContracts
+            .Where(pair =>
+                pair.Key.ClassName.Equals(className, StringComparison.Ordinal)
+                && pair.Key.MethodName.Equals(methodName, StringComparison.Ordinal))
+            .Select(pair => pair.Value)
+            .Take(2)
+            .ToArray();
+        return matches.Length == 1 ? matches[0] : null;
     }
+
+    public InheritedContractInfo? GetInheritedContracts(
+        string className,
+        MethodNode method) =>
+        InheritedContracts.TryGetValue(
+            MethodContractKey.Create(className, method),
+            out var info)
+            ? info
+            : null;
 }

--- a/src/Calor.Compiler/Verification/ContractSimplificationPass.cs
+++ b/src/Calor.Compiler/Verification/ContractSimplificationPass.cs
@@ -98,7 +98,8 @@ public sealed class ContractSimplificationPass
             module.InteropBlocks,
             module.RefinementTypes,
             module.IndexedTypes,
-            module.TypePreprocessorBlocks);
+            module.TypePreprocessorBlocks,
+            module.IdentifierSpan);
     }
 
     private FunctionNode SimplifyFunction(FunctionNode function)

--- a/tests/Calor.Compiler.Tests/ContractInheritanceTests.cs
+++ b/tests/Calor.Compiler.Tests/ContractInheritanceTests.cs
@@ -526,15 +526,12 @@ public class ContractInheritanceTests
     #region Z3 Integration Tests
 
     [SkippableFact]
-    public void Z3_ValidWithMultiplePreconditions_AtLeastOneMatches()
+    public void Z3_MultiplePreconditions_AreCheckedAsConjunction()
     {
         Skip.IfNot(Calor.Compiler.Verification.Z3.Z3ContextFactory.IsAvailable, "Z3 not available");
 
-        // Interface has one precondition, implementer has two.
-        // The first implementer precondition (>= x -10) is weaker than interface (>= x 0).
-        // The second implementer precondition (< x 1000) does NOT match the interface precondition.
-        // With correct "at least one matching" semantics, this should be VALID.
-        // With incorrect "all pairs" semantics, this would report a false positive violation.
+        // The second clause makes the complete implementation requirement stronger,
+        // despite the first clause being individually weaker.
         var source = @"
 §M{m001:Test}
   §IFACE{i001:IService}
@@ -559,14 +556,12 @@ public class ContractInheritanceTests
         using var checker = new ContractInheritanceChecker(checkDiags, useZ3: true);
         var result = checker.Check(module);
 
-        // Should be valid - the first precondition (>= x -10) is weaker than interface (>= x 0)
-        // The second precondition (< x 1000) should NOT cause a false positive
-        Assert.False(result.HasViolations,
-            "Expected no violations: at least one precondition matches. " +
+        Assert.True(result.HasViolations,
+            "Expected violation: the complete implementation conjunction is stronger. " +
             $"Diagnostics: {string.Join("; ", checkDiags.Select(d => d.Message))}");
-
-        // Should have Z3 proven diagnostic for the matching precondition
-        Assert.Contains(checkDiags, d => d.Code == DiagnosticCode.ImplicationProvenByZ3);
+        Assert.Contains(
+            checkDiags,
+            diagnostic => diagnostic.Code == DiagnosticCode.StrongerPrecondition);
     }
 
     [SkippableFact]
@@ -937,6 +932,776 @@ public class ContractInheritanceTests
         Assert.False(result.HasViolations);
         // Should report Z3 unavailable
         Assert.Contains(checkDiags, d => d.Code == DiagnosticCode.Z3UnavailableForInheritance);
+    }
+
+    [SkippableFact]
+    public void UnconstrainedInterface_RejectsImplementationPrecondition()
+    {
+        Skip.IfNot(
+            Calor.Compiler.Verification.Z3.Z3ContextFactory.IsAvailable,
+            "Z3 not available");
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IService}
+      §MT{m001:Process}
+          §I{i32:x}
+          §O{i32}
+  §CL{c001:Service:pub}
+      §IMPL{IService}
+      §MT{mt001:Process:pub}
+          §I{i32:x}
+          §O{i32}
+          §Q (> x INT:0)
+          §R x
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+
+        var result = checker.Check(module);
+
+        Assert.True(result.HasViolations);
+        Assert.Contains(
+            checkDiags,
+            diagnostic => diagnostic.Code == DiagnosticCode.StrongerPrecondition);
+    }
+
+    [Fact]
+    public void Overloads_KeepDistinctInheritedContracts()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IParser}
+      §MT{m001:Parse}
+          §I{i32:value}
+          §O{i32}
+          §Q (> value INT:0)
+      §MT{m002:Parse}
+          §I{str:value}
+          §O{str}
+          §Q (!= value null)
+  §CL{c001:Parser:pub}
+      §IMPL{IParser}
+      §MT{mt001:Parse:pub}
+          §I{i32:value}
+          §O{i32}
+          §R value
+      §MT{mt002:Parse:pub}
+          §I{str:value}
+          §O{str}
+          §R value
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+
+        var result = checker.Check(module);
+
+        Assert.Equal(2, result.InheritedContracts.Count);
+        Assert.NotNull(result.GetInheritedContracts(
+            "Parser",
+            module.Classes[0].Methods[0]));
+        Assert.NotNull(result.GetInheritedContracts(
+            "Parser",
+            module.Classes[0].Methods[1]));
+        Assert.Null(result.GetInheritedContracts("Parser", "Parse"));
+    }
+
+    [Fact]
+    public void MultipleInterfaces_CombineInheritedPreconditionsAsDisjunction()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IPositive}
+      §MT{m001:Use}
+          §I{i32:value}
+          §O{i32}
+          §Q (> value INT:0)
+  §IFACE{i002:INegative}
+      §MT{m002:Use}
+          §I{i32:value}
+          §O{i32}
+          §Q (< value INT:0)
+  §CL{c001:Service:pub}
+      §IMPL{IPositive}
+      §IMPL{INegative}
+      §MT{mt001:Use:pub}
+          §I{i32:value}
+          §O{i32}
+          §R value
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+        var result = checker.Check(module);
+
+        var inherited = result.GetInheritedContracts(
+            "Service",
+            module.Classes[0].Methods[0]);
+        var precondition = Assert.Single(inherited!.Preconditions);
+        var disjunction = Assert.IsType<BinaryOperationNode>(
+            precondition.Condition);
+        Assert.Equal(BinaryOperator.Or, disjunction.Operator);
+
+        var code = new CSharpEmitter(
+            ContractMode.Debug,
+            null,
+            result).Emit(module);
+        Assert.Contains("value < 0 || value > 0", code);
+    }
+
+    [Fact]
+    public void BaseClassContracts_AreInheritedBySignature()
+    {
+        var source = @"
+§M{m001:Test}
+  §CL{c001:Base:pub}
+      §MT{m001:Use:pub:virt}
+          §I{i32:value}
+          §O{i32}
+          §Q (> value INT:0)
+          §R value
+  §CL{c002:Derived:pub}
+      §EXT{Base}
+      §MT{m002:Use:pub:over}
+          §I{i32:value}
+          §O{i32}
+          §R value
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+
+        var result = checker.Check(module);
+
+        var derived = module.Classes.Single(classNode => classNode.Name == "Derived");
+        var inherited = result.GetInheritedContracts(
+            "Derived",
+            Assert.Single(derived.Methods));
+        Assert.NotNull(inherited);
+        Assert.Equal("Base", inherited!.InterfaceName);
+    }
+
+    [Fact]
+    public void InheritedContracts_RebindParameterNamesPositionally()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IService}
+      §MT{m001:Use}
+          §I{i32:x}
+          §O{i32}
+          §Q (> x INT:0)
+  §CL{c001:Service:pub}
+      §IMPL{IService}
+      §MT{mt001:Use:pub}
+          §I{i32:value}
+          §O{i32}
+          §R value
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+        var result = checker.Check(module);
+
+        var code = new CSharpEmitter(
+            ContractMode.Debug,
+            null,
+            result).Emit(module);
+
+        Assert.Contains("(value > 0)", code);
+        Assert.DoesNotContain("(x > 0)", code);
+    }
+
+    [Fact]
+    public void IntermediateOverride_PreservesEffectiveInterfaceContract()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IService}
+      §MT{m001:Use}
+          §I{i32:value}
+          §O{i32}
+          §Q (> value INT:0)
+  §CL{c001:Base:pub}
+      §IMPL{IService}
+      §MT{mt001:Use:pub:virt}
+          §I{i32:value}
+          §O{i32}
+          §R value
+  §CL{c002:Derived:pub}
+      §EXT{Base}
+      §MT{mt002:Use:pub:over}
+          §I{i32:value}
+          §O{i32}
+          §R value
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+        var result = checker.Check(module);
+        var derived = module.Classes.Single(classNode => classNode.Name == "Derived");
+
+        var inherited = result.GetInheritedContracts(
+            "Derived",
+            Assert.Single(derived.Methods));
+
+        Assert.NotNull(inherited);
+        Assert.Single(inherited!.Preconditions);
+    }
+
+    [Fact]
+    public void GenericInterface_ResolvesClosedMethodSignature()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IRepository}<T>
+      §MT{m001:Save}
+          §I{T:value}
+          §O{T}
+          §Q (!= value null)
+  §CL{c001:IntRepository:pub}
+      §IMPL{IRepository<i32>}
+      §MT{mt001:Save:pub}
+          §I{i32:value}
+          §O{i32}
+          §R value
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(
+            parseDiags.HasErrors,
+            string.Join("\n", parseDiags.Select(diagnostic => diagnostic.Message)));
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+
+        var result = checker.Check(module);
+
+        Assert.True(
+            result.InheritedContracts.Count == 1,
+            $"Interfaces: {string.Join(", ", module.Classes.Single().ImplementedInterfaces)}; "
+            + $"type parameters: {string.Join(", ", module.Interfaces.Single().TypeParameters.Select(parameter => parameter.Name))}; "
+            + $"contract parameter: {module.Interfaces.Single().Methods.Single().Parameters.Single().TypeName}; "
+            + $"implementation parameter: {module.Classes.Single().Methods.Single().Parameters.Single().TypeName}");
+    }
+
+    [Fact]
+    public void GenericBaseClass_ResolvesClosedMethodSignature()
+    {
+        var source = @"
+§M{m001:Test}
+  §CL{c001:Base:pub}<T>
+      §MT{mt001:Save:pub:virt}
+          §I{T:value}
+          §O{T}
+          §Q (!= value null)
+          §R value
+  §CL{c002:IntRepository:pub}
+      §EXT{Base<i32>}
+      §MT{mt002:Save:pub:over}
+          §I{i32:value}
+          §O{i32}
+          §R value
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+
+        var result = checker.Check(module);
+
+        Assert.Single(result.InheritedContracts);
+    }
+
+    [Fact]
+    public void ParameterModifiers_DisambiguateInheritedOverloads()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IService}
+      §MT{m001:Touch}
+          §I{i32:value}
+          §O{i32}
+          §Q (> value INT:0)
+      §MT{m002:Touch}
+          §I{i32:value:ref}
+          §O{i32}
+          §Q (>= value INT:0)
+  §CL{c001:Service:pub}
+      §IMPL{IService}
+      §MT{mt001:Touch:pub}
+          §I{i32:value}
+          §O{i32}
+          §R value
+      §MT{mt002:Touch:pub}
+          §I{i32:value:ref}
+          §O{i32}
+          §R value
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+
+        var result = checker.Check(module);
+
+        Assert.Equal(2, result.InheritedContracts.Count);
+    }
+
+    [Fact]
+    public void GenericMethodTypeParameters_MatchByPosition()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:ITransformer}
+      §MT{m001:Map}<T>
+          §I{T:item}
+          §I{i32:limit}
+          §O{T}
+          §Q (> limit INT:0)
+          §Q (is item T)
+  §CL{c001:Transformer:pub}
+      §IMPL{ITransformer}
+      §MT{mt001:Map:pub}<U>
+          §I{U:item}
+          §I{i32:limit}
+          §O{U}
+          §R item
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+
+        var result = checker.Check(module);
+
+        var inherited = Assert.Single(result.InheritedContracts).Value;
+        var conjunction = Assert.IsType<BinaryOperationNode>(
+            Assert.Single(inherited.Preconditions).Condition);
+        var typeCheck = Assert.IsType<IsPatternNode>(conjunction.Right);
+        Assert.Equal("U", typeCheck.TargetType);
+    }
+
+    [Fact]
+    public void InheritedContractCalls_RebindArgumentNames()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IService}
+      §MT{m001:Use}
+          §I{i32:x}
+          §O{i32}
+          §Q (IsValid x)
+  §CL{c001:Service:pub}
+      §IMPL{IService}
+      §MT{mt001:Use:pub}
+          §I{i32:value}
+          §O{i32}
+          §R value
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+        var result = checker.Check(module);
+        var inherited = Assert.Single(result.InheritedContracts).Value;
+        var call = Assert.IsType<CallExpressionNode>(
+            Assert.Single(inherited.Preconditions).Condition);
+
+        Assert.Equal("value", Assert.IsType<ReferenceNode>(Assert.Single(call.Arguments)).Name);
+    }
+
+    [Fact]
+    public void NestedNullCoalesce_RebindsParameterNames()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IService}
+      §MT{m001:Use}
+          §I{str:x}
+          §O{str}
+          §Q (!= (?? x STR:""fallback"") STR:""invalid"")
+  §CL{c001:Service:pub}
+      §IMPL{IService}
+      §MT{mt001:Use:pub}
+          §I{str:value}
+          §O{str}
+          §R value
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+        var result = checker.Check(module);
+        var inherited = Assert.Single(result.InheritedContracts).Value;
+        var comparison = Assert.IsType<BinaryOperationNode>(
+            Assert.Single(inherited.Preconditions).Condition);
+        var coalesce = Assert.IsType<NullCoalesceNode>(comparison.Left);
+
+        Assert.Equal("value", Assert.IsType<ReferenceNode>(coalesce.Left).Name);
+    }
+
+    [Fact]
+    public void InterpolatedString_RebindsHoleReferences()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IService}
+      §MT{m001:Use}
+          §I{str:x}
+          §O{str}
+          §Q (!= §INTERP ""id:"" §EXP x §/INTERP STR:"""")
+  §CL{c001:Service:pub}
+      §IMPL{IService}
+      §MT{mt001:Use:pub}
+          §I{str:value}
+          §O{str}
+          §R value
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+        var result = checker.Check(module);
+        var inherited = Assert.Single(result.InheritedContracts).Value;
+        var comparison = Assert.IsType<BinaryOperationNode>(
+            Assert.Single(inherited.Preconditions).Condition);
+        var interpolation = Assert.IsType<InterpolatedStringNode>(comparison.Left);
+        var hole = Assert.IsType<InterpolatedStringExpressionNode>(
+            interpolation.Parts.Single(part =>
+                part is InterpolatedStringExpressionNode));
+
+        Assert.Equal("value", Assert.IsType<ReferenceNode>(hole.Expression).Name);
+    }
+
+    [Fact]
+    public void IsPatternBinding_AvoidsParameterCapture()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IService}
+      §MT{m001:Use}
+          §I{object:x}
+          §O{bool}
+          §Q (&& (is x i32 value) (> value INT:0))
+  §CL{c001:Service:pub}
+      §IMPL{IService}
+      §MT{mt001:Use:pub}
+          §I{object:value}
+          §O{bool}
+          §R true
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+        var result = checker.Check(module);
+        var inherited = Assert.Single(result.InheritedContracts).Value;
+        var conjunction = Assert.IsType<BinaryOperationNode>(
+            Assert.Single(inherited.Preconditions).Condition);
+        var pattern = Assert.IsType<IsPatternNode>(conjunction.Left);
+        var comparison = Assert.IsType<BinaryOperationNode>(conjunction.Right);
+
+        Assert.NotEqual("value", pattern.VariableName);
+        Assert.Equal(
+            pattern.VariableName,
+            Assert.IsType<ReferenceNode>(comparison.Left).Name);
+    }
+
+    [Fact]
+    public void ClosedGenericBase_ComposesInheritedInterfaceSubstitutions()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IFoo}<T>
+      §MT{m001:Use}
+          §I{T:x}
+          §O{T}
+          §Q (is x T)
+  §CL{c001:Base:pub}<U>
+      §IMPL{IFoo<U>}
+      §MT{mt001:Use:pub:virt}
+          §I{U:x}
+          §O{U}
+          §R x
+  §CL{c002:Derived:pub}
+      §EXT{Base<i32>}
+      §MT{mt002:Use:pub:over}
+          §I{i32:value}
+          §O{i32}
+          §R value
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+        var result = checker.Check(module);
+        var derived = module.Classes.Single(classNode => classNode.Name == "Derived");
+        var inherited = result.GetInheritedContracts(
+            "Derived",
+            Assert.Single(derived.Methods));
+        var pattern = Assert.IsType<IsPatternNode>(
+            Assert.Single(inherited!.Preconditions).Condition);
+
+        Assert.Equal("i32", pattern.TargetType);
+    }
+
+    [Fact]
+    public void GenericCallTypeArguments_AreSubstituted()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IService}<T>
+      §MT{m001:Use}
+          §I{T:x}
+          §O{T}
+          §Q §C{Check<T>} §A x §/C
+  §CL{c001:IntService:pub}
+      §IMPL{IService<i32>}
+      §MT{mt001:Use:pub}
+          §I{i32:value}
+          §O{i32}
+          §R value
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+        var result = checker.Check(module);
+        var inherited = Assert.Single(result.InheritedContracts).Value;
+        var call = Assert.IsType<CallExpressionNode>(
+            Assert.Single(inherited.Preconditions).Condition);
+
+        Assert.Equal("i32", Assert.Single(call.TypeArguments!));
+    }
+
+    [Fact]
+    public void GenericConstructorTypeArguments_AreSubstituted()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IService}<T>
+      §MT{m001:Use}
+          §I{T:x}
+          §O{T}
+          §Q (!= §NEW{Box<T>} §/NEW null)
+  §CL{c001:IntService:pub}
+      §IMPL{IService<i32>}
+      §MT{mt001:Use:pub}
+          §I{i32:value}
+          §O{i32}
+          §R value
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+        var result = checker.Check(module);
+        var inherited = Assert.Single(result.InheritedContracts).Value;
+        var comparison = Assert.IsType<BinaryOperationNode>(
+            Assert.Single(inherited.Preconditions).Condition);
+        var creation = Assert.IsType<NewExpressionNode>(comparison.Left);
+
+        Assert.Equal("i32", Assert.Single(creation.TypeArguments));
+    }
+
+    [Fact]
+    public void ExplicitInterfaceImplementation_InheritsContract()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IService}
+      §MT{m001:Use}
+          §I{i32:value}
+          §O{i32}
+          §Q (> value INT:0)
+  §CL{c001:Service:pub}
+      §IMPL{IService}
+      §MT{mt001:IService.Use:pri}
+          §I{i32:value}
+          §O{i32}
+          §R value
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+
+        var result = checker.Check(module);
+
+        Assert.Single(result.InheritedContracts);
+        Assert.DoesNotContain(
+            checkDiags,
+            diagnostic => diagnostic.Code == DiagnosticCode.InterfaceMethodNotFound);
+    }
+
+    [Fact]
+    public void QuantifierRebinding_AvoidsCapturingImplementationParameter()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IService}
+      §MT{m001:Use}
+          §I{i32:limit}
+          §O{i32}
+          §Q (exists ((i i32)) (&& (>= i INT:0) (< i limit)))
+  §CL{c001:Service:pub}
+      §IMPL{IService}
+      §MT{mt001:Use:pub}
+          §I{i32:i}
+          §O{i32}
+          §R i
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+        var result = checker.Check(module);
+        var inherited = Assert.Single(result.InheritedContracts).Value;
+        var exists = Assert.IsType<ExistsExpressionNode>(
+            Assert.Single(inherited.Preconditions).Condition);
+        var body = Assert.IsType<BinaryOperationNode>(exists.Body);
+        var comparison = Assert.IsType<BinaryOperationNode>(body.Right);
+
+        Assert.NotEqual("i", Assert.Single(exists.BoundVariables).Name);
+        Assert.Equal("i", Assert.IsType<ReferenceNode>(comparison.Right).Name);
+        Assert.Equal(
+            Assert.Single(exists.BoundVariables).Name,
+            Assert.IsType<ReferenceNode>(comparison.Left).Name);
+    }
+
+    [Fact]
+    public void InterfaceImplementedOnlyByBaseMethod_FailsClosed()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IService}
+      §MT{m001:Use}
+          §I{i32:value}
+          §O{i32}
+          §Q (> value INT:0)
+  §CL{c001:Base:pub}
+      §MT{mt001:Use:pub:virt}
+          §I{i32:value}
+          §O{i32}
+          §R value
+  §CL{c002:Derived:pub}
+      §EXT{Base}
+      §IMPL{IService}
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+
+        checker.Check(module);
+
+        Assert.Contains(
+            checkDiags,
+            diagnostic => diagnostic.Code == DiagnosticCode.InterfaceMethodNotFound
+                && diagnostic.IsError);
+    }
+
+    [Fact]
+    public void DisjointSourcePostconditions_AreQualifiedByTheirPreconditions()
+    {
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IPositive}
+      §MT{m001:Use}
+          §I{i32:value}
+          §O{i32}
+          §Q (> value INT:0)
+          §S (> result INT:0)
+  §IFACE{i002:INegative}
+      §MT{m002:Use}
+          §I{i32:value}
+          §O{i32}
+          §Q (< value INT:0)
+          §S (< result INT:0)
+  §CL{c001:Service:pub}
+      §IMPL{IPositive}
+      §IMPL{INegative}
+      §MT{mt001:Use:pub}
+          §I{i32:value}
+          §O{i32}
+          §R value
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+        var result = checker.Check(module);
+        var inherited = Assert.Single(result.InheritedContracts).Value;
+
+        Assert.Equal(2, inherited.Postconditions.Count);
+        Assert.All(
+            inherited.Postconditions,
+            contract => Assert.IsType<ImplicationExpressionNode>(contract.Condition));
+    }
+
+    [SkippableFact]
+    public void IncompatibleInheritedPostconditions_AreDiagnosed()
+    {
+        Skip.IfNot(
+            Calor.Compiler.Verification.Z3.Z3ContextFactory.IsAvailable,
+            "Z3 not available");
+        var source = @"
+§M{m001:Test}
+  §IFACE{i001:IPositive}
+      §MT{m001:Get}
+          §O{i32}
+          §S (> result INT:0)
+  §IFACE{i002:INegative}
+      §MT{m002:Get}
+          §O{i32}
+          §S (< result INT:0)
+  §CL{c001:Service:pub}
+      §IMPL{IPositive}
+      §IMPL{INegative}
+      §MT{mt001:Get:pub}
+          §O{i32}
+          §R INT:1
+";
+
+        var module = Parse(source, out var parseDiags);
+        Assert.False(parseDiags.HasErrors);
+        var checkDiags = new DiagnosticBag();
+        using var checker = new ContractInheritanceChecker(checkDiags);
+
+        var result = checker.Check(module);
+
+        Assert.True(result.HasViolations);
+        Assert.Contains(
+            checkDiags,
+            diagnostic => diagnostic.Code
+                == DiagnosticCode.IncompatibleInheritedContracts);
     }
 
     #endregion

--- a/tests/Calor.Compiler.Tests/W1Slice1SimplificationPreservationTests.cs
+++ b/tests/Calor.Compiler.Tests/W1Slice1SimplificationPreservationTests.cs
@@ -42,6 +42,22 @@ public class W1Slice1SimplificationPreservationTests
         Assert.False(ReferenceEquals(simplified, module));
         // …and nothing was dropped.
         Assert.Single(simplified.InteropBlocks);
+
+        var transformedProperties = new HashSet<string>(StringComparer.Ordinal)
+        {
+            nameof(ModuleNode.Functions),
+            nameof(ModuleNode.Classes),
+            nameof(ModuleNode.Interfaces),
+            nameof(ModuleNode.Invariants)
+        };
+        foreach (var property in typeof(ModuleNode).GetProperties()
+                     .Where(property => property.GetIndexParameters().Length == 0)
+                     .Where(property => !transformedProperties.Contains(property.Name)))
+        {
+            Assert.Equal(
+                property.GetValue(module),
+                property.GetValue(simplified));
+        }
     }
 
     [Fact]

--- a/tests/E2E/scenarios/08_contract_inheritance_z3/input.calr
+++ b/tests/E2E/scenarios/08_contract_inheritance_z3/input.calr
@@ -1,6 +1,7 @@
 §M{m001:ContractZ3Test}
   §IFACE{i001:IService}
     §MT{m001:Process} (i32:value) -> i32
+      §Q (>= value 0)
 
   §CL{c001:ValidService:pub}
     §IMPL{IService}
@@ -18,5 +19,4 @@
       §Q (>= value 0)
       §S (>= result 10)
       §R (+ value 10)
-
 

--- a/tests/E2E/scenarios/08_contract_inheritance_z3/output.g.cs
+++ b/tests/E2E/scenarios/08_contract_inheritance_z3/output.g.cs
@@ -12,6 +12,10 @@ namespace ContractZ3Test
 {
     public interface IService
     {
+        /// <summary>
+        /// Interface method with contracts.
+        /// </summary>
+        /// <remarks>Requires: value >= 0</remarks>
         int Process(int value);
     }
 
@@ -19,12 +23,12 @@ namespace ContractZ3Test
     {
         public int Process(int value)
         {
-            if (!(value >= -10)) throw new Calor.Runtime.ContractViolationException("Precondition failed: value >= -10", "mt001", Calor.Runtime.ContractKind.Requires, startOffset: 192, length: 17, sourceFile: null, line: 9, column: 7, condition: "value >= -10");
+            if (!(value >= -10)) throw new Calor.Runtime.ContractViolationException("Precondition failed: value >= -10", "mt001", Calor.Runtime.ContractKind.Requires, startOffset: 214, length: 17, sourceFile: null, line: 10, column: 7, condition: "value >= -10");
             int __result__ = default;
 
             __result__ = value + 1;
 
-            if (!(__result__ >= 1)) throw new Calor.Runtime.ContractViolationException("Postcondition failed: __result__ >= 1", "mt001", Calor.Runtime.ContractKind.Ensures, startOffset: 216, length: 16, sourceFile: null, line: 10, column: 7, condition: "__result__ >= 1");
+            if (!(__result__ >= 1)) throw new Calor.Runtime.ContractViolationException("Postcondition failed: __result__ >= 1", "mt001", Calor.Runtime.ContractKind.Ensures, startOffset: 238, length: 16, sourceFile: null, line: 11, column: 7, condition: "__result__ >= 1");
             return __result__;
         }
 
@@ -34,12 +38,12 @@ namespace ContractZ3Test
     {
         public int Process(int value)
         {
-            if (!(value >= 0)) throw new Calor.Runtime.ContractViolationException("Precondition failed: value >= 0", "mt002", Calor.Runtime.ContractKind.Requires, startOffset: 365, length: 15, sourceFile: null, line: 18, column: 7, condition: "value >= 0");
+            if (!(value >= 0)) throw new Calor.Runtime.ContractViolationException("Precondition failed: value >= 0", "mt002", Calor.Runtime.ContractKind.Requires, startOffset: 387, length: 15, sourceFile: null, line: 19, column: 7, condition: "value >= 0");
             int __result__ = default;
 
             __result__ = value + 10;
 
-            if (!(__result__ >= 10)) throw new Calor.Runtime.ContractViolationException("Postcondition failed: __result__ >= 10", "mt002", Calor.Runtime.ContractKind.Ensures, startOffset: 387, length: 17, sourceFile: null, line: 19, column: 7, condition: "__result__ >= 10");
+            if (!(__result__ >= 10)) throw new Calor.Runtime.ContractViolationException("Postcondition failed: __result__ >= 10", "mt002", Calor.Runtime.ContractKind.Ensures, startOffset: 409, length: 17, sourceFile: null, line: 20, column: 7, condition: "__result__ >= 10");
             return __result__;
         }
 


### PR DESCRIPTION
## Summary
- prove Liskov pre/post rules over whole contract conjunctions
- key inherited contracts by full method identity and combine interface/base sources deterministically
- support overloads, explicit implementations, generic interface/base/method substitutions, and capture-safe parameter rebinding
- qualify inherited postconditions by their source preconditions and diagnose incompatible inherited guarantees
- preserve every unrelated `ModuleNode` field during contract simplification with reflection-enforced coverage

## Validation
- `dotnet test tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj --no-restore` — 6,913 passed, 2 skipped
- `dotnet build -c Release --no-restore` — 0 warnings, 0 errors
- `python3 scripts/run_mutation_gate.py` — verifier, emitter, binder, migration, dataflow, taint, and effects mutations killed
- blocking adversarial reviews completed; all findings remediated and regression-tested

Closes #781