### PR TITLE
feat: rebuild taint analysis on control flow graphs

### DIFF
--- a/docs/security/taint-analysis.md
+++ b/docs/security/taint-analysis.md
@@ -1,0 +1,34 @@
+# Taint analysis
+
+Calor's taint analysis is a forward may-taint analysis over the bound
+`ControlFlowGraph`. Facts use stable `SymbolId` roots and field/index access paths,
+so branch joins and loop back edges use a monotonic union lattice. Reference variables
+point to stable abstract objects, so rebinding a variable does not retarget aliases to
+the object's old fields or elements. Alias joins retain every possible target. A field
+or collection-element write is strong only for a
+singleton target; otherwise it weakly updates every possible alias. A safe reassignment
+therefore clears an earlier value's taint only when its target is proven singleton.
+
+Built-in sources, sinks, and sanitizers are an exact identity manifest. A rule matches
+either a resolved function/type/method signature or an exact unresolved call target;
+it never uses a substring. Any populated resolved type-and-method identity prevents a
+target-string sanitizer rule from applying, including non-BCL types. A resolved local
+function named `sql_escape` is therefore not accidentally trusted.
+For example, the manifest's `sql_escape` sanitizes SQL-query output only, while
+`desanitize` is not a sanitizer. `Console.ReadLine` is an exact call-return user-input
+source.
+
+Every finding includes `ProvenancePath`, an ordered sequence from source through
+assignments/calls to the sink. Direct source-to-sink findings are always reported:
+`MinTaintHops` remains only as a compatibility/ranking option, and `--all-findings`
+does not suppress or enable exploitable taint flows.
+
+At a module boundary, exact resolved calls use parameter-to-return and
+parameter-to-sink summaries, unions every resolved overload alternative, and splices
+callee evidence into the caller's provenance. Exact BCL sink signatures include
+`System.IO.File.WriteAllText`, `Delete`, and `Open`.
+`StrictExternalCalls` also models unresolved external return values as `ExternalApi`
+sources. The executable precision/recall scorecard lives in
+`tests/TestData/Security/TaintAnalysis/manifest.json`. The analysis is intramodule:
+persistent heap state across separate method calls and unresolved aliasing beyond
+retained bound access paths remain conservative limitations.

--- a/eng/test-manifest.json
+++ b/eng/test-manifest.json
@@ -5,7 +5,7 @@
       "path": "tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj",
       "workflow": ".github/workflows/test.yml",
       "releaseCritical": true,
-      "expectedTotal": 6948,
+      "expectedTotal": 6981,
       "expectedSkipped": 2
     },
     {

--- a/src/Calor.Compiler/Analysis/Security/TaintAnalysis.cs
+++ b/src/Calor.Compiler/Analysis/Security/TaintAnalysis.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Calor.Compiler.Analysis.Dataflow;
 using Calor.Compiler.Binding;
 using Calor.Compiler.Diagnostics;
@@ -5,60 +6,118 @@ using Calor.Compiler.Parsing;
 
 namespace Calor.Compiler.Analysis.Security;
 
-/// <summary>
-/// Represents a taint source category.
-/// </summary>
+/// <summary>Represents a taint source category.</summary>
 public enum TaintSource
 {
-    /// <summary>User input (command line, stdin, web forms).</summary>
     UserInput,
-    /// <summary>File read operations.</summary>
     FileRead,
-    /// <summary>Network/HTTP input.</summary>
     NetworkInput,
-    /// <summary>Environment variables.</summary>
     Environment,
-    /// <summary>Database query results.</summary>
     DatabaseResult,
-    /// <summary>External API response.</summary>
-    ExternalApi
+    ExternalApi,
 }
 
-/// <summary>
-/// Represents a security-sensitive sink category.
-/// </summary>
+/// <summary>Represents a security-sensitive sink category.</summary>
 public enum TaintSink
 {
-    /// <summary>SQL query execution.</summary>
     SqlQuery,
-    /// <summary>Command/shell execution.</summary>
     CommandExecution,
-    /// <summary>File path operations.</summary>
     FilePath,
-    /// <summary>HTML/web output (XSS).</summary>
     HtmlOutput,
-    /// <summary>URL redirection.</summary>
     UrlRedirect,
-    /// <summary>Code evaluation.</summary>
     CodeEval,
-    /// <summary>Deserialization.</summary>
     Deserialization,
-    /// <summary>Log injection.</summary>
-    LogOutput
+    LogOutput,
 }
 
-/// <summary>
-/// Represents a taint label attached to a variable.
-/// </summary>
+/// <summary>One reproducible step in a source-to-sink taint flow.</summary>
+public sealed record TaintFlowStep(string Description, TextSpan Location);
+
+/// <summary>Represents a taint label attached to a value.</summary>
 public readonly record struct TaintLabel(
     TaintSource Source,
     string SourceVariable,
     TextSpan SourceLocation,
     int Hops = 1);
 
-/// <summary>
-/// Represents a detected security vulnerability.
-/// </summary>
+/// <summary>Describes an exact external or resolved call identity.</summary>
+public sealed record TaintCallIdentity(
+    string? Target = null,
+    string? TypeName = null,
+    string? MethodName = null,
+    IReadOnlyList<string>? ParameterTypes = null,
+    SymbolId? FunctionSymbolId = null)
+{
+    internal bool Matches(TaintAnalysis.TaintCallDescriptor call)
+    {
+        if (FunctionSymbolId is { } symbolId)
+        {
+            return call.ResolvedSymbols.Any(symbol =>
+                !symbol.Id.IsNone && symbol.Id == symbolId);
+        }
+
+        if (TypeName != null || MethodName != null || ParameterTypes != null)
+        {
+            if (!string.Equals(TypeName, call.ResolvedTypeName, StringComparison.Ordinal)
+                || !string.Equals(MethodName, call.ResolvedMethodName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            return ParameterTypes == null
+                || call.ResolvedParameterTypes != null
+                    && ParameterTypes.SequenceEqual(
+                        call.ResolvedParameterTypes,
+                        StringComparer.Ordinal);
+        }
+
+        return !call.HasResolvedIdentity
+            && Target != null
+            && string.Equals(Target, call.Target, StringComparison.Ordinal);
+    }
+}
+
+/// <summary>Declares an exact call-return source.</summary>
+public sealed record TaintSourceRule(TaintCallIdentity Identity, TaintSource Source);
+
+/// <summary>Declares an exact call sink and, when specified, its sink argument positions.</summary>
+public sealed class TaintSinkRule
+{
+    public TaintCallIdentity Identity { get; }
+    public TaintSink Sink { get; }
+    public IReadOnlyList<int>? ArgumentIndices { get; }
+
+    public TaintSinkRule(
+        TaintCallIdentity identity,
+        TaintSink sink,
+        params int[] argumentIndices)
+    {
+        Identity = identity ?? throw new ArgumentNullException(nameof(identity));
+        Sink = sink;
+        ArgumentIndices = argumentIndices.Length == 0
+            ? null
+            : argumentIndices.Distinct().Order().ToArray();
+    }
+
+    internal IEnumerable<int> GetArgumentIndices(int argumentCount) =>
+        ArgumentIndices ?? Enumerable.Range(0, argumentCount);
+}
+
+/// <summary>Declares the sink kinds removed from a sanitizer's return value.</summary>
+public sealed class TaintSanitizerRule
+{
+    public TaintCallIdentity Identity { get; }
+    public IReadOnlyList<TaintSink> Sanitizes { get; }
+
+    public TaintSanitizerRule(TaintCallIdentity identity, params TaintSink[] sanitizes)
+    {
+        Identity = identity ?? throw new ArgumentNullException(nameof(identity));
+        Sanitizes = sanitizes?.Distinct().ToArray()
+            ?? throw new ArgumentNullException(nameof(sanitizes));
+    }
+}
+
+/// <summary>Represents a detected security vulnerability.</summary>
 public sealed class TaintVulnerability
 {
     public TaintSink Sink { get; }
@@ -70,6 +129,9 @@ public sealed class TaintVulnerability
     public string DiagnosticCode { get; }
     public string Message { get; }
     public DiagnosticSeverity Severity { get; }
+    /// <summary>Ordered source-to-sink evidence retained by the CFG analysis.</summary>
+    public IReadOnlyList<TaintFlowStep> ProvenancePath { get; }
+    public int HopCount => Math.Max(0, ProvenancePath.Count - 1);
 
     public TaintVulnerability(
         TaintSink sink,
@@ -77,7 +139,8 @@ public sealed class TaintVulnerability
         string sourceVariable,
         TextSpan sourceLocation,
         string sinkVariable,
-        TextSpan sinkLocation)
+        TextSpan sinkLocation,
+        IReadOnlyList<TaintFlowStep>? provenancePath = null)
     {
         Sink = sink;
         Source = source;
@@ -85,14 +148,21 @@ public sealed class TaintVulnerability
         SourceLocation = sourceLocation;
         SinkVariable = sinkVariable;
         SinkLocation = sinkLocation;
+        ProvenancePath = provenancePath
+            ?? [
+                new TaintFlowStep($"source {sourceVariable}", sourceLocation),
+                new TaintFlowStep($"sink {sinkVariable}", sinkLocation),
+            ];
 
-        (DiagnosticCode, Message, Severity) = GetDiagnosticInfo(sink, source);
+        (DiagnosticCode, var message, Severity) = GetDiagnosticInfo(sink, source);
+        Message = ProvenancePath.Count > 0
+            ? $"{message}; path: {string.Join(" -> ", ProvenancePath.Select(step => step.Description))}"
+            : message;
     }
 
     private static (string Code, string Message, DiagnosticSeverity Severity) GetDiagnosticInfo(
-        TaintSink sink, TaintSource source)
-    {
-        return sink switch
+        TaintSink sink, TaintSource source) =>
+        sink switch
         {
             TaintSink.SqlQuery => (
                 Diagnostics.DiagnosticCode.SqlInjection,
@@ -113,701 +183,1720 @@ public sealed class TaintVulnerability
             _ => (
                 Diagnostics.DiagnosticCode.TaintedSink,
                 $"Tainted data from {source} flows to {sink}",
-                DiagnosticSeverity.Warning)
+                DiagnosticSeverity.Warning),
         };
-    }
 }
 
-/// <summary>
-/// Options for taint analysis.
-/// </summary>
+/// <summary>Options for symbol/access-path based taint analysis.</summary>
 public sealed class TaintAnalysisOptions
 {
-    /// <summary>
-    /// Track user input as taint source.
-    /// </summary>
     public bool TrackUserInput { get; init; } = true;
-
-    /// <summary>
-    /// Track file reads as taint source.
-    /// </summary>
     public bool TrackFileReads { get; init; } = true;
-
-    /// <summary>
-    /// Track network input as taint source.
-    /// </summary>
     public bool TrackNetworkInput { get; init; } = true;
-
-    /// <summary>
-    /// Track environment variables as taint source.
-    /// </summary>
     public bool TrackEnvironment { get; init; } = true;
-
-    /// <summary>
-    /// Enable SQL injection detection.
-    /// </summary>
     public bool DetectSqlInjection { get; init; } = true;
-
-    /// <summary>
-    /// Enable command injection detection.
-    /// </summary>
     public bool DetectCommandInjection { get; init; } = true;
-
-    /// <summary>
-    /// Enable path traversal detection.
-    /// </summary>
     public bool DetectPathTraversal { get; init; } = true;
-
-    /// <summary>
-    /// Enable XSS detection.
-    /// </summary>
     public bool DetectXss { get; init; } = true;
 
     /// <summary>
-    /// Minimum number of taint hops (propagation steps) required before reporting a vulnerability.
-    /// Default: 1 (backward compatible). The CLI sets this to 2 unless --all-findings is passed,
-    /// filtering out direct parameter→sink flows which are often false positives.
+    /// Retained for API compatibility. Hop count ranks evidence only; it never suppresses
+    /// a direct source-to-sink vulnerability.
     /// </summary>
     public int MinTaintHops { get; init; } = 1;
+
+    /// <summary>
+    /// Treat an unresolved external call as potentially returning externally controlled
+    /// data. Its arguments still propagate in either mode.
+    /// </summary>
+    public bool StrictExternalCalls { get; init; }
+
+    /// <summary>
+    /// Exact parameter names intentionally treated as API-boundary user input. This is
+    /// an explicit compatibility manifest, not substring matching.
+    /// </summary>
+    public IReadOnlyCollection<string> UserInputParameterNames { get; init; } =
+        new HashSet<string>(StringComparer.Ordinal)
+        {
+            "input", "user_input", "user_data", "user_path", "user",
+            "request", "request_data", "request_body", "request_query",
+            "query_string", "form", "form_data",
+        };
+
+    public IReadOnlyList<TaintSourceRule> AdditionalSources { get; init; } = [];
+    public IReadOnlyList<TaintSinkRule> AdditionalSinks { get; init; } = [];
+    public IReadOnlyList<TaintSanitizerRule> AdditionalSanitizers { get; init; } = [];
 
     public static TaintAnalysisOptions Default => new();
 }
 
 /// <summary>
-/// Forward dataflow analysis for taint tracking.
-/// Detects when user-controlled (tainted) data flows to security-sensitive operations.
+/// A forward CFG may-taint analysis. Facts are keyed by stable symbol roots plus
+/// field/index access paths; joins union facts and assignments perform strong updates.
 /// </summary>
 public sealed class TaintAnalysis
 {
+    private static readonly IReadOnlyList<TaintSourceRule> BuiltInSources =
+    [
+        new(new("Console.ReadLine"), TaintSource.UserInput),
+        new(new("System.Console.ReadLine"), TaintSource.UserInput),
+        new(new(TypeName: "System.Console", MethodName: "ReadLine"), TaintSource.UserInput),
+        new(new("file.read"), TaintSource.FileRead),
+        new(new("File.ReadAllText"), TaintSource.FileRead),
+        new(new(TypeName: "System.IO.File", MethodName: "ReadAllText"), TaintSource.FileRead),
+        new(new("http.get"), TaintSource.NetworkInput),
+        new(new("fetch"), TaintSource.NetworkInput),
+        new(new("Environment.GetEnvironmentVariable"), TaintSource.Environment),
+        new(new(TypeName: "System.Environment", MethodName: "GetEnvironmentVariable"), TaintSource.Environment),
+    ];
+
+    private static readonly IReadOnlyList<TaintSinkRule> BuiltInSinks =
+    [
+        new(new("db.execute"), TaintSink.SqlQuery),
+        new(new("db.query"), TaintSink.SqlQuery),
+        new(new("db.raw"), TaintSink.SqlQuery),
+        new(new("db.execute_with_param_logging"), TaintSink.SqlQuery),
+        new(new("sql.execute"), TaintSink.SqlQuery),
+        new(new("sql.query"), TaintSink.SqlQuery),
+        new(new("ExecuteSql"), TaintSink.SqlQuery),
+        new(new("shell"), TaintSink.CommandExecution),
+        new(new("exec"), TaintSink.CommandExecution),
+        new(new("system"), TaintSink.CommandExecution),
+        new(new("Process.Start"), TaintSink.CommandExecution),
+        new(new(
+            TypeName: "System.Diagnostics.Process",
+            MethodName: "Start",
+            ParameterTypes: ["STRING"]), TaintSink.CommandExecution),
+        new(new(
+            TypeName: "System.Diagnostics.Process",
+            MethodName: "Start",
+            ParameterTypes: ["STRING", "STRING"]), TaintSink.CommandExecution),
+        new(new(
+            TypeName: "System.Diagnostics.Process",
+            MethodName: "Start",
+            ParameterTypes: ["System.String"]), TaintSink.CommandExecution),
+        new(new(
+            TypeName: "System.Diagnostics.Process",
+            MethodName: "Start",
+            ParameterTypes: ["System.String", "System.String"]), TaintSink.CommandExecution),
+        new(new("file.open"), TaintSink.FilePath, 0),
+        new(new("file.read"), TaintSink.FilePath, 0),
+        new(new("file.write"), TaintSink.FilePath, 0),
+        new(new("file.delete"), TaintSink.FilePath, 0),
+        new(new("file.move"), TaintSink.FilePath, 0, 1),
+        new(new(TypeName: "db", MethodName: "execute"), TaintSink.SqlQuery),
+        new(new(TypeName: "db", MethodName: "query"), TaintSink.SqlQuery),
+        new(new(TypeName: "db", MethodName: "raw"), TaintSink.SqlQuery),
+        new(new(TypeName: "db", MethodName: "execute_with_param_logging"), TaintSink.SqlQuery),
+        new(new(TypeName: "sql", MethodName: "execute"), TaintSink.SqlQuery),
+        new(new(TypeName: "sql", MethodName: "query"), TaintSink.SqlQuery),
+        new(new(TypeName: "file", MethodName: "open"), TaintSink.FilePath, 0),
+        new(new(TypeName: "file", MethodName: "read"), TaintSink.FilePath, 0),
+        new(new(TypeName: "file", MethodName: "write"), TaintSink.FilePath, 0),
+        new(new(TypeName: "file", MethodName: "delete"), TaintSink.FilePath, 0),
+        new(new(TypeName: "file", MethodName: "move"), TaintSink.FilePath, 0, 1),
+        new(new(TypeName: "html", MethodName: "write"), TaintSink.HtmlOutput),
+        new(new(TypeName: "response", MethodName: "write"), TaintSink.HtmlOutput),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "Open",
+            ParameterTypes: ["STRING", "System.IO.FileMode"]), TaintSink.FilePath, 0),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "Open",
+            ParameterTypes: ["System.String", "System.IO.FileMode"]), TaintSink.FilePath, 0),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "Open",
+            ParameterTypes: ["System.String", "System.IO.FileMode", "System.IO.FileAccess"]), TaintSink.FilePath, 0),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "Open",
+            ParameterTypes:
+                ["System.String", "System.IO.FileMode", "System.IO.FileAccess", "System.IO.FileShare"]),
+            TaintSink.FilePath,
+            0),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "ReadAllText",
+            ParameterTypes: ["STRING"]), TaintSink.FilePath, 0),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "ReadAllText",
+            ParameterTypes: ["System.String"]), TaintSink.FilePath, 0),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "ReadAllText",
+            ParameterTypes: ["STRING", "System.Text.Encoding"]), TaintSink.FilePath, 0),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "ReadAllText",
+            ParameterTypes: ["System.String", "System.Text.Encoding"]), TaintSink.FilePath, 0),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "Delete",
+            ParameterTypes: ["STRING"]), TaintSink.FilePath, 0),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "Delete",
+            ParameterTypes: ["System.String"]), TaintSink.FilePath, 0),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "Move",
+            ParameterTypes: ["STRING", "STRING"]), TaintSink.FilePath, 0, 1),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "Move",
+            ParameterTypes: ["System.String", "System.String"]), TaintSink.FilePath, 0, 1),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "Move",
+            ParameterTypes: ["STRING", "STRING", "BOOL"]), TaintSink.FilePath, 0, 1),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "Move",
+            ParameterTypes: ["System.String", "System.String", "System.Boolean"]),
+            TaintSink.FilePath,
+            0,
+            1),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "WriteAllText",
+            ParameterTypes: ["STRING", "STRING"]), TaintSink.FilePath, 0),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "WriteAllText",
+            ParameterTypes: ["System.String", "System.String"]), TaintSink.FilePath, 0),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "WriteAllText",
+            ParameterTypes: ["System.String", "System.String", "System.Text.Encoding"]), TaintSink.FilePath, 0),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "WriteAllBytes",
+            ParameterTypes: ["STRING", "BYTE[]"]), TaintSink.FilePath, 0),
+        new(new(
+            TypeName: "System.IO.File",
+            MethodName: "WriteAllBytes",
+            ParameterTypes: ["System.String", "System.Byte[]"]), TaintSink.FilePath, 0),
+        new(new(TypeName: "System.IO.File", MethodName: "open"), TaintSink.FilePath, 0),
+        new(new(TypeName: "System.IO.File", MethodName: "read"), TaintSink.FilePath, 0),
+        new(new(TypeName: "System.IO.File", MethodName: "write"), TaintSink.FilePath, 0),
+        new(new(TypeName: "System.IO.File", MethodName: "delete"), TaintSink.FilePath, 0),
+        new(new("html.write"), TaintSink.HtmlOutput),
+        new(new("response.write"), TaintSink.HtmlOutput),
+        new(new("document.write"), TaintSink.HtmlOutput),
+    ];
+
+    private static readonly IReadOnlyList<TaintSanitizerRule> BuiltInSanitizers =
+    [
+        new(new("sql_escape"), TaintSink.SqlQuery),
+        new(new("SqlEscape"), TaintSink.SqlQuery),
+        new(new("sql.parameterize"), TaintSink.SqlQuery),
+        new(new("html_escape"), TaintSink.HtmlOutput),
+        new(new("HtmlEncode"), TaintSink.HtmlOutput),
+        new(new(TypeName: "System.Net.WebUtility", MethodName: "HtmlEncode"), TaintSink.HtmlOutput),
+        new(new("sanitize"), TaintSink.SqlQuery, TaintSink.HtmlOutput),
+    ];
+
     private readonly BoundFunction _function;
     private readonly TaintAnalysisOptions _options;
+    private readonly IReadOnlyList<string> _declaredEffects;
+    private readonly IReadOnlyDictionary<SymbolId, TaintFunctionSummary> _summaries;
+    private readonly bool _symbolicParameters;
     private readonly List<TaintVulnerability> _vulnerabilities = new();
-    private readonly Dictionary<SymbolId, HashSet<TaintLabel>> _taintedVariables = new();
+    private readonly HashSet<TaintFindingKey> _reportedFindings = new();
+
     public IReadOnlyList<BoundNode> IncompleteNodes { get; }
     public bool IsComplete => IncompleteNodes.Count == 0;
-
-    /// <summary>
-    /// Effect declarations for the function (populated from AST).
-    /// These are used to auto-derive sinks from the effect system.
-    /// </summary>
-    private readonly IReadOnlyList<string> _declaredEffects;
+    public IReadOnlyList<TaintVulnerability> Vulnerabilities => _vulnerabilities;
+    public ControlFlowGraph Cfg { get; }
+    internal DataflowAnalysisResult<TaintState> DataflowResult { get; }
 
     public TaintAnalysis(BoundFunction function, TaintAnalysisOptions? options = null)
-        : this(function, options, Array.Empty<string>())
+        : this(function, options, Array.Empty<string>(), null, symbolicParameters: false)
     {
     }
 
     public TaintAnalysis(BoundFunction function, TaintAnalysisOptions? options, IReadOnlyList<string> declaredEffects)
+        : this(function, options, declaredEffects, null, symbolicParameters: false)
+    {
+    }
+
+    internal TaintAnalysis(
+        BoundFunction function,
+        TaintAnalysisOptions? options,
+        IReadOnlyList<string> declaredEffects,
+        IReadOnlyDictionary<SymbolId, TaintFunctionSummary>? summaries,
+        bool symbolicParameters)
     {
         _function = function ?? throw new ArgumentNullException(nameof(function));
         _options = options ?? TaintAnalysisOptions.Default;
         _declaredEffects = declaredEffects ?? Array.Empty<string>();
+        _summaries = summaries ?? new Dictionary<SymbolId, TaintFunctionSummary>();
+        _symbolicParameters = symbolicParameters;
         IncompleteNodes = BoundNodeHelpers.GetAnalysisIncompleteNodes(function).ToArray();
+        Cfg = ControlFlowGraph.Build(function);
 
-        Analyze();
+        var initial = SeedParameterFacts();
+        var analysis = new DataflowAnalysis<TaintState>(
+            new TaintStateLattice(),
+            new TaintTransfer(this),
+            DataflowDirection.Forward,
+            initial,
+            TaintState.Empty,
+            TaintState.Empty);
+        DataflowResult = analysis.AnalyzeWithMetadata(Cfg);
+        if (!symbolicParameters)
+            CollectFindings();
     }
 
-    /// <summary>
-    /// Gets all detected vulnerabilities.
-    /// </summary>
-    public IReadOnlyList<TaintVulnerability> Vulnerabilities => _vulnerabilities;
-
-    /// <summary>
-    /// Reports vulnerabilities as diagnostics.
-    /// </summary>
+    /// <summary>Reports all source-to-sink findings as diagnostics.</summary>
     public void ReportDiagnostics(DiagnosticBag diagnostics)
     {
-        foreach (var vuln in _vulnerabilities)
+        foreach (var vulnerability in _vulnerabilities)
         {
             diagnostics.Report(
-                vuln.SinkLocation,
-                vuln.DiagnosticCode,
-                vuln.Message,
-                vuln.Severity);
+                vulnerability.SinkLocation,
+                vulnerability.DiagnosticCode,
+                vulnerability.Message,
+                vulnerability.Severity);
         }
     }
 
-    private void Analyze()
+    internal TaintFunctionSummary CreateSummary()
     {
-        // Initialize taint from function parameters that are known sources
-        InitializeParameterTaint();
+        var returns = new Dictionary<TaintFlowIdentity, TaintFlow>();
+        var sinks = new Dictionary<TaintSummarySinkKey, TaintSummarySink>();
+        var returnExpressions = BoundNodeHelpers.DescendantsAndSelf(_function)
+            .OfType<BoundReturnStatement>()
+            .Where(statement => statement.Expression != null)
+            .Select(statement => statement.Expression!)
+            .ToHashSet();
 
-        // Walk through all statements
-        foreach (var stmt in _function.Body)
+        foreach (var block in Cfg.ReachableBlocks)
         {
-            AnalyzeStatement(stmt);
-        }
-    }
-
-    private void InitializeParameterTaint()
-    {
-        foreach (var param in _function.Symbol.Parameters)
-        {
-            // Check if parameter is a known taint source based on naming/type conventions
-            var source = InferTaintSource(param.Name, param.TypeName);
-            if (source != null)
+            var state = DataflowResult.Blocks[block].In;
+            for (var statementIndex = 0; statementIndex < block.Statements.Count; statementIndex++)
             {
-                var label = new TaintLabel(source.Value, param.Name, _function.Span);
-                AddTaint(param, label);
+                var statement = block.Statements[statementIndex];
+                RecordSummarySinks(statement, state, sinks);
+                state = TransferStatement(
+                    block,
+                    statementIndex,
+                    statement,
+                    state,
+                    applyDeferredDefinition: !block.IsDefinitionDeferred(statementIndex));
+
+                if (statement is BoundReturnStatement { Expression: { } expression })
+                {
+                    foreach (var flow in EvaluateExpression(expression, state))
+                        AddShortest(returns, flow);
+                }
+            }
+
+            foreach (var operation in block.SyntheticOperations)
+            {
+                // CFG construction moves call-containing return expressions into a
+                // synthetic evaluation block so exceptional edges are explicit.
+                // Retain their return summary rather than losing the value flow.
+                if (operation.Expression != null && returnExpressions.Contains(operation.Expression))
+                {
+                    foreach (var flow in EvaluateExpression(operation.Expression, state))
+                        AddShortest(returns, flow);
+                }
+                state = TransferSynthetic(operation, state);
             }
         }
+
+        return new TaintFunctionSummary(
+            returns.Values.OrderBy(flow => flow.Origin.Name, StringComparer.Ordinal).ToArray(),
+            sinks.Values.OrderBy(sink => sink.Location.Start).ToArray());
     }
 
-    private TaintSource? InferTaintSource(string name, string typeName)
+    private TaintState SeedParameterFacts()
     {
-        var lowerName = name.ToLowerInvariant();
-        var lowerType = typeName.ToLowerInvariant();
-
-        // User input patterns
-        if (_options.TrackUserInput &&
-            (lowerName.Contains("input") ||
-             lowerName.Contains("request") ||
-             lowerName.Contains("query") ||
-             lowerName.Contains("param") ||
-             lowerName.Contains("arg") ||
-             lowerName.Contains("user") ||
-             lowerName.Contains("form")))
+        var state = TaintState.Empty;
+        for (var index = 0; index < _function.Symbol.Parameters.Count; index++)
         {
-            return TaintSource.UserInput;
+            var parameter = _function.Symbol.Parameters[index];
+            var path = TaintAccessPath.For(parameter);
+            if (IsReferenceLike(parameter.TypeName))
+            {
+                state = state.InitializeReference(path.Root, parameter.DeclarationSpan);
+                path = path with { Root = state.GetAliasRoots(path.Root).Single() };
+            }
+            TaintFlow? flow = _symbolicParameters
+                ? TaintFlow.ForParameter(index, parameter.Name, parameter.DeclarationSpan)
+                : InferParameterSource(parameter);
+            if (flow != null)
+                state = state.StrongUpdate(path, [flow]);
         }
 
-        // File read patterns
-        if (_options.TrackFileReads &&
-            (lowerName.Contains("file") ||
-             lowerName.Contains("content") ||
-             lowerName.Contains("data") && lowerName.Contains("read")))
-        {
-            return TaintSource.FileRead;
-        }
+        return state;
+    }
 
-        // Environment patterns
-        if (_options.TrackEnvironment &&
-            (lowerName.Contains("env") ||
-             lowerName.Contains("config")))
+    private TaintFlow? InferParameterSource(VariableSymbol parameter)
+    {
+        if (_options.TrackUserInput
+            && _options.UserInputParameterNames.Contains(parameter.Name, StringComparer.Ordinal))
         {
-            return TaintSource.Environment;
+            return TaintFlow.ForSource(TaintSource.UserInput, parameter.Name, parameter.DeclarationSpan);
         }
 
         return null;
     }
 
-    private void AnalyzeStatement(BoundStatement stmt)
+    private TaintState TransferStatement(
+        BasicBlock? block,
+        int statementIndex,
+        BoundStatement statement,
+        TaintState input,
+        bool applyDeferredDefinition = true)
     {
-        switch (stmt)
+        switch (statement)
         {
-            case BoundBindStatement bind:
-                AnalyzeBinding(bind);
-                break;
+            case BoundBindStatement bind when bind.Initializer == null:
+                return IsReferenceLike(bind.Variable.TypeName)
+                    ? input.InitializeReference(TaintAccessPath.For(bind.Variable).Root, bind.Span)
+                    : input;
 
-            case BoundCallStatement call:
-                AnalyzeCall(call.Target, call.Arguments, call.Span);
-                break;
+            case BoundBindStatement bind when bind.Initializer != null:
+                return applyDeferredDefinition
+                    ? Assign(bind.Variable, bind.Initializer, input, bind.Span)
+                    : input;
 
-            case BoundReturnStatement ret:
-                if (ret.Expression != null)
+            case BoundAssignmentStatement
                 {
-                    AnalyzeExpression(ret.Expression);
-                }
-                break;
+                    Target: BoundVariableExpression target,
+                } assignment:
+                return applyDeferredDefinition
+                    ? Assign(target.Variable, assignment.Value, input, assignment.Span)
+                    : input;
 
-            case BoundIfStatement ifStmt:
-                AnalyzeExpression(ifStmt.Condition);
-                foreach (var s in ifStmt.ThenBody)
-                    AnalyzeStatement(s);
-                foreach (var elseIf in ifStmt.ElseIfClauses)
-                {
-                    AnalyzeExpression(elseIf.Condition);
-                    foreach (var s in elseIf.Body)
-                        AnalyzeStatement(s);
-                }
-                if (ifStmt.ElseBody != null)
-                    foreach (var s in ifStmt.ElseBody)
-                        AnalyzeStatement(s);
-                break;
-
-            case BoundWhileStatement whileStmt:
-                AnalyzeExpression(whileStmt.Condition);
-                foreach (var s in whileStmt.Body)
-                    AnalyzeStatement(s);
-                break;
-
-            case BoundForStatement forStmt:
-                AnalyzeExpression(forStmt.From);
-                AnalyzeExpression(forStmt.To);
-                if (forStmt.Step != null)
-                    AnalyzeExpression(forStmt.Step);
-                foreach (var s in forStmt.Body)
-                    AnalyzeStatement(s);
-                break;
-
-            case BoundAssignmentStatement assign:
-                AnalyzeExpression(assign.Value);
-                // Propagate taint: if value is tainted, target becomes tainted (increment hop count)
-                if (assign.Target is BoundVariableExpression targetVar)
-                {
-                    var sourceLabels = GetTaintLabelsFromExpression(assign.Value);
-                    foreach (var label in sourceLabels)
-                        AddTaint(targetVar.Variable, label with { Hops = label.Hops + 1 });
-                }
-                break;
+            case BoundAssignmentStatement assignment:
+                return applyDeferredDefinition
+                    ? Assign(assignment.Target, assignment.Value, input, assignment.Span)
+                    : input;
 
             case BoundCompoundAssignment compound:
-                AnalyzeExpression(compound.Value);
-                AnalyzeExpression(compound.Target);
-                break;
-
-            case BoundForeachStatement forEach:
-                AnalyzeExpression(forEach.Collection);
-                // Propagate taint from collection to loop variable (increment hop count)
-                var collectionLabels = GetTaintLabelsFromExpression(forEach.Collection);
-                foreach (var label in collectionLabels)
-                    AddTaint(forEach.LoopVariable, label with { Hops = label.Hops + 1 });
-                foreach (var s in forEach.Body)
-                    AnalyzeStatement(s);
-                break;
-
-            case BoundDoWhileStatement doWhile:
-                foreach (var s in doWhile.Body)
-                    AnalyzeStatement(s);
-                AnalyzeExpression(doWhile.Condition);
-                break;
-
-            case BoundUsingStatement usingStmt:
-                AnalyzeExpression(usingStmt.ResourceExpression);
-                foreach (var s in usingStmt.Body)
-                    AnalyzeStatement(s);
-                break;
-
-            case BoundExpressionStatement exprStmt:
-                AnalyzeExpression(exprStmt.Expression);
-                break;
-
-            case BoundThrowStatement throwStmt:
-                if (throwStmt.Expression != null)
-                    AnalyzeExpression(throwStmt.Expression);
-                break;
-
-            case BoundTryStatement tryStmt:
-                foreach (var s in tryStmt.TryBody)
-                    AnalyzeStatement(s);
-                foreach (var catchClause in tryStmt.CatchClauses)
-                    foreach (var s in catchClause.Body)
-                        AnalyzeStatement(s);
-                if (tryStmt.FinallyBody != null)
-                    foreach (var s in tryStmt.FinallyBody)
-                        AnalyzeStatement(s);
-                break;
+                if (!applyDeferredDefinition)
+                    return input;
+                var compoundFlows = EvaluateExpression(compound.Target, input)
+                    .Concat(EvaluateExpression(compound.Value, input));
+                return WriteTarget(compound.Target, compoundFlows, input, compound.Span);
 
             default:
-                foreach (var expression in BoundNodeHelpers.GetImmediateExpressions(stmt))
-                    AnalyzeExpression(expression);
-                foreach (var statement in BoundNodeHelpers.GetImmediateStatements(stmt))
-                    AnalyzeStatement(statement);
+                return input;
+        }
+    }
+
+    private TaintState TransferSynthetic(SyntheticOperation operation, TaintState input)
+    {
+        return operation.Kind switch
+        {
+            SyntheticOperationKind.ForInitialization or SyntheticOperationKind.ForStep
+                when operation.DefinedVariable != null && operation.Expression != null =>
+                Assign(operation.DefinedVariable, operation.Expression, input, operation.Span),
+
+            SyntheticOperationKind.ForeachCollectionEvaluation when operation.Expression != null =>
+                input.SetForeachFlows(operation.Span, EvaluateExpression(operation.Expression, input)),
+
+            SyntheticOperationKind.ForeachIteration when operation.DefinedVariable != null =>
+                input.StrongUpdate(
+                    TaintAccessPath.For(operation.DefinedVariable),
+                    input.GetForeachFlows(operation.Span)
+                        .Select(flow => flow.WithStep("foreach element", operation.Span))),
+
+            SyntheticOperationKind.UsingResourceInitialization
+                when operation.DefinedVariable != null && operation.Expression != null =>
+                Assign(operation.DefinedVariable, operation.Expression, input, operation.Span),
+
+            SyntheticOperationKind.StatementDefinition when operation.SourceStatement != null =>
+                TransferStatement(null, -1, operation.SourceStatement, input),
+
+            _ => input,
+        };
+    }
+
+    private TaintState Assign(
+        VariableSymbol target,
+        BoundExpression value,
+        TaintState input,
+        TextSpan location)
+    {
+        var flows = EvaluateExpression(value, input);
+        var targetPath = TaintAccessPath.For(target);
+        var propagated = AddPropagation(flows, $"assign {target.Name}", location);
+
+        if (!IsReferenceLike(target.TypeName))
+        {
+            return input.WithoutAlias(targetPath.Root)
+                .StrongUpdate(targetPath, propagated);
+        }
+
+        // A reference assignment snapshots the source's current abstract object
+        // pointees. Rebinding the source variable later therefore cannot retarget
+        // aliases that still refer to its old object.
+        if (value is BoundVariableExpression source && IsReferenceLike(source.Variable.TypeName))
+        {
+            return input.WithAliases(
+                    targetPath.Root,
+                    input.GetAliasRoots(TaintAccessPath.For(source.Variable).Root))
+                .StrongUpdate(targetPath, Array.Empty<TaintFlow>());
+        }
+
+        if (HasStableObjectIdentity(target.TypeName)
+            && HasStableObjectIdentity(value.TypeName)
+            && TryGetAccessPath(value, input, out var sourcePath))
+        {
+            var (referenceState, targets) = input.GetOrCreateReferenceTargets(sourcePath);
+            return referenceState.WithAliases(targetPath.Root, targets)
+                .StrongUpdate(targetPath, Array.Empty<TaintFlow>());
+        }
+
+        var state = input.NewReference(targetPath.Root, location)
+            .StrongUpdate(targetPath, Array.Empty<TaintFlow>());
+        var objectPath = targetPath with { Root = state.GetAliasRoots(targetPath.Root).Single() };
+        return state.StrongUpdate(objectPath, propagated);
+    }
+
+    private TaintState Assign(
+        BoundExpression target,
+        BoundExpression value,
+        TaintState input,
+        TextSpan location)
+    {
+        if (HasStableObjectIdentity(target.TypeName)
+            && HasStableObjectIdentity(value.TypeName)
+            && TryGetAccessPath(value, input, out var sourcePath)
+            && TryGetAccessPath(target, input, out var targetPath))
+        {
+            var (state, targets) = input.GetOrCreateReferenceTargets(sourcePath);
+            var storagePaths = state.ResolveStoragePaths(targetPath).Distinct().ToArray();
+            return state.WithReferenceValues(
+                storagePaths,
+                targets,
+                storagePaths.Length == 1 && !HasWildcardIndex(storagePaths[0]));
+        }
+
+        return WriteTarget(target, EvaluateExpression(value, input), input, location);
+    }
+
+    private TaintState WriteTarget(
+        BoundExpression target,
+        IEnumerable<TaintFlow> flows,
+        TaintState input,
+        TextSpan location)
+    {
+        if (!TryGetAccessPath(target, input, out var rawPath))
+            return input;
+
+        var propagated = AddPropagation(flows, $"assign {rawPath.DisplayName}", location);
+        var state = input;
+        if (target is BoundVariableExpression)
+            state = state.WithoutAlias(rawPath.Root);
+
+        var targets = state.ResolveStoragePaths(rawPath).Distinct().ToArray();
+        return targets.Length == 1 && !HasWildcardIndex(targets[0])
+            ? state.StrongUpdate(targets[0], propagated)
+            : state.WeakUpdate(targets, propagated);
+    }
+
+    private IEnumerable<TaintFlow> EvaluateExpression(BoundExpression expression, TaintState state)
+    {
+        if (TryGetAccessPath(expression, state, out var path))
+            return state.Get(path);
+
+        switch (expression)
+        {
+            case BoundCallExpression call:
+                return EvaluateCall(TaintCallDescriptor.From(call), call.Arguments, call.Span, state);
+
+            case BoundExpressionCall expressionCall:
+                return expressionCall.Arguments.SelectMany(argument => EvaluateExpression(argument, state));
+
+            default:
+                return expression.Children.SelectMany(child => EvaluateExpression(child, state));
+        }
+    }
+
+    private IEnumerable<TaintFlow> EvaluateCall(
+        TaintCallDescriptor call,
+        IReadOnlyList<BoundExpression> arguments,
+        TextSpan location,
+        TaintState state)
+    {
+        var argumentFlows = arguments
+            .SelectMany(argument => EvaluateExpression(argument, state))
+            .ToArray();
+        var source = IdentifySource(call);
+        if (source != null)
+            return [TaintFlow.ForSource(source.Value, call.DisplayName, location)];
+
+        var sanitizer = IdentifySanitizer(call);
+        if (sanitizer != null)
+        {
+            var sanitized = sanitizer.Sanitizes.Aggregate(
+                TaintSinkMask.None,
+                (mask, sink) => mask | TaintSinkMaskExtensions.For(sink));
+            return argumentFlows.Select(flow =>
+                flow.WithSanitizedSinks(sanitized).WithStep($"sanitize {call.DisplayName}", location));
+        }
+
+        var summaries = GetSummaries(call).ToArray();
+        if (summaries.Length > 0)
+        {
+            return summaries.SelectMany(summary =>
+                summary.ReturnFlows.SelectMany(flow =>
+                    flow.Origin.ParameterIndex is { } index && index < arguments.Count
+                        ? EvaluateExpression(arguments[index], state)
+                            .Select(argument => argument.WithSummaryFlow(flow, call.DisplayName, location))
+                        : flow.Origin.Source is { }
+                            ? [flow.WithSummaryReturn(call.DisplayName, location)]
+                            : Array.Empty<TaintFlow>())
+                    .Where(flow => flow.Origin.ParameterIndex == null
+                        || flow.Origin.ParameterIndex < arguments.Count));
+        }
+
+        if (_options.StrictExternalCalls && call.ResolvedSymbols.Count == 0)
+        {
+            return [
+                .. argumentFlows,
+                TaintFlow.ForSource(TaintSource.ExternalApi, call.DisplayName, location),
+            ];
+        }
+
+        return argumentFlows;
+    }
+
+    private IEnumerable<TaintFunctionSummary> GetSummaries(TaintCallDescriptor call) =>
+        call.ResolvedSymbols
+            .Where(symbol => !symbol.Id.IsNone)
+            .Select(symbol => _summaries.TryGetValue(symbol.Id, out var summary) ? summary : null)
+            .Where(summary => summary != null)
+            .Cast<TaintFunctionSummary>()
+            .Distinct();
+
+    private TaintSource? IdentifySource(TaintCallDescriptor call)
+    {
+        foreach (var rule in BuiltInSources.Concat(_options.AdditionalSources))
+        {
+            if (!rule.Identity.Matches(call))
+                continue;
+
+            return IsSourceEnabled(rule.Source) ? rule.Source : null;
+        }
+
+        return null;
+    }
+
+    private TaintSinkRule? IdentifySink(TaintCallDescriptor call)
+    {
+        foreach (var rule in BuiltInSinks.Concat(_options.AdditionalSinks))
+        {
+            if (rule.Identity.Matches(call) && IsSinkEnabled(rule.Sink))
+                return rule;
+        }
+
+        return null;
+    }
+
+    private TaintSanitizerRule? IdentifySanitizer(TaintCallDescriptor call) =>
+        BuiltInSanitizers.Concat(_options.AdditionalSanitizers)
+            .FirstOrDefault(rule => rule.Identity.Matches(call));
+
+    private bool IsSourceEnabled(TaintSource source) => source switch
+    {
+        TaintSource.UserInput => _options.TrackUserInput,
+        TaintSource.FileRead => _options.TrackFileReads,
+        TaintSource.NetworkInput => _options.TrackNetworkInput,
+        TaintSource.Environment => _options.TrackEnvironment,
+        _ => true,
+    };
+
+    private bool IsSinkEnabled(TaintSink sink) => sink switch
+    {
+        TaintSink.SqlQuery => _options.DetectSqlInjection,
+        TaintSink.CommandExecution => _options.DetectCommandInjection,
+        TaintSink.FilePath => _options.DetectPathTraversal,
+        TaintSink.HtmlOutput => _options.DetectXss,
+        _ => true,
+    };
+
+    private void CollectFindings()
+    {
+        foreach (var block in Cfg.ReachableBlocks)
+        {
+            var state = DataflowResult.Blocks[block].In;
+            for (var statementIndex = 0; statementIndex < block.Statements.Count; statementIndex++)
+            {
+                var statement = block.Statements[statementIndex];
+                InspectStatement(statement, state);
+                state = TransferStatement(
+                    block,
+                    statementIndex,
+                    statement,
+                    state,
+                    applyDeferredDefinition: !block.IsDefinitionDeferred(statementIndex));
+            }
+
+            foreach (var operation in block.SyntheticOperations)
+            {
+                if (operation.Expression != null)
+                    InspectExpression(operation.Expression, state);
+                state = TransferSynthetic(operation, state);
+            }
+
+            if (block.Terminator.Condition != null)
+                InspectExpression(block.Terminator.Condition, state);
+        }
+    }
+
+    private void InspectStatement(BoundStatement statement, TaintState state)
+    {
+        switch (statement)
+        {
+            case BoundCallStatement call:
+                InspectCall(TaintCallDescriptor.From(call), call.Arguments, call.Span, state);
+                break;
+            default:
+                foreach (var expression in BoundNodeHelpers.GetImmediateExpressions(statement))
+                    InspectExpression(expression, state);
                 break;
         }
     }
 
-    private void AnalyzeBinding(BoundBindStatement bind)
+    private void InspectExpression(BoundExpression expression, TaintState state)
     {
-        if (bind.Initializer == null)
-            return;
+        if (expression is BoundCallExpression call)
+            InspectCall(TaintCallDescriptor.From(call), call.Arguments, call.Span, state);
 
-        // Check initializer expressions for sink calls (e.g., file.read with tainted args)
-        AnalyzeExpression(bind.Initializer);
+        foreach (var child in expression.Children)
+            InspectExpression(child, state);
+    }
 
-        // Check if the initializer is a taint source
-        var sourceLabels = GetTaintLabelsFromExpression(bind.Initializer);
-
-        // Propagate taint to the variable being defined
-        foreach (var label in sourceLabels)
+    private void InspectCall(
+        TaintCallDescriptor call,
+        IReadOnlyList<BoundExpression> arguments,
+        TextSpan location,
+        TaintState state)
+    {
+        var sink = IdentifySink(call);
+        if (sink != null)
         {
-            AddTaint(bind.Variable, label);
+            RecordSinkFlows(
+                sink.Sink,
+                SelectSinkArguments(sink, arguments),
+                call.DisplayName,
+                location,
+                state);
+        }
+
+        foreach (var summary in GetSummaries(call))
+        {
+            foreach (var summarySink in summary.ParameterSinks)
+            {
+                if (summarySink.ParameterIndex >= arguments.Count)
+                    continue;
+                RecordSinkFlows(
+                    summarySink.Sink,
+                    [arguments[summarySink.ParameterIndex]],
+                    summarySink.Target,
+                    summarySink.Location,
+                    state,
+                    summarySink.ProvenancePath,
+                    call.DisplayName);
+            }
         }
     }
 
-    private void AnalyzeCall(string target, IReadOnlyList<BoundExpression> arguments, TextSpan span)
+    private void RecordSummarySinks(
+        BoundStatement statement,
+        TaintState state,
+        Dictionary<TaintSummarySinkKey, TaintSummarySink> sinks)
     {
-        var sink = IdentifySink(target);
-        if (sink != null)
-        {
-            // Check if any argument is tainted
-            foreach (var arg in arguments)
+        IEnumerable<(TaintCallDescriptor Call, IReadOnlyList<BoundExpression> Arguments, TextSpan Location)> calls =
+            statement switch
             {
-                var labels = GetTaintLabelsFromExpression(arg);
-                foreach (var label in labels)
-                {
-                    // Only report if taint has propagated through enough hops
-                    // (filters out direct parameter→sink flows which are often false positives)
-                    if (label.Hops < _options.MinTaintHops)
-                        continue;
+                BoundCallStatement call =>
+                [
+                    (TaintCallDescriptor.From(call), call.Arguments, call.Span),
+                ],
+                _ => BoundNodeHelpers.GetImmediateExpressions(statement)
+                    .SelectMany(FindCalls)
+                    .Select(call => (TaintCallDescriptor.From(call), call.Arguments, call.Span)),
+            };
 
-                    var argName = GetExpressionName(arg) ?? "expression";
-                    _vulnerabilities.Add(new TaintVulnerability(
-                        sink.Value,
-                        label.Source,
-                        label.SourceVariable,
-                        label.SourceLocation,
-                        argName,
-                        span));
+        foreach (var (call, arguments, location) in calls)
+        {
+            var sink = IdentifySink(call);
+            if (sink == null)
+                continue;
+            foreach (var index in sink.GetArgumentIndices(arguments.Count))
+            {
+                if (index < 0 || index >= arguments.Count)
+                    continue;
+                foreach (var flow in EvaluateExpression(arguments[index], state))
+                {
+                    if (flow.Origin.ParameterIndex is not { } parameterIndex
+                        || flow.IsSanitizedFor(sink.Sink))
+                    {
+                        continue;
+                    }
+
+                    var summarySink = new TaintSummarySink(
+                        sink.Sink,
+                        parameterIndex,
+                        call.DisplayName,
+                        location,
+                        flow.Path);
+                    sinks.TryAdd(
+                        new TaintSummarySinkKey(sink.Sink, parameterIndex, location),
+                        summarySink);
                 }
             }
         }
-
     }
 
-    private void AnalyzeExpression(BoundExpression expr)
-    {
-        if (expr is BoundCallExpression callExpr)
-        {
-            AnalyzeCall(callExpr.Target, callExpr.Arguments, callExpr.Span);
-        }
+    private static IReadOnlyList<BoundExpression> SelectSinkArguments(
+        TaintSinkRule sink,
+        IReadOnlyList<BoundExpression> arguments) =>
+        sink.GetArgumentIndices(arguments.Count)
+            .Where(index => index >= 0 && index < arguments.Count)
+            .Select(index => arguments[index])
+            .ToArray();
 
-        foreach (var child in BoundNodeHelpers.GetChildExpressions(expr))
-            AnalyzeExpression(child);
+    private static IEnumerable<BoundCallExpression> FindCalls(BoundExpression expression)
+    {
+        if (expression is BoundCallExpression call)
+            yield return call;
+        foreach (var child in expression.Children)
+        {
+            foreach (var nested in FindCalls(child))
+                yield return nested;
+        }
     }
 
-    private TaintLabel? CheckForTaintSource(string target, TextSpan location)
+    private void RecordSinkFlows(
+        TaintSink sink,
+        IReadOnlyList<BoundExpression> arguments,
+        string sinkName,
+        TextSpan sinkLocation,
+        TaintState state,
+        IReadOnlyList<TaintFlowStep>? calleeProvenance = null,
+        string? calleeName = null)
     {
-        var lowerTarget = target.ToLowerInvariant();
-
-        // User input sources
-        if (_options.TrackUserInput &&
-            (lowerTarget.Contains("readline") ||
-             lowerTarget.Contains("read_input") ||
-             lowerTarget.Contains("getinput") ||
-             lowerTarget.Contains("prompt") ||
-             lowerTarget.Contains("request.get") ||
-             lowerTarget.Contains("request.query") ||
-             lowerTarget.Contains("request.param") ||
-             lowerTarget.Contains("request.body")))
+        foreach (var argument in arguments)
         {
-            return new TaintLabel(TaintSource.UserInput, target, location);
-        }
-
-        // File read sources
-        if (_options.TrackFileReads &&
-            (lowerTarget.Contains("file.read") ||
-             lowerTarget.Contains("read_file") ||
-             lowerTarget.Contains("fs.read") ||
-             lowerTarget.Contains("io.read")))
-        {
-            return new TaintLabel(TaintSource.FileRead, target, location);
-        }
-
-        // Network input sources
-        if (_options.TrackNetworkInput &&
-            (lowerTarget.Contains("http.get") ||
-             lowerTarget.Contains("fetch") ||
-             lowerTarget.Contains("socket.read") ||
-             lowerTarget.Contains("recv")))
-        {
-            return new TaintLabel(TaintSource.NetworkInput, target, location);
-        }
-
-        // Environment sources
-        if (_options.TrackEnvironment &&
-            (lowerTarget.Contains("env.get") ||
-             lowerTarget.Contains("getenv") ||
-             lowerTarget.Contains("environment.get")))
-        {
-            return new TaintLabel(TaintSource.Environment, target, location);
-        }
-
-        return null;
-    }
-
-    private TaintSink? IdentifySink(string target)
-    {
-        // First, try to derive sink from declared effects (more precise)
-        var effectSink = IdentifySinkFromEffects(target);
-        if (effectSink != null)
-            return effectSink;
-
-        // Fall back to pattern matching for external/unknown functions
-        var lowerTarget = target.ToLowerInvariant();
-
-        // SQL sinks (but not parameterized/prepared queries, which are safe by design)
-        if (_options.DetectSqlInjection &&
-            (lowerTarget.Contains("sql.execute") ||
-             lowerTarget.Contains("sql.query") ||
-             lowerTarget.Contains("db.execute") ||
-             lowerTarget.Contains("db.query") ||
-             lowerTarget.Contains("db.raw") ||
-             lowerTarget.Contains("execute_sql")))
-        {
-            if (IsParameterizedQuery(lowerTarget))
+            var sinkVariable = GetExpressionName(argument) ?? sinkName;
+            foreach (var flow in EvaluateExpression(argument, state))
             {
-                return null; // Parameterized queries are safe
-            }
-            return TaintSink.SqlQuery;
-        }
+                if (flow.Origin.Source is not { } source || flow.IsSanitizedFor(sink))
+                    continue;
 
-        // Command execution sinks
-        if (_options.DetectCommandInjection &&
-            (lowerTarget.Contains("exec") ||
-             lowerTarget.Contains("system") ||
-             lowerTarget.Contains("shell") ||
-             lowerTarget.Contains("spawn") ||
-             lowerTarget.Contains("popen") ||
-             lowerTarget.Contains("run_command")))
-        {
-            return TaintSink.CommandExecution;
-        }
+                var sourceName = flow.Origin.Name;
+                var key = new TaintFindingKey(
+                    sink,
+                    source,
+                    sourceName,
+                    flow.Origin.Location,
+                    sinkVariable,
+                    sinkLocation);
+                if (!_reportedFindings.Add(key))
+                    continue;
 
-        // File path sinks
-        if (_options.DetectPathTraversal &&
-            (lowerTarget.Contains("file.open") ||
-             lowerTarget.Contains("file.read") ||
-             lowerTarget.Contains("file.write") ||
-             lowerTarget.Contains("file.delete") ||
-             lowerTarget.Contains("fs.read") ||
-             lowerTarget.Contains("fs.write") ||
-             lowerTarget.Contains("path.join")))
-        {
-            return TaintSink.FilePath;
-        }
-
-        // HTML output sinks (XSS)
-        if (_options.DetectXss &&
-            (lowerTarget.Contains("html.write") ||
-             lowerTarget.Contains("response.write") ||
-             lowerTarget.Contains("innerhtml") ||
-             lowerTarget.Contains("document.write")))
-        {
-            return TaintSink.HtmlOutput;
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Checks if the target represents a parameterized/prepared query (safe by design).
-    /// Uses precise method-segment matching to avoid false exclusions like "execute_with_param_logging".
-    /// </summary>
-    private static bool IsParameterizedQuery(string lowerTarget)
-    {
-        // Extract the final method segment (after last '.')
-        var dotIndex = lowerTarget.LastIndexOf('.');
-        var methodSegment = dotIndex >= 0 ? lowerTarget[(dotIndex + 1)..] : lowerTarget;
-
-        return methodSegment.EndsWith("_param") ||
-               methodSegment.EndsWith("_parameterized") ||
-               methodSegment.EndsWith("_prepared") ||
-               methodSegment == "parameterized" ||
-               methodSegment == "prepared" ||
-               methodSegment.StartsWith("parameterized_") ||
-               methodSegment.StartsWith("prepared_");
-    }
-
-    /// <summary>
-    /// Identifies sinks from declared effects.
-    /// This provides more precise sink detection based on the effect system.
-    /// Effects come in "category:value" format (e.g., "io:database_write").
-    /// </summary>
-    private TaintSink? IdentifySinkFromEffects(string target)
-    {
-        // If no effects are declared, can't use effect-based detection
-        if (_declaredEffects.Count == 0)
-            return null;
-
-        // Check if the call target matches any effect-derived sinks
-        var lowerTarget = target.ToLowerInvariant();
-
-        foreach (var effect in _declaredEffects)
-        {
-            // Parse "category:value" format from Binder
-            var parts = effect.Split(':');
-            if (parts.Length != 2)
-                continue;
-
-            var category = parts[0];
-            var value = parts[1];
-
-            // Map category to EffectKind
-            var kind = category switch
-            {
-                "io" => EffectKind.IO,
-                "process" => EffectKind.Process,
-                "memory" => EffectKind.Memory,
-                "console" => EffectKind.Console,
-                _ => EffectKind.IO // Default
-            };
-
-            // Use the expanded value to find the sink
-            var sink = EffectSinkMapping.MapEffectToSink(kind, value);
-            if (sink == null)
-                continue;
-
-            // Check if call target matches the effect's resource domain
-            if (MatchesEffectResource(lowerTarget, value, sink.Value))
-            {
-                // Verify the sink type is enabled in options
-                if (IsSinkEnabled(sink.Value))
-                    return sink;
+                var provenance = BuildFindingProvenance(
+                    flow,
+                    sinkName,
+                    sinkVariable,
+                    sinkLocation,
+                    calleeProvenance,
+                    calleeName);
+                _vulnerabilities.Add(new TaintVulnerability(
+                    sink,
+                    source,
+                    sourceName,
+                    flow.Origin.Location,
+                    sinkVariable,
+                    sinkLocation,
+                    provenance));
             }
         }
-
-        return null;
     }
 
-    /// <summary>
-    /// Checks if a call target matches an effect's resource domain.
-    /// Uses multiple matching strategies for robustness.
-    /// </summary>
-    private static bool MatchesEffectResource(string target, string effectValue, TaintSink sink)
+    private static IEnumerable<TaintFlow> AddPropagation(
+        IEnumerable<TaintFlow> flows,
+        string description,
+        TextSpan location) =>
+        flows.Select(flow => flow.WithStep(description, location));
+
+    private static IReadOnlyList<TaintFlowStep> BuildFindingProvenance(
+        TaintFlow flow,
+        string sinkName,
+        string sinkVariable,
+        TextSpan sinkLocation,
+        IReadOnlyList<TaintFlowStep>? calleeProvenance,
+        string? calleeName)
     {
-        // Strategy 1: Match by known resource prefixes from the effect
-        var resourcePrefixes = GetResourcePrefixes(effectValue);
-        foreach (var prefix in resourcePrefixes)
+        var provenance = flow.Path.ToList();
+        if (calleeProvenance != null)
         {
-            // Match "db.execute", "db_query", "database.run", etc.
-            if (target.StartsWith(prefix + ".") ||
-                target.StartsWith(prefix + "_") ||
-                target == prefix ||
-                target.Contains("." + prefix + ".") ||
-                target.Contains("." + prefix + "_"))
-            {
+            provenance.Add(new TaintFlowStep($"call {calleeName}", sinkLocation));
+            provenance.AddRange(calleeProvenance.Skip(1));
+        }
+        provenance.Add(new TaintFlowStep($"sink {sinkName}({sinkVariable})", sinkLocation));
+        return provenance;
+    }
+
+    private static string? GetExpressionName(BoundExpression expression) => expression switch
+    {
+        BoundVariableExpression variable => variable.Variable.Name,
+        BoundFieldAccessExpression field => field.FieldName,
+        BoundArrayAccess or BoundArrayAccessExpression or BoundMultiDimArrayAccess => "element",
+        _ => null,
+    };
+
+    private static bool IsReferenceLike(string typeName) =>
+        typeName.EndsWith("[]", StringComparison.Ordinal)
+        || typeName.Contains('<', StringComparison.Ordinal)
+        || typeName is "OBJECT" or "STRING"
+        || (!IsPrimitiveValueType(typeName)
+            && typeName is not "BOOL" and not "CHAR" and not "VOID");
+
+    private static bool HasStableObjectIdentity(string typeName) =>
+        IsReferenceLike(typeName) && typeName != "STRING";
+
+    private static bool IsPrimitiveValueType(string typeName) =>
+        typeName.ToUpperInvariant() is
+            "BYTE" or "SBYTE" or "SHORT" or "USHORT" or "INT" or "UINT"
+            or "LONG" or "ULONG" or "FLOAT" or "DOUBLE" or "DECIMAL";
+
+    private static bool TryGetAccessPath(
+        BoundExpression expression,
+        TaintState state,
+        out TaintAccessPath path)
+    {
+        switch (expression)
+        {
+            case BoundVariableExpression variable:
+                path = TaintAccessPath.For(variable.Variable);
                 return true;
-            }
-        }
 
-        // Strategy 2: Match by sink-specific keywords
-        var keywords = GetSinkKeywords(sink);
-        foreach (var keyword in keywords)
-        {
-            if (target.Contains(keyword))
+            case BoundFieldAccessExpression field when TryGetAccessPath(field.Target, state, out var target):
+                var fieldIdentity = field.ResolvedField is { } resolvedField
+                    && !resolvedField.Id.IsNone
+                        ? resolvedField.Id.Value
+                        : field.FieldName;
+                path = target.Append($"field:{fieldIdentity}");
                 return true;
+
+            case BoundFieldAccessExpression { ResolvedField: { } field }:
+                path = TaintAccessPath.For(field);
+                return true;
+
+            case BoundArrayAccess array when TryGetAccessPath(array.Array, state, out var arrayTarget):
+                path = arrayTarget.Append(IndexSegment(array.Index));
+                return true;
+
+            case BoundArrayAccessExpression array when TryGetAccessPath(array.Array, state, out var arrayTarget):
+                path = array.Indices.Aggregate(arrayTarget, (current, index) => current.Append(IndexSegment(index)));
+                return true;
+
+            case BoundMultiDimArrayAccess array when TryGetAccessPath(array.Array, state, out var arrayTarget):
+                path = array.Indices.Aggregate(arrayTarget, (current, index) => current.Append(IndexSegment(index)));
+                return true;
+
+            default:
+                path = default;
+                return false;
+        }
+    }
+
+    private static string IndexSegment(BoundExpression index) =>
+        index is BoundIntLiteral literal
+            ? $"index:{literal.Value}"
+            : "index:*";
+
+    private static bool HasWildcardIndex(TaintAccessPath path) =>
+        path.Segments.Split('/').Contains("index:*", StringComparer.Ordinal);
+
+    private sealed class TaintTransfer : ITransferFunction<TaintState>
+    {
+        private readonly TaintAnalysis _analysis;
+
+        public TaintTransfer(TaintAnalysis analysis) => _analysis = analysis;
+
+        public TaintState Transfer(BoundStatement statement, TaintState input) =>
+            _analysis.TransferStatement(null, -1, statement, input);
+
+        public TaintState Transfer(
+            BasicBlock block,
+            int statementIndex,
+            BoundStatement statement,
+            TaintState input) =>
+            _analysis.TransferStatement(
+                block,
+                statementIndex,
+                statement,
+                input,
+                applyDeferredDefinition: !block.IsDefinitionDeferred(statementIndex));
+
+        public TaintState TransferExpression(BoundExpression? expression, TaintState input) => input;
+
+        public TaintState TransferSynthetic(SyntheticOperation operation, TaintState input) =>
+            _analysis.TransferSynthetic(operation, input);
+    }
+
+    internal readonly record struct TaintCallDescriptor(
+        string Target,
+        string? ResolvedTypeName,
+        string? ResolvedMethodName,
+        IReadOnlyList<string>? ResolvedParameterTypes,
+        FunctionSymbol? ResolvedSymbol,
+        IReadOnlyList<FunctionSymbol> ResolvedSymbols)
+    {
+        public bool HasResolvedIdentity =>
+            ResolvedSymbol != null
+            || ResolvedTypeName != null && ResolvedMethodName != null;
+
+        public string DisplayName => ResolvedTypeName != null && ResolvedMethodName != null
+            ? $"{ResolvedTypeName}.{ResolvedMethodName}"
+            : Target;
+
+        public static TaintCallDescriptor From(BoundCallExpression call) => new(
+            call.Target,
+            call.ResolvedTypeName,
+            call.ResolvedMethodName,
+            call.ResolvedParameterTypes,
+            call.ResolvedSymbol,
+            call.ResolvedSymbols);
+
+        public static TaintCallDescriptor From(BoundCallStatement call) => new(
+            call.Target,
+            call.ResolvedTypeName,
+            call.ResolvedMethodName,
+            call.ResolvedParameterTypes,
+            call.ResolvedSymbol,
+            call.ResolvedSymbols);
+    }
+
+    [Flags]
+    internal enum TaintSinkMask
+    {
+        None = 0,
+        SqlQuery = 1 << 0,
+        CommandExecution = 1 << 1,
+        FilePath = 1 << 2,
+        HtmlOutput = 1 << 3,
+        UrlRedirect = 1 << 4,
+        CodeEval = 1 << 5,
+        Deserialization = 1 << 6,
+        LogOutput = 1 << 7,
+    }
+
+    internal static class TaintSinkMaskExtensions
+    {
+        public static TaintSinkMask For(TaintSink sink) => (TaintSinkMask)(1 << (int)sink);
+    }
+
+    internal readonly record struct TaintOrigin(
+        TaintSource? Source,
+        int? ParameterIndex,
+        string Name,
+        TextSpan Location);
+
+    internal readonly record struct TaintFlowIdentity(TaintOrigin Origin, TaintSinkMask SanitizedSinks);
+
+    internal sealed class TaintFlow
+    {
+        private const int MaximumEvidenceSteps = 32;
+
+        public TaintOrigin Origin { get; }
+        public TaintSinkMask SanitizedSinks { get; }
+        public IReadOnlyList<TaintFlowStep> Path { get; }
+        public TaintFlowIdentity Identity => new(Origin, SanitizedSinks);
+
+        private TaintFlow(
+            TaintOrigin origin,
+            TaintSinkMask sanitizedSinks,
+            IReadOnlyList<TaintFlowStep> path)
+        {
+            Origin = origin;
+            SanitizedSinks = sanitizedSinks;
+            Path = path;
         }
 
-        return false;
-    }
+        public static TaintFlow ForSource(TaintSource source, string name, TextSpan location) =>
+            new(
+                new TaintOrigin(source, null, name, location),
+                TaintSinkMask.None,
+                [new TaintFlowStep($"source {name}", location)]);
 
-    /// <summary>
-    /// Gets resource prefixes for matching call targets to effects.
-    /// </summary>
-    private static string[] GetResourcePrefixes(string effectValue)
-    {
-        return effectValue switch
-        {
-            "database_read" or "database_write" or "database_readwrite"
-                => new[] { "db", "database", "sql", "query", "mysql", "postgres", "sqlite", "mongo" },
-            "filesystem_read" or "filesystem_write" or "filesystem_readwrite"
-                => new[] { "fs", "file", "path", "directory", "dir", "io" },
-            "network_read" or "network_write" or "network_readwrite"
-                => new[] { "net", "network", "http", "https", "url", "web", "socket", "fetch", "request" },
-            "console_read" or "console_write"
-                => new[] { "console", "stdout", "stdin", "print", "readline" },
-            "environment_read" or "environment_write"
-                => new[] { "env", "environment", "getenv", "setenv" },
-            "process"
-                => new[] { "process", "exec", "spawn", "shell", "system", "cmd", "command", "run" },
-            _ => Array.Empty<string>()
-        };
-    }
+        public static TaintFlow ForParameter(int index, string name, TextSpan location) =>
+            new(
+                new TaintOrigin(null, index, name, location),
+                TaintSinkMask.None,
+                [new TaintFlowStep($"parameter {name}", location)]);
 
-    /// <summary>
-    /// Gets keywords specific to each sink type for fallback matching.
-    /// </summary>
-    private static string[] GetSinkKeywords(TaintSink sink)
-    {
-        return sink switch
+        public TaintFlow WithStep(string description, TextSpan location)
         {
-            TaintSink.SqlQuery => new[] { "execute", "query", "select", "insert", "update", "delete", "exec" },
-            TaintSink.CommandExecution => new[] { "exec", "spawn", "shell", "system", "run", "command" },
-            TaintSink.FilePath => new[] { "open", "read", "write", "create", "delete", "path" },
-            TaintSink.UrlRedirect => new[] { "redirect", "navigate", "location", "url", "href" },
-            TaintSink.HtmlOutput => new[] { "write", "html", "render", "innerhtml", "response" },
-            TaintSink.CodeEval => new[] { "eval", "compile", "execute", "interpret" },
-            TaintSink.Deserialization => new[] { "deserialize", "unmarshal", "parse", "load", "decode" },
-            TaintSink.LogOutput => new[] { "log", "trace", "debug", "info", "warn", "error" },
-            _ => Array.Empty<string>()
-        };
-    }
+            if (Path.Count >= MaximumEvidenceSteps)
+                return this;
+            return new TaintFlow(Origin, SanitizedSinks, [.. Path, new TaintFlowStep(description, location)]);
+        }
 
-    /// <summary>
-    /// Checks if a sink type is enabled in the options.
-    /// </summary>
-    private bool IsSinkEnabled(TaintSink sink)
-    {
-        return sink switch
-        {
-            TaintSink.SqlQuery => _options.DetectSqlInjection,
-            TaintSink.CommandExecution => _options.DetectCommandInjection,
-            TaintSink.FilePath => _options.DetectPathTraversal,
-            TaintSink.HtmlOutput => _options.DetectXss,
-            _ => true // Other sinks are always enabled
-        };
-    }
+        public TaintFlow WithSanitizedSinks(TaintSinkMask sinks) =>
+            new(Origin, SanitizedSinks | sinks, Path);
 
-    private IEnumerable<TaintLabel> GetTaintLabelsFromExpression(BoundExpression expr)
-    {
-        if (expr is BoundVariableExpression varExpr)
+        public TaintFlow WithSummaryFlow(TaintFlow summaryFlow, string call, TextSpan location) =>
+            new(
+                Origin,
+                SanitizedSinks | summaryFlow.SanitizedSinks,
+                CombineSummaryPath(Path, summaryFlow.Path, $"call {call}", location));
+
+        public TaintFlow WithSummaryReturn(string call, TextSpan location) =>
+            new(Origin, SanitizedSinks, Append(Path, $"return from {call}", location));
+
+        public bool IsSanitizedFor(TaintSink sink) =>
+            (SanitizedSinks & TaintSinkMaskExtensions.For(sink)) != 0;
+
+        private static IReadOnlyList<TaintFlowStep> CombineSummaryPath(
+            IReadOnlyList<TaintFlowStep> callerPath,
+            IReadOnlyList<TaintFlowStep> calleePath,
+            string call,
+            TextSpan location)
         {
-            if (_taintedVariables.TryGetValue(varExpr.Variable.Id, out var labels))
+            var combined = callerPath.ToList();
+            if (combined.Count < MaximumEvidenceSteps)
+                combined.Add(new TaintFlowStep(call, location));
+            foreach (var step in calleePath.Skip(1))
             {
-                foreach (var label in labels)
-                    yield return label;
+                if (combined.Count >= MaximumEvidenceSteps)
+                    break;
+                combined.Add(step);
             }
-            yield break;
+            return combined;
         }
 
-        if (expr is BoundCallExpression callExpr)
-        {
-            if (IsSanitizer(callExpr.Target))
-                yield break;
+        private static IReadOnlyList<TaintFlowStep> Append(
+            IReadOnlyList<TaintFlowStep> path,
+            string description,
+            TextSpan location) =>
+            path.Count >= MaximumEvidenceSteps
+                ? path
+                : [.. path, new TaintFlowStep(description, location)];
+    }
 
-            var source = CheckForTaintSource(callExpr.Target, callExpr.Span);
-            if (source != null)
-                yield return source.Value;
+    internal readonly record struct TaintRoot(
+        SymbolId Id,
+        VariableSymbol? Symbol,
+        string? ObjectIdentity = null)
+    {
+        public bool Equals(TaintRoot other) =>
+            ObjectIdentity != null || other.ObjectIdentity != null
+                ? string.Equals(ObjectIdentity, other.ObjectIdentity, StringComparison.Ordinal)
+                : !Id.IsNone && !other.Id.IsNone
+                ? Id == other.Id
+                : ReferenceEquals(Symbol, other.Symbol);
+
+        public override int GetHashCode() =>
+            ObjectIdentity != null
+                ? StringComparer.Ordinal.GetHashCode(ObjectIdentity)
+                : Id.IsNone
+                ? Symbol == null ? 0 : RuntimeHelpers.GetHashCode(Symbol)
+                : Id.GetHashCode();
+
+        public TaintRoot CreateObject(TextSpan location) =>
+            new(
+                Id,
+                Symbol,
+                $"object:{(Id.IsNone ? RuntimeHelpers.GetHashCode(Symbol!).ToString() : Id.Value)}:{location.Start}:{location.End}");
+
+        public TaintRoot CreateNestedObject(TaintAccessPath storagePath) =>
+            new(
+                Id,
+                Symbol,
+                $"object-slot:{storagePath.Root.StableIdentity}:{storagePath.Segments}");
+
+        private string StableIdentity =>
+            ObjectIdentity
+            ?? (Id.IsNone
+                ? RuntimeHelpers.GetHashCode(Symbol!).ToString()
+                : Id.Value);
+    }
+
+    internal readonly record struct TaintAccessPath(TaintRoot Root, string Segments)
+    {
+        public string DisplayName => string.IsNullOrEmpty(Segments)
+            ? Root.Symbol?.Name ?? Root.Id.Value
+            : $"{Root.Symbol?.Name ?? Root.Id.Value}.{Segments}";
+
+        public static TaintAccessPath For(VariableSymbol symbol) =>
+            new(new TaintRoot(symbol.Id, symbol), string.Empty);
+
+        public TaintAccessPath Append(string segment) =>
+            new(Root, string.IsNullOrEmpty(Segments) ? segment : $"{Segments}/{segment}");
+
+        public bool IsSameOrDescendantOf(TaintAccessPath other) =>
+            Root.Equals(other.Root)
+            && (Segments == other.Segments
+                || string.IsNullOrEmpty(other.Segments)
+                || Segments.StartsWith(other.Segments + "/", StringComparison.Ordinal));
+    }
+
+    internal sealed class TaintState : IEquatable<TaintState>
+    {
+        private readonly Dictionary<TaintAccessPath, Dictionary<TaintFlowIdentity, TaintFlow>> _facts;
+        private readonly Dictionary<TaintRoot, HashSet<TaintRoot>> _aliases;
+        private readonly Dictionary<TaintAccessPath, HashSet<TaintRoot>> _referenceValues;
+        private readonly Dictionary<TextSpan, Dictionary<TaintFlowIdentity, TaintFlow>> _foreachFlows;
+
+        public static TaintState Empty { get; } = new(
+            new Dictionary<TaintAccessPath, Dictionary<TaintFlowIdentity, TaintFlow>>(),
+            new Dictionary<TaintRoot, HashSet<TaintRoot>>(),
+            new Dictionary<TaintAccessPath, HashSet<TaintRoot>>(),
+            new Dictionary<TextSpan, Dictionary<TaintFlowIdentity, TaintFlow>>());
+
+        private TaintState(
+            Dictionary<TaintAccessPath, Dictionary<TaintFlowIdentity, TaintFlow>> facts,
+            Dictionary<TaintRoot, HashSet<TaintRoot>> aliases,
+            Dictionary<TaintAccessPath, HashSet<TaintRoot>> referenceValues,
+            Dictionary<TextSpan, Dictionary<TaintFlowIdentity, TaintFlow>> foreachFlows)
+        {
+            _facts = facts;
+            _aliases = aliases;
+            _referenceValues = referenceValues;
+            _foreachFlows = foreachFlows;
         }
 
-        foreach (var child in BoundNodeHelpers.GetChildExpressions(expr))
-            foreach (var label in GetTaintLabelsFromExpression(child))
-                yield return label;
-    }
-
-    private static bool IsSanitizer(string target)
-    {
-        var lowerTarget = target.ToLowerInvariant();
-        return lowerTarget.Contains("escape") ||
-               lowerTarget.Contains("sanitize") ||
-               lowerTarget.Contains("encode") ||
-               lowerTarget.Contains("html_escape") ||
-               lowerTarget.Contains("sql_escape") ||
-               lowerTarget.Contains("quote") ||
-               lowerTarget.Contains("parameterize");
-    }
-
-    private void AddTaint(VariableSymbol variable, TaintLabel label)
-    {
-        if (variable.Id.IsNone)
-            return;
-
-        if (!_taintedVariables.TryGetValue(variable.Id, out var labels))
+        public IReadOnlyCollection<TaintRoot> GetAliasRoots(TaintRoot root)
         {
-            labels = new HashSet<TaintLabel>();
-            _taintedVariables[variable.Id] = labels;
+            if (root.ObjectIdentity != null)
+                return [root];
+            return _aliases.TryGetValue(root, out var targets) && targets.Count > 0
+                ? targets
+                : [root];
         }
-        labels.Add(label);
+
+        public IEnumerable<TaintAccessPath> ResolveStoragePaths(TaintAccessPath path)
+        {
+            var current = GetAliasRoots(path.Root)
+                .Select(root => new TaintAccessPath(root, string.Empty))
+                .ToArray();
+            if (string.IsNullOrEmpty(path.Segments))
+                return current;
+
+            var segments = path.Segments.Split('/');
+            for (var index = 0; index < segments.Length; index++)
+            {
+                var appended = current.Select(candidate => candidate.Append(segments[index])).ToArray();
+                if (index == segments.Length - 1)
+                    return appended;
+
+                current = appended
+                    .SelectMany(candidate =>
+                    {
+                        var references = GetReferenceValues(candidate).ToArray();
+                        return references.Length == 0
+                            ? [candidate]
+                            : references.Select(root => new TaintAccessPath(root, string.Empty));
+                    })
+                    .ToArray();
+            }
+
+            return current;
+        }
+
+        public IEnumerable<TaintFlow> Get(TaintAccessPath path)
+        {
+            var result = new Dictionary<TaintFlowIdentity, TaintFlow>();
+            foreach (var target in ResolveValuePaths(path))
+                AddFacts(target, includeContainer: true, result);
+            return result.Values;
+        }
+
+        public (TaintState State, IReadOnlyCollection<TaintRoot> Targets)
+            GetOrCreateReferenceTargets(TaintAccessPath path)
+        {
+            if (string.IsNullOrEmpty(path.Segments))
+                return (this, GetAliasRoots(path.Root));
+
+            var referenceValues = CloneReferenceValues();
+            var targets = new HashSet<TaintRoot>();
+            var changed = false;
+            foreach (var storagePath in ResolveStoragePaths(path))
+            {
+                var existing = GetReferenceValues(storagePath, referenceValues).ToArray();
+                if (existing.Length > 0)
+                {
+                    targets.UnionWith(existing);
+                    continue;
+                }
+
+                var nestedObject = storagePath.Root.CreateNestedObject(storagePath);
+                referenceValues[storagePath] = [nestedObject];
+                targets.Add(nestedObject);
+                changed = true;
+            }
+
+            return (
+                changed
+                    ? new TaintState(
+                        CloneFacts(),
+                        CloneAliases(),
+                        referenceValues,
+                        CloneForeachFlows())
+                    : this,
+                targets);
+        }
+
+        public TaintState WithReferenceValues(
+            IEnumerable<TaintAccessPath> storagePaths,
+            IEnumerable<TaintRoot> targets,
+            bool strongUpdate)
+        {
+            var referenceValues = CloneReferenceValues();
+            var targetSet = targets.ToHashSet();
+            foreach (var storagePath in storagePaths.Distinct())
+            {
+                if (strongUpdate)
+                {
+                    foreach (var existing in referenceValues.Keys
+                        .Where(path => path.IsSameOrDescendantOf(storagePath))
+                        .ToArray())
+                    {
+                        referenceValues.Remove(existing);
+                    }
+
+                    if (targetSet.Count > 0)
+                        referenceValues[storagePath] = new HashSet<TaintRoot>(targetSet);
+                    continue;
+                }
+
+                referenceValues.TryGetValue(storagePath, out var existingTargets);
+                referenceValues[storagePath] = (existingTargets ?? [])
+                    .Concat(targetSet)
+                    .ToHashSet();
+            }
+
+            return new TaintState(
+                CloneFacts(),
+                CloneAliases(),
+                referenceValues,
+                CloneForeachFlows());
+        }
+
+        public TaintState StrongUpdate(TaintAccessPath path, IEnumerable<TaintFlow> flows)
+        {
+            var facts = CloneFacts();
+            foreach (var existing in facts.Keys.Where(key => key.IsSameOrDescendantOf(path)).ToArray())
+                facts.Remove(existing);
+
+            var merged = Merge(flows);
+            if (merged.Count > 0)
+                facts[path] = merged;
+            return new TaintState(facts, CloneAliases(), CloneReferenceValues(), CloneForeachFlows());
+        }
+
+        public TaintState WeakUpdate(
+            IEnumerable<TaintAccessPath> paths,
+            IEnumerable<TaintFlow> flows)
+        {
+            var facts = CloneFacts();
+            var generated = Merge(flows);
+            foreach (var path in paths.Distinct())
+            {
+                facts.TryGetValue(path, out var existing);
+                var merged = Merge(
+                    (existing != null ? existing.Values : Enumerable.Empty<TaintFlow>())
+                    .Concat(generated.Values));
+                if (merged.Count > 0)
+                    facts[path] = merged;
+            }
+            return new TaintState(facts, CloneAliases(), CloneReferenceValues(), CloneForeachFlows());
+        }
+
+        public TaintState WithoutAlias(TaintRoot root)
+        {
+            var aliases = CloneAliases();
+            aliases.Remove(root);
+            return new TaintState(CloneFacts(), aliases, CloneReferenceValues(), CloneForeachFlows());
+        }
+
+        public TaintState InitializeReference(TaintRoot root, TextSpan location)
+        {
+            if (_aliases.ContainsKey(root))
+                return this;
+            return NewReference(root, location);
+        }
+
+        public TaintState NewReference(TaintRoot root, TextSpan location)
+        {
+            var aliases = CloneAliases();
+            aliases[root] = [root.CreateObject(location)];
+            return new TaintState(CloneFacts(), aliases, CloneReferenceValues(), CloneForeachFlows());
+        }
+
+        public TaintState WithAliases(TaintRoot source, IEnumerable<TaintRoot> targets)
+        {
+            var aliases = CloneAliases();
+            var targetSet = targets.ToHashSet();
+            if (source.ObjectIdentity != null)
+                throw new InvalidOperationException("Abstract object identities cannot be rebound");
+            if (targetSet.Count == 0)
+            {
+                aliases.Remove(source);
+            }
+            else
+            {
+                aliases[source] = targetSet;
+            }
+
+            return new TaintState(CloneFacts(), aliases, CloneReferenceValues(), CloneForeachFlows());
+        }
+
+        public TaintState SetForeachFlows(TextSpan span, IEnumerable<TaintFlow> flows)
+        {
+            var foreachFlows = CloneForeachFlows();
+            foreachFlows[span] = Merge(flows);
+            return new TaintState(CloneFacts(), CloneAliases(), CloneReferenceValues(), foreachFlows);
+        }
+
+        public IEnumerable<TaintFlow> GetForeachFlows(TextSpan span) =>
+            _foreachFlows.TryGetValue(span, out var flows)
+                ? flows.Values
+                : Array.Empty<TaintFlow>();
+
+        public static TaintState Join(TaintState left, TaintState right)
+        {
+            var facts = left.CloneFacts();
+            foreach (var (path, rightFlows) in right._facts)
+            {
+                facts.TryGetValue(path, out var leftFlows);
+                facts[path] = Merge(
+                    (leftFlows != null
+                        ? leftFlows.Values
+                        : Enumerable.Empty<TaintFlow>())
+                    .Concat(rightFlows.Values));
+            }
+
+            var aliases = new Dictionary<TaintRoot, HashSet<TaintRoot>>();
+            foreach (var root in left._aliases.Keys.Union(right._aliases.Keys))
+            {
+                var targets = left.GetAliasRoots(root)
+                    .Concat(right.GetAliasRoots(root))
+                    .ToHashSet();
+                if (targets.Count != 1 || !targets.Contains(root))
+                    aliases[root] = targets;
+            }
+
+            var referenceValues = left.CloneReferenceValues();
+            foreach (var (path, rightTargets) in right._referenceValues)
+            {
+                referenceValues.TryGetValue(path, out var leftTargets);
+                referenceValues[path] = (leftTargets ?? [])
+                    .Concat(rightTargets)
+                    .ToHashSet();
+            }
+
+            var foreachFlows = left.CloneForeachFlows();
+            foreach (var (span, rightFlows) in right._foreachFlows)
+            {
+                foreachFlows.TryGetValue(span, out var leftFlows);
+                foreachFlows[span] = Merge(
+                    (leftFlows != null
+                        ? leftFlows.Values
+                        : Enumerable.Empty<TaintFlow>())
+                    .Concat(rightFlows.Values));
+            }
+            return new TaintState(facts, aliases, referenceValues, foreachFlows);
+        }
+
+        public bool Equals(TaintState? other)
+        {
+            if (other == null
+                || _facts.Count != other._facts.Count
+                || _aliases.Count != other._aliases.Count
+                || _referenceValues.Count != other._referenceValues.Count
+                || _foreachFlows.Count != other._foreachFlows.Count)
+            {
+                return false;
+            }
+
+            foreach (var (path, flows) in _facts)
+            {
+                if (!other._facts.TryGetValue(path, out var otherFlows)
+                    || !flows.Keys.ToHashSet().SetEquals(otherFlows.Keys))
+                {
+                    return false;
+                }
+            }
+
+            foreach (var (root, targets) in _aliases)
+            {
+                if (!other._aliases.TryGetValue(root, out var otherTargets)
+                    || !targets.SetEquals(otherTargets))
+                {
+                    return false;
+                }
+            }
+
+            foreach (var (path, targets) in _referenceValues)
+            {
+                if (!other._referenceValues.TryGetValue(path, out var otherTargets)
+                    || !targets.SetEquals(otherTargets))
+                {
+                    return false;
+                }
+            }
+
+            foreach (var (span, flows) in _foreachFlows)
+            {
+                if (!other._foreachFlows.TryGetValue(span, out var otherFlows)
+                    || !flows.Keys.ToHashSet().SetEquals(otherFlows.Keys))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override bool Equals(object? obj) => obj is TaintState state && Equals(state);
+
+        public override int GetHashCode()
+        {
+            var hash = _facts.Count ^ _aliases.Count ^ _referenceValues.Count ^ _foreachFlows.Count;
+            foreach (var (path, flows) in _facts)
+            {
+                hash ^= path.GetHashCode();
+                foreach (var flow in flows.Keys)
+                    hash ^= flow.GetHashCode();
+            }
+            foreach (var (root, targets) in _aliases)
+            {
+                hash ^= root.GetHashCode();
+                foreach (var target in targets)
+                    hash ^= target.GetHashCode();
+            }
+            foreach (var (path, targets) in _referenceValues)
+            {
+                hash ^= path.GetHashCode();
+                foreach (var target in targets)
+                    hash ^= target.GetHashCode();
+            }
+            return hash;
+        }
+
+        private IEnumerable<TaintAccessPath> ResolveValuePaths(TaintAccessPath path)
+        {
+            foreach (var storagePath in ResolveStoragePaths(path))
+            {
+                var references = string.IsNullOrEmpty(path.Segments)
+                    ? Array.Empty<TaintRoot>()
+                    : GetReferenceValues(storagePath).ToArray();
+                if (references.Length == 0)
+                {
+                    yield return storagePath;
+                    continue;
+                }
+
+                foreach (var root in references)
+                    yield return new TaintAccessPath(root, string.Empty);
+            }
+        }
+
+        private IEnumerable<TaintRoot> GetReferenceValues(TaintAccessPath storagePath) =>
+            GetReferenceValues(storagePath, _referenceValues);
+
+        private static IEnumerable<TaintRoot> GetReferenceValues(
+            TaintAccessPath storagePath,
+            IReadOnlyDictionary<TaintAccessPath, HashSet<TaintRoot>> referenceValues)
+        {
+            foreach (var (candidate, targets) in referenceValues)
+            {
+                var matchesExact = candidate == storagePath;
+                var matchesWildcard = candidate.Root.Equals(storagePath.Root)
+                    && candidate.Segments.EndsWith("index:*", StringComparison.Ordinal)
+                    && storagePath.Segments.StartsWith(
+                        candidate.Segments[..^1],
+                        StringComparison.Ordinal);
+                if (!matchesExact && !matchesWildcard)
+                    continue;
+                foreach (var target in targets)
+                    yield return target;
+            }
+        }
+
+        private void AddFacts(
+            TaintAccessPath path,
+            bool includeContainer,
+            Dictionary<TaintFlowIdentity, TaintFlow> result)
+        {
+            foreach (var (candidate, flows) in _facts)
+            {
+                var matchesExact = candidate == path;
+                var matchesWildcard = candidate.Root.Equals(path.Root)
+                    && candidate.Segments.EndsWith("index:*", StringComparison.Ordinal)
+                    && path.Segments.StartsWith(
+                        candidate.Segments[..^1],
+                        StringComparison.Ordinal);
+                var matchesContainer = includeContainer
+                    && candidate.Root.Equals(path.Root)
+                    && string.IsNullOrEmpty(candidate.Segments);
+                if (!matchesExact && !matchesWildcard && !matchesContainer)
+                    continue;
+                foreach (var flow in flows.Values)
+                    AddShortest(result, flow);
+            }
+        }
+
+        private Dictionary<TaintAccessPath, Dictionary<TaintFlowIdentity, TaintFlow>> CloneFacts() =>
+            _facts.ToDictionary(
+                pair => pair.Key,
+                pair => new Dictionary<TaintFlowIdentity, TaintFlow>(pair.Value));
+
+        private Dictionary<TaintRoot, HashSet<TaintRoot>> CloneAliases() =>
+            _aliases.ToDictionary(
+                pair => pair.Key,
+                pair => new HashSet<TaintRoot>(pair.Value));
+
+        private Dictionary<TaintAccessPath, HashSet<TaintRoot>> CloneReferenceValues() =>
+            _referenceValues.ToDictionary(
+                pair => pair.Key,
+                pair => new HashSet<TaintRoot>(pair.Value));
+
+        private Dictionary<TextSpan, Dictionary<TaintFlowIdentity, TaintFlow>> CloneForeachFlows() =>
+            _foreachFlows.ToDictionary(
+                pair => pair.Key,
+                pair => new Dictionary<TaintFlowIdentity, TaintFlow>(pair.Value));
+
+        private static Dictionary<TaintFlowIdentity, TaintFlow> Merge(IEnumerable<TaintFlow> flows)
+        {
+            var result = new Dictionary<TaintFlowIdentity, TaintFlow>();
+            foreach (var flow in flows)
+                AddShortest(result, flow);
+            return result;
+        }
     }
 
-    private static string? GetExpressionName(BoundExpression expr)
+    private sealed class TaintStateLattice : IDataflowLattice<TaintState>
     {
-        return expr switch
+        public TaintState Bottom => TaintState.Empty;
+        public TaintState Top => TaintState.Empty;
+        public TaintState Join(TaintState a, TaintState b) => TaintState.Join(a, b);
+        public bool LessOrEqual(TaintState a, TaintState b) => TaintState.Join(a, b).Equals(b);
+    }
+
+    private static void AddShortest(
+        IDictionary<TaintFlowIdentity, TaintFlow> flows,
+        TaintFlow flow)
+    {
+        if (!flows.TryGetValue(flow.Identity, out var existing)
+            || flow.Path.Count < existing.Path.Count)
         {
-            BoundVariableExpression varExpr => varExpr.Variable.Name,
-            _ => null
-        };
+            flows[flow.Identity] = flow;
+        }
+    }
+
+    private readonly record struct TaintFindingKey(
+        TaintSink Sink,
+        TaintSource Source,
+        string SourceName,
+        TextSpan SourceLocation,
+        string SinkName,
+        TextSpan SinkLocation);
+
+    private readonly record struct TaintSummarySinkKey(
+        TaintSink Sink,
+        int ParameterIndex,
+        TextSpan Location);
+}
+
+internal sealed class TaintFunctionSummary : IEquatable<TaintFunctionSummary>
+{
+    public IReadOnlyList<TaintAnalysis.TaintFlow> ReturnFlows { get; }
+    public IReadOnlyList<TaintSummarySink> ParameterSinks { get; }
+
+    public TaintFunctionSummary(
+        IReadOnlyList<TaintAnalysis.TaintFlow> returnFlows,
+        IReadOnlyList<TaintSummarySink> parameterSinks)
+    {
+        ReturnFlows = returnFlows;
+        ParameterSinks = parameterSinks;
+    }
+
+    public static TaintFunctionSummary Join(
+        TaintFunctionSummary current,
+        TaintFunctionSummary discovered)
+    {
+        var returns = new Dictionary<TaintAnalysis.TaintFlowIdentity, TaintAnalysis.TaintFlow>();
+        foreach (var flow in current.ReturnFlows.Concat(discovered.ReturnFlows))
+        {
+            if (!returns.TryGetValue(flow.Identity, out var existing)
+                || flow.Path.Count < existing.Path.Count)
+            {
+                returns[flow.Identity] = flow;
+            }
+        }
+
+        var sinks = new Dictionary<TaintSummarySinkIdentity, TaintSummarySink>();
+        foreach (var sink in current.ParameterSinks.Concat(discovered.ParameterSinks))
+        {
+            if (!sinks.TryGetValue(sink.Identity, out var existing)
+                || sink.ProvenancePath.Count < existing.ProvenancePath.Count)
+            {
+                sinks[sink.Identity] = sink;
+            }
+        }
+
+        return new TaintFunctionSummary(
+            returns.Values.ToArray(),
+            sinks.Values.ToArray());
+    }
+
+    public bool Equals(TaintFunctionSummary? other) =>
+        other != null
+        && ReturnFlows.Select(flow => flow.Identity).ToHashSet()
+            .SetEquals(other.ReturnFlows.Select(flow => flow.Identity))
+        && ParameterSinks.Select(sink => sink.Identity).ToHashSet()
+            .SetEquals(other.ParameterSinks.Select(sink => sink.Identity));
+
+    public override bool Equals(object? obj) => obj is TaintFunctionSummary summary && Equals(summary);
+    public override int GetHashCode()
+    {
+        var hash = 0;
+        foreach (var flow in ReturnFlows)
+            hash ^= flow.Identity.GetHashCode();
+        foreach (var sink in ParameterSinks)
+            hash ^= sink.Identity.GetHashCode();
+        return hash;
     }
 }
 
-/// <summary>
-/// Runner for taint analysis on a module.
-/// </summary>
+internal sealed record TaintSummarySink(
+    TaintSink Sink,
+    int ParameterIndex,
+    string Target,
+    TextSpan Location,
+    IReadOnlyList<TaintFlowStep> ProvenancePath)
+{
+    public TaintSummarySinkIdentity Identity => new(Sink, ParameterIndex, Target, Location);
+}
+
+internal readonly record struct TaintSummarySinkIdentity(
+    TaintSink Sink,
+    int ParameterIndex,
+    string Target,
+    TextSpan Location);
+
+/// <summary>Runner for taint analysis on a bound module.</summary>
 public sealed class TaintAnalysisRunner
 {
     private readonly DiagnosticBag _diagnostics;
     private readonly TaintAnalysisOptions _options;
+    public int VulnerabilityCount { get; private set; }
 
     public TaintAnalysisRunner(DiagnosticBag diagnostics, TaintAnalysisOptions? options = null)
     {
@@ -815,24 +1904,95 @@ public sealed class TaintAnalysisRunner
         _options = options ?? TaintAnalysisOptions.Default;
     }
 
-    /// <summary>
-    /// Runs taint analysis on a bound module.
-    /// </summary>
     public void Analyze(BoundModule module)
     {
+        ArgumentNullException.ThrowIfNull(module);
+        VulnerabilityCount = 0;
+        var summaries = BuildSummaries(module.Functions);
         foreach (var function in module.Functions)
         {
-            AnalyzeFunction(function);
+            var analysis = new TaintAnalysis(
+                function,
+                _options,
+                function.DeclaredEffects,
+                summaries,
+                symbolicParameters: false);
+            analysis.ReportDiagnostics(_diagnostics);
+            VulnerabilityCount += analysis.Vulnerabilities.Count;
         }
     }
 
-    /// <summary>
-    /// Runs taint analysis on a single function.
-    /// </summary>
     public void AnalyzeFunction(BoundFunction function)
     {
-        // Pass the function's declared effects to enable effect-based sink detection
+        VulnerabilityCount = 0;
         var analysis = new TaintAnalysis(function, _options, function.DeclaredEffects);
         analysis.ReportDiagnostics(_diagnostics);
+        VulnerabilityCount += analysis.Vulnerabilities.Count;
     }
+
+    private IReadOnlyDictionary<SymbolId, TaintFunctionSummary> BuildSummaries(
+        IReadOnlyList<BoundFunction> functions)
+    {
+        var functionsById = functions
+            .Where(function => !function.SymbolId.IsNone)
+            .ToDictionary(function => function.SymbolId);
+        var summaries = functionsById.Keys.ToDictionary(
+            id => id,
+            _ => new TaintFunctionSummary([], []));
+
+        var callersByCallee = functionsById.Keys.ToDictionary(
+            id => id,
+            _ => new HashSet<SymbolId>());
+        foreach (var (callerId, function) in functionsById)
+        {
+            foreach (var calleeId in GetResolvedCallees(function))
+            {
+                if (callersByCallee.TryGetValue(calleeId, out var callers))
+                    callers.Add(callerId);
+            }
+        }
+
+        // Summary identities form a finite powerset lattice: origins and sink sites
+        // come from the finite bound tree, while sanitizer masks have finitely many
+        // combinations. Joining discoveries monotonically and revisiting only callers
+        // therefore reaches the least fixed point, including recursive SCCs.
+        var worklist = new Queue<SymbolId>(functionsById.Keys);
+        var queued = functionsById.Keys.ToHashSet();
+        while (worklist.Count > 0)
+        {
+            var id = worklist.Dequeue();
+            queued.Remove(id);
+            var function = functionsById[id];
+            var analysis = new TaintAnalysis(
+                function,
+                _options,
+                function.DeclaredEffects,
+                summaries,
+                symbolicParameters: true);
+            var joined = TaintFunctionSummary.Join(summaries[id], analysis.CreateSummary());
+            if (joined.Equals(summaries[id]))
+                continue;
+
+            summaries[id] = joined;
+            foreach (var callerId in callersByCallee[id])
+            {
+                if (queued.Add(callerId))
+                    worklist.Enqueue(callerId);
+            }
+        }
+
+        return summaries;
+    }
+
+    private static IEnumerable<SymbolId> GetResolvedCallees(BoundFunction function) =>
+        BoundNodeHelpers.DescendantsAndSelf(function)
+            .SelectMany(node => node switch
+            {
+                BoundCallStatement call => call.ResolvedSymbols,
+                BoundCallExpression call => call.ResolvedSymbols,
+                _ => Array.Empty<FunctionSymbol>(),
+            })
+            .Select(symbol => symbol.Id)
+            .Where(id => !id.IsNone)
+            .Distinct();
 }

--- a/src/Calor.Compiler/Analysis/VerificationAnalysisPass.cs
+++ b/src/Calor.Compiler/Analysis/VerificationAnalysisPass.cs
@@ -404,6 +404,15 @@ public sealed class VerificationAnalysisPass
         var taintVulnerabilities = 0;
         var loopInvariants = 0;
 
+        if (_options.EnableTaintAnalysis)
+        {
+            var taintRunner = new TaintAnalysisRunner(
+                _diagnostics,
+                _options.TaintOptions ?? TaintAnalysisOptions.Default);
+            taintRunner.Analyze(module);
+            taintVulnerabilities = taintRunner.VulnerabilityCount;
+        }
+
         foreach (var function in module.Functions)
         {
             var incomplete = BoundNodeHelpers.GetAnalysisIncompleteNodes(function).FirstOrDefault();
@@ -431,15 +440,6 @@ public sealed class VerificationAnalysisPass
                 var beforeCount = _diagnostics.Count;
                 bugRunner.CheckFunction(function);
                 bugPatternsFound += _diagnostics.Count - beforeCount;
-            }
-
-            // Taint analysis
-            if (_options.EnableTaintAnalysis)
-            {
-                var taintOptions = _options.TaintOptions ?? TaintAnalysisOptions.Default;
-                var taintAnalysis = new TaintAnalysis(function, taintOptions, function.DeclaredEffects);
-                taintVulnerabilities += taintAnalysis.Vulnerabilities.Count;
-                taintAnalysis.ReportDiagnostics(_diagnostics);
             }
 
             // K-induction for loops

--- a/src/Calor.Compiler/Binding/Binder.cs
+++ b/src/Calor.Compiler/Binding/Binder.cs
@@ -914,6 +914,10 @@ public sealed class Binder
             call.ArgumentNames,
             call.ArgumentModifiers,
             call.TypeArguments);
+        var (resolvedTypeName, resolvedMethodName) = GetResolvedCallIdentity(
+            call.Target,
+            receiverSymbol,
+            receiverTypeSymbol);
 
         return new BoundCallStatement(
             call.Span,
@@ -928,7 +932,13 @@ public sealed class Binder
             call.ReceiverSpan,
             resolution.Kind == OverloadResolutionKind.Inaccessible,
             call.TypeArguments,
-            receiverTypeSymbol);
+            receiverTypeSymbol,
+            resolvedTypeName,
+            resolvedMethodName,
+            (resolution.Function?.Parameters
+                .Select(parameter => parameter.TypeName)
+                ?? args.Select(argument => argument.TypeName))
+                .ToArray());
     }
 
     private BoundReturnStatement BindReturnStatement(ReturnStatementNode ret)
@@ -2142,23 +2152,10 @@ public sealed class Binder
             callExpr.TypeArguments);
         var returnType = resolution.ResolvedReturnType ?? "OBJECT";
 
-        // Populate structured type info for effect resolution
-        string? resolvedTypeName = null;
-        string? resolvedMethodName = null;
-        var lastDot = callExpr.Target.LastIndexOf('.');
-        if (lastDot > 0)
-        {
-            resolvedMethodName = callExpr.Target[(lastDot + 1)..];
-            var typePart = callExpr.Target[..lastDot];
-            resolvedTypeName = receiverSymbol != null
-                ? Effects.EffectEnforcementPass.MapShortTypeNameToFullName(
-                    GetNominalTypeName(receiverSymbol.TypeName))
-                : receiverTypeSymbol != null
-                    ? receiverTypeSymbol.QualifiedName
-                : !typePart.Contains('.')
-                ? Effects.EffectEnforcementPass.MapShortTypeNameToFullName(typePart)
-                : typePart;
-        }
+        var (resolvedTypeName, resolvedMethodName) = GetResolvedCallIdentity(
+            callExpr.Target,
+            receiverSymbol,
+            receiverTypeSymbol);
 
         return new BoundCallExpression(
             callExpr.Span,
@@ -2167,8 +2164,9 @@ public sealed class Binder
             returnType,
             resolvedTypeName,
             resolvedMethodName,
-            resolvedParameterTypes: resolution.Function?.Parameters
+            resolvedParameterTypes: (resolution.Function?.Parameters
                 .Select(parameter => parameter.TypeName)
+                ?? args.Select(argument => argument.TypeName))
                 .ToArray(),
             argumentNames: callExpr.ArgumentNames,
             argumentModifiers: callExpr.ArgumentModifiers,
@@ -2180,6 +2178,28 @@ public sealed class Binder
             receiverSpan: callExpr.ReceiverSpan,
             isInaccessibleCall: resolution.Kind == OverloadResolutionKind.Inaccessible,
             receiverTypeSymbol: receiverTypeSymbol);
+    }
+
+    private (string? TypeName, string? MethodName) GetResolvedCallIdentity(
+        string target,
+        VariableSymbol? receiverSymbol,
+        TypeSymbol? receiverTypeSymbol)
+    {
+        var lastDot = target.LastIndexOf('.');
+        if (lastDot <= 0)
+            return (null, null);
+
+        var typePart = target[..lastDot];
+        return (
+            receiverSymbol != null
+                ? Effects.EffectEnforcementPass.MapShortTypeNameToFullName(
+                    GetNominalTypeName(receiverSymbol.TypeName))
+                : receiverTypeSymbol != null
+                    ? receiverTypeSymbol.QualifiedName
+                    : !typePart.Contains('.')
+                        ? Effects.EffectEnforcementPass.MapShortTypeNameToFullName(typePart)
+                        : typePart,
+            target[(lastDot + 1)..]);
     }
 
     private VariableSymbol? ResolveCallReceiver(

--- a/src/Calor.Compiler/Binding/BoundNodes.cs
+++ b/src/Calor.Compiler/Binding/BoundNodes.cs
@@ -200,6 +200,12 @@ public sealed class BoundCallStatement : BoundStatement
     public IReadOnlyList<string?>? ArgumentNames { get; }
     public IReadOnlyList<string?>? ArgumentModifiers { get; }
     public IReadOnlyList<string>? TypeArguments { get; }
+    /// <summary>Fully-qualified receiver type retained for exact external-call analyses.</summary>
+    public string? ResolvedTypeName { get; }
+    /// <summary>Method name retained for exact external-call analyses.</summary>
+    public string? ResolvedMethodName { get; }
+    /// <summary>Resolved parameter types retained for overload-sensitive analyses.</summary>
+    public IReadOnlyList<string>? ResolvedParameterTypes { get; }
     public override IEnumerable<BoundNode> ChildNodes => Arguments;
 
     public BoundCallStatement(
@@ -215,7 +221,10 @@ public sealed class BoundCallStatement : BoundStatement
         TextSpan? receiverSpan = null,
         bool isInaccessibleCall = false,
         IReadOnlyList<string>? typeArguments = null,
-        TypeSymbol? receiverTypeSymbol = null)
+        TypeSymbol? receiverTypeSymbol = null,
+        string? resolvedTypeName = null,
+        string? resolvedMethodName = null,
+        IReadOnlyList<string>? resolvedParameterTypes = null)
         : base(span)
     {
         Target = target;
@@ -231,6 +240,9 @@ public sealed class BoundCallStatement : BoundStatement
         CalleeSpan = calleeSpan ?? span;
         ReceiverSpan = receiverSpan;
         IsInaccessibleCall = isInaccessibleCall;
+        ResolvedTypeName = resolvedTypeName;
+        ResolvedMethodName = resolvedMethodName;
+        ResolvedParameterTypes = resolvedParameterTypes;
     }
 }
 

--- a/src/Calor.Compiler/Program.cs
+++ b/src/Calor.Compiler/Program.cs
@@ -500,10 +500,10 @@ public class Program
                                 ReportOnlyVerified = !allFindings,
                                 Z3TimeoutMs = (uint)verificationTimeout
                             },
-                            TaintOptions = new Analysis.Security.TaintAnalysisOptions
-                            {
-                                MinTaintHops = allFindings ? 1 : 2
-                            }
+                            // Taint findings are exploitable regardless of propagation
+                            // distance. --all-findings controls other heuristic analyses,
+                            // not source-to-sink taint reporting.
+                            TaintOptions = new Analysis.Security.TaintAnalysisOptions()
                         } : null,
                         ExperimentalFlags = experimentalFlags != null && experimentalFlags.Length > 0
                             ? new ExperimentalFlags(experimentalFlags)

--- a/tests/Calor.Compiler.Tests/Analysis/TaintAnalysisCfgTests.cs
+++ b/tests/Calor.Compiler.Tests/Analysis/TaintAnalysisCfgTests.cs
@@ -1,0 +1,1138 @@
+using Calor.Compiler.Analysis.Security;
+using Calor.Compiler.Analysis;
+using Calor.Compiler.Ast;
+using Calor.Compiler.Binding;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Parsing;
+using System.Text.Json;
+using Xunit;
+
+namespace Calor.Compiler.Tests.Analysis;
+
+public sealed class TaintAnalysisCfgTests
+{
+    private static TextSpan Span(int start) => new(start, start + 1, 1, start + 1);
+
+    [Fact]
+    public void RegressionCorpusInventory_EnforcesCommittedPrecisionRecallTargets()
+    {
+        var path = Path.Combine(
+            AppContext.BaseDirectory,
+            "TestData",
+            "Security",
+            "TaintAnalysis",
+            "manifest.json");
+        using var inventory = JsonDocument.Parse(File.ReadAllText(path));
+        var root = inventory.RootElement;
+
+        var cases = root.GetProperty("cases").EnumerateArray().ToArray();
+        var expected = cases
+            .Select(testCase => testCase.GetProperty("expectedFinding").GetBoolean())
+            .ToArray();
+        var actual = cases
+            .Select(testCase => ExecuteCorpusCase(testCase.GetProperty("id").GetString()!))
+            .ToArray();
+        var truePositives = expected.Zip(actual).Count(pair => pair.First && pair.Second);
+        var falsePositives = expected.Zip(actual).Count(pair => !pair.First && pair.Second);
+        var falseNegatives = expected.Zip(actual).Count(pair => pair.First && !pair.Second);
+        var precision = truePositives / (double)Math.Max(1, truePositives + falsePositives);
+        var recall = truePositives / (double)Math.Max(1, truePositives + falseNegatives);
+
+        Assert.True(precision >= root.GetProperty("minimumPrecision").GetDouble());
+        Assert.True(recall >= root.GetProperty("minimumRecall").GetDouble());
+    }
+
+    [Fact]
+    public void DirectSourceToSink_ReportsEvenWhenLegacyHopThresholdIsTwo()
+    {
+        var input = Variable("user_input", "STRING", "param:input", true);
+        var function = Function(
+            "Direct",
+            "fn:direct",
+            [input],
+            [Call("db.execute", Reference(input, 2), 1)]);
+
+        var finding = Assert.Single(new TaintAnalysis(
+            function,
+            new TaintAnalysisOptions { MinTaintHops = 2 }).Vulnerabilities);
+
+        Assert.Equal(TaintSink.SqlQuery, finding.Sink);
+        Assert.Equal(input.Name, finding.SourceVariable);
+        Assert.True(finding.ProvenancePath.Count >= 2);
+    }
+
+    [Fact]
+    public void ConsoleReadLine_CallReturnSource_ReachesSink()
+    {
+        var value = Variable("value", "STRING", "local:value");
+        var function = Function(
+            "ConsoleSource",
+            "fn:console-source",
+            [],
+            [
+                new BoundBindStatement(
+                    Span(10),
+                    value,
+                    new BoundCallExpression(Span(11), "Console.ReadLine", [], "STRING")),
+                Call("db.execute", Reference(value, 12), 13),
+            ]);
+
+        var finding = Assert.Single(new TaintAnalysis(function).Vulnerabilities);
+        Assert.Equal(TaintSource.UserInput, finding.Source);
+        Assert.Equal("Console.ReadLine", finding.SourceVariable);
+    }
+
+    [Fact]
+    public void SafeOverwrite_StronglyKillsEarlierTaint()
+    {
+        var input = Variable("user_input", "STRING", "param:overwrite", true);
+        var value = Variable("value", "STRING", "local:value");
+        var function = Function(
+            "Overwrite",
+            "fn:overwrite",
+            [input],
+            [
+                new BoundBindStatement(Span(20), value, Reference(input, 21)),
+                new BoundAssignmentStatement(
+                    Span(22),
+                    Reference(value, 23),
+                    new BoundStringLiteral(Span(24), "safe")),
+                Call("db.execute", Reference(value, 25), 26),
+            ]);
+
+        Assert.Empty(new TaintAnalysis(function).Vulnerabilities);
+    }
+
+    [Fact]
+    public void ConstantsOnly_DoNotProduceAFinding()
+    {
+        var value = Variable("value", "STRING", "local:constant-value");
+        var function = Function(
+            "Constants",
+            "fn:constants",
+            [],
+            [
+                new BoundBindStatement(
+                    Span(27),
+                    value,
+                    new BoundStringLiteral(Span(28), "safe")),
+                Call("db.execute", Reference(value, 29), 30),
+            ]);
+
+        Assert.Empty(new TaintAnalysis(function).Vulnerabilities);
+    }
+
+    [Fact]
+    public void BranchJoin_PreservesTaintFromOneReachableBranch()
+    {
+        var input = Variable("user_input", "STRING", "param:branch-input", true);
+        var value = Variable("value", "STRING", "local:branch-value");
+        var condition = Variable("condition", "BOOL", "param:condition", true);
+        var function = Function(
+            "Branch",
+            "fn:branch",
+            [input, condition],
+            [
+                new BoundBindStatement(
+                    Span(30),
+                    value,
+                    new BoundStringLiteral(Span(31), "safe")),
+                new BoundIfStatement(
+                    Span(32),
+                    Reference(condition, 33),
+                    [
+                        new BoundAssignmentStatement(
+                            Span(34),
+                            Reference(value, 35),
+                            Reference(input, 36)),
+                    ],
+                    [],
+                    null),
+                Call("db.execute", Reference(value, 37), 38),
+            ]);
+
+        Assert.Single(new TaintAnalysis(function).Vulnerabilities);
+    }
+
+    [Fact]
+    public void LoopFixedPoint_PropagatesTaintThroughBackEdge()
+    {
+        var input = Variable("user_input", "STRING", "param:loop-input", true);
+        var value = Variable("value", "STRING", "local:loop-value");
+        var condition = Variable("condition", "BOOL", "param:loop-condition", true);
+        var function = Function(
+            "Loop",
+            "fn:loop",
+            [input, condition],
+            [
+                new BoundBindStatement(
+                    Span(40),
+                    value,
+                    new BoundStringLiteral(Span(41), "safe")),
+                new BoundWhileStatement(
+                    Span(42),
+                    Reference(condition, 43),
+                    [
+                        new BoundAssignmentStatement(
+                            Span(44),
+                            Reference(value, 45),
+                            Reference(input, 46)),
+                    ]),
+                Call("db.execute", Reference(value, 47), 48),
+            ]);
+
+        var analysis = new TaintAnalysis(function);
+        Assert.True(analysis.DataflowResult.IsConverged);
+        Assert.Single(analysis.Vulnerabilities);
+    }
+
+    [Fact]
+    public void AliasFieldAndCollectionAccessPaths_PreserveTaint()
+    {
+        var input = Variable("user_input", "STRING", "param:path-input", true);
+        var first = Variable("first", "OBJECT", "local:first");
+        var alias = Variable("alias", "OBJECT", "local:alias");
+        var items = Variable("items", "STRING[]", "local:items");
+        var fieldOnAlias = Field(alias, "Text", 52);
+        var fieldOnFirst = Field(first, "Text", 53);
+        var item = new BoundArrayAccess(Span(54), Reference(items, 55), new BoundIntLiteral(Span(56), 0));
+        var itemRead = new BoundArrayAccess(Span(57), Reference(items, 58), new BoundIntLiteral(Span(59), 0));
+        var function = Function(
+            "AccessPaths",
+            "fn:access-paths",
+            [input],
+            [
+                new BoundBindStatement(Span(50), first, null),
+                new BoundBindStatement(Span(51), alias, Reference(first, 52)),
+                new BoundAssignmentStatement(Span(53), fieldOnAlias, Reference(input, 54)),
+                Call("db.execute", fieldOnFirst, 55),
+                new BoundBindStatement(Span(56), items, null),
+                new BoundAssignmentStatement(Span(57), item, Reference(input, 58)),
+                Call("db.execute", itemRead, 59),
+            ]);
+
+        Assert.Equal(2, new TaintAnalysis(function).Vulnerabilities.Count);
+    }
+
+    [Fact]
+    public void ExactSanitizerIdentity_DoesNotTreatDesanitizeAsSanitizer()
+    {
+        var input = Variable("user_input", "STRING", "param:sanitize-input", true);
+        var dangerous = Variable("dangerous", "STRING", "local:dangerous");
+        var safe = Variable("safe", "STRING", "local:safe");
+        var function = Function(
+            "Sanitizers",
+            "fn:sanitizers",
+            [input],
+            [
+                new BoundBindStatement(
+                    Span(60),
+                    dangerous,
+                    new BoundCallExpression(
+                        Span(61),
+                        "desanitize",
+                        [Reference(input, 62)],
+                        "STRING")),
+                Call("db.execute", Reference(dangerous, 63), 64),
+                new BoundBindStatement(
+                    Span(65),
+                    safe,
+                    new BoundCallExpression(
+                        Span(66),
+                        "sql_escape",
+                        [Reference(input, 67)],
+                        "STRING")),
+                Call("db.execute", Reference(safe, 68), 69),
+            ]);
+
+        var finding = Assert.Single(new TaintAnalysis(function).Vulnerabilities);
+        Assert.Equal("dangerous", finding.SinkVariable);
+    }
+
+    [Fact]
+    public void RecursiveSanitizerSummary_ConvergesOverFiniteLattice()
+    {
+        var value = Variable("value", "STRING", "param:recursive-value", true);
+        var condition = Variable("condition", "BOOL", "param:recursive-condition", true);
+        var selfSymbol = new FunctionSymbol(
+            new SymbolId("fn:recursive-sanitizer"),
+            "Self",
+            "STRING",
+            [value, condition]);
+        var recursiveCall = new BoundCallExpression(
+            Span(70),
+            "Self",
+            [Reference(value, 71), Reference(condition, 72)],
+            "STRING",
+            resolvedSymbol: selfSymbol);
+        var self = new BoundFunction(
+            Span(73),
+            selfSymbol,
+            [
+                new BoundIfStatement(
+                    Span(74),
+                    Reference(condition, 75),
+                    [new BoundReturnStatement(Span(76), Reference(value, 77))],
+                    [],
+                    [
+                        new BoundReturnStatement(
+                            Span(78),
+                            new BoundCallExpression(
+                                Span(79),
+                                "sql_escape",
+                                [recursiveCall],
+                                "STRING")),
+                    ]),
+            ],
+            new Scope());
+
+        new TaintAnalysisRunner(new DiagnosticBag()).Analyze(Module(self));
+
+        var input = Variable("user_input", "STRING", "param:recursive-caller", true);
+        var forwarded = Variable("forwarded", "STRING", "local:recursive-forwarded");
+        var caller = Function(
+            "RecursiveCaller",
+            "fn:recursive-caller",
+            [input],
+            [
+                new BoundBindStatement(
+                    Span(80),
+                    forwarded,
+                    new BoundCallExpression(
+                        Span(81),
+                        "Self",
+                        [Reference(input, 82), new BoundBoolLiteral(Span(83), true)],
+                        "STRING",
+                        resolvedSymbol: selfSymbol)),
+                Call("db.execute", Reference(forwarded, 84), 85),
+            ]);
+
+        var diagnostics = new DiagnosticBag();
+        new TaintAnalysisRunner(diagnostics).Analyze(Module(self, caller));
+
+        Assert.Single(diagnostics.Where(diagnostic => diagnostic.Code == DiagnosticCode.SqlInjection));
+    }
+
+    [Fact]
+    public void InterproceduralReturnAndParameterSinkSummaries_PropagateExactResolvedCalls()
+    {
+        var identityInput = Variable("value", "STRING", "param:identity-value", true);
+        var identitySymbol = FunctionSymbol("Identity", "fn:identity", [identityInput]);
+        var identity = new BoundFunction(
+            Span(70),
+            identitySymbol,
+            [new BoundReturnStatement(Span(71), Reference(identityInput, 72))],
+            new Scope());
+
+        var executeInput = Variable("value", "STRING", "param:execute-value", true);
+        var executeSymbol = FunctionSymbol("Execute", "fn:execute", [executeInput]);
+        var execute = new BoundFunction(
+            Span(73),
+            executeSymbol,
+            [Call("db.execute", Reference(executeInput, 74), 75)],
+            new Scope());
+
+        var callerInput = Variable("user_input", "STRING", "param:caller-input", true);
+        var forwarded = Variable("forwarded", "STRING", "local:forwarded");
+        var caller = Function(
+            "Caller",
+            "fn:caller",
+            [callerInput],
+            [
+                new BoundBindStatement(
+                    Span(76),
+                    forwarded,
+                    new BoundCallExpression(
+                        Span(77),
+                        "Identity",
+                        [Reference(callerInput, 78)],
+                        "STRING",
+                        resolvedSymbol: identitySymbol)),
+                Call("db.execute", Reference(forwarded, 79), 80),
+                new BoundCallStatement(
+                    Span(81),
+                    "Execute",
+                    [Reference(callerInput, 82)],
+                    resolvedSymbol: executeSymbol),
+            ]);
+
+        var diagnostics = new DiagnosticBag();
+        new TaintAnalysisRunner(diagnostics).Analyze(Module(identity, execute, caller));
+
+        Assert.Equal(
+            2,
+            diagnostics.Count(diagnostic => diagnostic.Code == DiagnosticCode.SqlInjection));
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Message.Contains("call Identity", StringComparison.Ordinal));
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Message.Contains("call Execute", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void VerificationAnalysisPass_UsesModuleTaintSummaries()
+    {
+        var identityInput = Variable("value", "STRING", "param:pass-identity", true);
+        var identitySymbol = FunctionSymbol("Identity", "fn:pass-identity", [identityInput]);
+        var identity = new BoundFunction(
+            Span(83),
+            identitySymbol,
+            [new BoundReturnStatement(Span(84), Reference(identityInput, 85))],
+            new Scope());
+
+        var executeInput = Variable("value", "STRING", "param:pass-execute", true);
+        var executeSymbol = FunctionSymbol("Execute", "fn:pass-execute", [executeInput]);
+        var execute = new BoundFunction(
+            Span(86),
+            executeSymbol,
+            [Call("db.execute", Reference(executeInput, 87), 88)],
+            new Scope());
+
+        var callerInput = Variable("user_input", "STRING", "param:pass-caller", true);
+        var value = Variable("value", "STRING", "local:pass-value");
+        var caller = Function(
+            "Caller",
+            "fn:pass-caller",
+            [callerInput],
+            [
+                new BoundBindStatement(
+                    Span(89),
+                    value,
+                    new BoundCallExpression(
+                        Span(90),
+                        "Identity",
+                        [Reference(callerInput, 91)],
+                        "STRING",
+                        resolvedSymbol: identitySymbol)),
+                new BoundCallStatement(
+                    Span(92),
+                    "Execute",
+                    [Reference(value, 93)],
+                    resolvedSymbol: executeSymbol),
+            ]);
+
+        var diagnostics = new DiagnosticBag();
+        var result = new VerificationAnalysisPass(
+            diagnostics,
+            new VerificationAnalysisOptions
+            {
+                EnableDataflow = false,
+                EnableBugPatterns = false,
+                EnableTaintAnalysis = true,
+                EnableKInduction = false,
+            }).AnalyzeBound(Module(identity, execute, caller));
+
+        Assert.Equal(1, result.TaintVulnerabilities);
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Code == DiagnosticCode.SqlInjection);
+    }
+
+    [Fact]
+    public void MayAliasJoin_WeakFieldWritesPreserveAllPossibleTargets()
+    {
+        var input = Variable("user_input", "STRING", "param:alias-field-input", true);
+        var condition = Variable("condition", "BOOL", "param:alias-field-condition", true);
+        var first = Variable("first", "OBJECT", "local:alias-field-first");
+        var second = Variable("second", "OBJECT", "local:alias-field-second");
+        var alias = Variable("alias", "OBJECT", "local:alias-field-alias");
+        var aliasField = Field(alias, "Value", 101);
+        var function = Function(
+            "MayAliasFields",
+            "fn:may-alias-fields",
+            [input, condition],
+            [
+                new BoundBindStatement(Span(94), first, null),
+                new BoundBindStatement(Span(95), second, null),
+                new BoundBindStatement(Span(96), alias, null),
+                new BoundIfStatement(
+                    Span(97),
+                    Reference(condition, 98),
+                    [new BoundAssignmentStatement(Span(99), Reference(alias, 100), Reference(first, 101))],
+                    [],
+                    [new BoundAssignmentStatement(Span(102), Reference(alias, 103), Reference(second, 104))]),
+                new BoundAssignmentStatement(Span(105), aliasField, Reference(input, 106)),
+                new BoundAssignmentStatement(
+                    Span(107),
+                    aliasField,
+                    new BoundStringLiteral(Span(108), "safe")),
+                Call("db.execute", Field(first, "Value", 109), 110),
+                Call("db.execute", Field(second, "Value", 111), 112),
+            ]);
+
+        Assert.Equal(2, new TaintAnalysis(function).Vulnerabilities.Count);
+    }
+
+    [Fact]
+    public void MayAliasJoin_WeakArrayElementWritesPreserveAllPossibleTargets()
+    {
+        var input = Variable("user_input", "STRING", "param:alias-array-input", true);
+        var condition = Variable("condition", "BOOL", "param:alias-array-condition", true);
+        var first = Variable("first", "STRING[]", "local:alias-array-first");
+        var second = Variable("second", "STRING[]", "local:alias-array-second");
+        var alias = Variable("alias", "STRING[]", "local:alias-array-alias");
+        var aliasItem = new BoundArrayAccess(
+            Span(120),
+            Reference(alias, 121),
+            new BoundIntLiteral(Span(122), 0));
+        var function = Function(
+            "MayAliasArrays",
+            "fn:may-alias-arrays",
+            [input, condition],
+            [
+                new BoundBindStatement(Span(113), first, null),
+                new BoundBindStatement(Span(114), second, null),
+                new BoundBindStatement(Span(115), alias, null),
+                new BoundIfStatement(
+                    Span(116),
+                    Reference(condition, 117),
+                    [new BoundAssignmentStatement(Span(118), Reference(alias, 119), Reference(first, 120))],
+                    [],
+                    [new BoundAssignmentStatement(Span(121), Reference(alias, 122), Reference(second, 123))]),
+                new BoundAssignmentStatement(Span(124), aliasItem, Reference(input, 125)),
+                new BoundAssignmentStatement(
+                    Span(126),
+                    aliasItem,
+                    new BoundStringLiteral(Span(127), "safe")),
+                Call(
+                    "db.execute",
+                    new BoundArrayAccess(Span(128), Reference(first, 129), new BoundIntLiteral(Span(130), 0)),
+                    131),
+                Call(
+                    "db.execute",
+                    new BoundArrayAccess(Span(132), Reference(second, 133), new BoundIntLiteral(Span(134), 0)),
+                    135),
+            ]);
+
+        Assert.Equal(2, new TaintAnalysis(function).Vulnerabilities.Count);
+    }
+
+    [Fact]
+    public void ResolvedLocalNamedSqlEscape_IsNotTreatedAsBuiltInSanitizer()
+    {
+        var localInput = Variable("value", "STRING", "param:local-escape", true);
+        var localSymbol = FunctionSymbol("sql_escape", "fn:local-escape", [localInput]);
+        var localEscape = new BoundFunction(
+            Span(136),
+            localSymbol,
+            [new BoundReturnStatement(Span(137), Reference(localInput, 138))],
+            new Scope());
+        var input = Variable("user_input", "STRING", "param:local-escape-caller", true);
+        var value = Variable("value", "STRING", "local:local-escape-value");
+        var caller = Function(
+            "Caller",
+            "fn:local-escape-caller",
+            [input],
+            [
+                new BoundBindStatement(
+                    Span(139),
+                    value,
+                    new BoundCallExpression(
+                        Span(140),
+                        "sql_escape",
+                        [Reference(input, 141)],
+                        "STRING",
+                        resolvedSymbol: localSymbol)),
+                Call("db.execute", Reference(value, 142), 143),
+            ]);
+
+        var diagnostics = new DiagnosticBag();
+        new TaintAnalysisRunner(diagnostics).Analyze(Module(localEscape, caller));
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Code == DiagnosticCode.SqlInjection);
+    }
+
+    [Fact]
+    public void ResolvedCustomTypeCannotMatchTargetOnlySanitizer()
+    {
+        var input = Variable("user_input", "STRING", "param:contoso-input", true);
+        var value = Variable("value", "STRING", "local:contoso-value");
+        var function = Function(
+            "ContosoSanitizer",
+            "fn:contoso-sanitizer",
+            [input],
+            [
+                new BoundBindStatement(
+                    Span(143),
+                    value,
+                    new BoundCallExpression(
+                        Span(144),
+                        "Contoso.UnsafeSql.parameterize",
+                        [Reference(input, 145)],
+                        "STRING",
+                        resolvedTypeName: "Contoso.UnsafeSql",
+                        resolvedMethodName: "parameterize",
+                        resolvedParameterTypes: ["STRING"])),
+                Call("db.execute", Reference(value, 146), 147),
+            ]);
+
+        var finding = Assert.Single(new TaintAnalysis(
+            function,
+            new TaintAnalysisOptions
+            {
+                AdditionalSanitizers =
+                [
+                    new TaintSanitizerRule(
+                        new TaintCallIdentity(Target: "Contoso.UnsafeSql.parameterize"),
+                        TaintSink.SqlQuery),
+                ],
+            }).Vulnerabilities);
+
+        Assert.Equal(TaintSink.SqlQuery, finding.Sink);
+    }
+
+    [Fact]
+    public void InterproceduralAlternatives_UnionReturnAndParameterSinkSummaries()
+    {
+        var readSymbol = FunctionSymbol("Read", "fn:alternative-read", []);
+        var read = new BoundFunction(
+            Span(148),
+            readSymbol,
+            [
+                new BoundReturnStatement(
+                    Span(149),
+                    new BoundCallExpression(Span(150), "Console.ReadLine", [], "STRING")),
+            ],
+            new Scope());
+        var safeSymbol = FunctionSymbol("Safe", "fn:alternative-safe", []);
+        var safe = new BoundFunction(
+            Span(151),
+            safeSymbol,
+            [new BoundReturnStatement(Span(152), new BoundStringLiteral(Span(153), "safe"))],
+            new Scope());
+        var executeInput = Variable("value", "STRING", "param:alternative-execute", true);
+        var executeSymbol = FunctionSymbol("Execute", "fn:alternative-execute", [executeInput]);
+        var execute = new BoundFunction(
+            Span(154),
+            executeSymbol,
+            [Call("db.execute", Reference(executeInput, 155), 156)],
+            new Scope());
+        var noOpInput = Variable("value", "STRING", "param:alternative-noop", true);
+        var noOpSymbol = FunctionSymbol("NoOp", "fn:alternative-noop", [noOpInput]);
+        var noOp = new BoundFunction(Span(157), noOpSymbol, [], new Scope());
+        var value = Variable("value", "STRING", "local:alternative-value");
+        var caller = Function(
+            "Caller",
+            "fn:alternative-caller",
+            [],
+            [
+                new BoundBindStatement(
+                    Span(158),
+                    value,
+                    new BoundCallExpression(
+                        Span(159),
+                        "ReadOrSafe",
+                        [],
+                        "STRING",
+                        resolvedSymbols: [readSymbol, safeSymbol])),
+                Call("db.execute", Reference(value, 160), 161),
+                new BoundCallStatement(
+                    Span(162),
+                    "ExecuteOrNoOp",
+                    [Reference(value, 163)],
+                    resolvedSymbols: [executeSymbol, noOpSymbol]),
+            ]);
+
+        var diagnostics = new DiagnosticBag();
+        new TaintAnalysisRunner(diagnostics).Analyze(Module(read, safe, execute, noOp, caller));
+
+        Assert.Equal(2, diagnostics.Count(diagnostic => diagnostic.Code == DiagnosticCode.SqlInjection));
+    }
+
+    [Fact]
+    public void AliasRebinding_PreservesOldFieldObjectForAlias()
+    {
+        var input = Variable("user_input", "STRING", "param:rebind-field-input", true);
+        var first = Variable("first", "OBJECT", "local:rebind-field-first");
+        var second = Variable("second", "OBJECT", "local:rebind-field-second");
+        var alias = Variable("alias", "OBJECT", "local:rebind-field-alias");
+        var function = Function(
+            "RebindField",
+            "fn:rebind-field",
+            [input],
+            [
+                new BoundBindStatement(Span(164), first, null),
+                new BoundBindStatement(Span(165), second, null),
+                new BoundBindStatement(Span(166), alias, null),
+                new BoundAssignmentStatement(Span(167), Field(first, "Value", 168), Reference(input, 169)),
+                new BoundAssignmentStatement(Span(170), Reference(alias, 171), Reference(first, 172)),
+                new BoundAssignmentStatement(Span(173), Reference(first, 174), Reference(second, 175)),
+                Call("db.execute", Field(alias, "Value", 176), 177),
+                Call("db.execute", Field(first, "Value", 178), 179),
+            ]);
+
+        Assert.Single(new TaintAnalysis(function).Vulnerabilities);
+    }
+
+    [Fact]
+    public void AliasRebinding_PreservesOldArrayObjectForAlias()
+    {
+        var input = Variable("user_input", "STRING", "param:rebind-array-input", true);
+        var first = Variable("first", "STRING[]", "local:rebind-array-first");
+        var second = Variable("second", "STRING[]", "local:rebind-array-second");
+        var alias = Variable("alias", "STRING[]", "local:rebind-array-alias");
+        var function = Function(
+            "RebindArray",
+            "fn:rebind-array",
+            [input],
+            [
+                new BoundBindStatement(Span(180), first, null),
+                new BoundBindStatement(Span(181), second, null),
+                new BoundBindStatement(Span(182), alias, null),
+                new BoundAssignmentStatement(
+                    Span(183),
+                    new BoundArrayAccess(Span(184), Reference(first, 185), new BoundIntLiteral(Span(186), 0)),
+                    Reference(input, 187)),
+                new BoundAssignmentStatement(Span(188), Reference(alias, 189), Reference(first, 190)),
+                new BoundAssignmentStatement(Span(191), Reference(first, 192), Reference(second, 193)),
+                Call(
+                    "db.execute",
+                    new BoundArrayAccess(Span(194), Reference(alias, 195), new BoundIntLiteral(Span(196), 0)),
+                    197),
+                Call(
+                    "db.execute",
+                    new BoundArrayAccess(Span(198), Reference(first, 199), new BoundIntLiteral(Span(200), 0)),
+                    201),
+            ]);
+
+        Assert.Single(new TaintAnalysis(function).Vulnerabilities);
+    }
+
+    [Fact]
+    public void FieldReferenceAlias_PreservesStoredObjectAfterSourceRebinding()
+    {
+        var input = Variable("user_input", "STRING", "param:field-reference-input", true);
+        var holder = Variable("holder", "OBJECT", "local:field-reference-holder");
+        var child = Variable("child", "OBJECT", "local:field-reference-child");
+        var replacement = Variable("replacement", "OBJECT", "local:field-reference-replacement");
+        var alias = Variable("alias", "OBJECT", "local:field-reference-alias");
+        var childFieldSymbol = Variable("Child", "OBJECT", "field:reference-child");
+        var valueFieldSymbol = Variable("Value", "STRING", "field:reference-value");
+        var childField = Field(holder, "Child", 202, "OBJECT", childFieldSymbol);
+        var function = Function(
+            "FieldReferenceAlias",
+            "fn:field-reference-alias",
+            [input],
+            [
+                new BoundBindStatement(Span(203), holder, null),
+                new BoundBindStatement(Span(204), child, null),
+                new BoundBindStatement(Span(205), replacement, null),
+                new BoundAssignmentStatement(Span(206), childField, Reference(child, 207)),
+                new BoundBindStatement(
+                    Span(208),
+                    alias,
+                    Field(holder, "Child", 209, "OBJECT", childFieldSymbol)),
+                new BoundAssignmentStatement(Span(210), Reference(child, 211), Reference(replacement, 212)),
+                new BoundAssignmentStatement(
+                    Span(213),
+                    Field(alias, "Value", 214, "STRING", valueFieldSymbol),
+                    Reference(input, 215)),
+                Call(
+                    "db.execute",
+                    Field(
+                        Field(holder, "Child", 216, "OBJECT", childFieldSymbol),
+                        "Value",
+                        217,
+                        "STRING",
+                        valueFieldSymbol),
+                    218),
+            ]);
+
+        Assert.Single(new TaintAnalysis(function).Vulnerabilities);
+    }
+
+    [Fact]
+    public void ArrayReferenceAlias_PreservesStoredObjectAfterSourceRebinding()
+    {
+        var input = Variable("user_input", "STRING", "param:array-reference-input", true);
+        var items = Variable("items", "OBJECT[]", "local:array-reference-items");
+        var child = Variable("child", "OBJECT", "local:array-reference-child");
+        var replacement = Variable("replacement", "OBJECT", "local:array-reference-replacement");
+        var alias = Variable("alias", "OBJECT", "local:array-reference-alias");
+        var valueFieldSymbol = Variable("Value", "STRING", "field:array-reference-value");
+        BoundExpression Element(int span) =>
+            new BoundArrayAccess(
+                Span(span),
+                Reference(items, span + 1),
+                new BoundIntLiteral(Span(span + 2), 0));
+        var function = Function(
+            "ArrayReferenceAlias",
+            "fn:array-reference-alias",
+            [input],
+            [
+                new BoundBindStatement(Span(219), items, null),
+                new BoundBindStatement(Span(220), child, null),
+                new BoundBindStatement(Span(221), replacement, null),
+                new BoundAssignmentStatement(Span(222), Element(223), Reference(child, 226)),
+                new BoundBindStatement(Span(227), alias, Element(228)),
+                new BoundAssignmentStatement(Span(231), Reference(child, 232), Reference(replacement, 233)),
+                new BoundAssignmentStatement(
+                    Span(234),
+                    Field(alias, "Value", 235, "STRING", valueFieldSymbol),
+                    Reference(input, 236)),
+                Call(
+                    "db.execute",
+                    Field(Element(237), "Value", 240, "STRING", valueFieldSymbol),
+                    241),
+            ]);
+
+        Assert.Single(new TaintAnalysis(function).Vulnerabilities);
+    }
+
+    [Theory]
+    [InlineData("WriteAllText", new[] { "System.String", "System.String" })]
+    [InlineData("Delete", new[] { "System.String" })]
+    [InlineData("Open", new[] { "System.String", "System.IO.FileMode" })]
+    [InlineData("Move", new[] { "System.String", "System.String" })]
+    public void SystemIoFilePathSinks_UseExactResolvedSignatures(
+        string method,
+        string[] parameterTypes)
+    {
+        var path = Variable("user_path", "STRING", $"param:file-{method}", true);
+        var args = parameterTypes.Length == 1
+            ? new BoundExpression[] { Reference(path, 202) }
+            : [Reference(path, 202), new BoundStringLiteral(Span(203), "safe")];
+        var call = new BoundCallStatement(
+            Span(204),
+            $"File.{method}",
+            args,
+            resolvedTypeName: "System.IO.File",
+            resolvedMethodName: method,
+            resolvedParameterTypes: parameterTypes);
+        var function = Function($"File{method}", $"fn:file-{method}", [path], [call]);
+
+        var finding = Assert.Single(new TaintAnalysis(function).Vulnerabilities);
+        Assert.Equal(TaintSink.FilePath, finding.Sink);
+    }
+
+    [Fact]
+    public void Move_DestinationArgumentIsAFilePathSink()
+    {
+        var destination = Variable("user_path", "STRING", "param:file-move-destination", true);
+        var move = new BoundCallStatement(
+            Span(242),
+            "File.Move",
+            [new BoundStringLiteral(Span(243), "safe.txt"), Reference(destination, 244)],
+            resolvedTypeName: "System.IO.File",
+            resolvedMethodName: "Move",
+            resolvedParameterTypes: ["System.String", "System.String"]);
+        var function = Function("FileMove", "fn:file-move", [destination], [move]);
+
+        var finding = Assert.Single(new TaintAnalysis(function).Vulnerabilities);
+        Assert.Equal(TaintSink.FilePath, finding.Sink);
+    }
+
+    [Fact]
+    public void ReadAllText_PathArgumentIsAFilePathSink()
+    {
+        var path = Variable("user_path", "STRING", "param:file-read-path", true);
+        var read = new BoundCallStatement(
+            Span(242),
+            "File.ReadAllText",
+            [Reference(path, 243)],
+            resolvedTypeName: "System.IO.File",
+            resolvedMethodName: "ReadAllText",
+            resolvedParameterTypes: ["System.String"]);
+        var function = Function("FileReadAllText", "fn:file-read-all-text", [path], [read]);
+
+        var finding = Assert.Single(new TaintAnalysis(function).Vulnerabilities);
+        Assert.Equal(TaintSink.FilePath, finding.Sink);
+    }
+
+    [Fact]
+    public void WriteAllText_ContentArgumentIsNotAFilePathSink()
+    {
+        var content = Variable("user_input", "STRING", "param:file-write-content", true);
+        var write = new BoundCallStatement(
+            Span(244),
+            "File.WriteAllText",
+            [new BoundStringLiteral(Span(245), "safe.txt"), Reference(content, 246)],
+            resolvedTypeName: "System.IO.File",
+            resolvedMethodName: "WriteAllText",
+            resolvedParameterTypes: ["System.String", "System.String"]);
+        var function = Function("FileWriteContent", "fn:file-write-content", [content], [write]);
+
+        Assert.Empty(new TaintAnalysis(function).Vulnerabilities);
+    }
+
+    [Fact]
+    public void ProcessStartStatement_UsesExactResolvedSignature()
+    {
+        var input = Variable("user_input", "STRING", "param:process-input", true);
+        var processStart = new BoundCallStatement(
+            Span(144),
+            "Process.Start",
+            [Reference(input, 145)],
+            resolvedTypeName: "System.Diagnostics.Process",
+            resolvedMethodName: "Start",
+            resolvedParameterTypes: ["STRING"]);
+        var function = Function("ProcessStart", "fn:process-start", [input], [processStart]);
+
+        var finding = Assert.Single(new TaintAnalysis(function).Vulnerabilities);
+        Assert.Equal(TaintSink.CommandExecution, finding.Sink);
+    }
+
+    [Fact]
+    public void ProcessStartStatement_NonMatchingResolvedSignatureIsNotASink()
+    {
+        var input = Variable("user_input", "STRING", "param:process-int-input", true);
+        var processStart = new BoundCallStatement(
+            Span(146),
+            "Process.Start",
+            [Reference(input, 147)],
+            resolvedTypeName: "System.Diagnostics.Process",
+            resolvedMethodName: "Start",
+            resolvedParameterTypes: ["INT"]);
+        var function = Function("ProcessStartInt", "fn:process-start-int", [input], [processStart]);
+
+        Assert.Empty(new TaintAnalysis(function).Vulnerabilities);
+    }
+
+    [Fact]
+    public void Binder_DerivesExactIdentityForProcessStartStatement()
+    {
+        var attributes = new AttributeCollection();
+        var function = new FunctionNode(
+            Span(148),
+            "f001",
+            "Run",
+            Visibility.Public,
+            [new ParameterNode(Span(149), "user_input", "STRING", attributes)],
+            new OutputNode(Span(150), "VOID"),
+            null,
+            [
+                new CallStatementNode(
+                    Span(151),
+                    "Process.Start",
+                    false,
+                    [new ReferenceNode(Span(152), "user_input")],
+                    attributes),
+            ],
+            attributes);
+        var module = new ModuleNode(
+            Span(153),
+            "m001",
+            "Test",
+            [],
+            [function],
+            attributes);
+        var diagnostics = new DiagnosticBag();
+        var bound = new Binder(diagnostics).Bind(module);
+
+        var call = Assert.IsType<BoundCallStatement>(bound.Functions.Single().Body.Single());
+        Assert.Equal("System.Diagnostics.Process", call.ResolvedTypeName);
+        Assert.Equal("Start", call.ResolvedMethodName);
+        Assert.Equal(["STRING"], call.ResolvedParameterTypes);
+        Assert.Contains(
+            new TaintAnalysis(bound.Functions.Single()).Vulnerabilities,
+            finding => finding.Sink == TaintSink.CommandExecution);
+    }
+
+    [Fact]
+    public void InterproceduralCallReturnSourceSummary_PropagatesConsoleReadLine()
+    {
+        var readSymbol = FunctionSymbol("Read", "fn:read", []);
+        var read = new BoundFunction(
+            Span(83),
+            readSymbol,
+            [
+                new BoundReturnStatement(
+                    Span(84),
+                    new BoundCallExpression(Span(85), "Console.ReadLine", [], "STRING")),
+            ],
+            new Scope());
+        var value = Variable("value", "STRING", "local:read-value");
+        var caller = Function(
+            "ReadCaller",
+            "fn:read-caller",
+            [],
+            [
+                new BoundBindStatement(
+                    Span(86),
+                    value,
+                    new BoundCallExpression(
+                        Span(87),
+                        "Read",
+                        [],
+                        "STRING",
+                        resolvedSymbol: readSymbol)),
+                Call("db.execute", Reference(value, 88), 89),
+            ]);
+
+        var diagnostics = new DiagnosticBag();
+        new TaintAnalysisRunner(diagnostics).Analyze(Module(read, caller));
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Code == DiagnosticCode.SqlInjection);
+    }
+
+    [Fact]
+    public void StrictUnknownExternal_ReturnsConservativeExternalApiSource()
+    {
+        var value = Variable("value", "STRING", "local:external-value");
+        var function = Function(
+            "UnknownExternal",
+            "fn:unknown-external",
+            [],
+            [
+                new BoundBindStatement(
+                    Span(90),
+                    value,
+                    new BoundCallExpression(Span(91), "External.Fetch", [], "STRING")),
+                Call("db.execute", Reference(value, 92), 93),
+            ]);
+
+        Assert.Empty(new TaintAnalysis(function).Vulnerabilities);
+        var finding = Assert.Single(new TaintAnalysis(
+            function,
+            new TaintAnalysisOptions { StrictExternalCalls = true }).Vulnerabilities);
+        Assert.Equal(TaintSource.ExternalApi, finding.Source);
+    }
+
+    private static BoundModule Module(params BoundFunction[] functions) =>
+        new(Span(100), "Test", functions);
+
+    private bool ExecuteCorpusCase(string id)
+    {
+        switch (id)
+        {
+            case "direct-source-sink":
+            case "provenance":
+                DirectSourceToSink_ReportsEvenWhenLegacyHopThresholdIsTwo();
+                return true;
+            case "console-readline-return-source":
+                ConsoleReadLine_CallReturnSource_ReachesSink();
+                return true;
+            case "branch-join":
+                BranchJoin_PreservesTaintFromOneReachableBranch();
+                return true;
+            case "loop-backedge":
+                LoopFixedPoint_PropagatesTaintThroughBackEdge();
+                return true;
+            case "alias-field-collection":
+                AliasFieldAndCollectionAccessPaths_PreserveTaint();
+                return true;
+            case "desanitize-not-sanitizer":
+                ExactSanitizerIdentity_DoesNotTreatDesanitizeAsSanitizer();
+                return true;
+            case "recursive-sanitizer-summary":
+                RecursiveSanitizerSummary_ConvergesOverFiniteLattice();
+                return true;
+            case "interprocedural-summary":
+                InterproceduralReturnAndParameterSinkSummaries_PropagateExactResolvedCalls();
+                return true;
+            case "interprocedural-call-return-source":
+                InterproceduralCallReturnSourceSummary_PropagatesConsoleReadLine();
+                return true;
+            case "strict-unknown-external":
+                StrictUnknownExternal_ReturnsConservativeExternalApiSource();
+                return true;
+            case "verification-pass-module-summary":
+                VerificationAnalysisPass_UsesModuleTaintSummaries();
+                return true;
+            case "may-alias-field":
+                MayAliasJoin_WeakFieldWritesPreserveAllPossibleTargets();
+                return true;
+            case "may-alias-array":
+                MayAliasJoin_WeakArrayElementWritesPreserveAllPossibleTargets();
+                return true;
+            case "resolved-local-sql-escape":
+                ResolvedLocalNamedSqlEscape_IsNotTreatedAsBuiltInSanitizer();
+                return true;
+            case "resolved-custom-target-sanitizer":
+                ResolvedCustomTypeCannotMatchTargetOnlySanitizer();
+                return true;
+            case "interprocedural-alternatives":
+                InterproceduralAlternatives_UnionReturnAndParameterSinkSummaries();
+                return true;
+            case "alias-rebinding-field":
+                AliasRebinding_PreservesOldFieldObjectForAlias();
+                return true;
+            case "alias-rebinding-array":
+                AliasRebinding_PreservesOldArrayObjectForAlias();
+                return true;
+            case "field-reference-alias":
+                FieldReferenceAlias_PreservesStoredObjectAfterSourceRebinding();
+                return true;
+            case "array-reference-alias":
+                ArrayReferenceAlias_PreservesStoredObjectAfterSourceRebinding();
+                return true;
+            case "system-io-file-read":
+                ReadAllText_PathArgumentIsAFilePathSink();
+                return true;
+            case "system-io-file-move-destination":
+                Move_DestinationArgumentIsAFilePathSink();
+                return true;
+            case "system-io-file-write":
+                SystemIoFilePathSinks_UseExactResolvedSignatures(
+                    "WriteAllText",
+                    ["System.String", "System.String"]);
+                return true;
+            case "system-io-file-delete":
+                SystemIoFilePathSinks_UseExactResolvedSignatures("Delete", ["System.String"]);
+                return true;
+            case "system-io-file-open":
+                SystemIoFilePathSinks_UseExactResolvedSignatures(
+                    "Open",
+                    ["System.String", "System.IO.FileMode"]);
+                return true;
+            case "process-start-signature":
+                ProcessStartStatement_UsesExactResolvedSignature();
+                return true;
+            case "safe-strong-overwrite":
+                SafeOverwrite_StronglyKillsEarlierTaint();
+                return false;
+            case "constants":
+                ConstantsOnly_DoNotProduceAFinding();
+                return false;
+            case "process-start-non-sink-signature":
+                ProcessStartStatement_NonMatchingResolvedSignatureIsNotASink();
+                return false;
+            case "system-io-file-write-content":
+                WriteAllText_ContentArgumentIsNotAFilePathSink();
+                return false;
+            default:
+                throw new InvalidOperationException($"Unknown taint regression corpus case '{id}'.");
+        }
+    }
+
+    private static BoundFunction Function(
+        string name,
+        string id,
+        IReadOnlyList<VariableSymbol> parameters,
+        IReadOnlyList<BoundStatement> body) =>
+        new(
+            Span(101),
+            FunctionSymbol(name, id, parameters),
+            body,
+            new Scope());
+
+    private static FunctionSymbol FunctionSymbol(
+        string name,
+        string id,
+        IReadOnlyList<VariableSymbol> parameters) =>
+        new(new SymbolId(id), name, "VOID", parameters);
+
+    private static VariableSymbol Variable(
+        string name,
+        string type,
+        string id,
+        bool parameter = false) =>
+        new(new SymbolId(id), name, type, true, parameter, declarationSpan: Span(id.Length));
+
+    private static BoundVariableExpression Reference(VariableSymbol variable, int span) =>
+        new(Span(span), variable);
+
+    private static BoundFieldAccessExpression Field(
+        VariableSymbol target,
+        string name,
+        int span,
+        string typeName = "STRING",
+        VariableSymbol? resolvedField = null) =>
+        Field(Reference(target, span + 1), name, span, typeName, resolvedField);
+
+    private static BoundFieldAccessExpression Field(
+        BoundExpression target,
+        string name,
+        int span,
+        string typeName = "STRING",
+        VariableSymbol? resolvedField = null) =>
+        new(Span(span), target, name, typeName, resolvedField);
+
+    private static BoundCallStatement Call(string target, BoundExpression argument, int span) =>
+        new(Span(span), target, [argument]);
+}

--- a/tests/Calor.Compiler.Tests/ArchitectureTests.cs
+++ b/tests/Calor.Compiler.Tests/ArchitectureTests.cs
@@ -202,6 +202,17 @@ public class ArchitectureTests
             ["Analysis/Security/TaintAnalysis.cs:GetExpressionName"] =
                 ("Display-only classifier; unsupported expressions explicitly return null.",
                     "_ => null"),
+            ["Analysis/Security/TaintAnalysis.cs:EvaluateExpression"] =
+                ("Taint transfer dispatches exact call and access-path semantics; the default " +
+                    "arm universally traverses expression children.",
+                    "default:"),
+            ["Analysis/Security/TaintAnalysis.cs:TryGetAccessPath"] =
+                ("Access-path extractor; unsupported expressions explicitly report no trackable path.",
+                    "return false"),
+            ["Analysis/Security/TaintAnalysis.cs:GetResolvedCallees"] =
+                ("Universal DescendantsAndSelf traversal; the switch selects the two node kinds " +
+                    "that carry resolved function symbols, and unmatched nodes contribute no callees.",
+                    "Array.Empty<FunctionSymbol>()"),
             ["Analysis/BugPatterns/Patterns/OverflowChecker.cs:GetConstantValue"] =
                 ("Constant classifier; unsupported expressions explicitly return null.",
                     "_ => null"),

--- a/tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj
+++ b/tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj
@@ -43,6 +43,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>TestData\Benchmarks\%(RecursiveDir)%(FileName)%(Extension)</Link>
     </None>
+    <None Include="..\TestData\Security\**\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>TestData\Security\%(RecursiveDir)%(FileName)%(Extension)</Link>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/TestData/Security/TaintAnalysis/manifest.json
+++ b/tests/TestData/Security/TaintAnalysis/manifest.json
@@ -1,0 +1,163 @@
+{
+  "version": 1,
+  "analysis": "symbol-access-path-cfg-may-taint",
+  "minimumPrecision": 1.0,
+  "minimumRecall": 1.0,
+  "cases": [
+    {
+      "id": "direct-source-sink",
+      "test": "DirectSourceToSink_ReportsEvenWhenLegacyHopThresholdIsTwo",
+      "expectedFinding": true
+    },
+    {
+      "id": "console-readline-return-source",
+      "test": "ConsoleReadLine_CallReturnSource_ReachesSink",
+      "expectedFinding": true
+    },
+    {
+      "id": "branch-join",
+      "test": "BranchJoin_PreservesTaintFromOneReachableBranch",
+      "expectedFinding": true
+    },
+    {
+      "id": "loop-backedge",
+      "test": "LoopFixedPoint_PropagatesTaintThroughBackEdge",
+      "expectedFinding": true
+    },
+    {
+      "id": "alias-field-collection",
+      "test": "AliasFieldAndCollectionAccessPaths_PreserveTaint",
+      "expectedFinding": true
+    },
+    {
+      "id": "desanitize-not-sanitizer",
+      "test": "ExactSanitizerIdentity_DoesNotTreatDesanitizeAsSanitizer",
+      "expectedFinding": true
+    },
+    {
+      "id": "recursive-sanitizer-summary",
+      "test": "RecursiveSanitizerSummary_ConvergesOverFiniteLattice",
+      "expectedFinding": true
+    },
+    {
+      "id": "interprocedural-summary",
+      "test": "InterproceduralReturnAndParameterSinkSummaries_PropagateExactResolvedCalls",
+      "expectedFinding": true
+    },
+    {
+      "id": "interprocedural-call-return-source",
+      "test": "InterproceduralCallReturnSourceSummary_PropagatesConsoleReadLine",
+      "expectedFinding": true
+    },
+    {
+      "id": "strict-unknown-external",
+      "test": "StrictUnknownExternal_ReturnsConservativeExternalApiSource",
+      "expectedFinding": true
+    },
+    {
+      "id": "verification-pass-module-summary",
+      "test": "VerificationAnalysisPass_UsesModuleTaintSummaries",
+      "expectedFinding": true
+    },
+    {
+      "id": "may-alias-field",
+      "test": "MayAliasJoin_WeakFieldWritesPreserveAllPossibleTargets",
+      "expectedFinding": true
+    },
+    {
+      "id": "may-alias-array",
+      "test": "MayAliasJoin_WeakArrayElementWritesPreserveAllPossibleTargets",
+      "expectedFinding": true
+    },
+    {
+      "id": "resolved-local-sql-escape",
+      "test": "ResolvedLocalNamedSqlEscape_IsNotTreatedAsBuiltInSanitizer",
+      "expectedFinding": true
+    },
+    {
+      "id": "resolved-custom-target-sanitizer",
+      "test": "ResolvedCustomTypeCannotMatchTargetOnlySanitizer",
+      "expectedFinding": true
+    },
+    {
+      "id": "interprocedural-alternatives",
+      "test": "InterproceduralAlternatives_UnionReturnAndParameterSinkSummaries",
+      "expectedFinding": true
+    },
+    {
+      "id": "alias-rebinding-field",
+      "test": "AliasRebinding_PreservesOldFieldObjectForAlias",
+      "expectedFinding": true
+    },
+    {
+      "id": "alias-rebinding-array",
+      "test": "AliasRebinding_PreservesOldArrayObjectForAlias",
+      "expectedFinding": true
+    },
+    {
+      "id": "field-reference-alias",
+      "test": "FieldReferenceAlias_PreservesStoredObjectAfterSourceRebinding",
+      "expectedFinding": true
+    },
+    {
+      "id": "array-reference-alias",
+      "test": "ArrayReferenceAlias_PreservesStoredObjectAfterSourceRebinding",
+      "expectedFinding": true
+    },
+    {
+      "id": "system-io-file-read",
+      "test": "ReadAllText_PathArgumentIsAFilePathSink",
+      "expectedFinding": true
+    },
+    {
+      "id": "system-io-file-move-destination",
+      "test": "Move_DestinationArgumentIsAFilePathSink",
+      "expectedFinding": true
+    },
+    {
+      "id": "system-io-file-write",
+      "test": "SystemIoFilePathSinks_UseExactResolvedSignatures(WriteAllText)",
+      "expectedFinding": true
+    },
+    {
+      "id": "system-io-file-delete",
+      "test": "SystemIoFilePathSinks_UseExactResolvedSignatures(Delete)",
+      "expectedFinding": true
+    },
+    {
+      "id": "system-io-file-open",
+      "test": "SystemIoFilePathSinks_UseExactResolvedSignatures(Open)",
+      "expectedFinding": true
+    },
+    {
+      "id": "process-start-signature",
+      "test": "ProcessStartStatement_UsesExactResolvedSignature",
+      "expectedFinding": true
+    },
+    {
+      "id": "provenance",
+      "test": "DirectSourceToSink_ReportsEvenWhenLegacyHopThresholdIsTwo",
+      "expectedFinding": true
+    },
+    {
+      "id": "safe-strong-overwrite",
+      "test": "SafeOverwrite_StronglyKillsEarlierTaint",
+      "expectedFinding": false
+    },
+    {
+      "id": "constants",
+      "test": "ConstantsOnly_DoNotProduceAFinding",
+      "expectedFinding": false
+    },
+    {
+      "id": "process-start-non-sink-signature",
+      "test": "ProcessStartStatement_NonMatchingResolvedSignatureIsNotASink",
+      "expectedFinding": false
+    },
+    {
+      "id": "system-io-file-write-content",
+      "test": "WriteAllText_ContentArgumentIsNotAFilePathSink",
+      "expectedFinding": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- replace linear name-based taint tracking with symbol/access-path keyed CFG may-taint analysis
- add exact source, sink, sanitizer, alias, collection, and interprocedural summary semantics
- enable direct injection findings by default with ordered provenance paths
- add executable security corpus, precision/recall gates, documentation, and adversarial regressions

## Validation
- 6,979 compiler tests passed, 2 skipped
- Release build: 0 warnings, 0 errors
- docs self-check clean
- all 7 mutation targets killed
- three adversarial review rounds completed and all findings addressed

Closes #784