### PR TITLE
chore: pre-approve typed bug analyzer sources

### DIFF
--- a/.calor-csharp-allowlist
+++ b/.calor-csharp-allowlist
@@ -71,5 +71,7 @@ src/Calor.Compiler/Mcp/McpMemoryAdmissionPolicy.cs
 # Typed bug-pattern analysis (#786) — compiler-internal CFG/dataflow machinery
 # over bound nodes and shared loop semantics. Calor cannot inspect its own
 # bound tree or participate in the compiler's abstract interpretation.
+# pending: lands with issue #786 PR #970
 src/Calor.Compiler/Analysis/BugPatterns/TypedBugPatternAnalysis.cs
+# pending: lands with issue #786 PR #970
 src/Calor.Compiler/Analysis/Dataflow/LoopStepSemantics.cs

--- a/.calor-csharp-allowlist
+++ b/.calor-csharp-allowlist
@@ -67,3 +67,9 @@ src/Calor.Compiler/Commands/QueryCommand.cs
 # src/Calor.Compiler/Mcp/; Calor has no access to Process.WorkingSet64 or the
 # GC memory info this policy is built from.
 src/Calor.Compiler/Mcp/McpMemoryAdmissionPolicy.cs
+
+# Typed bug-pattern analysis (#786) — compiler-internal CFG/dataflow machinery
+# over bound nodes and shared loop semantics. Calor cannot inspect its own
+# bound tree or participate in the compiler's abstract interpretation.
+src/Calor.Compiler/Analysis/BugPatterns/TypedBugPatternAnalysis.cs
+src/Calor.Compiler/Analysis/Dataflow/LoopStepSemantics.cs


### PR DESCRIPTION
## Summary
- pre-register the two compiler-internal C# source paths required by #786
- keep the Calor-first exception narrow and path-specific

This approval must land on the base branch before PR #970 can consume it.