### PR TITLE
feat: make control flow emission structural and reentrant

### DIFF
--- a/docs/syntax-reference/control-flow.md
+++ b/docs/syntax-reference/control-flow.md
@@ -28,6 +28,17 @@ Calor provides loops and conditionals with explicit structure.
 | `to` | Ending value (inclusive) |
 | `step` | Increment per iteration |
 
+The `from`, `to`, and `step` expressions are each evaluated exactly once, before
+the loop starts. The evaluated sign of `step` selects ascending (`<=`) or
+descending (`>=`) comparison. A zero step throws
+`ArgumentOutOfRangeException` before the first iteration. Integral advancement
+is checked: reaching a numeric minimum or maximum endpoint terminates normally
+instead of wrapping around into an unbounded loop.
+
+When `step` is omitted, Calor advances with a checked increment of the evaluated
+induction value itself. This keeps the implicit `+1` in the loop variable's
+integral type (`i8` through `u64`) and avoids mixed-type `+=` or narrowing.
+
 ### Examples
 
 **Count 1 to 10:**
@@ -320,6 +331,39 @@ Use conditionals with return for early exit:
   §IF{if1} (<= n 1) → §R 1
   §EL → §R (* n §C{Factorial} §A (- n 1) §/C)
 ```
+
+---
+
+## Iterators and Yield
+
+Use `§YIELD expression` to produce the next iterator value and `§YBRK` to stop
+iteration:
+
+```
+§F{f001:Count:pub}
+  §O{i32}
+  §YIELD 1
+  §YIELD 2
+  §YBRK
+```
+
+`§YIELD` always requires an expression. A valueless `§YIELD` is rejected; it
+does not mean `yield break`. Use `§YBRK` explicitly.
+
+Yield detection is structural across nested statement containers such as
+matches, loops, `using`, and synchronization blocks. A yield inside a nested
+lambda belongs to the lambda and is rejected rather than turning the enclosing
+function into an iterator. Calor also rejects C#-illegal suspension points:
+value-yields in catch, unsafe, fixed, or try-with-catch regions; every yield in
+finally; and all yields in constructors, property/indexer accessors, event
+accessors, operators, and async callables. Property and indexer iterators are
+fail-closed until Calor defines their return-type and deferred-execution
+semantics.
+
+Iterator functions and methods may only use value parameters. Parameters marked
+`ref`, `in`, or `out` are rejected before C# emission. This applies equally to
+generic, static, and async callable shapes; yields inside nested lambdas or local
+functions do not turn the enclosing callable into an iterator.
 
 ---
 

--- a/eng/test-manifest.json
+++ b/eng/test-manifest.json
@@ -5,7 +5,7 @@
       "path": "tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj",
       "workflow": ".github/workflows/test.yml",
       "releaseCritical": true,
-      "expectedTotal": 7139,
+      "expectedTotal": 7165,
       "expectedSkipped": 2
     },
     {

--- a/src/Calor.Compiler/Analysis/RecursiveAstWalker.cs
+++ b/src/Calor.Compiler/Analysis/RecursiveAstWalker.cs
@@ -25,6 +25,14 @@ namespace Calor.Compiler.Analysis;
 /// </summary>
 public static class RecursiveAstWalker
 {
+    /// <summary>
+    /// A structural edge from a parent AST node to one child, retaining the
+    /// public property that owns the child. Consumers that enforce context-
+    /// sensitive rules (for example catch/finally yield legality) can therefore
+    /// stay exhaustive without hand-maintaining a container switch.
+    /// </summary>
+    public readonly record struct ChildEdge(AstNode Node, PropertyInfo Property);
+
     private static readonly ConcurrentDictionary<Type, PropertyInfo[]> NonExpressionCache = new();
     private static readonly ConcurrentDictionary<Type, PropertyInfo[]> AllChildrenCache = new();
 
@@ -98,6 +106,13 @@ public static class RecursiveAstWalker
     /// calls or diagnostic seeds inside newly added expression wrappers.
     /// </summary>
     public static IEnumerable<AstNode> GetAllChildren(AstNode node)
+        => GetAllChildEdges(node).Select(edge => edge.Node);
+
+    /// <summary>
+    /// Enumerates every direct AST child, including expression subtrees, together
+    /// with the property that contains it.
+    /// </summary>
+    public static IEnumerable<ChildEdge> GetAllChildEdges(AstNode node)
     {
         ArgumentNullException.ThrowIfNull(node);
         var yielded = new HashSet<AstNode>(ReferenceEqualityComparer.Instance);
@@ -117,7 +132,7 @@ public static class RecursiveAstWalker
             if (value is AstNode single)
             {
                 if (yielded.Add(single))
-                    yield return single;
+                    yield return new ChildEdge(single, prop);
                 continue;
             }
 
@@ -127,8 +142,46 @@ public static class RecursiveAstWalker
             foreach (var item in sequence)
             {
                 if (item is AstNode child && yielded.Add(child))
-                    yield return child;
+                    yield return new ChildEdge(child, prop);
             }
+        }
+    }
+
+    /// <summary>
+    /// Enumerates statement roots and every nested statement container while
+    /// deliberately not crossing expression boundaries such as lambdas. This is
+    /// the shared statement traversal surface for iterator classification,
+    /// structural return lowering preflights, legality checks, and future
+    /// statement transforms.
+    /// </summary>
+    public static IEnumerable<StatementNode> EnumerateStatements(
+        IEnumerable<StatementNode> roots)
+    {
+        ArgumentNullException.ThrowIfNull(roots);
+
+        foreach (var root in roots)
+        {
+            foreach (var node in DescendantsAndSelf(root))
+            {
+                if (node is StatementNode statement)
+                    yield return statement;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Enumerates a node and all structural descendants without crossing into
+    /// expression subtrees.
+    /// </summary>
+    public static IEnumerable<AstNode> DescendantsAndSelf(AstNode root)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+
+        yield return root;
+        foreach (var child in GetChildren(root))
+        {
+            foreach (var descendant in DescendantsAndSelf(child))
+                yield return descendant;
         }
     }
 

--- a/src/Calor.Compiler/Analysis/ReturnShape.cs
+++ b/src/Calor.Compiler/Analysis/ReturnShape.cs
@@ -118,9 +118,9 @@ public static class ReturnShape
     {
         if (accessor.Kind == PropertyAccessorNode.AccessorKind.Get)
         {
-            // A getter returns the property value, so a value §R is expected —
-            // unless the getter is itself an iterator.
-            return IsIterator(accessor) ? Kind.Iterator : Kind.Value;
+            // Accessor iterators are fail-closed by ReturnValidationPass until
+            // their deferred execution and return-type semantics are defined.
+            return Kind.Value;
         }
 
         // set / init accessors never return a value.
@@ -129,44 +129,11 @@ public static class ReturnShape
 
     private static bool IsIterator(AstNode owner)
     {
-        foreach (var child in RecursiveAstWalker.GetChildren(owner))
-        {
-            if (ContainsYield(child))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return RecursiveAstWalker.GetChildren(owner)
+            .SelectMany(RecursiveAstWalker.DescendantsAndSelf)
+            .OfType<StatementNode>()
+            .Any(statement =>
+                statement is YieldReturnStatementNode
+                    or YieldBreakStatementNode);
     }
-
-    private static bool ContainsYield(AstNode node)
-    {
-        if (node is YieldReturnStatementNode or YieldBreakStatementNode)
-        {
-            return true;
-        }
-
-        // Do not cross into a nested owner boundary (defensive — statement bodies
-        // do not currently contain nested owners, and lambdas are expressions
-        // that RecursiveAstWalker already skips).
-        if (IsOwner(node))
-        {
-            return false;
-        }
-
-        foreach (var child in RecursiveAstWalker.GetChildren(node))
-        {
-            if (ContainsYield(child))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static bool IsOwner(AstNode node) => node is
-        FunctionNode or MethodNode or OperatorOverloadNode or
-        ConstructorNode or PropertyAccessorNode or EventDefinitionNode;
 }

--- a/src/Calor.Compiler/Analysis/ReturnValidationPass.cs
+++ b/src/Calor.Compiler/Analysis/ReturnValidationPass.cs
@@ -1,11 +1,16 @@
 using Calor.Compiler.Ast;
 using Calor.Compiler.Diagnostics;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Calor.Compiler.Analysis;
 
 /// <summary>
-/// Always-on semantic pass that emits <c>Calor0205</c> when a value-returning
-/// <c>§R expr</c> appears in the body of an owner that returns no value:
+/// Always-on structural control-flow validation for returns and yields.
+/// It emits <c>Calor0205</c> when a value-returning <c>§R expr</c> appears in
+/// the body of an owner that returns no value, and validates that every yield
+/// can be represented by legal generated C#.
 ///
 /// <list type="bullet">
 ///   <item>a <c>void</c> function/method (no <c>§O</c> / no header return type);</item>
@@ -35,6 +40,30 @@ namespace Calor.Compiler.Analysis;
 /// </summary>
 public sealed class ReturnValidationPass
 {
+    private enum YieldOwner
+    {
+        None,
+        Callable,
+        AsyncCallable,
+        Unsupported,
+    }
+
+    private readonly record struct YieldContext(
+        YieldOwner Owner,
+        string OwnerDescription,
+        bool InLambda,
+        bool InExpressionContainer,
+        bool InCatch,
+        bool InFinally,
+        bool InUnsafe,
+        bool InFixed,
+        bool InTryWithCatch)
+    {
+        public static YieldContext None =>
+            new(YieldOwner.None, "module scope", false, false, false, false,
+                false, false, false);
+    }
+
     private readonly DiagnosticBag _diagnostics;
 
     public ReturnValidationPass(DiagnosticBag diagnostics)
@@ -50,6 +79,7 @@ public sealed class ReturnValidationPass
         }
 
         Walk(module, ReturnShape.Kind.None);
+        WalkYields(module, YieldContext.None);
     }
 
     private void Walk(AstNode node, ReturnShape.Kind context)
@@ -74,6 +104,290 @@ public sealed class ReturnValidationPass
         {
             Walk(child, childContext);
         }
+    }
+
+    private void WalkYields(AstNode node, YieldContext context)
+    {
+        switch (node)
+        {
+            case FunctionNode function:
+                CheckIteratorParameters(
+                    function.Parameters,
+                    function.Body,
+                    $"function '{function.Name}'");
+                break;
+            case MethodNode method:
+                CheckIteratorParameters(
+                    method.Parameters,
+                    method.Body,
+                    $"method '{method.Name}'");
+                break;
+            case RawCSharpNode raw:
+                CheckRawCSharpIteratorParameters(raw.CSharpCode, raw.Span);
+                break;
+            case CSharpInteropBlockNode interop:
+                CheckRawCSharpIteratorParameters(
+                    interop.CSharpCode,
+                    interop.Span);
+                break;
+        }
+
+        var childContext = EnterYieldOwner(node, context);
+        if (node is YieldReturnStatementNode yieldReturn)
+        {
+            CheckYieldReturn(yieldReturn, context);
+        }
+        else if (node is YieldBreakStatementNode yieldBreak)
+        {
+            CheckYieldBreak(yieldBreak, context);
+        }
+
+        foreach (var edge in RecursiveAstWalker.GetAllChildEdges(node))
+        {
+            var edgeContext = ContextForEdge(node, edge, childContext);
+            WalkYields(edge.Node, edgeContext);
+        }
+    }
+
+    private void CheckIteratorParameters(
+        IReadOnlyList<ParameterNode> parameters,
+        IReadOnlyList<StatementNode> body,
+        string ownerDescription)
+    {
+        if (!RecursiveAstWalker.EnumerateStatements(body).Any(statement =>
+                statement is YieldReturnStatementNode
+                    or YieldBreakStatementNode))
+        {
+            return;
+        }
+
+        foreach (var parameter in parameters)
+        {
+            var forbidden = parameter.Modifier
+                & (ParameterModifier.Ref
+                    | ParameterModifier.In
+                    | ParameterModifier.Out);
+            if (forbidden == ParameterModifier.None)
+                continue;
+
+            _diagnostics.ReportError(
+                parameter.IdentifierSpan,
+                DiagnosticCode.IllegalYield,
+                $"Iterator {ownerDescription} cannot declare parameter " +
+                $"'{parameter.Name}' with modifier '{FormatModifiers(forbidden)}'. " +
+                "Iterator parameters must be passed by value.");
+        }
+    }
+
+    private void CheckRawCSharpIteratorParameters(
+        string source,
+        Parsing.TextSpan span)
+    {
+        var root = CSharpSyntaxTree.ParseText(source).GetRoot();
+        foreach (var callable in root.DescendantNodesAndSelf().Where(node =>
+                     node is MethodDeclarationSyntax
+                         or LocalFunctionStatementSyntax))
+        {
+            if (!ContainsOwnedYield(callable))
+                continue;
+
+            var (description, parameters) = callable switch
+            {
+                MethodDeclarationSyntax method =>
+                    ($"method '{method.Identifier.ValueText}'",
+                        method.ParameterList.Parameters),
+                LocalFunctionStatementSyntax local =>
+                    ($"local function '{local.Identifier.ValueText}'",
+                        local.ParameterList.Parameters),
+                _ => throw new InvalidOperationException(),
+            };
+
+            foreach (var parameter in parameters)
+            {
+                var modifiers = parameter.Modifiers
+                    .Where(token => token.IsKind(SyntaxKind.RefKeyword)
+                        || token.IsKind(SyntaxKind.InKeyword)
+                        || token.IsKind(SyntaxKind.OutKeyword))
+                    .Select(token => token.ValueText)
+                    .ToArray();
+                if (modifiers.Length == 0)
+                    continue;
+
+                _diagnostics.ReportError(
+                    span,
+                    DiagnosticCode.IllegalYield,
+                    $"Iterator {description} cannot declare parameter " +
+                    $"'{parameter.Identifier.ValueText}' with modifier " +
+                    $"'{string.Join(", ", modifiers)}'. Iterator parameters " +
+                    "must be passed by value.");
+            }
+        }
+    }
+
+    private static bool ContainsOwnedYield(SyntaxNode callable) =>
+        callable.DescendantNodes(descendIntoChildren: node =>
+                ReferenceEquals(node, callable)
+                || node is not AnonymousFunctionExpressionSyntax
+                    and not LocalFunctionStatementSyntax
+                    and not BaseMethodDeclarationSyntax)
+            .OfType<YieldStatementSyntax>()
+            .Any();
+
+    private static string FormatModifiers(ParameterModifier modifiers)
+    {
+        var names = new List<string>(3);
+        if (modifiers.HasFlag(ParameterModifier.Ref))
+            names.Add("ref");
+        if (modifiers.HasFlag(ParameterModifier.In))
+            names.Add("in");
+        if (modifiers.HasFlag(ParameterModifier.Out))
+            names.Add("out");
+        return string.Join(", ", names);
+    }
+
+    private static YieldContext EnterYieldOwner(
+        AstNode node,
+        YieldContext context) =>
+        node switch
+        {
+            FunctionNode function => ResetYieldContext(
+                function.IsAsync ? YieldOwner.AsyncCallable : YieldOwner.Callable,
+                $"function '{function.Name}'"),
+            MethodNode method => ResetYieldContext(
+                method.IsAsync ? YieldOwner.AsyncCallable : YieldOwner.Callable,
+                $"method '{method.Name}'"),
+            OperatorOverloadNode => ResetYieldContext(
+                YieldOwner.Unsupported,
+                "operator"),
+            ConstructorNode => ResetYieldContext(
+                YieldOwner.Unsupported,
+                "constructor"),
+            PropertyAccessorNode => ResetYieldContext(
+                YieldOwner.Unsupported,
+                "property/indexer accessor"),
+            EventDefinitionNode => ResetYieldContext(
+                YieldOwner.Unsupported,
+                "event accessor"),
+            LambdaExpressionNode => context with { InLambda = true },
+            MatchExpressionNode => context with { InExpressionContainer = true },
+            CatchClauseNode => context with { InCatch = true },
+            _ => context,
+        };
+
+    private static YieldContext ResetYieldContext(
+        YieldOwner owner,
+        string description) =>
+        new(
+            owner,
+            description,
+            InLambda: false,
+            InExpressionContainer: false,
+            InCatch: false,
+            InFinally: false,
+            InUnsafe: false,
+            InFixed: false,
+            InTryWithCatch: false);
+
+    private static YieldContext ContextForEdge(
+        AstNode parent,
+        RecursiveAstWalker.ChildEdge edge,
+        YieldContext context)
+    {
+        if (parent is TryStatementNode tryStatement)
+        {
+            if (edge.Property.Name == nameof(TryStatementNode.FinallyBody))
+            {
+                return context with { InFinally = true };
+            }
+            if (edge.Property.Name == nameof(TryStatementNode.TryBody)
+                && tryStatement.CatchClauses.Count > 0)
+            {
+                return context with { InTryWithCatch = true };
+            }
+        }
+
+        if (parent is UnsafeBlockNode
+            && edge.Property.Name == nameof(UnsafeBlockNode.Body))
+        {
+            return context with { InUnsafe = true };
+        }
+
+        if (parent is FixedStatementNode
+            && edge.Property.Name == nameof(FixedStatementNode.Body))
+        {
+            return context with { InFixed = true, InUnsafe = true };
+        }
+
+        return context;
+    }
+
+    private void CheckYieldReturn(
+        YieldReturnStatementNode yieldReturn,
+        YieldContext context)
+    {
+        if (yieldReturn.Expression is null)
+        {
+            _diagnostics.ReportError(
+                yieldReturn.Span,
+                DiagnosticCode.YieldRequiresValue,
+                "'§YIELD' requires a value. Use '§YBRK' for 'yield break'.");
+            return;
+        }
+
+        var reason = GetIllegalYieldReason(context, returnsValue: true);
+        if (reason != null)
+        {
+            _diagnostics.ReportError(
+                yieldReturn.Span,
+                DiagnosticCode.IllegalYield,
+                $"'§YIELD' is illegal {reason}.");
+        }
+    }
+
+    private void CheckYieldBreak(
+        YieldBreakStatementNode yieldBreak,
+        YieldContext context)
+    {
+        var reason = GetIllegalYieldReason(context, returnsValue: false);
+        if (reason != null)
+        {
+            _diagnostics.ReportError(
+                yieldBreak.Span,
+                DiagnosticCode.IllegalYield,
+                $"'§YBRK' is illegal {reason}.");
+        }
+    }
+
+    private static string? GetIllegalYieldReason(
+        YieldContext context,
+        bool returnsValue)
+    {
+        if (context.InLambda)
+            return "inside a lambda expression";
+        if (context.InExpressionContainer)
+            return "inside an expression-valued statement container";
+        if (context.Owner == YieldOwner.None)
+            return "outside a function or method";
+        if (context.Owner == YieldOwner.AsyncCallable)
+            return $"inside async {context.OwnerDescription}; async iterators are not supported";
+        if (context.Owner == YieldOwner.Unsupported)
+            return $"inside a {context.OwnerDescription}";
+        if (context.InFinally)
+            return "inside a finally block";
+
+        if (!returnsValue)
+            return null;
+
+        if (context.InCatch)
+            return "inside a catch block";
+        if (context.InFixed)
+            return "inside a fixed block";
+        if (context.InUnsafe)
+            return "inside an unsafe block";
+        if (context.InTryWithCatch)
+            return "inside a try block that has a catch clause";
+
+        return null;
     }
 
     private void CheckReturn(ReturnStatementNode ret, ReturnShape.Kind context)

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -36,8 +36,19 @@ public enum EmitContractMode
 /// </summary>
 public sealed class CSharpEmitter : IAstVisitor<string>
 {
-    private readonly StringBuilder _builder = new();
-    private int _indentLevel;
+    private sealed class EmissionContext
+    {
+        public EmissionContext(int indentLevel = 0)
+        {
+            IndentLevel = indentLevel;
+        }
+
+        public StringBuilder Writer { get; } = new();
+        public int IndentLevel { get; set; }
+    }
+
+    private EmissionContext _emissionContext = new();
+    private HashSet<string> _reservedGeneratedIdentifiers = new(StringComparer.Ordinal);
     private string? _currentClassName;
     private string _currentModuleName = "";
     private HashSet<string> _currentModuleFunctionNames = new(StringComparer.Ordinal);
@@ -451,8 +462,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Emit(ModuleNode module, string? filePath = null)
     {
-        _builder.Clear();
-        _indentLevel = 0;
+        _emissionContext = new EmissionContext();
+        _reservedGeneratedIdentifiers = CollectReservedModuleIdentifiers(module);
         _currentFilePath = filePath;
         _lineDirectiveFile = string.IsNullOrEmpty(LineDirectiveFilePath)
             ? null
@@ -467,23 +478,9 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         return Emit(module, null);
     }
 
-    private static IEnumerable<AstNode> DescendantStatementNodesAndSelf(
-        AstNode node)
-    {
-        yield return node;
-        foreach (var child in Analysis.RecursiveAstWalker.GetChildren(node))
-        {
-            foreach (var descendant in DescendantStatementNodesAndSelf(child))
-            {
-                yield return descendant;
-            }
-        }
-    }
-
     private static IEnumerable<StatementNode> TraverseStatements(
         IReadOnlyList<StatementNode> body) =>
-        body.SelectMany(DescendantStatementNodesAndSelf)
-            .OfType<StatementNode>();
+        Analysis.RecursiveAstWalker.EnumerateStatements(body);
 
     private static bool ContainsOpaqueCSharp(IReadOnlyList<StatementNode> body) =>
         TraverseStatements(body).Any(statement => statement is RawCSharpNode);
@@ -514,39 +511,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         foreach (var node in body.SelectMany(DescendantsAndSelf))
         {
-            string? name = node switch
-            {
-                BindStatementNode bind => bind.Name,
-                ForStatementNode loop => loop.VariableName,
-                ForeachStatementNode loop => loop.VariableName,
-                DictionaryForeachNode loop => loop.KeyName,
-                UsingStatementNode usingStatement => usingStatement.VariableName,
-                CatchClauseNode catchClause => catchClause.VariableName,
-                FixedStatementNode fixedStatement => fixedStatement.PointerName,
-                LabelStatementNode label => label.Label,
-                LambdaParameterNode parameter => parameter.Name,
-                QuantifierVariableNode variable => variable.Name,
-                IsPatternNode pattern => pattern.VariableName,
-                VariablePatternNode pattern => pattern.Name,
-                VarPatternNode pattern => pattern.Name,
-                TypePatternNode pattern => pattern.BindingName,
-                ReferenceNode reference when !reference.Name.Contains('.') =>
-                    reference.Name,
-                _ => null
-            };
-            if (!string.IsNullOrEmpty(name))
-            {
-                reserved.Add(SanitizeIdentifier(name));
-            }
-
-            if (node is ForeachStatementNode { IndexVariableName: { } indexName })
-            {
-                reserved.Add(SanitizeIdentifier(indexName));
-            }
-            else if (node is DictionaryForeachNode dictionaryLoop)
-            {
-                reserved.Add(SanitizeIdentifier(dictionaryLoop.ValueName));
-            }
+            AddReservedIdentifiers(reserved, node);
         }
 
         foreach (var node in postconditions
@@ -554,25 +519,124 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                          DescendantsAndSelf(
                              postcondition.Contract.Condition)))
         {
-            var name = node switch
-            {
-                LambdaParameterNode parameter => parameter.Name,
-                QuantifierVariableNode variable => variable.Name,
-                IsPatternNode pattern => pattern.VariableName,
-                VariablePatternNode pattern => pattern.Name,
-                VarPatternNode pattern => pattern.Name,
-                TypePatternNode pattern => pattern.BindingName,
-                ReferenceNode reference when !reference.Name.Contains('.') =>
-                    reference.Name,
-                _ => null
-            };
-            if (!string.IsNullOrEmpty(name))
-            {
-                reserved.Add(SanitizeIdentifier(name));
-            }
+            AddReservedIdentifiers(reserved, node);
         }
 
         return reserved;
+    }
+
+    private static HashSet<string> CollectReservedModuleIdentifiers(ModuleNode module)
+    {
+        var reserved = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var node in DescendantsAndSelf(module))
+        {
+            AddReservedIdentifiers(reserved, node);
+        }
+        return reserved;
+    }
+
+    private static void AddReservedIdentifiers(
+        HashSet<string> reserved,
+        AstNode node)
+    {
+        switch (node)
+        {
+            case RawCSharpNode raw:
+                AddRawCSharpIdentifiers(reserved, raw.CSharpCode);
+                break;
+            case RawCSharpExpressionNode raw:
+                AddRawCSharpIdentifiers(reserved, raw.CSharpCode);
+                break;
+            case CSharpInteropBlockNode interop:
+                AddRawCSharpIdentifiers(reserved, interop.CSharpCode);
+                break;
+        }
+
+        var name = node switch
+        {
+            BindStatementNode bind => bind.Name,
+            ForStatementNode loop => loop.VariableName,
+            ForeachStatementNode loop => loop.VariableName,
+            DictionaryForeachNode loop => loop.KeyName,
+            UsingStatementNode usingStatement => usingStatement.VariableName,
+            CatchClauseNode catchClause => catchClause.VariableName,
+            FixedStatementNode fixedStatement => fixedStatement.PointerName,
+            LabelStatementNode label => label.Label,
+            LambdaParameterNode parameter => parameter.Name,
+            ParameterNode parameter => parameter.Name,
+            TypeParameterNode parameter => parameter.Name,
+            QuantifierVariableNode variable => variable.Name,
+            IsPatternNode pattern => pattern.VariableName,
+            VariablePatternNode pattern => pattern.Name,
+            VarPatternNode pattern => pattern.Name,
+            TypePatternNode pattern => pattern.BindingName,
+            ReferenceNode reference when !reference.Name.Contains('.') =>
+                reference.Name,
+            _ => null
+        };
+        if (!string.IsNullOrEmpty(name))
+        {
+            reserved.Add(SanitizeIdentifier(name));
+        }
+
+        if (node is ForeachStatementNode { IndexVariableName: { } indexName })
+        {
+            reserved.Add(SanitizeIdentifier(indexName));
+        }
+        else if (node is DictionaryForeachNode dictionaryLoop)
+        {
+            reserved.Add(SanitizeIdentifier(dictionaryLoop.ValueName));
+        }
+    }
+
+    private static void AddRawCSharpIdentifiers(
+        HashSet<string> reserved,
+        string source)
+    {
+        var pending = new Stack<string>();
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        pending.Push(source);
+
+        while (pending.Count > 0)
+        {
+            var fragment = pending.Pop();
+            if (string.IsNullOrEmpty(fragment) || !visited.Add(fragment))
+                continue;
+
+            var root = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree
+                .ParseText(fragment)
+                .GetRoot();
+            foreach (var token in root.DescendantTokens())
+            {
+                if (token.RawKind
+                    != (int)Microsoft.CodeAnalysis.CSharp.SyntaxKind.IdentifierToken)
+                {
+                    continue;
+                }
+
+                var value = token.ValueText;
+                if (Microsoft.CodeAnalysis.CSharp.SyntaxFacts.GetKeywordKind(value)
+                        != Microsoft.CodeAnalysis.CSharp.SyntaxKind.None
+                    || Microsoft.CodeAnalysis.CSharp.SyntaxFacts
+                        .GetContextualKeywordKind(value)
+                        != Microsoft.CodeAnalysis.CSharp.SyntaxKind.None)
+                {
+                    continue;
+                }
+
+                reserved.Add(SanitizeIdentifier(value));
+            }
+
+            foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
+            {
+                if (trivia.RawKind
+                        is (int)Microsoft.CodeAnalysis.CSharp.SyntaxKind.DisabledTextTrivia
+                        or (int)Microsoft.CodeAnalysis.CSharp.SyntaxKind.SkippedTokensTrivia)
+                {
+                    pending.Push(trivia.ToFullString());
+                }
+            }
+        }
     }
 
     private static string ReserveUniqueIdentifier(
@@ -815,7 +879,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 Diagnostics.DiagnosticCode.IteratorPostconditionUnsupported);
             foreach (var statement in body)
             {
-                EmitStatement(statement);
+                EmitStatement(statement, _emissionContext);
             }
             return;
         }
@@ -829,7 +893,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 Diagnostics.DiagnosticCode.PostconditionCheckNotLowered);
             foreach (var statement in body)
             {
-                EmitStatement(statement);
+                EmitStatement(statement, _emissionContext);
             }
             return;
         }
@@ -842,7 +906,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             {
                 foreach (var statement in body)
                 {
-                    EmitStatement(statement);
+                    EmitStatement(statement, _emissionContext);
                 }
                 return;
             }
@@ -876,7 +940,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         {
             foreach (var statement in body)
             {
-                EmitStatement(statement);
+                EmitStatement(statement, _emissionContext);
             }
         }
         finally
@@ -948,32 +1012,44 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             Diagnostics.DiagnosticSeverity.Error));
     }
 
-    private void EmitStatement(AstNode statement, bool skipEmptyLine = false)
+    private void EmitStatement(
+        StatementNode statement,
+        EmissionContext context,
+        bool skipEmptyLine = false)
     {
-        var mapped = TryBeginLineMapping(statement);
-        var isMutableRebind = statement is BindStatementNode bindStatement
-            && bindStatement.IsMutable
-            && IsVarDeclaredInScope(SanitizeIdentifier(bindStatement.Name));
-        var code = statement.Accept(this);
-        if (!skipEmptyLine || !string.IsNullOrEmpty(code))
+        var previousContext = _emissionContext;
+        _emissionContext = context;
+        try
         {
-            AppendLine(code);
-            if (statement is BindStatementNode bind
-                && !isMutableRebind
-                && TryGetRefinementConstraint(bind.Name, out var bindConstraint))
+            var mapped = TryBeginLineMapping(statement);
+            var isMutableRebind = statement is BindStatementNode bindStatement
+                && bindStatement.IsMutable
+                && IsVarDeclaredInScope(SanitizeIdentifier(bindStatement.Name));
+            var code = statement.Accept(this);
+            if (!skipEmptyLine || !string.IsNullOrEmpty(code))
             {
-                if (ShouldEmitObligationGuard(
-                    Verification.Obligations.ObligationKind.Subtype,
-                    bind.Span,
-                    bind.Name))
+                AppendLine(code);
+                if (statement is BindStatementNode bind
+                    && !isMutableRebind
+                    && TryGetRefinementConstraint(bind.Name, out var bindConstraint))
                 {
-                    EmitRefinementValueGuard(
-                        bindConstraint,
-                        SanitizeIdentifier(bind.Name));
+                    if (ShouldEmitObligationGuard(
+                        Verification.Obligations.ObligationKind.Subtype,
+                        bind.Span,
+                        bind.Name))
+                    {
+                        EmitRefinementValueGuard(
+                            bindConstraint,
+                            SanitizeIdentifier(bind.Name));
+                    }
                 }
             }
+            EndLineMapping(mapped);
         }
-        EndLineMapping(mapped);
+        finally
+        {
+            _emissionContext = previousContext;
+        }
     }
 
     /// <summary>
@@ -1004,17 +1080,18 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     {
         if (string.IsNullOrEmpty(line))
         {
-            _builder.AppendLine();
+            _emissionContext.Writer.AppendLine();
         }
         else
         {
-            _builder.Append(new string(' ', _indentLevel * 4));
-            _builder.AppendLine(line);
+            _emissionContext.Writer.Append(
+                new string(' ', _emissionContext.IndentLevel * 4));
+            _emissionContext.Writer.AppendLine(line);
         }
     }
 
-    private void Indent() => _indentLevel++;
-    private void Dedent() => _indentLevel--;
+    private void Indent() => _emissionContext.IndentLevel++;
+    private void Dedent() => _emissionContext.IndentLevel--;
 
     public string Visit(ModuleNode node)
     {
@@ -1185,7 +1262,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         // Replace using placeholder with only the namespaces actually referenced.
         // Uses AST-level flags set during emission, with string-scanning fallback
         // for raw C# passthrough (§CS{}, §RAW) that may reference these namespaces.
-        var output = _builder.ToString();
+        var output = _emissionContext.Writer.ToString();
         var usingBlock = new StringBuilder();
         var emittedUsings = new HashSet<string>(StringComparer.Ordinal);
 
@@ -1546,7 +1623,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             }
 
             var continuationIndent = Environment.NewLine
-                + new string(' ', _indentLevel * 4);
+                + new string(' ', _emissionContext.IndentLevel * 4);
             return $"{lowering.ResultIdentifier} = {loweredExpression};"
                 + continuationIndent
                 + $"goto {lowering.ExitLabel};";
@@ -1570,7 +1647,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 GetEffectiveRefinementPredicate(refinementType),
                 resultName);
             var continuationIndent = Environment.NewLine
-                + new string(' ', _indentLevel * 4);
+                + new string(' ', _emissionContext.IndentLevel * 4);
             return $"var {resultName} = {expr};"
                 + continuationIndent
                 + $"if (!({condition})) throw new InvalidOperationException("
@@ -1980,26 +2057,92 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var varName = SanitizeIdentifier(node.VariableName);
         var from = node.From.Accept(this);
         var to = node.To.Accept(this);
-        var step = node.Step?.Accept(this) ?? "1";
+        var hasExplicitStep = node.Step != null;
+        var step = node.Step?.Accept(this);
+        var fromTemp = ReserveUniqueIdentifier(
+            _reservedGeneratedIdentifiers,
+            "__calorForFrom");
+        var toTemp = ReserveUniqueIdentifier(
+            _reservedGeneratedIdentifiers,
+            "__calorForTo");
+        var stepTemp = hasExplicitStep
+            ? ReserveUniqueIdentifier(
+                _reservedGeneratedIdentifiers,
+                "__calorForStep")
+            : null;
+        var ascendingTemp = hasExplicitStep
+            ? ReserveUniqueIdentifier(
+                _reservedGeneratedIdentifiers,
+                "__calorForAscending")
+            : null;
+        var firstTemp = ReserveUniqueIdentifier(
+            _reservedGeneratedIdentifiers,
+            "__calorForFirst");
 
-        var isPositiveStep = LoopStepSemantics.TryEvaluate(node.Step, out var stepValue)
-            ? stepValue.Sign >= 0
-            : !step.StartsWith("-");
-        var comparison = isPositiveStep ? "<=" : ">=";
-        var increment = step == "1" ? $"{varName}++" : $"{varName} += {step}";
-
-        AppendLine($"for (var {varName} = {from}; {varName} {comparison} {to}; {increment})");
         AppendLine("{");
         Indent();
+        AppendLine($"var {fromTemp} = {from};");
+        AppendLine($"var {toTemp} = {to};");
+        if (hasExplicitStep)
+        {
+            AppendLine($"var {stepTemp} = {step};");
+            AppendLine(
+                $"if ({stepTemp} == 0) throw new ArgumentOutOfRangeException(" +
+                $"nameof({stepTemp}), \"Calor for-loop step must not be zero\");");
+            AppendLine($"var {ascendingTemp} = {stepTemp} > 0;");
+        }
+        AppendLine($"var {firstTemp} = true;");
+        AppendLine($"var {varName} = {fromTemp};");
+        AppendLine("while (true)");
+        AppendLine("{");
+        Indent();
+
+        AppendLine($"if (!{firstTemp})");
+        AppendLine("{");
+        Indent();
+        AppendLine("try");
+        AppendLine("{");
+        Indent();
+        AppendLine("checked");
+        AppendLine("{");
+        Indent();
+        AppendLine(
+            hasExplicitStep
+                ? $"{varName} += {stepTemp};"
+                : $"{varName}++;");
+        Dedent();
+        AppendLine("}");
+        Dedent();
+        AppendLine("}");
+        AppendLine("catch (OverflowException)");
+        AppendLine("{");
+        Indent();
+        AppendLine("break;");
+        Dedent();
+        AppendLine("}");
+        Dedent();
+        AppendLine("}");
+        AppendLine("else");
+        AppendLine("{");
+        Indent();
+        AppendLine($"{firstTemp} = false;");
+        Dedent();
+        AppendLine("}");
+        AppendLine(hasExplicitStep
+            ? $"if (!({ascendingTemp} ? {varName} <= {toTemp} : " +
+                $"{varName} >= {toTemp})) break;"
+            : $"if (!({varName} <= {toTemp})) break;");
 
         PushDeclScope();
         DeclareVarInScope(varName); // the loop variable is in scope for the body (#732)
         foreach (var stmt in node.Body)
         {
-            EmitStatement(stmt);
+            EmitStatement(stmt, _emissionContext);
         }
         PopDeclScope();
 
+        Dedent();
+        AppendLine("}");
         Dedent();
         AppendLine("}");
 
@@ -2017,7 +2160,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         PushDeclScope();
         foreach (var stmt in node.Body)
         {
-            EmitStatement(stmt);
+            EmitStatement(stmt, _emissionContext);
         }
         PopDeclScope();
 
@@ -2038,7 +2181,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         PushDeclScope();
         foreach (var stmt in node.Body)
         {
-            EmitStatement(stmt);
+            EmitStatement(stmt, _emissionContext);
         }
         PopDeclScope();
 
@@ -2059,7 +2202,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         PushDeclScope();
         foreach (var stmt in node.ThenBody)
         {
-            EmitStatement(stmt);
+            EmitStatement(stmt, _emissionContext);
         }
         PopDeclScope();
 
@@ -2077,7 +2220,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             PushDeclScope();
             foreach (var stmt in elseIf.Body)
             {
-                EmitStatement(stmt);
+                EmitStatement(stmt, _emissionContext);
             }
             PopDeclScope();
 
@@ -2095,7 +2238,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             PushDeclScope();
             foreach (var stmt in node.ElseBody)
             {
-                EmitStatement(stmt);
+                EmitStatement(stmt, _emissionContext);
             }
             PopDeclScope();
 
@@ -2115,7 +2258,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         PushDeclScope();
         foreach (var stmt in node.Body)
         {
-            EmitStatement(stmt);
+            EmitStatement(stmt, _emissionContext);
         }
         PopDeclScope();
         Dedent();
@@ -2454,7 +2597,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     {
         if (node.Expression == null)
         {
-            return "yield return;";
+            throw new InvalidOperationException(
+                "A valueless §YIELD is invalid. Use §YBRK to emit 'yield break;'.");
         }
         var expr = node.Expression.Accept(this);
         if (_currentYieldRefinement != null
@@ -2469,7 +2613,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 GetEffectiveRefinementPredicate(refinementType),
                 resultName);
             var continuationIndent = Environment.NewLine
-                + new string(' ', _indentLevel * 4);
+                + new string(' ', _emissionContext.IndentLevel * 4);
             return $"var {resultName} = {expr};"
                 + continuationIndent
                 + $"if (!({condition})) throw new InvalidOperationException("
@@ -2850,26 +2994,43 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         foreach (var matchCase in node.Cases)
         {
-            if (matchCase.Pattern is WildcardPatternNode)
+            var previousShadowDepth = _postconditionResultShadowDepth;
+            if (PatternBindsName(matchCase.Pattern, "result"))
             {
-                AppendLine("default:");
+                _postconditionResultShadowDepth++;
             }
-            else
-            {
-                var pattern = EmitPattern(matchCase.Pattern);
-                AppendLine($"case {pattern}:");
-            }
-            Indent();
 
-            PushDeclScope();
-            foreach (var stmt in matchCase.Body)
+            try
             {
-                EmitStatement(stmt);
-            }
-            PopDeclScope();
+                var guard = matchCase.Guard != null
+                    ? $" when {matchCase.Guard.Accept(this)}"
+                    : "";
+                if (matchCase.Pattern is WildcardPatternNode
+                    && matchCase.Guard == null)
+                {
+                    AppendLine("default:");
+                }
+                else
+                {
+                    var pattern = EmitPattern(matchCase.Pattern);
+                    AppendLine($"case {pattern}{guard}:");
+                }
+                Indent();
 
-            AppendLine("break;");
-            Dedent();
+                PushDeclScope();
+                foreach (var stmt in matchCase.Body)
+                {
+                    EmitStatement(stmt, _emissionContext);
+                }
+                PopDeclScope();
+
+                AppendLine("break;");
+                Dedent();
+            }
+            finally
+            {
+                _postconditionResultShadowDepth = previousShadowDepth;
+            }
         }
 
         Dedent();
@@ -3177,7 +3338,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             DeclareVarInScope(indexName);
             foreach (var stmt in node.Body)
             {
-                EmitStatement(stmt);
+                EmitStatement(stmt, _emissionContext);
             }
             PopDeclScope();
 
@@ -3194,7 +3355,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             DeclareVarInScope(varName);
             foreach (var stmt in node.Body)
             {
-                EmitStatement(stmt);
+                EmitStatement(stmt, _emissionContext);
             }
             PopDeclScope();
 
@@ -3312,7 +3473,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
             var guardedIndex = $"__calorIndex{_indexGuardCounter++}";
             var continuationIndent = Environment.NewLine
-                + new string(' ', _indentLevel * 4);
+                + new string(' ', _emissionContext.IndentLevel * 4);
             return $"var {guardedIndex} = {index};"
                 + continuationIndent
                 + $"if ({guardedIndex} < 0"
@@ -3369,7 +3530,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         DeclareVarInScope(valueName);
         foreach (var stmt in node.Body)
         {
-            EmitStatement(stmt);
+            EmitStatement(stmt, _emissionContext);
         }
         PopDeclScope();
 
@@ -4406,7 +4567,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
             foreach (var stmt in node.Body)
             {
-                EmitStatement(stmt);
+                EmitStatement(stmt, _emissionContext);
             }
 
             Dedent();
@@ -4511,7 +4672,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         foreach (var stmt in node.Body)
         {
-            EmitStatement(stmt);
+            EmitStatement(stmt, _emissionContext);
         }
 
         Dedent();
@@ -4680,7 +4841,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     {
         var candidateName = $"__refinementCandidate{_mutationGuardCounter++}";
         var continuationIndent = Environment.NewLine
-            + new string(' ', _indentLevel * 4);
+            + new string(' ', _emissionContext.IndentLevel * 4);
         var initializeCandidate = compoundOperator is null
             ? $"{MapTypeName(constraint.TypeName)} {candidateName} = {value};"
             : $"var {candidateName} = {target};"
@@ -4768,7 +4929,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         var guardedIndex = $"__calorIndex{_indexGuardCounter++}";
         var continuationIndent = Environment.NewLine
-            + new string(' ', _indentLevel * 4);
+            + new string(' ', _emissionContext.IndentLevel * 4);
         code = $"var {guardedIndex} = {index};"
             + continuationIndent
             + $"if ({guardedIndex} < 0"
@@ -4797,7 +4958,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         }
         foreach (var stmt in node.Body)
         {
-            EmitStatement(stmt);
+            EmitStatement(stmt, _emissionContext);
         }
         PopDeclScope();
 
@@ -4818,7 +4979,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         PushDeclScope();
         foreach (var stmt in node.TryBody)
         {
-            EmitStatement(stmt);
+            EmitStatement(stmt, _emissionContext);
         }
         PopDeclScope();
 
@@ -4839,7 +5000,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             PushDeclScope();
             foreach (var stmt in node.FinallyBody)
             {
-                EmitStatement(stmt);
+                EmitStatement(stmt, _emissionContext);
             }
             PopDeclScope();
 
@@ -4884,7 +5045,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         }
         foreach (var stmt in node.Body)
         {
-            EmitStatement(stmt);
+            EmitStatement(stmt, _emissionContext);
         }
         PopDeclScope();
 
@@ -4991,26 +5152,21 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             }
             else if (node.StatementBody != null && node.StatementBody.Count > 0)
             {
-                var builderStart = _builder.Length;
-                var previousIndent = _indentLevel;
+                var lambdaContext = new EmissionContext(indentLevel: 1);
                 PushDeclScope();
                 RegisterLambdaParameters(node.Parameters);
 
                 string body;
                 try
                 {
-                    _indentLevel = 1;
                     foreach (var stmt in node.StatementBody)
                     {
-                        EmitStatement(stmt);
+                        EmitStatement(stmt, lambdaContext);
                     }
-                    body = _builder.ToString(builderStart, _builder.Length - builderStart)
-                        .TrimEnd();
+                    body = lambdaContext.Writer.ToString().TrimEnd();
                 }
                 finally
                 {
-                    _builder.Length = builderStart;
-                    _indentLevel = previousIndent;
                     PopDeclScope();
                 }
 
@@ -5116,7 +5272,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 Indent();
                 foreach (var stmt in node.AddBody)
                 {
-                    EmitStatement(stmt);
+                    EmitStatement(stmt, _emissionContext);
                 }
                 Dedent();
                 AppendLine("}");
@@ -5130,7 +5286,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 Indent();
                 foreach (var stmt in node.RemoveBody)
                 {
-                    EmitStatement(stmt);
+                    EmitStatement(stmt, _emissionContext);
                 }
                 Dedent();
                 AppendLine("}");
@@ -6246,7 +6402,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         // since the raw content has its own formatting.
         foreach (var line in node.CSharpCode.Split('\n'))
         {
-            _builder.AppendLine(line.TrimEnd('\r'));
+            _emissionContext.Writer.AppendLine(line.TrimEnd('\r'));
         }
         return "";
     }
@@ -6258,14 +6414,14 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         AppendLine($"#if {node.Condition}");
         foreach (var stmt in node.Body)
         {
-            EmitStatement(stmt, skipEmptyLine: true);
+            EmitStatement(stmt, _emissionContext, skipEmptyLine: true);
         }
         if (node.ElseBody != null && node.ElseBody.Count > 0)
         {
             AppendLine("#else");
             foreach (var stmt in node.ElseBody)
             {
-                EmitStatement(stmt, skipEmptyLine: true);
+                EmitStatement(stmt, _emissionContext, skipEmptyLine: true);
             }
         }
         AppendLine("#endif");
@@ -6436,7 +6592,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         foreach (var line in code.Split('\n'))
         {
-            _builder.AppendLine(line.TrimEnd('\r'));
+            _emissionContext.Writer.AppendLine(line.TrimEnd('\r'));
         }
         return "";
     }
@@ -6677,7 +6833,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         PushDeclScope();
         foreach (var stmt in node.Body)
         {
-            EmitStatement(stmt);
+            EmitStatement(stmt, _emissionContext);
         }
         PopDeclScope();
         Dedent();
@@ -6694,7 +6850,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         PushDeclScope();
         foreach (var stmt in node.Body)
         {
-            EmitStatement(stmt);
+            EmitStatement(stmt, _emissionContext);
         }
         PopDeclScope();
         Dedent();
@@ -6711,7 +6867,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         Indent();
         foreach (var stmt in node.Body)
         {
-            EmitStatement(stmt);
+            EmitStatement(stmt, _emissionContext);
         }
         Dedent();
         AppendLine("}");

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -141,6 +141,19 @@ public static class DiagnosticCode
     /// </summary>
     public const string NoMatchingOverload = "Calor0208";
 
+    /// <summary>
+    /// Error: a yield appears in a context that C# cannot lower as an iterator,
+    /// such as a lambda, constructor, async callable, catch/finally region, or
+    /// unsafe suspension point.
+    /// </summary>
+    public const string IllegalYield = "Calor0209";
+
+    /// <summary>
+    /// Error: <c>§YIELD</c> has no value. Calor rejects this form; use
+    /// <c>§YBRK</c> for <c>yield break</c>.
+    /// </summary>
+    public const string YieldRequiresValue = "Calor0210";
+
     // Bind inference diagnostics (Calor0250-0260) — RFC v0.6 bind-inference-formalization
 
     /// <summary>

--- a/src/Calor.Compiler/Parsing/AttributeHelper.cs
+++ b/src/Calor.Compiler/Parsing/AttributeHelper.cs
@@ -279,13 +279,12 @@ public static class AttributeHelper
     /// </summary>
     public static (string Id, string Var, string From, string To, string Step) InterpretForAttributes(AttributeCollection attrs)
     {
-        var step = attrs["_pos4"] ?? "";
-        if (string.IsNullOrEmpty(step))
-        {
-            step = "1";
-        }
-
-        return (attrs["_pos0"] ?? "", attrs["_pos1"] ?? "", attrs["_pos2"] ?? "", attrs["_pos3"] ?? "", step);
+        return (
+            attrs["_pos0"] ?? "",
+            attrs["_pos1"] ?? "",
+            attrs["_pos2"] ?? "",
+            attrs["_pos3"] ?? "",
+            attrs["_pos4"] ?? "");
     }
 
     /// <summary>

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -4399,10 +4399,6 @@ public sealed class Parser
             fromStr = attrs["_pos1"] ?? "";
             toStr = attrs["_pos2"] ?? "";
             stepStr = attrs["_pos3"] ?? "";
-            if (string.IsNullOrEmpty(stepStr))
-            {
-                stepStr = "1";
-            }
             id = GenerateParserAutoId("l");
             variableKey = "_pos0";
         }

--- a/src/Calor.Compiler/Resources/SelfTest/02_fizzbuzz.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/02_fizzbuzz.g.cs
@@ -13,25 +13,53 @@ namespace FizzBuzz
     {
         public static void Main()
         {
-            for (var i = 1; i <= 100; i++)
             {
-                if (i % 15 == 0)
+                var __calorForFrom = 1;
+                var __calorForTo = 100;
+                var __calorForStep = 1;
+                if (__calorForStep == 0) throw new ArgumentOutOfRangeException(nameof(__calorForStep), "Calor for-loop step must not be zero");
+                var __calorForAscending = __calorForStep > 0;
+                var __calorForFirst = true;
+                var i = __calorForFrom;
+                while (true)
                 {
-                    Console.WriteLine("FizzBuzz");
-                }
-                else if (i % 3 == 0)
-                {
-                    Console.WriteLine("Fizz");
-                }
-                else if (i % 5 == 0)
-                {
-                    Console.WriteLine("Buzz");
-                }
-                else
-                {
-                    Console.WriteLine(i);
-                }
+                    if (!__calorForFirst)
+                    {
+                        try
+                        {
+                            checked
+                            {
+                                i += __calorForStep;
+                            }
+                        }
+                        catch (OverflowException)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        __calorForFirst = false;
+                    }
+                    if (!(__calorForAscending ? i <= __calorForTo : i >= __calorForTo)) break;
+                    if (i % 15 == 0)
+                    {
+                        Console.WriteLine("FizzBuzz");
+                    }
+                    else if (i % 3 == 0)
+                    {
+                        Console.WriteLine("Fizz");
+                    }
+                    else if (i % 5 == 0)
+                    {
+                        Console.WriteLine("Buzz");
+                    }
+                    else
+                    {
+                        Console.WriteLine(i);
+                    }
 
+                }
             }
 
         }

--- a/src/Calor.Compiler/Resources/SelfTest/05_skill_syntax.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/05_skill_syntax.g.cs
@@ -58,9 +58,37 @@ namespace SkillSyntax
         private static void TestControlFlow()
         {
             Console.WriteLine("Testing control flow...");
-            for (var i = 1; i <= 5; i++)
             {
-                Console.WriteLine(i);
+                var __calorForFrom = 1;
+                var __calorForTo = 5;
+                var __calorForStep = 1;
+                if (__calorForStep == 0) throw new ArgumentOutOfRangeException(nameof(__calorForStep), "Calor for-loop step must not be zero");
+                var __calorForAscending = __calorForStep > 0;
+                var __calorForFirst = true;
+                var i = __calorForFrom;
+                while (true)
+                {
+                    if (!__calorForFirst)
+                    {
+                        try
+                        {
+                            checked
+                            {
+                                i += __calorForStep;
+                            }
+                        }
+                        catch (OverflowException)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        __calorForFirst = false;
+                    }
+                    if (!(__calorForAscending ? i <= __calorForTo : i >= __calorForTo)) break;
+                    Console.WriteLine(i);
+                }
             }
 
         }

--- a/src/Calor.Compiler/Resources/SelfTest/09_codegen_bugfixes.g.cs
+++ b/src/Calor.Compiler/Resources/SelfTest/09_codegen_bugfixes.g.cs
@@ -33,18 +33,46 @@ namespace Transliterator
             char[] buf = new char[256];
             var sb = new StringBuilder();
             ConsoleKeyInfo keyPressed = Console.ReadKey();
-            for (var i = 0; i <= input.Length; i++)
             {
-                char ch = input[i];
-                if (ch == 'Y')
+                var __calorForFrom = 0;
+                var __calorForTo = input.Length;
+                var __calorForStep = 1;
+                if (__calorForStep == 0) throw new ArgumentOutOfRangeException(nameof(__calorForStep), "Calor for-loop step must not be zero");
+                var __calorForAscending = __calorForStep > 0;
+                var __calorForFirst = true;
+                var i = __calorForFrom;
+                while (true)
                 {
-                    sb.Append("Y");
-                }
-                else
-                {
-                    sb.Append(ch);
-                }
+                    if (!__calorForFirst)
+                    {
+                        try
+                        {
+                            checked
+                            {
+                                i += __calorForStep;
+                            }
+                        }
+                        catch (OverflowException)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        __calorForFirst = false;
+                    }
+                    if (!(__calorForAscending ? i <= __calorForTo : i >= __calorForTo)) break;
+                    char ch = input[i];
+                    if (ch == 'Y')
+                    {
+                        sb.Append("Y");
+                    }
+                    else
+                    {
+                        sb.Append(ch);
+                    }
 
+                }
             }
 
             Console.WriteLine("{0} {1}", new StringBuilder(), new StringBuilder());

--- a/tests/Calor.Compiler.Tests/ControlFlowTests.cs
+++ b/tests/Calor.Compiler.Tests/ControlFlowTests.cs
@@ -227,7 +227,12 @@ public class ControlFlowTests
         var result = Program.Compile(source);
 
         Assert.False(result.HasErrors);
-        Assert.Contains("for (var i = 1; i <= 10; i++)", result.GeneratedCode);
+        Assert.Contains("var __calorForFrom = 1;", result.GeneratedCode);
+        Assert.Contains("var __calorForTo = 10;", result.GeneratedCode);
+        Assert.Contains("var __calorForStep = 1;", result.GeneratedCode);
+        Assert.Contains("while (true)", result.GeneratedCode);
+        Assert.Contains("checked", result.GeneratedCode);
+        Assert.Contains("catch (OverflowException)", result.GeneratedCode);
         Assert.Contains("Console.WriteLine(i)", result.GeneratedCode);
     }
 
@@ -428,8 +433,9 @@ public class ControlFlowTests
         var result = Program.Compile(source);
 
         Assert.False(result.HasErrors, string.Join("\n", result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).Select(d => d.Message)));
-        // Should generate for loop with (n - 1) as the upper bound
-        Assert.Contains("for (var i = 0; i <= n - 1; i++)", result.GeneratedCode);
+        Assert.Contains("var __calorForFrom = 0;", result.GeneratedCode);
+        Assert.Contains("var __calorForTo = n - 1;", result.GeneratedCode);
+        Assert.Contains("var __calorForStep = 1;", result.GeneratedCode);
     }
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/StructuralControlFlowTests.cs
+++ b/tests/Calor.Compiler.Tests/StructuralControlFlowTests.cs
@@ -1,0 +1,1395 @@
+using System.Reflection;
+using Calor.Compiler.Analysis;
+using Calor.Compiler.Ast;
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Migration;
+using Calor.Compiler.Parsing;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+public class StructuralControlFlowTests
+{
+    private static readonly TextSpan Span = TextSpan.Empty;
+
+    [Fact]
+    public void BlockBodiedLambda_ContainsEveryStructuralBlockStatement()
+    {
+        foreach (var sample in BlockStatementSamples())
+        {
+            var lambda = new LambdaExpressionNode(
+                Span,
+                $"lambda_{sample.Statement.GetType().Name}",
+                Array.Empty<LambdaParameterNode>(),
+                effects: null,
+                isAsync: false,
+                expressionBody: null,
+                statementBody: [sample.Statement],
+                new AttributeCollection());
+
+            var emitted = lambda.Accept(new CSharpEmitter());
+
+            Assert.StartsWith("() => {", emitted, StringComparison.Ordinal);
+            Assert.Contains(sample.Marker, emitted, StringComparison.Ordinal);
+            Assert.EndsWith("\n}", emitted, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void BlockBodiedLambdaSamples_CoverEveryStructuralBlockStatementType()
+    {
+        var sampled = BlockStatementSamples()
+            .Select(sample => sample.Statement.GetType())
+            .OrderBy(type => type.FullName, StringComparer.Ordinal)
+            .ToArray();
+        var discovered = typeof(StatementNode).Assembly.GetTypes()
+            .Where(type =>
+                !type.IsAbstract
+                && typeof(StatementNode).IsAssignableFrom(type)
+                && HasStatementBody(type, new HashSet<Type>()))
+            .OrderBy(type => type.FullName, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(discovered, sampled);
+    }
+
+    [Fact]
+    public void CSharpEmitter_UsesExplicitEmissionContextInsteadOfGlobalWriter()
+    {
+        var emitterType = typeof(CSharpEmitter);
+        Assert.DoesNotContain(
+            emitterType.GetFields(BindingFlags.Instance | BindingFlags.NonPublic),
+            field => field.FieldType == typeof(System.Text.StringBuilder));
+
+        var contextType = emitterType.GetNestedType(
+            "EmissionContext",
+            BindingFlags.NonPublic);
+        Assert.NotNull(contextType);
+        Assert.Contains(
+            emitterType.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic),
+            method =>
+                method.Name == "EmitStatement"
+                && method.GetParameters().Any(parameter =>
+                    parameter.ParameterType == contextType));
+    }
+
+    [Fact]
+    public void GuardedMatchStatement_UsesGuardForRuntimeSelection()
+    {
+        var assembly = Compile(
+            """
+            §M{m001:GuardedMatch}
+              §F{f001:Classify:pub} (i32 value) -> str
+                §W{m001} value
+                  §K §VAR{n} §WHEN (> n INT:10)
+                    §R STR:"large"
+                  §K §VAR{n} §WHEN (> n INT:0)
+                    §R STR:"positive"
+                  §K _
+                    §R STR:"other"
+            """,
+            out var generated);
+
+        Assert.Contains("case var n when", generated, StringComparison.Ordinal);
+        Assert.Contains("n > 10", generated, StringComparison.Ordinal);
+        Assert.Equal(
+            "large",
+            InvokeStatic(assembly, "GuardedMatchModule", "Classify", 20));
+        Assert.Equal(
+            "positive",
+            InvokeStatic(assembly, "GuardedMatchModule", "Classify", 5));
+        Assert.Equal(
+            "other",
+            InvokeStatic(assembly, "GuardedMatchModule", "Classify", -1));
+    }
+
+    [Fact]
+    public void ForLoops_HandleDynamicDirectionsExpressionsZeroAndExactOnceBounds()
+    {
+        var assembly = Compile(
+            """
+            §M{m001:StructuralLoops}
+              §F{f001:Encode:pub} (i32 from, i32 to, i32 step) -> i32
+                §B{~value:i32} INT:0
+                §L{l001:i:from:to:step}
+                  §B{~value:i32} (+ (* value INT:10) i)
+                §R value
+
+              §F{f002:ExpressionStep:pub} () -> i32
+                §B{one:i32} INT:1
+                §B{~value:i32} INT:0
+                §L{l002:i:1:5:(+ one one)}
+                  §B{~value:i32} (+ (* value INT:10) i)
+                §R value
+
+              §F{f003:ExactOnce:pub} () -> i32
+                §B{~fromCalls:i32} INT:0
+                §B{~toCalls:i32} INT:0
+                §B{~stepCalls:i32} INT:0
+                §B{~value:i32} INT:0
+                §L{l003:i:(pre-inc fromCalls):(+ (pre-inc toCalls) INT:2):(pre-inc stepCalls)}
+                  §B{~value:i32} (+ (* value INT:10) i)
+                §R (+ (* value INT:1000) (+ (* fromCalls INT:100) (+ (* toCalls INT:10) stepCalls)))
+
+              §F{f004:Collision:pub} () -> i32
+                §B{__calorForFrom:i32} INT:7
+                §B{~value:i32} INT:0
+                §L{l004:i:1:1:1}
+                  §B{~value:i32} (+ value i)
+                §R (+ value __calorForFrom)
+            """,
+            out var generated);
+
+        Assert.Equal(
+            123,
+            InvokeStatic(assembly, "StructuralLoopsModule", "Encode", 1, 3, 1));
+        Assert.Equal(
+            321,
+            InvokeStatic(assembly, "StructuralLoopsModule", "Encode", 3, 1, -1));
+        Assert.Equal(
+            135,
+            InvokeStatic(assembly, "StructuralLoopsModule", "ExpressionStep"));
+        Assert.Equal(
+            123111,
+            InvokeStatic(assembly, "StructuralLoopsModule", "ExactOnce"));
+        Assert.Equal(
+            8,
+            InvokeStatic(assembly, "StructuralLoopsModule", "Collision"));
+        Assert.Contains(
+            "int __calorForFrom = 7;",
+            generated,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "var __calorForFrom =",
+            generated,
+            StringComparison.Ordinal);
+
+        var exception = Assert.Throws<TargetInvocationException>(() =>
+            InvokeStatic(
+                assembly,
+                "StructuralLoopsModule",
+                "Encode",
+                1,
+                3,
+                0));
+        Assert.IsType<ArgumentOutOfRangeException>(exception.InnerException);
+    }
+
+    [Fact]
+    public void IntegralLoops_TerminateAtExtremaForEveryIntegralType()
+    {
+        var functions = new[]
+        {
+            "i8", "u8", "i16", "u16", "i32", "u32", "i64", "u64"
+        }.Select(CreateCountingLoopFunction).ToArray();
+        var module = new ModuleNode(
+            Span,
+            "integral-extrema",
+            "IntegralExtrema",
+            Array.Empty<UsingDirectiveNode>(),
+            functions,
+            new AttributeCollection());
+        var assembly = CompileGenerated(new CSharpEmitter().Emit(module));
+
+        AssertSignedExtrema<sbyte>(
+            assembly,
+            "Count_i8",
+            sbyte.MinValue,
+            sbyte.MaxValue);
+        AssertUnsignedExtrema<byte>(
+            assembly,
+            "Count_u8",
+            byte.MaxValue);
+        AssertSignedExtrema<short>(
+            assembly,
+            "Count_i16",
+            short.MinValue,
+            short.MaxValue);
+        AssertUnsignedExtrema<ushort>(
+            assembly,
+            "Count_u16",
+            ushort.MaxValue);
+        AssertSignedExtrema<int>(
+            assembly,
+            "Count_i32",
+            int.MinValue,
+            int.MaxValue);
+        AssertUnsignedExtrema<uint>(
+            assembly,
+            "Count_u32",
+            uint.MaxValue);
+        AssertSignedExtrema<long>(
+            assembly,
+            "Count_i64",
+            long.MinValue,
+            long.MaxValue);
+        AssertUnsignedExtrema<ulong>(
+            assembly,
+            "Count_u64",
+            ulong.MaxValue);
+    }
+
+    [Fact]
+    public void OmittedSteps_PreserveIntegralTypeAndExactDynamicSequence()
+    {
+        var functions = new[]
+        {
+            "i8", "u8", "i16", "u16", "i32", "u32", "i64", "u64"
+        }.Select(CreateOmittedStepSequenceFunction).ToArray();
+        var module = new ModuleNode(
+            Span,
+            "omitted-step",
+            "OmittedStep",
+            Array.Empty<UsingDirectiveNode>(),
+            functions,
+            new AttributeCollection());
+        var generated = new CSharpEmitter().Emit(module);
+        var assembly = CompileGenerated(generated);
+
+        AssertOmittedSequence<sbyte>(
+            assembly,
+            "Sequence_i8",
+            (sbyte)125,
+            sbyte.MaxValue);
+        AssertOmittedSequence<byte>(
+            assembly,
+            "Sequence_u8",
+            (byte)253,
+            byte.MaxValue);
+        AssertOmittedSequence<short>(
+            assembly,
+            "Sequence_i16",
+            (short)(short.MaxValue - 2),
+            short.MaxValue);
+        AssertOmittedSequence<ushort>(
+            assembly,
+            "Sequence_u16",
+            (ushort)(ushort.MaxValue - 2),
+            ushort.MaxValue);
+        AssertOmittedSequence<int>(
+            assembly,
+            "Sequence_i32",
+            int.MaxValue - 2,
+            int.MaxValue);
+        AssertOmittedSequence<uint>(
+            assembly,
+            "Sequence_u32",
+            uint.MaxValue - 2,
+            uint.MaxValue);
+        AssertOmittedSequence<long>(
+            assembly,
+            "Sequence_i64",
+            long.MaxValue - 2,
+            long.MaxValue);
+        AssertOmittedSequence<ulong>(
+            assembly,
+            "Sequence_u64",
+            ulong.MaxValue - 2,
+            ulong.MaxValue);
+
+        Assert.DoesNotContain("__calorForStep", generated, StringComparison.Ordinal);
+        Assert.DoesNotContain("+=", generated, StringComparison.Ordinal);
+        Assert.Contains("value++;", generated, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RawCSharpIdentifiers_CannotCollideWithGeneratedLoopState()
+    {
+        var assembly = Compile(
+            """
+            §M{m001:RawLoopCollision}
+              §F{f001:Run:pub} () -> i32
+                §B{~result:i32} INT:0
+                §RAW
+                int __calorForFrom = 10;
+                int __calorForTo = 20;
+                int __calorForStep = 30;
+                int __calorForAscending = 40;
+                int __calorForFirst = 50;
+                goto __calorForAdvance;
+                __calorForAdvance:
+                result += __calorForFrom + __calorForTo + __calorForStep
+                    + __calorForAscending + __calorForFirst;
+                §/RAW
+                §L{l001:i:1:2:1}
+                  §RAW
+                  if (i == 1) continue;
+                  §/RAW
+                  §B{~result:i32} (+ result i)
+                §R result
+            """,
+            out var generated);
+
+        Assert.Contains("var __calorForFrom_1 = 1;", generated);
+        Assert.Contains("var __calorForFirst_1 = true;", generated);
+        Assert.Contains("while (true)", generated);
+        Assert.Equal(
+            152,
+            InvokeStatic(assembly, "RawLoopCollisionModule", "Run"));
+    }
+
+    [Fact]
+    public void RawCSharpIdentifiers_AreReservedAcrossEveryPreprocessorBranch()
+    {
+        var defaultAssembly = Compile(
+            """
+            §M{m001:RawConditionalCollision}
+              §F{f001:Run:pub} () -> i32
+                §B{~result:i32} INT:0
+                §RAW
+                #if BROKEN
+                int __calorForFrom_1 = 1;
+                /* deliberately unterminated disabled fragment
+                #elif FOO
+                int __calorForFrom = 10;
+                int __calorForTo = 20;
+                __calorForFirst:
+                result += __calorForFrom + __calorForTo;
+                #elif BAR
+                int __calorForStep = 20;
+                result += __calorForStep;
+                #else
+                int __calorForAscending = 30;
+                #if NESTED
+                int __calorForFirst_1 = 40;
+                result += __calorForAscending + __calorForFirst_1;
+                #else
+                int __calorForFirst_1 = 50;
+                result += __calorForAscending + __calorForFirst_1;
+                #endif
+                #endif
+                // __calorForFrom_2 and keywords class while are lexical noise.
+                string lexicalNoise = "__calorForTo_1 __calorForStep_1";
+                _ = lexicalNoise;
+                §/RAW
+                §L{l001:i:1:2:1}
+                  §B{~result:i32} (+ result i)
+                §R result
+            """,
+            out var generated);
+
+        Assert.Contains("var __calorForFrom_2 = 1;", generated);
+        Assert.Contains("var __calorForTo_1 = 2;", generated);
+        Assert.Contains("var __calorForStep_1 = 1;", generated);
+        Assert.Contains("var __calorForAscending_1 =", generated);
+        Assert.Contains("var __calorForFirst_2 = true;", generated);
+        Assert.Equal(
+            83,
+            InvokeStatic(
+                defaultAssembly,
+                "RawConditionalCollisionModule",
+                "Run"));
+
+        var fooAssembly = CompileGenerated(generated, "FOO");
+        Assert.Equal(
+            33,
+            InvokeStatic(
+                fooAssembly,
+                "RawConditionalCollisionModule",
+                "Run"));
+
+        var barAssembly = CompileGenerated(generated, "BAR");
+        Assert.Equal(
+            23,
+            InvokeStatic(
+                barAssembly,
+                "RawConditionalCollisionModule",
+                "Run"));
+    }
+
+    [Fact]
+    public void YieldDetection_IsStructuralAcrossLegalContainers()
+    {
+        foreach (var statement in new StatementNode[]
+                 {
+                     MatchWith(YieldValue()),
+                     new UsingStatementNode(
+                         Span,
+                         "resource",
+                         "IDisposable",
+                         new ReferenceNode(Span, "source"),
+                         [YieldValue()]),
+                     new SyncBlockNode(
+                         Span,
+                         "sync",
+                         new ReferenceNode(Span, "gate"),
+                         [YieldValue()]),
+                 })
+        {
+            var (function, diagnostics) = ValidateFunctionBody(statement);
+
+            Assert.Equal(ReturnShape.Kind.Iterator, ReturnShape.Classify(function));
+            Assert.DoesNotContain(
+                diagnostics,
+                diagnostic => diagnostic.Code == DiagnosticCode.IllegalYield);
+        }
+    }
+
+    [Fact]
+    public void YieldAcrossMatchUsingAndSync_CompilesAndRuns()
+    {
+        var function = new FunctionNode(
+            Span,
+            "values",
+            "Values",
+            Visibility.Public,
+            [
+                new ParameterNode(
+                    Span,
+                    "source",
+                    "IDisposable",
+                    new AttributeCollection()),
+                new ParameterNode(
+                    Span,
+                    "gate",
+                    "object",
+                    new AttributeCollection())
+            ],
+            new OutputNode(Span, "i32"),
+            effects: null,
+            body:
+            [
+                new UsingStatementNode(
+                    Span,
+                    "resource",
+                    "IDisposable",
+                    new ReferenceNode(Span, "source"),
+                    [new YieldReturnStatementNode(Span, Int(1))]),
+                new SyncBlockNode(
+                    Span,
+                    "sync",
+                    new ReferenceNode(Span, "gate"),
+                    [new YieldReturnStatementNode(Span, Int(2))]),
+                MatchWith(new YieldReturnStatementNode(Span, Int(3)))
+            ],
+            new AttributeCollection());
+        var module = new ModuleNode(
+            Span,
+            "module",
+            "YieldContainers",
+            Array.Empty<UsingDirectiveNode>(),
+            [function],
+            new AttributeCollection());
+        var validation = new DiagnosticBag();
+        new ReturnValidationPass(validation).Check(module);
+        Assert.False(
+            validation.HasErrors,
+            string.Join(Environment.NewLine, validation.Errors));
+
+        var generated = new CSharpEmitter().Emit(module);
+        var assembly = CompileGenerated(generated);
+        using var source = new MemoryStream();
+        var values = Assert.IsAssignableFrom<IEnumerable<int>>(
+                InvokeStatic(
+                    assembly,
+                    "YieldContainersModule",
+                    "Values",
+                    source,
+                    new object()))
+            .ToArray();
+
+        Assert.Equal(new[] { 1, 2, 3 }, values);
+    }
+
+    [Fact]
+    public void IllegalYieldLocations_AreDiagnosedExhaustively()
+    {
+        foreach (var statement in new StatementNode[]
+                 {
+                     new UnsafeBlockNode(Span, "unsafe", [YieldValue()]),
+                     new FixedStatementNode(
+                         Span,
+                         "fixed",
+                         "pointer",
+                         "i32*",
+                         new ReferenceNode(Span, "source"),
+                         [YieldValue()]),
+                     new TryStatementNode(
+                         Span,
+                         "catch",
+                         Array.Empty<StatementNode>(),
+                         [
+                             new CatchClauseNode(
+                                 Span,
+                                 exceptionType: null,
+                                 variableName: null,
+                                 filter: null,
+                                 body: [YieldValue()],
+                                 new AttributeCollection())
+                         ],
+                         finallyBody: null,
+                         new AttributeCollection()),
+                     new TryStatementNode(
+                         Span,
+                         "finally",
+                         Array.Empty<StatementNode>(),
+                         Array.Empty<CatchClauseNode>(),
+                         finallyBody: [YieldValue()],
+                         new AttributeCollection()),
+                     new TryStatementNode(
+                         Span,
+                         "try-catch",
+                         [YieldValue()],
+                         [
+                             new CatchClauseNode(
+                                 Span,
+                                 exceptionType: null,
+                                 variableName: null,
+                                 filter: null,
+                                 body: Array.Empty<StatementNode>(),
+                                 new AttributeCollection())
+                         ],
+                         finallyBody: null,
+                         new AttributeCollection()),
+                 })
+        {
+            var (_, diagnostics) = ValidateFunctionBody(statement);
+            Assert.Contains(
+                diagnostics,
+                diagnostic => diagnostic.Code == DiagnosticCode.IllegalYield);
+        }
+    }
+
+    [Fact]
+    public void PropertyAndIndexerYields_FailClosedForScalarAndEnumerableTypes()
+    {
+        var properties = new[]
+        {
+            PropertyWithYield("Scalar", "i32"),
+            PropertyWithYield("Enumerable", "IEnumerable<i32>"),
+        };
+        var indexers = new[]
+        {
+            IndexerWithYield("i32"),
+            IndexerWithYield("IEnumerable<i32>"),
+        };
+        var type = new ClassDefinitionNode(
+            Span,
+            "accessors",
+            "AccessorYields",
+            isAbstract: false,
+            isSealed: false,
+            isPartial: false,
+            isStatic: false,
+            baseClass: null,
+            implementedInterfaces: Array.Empty<string>(),
+            typeParameters: Array.Empty<TypeParameterNode>(),
+            fields: Array.Empty<ClassFieldNode>(),
+            properties,
+            constructors: Array.Empty<ConstructorNode>(),
+            methods: Array.Empty<MethodNode>(),
+            events: Array.Empty<EventDefinitionNode>(),
+            operatorOverloads: Array.Empty<OperatorOverloadNode>(),
+            new AttributeCollection(),
+            csharpAttributes: Array.Empty<CalorAttributeNode>(),
+            indexers: indexers);
+        var module = new ModuleNode(
+            Span,
+            "module",
+            "AccessorYields",
+            Array.Empty<UsingDirectiveNode>(),
+            Array.Empty<InterfaceDefinitionNode>(),
+            [type],
+            Array.Empty<FunctionNode>(),
+            new AttributeCollection());
+        var diagnostics = new DiagnosticBag();
+
+        new ReturnValidationPass(diagnostics).Check(module);
+
+        var yieldErrors = diagnostics
+            .Where(diagnostic => diagnostic.Code == DiagnosticCode.IllegalYield)
+            .ToArray();
+        Assert.Equal(4, yieldErrors.Length);
+        Assert.All(
+            yieldErrors,
+            diagnostic => Assert.Contains(
+                "property/indexer accessor",
+                diagnostic.Message,
+                StringComparison.Ordinal));
+        Assert.True(diagnostics.HasErrors);
+    }
+
+    [Fact]
+    public void NestedLambdaYield_IsIllegalAndDoesNotClassifyOuterFunctionAsIterator()
+    {
+        var lambda = new LambdaExpressionNode(
+            Span,
+            "nested",
+            Array.Empty<LambdaParameterNode>(),
+            effects: null,
+            isAsync: false,
+            expressionBody: null,
+            statementBody: [YieldValue()],
+            new AttributeCollection());
+        var bind = new BindStatementNode(
+            Span,
+            "nested",
+            typeName: null,
+            isMutable: false,
+            lambda,
+            new AttributeCollection());
+        var (function, diagnostics) = ValidateFunctionBody(
+            bind,
+            [
+                new ParameterNode(
+                    Span,
+                    "value",
+                    "i32",
+                    Calor.Compiler.Ast.ParameterModifier.Ref,
+                    new AttributeCollection(),
+                    Array.Empty<CalorAttributeNode>())
+            ]);
+
+        Assert.Equal(ReturnShape.Kind.Void, ReturnShape.Classify(function));
+        Assert.Contains(
+            diagnostics,
+            diagnostic => diagnostic.Code == DiagnosticCode.IllegalYield);
+        Assert.DoesNotContain(
+            diagnostics,
+            diagnostic =>
+                diagnostic.Code == DiagnosticCode.IllegalYield
+                && diagnostic.Message.Contains(
+                    "Iterator function 'Values' cannot declare parameter",
+                    StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("in")]
+    [InlineData("out")]
+    public void CalorIterator_RejectsByReferenceParameters(string modifier)
+    {
+        var result = Program.Compile(
+            $$"""
+            §M{m001:IteratorParameters}
+              §F{f001:Values:pub}
+                §I{i32:value:{{modifier}}}
+                §O{i32}
+                §YIELD value
+            """);
+
+        Assert.Contains(
+            result.Diagnostics,
+            diagnostic =>
+                diagnostic.Code == DiagnosticCode.IllegalYield
+                && diagnostic.Message.Contains(
+                    $"modifier '{modifier}'",
+                    StringComparison.Ordinal));
+        Assert.Empty(result.GeneratedCode);
+    }
+
+    [Fact]
+    public void CalorIterator_AcceptsOrdinaryValueParameter()
+    {
+        var result = Program.Compile(
+            """
+            §M{m001:IteratorParameters}
+              §F{f001:Values:pub}
+                §I{i32:value}
+                §O{i32}
+                §YIELD value
+            """);
+
+        Assert.False(
+            result.HasErrors,
+            string.Join(Environment.NewLine, result.Diagnostics.Errors));
+        Assert.Contains("IEnumerable<int>", result.GeneratedCode);
+    }
+
+    [Fact]
+    public void AsyncAndStaticGenericIterators_StillRejectRefParameters()
+    {
+        foreach (var source in new[]
+                 {
+                     """
+                     §M{m001:AsyncIteratorParameters}
+                       §AF{f001:Values:pub}
+                         §I{i32:value:ref}
+                         §O{i32}
+                         §YIELD value
+                     """,
+                     """
+                     §M{m001:GenericIteratorParameters}
+                       §CL{c001:Container:pub}
+                         §MT{m001:Values:pub:stat}<T>
+                           §I{T:value:ref}
+                           §O{T}
+                           §YIELD value
+                     """
+                 })
+        {
+            var result = Program.Compile(source);
+            Assert.Contains(
+                result.Diagnostics,
+                diagnostic =>
+                    diagnostic.Code == DiagnosticCode.IllegalYield
+                    && diagnostic.Message.Contains(
+                        "modifier 'ref'",
+                        StringComparison.Ordinal));
+            Assert.Empty(result.GeneratedCode);
+        }
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("in")]
+    [InlineData("out")]
+    public void MigratedCSharpIterator_RejectsByReferenceParameters(
+        string modifier)
+    {
+        var assignment = modifier == "out" ? "value = 1;" : "";
+        var conversion = new CSharpToCalorConverter().Convert(
+            $$"""
+            using System.Collections.Generic;
+            public class IteratorParameters
+            {
+                public IEnumerable<int> Values({{modifier}} int value)
+                {
+                    {{assignment}}
+                    yield return value;
+                }
+            }
+            """);
+        Assert.False(conversion.Success);
+        Assert.Contains(
+            conversion.Issues,
+            issue => issue.Message.Contains(
+                $"modifier '{modifier}'",
+                StringComparison.Ordinal));
+        Assert.NotNull(conversion.Ast);
+        var diagnostics = new DiagnosticBag();
+
+        new ReturnValidationPass(diagnostics).Check(conversion.Ast!);
+
+        Assert.Contains(
+            diagnostics,
+            diagnostic =>
+                diagnostic.Code == DiagnosticCode.IllegalYield
+                && diagnostic.Message.Contains(
+                    $"modifier '{modifier}'",
+                    StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void MigratedStaticGenericIterator_AcceptsValueParameter()
+    {
+        var conversion = new CSharpToCalorConverter().Convert(
+            """
+            using System.Collections.Generic;
+            public static class IteratorParameters
+            {
+                public static IEnumerable<T> Values<T>(T value)
+                {
+                    yield return value;
+                }
+            }
+            """);
+        Assert.True(
+            conversion.Success,
+            string.Join(Environment.NewLine, conversion.Issues));
+        var diagnostics = new DiagnosticBag();
+
+        new ReturnValidationPass(diagnostics).Check(conversion.Ast!);
+
+        Assert.DoesNotContain(
+            diagnostics,
+            diagnostic => diagnostic.Code == DiagnosticCode.IllegalYield);
+    }
+
+    [Fact]
+    public void MigratedLocalIterator_DoesNotPoisonOuterRefParameter()
+    {
+        var conversion = new CSharpToCalorConverter().Convert(
+            """
+            using System.Collections.Generic;
+            public class IteratorParameters
+            {
+                public void Outer(ref int value)
+                {
+                    int copy = value;
+                    IEnumerable<int> Local()
+                    {
+                        yield return copy;
+                    }
+                }
+            }
+            """);
+        Assert.True(
+            conversion.Success,
+            string.Join(Environment.NewLine, conversion.Issues));
+        var diagnostics = new DiagnosticBag();
+
+        new ReturnValidationPass(diagnostics).Check(conversion.Ast!);
+
+        Assert.DoesNotContain(
+            diagnostics,
+            diagnostic =>
+                diagnostic.Code == DiagnosticCode.IllegalYield
+                && diagnostic.Message.Contains(
+                    "Outer",
+                    StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void MigratedLocalIterator_RejectsItsOwnRefParameter()
+    {
+        var conversion = new CSharpToCalorConverter().Convert(
+            """
+            using System.Collections.Generic;
+            public class IteratorParameters
+            {
+                public void Outer()
+                {
+                    IEnumerable<int> Local(ref int value)
+                    {
+                        yield return value;
+                    }
+                }
+            }
+            """);
+        Assert.False(conversion.Success);
+        Assert.Contains(
+            conversion.Issues,
+            issue => issue.Message.Contains(
+                "local function 'Local'",
+                StringComparison.Ordinal)
+                && issue.Message.Contains(
+                    "modifier 'ref'",
+                    StringComparison.Ordinal));
+        Assert.NotNull(conversion.Ast);
+        var interop = Assert.Single(
+            conversion.Ast.Classes.SelectMany(type => type.InteropBlocks));
+        Assert.Contains("Local(ref int value)", interop.CSharpCode);
+        var diagnostics = new DiagnosticBag();
+
+        new ReturnValidationPass(diagnostics).Check(conversion.Ast!);
+
+        Assert.Contains(
+            diagnostics,
+            diagnostic =>
+                diagnostic.Code == DiagnosticCode.IllegalYield
+                && diagnostic.Message.Contains(
+                    "local function 'Local'",
+                    StringComparison.Ordinal)
+                && diagnostic.Message.Contains(
+                    "modifier 'ref'",
+                    StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValuelessYield_IsRejectedAndNeverEmittedAsYieldReturn()
+    {
+        var result = Program.Compile(
+            """
+            §M{m001:ValuelessYield}
+              §F{f001:Values:pub} () -> i32
+                §YIELD
+            """);
+
+        Assert.Contains(
+            result.Diagnostics,
+            diagnostic => diagnostic.Code == DiagnosticCode.YieldRequiresValue);
+        Assert.DoesNotContain("yield return;", result.GeneratedCode, StringComparison.Ordinal);
+    }
+
+    private static IEnumerable<(StatementNode Statement, string Marker)>
+        BlockStatementSamples()
+    {
+        var leaf = Leaf();
+        yield return (
+            new ForStatementNode(
+                Span,
+                "for",
+                "i",
+                Int(0),
+                Int(0),
+                Int(1),
+                [leaf],
+                new AttributeCollection()),
+            "while (true)");
+        yield return (
+            new WhileStatementNode(
+                Span,
+                "while",
+                new BoolLiteralNode(Span, false),
+                [leaf],
+                new AttributeCollection()),
+            "while (");
+        yield return (
+            new DoWhileStatementNode(
+                Span,
+                "do",
+                [leaf],
+                new BoolLiteralNode(Span, false),
+                new AttributeCollection()),
+            "do\n");
+        yield return (
+            new IfStatementNode(
+                Span,
+                "if",
+                new BoolLiteralNode(Span, true),
+                [leaf],
+                [
+                    new ElseIfClauseNode(
+                        Span,
+                        new BoolLiteralNode(Span, false),
+                        [leaf])
+                ],
+                [leaf],
+                new AttributeCollection()),
+            "if (");
+        yield return (MatchWith(leaf), "switch (");
+        yield return (
+            new ForeachStatementNode(
+                Span,
+                "each",
+                "item",
+                "i32",
+                new ReferenceNode(Span, "items"),
+                [leaf],
+                new AttributeCollection()),
+            "foreach (");
+        yield return (
+            new DictionaryForeachNode(
+                Span,
+                "eachkv",
+                "key",
+                "value",
+                new ReferenceNode(Span, "items"),
+                [leaf],
+                new AttributeCollection()),
+            "foreach (");
+        yield return (
+            new UsingStatementNode(
+                Span,
+                "resource",
+                "IDisposable",
+                new ReferenceNode(Span, "source"),
+                [leaf]),
+            "using (");
+        yield return (
+            new TryStatementNode(
+                Span,
+                "try",
+                [leaf],
+                [
+                    new CatchClauseNode(
+                        Span,
+                        exceptionType: null,
+                        variableName: null,
+                        filter: null,
+                        body: [leaf],
+                        new AttributeCollection())
+                ],
+                finallyBody: [leaf],
+                new AttributeCollection()),
+            "try");
+        yield return (
+            new PreprocessorDirectiveNode(Span, "TEST", [leaf], [leaf]),
+            "#if TEST");
+        yield return (
+            new UnsafeBlockNode(Span, "unsafe", [leaf]),
+            "unsafe");
+        yield return (
+            new SyncBlockNode(
+                Span,
+                "sync",
+                new ReferenceNode(Span, "gate"),
+                [leaf]),
+            "lock (");
+        yield return (
+            new FixedStatementNode(
+                Span,
+                "fixed",
+                "pointer",
+                "i32*",
+                new ReferenceNode(Span, "source"),
+                [leaf]),
+            "fixed (");
+    }
+
+    private static bool HasStatementBody(Type type, HashSet<Type> visited)
+    {
+        if (!visited.Add(type))
+            return false;
+
+        foreach (var property in type.GetProperties(
+                     BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (property.GetIndexParameters().Length != 0)
+                continue;
+
+            var childType = GetEnumerableElementType(property.PropertyType)
+                ?? property.PropertyType;
+            if (typeof(StatementNode).IsAssignableFrom(childType))
+                return true;
+            if (typeof(AstNode).IsAssignableFrom(childType)
+                && !typeof(ExpressionNode).IsAssignableFrom(childType)
+                && HasStatementBody(childType, visited))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static Type? GetEnumerableElementType(Type type)
+    {
+        if (type == typeof(string))
+            return null;
+
+        foreach (var candidate in new[] { type }.Concat(type.GetInterfaces()))
+        {
+            if (candidate.IsGenericType
+                && candidate.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            {
+                return candidate.GetGenericArguments()[0];
+            }
+        }
+
+        return null;
+    }
+
+    private static (FunctionNode Function, DiagnosticBag Diagnostics)
+        ValidateFunctionBody(
+            StatementNode statement,
+            IReadOnlyList<ParameterNode>? parameters = null)
+    {
+        var function = new FunctionNode(
+            Span,
+            "function",
+            "Values",
+            Visibility.Public,
+            parameters ?? Array.Empty<ParameterNode>(),
+            output: null,
+            effects: null,
+            body: [statement],
+            new AttributeCollection());
+        var module = new ModuleNode(
+            Span,
+            "module",
+            "YieldValidation",
+            Array.Empty<UsingDirectiveNode>(),
+            [function],
+            new AttributeCollection());
+        var diagnostics = new DiagnosticBag();
+        new ReturnValidationPass(diagnostics).Check(module);
+        return (function, diagnostics);
+    }
+
+    private static MatchStatementNode MatchWith(StatementNode statement) =>
+        new(
+            Span,
+            "match",
+            Int(0),
+            [
+                new MatchCaseNode(
+                    Span,
+                    new WildcardPatternNode(Span),
+                    guard: null,
+                    body: [statement])
+            ],
+            new AttributeCollection());
+
+    private static YieldReturnStatementNode YieldValue() =>
+        new(Span, Int(1));
+
+    private static PrintStatementNode Leaf() =>
+        new(Span, Int(1));
+
+    private static IntLiteralNode Int(int value) =>
+        new(Span, value);
+
+    private static FunctionNode CreateCountingLoopFunction(string typeName)
+    {
+        var count = new BindStatementNode(
+            Span,
+            "count",
+            "i32",
+            isMutable: true,
+            Int(0),
+            new AttributeCollection());
+        var increment = new BindStatementNode(
+            Span,
+            "count",
+            "i32",
+            isMutable: true,
+            new BinaryOperationNode(
+                Span,
+                BinaryOperator.Add,
+                new ReferenceNode(Span, "count"),
+                Int(1)),
+            new AttributeCollection());
+        var loop = new ForStatementNode(
+            Span,
+            "loop",
+            "value",
+            new ReferenceNode(Span, "from"),
+            new ReferenceNode(Span, "to"),
+            new ReferenceNode(Span, "step"),
+            [increment],
+            new AttributeCollection());
+        return new FunctionNode(
+            Span,
+            $"count-{typeName}",
+            $"Count_{typeName}",
+            Visibility.Public,
+            [
+                new ParameterNode(
+                    Span,
+                    "from",
+                    typeName,
+                    new AttributeCollection()),
+                new ParameterNode(
+                    Span,
+                    "to",
+                    typeName,
+                    new AttributeCollection()),
+                new ParameterNode(
+                    Span,
+                    "step",
+                    typeName,
+                    new AttributeCollection()),
+            ],
+            new OutputNode(Span, "i32"),
+            effects: null,
+            body:
+            [
+                count,
+                loop,
+                new ReturnStatementNode(
+                    Span,
+                    new ReferenceNode(Span, "count"))
+            ],
+            new AttributeCollection());
+    }
+
+    private static FunctionNode CreateOmittedStepSequenceFunction(string typeName)
+    {
+        var loop = new ForStatementNode(
+            Span,
+            "loop",
+            "value",
+            new ReferenceNode(Span, "from"),
+            new ReferenceNode(Span, "to"),
+            step: null,
+            body:
+            [
+                new YieldReturnStatementNode(
+                    Span,
+                    new ReferenceNode(Span, "value"))
+            ],
+            new AttributeCollection());
+        return new FunctionNode(
+            Span,
+            $"sequence-{typeName}",
+            $"Sequence_{typeName}",
+            Visibility.Public,
+            [
+                new ParameterNode(
+                    Span,
+                    "from",
+                    typeName,
+                    new AttributeCollection()),
+                new ParameterNode(
+                    Span,
+                    "to",
+                    typeName,
+                    new AttributeCollection()),
+            ],
+            new OutputNode(Span, typeName),
+            effects: null,
+            body: [loop],
+            new AttributeCollection());
+    }
+
+    private static void AssertSignedExtrema<T>(
+        Assembly assembly,
+        string methodName,
+        T min,
+        T max)
+        where T : struct, System.Numerics.INumber<T>, System.Numerics.IMinMaxValue<T>
+    {
+        Assert.Equal(
+            2,
+            InvokeStatic(
+                assembly,
+                "IntegralExtremaModule",
+                methodName,
+                max - T.One,
+                max,
+                T.One));
+        Assert.Equal(
+            2,
+            InvokeStatic(
+                assembly,
+                "IntegralExtremaModule",
+                methodName,
+                min + T.One,
+                min,
+                -T.One));
+        Assert.Equal(
+            2,
+            InvokeStatic(
+                assembly,
+                "IntegralExtremaModule",
+                methodName,
+                T.Zero,
+                max,
+                max));
+        Assert.Equal(
+            2,
+            InvokeStatic(
+                assembly,
+                "IntegralExtremaModule",
+                methodName,
+                T.Zero,
+                min,
+                min));
+    }
+
+    private static void AssertUnsignedExtrema<T>(
+        Assembly assembly,
+        string methodName,
+        T max)
+        where T : struct, System.Numerics.INumber<T>
+    {
+        Assert.Equal(
+            2,
+            InvokeStatic(
+                assembly,
+                "IntegralExtremaModule",
+                methodName,
+                max - T.One,
+                max,
+                T.One));
+        Assert.Equal(
+            2,
+            InvokeStatic(
+                assembly,
+                "IntegralExtremaModule",
+                methodName,
+                T.Zero,
+                max,
+                max));
+    }
+
+    private static void AssertOmittedSequence<T>(
+        Assembly assembly,
+        string methodName,
+        T from,
+        T to)
+        where T : struct, System.Numerics.INumber<T>
+    {
+        var actual = Assert.IsAssignableFrom<IEnumerable<T>>(
+                InvokeStatic(
+                    assembly,
+                    "OmittedStepModule",
+                    methodName,
+                    from,
+                    to))
+            .ToArray();
+        Assert.Equal(
+            new[] { from, from + T.One, to },
+            actual);
+    }
+
+    private static PropertyNode PropertyWithYield(
+        string name,
+        string typeName) =>
+        new(
+            Span,
+            $"property-{name}",
+            name,
+            typeName,
+            Visibility.Public,
+            new PropertyAccessorNode(
+                Span,
+                PropertyAccessorNode.AccessorKind.Get,
+                visibility: null,
+                Array.Empty<RequiresNode>(),
+                [YieldValue()],
+                new AttributeCollection()),
+            setter: null,
+            initer: null,
+            defaultValue: null,
+            new AttributeCollection());
+
+    private static IndexerNode IndexerWithYield(string typeName) =>
+        new(
+            Span,
+            $"indexer-{typeName}",
+            typeName,
+            Visibility.Public,
+            MethodModifiers.None,
+            [
+                new ParameterNode(
+                    Span,
+                    "index",
+                    "i32",
+                    new AttributeCollection())
+            ],
+            new PropertyAccessorNode(
+                Span,
+                PropertyAccessorNode.AccessorKind.Get,
+                visibility: null,
+                Array.Empty<RequiresNode>(),
+                [YieldValue()],
+                new AttributeCollection()),
+            setter: null,
+            initer: null,
+            new AttributeCollection(),
+            Array.Empty<CalorAttributeNode>());
+
+    private static Assembly Compile(string source, out string generatedCode)
+    {
+        var result = Program.Compile(
+            source,
+            "structural-control-flow.calr",
+            new CompilationOptions
+            {
+                EnableTypeChecking = false,
+                EnforceEffects = false,
+            });
+        Assert.False(
+            result.HasErrors,
+            string.Join(Environment.NewLine, result.Diagnostics.Errors));
+        generatedCode = result.GeneratedCode;
+
+        return CompileGenerated(generatedCode);
+    }
+
+    private static Assembly CompileGenerated(
+        string generatedCode,
+        params string[] preprocessorSymbols)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            GeneratedCSharpCompiler.GlobalUsingsPreamble + generatedCode,
+            CSharpParseOptions.Default.WithPreprocessorSymbols(
+                preprocessorSymbols));
+        var compilation = CSharpCompilation.Create(
+            $"StructuralControlFlow_{Guid.NewGuid():N}",
+            [syntaxTree],
+            GeneratedCSharpCompiler.References,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var stream = new MemoryStream();
+        var emit = compilation.Emit(stream);
+        Assert.True(
+            emit.Success,
+            string.Join(Environment.NewLine, emit.Diagnostics));
+        return Assembly.Load(stream.ToArray());
+    }
+
+    private static object? InvokeStatic(
+        Assembly assembly,
+        string typeName,
+        string methodName,
+        params object?[] arguments) =>
+        Assert.Single(assembly.GetTypes(), type => type.Name == typeName)
+            .GetMethod(methodName)!
+            .Invoke(null, arguments);
+}

--- a/tests/Calor.Compiler.Tests/StructuralIdOptionalTests.cs
+++ b/tests/Calor.Compiler.Tests/StructuralIdOptionalTests.cs
@@ -78,6 +78,7 @@ public class StructuralIdOptionalTests
         var loop = Assert.Single(fn.Body.OfType<ForStatementNode>());
         Assert.Equal("i", loop.VariableName);
         Assert.Contains("_auto", loop.Id);
+        Assert.Null(loop.Step);
     }
 
     [Fact]
@@ -100,6 +101,7 @@ public class StructuralIdOptionalTests
         var loop = Assert.Single(fn.Body.OfType<ForStatementNode>());
         Assert.Equal("l001", loop.Id);
         Assert.Equal("i", loop.VariableName);
+        Assert.Null(loop.Step);
     }
 
     [Theory]

--- a/tests/Calor.Compiler.Tests/YieldReturnTests.cs
+++ b/tests/Calor.Compiler.Tests/YieldReturnTests.cs
@@ -133,15 +133,15 @@ public class YieldReturnTests
     }
 
     [Fact]
-    public void CSharpEmitter_YieldReturnNoExpression_EmitsCorrectly()
+    public void CSharpEmitter_YieldReturnNoExpression_RejectsInvalidAst()
     {
         var span = new TextSpan(0, 0, 0, 0);
         var node = new YieldReturnStatementNode(span, null);
 
         var emitter = new CSharpEmitter();
-        var output = node.Accept(emitter);
-
-        Assert.Equal("yield return;", output);
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => node.Accept(emitter));
+        Assert.Contains("§YBRK", exception.Message);
     }
 
     [Fact]

--- a/tests/E2E/scenarios/02_fizzbuzz/output.g.cs
+++ b/tests/E2E/scenarios/02_fizzbuzz/output.g.cs
@@ -13,25 +13,53 @@ namespace FizzBuzz
     {
         public static void Main()
         {
-            for (var i = 1; i <= 100; i++)
             {
-                if (i % 15 == 0)
+                var __calorForFrom = 1;
+                var __calorForTo = 100;
+                var __calorForStep = 1;
+                if (__calorForStep == 0) throw new ArgumentOutOfRangeException(nameof(__calorForStep), "Calor for-loop step must not be zero");
+                var __calorForAscending = __calorForStep > 0;
+                var __calorForFirst = true;
+                var i = __calorForFrom;
+                while (true)
                 {
-                    Console.WriteLine("FizzBuzz");
-                }
-                else if (i % 3 == 0)
-                {
-                    Console.WriteLine("Fizz");
-                }
-                else if (i % 5 == 0)
-                {
-                    Console.WriteLine("Buzz");
-                }
-                else
-                {
-                    Console.WriteLine(i);
-                }
+                    if (!__calorForFirst)
+                    {
+                        try
+                        {
+                            checked
+                            {
+                                i += __calorForStep;
+                            }
+                        }
+                        catch (OverflowException)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        __calorForFirst = false;
+                    }
+                    if (!(__calorForAscending ? i <= __calorForTo : i >= __calorForTo)) break;
+                    if (i % 15 == 0)
+                    {
+                        Console.WriteLine("FizzBuzz");
+                    }
+                    else if (i % 3 == 0)
+                    {
+                        Console.WriteLine("Fizz");
+                    }
+                    else if (i % 5 == 0)
+                    {
+                        Console.WriteLine("Buzz");
+                    }
+                    else
+                    {
+                        Console.WriteLine(i);
+                    }
 
+                }
             }
 
         }

--- a/tests/E2E/scenarios/02_fizzbuzz/verify.sh
+++ b/tests/E2E/scenarios/02_fizzbuzz/verify.sh
@@ -9,7 +9,9 @@ OUTPUT_FILE="$SCENARIO_DIR/output.g.cs"
 
 # Check for expected patterns
 grep -q "namespace FizzBuzz" "$OUTPUT_FILE" || { echo "Missing namespace"; exit 1; }
-grep -q "for.*var i = 1" "$OUTPUT_FILE" || { echo "Missing for loop"; exit 1; }
+grep -q "var __calorForFrom = 1" "$OUTPUT_FILE" || { echo "Missing evaluated loop start"; exit 1; }
+grep -q "while (true)" "$OUTPUT_FILE" || { echo "Missing overflow-safe loop"; exit 1; }
+grep -q "catch (OverflowException)" "$OUTPUT_FILE" || { echo "Missing overflow termination"; exit 1; }
 grep -q "i % 15" "$OUTPUT_FILE" || { echo "Missing modulo 15 check"; exit 1; }
 grep -q "i % 3" "$OUTPUT_FILE" || { echo "Missing modulo 3 check"; exit 1; }
 grep -q "i % 5" "$OUTPUT_FILE" || { echo "Missing modulo 5 check"; exit 1; }

--- a/tests/E2E/scenarios/05_skill_syntax/output.g.cs
+++ b/tests/E2E/scenarios/05_skill_syntax/output.g.cs
@@ -58,9 +58,37 @@ namespace SkillSyntax
         private static void TestControlFlow()
         {
             Console.WriteLine("Testing control flow...");
-            for (var i = 1; i <= 5; i++)
             {
-                Console.WriteLine(i);
+                var __calorForFrom = 1;
+                var __calorForTo = 5;
+                var __calorForStep = 1;
+                if (__calorForStep == 0) throw new ArgumentOutOfRangeException(nameof(__calorForStep), "Calor for-loop step must not be zero");
+                var __calorForAscending = __calorForStep > 0;
+                var __calorForFirst = true;
+                var i = __calorForFrom;
+                while (true)
+                {
+                    if (!__calorForFirst)
+                    {
+                        try
+                        {
+                            checked
+                            {
+                                i += __calorForStep;
+                            }
+                        }
+                        catch (OverflowException)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        __calorForFirst = false;
+                    }
+                    if (!(__calorForAscending ? i <= __calorForTo : i >= __calorForTo)) break;
+                    Console.WriteLine(i);
+                }
             }
 
         }

--- a/tests/E2E/scenarios/05_skill_syntax/verify.sh
+++ b/tests/E2E/scenarios/05_skill_syntax/verify.sh
@@ -27,6 +27,8 @@ grep -q "x > 0" "$OUTPUT_FILE" || { echo "Missing greater-than comparison"; exit
 grep -q "x == 0" "$OUTPUT_FILE" || { echo "Missing equality comparison"; exit 1; }
 
 # Check control flow
-grep -q "for.*var i = 1" "$OUTPUT_FILE" || { echo "Missing for loop"; exit 1; }
+grep -q "var __calorForFrom = 1" "$OUTPUT_FILE" || { echo "Missing evaluated loop start"; exit 1; }
+grep -q "while (true)" "$OUTPUT_FILE" || { echo "Missing overflow-safe loop"; exit 1; }
+grep -q "catch (OverflowException)" "$OUTPUT_FILE" || { echo "Missing overflow termination"; exit 1; }
 
 exit 0

--- a/tests/E2E/scenarios/09_codegen_bugfixes/output.g.cs
+++ b/tests/E2E/scenarios/09_codegen_bugfixes/output.g.cs
@@ -33,18 +33,46 @@ namespace Transliterator
             char[] buf = new char[256];
             var sb = new StringBuilder();
             ConsoleKeyInfo keyPressed = Console.ReadKey();
-            for (var i = 0; i <= input.Length; i++)
             {
-                char ch = input[i];
-                if (ch == 'Y')
+                var __calorForFrom = 0;
+                var __calorForTo = input.Length;
+                var __calorForStep = 1;
+                if (__calorForStep == 0) throw new ArgumentOutOfRangeException(nameof(__calorForStep), "Calor for-loop step must not be zero");
+                var __calorForAscending = __calorForStep > 0;
+                var __calorForFirst = true;
+                var i = __calorForFrom;
+                while (true)
                 {
-                    sb.Append("Y");
-                }
-                else
-                {
-                    sb.Append(ch);
-                }
+                    if (!__calorForFirst)
+                    {
+                        try
+                        {
+                            checked
+                            {
+                                i += __calorForStep;
+                            }
+                        }
+                        catch (OverflowException)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        __calorForFirst = false;
+                    }
+                    if (!(__calorForAscending ? i <= __calorForTo : i >= __calorForTo)) break;
+                    char ch = input[i];
+                    if (ch == 'Y')
+                    {
+                        sb.Append("Y");
+                    }
+                    else
+                    {
+                        sb.Append(ch);
+                    }
 
+                }
             }
 
             Console.WriteLine("{0} {1}", new StringBuilder(), new StringBuilder());


### PR DESCRIPTION
## Summary
- introduce isolated emission contexts and exhaustive structural statement traversal
- preserve guarded match selection and statement-lambda block structure
- lower loops with exact-once bounds, typed dynamic steps, zero checks, and overflow-safe termination
- enforce complete iterator/yield legality across nested control-flow containers
- add Roslyn compilation and runtime behavior regressions

## Validation
- 7,163 compiler tests passed, 2 skipped
- Release build: 0 warnings, 0 errors
- docs self-check clean
- all 7 mutation targets killed
- 5 adversarial remediation rounds completed; final approval obtained

Closes #763