### PR TITLE
fix(website): point the banner at the version people can actually install

### DIFF
--- a/website/content/changelog.mdx
+++ b/website/content/changelog.mdx
@@ -10,7 +10,7 @@ All notable changes to Calor, organized by release.
 
 ## [Unreleased]
 
-## [0.13.2] - 2026-08-12
+## [0.13.2] - 2026-08-12 — tagged, not yet on nuget.org
 
 Hardening release. The compiler's control-flow and dataflow foundation is rebuilt on explicit semantics, and the build and release chain becomes hermetic and supply-chain verified.
 

--- a/website/content/philosophy/tradeoffs.mdx
+++ b/website/content/philosophy/tradeoffs.mdx
@@ -45,7 +45,7 @@ This is a fundamental design choice, not a flaw to be fixed.
 | **Information Density** | 0.98x vs C# | Near parity; C# narrowly leads |
 | **Human Readability** | Unfamiliar syntax | Not the target audience |
 | **Ecosystem** | .NET interop may require manifests or preserved C# | Import, effect manifests, and interop blocks |
-| **Tooling** | Marketplace updates are opportunistic | Install the supported release VSIX, or use the CLI/LSP directly |
+| **Tooling** | No bundled editor extension | Use the CLI, or point any LSP-capable editor at `calor lsp` |
 
 ---
 

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calor-website",
-  "version": "0.13.2",
+  "version": "0.13.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -17,7 +17,7 @@ export function WhatsNewBanner() {
           <p className="text-center">
             <span className="font-semibold text-calor-cerulean">v0.13.0</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">The Trustworthy Project Model release: contracts, effects and bug patterns are checked across a whole project, and every answer says plainly when it is incomplete rather than guessing.</span>
+            <span className="text-foreground">The Trustworthy Project Model release: the binder dispatches every expression class through one authoritative path, and the verifier is pinned against real runtime execution so a proof and the running program cannot disagree.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -15,9 +15,9 @@ export function WhatsNewBanner() {
         <div className="flex items-center justify-center gap-3 text-sm">
           <Sparkles className="h-4 w-4 text-calor-cerulean flex-shrink-0" />
           <p className="text-center">
-            <span className="font-semibold text-calor-cerulean">v0.13.2</span>
+            <span className="font-semibold text-calor-cerulean">v0.13.0</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">Control flow and dataflow are rebuilt on explicit semantics, and the build chain is now hermetic and supply-chain verified: Z3 binaries are pinned by hash and size, restores are locked, and every release carries an SBOM and provenance.</span>
+            <span className="text-foreground">The Trustworthy Project Model release: contracts, effects and bug patterns are checked across a whole project, and every answer says plainly when it is incomplete rather than guessing.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"


### PR DESCRIPTION
The front page advertised **v0.13.2**, which is tagged but **not published**. `dotnet tool install calor` gets **0.13.0**.

```
flat-container:  calor -> [... 0.12.1, 0.13.0]     calor.sdk -> [0.12.1, 0.13.0]
direct nupkg:    calor.0.13.2.nupkg -> 404      calor.0.13.0.nupkg -> 200
```

The `publish` job has been **skipped in every run** — it depends on `release-quality` and `test (performance)`, which fail (#965), so it never executed and never pushed.

## Revised after adversarial review — the first version of this PR was wrong

The original change swapped the banner to `v0.13.0` with a headline I wrote. Review caught that it **replaced one false claim with a subtler one**, plus two things I had missed entirely. All four are fixed here, each verified rather than taken on trust.

**1. The banner advertised a 0.13.1 feature under the 0.13.0 label.** My headline said *"every answer says plainly when it is incomplete"* — that is `calor index` / `calor query`, which did **not** ship in 0.13.0:

```
git ls-tree v0.13.0 -- src/Calor.Compiler/Commands/   -> no IndexCommand/QueryCommand/RenameCommand
git ls-tree v0.13.1 -- src/Calor.Compiler/Commands/   -> all three present
```

Worse, *"effects checked across a whole project"* is precisely what 0.13.0 got **wrong**: qualified cross-module calls resolved as unknown external calls until #925 landed in 0.13.1. Someone installing 0.13.0 and running `calor query` gets an unknown-command error. That is harder to detect than the original bug, not better.

Replaced with two claims the 0.13.0 changelog actually supports: the binder's single authoritative expression dispatch (#762 B1), and the verifier-vs-runtime differential gate (#779 F-4).

**2. The footer would have contradicted the banner on every page.** `website/package.json` was still `0.13.2`, and `Footer.tsx` renders `v{packageJson.version}`; both the banner and footer are in the root layout. The site would have said `v0.13.0` at the top and `v0.13.2` at the bottom simultaneously. Bumped to `0.13.0`.

**3. The changelog disclosed the wrong unpublished version.** `changelog.mdx` explains that 0.13.1 was never published, while presenting `[0.13.2]` — the topmost section, the one a visitor reads first — as shipped. The heading now says `— tagged, not yet on nuget.org`. My earlier reasoning for leaving this alone was wrong: it is not rewriting history, it is stating a fact already verified twice.

**4. A live page still told visitors to install a removed VSIX.** `philosophy/tradeoffs.mdx` said *"Install the supported release VSIX"* — a channel removed in #952, which `getting-started/installation.mdx` on the same site says no longer exists. Fixed, along with the stale "Marketplace updates are opportunistic" framing beside it.

## Deploying this requires a manual dispatch

`nextjs-gh-pages.yml` triggers only on `release: [created]` and `workflow_dispatch` — there is **no** `push: main`. So merging this does not update calor.dev, and the `release` path is unavailable precisely because there is no new release. **After merge: `gh workflow run nextjs-gh-pages.yml --ref main`.**

## Known, not fixed here

- **The public v0.13.1 GitHub release** still leads with *"Persistent project index and `calor query`… now shipped"*, and every release in this repo is a pre-release so it sits at the top of the releases page. Nothing was published under 0.13.1 either. Worth drafting for the same reason v0.13.2 was — separate change.
- **`VSCodeExtension.tsx` and its analytics helper** survived #952 with a dead "Download the release VSIX" button. Verified **not imported by any page**, so no visitor sees it today — a landmine, not a live falsehood. Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)