### PR TITLE
fix(ci): stream perf-gate output for diagnostics (no mechanism claimed) (#965)

### DIFF
--- a/scripts/run_performance_gate.py
+++ b/scripts/run_performance_gate.py
@@ -58,13 +58,30 @@ def main() -> int:
             "--verbosity",
             "quiet",
         ]
-        started = time.monotonic()
-        result = subprocess.run(command, text=True, capture_output=True, check=False)
-        elapsed = time.monotonic() - started
         kind = "warmup" if index < warmups else "measured"
         log = log_dir / f"{kind}-{index + 1}.log"
-        log.write_text(result.stdout + result.stderr, encoding="utf-8")
-        if result.returncode != 0:
+
+        # Write the child's output straight to a file rather than capturing it
+        # through pipes.
+        #
+        # `capture_output=True` hands `dotnet test` a pipe that its grandchildren
+        # inherit — testhost, the MSBuild build-server nodes, VBCSCompiler.
+        # subprocess.run then waits for EOF, and EOF needs EVERY process holding
+        # the write end to exit. A build-server process outlives `dotnet test` by
+        # design, so the wrapper blocked forever after the tests had finished and
+        # the runner eventually terminated the job:
+        # "The runner has received a shutdown signal" / exit 143 (#965).
+        #
+        # It never reproduced locally, where those build-server processes are
+        # already running and shared, so nothing new was left holding the pipe.
+        # A file has no EOF dependency on the process tree.
+        started = time.monotonic()
+        with log.open("w", encoding="utf-8") as sink:
+            completed = subprocess.run(
+                command, text=True, stdout=sink, stderr=subprocess.STDOUT, check=False
+            )
+        elapsed = time.monotonic() - started
+        if completed.returncode != 0:
             print(f"ERROR: performance test run failed; see {log}")
             return 1
         trx = results_dir / "results.trx"

--- a/scripts/run_performance_gate.py
+++ b/scripts/run_performance_gate.py
@@ -61,24 +61,28 @@ def main() -> int:
         kind = "warmup" if index < warmups else "measured"
         log = log_dir / f"{kind}-{index + 1}.log"
 
-        # Write the child's output straight to a file rather than capturing it
-        # through pipes.
+        # Stream the child's output to a file rather than capturing it through
+        # pipes.
         #
-        # `capture_output=True` hands `dotnet test` a pipe that its grandchildren
-        # inherit — testhost, the MSBuild build-server nodes, VBCSCompiler.
-        # subprocess.run then waits for EOF, and EOF needs EVERY process holding
-        # the write end to exit. A build-server process outlives `dotnet test` by
-        # design, so the wrapper blocked forever after the tests had finished and
-        # the runner eventually terminated the job:
-        # "The runner has received a shutdown signal" / exit 143 (#965).
+        # NO MECHANISM IS CLAIMED HERE. Runs of this gate were terminated on
+        # 2026-08-13 with SIGTERM ("The runner has received a shutdown signal",
+        # exit 143) at widely varying elapsed times — 24s, 26s, 52s, 79s, 26m —
+        # and the same unmodified code then passed on main on 2026-08-14. Root
+        # cause is NOT established; see #965.
         #
-        # It never reproduced locally, where those build-server processes are
-        # already running and shared, so nothing new was left holding the pipe.
-        # A file has no EOF dependency on the process tree.
+        # This form is preferred on its own merits, independent of that:
+        #   * output survives the job being killed, instead of dying with the
+        #     parent's in-memory buffer — which is why the failing runs produced
+        #     no gate output at all to diagnose;
+        #   * the log is written even if subprocess.run raises, which the old
+        #     write-after-return form could not do;
+        #   * stdout and stderr are interleaved chronologically, which is what a
+        #     debugger wants. Nothing downstream reads these logs, so merging the
+        #     streams costs nothing.
         started = time.monotonic()
         with log.open("w", encoding="utf-8") as sink:
             completed = subprocess.run(
-                command, text=True, stdout=sink, stderr=subprocess.STDOUT, check=False
+                command, stdout=sink, stderr=subprocess.STDOUT, check=False
             )
         elapsed = time.monotonic() - started
         if completed.returncode != 0:


### PR DESCRIPTION
> **Revised after adversarial review, which refuted the causal claim this PR was originally built on.** The original body asserted a pipe-deadlock root cause. That was wrong. It is corrected in full below rather than quietly edited out.

## What the original PR claimed, and why it was wrong

I claimed `capture_output=True` deadlocked the runner via pipes inherited by `dotnet test`'s grandchildren. Three independent refutations:

**1. Unmodified main passed, 6.5 hours before this PR was opened.** Run `31781663089`, scheduled, `main` @ `f942c72e` — which contains `capture_output=True` at line 62 and has #938 as an ancestor — **succeeded** on 2026-08-14T07:52:

```
warmup run 1: 22.225s / measured 20.618s / 20.352s / 21.432s   median 20.618s  (max 21.000s)
```

All three probes ran at **14:08 on 08-14, with no contemporaneous control**. If main passes that day, B and C passing proves nothing. Two statements in my original body were false at the time of writing: *"the gate's entire scheduled record is one run — 2026-08-13 — which failed"* (there were two; the second passed), and the table row *"main, unmodified → crash"*, which cited the **previous day's** runs.

**2. The mechanism was self-refuting.** fd inheritance happens at spawn. If invocation 1 spawns the persistent MSBuild node, that node holds **invocation 1's** write end — so under my own story the hang must occur on run 1 or never. Probe A ran **one** invocation and did not hang. My explanation for probe A ("the nodes are spawned by the first invocation and outlive it") is precisely the thing that would make invocation 1 hang. Also, this gate passes `--no-build --no-restore`, so **no VBCSCompiler is spawned at all** — naming it was wrong.

**3. The same pattern is green everywhere else.** `scripts/run_mutation_gate.py` uses `capture_output=True` with `dotnet test` **without** `--no-build` — so it genuinely does compile and spawn build servers — and runs **before** this gate in the same `release-quality` step. It is **13/13 green**. Under my mechanism it would hang first and always.

**4. Durations rule out a wait-for-EOF hang.** `performance.yml` sets no `timeout-minutes` (360m default), yet the kills landed at **24s, 26s, 52s, 79s, and 26m**. A parent blocked on EOF would sit for six hours.

## What this PR is now

A diagnostics improvement, justified on its own merits and **claiming no root cause**:

- **Output survives the job being killed** instead of dying in the parent's in-memory buffer. This is not hypothetical: every failing run produced *no gate output at all*, which is a large part of why #965 took so long.
- **The log is written even if `subprocess.run` raises** — the old write-after-return form could not do that.
- **Streams are interleaved chronologically**, which is what a debugger wants. Nothing downstream reads these logs, so merging them costs nothing.
- `text=True` dropped — dead once stdout/stderr are file descriptors.

The in-code comment now states plainly that no mechanism is established, with the observed durations and the 08-14 green run recorded so the next person starts from the evidence rather than from my story.

## #965 stays OPEN

This does not close it and **should not be treated as unblocking the release**. A control is running now — `performance.yml` dispatched 3× on `main` and 3× on this branch, interleaved — which is the experiment I should have run before making any causal claim. Results will be posted to #965.

## Separate blocker, NOT deferrable

`eng/performance-baselines.json`'s `maximumMedian: 21.0` is too tight for CI. On main's own **passing** 08-14 run, one measured sample was **21.432s** — already over the ceiling; only the median saved it. Probe A's cold run hit 21.160s. The ratchet was calibrated from local runs (~19.8s), and the baseline's own `noisePolicy` records ~0.5s spread — larger than the remaining headroom. On the release path the gate also runs *after* a full build, five coverage-instrumented test runs and the mutation gate **in the same job**, i.e. on a hotter runner than the nightly it was measured on. I originally called this a follow-up; review is right that a single ~0.4s excursion fails the gate, so it needs its own change before the release can pass.

## Also confirmed by review — do not "fix" these

`run_mutation_gate.py` and `run_flake_gate.py` use the same `capture_output` pattern and are green. Their record is evidence the pattern is fine. `check_trx.py`, `check_coverage.py`, `verify-z3-assets.py` use no subprocess at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)