### PR TITLE
feat: preserve declaration, type, and module semantics

### DIFF
--- a/bench/phase0-agent-native/fixtures/d-s1.5/README.md
+++ b/bench/phase0-agent-native/fixtures/d-s1.5/README.md
@@ -14,7 +14,9 @@ only mergeable when a fixture demonstrates the claimed fidelity on real values.
 ```
 d-s1.5/<sanitized-key>/
   fixture.json     { "featureKey": "<exact FeatureSupport key>",
-                     "lossKindCertifiedAbsent": "<ConversionLossKind name or null>" }
+                     "lossKindCertifiedAbsent": "<ConversionLossKind name or null>",
+                     "runtimeEntryPoint": "<public static parameterless method>",
+                     "runtimeExpectedInt": <expected integer result> }
   input.cs         the C# input exercising the feature
   expected.calr    the expected converted Calor (exact match against `calor migrate` output)
   test.calr        the value-asserting test: a Calor program using the converted construct
@@ -46,14 +48,15 @@ discriminating pin, executed continuously rather than demonstrated once.
 
 ## Initial contents
 
-Empty, per the registration: frozen by location, schema, and entry point — not by content. The
-first fixtures are expected from roadmap §3.2's nullable-idiom migration work, which is blocked
-on this gate being green (roadmap §3.2 sequencing constraint).
+`conditional-using` is the first complete fixture. It certifies that
+`ConversionLossKind.InteropPreserved` is absent for the native conditional
+using/declaration path and includes an executable integer value oracle.
 
 ## Disclosed limits (decisions on record, not omissions)
 
-- **Value-assertion execution of `test.calr`** (beyond compile validation) lands with the first
-  fixture.
+- **Value assertions execute by manifest:** every `test.calr` exposes the
+  parameterless public static method named by `runtimeEntryPoint`; the registry
+  invokes it and compares its integer result with `runtimeExpectedInt`.
 - **Fixture-to-feature linkage is nominal**: nothing yet asserts `input.cs` actually exercises
   the promoted feature (a converter-ledger-touch check is the registered follow-up). Until it
   lands, a review of the fixture's content is part of reviewing the promotion PR.

--- a/bench/phase0-agent-native/fixtures/d-s1.5/conditional-using/expected.calr
+++ b/bench/phase0-agent-native/fixtures/d-s1.5/conditional-using/expected.calr
@@ -1,0 +1,17 @@
+§M{m001:Fixture}
+  §PP{FEATURE}
+    §U{Number:System.Int32}
+    §CL{c001:ConditionalValue:pub:stat}
+      §MT{m002:Get:pub:stat} () -> Number
+        §R 41
+
+
+  §PPE
+    §U{Number:System.Int32}
+    §CL{c003:ConditionalValue:pub:stat}
+      §MT{m004:Get:pub:stat} () -> Number
+        §R 42
+
+
+  §/PP{FEATURE}
+

--- a/bench/phase0-agent-native/fixtures/d-s1.5/conditional-using/fixture.json
+++ b/bench/phase0-agent-native/fixtures/d-s1.5/conditional-using/fixture.json
@@ -1,0 +1,6 @@
+{
+  "featureKey": "conditional-using",
+  "lossKindCertifiedAbsent": "InteropPreserved",
+  "runtimeEntryPoint": "Get",
+  "runtimeExpectedInt": 42
+}

--- a/bench/phase0-agent-native/fixtures/d-s1.5/conditional-using/input.cs
+++ b/bench/phase0-agent-native/fixtures/d-s1.5/conditional-using/input.cs
@@ -1,0 +1,15 @@
+#if FEATURE
+using Number = System.Int32;
+
+public static class ConditionalValue
+{
+    public static Number Get() => 41;
+}
+#else
+using Number = System.Int32;
+
+public static class ConditionalValue
+{
+    public static Number Get() => 42;
+}
+#endif

--- a/bench/phase0-agent-native/fixtures/d-s1.5/conditional-using/test.calr
+++ b/bench/phase0-agent-native/fixtures/d-s1.5/conditional-using/test.calr
@@ -1,0 +1,14 @@
+§M{m001:FixtureTest}
+  §PP{FEATURE}
+    §U{Number:System.Int32}
+    §CL{c001:ConditionalValue:pub:stat}
+      §MT{m001:Get:pub:stat} () -> Number
+        §S (== result INT:41)
+        §R INT:41
+  §PPE
+    §U{Number:System.Int32}
+    §CL{c002:ConditionalValue:pub:stat}
+      §MT{m002:Get:pub:stat} () -> Number
+        §S (== result INT:42)
+        §R INT:42
+  §/PP{FEATURE}

--- a/docs/semantics/inventory.md
+++ b/docs/semantics/inventory.md
@@ -225,10 +225,10 @@ Defined in `ExpressionNodes.cs:141-146`:
 
 ### 7.2 Using Statements
 
-| Construct | Node Type | File Reference |
-|-----------|-----------|----------------|
-| Using Directive | `UsingDirectiveNode` | `UsingDirectiveNode.cs` |
-| Using Statement | `UsingStatementNode` | `StatementNodes.cs` |
+| Construct | Node Type | Syntax | File Reference |
+|-----------|-----------|--------|----------------|
+| Using Directive | `UsingDirectiveNode` | `§U{target}`, `§U{alias:target}`, `§U{static:target}`, or global variants | `UsingDirectiveNode.cs` |
+| Using Statement | `UsingStatementNode` | `§USE ...` | `StatementNodes.cs` |
 
 ---
 

--- a/docs/syntax-reference/structure-tags.md
+++ b/docs/syntax-reference/structure-tags.md
@@ -66,10 +66,34 @@ Modules are like C# namespaces. They group related functions.
 ### Rules
 
 - `name` becomes the C# namespace
+- Each namespace segment is emitted as a valid C# identifier; keyword segments
+  are escaped independently (for example, `namespace.class` becomes
+  `@namespace.@class`)
 - The module block extends until the next line that dedents back to
   column 0 (or end of file)
 - Legacy `§/M` closers were removed in Phase 4d; an explicit closer now
   raises `Calor0830`. The module ends at the next dedent to column 0
+
+---
+
+## Using Directives
+
+Using directives retain their complete C# meaning. Exact duplicates are removed
+using the full `(target, alias, static, global)` tuple; directives that share a
+target but differ in alias or flags remain distinct.
+
+```calor
+§U{System.Collections.Generic}             // using System.Collections.Generic;
+§U{Gen:System.Collections.Generic}         // using Gen = System.Collections.Generic;
+§U{static:System.Math}                     // using static System.Math;
+§U{global:System.Text}                     // global using System.Text;
+§U{global:Gen:System.Collections.Generic}  // global using Gen = System.Collections.Generic;
+§U{global:static:System.Math}               // global using static System.Math;
+```
+
+Generated C# is standalone: namespace dependencies are registered from AST
+nodes and type references, and compilation does not require SDK implicit
+usings.
 
 ---
 
@@ -755,6 +779,16 @@ Type parameters are declared using `<T>` suffix syntax after the tag attributes.
 §MT{id:name:vis}<T>        // Generic method
 ```
 
+Variance is legal only on interface type parameters:
+
+```calor
+§IFACE{i001:IProducer}<out T>
+§IFACE{i002:IConsumer}<in T>
+```
+
+Using `in` or `out` on a class, function, or method type parameter is a
+`Calor0119` error.
+
 ### Constraints
 
 Type parameter constraints are declared using `§WHERE` clauses.
@@ -762,11 +796,21 @@ Type parameter constraints are declared using `§WHERE` clauses.
 **New syntax (recommended):**
 ```
 §WHERE T : class                    // T must be a reference type
+§WHERE T : class?                   // T may be a nullable reference type
 §WHERE T : struct                   // T must be a value type
+§WHERE T : unmanaged                // T must be unmanaged
+§WHERE T : notnull                  // T must be non-null
 §WHERE T : new()                    // T must have parameterless constructor
 §WHERE T : IComparable<T>           // T must implement interface
 §WHERE T : class, IComparable<T>    // Multiple constraints
+§WHERE T : default                  // Override or explicit-interface method only
+§WHERE T : allows ref struct        // Ref-struct anti-constraint
 ```
+
+Using `default` on an interface/class type parameter, interface method,
+ordinary class method, or module function is a `Calor0120` error. It is
+preserved only on C#-legal override methods and explicit interface
+implementations.
 
 **Legacy syntax (still supported):**
 ```

--- a/eng/test-manifest.json
+++ b/eng/test-manifest.json
@@ -5,7 +5,7 @@
       "path": "tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj",
       "workflow": ".github/workflows/test.yml",
       "releaseCritical": true,
-      "expectedTotal": 7215,
+      "expectedTotal": 7238,
       "expectedSkipped": 2
     },
     {

--- a/eng/test-manifest.json
+++ b/eng/test-manifest.json
@@ -5,7 +5,7 @@
       "path": "tests/Calor.Compiler.Tests/Calor.Compiler.Tests.csproj",
       "workflow": ".github/workflows/test.yml",
       "releaseCritical": true,
-      "expectedTotal": 7238,
+      "expectedTotal": 7239,
       "expectedSkipped": 2
     },
     {

--- a/scripts/check-d-s1.5-fixtures.sh
+++ b/scripts/check-d-s1.5-fixtures.sh
@@ -153,7 +153,10 @@ check_maps() {
 
 self_test() {
   local tmp; tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' RETURN
+  local registry_before="$REGISTRY"
+  REGISTRY="$tmp/registry"
+  mkdir -p "$REGISTRY"
+  trap 'REGISTRY="$registry_before"; rm -rf "$tmp"' RETURN
 
   cat > "$tmp/base.cs" <<'EOF'
         ["record"] = new FeatureInfo

--- a/src/Calor.Compiler/Analysis/RecursiveAstWalker.cs
+++ b/src/Calor.Compiler/Analysis/RecursiveAstWalker.cs
@@ -48,6 +48,7 @@ public static class RecursiveAstWalker
             yield break;
         }
 
+        var yielded = new HashSet<AstNode>(ReferenceEqualityComparer.Instance);
         foreach (var prop in GetChildProperties(node.GetType()))
         {
             object? value;
@@ -69,7 +70,7 @@ public static class RecursiveAstWalker
 
             if (value is AstNode single)
             {
-                if (single is not ExpressionNode)
+                if (single is not ExpressionNode && yielded.Add(single))
                 {
                     yield return single;
                 }
@@ -78,7 +79,9 @@ public static class RecursiveAstWalker
             {
                 foreach (var item in seq)
                 {
-                    if (item is AstNode child and not ExpressionNode)
+                    if (item is AstNode child
+                        && child is not ExpressionNode
+                        && yielded.Add(child))
                     {
                         yield return child;
                     }

--- a/src/Calor.Compiler/Ast/GenericNodes.cs
+++ b/src/Calor.Compiler/Ast/GenericNodes.cs
@@ -67,7 +67,15 @@ public enum TypeConstraintKind
     /// <summary>Type must be or derive from the specified type</summary>
     TypeName,
     /// <summary>Type must not be null (notnull constraint)</summary>
-    NotNull
+    NotNull,
+    /// <summary>Type must be an unmanaged value type</summary>
+    Unmanaged,
+    /// <summary>Nullable reference type constraint (<c>class?</c>)</summary>
+    ClassNullable,
+    /// <summary>Override/default constraint</summary>
+    Default,
+    /// <summary>Anti-constraint allowing ref struct type arguments</summary>
+    AllowsRefStruct
 }
 
 /// <summary>

--- a/src/Calor.Compiler/Ast/StatementNodes.cs
+++ b/src/Calor.Compiler/Ast/StatementNodes.cs
@@ -237,6 +237,8 @@ public sealed class MemberPreprocessorBlockNode : AstNode
     public IReadOnlyList<MethodNode> Methods { get; }
     public IReadOnlyList<EventDefinitionNode> Events { get; }
     public IReadOnlyList<OperatorOverloadNode> OperatorOverloads { get; }
+    public IReadOnlyList<CSharpInteropBlockNode> InteropBlocks { get; }
+    public IReadOnlyList<AstNode> Items { get; }
     public MemberPreprocessorBlockNode? ElseBranch { get; }
 
     public MemberPreprocessorBlockNode(
@@ -249,7 +251,9 @@ public sealed class MemberPreprocessorBlockNode : AstNode
         IReadOnlyList<EventDefinitionNode> events,
         IReadOnlyList<OperatorOverloadNode> operatorOverloads,
         MemberPreprocessorBlockNode? elseBranch = null,
-        IReadOnlyList<IndexerNode>? indexers = null)
+        IReadOnlyList<IndexerNode>? indexers = null,
+        IReadOnlyList<CSharpInteropBlockNode>? interopBlocks = null,
+        IReadOnlyList<AstNode>? items = null)
         : base(span)
     {
         Condition = condition ?? throw new ArgumentNullException(nameof(condition));
@@ -260,6 +264,17 @@ public sealed class MemberPreprocessorBlockNode : AstNode
         Methods = methods ?? Array.Empty<MethodNode>();
         Events = events ?? Array.Empty<EventDefinitionNode>();
         OperatorOverloads = operatorOverloads ?? Array.Empty<OperatorOverloadNode>();
+        InteropBlocks = interopBlocks ?? Array.Empty<CSharpInteropBlockNode>();
+        Items = items ?? Fields
+            .Cast<AstNode>()
+            .Concat(Properties)
+            .Concat(Indexers)
+            .Concat(Constructors)
+            .Concat(Methods)
+            .Concat(Events)
+            .Concat(OperatorOverloads)
+            .Concat(InteropBlocks)
+            .ToArray();
         ElseBranch = elseBranch;
     }
 
@@ -282,6 +297,9 @@ public sealed class TypePreprocessorBlockNode : AstNode
     public IReadOnlyList<InterfaceDefinitionNode> Interfaces { get; }
     public IReadOnlyList<EnumDefinitionNode> Enums { get; }
     public IReadOnlyList<DelegateDefinitionNode> Delegates { get; }
+    public IReadOnlyList<CSharpInteropBlockNode> InteropBlocks { get; }
+    public IReadOnlyList<TypePreprocessorBlockNode> NestedBlocks { get; }
+    public IReadOnlyList<AstNode> Items { get; }
     public TypePreprocessorBlockNode? ElseBranch { get; }
 
     public TypePreprocessorBlockNode(
@@ -292,7 +310,10 @@ public sealed class TypePreprocessorBlockNode : AstNode
         IReadOnlyList<EnumDefinitionNode> enums,
         IReadOnlyList<DelegateDefinitionNode> delegates,
         TypePreprocessorBlockNode? elseBranch = null,
-        IReadOnlyList<UsingDirectiveNode>? usings = null)
+        IReadOnlyList<UsingDirectiveNode>? usings = null,
+        IReadOnlyList<TypePreprocessorBlockNode>? nestedBlocks = null,
+        IReadOnlyList<AstNode>? items = null,
+        IReadOnlyList<CSharpInteropBlockNode>? interopBlocks = null)
         : base(span)
     {
         Condition = condition ?? throw new ArgumentNullException(nameof(condition));
@@ -301,6 +322,17 @@ public sealed class TypePreprocessorBlockNode : AstNode
         Interfaces = interfaces ?? Array.Empty<InterfaceDefinitionNode>();
         Enums = enums ?? Array.Empty<EnumDefinitionNode>();
         Delegates = delegates ?? Array.Empty<DelegateDefinitionNode>();
+        InteropBlocks = interopBlocks ?? Array.Empty<CSharpInteropBlockNode>();
+        NestedBlocks = nestedBlocks ?? Array.Empty<TypePreprocessorBlockNode>();
+        Items = items ?? Usings
+            .Cast<AstNode>()
+            .Concat(Classes)
+            .Concat(Interfaces)
+            .Concat(Enums)
+            .Concat(Delegates)
+            .Concat(InteropBlocks)
+            .Concat(NestedBlocks)
+            .ToArray();
         ElseBranch = elseBranch;
     }
 

--- a/src/Calor.Compiler/Ast/UsingDirectiveNode.cs
+++ b/src/Calor.Compiler/Ast/UsingDirectiveNode.cs
@@ -7,6 +7,9 @@ namespace Calor.Compiler.Ast;
 /// §U[System.Collections.Generic]            // using System.Collections.Generic;
 /// §U[Gen:System.Collections.Generic]        // using Gen = System.Collections.Generic;
 /// §U[static:System.Math]                    // using static System.Math;
+/// §U[global:System.Text]                    // global using System.Text;
+/// §U[global:static:System.Math]              // global using static System.Math;
+/// §U[global:Gen:System.Collections.Generic]  // global using Gen = System.Collections.Generic;
 /// </summary>
 public sealed class UsingDirectiveNode : AstNode
 {
@@ -25,12 +28,23 @@ public sealed class UsingDirectiveNode : AstNode
     /// </summary>
     public bool IsStatic { get; }
 
-    public UsingDirectiveNode(TextSpan span, string @namespace, string? alias = null, bool isStatic = false)
+    /// <summary>
+    /// Whether this is a file-wide <c>global using</c> directive.
+    /// </summary>
+    public bool IsGlobal { get; }
+
+    public UsingDirectiveNode(
+        TextSpan span,
+        string @namespace,
+        string? alias = null,
+        bool isStatic = false,
+        bool isGlobal = false)
         : base(span)
     {
         Namespace = @namespace ?? throw new ArgumentNullException(nameof(@namespace));
         Alias = alias;
         IsStatic = isStatic;
+        IsGlobal = isGlobal;
     }
 
     public override void Accept(IAstVisitor visitor) => visitor.Visit(this);

--- a/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
+++ b/src/Calor.Compiler/CodeGen/CSharpEmitter.cs
@@ -37,6 +37,12 @@ public enum EmitContractMode
 /// </summary>
 public sealed class CSharpEmitter : IAstVisitor<string>
 {
+    private readonly record struct UsingDirectiveKey(
+        string Namespace,
+        string? Alias,
+        bool IsStatic,
+        bool IsGlobal);
+
     private sealed class EmissionContext
     {
         public EmissionContext(int indentLevel = 0)
@@ -54,7 +60,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     private string _currentModuleName = "";
     private HashSet<string> _currentModuleFunctionNames = new(StringComparer.Ordinal);
     private HashSet<string> _currentClassMemberNames = new(StringComparer.Ordinal);
-    private readonly Stack<(HashSet<string> Members, bool Suppress)> _classMemberScopes = new();
+    private Stack<(HashSet<string> Members, bool Suppress)> _classMemberScopes = new();
     private bool _suppressCrossModuleQualification;
 
     /// <summary>
@@ -96,7 +102,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     // out-of-scope local (CS0103). Push on entering a control-flow block, pop on leaving.
     // Starts with a base scope so isolated statement/expression emission (tests, or any
     // path not entered through a function/method ResetDeclScopes) always has a live scope.
-    private readonly List<HashSet<string>> _declScopes = new() { new(StringComparer.Ordinal) };
+    private List<HashSet<string>> _declScopes = new() { new(StringComparer.Ordinal) };
     private sealed record RefinementConstraint(
         ExpressionNode Predicate,
         string Description,
@@ -113,11 +119,11 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     private sealed record ReturnLoweringContext(
         string ExitLabel,
         string? ResultIdentifier);
-    private readonly List<Dictionary<string, RefinementConstraint?>> _refinementDeclScopes =
+    private List<Dictionary<string, RefinementConstraint?>> _refinementDeclScopes =
         new() { new(StringComparer.Ordinal) };
-    private readonly List<Dictionary<string, string?>> _indexedBoundScopes =
+    private List<Dictionary<string, string?>> _indexedBoundScopes =
         new() { new(StringComparer.Ordinal) };
-    private readonly HashSet<string> _outParameterNames = new(StringComparer.Ordinal);
+    private HashSet<string> _outParameterNames = new(StringComparer.Ordinal);
     private int _indexGuardCounter;
     private int _mutationGuardCounter;
 
@@ -360,15 +366,14 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     }
 
 
-    // AST-level namespace usage tracking for conditional using emission
-    private bool _usesCalorRuntime;
-    private bool _usesSystemLinq;
-    private bool _usesCollectionsGeneric;
+    // AST/type-driven namespace dependency registry. Dependencies are registered
+    // by node visitors and the centralized type mapper, never inferred from text.
+    private HashSet<string> _requiredNamespaces = new(StringComparer.Ordinal);
 
     // Indexed type name → base type for erasure (populated during Visit(ModuleNode))
-    private readonly Dictionary<string, string> _indexedTypeErasure = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, IndexedTypeNode> _indexedTypes = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, RefinementTypeNode> _refinementTypes =
+    private Dictionary<string, string> _indexedTypeErasure = new(StringComparer.Ordinal);
+    private Dictionary<string, IndexedTypeNode> _indexedTypes = new(StringComparer.Ordinal);
+    private Dictionary<string, RefinementTypeNode> _refinementTypes =
         new(StringComparer.Ordinal);
 
     public CSharpEmitter() : this(EmitContractMode.Debug)
@@ -463,15 +468,56 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Emit(ModuleNode module, string? filePath = null)
     {
+        ResetModuleState(module, filePath);
+        return Visit(module);
+    }
+
+    private void ResetModuleState(ModuleNode module, string? filePath)
+    {
         _emissionContext = new EmissionContext();
         _reservedGeneratedIdentifiers = CollectReservedModuleIdentifiers(module);
+        _currentClassName = null;
+        _currentModuleName = "";
+        _currentModuleFunctionNames = new HashSet<string>(StringComparer.Ordinal);
+        _currentClassMemberNames = new HashSet<string>(StringComparer.Ordinal);
+        _classMemberScopes = new Stack<(HashSet<string> Members, bool Suppress)>();
+        _suppressCrossModuleQualification = false;
+        _currentFunctionId = null;
         _currentFilePath = filePath;
+        _currentNamespace = "";
+        _currentInlineReturnRefinement = null;
+        _currentYieldRefinement = null;
+        _inlineReturnGuardCounter = 0;
+        _currentReturnLowering = null;
+        _postconditionResultIdentifier = null;
+        _postconditionResultShadowDepth = 0;
+        _returnLoweringCounter = 0;
+        _currentPostconditionIndex = 0;
+        _declScopes = new List<HashSet<string>> { new(StringComparer.Ordinal) };
+        _refinementDeclScopes =
+            new List<Dictionary<string, RefinementConstraint?>>
+            {
+                new(StringComparer.Ordinal)
+            };
+        _indexedBoundScopes =
+            new List<Dictionary<string, string?>>
+            {
+                new(StringComparer.Ordinal)
+            };
+        _outParameterNames = new HashSet<string>(StringComparer.Ordinal);
+        _indexGuardCounter = 0;
+        _mutationGuardCounter = 0;
+        _requiredNamespaces = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "System"
+        };
+        _indexedTypeErasure = new Dictionary<string, string>(StringComparer.Ordinal);
+        _indexedTypes = new Dictionary<string, IndexedTypeNode>(StringComparer.Ordinal);
+        _refinementTypes =
+            new Dictionary<string, RefinementTypeNode>(StringComparer.Ordinal);
         _lineDirectiveFile = string.IsNullOrEmpty(LineDirectiveFilePath)
             ? null
             : EscapeString(LineDirectiveFilePath);
-
-        var result = Visit(module);
-        return result;
     }
 
     public string Emit(ModuleNode module)
@@ -804,6 +850,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var mappedType = MapTypeName(returnType);
         if (isIterator)
         {
+            RequireNamespace("System.Collections.Generic");
             return new CallableReturnShape(
                 WrapInIEnumerable(mappedType),
                 mappedType.Equals("void", StringComparison.OrdinalIgnoreCase)
@@ -820,6 +867,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                     : mappedType);
         }
 
+        RequireNamespace("System.Threading.Tasks");
         if (TryUnwrapAsyncValueType(mappedType, out var asyncValueType))
         {
             return new CallableReturnShape(mappedType, asyncValueType);
@@ -1109,15 +1157,6 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         AppendLine(usingPlaceholder);
         AppendLine();
 
-        // Collect user-defined usings for dedup
-        var userUsings = new List<string>();
-        foreach (var usingDirective in node.Usings)
-        {
-            var usingCode = Visit(usingDirective);
-            if (!string.IsNullOrEmpty(usingCode))
-                userUsings.Add(usingDirective.Namespace);
-        }
-
         // Register indexed type erasure mappings (name → base type)
         foreach (var itype in node.IndexedTypes)
         {
@@ -1127,6 +1166,28 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         foreach (var refinementType in node.RefinementTypes)
         {
             _refinementTypes[refinementType.Name] = refinementType;
+        }
+
+        // Preserve complete using directive objects. Exact duplicates are
+        // removed by the full semantic tuple, so aliases/static/global forms
+        // that target the same namespace remain distinct.
+        var userUsings = new List<UsingDirectiveNode>();
+        var seenUserUsings = new HashSet<UsingDirectiveKey>();
+        foreach (var usingDirective in node.Usings)
+        {
+            var key = GetUsingDirectiveKey(usingDirective);
+            if (seenUserUsings.Add(key))
+            {
+                userUsings.Add(usingDirective);
+            }
+        }
+        foreach (var usingDirective in userUsings)
+        {
+            _ = Visit(usingDirective);
+        }
+        foreach (var block in node.TypePreprocessorBlocks)
+        {
+            RegisterConditionalUsingDependencies(block);
         }
 
         var isGlobalNamespace = node.Name == "_global" || string.IsNullOrEmpty(node.Name);
@@ -1228,8 +1289,11 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         // Emit type-level preprocessor blocks
         foreach (var tpp in node.TypePreprocessorBlocks)
         {
-            Visit(tpp);
-            AppendLine();
+            if (ContainsConditionalTypes(tpp))
+            {
+                Visit(tpp);
+                AppendLine();
+            }
         }
 
         // Emit module-level functions in a static class
@@ -1260,50 +1324,38 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             AppendLine("}");
         }
 
-        // Replace using placeholder with only the namespaces actually referenced.
-        // Uses AST-level flags set during emission, with string-scanning fallback
-        // for raw C# passthrough (§CS{}, §RAW) that may reference these namespaces.
+        // Replace the placeholder from the structural dependency registry.
+        // No emitted-text scanning is permitted here: dependencies are registered
+        // by AST visitors and MapTypeName.
         var output = _emissionContext.Writer.ToString();
         var usingBlock = new StringBuilder();
-        var emittedUsings = new HashSet<string>(StringComparer.Ordinal);
+        var emittedUsings = new HashSet<UsingDirectiveKey>();
 
-        // System is always needed
-        usingBlock.AppendLine("using System;");
-        emittedUsings.Add("System");
+        // C# requires global usings to precede every non-global using.
+        foreach (var directive in userUsings.Where(u => u.IsGlobal))
+            AppendUsing(directive);
+        foreach (var block in node.TypePreprocessorBlocks)
+            AppendConditionalUsings(usingBlock, block, globalOnly: true);
 
-        // Calor.Runtime only if Option/Result/Contract types were emitted
-        if (_usesCalorRuntime || output.Contains("Calor.Runtime."))
+        foreach (var ns in OrderRequiredNamespaces(_requiredNamespaces))
         {
-            usingBlock.AppendLine("using Calor.Runtime;");
-            emittedUsings.Add("Calor.Runtime");
+            var directive = new UsingDirectiveNode(
+                TextSpan.Empty,
+                ns);
+            AppendUsing(directive);
         }
 
-        // System.Collections.Generic if collection creation nodes were emitted
-        if (_usesCollectionsGeneric || output.Contains("List<") || output.Contains("Dictionary<") || output.Contains("HashSet<"))
-        {
-            usingBlock.AppendLine("using System.Collections.Generic;");
-            emittedUsings.Add("System.Collections.Generic");
-        }
+        foreach (var directive in userUsings.Where(u => !u.IsGlobal))
+            AppendUsing(directive);
+        foreach (var block in node.TypePreprocessorBlocks)
+            AppendConditionalUsings(usingBlock, block, globalOnly: false);
 
-        // System.Linq only if quantifier nodes were emitted, or raw C# uses LINQ methods
-        if (_usesSystemLinq || output.Contains("Enumerable.")
-            || output.Contains(".Select(") || output.Contains(".Where(")
-            || output.Contains(".Any(") || output.Contains(".All(")
-            || output.Contains(".First(") || output.Contains(".OrderBy(")
-            || output.Contains(".GroupBy(") || output.Contains(".ToList(")
-            || output.Contains(".ToArray("))
+        void AppendUsing(UsingDirectiveNode directive)
         {
-            usingBlock.AppendLine("using System.Linq;");
-            emittedUsings.Add("System.Linq");
-        }
-
-        // Add user-defined usings
-        foreach (var ns in userUsings)
-        {
-            if (!emittedUsings.Contains(ns))
+            var key = GetUsingDirectiveKey(directive);
+            if (emittedUsings.Add(key))
             {
-                usingBlock.AppendLine($"using {ns};");
-                emittedUsings.Add(ns);
+                usingBlock.AppendLine(Visit(directive));
             }
         }
 
@@ -1314,19 +1366,97 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(UsingDirectiveNode node)
     {
+        var globalPrefix = node.IsGlobal ? "global " : "";
+        var target = node.IsStatic || node.Alias != null
+            ? MapTypeName(node.Namespace)
+            : node.Namespace.Contains("::", StringComparison.Ordinal)
+                ? SanitizeTypeName(node.Namespace)
+                : SanitizeNamespace(node.Namespace);
         if (node.IsStatic)
         {
-            return $"using static {node.Namespace};";
+            return $"{globalPrefix}using static {target};";
         }
         else if (node.Alias != null)
         {
-            return $"using {node.Alias} = {node.Namespace};";
+            return $"{globalPrefix}using {SanitizeSingleIdentifier(node.Alias)} = {target};";
         }
         else
         {
-            return $"using {node.Namespace};";
+            return $"{globalPrefix}using {target};";
         }
     }
+
+    private void RegisterConditionalUsingDependencies(TypePreprocessorBlockNode block)
+    {
+        foreach (var item in block.Items)
+        {
+            if (item is UsingDirectiveNode directive)
+                _ = Visit(directive);
+            else if (item is TypePreprocessorBlockNode nested)
+                RegisterConditionalUsingDependencies(nested);
+        }
+        if (block.ElseBranch != null)
+            RegisterConditionalUsingDependencies(block.ElseBranch);
+    }
+
+    private void AppendConditionalUsings(
+        StringBuilder builder,
+        TypePreprocessorBlockNode block,
+        bool globalOnly)
+    {
+        if (!ContainsConditionalUsing(block, globalOnly))
+            return;
+
+        AppendBranch(block, isFirst: true);
+        builder.AppendLine("#endif");
+
+        void AppendBranch(TypePreprocessorBlockNode branch, bool isFirst)
+        {
+            if (isFirst)
+                builder.AppendLine($"#if {branch.Condition}");
+            else if (!string.IsNullOrEmpty(branch.Condition))
+                builder.AppendLine($"#elif {branch.Condition}");
+            else
+                builder.AppendLine("#else");
+
+            var seen = new HashSet<UsingDirectiveKey>();
+            foreach (var item in branch.Items)
+            {
+                if (item is UsingDirectiveNode directive
+                    && directive.IsGlobal == globalOnly
+                    && seen.Add(GetUsingDirectiveKey(directive)))
+                {
+                    builder.AppendLine(Visit(directive));
+                }
+                else if (item is TypePreprocessorBlockNode nested)
+                {
+                    AppendConditionalUsings(builder, nested, globalOnly);
+                }
+            }
+
+            if (branch.ElseBranch != null)
+                AppendBranch(branch.ElseBranch, isFirst: false);
+        }
+    }
+
+    private static bool ContainsConditionalUsing(
+        TypePreprocessorBlockNode block,
+        bool isGlobal)
+        => block.Usings.Any(directive => directive.IsGlobal == isGlobal)
+            || block.NestedBlocks.Any(nested =>
+                ContainsConditionalUsing(nested, isGlobal))
+            || block.ElseBranch != null
+            && ContainsConditionalUsing(block.ElseBranch, isGlobal);
+
+    private static bool ContainsConditionalTypes(TypePreprocessorBlockNode block)
+        => block.Classes.Count > 0
+            || block.Interfaces.Count > 0
+            || block.Enums.Count > 0
+            || block.Delegates.Count > 0
+            || block.InteropBlocks.Count > 0
+            || block.NestedBlocks.Any(ContainsConditionalTypes)
+            || block.ElseBranch != null
+            && ContainsConditionalTypes(block.ElseBranch);
 
     public string Visit(FunctionNode node)
     {
@@ -1425,13 +1555,18 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             callableName = callableName[..genericStart];
         }
         var methodName = SanitizeIdentifier(callableName);
+        EnsureDefaultConstraintsLegal(
+            node.TypeParameters,
+            isLegal: false,
+            owner: "a function");
 
         // Build type parameters if present
         var typeParams = "";
         var whereClause = "";
         if (node.TypeParameters.Count > 0)
         {
-            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(tp => tp.Accept(this))) + ">";
+            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(
+                tp => EmitTypeParameter(tp, allowVariance: false, owner: "a function"))) + ">";
 
             // Build where clauses
             var whereClauses = new List<string>();
@@ -1440,7 +1575,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 if (tp.Constraints.Count > 0)
                 {
                     var constraints = string.Join(", ", tp.Constraints.Select(c => EmitConstraint(c)));
-                    whereClauses.Add($"where {tp.Name} : {constraints}");
+                    whereClauses.Add(
+                        $"where {SanitizeSingleIdentifier(tp.Name)} : {constraints}");
                 }
             }
             if (whereClauses.Count > 0)
@@ -1584,6 +1720,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     public string Visit(CallStatementNode node)
     {
         var target = QualifyCrossModuleTarget(node.Target);
+        RegisterQualifiedNameDependencies(target);
+        target = SanitizeQualifiedName(target);
         if (node.TypeArguments is { Count: > 0 })
         {
             var typeArgs = string.Join(", ", node.TypeArguments.Select(MapTypeName));
@@ -1599,7 +1737,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             }
             if (node.ArgumentNames != null && i < node.ArgumentNames.Count && node.ArgumentNames[i] != null)
             {
-                argStr = $"{node.ArgumentNames[i]}: {argStr}";
+                argStr = $"{SanitizeSingleIdentifier(node.ArgumentNames[i]!)}: {argStr}";
             }
             argStrings.Add(argStr);
         }
@@ -2013,14 +2151,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 : node.Name;
         }
 
-        // Handle member access like "args.Length" - preserve the dot notation
-        if (node.Name.Contains('.'))
-        {
-            var parts = node.Name.Split('.');
-            var sanitizedParts = parts.Select(SanitizeIdentifier);
-            return string.Join(".", sanitizedParts);
-        }
-        return SanitizeIdentifier(node.Name);
+        RegisterQualifiedNameDependencies(node.Name);
+        return SanitizeQualifiedName(node.Name);
     }
 
     // Phase 2: Control Flow
@@ -2808,13 +2940,18 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         var paramString = string.Join(", ", parameters);
         var methodName = SanitizeIdentifier(method.Name);
+        EnsureDefaultConstraintsLegal(
+            method.TypeParameters,
+            isLegal: false,
+            owner: "an enum extension method");
 
         // Build type parameters if present
         var typeParams = "";
         var whereClause = "";
         if (method.TypeParameters.Count > 0)
         {
-            typeParams = "<" + string.Join(", ", method.TypeParameters.Select(tp => tp.Accept(this))) + ">";
+            typeParams = "<" + string.Join(", ", method.TypeParameters.Select(
+                tp => EmitTypeParameter(tp, allowVariance: false, owner: "a method"))) + ">";
 
             var whereClauses = new List<string>();
             foreach (var tp in method.TypeParameters)
@@ -2822,7 +2959,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 if (tp.Constraints.Count > 0)
                 {
                     var constraints = string.Join(", ", tp.Constraints.Select(c => EmitConstraint(c)));
-                    whereClauses.Add($"where {tp.Name} : {constraints}");
+                    whereClauses.Add(
+                        $"where {SanitizeSingleIdentifier(tp.Name)} : {constraints}");
                 }
             }
             if (whereClauses.Count > 0)
@@ -2866,11 +3004,13 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     public string Visit(RecordCreationNode node)
     {
         var typeName = MapTypeName(node.TypeName);
-        var fields = string.Join(", ", node.Fields.Select(f => f.Value.Accept(this)));
+        var fields = string.Join(", ", node.Fields.Select(f =>
+            $"{SanitizeSingleIdentifier(f.FieldName)}: {f.Value.Accept(this)}"));
         return $"new {typeName}({fields})";
     }
 
-    public string Visit(FieldAssignmentNode node) => node.Value.Accept(this);
+    public string Visit(FieldAssignmentNode node)
+        => $"{SanitizeSingleIdentifier(node.FieldName)}: {node.Value.Accept(this)}";
 
     public string Visit(FieldAccessNode node)
     {
@@ -2881,14 +3021,14 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(SomeExpressionNode node)
     {
-        _usesCalorRuntime = true;
+        RequireNamespace("Calor.Runtime");
         var value = node.Value.Accept(this);
         return $"Calor.Runtime.Option.Some({value})";
     }
 
     public string Visit(NoneExpressionNode node)
     {
-        _usesCalorRuntime = true;
+        RequireNamespace("Calor.Runtime");
         if (node.TypeName != null)
         {
             var typeName = MapTypeName(node.TypeName);
@@ -2899,14 +3039,14 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(OkExpressionNode node)
     {
-        _usesCalorRuntime = true;
+        RequireNamespace("Calor.Runtime");
         var value = node.Value.Accept(this);
         return $"Calor.Runtime.Result.Ok<{GetInferredTypeName(node.Value)}, string>({value})";
     }
 
     public string Visit(ErrExpressionNode node)
     {
-        _usesCalorRuntime = true;
+        RequireNamespace("Calor.Runtime");
         var error = node.Error.Accept(this);
         return $"Calor.Runtime.Result.Err<object, {GetInferredTypeName(node.Error)}>({error})";
     }
@@ -3064,8 +3204,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(TypePatternNode node)
         => node.BindingName is { } name
-            ? $"{node.TypeName} {SanitizeIdentifier(name)}"
-            : node.TypeName;
+            ? $"{MapTypeName(node.TypeName)} {SanitizeIdentifier(name)}"
+            : MapTypeName(node.TypeName);
 
     public string Visit(OkPatternNode node)
         => $"{{ IsOk: true, Value: {node.InnerPattern.Accept(this)} }}";
@@ -3083,7 +3223,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             return ""; // No check emitted
         }
 
-        _usesCalorRuntime = true;
+        RequireNamespace("Calor.Runtime");
         var condition = node.Condition.Accept(this);
         var functionId = _currentFunctionId ?? "unknown";
 
@@ -3126,7 +3266,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             return ""; // No check emitted
         }
 
-        _usesCalorRuntime = true;
+        RequireNamespace("Calor.Runtime");
         var condition = node.Condition.Accept(this);
         var functionId = _currentFunctionId ?? "unknown";
 
@@ -3178,7 +3318,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             return ""; // No check emitted
         }
 
-        _usesCalorRuntime = true;
+        RequireNamespace("Calor.Runtime");
         var condition = node.Condition.Accept(this);
         var functionId = _currentFunctionId ?? "unknown";
 
@@ -3288,7 +3428,9 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(ForeachStatementNode node)
     {
-        var varType = MapTypeName(node.VariableType);
+        var varType = node.VariableType == "var"
+            ? "var"
+            : MapTypeName(node.VariableType);
         var varName = SanitizeIdentifier(node.VariableName);
         var collection = node.Collection.Accept(this);
 
@@ -3343,7 +3485,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(ListCreationNode node)
     {
-        _usesCollectionsGeneric = true;
+        RequireNamespace("System.Collections.Generic");
         var elementType = MapTypeName(node.ElementType);
 
         if (node.Elements.Count > 0)
@@ -3359,7 +3501,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(DictionaryCreationNode node)
     {
-        _usesCollectionsGeneric = true;
+        RequireNamespace("System.Collections.Generic");
         var keyType = MapTypeName(node.KeyType);
         var valueType = MapTypeName(node.ValueType);
 
@@ -3388,7 +3530,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(SetCreationNode node)
     {
-        _usesCollectionsGeneric = true;
+        RequireNamespace("System.Collections.Generic");
         var elementType = MapTypeName(node.ElementType);
 
         if (node.Elements.Count > 0)
@@ -3522,15 +3664,43 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     // Phase 7: Generics
 
     public string Visit(TypeParameterNode node)
+        => EmitTypeParameter(node, allowVariance: true, owner: "an interface");
+
+    private static string EmitTypeParameter(
+        TypeParameterNode node,
+        bool allowVariance,
+        string owner)
     {
-        // Type parameters are handled in function/method signature emission
+        if (!allowVariance && node.Variance != VarianceKind.None)
+        {
+            throw new InvalidOperationException(
+                $"Type parameter variance is only legal on interfaces and delegates, not {owner}.");
+        }
+
         var variance = node.Variance switch
         {
             VarianceKind.In => "in ",
             VarianceKind.Out => "out ",
             _ => ""
         };
-        return $"{variance}{node.Name}";
+        return $"{variance}{SanitizeSingleIdentifier(node.Name)}";
+    }
+
+    private static void EnsureDefaultConstraintsLegal(
+        IReadOnlyList<TypeParameterNode> typeParameters,
+        bool isLegal,
+        string owner)
+    {
+        if (isLegal
+            || !typeParameters.Any(typeParameter =>
+                typeParameter.Constraints.Any(constraint =>
+                    constraint.Kind == TypeConstraintKind.Default)))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"The 'default' constraint is only legal on override methods or explicit interface implementations, not {owner}.");
     }
 
     public string Visit(TypeConstraintNode node)
@@ -3555,12 +3725,16 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         return constraint.Kind switch
         {
             TypeConstraintKind.Class => "class",
+            TypeConstraintKind.ClassNullable => "class?",
             TypeConstraintKind.Struct => "struct",
+            TypeConstraintKind.Unmanaged => "unmanaged",
             TypeConstraintKind.New => "new()",
-            TypeConstraintKind.Interface => constraint.TypeName ?? "object",
-            TypeConstraintKind.BaseClass => constraint.TypeName ?? "object",
+            TypeConstraintKind.Interface => MapTypeName(constraint.TypeName ?? "object"),
+            TypeConstraintKind.BaseClass => MapTypeName(constraint.TypeName ?? "object"),
             TypeConstraintKind.TypeName => MapTypeName(constraint.TypeName ?? "object"),
             TypeConstraintKind.NotNull => "notnull",
+            TypeConstraintKind.Default => "default",
+            TypeConstraintKind.AllowsRefStruct => "allows ref struct",
             _ => "object"
         };
     }
@@ -3570,6 +3744,10 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     public string Visit(InterfaceDefinitionNode node)
     {
         EmitCSharpAttributes(node.CSharpAttributes);
+        EnsureDefaultConstraintsLegal(
+            node.TypeParameters,
+            isLegal: false,
+            owner: "an interface");
 
         var name = SanitizeIdentifier(node.Name);
 
@@ -3578,7 +3756,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var whereClause = "";
         if (node.TypeParameters.Count > 0)
         {
-            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(tp => tp.Accept(this))) + ">";
+            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(
+                tp => EmitTypeParameter(tp, allowVariance: true, owner: "an interface"))) + ">";
 
             // Build where clauses
             var whereClauses = new List<string>();
@@ -3587,7 +3766,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 if (tp.Constraints.Count > 0)
                 {
                     var constraints = string.Join(", ", tp.Constraints.Select(c => EmitConstraint(c)));
-                    whereClauses.Add($"where {tp.Name} : {constraints}");
+                    whereClauses.Add(
+                        $"where {SanitizeSingleIdentifier(tp.Name)} : {constraints}");
                 }
             }
             if (whereClauses.Count > 0)
@@ -3597,7 +3777,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         }
 
         var baseList = node.BaseInterfaces.Count > 0
-            ? " : " + string.Join(", ", node.BaseInterfaces)
+            ? " : " + string.Join(", ", node.BaseInterfaces.Select(MapTypeName))
             : "";
 
         AppendLine($"public interface {name}{typeParams}{baseList}{whereClause}");
@@ -3629,6 +3809,10 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(MethodSignatureNode node)
     {
+        EnsureDefaultConstraintsLegal(
+            node.TypeParameters,
+            isLegal: false,
+            owner: "an interface method");
         // Emit XML comments for contracts
         if (node.HasContracts)
         {
@@ -3659,7 +3843,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var whereClause = "";
         if (node.TypeParameters.Count > 0)
         {
-            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(tp => tp.Accept(this))) + ">";
+            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(
+                tp => EmitTypeParameter(tp, allowVariance: false, owner: "a method"))) + ">";
 
             // Build where clauses
             var whereClauses = new List<string>();
@@ -3668,7 +3853,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 if (tp.Constraints.Count > 0)
                 {
                     var constraints = string.Join(", ", tp.Constraints.Select(c => EmitConstraint(c)));
-                    whereClauses.Add($"where {tp.Name} : {constraints}");
+                    whereClauses.Add(
+                        $"where {SanitizeSingleIdentifier(tp.Name)} : {constraints}");
                 }
             }
             if (whereClauses.Count > 0)
@@ -3687,6 +3873,10 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     public string Visit(ClassDefinitionNode node)
     {
         EmitCSharpAttributes(node.CSharpAttributes);
+        EnsureDefaultConstraintsLegal(
+            node.TypeParameters,
+            isLegal: false,
+            owner: node.IsStruct ? "a struct" : "a class");
 
         var name = SanitizeIdentifier(node.Name);
 
@@ -3712,7 +3902,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var whereClause = "";
         if (node.TypeParameters.Count > 0)
         {
-            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(tp => tp.Accept(this))) + ">";
+            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(
+                tp => EmitTypeParameter(tp, allowVariance: false, owner: "a class"))) + ">";
 
             var whereClauses = new List<string>();
             foreach (var tp in node.TypeParameters)
@@ -3720,7 +3911,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 if (tp.Constraints.Count > 0)
                 {
                     var constraints = string.Join(", ", tp.Constraints.Select(c => EmitConstraint(c)));
-                    whereClauses.Add($"where {tp.Name} : {constraints}");
+                    whereClauses.Add(
+                        $"where {SanitizeSingleIdentifier(tp.Name)} : {constraints}");
                 }
             }
             if (whereClauses.Count > 0)
@@ -3733,9 +3925,9 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var baseList = new List<string>();
         if (!string.IsNullOrEmpty(node.BaseClass))
         {
-            baseList.Add(node.BaseClass);
+            baseList.Add(MapTypeName(node.BaseClass));
         }
-        baseList.AddRange(node.ImplementedInterfaces);
+        baseList.AddRange(node.ImplementedInterfaces.Select(MapTypeName));
         var inheritance = baseList.Count > 0 ? " : " + string.Join(", ", baseList) : "";
 
         AppendLine($"{modifiers} {keyword} {name}{typeParams}{inheritance}{whereClause}");
@@ -3912,6 +4104,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
         EmitCSharpAttributes(node.CSharpAttributes);
 
+        var isExplicitInterfaceImplementation =
+            node.Name.Contains('.', StringComparison.Ordinal);
         var visibility = node.Visibility switch
         {
             Visibility.Public => "public",
@@ -3922,7 +4116,9 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             _ => "private"
         };
 
-        var modifiers = new List<string> { visibility };
+        var modifiers = isExplicitInterfaceImplementation
+            ? new List<string>()
+            : new List<string> { visibility };
         if (node.IsStatic) modifiers.Add("static");
         if (node.IsUnsafe) modifiers.Add("unsafe");
         if (node.IsExtern) modifiers.Add("extern");
@@ -3941,13 +4137,22 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             isIterator);
         var hasReturnRefinement = _refinementTypes.ContainsKey(returnType);
         var methodName = SanitizeIdentifier(node.Name);
+        EnsureDefaultConstraintsLegal(
+            node.TypeParameters,
+            node.IsOverride || isExplicitInterfaceImplementation,
+            node.IsOverride
+                ? "an override method"
+                : isExplicitInterfaceImplementation
+                    ? "an explicit interface implementation"
+                    : "an ordinary method");
 
         // Build type parameters
         var typeParams = "";
         var whereClause = "";
         if (node.TypeParameters.Count > 0)
         {
-            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(tp => tp.Accept(this))) + ">";
+            typeParams = "<" + string.Join(", ", node.TypeParameters.Select(
+                tp => EmitTypeParameter(tp, allowVariance: false, owner: "a method"))) + ">";
 
             var whereClauses = new List<string>();
             foreach (var tp in node.TypeParameters)
@@ -3955,7 +4160,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
                 if (tp.Constraints.Count > 0)
                 {
                     var constraints = string.Join(", ", tp.Constraints.Select(c => EmitConstraint(c)));
-                    whereClauses.Add($"where {tp.Name} : {constraints}");
+                    whereClauses.Add(
+                        $"where {SanitizeSingleIdentifier(tp.Name)} : {constraints}");
                 }
             }
             if (whereClauses.Count > 0)
@@ -4276,6 +4482,8 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             target = "this" + target;
         else
             target = QualifyCrossModuleTarget(target);
+        RegisterQualifiedNameDependencies(target);
+        target = SanitizeQualifiedName(target);
 
         // Append explicit generic type arguments: target<T1, T2>(args)
         if (node.TypeArguments is { Count: > 0 })
@@ -4294,7 +4502,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             }
             if (node.ArgumentNames != null && i < node.ArgumentNames.Count && node.ArgumentNames[i] != null)
             {
-                argStr = $"{node.ArgumentNames[i]}: {argStr}";
+                argStr = $"{SanitizeSingleIdentifier(node.ArgumentNames[i]!)}: {argStr}";
             }
             argStrings.Add(argStr);
         }
@@ -4916,7 +5124,9 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(UsingStatementNode node)
     {
-        var typePart = node.VariableType != null ? MapTypeName(node.VariableType) : "var";
+        var typePart = node.VariableType is null or "var"
+            ? "var"
+            : MapTypeName(node.VariableType);
         var namePart = node.VariableName != null ? SanitizeIdentifier(node.VariableName) : "_";
         var resource = node.Resource.Accept(this);
 
@@ -5827,6 +6037,128 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         };
     }
 
+    private static UsingDirectiveKey GetUsingDirectiveKey(UsingDirectiveNode node)
+        => new(node.Namespace, node.Alias, node.IsStatic, node.IsGlobal);
+
+    private static IEnumerable<string> OrderRequiredNamespaces(
+        IEnumerable<string> namespaces)
+    {
+        string[] preferredOrder =
+        [
+            "System",
+            "Calor.Runtime",
+            "System.Collections.Generic",
+            "System.IO",
+            "System.Linq",
+            "System.Net.Http",
+            "System.Text",
+            "System.Threading",
+            "System.Threading.Tasks"
+        ];
+
+        return namespaces
+            .OrderBy(ns =>
+            {
+                var index = Array.IndexOf(preferredOrder, ns);
+                return index >= 0 ? index : preferredOrder.Length;
+            })
+            .ThenBy(ns => ns, StringComparer.Ordinal);
+    }
+
+    private void RequireNamespace(string @namespace)
+        => _requiredNamespaces.Add(@namespace);
+
+    private void RegisterTypeDependencies(string mappedType)
+    {
+        foreach (var identifier in EnumerateIdentifierTokens(mappedType))
+        {
+            switch (identifier)
+            {
+                case "List":
+                case "Dictionary":
+                case "HashSet":
+                case "IEnumerable":
+                case "IEnumerator":
+                case "IList":
+                case "IDictionary":
+                case "ICollection":
+                case "ISet":
+                case "IReadOnlyList":
+                case "IReadOnlyCollection":
+                case "IReadOnlyDictionary":
+                case "IReadOnlySet":
+                case "IAsyncEnumerable":
+                case "IAsyncEnumerator":
+                case "KeyValuePair":
+                    RequireNamespace("System.Collections.Generic");
+                    break;
+                case "Task":
+                case "ValueTask":
+                    RequireNamespace("System.Threading.Tasks");
+                    break;
+                case "CancellationToken":
+                    RequireNamespace("System.Threading");
+                    break;
+                case "File":
+                case "Directory":
+                case "Path":
+                case "Stream":
+                case "MemoryStream":
+                case "StreamReader":
+                case "StreamWriter":
+                case "FileInfo":
+                case "DirectoryInfo":
+                    RequireNamespace("System.IO");
+                    break;
+                case "HttpClient":
+                case "HttpRequestMessage":
+                case "HttpResponseMessage":
+                    RequireNamespace("System.Net.Http");
+                    break;
+                case "StringBuilder":
+                    RequireNamespace("System.Text");
+                    break;
+                case "Enumerable":
+                    RequireNamespace("System.Linq");
+                    break;
+                case "Option":
+                case "Result":
+                case "ContractViolationException":
+                    RequireNamespace("Calor.Runtime");
+                    break;
+            }
+        }
+    }
+
+    private void RegisterQualifiedNameDependencies(string name)
+    {
+        var identifiers = EnumerateIdentifierTokens(name).ToArray();
+        if (identifiers.Length == 0)
+            return;
+
+        RegisterTypeDependencies(name);
+
+        var finalIdentifier = identifiers[^1];
+        if (finalIdentifier is
+            "Select" or "Where" or "Any" or "All" or "First" or
+            "FirstOrDefault" or "OrderBy" or "OrderByDescending" or
+            "GroupBy" or "ToList" or "ToArray" or "Count" or "Single" or
+            "SingleOrDefault")
+        {
+            RequireNamespace("System.Linq");
+        }
+    }
+
+    private void RegisterOpaqueCSharpDependencies()
+    {
+        RequireNamespace("System.Collections.Generic");
+        RequireNamespace("System.IO");
+        RequireNamespace("System.Linq");
+        RequireNamespace("System.Net.Http");
+        RequireNamespace("System.Threading");
+        RequireNamespace("System.Threading.Tasks");
+    }
+
     private string MapTypeName(string calorType)
     {
         // Check indexed type erasure: SizedList → List, NonEmptyArr → int[], etc.
@@ -5845,8 +6177,11 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             baseTypeName = ResolveRefinementBaseType(refinementType);
         }
 
-        // Use the centralized TypeMapper for bidirectional type mapping
-        return TypeMapper.CalorToCSharp(baseTypeName);
+        // Use the centralized TypeMapper for every type-bearing position, then
+        // sanitize qualified identifiers without corrupting C# type syntax.
+        var mappedType = TypeMapper.CalorToCSharp(baseTypeName);
+        RegisterTypeDependencies(mappedType);
+        return SanitizeTypeName(mappedType);
     }
 
     private string ResolveRefinementBaseType(RefinementTypeNode refinementType)
@@ -5939,13 +6274,9 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     private static string SanitizeIdentifier(string name)
     {
-        // Handle qualified names (e.g., TimeUnit.Day) by sanitizing each part
-        if (name.Contains('.'))
-        {
-            var parts = name.Split('.');
-            return string.Join(".", parts.Select(SanitizeSingleIdentifier));
-        }
-        return SanitizeSingleIdentifier(name);
+        return name.Contains('.') || name.Contains("::", StringComparison.Ordinal)
+            ? SanitizeQualifiedName(name)
+            : SanitizeSingleIdentifier(name);
     }
 
     private static string SanitizeSingleIdentifier(string name)
@@ -5962,6 +6293,10 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         }
 
         var result = sb.ToString();
+        if (result.Length == 0)
+        {
+            return "_";
+        }
 
         // Ensure identifier doesn't start with a digit
         if (result.Length > 0 && char.IsDigit(result[0]))
@@ -5970,10 +6305,9 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         }
 
         // Handle reserved words — prefix with @ to make valid C# identifiers.
-        // Covers C# reserved keywords (ECMA-334 §6.4.4), excluding type alias
-        // keywords (object, byte, char, etc.) since SanitizeIdentifier is also
-        // called on type names in some contexts (NewExpression, CatchClause, etc.).
-        // Exclude this/base/null/true/false — they have special meaning.
+        // Type syntax is handled separately by SanitizeTypeName, which preserves
+        // predefined type keywords. Exclude this/base/null/true/false here because
+        // expression visitors handle their special meaning before sanitization.
         return result switch
         {
             "abstract" or "as" or "bool" or "break" or
@@ -5999,24 +6333,124 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         };
     }
 
-    private static string SanitizeNamespace(string name)
-    {
-        var sb = new StringBuilder();
-        for (int i = 0; i < name.Length; i++)
-        {
-            var c = name[i];
-            if (char.IsLetterOrDigit(c) || c == '_' || c == '.')
+    private static readonly HashSet<string> PredefinedTypeKeywords =
+    [
+        "bool", "byte", "sbyte", "short", "ushort", "int", "uint", "long",
+        "ulong", "nint", "nuint", "char", "float", "double", "decimal",
+        "string", "object", "dynamic", "void"
+    ];
+
+    private static string SanitizeQualifiedName(string name)
+        => RewriteIdentifierTokens(
+            name,
+            (identifier, start, end) =>
             {
-                sb.Append(c);
+                if (identifier is "this" or "base" or "global")
+                    return identifier;
+
+                var next = end;
+                while (next < name.Length && char.IsWhiteSpace(name[next]))
+                    next++;
+                if (PredefinedTypeKeywords.Contains(identifier)
+                    && ((next < name.Length && name[next] == '.')
+                        || IsInsideGenericTypeArgument(name, start)))
+                {
+                    return identifier;
+                }
+
+                return SanitizeSingleIdentifier(identifier);
+            });
+
+    private static bool IsInsideGenericTypeArgument(string text, int offset)
+    {
+        var depth = 0;
+        for (var i = 0; i < offset; i++)
+        {
+            if (text[i] == '<')
+                depth++;
+            else if (text[i] == '>' && depth > 0)
+                depth--;
+        }
+        return depth > 0;
+    }
+
+    private static string SanitizeTypeName(string name)
+        => RewriteIdentifierTokens(
+            name,
+            (identifier, _, _) =>
+                identifier == "global" || PredefinedTypeKeywords.Contains(identifier)
+                    ? identifier
+                    : SanitizeSingleIdentifier(identifier));
+
+    private static string RewriteIdentifierTokens(
+        string text,
+        Func<string, int, int, string> rewrite)
+    {
+        var result = new StringBuilder(text.Length);
+        for (var i = 0; i < text.Length;)
+        {
+            var tokenStart = i;
+            if (text[i] == '@'
+                && i + 1 < text.Length
+                && IsIdentifierStart(text[i + 1]))
+            {
+                i++;
+                tokenStart = i;
             }
+
+            if (!IsIdentifierStart(text[i]))
+            {
+                result.Append(text[i]);
+                i++;
+                continue;
+            }
+
+            i++;
+            while (i < text.Length && IsIdentifierPart(text[i]))
+                i++;
+
+            var identifier = text[tokenStart..i];
+            result.Append(rewrite(identifier, tokenStart, i));
         }
 
-        var result = sb.ToString();
-        if (result.Length > 0 && char.IsDigit(result[0]))
+        return result.ToString();
+    }
+
+    private static IEnumerable<string> EnumerateIdentifierTokens(string text)
+    {
+        for (var i = 0; i < text.Length;)
         {
-            result = "_" + result;
+            if (text[i] == '@'
+                && i + 1 < text.Length
+                && IsIdentifierStart(text[i + 1]))
+            {
+                i++;
+            }
+
+            if (!IsIdentifierStart(text[i]))
+            {
+                i++;
+                continue;
+            }
+
+            var start = i++;
+            while (i < text.Length && IsIdentifierPart(text[i]))
+                i++;
+            yield return text[start..i];
         }
-        return result;
+    }
+
+    private static bool IsIdentifierStart(char value)
+        => value == '_' || char.IsLetter(value);
+
+    private static bool IsIdentifierPart(char value)
+        => value == '_' || char.IsLetterOrDigit(value);
+
+    private static string SanitizeNamespace(string name)
+    {
+        return string.Join(
+            ".",
+            name.Split('.').Select(SanitizeSingleIdentifier));
     }
 
     /// <summary>
@@ -6058,7 +6492,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     public string Visit(QuantifierVariableNode node)
     {
         // Variable nodes are handled internally by quantifier translation
-        return $"{node.Name}: {MapTypeName(node.TypeName)}";
+        return $"{SanitizeSingleIdentifier(node.Name)}: {MapTypeName(node.TypeName)}";
     }
 
     public string Visit(ForallExpressionNode node)
@@ -6082,7 +6516,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     private string EmitForallExpression(ForallExpressionNode node)
     {
-        _usesSystemLinq = true;
+        RequireNamespace("System.Linq");
         // Try to extract finite range from the pattern:
         // (forall ((i type)) (-> (&& (>= i 0) (< i n)) body))
         var range = TryExtractFiniteRange(node);
@@ -6145,7 +6579,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     private string EmitExistsExpression(ExistsExpressionNode node)
     {
-        _usesSystemLinq = true;
+        RequireNamespace("System.Linq");
         // Try to extract finite range from the pattern:
         // (exists ((i type)) (&& (>= i 0) (< i n) body))
         var range = TryExtractFiniteRangeForExists(node);
@@ -6338,7 +6772,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
         var operand = node.Operand.Accept(this);
         var csharpType = MapTypeName(node.TargetType);
         return node.VariableName != null
-            ? $"{operand} is {csharpType} {node.VariableName}"
+            ? $"{operand} is {csharpType} {SanitizeSingleIdentifier(node.VariableName)}"
             : $"{operand} is {csharpType}";
     }
 
@@ -6374,6 +6808,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     public string Visit(FallbackExpressionNode node)
     {
         // Emit the original C# code with a TODO comment
+        RegisterOpaqueCSharpDependencies();
         return $"/* TODO: {node.FeatureName} */ {node.OriginalCSharp}";
     }
 
@@ -6416,7 +6851,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(NameOfExpressionNode node)
     {
-        return $"nameof({node.Name})";
+        return $"nameof({SanitizeQualifiedName(node.Name)})";
     }
 
     public string Visit(ExpressionCallNode node)
@@ -6428,11 +6863,16 @@ public sealed class CSharpEmitter : IAstVisitor<string>
 
     public string Visit(RawCSharpNode node)
     {
+        RegisterOpaqueCSharpDependencies();
         AppendRawCSharp(node.CSharpCode);
         return "";
     }
 
-    public string Visit(RawCSharpExpressionNode node) => node.CSharpCode;
+    public string Visit(RawCSharpExpressionNode node)
+    {
+        RegisterOpaqueCSharpDependencies();
+        return node.CSharpCode;
+    }
 
     public string Visit(PreprocessorDirectiveNode node)
     {
@@ -6462,36 +6902,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     private void EmitMemberPreprocessorBlock(MemberPreprocessorBlockNode node, bool isFirst)
     {
         AppendLine(isFirst ? $"#if {node.Condition}" : $"#elif {node.Condition}");
-
-        foreach (var field in node.Fields)
-            Visit(field);
-        foreach (var prop in node.Properties)
-        {
-            Visit(prop);
-            AppendLine();
-        }
-        foreach (var indexer in node.Indexers)
-        {
-            Visit(indexer);
-            AppendLine();
-        }
-        foreach (var ctor in node.Constructors)
-        {
-            Visit(ctor);
-            AppendLine();
-        }
-        foreach (var method in node.Methods)
-        {
-            Visit(method);
-            AppendLine();
-        }
-        foreach (var op in node.OperatorOverloads)
-        {
-            Visit(op);
-            AppendLine();
-        }
-        foreach (var evt in node.Events)
-            Visit(evt);
+        EmitMemberPreprocessorItems(node);
 
         if (node.ElseBranch != null)
         {
@@ -6503,34 +6914,54 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             else
             {
                 AppendLine("#else");
-                foreach (var field in node.ElseBranch.Fields)
-                    Visit(field);
-                foreach (var prop in node.ElseBranch.Properties)
-                {
-                    Visit(prop);
-                    AppendLine();
-                }
-                foreach (var ctor in node.ElseBranch.Constructors)
-                {
-                    Visit(ctor);
-                    AppendLine();
-                }
-                foreach (var method in node.ElseBranch.Methods)
-                {
-                    Visit(method);
-                    AppendLine();
-                }
-                foreach (var op in node.ElseBranch.OperatorOverloads)
-                {
-                    Visit(op);
-                    AppendLine();
-                }
-                foreach (var evt in node.ElseBranch.Events)
-                    Visit(evt);
+                EmitMemberPreprocessorItems(node.ElseBranch);
             }
         }
 
         AppendLine("#endif");
+    }
+
+    private void EmitMemberPreprocessorItems(MemberPreprocessorBlockNode node)
+    {
+        foreach (var item in node.Items)
+        {
+            switch (item)
+            {
+                case ClassFieldNode field:
+                    Visit(field);
+                    break;
+                case PropertyNode property:
+                    Visit(property);
+                    AppendLine();
+                    break;
+                case IndexerNode indexer:
+                    Visit(indexer);
+                    AppendLine();
+                    break;
+                case ConstructorNode constructor:
+                    Visit(constructor);
+                    AppendLine();
+                    break;
+                case MethodNode method:
+                    Visit(method);
+                    AppendLine();
+                    break;
+                case OperatorOverloadNode op:
+                    Visit(op);
+                    AppendLine();
+                    break;
+                case EventDefinitionNode evt:
+                    Visit(evt);
+                    break;
+                case CSharpInteropBlockNode interop:
+                    Visit(interop);
+                    AppendLine();
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unsupported member preprocessor item: {item.GetType().Name}");
+            }
+        }
     }
 
     public string Visit(TypePreprocessorBlockNode node)
@@ -6542,29 +6973,7 @@ public sealed class CSharpEmitter : IAstVisitor<string>
     private void EmitTypePreprocessorBlock(TypePreprocessorBlockNode node, bool isFirst)
     {
         AppendLine(isFirst ? $"#if {node.Condition}" : $"#elif {node.Condition}");
-
-        foreach (var u in node.Usings)
-            AppendLine(Visit(u));
-        foreach (var cls in node.Classes)
-        {
-            Visit(cls);
-            AppendLine();
-        }
-        foreach (var iface in node.Interfaces)
-        {
-            Visit(iface);
-            AppendLine();
-        }
-        foreach (var en in node.Enums)
-        {
-            Visit(en);
-            AppendLine();
-        }
-        foreach (var del in node.Delegates)
-        {
-            Visit(del);
-            AppendLine();
-        }
+        EmitTypePreprocessorDeclarations(node);
 
         if (node.ElseBranch != null)
         {
@@ -6576,36 +6985,55 @@ public sealed class CSharpEmitter : IAstVisitor<string>
             else
             {
                 AppendLine("#else");
-                foreach (var u in node.ElseBranch.Usings)
-                    AppendLine(Visit(u));
-                foreach (var cls in node.ElseBranch.Classes)
-                {
-                    Visit(cls);
-                    AppendLine();
-                }
-                foreach (var iface in node.ElseBranch.Interfaces)
-                {
-                    Visit(iface);
-                    AppendLine();
-                }
-                foreach (var en in node.ElseBranch.Enums)
-                {
-                    Visit(en);
-                    AppendLine();
-                }
-                foreach (var del in node.ElseBranch.Delegates)
-                {
-                    Visit(del);
-                    AppendLine();
-                }
+                EmitTypePreprocessorDeclarations(node.ElseBranch);
             }
         }
 
         AppendLine("#endif");
     }
 
+    private void EmitTypePreprocessorDeclarations(TypePreprocessorBlockNode node)
+    {
+        foreach (var item in node.Items)
+        {
+            switch (item)
+            {
+                case UsingDirectiveNode:
+                    break;
+                case ClassDefinitionNode cls:
+                    Visit(cls);
+                    AppendLine();
+                    break;
+                case InterfaceDefinitionNode iface:
+                    Visit(iface);
+                    AppendLine();
+                    break;
+                case EnumDefinitionNode en:
+                    Visit(en);
+                    AppendLine();
+                    break;
+                case DelegateDefinitionNode del:
+                    Visit(del);
+                    AppendLine();
+                    break;
+                case TypePreprocessorBlockNode nested:
+                    Visit(nested);
+                    AppendLine();
+                    break;
+                case CSharpInteropBlockNode interop:
+                    Visit(interop);
+                    AppendLine();
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unsupported type preprocessor item: {item.GetType().Name}");
+            }
+        }
+    }
+
     public string Visit(CSharpInteropBlockNode node)
     {
+        RegisterOpaqueCSharpDependencies();
         var code = node.CSharpCode;
 
         // Strip namespace declarations that match the current module namespace
@@ -7409,7 +7837,7 @@ public sealed record GeneratedCSharpCompilationContext
     public Microsoft.CodeAnalysis.CSharp.LanguageVersion LanguageVersion { get; init; } =
         Microsoft.CodeAnalysis.CSharp.LanguageVersion.Default;
     public IEnumerable<string>? PreprocessorSymbols { get; init; }
-    public bool IncludeImplicitGlobalUsings { get; init; } = true;
+    public bool IncludeImplicitGlobalUsings { get; init; }
     public IEnumerable<string>? AnalyzerPaths { get; init; }
     public IEnumerable<string>? AdditionalFilePaths { get; init; }
     public Microsoft.CodeAnalysis.NullableContextOptions NullableContextOptions { get; init; }
@@ -7421,12 +7849,11 @@ public sealed record GeneratedCSharpCompilationContext
 /// Shared Roslyn compilation helper for validating generated C# (#771/#761).
 ///
 /// <para>Resolves the full trusted-platform-assembly reference set plus
-/// <c>Calor.Runtime</c>, and supplies the implicit global usings the Calor SDK
-/// provides to generated code — the same environment the production self-check
-/// exemplar compile uses (<see cref="SelfCheck.ExemplarCompileChecker"/> delegates
-/// here). Test helpers must use this instead of hand-rolled minimal reference
-/// sets, whose failures are unassertable (missing-reference noise drowns real
-/// emitter defects).</para>
+/// <c>Calor.Runtime</c>. Generated C# is standalone by default, so implicit
+/// global usings are disabled unless the invoking project explicitly opts in.
+/// Test helpers must use this instead of hand-rolled minimal reference sets,
+/// whose failures are unassertable (missing-reference noise drowns real emitter
+/// defects).</para>
 /// </summary>
 public static class GeneratedCSharpCompiler
 {
@@ -7464,11 +7891,9 @@ public static class GeneratedCSharpCompiler
     }
 
     /// <summary>
-    /// The implicit global usings the Calor SDK provides to generated code —
-    /// mirrors Microsoft.NET.Sdk's ImplicitUsings set as of .NET 10. The emitter
-    /// relies on these (it emits <c>File.ReadAllLines(...)</c> with no
-    /// <c>using System.IO;</c>), so generated C# only compiles standalone when
-    /// they are supplied here too.
+    /// Optional compatibility preamble for callers validating in a project that
+    /// explicitly enables SDK implicit usings. Standalone validation does not
+    /// include this preamble.
     /// </summary>
     public const string GlobalUsingsPreamble =
         "global using System;\n" +

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -91,6 +91,8 @@ public static class DiagnosticCode
     /// </summary>
     public const string MisalignedElseClause = "Calor0117";
     public const string ExpressionNestingTooDeep = "Calor0118";
+    public const string InvalidTypeParameterVariance = "Calor0119";
+    public const string InvalidDefaultConstraintOwner = "Calor0120";
 
     // Call-elision diagnostics (Calor0150-0159) — RFC v0.6 call-closer-elision
 

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -355,6 +355,13 @@ public sealed class CalorEmitter : IAstVisitor<string>
             EmitOutputLine(node.Output);
             Dedent();
         }
+        if (node.TypeParameters.Any(typeParameter =>
+                typeParameter.Constraints.Count > 0))
+        {
+            Indent();
+            EmitTypeParameterConstraints(node.TypeParameters);
+            Dedent();
+        }
         EmitBlockEnd($"§/MT{{{node.Id}}}");
 
         return "";

--- a/src/Calor.Compiler/Migration/CalorEmitter.cs
+++ b/src/Calor.Compiler/Migration/CalorEmitter.cs
@@ -243,17 +243,20 @@ public sealed class CalorEmitter : IAstVisitor<string>
 
     public string Visit(UsingDirectiveNode node)
     {
+        var globalPrefix = node.IsGlobal ? "global:" : "";
         if (node.IsStatic)
         {
-            AppendLine($"§U{{static:{node.Namespace}}}");
+            AppendLine($"§U{{{globalPrefix}static:{node.Namespace}}}");
         }
         else if (node.Alias != null)
         {
-            AppendLine($"§U{{{node.Alias}:{node.Namespace}}}");
+            AppendLine($"§U{{{globalPrefix}{node.Alias}:{node.Namespace}}}");
         }
         else
         {
-            AppendLine($"§U{{{node.Namespace}}}");
+            AppendLine(node.IsGlobal
+                ? $"§U{{global:{node.Namespace}}}"
+                : $"§U{{{node.Namespace}}}");
         }
         return "";
     }
@@ -342,11 +345,11 @@ public sealed class CalorEmitter : IAstVisitor<string>
         {
             var inlineParams = node.Parameters.Count > 0 || node.Output != null ? $" ({inlineFmt})" : "";
             var inlineReturn = node.Output != null ? $" -> {TypeMapper.CSharpToCalor(node.Output.TypeName)}" : "";
-            AppendLine($"§MT{{{node.Id}:{node.Name}{typeParams}}}{attrs}{inlineParams}{inlineReturn}");
+            AppendLine($"§MT{{{node.Id}:{node.Name}}}{attrs}{typeParams}{inlineParams}{inlineReturn}");
         }
         else
         {
-            AppendLine($"§MT{{{node.Id}:{node.Name}{typeParams}}}{attrs}");
+            AppendLine($"§MT{{{node.Id}:{node.Name}}}{attrs}{typeParams}");
             Indent();
             EmitParameterLines(node.Parameters);
             EmitOutputLine(node.Output);
@@ -3264,11 +3267,17 @@ public sealed class CalorEmitter : IAstVisitor<string>
 
     public string Visit(RecordCreationNode node)
     {
-        var fields = string.Join(", ", node.Fields.Select(f => f.Value.Accept(this)));
-        return $"§NEW{{{node.TypeName}}} {fields}";
+        var fields = string.Join(
+            " ",
+            node.Fields.Select(f =>
+                $"§FL{{{f.FieldName}}} {f.Value.Accept(this)}"));
+        return fields.Length == 0
+            ? $"§D{{{node.TypeName}}}"
+            : $"§D{{{node.TypeName}}} {fields}";
     }
 
-    public string Visit(FieldAssignmentNode node) => node.Value.Accept(this);
+    public string Visit(FieldAssignmentNode node)
+        => $"§FL{{{node.FieldName}}} {node.Value.Accept(this)}";
 
     // Generic type nodes
     public string Visit(TypeParameterNode node)
@@ -3293,6 +3302,10 @@ public sealed class CalorEmitter : IAstVisitor<string>
             TypeConstraintKind.BaseClass => node.TypeName ?? "",
             TypeConstraintKind.TypeName => node.TypeName ?? "",
             TypeConstraintKind.NotNull => "notnull",
+            TypeConstraintKind.Unmanaged => "unmanaged",
+            TypeConstraintKind.ClassNullable => "class?",
+            TypeConstraintKind.Default => "default",
+            TypeConstraintKind.AllowsRefStruct => "allows ref struct",
             _ => node.TypeName ?? ""
         };
     }
@@ -4066,22 +4079,53 @@ public sealed class CalorEmitter : IAstVisitor<string>
 
     private void EmitMemberPreprocessorMembers(MemberPreprocessorBlockNode node)
     {
-        foreach (var field in node.Fields) Visit(field);
-        foreach (var prop in node.Properties) Visit(prop);
-        foreach (var indexer in node.Indexers) Visit(indexer);
-        foreach (var ctor in node.Constructors) Visit(ctor);
-        foreach (var method in node.Methods) { Visit(method); AppendLine(); }
-        foreach (var op in node.OperatorOverloads) { Visit(op); AppendLine(); }
-        foreach (var evt in node.Events) Visit(evt);
+        foreach (var item in node.Items)
+        {
+            switch (item)
+            {
+                case ClassFieldNode field:
+                    Visit(field);
+                    break;
+                case PropertyNode property:
+                    Visit(property);
+                    break;
+                case IndexerNode indexer:
+                    Visit(indexer);
+                    break;
+                case ConstructorNode constructor:
+                    Visit(constructor);
+                    break;
+                case MethodNode method:
+                    Visit(method);
+                    AppendLine();
+                    break;
+                case OperatorOverloadNode op:
+                    Visit(op);
+                    AppendLine();
+                    break;
+                case EventDefinitionNode evt:
+                    Visit(evt);
+                    break;
+                case CSharpInteropBlockNode interop:
+                    Visit(interop);
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unsupported member preprocessor item: {item.GetType().Name}");
+            }
+        }
     }
 
     public string Visit(TypePreprocessorBlockNode node)
     {
         AppendLine($"§PP{{{node.Condition}}}");
+        Indent();
         EmitTypePreprocessorTypes(node);
+        Dedent();
         if (node.ElseBranch != null)
         {
             AppendLine("§PPE");
+            Indent();
             if (!string.IsNullOrEmpty(node.ElseBranch.Condition))
             {
                 Visit(node.ElseBranch);
@@ -4090,18 +4134,49 @@ public sealed class CalorEmitter : IAstVisitor<string>
             {
                 EmitTypePreprocessorTypes(node.ElseBranch);
             }
+            Dedent();
         }
-        AppendLine($"§/PP{{{node.Condition}}}");
+        if (node.ElseBranch == null || string.IsNullOrEmpty(node.ElseBranch.Condition))
+            AppendLine($"§/PP{{{node.Condition}}}");
         return "";
     }
 
     private void EmitTypePreprocessorTypes(TypePreprocessorBlockNode node)
     {
-        foreach (var u in node.Usings) Visit(u);
-        foreach (var cls in node.Classes) { Visit(cls); AppendLine(); }
-        foreach (var iface in node.Interfaces) { Visit(iface); AppendLine(); }
-        foreach (var en in node.Enums) { Visit(en); AppendLine(); }
-        foreach (var del in node.Delegates) { Visit(del); AppendLine(); }
+        foreach (var item in node.Items)
+        {
+            switch (item)
+            {
+                case UsingDirectiveNode u:
+                    Visit(u);
+                    break;
+                case ClassDefinitionNode cls:
+                    Visit(cls);
+                    AppendLine();
+                    break;
+                case InterfaceDefinitionNode iface:
+                    Visit(iface);
+                    AppendLine();
+                    break;
+                case EnumDefinitionNode en:
+                    Visit(en);
+                    AppendLine();
+                    break;
+                case DelegateDefinitionNode del:
+                    Visit(del);
+                    AppendLine();
+                    break;
+                case TypePreprocessorBlockNode nested:
+                    Visit(nested);
+                    break;
+                case CSharpInteropBlockNode interop:
+                    Visit(interop);
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unsupported type preprocessor item: {item.GetType().Name}");
+            }
+        }
     }
 
     private void RecordEmitterFallback(AstNode node, string feature, string description)

--- a/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
+++ b/src/Calor.Compiler/Migration/RoslynSyntaxVisitor.cs
@@ -24,8 +24,10 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
     private readonly List<FunctionNode> _functions = new();
     private readonly List<StatementNode> _topLevelStatements = new();
     private readonly List<CSharpInteropBlockNode> _moduleInteropBlocks = new();
+    private List<CSharpInteropBlockNode>? _conditionalModuleInteropSink;
     private readonly List<TypePreprocessorBlockNode> _typePreprocessorBlocks = new();
     private bool _insideTypePreprocessorConversion;
+    private bool _insideConditionalModuleRecovery;
 
     // #769 (WS-W4 D2): bare type names declared by top-level types in two or more
     // distinct namespaces within this file. Flattening every namespace into one
@@ -33,9 +35,8 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
     // in this set is refused (escalated to §CSHARP interop) rather than merged.
     private readonly HashSet<string> _crossNamespaceCollisionNames = new(StringComparer.Ordinal);
     private HashSet<string> _reassignedVariables = new();
-    // Tracks active-branch conditional using groups across multiple VisitUsingDirective calls
-    private string? _activeConditionalUsingCondition;
-    private List<UsingDirectiveNode>? _activeConditionalUsings;
+    private readonly HashSet<int> _conditionalUsingDirectiveStarts = new();
+    private readonly HashSet<int> _conditionalTypeDeclarationStarts = new();
 
     /// <summary>
     /// Accumulates hoisted statements from expression-level chain decomposition.
@@ -98,9 +99,10 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         _functions.Clear();
         _topLevelStatements.Clear();
         _moduleInteropBlocks.Clear();
+        _conditionalModuleInteropSink = null;
         _typePreprocessorBlocks.Clear();
-        _activeConditionalUsingCondition = null;
-        _activeConditionalUsings = null;
+        _conditionalUsingDirectiveStarts.Clear();
+        _conditionalTypeDeclarationStarts.Clear();
         _crossNamespaceCollisionNames.Clear();
         _reassignedVariables = CollectReassignedVariables(root);
 
@@ -110,16 +112,13 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         ScanCrossNamespaceCollisions(root);
         _cancellationToken.ThrowIfCancellationRequested();
 
-        // Scan for module-level #if blocks wrapping type declarations
-        // (disabled by preprocessor — Roslyn excludes them from the tree)
-        ScanModuleLevelPreprocessorBlocks(root);
+        // Recover complete module-level conditional groups before the ordinary
+        // Roslyn walk, including disabled branches and nested groups.
+        ScanConditionalModuleBlocks(root);
         _cancellationToken.ThrowIfCancellationRequested();
 
         // Visit all nodes
         Visit(root);
-
-        // Flush any remaining conditional usings
-        FlushActiveConditionalUsings();
 
         // Use a fixed module ID — each file produces exactly one module, and generating
         // the ID after Visit(root) would give inconsistent IDs like m044 due to the
@@ -170,97 +169,487 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
 
     public override void VisitUsingDirective(UsingDirectiveSyntax node)
     {
-        if (node.Name != null)
+        if (!_conditionalUsingDirectiveStarts.Contains(node.SpanStart)
+            && TryConvertUsingDirective(node, GetTextSpan(node), out var usingNode))
         {
-            var namespaceName = node.Name.ToString().Replace("@", "");
-            var isStatic = node.StaticKeyword.IsKind(SyntaxKind.StaticKeyword);
-            var alias = node.Alias?.Name.ToString();
-
-            var usingNode = new UsingDirectiveNode(
-                GetTextSpan(node),
-                namespaceName,
-                alias,
-                isStatic);
-
-            // Check for #if start in leading trivia
-            var ifCondition = GetLeadingIfCondition(node);
-            if (ifCondition != null)
-            {
-                // Start a new conditional using group
-                FlushActiveConditionalUsings();
-                _activeConditionalUsingCondition = ifCondition;
-                _activeConditionalUsings = new List<UsingDirectiveNode> { usingNode };
-            }
-            else if (_activeConditionalUsings != null)
-            {
-                // Inside an active conditional group — add to it
-                _activeConditionalUsings.Add(usingNode);
-            }
-            else
-            {
-                _usings.Add(usingNode);
-            }
-
-            // Check for #endif in trailing trivia — closes the group
-            if (_activeConditionalUsings != null && HasTrailingEndif(node))
-            {
-                FlushActiveConditionalUsings();
-            }
+            _usings.Add(usingNode);
         }
 
         base.VisitUsingDirective(node);
     }
 
-    /// <summary>
-    /// Flushes any accumulated active-branch conditional usings into a TypePreprocessorBlockNode.
-    /// </summary>
-    private void FlushActiveConditionalUsings()
+    private static bool TryConvertUsingDirective(
+        UsingDirectiveSyntax node,
+        TextSpan span,
+        out UsingDirectiveNode usingNode)
     {
-        if (_activeConditionalUsings != null && _activeConditionalUsings.Count > 0 && _activeConditionalUsingCondition != null)
+        if (node.NamespaceOrType == null)
         {
-            _context.RecordFeatureUsage("conditional-using");
-            _context.RecordFeatureUsage("preprocessor-directive");
-            var ppNode = new TypePreprocessorBlockNode(
-                TextSpan.Empty,
-                _activeConditionalUsingCondition,
-                Array.Empty<ClassDefinitionNode>(),
-                Array.Empty<InterfaceDefinitionNode>(),
-                Array.Empty<EnumDefinitionNode>(),
-                Array.Empty<DelegateDefinitionNode>(),
-                usings: _activeConditionalUsings);
-            _typePreprocessorBlocks.Add(ppNode);
+            usingNode = null!;
+            return false;
         }
-        _activeConditionalUsingCondition = null;
-        _activeConditionalUsings = null;
+
+        usingNode = new UsingDirectiveNode(
+            span,
+            node.NamespaceOrType.ToString().Replace("@", ""),
+            node.Alias?.Name.ToString(),
+            node.StaticKeyword.IsKind(SyntaxKind.StaticKeyword),
+            node.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword));
+        return true;
     }
 
-    /// <summary>
-    /// Gets the #if condition from a node's leading trivia, if present.
-    /// </summary>
-    private static string? GetLeadingIfCondition(SyntaxNode node)
+    private void AddModuleInteropBlock(CSharpInteropBlockNode block)
     {
-        foreach (var trivia in node.GetLeadingTrivia())
+        if (_conditionalModuleInteropSink != null)
+            _conditionalModuleInteropSink.Add(block);
+        else
+            _moduleInteropBlocks.Add(block);
+    }
+
+    private sealed class ConditionalModuleSourceGroup
+    {
+        public int Start { get; set; }
+        public int End { get; set; }
+        public List<ConditionalModuleSourceBranch> Branches { get; } = new();
+    }
+
+    private sealed class ConditionalModuleSourceBranch
+    {
+        public string? Condition { get; set; }
+        public int ContentStart { get; set; }
+        public int ContentEnd { get; set; }
+        public List<ConditionalModuleSourceGroup> Children { get; } = new();
+    }
+
+    private sealed record ConditionalDirectiveFrame(
+        ConditionalModuleSourceGroup? Group);
+
+    private void ScanConditionalModuleBlocks(CompilationUnitSyntax root)
+    {
+        var source = root.SyntaxTree.GetText(_cancellationToken);
+        var roots = BuildConditionalModuleSourceTree(root, source);
+        var converted = new List<(ConditionalModuleSourceGroup Source, TypePreprocessorBlockNode Node)>();
+
+        foreach (var group in roots)
         {
-            if (trivia.IsKind(SyntaxKind.IfDirectiveTrivia) &&
-                trivia.GetStructure() is IfDirectiveTriviaSyntax ifDir)
+            var node = BuildConditionalModuleNode(group, source);
+            if (node != null)
+                converted.Add((group, node));
+        }
+
+        if (converted.Count == 0)
+            return;
+
+        foreach (var usingDirective in root.DescendantNodes().OfType<UsingDirectiveSyntax>())
+        {
+            if (converted.Any(item =>
+                    usingDirective.SpanStart >= item.Source.Start
+                    && usingDirective.Span.End <= item.Source.End))
             {
-                return ifDir.Condition.ToString();
+                _conditionalUsingDirectiveStarts.Add(usingDirective.SpanStart);
             }
         }
-        return null;
+        foreach (var declaration in root.DescendantNodes().Where(node =>
+                     node is BaseTypeDeclarationSyntax or DelegateDeclarationSyntax))
+        {
+            if (converted.Any(item =>
+                    declaration.SpanStart >= item.Source.Start
+                    && declaration.Span.End <= item.Source.End))
+            {
+                _conditionalTypeDeclarationStarts.Add(declaration.SpanStart);
+            }
+        }
+
+        foreach (var (_, node) in converted.OrderBy(item => item.Source.Start))
+            _typePreprocessorBlocks.Add(node);
+
+        if (converted.Any(item => ContainsConditionalUsings(item.Node))
+            && !_context.UsedFeatures.Contains("conditional-using"))
+            _context.RecordFeatureUsage("conditional-using");
+        if (!_context.UsedFeatures.Contains("preprocessor-directive"))
+            _context.RecordFeatureUsage("preprocessor-directive");
     }
 
-    /// <summary>
-    /// Checks if a using directive has #endif in its trailing trivia.
-    /// </summary>
-    private static bool HasTrailingEndif(UsingDirectiveSyntax node)
+    private static List<ConditionalModuleSourceGroup> BuildConditionalModuleSourceTree(
+        CompilationUnitSyntax root,
+        Microsoft.CodeAnalysis.Text.SourceText source)
     {
-        // Check both the node's trailing trivia and the semicolon token's trailing trivia
-        if (node.GetTrailingTrivia().Any(t => t.IsKind(SyntaxKind.EndIfDirectiveTrivia)))
-            return true;
-        if (node.SemicolonToken.TrailingTrivia.Any(t => t.IsKind(SyntaxKind.EndIfDirectiveTrivia)))
-            return true;
-        return false;
+        var roots = new List<ConditionalModuleSourceGroup>();
+        var stack = new Stack<ConditionalDirectiveFrame>();
+        var directives = root
+            .DescendantTrivia(descendIntoTrivia: true)
+            .Where(trivia => trivia.HasStructure)
+            .Select(trivia => trivia.GetStructure())
+            .OfType<DirectiveTriviaSyntax>()
+            .Where(directive => directive is
+                IfDirectiveTriviaSyntax
+                or ElifDirectiveTriviaSyntax
+                or ElseDirectiveTriviaSyntax
+                or EndIfDirectiveTriviaSyntax)
+            .OrderBy(directive => directive.SpanStart);
+
+        foreach (var directive in directives)
+        {
+            var line = source.Lines.GetLineFromPosition(directive.SpanStart);
+            switch (directive)
+            {
+                case IfDirectiveTriviaSyntax ifDirective:
+                {
+                    ConditionalModuleSourceGroup? group = null;
+                    if (IsModuleScopeDirective(ifDirective))
+                    {
+                        group = new ConditionalModuleSourceGroup
+                        {
+                            Start = line.Start
+                        };
+                        group.Branches.Add(new ConditionalModuleSourceBranch
+                        {
+                            Condition = ifDirective.Condition.ToString(),
+                            ContentStart = line.EndIncludingLineBreak
+                        });
+
+                        var parent = stack.FirstOrDefault(frame => frame.Group != null)?.Group;
+                        if (parent != null)
+                            parent.Branches[^1].Children.Add(group);
+                        else
+                            roots.Add(group);
+                    }
+                    stack.Push(new ConditionalDirectiveFrame(group));
+                    break;
+                }
+                case ElifDirectiveTriviaSyntax elifDirective when stack.Count > 0:
+                {
+                    var group = stack.Peek().Group;
+                    if (group == null)
+                        break;
+                    group.Branches[^1].ContentEnd = line.Start;
+                    group.Branches.Add(new ConditionalModuleSourceBranch
+                    {
+                        Condition = elifDirective.Condition.ToString(),
+                        ContentStart = line.EndIncludingLineBreak
+                    });
+                    break;
+                }
+                case ElseDirectiveTriviaSyntax when stack.Count > 0:
+                {
+                    var group = stack.Peek().Group;
+                    if (group == null)
+                        break;
+                    group.Branches[^1].ContentEnd = line.Start;
+                    group.Branches.Add(new ConditionalModuleSourceBranch
+                    {
+                        Condition = null,
+                        ContentStart = line.EndIncludingLineBreak
+                    });
+                    break;
+                }
+                case EndIfDirectiveTriviaSyntax when stack.Count > 0:
+                {
+                    var group = stack.Pop().Group;
+                    if (group != null)
+                    {
+                        group.Branches[^1].ContentEnd = line.Start;
+                        group.End = line.EndIncludingLineBreak;
+                    }
+                    break;
+                }
+            }
+        }
+
+        while (stack.Count > 0)
+        {
+            var group = stack.Pop().Group;
+            if (group != null)
+            {
+                group.Branches[^1].ContentEnd = source.Length;
+                group.End = source.Length;
+            }
+        }
+
+        return roots;
+    }
+
+    private static bool IsModuleScopeDirective(DirectiveTriviaSyntax directive)
+    {
+        var position = directive.SpanStart;
+        for (var node = directive.ParentTrivia.Token.Parent;
+             node != null;
+             node = node.Parent)
+        {
+            if (position < node.SpanStart || position > node.Span.End)
+                continue;
+
+            if (node is CompilationUnitSyntax or BaseNamespaceDeclarationSyntax)
+                return true;
+
+            if (node is BaseTypeDeclarationSyntax
+                or DelegateDeclarationSyntax
+                or BaseMethodDeclarationSyntax
+                or AccessorDeclarationSyntax
+                or LocalFunctionStatementSyntax
+                or AnonymousFunctionExpressionSyntax
+                or StatementSyntax)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private TypePreprocessorBlockNode? BuildConditionalModuleNode(
+        ConditionalModuleSourceGroup group,
+        Microsoft.CodeAnalysis.Text.SourceText source)
+    {
+        var branches = group.Branches
+            .Select(branch =>
+            {
+                var positionedItems = ParseDirectConditionalItems(branch, source);
+                var positionedNested = branch.Children
+                    .Select(child => (
+                        Position: child.Start,
+                        Node: BuildConditionalModuleNode(child, source)))
+                    .Where(item => item.Node != null)
+                    .Select(item => (item.Position, Node: item.Node!))
+                    .ToList();
+                return (
+                    branch.Condition,
+                    Usings: positionedItems
+                        .Where(item => item.Node is UsingDirectiveNode)
+                        .Select(item => (UsingDirectiveNode)item.Node)
+                        .ToList(),
+                    Classes: positionedItems
+                        .Where(item => item.Node is ClassDefinitionNode)
+                        .Select(item => (ClassDefinitionNode)item.Node)
+                        .ToList(),
+                    Interfaces: positionedItems
+                        .Where(item => item.Node is InterfaceDefinitionNode)
+                        .Select(item => (InterfaceDefinitionNode)item.Node)
+                        .ToList(),
+                    Enums: positionedItems
+                        .Where(item => item.Node is EnumDefinitionNode)
+                        .Select(item => (EnumDefinitionNode)item.Node)
+                        .ToList(),
+                    Delegates: positionedItems
+                        .Where(item => item.Node is DelegateDefinitionNode)
+                        .Select(item => (DelegateDefinitionNode)item.Node)
+                        .ToList(),
+                    InteropBlocks: positionedItems
+                        .Where(item => item.Node is CSharpInteropBlockNode)
+                        .Select(item => (CSharpInteropBlockNode)item.Node)
+                        .ToList(),
+                    Nested: positionedNested.Select(item => item.Node).ToList(),
+                    Items: positionedItems
+                        .Concat(positionedNested.Select(item =>
+                            (item.Position, Node: (AstNode)item.Node)))
+                        .OrderBy(item => item.Position)
+                        .Select(item => item.Node)
+                        .ToList());
+            })
+            .ToList();
+
+        if (!branches.Any(branch =>
+                branch.Items.Count > 0))
+        {
+            return null;
+        }
+
+        TypePreprocessorBlockNode? elseBranch = null;
+        for (var index = branches.Count - 1; index >= 1; index--)
+        {
+            var branch = branches[index];
+            elseBranch = new TypePreprocessorBlockNode(
+                TextSpan.Empty,
+                branch.Condition ?? "",
+                branch.Classes,
+                branch.Interfaces,
+                branch.Enums,
+                branch.Delegates,
+                elseBranch,
+                branch.Usings,
+                branch.Nested,
+                branch.Items,
+                branch.InteropBlocks);
+        }
+
+        var first = branches[0];
+        return new TypePreprocessorBlockNode(
+            TextSpan.Empty,
+            first.Condition ?? "IF",
+            first.Classes,
+            first.Interfaces,
+            first.Enums,
+            first.Delegates,
+            elseBranch,
+            first.Usings,
+            first.Nested,
+            first.Items,
+            first.InteropBlocks);
+    }
+
+    private List<(int Position, AstNode Node)> ParseDirectConditionalItems(
+        ConditionalModuleSourceBranch branch,
+        Microsoft.CodeAnalysis.Text.SourceText source)
+    {
+        if (branch.ContentEnd <= branch.ContentStart)
+            return new List<(int, AstNode)>();
+
+        var text = source.ToString(Microsoft.CodeAnalysis.Text.TextSpan.FromBounds(
+            branch.ContentStart,
+            branch.ContentEnd));
+        if (branch.Children.Count > 0)
+        {
+            var chars = text.ToCharArray();
+            foreach (var child in branch.Children)
+            {
+                var start = Math.Max(0, child.Start - branch.ContentStart);
+                var end = Math.Min(chars.Length, child.End - branch.ContentStart);
+                for (var index = start; index < end; index++)
+                {
+                    if (chars[index] is not '\r' and not '\n')
+                        chars[index] = ' ';
+                }
+            }
+            text = new string(chars);
+        }
+
+        var parsed = CSharpSyntaxTree.ParseText(
+            text,
+            new CSharpParseOptions(LanguageVersion.Preview))
+            .GetCompilationUnitRoot();
+        var result = new List<(int Position, AstNode Node)>();
+        foreach (var usingDirective in parsed.DescendantNodes().OfType<UsingDirectiveSyntax>())
+        {
+            if (TryConvertUsingDirective(
+                    usingDirective,
+                    TextSpan.Empty,
+                    out var usingNode))
+            {
+                result.Add((
+                    branch.ContentStart + usingDirective.SpanStart,
+                    usingNode));
+            }
+        }
+        foreach (var member in EnumerateConditionalTypeMembers(parsed))
+        {
+            _insideConditionalModuleRecovery = true;
+            (List<ClassDefinitionNode> classes,
+                List<InterfaceDefinitionNode> interfaces,
+                List<EnumDefinitionNode> enums,
+                List<DelegateDefinitionNode> delegates,
+                List<UsingDirectiveNode> usings) converted;
+            var branchInterop = new List<CSharpInteropBlockNode>();
+            var previousInteropSink = _conditionalModuleInteropSink;
+            _conditionalModuleInteropSink = branchInterop;
+            try
+            {
+                converted = ConvertDisabledTypeText(member.ToFullString());
+            }
+            finally
+            {
+                _conditionalModuleInteropSink = previousInteropSink;
+                _insideConditionalModuleRecovery = false;
+            }
+            foreach (var node in converted.classes.Cast<AstNode>()
+                         .Concat(converted.interfaces)
+                         .Concat(converted.enums)
+                         .Concat(converted.delegates)
+                         .Concat(branchInterop))
+            {
+                result.Add((
+                    branch.ContentStart + member.SpanStart,
+                    node));
+            }
+        }
+        return result.OrderBy(item => item.Position).ToList();
+    }
+
+    private static IEnumerable<MemberDeclarationSyntax> EnumerateConditionalTypeMembers(
+        CompilationUnitSyntax root)
+    {
+        foreach (var member in root.Members)
+        {
+            foreach (var result in Enumerate(member))
+                yield return result;
+        }
+
+        static IEnumerable<MemberDeclarationSyntax> Enumerate(
+            MemberDeclarationSyntax member)
+        {
+            if (member is BaseNamespaceDeclarationSyntax ns)
+            {
+                foreach (var nested in ns.Members)
+                {
+                    foreach (var result in Enumerate(nested))
+                        yield return result;
+                }
+                yield break;
+            }
+
+            if (member is BaseTypeDeclarationSyntax or DelegateDeclarationSyntax)
+                yield return member;
+        }
+    }
+
+    private static bool ContainsConditionalUsings(TypePreprocessorBlockNode block)
+        => block.Usings.Count > 0
+            || block.NestedBlocks.Any(ContainsConditionalUsings)
+            || block.ElseBranch != null
+            && ContainsConditionalUsings(block.ElseBranch);
+
+    private void RemoveUsingsFromScannedPreprocessorBlocks()
+    {
+        var stripped = _typePreprocessorBlocks
+            .Select(RemoveUsingsFromPreprocessorBlock)
+            .Where(block => block != null)
+            .Cast<TypePreprocessorBlockNode>()
+            .ToList();
+        _typePreprocessorBlocks.Clear();
+        _typePreprocessorBlocks.AddRange(stripped);
+    }
+
+    private static TypePreprocessorBlockNode? RemoveUsingsFromPreprocessorBlock(
+        TypePreprocessorBlockNode block)
+    {
+        var nestedMap = block.NestedBlocks.ToDictionary(
+            child => child,
+            RemoveUsingsFromPreprocessorBlock);
+        var nested = nestedMap.Values
+            .Where(child => child != null)
+            .Cast<TypePreprocessorBlockNode>()
+            .ToList();
+        var items = new List<AstNode>();
+        foreach (var item in block.Items)
+        {
+            if (item is UsingDirectiveNode)
+                continue;
+            if (item is TypePreprocessorBlockNode child)
+            {
+                if (nestedMap[child] is { } strippedChild)
+                    items.Add(strippedChild);
+                continue;
+            }
+            items.Add(item);
+        }
+        var elseBranch = block.ElseBranch == null
+            ? null
+            : RemoveUsingsFromPreprocessorBlock(block.ElseBranch);
+        var hasTypes = items.Count > 0;
+        if (!hasTypes && elseBranch == null)
+            return null;
+
+        return new TypePreprocessorBlockNode(
+            block.Span,
+            block.Condition,
+            block.Classes,
+            block.Interfaces,
+            block.Enums,
+            block.Delegates,
+            elseBranch,
+            usings: Array.Empty<UsingDirectiveNode>(),
+            nestedBlocks: nested,
+            items: items,
+            interopBlocks: block.InteropBlocks);
     }
 
     /// <summary>
@@ -487,6 +876,10 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
 
     public override void VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
     {
+        if (!_insideConditionalModuleRecovery
+            && _conditionalTypeDeclarationStarts.Contains(node.SpanStart))
+            return;
+
         // Check for #if wrapping entire type declaration
         if (!_insideTypePreprocessorConversion)
         {
@@ -514,7 +907,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         }
         catch (Exception ex) when (_context.ShouldPreserveCSharp || ex is MemberInteropEscalationException)
         {
-            _moduleInteropBlocks.Add(CreateInteropBlock(node, "interface", InteropMemberKind.Class));
+            AddModuleInteropBlock(CreateInteropBlock(node, "interface", InteropMemberKind.Class));
         }
         finally
         {
@@ -579,6 +972,10 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
 
     public override void VisitClassDeclaration(ClassDeclarationSyntax node)
     {
+        if (!_insideConditionalModuleRecovery
+            && _conditionalTypeDeclarationStarts.Contains(node.SpanStart))
+            return;
+
         if (!_insideTypePreprocessorConversion)
         {
             var ppCondition = GetTypePreprocessorCondition(node);
@@ -607,7 +1004,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         {
             // Unconditional catch for class conversion — if any class member crashes,
             // wrap the entire class as an interop block instead of failing the file.
-            _moduleInteropBlocks.Add(CreateInteropBlock(node, "class", InteropMemberKind.Class));
+            AddModuleInteropBlock(CreateInteropBlock(node, "class", InteropMemberKind.Class));
         }
         finally
         {
@@ -617,6 +1014,10 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
 
     public override void VisitRecordDeclaration(RecordDeclarationSyntax node)
     {
+        if (!_insideConditionalModuleRecovery
+            && _conditionalTypeDeclarationStarts.Contains(node.SpanStart))
+            return;
+
         if (!_insideTypePreprocessorConversion)
         {
             var ppCondition = GetTypePreprocessorCondition(node);
@@ -634,7 +1035,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         // properties and NO constructor — broken output). Counted as a loss.
         if (FeatureSupport.GetSupportLevel("record") != SupportLevel.Full)
         {
-            _moduleInteropBlocks.Add(CreateInteropBlock(node, "record", InteropMemberKind.Class));
+            AddModuleInteropBlock(CreateInteropBlock(node, "record", InteropMemberKind.Class));
             return;
         }
 
@@ -650,7 +1051,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         }
         catch (Exception ex) when (_context.ShouldPreserveCSharp || ex is MemberInteropEscalationException)
         {
-            _moduleInteropBlocks.Add(CreateInteropBlock(node, "record", InteropMemberKind.Class));
+            AddModuleInteropBlock(CreateInteropBlock(node, "record", InteropMemberKind.Class));
         }
         finally
         {
@@ -660,6 +1061,10 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
 
     public override void VisitStructDeclaration(StructDeclarationSyntax node)
     {
+        if (!_insideConditionalModuleRecovery
+            && _conditionalTypeDeclarationStarts.Contains(node.SpanStart))
+            return;
+
         if (!_insideTypePreprocessorConversion)
         {
             var ppCondition = GetTypePreprocessorCondition(node);
@@ -686,7 +1091,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         }
         catch (Exception ex) when (_context.ShouldPreserveCSharp || ex is MemberInteropEscalationException)
         {
-            _moduleInteropBlocks.Add(CreateInteropBlock(node, "struct", InteropMemberKind.Class));
+            AddModuleInteropBlock(CreateInteropBlock(node, "struct", InteropMemberKind.Class));
         }
         finally
         {
@@ -696,6 +1101,10 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
 
     public override void VisitEnumDeclaration(EnumDeclarationSyntax node)
     {
+        if (!_insideConditionalModuleRecovery
+            && _conditionalTypeDeclarationStarts.Contains(node.SpanStart))
+            return;
+
         if (!_insideTypePreprocessorConversion)
         {
             var ppCondition = GetTypePreprocessorCondition(node);
@@ -754,12 +1163,16 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         }
         catch (Exception ex) when (_context.ShouldPreserveCSharp || ex is MemberInteropEscalationException)
         {
-            _moduleInteropBlocks.Add(CreateInteropBlock(node, "enum", InteropMemberKind.Other));
+            AddModuleInteropBlock(CreateInteropBlock(node, "enum", InteropMemberKind.Other));
         }
     }
 
     public override void VisitDelegateDeclaration(DelegateDeclarationSyntax node)
     {
+        if (!_insideConditionalModuleRecovery
+            && _conditionalTypeDeclarationStarts.Contains(node.SpanStart))
+            return;
+
         // #773: DelegateDefinitionNode carries no type parameters, so a generic
         // delegate would silently lose its <T> and emit non-compiling C#.
         // Preserve generic delegates verbatim as §CSHARP interop instead.
@@ -767,7 +1180,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         {
             if (node.Parent is CompilationUnitSyntax or BaseNamespaceDeclarationSyntax)
             {
-                _moduleInteropBlocks.Add(CreateInteropBlock(node, "generic-delegate", InteropMemberKind.Other));
+                AddModuleInteropBlock(CreateInteropBlock(node, "generic-delegate", InteropMemberKind.Other));
                 return;
             }
             // Nested: escalate so the enclosing type's member loop preserves it.
@@ -804,7 +1217,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         }
         catch (Exception ex) when (_context.ShouldPreserveCSharp || ex is MemberInteropEscalationException)
         {
-            _moduleInteropBlocks.Add(CreateInteropBlock(node, "delegate", InteropMemberKind.Other));
+            AddModuleInteropBlock(CreateInteropBlock(node, "delegate", InteropMemberKind.Other));
         }
     }
 
@@ -972,29 +1385,25 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                 // Convert active members
                 var ppFields = new List<ClassFieldNode>();
                 var ppProperties = new List<PropertyNode>();
+                var ppIndexers = new List<IndexerNode>();
                 var ppConstructors = new List<ConstructorNode>();
                 var ppMethods = new List<MethodNode>();
                 var ppEvents = new List<EventDefinitionNode>();
                 var ppOperatorOverloads = new List<OperatorOverloadNode>();
+                var ppInteropBlocks = new List<CSharpInteropBlockNode>();
+                var ppItems = new List<AstNode>();
 
                 for (int bi = ppRegion.ActiveStart; bi < ppRegion.ActiveEnd; bi++)
                 {
-                    try
-                    {
-                        ConvertClassMember(node.Members[bi], ppFields, ppProperties, ppConstructors, ppMethods, ppEvents, ppOperatorOverloads);
-                    }
-                    catch (Exception ex) when (_context.ShouldPreserveCSharp || ex is MemberInteropEscalationException)
-                    {
-                        // Member inside an active #if branch could not convert
-                        // natively. Preserve it as §CSHARP at class level (outside
-                        // the #if — noted in the recorded loss) rather than
-                        // dropping it silently.
-                        interopBlocks.Add(CreateInteropBlock(node.Members[bi], null, InteropMemberKind.Other));
-                    }
+                    ConvertClassMemberIntoPreprocessor(
+                        node.Members[bi], ppFields, ppProperties, ppIndexers, ppConstructors,
+                        ppMethods, ppEvents, ppOperatorOverloads,
+                        ppInteropBlocks, ppItems);
                 }
 
                 preprocessorBlocks.Add(BuildMemberPreprocessorNode(span, ppRegion.Branches,
-                    ppFields, ppProperties, ppConstructors, ppMethods, ppEvents, ppOperatorOverloads));
+                    ppFields, ppProperties, ppConstructors, ppMethods, ppEvents,
+                    ppOperatorOverloads, ppInteropBlocks, ppItems, ppIndexers));
 
                 memberIndex = ppRegion.ActiveEnd - 1; // loop will increment
                 continue;
@@ -1477,28 +1886,25 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
 
                 var ppFields = new List<ClassFieldNode>();
                 var ppProperties = new List<PropertyNode>();
+                var ppIndexers = new List<IndexerNode>();
                 var ppConstructors = new List<ConstructorNode>();
                 var ppMethods = new List<MethodNode>();
                 var ppEvents = new List<EventDefinitionNode>();
                 var ppOperatorOverloads = new List<OperatorOverloadNode>();
+                var ppInteropBlocks = new List<CSharpInteropBlockNode>();
+                var ppItems = new List<AstNode>();
 
                 for (int bi = ppRegion.ActiveStart; bi < ppRegion.ActiveEnd; bi++)
                 {
-                    try
-                    {
-                        ConvertClassMember(node.Members[bi], ppFields, ppProperties, ppConstructors, ppMethods, ppEvents, ppOperatorOverloads);
-                    }
-                    catch (Exception ex) when (_context.ShouldPreserveCSharp || ex is MemberInteropEscalationException)
-                    {
-                        // Member inside an active #if branch could not convert
-                        // natively — preserve as §CSHARP at type level (outside
-                        // the #if — noted in the recorded loss), never drop.
-                        interopBlocks.Add(CreateInteropBlock(node.Members[bi], null, InteropMemberKind.Other));
-                    }
+                    ConvertClassMemberIntoPreprocessor(
+                        node.Members[bi], ppFields, ppProperties, ppIndexers, ppConstructors,
+                        ppMethods, ppEvents, ppOperatorOverloads,
+                        ppInteropBlocks, ppItems);
                 }
 
                 preprocessorBlocks.Add(BuildMemberPreprocessorNode(span, ppRegion.Branches,
-                    ppFields, ppProperties, ppConstructors, ppMethods, ppEvents, ppOperatorOverloads));
+                    ppFields, ppProperties, ppConstructors, ppMethods, ppEvents,
+                    ppOperatorOverloads, ppInteropBlocks, ppItems, ppIndexers));
 
                 memberIndex = ppRegion.ActiveEnd - 1; // loop will increment
                 continue;
@@ -2446,7 +2852,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             return false;
 
         _context.RecordFeatureUsage("namespace");
-        _moduleInteropBlocks.Add(CreateInteropBlock(node, "namespace-collision", kind));
+        AddModuleInteropBlock(CreateInteropBlock(node, "namespace-collision", kind));
         return true;
     }
 
@@ -3165,16 +3571,21 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
     /// Parses disabled text (from an inactive preprocessor branch) as class members
     /// and converts them to typed member lists for MemberPreprocessorBlockNode.
     /// </summary>
-    private (List<ClassFieldNode> fields, List<PropertyNode> properties, List<ConstructorNode> constructors,
-             List<MethodNode> methods, List<EventDefinitionNode> events, List<OperatorOverloadNode> operatorOverloads)
+    private (List<ClassFieldNode> fields, List<PropertyNode> properties, List<IndexerNode> indexers,
+             List<ConstructorNode> constructors,
+             List<MethodNode> methods, List<EventDefinitionNode> events, List<OperatorOverloadNode> operatorOverloads,
+             List<CSharpInteropBlockNode> interopBlocks, List<AstNode> items)
         ConvertDisabledMemberText(string disabledText)
     {
         var fields = new List<ClassFieldNode>();
         var properties = new List<PropertyNode>();
+        var indexers = new List<IndexerNode>();
         var constructors = new List<ConstructorNode>();
         var methods = new List<MethodNode>();
         var events = new List<EventDefinitionNode>();
         var operatorOverloads = new List<OperatorOverloadNode>();
+        var interopBlocks = new List<CSharpInteropBlockNode>();
+        var items = new List<AstNode>();
 
         var wrapper = $"class _PP {{ {disabledText} }}";
         try
@@ -3184,62 +3595,108 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             var classDecl = root.DescendantNodes()
                 .OfType<ClassDeclarationSyntax>()
                 .FirstOrDefault();
-            if (classDecl == null) return (fields, properties, constructors, methods, events, operatorOverloads);
+            if (classDecl == null)
+                return (fields, properties, indexers, constructors, methods, events,
+                    operatorOverloads, interopBlocks, items);
 
             foreach (var member in classDecl.Members)
             {
-                try
-                {
-                    ConvertClassMember(member, fields, properties, constructors, methods, events, operatorOverloads);
-                }
-                catch
-                {
-                    // #836 M1: preserve the member VERBATIM (in all modes — the
-                    // disabled branch is never active C#, so a §RAW body is
-                    // safe) and record the loss; the old comment-stub silently
-                    // deleted the original API with zero ledger entries.
-                    var fallbackId = _context.GenerateId("m");
-                    var fallbackBody = new List<StatementNode>
-                    {
-                        new RawCSharpNode(TextSpan.Empty, member.ToString().Trim())
-                    };
-                    _context.RecordLoss(ConversionLossKind.InteropPreserved, "preprocessor-disabled",
-                        $"Member in disabled #if branch preserved as raw C# inside a fallback stub: {TruncateForMessage(member.ToString())}");
-                    _context.AddWarning(
-                        $"Member in disabled preprocessor branch could not be converted; preserved verbatim: {TruncateForMessage(member.ToString())}",
-                        feature: "preprocessor-disabled");
-                    methods.Add(new MethodNode(TextSpan.Empty, fallbackId, $"_PP_Fallback_{fallbackId}",
-                        Visibility.Private, MethodModifiers.None,
-                        Array.Empty<TypeParameterNode>(), Array.Empty<ParameterNode>(),
-                        null, null, Array.Empty<RequiresNode>(), Array.Empty<EnsuresNode>(),
-                        fallbackBody, new AttributeCollection()));
-                }
+                ConvertClassMemberIntoPreprocessor(
+                    member, fields, properties, indexers, constructors, methods, events,
+                    operatorOverloads, interopBlocks, items,
+                    interopFeature: "preprocessor-disabled");
             }
         }
         catch
         {
-            // #836 M1: if the disabled text can't be parsed at all, preserve it
-            // VERBATIM (all modes) and record the loss — never a silent
-            // zero-ledger comment stub.
-            var fallbackId = _context.GenerateId("m");
-            var fallbackBody = new List<StatementNode>
-            {
-                new RawCSharpNode(TextSpan.Empty, disabledText.Trim())
-            };
+            var interop = new CSharpInteropBlockNode(
+                TextSpan.Empty,
+                disabledText.Trim(),
+                "preprocessor-disabled",
+                "Disabled preprocessor member text preserved verbatim",
+                InteropMemberKind.Other);
             _context.RecordLoss(ConversionLossKind.InteropPreserved, "preprocessor-disabled",
-                $"Disabled #if branch text preserved as raw C# inside a fallback stub: {TruncateForMessage(disabledText.Trim())}");
+                $"Disabled #if branch text preserved as §CSHARP interop: {TruncateForMessage(disabledText.Trim())}");
             _context.AddWarning(
                 $"Disabled preprocessor text could not be parsed as class members; preserved verbatim: {TruncateForMessage(disabledText.Trim())}",
                 feature: "preprocessor-disabled");
-            methods.Add(new MethodNode(TextSpan.Empty, fallbackId, $"_PP_Fallback_{fallbackId}",
-                Visibility.Private, MethodModifiers.None,
-                Array.Empty<TypeParameterNode>(), Array.Empty<ParameterNode>(),
-                null, null, Array.Empty<RequiresNode>(), Array.Empty<EnsuresNode>(),
-                fallbackBody, new AttributeCollection()));
+            interopBlocks.Add(interop);
+            items.Add(interop);
         }
 
-        return (fields, properties, constructors, methods, events, operatorOverloads);
+        return (fields, properties, indexers, constructors, methods, events,
+            operatorOverloads, interopBlocks, items);
     }
+
+    private void ConvertClassMemberIntoPreprocessor(
+        MemberDeclarationSyntax member,
+        List<ClassFieldNode> fields,
+        List<PropertyNode> properties,
+        List<IndexerNode> indexers,
+        List<ConstructorNode> constructors,
+        List<MethodNode> methods,
+        List<EventDefinitionNode> events,
+        List<OperatorOverloadNode> operatorOverloads,
+        List<CSharpInteropBlockNode> interopBlocks,
+        List<AstNode> items,
+        string interopFeature = "preprocessor-member")
+    {
+        if (member is BaseTypeDeclarationSyntax or DelegateDeclarationSyntax)
+        {
+            var nestedInterop = CreateInteropBlock(
+                member,
+                interopFeature,
+                InteropMemberKind.Class);
+            interopBlocks.Add(nestedInterop);
+            items.Add(nestedInterop);
+            return;
+        }
+
+        var fieldCount = fields.Count;
+        var propertyCount = properties.Count;
+        var indexerCount = indexers.Count;
+        var constructorCount = constructors.Count;
+        var methodCount = methods.Count;
+        var eventCount = events.Count;
+        var operatorCount = operatorOverloads.Count;
+        try
+        {
+            ConvertClassMember(
+                member, fields, properties, constructors, methods, events,
+                operatorOverloads, indexers);
+            items.AddRange(fields.Skip(fieldCount));
+            items.AddRange(properties.Skip(propertyCount));
+            items.AddRange(indexers.Skip(indexerCount));
+            items.AddRange(constructors.Skip(constructorCount));
+            items.AddRange(methods.Skip(methodCount));
+            items.AddRange(events.Skip(eventCount));
+            items.AddRange(operatorOverloads.Skip(operatorCount));
+        }
+        catch
+        {
+            var interop = CreateInteropBlock(
+                member,
+                interopFeature,
+                GetInteropMemberKind(member));
+            interopBlocks.Add(interop);
+            items.Add(interop);
+        }
+    }
+
+    private static InteropMemberKind GetInteropMemberKind(
+        MemberDeclarationSyntax member)
+        => member switch
+        {
+            MethodDeclarationSyntax => InteropMemberKind.Method,
+            PropertyDeclarationSyntax or IndexerDeclarationSyntax =>
+                InteropMemberKind.Property,
+            FieldDeclarationSyntax => InteropMemberKind.Field,
+            ConstructorDeclarationSyntax => InteropMemberKind.Constructor,
+            EventFieldDeclarationSyntax or EventDeclarationSyntax =>
+                InteropMemberKind.Event,
+            BaseTypeDeclarationSyntax => InteropMemberKind.Class,
+            _ => InteropMemberKind.Other
+        };
 
     /// <summary>
     /// Builds a (potentially nested) MemberPreprocessorBlockNode from an ordered list of branches.
@@ -3253,38 +3710,63 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         List<ConstructorNode> activeConstructors,
         List<MethodNode> activeMethods,
         List<EventDefinitionNode> activeEvents,
-        List<OperatorOverloadNode> activeOperatorOverloads)
+        List<OperatorOverloadNode> activeOperatorOverloads,
+        List<CSharpInteropBlockNode>? activeInteropBlocks = null,
+        List<AstNode>? activeItems = null,
+        List<IndexerNode>? activeIndexers = null)
     {
+        activeInteropBlocks ??= new List<CSharpInteropBlockNode>();
+        activeIndexers ??= new List<IndexerNode>();
+        activeItems ??= activeFields.Cast<AstNode>()
+            .Concat(activeProperties)
+            .Concat(activeIndexers)
+            .Concat(activeConstructors)
+            .Concat(activeMethods)
+            .Concat(activeEvents)
+            .Concat(activeOperatorOverloads)
+            .Concat(activeInteropBlocks)
+            .ToList();
         if (branches.Count == 0)
         {
             return new MemberPreprocessorBlockNode(span, "UNKNOWN",
                 activeFields, activeProperties, activeConstructors,
-                activeMethods, activeEvents, activeOperatorOverloads);
+                activeMethods, activeEvents, activeOperatorOverloads,
+                indexers: activeIndexers,
+                interopBlocks: activeInteropBlocks,
+                items: activeItems);
         }
 
         // Convert each branch's body
         var convertedBodies = new List<(string? condition, List<ClassFieldNode> fields, List<PropertyNode> properties,
+            List<IndexerNode> indexers,
             List<ConstructorNode> constructors, List<MethodNode> methods,
-            List<EventDefinitionNode> events, List<OperatorOverloadNode> operatorOverloads)>();
+            List<EventDefinitionNode> events, List<OperatorOverloadNode> operatorOverloads,
+            List<CSharpInteropBlockNode> interopBlocks, List<AstNode> items)>();
 
         foreach (var branch in branches)
         {
             if (branch.IsActive)
             {
-                convertedBodies.Add((branch.Condition, activeFields, activeProperties,
-                    activeConstructors, activeMethods, activeEvents, activeOperatorOverloads));
+                convertedBodies.Add((branch.Condition, activeFields, activeProperties, activeIndexers,
+                    activeConstructors, activeMethods, activeEvents,
+                    activeOperatorOverloads, activeInteropBlocks, activeItems));
             }
             else if (branch.DisabledText != null)
             {
-                var (fields, properties, constructors, methods, events, operatorOverloads) =
+                var (fields, properties, indexers, constructors, methods, events,
+                    operatorOverloads, interopBlocks, items) =
                     ConvertDisabledMemberText(branch.DisabledText);
-                convertedBodies.Add((branch.Condition, fields, properties, constructors, methods, events, operatorOverloads));
+                convertedBodies.Add((branch.Condition, fields, properties, indexers,
+                    constructors, methods, events, operatorOverloads,
+                    interopBlocks, items));
             }
             else
             {
                 convertedBodies.Add((branch.Condition, new List<ClassFieldNode>(), new List<PropertyNode>(),
+                    new List<IndexerNode>(),
                     new List<ConstructorNode>(), new List<MethodNode>(),
-                    new List<EventDefinitionNode>(), new List<OperatorOverloadNode>()));
+                    new List<EventDefinitionNode>(), new List<OperatorOverloadNode>(),
+                    new List<CSharpInteropBlockNode>(), new List<AstNode>()));
             }
         }
 
@@ -3293,18 +3775,24 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
 
         for (int idx = convertedBodies.Count - 1; idx >= 1; idx--)
         {
-            var (condition, fields, properties, constructors, methods, events, operatorOverloads) = convertedBodies[idx];
+            var (condition, fields, properties, indexers, constructors, methods, events,
+                operatorOverloads, interopBlocks, items) = convertedBodies[idx];
             if (condition == null)
             {
                 // #else branch — becomes the innermost else (empty condition)
                 currentElse = new MemberPreprocessorBlockNode(span, "",
-                    fields, properties, constructors, methods, events, operatorOverloads);
+                    fields, properties, constructors, methods, events,
+                    operatorOverloads, indexers: indexers,
+                    interopBlocks: interopBlocks, items: items);
             }
             else
             {
                 // #elif branch — wrap in a new MemberPreprocessorBlockNode
                 var elifNode = new MemberPreprocessorBlockNode(span, condition,
-                    fields, properties, constructors, methods, events, operatorOverloads, currentElse);
+                    fields, properties, constructors, methods, events,
+                    operatorOverloads, currentElse,
+                    indexers: indexers,
+                    interopBlocks: interopBlocks, items: items);
                 currentElse = elifNode;
             }
         }
@@ -3313,7 +3801,9 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
         var first = convertedBodies[0];
         return new MemberPreprocessorBlockNode(span, first.condition ?? "IF",
             first.fields, first.properties, first.constructors,
-            first.methods, first.events, first.operatorOverloads, currentElse);
+            first.methods, first.events, first.operatorOverloads, currentElse,
+            indexers: first.indexers,
+            interopBlocks: first.interopBlocks, items: first.items);
     }
 
     /// <summary>
@@ -3675,12 +4165,18 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
             // Extract using directives
             foreach (var usingDir in root.Usings)
             {
-                if (usingDir.Name != null)
+                if (usingDir.NamespaceOrType != null)
                 {
-                    var namespaceName = usingDir.Name.ToString();
+                    var namespaceName = usingDir.NamespaceOrType.ToString();
                     var isStatic = usingDir.StaticKeyword.IsKind(SyntaxKind.StaticKeyword);
+                    var isGlobal = usingDir.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword);
                     var alias = usingDir.Alias?.Name.ToString();
-                    usings.Add(new UsingDirectiveNode(TextSpan.Empty, namespaceName, alias, isStatic));
+                    usings.Add(new UsingDirectiveNode(
+                        TextSpan.Empty,
+                        namespaceName,
+                        alias,
+                        isStatic,
+                        isGlobal));
                 }
             }
 
@@ -9544,6 +10040,19 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
     private TypeConstraintNode? ConvertTypeConstraint(TypeParameterConstraintSyntax constraint)
     {
         var span = GetTextSpan(constraint);
+        var text = System.Text.RegularExpressions.Regex.Replace(
+            constraint.ToString(),
+            @"\s+",
+            " ").Trim();
+
+        if (text == "class?")
+            return new TypeConstraintNode(span, TypeConstraintKind.ClassNullable);
+        if (text == "unmanaged")
+            return new TypeConstraintNode(span, TypeConstraintKind.Unmanaged);
+        if (text == "default")
+            return new TypeConstraintNode(span, TypeConstraintKind.Default);
+        if (text == "allows ref struct")
+            return new TypeConstraintNode(span, TypeConstraintKind.AllowsRefStruct);
 
         return constraint switch
         {
@@ -9566,8 +10075,7 @@ public sealed class RoslynSyntaxVisitor : CSharpSyntaxWalker
                         typeConstraint.Type.ToString(), @"\s+", " ").Trim()),
 
             DefaultConstraintSyntax =>
-                // 'default' constraint (C# 9+) - no direct Calor equivalent, skip
-                null,
+                new TypeConstraintNode(span, TypeConstraintKind.Default),
 
             _ => null
         };

--- a/src/Calor.Compiler/Parsing/Parser.cs
+++ b/src/Calor.Compiler/Parsing/Parser.cs
@@ -433,7 +433,121 @@ public sealed class Parser
 
     public ModuleNode Parse()
     {
-        return ParseModule();
+        var module = ParseModule();
+        ValidateDefaultConstraintOwners(module);
+        return module;
+    }
+
+    private void ValidateDefaultConstraintOwners(ModuleNode module)
+    {
+        foreach (var function in module.Functions)
+            ValidateDefaultConstraints(
+                function.TypeParameters,
+                isLegal: false,
+                owner: "a function");
+        foreach (var extension in module.EnumExtensions)
+        {
+            foreach (var method in extension.Methods)
+                ValidateDefaultConstraints(
+                    method.TypeParameters,
+                    isLegal: false,
+                    owner: "an enum extension method");
+        }
+        foreach (var iface in module.Interfaces)
+            ValidateInterfaceDefaultConstraints(iface);
+        foreach (var type in module.Classes)
+            ValidateClassDefaultConstraints(type);
+        foreach (var block in module.TypePreprocessorBlocks)
+            ValidateTypePreprocessorDefaultConstraints(block);
+    }
+
+    private void ValidateInterfaceDefaultConstraints(InterfaceDefinitionNode node)
+    {
+        ValidateDefaultConstraints(
+            node.TypeParameters,
+            isLegal: false,
+            owner: "an interface");
+        foreach (var method in node.Methods)
+            ValidateDefaultConstraints(
+                method.TypeParameters,
+                isLegal: false,
+                owner: "an interface method");
+    }
+
+    private void ValidateClassDefaultConstraints(ClassDefinitionNode node)
+    {
+        ValidateDefaultConstraints(
+            node.TypeParameters,
+            isLegal: false,
+            owner: node.IsStruct ? "a struct" : "a class");
+        foreach (var method in node.Methods)
+        {
+            var isExplicitInterfaceImplementation =
+                method.Name.Contains('.', StringComparison.Ordinal);
+            ValidateDefaultConstraints(
+                method.TypeParameters,
+                method.IsOverride || isExplicitInterfaceImplementation,
+                method.IsOverride
+                    ? "an override method"
+                    : isExplicitInterfaceImplementation
+                        ? "an explicit interface implementation"
+                        : "an ordinary method");
+        }
+        foreach (var block in node.PreprocessorBlocks)
+            ValidateMemberPreprocessorDefaultConstraints(block);
+        foreach (var nested in node.NestedClasses)
+            ValidateClassDefaultConstraints(nested);
+        foreach (var nested in node.NestedInterfaces)
+            ValidateInterfaceDefaultConstraints(nested);
+    }
+
+    private void ValidateMemberPreprocessorDefaultConstraints(
+        MemberPreprocessorBlockNode block)
+    {
+        foreach (var method in block.Methods)
+        {
+            ValidateDefaultConstraints(
+                method.TypeParameters,
+                method.IsOverride
+                    || method.Name.Contains('.', StringComparison.Ordinal),
+                "a conditional method");
+        }
+        if (block.ElseBranch != null)
+            ValidateMemberPreprocessorDefaultConstraints(block.ElseBranch);
+    }
+
+    private void ValidateTypePreprocessorDefaultConstraints(
+        TypePreprocessorBlockNode block)
+    {
+        foreach (var iface in block.Interfaces)
+            ValidateInterfaceDefaultConstraints(iface);
+        foreach (var type in block.Classes)
+            ValidateClassDefaultConstraints(type);
+        foreach (var nested in block.NestedBlocks)
+            ValidateTypePreprocessorDefaultConstraints(nested);
+        if (block.ElseBranch != null)
+            ValidateTypePreprocessorDefaultConstraints(block.ElseBranch);
+    }
+
+    private void ValidateDefaultConstraints(
+        IReadOnlyList<TypeParameterNode> typeParameters,
+        bool isLegal,
+        string owner)
+    {
+        if (isLegal)
+            return;
+
+        foreach (var typeParameter in typeParameters)
+        {
+            foreach (var constraint in typeParameter.Constraints.Where(
+                         constraint => constraint.Kind == TypeConstraintKind.Default))
+            {
+                _diagnostics.ReportError(
+                    constraint.Span,
+                    DiagnosticCode.InvalidDefaultConstraintOwner,
+                    $"The 'default' constraint on '{typeParameter.Name}' is only legal on override methods or explicit interface implementations, not {owner}.");
+            }
+        }
     }
 
     /// <summary>
@@ -685,6 +799,9 @@ public sealed class Parser
     /// §U[System.Collections.Generic]            // using System.Collections.Generic;
     /// §U[Gen:System.Collections.Generic]        // using Gen = System.Collections.Generic;
     /// §U[static:System.Math]                    // using static System.Math;
+    /// §U[global:System.Text]                    // global using System.Text;
+    /// §U[global:static:System.Math]              // global using static System.Math;
+    /// §U[global:Gen:System.Collections.Generic]  // global using Gen = System.Collections.Generic;
     /// </summary>
     private UsingDirectiveNode ParseUsingDirective()
     {
@@ -696,14 +813,39 @@ public sealed class Parser
         // [namespace]                   -> using namespace;
         // [alias:namespace]             -> using alias = namespace;
         // [static:namespace]            -> using static namespace;
+        // [global:namespace]            -> global using namespace;
+        // [global:static:namespace]     -> global using static namespace;
+        // [global:alias:namespace]      -> global using alias = namespace;
         var pos0 = attrs["_pos0"] ?? "";
         var pos1 = attrs["_pos1"];
+        var pos2 = attrs["_pos2"];
 
         string @namespace;
         string? alias = null;
         bool isStatic = false;
+        bool isGlobal = false;
 
-        if (pos1 != null)
+        if (pos0.Equals("global", StringComparison.OrdinalIgnoreCase))
+        {
+            isGlobal = true;
+            if (pos2 != null)
+            {
+                if (pos1!.Equals("static", StringComparison.OrdinalIgnoreCase))
+                {
+                    isStatic = true;
+                }
+                else
+                {
+                    alias = pos1;
+                }
+                @namespace = pos2;
+            }
+            else
+            {
+                @namespace = pos1 ?? "";
+            }
+        }
+        else if (pos1 != null)
         {
             // Two-part format: [prefix:namespace]
             if (pos0.Equals("static", StringComparison.OrdinalIgnoreCase))
@@ -729,7 +871,7 @@ public sealed class Parser
             _diagnostics.ReportMissingRequiredAttribute(startToken.Span, "USING", "namespace");
         }
 
-        return new UsingDirectiveNode(startToken.Span, @namespace, alias, isStatic);
+        return new UsingDirectiveNode(startToken.Span, @namespace, alias, isStatic, isGlobal);
     }
 
     private FunctionNode ParseFunction()
@@ -7027,7 +7169,10 @@ public sealed class Parser
     /// &lt;T&gt; or &lt;T, U&gt; or &lt;TKey, TValue&gt;
     /// Returns an empty list if no type parameters are present.
     /// </summary>
-    private List<TypeParameterNode> ParseOptionalTypeParameterList(TextSpan defaultSpan)
+    private List<TypeParameterNode> ParseOptionalTypeParameterList(
+        TextSpan defaultSpan,
+        bool allowVariance = false,
+        string owner = "this declaration")
     {
         var typeParams = new List<TypeParameterNode>();
 
@@ -7045,6 +7190,13 @@ public sealed class Parser
             if (Check(TokenKind.Identifier) && Current.Text is "in" or "out")
             {
                 variance = Current.Text == "out" ? Ast.VarianceKind.Out : Ast.VarianceKind.In;
+                if (!allowVariance)
+                {
+                    _diagnostics.ReportError(
+                        Current.Span,
+                        DiagnosticCode.InvalidTypeParameterVariance,
+                        $"Type parameter variance is only legal on interfaces and delegates, not {owner}.");
+                }
                 Advance(); // consume in/out
             }
 
@@ -7153,9 +7305,13 @@ public sealed class Parser
             var (kind, typeName) = constraintText.ToLowerInvariant() switch
             {
                 "class" => (TypeConstraintKind.Class, (string?)null),
+                "class?" => (TypeConstraintKind.ClassNullable, (string?)null),
                 "struct" => (TypeConstraintKind.Struct, (string?)null),
                 "new" or "new()" => (TypeConstraintKind.New, (string?)null),
                 "notnull" => (TypeConstraintKind.NotNull, (string?)null),
+                "unmanaged" => (TypeConstraintKind.Unmanaged, (string?)null),
+                "default" => (TypeConstraintKind.Default, (string?)null),
+                "allows ref struct" => (TypeConstraintKind.AllowsRefStruct, (string?)null),
                 _ => (TypeConstraintKind.TypeName, constraintText)
             };
 
@@ -7165,7 +7321,11 @@ public sealed class Parser
 
         // Replace the type parameter with one that includes the new constraints
         var oldTypeParam = typeParameters[typeParamIndex];
-        typeParameters[typeParamIndex] = new TypeParameterNode(oldTypeParam.Span, oldTypeParam.Name, newConstraints);
+        typeParameters[typeParamIndex] = new TypeParameterNode(
+            oldTypeParam.Span,
+            oldTypeParam.Name,
+            newConstraints,
+            oldTypeParam.Variance);
     }
 
     /// <summary>
@@ -7198,10 +7358,30 @@ public sealed class Parser
         if (Check(TokenKind.Identifier))
         {
             var text = Current.Text.ToLowerInvariant();
-            if (text == "class" || text == "struct" || text == "notnull")
+            if (text == "class")
+            {
+                Advance();
+                if (Match(TokenKind.Question))
+                {
+                    return "class?";
+                }
+                return text;
+            }
+            if (text == "struct" || text == "notnull" || text == "unmanaged" || text == "default")
             {
                 Advance();
                 return text;
+            }
+            if (text == "allows"
+                && Peek(1).Kind == TokenKind.Identifier
+                && Peek(1).Text.Equals("ref", StringComparison.OrdinalIgnoreCase)
+                && Peek(2).Kind == TokenKind.Identifier
+                && Peek(2).Text.Equals("struct", StringComparison.OrdinalIgnoreCase))
+            {
+                Advance();
+                Advance();
+                Advance();
+                return "allows ref struct";
             }
             if (text == "new")
             {
@@ -7449,7 +7629,10 @@ public sealed class Parser
         }
 
         // NEW: Parse optional type parameters §IFACE{...}<T, U>
-        var typeParameters = ParseOptionalTypeParameterList(startToken.Span);
+        var typeParameters = ParseOptionalTypeParameterList(
+            startToken.Span,
+            allowVariance: true,
+            owner: "an interface");
 
         // Legacy: Extract type parameters from name if present (e.g., IProducer<out T>)
         if (typeParameters.Count == 0)
@@ -7801,6 +7984,13 @@ public sealed class Parser
                             {
                                 variance = Ast.VarianceKind.In;
                                 trimmedName = trimmedName.Substring(3);
+                            }
+                            if (variance != Ast.VarianceKind.None)
+                            {
+                                _diagnostics.ReportError(
+                                    startToken.Span,
+                                    DiagnosticCode.InvalidTypeParameterVariance,
+                                    "Type parameter variance is only legal on interfaces and delegates, not a class.");
                             }
                             typeParameters.Add(new TypeParameterNode(startToken.Span, trimmedName, Array.Empty<TypeConstraintNode>(), variance));
                         }
@@ -10182,11 +10372,15 @@ public sealed class Parser
         var methods = new List<MethodNode>();
         var events = new List<EventDefinitionNode>();
         var operatorOverloads = new List<OperatorOverloadNode>();
+        var interopBlocks = new List<CSharpInteropBlockNode>();
+        var items = new List<AstNode>();
 
         // Parse members until §PPE or §/PP
         while (!IsBlockEnd(TokenKind.EndPreprocessor) && !Check(TokenKind.PreprocessorElse) && !Check(TokenKind.Eof))
         {
-            ParseMemberInPreprocessorBlock(fields, properties, constructors, methods, events, operatorOverloads);
+            ParseMemberInPreprocessorBlock(
+                fields, properties, constructors, methods, events,
+                operatorOverloads, interopBlocks: interopBlocks, items: items);
         }
 
         MemberPreprocessorBlockNode? elseBranch = null;
@@ -10206,14 +10400,23 @@ public sealed class Parser
                 var elseMethods = new List<MethodNode>();
                 var elseEvents = new List<EventDefinitionNode>();
                 var elseOperatorOverloads = new List<OperatorOverloadNode>();
+                var elseInteropBlocks = new List<CSharpInteropBlockNode>();
+                var elseItems = new List<AstNode>();
 
                 while (!IsBlockEnd(TokenKind.EndPreprocessor) && !Check(TokenKind.Eof))
                 {
-                    ParseMemberInPreprocessorBlock(elseFields, elseProperties, elseConstructors, elseMethods, elseEvents, elseOperatorOverloads);
+                    ParseMemberInPreprocessorBlock(
+                        elseFields, elseProperties, elseConstructors, elseMethods,
+                        elseEvents, elseOperatorOverloads,
+                        interopBlocks: elseInteropBlocks,
+                        items: elseItems);
                 }
 
                 elseBranch = new MemberPreprocessorBlockNode(startToken.Span, "",
-                    elseFields, elseProperties, elseConstructors, elseMethods, elseEvents, elseOperatorOverloads);
+                    elseFields, elseProperties, elseConstructors, elseMethods,
+                    elseEvents, elseOperatorOverloads,
+                    interopBlocks: elseInteropBlocks,
+                    items: elseItems);
             }
         }
 
@@ -10224,7 +10427,8 @@ public sealed class Parser
         }
 
         return new MemberPreprocessorBlockNode(startToken.Span, condition,
-            fields, properties, constructors, methods, events, operatorOverloads, elseBranch);
+            fields, properties, constructors, methods, events, operatorOverloads,
+            elseBranch, interopBlocks: interopBlocks, items: items);
     }
 
     /// <summary>
@@ -10241,12 +10445,26 @@ public sealed class Parser
         var interfaces = new List<InterfaceDefinitionNode>();
         var enums = new List<EnumDefinitionNode>();
         var delegates = new List<DelegateDefinitionNode>();
+        var nestedBlocks = new List<TypePreprocessorBlockNode>();
+        var interopBlocks = new List<CSharpInteropBlockNode>();
+        var items = new List<AstNode>();
 
         // Parse type declarations until §PPE or §/PP
         while (!IsBlockEnd(TokenKind.EndPreprocessor) && !Check(TokenKind.PreprocessorElse) && !Check(TokenKind.Eof))
         {
-            ParseTypeInPreprocessorBlock(classes, interfaces, enums, delegates, usings);
+            ParseTypeInPreprocessorBlock(
+                classes,
+                interfaces,
+                enums,
+                delegates,
+                usings,
+                nestedBlocks,
+                items,
+                interopBlocks);
         }
+        ConsumeDedentBeforeChain(
+            TokenKind.PreprocessorElse,
+            TokenKind.EndPreprocessor);
 
         TypePreprocessorBlockNode? elseBranch = null;
         if (Match(TokenKind.PreprocessorElse))
@@ -10262,14 +10480,30 @@ public sealed class Parser
                 var elseInterfaces = new List<InterfaceDefinitionNode>();
                 var elseEnums = new List<EnumDefinitionNode>();
                 var elseDelegates = new List<DelegateDefinitionNode>();
+                var elseNestedBlocks = new List<TypePreprocessorBlockNode>();
+                var elseInteropBlocks = new List<CSharpInteropBlockNode>();
+                var elseItems = new List<AstNode>();
 
                 while (!IsBlockEnd(TokenKind.EndPreprocessor) && !Check(TokenKind.Eof))
                 {
-                    ParseTypeInPreprocessorBlock(elseClasses, elseInterfaces, elseEnums, elseDelegates, elseUsings);
+                    ParseTypeInPreprocessorBlock(
+                        elseClasses,
+                        elseInterfaces,
+                        elseEnums,
+                        elseDelegates,
+                        elseUsings,
+                        elseNestedBlocks,
+                        elseItems,
+                        elseInteropBlocks);
                 }
+                ConsumeDedentBeforeChain(TokenKind.EndPreprocessor);
 
                 elseBranch = new TypePreprocessorBlockNode(startToken.Span, "",
-                    elseClasses, elseInterfaces, elseEnums, elseDelegates, usings: elseUsings);
+                    elseClasses, elseInterfaces, elseEnums, elseDelegates,
+                    usings: elseUsings,
+                    nestedBlocks: elseNestedBlocks,
+                    items: elseItems,
+                    interopBlocks: elseInteropBlocks);
             }
         }
 
@@ -10279,7 +10513,8 @@ public sealed class Parser
         }
 
         return new TypePreprocessorBlockNode(startToken.Span, condition,
-            classes, interfaces, enums, delegates, elseBranch, usings);
+            classes, interfaces, enums, delegates, elseBranch, usings,
+            nestedBlocks, items, interopBlocks);
     }
 
     private void ParseTypeInPreprocessorBlock(
@@ -10287,31 +10522,56 @@ public sealed class Parser
         List<InterfaceDefinitionNode> interfaces,
         List<EnumDefinitionNode> enums,
         List<DelegateDefinitionNode> delegates,
-        List<UsingDirectiveNode>? usings = null)
+        List<UsingDirectiveNode>? usings = null,
+        List<TypePreprocessorBlockNode>? nestedBlocks = null,
+        List<AstNode>? items = null,
+        List<CSharpInteropBlockNode>? interopBlocks = null)
     {
         if (usings != null && Check(TokenKind.Using))
         {
-            usings.Add(ParseUsingDirective());
+            var node = ParseUsingDirective();
+            usings.Add(node);
+            items?.Add(node);
         }
         else if (Check(TokenKind.Class))
         {
-            classes.Add(ParseClassDefinition());
+            var node = ParseClassDefinition();
+            classes.Add(node);
+            items?.Add(node);
         }
         else if (Check(TokenKind.Interface))
         {
-            interfaces.Add(ParseInterfaceDefinition());
+            var node = ParseInterfaceDefinition();
+            interfaces.Add(node);
+            items?.Add(node);
         }
         else if (Check(TokenKind.Enum))
         {
-            enums.Add(ParseEnumDefinition());
+            var node = ParseEnumDefinition();
+            enums.Add(node);
+            items?.Add(node);
         }
         else if (Check(TokenKind.Delegate))
         {
-            delegates.Add(ParseDelegateDefinition());
+            var node = ParseDelegateDefinition();
+            delegates.Add(node);
+            items?.Add(node);
+        }
+        else if (nestedBlocks != null && Check(TokenKind.Preprocessor))
+        {
+            var node = ParseTypePreprocessorBlock();
+            nestedBlocks.Add(node);
+            items?.Add(node);
+        }
+        else if (interopBlocks != null && Check(TokenKind.CSharpInterop))
+        {
+            var node = ParseCSharpInteropBlock();
+            interopBlocks.Add(node);
+            items?.Add(node);
         }
         else
         {
-            _diagnostics.ReportUnexpectedToken(Current.Span, "U, CLASS, IFACE, EN, DEL, PPE, or END_PP", Current.Kind);
+            _diagnostics.ReportUnexpectedToken(Current.Span, "U, CLASS, IFACE, EN, DEL, PP, CSHARP, PPE, or END_PP", Current.Kind);
             Advance();
         }
     }
@@ -10323,27 +10583,67 @@ public sealed class Parser
         List<MethodNode> methods,
         List<EventDefinitionNode> events,
         List<OperatorOverloadNode> operatorOverloads,
-        List<IndexerNode>? indexers = null)
+        List<IndexerNode>? indexers = null,
+        List<CSharpInteropBlockNode>? interopBlocks = null,
+        List<AstNode>? items = null)
     {
         if (Check(TokenKind.FieldDef))
-            fields.Add(ParseClassField());
+        {
+            var node = ParseClassField();
+            fields.Add(node);
+            items?.Add(node);
+        }
         else if (Check(TokenKind.Property))
-            properties.Add(ParseProperty());
+        {
+            var node = ParseProperty();
+            properties.Add(node);
+            items?.Add(node);
+        }
         else if (Check(TokenKind.Indexer))
-            indexers?.Add(ParseIndexer());
+        {
+            var node = ParseIndexer();
+            indexers?.Add(node);
+            items?.Add(node);
+        }
         else if (Check(TokenKind.Constructor))
-            constructors.Add(ParseConstructor());
+        {
+            var node = ParseConstructor();
+            constructors.Add(node);
+            items?.Add(node);
+        }
         else if (Check(TokenKind.OperatorOverload))
-            operatorOverloads.Add(ParseOperatorOverload());
+        {
+            var node = ParseOperatorOverload();
+            operatorOverloads.Add(node);
+            items?.Add(node);
+        }
         else if (Check(TokenKind.Method))
-            methods.Add(ParseMethodDefinition());
+        {
+            var node = ParseMethodDefinition();
+            methods.Add(node);
+            items?.Add(node);
+        }
         else if (Check(TokenKind.AsyncMethod))
-            methods.Add(ParseAsyncMethodDefinition());
+        {
+            var node = ParseAsyncMethodDefinition();
+            methods.Add(node);
+            items?.Add(node);
+        }
         else if (Check(TokenKind.Event))
-            events.Add(ParseEventDefinition());
+        {
+            var node = ParseEventDefinition();
+            events.Add(node);
+            items?.Add(node);
+        }
+        else if (interopBlocks != null && Check(TokenKind.CSharpInterop))
+        {
+            var node = ParseCSharpInteropBlock();
+            interopBlocks.Add(node);
+            items?.Add(node);
+        }
         else
         {
-            _diagnostics.ReportUnexpectedToken(Current.Span, "FLD, PROP, IXER, CTOR, OP, METHOD, AMT, EVT, PPE, or END_PP", Current.Kind);
+            _diagnostics.ReportUnexpectedToken(Current.Span, "FLD, PROP, IXER, CTOR, OP, METHOD, AMT, EVT, CSHARP, PPE, or END_PP", Current.Kind);
             Advance();
         }
     }

--- a/tests/Calor.Compiler.Tests/InheritanceTests.cs
+++ b/tests/Calor.Compiler.Tests/InheritanceTests.cs
@@ -273,7 +273,7 @@ public class InheritanceTests
 
         var result = ParseAndEmit(source);
 
-        Assert.Contains("IEquatable<Dictionary<TKey,List<TValue>>>", result);
+        Assert.Contains("IEquatable<Dictionary<TKey, List<TValue>>>", result);
     }
 
     [Fact]

--- a/tests/Calor.Compiler.Tests/Issue766DeclarationModuleSemanticsTests.cs
+++ b/tests/Calor.Compiler.Tests/Issue766DeclarationModuleSemanticsTests.cs
@@ -999,6 +999,132 @@ public class Issue766DeclarationModuleSemanticsTests
     }
 
     [Fact]
+    public void InterfaceGenericMethodConstraints_RoundTripWithImplementation()
+    {
+        var conversion = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Fidelity = ConversionFidelity.Lossy,
+            ModuleName = "ConstraintRelationship",
+            AutoGenerateIds = true,
+            StripPreprocessor = false
+        }).Convert(
+            """
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            public interface IRequest
+            {
+                int Marker { get; }
+            }
+
+            public interface IRequest<TResponse>
+            {
+                TResponse Response { get; }
+            }
+
+            public interface INotification
+            {
+                int Marker { get; }
+            }
+
+            public interface ISender
+            {
+                Task Send<TRequest>(
+                    TRequest request,
+                    CancellationToken cancellationToken = default)
+                    where TRequest : IRequest;
+
+                Task<TResponse> Send<TRequest, TResponse>(
+                    TRequest request,
+                    CancellationToken cancellationToken = default)
+                    where TRequest : IRequest<TResponse>;
+            }
+
+            public interface IPublisher
+            {
+                Task Publish<TNotification>(
+                    TNotification notification,
+                    CancellationToken cancellationToken = default)
+                    where TNotification : INotification;
+            }
+
+            public abstract class Mediator : ISender, IPublisher
+            {
+                public abstract Task Send<TRequest>(
+                    TRequest request,
+                    CancellationToken cancellationToken = default)
+                    where TRequest : IRequest;
+
+                public abstract Task<TResponse> Send<TRequest, TResponse>(
+                    TRequest request,
+                    CancellationToken cancellationToken = default)
+                    where TRequest : IRequest<TResponse>;
+
+                public abstract Task Publish<TNotification>(
+                    TNotification notification,
+                    CancellationToken cancellationToken = default)
+                    where TNotification : INotification;
+            }
+            """);
+
+        Assert.True(
+            conversion.Success,
+            string.Join("; ", conversion.Issues.Select(issue => issue.Message)));
+        var sender = Assert.Single(
+            conversion.Ast!.Interfaces.Where(type => type.Name == "ISender"));
+        Assert.Collection(
+            sender.Methods,
+            method => Assert.Equal(
+                "IRequest",
+                Assert.Single(method.TypeParameters[0].Constraints).TypeName),
+            method => Assert.Equal(
+                "IRequest<TResponse>",
+                Assert.Single(method.TypeParameters[0].Constraints).TypeName));
+        var publisher = Assert.Single(
+            conversion.Ast.Interfaces.Where(type => type.Name == "IPublisher"));
+        Assert.Equal(
+            "INotification",
+            Assert.Single(
+                Assert.Single(publisher.Methods)
+                    .TypeParameters[0]
+                    .Constraints).TypeName);
+
+        Assert.Contains("§WHERE TRequest : IRequest", conversion.CalorSource);
+        Assert.Contains(
+            "§WHERE TRequest : IRequest<TResponse>",
+            conversion.CalorSource);
+        Assert.Contains(
+            "§WHERE TNotification : INotification",
+            conversion.CalorSource);
+
+        var compiled = Program.Compile(
+            conversion.CalorSource!,
+            null,
+            new CompilationOptions
+            {
+                DeferGeneratedOutputValidation = true
+            });
+        Assert.False(
+            compiled.HasErrors,
+            string.Join("; ", compiled.Diagnostics.Select(diagnostic => diagnostic.Message)));
+        Assert.Contains(
+            "where TRequest : IRequest",
+            compiled.GeneratedCode);
+        Assert.Contains(
+            "where TRequest : IRequest<TResponse>",
+            compiled.GeneratedCode);
+        Assert.Contains(
+            "where TNotification : INotification",
+            compiled.GeneratedCode);
+        var validation = GeneratedCSharpCompiler.Validate(compiled.GeneratedCode);
+        Assert.True(
+            validation.CompilationSuccess,
+            string.Join(
+                Environment.NewLine,
+                validation.FormattedCompilationErrors));
+    }
+
+    [Fact]
     public void AliasesInBaseAndInterfaceGenericPositions_UseCentralTypeMapping()
     {
         var result = Program.Compile(

--- a/tests/Calor.Compiler.Tests/Issue766DeclarationModuleSemanticsTests.cs
+++ b/tests/Calor.Compiler.Tests/Issue766DeclarationModuleSemanticsTests.cs
@@ -1,0 +1,1399 @@
+using System.Reflection;
+using Calor.Compiler.Ast;
+using Calor.Compiler.CodeGen;
+using Calor.Compiler.Diagnostics;
+using Calor.Compiler.Migration;
+using Calor.Compiler.Parsing;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Calor.Compiler.Tests;
+
+public class Issue766DeclarationModuleSemanticsTests
+{
+    private static readonly TextSpan Span = TextSpan.Empty;
+
+    [Fact]
+    public void UsingDirectives_PreserveCompleteObjectsAndDedupeBySemanticTuple()
+    {
+        var module = Parse(
+            """
+            §M{m001:UsingCases}
+              §U{System.Text}
+              §U{System.Text}
+              §U{Alias:System.Collections.Generic}
+              §U{static:System.Math}
+              §U{global:System.Threading}
+              §U{global:Tasks:System.Threading.Tasks}
+              §U{global:static:System.Math}
+              §F{f001:Value:pub} () -> i32
+                §R INT:1
+            """);
+
+        Assert.Collection(
+            module.Usings,
+            u => AssertUsing(u, "System.Text"),
+            u => AssertUsing(u, "System.Text"),
+            u => AssertUsing(u, "System.Collections.Generic", alias: "Alias"),
+            u => AssertUsing(u, "System.Math", isStatic: true),
+            u => AssertUsing(u, "System.Threading", isGlobal: true),
+            u => AssertUsing(
+                u,
+                "System.Threading.Tasks",
+                alias: "Tasks",
+                isGlobal: true),
+            u => AssertUsing(
+                u,
+                "System.Math",
+                isStatic: true,
+                isGlobal: true));
+
+        var generated = new CSharpEmitter().Emit(module);
+
+        Assert.Equal(1, CountOccurrences(generated, "using System.Text;"));
+        Assert.Contains("using Alias = System.Collections.Generic;", generated);
+        Assert.Contains("using static System.Math;", generated);
+        Assert.Contains("global using System.Threading;", generated);
+        Assert.Contains("global using Tasks = System.Threading.Tasks;", generated);
+        Assert.Contains("global using static System.Math;", generated);
+        Assert.True(
+            generated.IndexOf("global using", StringComparison.Ordinal)
+            < generated.IndexOf("using System;", StringComparison.Ordinal));
+        Assert.True(GeneratedCSharpCompiler.Validate(generated).CompilationSuccess);
+        Assert.Equal(
+            "using Pair = (int Left, int Right);",
+            new UsingDirectiveNode(
+                Span,
+                "(i32 Left, i32 Right)",
+                alias: "Pair").Accept(new CSharpEmitter()));
+
+        var conditional = new CSharpEmitter().Emit(Parse(
+            """
+            §M{m002:ConditionalUsing}
+              §PP{FEATURE}
+                §U{global:System.Text}
+                §U{Buffers:System.Buffers}
+            """));
+        Assert.True(
+            conditional.IndexOf("global using System.Text;", StringComparison.Ordinal)
+            < conditional.IndexOf("namespace ConditionalUsing", StringComparison.Ordinal));
+        Assert.True(
+            conditional.IndexOf("using Buffers = System.Buffers;", StringComparison.Ordinal)
+            < conditional.IndexOf("namespace ConditionalUsing", StringComparison.Ordinal));
+        var conditionalValidation = GeneratedCSharpCompiler.Validate(
+            [new GeneratedCSharpSource(conditional, "conditional.g.cs")],
+            new GeneratedCSharpCompilationContext
+            {
+                IncludeImplicitGlobalUsings = false,
+                PreprocessorSymbols = ["FEATURE"]
+            });
+        Assert.True(
+            conditionalValidation.CompilationSuccess,
+            string.Join(
+                Environment.NewLine,
+                conditionalValidation.FormattedCompilationErrors));
+    }
+
+    [Fact]
+    public void CSharpConversion_PreservesNormalAliasStaticAndGlobalUsings()
+    {
+        const string csharp =
+            """
+            global using System;
+            global using Text = System.Text;
+            global using static System.Math;
+            using Collections = System.Collections.Generic;
+
+            public class Demo { }
+            """;
+
+        var result = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Fidelity = ConversionFidelity.Lossy,
+            ModuleName = "UsingConversion",
+            AutoGenerateIds = true
+        }).Convert(csharp);
+
+        Assert.True(result.Success, string.Join("; ", result.Issues.Select(i => i.Message)));
+        Assert.NotNull(result.Ast);
+        Assert.Contains(
+            result.Ast.Usings,
+            u => u.Namespace == "System" && u.IsGlobal && !u.IsStatic && u.Alias == null);
+        Assert.Contains(
+            result.Ast.Usings,
+            u => u.Namespace == "System.Text" && u.IsGlobal && u.Alias == "Text");
+        Assert.Contains(
+            result.Ast.Usings,
+            u => u.Namespace == "System.Math" && u.IsGlobal && u.IsStatic);
+        Assert.Contains(
+            result.Ast.Usings,
+            u => u.Namespace == "System.Collections.Generic"
+                && !u.IsGlobal
+                && u.Alias == "Collections");
+        Assert.Contains("§U{global:System}", result.CalorSource);
+        Assert.Contains("§U{global:Text:System.Text}", result.CalorSource);
+        Assert.Contains("§U{global:static:System.Math}", result.CalorSource);
+    }
+
+    [Fact]
+    public void ConditionalUsingMigration_PreservesAllBranchesWithoutRootDuplicates()
+    {
+        var result = ConvertWithoutPreprocessorStripping(
+            """
+            #if FEATURE
+            using Selected = FeatureNs.Marker;
+            #elif ALT
+            using Selected = AltNs.Marker;
+            #else
+            using Selected = FallbackNs.Marker;
+            #endif
+
+            public class Consumer
+            {
+                public object Create() => new Selected();
+            }
+            """);
+
+        Assert.Empty(result.Ast!.Usings);
+        var block = Assert.Single(result.Ast.TypePreprocessorBlocks);
+        Assert.Equal("FEATURE", block.Condition);
+        Assert.Equal("FeatureNs.Marker", Assert.Single(block.Usings).Namespace);
+        Assert.Equal("Selected", block.Usings[0].Alias);
+        Assert.NotNull(block.ElseBranch);
+        Assert.Equal("ALT", block.ElseBranch!.Condition);
+        Assert.Equal("AltNs.Marker", Assert.Single(block.ElseBranch.Usings).Namespace);
+        Assert.NotNull(block.ElseBranch.ElseBranch);
+        Assert.Equal("", block.ElseBranch.ElseBranch!.Condition);
+        Assert.Equal(
+            "FallbackNs.Marker",
+            Assert.Single(block.ElseBranch.ElseBranch.Usings).Namespace);
+
+        var generated = CompileConvertedCalor(result);
+        const string definitions =
+            """
+            namespace FeatureNs { public sealed class Marker { } }
+            namespace AltNs { public sealed class Marker { } }
+            namespace FallbackNs { public sealed class Marker { } }
+            """;
+
+        Assert.Equal(
+            "FeatureNs.Marker",
+            InvokeCreatedType(CompileAssembly(generated + definitions, ["FEATURE"])));
+        Assert.Equal(
+            "AltNs.Marker",
+            InvokeCreatedType(CompileAssembly(generated + definitions, ["ALT"])));
+        Assert.Equal(
+            "FallbackNs.Marker",
+            InvokeCreatedType(CompileAssembly(generated + definitions)));
+    }
+
+    [Fact]
+    public void ConditionalUsingMigration_PreservesNestedGroupsAndAliasScopes()
+    {
+        var result = ConvertWithoutPreprocessorStripping(
+            """
+            #if OUTER
+            using Root = OuterNs.Root;
+            #if INNER
+            using Leaf = InnerNs.Leaf;
+            #else
+            using Leaf = FallbackNs.Leaf;
+            #endif
+            using Tail = TailNs.Marker;
+            #else
+            using Root = OtherNs.Root;
+            #endif
+            """);
+
+        Assert.Empty(result.Ast!.Usings);
+        var outer = Assert.Single(result.Ast.TypePreprocessorBlocks);
+        Assert.Equal("OUTER", outer.Condition);
+        Assert.Equal(
+            ["OuterNs.Root", "TailNs.Marker"],
+            outer.Usings.Select(usingDirective => usingDirective.Namespace));
+        var inner = Assert.Single(outer.NestedBlocks);
+        Assert.Collection(
+            outer.Items,
+            item => Assert.IsType<UsingDirectiveNode>(item),
+            item => Assert.Same(inner, item),
+            item => Assert.IsType<UsingDirectiveNode>(item));
+        Assert.Equal("INNER", inner.Condition);
+        Assert.Equal("InnerNs.Leaf", Assert.Single(inner.Usings).Namespace);
+        Assert.Equal(
+            "FallbackNs.Leaf",
+            Assert.Single(inner.ElseBranch!.Usings).Namespace);
+        Assert.Equal(
+            "OtherNs.Root",
+            Assert.Single(outer.ElseBranch!.Usings).Namespace);
+        var conditionalUsingCode = CompileConvertedCalor(result);
+        Assert.True(
+            conditionalUsingCode.IndexOf("using Root = OuterNs.Root;", StringComparison.Ordinal)
+            < conditionalUsingCode.IndexOf("#if INNER", StringComparison.Ordinal));
+        Assert.True(
+            conditionalUsingCode.IndexOf("#endif", conditionalUsingCode.IndexOf("#if INNER", StringComparison.Ordinal), StringComparison.Ordinal)
+            < conditionalUsingCode.IndexOf("using Tail = TailNs.Marker;", StringComparison.Ordinal));
+
+        var generated = conditionalUsingCode
+            + """
+
+              public static class ConditionalAliasHarness
+              {
+                  public static object CreateRoot() => new Root();
+              #if OUTER
+                  public static object CreateLeaf() => new Leaf();
+              #endif
+              }
+              namespace OuterNs { public sealed class Root { } }
+              namespace OtherNs { public sealed class Root { } }
+              namespace InnerNs { public sealed class Leaf { } }
+              namespace FallbackNs { public sealed class Leaf { } }
+              namespace TailNs { public sealed class Marker { } }
+              """;
+
+        var innerAssembly = CompileAssembly(generated, ["OUTER", "INNER"]);
+        Assert.Equal(
+            "OuterNs.Root",
+            InvokeStaticCreatedType(innerAssembly, "CreateRoot"));
+        Assert.Equal(
+            "InnerNs.Leaf",
+            InvokeStaticCreatedType(innerAssembly, "CreateLeaf"));
+
+        var fallbackAssembly = CompileAssembly(generated, ["OUTER"]);
+        Assert.Equal(
+            "OuterNs.Root",
+            InvokeStaticCreatedType(fallbackAssembly, "CreateRoot"));
+        Assert.Equal(
+            "FallbackNs.Leaf",
+            InvokeStaticCreatedType(fallbackAssembly, "CreateLeaf"));
+
+        Assert.Equal(
+            "OtherNs.Root",
+            InvokeStaticCreatedType(
+                CompileAssembly(generated),
+                "CreateRoot"));
+    }
+
+    [Fact]
+    public void TypePreprocessorElse_EmitsNestedIfDeclarationsUnderEverySymbolSet()
+    {
+        var result = Program.Compile(
+            """
+            §M{m001:NestedElseTypes}
+              §PP{OUTER}
+                §CL{c001:OuterSelected:pub}
+                  §MT{m001:Value:pub:stat} () -> i32
+                    §R INT:1
+              §PPE
+                §CL{c002:ElseDirect:pub}
+                  §FLD{i32:Value:pub}
+                §PP{INNER}
+                  §CL{c003:InnerSelected:pub}
+                    §MT{m003:Value:pub:stat} () -> i32
+                      §R INT:2
+                §PPE
+                  §CL{c004:InnerFallback:pub}
+                    §MT{m004:Value:pub:stat} () -> i32
+                      §R INT:3
+                §/PP{INNER}
+                §IFACE{i005:IElseTail}
+              §/PP{OUTER}
+            """,
+            null,
+            new CompilationOptions { DeferGeneratedOutputValidation = true });
+
+        Assert.False(result.HasErrors, string.Join("; ", result.Diagnostics));
+        var generated = result.GeneratedCode;
+        Assert.Contains("#else", generated);
+        Assert.Contains("#if INNER", generated);
+        var elseDirect = generated.IndexOf("class ElseDirect", StringComparison.Ordinal);
+        var nestedTypeIf = generated.IndexOf("#if INNER", elseDirect, StringComparison.Ordinal);
+        Assert.True(
+            elseDirect < nestedTypeIf,
+            generated);
+        Assert.True(
+            generated.IndexOf("#endif", nestedTypeIf, StringComparison.Ordinal)
+            < generated.IndexOf("interface IElseTail", StringComparison.Ordinal),
+            generated);
+
+        var outerAssembly = CompileAssembly(generated, ["OUTER"]);
+        AssertTypePresence(
+            outerAssembly,
+            present: ["OuterSelected"],
+            absent: ["ElseDirect", "InnerSelected", "InnerFallback", "IElseTail"]);
+        Assert.Equal(1, InvokeStaticInt(outerAssembly, "OuterSelected", "Value"));
+
+        var innerAssembly = CompileAssembly(generated, ["INNER"]);
+        AssertTypePresence(
+            innerAssembly,
+            present: ["ElseDirect", "InnerSelected", "IElseTail"],
+            absent: ["OuterSelected", "InnerFallback"]);
+        Assert.Equal(2, InvokeStaticInt(innerAssembly, "InnerSelected", "Value"));
+
+        var fallbackAssembly = CompileAssembly(generated);
+        AssertTypePresence(
+            fallbackAssembly,
+            present: ["ElseDirect", "InnerFallback", "IElseTail"],
+            absent: ["OuterSelected", "InnerSelected"]);
+        Assert.Equal(3, InvokeStaticInt(fallbackAssembly, "InnerFallback", "Value"));
+    }
+
+    [Fact]
+    public void RoslynMigration_ElseNestedIfDeclarationsCompileAndRunForBothSymbols()
+    {
+        var conversion = ConvertWithoutPreprocessorStripping(
+            """
+            #if OUTER
+            using SelectedMarker = OuterNs.Marker;
+            public static class OuterSelected
+            {
+                public static int Value() => new SelectedMarker().Value;
+            }
+            #else
+            using DirectMarker = ElseNs.Marker;
+            #if INNER
+            using SelectedMarker = InnerNs.Marker;
+            #else
+            using SelectedMarker = InnerFallbackNs.Marker;
+            #endif
+            public sealed class ElseDirect
+            {
+                public int Value => new DirectMarker().Value;
+            }
+            #if INNER
+            public static class InnerSelected
+            {
+                public static int Value() => new SelectedMarker().Value;
+            }
+            #else
+            public static class InnerFallback
+            {
+                public static int Value() => new SelectedMarker().Value;
+            }
+            #endif
+            public interface IElseTail
+            {
+                int Value { get; }
+            }
+            #endif
+            """);
+
+        var generated = CompileConvertedCalor(conversion)
+            + """
+
+              namespace OuterNs { public sealed class Marker { public int Value => 1; } }
+              namespace ElseNs { public sealed class Marker { public int Value => 10; } }
+              namespace InnerNs { public sealed class Marker { public int Value => 2; } }
+              namespace InnerFallbackNs { public sealed class Marker { public int Value => 3; } }
+              """;
+        Assert.Contains("#else", generated);
+        Assert.Contains("#if INNER", generated);
+        var elseDirect = generated.IndexOf("class ElseDirect", StringComparison.Ordinal);
+        var nestedTypeIf = generated.IndexOf("#if INNER", elseDirect, StringComparison.Ordinal);
+        Assert.True(
+            elseDirect < nestedTypeIf,
+            generated);
+        Assert.True(
+            generated.IndexOf("#endif", nestedTypeIf, StringComparison.Ordinal)
+            < generated.IndexOf("interface IElseTail", StringComparison.Ordinal),
+            generated);
+
+        var innerAssembly = CompileAssembly(generated, ["INNER"]);
+        AssertTypePresence(
+            innerAssembly,
+            present: ["ElseDirect", "InnerSelected", "IElseTail"],
+            absent: ["OuterSelected", "InnerFallback"]);
+        Assert.Equal(2, InvokeStaticInt(innerAssembly, "InnerSelected", "Value"));
+
+        var fallbackAssembly = CompileAssembly(generated);
+        AssertTypePresence(
+            fallbackAssembly,
+            present: ["ElseDirect", "InnerFallback", "IElseTail"],
+            absent: ["OuterSelected", "InnerSelected"]);
+        Assert.Equal(3, InvokeStaticInt(fallbackAssembly, "InnerFallback", "Value"));
+    }
+
+    [Fact]
+    public void ConditionalUnsupportedRecord_RemainsGuardedAndRunsPerSymbol()
+    {
+        var conversion = ConvertWithoutPreprocessorStripping(
+            """
+            #if FEATURE
+            public record Selected(int Value);
+            public delegate T Factory<T>();
+            #else
+            public sealed class Fallback
+            {
+                public int Value => 2;
+            }
+            #endif
+
+            public static class RecordHarness
+            {
+            #if FEATURE
+                public static int Run() => new Selected(7).Value;
+            #else
+                public static int Run() => new Fallback().Value;
+            #endif
+            }
+            """);
+
+        Assert.DoesNotContain(
+            conversion.Ast!.InteropBlocks,
+            interop => interop.CSharpCode.Contains("record Selected", StringComparison.Ordinal));
+        var typeBlock = Assert.Single(conversion.Ast.TypePreprocessorBlocks);
+        Assert.Equal(2, typeBlock.InteropBlocks.Count);
+        var recordInterop = Assert.Single(
+            typeBlock.InteropBlocks.Where(interop =>
+                interop.CSharpCode.Contains("record Selected", StringComparison.Ordinal)));
+        Assert.Contains("record Selected", recordInterop.CSharpCode);
+        Assert.Contains(
+            typeBlock.InteropBlocks,
+            interop => interop.CSharpCode.Contains(
+                "delegate T Factory<T>()",
+                StringComparison.Ordinal));
+        Assert.Empty(typeBlock.ElseBranch!.InteropBlocks);
+
+        var generated = CompileConvertedCalor(conversion);
+        var featureAssembly = CompileAssembly(generated, ["FEATURE"]);
+        AssertTypePresence(
+            featureAssembly,
+            present: ["Selected", "Factory`1", "RecordHarness"],
+            absent: ["Fallback"]);
+        Assert.Equal(7, InvokeStaticInt(featureAssembly, "RecordHarness", "Run"));
+
+        var fallbackAssembly = CompileAssembly(generated);
+        AssertTypePresence(
+            fallbackAssembly,
+            present: ["Fallback", "RecordHarness"],
+            absent: ["Selected", "Factory`1"]);
+        Assert.Equal(2, InvokeStaticInt(fallbackAssembly, "RecordHarness", "Run"));
+    }
+
+    [Fact]
+    public void ConditionalUnsupportedNestedTypes_RemainInsideMemberBranches()
+    {
+        var conversion = ConvertWithoutPreprocessorStripping(
+            """
+            public class Container
+            {
+            #if FEATURE
+                public int Before;
+                public record Inner(int Value);
+                public int After;
+            #else
+                public int BeforeElse;
+                public struct Inner
+                {
+                    public int Value;
+                }
+                public int AfterElse;
+            #endif
+            }
+            """);
+
+        var container = Assert.Single(
+            conversion.Ast!.Classes.Where(type => type.Name == "Container"));
+        Assert.DoesNotContain(
+            conversion.Ast.Classes,
+            type => type.Name == "Inner");
+        Assert.Empty(container.InteropBlocks);
+        var block = Assert.Single(container.PreprocessorBlocks);
+        Assert.Collection(
+            block.Items,
+            item => Assert.Equal("Before", Assert.IsType<ClassFieldNode>(item).Name),
+            item => Assert.IsType<CSharpInteropBlockNode>(item),
+            item => Assert.Equal("After", Assert.IsType<ClassFieldNode>(item).Name));
+        Assert.Contains(
+            "record Inner",
+            Assert.Single(block.InteropBlocks).CSharpCode);
+        Assert.Collection(
+            block.ElseBranch!.Items,
+            item => Assert.Equal("BeforeElse", Assert.IsType<ClassFieldNode>(item).Name),
+            item => Assert.IsType<CSharpInteropBlockNode>(item),
+            item => Assert.Equal("AfterElse", Assert.IsType<ClassFieldNode>(item).Name));
+        Assert.Contains(
+            "struct Inner",
+            Assert.Single(block.ElseBranch!.InteropBlocks).CSharpCode);
+
+        var featureInner = CompileAssembly(
+                CompileConvertedCalor(conversion),
+                ["FEATURE"])
+            .GetTypes()
+            .Single(type =>
+                type.Name == "Inner"
+                && type.DeclaringType?.Name == "Container");
+        Assert.False(featureInner.IsValueType);
+        Assert.NotNull(featureInner.GetProperty("Value"));
+        Assert.NotNull(featureInner.DeclaringType!.GetField("Before"));
+        Assert.NotNull(featureInner.DeclaringType.GetField("After"));
+
+        var fallbackInner = CompileAssembly(CompileConvertedCalor(conversion))
+            .GetTypes()
+            .Single(type =>
+                type.Name == "Inner"
+                && type.DeclaringType?.Name == "Container");
+        Assert.True(fallbackInner.IsValueType);
+        Assert.NotNull(fallbackInner.GetField("Value"));
+        Assert.NotNull(fallbackInner.DeclaringType!.GetField("BeforeElse"));
+        Assert.NotNull(fallbackInner.DeclaringType.GetField("AfterElse"));
+    }
+
+    [Fact]
+    public void ModuleConditionalScanner_ExcludesNestedGroupsForBothNamespaceForms()
+    {
+        string[] sources =
+        [
+            """
+            namespace BlockScoped
+            {
+            #if TOP
+                public record Same(int Value);
+            #else
+                public sealed class Same
+                {
+                    public int Value => 2;
+                }
+            #endif
+
+                public class Container
+                {
+                #if NESTED
+                    public record Same(int Value);
+                #else
+                    public sealed class Same
+                    {
+                        public int Value => 4;
+                    }
+                #endif
+                }
+            }
+            """,
+            """
+            namespace FileScoped;
+
+            #if TOP
+            public record Same(int Value);
+            #else
+            public sealed class Same
+            {
+                public int Value => 2;
+            }
+            #endif
+
+            public class Container
+            {
+            #if NESTED
+                public record Same(int Value);
+            #else
+                public sealed class Same
+                {
+                    public int Value => 4;
+                }
+            #endif
+            }
+            """
+        ];
+
+        foreach (var source in sources)
+        {
+            var conversion = ConvertWithoutPreprocessorStripping(source);
+            Assert.Empty(conversion.Ast!.InteropBlocks);
+            var moduleBlock = Assert.Single(conversion.Ast.TypePreprocessorBlocks);
+            Assert.Equal("TOP", moduleBlock.Condition);
+
+            var container = Assert.Single(
+                conversion.Ast.Classes.Where(type => type.Name == "Container"));
+            var memberBlock = Assert.Single(container.PreprocessorBlocks);
+            Assert.Equal("NESTED", memberBlock.Condition);
+            Assert.DoesNotContain(
+                conversion.Ast.TypePreprocessorBlocks,
+                block => block.Condition == "NESTED");
+
+            var generated = CompileConvertedCalor(conversion);
+            AssertConditionalSameTypes(CompileAssembly(generated), false, false);
+            AssertConditionalSameTypes(
+                CompileAssembly(generated, ["TOP"]),
+                true,
+                false);
+            AssertConditionalSameTypes(
+                CompileAssembly(generated, ["NESTED"]),
+                false,
+                true);
+            AssertConditionalSameTypes(
+                CompileAssembly(generated, ["TOP", "NESTED"]),
+                true,
+                true);
+        }
+    }
+
+    [Fact]
+    public void TypePreprocessorElif_EmitsNestedDeclarationBranchesInSourceOrder()
+    {
+        var result = Program.Compile(
+            """
+            §M{m001:ElifNestedTypes}
+              §PP{FIRST}
+                §CL{c001:FirstSelected:pub}
+                  §FLD{i32:Value:pub}
+              §PPE
+                §PP{SECOND}
+                  §IFACE{i002:ISecondBefore}
+                    §PROP{p002:Value:i32:pub:get}
+                  §PP{DEEP}
+                    §CL{c003:DeepSelected:pub}
+                      §FLD{i32:Value:pub}
+                  §/PP{DEEP}
+                  §CL{c004:SecondAfter:pub}
+                    §FLD{i32:Value:pub}
+                §PPE
+                  §CL{c005:FinalFallback:pub}
+                    §FLD{i32:Value:pub}
+                §/PP{SECOND}
+            """,
+            null,
+            new CompilationOptions { DeferGeneratedOutputValidation = true });
+
+        Assert.False(result.HasErrors, string.Join("; ", result.Diagnostics));
+        var generated = result.GeneratedCode;
+        Assert.Contains("#elif SECOND", generated);
+        var second = generated.IndexOf("#elif SECOND", StringComparison.Ordinal);
+        var before = generated.IndexOf("interface ISecondBefore", second, StringComparison.Ordinal);
+        var nested = generated.IndexOf("#if DEEP", second, StringComparison.Ordinal);
+        var after = generated.IndexOf("class SecondAfter", second, StringComparison.Ordinal);
+        Assert.True(second < before && before < nested && nested < after);
+
+        AssertTypePresence(
+            CompileAssembly(generated, ["FIRST"]),
+            present: ["FirstSelected"],
+            absent: ["ISecondBefore", "DeepSelected", "SecondAfter", "FinalFallback"]);
+        AssertTypePresence(
+            CompileAssembly(generated, ["SECOND", "DEEP"]),
+            present: ["ISecondBefore", "DeepSelected", "SecondAfter"],
+            absent: ["FirstSelected", "FinalFallback"]);
+        AssertTypePresence(
+            CompileAssembly(generated),
+            present: ["FinalFallback"],
+            absent: ["FirstSelected", "ISecondBefore", "DeepSelected", "SecondAfter"]);
+    }
+
+    [Fact]
+    public void ReorderedSameTypeRecordFields_PreserveRuntimeValues()
+    {
+        var creation = new RecordCreationNode(
+            Span,
+            "Pair",
+            [
+                new FieldAssignmentNode(
+                    Span,
+                    "Right",
+                    new StringLiteralNode(Span, "right")),
+                new FieldAssignmentNode(
+                    Span,
+                    "Left",
+                    new StringLiteralNode(Span, "left"))
+            ]);
+
+        var expression = creation.Accept(new CSharpEmitter());
+        Assert.Equal(
+            "new Pair(Right: \"right\", Left: \"left\")",
+            expression);
+
+        var assembly = CompileAssembly(
+            $$"""
+              public record Pair(string Left, string Right);
+              public static class RecordHarness
+              {
+                  public static Pair Create() => {{expression}};
+              }
+              """);
+        var pair = assembly
+            .GetType("RecordHarness")!
+            .GetMethod("Create", BindingFlags.Public | BindingFlags.Static)!
+            .Invoke(null, null)!;
+
+        Assert.Equal("left", pair.GetType().GetProperty("Left")!.GetValue(pair));
+        Assert.Equal("right", pair.GetType().GetProperty("Right")!.GetValue(pair));
+    }
+
+    [Fact]
+    public void CalorEmitter_PreservesRecordFieldNames()
+    {
+        var creation = new RecordCreationNode(
+            Span,
+            "Pair",
+            [
+                new FieldAssignmentNode(Span, "Right", new StringLiteralNode(Span, "r")),
+                new FieldAssignmentNode(Span, "Left", new StringLiteralNode(Span, "l"))
+            ]);
+
+        Assert.Equal(
+            "§D{Pair} §FL{Right} \"r\" §FL{Left} \"l\"",
+            creation.Accept(new CalorEmitter()));
+    }
+
+    [Fact]
+    public void InterfaceVarianceAndConstraints_ArePreservedMappedAndCompilable()
+    {
+        var module = Parse(
+            """
+            §M{m001:Variance}
+              §IFACE{i001:IVariant}<out TOut, in TIn, TUnmanaged, TNotNull, TDerived>
+                §WHERE TOut : class?
+                §WHERE TIn : class, new()
+                §WHERE TUnmanaged : unmanaged
+                §WHERE TNotNull : notnull, System.IComparable<TNotNull>
+                §WHERE TDerived : ExternalBase, IMarker, new()
+            """);
+
+        var typeParameters = Assert.Single(module.Interfaces).TypeParameters;
+        Assert.Equal(Calor.Compiler.Ast.VarianceKind.Out, typeParameters[0].Variance);
+        Assert.Equal(Calor.Compiler.Ast.VarianceKind.In, typeParameters[1].Variance);
+        Assert.Equal(TypeConstraintKind.ClassNullable, Assert.Single(typeParameters[0].Constraints).Kind);
+        Assert.Equal(
+            [TypeConstraintKind.NotNull, TypeConstraintKind.TypeName],
+            typeParameters[3].Constraints.Select(c => c.Kind));
+
+        var generated = new CSharpEmitter().Emit(module);
+        Assert.Contains("IVariant<out TOut, in TIn, TUnmanaged, TNotNull, TDerived>", generated);
+        Assert.Contains("where TOut : class?", generated);
+        Assert.Contains("where TIn : class, new()", generated);
+        Assert.Contains("where TUnmanaged : unmanaged", generated);
+        Assert.Contains("where TNotNull : notnull, System.IComparable<TNotNull>", generated);
+        Assert.Contains("where TDerived : ExternalBase, IMarker, new()", generated);
+
+        var validation = GeneratedCSharpCompiler.Validate(
+            generated,
+            "public class ExternalBase { } public interface IMarker { }");
+        Assert.True(
+            validation.CompilationSuccess,
+            string.Join(Environment.NewLine, validation.FormattedCompilationErrors));
+    }
+
+    [Fact]
+    public void Variance_OnIllegalOwner_IsRejectedWithoutDiscardingTheAstField()
+    {
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(
+            """
+            §M{m001:InvalidVariance}
+              §CL{c001:Box:pub}<out T>
+            """,
+            diagnostics);
+        var parser = new Parser(lexer.TokenizeAllForParser(), diagnostics);
+        var module = parser.Parse();
+
+        Assert.Equal(
+            Calor.Compiler.Ast.VarianceKind.Out,
+            Assert.Single(module.Classes).TypeParameters[0].Variance);
+        Assert.Contains(
+            diagnostics,
+            diagnostic => diagnostic.Code == DiagnosticCode.InvalidTypeParameterVariance);
+    }
+
+    [Fact]
+    public void EverySupportedConstraintKind_HasAnExplicitEmission()
+    {
+        var emitter = new CSharpEmitter();
+        var cases = new Dictionary<TypeConstraintKind, string>
+        {
+            [TypeConstraintKind.Class] = "class",
+            [TypeConstraintKind.ClassNullable] = "class?",
+            [TypeConstraintKind.Struct] = "struct",
+            [TypeConstraintKind.Unmanaged] = "unmanaged",
+            [TypeConstraintKind.New] = "new()",
+            [TypeConstraintKind.Interface] = "IFace<int>",
+            [TypeConstraintKind.BaseClass] = "Base<string>",
+            [TypeConstraintKind.TypeName] = "Alias.@class<int>",
+            [TypeConstraintKind.NotNull] = "notnull",
+            [TypeConstraintKind.Default] = "default",
+            [TypeConstraintKind.AllowsRefStruct] = "allows ref struct"
+        };
+
+        foreach (var (kind, expected) in cases)
+        {
+            var typeName = kind switch
+            {
+                TypeConstraintKind.Interface => "IFace<i32>",
+                TypeConstraintKind.BaseClass => "Base<str>",
+                TypeConstraintKind.TypeName => "Alias.class<i32>",
+                _ => null
+            };
+            var node = new TypeConstraintNode(Span, kind, typeName);
+            Assert.Equal(expected, node.Accept(emitter));
+        }
+
+        var parsed = Parse(
+            """
+            §M{m001:ConstraintParsing}
+              §IFACE{i001:IConstraintHost}
+                §MT{m001:Apply}<T>
+                  §WHERE T : allows ref struct
+            """);
+        Assert.Equal(
+            TypeConstraintKind.AllowsRefStruct,
+            Assert.Single(
+                Assert.Single(Assert.Single(parsed.Interfaces).Methods)
+                .TypeParameters[0]
+                .Constraints).Kind);
+
+        var allowsConversion = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Fidelity = ConversionFidelity.Lossy,
+            ModuleName = "AllowsConstraint",
+            AutoGenerateIds = true
+        }).Convert(
+            """
+            public interface IRefConsumer
+            {
+                void Apply<T>(T value) where T : allows ref struct;
+            }
+            """);
+        Assert.True(allowsConversion.Success);
+        Assert.Equal(
+            TypeConstraintKind.AllowsRefStruct,
+            Assert.Single(
+                Assert.Single(
+                    Assert.Single(allowsConversion.Ast!.Interfaces).Methods)
+                .TypeParameters[0]
+                .Constraints).Kind);
+
+        var defaultConversion = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Fidelity = ConversionFidelity.Lossy,
+            ModuleName = "DefaultConstraint",
+            AutoGenerateIds = true
+        }).Convert(
+            """
+            #nullable enable
+            public abstract class Base
+            {
+                public abstract T? Echo<T>(T? value);
+            }
+            public sealed class Derived : Base
+            {
+                public override T? Echo<T>(T? value) where T : default => value;
+            }
+            """);
+        Assert.True(defaultConversion.Success);
+        var derived = Assert.Single(
+            defaultConversion.Ast!.Classes.Where(type => type.Name == "Derived"));
+        Assert.Equal(
+            TypeConstraintKind.Default,
+            Assert.Single(
+                Assert.Single(derived.Methods).TypeParameters[0].Constraints).Kind);
+    }
+
+    [Fact]
+    public void DefaultConstraint_IsRejectedOnEveryIllegalOwner()
+    {
+        string[] invalidSources =
+        [
+            """
+            §M{m001:BadFunction}
+              §F{f001:Bad:pub}<T>
+                §WHERE T : default
+            """,
+            """
+            §M{m001:BadClass}
+              §CL{c001:Bad:pub}<T>
+                §WHERE T : default
+            """,
+            """
+            §M{m001:BadInterface}
+              §IFACE{i001:IBad}<T>
+                §WHERE T : default
+            """,
+            """
+            §M{m001:BadMethod}
+              §CL{c001:Host:pub}
+                §MT{m001:Bad:pub}<T>
+                  §WHERE T : default
+            """,
+            """
+            §M{m001:BadInterfaceMethod}
+              §IFACE{i001:IHost}
+                §MT{m001:Bad}<T>
+                  §WHERE T : default
+            """
+        ];
+
+        foreach (var source in invalidSources)
+        {
+            var diagnostics = new DiagnosticBag();
+            var lexer = new Lexer(source, diagnostics);
+            var parser = new Parser(lexer.TokenizeAllForParser(), diagnostics);
+            _ = parser.Parse();
+            Assert.Contains(
+                diagnostics,
+                diagnostic =>
+                    diagnostic.Code == DiagnosticCode.InvalidDefaultConstraintOwner);
+        }
+    }
+
+    [Fact]
+    public void DefaultConstraint_MigrationPreservesOverrideAndExplicitInterfaceOwners()
+    {
+        var overrideResult = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Fidelity = ConversionFidelity.Lossy,
+            ModuleName = "DefaultOverride",
+            AutoGenerateIds = true
+        }).Convert(
+            """
+            #nullable enable
+            public abstract class Base
+            {
+                public abstract T? Echo<T>(T? value);
+            }
+            public sealed class Derived : Base
+            {
+                public override T? Echo<T>(T? value) where T : default => value;
+            }
+            """);
+        Assert.True(
+            overrideResult.Success,
+            string.Join("; ", overrideResult.Issues.Select(issue => issue.Message)));
+        Assert.Contains(
+            "where T : default",
+            CompileConvertedCalor(overrideResult));
+
+        var explicitResult = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Fidelity = ConversionFidelity.Lossy,
+            ModuleName = "DefaultExplicit",
+            AutoGenerateIds = true
+        }).Convert(
+            """
+            #nullable enable
+            public interface IExplicit
+            {
+                T? Echo<T>(T? value);
+            }
+            public sealed class Explicit : IExplicit
+            {
+                T? IExplicit.Echo<T>(T? value) where T : default => value;
+            }
+            """);
+        Assert.True(
+            explicitResult.Success,
+            string.Join("; ", explicitResult.Issues.Select(issue => issue.Message)));
+        var explicitMethod = Assert.Single(
+            Assert.Single(
+                explicitResult.Ast!.Classes.Where(type => type.Name == "Explicit"))
+            .Methods);
+        Assert.Equal("IExplicit.Echo", explicitMethod.Name);
+        Assert.Equal(
+            TypeConstraintKind.Default,
+            Assert.Single(explicitMethod.TypeParameters[0].Constraints).Kind);
+
+        var generated = CompileConvertedCalor(explicitResult);
+        Assert.Contains("IExplicit.Echo<T>", generated);
+        Assert.DoesNotContain("private T? IExplicit.Echo<T>", generated);
+        var validation = GeneratedCSharpCompiler.Validate(generated);
+        Assert.True(
+            validation.CompilationSuccess,
+            string.Join(
+                Environment.NewLine,
+                validation.FormattedCompilationErrors));
+    }
+
+    [Fact]
+    public void AliasesInBaseAndInterfaceGenericPositions_UseCentralTypeMapping()
+    {
+        var result = Program.Compile(
+            """
+            §M{m001:AliasBases}
+              §U{Alias:External}
+              §CL{c001:Derived:pub}
+                §EXT{Alias.Base<i32>}
+                §IMPL{Alias.IFace<str>}
+            """,
+            null,
+            new CompilationOptions { DeferGeneratedOutputValidation = true });
+
+        Assert.False(result.HasErrors, string.Join("; ", result.Diagnostics));
+        Assert.Contains("using Alias = External;", result.GeneratedCode);
+        Assert.Contains(
+            "class Derived : Alias.Base<int>, Alias.IFace<string>",
+            result.GeneratedCode);
+
+        var validation = GeneratedCSharpCompiler.Validate(
+            result.GeneratedCode,
+            """
+            namespace External
+            {
+                public class Base<T> { }
+                public interface IFace<T> { }
+            }
+            """);
+        Assert.True(
+            validation.CompilationSuccess,
+            string.Join(Environment.NewLine, validation.FormattedCompilationErrors));
+    }
+
+    [Fact]
+    public void QualifiedNames_SanitizeKeywordsAcrossNamespacesCallsArgumentsAndTypes()
+    {
+        var result = Program.Compile(
+            """
+            §M{m001:namespace.123bad.class}
+              §F{f001:event:pub} (i32:class) -> i32
+                §R class
+            """);
+
+        Assert.False(result.HasErrors, string.Join("; ", result.Diagnostics));
+        Assert.Contains("namespace @namespace._123bad.@class", result.GeneratedCode);
+        Assert.Contains("int @event(int @class)", result.GeneratedCode);
+        Assert.Contains("return @class;", result.GeneratedCode);
+
+        var call = new CallExpressionNode(
+            Span,
+            "namespace.class",
+            [new IntLiteralNode(Span, 1)],
+            ["event"]);
+        Assert.Equal(
+            "@namespace.@class(@event: 1)",
+            call.Accept(new CSharpEmitter()));
+        Assert.Equal(
+            "Factory<int>.@class()",
+            new CallExpressionNode(
+                Span,
+                "Factory<int>.class",
+                []).Accept(new CSharpEmitter()));
+
+        var type = new GenericTypeNode(
+            Span,
+            "namespace.class",
+            ["str"]);
+        Assert.Equal(
+            "@namespace.@class<string>",
+            type.Accept(new CSharpEmitter()));
+        Assert.Equal(
+            "@var",
+            new GenericTypeNode(Span, "var", []).Accept(new CSharpEmitter()));
+    }
+
+    [Fact]
+    public void ReusingEmitterAcrossModules_IsByteIdenticalToFreshEmitter()
+    {
+        var indexedModule = Parse(
+            """
+            §M{m001:First}
+              §ITYPE{it001:Leaky:i32[]:n}
+            """);
+        var unrelatedModule = Parse(
+            """
+            §M{m002:Second}
+              §F{f002:Echo:pub} (Leaky:value) -> Leaky
+                §R value
+            """);
+
+        var reused = new CSharpEmitter();
+        _ = reused.Emit(indexedModule);
+        var reusedOutput = reused.Emit(unrelatedModule);
+        var freshOutput = new CSharpEmitter().Emit(unrelatedModule);
+
+        Assert.Equal(freshOutput, reusedOutput);
+        Assert.Contains("Leaky value", reusedOutput);
+        Assert.DoesNotContain("int[] value", reusedOutput);
+    }
+
+    [Fact]
+    public void GeneratedCSharp_CompilesWithImplicitUsingsDisabled()
+    {
+        var result = Program.Compile(
+            """
+            §M{m001:Standalone}
+              §F{f001:Echo:pub}<T> (List<T>:items) -> List<T>
+                §R items
+              §AF{f002:EchoAsync:pub} (i32:value) -> i32
+                §R value
+            """,
+            null,
+            new CompilationOptions { DeferGeneratedOutputValidation = true });
+
+        Assert.False(result.HasErrors, string.Join("; ", result.Diagnostics));
+        Assert.Contains("using System.Collections.Generic;", result.GeneratedCode);
+        Assert.Contains("using System.Threading.Tasks;", result.GeneratedCode);
+
+        var validation = GeneratedCSharpCompiler.Validate(
+            [new GeneratedCSharpSource(result.GeneratedCode, "standalone.g.cs")],
+            new GeneratedCSharpCompilationContext
+            {
+                IncludeImplicitGlobalUsings = false
+            });
+        Assert.True(
+            validation.CompilationSuccess,
+            string.Join(Environment.NewLine, validation.FormattedCompilationErrors));
+    }
+
+    [Fact]
+    public void BuiltInShortTypeMatrix_CompilesStandaloneWithoutImplicitUsings()
+    {
+        string[] types =
+        [
+            "i8", "i16", "i32", "i64",
+            "u8", "u16", "u32", "u64",
+            "f32", "f64", "dec", "bool", "str", "char", "any",
+            "List<i32>", "Dict<str, i32>", "Set<i32>",
+            "Seq<i32>", "IList<i32>", "IDict<str, i32>",
+            "ICollection<i32>", "ISet<i32>",
+            "ReadList<i32>", "ReadCollection<i32>",
+            "ReadDict<str, i32>", "ReadSet<i32>",
+            "Task", "Task<i32>", "ValueTask", "ValueTask<i32>",
+            "datetime", "datetimeoffset", "timespan", "date", "time", "guid",
+            "Span<i32>", "ReadOnlySpan<i32>", "Memory<i32>", "ReadOnlyMemory<i32>",
+            "StringBuilder", "void"
+        ];
+
+        foreach (var type in types)
+        {
+            var signature = type == "void"
+                ? "() -> void"
+                : $"({type}:value) -> {type}";
+            var body = type == "void" ? "" : "    §R value";
+            var result = Program.Compile(
+                $$"""
+                  §M{m001:BuiltInMatrix}
+                    §F{f001:Echo:pub} {{signature}}
+                  {{body}}
+                  """,
+                null,
+                new CompilationOptions
+                {
+                    DeferGeneratedOutputValidation = true
+                });
+            Assert.False(
+                result.HasErrors,
+                $"{type}: {string.Join("; ", result.Diagnostics.Select(d => d.Message))}");
+
+            var validation = GeneratedCSharpCompiler.Validate(
+                [new GeneratedCSharpSource(result.GeneratedCode, $"{type}.g.cs")],
+                new GeneratedCSharpCompilationContext
+                {
+                    IncludeImplicitGlobalUsings = false
+                });
+            Assert.True(
+                validation.CompilationSuccess,
+                $"{type}:{Environment.NewLine}"
+                + string.Join(
+                    Environment.NewLine,
+                    validation.FormattedCompilationErrors));
+
+            if (type == "StringBuilder")
+                Assert.Contains("using System.Text;", result.GeneratedCode);
+        }
+    }
+
+    [Fact]
+    public void DeclarationNodes_ExposeOnlyEmitterAccountedFields()
+    {
+        var expected = new Dictionary<Type, string[]>
+        {
+            [typeof(UsingDirectiveNode)] =
+                ["Alias", "IsGlobal", "IsStatic", "Namespace"],
+            [typeof(RecordCreationNode)] =
+                ["Fields", "TypeName", "TypeNameSpan"],
+            [typeof(FieldAssignmentNode)] =
+                ["FieldName", "Value"],
+            [typeof(TypeParameterNode)] =
+                ["Constraints", "Name", "Variance"],
+            [typeof(TypeConstraintNode)] =
+                ["Kind", "TypeName"],
+            [typeof(TypePreprocessorBlockNode)] =
+                ["Classes", "Condition", "Delegates", "ElseBranch", "Enums",
+                    "Interfaces", "InteropBlocks", "Items", "NestedBlocks", "Usings"],
+            [typeof(MemberPreprocessorBlockNode)] =
+                ["Condition", "Constructors", "ElseBranch", "Events", "Fields",
+                    "Indexers", "InteropBlocks", "Items", "Methods",
+                    "OperatorOverloads", "Properties"]
+        };
+
+        foreach (var (type, properties) in expected)
+        {
+            var actual = type
+                .GetProperties(
+                    BindingFlags.Public
+                    | BindingFlags.Instance
+                    | BindingFlags.DeclaredOnly)
+                .Select(property => property.Name)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+            Assert.Equal(properties, actual);
+        }
+    }
+
+    private static ModuleNode Parse(string source)
+    {
+        var diagnostics = new DiagnosticBag();
+        var lexer = new Lexer(source, diagnostics);
+        var parser = new Parser(lexer.TokenizeAllForParser(), diagnostics);
+        var module = parser.Parse();
+        Assert.False(
+            diagnostics.HasErrors,
+            string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString())));
+        return module;
+    }
+
+    private static ConversionResult ConvertWithoutPreprocessorStripping(string source)
+    {
+        var result = new CSharpToCalorConverter(new ConversionOptions
+        {
+            Fidelity = ConversionFidelity.Lossy,
+            ModuleName = "Issue766Conditional",
+            AutoGenerateIds = true,
+            StripPreprocessor = false,
+            ValidateRoundTripCSharp = false
+        }).Convert(source);
+        Assert.True(
+            result.Success,
+            string.Join("; ", result.Issues.Select(issue => issue.Message))
+            + Environment.NewLine
+            + result.CalorSource);
+        Assert.NotNull(result.Ast);
+        Assert.NotNull(result.CalorSource);
+        return result;
+    }
+
+    private static string CompileConvertedCalor(ConversionResult conversion)
+    {
+        var result = Program.Compile(
+            conversion.CalorSource!,
+            null,
+            new CompilationOptions
+            {
+                DeferGeneratedOutputValidation = true,
+                UnknownCallPolicy = Calor.Compiler.Effects.UnknownCallPolicy.Permissive
+            });
+        Assert.False(
+            result.HasErrors,
+            string.Join("; ", result.Diagnostics.Select(diagnostic => diagnostic.Message)));
+        return result.GeneratedCode;
+    }
+
+    private static string InvokeCreatedType(Assembly assembly)
+    {
+        var consumer = Assert.Single(
+            assembly.GetTypes().Where(type => type.Name == "Consumer"));
+        return consumer.GetMethod("Create")!
+            .Invoke(Activator.CreateInstance(consumer), null)!
+            .GetType()
+            .FullName!;
+    }
+
+    private static string InvokeStaticCreatedType(
+        Assembly assembly,
+        string methodName)
+        => assembly.GetType("ConditionalAliasHarness")!
+            .GetMethod(methodName, BindingFlags.Public | BindingFlags.Static)!
+            .Invoke(null, null)!
+            .GetType()
+            .FullName!;
+
+    private static void AssertTypePresence(
+        Assembly assembly,
+        IReadOnlyList<string> present,
+        IReadOnlyList<string> absent)
+    {
+        var names = assembly.GetTypes()
+            .Select(type => type.Name)
+            .ToHashSet(StringComparer.Ordinal);
+        Assert.All(present, name => Assert.Contains(name, names));
+        Assert.All(absent, name => Assert.DoesNotContain(name, names));
+    }
+
+    private static int InvokeStaticInt(
+        Assembly assembly,
+        string typeName,
+        string methodName)
+        => Assert.IsType<int>(
+            assembly.GetTypes()
+                .Single(type => type.Name == typeName)
+                .GetMethod(methodName, BindingFlags.Public | BindingFlags.Static)!
+                .Invoke(null, null));
+
+    private static void AssertConditionalSameTypes(
+        Assembly assembly,
+        bool topIsRecord,
+        bool nestedIsRecord)
+    {
+        var top = assembly.GetTypes().Single(type =>
+            type.Name == "Same" && type.DeclaringType == null);
+        var container = assembly.GetTypes().Single(type =>
+            type.Name == "Container");
+        var nested = assembly.GetTypes().Single(type =>
+            type.Name == "Same" && type.DeclaringType == container);
+
+        Assert.Equal(
+            topIsRecord,
+            top.GetConstructor([typeof(int)]) != null);
+        Assert.Equal(
+            nestedIsRecord,
+            nested.GetConstructor([typeof(int)]) != null);
+
+        var topInstance = topIsRecord
+            ? Activator.CreateInstance(top, [11])!
+            : Activator.CreateInstance(top)!;
+        var nestedInstance = nestedIsRecord
+            ? Activator.CreateInstance(nested, [13])!
+            : Activator.CreateInstance(nested)!;
+        Assert.Equal(
+            topIsRecord ? 11 : 2,
+            top.GetProperty("Value")!.GetValue(topInstance));
+        Assert.Equal(
+            nestedIsRecord ? 13 : 4,
+            nested.GetProperty("Value")!.GetValue(nestedInstance));
+    }
+
+    private static void AssertUsing(
+        UsingDirectiveNode node,
+        string target,
+        string? alias = null,
+        bool isStatic = false,
+        bool isGlobal = false)
+    {
+        Assert.Equal(target, node.Namespace);
+        Assert.Equal(alias, node.Alias);
+        Assert.Equal(isStatic, node.IsStatic);
+        Assert.Equal(isGlobal, node.IsGlobal);
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        var count = 0;
+        var offset = 0;
+        while ((offset = text.IndexOf(value, offset, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            offset += value.Length;
+        }
+        return count;
+    }
+
+    private static Assembly CompileAssembly(
+        string source,
+        IReadOnlyList<string>? preprocessorSymbols = null)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(
+                LanguageVersion.Latest,
+                preprocessorSymbols: preprocessorSymbols ?? []));
+        var compilation = CSharpCompilation.Create(
+            $"Issue766_{Guid.NewGuid():N}",
+            [syntaxTree],
+            GeneratedCSharpCompiler.References,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var stream = new MemoryStream();
+        var emit = compilation.Emit(stream);
+        Assert.True(
+            emit.Success,
+            string.Join(
+                Environment.NewLine,
+                emit.Diagnostics
+                    .Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                    .Select(d => d.ToString())));
+        return Assembly.Load(stream.ToArray());
+    }
+}

--- a/tests/Calor.Compiler.Tests/TypeSystemTests.cs
+++ b/tests/Calor.Compiler.Tests/TypeSystemTests.cs
@@ -319,7 +319,7 @@ public class TypeSystemTests
         var emitter = new CSharpEmitter();
         var result = recordCreation.Accept(emitter);
 
-        Assert.Equal("new Person(\"Alice\", 30)", result);
+        Assert.Equal("new Person(Name: \"Alice\", Age: 30)", result);
     }
 
     [Fact]

--- a/tests/Calor.Conversion.Tests/ConversionCatalog.cs
+++ b/tests/Calor.Conversion.Tests/ConversionCatalog.cs
@@ -233,13 +233,20 @@ public static class ConversionCatalog
         """);
 
     public static readonly ConversionSnippet Variance = new(
-        "04-04", "Generics", "Covariant and contravariant interfaces",
+        "04-04", "Generics", "Usings, variance, aliases, and generic constraints",
         """
-        public interface IProducer<out T>
+        global using System;
+        global using Collections = System.Collections.Generic;
+        global using static System.Math;
+        using Text = System.String;
+
+        public interface IProducer<out T> : Collections.IEnumerable<T>
+            where T : class?
         {
             T Produce();
         }
         public interface IConsumer<in T>
+            where T : notnull
         {
             void Consume(T item);
         }

--- a/tests/Calor.Conversion.Tests/DS15FixtureRegistryTests.cs
+++ b/tests/Calor.Conversion.Tests/DS15FixtureRegistryTests.cs
@@ -1,6 +1,9 @@
 using System.Text.Json;
 using Calor.Compiler;
+using Calor.Compiler.CodeGen;
 using Calor.Compiler.Migration;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
 namespace Calor.Conversion.Tests;
@@ -81,6 +84,17 @@ public class DS15FixtureRegistryTests
         var featureKey = doc.RootElement.GetProperty("featureKey").GetString();
         Assert.False(string.IsNullOrWhiteSpace(featureKey), $"{name}: featureKey empty");
         Assert.Equal(SanitizeKey(featureKey!), name);
+        var certifiedAbsent = doc.RootElement
+            .GetProperty("lossKindCertifiedAbsent");
+        var runtimeEntryPoint = doc.RootElement
+            .GetProperty("runtimeEntryPoint")
+            .GetString();
+        Assert.False(
+            string.IsNullOrWhiteSpace(runtimeEntryPoint),
+            $"{name}: runtimeEntryPoint empty");
+        var runtimeExpectedInt = doc.RootElement
+            .GetProperty("runtimeExpectedInt")
+            .GetInt32();
 
         // 3. Conversion match: input.cs converts to exactly expected.calr.
         var converter = new CSharpToCalorConverter(new ConversionOptions
@@ -88,10 +102,25 @@ public class DS15FixtureRegistryTests
             Fidelity = ConversionFidelity.Lossy,
             ModuleName = "Fixture",
             GracefulFallback = true,
-            AutoGenerateIds = true
+            AutoGenerateIds = true,
+            StripPreprocessor = false
         });
         var converted = converter.Convert(File.ReadAllText(inputPath), $"{name}.cs");
+        Assert.True(
+            converted.Success,
+            $"{name}: conversion failed: "
+            + string.Join("; ", converted.Issues.Select(issue => issue.Message)));
         Assert.NotNull(converted.CalorSource);
+        if (certifiedAbsent.ValueKind != JsonValueKind.Null)
+        {
+            var lossName = certifiedAbsent.GetString();
+            Assert.True(
+                Enum.TryParse<ConversionLossKind>(lossName, out var lossKind),
+                $"{name}: unknown loss kind '{lossName}'");
+            Assert.DoesNotContain(
+                converted.Losses,
+                loss => loss.Kind == lossKind);
+        }
         Assert.Equal(
             Normalize(File.ReadAllText(expectedPath)),
             Normalize(converted.CalorSource!));
@@ -100,11 +129,56 @@ public class DS15FixtureRegistryTests
         foreach (var calr in new[] { expectedPath, testPath })
         {
             var result = Program.Compile(File.ReadAllText(calr),
-                Path.GetFileName(calr), new CompilationOptions());
+                Path.GetFileName(calr), new Calor.Compiler.CompilationOptions());
             Assert.False(result.HasErrors,
                 $"{name}/{Path.GetFileName(calr)} does not compile: " +
                 string.Join("; ", result.Diagnostics.Where(d => d.IsError).Select(d => d.Message)));
+            if (calr == testPath)
+                AssertValueTestPasses(
+                    name,
+                    result.GeneratedCode,
+                    runtimeEntryPoint!,
+                    runtimeExpectedInt);
         }
+    }
+
+    private static void AssertValueTestPasses(
+        string name,
+        string generatedCode,
+        string entryPoint,
+        int expected)
+    {
+        var tree = CSharpSyntaxTree.ParseText(
+            generatedCode,
+            new CSharpParseOptions(LanguageVersion.Latest));
+        var compilation = CSharpCompilation.Create(
+            $"DS15_{name}_{Guid.NewGuid():N}",
+            [tree],
+            GeneratedCSharpCompiler.References,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var stream = new MemoryStream();
+        var emit = compilation.Emit(stream);
+        Assert.True(
+            emit.Success,
+            $"{name}/test.calr generated C# failed: "
+            + string.Join("; ", emit.Diagnostics
+                .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+                .Select(diagnostic => diagnostic.ToString())));
+
+        var assembly = System.Reflection.Assembly.Load(stream.ToArray());
+        var methods = assembly.GetTypes()
+            .SelectMany(type => type.GetMethods(
+                System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.Static))
+            .Where(method =>
+                method.GetParameters().Length == 0
+                && !method.IsSpecialName)
+            .ToArray();
+        foreach (var method in methods)
+            _ = method.Invoke(null, null);
+        var entry = Assert.Single(methods.Where(method =>
+            method.Name == entryPoint && method.ReturnType == typeof(int)));
+        Assert.Equal(expected, Assert.IsType<int>(entry.Invoke(null, null)));
     }
 
     private static string Normalize(string s) =>

--- a/tests/Calor.Conversion.Tests/Snapshots/04-04.approved.calr
+++ b/tests/Calor.Conversion.Tests/Snapshots/04-04.approved.calr
@@ -1,7 +1,13 @@
 §M{m001:Test_04_04}
-  §IFACE{i001:IProducer<out T>}
+  §U{global:System}
+  §U{global:Collections:System.Collections.Generic}
+  §U{global:static:System.Math}
+  §U{Text:System.String}
+
+  §IFACE{i001:IProducer<out T>:Collections.IEnumerable<T>}
+    §WHERE T : class?
     §MT{m002:Produce} () -> T
 
   §IFACE{i003:IConsumer<in T>}
+    §WHERE T : notnull
     §MT{m004:Consume} (T:item)
-

--- a/tests/Calor.Conversion.Tests/Snapshots/11-04.approved.calr
+++ b/tests/Calor.Conversion.Tests/Snapshots/11-04.approved.calr
@@ -1,8 +1,7 @@
 §M{m001:Test_11_04}
   §PP{NET6_0_OR_GREATER}
-  §CL{c001:NetSixFeature:pub}
-    §PROP{p002:Name:str:pub:get,set}
+    §CL{c001:NetSixFeature:pub}
+      §PROP{p002:Name:str:pub:get,set}
 
 
   §/PP{NET6_0_OR_GREATER}
-

--- a/tests/Calor.Evaluation/Scorecard/ConversionScorecardTests.cs
+++ b/tests/Calor.Evaluation/Scorecard/ConversionScorecardTests.cs
@@ -14,20 +14,15 @@ namespace Calor.Evaluation.Scorecard;
 /// </summary>
 public class ConversionScorecardTests
 {
-    // Re-calibrated 2026-08-01 (W1 Slice 3, #771): FullyConverted now requires a
-    // FULL Roslyn semantic compilation of the generated C# (via the shared
-    // GeneratedCSharpCompiler helper), not merely a syntax parse. Under the old
-    // parse-only criterion the corpus scored 96/100; the honest compile-based
-    // number is 93/100 — the 7 partials are real emitter defects (local-function
-    // scoping, indexer emission, generic-method temp naming, pattern-matching
-    // type info, null-coalescing method group, generic array creation,
-    // deconstruction). The drop is the point of the change: syntax-valid but
-    // type-invalid output no longer counts as converted.
+    // Re-calibrated 2026-08-14 (#766): standalone generated C#, complete
+    // declaration/type mapping, and structural conditional imports raise the
+    // full semantic round-trip result to 96/100. The remaining 4 partials are
+    // pinned per fixture in baseline.json.
     // Baselines are exact (no slack): the corpus and converter are
     // deterministic, and per-fixture zero-regression is enforced against
     // baseline.json by NoRegressionsVsCommittedBaseline.
-    private const int BASELINE_FULLY_CONVERTED = 95;
-    private const int BASELINE_ROUNDTRIP = 95;
+    private const int BASELINE_FULLY_CONVERTED = 96;
+    private const int BASELINE_ROUNDTRIP = 96;
 
     private static readonly Lazy<ConversionScorecard> _scorecard = new(() =>
     {

--- a/tests/Calor.Evaluation/Scorecard/baseline.json
+++ b/tests/Calor.Evaluation/Scorecard/baseline.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-08-01T04:32:05.993661Z",
-  "commitHash": "08341e44",
+  "timestamp": "2026-08-14T18:37:56.257566Z",
+  "commitHash": "a986d0ef",
   "version": "1.0",
   "total": 100,
-  "fullyConverted": 93,
-  "partiallyConverted": 7,
+  "fullyConverted": 96,
+  "partiallyConverted": 4,
   "blocked": 0,
   "crashed": 0,
-  "roundTripPassing": 93,
+  "roundTripPassing": 96,
   "byLevel": {
     "1": {
       "total": 20,
@@ -26,13 +26,13 @@
     },
     "4": {
       "total": 20,
-      "passed": 18,
-      "rate": 0.9
+      "passed": 19,
+      "rate": 0.95
     },
     "5": {
       "total": 20,
-      "passed": 15,
-      "rate": 0.75
+      "passed": 17,
+      "rate": 0.85
     }
   },
   "byFeature": {
@@ -348,13 +348,13 @@
     },
     "switch_expression": {
       "total": 2,
-      "passed": 1,
-      "rate": 0.5
+      "passed": 2,
+      "rate": 1
     },
     "pattern_matching": {
       "total": 2,
-      "passed": 1,
-      "rate": 0.5
+      "passed": 2,
+      "rate": 1
     },
     "break": {
       "total": 1,
@@ -743,8 +743,8 @@
     },
     "local_function": {
       "total": 1,
-      "passed": 0,
-      "rate": 0
+      "passed": 1,
+      "rate": 1
     },
     "extension_method": {
       "total": 1,
@@ -958,23 +958,23 @@
     },
     "is_expression": {
       "total": 1,
-      "passed": 0,
-      "rate": 0
+      "passed": 1,
+      "rate": 1
     },
     "null_coalescing": {
       "total": 1,
-      "passed": 0,
-      "rate": 0
+      "passed": 1,
+      "rate": 1
     },
     "null_conditional": {
       "total": 1,
-      "passed": 0,
-      "rate": 0
+      "passed": 1,
+      "rate": 1
     },
     "null_assignment": {
       "total": 1,
-      "passed": 0,
-      "rate": 0
+      "passed": 1,
+      "rate": 1
     },
     "string_interpolation": {
       "total": 1,
@@ -1053,8 +1053,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.1118867",
-      "compilationDuration": "00:00:00.0523710",
+      "conversionDuration": "00:00:00.4899173",
+      "compilationDuration": "00:00:00.0035024",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1077,8 +1079,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0051217",
-      "compilationDuration": "00:00:00.0041791",
+      "conversionDuration": "00:00:00.0226070",
+      "compilationDuration": "00:00:00.0030263",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1099,8 +1103,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035421",
-      "compilationDuration": "00:00:00.0017052",
+      "conversionDuration": "00:00:00.0087187",
+      "compilationDuration": "00:00:00.0029925",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1122,8 +1128,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0040708",
-      "compilationDuration": "00:00:00.0061930",
+      "conversionDuration": "00:00:00.0144173",
+      "compilationDuration": "00:00:00.0030002",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1145,8 +1153,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035860",
-      "compilationDuration": "00:00:00.0009281",
+      "conversionDuration": "00:00:00.0073247",
+      "compilationDuration": "00:00:00.0028623",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1167,8 +1177,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0062983",
-      "compilationDuration": "00:00:00.0012787",
+      "conversionDuration": "00:00:00.0124056",
+      "compilationDuration": "00:00:00.0147504",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1190,8 +1202,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0065264",
-      "compilationDuration": "00:00:00.0021472",
+      "conversionDuration": "00:00:00.0229998",
+      "compilationDuration": "00:00:00.0027009",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1213,8 +1227,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0028697",
-      "compilationDuration": "00:00:00.0017430",
+      "conversionDuration": "00:00:00.0068223",
+      "compilationDuration": "00:00:00.0025664",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1236,8 +1252,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0028918",
-      "compilationDuration": "00:00:00.0018517",
+      "conversionDuration": "00:00:00.0060030",
+      "compilationDuration": "00:00:00.0021164",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1259,8 +1277,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0028734",
-      "compilationDuration": "00:00:00.0019022",
+      "conversionDuration": "00:00:00.0083361",
+      "compilationDuration": "00:00:00.0019496",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1281,8 +1301,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0028607",
-      "compilationDuration": "00:00:00.0018017",
+      "conversionDuration": "00:00:00.0054756",
+      "compilationDuration": "00:00:00.0018640",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1303,8 +1325,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0028462",
-      "compilationDuration": "00:00:00.0017100",
+      "conversionDuration": "00:00:00.0059155",
+      "compilationDuration": "00:00:00.0018300",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1326,8 +1350,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0285078",
-      "compilationDuration": "00:00:00.0033553",
+      "conversionDuration": "00:00:00.0295152",
+      "compilationDuration": "00:00:00.0020123",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1348,8 +1374,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0138357",
-      "compilationDuration": "00:00:00.0013839",
+      "conversionDuration": "00:00:00.0092161",
+      "compilationDuration": "00:00:00.0021947",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1373,8 +1401,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0038178",
-      "compilationDuration": "00:00:00.0010734",
+      "conversionDuration": "00:00:00.0090913",
+      "compilationDuration": "00:00:00.0022120",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1396,8 +1426,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035199",
-      "compilationDuration": "00:00:00.0011971",
+      "conversionDuration": "00:00:00.0082350",
+      "compilationDuration": "00:00:00.0020246",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1411,15 +1443,19 @@
       "status": "FullyConverted",
       "conversionSuccess": true,
       "conversionErrors": 0,
-      "conversionWarnings": 0,
-      "conversionIssues": [],
+      "conversionWarnings": 1,
+      "conversionIssues": [
+        "Warning [unsupported-prefix-operator] (line 12): Unsupported feature [unsupported-prefix-operator] escalated to \u00A7CSHARP interop preservation: \u002Bx"
+      ],
       "compilationSuccess": true,
       "compilationErrors": 0,
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0032463",
-      "compilationDuration": "00:00:00.0007624",
+      "conversionDuration": "00:00:00.0106874",
+      "compilationDuration": "00:00:00.0021700",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1440,8 +1476,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0048271",
-      "compilationDuration": "00:00:00.0010625",
+      "conversionDuration": "00:00:00.0070033",
+      "compilationDuration": "00:00:00.0019330",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1462,8 +1500,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0065532",
-      "compilationDuration": "00:00:00.0007547",
+      "conversionDuration": "00:00:00.0239081",
+      "compilationDuration": "00:00:00.0024080",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1484,8 +1524,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035046",
-      "compilationDuration": "00:00:00.0008580",
+      "conversionDuration": "00:00:00.0061583",
+      "compilationDuration": "00:00:00.0021252",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1506,8 +1548,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0063835",
-      "compilationDuration": "00:00:00.0021458",
+      "conversionDuration": "00:00:00.0114253",
+      "compilationDuration": "00:00:00.0019684",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1528,8 +1572,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035629",
-      "compilationDuration": "00:00:00.0007494",
+      "conversionDuration": "00:00:00.0058640",
+      "compilationDuration": "00:00:00.0018669",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1550,8 +1596,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0036396",
-      "compilationDuration": "00:00:00.0008814",
+      "conversionDuration": "00:00:00.0071167",
+      "compilationDuration": "00:00:00.0034688",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1573,8 +1621,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0107805",
-      "compilationDuration": "00:00:00.0026991",
+      "conversionDuration": "00:00:00.0292792",
+      "compilationDuration": "00:00:00.0026867",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1594,8 +1644,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0072573",
-      "compilationDuration": "00:00:00.0039066",
+      "conversionDuration": "00:00:00.0088740",
+      "compilationDuration": "00:00:00.0021034",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1615,8 +1667,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0091918",
-      "compilationDuration": "00:00:00.0021513",
+      "conversionDuration": "00:00:00.0104523",
+      "compilationDuration": "00:00:00.0020716",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1637,8 +1691,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0066283",
-      "compilationDuration": "00:00:00.0008921",
+      "conversionDuration": "00:00:00.0117472",
+      "compilationDuration": "00:00:00.0029045",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1660,8 +1716,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0061113",
-      "compilationDuration": "00:00:00.0020297",
+      "conversionDuration": "00:00:00.0107009",
+      "compilationDuration": "00:00:00.0022517",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1682,8 +1740,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0064575",
-      "compilationDuration": "00:00:00.0007619",
+      "conversionDuration": "00:00:00.0092614",
+      "compilationDuration": "00:00:00.0025938",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1704,8 +1764,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0061825",
-      "compilationDuration": "00:00:00.0025255",
+      "conversionDuration": "00:00:00.0151697",
+      "compilationDuration": "00:00:00.0021887",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1726,8 +1788,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0072057",
-      "compilationDuration": "00:00:00.0007730",
+      "conversionDuration": "00:00:00.0131462",
+      "compilationDuration": "00:00:00.0027728",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1748,8 +1812,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0032502",
-      "compilationDuration": "00:00:00.0011177",
+      "conversionDuration": "00:00:00.0061893",
+      "compilationDuration": "00:00:00.0021299",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1771,8 +1837,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0081868",
-      "compilationDuration": "00:00:00.0036401",
+      "conversionDuration": "00:00:00.0316082",
+      "compilationDuration": "00:00:00.0023617",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1793,8 +1861,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0059292",
-      "compilationDuration": "00:00:00.0012532",
+      "conversionDuration": "00:00:00.0127152",
+      "compilationDuration": "00:00:00.0020820",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1815,8 +1885,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0068202",
-      "compilationDuration": "00:00:00.0013101",
+      "conversionDuration": "00:00:00.0112946",
+      "compilationDuration": "00:00:00.0089327",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1837,8 +1909,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0069091",
-      "compilationDuration": "00:00:00.0010474",
+      "conversionDuration": "00:00:00.0132942",
+      "compilationDuration": "00:00:00.0026351",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1859,8 +1933,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0052680",
-      "compilationDuration": "00:00:00.0010617",
+      "conversionDuration": "00:00:00.0070662",
+      "compilationDuration": "00:00:00.0021768",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1881,8 +1957,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0031385",
-      "compilationDuration": "00:00:00.0007970",
+      "conversionDuration": "00:00:00.0056119",
+      "compilationDuration": "00:00:00.0019697",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1903,8 +1981,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0031884",
-      "compilationDuration": "00:00:00.0007718",
+      "conversionDuration": "00:00:00.0056607",
+      "compilationDuration": "00:00:00.0019177",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1925,8 +2005,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0033865",
-      "compilationDuration": "00:00:00.0008686",
+      "conversionDuration": "00:00:00.0077866",
+      "compilationDuration": "00:00:00.0023333",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1948,8 +2030,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0164389",
-      "compilationDuration": "00:00:00.0034765",
+      "conversionDuration": "00:00:00.0322010",
+      "compilationDuration": "00:00:00.0022888",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1971,8 +2055,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035623",
-      "compilationDuration": "00:00:00.0012209",
+      "conversionDuration": "00:00:00.0071772",
+      "compilationDuration": "00:00:00.0024932",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -1993,8 +2079,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0071203",
-      "compilationDuration": "00:00:00.0024247",
+      "conversionDuration": "00:00:00.0408270",
+      "compilationDuration": "00:00:00.0033135",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2017,8 +2105,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0055535",
-      "compilationDuration": "00:00:00.0025768",
+      "conversionDuration": "00:00:00.0283997",
+      "compilationDuration": "00:00:00.0034452",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2039,8 +2129,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0054229",
-      "compilationDuration": "00:00:00.0015032",
+      "conversionDuration": "00:00:00.0137316",
+      "compilationDuration": "00:00:00.0033505",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2062,8 +2154,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0045557",
-      "compilationDuration": "00:00:00.0024847",
+      "conversionDuration": "00:00:00.0150607",
+      "compilationDuration": "00:00:00.0036427",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2085,8 +2179,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0175977",
-      "compilationDuration": "00:00:00.0020420",
+      "conversionDuration": "00:00:00.0265935",
+      "compilationDuration": "00:00:00.0036726",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2107,8 +2203,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0081836",
-      "compilationDuration": "00:00:00.0010304",
+      "conversionDuration": "00:00:00.0192884",
+      "compilationDuration": "00:00:00.0048413",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2130,8 +2228,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0277887",
-      "compilationDuration": "00:00:00.0019370",
+      "conversionDuration": "00:00:00.0261751",
+      "compilationDuration": "00:00:00.0040941",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2153,8 +2253,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0089723",
-      "compilationDuration": "00:00:00.0011505",
+      "conversionDuration": "00:00:00.0175792",
+      "compilationDuration": "00:00:00.0029254",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2175,8 +2277,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0104346",
-      "compilationDuration": "00:00:00.0007726",
+      "conversionDuration": "00:00:00.0141527",
+      "compilationDuration": "00:00:00.0024241",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2198,8 +2302,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0040162",
-      "compilationDuration": "00:00:00.0008210",
+      "conversionDuration": "00:00:00.0081513",
+      "compilationDuration": "00:00:00.0022975",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2221,8 +2327,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0051444",
-      "compilationDuration": "00:00:00.0016630",
+      "conversionDuration": "00:00:00.0101021",
+      "compilationDuration": "00:00:00.0025659",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2244,8 +2352,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0041411",
-      "compilationDuration": "00:00:00.0007709",
+      "conversionDuration": "00:00:00.0082241",
+      "compilationDuration": "00:00:00.0020977",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2266,8 +2376,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0056393",
-      "compilationDuration": "00:00:00.0038007",
+      "conversionDuration": "00:00:00.0127397",
+      "compilationDuration": "00:00:00.0022854",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2289,8 +2401,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0034957",
-      "compilationDuration": "00:00:00.0008200",
+      "conversionDuration": "00:00:00.0066555",
+      "compilationDuration": "00:00:00.0021755",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2311,8 +2425,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035164",
-      "compilationDuration": "00:00:00.0008027",
+      "conversionDuration": "00:00:00.0070637",
+      "compilationDuration": "00:00:00.0020325",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2333,8 +2449,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0089004",
-      "compilationDuration": "00:00:00.0008057",
+      "conversionDuration": "00:00:00.0145741",
+      "compilationDuration": "00:00:00.0028218",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2356,8 +2474,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0054514",
-      "compilationDuration": "00:00:00.0010886",
+      "conversionDuration": "00:00:00.0136019",
+      "compilationDuration": "00:00:00.0022993",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2377,8 +2497,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0045559",
-      "compilationDuration": "00:00:00.0014780",
+      "conversionDuration": "00:00:00.0099109",
+      "compilationDuration": "00:00:00.0023241",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2399,8 +2521,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0037539",
-      "compilationDuration": "00:00:00.0008287",
+      "conversionDuration": "00:00:00.0062162",
+      "compilationDuration": "00:00:00.0023323",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2421,8 +2545,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0043880",
-      "compilationDuration": "00:00:00.0013276",
+      "conversionDuration": "00:00:00.0086662",
+      "compilationDuration": "00:00:00.0025220",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2442,8 +2568,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0067740",
-      "compilationDuration": "00:00:00.0007931",
+      "conversionDuration": "00:00:00.0080024",
+      "compilationDuration": "00:00:00.0021616",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2463,8 +2591,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0038165",
-      "compilationDuration": "00:00:00.0009710",
+      "conversionDuration": "00:00:00.0063313",
+      "compilationDuration": "00:00:00.0022089",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2484,8 +2614,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0034546",
-      "compilationDuration": "00:00:00.0037306",
+      "conversionDuration": "00:00:00.0063582",
+      "compilationDuration": "00:00:00.0021294",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2505,8 +2637,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0041137",
-      "compilationDuration": "00:00:00.0008454",
+      "conversionDuration": "00:00:00.0064458",
+      "compilationDuration": "00:00:00.0022212",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2527,8 +2661,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0037058",
-      "compilationDuration": "00:00:00.0008271",
+      "conversionDuration": "00:00:00.0082933",
+      "compilationDuration": "00:00:00.0022869",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2550,8 +2686,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035922",
-      "compilationDuration": "00:00:00.0008332",
+      "conversionDuration": "00:00:00.0060262",
+      "compilationDuration": "00:00:00.0021438",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2573,8 +2711,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0043136",
-      "compilationDuration": "00:00:00.0009758",
+      "conversionDuration": "00:00:00.0071975",
+      "compilationDuration": "00:00:00.0022897",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2595,8 +2735,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0036994",
-      "compilationDuration": "00:00:00.0008193",
+      "conversionDuration": "00:00:00.0070267",
+      "compilationDuration": "00:00:00.0025071",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2617,8 +2759,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0075841",
-      "compilationDuration": "00:00:00.0009090",
+      "conversionDuration": "00:00:00.0136902",
+      "compilationDuration": "00:00:00.0035528",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2638,8 +2782,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0045019",
-      "compilationDuration": "00:00:00.0010685",
+      "conversionDuration": "00:00:00.0079752",
+      "compilationDuration": "00:00:00.0024217",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2660,8 +2806,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0037372",
-      "compilationDuration": "00:00:00.0008945",
+      "conversionDuration": "00:00:00.0069938",
+      "compilationDuration": "00:00:00.0025882",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2671,23 +2819,26 @@
       "features": [
         "local_function"
       ],
-      "status": "PartiallyConverted",
+      "status": "FullyConverted",
       "conversionSuccess": true,
       "conversionErrors": 0,
-      "conversionWarnings": 0,
-      "conversionIssues": [],
-      "compilationSuccess": true,
-      "compilationErrors": 3,
-      "compilationDiagnostics": [
-        "Roslyn: CS0103: The name \u0027Add\u0027 does not exist in the current context (line 17)",
-        "Roslyn: CS0103: The name \u0027Multiply\u0027 does not exist in the current context (line 20)",
-        "Roslyn: CS0103: The name \u0027FactorialInternal\u0027 does not exist in the current context (line 30)"
+      "conversionWarnings": 2,
+      "conversionIssues": [
+        "Warning [local-function] (line 7): Unsupported feature [local-function] escalated to \u00A7CSHARP interop preservation: int Add(int a, int b)\n            {\n                return a \u002B b;\n            }",
+        "Info [method] (line 5): C# interop block preserved for [method]",
+        "Warning [local-function] (line 24): Unsupported feature [local-function] escalated to \u00A7CSHARP interop preservation: int FactorialInternal(int num)\n            {\n                if (num \u003C= 1)\n  ...",
+        "Info [method] (line 22): C# interop block preserved for [method]"
       ],
+      "compilationSuccess": true,
+      "compilationErrors": 0,
+      "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
-      "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0172164",
-      "compilationDuration": "00:00:00.0046084",
-      "roundTripSuccess": false
+      "cSharpCompilationSuccess": true,
+      "conversionDuration": "00:00:00.0139597",
+      "compilationDuration": "00:00:00.0026385",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
+      "roundTripSuccess": true
     },
     {
       "id": "075",
@@ -2707,8 +2858,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0100850",
-      "compilationDuration": "00:00:00.0016203",
+      "conversionDuration": "00:00:00.0235542",
+      "compilationDuration": "00:00:00.0033188",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2729,8 +2882,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0035876",
-      "compilationDuration": "00:00:00.0008526",
+      "conversionDuration": "00:00:00.0072779",
+      "compilationDuration": "00:00:00.0022022",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2752,8 +2907,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0039900",
-      "compilationDuration": "00:00:00.0013044",
+      "conversionDuration": "00:00:00.0095081",
+      "compilationDuration": "00:00:00.0027900",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2764,21 +2921,23 @@
         "indexer"
       ],
       "status": "PartiallyConverted",
-      "conversionSuccess": true,
-      "conversionErrors": 0,
+      "conversionSuccess": false,
+      "conversionErrors": 3,
       "conversionWarnings": 0,
-      "conversionIssues": [],
-      "compilationSuccess": true,
-      "compilationErrors": 3,
-      "compilationDiagnostics": [
-        "Roslyn: CS1551: Indexers must have at least one parameter (line 26)",
-        "Roslyn: CS0103: The name \u0027index\u0027 does not exist in the current context (line 31)",
-        "Roslyn: CS0103: The name \u0027index\u0027 does not exist in the current context (line 37)"
+      "conversionIssues": [
+        "Error [roundtrip-calor-validation] (line 26, col 25): Generated Calor failed compilation: Generated C# failed compilation (CS1551): Indexers must have at least one parameter",
+        "Error [roundtrip-calor-validation] (line 12, col 29): Generated Calor failed compilation: Generated C# failed compilation (CS0103): The name \u0027index\u0027 does not exist in the current context",
+        "Error [roundtrip-calor-validation] (line 14, col 22): Generated Calor failed compilation: Generated C# failed compilation (CS0103): The name \u0027index\u0027 does not exist in the current context"
       ],
-      "cSharpSyntaxSuccess": true,
+      "compilationSuccess": false,
+      "compilationErrors": 0,
+      "compilationDiagnostics": [],
+      "cSharpSyntaxSuccess": false,
       "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0061879",
-      "compilationDuration": "00:00:00.0021269",
+      "conversionDuration": "00:00:00.0134950",
+      "compilationDuration": "00:00:00",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": false
     },
     {
@@ -2798,8 +2957,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0060407",
-      "compilationDuration": "00:00:00.0023220",
+      "conversionDuration": "00:00:00.0163465",
+      "compilationDuration": "00:00:00.0030237",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2820,8 +2981,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0048211",
-      "compilationDuration": "00:00:00.0009195",
+      "conversionDuration": "00:00:00.0093597",
+      "compilationDuration": "00:00:00.0031200",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2843,8 +3006,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0044655",
-      "compilationDuration": "00:00:00.0018400",
+      "conversionDuration": "00:00:00.0149701",
+      "compilationDuration": "00:00:00.0028155",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2866,8 +3031,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0580275",
-      "compilationDuration": "00:00:00.0021496",
+      "conversionDuration": "00:00:00.0458884",
+      "compilationDuration": "00:00:00.0028812",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2889,8 +3056,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0175450",
-      "compilationDuration": "00:00:00.0009145",
+      "conversionDuration": "00:00:00.0479499",
+      "compilationDuration": "00:00:00.0147897",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2912,8 +3081,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0145130",
-      "compilationDuration": "00:00:00.0010142",
+      "conversionDuration": "00:00:00.0401456",
+      "compilationDuration": "00:00:00.0131199",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2934,8 +3105,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0049593",
-      "compilationDuration": "00:00:00.0012786",
+      "conversionDuration": "00:00:00.0143439",
+      "compilationDuration": "00:00:00.0029644",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -2947,22 +3120,24 @@
         "type_constraint"
       ],
       "status": "PartiallyConverted",
-      "conversionSuccess": true,
-      "conversionErrors": 0,
+      "conversionSuccess": false,
+      "conversionErrors": 4,
       "conversionWarnings": 0,
-      "conversionIssues": [],
-      "compilationSuccess": true,
-      "compilationErrors": 4,
-      "compilationDiagnostics": [
-        "Roslyn: CS0246: The type or namespace name \u0027temp\u0027 could not be found (are you missing a using directive or an assembly reference?) (line 24)",
-        "Roslyn: CS0412: \u0027T\u0027: a parameter, local variable, or local function cannot have the same name as a method type parameter (line 24)",
-        "Roslyn: CS0103: The name \u0027temp\u0027 does not exist in the current context (line 30)",
-        "Roslyn: CS0118: \u0027result\u0027 is a variable but is used like a type (line 37)"
+      "conversionIssues": [
+        "Error [roundtrip-calor-validation] (line 7, col 13): Generated Calor failed compilation: Generated C# failed compilation (CS0246): The type or namespace name \u0027temp\u0027 could not be found (are you missing a using directive or an assembly reference?)",
+        "Error [roundtrip-calor-validation] (line 7, col 18): Generated Calor failed compilation: Generated C# failed compilation (CS0412): \u0027T\u0027: a parameter, local variable, or local function cannot have the same name as a method type parameter",
+        "Error [roundtrip-calor-validation] (line 9, col 17): Generated Calor failed compilation: Generated C# failed compilation (CS0103): The name \u0027temp\u0027 does not exist in the current context",
+        "Error [roundtrip-calor-validation] (line 13, col 30): Generated Calor failed compilation: Generated C# failed compilation (CS0118): \u0027result\u0027 is a variable but is used like a type"
       ],
-      "cSharpSyntaxSuccess": true,
+      "compilationSuccess": false,
+      "compilationErrors": 0,
+      "compilationDiagnostics": [],
+      "cSharpSyntaxSuccess": false,
       "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0103605",
-      "compilationDuration": "00:00:00.0023741",
+      "conversionDuration": "00:00:00.0176103",
+      "compilationDuration": "00:00:00",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": false
     },
     {
@@ -2984,8 +3159,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0108507",
-      "compilationDuration": "00:00:00.0022030",
+      "conversionDuration": "00:00:00.0195886",
+      "compilationDuration": "00:00:00.0034654",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3006,8 +3183,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0089936",
-      "compilationDuration": "00:00:00.0015652",
+      "conversionDuration": "00:00:00.0212513",
+      "compilationDuration": "00:00:00.0041575",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3031,8 +3210,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0038972",
-      "compilationDuration": "00:00:00.0009087",
+      "conversionDuration": "00:00:00.0328530",
+      "compilationDuration": "00:00:00.0200512",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3054,8 +3235,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0115552",
-      "compilationDuration": "00:00:00.0010052",
+      "conversionDuration": "00:00:00.0346001",
+      "compilationDuration": "00:00:00.0132127",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3077,8 +3260,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0097665",
-      "compilationDuration": "00:00:00.0009581",
+      "conversionDuration": "00:00:00.0362481",
+      "compilationDuration": "00:00:00.0126254",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3100,8 +3285,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0050896",
-      "compilationDuration": "00:00:00.0017021",
+      "conversionDuration": "00:00:00.0137628",
+      "compilationDuration": "00:00:00.0030301",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3122,8 +3309,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0095558",
-      "compilationDuration": "00:00:00.0017813",
+      "conversionDuration": "00:00:00.0203963",
+      "compilationDuration": "00:00:00.0041257",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3135,22 +3324,21 @@
         "is_expression",
         "switch_expression"
       ],
-      "status": "PartiallyConverted",
+      "status": "FullyConverted",
       "conversionSuccess": true,
       "conversionErrors": 0,
       "conversionWarnings": 0,
       "conversionIssues": [],
       "compilationSuccess": true,
-      "compilationErrors": 2,
-      "compilationDiagnostics": [
-        "Roslyn: CS1061: \u0027object\u0027 does not contain a definition for \u0027Length\u0027 and no accessible extension method \u0027Length\u0027 accepting a first argument of type \u0027object\u0027 could be found (are you missing a using directive or an assembly reference?) (line 67)",
-        "Roslyn: CS1061: \u0027object\u0027 does not contain a definition for \u0027Length\u0027 and no accessible extension method \u0027Length\u0027 accepting a first argument of type \u0027object\u0027 could be found (are you missing a using directive or an assembly reference?) (line 67)"
-      ],
+      "compilationErrors": 0,
+      "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
-      "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0065933",
-      "compilationDuration": "00:00:00.0015694",
-      "roundTripSuccess": false
+      "cSharpCompilationSuccess": true,
+      "conversionDuration": "00:00:00.0194898",
+      "compilationDuration": "00:00:00.0036751",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
+      "roundTripSuccess": true
     },
     {
       "id": "095",
@@ -3161,21 +3349,21 @@
         "null_conditional",
         "null_assignment"
       ],
-      "status": "PartiallyConverted",
+      "status": "FullyConverted",
       "conversionSuccess": true,
       "conversionErrors": 0,
       "conversionWarnings": 0,
       "conversionIssues": [],
       "compilationSuccess": true,
-      "compilationErrors": 1,
-      "compilationDiagnostics": [
-        "Roslyn: CS8978: \u0027method group\u0027 cannot be made nullable. (line 45)"
-      ],
+      "compilationErrors": 0,
+      "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
-      "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0058190",
-      "compilationDuration": "00:00:00.0011122",
-      "roundTripSuccess": false
+      "cSharpCompilationSuccess": true,
+      "conversionDuration": "00:00:00.0115692",
+      "compilationDuration": "00:00:00.0027527",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
+      "roundTripSuccess": true
     },
     {
       "id": "096",
@@ -3195,8 +3383,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0106727",
-      "compilationDuration": "00:00:00.0016330",
+      "conversionDuration": "00:00:00.0273372",
+      "compilationDuration": "00:00:00.0030990",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3219,8 +3409,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0140470",
-      "compilationDuration": "00:00:00.0009379",
+      "conversionDuration": "00:00:00.0168350",
+      "compilationDuration": "00:00:00.0041945",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     },
     {
@@ -3233,19 +3425,21 @@
         "new_constraint"
       ],
       "status": "PartiallyConverted",
-      "conversionSuccess": true,
-      "conversionErrors": 0,
+      "conversionSuccess": false,
+      "conversionErrors": 1,
       "conversionWarnings": 0,
-      "conversionIssues": [],
-      "compilationSuccess": true,
-      "compilationErrors": 1,
-      "compilationDiagnostics": [
-        "Roslyn: CS0246: The type or namespace name \u0027arrT004\u0027 could not be found (are you missing a using directive or an assembly reference?) (line 20)"
+      "conversionIssues": [
+        "Error [roundtrip-calor-validation] (line 20, col 33): Generated Calor failed compilation: Generated C# failed compilation (CS0246): The type or namespace name \u0027arrT004\u0027 could not be found (are you missing a using directive or an assembly reference?)"
       ],
-      "cSharpSyntaxSuccess": true,
+      "compilationSuccess": false,
+      "compilationErrors": 0,
+      "compilationDiagnostics": [],
+      "cSharpSyntaxSuccess": false,
       "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0049894",
-      "compilationDuration": "00:00:00.0013335",
+      "conversionDuration": "00:00:00.0106642",
+      "compilationDuration": "00:00:00",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": false
     },
     {
@@ -3257,20 +3451,22 @@
         "tuple_deconstruct"
       ],
       "status": "PartiallyConverted",
-      "conversionSuccess": true,
-      "conversionErrors": 0,
+      "conversionSuccess": false,
+      "conversionErrors": 2,
       "conversionWarnings": 0,
-      "conversionIssues": [],
-      "compilationSuccess": true,
-      "compilationErrors": 2,
-      "compilationDiagnostics": [
-        "Roslyn: CS1061: \u0027Point\u0027 does not contain a definition for \u0027Item1\u0027 and no accessible extension method \u0027Item1\u0027 accepting a first argument of type \u0027Point\u0027 could be found (are you missing a using directive or an assembly reference?) (line 71)",
-        "Roslyn: CS1061: \u0027Point\u0027 does not contain a definition for \u0027Item2\u0027 and no accessible extension method \u0027Item2\u0027 accepting a first argument of type \u0027Point\u0027 could be found (are you missing a using directive or an assembly reference?) (line 74)"
+      "conversionIssues": [
+        "Error [roundtrip-calor-validation] (line 27, col 29): Generated Calor failed compilation: Generated C# failed compilation (CS1061): \u0027Point\u0027 does not contain a definition for \u0027Item1\u0027 and no accessible extension method \u0027Item1\u0027 accepting a first argument of type \u0027Point\u0027 could be found (are you missing a using directive or an assembly reference?)",
+        "Error [roundtrip-calor-validation] (line 28, col 29): Generated Calor failed compilation: Generated C# failed compilation (CS1061): \u0027Point\u0027 does not contain a definition for \u0027Item2\u0027 and no accessible extension method \u0027Item2\u0027 accepting a first argument of type \u0027Point\u0027 could be found (are you missing a using directive or an assembly reference?)"
       ],
-      "cSharpSyntaxSuccess": true,
+      "compilationSuccess": false,
+      "compilationErrors": 0,
+      "compilationDiagnostics": [],
+      "cSharpSyntaxSuccess": false,
       "cSharpCompilationSuccess": false,
-      "conversionDuration": "00:00:00.0076996",
-      "compilationDuration": "00:00:00.0011303",
+      "conversionDuration": "00:00:00.0215250",
+      "compilationDuration": "00:00:00",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": false
     },
     {
@@ -3295,8 +3491,10 @@
       "compilationDiagnostics": [],
       "cSharpSyntaxSuccess": true,
       "cSharpCompilationSuccess": true,
-      "conversionDuration": "00:00:00.0043359",
-      "compilationDuration": "00:00:00.0006440",
+      "conversionDuration": "00:00:00.0104407",
+      "compilationDuration": "00:00:00.0036917",
+      "semanticLossCount": 0,
+      "semanticLossDiagnostics": [],
       "roundTripSuccess": true
     }
   ]

--- a/tests/Calor.Evaluation/Skills/calor-language-skills.md
+++ b/tests/Calor.Evaluation/Skills/calor-language-skills.md
@@ -199,7 +199,10 @@ The `(len arr)` operation will throw `NullReferenceException` if `arr` is null. 
 §F{id:Name:vis} (type:name, ...) -> returnType
                       Function (pub|pri) with parameters and return type
 §E{effects}           Side effects: cw,cr,fs:r,fs:w,net:rw,db:rw
-§U{namespace}         Using directive
+§U{namespace}         Normal using directive
+§U{Alias:target}      Using alias
+§U{static:target}     Using static directive
+§U{global:target}     Global using (also supports global:Alias and global:static)
 Indentation delimits modules/functions; do not write structural close tags
 ```
 
@@ -935,10 +938,15 @@ Type parameters use `<T>` suffix syntax after tag attributes:
 
 ```calor
 §WHERE T : class              // Reference type constraint
+§WHERE T : class?             // Nullable reference type constraint
 §WHERE T : struct             // Value type constraint
+§WHERE T : unmanaged          // Unmanaged value type
+§WHERE T : notnull            // Non-null type
 §WHERE T : new()              // Parameterless constructor
 §WHERE T : IComparable<T>     // Interface constraint
 §WHERE T : class, IDisposable // Multiple constraints
+§WHERE T : default            // Only override/explicit-interface methods (Calor0120 otherwise)
+§WHERE T : allows ref struct  // Ref-struct anti-constraint
 ```
 
 ### Template: Generic Repository

--- a/tests/Calor.Tasks.Tests/CompileCalorIntegrationTests.cs
+++ b/tests/Calor.Tasks.Tests/CompileCalorIntegrationTests.cs
@@ -361,7 +361,7 @@ public class CompileCalorIntegrationTests : IDisposable
     }
 
     [Fact]
-    public void GeneratedCSharpValidation_HonorsDisabledImplicitUsings()
+    public void GeneratedCSharpValidation_DisabledImplicitUsings_UsesStandaloneStructuralUsings()
     {
         var src = CreateSourceFile(
             "ImplicitUsings.calr",
@@ -373,10 +373,12 @@ public class CompileCalorIntegrationTests : IDisposable
         var task = CreateTask(src);
         task.ImplicitUsings = "disable";
 
-        Assert.False(task.Execute());
-        Assert.Contains(
-            ((TestBuildEngine)task.BuildEngine).Errors,
-            error => error.Contains("CS0103", StringComparison.Ordinal));
+        Assert.True(
+            task.Execute(),
+            string.Join("; ", ((TestBuildEngine)task.BuildEngine).Errors));
+        var generated = File.ReadAllText(task.GeneratedFiles.Single().ItemSpec);
+        Assert.Contains("using System.IO;", generated);
+        Assert.Contains("File.ReadAllText", generated);
     }
 
     [Fact]

--- a/tests/TestData/Formatting/formatter-corpus-baseline.json
+++ b/tests/TestData/Formatting/formatter-corpus-baseline.json
@@ -1,6 +1,6 @@
 {
-  "trackedFileCount": 878,
-  "successfulTransformationCount": 646,
+  "trackedFileCount": 880,
+  "successfulTransformationCount": 648,
   "parseFailurePaths": [
     "bench/mcp/tasks/01-fix-closing-tag/expected.calr",
     "bench/mcp/tasks/01-fix-closing-tag/input.calr",


### PR DESCRIPTION
## Summary
- preserve complete using directives, conditional branches, and source ordering
- validate/reorder named record construction and generic variance/constraints
- centralize type mapping, namespace dependencies, and qualified-name sanitization
- isolate all per-module emitter state and support deterministic emitter reuse
- generate standalone C# with implicit usings disabled

## Validation
- 7,236 compiler tests passed, 2 skipped
- 380 conversion tests passed
- Release build: 0 warnings, 0 errors
- docs self-check clean
- all 7 mutation targets killed
- 5 adversarial remediation rounds completed; final approval obtained

Closes #766