### PR TITLE
fix(website): point the site at 0.13.2, now that it is actually installable

### DIFF
--- a/website/content/changelog.mdx
+++ b/website/content/changelog.mdx
@@ -10,7 +10,7 @@ All notable changes to Calor, organized by release.
 
 ## [Unreleased]
 
-## [0.13.2] - 2026-08-12 — tagged, not yet on nuget.org
+## [0.13.2] - 2026-08-12
 
 Hardening release. The compiler's control-flow and dataflow foundation is rebuilt on explicit semantics, and the build and release chain becomes hermetic and supply-chain verified.
 

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calor-website",
-  "version": "0.13.0",
+  "version": "0.13.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/website/src/components/landing/WhatsNewBanner.tsx
+++ b/website/src/components/landing/WhatsNewBanner.tsx
@@ -15,9 +15,9 @@ export function WhatsNewBanner() {
         <div className="flex items-center justify-center gap-3 text-sm">
           <Sparkles className="h-4 w-4 text-calor-cerulean flex-shrink-0" />
           <p className="text-center">
-            <span className="font-semibold text-calor-cerulean">v0.13.0</span>
+            <span className="font-semibold text-calor-cerulean">v0.13.2</span>
             <span className="text-muted-foreground mx-1.5">&mdash;</span>
-            <span className="text-foreground">The Trustworthy Project Model release: the binder dispatches every expression class through one authoritative path, and the verifier is pinned against real runtime execution so a proof and the running program cannot disagree.</span>
+            <span className="text-foreground">Control flow and dataflow are rebuilt on explicit semantics, Z3 translation matches executable C# numeric rules, and the build chain is hermetic and supply-chain verified with hash- and size-pinned Z3 binaries.</span>
             <Link
               href="/docs/changelog/"
               className="ml-2 font-medium text-calor-cerulean hover:text-calor-cerulean/80 underline underline-offset-4"


### PR DESCRIPTION
Reverses #973, which pointed the site at 0.13.0 while 0.13.2 was tagged but unpublished. **0.13.2 is now published and verified.**

## Verified before making this change

```
calor:     ["0.12.1","0.13.0","0.13.2"]      calor.0.13.2.nupkg     -> 200
calor.sdk: ["0.12.1","0.13.0","0.13.2"]      calor.sdk.0.13.2.nupkg -> 200

dotnet tool install calor --version 0.13.2   -> reports 0.13.2
calor verify samples/Verification/proven-contracts.calr
   Proven: 14   Skipped: 0   exit 0   Calor0710 occurrences: 0
```

That last line is the one that matters: the Z3 payload works **in the published package**, not just in CI.

## Three changes, matching what #973 changed

| file | 0.13.0 → 0.13.2 |
|---|---|
| `WhatsNewBanner.tsx` | version + headline |
| `website/package.json` | drives the **footer on every page** via `Footer.tsx` |
| `changelog.mdx` | drops `— tagged, not yet on nuget.org` |

The `package.json` bump is not cosmetic — review of #973 caught that leaving it stale makes the footer contradict the banner on every page.

## Banner claims verified against the shipped tag

#973's first attempt advertised **0.13.1 features under a 0.13.0 label** (`calor query`, which did not exist in 0.13.0). So each claim here was checked twice — against the 0.13.2 changelog section, and against `git log v0.13.0..v0.13.2`:

| claim | PR | in tag |
|---|---|---|
| control flow and dataflow rebuilt on explicit semantics | #960 | ✅ |
| Z3 translation matches executable C# numeric rules | #961 | ✅ |
| hermetic, hash- and size-pinned Z3 binaries | #954 | ✅ |

Also confirmed zero references to the removed VS Code extension.

## Merging does not deploy

`nextjs-gh-pages.yml` triggers only on `release: [created]` and `workflow_dispatch` — there is no `push: main`. **After merge: `gh workflow run nextjs-gh-pages.yml --ref main`**, then verify the live page rather than assuming. Publishing the draft release did not fire the deploy either, since the release was created on 08-12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)