### PR TITLE
Harden immutable LSP analysis and live E2E flows

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -248,11 +248,11 @@ jobs:
           done
           python3 scripts/check_coverage.py
 
-      - name: Run mutation, performance, and flake ratchets
+      - name: Run mutation, performance, and release flake ratchets
         run: |
           python3 scripts/run_mutation_gate.py
           python3 scripts/run_performance_gate.py
-          python3 scripts/run_flake_gate.py
+          python3 scripts/run_flake_gate.py --runs 100
 
       - name: Run blocking round-trip verification
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -274,7 +274,7 @@ jobs:
         run: python3 scripts/run_mutation_gate.py
 
       - name: Run live LSP flake gate
-        run: python3 scripts/run_flake_gate.py
+        run: python3 scripts/run_flake_gate.py --runs 10
 
       - name: Upload test, coverage, mutation, and flake reports
         if: always()

--- a/docs/ci-quality-gates.md
+++ b/docs/ci-quality-gates.md
@@ -24,6 +24,15 @@ the corresponding report and rationale in the pull request.
 
 ## Published reports
 
-CI retains test TRX, coverage, mutation, performance, migration/round-trip, and repeated
-live-LSP flake reports. The NuGet release job depends on the manifest-declared test,
+CI retains test TRX, coverage, mutation, performance, migration/round-trip, and live-LSP
+core-capability stress reports. Regular PR CI explicitly runs 10 repetitions; the NuGet
+release workflow explicitly runs 100. The process-level E2E test owns the exact `calor-lsp`
+process and asserts that exact PID exits after shutdown/disposal. The outer runner accepts
+only one Passed TRX result mapped by `testId` to that exact fully-qualified test method; substring
+matches, noncanonical/misnested TRX structures, duplicate containers or counters, inconsistent
+or missing standard counter fields, nonzero failure/nonterminal counters, skipped results, and
+missing definitions fail closed. The runner
+provides bounded root-process timeout handling and best-effort cleanup of observed children;
+it is not a kernel containment boundary and never certifies a timeout or supervision failure.
+The NuGet release job depends on the manifest-declared test,
 packaged-SDK consumer, and release-quality jobs.

--- a/eng/test-manifest.json
+++ b/eng/test-manifest.json
@@ -54,7 +54,7 @@
       "path": "tests/Calor.LanguageServer.Tests/Calor.LanguageServer.Tests.csproj",
       "workflow": ".github/workflows/test.yml",
       "releaseCritical": true,
-      "expectedTotal": 436,
+      "expectedTotal": 474,
       "expectedSkipped": 0
     },
     {

--- a/scripts/check_test_quality.py
+++ b/scripts/check_test_quality.py
@@ -126,6 +126,19 @@ def check_manifest(root: Path, manifest: dict) -> list[str]:
                 "publish job does not depend on release gates: "
                 + ", ".join(sorted(missing_needs))
             )
+        if "python3 scripts/run_flake_gate.py --runs 100" not in release_text:
+            errors.append(
+                "release workflow must run the live LSP flake gate with --runs 100"
+            )
+
+    pr_workflow = root / ".github/workflows/test.yml"
+    if pr_workflow.is_file():
+        pr_text = pr_workflow.read_text(encoding="utf-8")
+        if "python3 scripts/run_flake_gate.py --runs 10" not in pr_text:
+            errors.append(
+                "regular CI workflow must explicitly run the live LSP flake gate "
+                "with --runs 10"
+            )
     return errors
 
 

--- a/scripts/run_flake_gate.py
+++ b/scripts/run_flake_gate.py
@@ -1,26 +1,940 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import argparse
+import errno
 import json
+import os
+import signal
 import subprocess
+import sys
 import time
 import xml.etree.ElementTree as ET
+from dataclasses import dataclass
 from pathlib import Path
+
+EXPECTED_TEST_CLASS = "Calor.LanguageServer.Tests.E2E.LspE2ETests"
+EXPECTED_TEST_METHOD = "CoreCapabilityFlow_IsReadyBoundedAndLeakFreeAsync"
+EXPECTED_TEST_FQN = f"{EXPECTED_TEST_CLASS}.{EXPECTED_TEST_METHOD}"
+TRX_NAMESPACE = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010"
 
 
 def is_valid_run(return_code: int, executed: int, passed: int) -> bool:
-    return return_code == 0 and executed == 2 and passed == 2
+    return return_code == 0 and executed == 1 and passed == 1
+
+
+@dataclass(frozen=True)
+class TrxValidation:
+    valid: bool
+    executed: int
+    passed: int
+    error: str
+
+
+def validate_trx_root(root: ET.Element) -> TrxValidation:
+    def split_tag(element: ET.Element) -> tuple[str, str]:
+        if element.tag.startswith("{"):
+            namespace, local_name = element.tag[1:].split("}", 1)
+            return namespace, local_name
+        return "", element.tag
+
+    def canonical_children(
+        parent: ET.Element,
+        local_name: str,
+    ) -> list[ET.Element]:
+        return [
+            child
+            for child in list(parent)
+            if split_tag(child) == (TRX_NAMESPACE, local_name)
+        ]
+
+    root_namespace, root_name = split_tag(root)
+    if root_name != "TestRun" or root_namespace != TRX_NAMESPACE:
+        return TrxValidation(
+            False,
+            0,
+            0,
+            "TRX root must be TestRun in the Visual Studio TeamTest 2010 namespace",
+        )
+
+    required_containers = (
+        "TestDefinitions",
+        "Results",
+        "ResultSummary",
+    )
+    containers: dict[str, ET.Element] = {}
+    for local_name in required_containers:
+        all_matches = [
+            element
+            for element in root.iter()
+            if split_tag(element)[1] == local_name
+        ]
+        direct_matches = canonical_children(root, local_name)
+        if len(all_matches) != 1 or len(direct_matches) != 1:
+            return TrxValidation(
+                False,
+                0,
+                0,
+                f"TRX must contain exactly one direct {local_name}",
+            )
+        containers[local_name] = direct_matches[0]
+
+    all_counters = [
+        element
+        for element in root.iter()
+        if split_tag(element)[1] == "Counters"
+    ]
+    direct_counters = canonical_children(
+        containers["ResultSummary"],
+        "Counters",
+    )
+    if len(all_counters) != 1 or len(direct_counters) != 1:
+        return TrxValidation(
+            False,
+            0,
+            0,
+            "TRX must contain exactly one Counters directly under ResultSummary",
+        )
+    counters = direct_counters[0]
+
+    required_counter_values = {
+        "total": 1,
+        "executed": 1,
+        "passed": 1,
+        "failed": 0,
+        "error": 0,
+        "timeout": 0,
+        "aborted": 0,
+        "inconclusive": 0,
+        "passedButRunAborted": 0,
+        "notRunnable": 0,
+        "notExecuted": 0,
+        "disconnected": 0,
+        "warning": 0,
+        # VSTest's TRX schema reports Passed separately; its Completed outcome
+        # bucket is therefore zero for this real one-Passed-result inventory.
+        "completed": 0,
+        "inProgress": 0,
+        "pending": 0,
+    }
+    parsed_counters: dict[str, int] = {}
+    for attribute, expected in required_counter_values.items():
+        raw = counters.attrib.get(attribute)
+        if raw is None:
+            return TrxValidation(
+                False,
+                0,
+                0,
+                f"TRX Counters is missing {attribute}",
+            )
+        try:
+            value = int(raw)
+        except ValueError:
+            return TrxValidation(
+                False,
+                0,
+                0,
+                f"TRX counter {attribute} is not an integer",
+            )
+        parsed_counters[attribute] = value
+        if value != expected:
+            return TrxValidation(
+                False,
+                parsed_counters.get("executed", 0),
+                parsed_counters.get("passed", 0),
+                f"TRX counter {attribute} is {value}, expected {expected}",
+            )
+    for attribute, raw in counters.attrib.items():
+        if attribute in required_counter_values:
+            continue
+        try:
+            value = int(raw)
+        except ValueError:
+            continue
+        if value != 0:
+            return TrxValidation(
+                False,
+                executed,
+                passed,
+                f"TRX unrecognized counter {attribute} is nonzero",
+            )
+
+    executed = parsed_counters["executed"]
+    passed = parsed_counters["passed"]
+    if not is_valid_run(0, executed, passed):
+        return TrxValidation(
+            False,
+            executed,
+            passed,
+            f"TRX counters are {passed}/{executed}, expected 1/1",
+        )
+
+    definitions = canonical_children(
+        containers["TestDefinitions"],
+        "UnitTest",
+    )
+    all_definitions = [
+        element
+        for element in root.iter()
+        if split_tag(element)[1] == "UnitTest"
+    ]
+    results = canonical_children(
+        containers["Results"],
+        "UnitTestResult",
+    )
+    all_results = [
+        element
+        for element in root.iter()
+        if split_tag(element)[1] == "UnitTestResult"
+    ]
+    if len(definitions) != 1 or len(all_definitions) != 1:
+        return TrxValidation(
+            False,
+            executed,
+            passed,
+            f"TRX has {len(definitions)} test definitions, expected exactly one",
+        )
+    if len(results) != 1 or len(all_results) != 1:
+        return TrxValidation(
+            False,
+            executed,
+            passed,
+            f"TRX has {len(results)} test results, expected exactly one",
+        )
+
+    definition = definitions[0]
+    result = results[0]
+    test_id = definition.attrib.get("id")
+    if not test_id or result.attrib.get("testId") != test_id:
+        return TrxValidation(
+            False,
+            executed,
+            passed,
+            "TRX result testId does not map to the sole definition",
+        )
+    if definition.attrib.get("name") != EXPECTED_TEST_FQN:
+        return TrxValidation(
+            False,
+            executed,
+            passed,
+            f"TRX definition is not {EXPECTED_TEST_FQN}",
+        )
+    if result.attrib.get("testName") != EXPECTED_TEST_FQN:
+        return TrxValidation(
+            False,
+            executed,
+            passed,
+            f"TRX result is not {EXPECTED_TEST_FQN}",
+        )
+    if result.attrib.get("outcome") != "Passed":
+        return TrxValidation(
+            False,
+            executed,
+            passed,
+            f"TRX result outcome is {result.attrib.get('outcome')!r}",
+        )
+
+    methods = canonical_children(definition, "TestMethod")
+    all_methods = [
+        element
+        for element in definition.iter()
+        if split_tag(element)[1] == "TestMethod"
+    ]
+    if len(methods) != 1 or len(all_methods) != 1:
+        return TrxValidation(
+            False,
+            executed,
+            passed,
+            "TRX definition does not contain exactly one TestMethod",
+        )
+    method = methods[0]
+    if (
+        method.attrib.get("className") != EXPECTED_TEST_CLASS
+        or method.attrib.get("name") != EXPECTED_TEST_METHOD
+    ):
+        return TrxValidation(
+            False,
+            executed,
+            passed,
+            "TRX TestMethod class/name does not match the expected FQN",
+        )
+    return TrxValidation(True, executed, passed, "")
+
+
+def validate_trx(path: Path) -> TrxValidation:
+    if not path.is_file():
+        return TrxValidation(False, 0, 0, "TRX result file is missing")
+    try:
+        root = ET.parse(path).getroot()
+    except (ET.ParseError, OSError) as error:
+        return TrxValidation(False, 0, 0, f"TRX parse failed: {error}")
+    return validate_trx_root(root)
+
+
+def process_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def decode_output(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    return value.decode("utf-8", errors="replace") if isinstance(value, bytes) else value
+
+
+@dataclass(frozen=True)
+class ProcessIdentity:
+    pid: int
+    birth: str
+
+
+@dataclass(frozen=True)
+class ProcessGroupIdentity:
+    pgid: int
+    leader_birth: str
+
+
+@dataclass(frozen=True)
+class ProcessRecord:
+    parent: int
+    group: int
+    birth: str
+
+
+class SupervisionError(RuntimeError):
+    pass
+
+
+def read_process_table() -> dict[int, ProcessRecord]:
+    if os.name != "posix":
+        raise SupervisionError("process supervision requires a POSIX host")
+    try:
+        completed = subprocess.run(
+            ["ps", "-axo", "pid=,ppid=,pgid=,lstart="],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=2,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise SupervisionError(f"process table query failed: {error}") from error
+    if completed.returncode != 0:
+        raise SupervisionError(
+            f"process table query exited {completed.returncode}"
+        )
+
+    records: dict[int, ProcessRecord] = {}
+    for line in completed.stdout.splitlines():
+        parts = line.strip().split(None, 7)
+        if len(parts) != 8:
+            continue
+        try:
+            pid, parent, group = (int(part) for part in parts[:3])
+        except ValueError:
+            continue
+        records[pid] = ProcessRecord(
+            parent,
+            group,
+            " ".join(parts[3:8]),
+        )
+    if not records:
+        raise SupervisionError("process table query returned no parseable records")
+    return records
+
+
+def preflight_supervision() -> tuple[bool, str]:
+    try:
+        records = read_process_table()
+    except SupervisionError as error:
+        return False, str(error)
+    current = records.get(os.getpid())
+    if current is None or current.parent <= 0 or current.group <= 0:
+        return False, "process supervision preflight could not identify itself"
+    return True, ""
+
+
+class ProcessTracker:
+    """Tracks only observed descendants. This is not a containment boundary."""
+
+    def __init__(self, root_pid: int):
+        self.root_pid = root_pid
+        self.known_processes: dict[int, ProcessIdentity] = {}
+        self.known_groups: set[ProcessGroupIdentity] = set()
+
+    def scan(
+        self,
+    ) -> tuple[set[ProcessIdentity], set[ProcessGroupIdentity]]:
+        records = read_process_table()
+        root = records.get(self.root_pid)
+        if not self.known_processes and root is not None:
+            self.known_processes[self.root_pid] = ProcessIdentity(
+                self.root_pid,
+                root.birth,
+            )
+
+        owned = {
+            pid
+            for pid, identity in self.known_processes.items()
+            if pid in records and records[pid].birth == identity.birth
+        }
+        changed = True
+        while changed:
+            changed = False
+            for pid, record in records.items():
+                if record.parent in owned and pid not in owned:
+                    owned.add(pid)
+                    changed = True
+
+        live = {
+            ProcessIdentity(pid, records[pid].birth)
+            for pid in owned
+            if pid in records
+        }
+        for identity in live:
+            existing = self.known_processes.get(identity.pid)
+            if existing is None or existing.birth == identity.birth:
+                self.known_processes[identity.pid] = identity
+
+        live_pids = {identity.pid for identity in live}
+        groups: set[ProcessGroupIdentity] = set()
+        for identity in live:
+            group = records[identity.pid].group
+            leader = records.get(group)
+            if group in live_pids and leader is not None:
+                groups.add(ProcessGroupIdentity(group, leader.birth))
+        self.known_groups.update(groups)
+        return live, groups
+
+    def identity_is_current(self, identity: ProcessIdentity) -> bool:
+        try:
+            record = read_process_table().get(identity.pid)
+        except SupervisionError:
+            return False
+        return (
+            record is not None
+            and record.birth == identity.birth
+            and self.known_processes.get(identity.pid) == identity
+        )
+
+    def group_is_current(self, group: ProcessGroupIdentity) -> bool:
+        return self.identity_is_current(
+            ProcessIdentity(group.pgid, group.leader_birth)
+        )
+
+
+def safe_signal_pid(
+    tracker: ProcessTracker,
+    identity: ProcessIdentity,
+    sig: signal.Signals,
+) -> bool:
+    if not tracker.identity_is_current(identity):
+        return False
+    try:
+        os.kill(identity.pid, sig)
+        return True
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        return False
+    except OSError as error:
+        return error.errno == errno.ESRCH
+
+
+def safe_signal_group(
+    tracker: ProcessTracker,
+    group: ProcessGroupIdentity,
+    sig: signal.Signals,
+) -> bool:
+    if (
+        group.pgid <= 0
+        or group.pgid == os.getpgrp()
+        or not tracker.group_is_current(group)
+    ):
+        return False
+    try:
+        os.killpg(group.pgid, sig)
+        return True
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        return False
+    except OSError as error:
+        return error.errno == errno.ESRCH
+
+
+def terminate_root(process: subprocess.Popen[str]) -> bool:
+    process.poll()
+    if process.returncode is not None:
+        return True
+    try:
+        process.terminate()
+        process.wait(timeout=1)
+        return True
+    except subprocess.TimeoutExpired:
+        try:
+            process.kill()
+            process.wait(timeout=1)
+            return True
+        except (subprocess.TimeoutExpired, OSError, PermissionError):
+            return False
+    except (OSError, PermissionError):
+        return False
+
+
+def best_effort_known_descendant_cleanup(
+    tracker: ProcessTracker,
+) -> bool:
+    identities = set(tracker.known_processes.values())
+    groups = set(tracker.known_groups)
+    for group in groups:
+        safe_signal_group(tracker, group, signal.SIGTERM)
+    for identity in identities:
+        safe_signal_pid(tracker, identity, signal.SIGTERM)
+    time.sleep(0.05)
+    for group in groups:
+        safe_signal_group(tracker, group, signal.SIGKILL)
+    for identity in identities:
+        safe_signal_pid(tracker, identity, signal.SIGKILL)
+    try:
+        live, _ = tracker.scan()
+    except SupervisionError:
+        return False
+    return not live
+
+
+def bounded_communicate(
+    process: subprocess.Popen[str],
+    timeout: float,
+) -> tuple[str, str, bool]:
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+        return stdout, stderr, True
+    except subprocess.TimeoutExpired as error:
+        stdout = decode_output(error.stdout)
+        stderr = decode_output(error.stderr)
+        for stream in (process.stdout, process.stderr):
+            if stream is not None:
+                try:
+                    stream.close()
+                except OSError:
+                    pass
+        return stdout, stderr, False
+
+
+def run_with_tree_timeout(
+    command: list[str],
+    timeout: float,
+) -> tuple[subprocess.CompletedProcess[str], bool, bool, bool]:
+    preflight_ok, preflight_error = preflight_supervision()
+    if not preflight_ok:
+        return (
+            subprocess.CompletedProcess(command, 126, "", preflight_error + "\n"),
+            False,
+            False,
+            False,
+        )
+
+    process: subprocess.Popen[str] | None = None
+    tracker: ProcessTracker | None = None
+    stdout = ""
+    stderr = ""
+    return_code = 125
+    timed_out = False
+    supervision_failed = False
+    known_descendants_remaining = False
+    normal_completion = False
+    root_exited = False
+    pipes_drained = False
+    try:
+        process = subprocess.Popen(
+            command,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        tracker = ProcessTracker(process.pid)
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                tracker.scan()
+            except Exception as error:
+                supervision_failed = True
+                stderr += (
+                    f"Process supervision failed: "
+                    f"{type(error).__name__}: {error}\n"
+                )
+                break
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                return_code = 124
+                stderr += "Live LSP run exceeded 30 seconds.\n"
+                break
+            try:
+                stdout, process_stderr = process.communicate(
+                    timeout=min(0.1, remaining)
+                )
+                stderr = process_stderr + stderr
+                return_code = process.returncode
+                normal_completion = True
+                try:
+                    live, _ = tracker.scan()
+                    known_descendants_remaining = bool(live)
+                except Exception as error:
+                    supervision_failed = True
+                    stderr += (
+                        f"Final process supervision failed: "
+                        f"{type(error).__name__}: {error}\n"
+                    )
+                break
+            except subprocess.TimeoutExpired:
+                continue
+    except Exception as error:
+        supervision_failed = True
+        stderr += f"Supervisor lifecycle failed: {type(error).__name__}: {error}\n"
+    finally:
+        if process is not None:
+            root_exited = terminate_root(process)
+            if tracker is not None:
+                try:
+                    descendants_cleaned = best_effort_known_descendant_cleanup(
+                        tracker
+                    )
+                    known_descendants_remaining = (
+                        known_descendants_remaining or not descendants_cleaned
+                    )
+                except Exception as error:
+                    known_descendants_remaining = True
+                    stderr += (
+                        f"Best-effort descendant cleanup failed: "
+                        f"{type(error).__name__}: {error}\n"
+                    )
+            try:
+                drained_stdout, drained_stderr, pipes_drained = bounded_communicate(
+                    process,
+                    timeout=2,
+                )
+                if drained_stdout:
+                    stdout = drained_stdout
+                if drained_stderr:
+                    stderr = drained_stderr + stderr
+            except Exception as error:
+                stderr += (
+                    f"Bounded pipe drain failed: {type(error).__name__}: {error}\n"
+                )
+
+    cleanup_verified = (
+        normal_completion
+        and not timed_out
+        and not supervision_failed
+        and root_exited
+        and pipes_drained
+        and not known_descendants_remaining
+    )
+    if not cleanup_verified and return_code == 0:
+        return_code = 125
+    return (
+        subprocess.CompletedProcess(command, return_code, stdout, stderr),
+        cleanup_verified,
+        known_descendants_remaining,
+        timed_out,
+    )
+
+
+def assert_process_dead(pid: int) -> None:
+    if process_exists(pid):
+        raise AssertionError(f"process {pid} is still alive")
+
+
+def self_test() -> None:
+    if is_valid_run(0, 0, 0) or not is_valid_run(0, 1, 1):
+        raise AssertionError("flake gate did not enforce the exact test inventory")
+
+    def make_trx(
+        fqn: str,
+        *,
+        outcome: str = "Passed",
+        duplicate_result: bool = False,
+        include_definition: bool = True,
+        root_name: str = "TestRun",
+        namespace: str = TRX_NAMESPACE,
+        counter_overrides: dict[str, int] | None = None,
+    ) -> ET.Element:
+        class_name, method_name = fqn.rsplit(".", 1)
+        definition = (
+            f"""
+            <TestDefinitions>
+              <UnitTest name="{fqn}" id="test-1">
+                <TestMethod className="{class_name}" name="{method_name}" />
+              </UnitTest>
+            </TestDefinitions>
+            """
+            if include_definition
+            else "<TestDefinitions />"
+        )
+        result = (
+            f'<UnitTestResult testId="test-1" testName="{fqn}" '
+            f'outcome="{outcome}" />'
+        )
+        results = result + (result if duplicate_result else "")
+        counter_values = {
+            "total": 1,
+            "executed": 1,
+            "passed": 1,
+            "failed": 0,
+            "error": 0,
+            "timeout": 0,
+            "aborted": 0,
+            "inconclusive": 0,
+            "passedButRunAborted": 0,
+            "notRunnable": 0,
+            "notExecuted": 0,
+            "disconnected": 0,
+            "warning": 0,
+            "completed": 0,
+            "inProgress": 0,
+            "pending": 0,
+        }
+        counter_values.update(counter_overrides or {})
+        counters = " ".join(
+            f'{name}="{value}"'
+            for name, value in counter_values.items()
+        )
+        return ET.fromstring(
+            f"""
+            <{root_name} xmlns="{namespace}">
+              {definition}
+              <Results>{results}</Results>
+              <ResultSummary>
+                <Counters {counters} />
+              </ResultSummary>
+            </{root_name}>
+            """
+        )
+
+    if not validate_trx_root(make_trx(EXPECTED_TEST_FQN)).valid:
+        raise AssertionError("exact TRX identity was rejected")
+    impostor = EXPECTED_TEST_FQN + "_Impostor"
+    if validate_trx_root(make_trx(impostor)).valid:
+        raise AssertionError("same-substring impostor TRX was accepted")
+    if validate_trx_root(
+        make_trx(EXPECTED_TEST_FQN, duplicate_result=True)
+    ).valid:
+        raise AssertionError("duplicate TRX result was accepted")
+    if validate_trx_root(
+        make_trx(EXPECTED_TEST_FQN, outcome="NotExecuted")
+    ).valid:
+        raise AssertionError("skipped TRX result was accepted")
+    if validate_trx_root(
+        make_trx(EXPECTED_TEST_FQN, include_definition=False)
+    ).valid:
+        raise AssertionError("TRX without a definition was accepted")
+    if validate_trx_root(
+        make_trx(EXPECTED_TEST_FQN, root_name="NotATestRun")
+    ).valid:
+        raise AssertionError("non-TestRun root was accepted")
+    if validate_trx_root(
+        make_trx(EXPECTED_TEST_FQN, namespace="urn:not-trx")
+    ).valid:
+        raise AssertionError("unexpected TRX namespace was accepted")
+    inconsistent = make_trx(
+        EXPECTED_TEST_FQN,
+        counter_overrides={"total": 2},
+    )
+    if validate_trx_root(inconsistent).valid:
+        raise AssertionError("inconsistent TRX counters were accepted")
+    for counter in (
+        "passedButRunAborted",
+        "notRunnable",
+        "disconnected",
+        "warning",
+        "completed",
+        "inProgress",
+        "pending",
+    ):
+        if validate_trx_root(
+            make_trx(
+                EXPECTED_TEST_FQN,
+                counter_overrides={counter: 1},
+            )
+        ).valid:
+            raise AssertionError(f"nonzero {counter} counter was accepted")
+    missing_counter = make_trx(EXPECTED_TEST_FQN)
+    missing_summary = next(
+        element
+        for element in missing_counter
+        if element.tag.endswith("ResultSummary")
+    )
+    missing_counters = next(
+        element
+        for element in missing_summary
+        if element.tag.endswith("Counters")
+    )
+    del missing_counters.attrib["pending"]
+    if validate_trx_root(missing_counter).valid:
+        raise AssertionError("missing required standard counter was accepted")
+
+    duplicate_containers = make_trx(EXPECTED_TEST_FQN)
+    definitions = next(
+        element
+        for element in duplicate_containers
+        if element.tag.endswith("TestDefinitions")
+    )
+    duplicate_containers.append(
+        ET.fromstring(ET.tostring(definitions))
+    )
+    if validate_trx_root(duplicate_containers).valid:
+        raise AssertionError("duplicate TRX containers were accepted")
+
+    duplicate_counters = make_trx(EXPECTED_TEST_FQN)
+    summary = next(
+        element
+        for element in duplicate_counters
+        if element.tag.endswith("ResultSummary")
+    )
+    counters = next(
+        element
+        for element in summary
+        if element.tag.endswith("Counters")
+    )
+    summary.append(ET.fromstring(ET.tostring(counters)))
+    if validate_trx_root(duplicate_counters).valid:
+        raise AssertionError("duplicate TRX counters were accepted")
+
+    misnested = make_trx(EXPECTED_TEST_FQN)
+    results_container = next(
+        element
+        for element in misnested
+        if element.tag.endswith("Results")
+    )
+    result_summary = next(
+        element
+        for element in misnested
+        if element.tag.endswith("ResultSummary")
+    )
+    misnested.remove(results_container)
+    result_summary.append(results_container)
+    if validate_trx_root(misnested).valid:
+        raise AssertionError("misnested TRX Results was accepted")
+
+    original_preflight = preflight_supervision
+    original_popen = subprocess.Popen
+    spawned = False
+    try:
+        globals()["preflight_supervision"] = lambda: (False, "injected")
+
+        def reject_spawn(*_args, **_kwargs):
+            nonlocal spawned
+            spawned = True
+            raise AssertionError("spawned despite failed preflight")
+
+        subprocess.Popen = reject_spawn
+        result = run_with_tree_timeout(
+            [sys.executable, "-c", "raise SystemExit(0)"],
+            timeout=1,
+        )
+    finally:
+        globals()["preflight_supervision"] = original_preflight
+        subprocess.Popen = original_popen
+    if result[0].returncode != 126 or result[1] or spawned:
+        raise AssertionError("preflight did not fail closed before spawn")
+
+    timeout_script = (
+        "import os,time;"
+        "print(os.getpid(),flush=True);"
+        "time.sleep(60)"
+    )
+    started = time.monotonic()
+    timeout_result = run_with_tree_timeout(
+        [sys.executable, "-c", timeout_script],
+        timeout=0.25,
+    )
+    timeout_pid = int(timeout_result[0].stdout.strip().splitlines()[0])
+    if (
+        timeout_result[0].returncode != 124
+        or timeout_result[1]
+        or not timeout_result[3]
+        or time.monotonic() - started > 6
+    ):
+        raise AssertionError("timeout was incorrectly certified or unbounded")
+    assert_process_dead(timeout_pid)
+
+    escape_script = """
+import os
+import time
+
+print(f"root:{os.getpid()}", flush=True)
+first = os.fork()
+if first == 0:
+    os.setsid()
+    second = os.fork()
+    if second > 0:
+        os._exit(0)
+    os.environ.clear()
+    print(f"escape:{os.getpid()}", flush=True)
+    time.sleep(60)
+os.waitpid(first, 0)
+time.sleep(60)
+"""
+    escape_result = run_with_tree_timeout(
+        [sys.executable, "-c", escape_script],
+        timeout=0.5,
+    )
+    escape_pids = {
+        int(line.split(":", 1)[1])
+        for line in escape_result[0].stdout.splitlines()
+        if line.startswith(("root:", "escape:"))
+    }
+    if escape_result[0].returncode != 124 or escape_result[1]:
+        raise AssertionError("env-clearing escape was falsely certified")
+    for pid in escape_pids:
+        if process_exists(pid):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+    original_scan = ProcessTracker.scan
+    scan_calls = 0
+    try:
+        def scan_then_raise(self):
+            nonlocal scan_calls
+            scan_calls += 1
+            if scan_calls == 1:
+                time.sleep(0.15)
+                return original_scan(self)
+            raise RuntimeError("injected scanner exception")
+
+        ProcessTracker.scan = scan_then_raise
+        scanner_result = run_with_tree_timeout(
+            [sys.executable, "-c", timeout_script],
+            timeout=5,
+        )
+    finally:
+        ProcessTracker.scan = original_scan
+    scanner_pid = int(scanner_result[0].stdout.strip().splitlines()[0])
+    if scanner_result[0].returncode != 125 or scanner_result[1]:
+        raise AssertionError("scanner exception was falsely certified")
+    assert_process_dead(scanner_pid)
+
+    print("Flake gate negative self-test passed.")
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--runs", type=int, default=3)
+    parser.add_argument("--runs", type=int, default=10)
     parser.add_argument("--output", default="artifacts/flake/flake-report.json")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
     if args.self_test:
-        if is_valid_run(0, 0, 0) or not is_valid_run(0, 2, 2):
-            raise AssertionError("flake gate did not enforce the exact test inventory")
-        print("Flake gate negative self-test passed.")
+        self_test()
         return 0
     if args.runs < 2:
         parser.error("--runs must be at least 2")
@@ -33,54 +947,72 @@ def main() -> int:
     for run in range(1, args.runs + 1):
         results_dir = logs / f"results-{run}"
         started = time.monotonic()
-        completed = subprocess.run(
-            [
-                "dotnet",
-                "test",
-                "tests/Calor.LanguageServer.Tests/Calor.LanguageServer.Tests.csproj",
-                "-c",
-                "Release",
-                "--no-build",
-                "--no-restore",
-                "--filter",
-                "FullyQualifiedName~LspE2ETests.HoverAsync_ReturnsInfo|FullyQualifiedName~LspE2ETests.CompletionAsync_ReturnsItems",
-                "--logger",
-                "trx;LogFileName=results.trx",
-                "--results-directory",
-                str(results_dir),
-                "--verbosity",
-                "minimal",
-            ],
-            text=True,
-            capture_output=True,
-            check=False,
+        completed, cleanup_verified, known_remaining, timed_out = (
+            run_with_tree_timeout(
+                [
+                    "dotnet",
+                    "test",
+                    "tests/Calor.LanguageServer.Tests/Calor.LanguageServer.Tests.csproj",
+                    "-c",
+                    "Release",
+                    "--no-build",
+                    "--no-restore",
+                    "--filter",
+                    f"FullyQualifiedName={EXPECTED_TEST_FQN}",
+                    "--logger",
+                    "trx;LogFileName=results.trx",
+                    "--results-directory",
+                    str(results_dir),
+                    "--verbosity",
+                    "minimal",
+                ],
+                timeout=30,
+            )
         )
         elapsed = time.monotonic() - started
         (logs / f"run-{run}.log").write_text(
-            completed.stdout + completed.stderr, encoding="utf-8"
+            completed.stdout + completed.stderr,
+            encoding="utf-8",
         )
         trx = results_dir / "results.trx"
-        executed = passed = 0
-        if trx.is_file():
-            counters = ET.parse(trx).find(".//{*}Counters")
-            if counters is not None:
-                executed = int(counters.attrib.get("executed", "0"))
-                passed = int(counters.attrib.get("passed", "0"))
-        run_passed = is_valid_run(completed.returncode, executed, passed)
+        trx_validation = validate_trx(trx)
+        executed = trx_validation.executed
+        passed = trx_validation.passed
+        run_passed = (
+            completed.returncode == 0
+            and trx_validation.valid
+            and cleanup_verified
+            and not known_remaining
+            and not timed_out
+        )
         results.append(
             {
                 "run": run,
                 "executed": executed,
                 "passedTests": passed,
                 "passed": run_passed,
+                "cleanupVerified": cleanup_verified,
+                "knownDescendantsRemaining": known_remaining,
+                "timedOut": timed_out,
+                "testIdentityVerified": trx_validation.valid,
+                "trxError": trx_validation.error,
                 "seconds": round(elapsed, 3),
             }
         )
-        print(f"flake run {run}: {'passed' if run_passed else 'failed'} ({passed}/{executed})")
+        print(
+            f"flake run {run}: "
+            f"{'passed' if run_passed else 'failed'} ({passed}/{executed})"
+        )
 
     report = {
-        "schemaVersion": 1,
-        "test": "live LSP hover and completion",
+        "schemaVersion": 2,
+        "test": "live LSP core capability and exact server PID teardown flow",
+        "certification": (
+            f"The sole Passed TRX result must map by testId to {EXPECTED_TEST_FQN}, "
+            "which asserts its exact calor-lsp PID exits. "
+            "Outer cleanup is bounded root supervision plus best-effort "
+            "observed-descendant cleanup, not a kernel containment boundary."
+        ),
         "runs": results,
         "passed": all(result["passed"] for result in results),
     }

--- a/src/Calor.Compiler/Diagnostics/Diagnostic.cs
+++ b/src/Calor.Compiler/Diagnostics/Diagnostic.cs
@@ -264,6 +264,11 @@ public static class DiagnosticCode
     /// </summary>
     public const string InstanceMemberInStaticContext = "Calor0261";
 
+    /// <summary>
+    /// Error: the workspace inheritance graph contains a direct or indirect cycle.
+    /// </summary>
+    public const string InheritanceCycle = "Calor0262";
+
     // Contract errors (Calor0300-0399)
     public const string InvalidPrecondition = "Calor0300";
     public const string InvalidPostcondition = "Calor0301";

--- a/src/Calor.Compiler/Diagnostics/DiagnosticFormatter.cs
+++ b/src/Calor.Compiler/Diagnostics/DiagnosticFormatter.cs
@@ -412,6 +412,7 @@ public sealed class SarifDiagnosticFormatter : IDiagnosticFormatter
         DiagnosticCode.BindReassignsImmutable => "Cannot rebind immutable symbol",
         DiagnosticCode.AmbiguousOverload => "Ambiguous overload",
         DiagnosticCode.NoMatchingOverload => "No matching overload",
+        DiagnosticCode.InheritanceCycle => "Inheritance cycle",
         DiagnosticCode.NonExhaustiveMatch => "Non-exhaustive match expression",
         DiagnosticCode.UnreachablePattern => "Unreachable pattern",
         DiagnosticCode.DuplicatePattern => "Duplicate pattern",

--- a/src/Calor.LanguageServer/Handlers/CodeActionHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/CodeActionHandler.cs
@@ -32,8 +32,8 @@ public sealed class CodeActionHandler : CodeActionHandlerBase
 
     public override Task<CommandOrCodeActionContainer?> Handle(CodeActionParams request, CancellationToken cancellationToken)
     {
-        var state = _workspace.Get(request.TextDocument.Uri);
-        if (state == null)
+        var snapshot = _workspace.Get(request.TextDocument.Uri)?.Snapshot;
+        if (snapshot == null)
         {
             return Task.FromResult<CommandOrCodeActionContainer?>(null);
         }
@@ -41,10 +41,10 @@ public sealed class CodeActionHandler : CodeActionHandlerBase
         var codeActions = new List<CommandOrCodeAction>();
 
         // Check if there are any diagnostics with fixes at the requested range
-        foreach (var diagnostic in state.DiagnosticsWithFixes)
+        foreach (var diagnostic in snapshot.DiagnosticsWithFixes)
         {
             // Check if the diagnostic overlaps with the requested range
-            var diagRange = PositionConverter.ToLspRange(diagnostic.Span, state.Source);
+            var diagRange = PositionConverter.ToLspRange(diagnostic.Span, snapshot.Source);
             if (!RangesOverlap(diagRange, request.Range))
                 continue;
 
@@ -78,7 +78,7 @@ public sealed class CodeActionHandler : CodeActionHandlerBase
                             diagnostic.Span,
                             diagnostic.Severity,
                             diagnostic.FilePath),
-                        state.Source)),
+                        snapshot.Source)),
                 Edit = workspaceEdit,
                 IsPreferred = true
             };
@@ -87,18 +87,20 @@ public sealed class CodeActionHandler : CodeActionHandlerBase
         }
 
         // Add source actions even without diagnostics
-        codeActions.AddRange(GetSourceActions(state, request));
+        codeActions.AddRange(GetSourceActions(snapshot, request));
 
         return Task.FromResult<CommandOrCodeActionContainer?>(
             codeActions.Count > 0 ? new CommandOrCodeActionContainer(codeActions) : null);
     }
 
-    private static IEnumerable<CommandOrCodeAction> GetSourceActions(DocumentState state, CodeActionParams request)
+    private static IEnumerable<CommandOrCodeAction> GetSourceActions(
+        DocumentSnapshot snapshot,
+        CodeActionParams request)
     {
         var actions = new List<CommandOrCodeAction>();
 
         // Add "Organize imports" action if there are using directives
-        if (state.Ast?.Usings.Count > 0)
+        if (snapshot.Ast?.Usings.Count > 0)
         {
             // Could add action to sort using directives
         }

--- a/src/Calor.LanguageServer/Handlers/CompletionHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/CompletionHandler.cs
@@ -2,6 +2,7 @@ using Calor.Compiler.Ast;
 using Calor.Compiler.Parsing;
 using Calor.LanguageServer.State;
 using Calor.LanguageServer.Utilities;
+using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -132,17 +133,19 @@ public sealed class CompletionHandler : CompletionHandlerBase
 
     public override Task<CompletionList> Handle(CompletionParams request, CancellationToken cancellationToken)
     {
-        var state = _workspace.Get(request.TextDocument.Uri);
-        if (state == null)
+        var workspace = _workspace.CaptureSnapshot();
+        var document = workspace.GetDocument(request.TextDocument.Uri);
+        if (document == null)
         {
             return Task.FromResult(new CompletionList());
         }
 
+        var snapshot = document.Analysis;
         var items = new List<CompletionItem>();
-        var offset = PositionConverter.ToOffset(request.Position, state.Source);
+        var offset = PositionConverter.ToOffset(request.Position, snapshot.Source);
 
         // Determine context
-        var context = GetCompletionContext(state.Source, offset);
+        var context = GetCompletionContext(snapshot.Source, offset);
 
         switch (context)
         {
@@ -153,41 +156,46 @@ public sealed class CompletionHandler : CompletionHandlerBase
 
             case CompletionContext.InType:
                 // In type position - suggest types
-                items.AddRange(GetTypeCompletions(state.Ast));
-                items.AddRange(GetCrossFileTypeCompletions(_workspace, state));
+                items.AddRange(GetTypeCompletions(snapshot.Ast));
+                items.AddRange(GetCrossFileTypeCompletions(workspace, document));
                 break;
 
             case CompletionContext.AfterDot:
                 // After a dot - suggest members
-                items.AddRange(GetMemberCompletions(state, offset, _workspace));
+                items.AddRange(GetMemberCompletionsFromSnapshot(
+                    document,
+                    offset,
+                    workspace));
                 break;
 
             case CompletionContext.InExpression:
                 // In expression - suggest variables and functions
-                items.AddRange(GetExpressionCompletions(state, offset));
-                items.AddRange(GetCrossFileSymbolCompletions(_workspace, state));
+                items.AddRange(GetExpressionCompletionsFromSnapshot(snapshot, offset));
+                items.AddRange(GetCrossFileSymbolCompletions(workspace, document));
                 break;
 
             default:
                 // General context - provide all completions
                 items.AddRange(GetTagCompletions());
-                items.AddRange(GetTypeCompletions(state.Ast));
-                items.AddRange(GetExpressionCompletions(state, offset));
-                items.AddRange(GetCrossFileSymbolCompletions(_workspace, state));
+                items.AddRange(GetTypeCompletions(snapshot.Ast));
+                items.AddRange(GetExpressionCompletionsFromSnapshot(snapshot, offset));
+                items.AddRange(GetCrossFileSymbolCompletions(workspace, document));
                 break;
         }
 
         return Task.FromResult(new CompletionList(items));
     }
 
-    private static IEnumerable<CompletionItem> GetCrossFileTypeCompletions(WorkspaceState workspace, DocumentState currentDoc)
+    private static IEnumerable<CompletionItem> GetCrossFileTypeCompletions(
+        WorkspaceIndexSnapshot workspace,
+        WorkspaceDocumentSnapshot currentDoc)
     {
         var items = new List<CompletionItem>();
 
-        foreach (var (doc, name, kind, type) in workspace.GetAllPublicSymbols())
+        foreach (var (doc, name, kind, type) in GetAllPublicSymbols(workspace))
         {
             // Skip symbols from the current document
-            if (doc.Uri == currentDoc.Uri) continue;
+            if (doc.Document.Uri == currentDoc.Document.Uri) continue;
 
             // Only include types (classes, interfaces, enums)
             if (kind is "class" or "interface" or "enum")
@@ -202,7 +210,7 @@ public sealed class CompletionHandler : CompletionHandlerBase
                         "enum" => CompletionItemKind.Enum,
                         _ => CompletionItemKind.TypeParameter
                     },
-                    Detail = $"[{GetFileName(doc.Uri)}] {kind} {name}",
+                    Detail = $"[{GetFileName(doc.Document.Uri)}] {kind} {name}",
                     InsertText = name,
                     SortText = "z" + name // Sort after local completions
                 });
@@ -212,14 +220,16 @@ public sealed class CompletionHandler : CompletionHandlerBase
         return items;
     }
 
-    private static IEnumerable<CompletionItem> GetCrossFileSymbolCompletions(WorkspaceState workspace, DocumentState currentDoc)
+    private static IEnumerable<CompletionItem> GetCrossFileSymbolCompletions(
+        WorkspaceIndexSnapshot workspace,
+        WorkspaceDocumentSnapshot currentDoc)
     {
         var items = new List<CompletionItem>();
 
-        foreach (var (doc, name, kind, type) in workspace.GetAllPublicSymbols())
+        foreach (var (doc, name, kind, type) in GetAllPublicSymbols(workspace))
         {
             // Skip symbols from the current document
-            if (doc.Uri == currentDoc.Uri) continue;
+            if (doc.Document.Uri == currentDoc.Document.Uri) continue;
 
             items.Add(new CompletionItem
             {
@@ -233,7 +243,7 @@ public sealed class CompletionHandler : CompletionHandlerBase
                     "delegate" => CompletionItemKind.Function,
                     _ => CompletionItemKind.Reference
                 },
-                Detail = $"[{GetFileName(doc.Uri)}] {kind}{(type != null ? ": " + type : "")}",
+                Detail = $"[{GetFileName(doc.Document.Uri)}] {kind}{(type != null ? ": " + type : "")}",
                 InsertText = name,
                 SortText = "z" + name // Sort after local completions
             });
@@ -245,6 +255,34 @@ public sealed class CompletionHandler : CompletionHandlerBase
     private static string GetFileName(Uri uri)
     {
         return System.IO.Path.GetFileName(uri.LocalPath);
+    }
+
+    private static IEnumerable<(
+        WorkspaceDocumentSnapshot Doc,
+        string Name,
+        string Kind,
+        string? Type)> GetAllPublicSymbols(WorkspaceIndexSnapshot workspace)
+    {
+        foreach (var doc in workspace.Documents)
+        {
+            var ast = doc.Analysis.Ast;
+            if (ast == null)
+                continue;
+
+            foreach (var func in ast.Functions)
+            {
+                if (func.Visibility != Visibility.Private)
+                    yield return (doc, func.Name, "function", func.Output?.TypeName ?? "void");
+            }
+            foreach (var cls in ast.Classes)
+                yield return (doc, cls.Name, "class", null);
+            foreach (var iface in ast.Interfaces)
+                yield return (doc, iface.Name, "interface", null);
+            foreach (var enumDef in ast.Enums)
+                yield return (doc, enumDef.Name, "enum", enumDef.UnderlyingType);
+            foreach (var del in ast.Delegates)
+                yield return (doc, del.Name, "delegate", del.Output?.TypeName ?? "void");
+        }
     }
 
     private static CompletionContext GetCompletionContext(string source, int offset)
@@ -337,9 +375,14 @@ public sealed class CompletionHandler : CompletionHandlerBase
     }
 
     private static IEnumerable<CompletionItem> GetExpressionCompletions(DocumentState state, int offset)
+        => GetExpressionCompletionsFromSnapshot(state.Snapshot, offset);
+
+    private static IEnumerable<CompletionItem> GetExpressionCompletionsFromSnapshot(
+        DocumentSnapshot snapshot,
+        int offset)
     {
         var items = new List<CompletionItem>();
-        var ast = state.Ast;
+        var ast = snapshot.Ast;
 
         if (ast == null)
             return items;
@@ -368,14 +411,27 @@ public sealed class CompletionHandler : CompletionHandlerBase
 
     private static IEnumerable<CompletionItem> GetMemberCompletions(DocumentState state, int offset, WorkspaceState workspace)
     {
+        var workspaceSnapshot = workspace.CaptureSnapshot();
+        var document = workspaceSnapshot.GetDocument(DocumentUri.From(state.Uri));
+        return document == null
+            ? Enumerable.Empty<CompletionItem>()
+            : GetMemberCompletionsFromSnapshot(document, offset, workspaceSnapshot);
+    }
+
+    private static IEnumerable<CompletionItem> GetMemberCompletionsFromSnapshot(
+        WorkspaceDocumentSnapshot document,
+        int offset,
+        WorkspaceIndexSnapshot workspace)
+    {
         var items = new List<CompletionItem>();
-        var ast = state.Ast;
+        var snapshot = document.Analysis;
+        var ast = snapshot.Ast;
 
         if (ast == null)
             return items;
 
         // Find the expression before the dot
-        var source = state.Source;
+        var source = snapshot.Source;
         var exprBeforeDot = ExtractExpressionBeforeDot(source, offset);
 
         if (string.IsNullOrEmpty(exprBeforeDot))
@@ -391,7 +447,7 @@ public sealed class CompletionHandler : CompletionHandlerBase
         }
 
         // Find members for this type
-        items.AddRange(GetMembersForType(typeName, ast, workspace, state));
+        items.AddRange(GetMembersForType(typeName, ast, workspace, document));
 
         return items;
     }
@@ -460,7 +516,11 @@ public sealed class CompletionHandler : CompletionHandlerBase
         return result.TrimStart('.');
     }
 
-    private static string? ResolveExpressionType(string expression, ModuleNode ast, int offset, WorkspaceState workspace)
+    private static string? ResolveExpressionType(
+        string expression,
+        ModuleNode ast,
+        int offset,
+        WorkspaceIndexSnapshot workspace)
     {
         // Handle chained expressions like "a.b.c"
         if (expression.Contains('.'))
@@ -481,7 +541,11 @@ public sealed class CompletionHandler : CompletionHandlerBase
         return ResolveSingleIdentifierType(expression, ast, offset, workspace);
     }
 
-    private static string? ResolveSingleIdentifierType(string expression, ModuleNode ast, int offset, WorkspaceState workspace)
+    private static string? ResolveSingleIdentifierType(
+        string expression,
+        ModuleNode ast,
+        int offset,
+        WorkspaceIndexSnapshot workspace)
     {
         // Handle 'this' keyword
         if (expression == "this")
@@ -554,7 +618,11 @@ public sealed class CompletionHandler : CompletionHandlerBase
         return null;
     }
 
-    private static string? ResolveChainedExpressionType(string expression, ModuleNode ast, int offset, WorkspaceState workspace)
+    private static string? ResolveChainedExpressionType(
+        string expression,
+        ModuleNode ast,
+        int offset,
+        WorkspaceIndexSnapshot workspace)
     {
         // Split into parts, handling potential method calls
         var parts = SplitChainedExpression(expression);
@@ -707,7 +775,12 @@ public sealed class CompletionHandler : CompletionHandlerBase
         return null;
     }
 
-    private static string? ResolveMemberType(string typeName, string memberName, bool isMethodCall, ModuleNode ast, WorkspaceState workspace)
+    private static string? ResolveMemberType(
+        string typeName,
+        string memberName,
+        bool isMethodCall,
+        ModuleNode ast,
+        WorkspaceIndexSnapshot workspace)
     {
         // Handle generic types - extract base type name
         var (baseTypeName, typeArgs) = ParseGenericType(typeName);
@@ -757,55 +830,64 @@ public sealed class CompletionHandler : CompletionHandlerBase
         return null;
     }
 
-    private static string? ResolveMemberTypeInClassHierarchy(ClassDefinitionNode cls, string memberName, bool isMethodCall, ModuleNode ast, WorkspaceState workspace)
+    private static string? ResolveMemberTypeInClassHierarchy(
+        ClassDefinitionNode cls,
+        string memberName,
+        bool isMethodCall,
+        ModuleNode ast,
+        WorkspaceIndexSnapshot workspace)
     {
-        // Check current class
-        if (isMethodCall)
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var current = cls;
+        while (visited.Add(current.Name))
         {
-            var method = cls.Methods.FirstOrDefault(m => m.Name == memberName);
-            if (method != null)
-                return method.Output?.TypeName;
-        }
-        else
-        {
-            var field = cls.Fields.FirstOrDefault(f => f.Name == memberName);
-            if (field != null)
-                return field.TypeName;
-
-            var prop = cls.Properties.FirstOrDefault(p => p.Name == memberName);
-            if (prop != null)
-                return prop.TypeName;
-        }
-
-        // Check base class if exists
-        if (!string.IsNullOrEmpty(cls.BaseClass))
-        {
-            var baseClass = FindClassByName(cls.BaseClass, ast, workspace);
-            if (baseClass != null)
+            if (isMethodCall)
             {
-                return ResolveMemberTypeInClassHierarchy(baseClass, memberName, isMethodCall, ast, workspace);
+                var method = current.Methods.FirstOrDefault(
+                    candidate => candidate.Name == memberName);
+                if (method != null)
+                    return method.Output?.TypeName;
             }
-        }
-
-        // Check implemented interfaces for method signatures
-        if (isMethodCall)
-        {
-            foreach (var ifaceName in cls.ImplementedInterfaces)
+            else
             {
-                var iface = FindInterfaceByName(ifaceName, ast, workspace);
-                if (iface != null)
+                var field = current.Fields.FirstOrDefault(
+                    candidate => candidate.Name == memberName);
+                if (field != null)
+                    return field.TypeName;
+
+                var prop = current.Properties.FirstOrDefault(
+                    candidate => candidate.Name == memberName);
+                if (prop != null)
+                    return prop.TypeName;
+            }
+
+            if (isMethodCall)
+            {
+                foreach (var ifaceName in current.ImplementedInterfaces)
                 {
-                    var method = iface.Methods.FirstOrDefault(m => m.Name == memberName);
+                    var iface = FindInterfaceByName(ifaceName, ast, workspace);
+                    var method = iface?.Methods.FirstOrDefault(
+                        candidate => candidate.Name == memberName);
                     if (method != null)
                         return method.Output?.TypeName;
                 }
             }
+
+            if (string.IsNullOrEmpty(current.BaseClass))
+                break;
+            var baseClass = FindClassByName(current.BaseClass, ast, workspace);
+            if (baseClass == null)
+                break;
+            current = baseClass;
         }
 
         return null;
     }
 
-    private static ClassDefinitionNode? FindClassByName(string name, ModuleNode ast, WorkspaceState workspace)
+    private static ClassDefinitionNode? FindClassByName(
+        string name,
+        ModuleNode ast,
+        WorkspaceIndexSnapshot workspace)
     {
         // Check local AST
         var cls = ast.Classes.FirstOrDefault(c => c.Name == name);
@@ -813,10 +895,10 @@ public sealed class CompletionHandler : CompletionHandlerBase
             return cls;
 
         // Check other documents
-        foreach (var doc in workspace.GetAllDocuments())
+        foreach (var doc in workspace.Documents)
         {
-            if (doc.Ast == null) continue;
-            cls = doc.Ast.Classes.FirstOrDefault(c => c.Name == name);
+            if (doc.Analysis.Ast == null) continue;
+            cls = doc.Analysis.Ast.Classes.FirstOrDefault(c => c.Name == name);
             if (cls != null)
                 return cls;
         }
@@ -824,7 +906,10 @@ public sealed class CompletionHandler : CompletionHandlerBase
         return null;
     }
 
-    private static InterfaceDefinitionNode? FindInterfaceByName(string name, ModuleNode ast, WorkspaceState workspace)
+    private static InterfaceDefinitionNode? FindInterfaceByName(
+        string name,
+        ModuleNode ast,
+        WorkspaceIndexSnapshot workspace)
     {
         // Check local AST
         var iface = ast.Interfaces.FirstOrDefault(i => i.Name == name);
@@ -832,10 +917,10 @@ public sealed class CompletionHandler : CompletionHandlerBase
             return iface;
 
         // Check other documents
-        foreach (var doc in workspace.GetAllDocuments())
+        foreach (var doc in workspace.Documents)
         {
-            if (doc.Ast == null) continue;
-            iface = doc.Ast.Interfaces.FirstOrDefault(i => i.Name == name);
+            if (doc.Analysis.Ast == null) continue;
+            iface = doc.Analysis.Ast.Interfaces.FirstOrDefault(i => i.Name == name);
             if (iface != null)
                 return iface;
         }
@@ -984,7 +1069,12 @@ public sealed class CompletionHandler : CompletionHandlerBase
         };
     }
 
-    private static string? ResolveMethodReturnType(string methodName, ModuleNode ast, int offset, WorkspaceState workspace, string? containingType)
+    private static string? ResolveMethodReturnType(
+        string methodName,
+        ModuleNode ast,
+        int offset,
+        WorkspaceIndexSnapshot workspace,
+        string? containingType)
     {
         // If we have a containing type, search for methods on that type
         if (containingType != null)
@@ -1010,7 +1100,11 @@ public sealed class CompletionHandler : CompletionHandlerBase
         return null;
     }
 
-    private static IEnumerable<CompletionItem> GetMembersForType(string typeName, ModuleNode ast, WorkspaceState workspace, DocumentState currentDoc)
+    private static IEnumerable<CompletionItem> GetMembersForType(
+        string typeName,
+        ModuleNode ast,
+        WorkspaceIndexSnapshot workspace,
+        WorkspaceDocumentSnapshot currentDoc)
     {
         var items = new List<CompletionItem>();
 
@@ -1049,18 +1143,23 @@ public sealed class CompletionHandler : CompletionHandlerBase
         }
 
         // Check other documents for enums
-        foreach (var doc in workspace.GetAllDocuments())
+        foreach (var doc in workspace.Documents)
         {
-            if (doc.Uri == currentDoc.Uri || doc.Ast == null) continue;
+            if (doc.Document.Uri == currentDoc.Document.Uri
+                || doc.Analysis.Ast == null)
+            {
+                continue;
+            }
 
-            var otherEnum = doc.Ast.Enums.FirstOrDefault(e => e.Name == baseTypeName);
+            var otherEnum = doc.Analysis.Ast.Enums.FirstOrDefault(
+                e => e.Name == baseTypeName);
             if (otherEnum != null)
             {
                 items.AddRange(GetEnumMembers(otherEnum).Select(i => new CompletionItem
                 {
                     Label = i.Label,
                     Kind = i.Kind,
-                    Detail = $"[{GetFileName(doc.Uri)}] {i.Detail}",
+                    Detail = $"[{GetFileName(doc.Document.Uri)}] {i.Detail}",
                     InsertText = i.InsertText
                 }));
                 return items;
@@ -1094,7 +1193,10 @@ public sealed class CompletionHandler : CompletionHandlerBase
         return items;
     }
 
-    private static IEnumerable<CompletionItem> GetClassMembersWithInheritance(ClassDefinitionNode cls, ModuleNode ast, WorkspaceState workspace)
+    private static IEnumerable<CompletionItem> GetClassMembersWithInheritance(
+        ClassDefinitionNode cls,
+        ModuleNode ast,
+        WorkspaceIndexSnapshot workspace)
     {
         var items = new List<CompletionItem>();
         var visitedClasses = new HashSet<string>();
@@ -1104,7 +1206,7 @@ public sealed class CompletionHandler : CompletionHandlerBase
         return items;
     }
 
-    private static void CollectClassMembersRecursive(ClassDefinitionNode cls, ModuleNode ast, WorkspaceState workspace,
+    private static void CollectClassMembersRecursive(ClassDefinitionNode cls, ModuleNode ast, WorkspaceIndexSnapshot workspace,
         List<CompletionItem> items, HashSet<string> visitedClasses, bool isInherited)
     {
         if (visitedClasses.Contains(cls.Name))

--- a/src/Calor.LanguageServer/Handlers/DefinitionHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/DefinitionHandler.cs
@@ -20,24 +20,32 @@ public sealed class DefinitionHandler : DefinitionHandlerBase
         _workspace = workspace;
     }
 
-    public override Task<LocationOrLocationLinks?> Handle(
+    public override async Task<LocationOrLocationLinks?> Handle(
         DefinitionParams request,
         CancellationToken cancellationToken)
     {
-        var state = _workspace.Get(request.TextDocument.Uri);
-        var snapshot = state?.Snapshot;
-        if (snapshot == null)
-            return Task.FromResult<LocationOrLocationLinks?>(null);
+        var workspace = await _workspace.CaptureSnapshotAsync(
+            refreshClosedDocuments: true,
+            cancellationToken).ConfigureAwait(false);
+        var document = workspace.GetDocument(request.TextDocument.Uri);
+        if (document == null)
+            return null;
 
-        _workspace.RefreshClosedDocuments();
-        var offset = PositionConverter.ToOffset(request.Position, snapshot.Source);
-        var occurrence = _workspace.ResolveOccurrence(request.TextDocument.Uri, offset);
+        var offset = PositionConverter.ToOffset(
+            request.Position,
+            document.Analysis.Source);
+        var occurrence = _workspace.ResolveOccurrence(
+            workspace,
+            request.TextDocument.Uri,
+            offset);
         if (occurrence == null)
-            return Task.FromResult<LocationOrLocationLinks?>(null);
+            return null;
 
-        var definition = _workspace.FindSymbolDefinition(occurrence.SymbolId);
+        var definition = _workspace.FindSymbolDefinition(
+            workspace,
+            occurrence.SymbolId);
         if (definition == null)
-            return Task.FromResult<LocationOrLocationLinks?>(null);
+            return null;
 
         var location = new Location
         {
@@ -47,9 +55,8 @@ public sealed class DefinitionHandler : DefinitionHandlerBase
                 definition.Span,
                 definition.Snapshot.Source),
         };
-        return Task.FromResult<LocationOrLocationLinks?>(
-            new LocationOrLocationLinks(
-                new[] { new LocationOrLocationLink(location) }));
+        return new LocationOrLocationLinks(
+            new[] { new LocationOrLocationLink(location) });
     }
 
     protected override DefinitionRegistrationOptions CreateRegistrationOptions(

--- a/src/Calor.LanguageServer/Handlers/DocumentSymbolHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/DocumentSymbolHandler.cs
@@ -25,15 +25,15 @@ public sealed class DocumentSymbolHandler : DocumentSymbolHandlerBase
         DocumentSymbolParams request,
         CancellationToken cancellationToken)
     {
-        var state = _workspace.Get(request.TextDocument.Uri);
-        if (state?.Ast == null)
+        var snapshot = _workspace.Get(request.TextDocument.Uri)?.Snapshot;
+        if (snapshot?.Ast == null)
         {
             return Task.FromResult<SymbolInformationOrDocumentSymbolContainer?>(null);
         }
 
         var symbols = new List<SymbolInformationOrDocumentSymbol>();
-        var ast = state.Ast;
-        var source = state.Source;
+        var ast = snapshot.Ast;
+        var source = snapshot.Source;
 
         // Module symbol
         var moduleSymbol = new DocumentSymbol

--- a/src/Calor.LanguageServer/Handlers/FormattingHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/FormattingHandler.cs
@@ -52,12 +52,12 @@ public sealed class FormattingHandler : DocumentFormattingHandlerBase
     }
 
     internal static TextEditContainer? FormatSnapshot(
-        DocumentAnalysisSnapshot snapshot,
+        DocumentSnapshot snapshot,
         Uri documentUri,
         DocumentUri requestedDocumentUri,
         ILogger<FormattingHandler> logger)
     {
-        if (snapshot.Ast == null || snapshot.Diagnostics.HasErrors)
+        if (snapshot.Ast == null || snapshot.HasErrors)
         {
             logger.LogWarning(
                 "Formatting returned no edits for {DocumentUri} because the document has compiler errors.",

--- a/src/Calor.LanguageServer/Handlers/HoverHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/HoverHandler.cs
@@ -35,7 +35,7 @@ public sealed class HoverHandler : HoverHandlerBase
     }
 
     internal static Hover? BuildHover(
-        DocumentAnalysisSnapshot snapshot,
+        DocumentSnapshot snapshot,
         Position position)
     {
         var (line, column) = PositionConverter.ToCalorPosition(position);

--- a/src/Calor.LanguageServer/Handlers/ReferencesHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/ReferencesHandler.cs
@@ -20,22 +20,29 @@ public sealed class ReferencesHandler : ReferencesHandlerBase
         _workspace = workspace;
     }
 
-    public override Task<LocationContainer?> Handle(
+    public override async Task<LocationContainer?> Handle(
         ReferenceParams request,
         CancellationToken cancellationToken)
     {
-        var state = _workspace.Get(request.TextDocument.Uri);
-        var snapshot = state?.Snapshot;
-        if (snapshot == null)
-            return Task.FromResult<LocationContainer?>(null);
+        var workspace = await _workspace.CaptureSnapshotAsync(
+            refreshClosedDocuments: true,
+            cancellationToken).ConfigureAwait(false);
+        var document = workspace.GetDocument(request.TextDocument.Uri);
+        if (document == null)
+            return null;
 
-        _workspace.RefreshClosedDocuments();
-        var offset = PositionConverter.ToOffset(request.Position, snapshot.Source);
-        var occurrence = _workspace.ResolveOccurrence(request.TextDocument.Uri, offset);
+        var offset = PositionConverter.ToOffset(
+            request.Position,
+            document.Analysis.Source);
+        var occurrence = _workspace.ResolveOccurrence(
+            workspace,
+            request.TextDocument.Uri,
+            offset);
         if (occurrence == null)
-            return Task.FromResult<LocationContainer?>(null);
+            return null;
 
         var locations = _workspace.FindSymbolOccurrences(
+                workspace,
                 occurrence.SymbolId,
                 request.Context.IncludeDeclaration)
             .Select(reference => new Location
@@ -47,8 +54,7 @@ public sealed class ReferencesHandler : ReferencesHandlerBase
                     reference.Snapshot.Source),
             })
             .ToArray();
-        return Task.FromResult<LocationContainer?>(
-            locations.Length == 0 ? null : new LocationContainer(locations));
+        return locations.Length == 0 ? null : new LocationContainer(locations);
     }
 
     protected override ReferenceRegistrationOptions CreateRegistrationOptions(

--- a/src/Calor.LanguageServer/Handlers/RenameHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/RenameHandler.cs
@@ -28,20 +28,27 @@ public sealed class RenameHandler : RenameHandlerBase
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        var state = _workspace.Get(request.TextDocument.Uri);
-        var snapshot = state?.Snapshot;
-        if (snapshot == null
+        var workspace = await _workspace.CaptureSnapshotAsync(
+            refreshClosedDocuments: true,
+            cancellationToken).ConfigureAwait(false);
+        var document = workspace.GetDocument(request.TextDocument.Uri);
+        if (document == null
             || string.IsNullOrWhiteSpace(request.NewName)
             || !IsValidIdentifier(request.NewName))
         {
             return null;
         }
 
-        _workspace.RefreshClosedDocuments();
         cancellationToken.ThrowIfCancellationRequested();
-        var offset = PositionConverter.ToOffset(request.Position, snapshot.Source);
-        var occurrence = _workspace.ResolveOccurrence(request.TextDocument.Uri, offset);
-        if (occurrence == null || !_workspace.CanRenameSymbol(occurrence.SymbolId))
+        var offset = PositionConverter.ToOffset(
+            request.Position,
+            document.Analysis.Source);
+        var occurrence = _workspace.ResolveOccurrence(
+            workspace,
+            request.TextDocument.Uri,
+            offset);
+        if (occurrence == null
+            || !_workspace.CanRenameSymbol(workspace, occurrence.SymbolId))
             return null;
 
         var oldName = occurrence.Snapshot.Source.Substring(
@@ -51,6 +58,7 @@ public sealed class RenameHandler : RenameHandlerBase
             return null;
 
         var occurrences = _workspace.FindSymbolOccurrences(
+            workspace,
             occurrence.SymbolId,
             includeDeclaration: true);
         // Fail closed on declarations whose identity this index keys per file —
@@ -68,6 +76,7 @@ public sealed class RenameHandler : RenameHandlerBase
         }
 
         if (!await _workspace.ValidateRenameAsync(
+                workspace,
                 occurrences,
                 oldName,
                 request.NewName,

--- a/src/Calor.LanguageServer/Handlers/SemanticTokensHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/SemanticTokensHandler.cs
@@ -105,13 +105,14 @@ public sealed class SemanticTokensHandler : SemanticTokensHandlerBase
         CancellationToken cancellationToken)
     {
         var state = _workspace.Get(identifier.TextDocument.Uri);
-        if (state?.Ast == null)
+        var snapshot = state?.Snapshot;
+        if (snapshot?.Ast == null)
         {
             return Task.CompletedTask;
         }
 
-        var visitor = new SemanticTokenVisitor(builder, state.Source);
-        visitor.Visit(state.Ast);
+        var visitor = new SemanticTokenVisitor(builder, snapshot.Source);
+        visitor.Visit(snapshot.Ast);
 
         return Task.CompletedTask;
     }

--- a/src/Calor.LanguageServer/Handlers/SignatureHelpHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/SignatureHelpHandler.cs
@@ -24,9 +24,10 @@ public sealed class SignatureHelpHandler : SignatureHelpHandlerBase
 
     public override Task<SignatureHelp?> Handle(SignatureHelpParams request, CancellationToken cancellationToken)
     {
-        var state = _workspace.Get(request.TextDocument.Uri);
-        var snapshot = state?.Snapshot;
-        if (state == null || snapshot?.Ast == null)
+        var workspace = _workspace.CaptureSnapshot();
+        var document = workspace.GetDocument(request.TextDocument.Uri);
+        var snapshot = document?.Analysis;
+        if (document == null || snapshot?.Ast == null)
         {
             return Task.FromResult<SignatureHelp?>(null);
         }
@@ -53,7 +54,10 @@ public sealed class SignatureHelpHandler : SignatureHelpHandlerBase
             snapshot.BoundModule,
             offset,
             callContext.FunctionName);
-        var projectCall = _workspace.ResolveProjectCall(state, snapshot, boundCall);
+        var projectCall = _workspace.ResolveProjectCall(
+            workspace,
+            document,
+            boundCall);
         if (projectCall.Symbol != null)
         {
             return Task.FromResult<SignatureHelp?>(

--- a/src/Calor.LanguageServer/Handlers/TextDocumentSyncHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/TextDocumentSyncHandler.cs
@@ -12,6 +12,48 @@ using TextDocumentSelector = OmniSharp.Extensions.LanguageServer.Protocol.Models
 
 namespace Calor.LanguageServer.Handlers;
 
+internal sealed record DiagnosticPublication(
+    DocumentUri Uri,
+    Func<bool> Publish);
+
+internal sealed class DiagnosticPublicationCoordinator
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly Dictionary<DocumentUri, long> _publishedGenerations = [];
+
+    internal async Task PublishAsync(
+        Func<(long Generation, IReadOnlyList<DiagnosticPublication> Publications)>
+            createBatch,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(createBatch);
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var batch = createBatch();
+            foreach (var publication in batch.Publications)
+            {
+                if (_publishedGenerations.TryGetValue(
+                        publication.Uri,
+                        out var publishedGeneration)
+                    && publishedGeneration >= batch.Generation)
+                {
+                    continue;
+                }
+
+                if (publication.Publish())
+                {
+                    _publishedGenerations[publication.Uri] = batch.Generation;
+                }
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}
+
 /// <summary>
 /// Handles text document synchronization (open, change, close).
 /// </summary>
@@ -20,6 +62,7 @@ public sealed class TextDocumentSyncHandler :
 {
     private readonly WorkspaceState _workspace;
     private readonly ILanguageServerFacade _server;
+    private readonly DiagnosticPublicationCoordinator _publicationCoordinator = new();
 
     public TextDocumentSyncHandler(WorkspaceState workspace, ILanguageServerFacade server)
     {
@@ -32,54 +75,80 @@ public sealed class TextDocumentSyncHandler :
         return new TextDocumentAttributes(uri, "calor");
     }
 
-    public override Task<Unit> Handle(DidOpenTextDocumentParams request, CancellationToken cancellationToken)
+    public override async Task<Unit> Handle(
+        DidOpenTextDocumentParams request,
+        CancellationToken cancellationToken)
     {
         var document = request.TextDocument;
-        var state = _workspace.GetOrCreate(document.Uri, document.Text, document.Version ?? 0);
+        var accepted = await _workspace.GetOrCreateAsync(
+            document.Uri,
+            document.Text,
+            document.Version ?? 0,
+            cancellationToken).ConfigureAwait(false);
+        if (accepted)
+        {
+            await PublishWorkspaceDiagnosticsAsync(
+                [],
+                cancellationToken).ConfigureAwait(false);
+        }
 
-        PublishDiagnostics(document.Uri, state);
-
-        return Unit.Task;
+        return Unit.Value;
     }
 
-    public override Task<Unit> Handle(DidChangeTextDocumentParams request, CancellationToken cancellationToken)
+    public override async Task<Unit> Handle(
+        DidChangeTextDocumentParams request,
+        CancellationToken cancellationToken)
     {
         var document = request.TextDocument;
 
         // Get the full text from the changes (we use full sync)
         var text = request.ContentChanges.FirstOrDefault()?.Text ?? string.Empty;
 
-        var state = _workspace.Update(document.Uri, text, document.Version ?? 0);
-
-        PublishDiagnostics(document.Uri, state);
-
-        return Unit.Task;
-    }
-
-    public override Task<Unit> Handle(DidCloseTextDocumentParams request, CancellationToken cancellationToken)
-    {
-        _workspace.Remove(request.TextDocument.Uri);
-
-        // Clear diagnostics for closed document
-        _server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
+        var accepted = await _workspace.UpdateAsync(
+            document.Uri,
+            text,
+            document.Version ?? 0,
+            cancellationToken).ConfigureAwait(false);
+        if (accepted)
         {
-            Uri = request.TextDocument.Uri,
-            Diagnostics = new Container<Diagnostic>()
-        });
-
-        return Unit.Task;
-    }
-
-    public override Task<Unit> Handle(DidSaveTextDocumentParams request, CancellationToken cancellationToken)
-    {
-        // Optionally re-analyze on save
-        var state = _workspace.Reanalyze(request.TextDocument.Uri);
-        if (state != null)
-        {
-            PublishDiagnostics(request.TextDocument.Uri, state);
+            await PublishWorkspaceDiagnosticsAsync(
+                [],
+                cancellationToken).ConfigureAwait(false);
         }
 
-        return Unit.Task;
+        return Unit.Value;
+    }
+
+    public override async Task<Unit> Handle(
+        DidCloseTextDocumentParams request,
+        CancellationToken cancellationToken)
+    {
+        await _workspace.RemoveAsync(
+            request.TextDocument.Uri,
+            cancellationToken).ConfigureAwait(false);
+
+        await PublishWorkspaceDiagnosticsAsync(
+            [request.TextDocument.Uri],
+            cancellationToken).ConfigureAwait(false);
+
+        return Unit.Value;
+    }
+
+    public override async Task<Unit> Handle(
+        DidSaveTextDocumentParams request,
+        CancellationToken cancellationToken)
+    {
+        var accepted = await _workspace.ReanalyzeAsync(
+            request.TextDocument.Uri,
+            cancellationToken).ConfigureAwait(false);
+        if (accepted)
+        {
+            await PublishWorkspaceDiagnosticsAsync(
+                [],
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        return Unit.Value;
     }
 
     protected override TextDocumentSyncRegistrationOptions CreateRegistrationOptions(
@@ -94,15 +163,58 @@ public sealed class TextDocumentSyncHandler :
         };
     }
 
-    private void PublishDiagnostics(DocumentUri uri, DocumentState state)
+    private Task PublishWorkspaceDiagnosticsAsync(
+        IReadOnlyCollection<DocumentUri> clearUris,
+        CancellationToken cancellationToken)
     {
-        var lspDiagnostics = DiagnosticConverter.ToLspDiagnostics(state.Diagnostics, state.Source);
+        return _publicationCoordinator.PublishAsync(
+            () =>
+            {
+                var workspace = _workspace.CaptureSnapshot();
+                var publications = new List<DiagnosticPublication>();
+                foreach (var uri in clearUris)
+                {
+                    if (_workspace.Contains(uri))
+                        continue;
+                    publications.Add(new DiagnosticPublication(
+                        uri,
+                        () => _workspace.TryPublishGeneration(
+                            workspace,
+                            () => _server.TextDocument.PublishDiagnostics(
+                                new PublishDiagnosticsParams
+                                {
+                                    Uri = uri,
+                                    Diagnostics = new Container<Diagnostic>(),
+                                }))));
+                }
 
-        _server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
-        {
-            Uri = uri,
-            Version = state.Version,
-            Diagnostics = new Container<Diagnostic>(lspDiagnostics)
-        });
+                foreach (var document in workspace.Documents)
+                {
+                    var uri = DocumentUri.From(document.Document.Uri);
+                    if (!_workspace.Contains(uri))
+                        continue;
+
+                    var lspDiagnostics = DiagnosticConverter.ToLspDiagnostics(
+                            _workspace.GetDiagnostics(workspace, document),
+                            document.Analysis.Source)
+                        .ToArray();
+                    publications.Add(new DiagnosticPublication(
+                        uri,
+                        () => _workspace.TryPublishDiagnostics(
+                            workspace,
+                            document,
+                            () => _server.TextDocument.PublishDiagnostics(
+                                new PublishDiagnosticsParams
+                                {
+                                    Uri = uri,
+                                    Version = document.Analysis.Version,
+                                    Diagnostics =
+                                        new Container<Diagnostic>(lspDiagnostics),
+                                }))));
+                }
+
+                return (workspace.Generation, publications);
+            },
+            cancellationToken);
     }
 }

--- a/src/Calor.LanguageServer/Handlers/WorkspaceSymbolHandler.cs
+++ b/src/Calor.LanguageServer/Handlers/WorkspaceSymbolHandler.cs
@@ -25,9 +25,10 @@ public sealed class WorkspaceSymbolHandler : WorkspaceSymbolsHandlerBase
         var query = request.Query?.Trim() ?? "";
         var symbols = new List<WorkspaceSymbol>();
 
-        foreach (var doc in _workspace.GetAllDocuments())
+        var workspace = _workspace.CaptureSnapshot();
+        foreach (var doc in workspace.Documents)
         {
-            if (doc.Ast == null) continue;
+            if (doc.Analysis.Ast == null) continue;
 
             var docSymbols = CollectWorkspaceSymbols(doc, query);
             symbols.AddRange(docSymbols);
@@ -43,24 +44,28 @@ public sealed class WorkspaceSymbolHandler : WorkspaceSymbolsHandlerBase
         return Task.FromResult<Container<WorkspaceSymbol>?>(new Container<WorkspaceSymbol>(symbols));
     }
 
-    private IEnumerable<WorkspaceSymbol> CollectWorkspaceSymbols(DocumentState doc, string query)
+    private static IEnumerable<WorkspaceSymbol> CollectWorkspaceSymbols(
+        WorkspaceDocumentSnapshot doc,
+        string query)
     {
-        if (doc.Ast == null) yield break;
+        if (doc.Analysis.Ast == null) yield break;
 
-        var uri = DocumentUri.From(doc.Uri);
+        var uri = DocumentUri.From(doc.Document.Uri);
+        var ast = doc.Analysis.Ast;
+        var source = doc.Analysis.Source;
 
         // Functions
-        foreach (var func in doc.Ast.Functions)
+        foreach (var func in ast.Functions)
         {
             if (MatchesQuery(func.Name, query))
             {
-                var range = PositionConverter.ToLspRange(func.Span, doc.Source);
+                var range = PositionConverter.ToLspRange(func.Span, source);
                 yield return new WorkspaceSymbol
                 {
                     Name = func.Name,
                     Kind = SymbolKind.Function,
                     Location = new Location { Uri = uri, Range = range },
-                    ContainerName = doc.Ast.Name
+                    ContainerName = ast.Name
                 };
             }
 
@@ -71,13 +76,13 @@ public sealed class WorkspaceSymbolHandler : WorkspaceSymbolsHandlerBase
                 {
                     if (MatchesQuery(param.Name, query))
                     {
-                        var range = PositionConverter.ToLspRange(param.Span, doc.Source);
+                        var range = PositionConverter.ToLspRange(param.Span, source);
                         yield return new WorkspaceSymbol
                         {
                             Name = param.Name,
                             Kind = SymbolKind.Variable,
                             Location = new Location { Uri = uri, Range = range },
-                            ContainerName = $"{doc.Ast.Name}.{func.Name}"
+                            ContainerName = $"{ast.Name}.{func.Name}"
                         };
                     }
                 }
@@ -85,17 +90,17 @@ public sealed class WorkspaceSymbolHandler : WorkspaceSymbolsHandlerBase
         }
 
         // Classes
-        foreach (var cls in doc.Ast.Classes)
+        foreach (var cls in ast.Classes)
         {
             if (MatchesQuery(cls.Name, query))
             {
-                var range = PositionConverter.ToLspRange(cls.Span, doc.Source);
+                var range = PositionConverter.ToLspRange(cls.Span, source);
                 yield return new WorkspaceSymbol
                 {
                     Name = cls.Name,
                     Kind = SymbolKind.Class,
                     Location = new Location { Uri = uri, Range = range },
-                    ContainerName = doc.Ast.Name
+                    ContainerName = ast.Name
                 };
             }
 
@@ -104,13 +109,13 @@ public sealed class WorkspaceSymbolHandler : WorkspaceSymbolsHandlerBase
             {
                 if (MatchesQuery(field.Name, query))
                 {
-                    var range = PositionConverter.ToLspRange(field.Span, doc.Source);
+                    var range = PositionConverter.ToLspRange(field.Span, source);
                     yield return new WorkspaceSymbol
                     {
                         Name = field.Name,
                         Kind = SymbolKind.Field,
                         Location = new Location { Uri = uri, Range = range },
-                        ContainerName = $"{doc.Ast.Name}.{cls.Name}"
+                        ContainerName = $"{ast.Name}.{cls.Name}"
                     };
                 }
             }
@@ -119,13 +124,13 @@ public sealed class WorkspaceSymbolHandler : WorkspaceSymbolsHandlerBase
             {
                 if (MatchesQuery(prop.Name, query))
                 {
-                    var range = PositionConverter.ToLspRange(prop.Span, doc.Source);
+                    var range = PositionConverter.ToLspRange(prop.Span, source);
                     yield return new WorkspaceSymbol
                     {
                         Name = prop.Name,
                         Kind = SymbolKind.Property,
                         Location = new Location { Uri = uri, Range = range },
-                        ContainerName = $"{doc.Ast.Name}.{cls.Name}"
+                        ContainerName = $"{ast.Name}.{cls.Name}"
                     };
                 }
             }
@@ -134,13 +139,13 @@ public sealed class WorkspaceSymbolHandler : WorkspaceSymbolsHandlerBase
             {
                 if (MatchesQuery(method.Name, query))
                 {
-                    var range = PositionConverter.ToLspRange(method.Span, doc.Source);
+                    var range = PositionConverter.ToLspRange(method.Span, source);
                     yield return new WorkspaceSymbol
                     {
                         Name = method.Name,
                         Kind = SymbolKind.Method,
                         Location = new Location { Uri = uri, Range = range },
-                        ContainerName = $"{doc.Ast.Name}.{cls.Name}"
+                        ContainerName = $"{ast.Name}.{cls.Name}"
                     };
                 }
             }
@@ -149,30 +154,30 @@ public sealed class WorkspaceSymbolHandler : WorkspaceSymbolsHandlerBase
             {
                 if (MatchesQuery(cls.Name, query) || MatchesQuery("constructor", query))
                 {
-                    var range = PositionConverter.ToLspRange(ctor.Span, doc.Source);
+                    var range = PositionConverter.ToLspRange(ctor.Span, source);
                     yield return new WorkspaceSymbol
                     {
                         Name = $"{cls.Name}()",
                         Kind = SymbolKind.Constructor,
                         Location = new Location { Uri = uri, Range = range },
-                        ContainerName = $"{doc.Ast.Name}.{cls.Name}"
+                        ContainerName = $"{ast.Name}.{cls.Name}"
                     };
                 }
             }
         }
 
         // Interfaces
-        foreach (var iface in doc.Ast.Interfaces)
+        foreach (var iface in ast.Interfaces)
         {
             if (MatchesQuery(iface.Name, query))
             {
-                var range = PositionConverter.ToLspRange(iface.Span, doc.Source);
+                var range = PositionConverter.ToLspRange(iface.Span, source);
                 yield return new WorkspaceSymbol
                 {
                     Name = iface.Name,
                     Kind = SymbolKind.Interface,
                     Location = new Location { Uri = uri, Range = range },
-                    ContainerName = doc.Ast.Name
+                    ContainerName = ast.Name
                 };
             }
 
@@ -180,30 +185,30 @@ public sealed class WorkspaceSymbolHandler : WorkspaceSymbolsHandlerBase
             {
                 if (MatchesQuery(method.Name, query))
                 {
-                    var range = PositionConverter.ToLspRange(method.Span, doc.Source);
+                    var range = PositionConverter.ToLspRange(method.Span, source);
                     yield return new WorkspaceSymbol
                     {
                         Name = method.Name,
                         Kind = SymbolKind.Method,
                         Location = new Location { Uri = uri, Range = range },
-                        ContainerName = $"{doc.Ast.Name}.{iface.Name}"
+                        ContainerName = $"{ast.Name}.{iface.Name}"
                     };
                 }
             }
         }
 
         // Enums
-        foreach (var enumDef in doc.Ast.Enums)
+        foreach (var enumDef in ast.Enums)
         {
             if (MatchesQuery(enumDef.Name, query))
             {
-                var range = PositionConverter.ToLspRange(enumDef.Span, doc.Source);
+                var range = PositionConverter.ToLspRange(enumDef.Span, source);
                 yield return new WorkspaceSymbol
                 {
                     Name = enumDef.Name,
                     Kind = SymbolKind.Enum,
                     Location = new Location { Uri = uri, Range = range },
-                    ContainerName = doc.Ast.Name
+                    ContainerName = ast.Name
                 };
             }
 
@@ -211,49 +216,49 @@ public sealed class WorkspaceSymbolHandler : WorkspaceSymbolsHandlerBase
             {
                 if (MatchesQuery(member.Name, query))
                 {
-                    var range = PositionConverter.ToLspRange(member.Span, doc.Source);
+                    var range = PositionConverter.ToLspRange(member.Span, source);
                     yield return new WorkspaceSymbol
                     {
                         Name = member.Name,
                         Kind = SymbolKind.EnumMember,
                         Location = new Location { Uri = uri, Range = range },
-                        ContainerName = $"{doc.Ast.Name}.{enumDef.Name}"
+                        ContainerName = $"{ast.Name}.{enumDef.Name}"
                     };
                 }
             }
         }
 
         // Enum extensions
-        foreach (var enumExt in doc.Ast.EnumExtensions)
+        foreach (var enumExt in ast.EnumExtensions)
         {
             foreach (var method in enumExt.Methods)
             {
                 if (MatchesQuery(method.Name, query))
                 {
-                    var range = PositionConverter.ToLspRange(method.Span, doc.Source);
+                    var range = PositionConverter.ToLspRange(method.Span, source);
                     yield return new WorkspaceSymbol
                     {
                         Name = method.Name,
                         Kind = SymbolKind.Method,
                         Location = new Location { Uri = uri, Range = range },
-                        ContainerName = $"{doc.Ast.Name}.{enumExt.EnumName}Extensions"
+                        ContainerName = $"{ast.Name}.{enumExt.EnumName}Extensions"
                     };
                 }
             }
         }
 
         // Delegates
-        foreach (var del in doc.Ast.Delegates)
+        foreach (var del in ast.Delegates)
         {
             if (MatchesQuery(del.Name, query))
             {
-                var range = PositionConverter.ToLspRange(del.Span, doc.Source);
+                var range = PositionConverter.ToLspRange(del.Span, source);
                 yield return new WorkspaceSymbol
                 {
                     Name = del.Name,
                     Kind = SymbolKind.Function, // No delegate kind, use function
                     Location = new Location { Uri = uri, Range = range },
-                    ContainerName = doc.Ast.Name
+                    ContainerName = ast.Name
                 };
             }
         }

--- a/src/Calor.LanguageServer/Program.cs
+++ b/src/Calor.LanguageServer/Program.cs
@@ -10,8 +10,6 @@ public static class Program
 {
     public static async Task<int> Main(string[] args)
     {
-        var workspace = new WorkspaceState();
-
         var server = await OmniSharp.Extensions.LanguageServer.Server.LanguageServer.From(options =>
         {
             options
@@ -23,7 +21,8 @@ public static class Program
                 })
                 .WithServices(services =>
                 {
-                    services.AddSingleton(workspace);
+                    services.AddSingleton(provider => new WorkspaceState(
+                        logger: provider.GetRequiredService<ILogger<WorkspaceState>>()));
                 })
                 .WithHandler<DocumentSymbolHandler>()
                 .WithHandler<DefinitionHandler>()
@@ -36,18 +35,24 @@ public static class Program
                 .WithHandler<RenameHandler>()
                 .WithHandler<WorkspaceSymbolHandler>()
                 .WithHandler<SemanticTokensHandler>()
-                .OnInitialize((server, request, token) =>
+                .OnInitialize(async (server, request, token) =>
                 {
+                    var workspace =
+                        server.Services.GetRequiredService<WorkspaceState>();
                     var workspaceFolders = request.WorkspaceFolders?
                         .Select(folder => folder.Uri.ToUri())
                         .ToArray();
                     if (workspaceFolders is { Length: > 0 })
                     {
-                        workspace.ConfigureWorkspaceRoots(workspaceFolders);
+                        await workspace.ConfigureWorkspaceRootsAsync(
+                            workspaceFolders,
+                            token).ConfigureAwait(false);
                     }
                     else if (request.RootUri is { } rootUri)
                     {
-                        workspace.ConfigureWorkspaceRoot(rootUri.ToUri());
+                        await workspace.ConfigureWorkspaceRootAsync(
+                            rootUri.ToUri(),
+                            token).ConfigureAwait(false);
                     }
 
                     // Register TextDocumentSyncHandler which needs the server reference
@@ -55,7 +60,6 @@ public static class Program
                     {
                         opts.AddHandler(new TextDocumentSyncHandler(workspace, server));
                     });
-                    return Task.CompletedTask;
                 });
         }).ConfigureAwait(false);
 

--- a/src/Calor.LanguageServer/State/DocumentState.cs
+++ b/src/Calor.LanguageServer/State/DocumentState.cs
@@ -1,258 +1,578 @@
-using Calor.Compiler.Ast;
+using System.Collections.Immutable;
 using Calor.Compiler.Analysis;
+using Calor.Compiler.Ast;
 using Calor.Compiler.Binding;
 using Calor.Compiler.Diagnostics;
 using Calor.Compiler.Parsing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Calor.LanguageServer.State;
 
-public sealed record DocumentAnalysisSnapshot(
+public sealed class ImmutableDiagnostics : IReadOnlyList<Diagnostic>
+{
+    private readonly ImmutableArray<Diagnostic> _items;
+
+    public ImmutableDiagnostics(IEnumerable<Diagnostic> diagnostics)
+    {
+        _items = diagnostics.ToImmutableArray();
+    }
+
+    public int Count => _items.Length;
+    public Diagnostic this[int index] => _items[index];
+    public bool HasErrors => _items.Any(diagnostic => diagnostic.IsError);
+    public IReadOnlyList<Diagnostic> Errors =>
+        _items.Where(diagnostic => diagnostic.IsError).ToImmutableArray();
+    public IReadOnlyList<Diagnostic> Warnings =>
+        _items.Where(diagnostic => diagnostic.IsWarning).ToImmutableArray();
+
+    public ImmutableArray<Diagnostic>.Enumerator GetEnumerator() =>
+        _items.GetEnumerator();
+
+    IEnumerator<Diagnostic> IEnumerable<Diagnostic>.GetEnumerator() =>
+        ((IEnumerable<Diagnostic>)_items).GetEnumerator();
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() =>
+        ((System.Collections.IEnumerable)_items).GetEnumerator();
+}
+
+public sealed record DocumentSnapshot(
     int Version,
     string Source,
-    List<Token>? Tokens,
+    ImmutableArray<Token> Tokens,
     ModuleNode? Ast,
     BoundModule? BoundModule,
-    DiagnosticBag Diagnostics,
-    List<DiagnosticWithFix> DiagnosticsWithFixes);
+    ImmutableDiagnostics Diagnostics,
+    ImmutableArray<DiagnosticWithFix> DiagnosticsWithFixes)
+{
+    public bool HasErrors => Diagnostics.Any(diagnostic => diagnostic.IsError);
+
+    public Token? GetTokenAtPosition(int line, int column)
+    {
+        foreach (var token in Tokens)
+        {
+            if (token.Span.Line == line
+                && column >= token.Span.Column
+                && column < token.Span.Column + token.Span.Length)
+            {
+                return token;
+            }
+        }
+
+        return null;
+    }
+
+    public Token? GetTokenAtOffset(int offset)
+    {
+        foreach (var token in Tokens)
+        {
+            if (token.Span.Contains(offset))
+                return token;
+        }
+
+        return null;
+    }
+}
 
 /// <summary>
-/// Holds the analysis state for a single document.
+/// Owns the immutable, versioned analysis snapshot for one document.
 /// </summary>
-public sealed class DocumentState
+public sealed class DocumentState : IDisposable
 {
+    private readonly record struct AnalysisOutcome(
+        DocumentSnapshot Snapshot,
+        bool Published);
+
     private readonly string _sourceIdentity;
-    private DocumentAnalysisSnapshot _snapshot;
+    private readonly ILogger _logger;
+    private readonly Func<DocumentAnalysisPhase, Exception?>? _failureInjector;
+    private readonly Func<Task>? _reanalysisRegistrationBarrier;
+    private readonly object _updateGate = new();
+    private CancellationTokenSource? _analysisCancellation;
+    private DocumentSnapshot _snapshot;
+    private int _desiredVersion;
+    private string _desiredSource;
+    private long _contentGeneration;
+    private bool _hasCompletedAnalysis;
+    private bool _disposed;
 
-    /// <summary>
-    /// The document URI.
-    /// </summary>
+    internal enum DocumentAnalysisPhase
+    {
+        Lexing,
+        Parsing,
+        Binding,
+        BindValidation,
+        ReturnValidation,
+    }
+
     public Uri Uri { get; }
-
-    /// <summary>
-    /// The document version (incremented on each change).
-    /// </summary>
     public int Version => Snapshot.Version;
-
-    /// <summary>
-    /// The source text content.
-    /// </summary>
     public string Source => Snapshot.Source;
-
-    /// <summary>
-    /// The parsed tokens.
-    /// </summary>
-    public List<Token>? Tokens => Snapshot.Tokens;
-
-    /// <summary>
-    /// The parsed AST.
-    /// </summary>
+    public ImmutableArray<Token> Tokens => Snapshot.Tokens;
     public ModuleNode? Ast => Snapshot.Ast;
-
-    /// <summary>
-    /// The bound module (with resolved symbols).
-    /// </summary>
     public BoundModule? BoundModule => Snapshot.BoundModule;
-
-    /// <summary>
-    /// All diagnostics from lexing, parsing, and binding.
-    /// </summary>
-    public DiagnosticBag Diagnostics => Snapshot.Diagnostics;
-
-    /// <summary>
-    /// Diagnostics with suggested fixes.
-    /// </summary>
-    public List<DiagnosticWithFix> DiagnosticsWithFixes => Snapshot.DiagnosticsWithFixes;
-
-    public DocumentAnalysisSnapshot Snapshot => Volatile.Read(ref _snapshot);
+    public ImmutableDiagnostics Diagnostics => Snapshot.Diagnostics;
+    public ImmutableArray<DiagnosticWithFix> DiagnosticsWithFixes =>
+        Snapshot.DiagnosticsWithFixes;
+    public DocumentSnapshot Snapshot => Volatile.Read(ref _snapshot);
 
     public DocumentState(
         Uri uri,
         string source,
         int version = 0,
         string? sourceIdentity = null)
+        : this(
+            uri,
+            source,
+            version,
+            sourceIdentity,
+            NullLogger.Instance,
+            failureInjector: null,
+            reanalysisRegistrationBarrier: null)
+    {
+    }
+
+    internal DocumentState(
+        Uri uri,
+        string source,
+        int version,
+        string? sourceIdentity,
+        ILogger logger,
+        Func<DocumentAnalysisPhase, Exception?>? failureInjector,
+        Func<Task>? reanalysisRegistrationBarrier = null)
     {
         Uri = uri;
         _sourceIdentity = SymbolSourceIdentity.Canonicalize(sourceIdentity ?? uri.ToString());
-        _snapshot = new DocumentAnalysisSnapshot(
+        _logger = logger;
+        _failureInjector = failureInjector;
+        _reanalysisRegistrationBarrier = reanalysisRegistrationBarrier;
+        _desiredVersion = version;
+        _desiredSource = source;
+        _snapshot = new DocumentSnapshot(
             version,
             source,
+            ImmutableArray<Token>.Empty,
             null,
             null,
-            null,
-            new DiagnosticBag(),
-            []);
+            new ImmutableDiagnostics([]),
+            ImmutableArray<DiagnosticWithFix>.Empty);
     }
 
-    /// <summary>
-    /// Update the document content and reanalyze.
-    /// </summary>
+    private async Task<(bool Accepted, Task<AnalysisOutcome> Analysis)>
+        StartAnalysisAsync(
+        string source,
+        int version,
+        bool requireNewerVersion,
+        long? expectedContentGeneration,
+        CancellationToken cancellationToken)
+    {
+        CancellationTokenSource? previousCancellation;
+        CancellationTokenSource analysisCancellation;
+        CancellationToken analysisToken;
+        lock (_updateGate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (requireNewerVersion && version < _desiredVersion)
+            {
+                return (false, Task.FromResult(
+                    new AnalysisOutcome(Snapshot, Published: false)));
+            }
+            if (requireNewerVersion
+                && version == _desiredVersion
+                && (_analysisCancellation != null
+                    || (_hasCompletedAnalysis
+                        && Snapshot.Version == version)
+                    || !string.Equals(
+                        source,
+                        _desiredSource,
+                        StringComparison.Ordinal)))
+            {
+                return (false, Task.FromResult(
+                    new AnalysisOutcome(Snapshot, Published: false)));
+            }
+            if (expectedContentGeneration is { } expected
+                && expected != _contentGeneration)
+            {
+                return (false, Task.FromResult(
+                    new AnalysisOutcome(Snapshot, Published: false)));
+            }
+
+            if (requireNewerVersion && version > _desiredVersion)
+            {
+                _desiredVersion = version;
+                _desiredSource = source;
+                _contentGeneration++;
+            }
+            previousCancellation = _analysisCancellation;
+            analysisCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken);
+            analysisToken = analysisCancellation.Token;
+            _analysisCancellation = analysisCancellation;
+        }
+
+        var analysis = Task.Run(
+            () => AnalyzeAndPublish(
+                source,
+                version,
+                analysisToken,
+                analysisCancellation),
+            CancellationToken.None);
+        await CancelAnalysisAsync(previousCancellation).ConfigureAwait(false);
+        return (true, analysis);
+    }
+
+    public async Task<DocumentSnapshot> ReanalyzeAsync(
+        CancellationToken cancellationToken = default)
+    {
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string source;
+            int version;
+            long contentGeneration;
+            lock (_updateGate)
+            {
+                ObjectDisposedException.ThrowIf(_disposed, this);
+                source = _desiredSource;
+                version = _desiredVersion;
+                contentGeneration = _contentGeneration;
+            }
+
+            if (_reanalysisRegistrationBarrier != null)
+            {
+                await _reanalysisRegistrationBarrier()
+                    .WaitAsync(cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            var request = await StartAnalysisAsync(
+                source,
+                version,
+                requireNewerVersion: false,
+                expectedContentGeneration: contentGeneration,
+                cancellationToken).ConfigureAwait(false);
+            if (!request.Accepted)
+                continue;
+#pragma warning disable VSTHRD003 // The task is explicitly started with Task.Run in StartAnalysisAsync.
+            var outcome = await request.Analysis.ConfigureAwait(false);
+#pragma warning restore VSTHRD003
+            cancellationToken.ThrowIfCancellationRequested();
+            if (outcome.Published)
+                return outcome.Snapshot;
+            lock (_updateGate)
+            {
+                if (_disposed)
+                    return outcome.Snapshot;
+            }
+        }
+    }
+
     public void Update(string newSource, int newVersion)
     {
-        var next = Analyze(newSource, newVersion);
-        while (true)
+#pragma warning disable VSTHRD002 // Compatibility wrapper; analysis itself runs on TaskScheduler.Default.
+        var request = StartAnalysisAsync(
+                newSource,
+                newVersion,
+                requireNewerVersion: true,
+                expectedContentGeneration: null,
+                CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
+        if (request.Accepted)
         {
-            var current = Snapshot;
-            if (newVersion < current.Version)
-                return;
-            if (ReferenceEquals(
-                    Interlocked.CompareExchange(ref _snapshot, next, current),
-                    current))
-            {
-                return;
-            }
+            request.Analysis.GetAwaiter().GetResult();
         }
+#pragma warning restore VSTHRD002
     }
 
-    /// <summary>
-    /// Full reparse and rebind of the document.
-    /// </summary>
-    public void Reanalyze()
+    public async Task<(DocumentSnapshot Snapshot, bool Accepted)> UpdateAsync(
+        string newSource,
+        int newVersion,
+        CancellationToken cancellationToken = default)
     {
-        while (true)
+        var request = await StartAnalysisAsync(
+                newSource,
+                newVersion,
+                requireNewerVersion: true,
+                expectedContentGeneration: null,
+                cancellationToken).ConfigureAwait(false);
+        if (!request.Accepted)
         {
-            var current = Snapshot;
-            var next = Analyze(current.Source, current.Version);
-            if (ReferenceEquals(
-                    Interlocked.CompareExchange(ref _snapshot, next, current),
-                    current))
+            return (Snapshot, false);
+        }
+
+#pragma warning disable VSTHRD003 // The task is explicitly started with Task.Run in StartAnalysisAsync.
+        var outcome = await request.Analysis.ConfigureAwait(false);
+#pragma warning restore VSTHRD003
+        return (outcome.Snapshot, outcome.Published
+            && IsCurrent(outcome.Snapshot)
+            && outcome.Snapshot.Version == newVersion
+            && string.Equals(
+                outcome.Snapshot.Source,
+                newSource,
+                StringComparison.Ordinal));
+    }
+
+    public void Reanalyze() =>
+#pragma warning disable VSTHRD002 // Compatibility wrapper; analysis itself runs on TaskScheduler.Default.
+        ReanalyzeAsync().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
+
+    private AnalysisOutcome AnalyzeAndPublish(
+        string source,
+        int version,
+        CancellationToken analysisToken,
+        CancellationTokenSource analysisCancellation)
+    {
+        try
+        {
+            var next = Analyze(source, version, analysisToken);
+            lock (_updateGate)
             {
-                return;
+                if (!_disposed
+                    && version == _desiredVersion
+                    && string.Equals(
+                        source,
+                        _desiredSource,
+                        StringComparison.Ordinal)
+                    && ReferenceEquals(_analysisCancellation, analysisCancellation)
+                    && !analysisCancellation.IsCancellationRequested)
+                {
+                    Volatile.Write(ref _snapshot, next);
+                    _hasCompletedAnalysis = true;
+                    return new AnalysisOutcome(next, Published: true);
+                }
             }
+
+            return new AnalysisOutcome(Snapshot, Published: false);
+        }
+        catch (OperationCanceledException) when (analysisToken.IsCancellationRequested)
+        {
+            return new AnalysisOutcome(Snapshot, Published: false);
+        }
+        finally
+        {
+            lock (_updateGate)
+            {
+                if (ReferenceEquals(_analysisCancellation, analysisCancellation))
+                    _analysisCancellation = null;
+            }
+            analysisCancellation.Dispose();
         }
     }
 
-    private DocumentAnalysisSnapshot Analyze(string source, int version)
+    private DocumentSnapshot Analyze(
+        string source,
+        int version,
+        CancellationToken cancellationToken)
     {
         var diagnostics = new DiagnosticBag();
-        var diagnosticsWithFixes = new List<DiagnosticWithFix>();
-        List<Token>? tokens = null;
+        List<Token> tokens = [];
         ModuleNode? ast = null;
         BoundModule? boundModule = null;
-
-        // Set file path for diagnostics
         var filePath = Uri.IsFile ? Uri.LocalPath : Uri.ToString();
+        var currentPhase = DocumentAnalysisPhase.Lexing;
         diagnostics.SetFilePath(filePath);
 
         try
         {
-            // Phase 1: Lexing
-            var lexer = new Lexer(source, diagnostics);
-            tokens = lexer.TokenizeAll();
+            cancellationToken.ThrowIfCancellationRequested();
+            currentPhase = DocumentAnalysisPhase.Lexing;
+            ThrowInjectedFailure(currentPhase);
+            cancellationToken.ThrowIfCancellationRequested();
+            tokens = new Lexer(source, diagnostics).TokenizeAll();
+            cancellationToken.ThrowIfCancellationRequested();
 
-            // Phase 2: Parsing (uses indent-aware token stream)
-            var parserLexer = new Lexer(source, new DiagnosticBag());
-            var parserTokens = parserLexer.TokenizeAllForParser();
-            var parser = new Parser(parserTokens, diagnostics);
-            ast = parser.Parse();
+            cancellationToken.ThrowIfCancellationRequested();
+            currentPhase = DocumentAnalysisPhase.Parsing;
+            ThrowInjectedFailure(currentPhase);
+            cancellationToken.ThrowIfCancellationRequested();
+            var parserTokens = new Lexer(source, new DiagnosticBag()).TokenizeAllForParser();
+            cancellationToken.ThrowIfCancellationRequested();
+            ast = new Parser(parserTokens, diagnostics).Parse();
+            cancellationToken.ThrowIfCancellationRequested();
 
-            // Phase 3: Binding (only if parsing succeeded without critical errors)
             if (ast != null && !diagnostics.HasErrors)
             {
-                try
-                {
-                    var binder = new Binder(diagnostics, _sourceIdentity);
-                    boundModule = binder.Bind(ast);
-                }
-                catch (Exception ex)
-                {
-                    diagnostics.ReportInfo(
-                        ast.Span,
-                        DiagnosticCode.AnalysisSkipped,
-                        $"Bound symbol analysis did not complete: {ex.GetType().Name}");
-                }
+                RunAnalysisPhase(
+                    DocumentAnalysisPhase.Binding,
+                    ast.Span,
+                    diagnostics,
+                    () =>
+                    {
+                        boundModule = new Binder(diagnostics, _sourceIdentity).Bind(ast);
+                    });
             }
 
-            // Phase 4: Bind validation (Calor0250-0253). Always runs when an
-            // AST is available so quick-fixes for strict bind-inference
-            // diagnostics surface in the IDE. Strict checks default-on per
-            // v0.6.3 (RFC v0.6 bind-inference-formalization §6 Phase 4).
             if (ast != null)
             {
-                try
-                {
-                    var bindValidator = new BindValidationPass(diagnostics, source, strictInference: true);
-                    bindValidator.Check(ast);
-                }
-                catch (Exception)
-                {
-                    // Validation should never throw on a parsed AST, but be defensive.
-                }
+                RunAnalysisPhase(
+                    DocumentAnalysisPhase.BindValidation,
+                    ast.Span,
+                    diagnostics,
+                    () => new BindValidationPass(
+                        diagnostics,
+                        source,
+                        strictInference: true).Check(ast));
+                RunAnalysisPhase(
+                    DocumentAnalysisPhase.ReturnValidation,
+                    ast.Span,
+                    diagnostics,
+                    () => new ReturnValidationPass(diagnostics).Check(ast));
             }
-
-            // Phase 5: Return validation (Calor0205). Always runs when an AST is
-            // available so the IDE surfaces value-returned-from-void-owner errors.
-            if (ast != null)
-            {
-                try
-                {
-                    var returnValidator = new ReturnValidationPass(diagnostics);
-                    returnValidator.Check(ast);
-                }
-                catch (Exception)
-                {
-                    // Validation should never throw on a parsed AST, but be defensive.
-                }
-            }
-
-            // Populate DiagnosticsWithFixes from DiagnosticBag
-            diagnosticsWithFixes.AddRange(diagnostics.DiagnosticsWithFixes);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
-            // Log unexpected errors as diagnostics
-            diagnostics.ReportError(
+            ReportInternalFailure(
+                currentPhase,
+                ex,
                 TextSpan.Empty,
-                "Calor9999",
-                $"Internal error: {ex.Message}");
+                diagnostics,
+                version);
         }
 
-        return new DocumentAnalysisSnapshot(
+        cancellationToken.ThrowIfCancellationRequested();
+        return new DocumentSnapshot(
             version,
             source,
-            tokens,
+            tokens.ToImmutableArray(),
             ast,
             boundModule,
-            diagnostics,
-            diagnosticsWithFixes);
-    }
+            new ImmutableDiagnostics(diagnostics),
+            diagnostics.DiagnosticsWithFixes.ToImmutableArray());
 
-    /// <summary>
-    /// Find the token at a given position.
-    /// </summary>
-    public Token? GetTokenAtPosition(int line, int column)
-    {
-        if (Tokens == null)
-            return null;
-
-        foreach (var token in Tokens)
+        void RunAnalysisPhase(
+            DocumentAnalysisPhase phase,
+            TextSpan span,
+            DiagnosticBag bag,
+            Action action)
         {
-            if (token.Span.Line == line &&
-                column >= token.Span.Column &&
-                column < token.Span.Column + token.Span.Length)
+            cancellationToken.ThrowIfCancellationRequested();
+            try
             {
-                return token;
+                ThrowInjectedFailure(phase);
+                cancellationToken.ThrowIfCancellationRequested();
+                action();
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                ReportInternalFailure(phase, ex, span, bag, version);
             }
         }
-
-        return null;
     }
 
-    /// <summary>
-    /// Find the token at a given offset.
-    /// </summary>
-    public Token? GetTokenAtOffset(int offset)
+    private void ThrowInjectedFailure(DocumentAnalysisPhase phase)
     {
-        if (Tokens == null)
-            return null;
+        var failure = _failureInjector?.Invoke(phase);
+        if (failure != null)
+            throw failure;
+    }
 
-        foreach (var token in Tokens)
+    private void ReportInternalFailure(
+        DocumentAnalysisPhase phase,
+        Exception exception,
+        TextSpan span,
+        DiagnosticBag diagnostics,
+        int version)
+    {
+        _logger.LogError(
+            exception,
+            "LSP document analysis failed in {AnalysisPhase} for {DocumentUri} at version {DocumentVersion}.",
+            phase,
+            Uri,
+            version);
+        diagnostics.ReportError(
+            span,
+            "Calor9999",
+            $"Internal {GetPhaseName(phase)} analysis error ({exception.GetType().Name}).");
+    }
+
+    private static string GetPhaseName(DocumentAnalysisPhase phase) => phase switch
+    {
+        DocumentAnalysisPhase.BindValidation => "bind validation",
+        DocumentAnalysisPhase.ReturnValidation => "return validation",
+        _ => phase.ToString().ToLowerInvariant(),
+    };
+
+    public Token? GetTokenAtPosition(int line, int column) =>
+        Snapshot.GetTokenAtPosition(line, column);
+
+    public Token? GetTokenAtOffset(int offset) =>
+        Snapshot.GetTokenAtOffset(offset);
+
+    public bool IsCurrent(DocumentSnapshot snapshot)
+    {
+        lock (_updateGate)
         {
-            if (token.Span.Contains(offset))
-            {
-                return token;
-            }
+            return !_disposed
+                && ReferenceEquals(_snapshot, snapshot)
+                && _hasCompletedAnalysis
+                && snapshot.Version == _desiredVersion;
         }
+    }
 
-        return null;
+    internal bool TryUseCurrentSnapshot(
+        DocumentSnapshot snapshot,
+        Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        lock (_updateGate)
+        {
+            if (_disposed
+                || !ReferenceEquals(_snapshot, snapshot)
+                || !_hasCompletedAnalysis
+                || snapshot.Version != _desiredVersion)
+            {
+                return false;
+            }
+
+            action();
+            return true;
+        }
+    }
+
+    public void Dispose()
+    {
+        CancellationTokenSource? cancellation;
+        lock (_updateGate)
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            cancellation = _analysisCancellation;
+            _analysisCancellation = null;
+        }
+        _ = CancelAnalysisAsync(cancellation);
+    }
+
+    private async Task CancelAnalysisAsync(
+        CancellationTokenSource? cancellation)
+    {
+        if (cancellation == null)
+            return;
+
+        try
+        {
+            await cancellation.CancelAsync().ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "LSP document analysis cancellation failed for {DocumentUri}.",
+                Uri);
+        }
     }
 }

--- a/src/Calor.LanguageServer/State/WorkspaceState.cs
+++ b/src/Calor.LanguageServer/State/WorkspaceState.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using Calor.Compiler;
 using Calor.Compiler.Ast;
 using Calor.Compiler.Binding;
@@ -8,27 +9,29 @@ using Calor.LanguageServer.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 
 namespace Calor.LanguageServer.State;
 
 public sealed record WorkspaceDocumentSnapshot(
     DocumentState Document,
-    DocumentAnalysisSnapshot Analysis);
+    DocumentSnapshot Analysis);
 
 public sealed record ProjectSymbolLocation(
     DocumentState? Doc,
-    DocumentAnalysisSnapshot? Snapshot,
+    DocumentSnapshot? Snapshot,
     Symbol? Symbol);
 
 public sealed record ProjectFunctionLocation(
     DocumentState? Doc,
-    DocumentAnalysisSnapshot? Snapshot,
+    DocumentSnapshot? Snapshot,
     FunctionSymbol? Symbol);
 
 public sealed record ProjectReferenceLocation(
     DocumentState Doc,
-    DocumentAnalysisSnapshot Snapshot,
+    DocumentSnapshot Snapshot,
     TextSpan Span);
 
 public enum SymbolOccurrenceKind
@@ -39,13 +42,23 @@ public enum SymbolOccurrenceKind
 
 public sealed record ProjectSymbolOccurrence(
     DocumentState Doc,
-    DocumentAnalysisSnapshot Snapshot,
+    DocumentSnapshot Snapshot,
     SymbolId SymbolId,
     TextSpan Span,
     SymbolOccurrenceKind Kind,
     bool IsOpen,
     bool IsAmbiguous,
     bool IsSplitDeclaration = false);
+
+internal sealed record WorkspaceIndexSnapshot(
+    long Generation,
+    ImmutableArray<WorkspaceDocumentSnapshot> Documents,
+    WorkspaceState.WorkspaceSymbolIndex Index)
+{
+    public WorkspaceDocumentSnapshot? GetDocument(DocumentUri uri) =>
+        Documents.FirstOrDefault(document =>
+            DocumentUri.From(document.Document.Uri) == uri);
+}
 
 /// <summary>
 /// Manages document state for the entire workspace.
@@ -56,6 +69,15 @@ public sealed class WorkspaceState
     private readonly record struct WorkspaceFileStamp(
         long Length,
         DateTime LastWriteTimeUtc);
+    private sealed record ScannedWorkspaceFile(
+        DocumentUri Uri,
+        WorkspaceFileStamp Stamp,
+        string Source,
+        DocumentState? Analysis);
+    private sealed record WorkspaceScanResult(
+        WorkspaceRoot[] Roots,
+        HashSet<DocumentUri> Seen,
+        IReadOnlyList<ScannedWorkspaceFile> Files);
     private readonly record struct CompilationError(
         string Id,
         string Path,
@@ -68,26 +90,76 @@ public sealed class WorkspaceState
         string Path,
         string Baseline,
         string Candidate);
-    private sealed record DocumentSymbolIndex(
-        IReadOnlyDictionary<SymbolId, ProjectSymbolOccurrence[]> BySymbol,
-        ProjectSymbolOccurrence[] Occurrences);
-    private sealed record WorkspaceSymbolIndex(
+    private readonly record struct WorkspaceTypeGraphKey(
+        string ModuleName,
+        string ContainingTypePath,
+        string SimpleName,
+        int Arity)
+    {
+        public string QualifiedName => string.IsNullOrEmpty(ContainingTypePath)
+            ? SimpleName
+            : $"{ContainingTypePath}.{SimpleName}";
+        public string DisplayName => Arity == 0
+            ? QualifiedName
+            : $"{QualifiedName}`{Arity}";
+    }
+    private readonly record struct WorkspaceTypeLookupKey(
+        string Name,
+        int Arity);
+    private readonly record struct WorkspaceTypeReference(
+        string Name,
+        string SimpleName,
+        int Arity);
+    private enum WorkspaceTypeResolutionKind
+    {
+        NotFound,
+        Found,
+        Ambiguous,
+    }
+    private readonly record struct WorkspaceTypeResolution(
+        WorkspaceTypeResolutionKind Kind,
+        WorkspaceTypeGraphNode? Node);
+    private sealed record WorkspaceTypeDeclarationPart(
+        SymbolId Identity,
+        WorkspaceTypeGraphKey Key,
+        WorkspaceDocumentSnapshot Document,
+        ClassDefinitionNode Node);
+    private sealed record WorkspaceTypeGraphNode(
+        WorkspaceTypeGraphKey Key,
+        WorkspaceTypeReference? BaseClass,
+        bool IsAmbiguous,
+        ImmutableArray<string> Imports,
+        ImmutableArray<WorkspaceTypeDeclarationPart> Parts);
+    internal sealed record DocumentSymbolIndex(
+        ImmutableDictionary<SymbolId, ImmutableArray<ProjectSymbolOccurrence>> BySymbol,
+        ImmutableArray<ProjectSymbolOccurrence> Occurrences);
+    internal sealed record WorkspaceSymbolIndex(
         long Generation,
-        IReadOnlyDictionary<DocumentUri, DocumentSymbolIndex> ByDocument,
-        IReadOnlyDictionary<SymbolId, ProjectSymbolOccurrence[]> BySymbol,
-        IReadOnlySet<SymbolId> AmbiguousSymbols,
-        IReadOnlySet<SymbolId> IncompleteTypeSymbols);
+        ImmutableDictionary<DocumentUri, DocumentSymbolIndex> ByDocument,
+        ImmutableDictionary<SymbolId, ImmutableArray<ProjectSymbolOccurrence>> BySymbol,
+        ImmutableHashSet<SymbolId> AmbiguousSymbols,
+        ImmutableHashSet<SymbolId> IncompleteTypeSymbols,
+        ImmutableDictionary<DocumentUri, DocumentSnapshot> DocumentSnapshots,
+        ImmutableDictionary<
+            DocumentUri,
+            ImmutableArray<Calor.Compiler.Diagnostics.Diagnostic>> InheritanceDiagnostics);
 
     private readonly ConcurrentDictionary<DocumentUri, DocumentState> _documents = new();
     private readonly ConcurrentDictionary<DocumentUri, DocumentState> _closedDocuments = new();
     private readonly ConcurrentDictionary<DocumentUri, WorkspaceFileStamp> _closedDocumentStamps = new();
     private readonly object _workspaceRootsGate = new();
     private readonly object _indexGate = new();
+    private readonly object _registryGate = new();
+    private readonly SemaphoreSlim _workspaceScanGate = new(1, 1);
     private WorkspaceRoot[] _workspaceRoots = [];
     private long _workspaceGeneration;
     private long _workspaceFileReadCount;
     private long _renameValidationCompilationCount;
     private WorkspaceSymbolIndex? _symbolIndex;
+    private readonly ILogger _logger;
+    private readonly Func<string, CancellationToken, Task<string>> _workspaceFileReader;
+    private readonly Func<string, IEnumerable<string>> _workspaceFileEnumerator;
+    private readonly Func<Task>? _beforeWorkspaceScanApply;
     private static readonly Lazy<IReadOnlyList<MetadataReference>> PlatformReferences =
         new(CreatePlatformReferences);
     // Validation is exhaustive through five relevant symbols (2^5 configurations).
@@ -99,8 +171,40 @@ public sealed class WorkspaceState
     internal long RenameValidationCompilationCount =>
         Interlocked.Read(ref _renameValidationCompilationCount);
 
-    public WorkspaceState(string? workspaceRootPath = null)
+    public WorkspaceState(
+        string? workspaceRootPath = null,
+        ILogger<WorkspaceState>? logger = null)
+        : this(
+            workspaceRootPath,
+            logger,
+            static (path, cancellationToken) =>
+                File.ReadAllTextAsync(path, cancellationToken),
+            workspaceFileEnumerator: null,
+            beforeWorkspaceScanApply: null)
     {
+    }
+
+    internal WorkspaceState(
+        string? workspaceRootPath,
+        ILogger<WorkspaceState>? logger,
+        Func<string, CancellationToken, Task<string>> workspaceFileReader,
+        Func<string, IEnumerable<string>>? workspaceFileEnumerator = null,
+        Func<Task>? beforeWorkspaceScanApply = null)
+    {
+        _logger = logger ?? NullLogger<WorkspaceState>.Instance;
+        _workspaceFileReader = workspaceFileReader
+            ?? throw new ArgumentNullException(nameof(workspaceFileReader));
+        _workspaceFileEnumerator = workspaceFileEnumerator
+            ?? (path => Directory.EnumerateFiles(
+                path,
+                "*.calr",
+                new EnumerationOptions
+                {
+                    RecurseSubdirectories = true,
+                    IgnoreInaccessible = true,
+                    AttributesToSkip = FileAttributes.ReparsePoint,
+                }));
+        _beforeWorkspaceScanApply = beforeWorkspaceScanApply;
         ConfigureWorkspaceRoot(workspaceRootPath);
     }
 
@@ -135,6 +239,33 @@ public sealed class WorkspaceState
             ConfigureWorkspaceRoot(workspaceRoot.LocalPath);
     }
 
+    internal async Task ConfigureWorkspaceRootAsync(
+        Uri? workspaceRoot,
+        CancellationToken cancellationToken)
+    {
+        if (workspaceRoot?.IsFile != true)
+            return;
+
+        var normalized = NormalizeWorkspaceRoot(workspaceRoot.LocalPath);
+        lock (_workspaceRootsGate)
+        {
+            var current = Volatile.Read(ref _workspaceRoots);
+            if (current.Any(root =>
+                    string.Equals(root.Path, normalized, StringComparison.Ordinal)))
+            {
+                return;
+            }
+
+            Volatile.Write(
+                ref _workspaceRoots,
+                current
+                    .Append(new WorkspaceRoot(normalized, $"root{current.Length}"))
+                    .ToArray());
+        }
+
+        await RefreshClosedDocumentsAsync(cancellationToken).ConfigureAwait(false);
+    }
+
     public void ConfigureWorkspaceRoots(IEnumerable<Uri> workspaceRoots)
     {
         ArgumentNullException.ThrowIfNull(workspaceRoots);
@@ -153,25 +284,126 @@ public sealed class WorkspaceState
         RefreshWorkspaceIndex();
     }
 
+    internal async Task ConfigureWorkspaceRootsAsync(
+        IEnumerable<Uri> workspaceRoots,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(workspaceRoots);
+        var normalized = workspaceRoots
+            .Where(root => root.IsFile)
+            .Select(root => NormalizeWorkspaceRoot(root.LocalPath))
+            .Distinct(StringComparer.Ordinal)
+            .Select((path, index) => new WorkspaceRoot(path, $"root{index}"))
+            .ToArray();
+        if (normalized.Length == 0)
+            return;
+
+        lock (_workspaceRootsGate)
+            Volatile.Write(ref _workspaceRoots, normalized);
+
+        await RefreshClosedDocumentsAsync(cancellationToken).ConfigureAwait(false);
+    }
+
     /// <summary>
     /// Get or create a document state for the given URI.
     /// </summary>
     public DocumentState GetOrCreate(DocumentUri uri, string source, int version = 0)
+#pragma warning disable VSTHRD002 // Compatibility wrapper for synchronous handler tests.
     {
-        _closedDocuments.TryRemove(uri, out _);
-        _closedDocumentStamps.TryRemove(uri, out _);
-        if (_documents.TryGetValue(uri, out var existing))
+        GetOrCreateAsync(uri, source, version).GetAwaiter().GetResult();
+        return Get(uri)
+            ?? throw new InvalidOperationException(
+                $"Document '{uri}' was removed during creation.");
+    }
+#pragma warning restore VSTHRD002
+
+    internal async Task<bool> GetOrCreateAsync(
+        DocumentUri uri,
+        string source,
+        int version = 0,
+        CancellationToken cancellationToken = default)
+    {
+        DocumentState? existing;
+        DocumentState? staleClosed = null;
+        lock (_registryGate)
         {
-            var before = existing.Snapshot;
-            existing.Update(source, version);
-            if (!ReferenceEquals(before, existing.Snapshot))
+            _documents.TryGetValue(uri, out existing);
+            if (existing != null)
+            {
+                _closedDocuments.TryRemove(uri, out staleClosed);
+                _closedDocumentStamps.TryRemove(uri, out _);
+            }
+        }
+        staleClosed?.Dispose();
+        if (existing != null)
+        {
+            var update = await existing.UpdateAsync(
+                source,
+                version,
+                cancellationToken).ConfigureAwait(false);
+            if (update.Accepted)
                 InvalidateSymbolIndex();
-            return existing;
+            return update.Accepted;
         }
 
-        var state = _documents.GetOrAdd(uri, _ => CreateAndAnalyze(uri, source, version));
+        var candidate = CreateDocumentState(uri, source, version);
+        DocumentSnapshot candidateSnapshot;
+        try
+        {
+            candidateSnapshot = await candidate.ReanalyzeAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            candidate.Dispose();
+            return false;
+        }
+        if (cancellationToken.IsCancellationRequested)
+        {
+            candidate.Dispose();
+            return false;
+        }
+        if (!candidate.IsCurrent(candidateSnapshot)
+            || !string.Equals(
+                candidateSnapshot.Source,
+                source,
+                StringComparison.Ordinal))
+        {
+            candidate.Dispose();
+            return false;
+        }
+
+        DocumentState state;
+        staleClosed = null;
+        lock (_registryGate)
+        {
+            _closedDocuments.TryRemove(uri, out staleClosed);
+            _closedDocumentStamps.TryRemove(uri, out _);
+            if (_documents.TryGetValue(uri, out var open))
+            {
+                state = open;
+            }
+            else
+            {
+                _documents[uri] = candidate;
+                state = candidate;
+            }
+        }
+        staleClosed?.Dispose();
+        if (!ReferenceEquals(state, candidate))
+        {
+            candidate.Dispose();
+            var update = await state.UpdateAsync(
+                source,
+                version,
+                cancellationToken).ConfigureAwait(false);
+            if (update.Accepted)
+                InvalidateSymbolIndex();
+            return update.Accepted;
+        }
+
         InvalidateSymbolIndex();
-        return state;
+        return true;
     }
 
     /// <summary>
@@ -179,20 +411,46 @@ public sealed class WorkspaceState
     /// </summary>
     public DocumentState? Get(DocumentUri uri)
     {
-        return _documents.TryGetValue(uri, out var state) ? state : null;
+        lock (_registryGate)
+            return _documents.TryGetValue(uri, out var state) ? state : null;
     }
 
     /// <summary>
     /// Update a document's content.
     /// </summary>
     public DocumentState Update(DocumentUri uri, string source, int version)
+#pragma warning disable VSTHRD002 // Compatibility wrapper for synchronous handler tests.
     {
-        var state = _documents.GetOrAdd(uri, _ => CreateAndAnalyze(uri, source, version));
-        var before = state.Snapshot;
-        state.Update(source, version);
-        if (!ReferenceEquals(before, state.Snapshot))
+        UpdateAsync(uri, source, version).GetAwaiter().GetResult();
+        return Get(uri)
+            ?? throw new InvalidOperationException(
+                $"Document '{uri}' was removed during update.");
+    }
+#pragma warning restore VSTHRD002
+
+    internal async Task<bool> UpdateAsync(
+        DocumentUri uri,
+        string source,
+        int version,
+        CancellationToken cancellationToken = default)
+    {
+        DocumentState? state;
+        lock (_registryGate)
+            _documents.TryGetValue(uri, out state);
+        if (state == null)
+            return await GetOrCreateAsync(
+                uri,
+                source,
+                version,
+                cancellationToken).ConfigureAwait(false);
+
+        var update = await state.UpdateAsync(
+            source,
+            version,
+            cancellationToken).ConfigureAwait(false);
+        if (update.Accepted)
             InvalidateSymbolIndex();
-        return state;
+        return update.Accepted;
     }
 
     /// <summary>
@@ -200,23 +458,55 @@ public sealed class WorkspaceState
     /// </summary>
     public bool Remove(DocumentUri uri)
     {
-        var removed = _documents.TryRemove(uri, out _);
+        bool removed;
+        DocumentState? state;
+        lock (_registryGate)
+            removed = _documents.TryRemove(uri, out state);
         if (removed)
         {
+            state!.Dispose();
             InvalidateSymbolIndex();
-            RefreshWorkspaceIndex();
+        }
+        return removed;
+    }
+
+    internal async Task<bool> RemoveAsync(
+        DocumentUri uri,
+        CancellationToken cancellationToken)
+    {
+        var removed = Remove(uri);
+        if (removed)
+        {
+            await RefreshClosedDocumentsAsync(cancellationToken)
+                .ConfigureAwait(false);
         }
         return removed;
     }
 
     public DocumentState? Reanalyze(DocumentUri uri)
+#pragma warning disable VSTHRD002 // Compatibility wrapper for synchronous handler tests.
     {
-        if (!_documents.TryGetValue(uri, out var state))
-            return null;
+        return ReanalyzeAsync(uri).GetAwaiter().GetResult()
+            ? Get(uri)
+            : null;
+    }
+#pragma warning restore VSTHRD002
 
-        state.Reanalyze();
-        InvalidateSymbolIndex();
-        return state;
+    internal async Task<bool> ReanalyzeAsync(
+        DocumentUri uri,
+        CancellationToken cancellationToken = default)
+    {
+        DocumentState? state;
+        lock (_registryGate)
+            _documents.TryGetValue(uri, out state);
+        if (state == null)
+            return false;
+
+        var before = state.Snapshot;
+        var snapshot = await state.ReanalyzeAsync(cancellationToken).ConfigureAwait(false);
+        if (!ReferenceEquals(before, snapshot))
+            InvalidateSymbolIndex();
+        return state.IsCurrent(snapshot);
     }
 
     /// <summary>
@@ -224,7 +514,8 @@ public sealed class WorkspaceState
     /// </summary>
     public IEnumerable<DocumentState> GetAllDocuments()
     {
-        return _documents.Values;
+        lock (_registryGate)
+            return _documents.Values.ToArray();
     }
 
     /// <summary>
@@ -232,12 +523,19 @@ public sealed class WorkspaceState
     /// </summary>
     public bool Contains(DocumentUri uri)
     {
-        return _documents.ContainsKey(uri);
+        lock (_registryGate)
+            return _documents.ContainsKey(uri);
     }
 
     public ProjectSymbolOccurrence? ResolveOccurrence(DocumentUri uri, int offset)
+        => ResolveOccurrence(CaptureSnapshot(), uri, offset);
+
+    internal ProjectSymbolOccurrence? ResolveOccurrence(
+        WorkspaceIndexSnapshot snapshot,
+        DocumentUri uri,
+        int offset)
     {
-        var index = GetSymbolIndex();
+        var index = GetIndex(snapshot);
         if (!index.ByDocument.TryGetValue(uri, out var documentIndex))
             return null;
 
@@ -263,11 +561,16 @@ public sealed class WorkspaceState
     }
 
     public ProjectSymbolOccurrence? FindSymbolDefinition(SymbolId symbolId)
+        => FindSymbolDefinition(CaptureSnapshot(), symbolId);
+
+    internal ProjectSymbolOccurrence? FindSymbolDefinition(
+        WorkspaceIndexSnapshot snapshot,
+        SymbolId symbolId)
     {
         if (symbolId.IsNone)
             return null;
 
-        var index = GetSymbolIndex();
+        var index = GetIndex(snapshot);
         if (index.AmbiguousSymbols.Contains(symbolId))
             return null;
 
@@ -278,11 +581,16 @@ public sealed class WorkspaceState
     }
 
     public bool CanRenameSymbol(SymbolId symbolId)
+        => CanRenameSymbol(CaptureSnapshot(), symbolId);
+
+    internal bool CanRenameSymbol(
+        WorkspaceIndexSnapshot snapshot,
+        SymbolId symbolId)
     {
         if (symbolId.IsNone)
             return false;
 
-        var index = GetSymbolIndex();
+        var index = GetIndex(snapshot);
         return !index.AmbiguousSymbols.Contains(symbolId)
             && !index.IncompleteTypeSymbols.Contains(symbolId)
             && index.BySymbol.TryGetValue(symbolId, out var occurrences)
@@ -294,9 +602,15 @@ public sealed class WorkspaceState
     public IReadOnlyList<ProjectSymbolOccurrence> FindSymbolOccurrences(
         SymbolId symbolId,
         bool includeDeclaration)
+        => FindSymbolOccurrences(CaptureSnapshot(), symbolId, includeDeclaration);
+
+    internal IReadOnlyList<ProjectSymbolOccurrence> FindSymbolOccurrences(
+        WorkspaceIndexSnapshot snapshot,
+        SymbolId symbolId,
+        bool includeDeclaration)
     {
         if (symbolId.IsNone
-            || !GetSymbolIndex().BySymbol.TryGetValue(symbolId, out var occurrences))
+            || !GetIndex(snapshot).BySymbol.TryGetValue(symbolId, out var occurrences))
         {
             return Array.Empty<ProjectSymbolOccurrence>();
         }
@@ -370,6 +684,19 @@ public sealed class WorkspaceState
         string oldName,
         string newName,
         CancellationToken cancellationToken)
+        => ValidateRenameAsync(
+            CaptureSnapshot(),
+            occurrences,
+            oldName,
+            newName,
+            cancellationToken);
+
+    internal Task<bool> ValidateRenameAsync(
+        WorkspaceIndexSnapshot workspaceSnapshot,
+        IReadOnlyList<ProjectSymbolOccurrence> occurrences,
+        string oldName,
+        string newName,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(occurrences);
         ArgumentException.ThrowIfNullOrWhiteSpace(oldName);
@@ -377,13 +704,8 @@ public sealed class WorkspaceState
         if (occurrences.Count == 0)
             return Task.FromResult(false);
 
-        WorkspaceDocumentSnapshot[] documents;
-        long generation;
-        lock (_indexGate)
-        {
-            documents = CaptureDocumentsCore();
-            generation = _workspaceGeneration;
-        }
+        var documents = workspaceSnapshot.Documents;
+        var generation = workspaceSnapshot.Generation;
         return Task.Run(
             () =>
             {
@@ -403,8 +725,13 @@ public sealed class WorkspaceState
                 {
                     throw;
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    _logger.LogError(
+                        ex,
+                        "LSP rename validation failed for symbol {SymbolName} in workspace generation {WorkspaceGeneration}.",
+                        oldName,
+                        generation);
                     return false;
                 }
             },
@@ -470,13 +797,15 @@ public sealed class WorkspaceState
                 document.Document.Uri,
                 source,
                 document.Analysis.Version,
-                GetCanonicalSourceIdentity(document.Document.Uri));
+                GetCanonicalSourceIdentity(document.Document.Uri),
+                _logger,
+                failureInjector: null);
             candidate.Reanalyze();
             if (HasNewErrors(
                     GetAnalysisErrors(document.Analysis, document.Document.Uri),
                     GetAnalysisErrors(candidate.Snapshot, candidate.Uri))
-                || candidate.Ast == null
-                || candidate.BoundModule == null)
+                || candidate.Snapshot.Ast == null
+                || candidate.Snapshot.BoundModule == null)
             {
                 return false;
             }
@@ -694,7 +1023,7 @@ public sealed class WorkspaceState
 
     public ProjectFunctionLocation ResolveProjectCall(
         DocumentState caller,
-        DocumentAnalysisSnapshot callerSnapshot,
+        DocumentSnapshot callerSnapshot,
         BoundNode? call)
     {
         return ResolveProjectCall(CaptureDocuments(), caller, callerSnapshot, call);
@@ -705,10 +1034,20 @@ public sealed class WorkspaceState
         return ResolveProjectCall(CaptureDocuments(), null, null, call);
     }
 
+    internal ProjectFunctionLocation ResolveProjectCall(
+        WorkspaceIndexSnapshot workspace,
+        WorkspaceDocumentSnapshot caller,
+        BoundNode? call) =>
+        ResolveProjectCall(
+            workspace.Documents,
+            caller.Document,
+            caller.Analysis,
+            call);
+
     private static ProjectFunctionLocation ResolveProjectCall(
         IReadOnlyList<WorkspaceDocumentSnapshot> documents,
         DocumentState? caller,
-        DocumentAnalysisSnapshot? callerSnapshot,
+        DocumentSnapshot? callerSnapshot,
         BoundNode? call)
     {
         if (call == null)
@@ -807,7 +1146,7 @@ public sealed class WorkspaceState
 
     public ProjectSymbolLocation ResolveProjectType(
         DocumentState caller,
-        DocumentAnalysisSnapshot callerSnapshot,
+        DocumentSnapshot callerSnapshot,
         BoundNewExpression creation)
     {
         var documents = CaptureDocuments();
@@ -1073,7 +1412,7 @@ public sealed class WorkspaceState
     }
 
     private static string? FindCallerContainingType(
-        DocumentAnalysisSnapshot? callerSnapshot,
+        DocumentSnapshot? callerSnapshot,
         BoundNode call)
     {
         return callerSnapshot?.BoundModule?.Functions
@@ -1155,16 +1494,99 @@ public sealed class WorkspaceState
     }
 
     private WorkspaceSymbolIndex GetSymbolIndex()
+        => GetIndex(CaptureSnapshot());
+
+    internal WorkspaceIndexSnapshot CaptureSnapshot(
+        bool refreshClosedDocuments = false)
+    {
+        if (refreshClosedDocuments)
+            RefreshClosedDocuments();
+
+        lock (_indexGate)
+        {
+            var documents = CaptureDocumentsCore();
+            if (_symbolIndex?.Generation == _workspaceGeneration
+                && IndexMatchesDocuments(_symbolIndex, documents))
+            {
+                return new WorkspaceIndexSnapshot(
+                    _workspaceGeneration,
+                    documents.ToImmutableArray(),
+                    _symbolIndex);
+            }
+
+            if (_symbolIndex?.Generation == _workspaceGeneration)
+                _workspaceGeneration++;
+            _symbolIndex = BuildSymbolIndex(
+                documents,
+                _workspaceGeneration);
+            return new WorkspaceIndexSnapshot(
+                _workspaceGeneration,
+                documents.ToImmutableArray(),
+                _symbolIndex);
+        }
+    }
+
+    internal async Task<WorkspaceIndexSnapshot> CaptureSnapshotAsync(
+        bool refreshClosedDocuments,
+        CancellationToken cancellationToken)
+    {
+        if (refreshClosedDocuments)
+        {
+            await RefreshClosedDocumentsAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return CaptureSnapshot(refreshClosedDocuments: false);
+    }
+
+    private static WorkspaceSymbolIndex GetIndex(WorkspaceIndexSnapshot snapshot) =>
+        snapshot.Index;
+
+    internal IReadOnlyList<Calor.Compiler.Diagnostics.Diagnostic> GetDiagnostics(
+        WorkspaceIndexSnapshot workspace,
+        WorkspaceDocumentSnapshot document)
+    {
+        var index = GetIndex(workspace);
+        var uri = DocumentUri.From(document.Document.Uri);
+        return index.InheritanceDiagnostics.TryGetValue(uri, out var inheritance)
+            ? document.Analysis.Diagnostics.Concat(inheritance).ToArray()
+            : document.Analysis.Diagnostics;
+    }
+
+    internal bool TryPublishDiagnostics(
+        WorkspaceIndexSnapshot workspace,
+        WorkspaceDocumentSnapshot document,
+        Action publish)
     {
         lock (_indexGate)
         {
-            if (_symbolIndex?.Generation == _workspaceGeneration)
-                return _symbolIndex;
+            if (_workspaceGeneration != workspace.Generation
+                || !ReferenceEquals(_symbolIndex, workspace.Index))
+            {
+                return false;
+            }
 
-            _symbolIndex = BuildSymbolIndex(
-                CaptureDocumentsCore(),
-                _workspaceGeneration);
-            return _symbolIndex;
+            return document.Document.TryUseCurrentSnapshot(
+                document.Analysis,
+                publish);
+        }
+    }
+
+    internal bool TryPublishGeneration(
+        WorkspaceIndexSnapshot workspace,
+        Action publish)
+    {
+        lock (_indexGate)
+        {
+            if (_workspaceGeneration != workspace.Generation
+                || !ReferenceEquals(_symbolIndex, workspace.Index))
+            {
+                return false;
+            }
+
+            publish();
+            return true;
         }
     }
 
@@ -1344,7 +1766,7 @@ public sealed class WorkspaceState
 
         return new WorkspaceSymbolIndex(
             generation,
-            byDocument.ToDictionary(
+            byDocument.ToImmutableDictionary(
                 pair => pair.Key,
                 pair =>
                 {
@@ -1354,24 +1776,28 @@ public sealed class WorkspaceState
                         .ThenBy(
                             occurrence => occurrence.SymbolId.Value,
                             StringComparer.Ordinal)
-                        .ToArray();
+                        .ToImmutableArray();
                     return new DocumentSymbolIndex(
                         occurrences
                             .GroupBy(occurrence => occurrence.SymbolId)
-                            .ToDictionary(
+                            .ToImmutableDictionary(
                                 group => group.Key,
-                                group => group.ToArray()),
+                                group => group.ToImmutableArray()),
                         occurrences);
                 }),
-            bySymbol.ToDictionary(
+            bySymbol.ToImmutableDictionary(
                 pair => pair.Key,
                 pair => pair.Value
                     .OrderBy(occurrence => occurrence.Doc.Uri.ToString(), StringComparer.Ordinal)
                     .ThenBy(occurrence => occurrence.Span.Start)
                     .ThenBy(occurrence => occurrence.Kind)
-                    .ToArray()),
-            ambiguousSymbols,
-            incompleteTypeSymbols);
+                    .ToImmutableArray()),
+            ambiguousSymbols.ToImmutableHashSet(),
+            incompleteTypeSymbols.ToImmutableHashSet(),
+            documents.ToImmutableDictionary(
+                document => DocumentUri.From(document.Document.Uri),
+                document => document.Analysis),
+            BuildInheritanceDiagnostics(documents));
 
         void AddCallOccurrences(
             WorkspaceDocumentSnapshot document,
@@ -1488,6 +1914,531 @@ public sealed class WorkspaceState
             }
             symbolOccurrences.Add(occurrence);
         }
+    }
+
+    private static ImmutableDictionary<
+        DocumentUri,
+        ImmutableArray<Calor.Compiler.Diagnostics.Diagnostic>> BuildInheritanceDiagnostics(
+        IReadOnlyList<WorkspaceDocumentSnapshot> documents)
+    {
+        var declarationParts = documents
+            .SelectMany(GetTypeDeclarations)
+            .OrderBy(item => item.Identity.Value, StringComparer.Ordinal)
+            .ToArray();
+        var nodes = declarationParts
+            .GroupBy(part => part.Key)
+            .Select(group => CreateGraphNode(group.ToArray()))
+            .OrderBy(node => node.Key.ModuleName, StringComparer.Ordinal)
+            .ThenBy(node => node.Key.ContainingTypePath, StringComparer.Ordinal)
+            .ThenBy(node => node.Key.SimpleName, StringComparer.Ordinal)
+            .ThenBy(node => node.Key.Arity)
+            .ToArray();
+        var byKey = nodes.ToDictionary(
+            node => node.Key);
+        var byModuleQualifiedName = nodes
+            .GroupBy(node => new WorkspaceTypeLookupKey(
+                $"{node.Key.ModuleName}.{node.Key.QualifiedName}",
+                node.Key.Arity))
+            .ToDictionary(
+                group => group.Key,
+                CreateResolution);
+        var byUnqualifiedName = nodes
+            .GroupBy(node => new WorkspaceTypeLookupKey(
+                node.Key.QualifiedName,
+                node.Key.Arity))
+            .ToDictionary(
+                group => group.Key,
+                CreateResolution);
+        var bySimpleName = nodes
+            .GroupBy(node => new WorkspaceTypeLookupKey(
+                node.Key.SimpleName,
+                node.Key.Arity))
+            .ToDictionary(
+                group => group.Key,
+                CreateResolution);
+        var edges = new Dictionary<
+            WorkspaceTypeGraphKey,
+            WorkspaceTypeGraphKey>();
+        foreach (var node in nodes.Where(item => !item.IsAmbiguous))
+        {
+            if (node.BaseClass is not { } reference)
+                continue;
+
+            var resolution = ResolveBaseType(node, reference);
+            if (resolution.Kind == WorkspaceTypeResolutionKind.Found)
+                edges[node.Key] = resolution.Node!.Key;
+        }
+
+        var state = new Dictionary<WorkspaceTypeGraphKey, int>();
+        var stack = new List<WorkspaceTypeGraphKey>();
+        var diagnostics = new Dictionary<
+            DocumentUri,
+            List<Calor.Compiler.Diagnostics.Diagnostic>>();
+        foreach (var node in nodes.Where(item => !item.IsAmbiguous))
+            Visit(node.Key);
+
+        return diagnostics.ToImmutableDictionary(
+            pair => pair.Key,
+            pair => pair.Value
+                .OrderBy(diagnostic => diagnostic.Span.Start)
+                .ThenBy(diagnostic => diagnostic.Message, StringComparer.Ordinal)
+                .ToImmutableArray());
+
+        WorkspaceTypeResolution ResolveBaseType(
+            WorkspaceTypeGraphNode source,
+            WorkspaceTypeReference reference)
+        {
+            var containingPath = source.Key.ContainingTypePath;
+            while (true)
+            {
+                var lexicalName = string.IsNullOrEmpty(containingPath)
+                    ? reference.Name
+                    : $"{containingPath}.{reference.Name}";
+                var lexical = ResolveKey(CreateGraphKey(
+                    source.Key.ModuleName,
+                    lexicalName,
+                    reference.Arity));
+                if (lexical.Kind != WorkspaceTypeResolutionKind.NotFound)
+                    return lexical;
+                if (string.IsNullOrEmpty(containingPath))
+                    break;
+                var separator = containingPath.LastIndexOf('.');
+                containingPath = separator < 0
+                    ? string.Empty
+                    : containingPath[..separator];
+            }
+
+            var imported = ResolveImports(source, reference);
+            if (imported.Kind != WorkspaceTypeResolutionKind.NotFound)
+                return imported;
+
+            var lookup = new WorkspaceTypeLookupKey(
+                reference.Name,
+                reference.Arity);
+            var moduleQualified = ResolveLookup(
+                byModuleQualifiedName,
+                lookup);
+            if (moduleQualified.Kind != WorkspaceTypeResolutionKind.NotFound)
+                return moduleQualified;
+
+            var qualified = ResolveLookup(byUnqualifiedName, lookup);
+            if (qualified.Kind != WorkspaceTypeResolutionKind.NotFound)
+                return qualified;
+
+            return reference.Name.Contains('.', StringComparison.Ordinal)
+                ? new WorkspaceTypeResolution(
+                    WorkspaceTypeResolutionKind.NotFound,
+                    null)
+                : ResolveLookup(
+                    bySimpleName,
+                    new WorkspaceTypeLookupKey(
+                        reference.SimpleName,
+                        reference.Arity));
+        }
+
+        WorkspaceTypeResolution ResolveImports(
+            WorkspaceTypeGraphNode source,
+            WorkspaceTypeReference reference)
+        {
+            var found = new Dictionary<
+                WorkspaceTypeGraphKey,
+                WorkspaceTypeGraphNode>();
+            foreach (var import in source.Imports)
+            {
+                var resolution = ResolveLookup(
+                    byModuleQualifiedName,
+                    new WorkspaceTypeLookupKey(
+                        $"{import}.{reference.Name}",
+                        reference.Arity));
+                if (resolution.Kind == WorkspaceTypeResolutionKind.Ambiguous)
+                    return resolution;
+                if (resolution.Kind == WorkspaceTypeResolutionKind.Found)
+                    found.TryAdd(resolution.Node!.Key, resolution.Node);
+            }
+
+            return found.Count switch
+            {
+                0 => new WorkspaceTypeResolution(
+                    WorkspaceTypeResolutionKind.NotFound,
+                    null),
+                1 => new WorkspaceTypeResolution(
+                    WorkspaceTypeResolutionKind.Found,
+                    found.Values.Single()),
+                _ => new WorkspaceTypeResolution(
+                    WorkspaceTypeResolutionKind.Ambiguous,
+                    null),
+            };
+        }
+
+        WorkspaceTypeResolution ResolveKey(WorkspaceTypeGraphKey key)
+        {
+            if (!byKey.TryGetValue(key, out var node))
+            {
+                return new WorkspaceTypeResolution(
+                    WorkspaceTypeResolutionKind.NotFound,
+                    null);
+            }
+            return node.IsAmbiguous
+                ? new WorkspaceTypeResolution(
+                    WorkspaceTypeResolutionKind.Ambiguous,
+                    null)
+                : new WorkspaceTypeResolution(
+                    WorkspaceTypeResolutionKind.Found,
+                    node);
+        }
+
+        static WorkspaceTypeResolution ResolveLookup(
+            IReadOnlyDictionary<
+                WorkspaceTypeLookupKey,
+                WorkspaceTypeResolution> lookup,
+            WorkspaceTypeLookupKey key) =>
+            lookup.TryGetValue(key, out var resolution)
+                ? resolution
+                : new WorkspaceTypeResolution(
+                    WorkspaceTypeResolutionKind.NotFound,
+                    null);
+
+        static WorkspaceTypeResolution CreateResolution(
+            IGrouping<WorkspaceTypeLookupKey, WorkspaceTypeGraphNode> group)
+        {
+            var candidates = group.ToArray();
+            return candidates.Length == 1 && !candidates[0].IsAmbiguous
+                ? new WorkspaceTypeResolution(
+                    WorkspaceTypeResolutionKind.Found,
+                    candidates[0])
+                : new WorkspaceTypeResolution(
+                    WorkspaceTypeResolutionKind.Ambiguous,
+                    null);
+        }
+
+        void Visit(WorkspaceTypeGraphKey key)
+        {
+            if (state.GetValueOrDefault(key) == 2)
+                return;
+            if (state.GetValueOrDefault(key) == 1)
+                return;
+
+            state[key] = 1;
+            stack.Add(key);
+            if (edges.TryGetValue(key, out var next))
+            {
+                if (state.GetValueOrDefault(next) == 0)
+                {
+                    Visit(next);
+                }
+                else if (state.GetValueOrDefault(next) == 1)
+                {
+                    var start = stack.FindIndex(item =>
+                        item == next);
+                    if (start >= 0)
+                        ReportCycle(stack.Skip(start).ToArray());
+                }
+            }
+            stack.RemoveAt(stack.Count - 1);
+            state[key] = 2;
+        }
+
+        void ReportCycle(IReadOnlyList<WorkspaceTypeGraphKey> cycleKeys)
+        {
+            if (cycleKeys.Count == 0)
+                return;
+
+            var cycle = cycleKeys
+                .Select(key => byKey[key])
+                .ToArray();
+            var start = Enumerable.Range(0, cycle.Length)
+                .OrderBy(
+                    index => cycle[index].Key.DisplayName,
+                    StringComparer.Ordinal)
+                .ThenBy(
+                    index => cycle[index].Key.ModuleName,
+                    StringComparer.Ordinal)
+                .First();
+            var ordered = Enumerable.Range(0, cycle.Length)
+                .Select(offset => cycle[(start + offset) % cycle.Length])
+                .ToArray();
+            var description = string.Join(
+                " -> ",
+                ordered.Select(item => item.Key.DisplayName)
+                    .Append(ordered[0].Key.DisplayName));
+
+            var message = $"Inheritance cycle detected: {description}.";
+            foreach (var node in ordered)
+            {
+                foreach (var part in node.Parts
+                             .OrderBy(
+                                 item => item.Document.Document.Uri.ToString(),
+                                 StringComparer.Ordinal)
+                             .ThenBy(item => item.Node.Span.Start))
+                {
+                    var uri = DocumentUri.From(part.Document.Document.Uri);
+                    if (!diagnostics.TryGetValue(uri, out var documentDiagnostics))
+                    {
+                        documentDiagnostics = [];
+                        diagnostics.Add(uri, documentDiagnostics);
+                    }
+
+                    documentDiagnostics.Add(new Calor.Compiler.Diagnostics.Diagnostic(
+                        Calor.Compiler.Diagnostics.DiagnosticCode.InheritanceCycle,
+                        message,
+                        part.Node.BaseClassSpan ?? part.Node.IdentifierSpan,
+                        Calor.Compiler.Diagnostics.DiagnosticSeverity.Error,
+                        part.Document.Document.Uri.IsFile
+                            ? part.Document.Document.Uri.LocalPath
+                            : part.Document.Document.Uri.ToString()));
+                }
+            }
+        }
+
+        static WorkspaceTypeGraphNode CreateGraphNode(
+            IReadOnlyList<WorkspaceTypeDeclarationPart> parts)
+        {
+            var first = parts[0];
+            var compatible = parts.Count == 1
+                || ArePartialDeclarationsCompatible(parts);
+            var baseClasses = parts
+                .Select(part => part.Node.BaseClass)
+                .Where(baseClass => !string.IsNullOrWhiteSpace(baseClass))
+                .Select(baseClass => ParseTypeReference(baseClass!))
+                .Distinct()
+                .ToArray();
+            return new WorkspaceTypeGraphNode(
+                first.Key,
+                compatible && baseClasses.Length == 1
+                    ? baseClasses[0]
+                    : null,
+                IsAmbiguous: !compatible || baseClasses.Length > 1,
+                parts
+                    .SelectMany(part =>
+                        part.Document.Analysis.Ast?.Usings
+                            .Select(directive => directive.Namespace)
+                        ?? Enumerable.Empty<string>())
+                    .Distinct(StringComparer.Ordinal)
+                    .OrderBy(import => import, StringComparer.Ordinal)
+                    .ToImmutableArray(),
+                parts
+                    .OrderBy(
+                        part => part.Document.Document.Uri.ToString(),
+                        StringComparer.Ordinal)
+                    .ThenBy(part => part.Node.Span.Start)
+                    .ToImmutableArray());
+        }
+
+        static bool ArePartialDeclarationsCompatible(
+            IReadOnlyList<WorkspaceTypeDeclarationPart> parts)
+        {
+            if (parts.Any(part => !part.Node.IsPartial))
+                return false;
+
+            var first = parts[0].Node;
+            return parts.Skip(1).All(part =>
+            {
+                var node = part.Node;
+                return node.IsStruct == first.IsStruct
+                    && node.IsStatic == first.IsStatic
+                    && node.IsReadOnly == first.IsReadOnly
+                    && node.Visibility == first.Visibility
+                    && TypeParametersMatch(
+                        first.TypeParameters,
+                        node.TypeParameters);
+            });
+
+            static bool TypeParametersMatch(
+                IReadOnlyList<TypeParameterNode> left,
+                IReadOnlyList<TypeParameterNode> right)
+            {
+                if (left.Count != right.Count)
+                    return false;
+                for (var index = 0; index < left.Count; index++)
+                {
+                    if (!string.Equals(
+                            left[index].Name,
+                            right[index].Name,
+                            StringComparison.Ordinal)
+                        || left[index].Variance != right[index].Variance
+                        || !ConstraintsMatch(
+                            left[index].Constraints,
+                            right[index].Constraints))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            static bool ConstraintsMatch(
+                IReadOnlyList<TypeConstraintNode> left,
+                IReadOnlyList<TypeConstraintNode> right)
+            {
+                if (left.Count != right.Count)
+                    return false;
+                for (var index = 0; index < left.Count; index++)
+                {
+                    if (left[index].Kind != right[index].Kind
+                        || !string.Equals(
+                            left[index].TypeName?.Trim(),
+                            right[index].TypeName?.Trim(),
+                            StringComparison.Ordinal))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+
+        static IEnumerable<WorkspaceTypeDeclarationPart> GetTypeDeclarations(
+            WorkspaceDocumentSnapshot document)
+        {
+            var ast = document.Analysis.Ast;
+            if (ast == null)
+                yield break;
+
+            var symbols = document.Analysis.BoundModule?.SymbolsById.Values
+                .OfType<TypeSymbol>()
+                .ToArray() ?? [];
+            foreach (var item in EnumerateClasses(
+                         ast.Classes,
+                         containingType: null))
+            {
+                var symbol = symbols.SingleOrDefault(candidate =>
+                    candidate.DeclarationSpan == item.Node.IdentifierSpan
+                    && string.Equals(
+                        candidate.QualifiedName,
+                        item.QualifiedName,
+                        StringComparison.Ordinal));
+                var identity = symbol?.Id ?? SymbolId.Create(
+                    "lsp-inheritance",
+                    SymbolSourceIdentity.Canonicalize(
+                        document.Document.Uri.ToString()),
+                    ast.Id,
+                    item.Node.Id,
+                    item.QualifiedName);
+                var lastSeparator = item.QualifiedName.LastIndexOf('.');
+                var containingTypePath = lastSeparator < 0
+                    ? string.Empty
+                    : item.QualifiedName[..lastSeparator];
+                yield return new WorkspaceTypeDeclarationPart(
+                    identity,
+                    new WorkspaceTypeGraphKey(
+                        ast.Name,
+                        containingTypePath,
+                        item.Node.Name,
+                        item.Node.TypeParameters.Count),
+                    document,
+                    item.Node);
+            }
+        }
+
+        static WorkspaceTypeGraphKey CreateGraphKey(
+            string moduleName,
+            string qualifiedName,
+            int arity)
+        {
+            var lastSeparator = qualifiedName.LastIndexOf('.');
+            return new WorkspaceTypeGraphKey(
+                moduleName,
+                lastSeparator < 0
+                    ? string.Empty
+                    : qualifiedName[..lastSeparator],
+                lastSeparator < 0
+                    ? qualifiedName
+                    : qualifiedName[(lastSeparator + 1)..],
+                arity);
+        }
+
+        static WorkspaceTypeReference ParseTypeReference(string typeName)
+        {
+            var type = typeName.Trim().TrimStart('?');
+            var genericStart = type.IndexOf('<');
+            if (genericStart < 0)
+            {
+                var nominal = GetNominalTypeName(type);
+                var separator = nominal.LastIndexOf('.');
+                return new WorkspaceTypeReference(
+                    nominal,
+                    separator < 0 ? nominal : nominal[(separator + 1)..],
+                    Arity: 0);
+            }
+
+            var name = type[..genericStart].Trim();
+            var genericEnd = type.LastIndexOf('>');
+            if (genericEnd <= genericStart)
+            {
+                var separator = name.LastIndexOf('.');
+                return new WorkspaceTypeReference(
+                    name,
+                    separator < 0 ? name : name[(separator + 1)..],
+                    Arity: 0);
+            }
+
+            var arity = 1;
+            var angleDepth = 0;
+            var parenthesisDepth = 0;
+            var bracketDepth = 0;
+            var braceDepth = 0;
+            for (var index = genericStart + 1; index < genericEnd; index++)
+            {
+                switch (type[index])
+                {
+                    case '<':
+                        angleDepth++;
+                        break;
+                    case '>':
+                        angleDepth--;
+                        break;
+                    case '(':
+                        parenthesisDepth++;
+                        break;
+                    case ')':
+                        parenthesisDepth--;
+                        break;
+                    case '[':
+                        bracketDepth++;
+                        break;
+                    case ']':
+                        bracketDepth--;
+                        break;
+                    case '{':
+                        braceDepth++;
+                        break;
+                    case '}':
+                        braceDepth--;
+                        break;
+                    case ',' when angleDepth == 0
+                        && parenthesisDepth == 0
+                        && bracketDepth == 0
+                        && braceDepth == 0:
+                        arity++;
+                        break;
+                }
+            }
+            var lastSeparator = name.LastIndexOf('.');
+            return new WorkspaceTypeReference(
+                name,
+                lastSeparator < 0 ? name : name[(lastSeparator + 1)..],
+                arity);
+        }
+    }
+
+    private static bool IndexMatchesDocuments(
+        WorkspaceSymbolIndex index,
+        IReadOnlyList<WorkspaceDocumentSnapshot> documents)
+    {
+        if (index.DocumentSnapshots.Count != documents.Count)
+            return false;
+
+        foreach (var document in documents)
+        {
+            var uri = DocumentUri.From(document.Document.Uri);
+            if (!index.DocumentSnapshots.TryGetValue(uri, out var indexed)
+                || !ReferenceEquals(indexed, document.Analysis))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static IReadOnlyList<VariableSymbol> ResolveProjectFields(
@@ -1620,137 +2571,281 @@ public sealed class WorkspaceState
 
     private WorkspaceDocumentSnapshot[] CaptureDocumentsCore()
     {
-        return _documents.Values
-            .Concat(_closedDocuments
-                .Where(pair => !_documents.ContainsKey(pair.Key))
-                .Select(pair => pair.Value))
-            .Select(document => new WorkspaceDocumentSnapshot(document, document.Snapshot))
-            .ToArray();
+        List<DocumentState> staleClosed = [];
+        WorkspaceDocumentSnapshot[] documents;
+        lock (_registryGate)
+        {
+            foreach (var uri in _documents.Keys)
+            {
+                if (_closedDocuments.TryRemove(uri, out var stale))
+                {
+                    staleClosed.Add(stale);
+                    _closedDocumentStamps.TryRemove(uri, out _);
+                }
+            }
+
+            documents = _documents
+                .Select(pair => new WorkspaceDocumentSnapshot(
+                    pair.Value,
+                    pair.Value.Snapshot))
+                .Concat(_closedDocuments.Select(pair =>
+                    new WorkspaceDocumentSnapshot(
+                        pair.Value,
+                        pair.Value.Snapshot)))
+                .GroupBy(document => DocumentUri.From(document.Document.Uri))
+                .Select(group => group.First())
+                .ToArray();
+        }
+        foreach (var stale in staleClosed)
+            stale.Dispose();
+        return documents;
     }
 
     public void RefreshClosedDocuments()
     {
-        lock (_indexGate)
-            RefreshWorkspaceIndexCore();
+#pragma warning disable VSTHRD002 // Compatibility wrapper; scanning runs off-thread.
+        RefreshClosedDocumentsAsync(CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
+#pragma warning restore VSTHRD002
     }
 
     private void RefreshWorkspaceIndex() => RefreshClosedDocuments();
 
-    private void RefreshWorkspaceIndexCore()
+    internal async Task RefreshClosedDocumentsAsync(
+        CancellationToken cancellationToken)
     {
-        var roots = Volatile.Read(ref _workspaceRoots);
-        if (roots.Length == 0)
-            return;
+        await _workspaceScanGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        WorkspaceScanResult? scan = null;
+        try
+        {
+            var roots = Volatile.Read(ref _workspaceRoots);
+            if (roots.Length == 0)
+                return;
 
+            scan = await Task.Run(
+                    () => ScanWorkspaceAsync(roots, cancellationToken),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!ReferenceEquals(roots, Volatile.Read(ref _workspaceRoots)))
+                return;
+            if (_beforeWorkspaceScanApply != null)
+            {
+                await _beforeWorkspaceScanApply()
+                    .WaitAsync(cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            ApplyWorkspaceScan(scan);
+            scan = null;
+        }
+        finally
+        {
+            if (scan != null)
+                DisposeScannedAnalyses(scan.Files);
+            _workspaceScanGate.Release();
+        }
+    }
+
+    private async Task<WorkspaceScanResult> ScanWorkspaceAsync(
+        WorkspaceRoot[] roots,
+        CancellationToken cancellationToken)
+    {
         var seen = new HashSet<DocumentUri>();
-        var changed = false;
-        foreach (var root in roots)
+        var files = new List<ScannedWorkspaceFile>();
+        try
         {
-            if (!Directory.Exists(root.Path))
-                continue;
-
-            IEnumerable<string> paths;
-            try
+            foreach (var root in roots)
             {
-                paths = Directory.EnumerateFiles(
-                    root.Path,
-                    "*.calr",
-                    new EnumerationOptions
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!Directory.Exists(root.Path))
+                    continue;
+
+                string[] paths;
+                try
+                {
+                    paths = _workspaceFileEnumerator(root.Path)
+                        .Where(ShouldIndexPath)
+                        .ToArray();
+                }
+                catch (IOException ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Workspace scan skipped {WorkspaceRoot} because file enumeration failed.",
+                        root.Path);
+                    continue;
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Workspace scan skipped {WorkspaceRoot} because file enumeration was denied.",
+                        root.Path);
+                    continue;
+                }
+
+                foreach (var path in paths)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var fullPath = Path.GetFullPath(path);
+                    var uri = DocumentUri.FromFileSystemPath(fullPath);
+                    if (!seen.Add(uri) || _documents.ContainsKey(uri))
+                        continue;
+
+                    WorkspaceFileStamp stamp;
+                    try
                     {
-                        RecurseSubdirectories = true,
-                        IgnoreInaccessible = true,
-                        AttributesToSkip = FileAttributes.ReparsePoint,
-                    })
-                    .Where(ShouldIndexPath)
-                    .ToArray();
+                        var info = new FileInfo(fullPath);
+                        stamp = new WorkspaceFileStamp(
+                            info.Length,
+                            info.LastWriteTimeUtc);
+                    }
+                    catch (IOException)
+                    {
+                        continue;
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        continue;
+                    }
+
+                    if (_closedDocuments.ContainsKey(uri)
+                        && _closedDocumentStamps.TryGetValue(
+                            uri,
+                            out var existingStamp)
+                        && existingStamp == stamp)
+                    {
+                        continue;
+                    }
+
+                    string source;
+                    try
+                    {
+                        Interlocked.Increment(ref _workspaceFileReadCount);
+                        source = await _workspaceFileReader(
+                                fullPath,
+                                cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                    catch (IOException)
+                    {
+                        continue;
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        continue;
+                    }
+
+                    if (_closedDocuments.TryGetValue(uri, out var existing)
+                        && string.Equals(
+                            existing.Source,
+                            source,
+                            StringComparison.Ordinal))
+                    {
+                        files.Add(new ScannedWorkspaceFile(
+                            uri,
+                            stamp,
+                            source,
+                            Analysis: null));
+                        continue;
+                    }
+
+                    var analysis = CreateDocumentState(uri, source, version: 0);
+                    try
+                    {
+                        await analysis.ReanalyzeAsync(cancellationToken)
+                            .ConfigureAwait(false);
+                        cancellationToken.ThrowIfCancellationRequested();
+                        files.Add(new ScannedWorkspaceFile(
+                            uri,
+                            stamp,
+                            source,
+                            analysis));
+                    }
+                    catch
+                    {
+                        analysis.Dispose();
+                        throw;
+                    }
+                }
             }
-            catch (IOException)
-            {
-                continue;
-            }
-            catch (UnauthorizedAccessException)
-            {
-                continue;
-            }
 
-            foreach (var path in paths)
-            {
-                var fullPath = Path.GetFullPath(path);
-                var uri = DocumentUri.FromFileSystemPath(fullPath);
-                seen.Add(uri);
-                if (_documents.ContainsKey(uri))
-                {
-                    changed |= _closedDocuments.TryRemove(uri, out _);
-                    _closedDocumentStamps.TryRemove(uri, out _);
-                    continue;
-                }
-
-                WorkspaceFileStamp stamp;
-                try
-                {
-                    var info = new FileInfo(fullPath);
-                    stamp = new WorkspaceFileStamp(
-                        info.Length,
-                        info.LastWriteTimeUtc);
-                }
-                catch (IOException)
-                {
-                    continue;
-                }
-                catch (UnauthorizedAccessException)
-                {
-                    continue;
-                }
-
-                if (_closedDocuments.ContainsKey(uri)
-                    && _closedDocumentStamps.TryGetValue(uri, out var existingStamp)
-                    && existingStamp == stamp)
-                {
-                    continue;
-                }
-
-                string source;
-                try
-                {
-                    Interlocked.Increment(ref _workspaceFileReadCount);
-                    source = File.ReadAllText(fullPath);
-                }
-                catch (IOException)
-                {
-                    continue;
-                }
-                catch (UnauthorizedAccessException)
-                {
-                    continue;
-                }
-
-                if (_closedDocuments.TryGetValue(uri, out var existing)
-                    && string.Equals(existing.Source, source, StringComparison.Ordinal))
-                {
-                    _closedDocumentStamps[uri] = stamp;
-                    continue;
-                }
-
-                _closedDocuments[uri] = CreateAndAnalyze(uri, source, version: 0);
-                _closedDocumentStamps[uri] = stamp;
-                changed = true;
-            }
+            return new WorkspaceScanResult(roots, seen, files);
         }
-
-        foreach (var uri in _closedDocuments.Keys)
+        catch
         {
-            if (!seen.Contains(uri) && _closedDocuments.TryRemove(uri, out _))
+            DisposeScannedAnalyses(files);
+            throw;
+        }
+    }
+
+    private void ApplyWorkspaceScan(WorkspaceScanResult scan)
+    {
+        var changed = false;
+        lock (_indexGate)
+        {
+            lock (_registryGate)
             {
-                _closedDocumentStamps.TryRemove(uri, out _);
-                changed = true;
+                foreach (var file in scan.Files)
+                {
+                    if (_documents.ContainsKey(file.Uri))
+                    {
+                        file.Analysis?.Dispose();
+                        changed |= _closedDocuments.TryRemove(
+                            file.Uri,
+                            out var replacedOpen);
+                        replacedOpen?.Dispose();
+                        _closedDocumentStamps.TryRemove(file.Uri, out _);
+                        continue;
+                    }
+
+                    if (file.Analysis == null)
+                    {
+                        if (_closedDocuments.TryGetValue(file.Uri, out var existing)
+                            && string.Equals(
+                                existing.Snapshot.Source,
+                                file.Source,
+                                StringComparison.Ordinal))
+                        {
+                            _closedDocumentStamps[file.Uri] = file.Stamp;
+                        }
+                        continue;
+                    }
+
+                    if (_closedDocuments.TryGetValue(file.Uri, out var replaced))
+                        replaced.Dispose();
+                    _closedDocuments[file.Uri] = file.Analysis;
+                    _closedDocumentStamps[file.Uri] = file.Stamp;
+                    changed = true;
+                }
+
+                foreach (var uri in _closedDocuments.Keys)
+                {
+                    if (!scan.Seen.Contains(uri)
+                        && _closedDocuments.TryRemove(uri, out var removed))
+                    {
+                        removed.Dispose();
+                        _closedDocumentStamps.TryRemove(uri, out _);
+                        changed = true;
+                    }
+                }
+
+                if (changed)
+                {
+                    _workspaceGeneration++;
+                    _symbolIndex = null;
+                }
             }
         }
+    }
 
-        if (changed)
-        {
-            _workspaceGeneration++;
-            _symbolIndex = null;
-        }
+    private static void DisposeScannedAnalyses(
+        IEnumerable<ScannedWorkspaceFile> files)
+    {
+        foreach (var file in files)
+            file.Analysis?.Dispose();
     }
 
     private static IEnumerable<string> ExtractPreprocessorSymbols(string source)
@@ -1839,7 +2934,7 @@ public sealed class WorkspaceState
     }
 
     private static IReadOnlyList<CompilationError> GetAnalysisErrors(
-        DocumentAnalysisSnapshot analysis,
+        DocumentSnapshot analysis,
         Uri uri)
     {
         var path = uri.IsFile ? uri.LocalPath : uri.ToString();
@@ -2172,14 +3267,22 @@ public sealed class WorkspaceState
 
     private DocumentState CreateAndAnalyze(DocumentUri uri, string source, int version)
     {
-        var state = new DocumentState(
-            uri.ToUri(),
-            source,
-            version,
-            GetCanonicalSourceIdentity(uri.ToUri()));
+        var state = CreateDocumentState(uri, source, version);
         state.Reanalyze();
         return state;
     }
+
+    private DocumentState CreateDocumentState(
+        DocumentUri uri,
+        string source,
+        int version) =>
+        new(
+            uri.ToUri(),
+            source,
+            version,
+            GetCanonicalSourceIdentity(uri.ToUri()),
+            _logger,
+            failureInjector: null);
 
     private string GetCanonicalSourceIdentity(Uri uri)
     {
@@ -2210,29 +3313,30 @@ public sealed class WorkspaceState
     /// </summary>
     public (DocumentState? Doc, Calor.Compiler.Ast.AstNode? Node) FindDefinitionAcrossFiles(string name)
     {
-        foreach (var doc in _documents.Values)
+        foreach (var doc in CaptureSnapshot().Documents)
         {
-            if (doc.Ast == null) continue;
+            var ast = doc.Analysis.Ast;
+            if (ast == null) continue;
 
             // Check functions
-            var func = doc.Ast.Functions.FirstOrDefault(f => f.Name == name);
-            if (func != null) return (doc, func);
+            var func = ast.Functions.FirstOrDefault(f => f.Name == name);
+            if (func != null) return (doc.Document, func);
 
             // Check classes
-            var cls = doc.Ast.Classes.FirstOrDefault(c => c.Name == name);
-            if (cls != null) return (doc, cls);
+            var cls = ast.Classes.FirstOrDefault(c => c.Name == name);
+            if (cls != null) return (doc.Document, cls);
 
             // Check interfaces
-            var iface = doc.Ast.Interfaces.FirstOrDefault(i => i.Name == name);
-            if (iface != null) return (doc, iface);
+            var iface = ast.Interfaces.FirstOrDefault(i => i.Name == name);
+            if (iface != null) return (doc.Document, iface);
 
             // Check enums
-            var enumDef = doc.Ast.Enums.FirstOrDefault(e => e.Name == name);
-            if (enumDef != null) return (doc, enumDef);
+            var enumDef = ast.Enums.FirstOrDefault(e => e.Name == name);
+            if (enumDef != null) return (doc.Document, enumDef);
 
             // Check delegates
-            var del = doc.Ast.Delegates.FirstOrDefault(d => d.Name == name);
-            if (del != null) return (doc, del);
+            var del = ast.Delegates.FirstOrDefault(d => d.Name == name);
+            if (del != null) return (doc.Document, del);
         }
 
         return (null, null);
@@ -2243,56 +3347,81 @@ public sealed class WorkspaceState
     /// </summary>
     public (DocumentState? Doc, Calor.Compiler.Ast.AstNode? Node) FindMemberAcrossFiles(string typeName, string memberName)
     {
-        foreach (var doc in _documents.Values)
+        var workspace = CaptureSnapshot();
+        return FindMemberAcrossFiles(
+            workspace.Documents,
+            typeName,
+            memberName,
+            new HashSet<string>(StringComparer.Ordinal));
+    }
+
+    private static (DocumentState? Doc, Calor.Compiler.Ast.AstNode? Node)
+        FindMemberAcrossFiles(
+            IReadOnlyList<WorkspaceDocumentSnapshot> documents,
+            string typeName,
+            string memberName,
+            HashSet<string> visitedTypes)
+    {
+        var nominalType = GetNominalTypeName(typeName);
+        if (!visitedTypes.Add(nominalType))
+            return (null, null);
+
+        foreach (var doc in documents)
         {
-            if (doc.Ast == null) continue;
+            var ast = doc.Analysis.Ast;
+            if (ast == null) continue;
 
             // Check classes
-            var cls = doc.Ast.Classes.FirstOrDefault(c => c.Name == typeName);
+            var cls = ast.Classes.FirstOrDefault(c => c.Name == nominalType);
             if (cls != null)
             {
                 // Check fields
                 var field = cls.Fields.FirstOrDefault(f => f.Name == memberName);
-                if (field != null) return (doc, field);
+                if (field != null) return (doc.Document, field);
 
                 // Check properties
                 var prop = cls.Properties.FirstOrDefault(p => p.Name == memberName);
-                if (prop != null) return (doc, prop);
+                if (prop != null) return (doc.Document, prop);
 
                 // Check methods
                 var method = cls.Methods.FirstOrDefault(m => m.Name == memberName);
-                if (method != null) return (doc, method);
+                if (method != null) return (doc.Document, method);
 
                 // Check base class (recursively)
                 if (!string.IsNullOrEmpty(cls.BaseClass))
                 {
-                    var baseResult = FindMemberAcrossFiles(cls.BaseClass, memberName);
+                    var baseResult = FindMemberAcrossFiles(
+                        documents,
+                        cls.BaseClass,
+                        memberName,
+                        visitedTypes);
                     if (baseResult.Node != null) return baseResult;
                 }
             }
 
             // Check interfaces
-            var iface = doc.Ast.Interfaces.FirstOrDefault(i => i.Name == typeName);
+            var iface = ast.Interfaces.FirstOrDefault(i => i.Name == nominalType);
             if (iface != null)
             {
                 var method = iface.Methods.FirstOrDefault(m => m.Name == memberName);
-                if (method != null) return (doc, method);
+                if (method != null) return (doc.Document, method);
             }
 
             // Check enums for enum members
-            var enumDef = doc.Ast.Enums.FirstOrDefault(e => e.Name == typeName);
+            var enumDef = ast.Enums.FirstOrDefault(e => e.Name == nominalType);
             if (enumDef != null)
             {
                 var member = enumDef.Members.FirstOrDefault(m => m.Name == memberName);
-                if (member != null) return (doc, member);
+                if (member != null) return (doc.Document, member);
             }
 
             // Check enum extensions
-            var enumExt = doc.Ast.EnumExtensions.FirstOrDefault(e => e.EnumName == typeName);
+            var enumExt = ast.EnumExtensions.FirstOrDefault(
+                e => e.EnumName == nominalType);
             if (enumExt != null)
             {
                 var method = enumExt.Methods.FirstOrDefault(m => m.Name == memberName);
-                if (method != null) return (doc, method);
+                if (method != null) return (doc.Document, method);
             }
         }
 
@@ -2304,41 +3433,42 @@ public sealed class WorkspaceState
     /// </summary>
     public IEnumerable<(DocumentState Doc, string Name, string Kind, string? Type)> GetAllPublicSymbols()
     {
-        foreach (var doc in _documents.Values)
+        foreach (var doc in CaptureSnapshot().Documents)
         {
-            if (doc.Ast == null) continue;
+            var ast = doc.Analysis.Ast;
+            if (ast == null) continue;
 
             // Functions (public by default unless marked private)
-            foreach (var func in doc.Ast.Functions)
+            foreach (var func in ast.Functions)
             {
                 if (func.Visibility != Calor.Compiler.Ast.Visibility.Private)
                 {
-                    yield return (doc, func.Name, "function", func.Output?.TypeName ?? "void");
+                    yield return (doc.Document, func.Name, "function", func.Output?.TypeName ?? "void");
                 }
             }
 
             // Classes
-            foreach (var cls in doc.Ast.Classes)
+            foreach (var cls in ast.Classes)
             {
-                yield return (doc, cls.Name, "class", null);
+                yield return (doc.Document, cls.Name, "class", null);
             }
 
             // Interfaces
-            foreach (var iface in doc.Ast.Interfaces)
+            foreach (var iface in ast.Interfaces)
             {
-                yield return (doc, iface.Name, "interface", null);
+                yield return (doc.Document, iface.Name, "interface", null);
             }
 
             // Enums
-            foreach (var enumDef in doc.Ast.Enums)
+            foreach (var enumDef in ast.Enums)
             {
-                yield return (doc, enumDef.Name, "enum", enumDef.UnderlyingType);
+                yield return (doc.Document, enumDef.Name, "enum", enumDef.UnderlyingType);
             }
 
             // Delegates
-            foreach (var del in doc.Ast.Delegates)
+            foreach (var del in ast.Delegates)
             {
-                yield return (doc, del.Name, "delegate", del.Output?.TypeName ?? "void");
+                yield return (doc.Document, del.Name, "delegate", del.Output?.TypeName ?? "void");
             }
         }
     }

--- a/tests/Calor.LanguageServer.Tests/E2E/LspE2ETests.cs
+++ b/tests/Calor.LanguageServer.Tests/E2E/LspE2ETests.cs
@@ -1,410 +1,697 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Channels;
 using Xunit;
 using Xunit.Abstractions;
 
-#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods - these are test methods
-
 namespace Calor.LanguageServer.Tests.E2E;
 
-/// <summary>
-/// End-to-end tests that start the actual LSP server process and communicate via JSON-RPC.
-/// </summary>
-public class LspE2ETests : IDisposable
+public class LspE2ETests
 {
+    private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(10);
     private readonly ITestOutputHelper _output;
-    private Process? _serverProcess;
-    private StreamWriter? _serverInput;
-    private Stream? _serverOutput;
-    private int _messageId = 0;
 
     public LspE2ETests(ITestOutputHelper output)
     {
         _output = output;
     }
 
-    private async Task StartServerAsync()
-    {
-        // Find the LSP server DLL - check both Release and Debug configurations
-        var solutionDir = FindSolutionDirectory();
-        var releasePath = Path.Combine(solutionDir, "src", "Calor.LanguageServer", "bin", "Release", "net10.0", "calor-lsp.dll");
-        var debugPath = Path.Combine(solutionDir, "src", "Calor.LanguageServer", "bin", "Debug", "net10.0", "calor-lsp.dll");
-
-        // Prefer Release (used in CI) over Debug
-        var lspServerPath = File.Exists(releasePath) ? releasePath : debugPath;
-
-        if (!File.Exists(lspServerPath))
-        {
-            throw new InvalidOperationException($"LSP server not found. Checked:\n  {releasePath}\n  {debugPath}\nPlease build the solution first.");
-        }
-
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = "dotnet",
-            Arguments = $"\"{lspServerPath}\"",
-            UseShellExecute = false,
-            RedirectStandardInput = true,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true
-        };
-
-        _serverProcess = Process.Start(startInfo);
-        if (_serverProcess == null)
-        {
-            throw new InvalidOperationException("Failed to start LSP server process");
-        }
-
-        _serverInput = _serverProcess.StandardInput;
-        _serverOutput = _serverProcess.StandardOutput.BaseStream;
-
-        // Capture stderr for debugging
-        _serverProcess.ErrorDataReceived += (sender, e) =>
-        {
-            if (!string.IsNullOrEmpty(e.Data))
-            {
-                _output.WriteLine($"Server stderr: {e.Data}");
-            }
-        };
-        _serverProcess.BeginErrorReadLine();
-
-        // Give the server time to start - increased for reliability
-        await Task.Delay(2000);
-    }
-
-    private static string FindSolutionDirectory()
-    {
-        var dir = Directory.GetCurrentDirectory();
-        while (dir != null)
-        {
-            if (File.Exists(Path.Combine(dir, "Calor.sln")))
-            {
-                return dir;
-            }
-            dir = Directory.GetParent(dir)?.FullName;
-        }
-        throw new InvalidOperationException("Could not find solution directory");
-    }
-
-    private async Task<JsonDocument> SendRequestAsync(string method, object? @params = null)
-    {
-        var id = Interlocked.Increment(ref _messageId);
-        var message = new
-        {
-            jsonrpc = "2.0",
-            id,
-            method,
-            @params
-        };
-
-        var json = JsonSerializer.Serialize(message);
-        var contentLength = Encoding.UTF8.GetByteCount(json);
-        var header = $"Content-Length: {contentLength}\r\n\r\n";
-
-        _output.WriteLine($"Content-Length: {contentLength}, JSON length: {json.Length}");
-        _output.WriteLine($"Sending: {json}");
-
-        await _serverInput!.WriteAsync(header);
-        await _serverInput!.WriteAsync(json);
-        await _serverInput!.FlushAsync();
-
-        // Read responses until we get one with matching ID (skip notifications)
-        var maxAttempts = 10;
-        for (int attempt = 0; attempt < maxAttempts; attempt++)
-        {
-            var response = await ReadResponseAsync();
-            _output.WriteLine($"Received: {response}");
-
-            var doc = JsonDocument.Parse(response);
-
-            // Check if this is a response (has id) or a notification (no id)
-            if (doc.RootElement.TryGetProperty("id", out var responseId))
-            {
-                // It's a response - check if it matches our request
-                if (responseId.GetInt32() == id)
-                {
-                    return doc;
-                }
-            }
-            // If it's a notification (no id), continue reading
-        }
-
-        throw new InvalidOperationException($"Did not receive response for request {id} after {maxAttempts} attempts");
-    }
-
-    private async Task SendNotificationAsync(string method, object? @params = null)
-    {
-        var message = new
-        {
-            jsonrpc = "2.0",
-            method,
-            @params
-        };
-
-        var json = JsonSerializer.Serialize(message);
-        var contentLength = Encoding.UTF8.GetByteCount(json);
-        var header = $"Content-Length: {contentLength}\r\n\r\n";
-
-        _output.WriteLine($"Sending notification: {json}");
-
-        await _serverInput!.WriteAsync(header);
-        await _serverInput!.WriteAsync(json);
-        await _serverInput!.FlushAsync();
-    }
-
-    private async Task<string> ReadResponseAsync(int timeoutMs = 10000)
-    {
-        using var cts = new CancellationTokenSource(timeoutMs);
-        try
-        {
-            var output = _serverOutput ?? throw new InvalidOperationException("Server output is unavailable");
-            // Read headers
-            var headerLine = await ReadLineAsync(output, cts.Token);
-            if (headerLine == null)
-            {
-                throw new InvalidOperationException("Server closed connection");
-            }
-
-            // Parse Content-Length
-            var contentLengthPrefix = "Content-Length: ";
-            if (!headerLine.StartsWith(contentLengthPrefix))
-            {
-                throw new InvalidOperationException($"Expected Content-Length header, got: {headerLine}");
-            }
-
-            var contentLength = int.Parse(headerLine.Substring(contentLengthPrefix.Length));
-
-            // Read empty line
-            await ReadLineAsync(output, cts.Token);
-
-            // Content-Length is a byte count, not a UTF-16 character count.
-            var buffer = new byte[contentLength];
-            var totalRead = 0;
-            while (totalRead < contentLength)
-            {
-                var read = await output.ReadAsync(buffer.AsMemory(totalRead, contentLength - totalRead), cts.Token);
-                if (read == 0)
-                {
-                    throw new InvalidOperationException("Server closed connection while reading content");
-                }
-                totalRead += read;
-            }
-
-            return Encoding.UTF8.GetString(buffer);
-        }
-
-        catch (OperationCanceledException)
-        {
-            throw new TimeoutException($"Timed out after {timeoutMs}ms waiting for server response");
-        }
-    }
-
-    private static async Task<string?> ReadLineAsync(Stream stream, CancellationToken cancellationToken)
-    {
-        using var buffer = new MemoryStream();
-        var singleByte = new byte[1];
-        while (true)
-        {
-            var read = await stream.ReadAsync(singleByte, cancellationToken);
-            if (read == 0)
-                return buffer.Length == 0 ? null : Encoding.ASCII.GetString(buffer.ToArray());
-            if (singleByte[0] == (byte)'\n')
-            {
-                var bytes = buffer.ToArray();
-                var length = bytes.Length > 0 && bytes[^1] == (byte)'\r' ? bytes.Length - 1 : bytes.Length;
-                return Encoding.ASCII.GetString(bytes, 0, length);
-            }
-            buffer.WriteByte(singleByte[0]);
-        }
-    }
-
     [Fact]
-    public async Task InitializeAsync_ReturnsCapabilities()
+    public async Task Initialize_AdvertisesRealClientCapabilitiesAsync()
     {
-        await StartServerAsync();
+        await using var client = await LspClient.StartAsync(_output);
+        var initialize = await client.InitializeAsync();
+        var capabilities = initialize.GetProperty("capabilities");
 
-        // Note: Using empty capabilities due to OmniSharp library issue with textDocument processing
-        var response = await SendRequestAsync("initialize", new
-        {
-            processId = Environment.ProcessId,
-            rootUri = "file:///test",
-            capabilities = new { }
-        });
-
-        Assert.True(response.RootElement.TryGetProperty("result", out var result));
-        Assert.True(result.TryGetProperty("capabilities", out var capabilities));
         Assert.True(capabilities.TryGetProperty("textDocumentSync", out _));
+        Assert.True(capabilities.TryGetProperty("hoverProvider", out _));
+        Assert.True(capabilities.TryGetProperty("completionProvider", out _));
+        Assert.True(capabilities.TryGetProperty("definitionProvider", out _));
+        Assert.True(capabilities.TryGetProperty("referencesProvider", out _));
+        Assert.True(capabilities.TryGetProperty("renameProvider", out _));
+
+        await client.ShutdownAsync();
+        AssertProcessExited(client.ProcessId);
+    }
+
+    [Theory]
+    [InlineData(
+        """{"jsonrpc":"2.0","id":1,"method":"workspace/configuration","params":{}}""",
+        "Request")]
+    [InlineData(
+        """{"jsonrpc":"2.0","id":"server-1","method":"workspace/configuration","params":{}}""",
+        "Request")]
+    [InlineData(
+        """{"jsonrpc":"2.0","method":"window/logMessage","params":{}}""",
+        "Notification")]
+    [InlineData(
+        """{"jsonrpc":"2.0","id":1,"result":null}""",
+        "Response")]
+    public void JsonRpcDispatch_ClassifiesMethodBeforeCollidingResponseId(
+        string json,
+        string expected)
+    {
+        using var document = JsonDocument.Parse(json);
+        Assert.Equal(
+            expected,
+            LspClient.ClassifyMessage(document.RootElement).ToString());
+    }
+
+    [Theory]
+    [InlineData("""1""")]
+    [InlineData("\"server-request-1\"")]
+    public void JsonRpcServerResponse_PreservesNumericAndStringIds(string idJson)
+    {
+        using var id = JsonDocument.Parse(idJson);
+        var response = LspClient.CreateServerResponse(
+            id.RootElement,
+            result: null);
+
+        Assert.Equal(
+            id.RootElement.GetRawText(),
+            response.GetProperty("id").GetRawText());
     }
 
     [Fact]
-    public async Task TextDocumentOpenAsync_DoesNotCrash()
+    public async Task CoreCapabilityFlow_IsReadyBoundedAndLeakFreeAsync()
     {
-        await StartServerAsync();
+        const string uri = "file:///calor-lsp-e2e/main.calr";
+        const string source = """
+            §M{m001:TestModule}
+              §F{f001:Compute:pub} () -> i32
+                §R 42
+              §F{f002:Use:pub} () -> i32
+                §R §C{Compute} §/C
+            """;
+        await using var client = await LspClient.StartAsync(_output);
+        await client.InitializeAsync();
 
-        // Initialize first (using empty capabilities due to OmniSharp issue)
-        await SendRequestAsync("initialize", new
-        {
-            processId = Environment.ProcessId,
-            rootUri = "file:///test",
-            capabilities = new { }
-        });
+        await client.OpenAsync(uri, source, version: 1);
+        var initialDiagnostics = await client.WaitForDiagnosticsAsync(uri, version: 1);
+        Assert.Equal(0, initialDiagnostics.GetArrayLength());
 
-        // Send initialized notification
-        await SendNotificationAsync("initialized", new { });
-
-        // Open a document
-        await SendNotificationAsync("textDocument/didOpen", new
-        {
-            textDocument = new
+        var declaration = PositionOf(source, "Compute");
+        var reference = PositionOf(source, "Compute", occurrence: 2);
+        var hover = await client.RequestResultAsync(
+            "textDocument/hover",
+            new
             {
-                uri = "file:///test/test.calr",
-                languageId = "calor",
-                version = 1,
-                text = @"§M{m001:TestModule}
-  §F{f001:Test}
-    §R 0"
-            }
-        });
+                textDocument = new { uri },
+                position = declaration,
+            });
+        Assert.NotEqual(JsonValueKind.Null, hover.ValueKind);
+        Assert.Contains("Compute", hover.GetRawText(), StringComparison.Ordinal);
 
-        // Give it time to process
-        await Task.Delay(500);
-
-        // Server should still be running
-        Assert.False(_serverProcess!.HasExited);
-    }
-
-    [Fact]
-    public async Task HoverAsync_ReturnsInfo()
-    {
-        await StartServerAsync();
-
-        // Initialize (using empty capabilities due to OmniSharp issue with textDocument processing)
-        // Note: With empty capabilities, hover capability won't be advertised, but protocol still works
-        var initResponse = await SendRequestAsync("initialize", new
-        {
-            processId = Environment.ProcessId,
-            rootUri = "file:///test",
-            capabilities = new { }
-        });
-        _output.WriteLine($"Init result: {initResponse.RootElement}");
-        await SendNotificationAsync("initialized", new { });
-
-        // Open document
-        await SendNotificationAsync("textDocument/didOpen", new
-        {
-            textDocument = new
+        var definition = await client.RequestResultAsync(
+            "textDocument/definition",
+            new
             {
-                uri = "file:///test/test.calr",
-                languageId = "calor",
-                version = 1,
-                text = @"§M{m001:TestModule}
-  §F{f001:Add}
-    §I{i32:a}
-    §O{i32}
-    §R a"
-            }
-        });
+                textDocument = new { uri },
+                position = reference,
+            });
+        Assert.Contains("main.calr", definition.GetRawText(), StringComparison.Ordinal);
 
-        await Task.Delay(500);
-
-        // Request hover
-        var response = await SendRequestAsync("textDocument/hover", new
-        {
-            textDocument = new { uri = "file:///test/test.calr" },
-            position = new { line = 1, character = 11 }
-        });
-
-        Assert.True(response.RootElement.TryGetProperty("result", out var result));
-        Assert.NotEqual(JsonValueKind.Null, result.ValueKind);
-        Assert.Contains("Add", result.GetRawText(), StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public async Task CompletionAsync_ReturnsItems()
-    {
-        await StartServerAsync();
-
-        // Initialize (using empty capabilities due to OmniSharp issue)
-        await SendRequestAsync("initialize", new
-        {
-            processId = Environment.ProcessId,
-            rootUri = "file:///test",
-            capabilities = new { }
-        });
-        await SendNotificationAsync("initialized", new { });
-
-        // Open document
-        await SendNotificationAsync("textDocument/didOpen", new
-        {
-            textDocument = new
+        var references = await client.RequestResultAsync(
+            "textDocument/references",
+            new
             {
-                uri = "file:///test/test.calr",
-                languageId = "calor",
-                version = 1,
-                text = "§"
-            }
-        });
+                textDocument = new { uri },
+                position = declaration,
+                context = new { includeDeclaration = true },
+            });
+        Assert.Equal(2, references.GetArrayLength());
 
-        await Task.Delay(500);
+        var rename = await client.RequestResultAsync(
+            "textDocument/rename",
+            new
+            {
+                textDocument = new { uri },
+                position = declaration,
+                newName = "Calculate",
+            });
+        Assert.Contains("Calculate", rename.GetRawText(), StringComparison.Ordinal);
+        Assert.Equal(
+            2,
+            rename.GetProperty("documentChanges")[0]
+                .GetProperty("edits")
+                .GetArrayLength());
 
-        // Request completion
-        var response = await SendRequestAsync("textDocument/completion", new
-        {
-            textDocument = new { uri = "file:///test/test.calr" },
-            position = new { line = 0, character = 1 } // Right after §
-        });
+        const string changedSource = """
+            §M{m001:TestModule}
+              §F{f001:Calculate:pub} () -> i32
+                §R 42
+              §F{f002:Use:pub} () -> i32
+                §R §C{Calculate} §/C
+            """;
+        await client.ChangeAsync(uri, changedSource, version: 2);
+        var changedDiagnostics = await client.WaitForDiagnosticsAsync(uri, version: 2);
+        Assert.Equal(0, changedDiagnostics.GetArrayLength());
 
-        Assert.True(response.RootElement.TryGetProperty("result", out var result));
-        Assert.Equal(JsonValueKind.Array, result.ValueKind);
-        Assert.NotEmpty(result.EnumerateArray());
+        const string completionUri = "file:///calor-lsp-e2e/completion.calr";
+        await client.OpenAsync(completionUri, "§", version: 1);
+        await client.WaitForDiagnosticsAsync(completionUri, version: 1);
+        var completion = await client.RequestResultAsync(
+            "textDocument/completion",
+            new
+            {
+                textDocument = new { uri = completionUri },
+                position = new { line = 0, character = 1 },
+            });
+        var completionItems = completion.ValueKind == JsonValueKind.Array
+            ? completion
+            : completion.GetProperty("items");
         Assert.Contains(
-            result.EnumerateArray(),
-            item => item.TryGetProperty("label", out var label) && label.GetString() == "§M");
+            completionItems.EnumerateArray(),
+            item => item.GetProperty("label").GetString() == "§M");
+
+        const string diagnosticUri = "file:///calor-lsp-e2e/diagnostics.calr";
+        await client.OpenAsync(
+            diagnosticUri,
+            "§M{m003:Broken}\n  §UNKNOWN_TOKEN_XYZ",
+            version: 1);
+        var errors = await client.WaitForDiagnosticsAsync(diagnosticUri, version: 1);
+        Assert.Contains(errors.EnumerateArray(), diagnostic =>
+            diagnostic.GetProperty("severity").GetInt32() == 1);
+        await client.ChangeAsync(
+            diagnosticUri,
+            "§M{m003:Fixed}\n",
+            version: 2);
+        var cleared = await client.WaitForDiagnosticsAsync(diagnosticUri, version: 2);
+        Assert.Equal(0, cleared.GetArrayLength());
+
+        await client.ShutdownAsync();
+        AssertProcessExited(client.ProcessId);
     }
 
-    [Fact]
-    public async Task ShutdownAsync_ExitsGracefully()
+    private static object PositionOf(
+        string source,
+        string value,
+        int occurrence = 1)
     {
-        await StartServerAsync();
-
-        // Initialize (using empty capabilities due to OmniSharp issue)
-        await SendRequestAsync("initialize", new
+        var offset = -1;
+        for (var index = 0; index < occurrence; index++)
         {
-            processId = Environment.ProcessId,
-            rootUri = "file:///test",
-            capabilities = new { }
-        });
-        await SendNotificationAsync("initialized", new { });
+            offset = source.IndexOf(value, offset + 1, StringComparison.Ordinal);
+            if (offset < 0)
+                throw new InvalidOperationException($"'{value}' occurrence {occurrence} not found.");
+        }
 
-        // Shutdown
-        var response = await SendRequestAsync("shutdown");
-        Assert.True(response.RootElement.TryGetProperty("result", out _));
-
-        // Exit
-        await SendNotificationAsync("exit");
-
-        // Wait for process to exit
-        var exited = _serverProcess!.WaitForExit(5000);
-        Assert.True(exited);
-        Assert.Equal(0, _serverProcess.ExitCode);
-    }
-
-    public void Dispose()
-    {
-        try
+        var line = 0;
+        var character = 0;
+        for (var index = 0; index < offset; index++)
         {
-            _serverInput?.Dispose();
-            _serverOutput?.Dispose();
-            if (_serverProcess != null && !_serverProcess.HasExited)
+            if (source[index] == '\n')
             {
-                _serverProcess.Kill();
-                _serverProcess.Dispose();
+                line++;
+                character = 0;
+            }
+            else
+            {
+                character++;
             }
         }
-        catch
+
+        return new { line, character };
+    }
+
+    private static void AssertProcessExited(int processId)
+    {
+        Assert.Throws<ArgumentException>(() => Process.GetProcessById(processId));
+    }
+
+    private sealed class LspClient : IAsyncDisposable
+    {
+        internal enum JsonRpcMessageKind
         {
-            // Ignore dispose errors
+            Invalid,
+            Request,
+            Notification,
+            Response,
+        }
+
+        private readonly ITestOutputHelper _output;
+        private readonly Process _process;
+        private readonly Stream _input;
+        private readonly Stream _outputStream;
+        private readonly SemaphoreSlim _writeGate = new(1, 1);
+        private readonly ConcurrentDictionary<
+            string,
+            TaskCompletionSource<JsonElement>> _pending = new();
+        private readonly Channel<(string Method, JsonElement Params)> _notifications =
+            Channel.CreateUnbounded<(string Method, JsonElement Params)>(
+                new UnboundedChannelOptions
+                {
+                    SingleReader = true,
+                    SingleWriter = true,
+                });
+        private readonly CancellationTokenSource _readerCancellation = new();
+        private readonly Task _readerTask;
+        private int _messageId;
+        private bool _shutdown;
+
+        private LspClient(Process process, ITestOutputHelper output)
+        {
+            _process = process;
+            _output = output;
+            _input = process.StandardInput.BaseStream;
+            _outputStream = process.StandardOutput.BaseStream;
+            process.ErrorDataReceived += (_, eventArgs) =>
+            {
+                if (!string.IsNullOrWhiteSpace(eventArgs.Data))
+                    output.WriteLine($"server stderr: {eventArgs.Data}");
+            };
+            process.BeginErrorReadLine();
+            _readerTask = ReadMessagesAsync();
+        }
+
+        public int ProcessId => _process.Id;
+
+        public static Task<LspClient> StartAsync(ITestOutputHelper output)
+        {
+            var serverPath = Path.Combine(AppContext.BaseDirectory, "calor-lsp.dll");
+            if (!File.Exists(serverPath))
+            {
+                throw new InvalidOperationException(
+                    $"LSP server not found at '{serverPath}'. Build the test project first.");
+            }
+
+            var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                ArgumentList = { serverPath },
+                UseShellExecute = false,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            }) ?? throw new InvalidOperationException("Failed to start the LSP server.");
+            return Task.FromResult(new LspClient(process, output));
+        }
+
+        public async Task<JsonElement> InitializeAsync()
+        {
+            var result = await RequestResultAsync(
+                "initialize",
+                new
+                {
+                    processId = Environment.ProcessId,
+                    rootUri = "file:///calor-lsp-e2e",
+                    capabilities = new
+                    {
+                        workspace = new
+                        {
+                            workspaceFolders = true,
+                            configuration = false,
+                            symbol = new { dynamicRegistration = false },
+                        },
+                        textDocument = new
+                        {
+                            synchronization = new
+                            {
+                                dynamicRegistration = false,
+                                didSave = true,
+                            },
+                            hover = new
+                            {
+                                dynamicRegistration = false,
+                                contentFormat = new[] { "markdown", "plaintext" },
+                            },
+                            completion = new
+                            {
+                                dynamicRegistration = false,
+                                completionItem = new
+                                {
+                                    snippetSupport = true,
+                                    documentationFormat = new[] { "markdown", "plaintext" },
+                                },
+                            },
+                            definition = new { dynamicRegistration = false },
+                            references = new { dynamicRegistration = false },
+                            rename = new
+                            {
+                                dynamicRegistration = false,
+                                prepareSupport = false,
+                            },
+                            publishDiagnostics = new
+                            {
+                                relatedInformation = true,
+                                versionSupport = true,
+                            },
+                        },
+                    },
+                    workspaceFolders = new[]
+                    {
+                        new
+                        {
+                            uri = "file:///calor-lsp-e2e",
+                            name = "calor-lsp-e2e",
+                        },
+                    },
+                });
+            await SendNotificationAsync("initialized", new { });
+            return result;
+        }
+
+        public Task OpenAsync(string uri, string text, int version) =>
+            SendNotificationAsync(
+                "textDocument/didOpen",
+                new
+                {
+                    textDocument = new
+                    {
+                        uri,
+                        languageId = "calor",
+                        version,
+                        text,
+                    },
+                });
+
+        public Task ChangeAsync(string uri, string text, int version) =>
+            SendNotificationAsync(
+                "textDocument/didChange",
+                new
+                {
+                    textDocument = new { uri, version },
+                    contentChanges = new[] { new { text } },
+                });
+
+        public async Task<JsonElement> WaitForDiagnosticsAsync(
+            string uri,
+            int version)
+        {
+            var message = await WaitForNotificationAsync(
+                "textDocument/publishDiagnostics",
+                parameters =>
+                    parameters.GetProperty("uri").GetString() == uri
+                    && parameters.TryGetProperty(
+                        "version",
+                        out var publishedVersion)
+                    && publishedVersion.GetInt32() == version);
+            return message.GetProperty("diagnostics");
+        }
+
+        public async Task<JsonElement> RequestResultAsync(
+            string method,
+            object? parameters = null)
+        {
+            var id = Interlocked.Increment(ref _messageId);
+            var completion = new TaskCompletionSource<JsonElement>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var idKey = $"n:{id}";
+            if (!_pending.TryAdd(idKey, completion))
+                throw new InvalidOperationException($"Duplicate JSON-RPC id {id}.");
+
+            try
+            {
+                await WriteMessageAsync(new
+                {
+                    jsonrpc = "2.0",
+                    id,
+                    method,
+                    @params = parameters,
+                });
+                var response = await completion.Task.WaitAsync(RequestTimeout);
+                if (response.TryGetProperty("error", out var error))
+                {
+                    throw new InvalidOperationException(
+                        $"JSON-RPC {method} failed: {error.GetRawText()}");
+                }
+                return response.TryGetProperty("result", out var result)
+                    ? result.Clone()
+                    : default;
+            }
+            finally
+            {
+                _pending.TryRemove(idKey, out _);
+            }
+        }
+
+        public Task SendNotificationAsync(
+            string method,
+            object? parameters = null) =>
+            WriteMessageAsync(new
+            {
+                jsonrpc = "2.0",
+                method,
+                @params = parameters,
+            });
+
+        public async Task ShutdownAsync()
+        {
+            if (_shutdown)
+                return;
+            _shutdown = true;
+            await RequestResultAsync("shutdown");
+            await SendNotificationAsync("exit");
+            await _process.WaitForExitAsync().WaitAsync(RequestTimeout);
+            Assert.Equal(0, _process.ExitCode);
+            await _readerTask.WaitAsync(RequestTimeout);
+        }
+
+        private async Task<JsonElement> WaitForNotificationAsync(
+            string method,
+            Func<JsonElement, bool> predicate)
+        {
+            using var timeout = new CancellationTokenSource(RequestTimeout);
+            await foreach (var notification in _notifications.Reader.ReadAllAsync(
+                               timeout.Token))
+            {
+                if (notification.Method == method
+                    && predicate(notification.Params))
+                {
+                    return notification.Params;
+                }
+            }
+
+            throw new InvalidOperationException(
+                $"Notification '{method}' channel completed before a match arrived.");
+        }
+
+        private async Task ReadMessagesAsync()
+        {
+            try
+            {
+                while (!_readerCancellation.IsCancellationRequested)
+                {
+                    var message = await ReadMessageAsync(_readerCancellation.Token);
+                    if (message == null)
+                        break;
+                    using (message)
+                    {
+                        var root = message.RootElement;
+                        switch (ClassifyMessage(root))
+                        {
+                            case JsonRpcMessageKind.Request:
+                                var requestId = root.GetProperty("id");
+                                var methodName = root.GetProperty("method").GetString()
+                                    ?? throw new InvalidDataException(
+                                        "JSON-RPC request method was not a string.");
+                                await WriteMessageAsync(CreateServerResponse(
+                                    requestId,
+                                    GetServerRequestResult(methodName)));
+                                break;
+
+                            case JsonRpcMessageKind.Notification:
+                                var method = root.GetProperty("method").GetString()
+                                    ?? throw new InvalidDataException(
+                                        "JSON-RPC notification method was not a string.");
+                                var parameters = root.TryGetProperty(
+                                    "params",
+                                    out var parameterElement)
+                                    ? parameterElement.Clone()
+                                    : JsonSerializer.SerializeToElement(new { });
+                                await _notifications.Writer.WriteAsync(
+                                    (method, parameters),
+                                    _readerCancellation.Token);
+                                break;
+
+                            case JsonRpcMessageKind.Response:
+                                var responseId = root.GetProperty("id");
+                                var responseKey = GetIdKey(responseId);
+                                if (responseKey != null
+                                    && _pending.TryGetValue(
+                                        responseKey,
+                                        out var pending))
+                                {
+                                    pending.TrySetResult(root.Clone());
+                                }
+                                break;
+
+                            default:
+                                throw new InvalidDataException(
+                                    $"Invalid JSON-RPC message: {root.GetRawText()}");
+                        }
+                    }
+                }
+            }
+
+            catch (OperationCanceledException) when (_readerCancellation.IsCancellationRequested)
+            {
+            }
+            catch (Exception exception)
+            {
+                _output.WriteLine($"LSP reader failed: {exception}");
+                foreach (var pending in _pending.Values)
+                    pending.TrySetException(exception);
+            }
+            finally
+            {
+                _notifications.Writer.TryComplete();
+                foreach (var pending in _pending.Values)
+                {
+                    pending.TrySetException(
+                        new EndOfStreamException("The LSP server closed its output."));
+                }
+            }
+        }
+
+        internal static JsonRpcMessageKind ClassifyMessage(JsonElement message)
+        {
+            if (message.TryGetProperty("method", out var method)
+                && method.ValueKind == JsonValueKind.String)
+            {
+                return message.TryGetProperty("id", out _)
+                    ? JsonRpcMessageKind.Request
+                    : JsonRpcMessageKind.Notification;
+            }
+
+            return message.TryGetProperty("id", out _)
+                ? JsonRpcMessageKind.Response
+                : JsonRpcMessageKind.Invalid;
+        }
+
+        internal static JsonElement CreateServerResponse(
+            JsonElement id,
+            object? result) =>
+            JsonSerializer.SerializeToElement(
+                new Dictionary<string, object?>
+                {
+                    ["jsonrpc"] = "2.0",
+                    ["id"] = id.Clone(),
+                    ["result"] = result,
+                });
+
+        private static string? GetIdKey(JsonElement id) => id.ValueKind switch
+        {
+            JsonValueKind.Number => $"n:{id.GetRawText()}",
+            JsonValueKind.String => $"s:{id.GetString()}",
+            _ => null,
+        };
+
+        private static object? GetServerRequestResult(string method) =>
+            method == "workspace/configuration"
+                ? Array.Empty<object?>()
+                : null;
+
+        private async Task<JsonDocument?> ReadMessageAsync(
+            CancellationToken cancellationToken)
+        {
+            int? contentLength = null;
+            while (true)
+            {
+                var header = await ReadLineAsync(_outputStream, cancellationToken);
+                if (header == null)
+                    return null;
+                if (header.Length == 0)
+                    break;
+                const string prefix = "Content-Length:";
+                if (header.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    contentLength = int.Parse(
+                        header[prefix.Length..].Trim(),
+                        System.Globalization.CultureInfo.InvariantCulture);
+                }
+            }
+
+            if (contentLength is not > 0)
+                throw new InvalidDataException("JSON-RPC message omitted Content-Length.");
+            var bytes = new byte[contentLength.Value];
+            await _outputStream.ReadExactlyAsync(bytes, cancellationToken);
+            return JsonDocument.Parse(bytes);
+        }
+
+        private async Task WriteMessageAsync(object message)
+        {
+            var bytes = JsonSerializer.SerializeToUtf8Bytes(message);
+            var header = Encoding.ASCII.GetBytes(
+                $"Content-Length: {bytes.Length}\r\n\r\n");
+            await _writeGate.WaitAsync().WaitAsync(RequestTimeout);
+            try
+            {
+                await _input.WriteAsync(header).AsTask().WaitAsync(RequestTimeout);
+                await _input.WriteAsync(bytes).AsTask().WaitAsync(RequestTimeout);
+                await _input.FlushAsync().WaitAsync(RequestTimeout);
+            }
+            finally
+            {
+                _writeGate.Release();
+            }
+        }
+
+        private static async Task<string?> ReadLineAsync(
+            Stream stream,
+            CancellationToken cancellationToken)
+        {
+            using var bytes = new MemoryStream();
+            var buffer = new byte[1];
+            while (true)
+            {
+                var read = await stream.ReadAsync(buffer, cancellationToken);
+                if (read == 0)
+                    return bytes.Length == 0
+                        ? null
+                        : Encoding.ASCII.GetString(bytes.ToArray());
+                if (buffer[0] == (byte)'\n')
+                {
+                    var line = bytes.ToArray();
+                    var length = line.Length > 0 && line[^1] == (byte)'\r'
+                        ? line.Length - 1
+                        : line.Length;
+                    return Encoding.ASCII.GetString(line, 0, length);
+                }
+                bytes.WriteByte(buffer[0]);
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                if (!_shutdown && !_process.HasExited)
+                {
+                    try
+                    {
+                        await ShutdownAsync();
+                    }
+                    catch (Exception exception)
+                    {
+                        _output.WriteLine($"Graceful LSP shutdown failed: {exception.Message}");
+                    }
+                }
+            }
+            finally
+            {
+                if (!_process.HasExited)
+                {
+                    _process.Kill(entireProcessTree: true);
+                    await _process.WaitForExitAsync().WaitAsync(RequestTimeout);
+                }
+                await _readerCancellation.CancelAsync();
+                try
+                {
+                    await _readerTask.WaitAsync(RequestTimeout);
+                }
+                catch (Exception)
+                {
+                }
+                _readerCancellation.Dispose();
+                _writeGate.Dispose();
+                _input.Dispose();
+                _outputStream.Dispose();
+                _process.Dispose();
+            }
         }
     }
 }

--- a/tests/Calor.LanguageServer.Tests/Helpers/LspTestHarness.cs
+++ b/tests/Calor.LanguageServer.Tests/Helpers/LspTestHarness.cs
@@ -70,7 +70,7 @@ public static class LspTestHarness
     /// <summary>
     /// Compiles source and returns diagnostics.
     /// </summary>
-    public static DiagnosticBag GetDiagnostics(string source)
+    public static ImmutableDiagnostics GetDiagnostics(string source)
     {
         var state = CreateDocument(source);
         return state.Diagnostics;
@@ -79,7 +79,7 @@ public static class LspTestHarness
     /// <summary>
     /// Compiles source and returns diagnostics with fixes.
     /// </summary>
-    public static List<DiagnosticWithFix> GetDiagnosticsWithFixes(string source)
+    public static IReadOnlyList<DiagnosticWithFix> GetDiagnosticsWithFixes(string source)
     {
         var state = CreateDocument(source);
         return state.DiagnosticsWithFixes;

--- a/tests/Calor.LanguageServer.Tests/Integration/CrossFileResolutionTests.cs
+++ b/tests/Calor.LanguageServer.Tests/Integration/CrossFileResolutionTests.cs
@@ -2,6 +2,7 @@ using Calor.Compiler.Binding;
 using Calor.LanguageServer.State;
 using Calor.LanguageServer.Tests.Helpers;
 using Calor.LanguageServer.Utilities;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using Xunit;
 
@@ -1036,6 +1037,818 @@ public class CrossFileResolutionTests
     }
 
     [Fact]
+    public async Task DirectCrossFileInheritanceCycle_IsDeterministicAndTraversalTerminatesAsync()
+    {
+        var workspace = new WorkspaceState();
+        var aUri = DocumentUri.From("file:///cycle-a.calr");
+        var bUri = DocumentUri.From("file:///cycle-b.calr");
+        workspace.GetOrCreate(aUri, """
+            §M{m001:CycleA}
+              §CL{c001:A}
+                §EXT{B}
+            """);
+        workspace.GetOrCreate(bUri, """
+            §M{m002:CycleB}
+              §CL{c002:B}
+                §EXT{A}
+            """);
+
+        var snapshot = workspace.CaptureSnapshot();
+        var aDiagnostic = Assert.Single(
+            workspace.GetDiagnostics(snapshot, snapshot.GetDocument(aUri)!)
+                .Where(diagnostic =>
+                    diagnostic.Code == Compiler.Diagnostics.DiagnosticCode.InheritanceCycle));
+        var bDiagnostic = Assert.Single(
+            workspace.GetDiagnostics(snapshot, snapshot.GetDocument(bUri)!)
+                .Where(diagnostic =>
+                    diagnostic.Code == Compiler.Diagnostics.DiagnosticCode.InheritanceCycle));
+
+        Assert.Equal("Inheritance cycle detected: A -> B -> A.", aDiagnostic.Message);
+        Assert.Equal(aDiagnostic.Message, bDiagnostic.Message);
+        var result = await Task.Run(() =>
+                workspace.FindMemberAcrossFiles("A", "missing"))
+            .WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Null(result.Doc);
+        Assert.Null(result.Node);
+    }
+
+    [Fact]
+    public async Task IndirectCrossFileInheritanceCycle_IsCanonicalAcrossAllFilesAsync()
+    {
+        var workspace = new WorkspaceState();
+        var aUri = DocumentUri.From("file:///indirect-a.calr");
+        var bUri = DocumentUri.From("file:///indirect-b.calr");
+        var cUri = DocumentUri.From("file:///indirect-c.calr");
+        workspace.GetOrCreate(aUri, """
+            §M{m001:CycleA}
+              §CL{c001:A}
+                §EXT{B}
+            """);
+        workspace.GetOrCreate(bUri, """
+            §M{m002:CycleB}
+              §CL{c002:B}
+                §EXT{C}
+            """);
+        workspace.GetOrCreate(cUri, """
+            §M{m003:CycleC}
+              §CL{c003:C}
+                §EXT{A}
+            """);
+
+        var snapshot = workspace.CaptureSnapshot();
+        var messages = new[] { aUri, bUri, cUri }
+            .Select(uri => Assert.Single(
+                workspace.GetDiagnostics(snapshot, snapshot.GetDocument(uri)!)
+                    .Where(diagnostic =>
+                        diagnostic.Code == Compiler.Diagnostics.DiagnosticCode.InheritanceCycle))
+                .Message)
+            .ToArray();
+
+        Assert.All(messages, message =>
+            Assert.Equal(
+                "Inheritance cycle detected: A -> B -> C -> A.",
+                message));
+        var result = await Task.Run(() =>
+                workspace.FindMemberAcrossFiles("B", "missing"))
+            .WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Null(result.Doc);
+        Assert.Null(result.Node);
+    }
+
+    [Fact]
+    public void QualifiedCrossFileInheritanceCycle_ResolvesModuleQualifiedBases()
+    {
+        var workspace = new WorkspaceState();
+        var aUri = DocumentUri.From("file:///qualified-cycle-a.calr");
+        var bUri = DocumentUri.From("file:///qualified-cycle-b.calr");
+        workspace.GetOrCreate(aUri, """
+            §M{m001:CycleA}
+              §CL{c001:A}
+                §EXT{CycleB.B}
+            """);
+        workspace.GetOrCreate(bUri, """
+            §M{m002:CycleB}
+              §CL{c002:B}
+                §EXT{CycleA.A}
+            """);
+
+        var snapshot = workspace.CaptureSnapshot();
+        var diagnostics = new[] { aUri, bUri }
+            .Select(uri => Assert.Single(
+                workspace.GetDiagnostics(snapshot, snapshot.GetDocument(uri)!)
+                    .Where(diagnostic =>
+                        diagnostic.Code == Compiler.Diagnostics.DiagnosticCode.InheritanceCycle)))
+            .ToArray();
+
+        Assert.All(diagnostics, diagnostic =>
+            Assert.Equal("Inheritance cycle detected: A -> B -> A.", diagnostic.Message));
+    }
+
+    [Fact]
+    public void DistinctSameDisplayInheritanceCycles_AreNotDeduplicatedByMessage()
+    {
+        var workspace = new WorkspaceState();
+        var sources = new Dictionary<DocumentUri, string>
+        {
+            [DocumentUri.From("file:///left-a.calr")] = """
+                §M{m001:LeftA}
+                  §CL{c001:A}
+                    §EXT{LeftB.B}
+                """,
+            [DocumentUri.From("file:///left-b.calr")] = """
+                §M{m002:LeftB}
+                  §CL{c002:B}
+                    §EXT{LeftA.A}
+                """,
+            [DocumentUri.From("file:///right-a.calr")] = """
+                §M{m003:RightA}
+                  §CL{c003:A}
+                    §EXT{RightB.B}
+                """,
+            [DocumentUri.From("file:///right-b.calr")] = """
+                §M{m004:RightB}
+                  §CL{c004:B}
+                    §EXT{RightA.A}
+                """,
+        };
+        foreach (var (uri, source) in sources)
+            workspace.GetOrCreate(uri, source);
+
+        var snapshot = workspace.CaptureSnapshot();
+        var diagnostics = sources.Keys
+            .Select(uri => Assert.Single(
+                workspace.GetDiagnostics(snapshot, snapshot.GetDocument(uri)!)
+                    .Where(diagnostic =>
+                        diagnostic.Code == Compiler.Diagnostics.DiagnosticCode.InheritanceCycle)))
+            .ToArray();
+
+        Assert.Equal(4, diagnostics.Length);
+        Assert.All(diagnostics, diagnostic =>
+            Assert.Equal("Inheritance cycle detected: A -> B -> A.", diagnostic.Message));
+    }
+
+    [Fact]
+    public void DirectCrossFilePartialInheritanceCycle_DiagnosesEveryPart()
+    {
+        var workspace = new WorkspaceState();
+        var sources = new Dictionary<DocumentUri, string>
+        {
+            [DocumentUri.From("file:///partial-a-base.calr")] = """
+                §M{ma1:CycleA}
+                  §CL{a1:A:pub:partial}
+                    §EXT{CycleB.B}
+                """,
+            [DocumentUri.From("file:///partial-a-members.calr")] = """
+                §M{ma2:CycleA}
+                  §CL{a2:A:pub:partial}
+                    §FLD{i32:value}
+                """,
+            [DocumentUri.From("file:///partial-b-base.calr")] = """
+                §M{mb1:CycleB}
+                  §CL{b1:B:pub:partial}
+                    §EXT{CycleA.A}
+                """,
+            [DocumentUri.From("file:///partial-b-members.calr")] = """
+                §M{mb2:CycleB}
+                  §CL{b2:B:pub:partial}
+                    §FLD{i32:value}
+                """,
+        };
+        foreach (var (uri, source) in sources)
+            workspace.GetOrCreate(uri, source);
+
+        var snapshot = workspace.CaptureSnapshot();
+        var diagnostics = sources.Keys
+            .Select(uri => Assert.Single(
+                workspace.GetDiagnostics(snapshot, snapshot.GetDocument(uri)!)
+                    .Where(diagnostic =>
+                        diagnostic.Code == Compiler.Diagnostics.DiagnosticCode.InheritanceCycle)))
+            .ToArray();
+
+        Assert.Equal(4, diagnostics.Length);
+        Assert.All(diagnostics, diagnostic =>
+            Assert.Equal("Inheritance cycle detected: A -> B -> A.", diagnostic.Message));
+    }
+
+    [Fact]
+    public void IndirectCrossFilePartialInheritanceCycle_DiagnosesEveryPart()
+    {
+        var workspace = new WorkspaceState();
+        var sources = new Dictionary<DocumentUri, string>
+        {
+            [DocumentUri.From("file:///partial-indirect-a-base.calr")] = """
+                §M{ma1:CycleA}
+                  §CL{a1:A:pub:partial}
+                    §EXT{CycleB.B}
+                """,
+            [DocumentUri.From("file:///partial-indirect-a-part.calr")] = """
+                §M{ma2:CycleA}
+                  §CL{a2:A:pub:partial}
+                """,
+            [DocumentUri.From("file:///partial-indirect-b-base.calr")] = """
+                §M{mb1:CycleB}
+                  §CL{b1:B:pub:partial}
+                    §EXT{CycleC.C}
+                """,
+            [DocumentUri.From("file:///partial-indirect-b-part.calr")] = """
+                §M{mb2:CycleB}
+                  §CL{b2:B:pub:partial}
+                """,
+            [DocumentUri.From("file:///partial-indirect-c-base.calr")] = """
+                §M{mc1:CycleC}
+                  §CL{c1:C:pub:partial}
+                    §EXT{CycleA.A}
+                """,
+            [DocumentUri.From("file:///partial-indirect-c-part.calr")] = """
+                §M{mc2:CycleC}
+                  §CL{c2:C:pub:partial}
+                """,
+        };
+        foreach (var (uri, source) in sources)
+            workspace.GetOrCreate(uri, source);
+
+        var snapshot = workspace.CaptureSnapshot();
+        var diagnostics = sources.Keys
+            .Select(uri => Assert.Single(
+                workspace.GetDiagnostics(snapshot, snapshot.GetDocument(uri)!)
+                    .Where(diagnostic =>
+                        diagnostic.Code == Compiler.Diagnostics.DiagnosticCode.InheritanceCycle)))
+            .ToArray();
+
+        Assert.Equal(6, diagnostics.Length);
+        Assert.All(diagnostics, diagnostic =>
+            Assert.Equal(
+                "Inheritance cycle detected: A -> B -> C -> A.",
+                diagnostic.Message));
+    }
+
+    [Fact]
+    public void NonPartialDuplicateDeclarations_AreNotMergedIntoInheritanceGraph()
+    {
+        var workspace = new WorkspaceState();
+        var sources = new Dictionary<DocumentUri, string>
+        {
+            [DocumentUri.From("file:///duplicate-a-one.calr")] = """
+                §M{ma1:Duplicate}
+                  §CL{a1:A:pub}
+                    §EXT{Other.B}
+                """,
+            [DocumentUri.From("file:///duplicate-a-two.calr")] = """
+                §M{ma2:Duplicate}
+                  §CL{a2:A:pub}
+                """,
+            [DocumentUri.From("file:///duplicate-b.calr")] = """
+                §M{mb1:Other}
+                  §CL{b1:B:pub}
+                    §EXT{Duplicate.A}
+                """,
+        };
+        foreach (var (uri, source) in sources)
+            workspace.GetOrCreate(uri, source);
+
+        var snapshot = workspace.CaptureSnapshot();
+        Assert.All(sources.Keys, uri =>
+            Assert.DoesNotContain(
+                workspace.GetDiagnostics(snapshot, snapshot.GetDocument(uri)!),
+                diagnostic =>
+                    diagnostic.Code == Compiler.Diagnostics.DiagnosticCode.InheritanceCycle));
+    }
+
+    [Fact]
+    public void GenericInheritanceCycles_ResolveMatchingArityOnly()
+    {
+        var workspace = new WorkspaceState();
+        var sources = new Dictionary<DocumentUri, string>
+        {
+            [DocumentUri.From("file:///generic-foo-one.calr")] = """
+                §M{m1:Generic}
+                  §CL{f1:Foo:pub}<T>
+                    §EXT{Generic.Bar<T>}
+                """,
+            [DocumentUri.From("file:///generic-bar-one.calr")] = """
+                §M{m2:Generic}
+                  §CL{b1:Bar:pub}<T>
+                    §EXT{Generic.Foo<T>}
+                """,
+            [DocumentUri.From("file:///generic-foo-two.calr")] = """
+                §M{m3:Generic}
+                  §CL{f2:Foo:pub}<T,U>
+                    §EXT{Generic.Bar<T,U>}
+                """,
+            [DocumentUri.From("file:///generic-bar-two.calr")] = """
+                §M{m4:Generic}
+                  §CL{b2:Bar:pub}<T,U>
+                    §EXT{Generic.Foo<T,U>}
+                """,
+        };
+        foreach (var (uri, source) in sources)
+            workspace.GetOrCreate(uri, source);
+
+        var snapshot = workspace.CaptureSnapshot();
+        foreach (var uri in sources.Keys)
+        {
+            var diagnostic = Assert.Single(
+                workspace.GetDiagnostics(snapshot, snapshot.GetDocument(uri)!)
+                    .Where(item =>
+                        item.Code == Compiler.Diagnostics.DiagnosticCode.InheritanceCycle));
+            var expectedArity = uri.ToString().Contains("-one.", StringComparison.Ordinal)
+                ? "`1"
+                : "`2";
+            Assert.Contains(expectedArity, diagnostic.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                expectedArity == "`1" ? "`2" : "`1",
+                diagnostic.Message,
+                StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("i32[,]")]
+    [InlineData("Nested<A,B>")]
+    [InlineData("(A,B)")]
+    [InlineData("(Nested<A,B>[,],(C,D))")]
+    public void GenericArityParser_IgnoresNestedDelimiterCommas(
+        string typeArgument)
+    {
+        var workspace = new WorkspaceState();
+        var fooUri = DocumentUri.From(
+            $"file:///arity-foo-{typeArgument.Length}.calr");
+        var barUri = DocumentUri.From(
+            $"file:///arity-bar-{typeArgument.Length}.calr");
+        workspace.GetOrCreate(fooUri, $$"""
+            §M{m1:Generic}
+              §CL{f1:Foo:pub}<T>
+                §EXT{Generic.Bar<{{typeArgument}}>}
+            """);
+        workspace.GetOrCreate(barUri, $$"""
+            §M{m2:Generic}
+              §CL{b1:Bar:pub}<T>
+                §EXT{Generic.Foo<{{typeArgument}}>}
+            """);
+
+        var snapshot = workspace.CaptureSnapshot();
+        Assert.All(new[] { fooUri, barUri }, uri =>
+        {
+            var diagnostic = Assert.Single(
+                workspace.GetDiagnostics(snapshot, snapshot.GetDocument(uri)!)
+                    .Where(item =>
+                        item.Code == Compiler.Diagnostics.DiagnosticCode.InheritanceCycle));
+            Assert.Contains("`1", diagnostic.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain("`2", diagnostic.Message, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void LexicalNestedTypeResolution_WinsOverAmbiguousGlobalSimpleName()
+    {
+        var workspace = new WorkspaceState();
+        var localUri = DocumentUri.From("file:///lexical-local.calr");
+        var globalUri = DocumentUri.From("file:///lexical-global.calr");
+        workspace.GetOrCreate(localUri, """
+            §M{m1:Local}
+              §CL{h1:Host:pub}
+                §CL{Parent:pub}
+                  §EXT{Child}
+                §CL{Child:pub}
+                  §EXT{Parent}
+            """);
+        workspace.GetOrCreate(globalUri, """
+            §M{m2:Other}
+              §CL{p1:Parent:pub}
+            """);
+
+        var snapshot = workspace.CaptureSnapshot();
+        var localAst = snapshot.GetDocument(localUri)!.Analysis.Ast!;
+        var host = Assert.Single(localAst.Classes);
+        Assert.Equal(2, host.NestedClasses.Count);
+        Assert.Equal(
+            new[] { "Parent", "Child" },
+            host.NestedClasses.Select(node => node.Name).ToArray());
+        Assert.Equal(
+            "Child",
+            host.NestedClasses.Single(node => node.Name == "Parent").BaseClass);
+        Assert.Equal(
+            "Parent",
+            host.NestedClasses.Single(node => node.Name == "Child").BaseClass);
+        var localDiagnostics = workspace.GetDiagnostics(
+                snapshot,
+                snapshot.GetDocument(localUri)!)
+            .Where(item =>
+                item.Code == Compiler.Diagnostics.DiagnosticCode.InheritanceCycle)
+            .ToArray();
+
+        Assert.Equal(2, localDiagnostics.Length);
+        Assert.DoesNotContain(
+            workspace.GetDiagnostics(snapshot, snapshot.GetDocument(globalUri)!),
+            item => item.Code == Compiler.Diagnostics.DiagnosticCode.InheritanceCycle);
+    }
+
+    [Fact]
+    public void AmbiguousLocalTypeResolution_DoesNotFallThroughToImportedGlobal()
+    {
+        var workspace = new WorkspaceState();
+        var sources = new Dictionary<DocumentUri, string>
+        {
+            [DocumentUri.From("file:///ambiguous-base-one.calr")] = """
+                §M{m1:Local}
+                  §CL{b1:Base:pub}
+                """,
+            [DocumentUri.From("file:///ambiguous-base-two.calr")] = """
+                §M{m2:Local}
+                  §CL{b2:Base:pub}
+                """,
+            [DocumentUri.From("file:///ambiguous-derived.calr")] = """
+                §M{m3:Local}
+                  §U{Other}
+                  §CL{d1:Derived:pub}
+                    §EXT{Base}
+                """,
+            [DocumentUri.From("file:///ambiguous-import.calr")] = """
+                §M{m4:Other}
+                  §CL{b3:Base:pub}
+                    §EXT{Local.Derived}
+                """,
+        };
+        foreach (var (uri, source) in sources)
+            workspace.GetOrCreate(uri, source);
+
+        var snapshot = workspace.CaptureSnapshot();
+        Assert.All(sources.Keys, uri =>
+            Assert.DoesNotContain(
+                workspace.GetDiagnostics(snapshot, snapshot.GetDocument(uri)!),
+                item => item.Code == Compiler.Diagnostics.DiagnosticCode.InheritanceCycle));
+    }
+
+    [Fact]
+    public void PartialGenericParameterNameMismatch_IsNotMergedIntoCycle()
+    {
+        AssertIncompatiblePartialGenericDoesNotCycle(
+            "§CL{f1:Foo:pub:partial}<T>\n    §EXT{Generic.Bar<T>}",
+            "§CL{f2:Foo:pub:partial}<U>");
+    }
+
+    [Fact]
+    public void PartialGenericConstraintMismatch_IsNotMergedIntoCycle()
+    {
+        AssertIncompatiblePartialGenericDoesNotCycle(
+            "§CL{f1:Foo:pub:partial}<T>\n    §WHERE T : class\n    §EXT{Generic.Bar<T>}",
+            "§CL{f2:Foo:pub:partial}<T>\n    §WHERE T : struct");
+    }
+
+    [Fact]
+    public void CompatiblePartialGenericDeclarations_MergeIntoCycle()
+    {
+        var workspace = new WorkspaceState();
+        var firstUri = DocumentUri.From("file:///compatible-partial-one.calr");
+        var secondUri = DocumentUri.From("file:///compatible-partial-two.calr");
+        var barUri = DocumentUri.From("file:///compatible-partial-bar.calr");
+        var firstState = workspace.GetOrCreate(firstUri, """
+            §M{m1:Generic}
+              §CL{f1:Foo:pub:partial}<T>
+                §WHERE T : class
+                §EXT{Generic.Bar<T>}
+            """);
+        var secondState = workspace.GetOrCreate(secondUri, """
+            §M{m2:Generic}
+              §CL{f2:Foo:pub:partial}<T>
+                §WHERE T : class
+            """);
+        workspace.GetOrCreate(barUri, """
+            §M{m3:Generic}
+              §CL{b1:Bar:pub}<T>
+                §EXT{Generic.Foo<T>}
+            """);
+
+        foreach (var node in new[]
+                 {
+                     Assert.Single(firstState.Snapshot.Ast!.Classes),
+                     Assert.Single(secondState.Snapshot.Ast!.Classes),
+                 })
+        {
+            Assert.True(node.IsPartial);
+            Assert.Equal("Foo", node.Name);
+            var parameter = Assert.Single(node.TypeParameters);
+            Assert.Equal("T", parameter.Name);
+            Assert.Equal(
+                Compiler.Ast.TypeConstraintKind.Class,
+                Assert.Single(parameter.Constraints).Kind);
+        }
+        Assert.Equal(
+            "Generic.Bar<T>",
+            Assert.Single(firstState.Snapshot.Ast!.Classes).BaseClass);
+        Assert.Equal(
+            "Generic.Foo<T>",
+            Assert.Single(workspace.Get(barUri)!.Snapshot.Ast!.Classes).BaseClass);
+        Assert.Equal(
+            "Bar",
+            Assert.Single(workspace.Get(barUri)!.Snapshot.Ast!.Classes).Name);
+
+        var snapshot = workspace.CaptureSnapshot();
+        Assert.All(new[] { firstUri, secondUri, barUri }, uri =>
+            Assert.Single(
+                workspace.GetDiagnostics(snapshot, snapshot.GetDocument(uri)!)
+                    .Where(item =>
+                        item.Code == Compiler.Diagnostics.DiagnosticCode.InheritanceCycle)));
+    }
+
+    [Fact]
+    public void ModuleNestedTypeFlatteningCollision_IsAmbiguousWithoutThrowing()
+    {
+        var workspace = new WorkspaceState();
+        var nestedUri = DocumentUri.From("file:///structured-nested.calr");
+        var moduleUri = DocumentUri.From("file:///structured-module.calr");
+        workspace.GetOrCreate(nestedUri, """
+            §M{m1:A}
+              §CL{b1:B:pub}
+                §CL{C:pub}
+                  §EXT{A.B.C}
+            """);
+        workspace.GetOrCreate(moduleUri, """
+            §M{m2:A.B}
+              §CL{c2:C:pub}
+                §EXT{A.B.C}
+            """);
+
+        var snapshot = workspace.CaptureSnapshot();
+
+        Assert.Equal(2, snapshot.Documents.Length);
+        Assert.All(new[] { nestedUri, moduleUri }, uri =>
+            Assert.DoesNotContain(
+                workspace.GetDiagnostics(snapshot, snapshot.GetDocument(uri)!),
+                diagnostic =>
+                    diagnostic.Code == Compiler.Diagnostics.DiagnosticCode.InheritanceCycle));
+    }
+
+    private static void AssertIncompatiblePartialGenericDoesNotCycle(
+        string firstDeclaration,
+        string secondDeclaration)
+    {
+        var workspace = new WorkspaceState();
+        var firstUri = DocumentUri.From("file:///incompatible-partial-one.calr");
+        var secondUri = DocumentUri.From("file:///incompatible-partial-two.calr");
+        var barUri = DocumentUri.From("file:///incompatible-partial-bar.calr");
+        workspace.GetOrCreate(firstUri, $"§M{{m1:Generic}}\n  {firstDeclaration}\n");
+        workspace.GetOrCreate(secondUri, $"§M{{m2:Generic}}\n  {secondDeclaration}\n");
+        workspace.GetOrCreate(barUri, """
+            §M{m3:Generic}
+              §CL{b1:Bar:pub}<T>
+                §EXT{Generic.Foo<T>}
+            """);
+
+        var snapshot = workspace.CaptureSnapshot();
+        Assert.All(new[] { firstUri, secondUri, barUri }, uri =>
+            Assert.DoesNotContain(
+                workspace.GetDiagnostics(snapshot, snapshot.GetDocument(uri)!),
+                item => item.Code == Compiler.Diagnostics.DiagnosticCode.InheritanceCycle));
+    }
+
+    [Fact]
+    public async Task CapturedWorkspaceIndex_RemainsVersionCoherentAfterUpdateAsync()
+    {
+        const string original = """
+            §M{m001:TestModule}
+              §F{f001:Compute:pub} () -> i32
+                §R 42
+              §F{f002:Use:pub} () -> i32
+                §R §C{Compute} §/C
+            """;
+        const string updated = """
+            §M{m001:TestModule}
+              §F{f001:Calculate:pub} () -> i32
+                §R 42
+              §F{f002:Use:pub} () -> i32
+                §R §C{Calculate} §/C
+            """;
+        var workspace = new WorkspaceState();
+        var uri = DocumentUri.From("file:///workspace-snapshot.calr");
+        workspace.GetOrCreate(uri, original, version: 1);
+        var captured = workspace.CaptureSnapshot();
+        var capturedDocument = captured.GetDocument(uri)!;
+        var originalReference = original.LastIndexOf("Compute", StringComparison.Ordinal);
+        var capturedOccurrence = workspace.ResolveOccurrence(
+            captured,
+            uri,
+            originalReference);
+
+        var directUpdate = await workspace.Get(uri)!.UpdateAsync(
+            updated,
+            newVersion: 2);
+        Assert.True(directUpdate.Accepted);
+        var current = workspace.CaptureSnapshot();
+        var currentReference = updated.LastIndexOf("Calculate", StringComparison.Ordinal);
+        var currentOccurrence = workspace.ResolveOccurrence(
+            current,
+            uri,
+            currentReference);
+
+        Assert.NotNull(capturedOccurrence);
+        Assert.Equal(1, capturedDocument.Analysis.Version);
+        Assert.Contains("Compute", capturedDocument.Analysis.Source, StringComparison.Ordinal);
+        Assert.Equal(
+            "Compute",
+            capturedDocument.Analysis.Source.Substring(
+                capturedOccurrence.Span.Start,
+                capturedOccurrence.Span.Length));
+        Assert.Equal(2, current.GetDocument(uri)!.Analysis.Version);
+        Assert.NotNull(currentOccurrence);
+        Assert.Equal(
+            "Calculate",
+            current.GetDocument(uri)!.Analysis.Source.Substring(
+                currentOccurrence.Span.Start,
+                currentOccurrence.Span.Length));
+        Assert.Contains(
+            "Calculate",
+            current.GetDocument(uri)!.Analysis.Source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CancelledWorkspaceScan_IsBoundedAndDoesNotHoldIndexLockAsync()
+    {
+        var repositoryRoot = Directory.GetCurrentDirectory();
+        while (!File.Exists(Path.Combine(repositoryRoot, "Calor.sln")))
+        {
+            repositoryRoot = Directory.GetParent(repositoryRoot)?.FullName
+                ?? throw new InvalidOperationException("Repository root not found.");
+        }
+        var directory = Path.Combine(
+            repositoryRoot,
+            $"workspace-scan-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        await File.WriteAllTextAsync(
+            Path.Combine(directory, "blocked.calr"),
+            "§M{m001:Blocked}\n");
+        var readerStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var workspace = new WorkspaceState(
+            workspaceRootPath: null,
+            logger: null,
+            workspaceFileReader: async (_, cancellationToken) =>
+            {
+                readerStarted.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return string.Empty;
+            });
+        using var cancellation = new CancellationTokenSource();
+
+        try
+        {
+            var scan = workspace.ConfigureWorkspaceRootAsync(
+                new UriBuilder(Uri.UriSchemeFile, string.Empty)
+                {
+                    Path = directory + Path.DirectorySeparatorChar,
+                }.Uri,
+                cancellation.Token);
+            await readerStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+            var snapshot = await Task.Run(() => workspace.CaptureSnapshot())
+                .WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.Empty(snapshot.Documents);
+
+            await cancellation.CancelAsync();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => scan.WaitAsync(TimeSpan.FromSeconds(2)));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task WorkspaceEnumerationFailure_IsLoggedAndDoesNotAbortInitializationAsync()
+    {
+        var repositoryRoot = Directory.GetCurrentDirectory();
+        while (!File.Exists(Path.Combine(repositoryRoot, "Calor.sln")))
+        {
+            repositoryRoot = Directory.GetParent(repositoryRoot)?.FullName
+                ?? throw new InvalidOperationException("Repository root not found.");
+        }
+        var directory = Path.Combine(
+            repositoryRoot,
+            $"workspace-enumeration-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var logger = new CapturingWorkspaceLogger();
+        var workspace = new WorkspaceState(
+            workspaceRootPath: null,
+            logger,
+            workspaceFileReader: File.ReadAllTextAsync,
+            workspaceFileEnumerator: _ => Enumerable.Range(0, 1)
+                .Select<int, string>(_ =>
+                    throw new IOException("injected enumeration failure")));
+
+        try
+        {
+            await workspace.ConfigureWorkspaceRootAsync(
+                    new UriBuilder(Uri.UriSchemeFile, string.Empty)
+                    {
+                        Path = directory + Path.DirectorySeparatorChar,
+                    }.Uri,
+                    CancellationToken.None)
+                .WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.Empty(workspace.CaptureSnapshot().Documents);
+            var entry = Assert.Single(logger.Entries);
+            Assert.Equal(LogLevel.Warning, entry.Level);
+            Assert.IsType<IOException>(entry.Exception);
+            Assert.Equal(
+                Path.GetFullPath(directory),
+                entry.Properties["WorkspaceRoot"]);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ReopenDuringWorkspaceScan_OpenDocumentWinsWithoutDuplicateRegistryEntryAsync()
+    {
+        var repositoryRoot = Directory.GetCurrentDirectory();
+        while (!File.Exists(Path.Combine(repositoryRoot, "Calor.sln")))
+        {
+            repositoryRoot = Directory.GetParent(repositoryRoot)?.FullName
+                ?? throw new InvalidOperationException("Repository root not found.");
+        }
+        var directory = Path.Combine(
+            repositoryRoot,
+            $"workspace-registry-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "race.calr");
+        const string diskSource = "§M{d001:Disk}\n";
+        const string openSource = "§M{o001:Open}\n";
+        const string reopenedSource = "§M{r001:Reopened}\n";
+        await File.WriteAllTextAsync(path, diskSource);
+        var uri = DocumentUri.FromFileSystemPath(path);
+        var scanReadyToApply = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowScanApply = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var applyCalls = 0;
+        var workspace = new WorkspaceState(
+            workspaceRootPath: null,
+            logger: null,
+            workspaceFileReader: File.ReadAllTextAsync,
+            workspaceFileEnumerator: null,
+            beforeWorkspaceScanApply: () =>
+            {
+                if (Interlocked.Increment(ref applyCalls) == 1)
+                {
+                    scanReadyToApply.TrySetResult();
+                    return allowScanApply.Task;
+                }
+                return Task.CompletedTask;
+            });
+
+        try
+        {
+            var scan = workspace.ConfigureWorkspaceRootAsync(
+                new UriBuilder(Uri.UriSchemeFile, string.Empty)
+                {
+                    Path = directory + Path.DirectorySeparatorChar,
+                }.Uri,
+                CancellationToken.None);
+            await scanReadyToApply.Task.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.True(await workspace.GetOrCreateAsync(
+                uri,
+                openSource,
+                version: 7));
+            allowScanApply.TrySetResult();
+            await scan.WaitAsync(TimeSpan.FromSeconds(2));
+
+            var openSnapshot = workspace.CaptureSnapshot();
+            var openDocument = Assert.Single(openSnapshot.Documents);
+            Assert.Equal(uri, DocumentUri.From(openDocument.Document.Uri));
+            Assert.Equal(7, openDocument.Analysis.Version);
+            Assert.Equal(openSource, openDocument.Analysis.Source);
+            Assert.True(workspace.Contains(uri));
+
+            Assert.True(workspace.Remove(uri));
+            await workspace.RefreshClosedDocumentsAsync(CancellationToken.None);
+            var closedDocument = Assert.Single(
+                workspace.CaptureSnapshot().Documents);
+            Assert.Equal(diskSource, closedDocument.Analysis.Source);
+            Assert.False(workspace.Contains(uri));
+
+            Assert.True(await workspace.GetOrCreateAsync(
+                uri,
+                reopenedSource,
+                version: 8));
+            var reopened = Assert.Single(workspace.CaptureSnapshot().Documents);
+            Assert.Equal(8, reopened.Analysis.Version);
+            Assert.Equal(reopenedSource, reopened.Analysis.Source);
+
+            Assert.True(workspace.Remove(uri));
+            File.Delete(path);
+            await workspace.RefreshClosedDocumentsAsync(CancellationToken.None);
+            Assert.Empty(workspace.CaptureSnapshot().Documents);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void FindMemberAcrossFiles_NonExistentMember_ReturnsNull()
     {
         var workspace = new WorkspaceState();
@@ -1147,6 +1960,45 @@ public class CrossFileResolutionTests
         Assert.NotNull(doc);
         Assert.NotNull(node);
     }
+
+    private sealed class CapturingWorkspaceLogger : ILogger<WorkspaceState>
+    {
+        public List<WorkspaceLogEntry> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) =>
+            EmptyScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var properties = state is IEnumerable<KeyValuePair<string, object?>> values
+                ? values.ToDictionary(pair => pair.Key, pair => pair.Value)
+                : new Dictionary<string, object?>();
+            Entries.Add(new WorkspaceLogEntry(
+                logLevel,
+                exception,
+                properties));
+        }
+
+        private sealed class EmptyScope : IDisposable
+        {
+            public static EmptyScope Instance { get; } = new();
+            public void Dispose()
+            {
+            }
+        }
+    }
+
+    private sealed record WorkspaceLogEntry(
+        LogLevel Level,
+        Exception? Exception,
+        IReadOnlyDictionary<string, object?> Properties);
 
     #endregion
 }

--- a/tests/Calor.LanguageServer.Tests/State/DocumentStateTests.cs
+++ b/tests/Calor.LanguageServer.Tests/State/DocumentStateTests.cs
@@ -1,5 +1,8 @@
 using Calor.LanguageServer.State;
+using Calor.LanguageServer.Handlers;
 using Calor.LanguageServer.Tests.Helpers;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Calor.LanguageServer.Tests.State;
@@ -31,7 +34,7 @@ public class DocumentStateTests
         var state = LspTestHarness.CreateDocument(source);
 
         Assert.NotNull(state.Ast);
-        Assert.NotNull(state.Tokens);
+        Assert.NotEmpty(state.Tokens);
         Assert.False(state.Diagnostics.HasErrors);
     }
 
@@ -219,4 +222,454 @@ public class DocumentStateTests
         Assert.NotEmpty(undefinedFix.Fix.Edits);
         Assert.Equal("value", undefinedFix.Fix.Edits.First().NewText);
     }
+
+    [Fact]
+    public async Task ConcurrentUpdatesAndReads_PublishOnlyCoherentLatestSnapshotAsync()
+    {
+        var state = new DocumentState(
+            new Uri("file:///concurrent.calr"),
+            VersionedSource(0),
+            version: 0);
+        await state.ReanalyzeAsync();
+        using var stopReaders = new CancellationTokenSource();
+        var reader = Task.Run(() =>
+        {
+            while (!stopReaders.IsCancellationRequested)
+                AssertCoherent(state.Snapshot);
+        });
+
+        var updates = Enumerable.Range(1, 200)
+            .Select(version => state.UpdateAsync(
+                VersionedSource(version),
+                version))
+            .ToArray();
+        await Task.WhenAll(updates);
+        await stopReaders.CancelAsync();
+        await reader;
+
+        var latest = state.Snapshot;
+        Assert.Equal(200, latest.Version);
+        AssertCoherent(latest);
+        Assert.Equal("Version200", latest.Ast!.Functions.Single().Name);
+    }
+
+    [Fact]
+    public async Task CancellationRace_NewerVersionWinsAndCanceledAnalysisCannotPublishAsync()
+    {
+        using var firstBindingEntered = new ManualResetEventSlim();
+        using var releaseFirstBinding = new ManualResetEventSlim();
+        var bindingCalls = 0;
+        var state = new DocumentState(
+            new Uri("file:///cancellation.calr"),
+            VersionedSource(1),
+            version: 1,
+            sourceIdentity: null,
+            logger: new CapturingLogger(),
+            failureInjector: phase =>
+            {
+                if (phase == DocumentState.DocumentAnalysisPhase.Binding
+                    && Interlocked.Increment(ref bindingCalls) == 1)
+                {
+                    firstBindingEntered.Set();
+                    Assert.True(releaseFirstBinding.Wait(TimeSpan.FromSeconds(10)));
+                }
+                return null;
+            });
+
+        var canceledAnalysis = state.ReanalyzeAsync();
+        Assert.True(firstBindingEntered.Wait(TimeSpan.FromSeconds(10)));
+        var latest = await state.UpdateAsync(VersionedSource(2), newVersion: 2);
+        Assert.True(latest.Accepted);
+        releaseFirstBinding.Set();
+        await canceledAnalysis;
+
+        Assert.Equal(2, state.Snapshot.Version);
+        Assert.Equal("Version2", state.Snapshot.Ast!.Functions.Single().Name);
+        AssertCoherent(state.Snapshot);
+    }
+
+    [Fact]
+    public async Task DisposeDuringBlockedAnalysis_CancelsWithoutDisposingWorkerTokenAsync()
+    {
+        using var workerEntered = new ManualResetEventSlim();
+        using var releaseWorker = new ManualResetEventSlim();
+        var logger = new CapturingLogger();
+        var state = new DocumentState(
+            new Uri("file:///dispose-race.calr"),
+            VersionedSource(1),
+            version: 1,
+            sourceIdentity: null,
+            logger,
+            failureInjector: phase =>
+            {
+                if (phase == DocumentState.DocumentAnalysisPhase.Lexing)
+                {
+                    workerEntered.Set();
+                    Assert.True(releaseWorker.Wait(TimeSpan.FromSeconds(10)));
+                }
+                return null;
+            });
+
+        var analysis = state.ReanalyzeAsync();
+        Assert.True(workerEntered.Wait(TimeSpan.FromSeconds(10)));
+        state.Dispose();
+        releaseWorker.Set();
+        var snapshot = await analysis.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(1, snapshot.Version);
+        Assert.Empty(logger.Entries);
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => state.ReanalyzeAsync());
+    }
+
+    [Fact]
+    public async Task ReanalysisRegistrationRace_DidChangeVersionAlwaysWinsAsync()
+    {
+        var reanalysisCapturedOldContent = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowReanalysisRegistration = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var barrierCalls = 0;
+        var state = new DocumentState(
+            new Uri("file:///save-change-race.calr"),
+            VersionedSource(1),
+            version: 1,
+            sourceIdentity: null,
+            logger: new CapturingLogger(),
+            failureInjector: null,
+            reanalysisRegistrationBarrier: () =>
+            {
+                if (Interlocked.Increment(ref barrierCalls) == 2)
+                {
+                    reanalysisCapturedOldContent.TrySetResult();
+                    return allowReanalysisRegistration.Task;
+                }
+                return Task.CompletedTask;
+            });
+        await state.ReanalyzeAsync();
+
+        var save = state.ReanalyzeAsync();
+        await reanalysisCapturedOldContent.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        var change = await state.UpdateAsync(
+            VersionedSource(2),
+            newVersion: 2);
+        Assert.True(change.Accepted);
+        allowReanalysisRegistration.TrySetResult();
+        var saveSnapshot = await save.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(2, saveSnapshot.Version);
+        Assert.Equal(2, state.Snapshot.Version);
+        Assert.Equal(VersionedSource(2), state.Snapshot.Source);
+        Assert.Equal("Version2", state.Snapshot.Ast!.Functions.Single().Name);
+        AssertCoherent(state.Snapshot);
+    }
+
+    [Fact]
+    public async Task CancelledInitialOpen_IsUnacceptedAndAbsentAsync()
+    {
+        var workspace = new WorkspaceState();
+        var uri = DocumentUri.From("file:///cancelled-initial-open.calr");
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        var accepted = await workspace.GetOrCreateAsync(
+            uri,
+            VersionedSource(1),
+            version: 1,
+            cancellation.Token);
+
+        Assert.False(accepted);
+        Assert.False(workspace.Contains(uri));
+        Assert.Null(workspace.Get(uri));
+    }
+
+    [Fact]
+    public async Task CancelledUpdate_PreservesCompletedSnapshotAndSameVersionRetrySucceedsAsync()
+    {
+        using var updateEntered = new ManualResetEventSlim();
+        using var releaseUpdate = new ManualResetEventSlim();
+        var bindingCalls = 0;
+        var state = new DocumentState(
+            new Uri("file:///cancelled-retry.calr"),
+            VersionedSource(1),
+            version: 1,
+            sourceIdentity: null,
+            logger: new CapturingLogger(),
+            failureInjector: phase =>
+            {
+                if (phase == DocumentState.DocumentAnalysisPhase.Binding
+                    && Interlocked.Increment(ref bindingCalls) == 2)
+                {
+                    updateEntered.Set();
+                    Assert.True(releaseUpdate.Wait(TimeSpan.FromSeconds(10)));
+                }
+                return null;
+            });
+        await state.ReanalyzeAsync();
+        var completed = state.Snapshot;
+        using var cancellation = new CancellationTokenSource();
+
+        var canceledUpdate = state.UpdateAsync(
+            VersionedSource(2),
+            newVersion: 2,
+            cancellation.Token);
+        Assert.True(updateEntered.Wait(TimeSpan.FromSeconds(10)));
+        await cancellation.CancelAsync();
+        releaseUpdate.Set();
+        var canceled = await canceledUpdate;
+
+        Assert.False(canceled.Accepted);
+        Assert.Same(completed, state.Snapshot);
+        Assert.Equal(1, state.Snapshot.Version);
+
+        var retry = await state.UpdateAsync(
+            VersionedSource(2),
+            newVersion: 2);
+        Assert.True(retry.Accepted);
+        Assert.Equal(2, state.Snapshot.Version);
+        Assert.Equal(VersionedSource(2), state.Snapshot.Source);
+        AssertCoherent(state.Snapshot);
+    }
+
+    [Fact]
+    public async Task NewerPendingUpdateWinsAndOlderRetryRemainsRejectedAsync()
+    {
+        using var newerEntered = new ManualResetEventSlim();
+        using var releaseNewer = new ManualResetEventSlim();
+        var bindingCalls = 0;
+        var state = new DocumentState(
+            new Uri("file:///pending-order.calr"),
+            VersionedSource(1),
+            version: 1,
+            sourceIdentity: null,
+            logger: new CapturingLogger(),
+            failureInjector: phase =>
+            {
+                if (phase == DocumentState.DocumentAnalysisPhase.Binding
+                    && Interlocked.Increment(ref bindingCalls) == 2)
+                {
+                    newerEntered.Set();
+                    Assert.True(releaseNewer.Wait(TimeSpan.FromSeconds(10)));
+                }
+                return null;
+            });
+        await state.ReanalyzeAsync();
+
+        var newer = state.UpdateAsync(VersionedSource(3), newVersion: 3);
+        Assert.True(newerEntered.Wait(TimeSpan.FromSeconds(10)));
+        var older = await state.UpdateAsync(VersionedSource(2), newVersion: 2);
+        Assert.False(older.Accepted);
+        releaseNewer.Set();
+        Assert.True((await newer).Accepted);
+
+        Assert.Equal(3, state.Snapshot.Version);
+        Assert.Equal(VersionedSource(3), state.Snapshot.Source);
+        AssertCoherent(state.Snapshot);
+    }
+
+    [Fact]
+    public async Task DiagnosticPublicationRace_NeverRegressesGenerationForUnchangedUriAsync()
+    {
+        var coordinator = new DiagnosticPublicationCoordinator();
+        var uri = DocumentUri.From("file:///unchanged-b.calr");
+        var published = new List<long>();
+        var tasks = Enumerable.Range(1, 100)
+            .OrderByDescending(generation => generation % 7)
+            .Select(generation => Task.Run(() => coordinator.PublishAsync(
+                () => (
+                    generation,
+                    (IReadOnlyList<DiagnosticPublication>)
+                    [
+                        new DiagnosticPublication(
+                            uri,
+                            () =>
+                            {
+                                published.Add(generation);
+                                return true;
+                            }),
+                    ]),
+                CancellationToken.None)))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+        await coordinator.PublishAsync(
+            () => (
+                99L,
+                (IReadOnlyList<DiagnosticPublication>)
+                [
+                    new DiagnosticPublication(
+                        uri,
+                        () =>
+                        {
+                            published.Add(99);
+                            return true;
+                        }),
+                ]),
+            CancellationToken.None);
+
+        Assert.NotEmpty(published);
+        Assert.Equal(100, published[^1]);
+        Assert.True(published.Zip(published.Skip(1), (left, right) => left < right)
+            .All(increasing => increasing));
+    }
+
+    [Fact]
+    public async Task SupersededWorkspaceDiagnostics_CannotOverwriteUnchangedDocumentAsync()
+    {
+        var workspace = new WorkspaceState();
+        var aUri = DocumentUri.From("file:///publication-a.calr");
+        var bUri = DocumentUri.From("file:///publication-b.calr");
+        workspace.GetOrCreate(aUri, "§M{m001:A}\n", version: 1);
+        workspace.GetOrCreate(bUri, "§M{m002:B}\n", version: 1);
+        var older = workspace.CaptureSnapshot();
+        var olderB = older.GetDocument(bUri)!;
+
+        workspace.Update(aUri, "§M{m001:A2}\n", version: 2);
+        var newer = workspace.CaptureSnapshot();
+        var newerB = newer.GetDocument(bUri)!;
+        Assert.Same(olderB.Analysis, newerB.Analysis);
+        Assert.Equal(olderB.Analysis.Version, newerB.Analysis.Version);
+
+        var coordinator = new DiagnosticPublicationCoordinator();
+        var published = new List<string>();
+        await coordinator.PublishAsync(
+            () => (
+                newer.Generation,
+                (IReadOnlyList<DiagnosticPublication>)
+                [
+                    new DiagnosticPublication(
+                        bUri,
+                        () => workspace.TryPublishDiagnostics(
+                            newer,
+                            newerB,
+                            () => published.Add("newer"))),
+                ]),
+            CancellationToken.None);
+        await coordinator.PublishAsync(
+            () => (
+                older.Generation,
+                (IReadOnlyList<DiagnosticPublication>)
+                [
+                    new DiagnosticPublication(
+                        bUri,
+                        () => workspace.TryPublishDiagnostics(
+                            older,
+                            olderB,
+                            () => published.Add("older"))),
+                ]),
+            CancellationToken.None);
+
+        Assert.Equal(["newer"], published);
+    }
+
+    [Fact]
+    public async Task OutOfOrderAndEqualVersions_AreIgnoredAsync()
+    {
+        var state = new DocumentState(
+            new Uri("file:///ordering.calr"),
+            VersionedSource(5),
+            version: 5);
+        await state.ReanalyzeAsync();
+        var captured = state.Snapshot;
+
+        var older = await state.UpdateAsync(VersionedSource(4), newVersion: 4);
+        var equal = await state.UpdateAsync(VersionedSource(50), newVersion: 5);
+
+        Assert.False(older.Accepted);
+        Assert.False(equal.Accepted);
+        Assert.Same(captured, state.Snapshot);
+        Assert.Equal("Version5", state.Snapshot.Ast!.Functions.Single().Name);
+    }
+
+    [Theory]
+    [InlineData((int)DocumentState.DocumentAnalysisPhase.Binding)]
+    [InlineData((int)DocumentState.DocumentAnalysisPhase.BindValidation)]
+    [InlineData((int)DocumentState.DocumentAnalysisPhase.ReturnValidation)]
+    public async Task AnalysisFailure_IsObservableAsCalor9999AndStructuredLogAsync(
+        int phaseValue)
+    {
+        var phase = (DocumentState.DocumentAnalysisPhase)phaseValue;
+        var logger = new CapturingLogger();
+        var state = new DocumentState(
+            new Uri("file:///failure.calr"),
+            VersionedSource(7),
+            version: 7,
+            sourceIdentity: null,
+            logger: logger,
+            failureInjector: candidate => candidate == phase
+                ? new InvalidOperationException("injected")
+                : null);
+
+        var snapshot = await state.ReanalyzeAsync();
+
+        var diagnostic = Assert.Single(
+            snapshot.Diagnostics.Where(item => item.Code == "Calor9999"));
+        Assert.Contains("Internal", diagnostic.Message, StringComparison.Ordinal);
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Error, entry.Level);
+        Assert.IsType<InvalidOperationException>(entry.Exception);
+        Assert.Equal(phase, entry.Properties["AnalysisPhase"]);
+        Assert.Equal(state.Uri, entry.Properties["DocumentUri"]);
+        Assert.Equal(7, entry.Properties["DocumentVersion"]);
+    }
+
+    private static string VersionedSource(int version) => $$"""
+        §M{m001:Versioned}
+          §F{f001:Version{{version}}:pub} () -> i32
+            §R MissingVersion{{version}}
+        """;
+
+    private static void AssertCoherent(DocumentSnapshot snapshot)
+    {
+        var expectedName = $"Version{snapshot.Version}";
+        Assert.Contains(expectedName, snapshot.Source, StringComparison.Ordinal);
+        Assert.Contains(snapshot.Tokens, token =>
+            token.Text.Contains(expectedName, StringComparison.Ordinal));
+        Assert.Equal(expectedName, snapshot.Ast?.Functions.Single().Name);
+        Assert.Contains(snapshot.BoundModule?.Functions ?? [], function =>
+            function.Symbol.Name.EndsWith(expectedName, StringComparison.Ordinal));
+        Assert.Contains(snapshot.Diagnostics, diagnostic =>
+            diagnostic.Code == Compiler.Diagnostics.DiagnosticCode.UndefinedReference
+            && diagnostic.Message.Contains(
+                $"MissingVersion{snapshot.Version}",
+                StringComparison.Ordinal));
+        Assert.DoesNotContain(snapshot.Diagnostics, diagnostic =>
+            diagnostic.Code == "Calor9999");
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) =>
+            NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var properties = state is IEnumerable<KeyValuePair<string, object?>> values
+                ? values.ToDictionary(pair => pair.Key, pair => pair.Value)
+                : new Dictionary<string, object?>();
+            Entries.Add(new LogEntry(logLevel, exception, properties));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static NullScope Instance { get; } = new();
+            public void Dispose()
+            {
+            }
+        }
+    }
+
+    private sealed record LogEntry(
+        LogLevel Level,
+        Exception? Exception,
+        IReadOnlyDictionary<string, object?> Properties);
 }


### PR DESCRIPTION
Closes #767

## Summary
- publish immutable versioned document/workspace snapshots with cancellation-safe atomic updates
- reject stale versions and surface internal failures plus deterministic inheritance-cycle diagnostics
- make handlers consume coherent snapshots and workspace scans cancellable
- replace fixed-delay JSON-RPC tests with bounded core-capability and exact PID teardown flows
- enforce 10-run PR and 100-run release live-LSP stress gates with strict TRX identity validation

## Validation
- 474/474 language-server tests
- compiler tests: 7,237 passed, 2 expected skips
- Release build: zero warnings/errors
- live E2E stress: 100/100, exact PID teardown verified
- adversarial review: approved with no blockers