### PR TITLE
ci: close roadmap gate 7's CLI leg, and fix what building it found

### DIFF
--- a/.github/scripts/test-cli-tool-consumer.sh
+++ b/.github/scripts/test-cli-tool-consumer.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Roadmap §2.5 gate 7 — clean-consumer install, CLI leg (#790).
+#
+# The Sdk leg of gate 7 is `sdk-package-consumer` / test-sdk-package.sh. This is
+# its counterpart for the `calor` global tool, which until now was only ever
+# verified by hand after a publish.
+#
+# The bar is deliberately NOT exit-0 install. The pre-closure osx-x64 state was
+# precisely "installs successfully, silently loses verification" — a consumer
+# whose Z3 native is missing still installs, still exits 0 on `calor verify`,
+# and reports every contract Skipped. So this script requires a *solver verdict*:
+# contracts Proven, none Skipped, no Calor0710.
+#
+# It then runs the gate's 2026-08-11 amendment (#916 review F3) as a test rather
+# than a promise. #916 dropped the mislabeled osx-x64 RID from the package, and
+# the roadmap requires that an Intel-mac consumer get *documented degradation* —
+# a loud Calor0710, no crash, no silent pass. GitHub does not offer an Intel-mac
+# runner we can rely on, so the condition is reproduced exactly on whatever
+# runner we have: remove the native for the runner's own RID from the installed
+# tool, which is the same state an osx-x64 consumer is in, and assert the
+# documented degradation.
+#
+# Env:
+#   CALOR_CLI_VERSION   override the version to pack/install (default: Directory.Build.props)
+#   CALOR_EXPECTED_RID  require the runner RID to match (CI pins this per matrix leg)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+VERSION="${CALOR_CLI_VERSION:-$(sed -n 's/.*<Version>\(.*\)<\/Version>.*/\1/p' "$REPO_ROOT/Directory.Build.props" | head -1)}"
+if [ -z "$VERSION" ]; then
+  echo "ERROR: could not read <Version> from Directory.Build.props" >&2
+  exit 1
+fi
+echo "== gate 7 CLI clean-consumer check (calor $VERSION) =="
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+FEED="$WORK/feed"
+TOOLDIR="$WORK/tools"
+CONSUMER="$WORK/consumer"
+mkdir -p "$FEED" "$CONSUMER"
+
+RID="$(dotnet --info | sed -n 's/^[[:space:]]*RID:[[:space:]]*//p' | head -1 | tr -d '\r')"
+if [ -z "$RID" ]; then
+  echo "ERROR: could not determine the runner RID from 'dotnet --info'" >&2
+  exit 1
+fi
+if [ -n "${CALOR_EXPECTED_RID:-}" ] && [ "$RID" != "$CALOR_EXPECTED_RID" ]; then
+  echo "ERROR: expected runner RID $CALOR_EXPECTED_RID, actual RID $RID" >&2
+  exit 1
+fi
+echo "runner RID: $RID"
+
+case "$RID" in
+  linux-x64|linux-arm64) NATIVE_NAME="libz3.so" ;;
+  osx-arm64)             NATIVE_NAME="libz3.dylib" ;;
+  win-x64|win-arm64)     NATIVE_NAME="libz3.dll" ;;
+  *)
+    echo "ERROR: gate 7's frozen RID matrix does not include $RID" >&2
+    exit 1
+    ;;
+esac
+NATIVE_ENTRY="tools/net10.0/any/runtimes/$RID/native/$NATIVE_NAME"
+
+echo "== 1. pack calor -> local feed =="
+dotnet pack "$REPO_ROOT/src/Calor.Compiler/Calor.Compiler.csproj" -c Release -o "$FEED" -p:Version="$VERSION"
+
+NUPKG="$FEED/calor.$VERSION.nupkg"
+if [ ! -f "$NUPKG" ]; then
+  echo "ERROR: expected package not produced: $NUPKG" >&2
+  ls -la "$FEED" >&2
+  exit 1
+fi
+
+echo "== 2. package-content inspection =="
+ENTRIES="$WORK/entries.txt"
+unzip -Z1 "$NUPKG" >"$ENTRIES"
+
+if ! grep -qxF "$NATIVE_ENTRY" "$ENTRIES"; then
+  echo "ERROR: package is missing the native for the runner RID: $NATIVE_ENTRY" >&2
+  grep "runtimes/" "$ENTRIES" >&2 || true
+  exit 1
+fi
+echo "OK: package carries $NATIVE_ENTRY"
+
+# #916 dropped osx-x64 because upstream ships an arm64 binary under the x64
+# label. Asserting its absence keeps the drop a tested fact: if it silently
+# returns, the degradation oracle in step 5 stops describing real consumers.
+if grep -q "runtimes/osx-x64/" "$ENTRIES"; then
+  echo "ERROR: package carries an osx-x64 native; #916 dropped that RID" >&2
+  grep "runtimes/osx-x64/" "$ENTRIES" >&2
+  exit 1
+fi
+echo "OK: no osx-x64 native (#916 drop holds)"
+
+echo "== 3. clean-consumer install from the feed =="
+export NUGET_PACKAGES="$WORK/packages"   # cold cache: the install must come from the feed
+dotnet tool install calor \
+  --version "$VERSION" \
+  --add-source "$FEED" \
+  --tool-path "$TOOLDIR" \
+  --ignore-failed-sources
+
+if [ -f "$TOOLDIR/calor.exe" ]; then
+  TOOL="$TOOLDIR/calor.exe"
+elif [ -f "$TOOLDIR/calor" ]; then
+  TOOL="$TOOLDIR/calor"
+else
+  echo "ERROR: tool install produced no calor executable in $TOOLDIR" >&2
+  ls -la "$TOOLDIR" >&2
+  exit 1
+fi
+
+INSTALLED_VERSION="$("$TOOL" --version | tr -d '\r' | head -1)"
+if [ "$INSTALLED_VERSION" != "$VERSION" ]; then
+  echo "ERROR: installed tool reports '$INSTALLED_VERSION', expected '$VERSION'" >&2
+  exit 1
+fi
+echo "OK: installed calor reports $INSTALLED_VERSION"
+
+# A clean consumer works on its own files, outside the repo tree.
+cp "$REPO_ROOT/samples/Verification/proven-contracts.calr" "$CONSUMER/proven-contracts.calr"
+
+echo "== 4. solver verdict (the gate's actual bar) =="
+VERIFY_LOG="$WORK/verify.log"
+set +e
+(cd "$CONSUMER" && "$TOOL" verify proven-contracts.calr) >"$VERIFY_LOG" 2>&1
+VERIFY_EXIT=$?
+set -e
+cat "$VERIFY_LOG"
+
+if [ "$VERIFY_EXIT" -ne 0 ]; then
+  echo "ERROR: 'calor verify' exited $VERIFY_EXIT on a fixture whose contracts all prove" >&2
+  exit 1
+fi
+if grep -q "Calor0710" "$VERIFY_LOG"; then
+  echo "ERROR: Calor0710 (Z3 unavailable) from a clean tool install — the packaged solver did not load" >&2
+  exit 1
+fi
+
+PROVEN="$(sed -n 's/^[[:space:]]*Proven:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$VERIFY_LOG" | head -1)"
+SKIPPED="$(sed -n 's/^[[:space:]]*Skipped:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$VERIFY_LOG" | head -1)"
+if [ -z "$PROVEN" ] || [ -z "$SKIPPED" ]; then
+  echo "ERROR: could not read a Proven/Skipped summary out of 'calor verify' output" >&2
+  exit 1
+fi
+if [ "$PROVEN" -lt 1 ]; then
+  echo "ERROR: 0 contracts Proven — install succeeded but verification did not happen" >&2
+  exit 1
+fi
+if [ "$SKIPPED" -ne 0 ]; then
+  echo "ERROR: $SKIPPED contracts Skipped — this is the silent-degradation state gate 7 exists to catch" >&2
+  exit 1
+fi
+echo "OK: solver verdict on a clean install — Proven $PROVEN, Skipped $SKIPPED"
+
+echo "== 5. degradation oracle: the RID whose native we do not ship =="
+# Reproduce an osx-x64 consumer's state: the tool is installed, and there is no
+# Z3 native for its RID.
+rm -rf "$TOOLDIR/.store/calor/$VERSION/calor/$VERSION/tools/net10.0/any/runtimes/$RID"
+if find "$TOOLDIR" -name "$NATIVE_NAME" -print -quit | grep -q .; then
+  echo "ERROR: $NATIVE_NAME still present after removal — the oracle would not be testing degradation" >&2
+  find "$TOOLDIR" -name "$NATIVE_NAME" >&2
+  exit 1
+fi
+
+DEGRADED_LOG="$WORK/degraded.log"
+set +e
+(cd "$CONSUMER" && "$TOOL" verify proven-contracts.calr) >"$DEGRADED_LOG" 2>&1
+DEGRADED_EXIT=$?
+set -e
+cat "$DEGRADED_LOG"
+
+# No crash: a missing native must degrade, not abort. Anything above 128 on
+# POSIX is a signal (SIGSEGV/SIGABRT); an unhandled managed exception prints a
+# stack trace.
+if [ "$DEGRADED_EXIT" -gt 128 ]; then
+  echo "ERROR: 'calor verify' died with exit $DEGRADED_EXIT (signal) when Z3 was absent — must degrade, not crash" >&2
+  exit 1
+fi
+if grep -q "Unhandled exception" "$DEGRADED_LOG"; then
+  echo "ERROR: unhandled exception when Z3 was absent — must degrade, not crash" >&2
+  exit 1
+fi
+
+# Loud: the consumer is told verification did not happen.
+if ! grep -q "Calor0710" "$DEGRADED_LOG"; then
+  echo "ERROR: no Calor0710 when Z3 was absent — this is the silent-verification-loss state" >&2
+  exit 1
+fi
+
+# No silent pass: nothing may be reported Proven without a solver.
+DEGRADED_PROVEN="$(sed -n 's/^[[:space:]]*Proven:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$DEGRADED_LOG" | head -1)"
+if [ -n "$DEGRADED_PROVEN" ] && [ "$DEGRADED_PROVEN" -ne 0 ]; then
+  echo "ERROR: $DEGRADED_PROVEN contracts reported Proven with no solver present" >&2
+  exit 1
+fi
+echo "OK: documented degradation — Calor0710 raised, nothing Proven, exit $DEGRADED_EXIT, no crash"
+
+echo "== gate 7 CLI leg PASS: clean install of calor $VERSION on $RID returns a solver verdict, and degrades loudly without its native =="

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -783,6 +783,51 @@ jobs:
           CALOR_SDK_EXPECTED_RID: ${{ matrix.rid }}
         run: bash .github/scripts/test-sdk-package.sh
 
+  cli-tool-consumer:
+    # Roadmap §2.5 gate 7 — clean-consumer install, CLI leg (#790). The Sdk leg
+    # is sdk-package-consumer above; this is the `calor` global tool, which was
+    # previously only ever checked by hand after a publish.
+    #
+    # The matrix is gate 7's frozen RID set (win-x64, linux-x64, osx-arm64). The
+    # dropped osx-x64 RID (#916) is not a runner here — its amended oracle, the
+    # documented degradation, is reproduced inside the script on every leg.
+    name: cli-tool-consumer (${{ matrix.rid }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            rid: linux-x64
+          - runner: macos-14
+            rid: osx-arm64
+          - runner: windows-latest
+            rid: win-x64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Bootstrap verified Z3 assets
+        if: runner.os != 'Windows'
+        run: bash src/Calor.Compiler/scripts/download-z3.sh
+
+      - name: Bootstrap verified Z3 assets (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: pwsh -NoProfile -File src/Calor.Compiler/scripts/download-z3.ps1
+
+      - name: Run gate 7 CLI consumer check (pack -> tool install -> solver verdict)
+        env:
+          CALOR_EXPECTED_RID: ${{ matrix.rid }}
+        run: bash .github/scripts/test-cli-tool-consumer.sh
+
   verify-phase1:
     # Tier 1 self-verification harness — v6 §3.1.
     # Goal: every PR finishes Tier 1 in < 60s.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,83 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+Ten changes have landed on `main` since the v0.13.2 tag. Eight of them close issues this repo's own
+roadmap scheduled for **0.14 or 0.15** — #763, #766, #768, #781, #782, #784, #785, #786 — so the
+staircase in `docs/plans/roadmap-v0.13-v0.15.md` is ahead of its own schedule in the analysis and
+emission layers, and behind it nowhere. Several are behaviour changes that can newly *reject* or
+newly *diagnose* code that v0.13.2 accepted; those are marked below. Entries are derived from the
+merged pull requests named in each line.
+
+### Changed
+
+- **Effect enforcement is symbol-resolved, exhaustive, and fail-closed (#968, closes #785).** Calls,
+  constructors, accessors, overloads, delegates and inherited members resolve by symbol and
+  signature instead of bare-name purity heuristics, and allocation, initialization, disposal, event,
+  getter, setter and constructor effects are charged. **Behaviour change:** an operation that cannot
+  be resolved now fails closed rather than being assumed pure, so programs that passed enforcement
+  under the name-matching heuristic may now be rejected. The source, manifest and emitter effect
+  taxonomies are unified, drifted or misspelled effect codes are rejected, and CLI, MCP, MSBuild and
+  SDK enforcement defaults are equivalent.
+- **Bug-pattern analyzers rebuilt on typed CFG/SSA semantics (#970, closes #786).** Heuristic checks
+  are replaced by typed control-flow and dataflow analysis modelling strong updates, path
+  conditions, evaluation order, numeric promotions, casts, bounds, `Option`/`Result` state and loop
+  semantics. **Behaviour change:** findings are now separated into verified findings, heuristic
+  hints, and explicit incomplete-analysis results, so both the set of findings and their
+  presentation move.
+- **Taint analysis rebuilt on control-flow graphs (#969, closes #784).** Linear name-based tracking
+  is replaced by symbol- and access-path-keyed may-taint analysis over the CFG, with source, sink,
+  sanitizer, alias, collection and interprocedural summary semantics, and ordered provenance paths.
+  **Behaviour change:** direct-injection findings are reported by default, so existing code can
+  produce new diagnostics without any source edit.
+- **Control-flow emission is structural and reentrant (#972, closes #763).** Emission runs in
+  isolated contexts over an exhaustive structural traversal; guarded match selection and
+  statement-lambda block structure are preserved; loops lower with exact-once bounds, typed dynamic
+  steps, zero checks and overflow-safe termination. Iterator/`yield` legality is enforced across
+  nested control-flow containers.
+- **Contract inheritance is sound (#966, closes #781).** Liskov pre/post rules are proved over whole
+  contract conjunctions rather than clause-by-clause, inherited contracts are keyed by full method
+  identity, and interface and base sources combine deterministically across overloads, explicit
+  implementations, and generic interface/base/method substitutions. **Behaviour change:** inherited
+  guarantees that are incompatible with an override are now diagnosed. Contract simplification
+  preserves every unrelated `ModuleNode` field, enforced by reflection coverage.
+- **Postcondition returns are structurally lowered (#967, closes #764).** One shared lowering path
+  replaces the duplicated direct-return rewriting across functions, methods, enum extensions and
+  operators; nested and early returns keep their control flow, values are evaluated once, and
+  postconditions run exactly once on normal exits. The `result` pseudo-variable binds structurally
+  under quantifier, pattern and lambda scope with hygienic synthesized names. **Behaviour change:**
+  postconditions on iterators are rejected explicitly, and opaque raw-C# returns fail closed.
+- **Proof and refinement guards use program state (#964, closes #782).** Nested proof,
+  refinement-return, subtype-transition and runtime index-bound obligations are generated, and
+  fail-closed guards are emitted for refined parameters, returns, bindings, assignments and explicit
+  proof sites. Guards are retained for incomplete proof outcomes, and obligation policy is wired
+  into guard elision.
+- **Literal, interpolation and raw-C# semantics are preserved through emission (#975, closes
+  #768).** Integer sign, base, width, signedness, suffix and separator semantics survive; string
+  interpolation is represented structurally with placeholder and escape intent preserved; emitted
+  expressions are precedence- and associativity-safe; raw C# is scanned with lexical and
+  preprocessor awareness and its bytes preserved exactly.
+- **Declaration, type and module semantics are preserved through emission (#977, closes #766).**
+  Using directives, conditional branches and source ordering are preserved; named record
+  construction is validated and reordered; generic variance and constraints are validated; type
+  mapping, namespace dependencies and qualified-name sanitization are centralized; per-module
+  emitter state is isolated so an emitter can be reused deterministically. **Behaviour change:**
+  generated C# is standalone, with implicit usings disabled.
+- **LSP analysis is immutable and cycle-safe (#980, closes #767).** Document and workspace snapshots
+  are published as immutable versioned values with cancellation-safe atomic updates; stale versions
+  are rejected; internal failures and inheritance cycles surface as deterministic diagnostics; and
+  handlers consume coherent snapshots with cancellable workspace scans. Live end-to-end LSP stress
+  gates run 10 iterations per PR and 100 per release, with exact process teardown verified.
+
+### Fixed
+
+- **The CI performance ceiling is calibrated from CI, not from a developer machine (#978, #974,
+  toward #965).** The 21.0s aggregate ceiling had been derived from a ~19.8s dev-machine
+  measurement and sat *inside* the observed CI distribution (18 samples, 20.352-21.439s), so the
+  gate fired on runner assignment rather than on any regression; it is raised to 24.0s with the
+  evidence recorded, and the gate's output is streamed for diagnosis. **#965 remains open and is not
+  root-caused** — the exit-143 runner terminations behind the v0.13.1/v0.13.2 publish failures are
+  still unexplained, and a green pipeline is not evidence that they are understood.
+
 ## [0.13.2] - 2026-08-12
 
 ### Benchmark Results (Statistical: 30 runs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,16 @@ merged pull requests named in each line.
 
 ### Fixed
 
+- **`calor verify` states, on its default surface, that it did not verify anything.** When the Z3
+  native library is missing, every contract is reported `Skipped` and the run exits 0 — and the
+  reason, `Calor0710`, was `info` severity, which the text report never printed. It appeared only
+  under `--format json`; `--verbose` did not surface it either. A consumer whose solver failed to
+  load therefore saw a clean-looking report with a 0.0% proven rate and no stated cause: the
+  "installs successfully, silently loses verification" state that roadmap §2.5 gate 7 exists to
+  catch, found by building that gate's CLI leg. The text report now names it above the counts it
+  explains, and repeats it in the overall summary. Diagnostic severity, the JSON envelope, and the
+  exit code are unchanged.
+
 - **The CI performance ceiling is calibrated from CI, not from a developer machine (#978, #974,
   toward #965).** The 21.0s aggregate ceiling had been derived from a ~19.8s dev-machine
   measurement and sat *inside* the observed CI distribution (18 samples, 20.352-21.439s), so the

--- a/docs/plans/roadmap-v0.13-v0.15.md
+++ b/docs/plans/roadmap-v0.13-v0.15.md
@@ -202,6 +202,17 @@ gates 1, 4, 5, 6, 7, and gate 2's diagnostics leg.
    must get the *documented degradation* (a loud "Z3 unavailable"/Calor0710 signal, no crash, no
    silent pass), which turns the drop decision itself into a tested claim. NuGet registries and
    GitHub release assets are verified **after** publishing (a workflow firing is not a publish).
+   **Status (2026-08-15).** Both legs are now instruments in CI rather than post-publish habits:
+   `sdk-package-consumer` (5 RIDs, Calor0712 canary in the MSBuild task context) and
+   `cli-tool-consumer` (the frozen 3 RIDs — win-x64, linux-x64, osx-arm64 — packing `calor`,
+   installing it from a local feed with a cold package cache, and requiring a *solver verdict*:
+   contracts Proven, none Skipped, no Calor0710). The VSIX leg is retired with the extension
+   itself (#952). The dropped osx-x64 RID has no runner, so its amended oracle is reproduced on
+   every leg by removing the runner's own Z3 native from the installed tool — the same state an
+   Intel-mac consumer is in — and asserting documented degradation. **Building that oracle found
+   the gate's own failure mode live in the shipped CLI**: `Calor0710` was `info` severity and the
+   text report prints only errors and warnings, so a solverless consumer saw 14 `Skipped`, exit 0,
+   and no stated reason outside `--format json`. Fixed in the same PR.
 8. **Performance envelope (project scale needs a number)**: index build ≤ 30s and warm `calor query`
    ≤ 500ms on the largest pinned conversion subject, measured in CI. Generous by design; the point
    is that "usable at project scale" is adjudicable at all. Frozen here, before the index exists.

--- a/src/Calor.Compiler/Commands/VerifyCommand.cs
+++ b/src/Calor.Compiler/Commands/VerifyCommand.cs
@@ -427,6 +427,21 @@ public static class VerifyCommand
         foreach (var file in results)
         {
             sb.AppendLine($"File: {file.FileName}");
+
+            // Calor0710 is info-severity, and the text report prints only errors and
+            // warnings — so without this a consumer whose Z3 native is missing saw every
+            // contract "Skipped", exit 0, and no stated reason anywhere outside
+            // `--format json`. That is the state roadmap §2.5 gate 7 exists to catch
+            // ("installs successfully, silently loses verification"), so the reason is
+            // stated on the default surface, above the counts it explains.
+            var z3Unavailable = file.Diagnostics
+                .FirstOrDefault(d => d.Code == DiagnosticCode.Z3Unavailable);
+            if (z3Unavailable != null)
+            {
+                sb.AppendLine("  !! NOT VERIFIED: the Z3 solver is unavailable, so nothing below was proved.");
+                sb.AppendLine($"     {DiagnosticCode.Z3Unavailable}: {z3Unavailable.Message}");
+            }
+
             sb.AppendLine($"  Proven:      {file.Summary.Proven}");
             // `Assumed` collapses into the legacy `Unproven` bucket (ProofOutcome.ToContractStatus),
             // so without this line a demoted proof reads as an outright failure to prove — visually
@@ -517,6 +532,20 @@ public static class VerifyCommand
         {
             var provenRate = (double)totalProven / total * 100;
             sb.AppendLine($"  Proven Rate: {provenRate:F1}%");
+        }
+
+        // Repeated at the bottom because on a multi-file run the per-file notice
+        // scrolls away, and "Proven Rate: 0.0%" alone does not distinguish "nothing
+        // proved" from "nothing attempted".
+        var filesWithoutSolver = results
+            .Count(r => r.Diagnostics.Any(d => d.Code == DiagnosticCode.Z3Unavailable));
+        if (filesWithoutSolver > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"  !! {filesWithoutSolver} of {results.Count} file(s) were NOT verified: "
+                + $"the Z3 solver is unavailable ({DiagnosticCode.Z3Unavailable}).");
+            sb.AppendLine("     Their contracts are Skipped, not proved. Install the Z3 native library "
+                + "for static verification.");
         }
 
         return sb.ToString();


### PR DESCRIPTION
Stacked on #981 (base retargets to `main` when that merges).

Roadmap §2.5 gate 7 was the one release gate still open at 0.13.x. Its Sdk half has been in CI as `sdk-package-consumer` since v0.11. Its CLI half — the `calor` global tool — was only ever a **manual post-publish check**, which is exactly the kind of gate the #790 rewrite was supposed to eliminate.

## The bar is a solver verdict, not exit 0

The state gate 7 was written against is *"installs successfully, silently loses verification"*. A consumer with no working Z3 still installs, still exits 0, and reports every contract `Skipped`. So `cli-tool-consumer` packs `calor`, installs it from a local feed with a cold package cache, and requires **Proven > 0, Skipped == 0, no Calor0710** — on gate 7's frozen RIDs (win-x64, linux-x64, osx-arm64). It also asserts the package carries the runner's native and *does not* carry an osx-x64 one, so the #916 drop stays a tested fact.

## The amendment, as a test instead of a promise

The 2026-08-11 amendment (#916 review F3) requires that a clean Intel-mac consumer get **documented degradation**: loud, no crash, no silent pass. There is no Intel-mac runner to depend on, so the script reproduces the condition exactly — remove the Z3 native for the runner's *own* RID from the installed tool, which is the state an osx-x64 consumer is in — and asserts all three properties.

## That oracle failed on first run, against shipped 0.13.2

`Calor0710` is `info` severity, and the verify text report prints only errors and warnings. So with the native removed:

```
File: proven-contracts.calr
  Proven:      0
  Skipped:     14
  Proven Rate: 0.0%
```

Exit 0. No mention of Z3 anywhere in the output. `--verbose` did not surface it either — the diagnostic existed **only** under `--format json`.

That is gate 7's own failure mode, live in the product, found by building the gate. "No silent pass" held — nothing was reported `Proven` — but "loud" did not, on the surface a human or agent actually reads.

The text report now names the reason above the counts it explains, and repeats it in the overall summary (on a multi-file run the per-file notice scrolls away, and `Proven Rate: 0.0%` alone does not distinguish *nothing proved* from *nothing attempted*). **Severity, the JSON envelope, and the exit code are unchanged** — this is a reporting fix, not a diagnostic-semantics change.

## Discrimination and its limit

The pin discriminates in the strongest available order: it was written first, **failed against the unfixed compiler**, and passes after. The transcript of the failing run is in the commit message.

It is an end-to-end shell gate rather than an xUnit test, deliberately. Forcing Z3-unavailable in-process means adding a mutable seam to `Z3ContextFactory`'s static availability cache, which every test in the assembly shares — this repo has already been bitten once by cross-test contamination through exactly that kind of shared static. The tradeoff is stated rather than hidden: **the loudness behaviour is pinned by CI, not by the unit suite.**

## Verification

- both legs pass locally on osx-arm64 (`Proven 14, Skipped 0`; then `Calor0710` raised, nothing Proven, exit 0, no crash)
- `Calor.Verification.Tests` 393/393
- Release build, 0 warnings
- `check_test_quality.py` passes; `shellcheck` clean; workflow YAML parses, job registered, matrix correct

## Not done here

Branch protection is unchanged. Gate 7 is a release gate, so `cli-tool-consumer (…)` arguably belongs in the required contexts — but #949 is the open record of what happens when required contexts and job names drift, and changing protection is the maintainer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)